### PR TITLE
add other arm targets for cargo-binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,10 @@ pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-macos-x64{ ar
 pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-arm64{ archive-suffix }"
 [package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
 pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-x64{ archive-suffix }"
+[package.metadata.binstall.overrides.armv7-unknown-linux-gnueabihf]
+pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-armv7{ archive-suffix }"
+[package.metadata.binstall.overrides.armv6-unknown-linux-gnueabihf]
+pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-armv6{ archive-suffix }"
 
 [package.metadata.cargo-machete]
 ignored = ["built", "openssl"]


### PR DESCRIPTION
relevance: #1327

I looked at adding `armv7` and `armv6`.



