### PR TITLE
[bug] fixed 2 styling issues with `rtx current`

### DIFF
--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -38,8 +38,9 @@ impl Command for Current {
                 let source = config.ts.get_source_for_plugin(&rtv.plugin.name).unwrap();
                 warn!(
                     "{}@{} is specified in {}, but not installed",
-                    rtv.plugin.name, source, rtv.version
+                    rtv.plugin.name, rtv.version, source
                 );
+                continue;
             }
             if let Some(plugin) = &plugin {
                 if plugin != &rtv.plugin {


### PR DESCRIPTION
Before:

```
[WARN] shfmt@~/.tool-versions is specified in 2, but not installed
shfmt@2
[WARN] python@~/.tool-versions is specified in 3.10, but not installed
python@3.10
[WARN] nodejs@~/.tool-versions is specified in 18.13.0, but not installed
nodejs@18.13.0
[WARN] java@~/.tool-versions is specified in openjdk-19.0.2, but not installed
java@openjdk-19.0.2
[WARN] golang@~/.tool-versions is specified in 1.19.5, but not installed
golang@1.19.5
[WARN] ruby@~/.tool-versions is specified in 3, but not installed
ruby@3
```

After:

```
[WARN] shfmt@2 is specified in ~/.tool-versions, but not installed
[WARN] python@3.10 is specified in ~/.tool-versions, but not installed
nodejs@18.13.0
[WARN] java@openjdk-19.0.2 is specified in ~/.tool-versions, but not installed
[WARN] golang@1.19.5 is specified in ~/.tool-versions, but not installed
[WARN] ruby@3 is specified in ~/.tool-versions, but not installed.
```
