### PR TITLE
allow expanding "~" for trusted_config_paths

### DIFF
--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -224,7 +224,7 @@ pub fn is_trusted(path: &Path) -> bool {
             return true;
         }
         let settings = Settings::get();
-        for p in settings.trusted_config_paths.iter() {
+        for p in settings.trusted_config_paths() {
             if path.starts_with(p) {
                 cached.insert(path);
                 return true;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -238,6 +238,10 @@ impl Settings {
         ensure!(self.experimental, msg);
         Ok(())
     }
+
+    pub fn trusted_config_paths(&self) -> impl Iterator<Item = PathBuf> + '_ {
+        self.trusted_config_paths.iter().map(file::replace_path)
+    }
 }
 
 impl Display for Settings {


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/issues/1402