### PR TITLE
Update README.md to link to rtx page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <a href="https://github.com/jdx/mise/actions/workflows/test.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/jdx/mise/test.yml?color=%2320A920&style=for-the-badge"></a>
 <!-- <a href="https://codecov.io/gh/jdx/mise"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/jdx/mise?color=%2320A920&style=for-the-badge"></a> -->
 <a href="https://discord.gg/mABnUDvP57"><img alt="Discord" src="https://img.shields.io/discord/1066429325269794907?color=%23738ADB&style=for-the-badge"></a>
-<p><em>The front-end to your dev env. (formerly called "[rtx](https://mise.jdx.dev/rtx.html)")</em></p>
+<p><em>The front-end to your dev env. (formerly called "<a href="https://mise.jdx.dev/rtx.html">rtx</a>")</em></p>
 </div>
 
 ## What is it?

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <a href="https://github.com/jdx/mise/actions/workflows/test.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/jdx/mise/test.yml?color=%2320A920&style=for-the-badge"></a>
 <!-- <a href="https://codecov.io/gh/jdx/mise"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/jdx/mise?color=%2320A920&style=for-the-badge"></a> -->
 <a href="https://discord.gg/mABnUDvP57"><img alt="Discord" src="https://img.shields.io/discord/1066429325269794907?color=%23738ADB&style=for-the-badge"></a>
-<p><em>The front-end to your dev env. (formerly called "<a href="https://mise.jdx.dev/rtx.html">rtx</a>")</em></p>
+<p><em>The front-end to your dev env. (<a href="https://mise.jdx.dev/rtx.html">formerly called "rtx"</a>)</em></p>
 </div>
 
 ## What is it?

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <a href="https://github.com/jdx/mise/actions/workflows/test.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/jdx/mise/test.yml?color=%2320A920&style=for-the-badge"></a>
 <!-- <a href="https://codecov.io/gh/jdx/mise"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/jdx/mise?color=%2320A920&style=for-the-badge"></a> -->
 <a href="https://discord.gg/mABnUDvP57"><img alt="Discord" src="https://img.shields.io/discord/1066429325269794907?color=%23738ADB&style=for-the-badge"></a>
-<p><em>The front-end to your dev env. (formerly called "rtx")</em></p>
+<p><em>The front-end to your dev env. (formerly called "[rtx](https://mise.jdx.dev/rtx.html)")</em></p>
 </div>
 
 ## What is it?


### PR DESCRIPTION
Found it somewhat confusing on how [rtx got renamed to mise](https://github.com/jdx/mise/issues/1350) and what the migration path is.  https://mise.jdx.dev/rtx.html page answers a lot of my questions.  Might be helpful for others as well.  