### PR TITLE
[bug] add watch on ROOT directory

### DIFF
--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -49,6 +49,9 @@ impl Command for HookEnv {
 
 fn get_watches(config: &Config) -> Result<HookEnvWatches> {
     let mut watches = HookEnvWatches::new();
+    if dirs::ROOT.exists() {
+        watches.insert(dirs::ROOT.clone(), dirs::ROOT.metadata()?.modified()?);
+    }
     for cf in &config.config_files {
         watches.insert(cf.clone(), cf.metadata()?.modified()?);
     }

--- a/src/runtimes/mod.rs
+++ b/src/runtimes/mod.rs
@@ -104,8 +104,10 @@ impl RuntimeVersion {
         conf.write(&self.runtime_conf_path)?;
 
         // attempt to touch all the .tool-version files to trigger updates in hook-env
-        for path in &config.config_files {
-            let err = file::touch_dir(path);
+        let mut touch_dirs = vec![dirs::ROOT.to_path_buf()];
+        touch_dirs.extend(config.config_files.iter().cloned());
+        for path in touch_dirs {
+            let err = file::touch_dir(&path);
             if let Err(err) = err {
                 debug!("error touching config file: {:?} {:?}", path, err);
             }


### PR DESCRIPTION
This prevents issues around not having a .tool-version file with any active plugins, then running `rtx install`. There are cases where rtx won't update when it should. Writing to this directory should be accessible globally on the machine.