### PR TITLE
fix(tasks): prevent implicit globbing of sources/outputs

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -203,7 +203,7 @@
               "description": "files that this task depends on",
               "type": "array",
               "items": {
-                "description": "glob pattern for files that this task depends on",
+                "description": "glob pattern or path to files that this task depends on",
                 "type": "string"
               }
             },
@@ -211,7 +211,7 @@
               "description": "files created by this task",
               "type": "array",
               "items": {
-                "description": "glob pattern for files created by this task",
+                "description": "glob pattern or path to files created by this task",
                 "type": "string"
               }
             }


### PR DESCRIPTION
### Summary

Fixes #1372

Ensures that `sources` or `outputs` defined for tasks are not implicitly matched recursively by base name even when a glob pattern is not provided.

### Notes
- Special handling is included for relative and absolute paths
- Glob character detection matches [globwalk](https://github.com/Gilnaa/globwalk/blob/master/src/lib.rs#L427-L432)