### PR TITLE
python: add support for precompiled binaries

### DIFF
--- a/e2e/test_poetry
+++ b/e2e/test_poetry
@@ -6,6 +6,7 @@ source "$(dirname "$0")/assert.sh"
 rm -rf "$MISE_DATA_DIR/cache/poetry"
 
 export POETRY_HOME=".poetry"
+mise settings set experimental n
 
 eval "$(mise activate bash)"
 cat >.e2e.mise.toml <<EOF

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -24,7 +24,8 @@
     },
     "color": {
       "description": "colorize output",
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     },
     "disable_default_shorthands": {
       "description": "disables built-in shorthands",
@@ -64,7 +65,8 @@
     },
     "not_found_auto_install": {
       "description": "adds a shell hook to `mise activate` and shims to automatically install tools when they need to be installed",
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     },
     "paranoid": {
       "description": "extra-security mode, see https://mise.jdx.dev/paranoid.html for details",
@@ -73,6 +75,14 @@
     "plugin_autoupdate_last_check_duration": {
       "description": "how often to check for plugin updates",
       "type": "string"
+    },
+    "python_compile": {
+      "description": "do not use precompiled binaries for python",
+      "type": "boolean"
+    },
+    "python_venv_auto_create": {
+      "description": "automatically create a virtualenv for python tools",
+      "type": "boolean"
     },
     "raw": {
       "description": "directly connect plugin scripts to stdin/stdout, implies --jobs=1",

--- a/src/cli/settings/ls.rs
+++ b/src/cli/settings/ls.rs
@@ -60,6 +60,8 @@ mod tests {
         not_found_auto_install = true
         paranoid = false
         plugin_autoupdate_last_check_duration = "20m"
+        python_compile = false
+        python_venv_auto_create = false
         quiet = false
         raw = false
         shorthands_file = null

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -106,6 +106,8 @@ pub mod tests {
         not_found_auto_install = true
         paranoid = false
         plugin_autoupdate_last_check_duration = "7d"
+        python_compile = false
+        python_venv_auto_create = false
         quiet = false
         raw = false
         shorthands_file = null

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -56,6 +56,8 @@ mod tests {
         not_found_auto_install = true
         paranoid = false
         plugin_autoupdate_last_check_duration = "20m"
+        python_compile = false
+        python_venv_auto_create = false
         quiet = false
         raw = false
         shorthands_file = null

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -46,6 +46,10 @@ pub struct Settings {
     pub paranoid: bool,
     #[config(env = "MISE_PLUGIN_AUTOUPDATE_LAST_CHECK_DURATION", default = "7d")]
     pub plugin_autoupdate_last_check_duration: String,
+    #[config(env = "MISE_PYTHON_COMPILE", default = false)]
+    pub python_compile: bool,
+    #[config(env = "MISE_PYTHON_VENV_AUTO_CREATE", default = false)]
+    pub python_venv_auto_create: bool,
     #[config(env = "MISE_RAW", default = false)]
     pub raw: bool,
     #[config(env = "MISE_SHORTHANDS_FILE")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -59,8 +59,11 @@ impl Client {
 
     pub fn get_text<U: IntoUrl>(&self, url: U) -> Result<String> {
         let url = url.into_url().unwrap();
-        let resp = self.get(url)?;
+        let resp = self.get(url.clone())?;
         let text = resp.text().into_diagnostic()?;
+        if text.starts_with("<!DOCTYPE html>") {
+            bail!("Got HTML instead of text from {}", url);
+        }
         Ok(text)
     }
 

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -95,12 +95,7 @@ impl CorePlugin {
         if !*env::MISE_USE_VERSIONS_HOST {
             return Ok(None);
         }
-        let raw = HTTP_FETCH.get_text(format!("http://rtx-versions.jdx.dev/{}", &self.name))?;
-        if raw.starts_with("<!DOCTYPE html>") {
-            debug!("Got HTML response from versions host, ignoring");
-            trace!("HTML response: {}", raw);
-            return Ok(None);
-        }
+        let raw = HTTP_FETCH.get_text(format!("http://mise-versions.jdx.dev/{}", &self.name))?;
         let versions = raw
             .lines()
             .map(|v| v.trim().to_string())

--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -146,15 +146,10 @@ impl ExternalPlugin {
             return Ok(None);
         }
         let versions =
-            match HTTP_FETCH.get_text(format!("http://rtx-versions.jdx.dev/{}", self.name)) {
+            match HTTP_FETCH.get_text(format!("http://mise-versions.jdx.dev/{}", self.name)) {
                 Err(err) if http::error_code(&err) == Some(404) => return Ok(None),
                 res => res?,
             };
-        if versions.starts_with("<!DOCTYPE html>") {
-            debug!("versions host returned html, assuming it's not a valid response");
-            trace!("versions host response: {}", versions);
-            return Ok(None);
-        }
         let versions = versions
             .lines()
             .map(|v| v.trim().to_string())


### PR DESCRIPTION
requires `experimental=1` for now