### PR TITLE
fix: bail out of task suggestion if there are no tasks

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -332,6 +332,12 @@ impl Run {
 
     fn prompt_for_task(&self, config: &Config, t: &str) -> Result<Task> {
         let tasks = config.tasks();
+        if tasks.is_empty() {
+            bail!(format!(
+                "no tasks defined. see {url}",
+                url = style("https://mise.jdx.dev/tasks/").underlined()
+            ));
+        }
         let task_names = tasks.keys().sorted().collect_vec();
         let t = style(&t).yellow().for_stderr();
         let msg = format!("no task named `{t}` found. select a task to run:");


### PR DESCRIPTION
we should probably `bail` if the user is in a directory with no taks defined