### PR TITLE
fix(go): reflect on proper path for `GOROOT`

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -66,7 +66,7 @@ pub struct Settings {
     /// See https://github.com/jdx/mise/discussions/1638
     #[config(env = "MISE_GO_SET_GOPATH", default = false)]
     pub go_set_gopath: bool,
-    /// sets GOROOT=~/.local/share/mise/installs/go/.../go
+    /// sets GOROOT=~/.local/share/mise/installs/go/...
     /// you probably always want this set to be set unless you want GOROOT to point to something
     /// other than the sdk mise is currently set to
     #[config(env = "MISE_GO_SET_GOROOT", default = true)]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -66,7 +66,7 @@ pub struct Settings {
     /// See https://github.com/jdx/mise/discussions/1638
     #[config(env = "MISE_GO_SET_GOPATH", default = false)]
     pub go_set_gopath: bool,
-    /// sets GOROOT=~/.local/share/mise/installs/go/...
+    /// sets GOROOT=~/.local/share/mise/installs/go/.../
     /// you probably always want this set to be set unless you want GOROOT to point to something
     /// other than the sdk mise is currently set to
     #[config(env = "MISE_GO_SET_GOROOT", default = true)]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -66,7 +66,7 @@ pub struct Settings {
     /// See https://github.com/jdx/mise/discussions/1638
     #[config(env = "MISE_GO_SET_GOPATH", default = false)]
     pub go_set_gopath: bool,
-    /// sets GOROOT=~/.local/share/mise/installs/go/.../
+    /// sets GOROOT=~/.local/share/mise/installs/go/.../go
     /// you probably always want this set to be set unless you want GOROOT to point to something
     /// other than the sdk mise is currently set to
     #[config(env = "MISE_GO_SET_GOROOT", default = true)]

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -157,7 +157,7 @@ impl GoPlugin {
             set("GOBIN", tv.install_path().join("bin"));
         }
         if settings.go_set_goroot {
-            set("GOROOT", tv.install_path());
+            set("GOROOT", tv.install_path().join("go"));
         }
         if settings.go_set_gopath {
             set("GOPATH", self.gopath(tv));

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -62,7 +62,11 @@ impl GoPlugin {
 
     // Represents GOROOT environment variable
     fn goroot(&self, tv: &ToolVersion) -> PathBuf {
-        tv.install_path().join("go")
+        let old_path = tv.install_path().join("go");
+        if old_path.exists() {
+            return old_path;
+        }
+        tv.install_path()
     }
 
     // Represents GOBIN environment variable

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -50,11 +50,24 @@ impl GoPlugin {
         })
     }
 
+    // Represents go binary path
     fn go_bin(&self, tv: &ToolVersion) -> PathBuf {
         tv.install_path().join("bin/go")
     }
+
+    // Represents GOPATH environment variable
     fn gopath(&self, tv: &ToolVersion) -> PathBuf {
         tv.install_path().join("packages")
+    }
+
+    // Represents GOROOT environment variable
+    fn goroot(&self, tv: &ToolVersion) -> PathBuf {
+        tv.install_path().join("go")
+    }
+
+    // Represents GOBIN environment variable
+    fn gobin(&self, tv: &ToolVersion) -> PathBuf {
+        tv.install_path().join("bin")
     }
 
     fn install_default_packages(
@@ -154,10 +167,10 @@ impl GoPlugin {
         let gobin = settings.go_set_gobin;
         let gobin_env_is_set = env::PRISTINE_ENV.contains_key("GOBIN");
         if gobin == Some(true) || (gobin.is_none() && !gobin_env_is_set) {
-            set("GOBIN", tv.install_path().join("bin"));
+            set("GOBIN", self.gobin(tv));
         }
         if settings.go_set_goroot {
-            set("GOROOT", tv.install_path().join("go"));
+            set("GOROOT", self.goroot(tv));
         }
         if settings.go_set_gopath {
             set("GOPATH", self.gopath(tv));
@@ -202,7 +215,7 @@ impl Forge for GoPlugin {
         }
         // goroot/bin must always be included, irrespective of MISE_GO_SET_GOROOT
         let mut paths = vec![
-            tv.install_path().join("bin"),
+            self.gobin(tv),
             // TODO: this can be removed at some point since go is not installed here anymore
             tv.install_path().join("go/bin"),
         ];


### PR DESCRIPTION
The last [patches](https://github.com/jdx/mise/commit/786220c6178625980bdcc61403c32db19d51360f) to `GOROOT` did miss to take over the `/go` suffix in the path, which ends up in various arbitrary errors when running go CLI commands.

The suffix has been added properly before: https://github.com/jdx/mise/commit/786220c6178625980bdcc61403c32db19d51360f#diff-352f25ac643733cdd2fb54a78ced508b3658cab947230ab610b968f154840413L54
