### PR TITLE
settings: read from config.toml

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -49,6 +49,12 @@
           "type": "string"
         }
       }
+    },
+    "settings": {
+      "description": "mise settings",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {"$ref": "#/$defs/settings"}
     }
   },
   "$defs": {
@@ -213,6 +219,120 @@
           "additionalProperties": false
         }
       ]
+    },
+    "settings": {
+      "all_compile": {
+        "description": "do not use precompiled binaries for any tool",
+        "type": "boolean"
+      },
+      "always_keep_download": {
+        "description": "should mise keep downloaded files after installation",
+        "type": "boolean"
+      },
+      "always_keep_install": {
+        "description": "should mise keep install files after installation even if the installation fails",
+        "type": "boolean"
+      },
+      "asdf_compat": {
+        "description": "set to true to ensure .tool-versions will be compatible with asdf",
+        "type": "boolean"
+      },
+      "color": {
+        "description": "colorize output",
+        "type": "boolean",
+        "default": true
+      },
+      "disable_default_shorthands": {
+        "description": "disables built-in shorthands",
+        "type": "boolean"
+      },
+      "disable_tools": {
+        "description": "tools that should not be used",
+        "items": {
+          "description": "tool name",
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "experimental": {
+        "description": "enable experimental features",
+        "type": "boolean"
+      },
+      "jobs": {
+        "description": "number of tools to install in parallel, default is 4",
+        "type": "integer"
+      },
+      "legacy_version_file": {
+        "description": "should mise parse legacy version files (e.g. .node-version)",
+        "type": "boolean"
+      },
+      "legacy_version_file_disable_tools": {
+        "description": "tools that should not have their legacy version files parsed",
+        "items": {
+          "description": "tool name",
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "node_compile": {
+        "description": "do not use precompiled binaries for node",
+        "type": "boolean"
+      },
+      "not_found_auto_install": {
+        "description": "adds a shell hook to `mise activate` and shims to automatically install tools when they need to be installed",
+        "type": "boolean",
+        "default": true
+      },
+      "paranoid": {
+        "description": "extra-security mode, see https://mise.jdx.dev/paranoid.html for details",
+        "type": "boolean"
+      },
+      "plugin_autoupdate_last_check_duration": {
+        "description": "how often to check for plugin updates",
+        "type": "string"
+      },
+      "python_compile": {
+        "description": "do not use precompiled binaries for python",
+        "type": "boolean"
+      },
+      "python_venv_auto_create": {
+        "description": "automatically create a virtualenv for python tools",
+        "type": "boolean"
+      },
+      "raw": {
+        "description": "directly connect plugin scripts to stdin/stdout, implies --jobs=1",
+        "type": "boolean"
+      },
+      "shorthands_file": {
+        "description": "path to file containing shorthand mappings",
+        "type": "string"
+      },
+      "task_output": {
+        "default": "prefix",
+        "description": "how to display task output",
+        "enum": ["prefix", "interleave"],
+        "type": "string"
+      },
+      "trusted_config_paths": {
+        "description": "config files with these prefixes will be trusted by default",
+        "items": {
+          "description": "a path to add to PATH",
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "quiet": {
+        "description": "suppress all non-error output",
+        "type": "boolean"
+      },
+      "verbose": {
+        "description": "display extra output",
+        "type": "boolean"
+      },
+      "yes": {
+        "description": "assume yes for all prompts",
+        "type": "boolean"
+      }
     }
   }
 }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -54,7 +54,7 @@
       "description": "mise settings",
       "type": "object",
       "additionalProperties": false,
-      "properties": {"$ref": "#/$defs/settings"}
+      "properties": { "$ref": "#/$defs/settings" }
     }
   },
   "$defs": {

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -34,7 +34,6 @@ impl Doctor {
         miseprintln!("{}", shell());
         miseprintln!("{}", mise_data_dir());
         miseprintln!("{}", mise_env_vars());
-        miseprintln!("{}", mise_settings_file());
         match Settings::try_get() {
             Ok(settings) => {
                 miseprintln!(
@@ -121,12 +120,6 @@ fn mise_env_vars() -> String {
     for (k, v) in vars {
         s.push_str(&format!("  {}={}\n", k, v));
     }
-    s
-}
-
-fn mise_settings_file() -> String {
-    let mut s = style("mise settings file:\n").bold().to_string();
-    s.push_str(&format!("  {}\n", display_path(&env::MISE_SETTINGS_FILE)));
     s
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -54,11 +54,6 @@ pub fn reset_config() {
         indoc! {r#"
             experimental = true
             verbose = true
-            always_keep_download= true
-            always_keep_install= true
-            legacy_version_file= true
-            plugin_autoupdate_last_check_duration = "20m"
-            jobs = 2
             "#},
     )
     .unwrap();
@@ -77,6 +72,12 @@ pub fn reset_config() {
             run = 'echo "linting!"'
             [tasks.test]
             run = 'echo "testing!"'
+            [settings]
+            always_keep_download= true
+            always_keep_install= true
+            legacy_version_file= true
+            plugin_autoupdate_last_check_duration = "20m"
+            jobs = 2
             "#},
     )
     .unwrap();

--- a/test/config/config.toml
+++ b/test/config/config.toml
@@ -10,3 +10,9 @@ run = 'echo "configtask:"'
 run = 'echo "linting!"'
 [tasks.test]
 run = 'echo "testing!"'
+[settings]
+always_keep_download= true
+always_keep_install= true
+legacy_version_file= true
+plugin_autoupdate_last_check_duration = "20m"
+jobs = 2

--- a/test/config/settings.toml
+++ b/test/config/settings.toml
@@ -1,7 +1,2 @@
 experimental = true
 verbose = true
-always_keep_download= true
-always_keep_install= true
-legacy_version_file= true
-plugin_autoupdate_last_check_duration = "20m"
-jobs = 2


### PR DESCRIPTION
Fixes #1436

Moving to `settings.toml` was a regretful mistake. It turns out that having 2 config files in a CLI is just a bad idea. It's confusing to users and ultimately wasn't even necessary so we're going back to 1 file.

Sorry for the musical chairs here. I know breaking changes like that are not great and especially when they get _reverted_ it would be especially maddening. Moving back, however, should not be a breaking change.

We've taken steps to correct this from a project management perspective by setting up an advisory board: https://mise.jdx.dev/team.html You can certainly expect fewer abrupt changes in the future. A group of people able to review decisions like this before I roll out a change is exactly what this project needed.

We've gone through this together and came up with a plan to get us off of having `settings.toml` and back to `config.toml` in a way that should involve minimal disruption—in fact I think it's possible nobody may even notice this change.

This change should not negatively impact anyone. mise will read from both files and merge the contents, preferring `config.toml`. You can continue to use `settings.toml` and not change a thing. In a few weeks, I'm going to roll out another change to silently merge the contents of `settings.toml` into `config.toml`. If you'd like to stay ahead of that, go ahead and put the contents of `settings.toml` back into `config.toml` like before and nothing will change for you.

I really am sorry for this one. I should've been a lot more careful rolling out the initial change to split these files up. Just know that we've definitely taken some steps to correct that.