### PR TITLE
added support for installing directly from npm

### DIFF
--- a/e2e/test_npm
+++ b/e2e/test_npm
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "$0")/assert.sh"
+
+export MISE_EXPERIMENTAL=1
+
+assert "mise x npm-prettier@3.1.0 -- prettier -v" "3.1.0"

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -27,6 +27,7 @@ use crate::ui::progress_report::SingleReport;
 use crate::{dirs, file};
 
 mod cargo;
+mod npm;
 
 pub type AForge = Arc<dyn Forge>;
 pub type ForgeMap = BTreeMap<ForgeArg, AForge>;
@@ -37,6 +38,7 @@ pub type ForgeList = Vec<AForge>;
 pub enum ForgeType {
     Asdf,
     Cargo,
+    Npm,
 }
 
 static FORGES: Mutex<Option<ForgeMap>> = Mutex::new(None);
@@ -74,6 +76,7 @@ pub fn get(fa: &ForgeArg) -> AForge {
             .or_insert_with(|| match fa.forge_type {
                 ForgeType::Asdf => Arc::new(ExternalPlugin::new(name)),
                 ForgeType::Cargo => Arc::new(CargoForge::new(fa.clone())),
+                ForgeType::Npm => Arc::new(npm::NPMForge::new(fa.clone())),
             })
             .clone()
     }

--- a/src/forge/npm.rs
+++ b/src/forge/npm.rs
@@ -1,0 +1,61 @@
+use std::fmt::Debug;
+
+use crate::cache::CacheManager;
+use crate::cli::args::ForgeArg;
+use crate::cmd::CmdLineRunner;
+use crate::config::Settings;
+use crate::dirs;
+use crate::forge::{Forge, ForgeType};
+use crate::install_context::InstallContext;
+
+#[derive(Debug)]
+pub struct NPMForge {
+    fa: ForgeArg,
+    remote_version_cache: CacheManager<Vec<String>>,
+}
+
+impl Forge for NPMForge {
+    fn get_type(&self) -> ForgeType {
+        ForgeType::Npm
+    }
+
+    fn fa(&self) -> &ForgeArg {
+        &self.fa
+    }
+
+    fn list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+        self.remote_version_cache
+            .get_or_try_init(|| {
+                let raw = cmd!("npm", "view", self.name(), "versions", "--json").read()?;
+                let versions: Vec<String> = serde_json::from_str(&raw)?;
+                Ok(versions)
+            })
+            .cloned()
+    }
+
+    fn install_version_impl(&self, ctx: &InstallContext) -> eyre::Result<()> {
+        let settings = Settings::get();
+        settings.ensure_experimental()?;
+
+        CmdLineRunner::new("npm")
+            .arg("install")
+            .arg("-g")
+            .arg(&format!("{}@{}", self.name(), ctx.tv.version))
+            .arg("--prefix")
+            .arg(ctx.tv.install_path())
+            .with_pr(ctx.pr.as_ref())
+            .execute()?;
+
+        Ok(())
+    }
+}
+
+impl NPMForge {
+    pub fn new(fa: ForgeArg) -> Self {
+        let cache_dir = dirs::CACHE.join(&fa.id);
+        Self {
+            fa,
+            remote_version_cache: CacheManager::new(cache_dir.join("remote_versions.msgpack.z")),
+        }
+    }
+}


### PR DESCRIPTION
e.g.: `mise use -g npm-prettier@3.2.0`
