### PR TITLE
tasks: fix project_root when using .config/mise.toml or .mise/config.toml

### DIFF
--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -611,8 +611,8 @@ impl ConfigFile for MiseToml {
                 dir if dir.starts_with(*dirs::CONFIG) => None,
                 dir if dir.starts_with(*dirs::SYSTEM) => None,
                 dir if dir == *dirs::HOME => None,
-                dir if !filename.starts_with('.') && dir.ends_with("/.mise") => dir.parent(),
-                dir if !filename.starts_with('.') && dir.ends_with("/.config/mise") => {
+                dir if !filename.starts_with('.') && dir.ends_with(".mise") => dir.parent(),
+                dir if !filename.starts_with('.') && dir.ends_with(".config/mise") => {
                     dir.parent().unwrap().parent()
                 }
                 dir => Some(dir),


### PR DESCRIPTION
Fixes #1480
