### PR TITLE
docs: make README logo link to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
-<h1><img src="https://github.com/jdx/mise/assets/216188/27a8ea18-9383-4d86-a445-305b9a6248c1" alt="mise-logo" width="400" /><br />
-<a href="https://mise.jdx.dev">mise-en-place</a></h1>
+<h1><a href="https://mise.jdx.dev">
+  <img src="https://github.com/jdx/mise/assets/216188/27a8ea18-9383-4d86-a445-305b9a6248c1" alt="mise-logo" width="400" /><br />
+  mise-en-place
+</a></h1>
 <!-- <a href="https://mise.jdx.dev"><picture> -->
 <!--   <source media="(prefers-color-scheme: dark)" width="617" srcset="./docs/logo-dark@2x.png"> -->
 <!--   <img alt="mise logo" width="617" src="./docs/logo-light@2x.png"> -->


### PR DESCRIPTION
Make README logo link to site.

Looks like without a wrapping anchor tag, GitHub will still render the image as a link, but the link is just to the raw image.