### PR TITLE
fix(java): use tar.gz archives to enable symlink support

### DIFF
--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -148,11 +148,7 @@ impl JavaPlugin {
         m: &JavaMetadata,
     ) -> Result<()> {
         pr.set_message(format!("installing {}", tarball_path.display()));
-        if m.file_type == Some("zip".to_string()) {
-            file::unzip(tarball_path, &tv.download_path())?;
-        } else {
-            file::untar(tarball_path, &tv.download_path())?;
-        }
+        file::untar(tarball_path, &tv.download_path())?;
         self.move_to_install_path(tv, m)
     }
 
@@ -407,4 +403,4 @@ impl Display for JavaMetadata {
 static JAVA_FEATURES: Lazy<HashSet<String>> =
     Lazy::new(|| HashSet::from(["musl", "javafx", "lite", "large_heap"].map(|s| s.to_string())));
 static JAVA_FILE_TYPES: Lazy<HashSet<String>> =
-    Lazy::new(|| HashSet::from(["tar.gz", "zip"].map(|s| s.to_string())));
+    Lazy::new(|| HashSet::from(["tar.gz"].map(|s| s.to_string())));


### PR DESCRIPTION
IMO easiest fix for #1329 would be to only support `tar.gz` for now. It seems all vendors ship archives in this format which also seems to support symlinks properly as opposed to ZIP (rs-zip).