### PR TITLE
build: use vendored openssl crate feature to mitigate missing headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,6 +1564,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.2.3+3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1580,7 @@ checksum = "ae94056a791d0e1217d18b6cbdccb02c61e3054fc69893607f4067e3bb0b1fd1"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.100"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae94056a791d0e1217d18b6cbdccb02c61e3054fc69893607f4067e3bb0b1fd1"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ itertools = "0.12.1"
 log = "0.4.20"
 num_cpus = "1.16.0"
 once_cell = "1.19.0"
-openssl = { version = "0.10.63", optional = true }
+openssl = { version = "0.10.63", optional = true, features = ["vendored"] }
 path-absolutize = "3.1.1"
 petgraph = "0.6.4"
 rand = "0.8.5"


### PR DESCRIPTION
Hopefully fixes these kinda errors: https://github.com/jdx/mise/actions/runs/7996715229/job/21839765074

Not quite sure yet, but found [hints](https://github.com/sfackler/rust-openssl/issues/1021#issuecomment-605602642) that openssl headers might be missing. Using the vendored feature of openssl crate, these should be used from openssl-src.