### PR TITLE
test: move e2e directory to home directory

### DIFF
--- a/e2e/cd/test_bash
+++ b/e2e/cd/test_bash
@@ -22,10 +22,11 @@ assert() {
 }
 
 assert_path() {
-  local expected="${1//$ROOT/\$ROOT}"
+  local expected="$1"
   local actual="${PATH/%$orig_path/}"
   actual="${actual/%:/}"
-  actual="${actual//$ROOT/\$ROOT}"
+  actual="${actual//$ROOT/ROOT}"
+  actual="${actual//$RTX_DATA_DIR\/installs/INSTALLS}"
   if [[ "$actual" != "$expected" ]]; then
     echo "Invalid PATH:  $actual"
     echo "Expected PATH: $expected"
@@ -34,17 +35,17 @@ assert_path() {
 }
 
 test "$(node -v)" = "v20.0.0"
-assert_path "/root:\$ROOT/e2e/cwd:\$ROOT/e2e/.rtx/installs/node/20.0.0/bin:\$ROOT/e2e/.rtx/installs/tiny/3.1.0/bin:\$ROOT/e2e/.rtx/installs/shellcheck/0.9.0/bin:\$ROOT/e2e/.rtx/installs/shfmt/3.6.0/bin"
+assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/20.0.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
 assert "$FOO" "cd"
 
 cd 18 && _rtx_hook
 test "$(node -v)" = "v18.0.0"
-assert_path "/root:\$ROOT/e2e/cwd:\$ROOT/e2e/.rtx/installs/node/18.0.0/bin:\$ROOT/e2e/.rtx/installs/tiny/3.1.0/bin:\$ROOT/e2e/.rtx/installs/shellcheck/0.9.0/bin:$ROOT/e2e/.rtx/installs/shfmt/3.6.0/bin"
+assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/18.0.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
 assert "$FOO" "18"
 
 cd .. && _rtx_hook
 test "$(node -v)" = "v20.0.0"
-assert_path "/root:\$ROOT/e2e/cwd:\$ROOT/e2e/.rtx/installs/node/20.0.0/bin:\$ROOT/e2e/.rtx/installs/tiny/3.1.0/bin:\$ROOT/e2e/.rtx/installs/shellcheck/0.9.0/bin:\$ROOT/e2e/.rtx/installs/shfmt/3.6.0/bin"
+assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/20.0.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
 
 rtx shell node@18.0.0 && _rtx_hook
 test "$(node -v)" = "v18.0.0"

--- a/e2e/run_test
+++ b/e2e/run_test
@@ -10,9 +10,9 @@ setup_env() {
   export PATH="$ROOT/target/debug:$PATH"
   export RTX_USE_TOML="0"
   export RTX_MISSING_RUNTIME_BEHAVIOR="autoinstall"
-  export RTX_DATA_DIR="$ROOT/e2e/.rtx"
-  export RTX_CACHE_DIR="$ROOT/e2e/.rtx/cache"
-  export RTX_CONFIG_DIR="$ROOT/e2e/.rtx/config"
+  export RTX_DATA_DIR="$HOME/.rtx/e2e"
+  export RTX_CACHE_DIR="$HOME/.rtx/e2e/cache"
+  export RTX_CONFIG_DIR="$HOME/.rtx/e2e/config"
   export RTX_DEFAULT_TOOL_VERSIONS_FILENAME=.e2e-tool-versions
   export RTX_DEFAULT_CONFIG_FILENAME=.e2e.rtx.toml
   export RTX_CONFIG_FILE="$ROOT/e2e/.config/rtx/config.toml"

--- a/e2e/test_link
+++ b/e2e/test_link
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "$0")/assert.sh"
 
 rtx plugins uninstall tiny

--- a/e2e/test_tiny
+++ b/e2e/test_tiny
@@ -3,7 +3,7 @@ set -euo pipefail
 source "$(dirname "$0")/assert.sh"
 
 rtx cache clean
-rm -rf .rtx/installs/tiny
+rm -rf "$RTX_DATA_DIR/installs/tiny"
 RTX_CONFIRM=y rtx ls # auto-trust
 
 # this will fail when calling bin/list-all, but it won't stop it from executing
@@ -20,9 +20,9 @@ assert "rtx current tiny" "3.1.0"
 
 # test outdated/upgrade
 rtx settings set experimental true
-rm -rf .rtx/installs/tiny
+rm -rf "$RTX_DATA_DIR/installs/tiny"
 rtx use tiny@3
-mv .rtx/installs/tiny/{3.1.0,3.0.0}
+mv "$RTX_DATA_DIR/installs/tiny/"{3.1.0,3.0.0}
 assert "rtx current tiny" "3.0.0"
 assert "rtx outdated tiny" "Tool    Requested  Current  Latest
 tiny    3          3.0.0    3.1.0"


### PR DESCRIPTION
avoids a warning from cargo about circular symlinks
