### PR TITLE
prevent adding relative/empty paths during activation

### DIFF
--- a/e2e/test_path_safety
+++ b/e2e/test_path_safety
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "$0")/assert.sh"
+
+export MISE_EXPERIMENTAL=1
+eval "$(mise activate bash)" && eval "$(mise hook-env)"
+install -m 0755 /dev/null /tmp/MISE_PATH_SAFETY_CHECK
+cd /tmp && assert_fail "command -v MISE_PATH_SAFETY_CHECK"

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -11,7 +11,7 @@ impl Shell for Bash {
         let dir = exe.parent().unwrap();
         let exe = exe.to_string_lossy();
         let mut out = String::new();
-        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) && !dir.is_relative() {
             out.push_str(&format!("export PATH=\"{}:$PATH\"\n", dir.display()));
         }
         out.push_str(&formatdoc! {r#"

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -13,7 +13,7 @@ impl Shell for Fish {
         let description = "'Update mise environment when changing directories'";
         let mut out = String::new();
 
-        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) && !dir.is_relative() {
             out.push_str(&format!("fish_add_path -g {dir}\n", dir = dir.display()));
         }
 

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -26,7 +26,7 @@ impl Shell for Nushell {
         let exe = exe.display();
         let mut out = String::new();
 
-        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) && !dir.is_relative() {
             out.push_str(&format!(
                 "$env.PATH = ($env.PATH | prepend '{}')\n", // TODO: set PATH as Path on windows
                 dir.display()

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -49,7 +49,7 @@ impl Shell for Xonsh {
             from xonsh.built_ins  import XSH
 
         "#});
-        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) && !dir.is_relative() {
             let dir_str = dir.to_string_lossy();
             let dir_esc = xonsh_escape_sq(&dir_str);
             out.push_str(&formatdoc! {r#"

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -15,7 +15,7 @@ impl Shell for Zsh {
 
         // much of this is from direnv
         // https://github.com/direnv/direnv/blob/cb5222442cb9804b1574954999f6073cc636eff0/internal/cmd/shell_zsh.go#L10-L22
-        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) && !dir.is_relative() {
             out.push_str(&format!("export PATH=\"{}:$PATH\"\n", dir.display()));
         }
         out.push_str(&formatdoc! {r#"


### PR DESCRIPTION
attempting to address #1380

After some initial reading/testing, this seems to fix the problematic cases I found, and hopefully the test is helpful.

Also, because the behavior was a bit non-obvious to me, a link to some is_relative() examples

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=e806075e086f5d669ae4dfc0f0b40aa9