### PR TITLE
refactor: env parsing

### DIFF
--- a/src/cli/direnv/envrc.rs
+++ b/src/cli/direnv/envrc.rs
@@ -33,7 +33,7 @@ impl Envrc {
         for cf in config.config_files.keys() {
             writeln!(file, "watch_file {}", cf.to_string_lossy())?;
         }
-        for (k, v) in ts.env(config) {
+        for (k, v) in ts.env(config)? {
             if k == "PATH" {
                 writeln!(file, "PATH_add {}", v)?;
             } else {

--- a/src/cli/direnv/exec.rs
+++ b/src/cli/direnv/exec.rs
@@ -24,7 +24,7 @@ impl DirenvExec {
 
         let mut cmd = env_cmd();
 
-        for (k, v) in ts.env_with_path(config) {
+        for (k, v) in ts.env_with_path(config)? {
             cmd = cmd.env(k, v);
         }
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -40,7 +40,7 @@ impl Env {
     }
 
     fn output_json(&self, config: &Config, ts: Toolset) -> Result<()> {
-        let env = ts.env_with_path(config);
+        let env = ts.env_with_path(config)?;
         miseprintln!("{}", serde_json::to_string_pretty(&env)?);
         Ok(())
     }
@@ -48,7 +48,7 @@ impl Env {
     fn output_shell(&self, config: &Config, ts: Toolset) -> Result<()> {
         let default_shell = get_shell(Some(ShellType::Bash)).unwrap();
         let shell = get_shell(self.shell).unwrap_or(default_shell);
-        for (k, v) in ts.env_with_path(config) {
+        for (k, v) in ts.env_with_path(config)? {
             let k = k.to_string();
             let v = v.to_string();
             miseprint!("{}", shell.set_env(&k, &v));

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -62,7 +62,7 @@ impl Exec {
         ts.notify_if_versions_missing();
 
         let (program, args) = parse_command(&env::SHELL, &self.command, &self.c);
-        let env = ts.env_with_path(&config);
+        let env = ts.env_with_path(&config)?;
 
         self.exec(program, args, env)
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -146,7 +146,7 @@ impl Run {
 
         ts.install_arg_versions(config, &InstallOptions::new())?;
         ts.notify_if_versions_missing();
-        let mut env = ts.env_with_path(config);
+        let mut env = ts.env_with_path(config)?;
         if let Some(root) = &config.project_root {
             env.insert("MISE_PROJECT_ROOT".into(), root.display().to_string());
         }

--- a/src/cli/set.rs
+++ b/src/cli/set.rs
@@ -45,12 +45,12 @@ impl Set {
         let config = Config::try_get()?;
         if self.remove.is_none() && self.env_vars.is_none() {
             let rows = config
-                .env
+                .env_with_sources()?
                 .iter()
-                .map(|(key, value)| Row {
+                .map(|(key, (value, source))| Row {
                     key: key.clone(),
                     value: value.clone(),
-                    source: display_path(&config.env_sources.get(key).unwrap().clone()),
+                    source: display_path(source),
                 })
                 .collect::<Vec<_>>();
             let mut table = tabled::Table::new(rows);
@@ -75,7 +75,7 @@ impl Set {
         if let Some(env_vars) = self.env_vars {
             if env_vars.len() == 1 && env_vars[0].value.is_none() {
                 let key = &env_vars[0].key;
-                match config.env.get(key) {
+                match config.env()?.get(key) {
                     Some(value) => miseprintln!("{value}"),
                     None => bail!("Environment variable {key} not found"),
                 }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -111,7 +111,7 @@ impl Watch {
         }
         info!("$ watchexec {}", args.join(" "));
         let mut cmd = cmd::cmd("watchexec", &args);
-        for (k, v) in ts.env_with_path(&config) {
+        for (k, v) in ts.env_with_path(&config)? {
             cmd = cmd.env(k, v);
         }
         if let Some(root) = &config.project_root {

--- a/src/forge/cargo.rs
+++ b/src/forge/cargo.rs
@@ -59,7 +59,7 @@ impl Forge for CargoForge {
             .arg("--root")
             .arg(ctx.tv.install_path())
             .with_pr(ctx.pr.as_ref())
-            .envs(&config.env)
+            .envs(config.env()?)
             .prepend_path(ctx.ts.list_paths())?
             .execute()?;
 

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -42,7 +42,7 @@ impl Forge for GoForge {
             .arg("install")
             .arg(&format!("{}@{}", self.name(), ctx.tv.version))
             .with_pr(ctx.pr.as_ref())
-            .envs(&config.env)
+            .envs(config.env()?)
             .env("GOPATH", ctx.tv.cache_path())
             .env("GOBIN", ctx.tv.install_path().join("bin"))
             .execute()?;

--- a/src/forge/npm.rs
+++ b/src/forge/npm.rs
@@ -45,7 +45,7 @@ impl Forge for NPMForge {
             .arg("--prefix")
             .arg(ctx.tv.install_path())
             .with_pr(ctx.pr.as_ref())
-            .envs(&config.env)
+            .envs(config.env()?)
             .prepend_path(ctx.ts.list_paths())?
             .execute()?;
 

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -183,7 +183,7 @@ impl NodePlugin {
                 .arg("install")
                 .arg("--global")
                 .arg(package)
-                .envs(&config.env)
+                .envs(config.env()?)
                 .env("PATH", CorePlugin::path_env_with_tv_path(tv)?)
                 .execute()?;
         }
@@ -213,7 +213,7 @@ impl NodePlugin {
         CmdLineRunner::new(self.node_path(tv))
             .with_pr(pr)
             .arg("-v")
-            .envs(&config.env)
+            .envs(config.env()?)
             .execute()
     }
 
@@ -223,7 +223,7 @@ impl NodePlugin {
             .env("PATH", CorePlugin::path_env_with_tv_path(tv)?)
             .with_pr(pr)
             .arg("-v")
-            .envs(&config.env)
+            .envs(config.env()?)
             .execute()
     }
 

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -169,7 +169,7 @@ impl PythonPlugin {
             .with_pr(ctx.pr.as_ref())
             .arg(ctx.tv.version.as_str())
             .arg(&ctx.tv.install_path())
-            .envs(&config.env);
+            .envs(config.env()?);
         if settings.verbose {
             cmd = cmd.arg("--verbose");
         }
@@ -213,7 +213,7 @@ impl PythonPlugin {
             .arg("--upgrade")
             .arg("-r")
             .arg(packages_file)
-            .envs(&config.env)
+            .envs(config.env()?)
             .execute()
     }
 
@@ -245,7 +245,7 @@ impl PythonPlugin {
                         .arg("-m")
                         .arg("venv")
                         .arg(&virtualenv)
-                        .envs(&config.env);
+                        .envs(config.env()?);
                     if let Some(pr) = pr {
                         cmd = cmd.with_pr(pr);
                     }
@@ -288,7 +288,7 @@ impl PythonPlugin {
         pr.set_message("python --version".into());
         CmdLineRunner::new(self.python_path(tv))
             .arg("--version")
-            .envs(&config.env)
+            .envs(config.env()?)
             .execute()
     }
 }

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -191,7 +191,7 @@ impl RubyPlugin {
             let mut cmd = CmdLineRunner::new(gem)
                 .with_pr(pr)
                 .arg("install")
-                .envs(&config.env);
+                .envs(config.env()?);
             match package.split_once(' ') {
                 Some((name, "--pre")) => cmd = cmd.arg(name).arg("--pre"),
                 Some((name, version)) => cmd = cmd.arg(name).arg("--version").arg(version),
@@ -208,7 +208,7 @@ impl RubyPlugin {
         CmdLineRunner::new(self.ruby_path(tv))
             .with_pr(pr)
             .arg("-v")
-            .envs(&config.env)
+            .envs(config.env()?)
             .execute()
     }
 
@@ -217,7 +217,7 @@ impl RubyPlugin {
         CmdLineRunner::new(self.gem_path(tv))
             .with_pr(pr)
             .arg("-v")
-            .envs(&config.env)
+            .envs(config.env()?)
             .env("PATH", CorePlugin::path_env_with_tv_path(tv)?)
             .execute()
     }
@@ -260,7 +260,7 @@ impl RubyPlugin {
                 .args(self.install_args_ruby_build(tv)?)
                 .stdin_string(self.fetch_patches()?)
         };
-        Ok(cmd.with_pr(pr).envs(&config.env))
+        Ok(cmd.with_pr(pr).envs(config.env()?))
     }
     fn install_args_ruby_build(&self, tv: &ToolVersion) -> Result<Vec<String>> {
         let mut args = env::MISE_RUBY_BUILD_OPTS.clone()?;

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -274,12 +274,12 @@ impl Toolset {
             })
             .collect()
     }
-    pub fn env_with_path(&self, config: &Config) -> BTreeMap<String, String> {
+    pub fn env_with_path(&self, config: &Config) -> Result<BTreeMap<String, String>> {
         let mut path_env = PathEnv::from_iter(env::PATH.clone());
         for p in config.path_dirs.clone() {
             path_env.add(p);
         }
-        let mut env = self.env(config);
+        let mut env = self.env(config)?;
         if let Some(path) = env.get("PATH") {
             path_env.add(PathBuf::from(path));
         }
@@ -287,9 +287,9 @@ impl Toolset {
             path_env.add(p);
         }
         env.insert("PATH".to_string(), path_env.to_string());
-        env
+        Ok(env)
     }
-    pub fn env(&self, config: &Config) -> BTreeMap<String, String> {
+    pub fn env(&self, config: &Config) -> Result<BTreeMap<String, String>> {
         let entries = self
             .list_current_installed_versions()
             .into_par_iter()
@@ -317,8 +317,8 @@ impl Toolset {
         if !add_paths.is_empty() {
             entries.insert("PATH".to_string(), add_paths);
         }
-        entries.extend(config.env.clone());
-        entries
+        entries.extend(config.env()?.clone());
+        Ok(entries)
     }
     pub fn list_paths(&self) -> Vec<PathBuf> {
         self.list_current_installed_versions()


### PR DESCRIPTION
This lazy-loads the env vars from config files.
This is a prereq for #1262 and other env var changes. It will make it easier to perform the template logic in order across the env vars rather than when the file is parsed
