### PR TITLE
not-found: use "[" instead of "test"

### DIFF
--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -52,7 +52,7 @@ impl Shell for Bash {
             out.push_str(&formatdoc! {r#"
             if [ -z "${{_mise_cmd_not_found:-}}" ]; then
                 _mise_cmd_not_found=1
-                test -n "$(declare -f command_not_found_handle)" && eval "${{_/command_not_found_handle/_command_not_found_handle}}"
+                [ -n "$(declare -f command_not_found_handle)" ] && eval "${{_/command_not_found_handle/_command_not_found_handle}}"
 
                 command_not_found_handle() {{
                     if {exe} hook-not-found -s bash "$1"; then

--- a/src/shell/snapshots/mise__shell__bash__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__hook_init.snap
@@ -37,7 +37,7 @@ if [[ ";${PROMPT_COMMAND:-};" != *";_mise_hook;"* ]]; then
 fi
 if [ -z "${_mise_cmd_not_found:-}" ]; then
     _mise_cmd_not_found=1
-    test -n "$(declare -f command_not_found_handle)" && eval "${_/command_not_found_handle/_command_not_found_handle}"
+    [ -n "$(declare -f command_not_found_handle)" ] && eval "${_/command_not_found_handle/_command_not_found_handle}"
 
     command_not_found_handle() {
         if /some/dir/mise hook-not-found -s bash "$1"; then

--- a/src/shell/snapshots/mise__shell__bash__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__hook_init_nix.snap
@@ -36,7 +36,7 @@ if [[ ";${PROMPT_COMMAND:-};" != *";_mise_hook;"* ]]; then
 fi
 if [ -z "${_mise_cmd_not_found:-}" ]; then
     _mise_cmd_not_found=1
-    test -n "$(declare -f command_not_found_handle)" && eval "${_/command_not_found_handle/_command_not_found_handle}"
+    [ -n "$(declare -f command_not_found_handle)" ] && eval "${_/command_not_found_handle/_command_not_found_handle}"
 
     command_not_found_handle() {
         if /nix/store/mise hook-not-found -s bash "$1"; then

--- a/src/shell/snapshots/mise__shell__zsh__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__hook_init.snap
@@ -41,7 +41,7 @@ fi
 
 if [ -z "${_mise_cmd_not_found:-}" ]; then
     _mise_cmd_not_found=1
-    test -n "$(declare -f command_not_found_handler)" && eval "${_/command_not_found_handler/_command_not_found_handler}"
+    [ -n "$(declare -f command_not_found_handler)" ] && eval "${_/command_not_found_handler/_command_not_found_handler}"
 
     function command_not_found_handler() {
         if /some/dir/mise hook-not-found -s zsh "$1"; then

--- a/src/shell/snapshots/mise__shell__zsh__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__hook_init_nix.snap
@@ -40,7 +40,7 @@ fi
 
 if [ -z "${_mise_cmd_not_found:-}" ]; then
     _mise_cmd_not_found=1
-    test -n "$(declare -f command_not_found_handler)" && eval "${_/command_not_found_handler/_command_not_found_handler}"
+    [ -n "$(declare -f command_not_found_handler)" ] && eval "${_/command_not_found_handler/_command_not_found_handler}"
 
     function command_not_found_handler() {
         if /nix/store/mise hook-not-found -s zsh "$1"; then

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -60,7 +60,7 @@ impl Shell for Zsh {
             out.push_str(&formatdoc! {r#"
             if [ -z "${{_mise_cmd_not_found:-}}" ]; then
                 _mise_cmd_not_found=1
-                test -n "$(declare -f command_not_found_handler)" && eval "${{_/command_not_found_handler/_command_not_found_handler}}"
+                [ -n "$(declare -f command_not_found_handler)" ] && eval "${{_/command_not_found_handler/_command_not_found_handler}}"
 
                 function command_not_found_handler() {{
                     if {exe} hook-not-found -s zsh "$1"; then


### PR DESCRIPTION
This did not have any technical issues except in the edge-case where the user overrides "test" such as having alias test="...". It's highly unlikely someone would do this with "[".

See https://github.com/jdx/mise/discussions/1338#discussioncomment-8014200
