### PR TITLE
feat(tasks): make script task dirs configurable

### DIFF
--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -7,6 +7,7 @@ use std::sync::Mutex;
 
 use eyre::Result;
 use once_cell::sync::Lazy;
+use serde_derive::Deserialize;
 use versions::Versioning;
 
 use tool_versions::ToolVersions;
@@ -76,6 +77,17 @@ pub trait ConfigFile: Debug + Send + Sync {
     fn to_toolset(&self) -> &Toolset;
     fn aliases(&self) -> AliasMap {
         Default::default()
+    }
+    fn task_config(&self) -> TaskConfig {
+        let includes = match self.project_root() {
+            Some(pr) => vec![
+                pr.join(".mise").join("tasks"),
+                pr.join(".config").join("mise").join("tasks"),
+            ],
+            None => vec![],
+        };
+
+        TaskConfig { includes }
     }
 }
 
@@ -325,6 +337,11 @@ impl Hash for dyn ConfigFile {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.get_path().hash(state);
     }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct TaskConfig {
+    pub includes: Vec<PathBuf>,
 }
 
 #[cfg(test)]

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-5.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-5.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config/config_file/mise_toml.rs
-expression: "replace_path(&format!(\"{:#?}\", &cf))"
+expression: "replace_path(&format!(\"{:#?}\", & cf))"
 ---
 MiseToml(~/fixtures/.mise.toml): terraform@1.0.0, node@18 node@prefix:20 node@ref:master node@path:~/.nodes/18, jq@prefix:1.6, shellcheck@0.9.0, python@3.10.0 python@3.9.0 {
     env: [
@@ -16,5 +16,11 @@ MiseToml(~/fixtures/.mise.toml): terraform@1.0.0, node@18 node@prefix:20 node@re
     },
     plugins: {
         "node": "https://github.com/jdx/rtx-node",
+    },
+    task_config: TaskConfig {
+        includes: [
+            "~/fixtures/.mise/tasks",
+            "~/fixtures/.config/mise/tasks",
+        ],
     },
 }

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__remove_alias-4.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__remove_alias-4.snap
@@ -8,4 +8,10 @@ MiseToml(/tmp/.mise.toml):  {
             "18": "18.0.0",
         },
     },
+    task_config: TaskConfig {
+        includes: [
+            "/tmp/.mise/tasks",
+            "/tmp/.config/mise/tasks",
+        ],
+    },
 }

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__remove_plugin-4.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__remove_plugin-4.snap
@@ -2,4 +2,11 @@
 source: src/config/config_file/mise_toml.rs
 expression: cf
 ---
-MiseToml(/tmp/.mise.toml): 
+MiseToml(/tmp/.mise.toml):  {
+    task_config: TaskConfig {
+        includes: [
+            "/tmp/.mise/tasks",
+            "/tmp/.config/mise/tasks",
+        ],
+    },
+}

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__replace_versions-4.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__replace_versions-4.snap
@@ -2,4 +2,11 @@
 source: src/config/config_file/mise_toml.rs
 expression: cf
 ---
-MiseToml(/tmp/.mise.toml): node@16.0.1 node@18.0.1
+MiseToml(/tmp/.mise.toml): node@16.0.1 node@18.0.1 {
+    task_config: TaskConfig {
+        includes: [
+            "/tmp/.mise/tasks",
+            "/tmp/.config/mise/tasks",
+        ],
+    },
+}

--- a/src/task.rs
+++ b/src/task.rs
@@ -323,7 +323,7 @@ fn config_root(config_source: &impl AsRef<Path>) -> Option<&Path> {
         }
     }
 
-    Some(config_source.as_ref())
+    config_source.as_ref().parent()
 }
 
 pub trait GetMatchingExt<T> {
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn test_config_root() {
         let test_cases = [
-            ("/base", Some(Path::new("/base"))),
+            ("/base", Some(Path::new("/"))),
             ("/base/.mise/tasks", Some(Path::new("/base"))),
             ("/base/.config/mise/tasks", Some(Path::new("/base"))),
         ];


### PR DESCRIPTION
### Summary

Closes #1270 

Adds a top-level config Table, `task_config`, which currently has one property `includes`. `includes` is an array of paths which can be used to alter the locations from which file tasks are loaded from.

These paths can be absolute, relative, inside/outside the project, and accepts `~` as a substitution for `$HOME`.

### Additional Notes
- `includes` is represented as a `BTreeSet` to preserve ordering, allows users to influence load ordering, and to ensure uniqueness.