### PR TITLE
Fix missing ASDF_PLUGIN_PATH environment variable

### DIFF
--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -401,7 +401,8 @@ impl ExternalPlugin {
 fn build_script_man(name: &str, plugin_path: &Path) -> ScriptManager {
     let plugin_path_s = plugin_path.to_string_lossy().to_string();
     ScriptManager::new(plugin_path.to_path_buf())
-        .with_env("RTX_PLUGIN_PATH", plugin_path_s)
+        .with_env("ASDF_PLUGIN_PATH", plugin_path_s.clone())
+        .with_env("RTX_PLUGIN_PATH", plugin_path_s.clone())
         .with_env("RTX_PLUGIN_NAME", name.to_string())
         .with_env("RTX_SHIMS_DIR", &*dirs::SHIMS)
         .with_env("MISE_PLUGIN_NAME", name.to_string())


### PR DESCRIPTION
Some ASDF scripts need ASDF_PLUGIN_PATH to reference patches or other scripts. For compatibility, it is added to the environment variables provided to executed plugin scripts.