### PR TITLE
Add `description` to task object in JSON schema

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -163,6 +163,10 @@
                 }
               ]
             },
+            "description": {
+              "description": "description of task",
+              "type": "string"
+            },
             "depends": {
               "description": "other tasks to run before this task",
               "type": "array",


### PR DESCRIPTION
Support tasks with a `description` key in the definition. This allows configs with a description to be validated correctly.
