### PR TITLE
add support for installing directly with go modules

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,4 +25,7 @@ RUN mkdir /workspaces/target \
     # npm packages
     && npm install -g prettier@3.1.0 markdownlint-cli@0.37.0 markdown-magic@2.6.1
 
+COPY --from=golang:1.21-bullseye /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 ENTRYPOINT [ "/bin/bash" ]

--- a/e2e/test_go_install
+++ b/e2e/test_go_install
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "$0")/assert.sh"
+
+export MISE_EXPERIMENTAL=1
+
+assert "mise x go:github.com/DarthSim/hivemind@v1.1.0 -- hivemind --version" "Hivemind version 1.1.0"

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -16,7 +16,7 @@ pub struct GoForge {
 
 impl Forge for GoForge {
     fn get_type(&self) -> ForgeType {
-        ForgeType::Npm
+        ForgeType::Go
     }
 
     fn fa(&self) -> &ForgeArg {

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -1,0 +1,68 @@
+use std::fmt::Debug;
+
+use crate::cache::CacheManager;
+use crate::cli::args::ForgeArg;
+use crate::cmd::CmdLineRunner;
+use crate::config::{Config, Settings};
+
+use crate::forge::{Forge, ForgeType};
+use crate::install_context::InstallContext;
+
+#[derive(Debug)]
+pub struct GoForge {
+    fa: ForgeArg,
+    remote_version_cache: CacheManager<Vec<String>>,
+}
+
+impl Forge for GoForge {
+    fn get_type(&self) -> ForgeType {
+        ForgeType::Npm
+    }
+
+    fn fa(&self) -> &ForgeArg {
+        &self.fa
+    }
+
+    fn list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+        self.remote_version_cache
+            .get_or_try_init(|| {
+                let raw = cmd!("go", "list", "-m", "-versions", "-json", self.name()).read()?;
+                let mod_info: GoModInfo = serde_json::from_str(&raw)?;
+                Ok(mod_info.versions)
+            })
+            .cloned()
+    }
+
+    fn install_version_impl(&self, ctx: &InstallContext) -> eyre::Result<()> {
+        let config = Config::try_get()?;
+        let settings = Settings::get();
+        settings.ensure_experimental()?;
+
+        CmdLineRunner::new("go")
+            .arg("install")
+            .arg(&format!("{}@{}", self.name(), ctx.tv.version))
+            .with_pr(ctx.pr.as_ref())
+            .envs(&config.env)
+            .env("GOPATH", ctx.tv.install_path())
+            .execute()?;
+
+        Ok(())
+    }
+}
+
+impl GoForge {
+    pub fn new(fa: ForgeArg) -> Self {
+        Self {
+            remote_version_cache: CacheManager::new(
+                fa.cache_path.join("remote_versions.msgpack.z"),
+            ),
+            fa,
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct GoModInfo {
+    versions: Vec<String>,
+}

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -43,7 +43,8 @@ impl Forge for GoForge {
             .arg(&format!("{}@{}", self.name(), ctx.tv.version))
             .with_pr(ctx.pr.as_ref())
             .envs(&config.env)
-            .env("GOPATH", ctx.tv.install_path())
+            .env("GOPATH", ctx.tv.cache_path())
+            .env("GOBIN", ctx.tv.install_path().join("bin"))
             .execute()?;
 
         Ok(())

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -27,6 +27,7 @@ use crate::ui::progress_report::SingleReport;
 use crate::{dirs, file};
 
 mod cargo;
+mod go;
 mod npm;
 
 pub type AForge = Arc<dyn Forge>;
@@ -39,6 +40,7 @@ pub enum ForgeType {
     Asdf,
     Cargo,
     Npm,
+    Go,
 }
 
 static FORGES: Mutex<Option<ForgeMap>> = Mutex::new(None);
@@ -77,6 +79,7 @@ pub fn get(fa: &ForgeArg) -> AForge {
                 ForgeType::Asdf => Arc::new(ExternalPlugin::new(name)),
                 ForgeType::Cargo => Arc::new(CargoForge::new(fa.clone())),
                 ForgeType::Npm => Arc::new(npm::NPMForge::new(fa.clone())),
+                ForgeType::Go => Arc::new(go::GoForge::new(fa.clone())),
             })
             .clone()
     }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -39,8 +39,8 @@ pub type ForgeList = Vec<AForge>;
 pub enum ForgeType {
     Asdf,
     Cargo,
-    Npm,
     Go,
+    Npm,
 }
 
 static FORGES: Mutex<Option<ForgeMap>> = Mutex::new(None);


### PR DESCRIPTION
This mimics the NPM/Cargo functionality for Go install.

Things you should look at:
1. is that the best way to get Go into the build/test process?
2. should I be only installing the binary into the rtx path or moving the whole gopath like I am currently? The whole GOPATH benefits sandboxing I guess but would almost definitely result in duplication of libraries across similar project installs. Could alternatively set GOBIN and do an mkdir of the /bin inside the version folder.

Things I noticed while contributing:
- docs on *running* mise or tests without the devcontainer are sparse at best, couldn't figure out how to deactivate mise enough to satisfy the tests
- perhaps an option to run tests in a container would be good? Maybe stepchowfun/toast or earthly or similar?
- It is also pretty hard to wipe a messed up package install, or at least undocumented.
- you mention something about a shim in CONTRIBUTING.md, but I couldn't figure out how this was meant to work it seems like not all the info required to set it up
- pre commit hooks don't work without some md-magic thing I don't have installed