### PR TITLE
status: make missing tool warning more granular

### DIFF
--- a/completions/_mise
+++ b/completions/_mise
@@ -429,7 +429,7 @@ __mise_ls_cmd() {
     '*::plugin:__mise_plugins' \
     '(-c --current)'{-c,--current}'[Only show tool versions currently specified in a .tool-versions/.mise.toml]' \
     '(-g --global)'{-g,--global}'[Only show tool versions currently specified in a the global .tool-versions/.mise.toml]' \
-    '(-i --installed)'{-i,--installed}'[Only show tool versions that are installed Hides missing ones defined in .tool-versions/.mise.toml but not yet installed]' \
+    '(-i --installed)'{-i,--installed}'[Only show tool versions that are installed (Hides tools defined in .tool-versions/.mise.toml but not installed)]' \
     '(-J --json)'{-J,--json}'[Output in json format]' \
     '(-m --missing)'{-m,--missing}'[Display missing tool versions]' \
     '--prefix=[Display versions matching this prefix]:prefix:__mise_prefixes' \

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -152,7 +152,7 @@ complete -kxc mise -n "$fssf link" -a "(__mise_tool_versions)" -d 'Tool name and
 # ls
 complete -kxc mise -n "$fssf ls" -s c -l current -d 'Only show tool versions currently specified in a .tool-versions/.mise.toml'
 complete -kxc mise -n "$fssf ls" -s g -l global -d 'Only show tool versions currently specified in a the global .tool-versions/.mise.toml'
-complete -kxc mise -n "$fssf ls" -s i -l installed -d 'Only show tool versions that are installed Hides missing ones defined in .tool-versions/.mise.toml but not yet installed'
+complete -kxc mise -n "$fssf ls" -s i -l installed -d 'Only show tool versions that are installed (Hides tools defined in .tool-versions/.mise.toml but not installed)'
 complete -kxc mise -n "$fssf ls" -s J -l json -d 'Output in json format'
 complete -kxc mise -n "$fssf ls" -s m -l missing -d 'Display missing tool versions'
 complete -kxc mise -n "$fssf ls" -l no-header -d 'Don'\''t display headers'

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,6 +11,9 @@ This should go into your shell's rc file.
 Otherwise, it will only take effect in the current session.
 (e.g. ~/.zshrc, ~/.bashrc)
 
+Customize status output with `mise settings set status.missing_tools 0`
+and related commands.
+
 This is only intended to be used in interactive sessions, not scripts.
 mise is only capable of updating PATH when the prompt is displayed to the user.
 For non-interactive use-cases, use shims instead.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,9 +11,6 @@ This should go into your shell's rc file.
 Otherwise, it will only take effect in the current session.
 (e.g. ~/.zshrc, ~/.bashrc)
 
-Customize status output with `mise settings set status.missing_tools 0`
-and related commands.
-
 This is only intended to be used in interactive sessions, not scripts.
 mise is only capable of updating PATH when the prompt is displayed to the user.
 For non-interactive use-cases, use shims instead.
@@ -26,6 +23,8 @@ However, this requires that "mise" is in your PATH. If it is not, you need to
 specify the full path like this:
 
     echo 'eval "$(/path/to/mise activate)"' >> ~/.zshrc
+
+Customize status output with `status` settings.
 
 Usage: activate [OPTIONS] [SHELL_TYPE]
 
@@ -518,7 +517,7 @@ Options:
           Only show tool versions currently specified in a the global .tool-versions/.mise.toml
 
   -i, --installed
-          Only show tool versions that are installed Hides missing ones defined in .tool-versions/.mise.toml but not yet installed
+          Only show tool versions that are installed (Hides tools defined in .tool-versions/.mise.toml but not installed)
 
   -J, --json
           Output in json format

--- a/e2e/test_tool_versions_alt
+++ b/e2e/test_tool_versions_alt
@@ -4,7 +4,7 @@ set -euo pipefail
 export MISE_DEFAULT_TOOL_VERSIONS_FILENAME=.alternate-tool-versions
 export MISE_DEFAULT_CONFIG_FILENAME=.MISSING
 
-cat <<EOF > .alternate-tool-versions
+cat <<EOF >.alternate-tool-versions
 shfmt 3.5.0
 EOF
 

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -12,9 +12,6 @@ use crate::{dirs, env};
 /// Otherwise, it will only take effect in the current session.
 /// (e.g. ~/.zshrc, ~/.bashrc)
 ///
-/// Customize status output with `mise settings set status.missing_tools 0`
-/// and related commands.
-///
 /// This is only intended to be used in interactive sessions, not scripts.
 /// mise is only capable of updating PATH when the prompt is displayed to the user.
 /// For non-interactive use-cases, use shims instead.
@@ -27,6 +24,8 @@ use crate::{dirs, env};
 /// specify the full path like this:
 ///
 ///     echo 'eval "$(/path/to/mise activate)"' >> ~/.zshrc
+///
+/// Customize status output with `status` settings.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Activate {

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -12,6 +12,9 @@ use crate::{dirs, env};
 /// Otherwise, it will only take effect in the current session.
 /// (e.g. ~/.zshrc, ~/.bashrc)
 ///
+/// Customize status output with `mise settings set status.missing_tools 0`
+/// and related commands.
+///
 /// This is only intended to be used in interactive sessions, not scripts.
 /// mise is only capable of updating PATH when the prompt is displayed to the user.
 /// For non-interactive use-cases, use shims instead.

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -38,7 +38,7 @@ pub struct Ls {
     global: bool,
 
     /// Only show tool versions that are installed
-    /// Hides missing ones defined in .tool-versions/.mise.toml but not yet installed
+    /// (Hides tools defined in .tool-versions/.mise.toml but not installed)
     #[clap(long, short)]
     installed: bool,
 

--- a/src/cli/settings/ls.rs
+++ b/src/cli/settings/ls.rs
@@ -24,6 +24,10 @@ impl SettingsLs {
             if Settings::hidden_configs().contains(key.as_str()) {
                 continue;
             }
+            if key == "status" {
+                // TODO: print this properly
+                continue;
+            }
             miseprintln!("{} = {}", key, value);
         }
         Ok(())
@@ -73,7 +77,6 @@ mod tests {
         quiet = false
         raw = false
         shorthands_file = null
-        status = {"missing_tools":true,"show_env":false,"show_tools":false}
         task_output = null
         trusted_config_paths = []
         verbose = true

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -1,6 +1,7 @@
 use eyre::Result;
 use toml_edit::Document;
 
+use crate::config::settings::SettingsStatusMissingTools;
 use crate::{env, file};
 
 /// Add/update a setting
@@ -39,7 +40,11 @@ impl SettingsSet {
             "quiet" => parse_bool(&self.value)?,
             "raw" => parse_bool(&self.value)?,
             "shorthands_file" => self.value.into(),
-            "status.missing_tools" => parse_bool(&self.value)?,
+            "status.missing_tools" => self
+                .value
+                .parse::<SettingsStatusMissingTools>()?
+                .to_string()
+                .into(),
             "status.show_env" => parse_bool(&self.value)?,
             "status.show_tools" => parse_bool(&self.value)?,
             "task_output" => self.value.into(),
@@ -101,7 +106,7 @@ pub mod tests {
         reset_config();
         assert_cli!("settings", "set", "legacy_version_file", "0");
         assert_cli!("settings", "set", "always_keep_download", "y");
-        assert_cli!("settings", "set", "status.missing_tools", "0");
+        assert_cli!("settings", "set", "status.missing_tools", "never");
         assert_cli!(
             "settings",
             "set",

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -19,6 +19,7 @@ pub struct SettingsSet {
 impl SettingsSet {
     pub fn run(self) -> Result<()> {
         let value: toml_edit::Value = match self.setting.as_str() {
+            "activate_aggressive" => parse_bool(&self.value)?,
             "all_compile" => parse_bool(&self.value)?,
             "always_keep_download" => parse_bool(&self.value)?,
             "always_keep_install" => parse_bool(&self.value)?,
@@ -38,6 +39,9 @@ impl SettingsSet {
             "quiet" => parse_bool(&self.value)?,
             "raw" => parse_bool(&self.value)?,
             "shorthands_file" => self.value.into(),
+            "status.missing_tools" => parse_bool(&self.value)?,
+            "status.show_env" => parse_bool(&self.value)?,
+            "status.show_tools" => parse_bool(&self.value)?,
             "task_output" => self.value.into(),
             "trusted_config_paths" => self.value.split(':').map(|s| s.to_string()).collect(),
             "verbose" => parse_bool(&self.value)?,
@@ -53,7 +57,16 @@ impl SettingsSet {
             config["settings"] = toml_edit::Item::Table(toml_edit::Table::new());
         }
         let settings = config["settings"].as_table_mut().unwrap();
-        settings.insert(&self.setting, toml_edit::Item::Value(value));
+        if self.setting.as_str().starts_with("status.") {
+            let status = settings
+                .entry("status")
+                .or_insert(toml_edit::Item::Table(toml_edit::Table::new()))
+                .as_table_mut()
+                .unwrap();
+            status.insert(&self.setting[7..], toml_edit::Item::Value(value));
+        } else {
+            settings.insert(&self.setting, toml_edit::Item::Value(value));
+        }
         file::write(path, config.to_string())
     }
 }
@@ -88,6 +101,7 @@ pub mod tests {
         reset_config();
         assert_cli!("settings", "set", "legacy_version_file", "0");
         assert_cli!("settings", "set", "always_keep_download", "y");
+        assert_cli!("settings", "set", "status.missing_tools", "0");
         assert_cli!(
             "settings",
             "set",
@@ -124,7 +138,6 @@ pub mod tests {
         quiet = false
         raw = false
         shorthands_file = null
-        status = {"missing_tools":true,"show_env":false,"show_tools":false}
         task_output = null
         trusted_config_paths = []
         verbose = true

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -68,7 +68,6 @@ mod tests {
         quiet = false
         raw = false
         shorthands_file = null
-        status = {"missing_tools":true,"show_env":false,"show_tools":false}
         task_output = null
         trusted_config_paths = []
         verbose = true

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -79,7 +79,7 @@ pub trait ConfigFile: Debug + Send + Sync {
         Default::default()
     }
     fn task_config(&self) -> &TaskConfig {
-        static DEFAULT_TASK_CONFIG: Lazy<TaskConfig> = Lazy::new(|| TaskConfig::default());
+        static DEFAULT_TASK_CONFIG: Lazy<TaskConfig> = Lazy::new(TaskConfig::default);
         &DEFAULT_TASK_CONFIG
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -218,7 +218,7 @@ impl Config {
                     .task_config()
                     .includes
                     .clone()
-                    .unwrap_or_else(|| default_task_includes(&cf))
+                    .unwrap_or_else(|| default_task_includes(cf))
                     .iter()
                     .map(|p| {
                         if let Some(pr) = cf.project_root() {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -115,14 +115,30 @@ pub struct Settings {
 #[config(partial_attr(serde(deny_unknown_fields)))]
 pub struct SettingsStatus {
     /// warn if a tool is missing
-    #[config(env = "MISE_STATUS_MESSAGE_MISSING_TOOLS", default = true)]
-    pub missing_tools: bool,
+    #[config(
+        env = "MISE_STATUS_MESSAGE_MISSING_TOOLS",
+        default = "if_other_versions_installed"
+    )]
+    pub missing_tools: SettingsStatusMissingTools,
     /// show env var keys when entering directories
     #[config(env = "MISE_STATUS_MESSAGE_SHOW_ENV", default = false)]
     pub show_env: bool,
     /// show active tools when entering directories
     #[config(env = "MISE_STATUS_MESSAGE_SHOW_TOOLS", default = false)]
     pub show_tools: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, EnumString, Display)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum SettingsStatusMissingTools {
+    /// never show the warning
+    Never,
+    /// hide this warning if the user hasn't installed at least 1 version of the tool before
+    #[default]
+    IfOtherVersionsInstalled,
+    /// always show the warning if tools are missing
+    Always,
 }
 
 pub type SettingsPartial = <Settings as Config>::Partial;


### PR DESCRIPTION
by default this will only show when at least 1 version of the tool has been installed