### PR TITLE
disallow [settings] header in settings.toml

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -15,6 +15,7 @@ use crate::{env, file};
 
 #[derive(Config, Debug, Clone, Serialize)]
 #[config(partial_attr(derive(Clone, Serialize, Default)))]
+#[config(partial_attr(serde(deny_unknown_fields)))]
 pub struct Settings {
     #[config(env = "MISE_ALL_COMPILE", default = false)]
     pub all_compile: bool,


### PR DESCRIPTION
Before this would silently ignore everything in the file.

Fixes https://github.com/jdx/mise/issues/1403