### PR TITLE
revert version bump of `curve25519-dalek` to v4.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
fixes x86-64 builds, as described in #1630 

closes #1630