### PR TITLE
global local double arg support

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -46,7 +46,8 @@ impl Command for Global {
             }
         }
         if let Some(runtimes) = &self.runtime {
-            cf.add_runtimes(&config, runtimes, self.fuzzy)?;
+            let runtimes = RuntimeArg::double_runtime_condition(&runtimes.clone());
+            cf.add_runtimes(&config, &runtimes, self.fuzzy)?;
         }
 
         if self.runtime.is_some() || self.remove.is_some() {
@@ -90,6 +91,8 @@ mod test {
         let stdout = assert_cli!("global", "--fuzzy", "shfmt@2");
         assert_snapshot!(stdout);
         let stdout = assert_cli!("global", "--remove", "nodejs");
+        assert_snapshot!(stdout);
+        let stdout = assert_cli!("global", "tiny", "2");
         assert_snapshot!(stdout);
 
         if let Some(orig) = orig {

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -55,14 +55,14 @@ impl Install {
         &self,
         config: Config,
         out: &mut Output,
-        runtime: &[RuntimeArg],
+        runtimes: &[RuntimeArg],
     ) -> Result<()> {
         let settings = Settings {
             missing_runtime_behavior: AutoInstall,
             ..config.settings.clone()
         };
 
-        for r in runtime {
+        for r in RuntimeArg::double_runtime_condition(runtimes) {
             if r.version == "system" {
                 continue;
             }
@@ -160,8 +160,13 @@ mod test {
     use crate::assert_cli;
 
     #[test]
-    fn test_install() {
+    fn test_install_force() {
         assert_cli!("install", "-f", "shfmt");
+    }
+
+    #[test]
+    fn test_install_asdf_style() {
+        assert_cli!("install", "shfmt", "2");
     }
 
     #[test]

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -62,8 +62,10 @@ impl Command for Local {
                 cf.remove_plugin(plugin);
             }
         }
+
         if let Some(runtimes) = &self.runtime {
-            cf.add_runtimes(&config, runtimes, self.fuzzy)?;
+            let runtimes = RuntimeArg::double_runtime_condition(runtimes);
+            cf.add_runtimes(&config, &runtimes, self.fuzzy)?;
         }
 
         if self.runtime.is_some() || self.remove.is_some() {
@@ -101,7 +103,6 @@ mod test {
     use pretty_assertions::assert_str_eq;
 
     use crate::cli::test::grep;
-
     use crate::{assert_cli, dirs};
 
     #[test]
@@ -122,6 +123,10 @@ mod test {
             grep(stdout, "nodejs"),
             "   nodejs     18.0.0 (missing)   (set by ~/cwd/.node-version)"
         );
+        let stdout = assert_cli!("local", "tiny@1");
+        assert_str_eq!(grep(stdout, "tiny"), "tiny 1.0.1");
+        let stdout = assert_cli!("local", "tiny", "2");
+        assert_str_eq!(grep(stdout, "tiny"), "tiny 2.1.0");
 
         fs::write(cf_path, orig).unwrap();
     }

--- a/src/cli/snapshots/rtx__cli__global__test__global-4.snap
+++ b/src/cli/snapshots/rtx__cli__global__test__global-4.snap
@@ -1,0 +1,7 @@
+---
+source: src/cli/global.rs
+expression: stdout
+---
+shfmt 2
+tiny 2.1.0
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ use crate::output::Output;
 #[macro_use]
 mod output;
 
+#[macro_use]
+mod regex;
+
 pub mod build_time;
 mod cli;
 mod cmd;

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,0 +1,8 @@
+pub use regex;
+
+macro_rules! regex {
+    ($re:literal $(,)?) => {{
+        static RE: once_cell::sync::OnceCell<regex::Regex> = once_cell::sync::OnceCell::new();
+        RE.get_or_init(|| regex::Regex::new($re).unwrap())
+    }};
+}


### PR DESCRIPTION
[feat] this makes it so running `rtx local nodejs 20` does what the user expects. There are probably other places I should add this too
