### PR TITLE
fix(java): enable macOS integration hint for Zulu distribution

### DIFF
--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -174,8 +174,21 @@ impl JavaPlugin {
             file::rename(entry.path(), dest)?;
         }
 
+        if os() == "macosx" {
+            self.handle_macos_integration(&contents_dir, tv, m)?;
+        }
+
+        Ok(())
+    }
+
+    fn handle_macos_integration(
+        &self,
+        contents_dir: &Path,
+        tv: &ToolVersion,
+        m: &JavaMetadata,
+    ) -> Result<()> {
         // move Contents dir to install path for macOS, if it exists
-        if os() == "macosx" && contents_dir.exists() {
+        if contents_dir.exists() {
             file::create_dir_all(tv.install_path().join("Contents"))?;
             for entry in fs::read_dir(contents_dir)? {
                 let entry = entry?;
@@ -191,6 +204,21 @@ impl JavaPlugin {
                 tv.install_path().as_path(),
                 &tv.install_path().join("Contents").join("Home"),
             )?;
+        }
+
+        // if vendor is Zulu, symlink zulu-{major_version}.jdk/Contents to install path for macOS
+        if m.vendor.as_str() == "zulu" {
+            let major_version = m.version.split('.').next().unwrap();
+            file::make_symlink(
+                tv.install_path()
+                    .join(format!("zulu-{}.jdk", major_version))
+                    .join("Contents")
+                    .as_path(),
+                &tv.install_path().join("Contents"),
+            )?;
+        }
+
+        if tv.install_path().join("Contents").exists() {
             info!(
                 "{}",
                 formatdoc! {r#"
@@ -203,7 +231,6 @@ impl JavaPlugin {
                 }
             );
         }
-
         Ok(())
     }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -174,7 +174,7 @@ impl JavaPlugin {
             file::rename(entry.path(), dest)?;
         }
 
-        if os() == "macosx" {
+        if cfg!(target_os = "macos") {
             self.handle_macos_integration(&contents_dir, tv, m)?;
         }
 
@@ -208,7 +208,10 @@ impl JavaPlugin {
 
         // if vendor is Zulu, symlink zulu-{major_version}.jdk/Contents to install path for macOS
         if m.vendor.as_str() == "zulu" {
-            let major_version = m.version.split('.').next().unwrap();
+            let (major_version, _) = m
+                .version
+                .split_once('.')
+                .unwrap_or_else(|| (&m.version, ""));
             file::make_symlink(
                 tv.install_path()
                     .join(format!("zulu-{}.jdk", major_version))


### PR DESCRIPTION
Currently the macOS integration hint is not shown for Zulu distributions since the archive does not contain the `/Contents` folder in the root directory but within a `zulu-{major}.jdk` directory.

We can simply symlink that directory and then check for a `/Contents` directory in the installation root to show the hint for all vendors that support the integration.