### PR TITLE
fixed ctrlc handler

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -380,7 +380,7 @@ impl Run {
         for name in tasks.keys() {
             s = s.option(DemandOption::new(name));
         }
-        let _ = ctrlc::handle_ctrlc()?;
+        let _ctrlc = ctrlc::handle_ctrlc()?;
         let name = s.run()?;
         match tasks.get(name) {
             Some(task) => Ok((*task).clone()),

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -126,7 +126,7 @@ impl Upgrade {
     }
 
     fn get_interactive_tool_set(&self, outdated: &OutputVec) -> Result<HashSet<ToolVersion>> {
-        let _ = ui::ctrlc::handle_ctrlc()?;
+        let _ctrlc = ui::ctrlc::handle_ctrlc()?;
         let mut ms = demand::MultiSelect::new("mise upgrade")
             .description("Select tools to upgrade")
             .filterable(true)

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -28,8 +28,7 @@ pub struct ProgressReport {
     pub pb: ProgressBar,
     prefix: String,
     pad: usize,
-    #[allow(dead_code)]
-    handle: Option<ui::ctrlc::HandleGuard>,
+    _ctrlc: Option<ui::ctrlc::HandleGuard>,
 }
 
 static LONGEST_PLUGIN_NAME: Lazy<usize> = Lazy::new(|| {
@@ -58,7 +57,7 @@ fn success_prefix(pad: usize, prefix: &str) -> String {
 
 impl ProgressReport {
     pub fn new(prefix: String) -> ProgressReport {
-        let handle = ui::ctrlc::handle_ctrlc().unwrap_or_default();
+        let _ctrlc = ui::ctrlc::handle_ctrlc().unwrap_or_default();
         let pad = *LONGEST_PLUGIN_NAME;
         let pb = ProgressBar::new(100)
             .with_style(PROG_TEMPLATE.clone())
@@ -68,7 +67,7 @@ impl ProgressReport {
             prefix,
             pb,
             pad,
-            handle,
+            _ctrlc,
         }
     }
 }

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -8,7 +8,7 @@ static MUTEX: Mutex<()> = Mutex::new(());
 
 pub fn confirm<S: Into<String>>(message: S) -> eyre::Result<bool> {
     let _lock = MUTEX.lock().unwrap(); // Prevent multiple prompts at once
-    let _ = ctrlc::handle_ctrlc()?;
+    let _ctrlc = ctrlc::handle_ctrlc()?;
 
     if !console::user_attended_stderr() {
         return Ok(false);


### PR DESCRIPTION
I didn't realize you need to give vars a name to prevent them from dropping