### PR TITLE
added `env._.source` feature

### DIFF
--- a/e2e/test_env_source
+++ b/e2e/test_env_source
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "$0")/assert.sh"
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$(dirname "$MISE_GLOBAL_CONFIG_FILE")" "$MISE_CONFIG_DIR"
+
+cat >"$MISE_GLOBAL_CONFIG_FILE" <<EOF
+[env]
+_.source = "{{ env.MISE_CONFIG_DIR }}/source.sh"
+EOF
+
+cat >"$MISE_CONFIG_DIR/source.sh" <<EOF
+#!/usr/bin/env bash
+export MISE_TEST_SOURCE=1234
+EOF
+
+assert_contains "mise env -s bash" "export MISE_TEST_SOURCE=1234"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.1.26" 
+.TH mise 1  "mise 2024.1.27" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -179,6 +179,6 @@ Examples:
   $ mise settings                  Show settings in use
   $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.1.26
+v2024.1.27
 .SH AUTHORS
 Jeff Dickey <@jdx>


### PR DESCRIPTION
now you can source bash scripts to get the env vars they export like this:

```toml
[env]
_.source = "some_script.sh"
```