### PR TITLE
fix: nix flake build errors

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,5 @@
-{ pkgs, lib, stdenv, fetchFromGitHub, rustPlatform, coreutils, bash, direnv, perl }:
-let
-  libssl = with pkgs; symlinkJoin {
-    name = "libssl-merged";
-    paths = [ openssl.out openssl.dev ];
-  };
-in
+{ pkgs, lib, stdenv, fetchFromGitHub, rustPlatform, coreutils, bash, direnv, openssl }:
+
 rustPlatform.buildRustPackage {
   pname = "mise";
   version = "2024.1.8";
@@ -23,6 +18,7 @@ rustPlatform.buildRustPackage {
     gnused
     git
     gawk
+    openssl
   ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security darwin.apple_sdk.frameworks.SystemConfiguration ];
 
   prePatch = ''
@@ -32,6 +28,8 @@ rustPlatform.buildRustPackage {
       --replace '#!/bin/sh' '#!${bash}/bin/sh'
     substituteInPlace ./src/env_diff.rs \
       --replace '"bash"' '"${bash}/bin/bash"'
+    substituteInPlace ./test/cwd/.mise/tasks/filetask \
+      --replace '#!/usr/bin/env bash' '#!${bash}/bin/bash'
     substituteInPlace ./src/cli/direnv/exec.rs \
       --replace '"env"' '"${coreutils}/bin/env"' \
       --replace 'cmd!("direnv"' 'cmd!("${direnv}/bin/direnv"'
@@ -43,11 +41,6 @@ rustPlatform.buildRustPackage {
     RUST_BACKTRACE=full cargo test --all-features -- \
       --skip cli::plugins::ls::tests::test_plugin_list_urls
   '';
-
-  # Need this to ensure openssl-src's build uses an available version of `perl`
-  # https://github.com/alexcrichton/openssl-src-rs/issues/45
-  OPENSSL_SRC_PERL = "${perl}/bin/perl";
-  OPENSSL_DIR = "${libssl}";
 
   meta = with lib; {
     description = "The front-end to your dev env";

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679410443,
-        "narHash": "sha256-xDHO/jixWD+y5pmW5+2q4Z4O/I/nA4MAa30svnZKK+M=",
+        "lastModified": 1704161960,
+        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c9ece0059f42e0ab53ac870104ca4049df41b133",
+        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
               shfmt
               nodejs
               cargo-release
+              cargo-insta
+              cargo-llvm-cov
             ];
           };
         }


### PR DESCRIPTION
Thank you for your awesome project. This tool is so powerful for me.

I've added some patches to fix build errors on nix flake.

### Details

- fix nix flake (fc0534ce9b7cbb3da3fb5a4698b82c71ee3f1822)
  -  update lockfile (because rustc 1.70.0 or newer is required)
  - resolve OpenSSL error on build
  - fix a test to pass because of bash path in `test/cwd/.mise/tasks/filetask`
- add cargo crates required for tests  (9a4547b93d465b38198ee10ecec9d9a0c294b102)

### Tests

- [x] pass `nix build`
- [x] pass `nix develop`
