### PR TITLE
fix: allow go forge to install SHA versions when no tagged versions present

### DIFF
--- a/e2e/test_go_install
+++ b/e2e/test_go_install
@@ -9,3 +9,5 @@ mise use go@prefix:1.20
 
 assert "mise x go:github.com/DarthSim/hivemind@v1.1.0 -- hivemind --version" "Hivemind version 1.1.0"
 assert "mise x go:github.com/go-task/task/v3/cmd/task@v3.34.1 -- task --version" "Task version: v3.34.1 (h1:yAAxUM54zoaHv+OtDnGgkWSVeiRuaOCn1lPUXPQQA0o=)"
+# See https://github.com/jdx/mise/issues/1667
+assert "mise x go:github.com/jdx/go-example@e16a340 -- go-example" "hello world"

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -29,18 +29,18 @@ impl Forge for GoForge {
                 let mut mod_path = Some(self.name());
 
                 while let Some(cur_mod_path) = mod_path {
-                    let raw =
-                        cmd!("go", "list", "-m", "-versions", "-json", cur_mod_path).read()?;
-
-                    let result = serde_json::from_str::<GoModInfo>(&raw);
-                    if let Ok(mod_info) = result {
-                        return Ok(mod_info.versions);
-                    }
+                    let res = cmd!("go", "list", "-m", "-versions", "-json", cur_mod_path).read();
+                    if let Ok(raw) = res {
+                        let res = serde_json::from_str::<GoModInfo>(&raw);
+                        if let Ok(mod_info) = res {
+                            return Ok(mod_info.versions);
+                        }
+                    };
 
                     mod_path = trim_after_last_slash(cur_mod_path);
                 }
 
-                Err(eyre!("couldn't find module versions"))
+                Ok(vec![])
             })
             .cloned()
     }


### PR DESCRIPTION
### Summary

Fixes #1667 

Makes it possible to install a go module from SHA when no tagged versions are available.