### PR TITLE
feat(tasks): infer bash task topics from folder structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,6 +1367,7 @@ dependencies = [
  "toml_edit",
  "url",
  "versions",
+ "walkdir",
  "which",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ toml = { version = "0.8.8", features = ["parse"] }
 toml_edit = { version = "0.21.0", features = ["parse"] }
 url = "2.5.0"
 versions = { version = "6.1.0" , features=["serde"]}
+walkdir = "2.4.0"
 which = "6.0.0"
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -197,7 +197,9 @@ impl Config {
                     None => vec![],
                 }
                 .into_par_iter()
-                .flat_map(|dir| file::ls(&dir).map_err(|err| warn!("load_all_tasks: {err}")))
+                .flat_map(|dir| {
+                    file::recursive_ls(&dir).map_err(|err| warn!("load_all_tasks: {err}"))
+                })
                 .flatten()
                 .map(Either::Right)
                 .chain(rayon::iter::once(Either::Left(cf)))


### PR DESCRIPTION
### Summary

Closes #1269

These changes make it possible to define bash tasks in a nested folder structure under the predefined task directories. Tasks defined in directories below the parent `tasks` directory will have implied scope in their names by joining their relative path with `:`s.

For example a task defined at `{{config_root}}/.mise/tasks/a/b/task` will have task name `a:b:task`.

### Additional Notes

- While `walkdir` was already a transitive dependency it is now a direct dependency to provide recursive walks through the filesystem.
- If a bash script task contains the `:` character it will be replaced by `_` to prevent name collisions.
- Simple enough to test locally so I did, but some integration/e2e tests wouldn't hurt here.