### PR TITLE
fix not_found handler when command start with "--"

### DIFF
--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -55,7 +55,7 @@ impl Shell for Bash {
                 [ -n "$(declare -f command_not_found_handler)" ] && eval "${{$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}}"
 
                 command_not_found_handle() {{
-                    if {exe} hook-not-found -s bash "$1"; then
+                    if {exe} hook-not-found -s bash -- "$1"; then
                       _mise_hook
                       "$@"
                     elif [ -n "$(declare -f _command_not_found_handle)" ]; then

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -79,7 +79,7 @@ impl Shell for Fish {
         if Settings::get().not_found_auto_install {
             out.push_str(&formatdoc! {r#"
             function fish_command_not_found
-                if {exe} hook-not-found -s fish $argv[1]
+                if {exe} hook-not-found -s fish -- $argv[1]
                     {exe} hook-env{flags} -s fish | source
                 else
                     __fish_default_command_not_found_handler $argv

--- a/src/shell/snapshots/mise__shell__bash__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__hook_init.snap
@@ -40,7 +40,7 @@ if [ -z "${_mise_cmd_not_found:-}" ]; then
     [ -n "$(declare -f command_not_found_handler)" ] && eval "${$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}"
 
     command_not_found_handle() {
-        if /some/dir/mise hook-not-found -s bash "$1"; then
+        if /some/dir/mise hook-not-found -s bash -- "$1"; then
           _mise_hook
           "$@"
         elif [ -n "$(declare -f _command_not_found_handle)" ]; then

--- a/src/shell/snapshots/mise__shell__bash__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__hook_init_nix.snap
@@ -39,7 +39,7 @@ if [ -z "${_mise_cmd_not_found:-}" ]; then
     [ -n "$(declare -f command_not_found_handler)" ] && eval "${$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}"
 
     command_not_found_handle() {
-        if /nix/store/mise hook-not-found -s bash "$1"; then
+        if /nix/store/mise hook-not-found -s bash -- "$1"; then
           _mise_hook
           "$@"
         elif [ -n "$(declare -f _command_not_found_handle)" ]; then

--- a/src/shell/snapshots/mise__shell__fish__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__hook_init.snap
@@ -59,7 +59,7 @@ function __mise_env_eval_2 --on-event fish_preexec --description 'Update mise en
     functions --erase __mise_cd_hook;
 end;
 function fish_command_not_found
-    if /some/dir/mise hook-not-found -s fish $argv[1]
+    if /some/dir/mise hook-not-found -s fish -- $argv[1]
         /some/dir/mise hook-env --status -s fish | source
     else
         __fish_default_command_not_found_handler $argv

--- a/src/shell/snapshots/mise__shell__fish__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__hook_init_nix.snap
@@ -58,7 +58,7 @@ function __mise_env_eval_2 --on-event fish_preexec --description 'Update mise en
     functions --erase __mise_cd_hook;
 end;
 function fish_command_not_found
-    if /nix/store/mise hook-not-found -s fish $argv[1]
+    if /nix/store/mise hook-not-found -s fish -- $argv[1]
         /nix/store/mise hook-env --status -s fish | source
     else
         __fish_default_command_not_found_handler $argv

--- a/src/shell/snapshots/mise__shell__zsh__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__hook_init.snap
@@ -44,7 +44,7 @@ if [ -z "${_mise_cmd_not_found:-}" ]; then
     [ -n "$(declare -f command_not_found_handler)" ] && eval "${$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}"
 
     function command_not_found_handler() {
-        if /some/dir/mise hook-not-found -s zsh "$1"; then
+        if /some/dir/mise hook-not-found -s zsh -- "$1"; then
           _mise_hook
           "$@"
         elif [ -n "$(declare -f _command_not_found_handler)" ]; then

--- a/src/shell/snapshots/mise__shell__zsh__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__hook_init_nix.snap
@@ -43,7 +43,7 @@ if [ -z "${_mise_cmd_not_found:-}" ]; then
     [ -n "$(declare -f command_not_found_handler)" ] && eval "${$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}"
 
     function command_not_found_handler() {
-        if /nix/store/mise hook-not-found -s zsh "$1"; then
+        if /nix/store/mise hook-not-found -s zsh -- "$1"; then
           _mise_hook
           "$@"
         elif [ -n "$(declare -f _command_not_found_handler)" ]; then

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -63,7 +63,7 @@ impl Shell for Zsh {
                 [ -n "$(declare -f command_not_found_handler)" ] && eval "${{$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}}"
 
                 function command_not_found_handler() {{
-                    if {exe} hook-not-found -s zsh "$1"; then
+                    if {exe} hook-not-found -s zsh -- "$1"; then
                       _mise_hook
                       "$@"
                     elif [ -n "$(declare -f _command_not_found_handler)" ]; then


### PR DESCRIPTION
if you type something like "--profile" in you would get a strange error
