### PR TITLE
feat: added "en" command

### DIFF
--- a/docs/.vitepress/cli_commands.ts
+++ b/docs/.vitepress/cli_commands.ts
@@ -96,6 +96,9 @@ export const commands: { [key: string]: Command } = {
   doctor: {
     hide: false,
   },
+  en: {
+    hide: false,
+  },
   env: {
     hide: false,
   },

--- a/docs/cli/en.md
+++ b/docs/cli/en.md
@@ -9,12 +9,6 @@ This is an alternative to `mise activate` that allows you to explicitly start a 
 It will have the tools and environment variables in the configs loaded.
 Note that changing directories will not update the mise environment.
 
-It's a lightweight alternative to `mise activate` if you don't want to put that into your shell rc but
-still don't want to deal with shims. It probably only makes sense for interactive use-cases.
-
-It's sort of akin to manually running `source .venv/bin/activate` for Python virtualenvs if you're
-familiar with that workflow.
-
 ## Arguments
 
 ### `[DIR]`

--- a/docs/cli/en.md
+++ b/docs/cli/en.md
@@ -1,0 +1,44 @@
+# `mise en`
+
+- **Usage**: `mise en [-s --shell <SHELL>] [DIR]`
+- **Source code**: [`src/cli/en.rs`](https://github.com/jdx/mise/blob/main/src/cli/en.rs)
+
+[experimental] starts a new shell with the mise environment built from the current configuration
+
+This is an alternative to `mise activate` that allows you to explicitly start a mise session.
+It will have the tools and environment variables in the configs loaded.
+Note that changing directories will not update the mise environment.
+
+It's a lightweight alternative to `mise activate` if you don't want to put that into your shell rc but
+still don't want to deal with shims. It probably only makes sense for interactive use-cases.
+
+It's sort of akin to manually running `source .venv/bin/activate` for Python virtualenvs if you're
+familiar with that workflow.
+
+## Arguments
+
+### `[DIR]`
+
+Directory to start the shell in
+
+**Default:** `.`
+
+## Flags
+
+### `-s --shell <SHELL>`
+
+Shell to start
+
+Defaults to $SHELL
+
+Examples:
+
+    $ mise en .
+    $ node -v
+    v20.0.0
+
+    Skip loading bashrc:
+    $ mise en -s "bash --norc"
+
+    Skip loading zshrc:
+    $ mise en -s "zsh -f"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -66,6 +66,7 @@ Answer yes to all confirmation prompts
 - [`mise direnv <SUBCOMMAND>`](/cli/direnv.md)
 - [`mise direnv activate`](/cli/direnv/activate.md)
 - [`mise doctor`](/cli/doctor.md)
+- [`mise en [-s --shell <SHELL>] [DIR]`](/cli/en.md)
 - [`mise env [FLAGS] [TOOL@VERSION]...`](/cli/env.md)
 - [`mise exec [FLAGS] [TOOL@VERSION]... [COMMAND]...`](/cli/exec.md)
 - [`mise generate <SUBCOMMAND>`](/cli/generate.md)

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -56,6 +56,14 @@ Print directly to stdout/stderr instead of by line
 Defaults to true if --jobs == 1
 Configure with `task_output` config or `MISE_TASK_OUTPUT` env var
 
+### `-s --shell <SHELL>`
+
+Shell to use to run toml tasks
+
+Defaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows
+Can also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`
+Or it can be overridden with the `shell` property on a task.
+
 ### `-t --tool... <TOOL@VERSION>`
 
 Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -70,6 +70,14 @@ Print directly to stdout/stderr instead of by line
 Defaults to true if --jobs == 1
 Configure with `task_output` config or `MISE_TASK_OUTPUT` env var
 
+### `-s --shell <SHELL>`
+
+Shell to use to run toml tasks
+
+Defaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows
+Can also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`
+Or it can be overridden with the `shell` property on a task.
+
 ### `-t --tool... <TOOL@VERSION>`
 
 Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -83,6 +83,9 @@ Output direnv function to use mise inside direnv
 mise\-doctor(1)
 Check mise installation for possible problems
 .TP
+mise\-en(1)
+[experimental] starts a new shell with the mise environment built from the current configuration
+.TP
 mise\-env(1)
 Exports env vars to activate mise a single time
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1520,12 +1520,18 @@ See https://usage.jdx.dev for more information on this specification."
 }
 cmd "use" help="Installs a tool and adds the version it to mise.toml." {
     alias "u"
-    long_help r"Installs a tool and adds the version it to mise.toml.
+    long_help r#"Installs a tool and adds the version it to mise.toml.
 
 This will install the tool version if it is not already installed.
 By default, this will use a `mise.toml` file in the current directory.
 
-Use the `--global` flag to use the global config file instead."
+In the following order:
+  - If `MISE_DEFAULT_CONFIG_FILENAME` is set, it will use that instead.
+  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
+  - If `MISE_ENV` is set, it will use a `mise.<env>.toml` instead.
+  - Otherwise just "mise.toml"
+
+Use the `--global` flag to use the global config file instead."#
     after_long_help r"Examples:
 
     # set the current version of node to 20.x in mise.toml of current directory

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -34,6 +34,9 @@ flag "-p --prefix" hide=true
 flag "-P --profile" help="Set the profile (environment)" hide=true global=true {
     arg "<PROFILE>"
 }
+flag "-s --shell" hide=true {
+    arg "<SHELL>"
+}
 flag "-t --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=true hide=true {
     arg "<TOOL@VERSION>"
 }
@@ -982,6 +985,10 @@ The name of the script will be the name of the tasks.
     flag "-f --force" help="Force the tasks to run even if outputs are up to date"
     flag "-p --prefix" help="Print stdout/stderr by line, prefixed with the tasks's label\nDefaults to true if --jobs > 1\nConfigure with `task_output` config or `MISE_TASK_OUTPUT` env var"
     flag "-i --interleave" help="Print directly to stdout/stderr instead of by line\nDefaults to true if --jobs == 1\nConfigure with `task_output` config or `MISE_TASK_OUTPUT` env var"
+    flag "-s --shell" help="Shell to use to run toml tasks" {
+        long_help "Shell to use to run toml tasks\n\nDefaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows\nCan also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`\nOr it can be overridden with the `shell` property on a task."
+        arg "<SHELL>"
+    }
     flag "-t --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=true {
         arg "<TOOL@VERSION>"
     }
@@ -1345,6 +1352,10 @@ The name of the script will be the name of the tasks.
         flag "-f --force" help="Force the tasks to run even if outputs are up to date"
         flag "-p --prefix" help="Print stdout/stderr by line, prefixed with the tasks's label\nDefaults to true if --jobs > 1\nConfigure with `task_output` config or `MISE_TASK_OUTPUT` env var"
         flag "-i --interleave" help="Print directly to stdout/stderr instead of by line\nDefaults to true if --jobs == 1\nConfigure with `task_output` config or `MISE_TASK_OUTPUT` env var"
+        flag "-s --shell" help="Shell to use to run toml tasks" {
+            long_help "Shell to use to run toml tasks\n\nDefaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows\nCan also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`\nOr it can be overridden with the `shell` property on a task."
+            arg "<SHELL>"
+        }
         flag "-t --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=true {
             arg "<TOOL@VERSION>"
         }
@@ -1509,18 +1520,12 @@ See https://usage.jdx.dev for more information on this specification."
 }
 cmd "use" help="Installs a tool and adds the version it to mise.toml." {
     alias "u"
-    long_help r#"Installs a tool and adds the version it to mise.toml.
+    long_help r"Installs a tool and adds the version it to mise.toml.
 
 This will install the tool version if it is not already installed.
 By default, this will use a `mise.toml` file in the current directory.
 
-In the following order:
-  - If `MISE_DEFAULT_CONFIG_FILENAME` is set, it will use that instead.
-  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.
-  - If `MISE_ENV` is set, it will use a `mise.<env>.toml` instead.
-  - Otherwise just "mise.toml"
-
-Use the `--global` flag to use the global config file instead."#
+Use the `--global` flag to use the global config file instead."
     after_long_help r"Examples:
 
     # set the current version of node to 20.x in mise.toml of current directory

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -343,6 +343,30 @@ cmd "doctor" help="Check mise installation for possible problems" {
     [WARN] plugin node is not installed
 "
 }
+cmd "en" help="[experimental] starts a new shell with the mise environment built from the current configuration" {
+    long_help r"[experimental] starts a new shell with the mise environment built from the current configuration
+
+This is an alternative to `mise activate` that allows you to explicitly start a mise session.
+It will have the tools and environment variables in the configs loaded.
+Note that changing directories will not update the mise environment."
+    after_long_help r#"Examples:
+
+    $ mise en .
+    $ node -v
+    v20.0.0
+
+    Skip loading bashrc:
+    $ mise en -s "bash --norc"
+
+    Skip loading zshrc:
+    $ mise en -s "zsh -f"
+"#
+    flag "-s --shell" help="Shell to start" {
+        long_help "Shell to start\n\nDefaults to $SHELL"
+        arg "<SHELL>"
+    }
+    arg "[DIR]" help="Directory to start the shell in" default="."
+}
 cmd "env" help="Exports env vars to activate mise a single time" {
     alias "e"
     long_help r"Exports env vars to activate mise a single time

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -187,9 +187,23 @@
           "description": "Use color in mise terminal output",
           "type": "boolean"
         },
+        "config_file": {
+          "description": "Path to the global mise config file. Default is `~/.config/mise/config.toml`. This must be an env var.",
+          "type": "string"
+        },
         "debug": {
           "description": "Sets log level to debug",
           "type": "boolean"
+        },
+        "default_config_filename": {
+          "default": "mise.toml",
+          "description": "The default config filename read. `mise use` and other commands that create new config files will use this value. This must be an env var.",
+          "type": "string"
+        },
+        "default_tool_versions_filename": {
+          "default": ".tool-versions",
+          "description": "The default .tool-versions filename read. `mise use` and other commands that write to new config files will use this if asdf_compat=1. This must be an env var.",
+          "type": "string"
         },
         "disable_backends": {
           "default": [],
@@ -375,6 +389,22 @@
               "description": "Use bun instead of npm if bun is installed and on PATH.",
               "type": "boolean"
             }
+          }
+        },
+        "override_config_filenames": {
+          "default": [],
+          "description": "If set, mise will ignore default config files like `mise.toml` and use these filenames instead. This must be an env var.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "override_tool_versions_filename": {
+          "default": [],
+          "description": "If set, mise will ignore .tool-versions files and use these filename instead. Can be set to `none` to disable .tool-versions. This must be an env var.",
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         },
         "paranoid": {
@@ -578,6 +608,15 @@
             },
             "show_tools": {
               "description": "Show configured env vars when entering a directory with a mise.toml file.",
+              "type": "boolean"
+            }
+          }
+        },
+        "swift": {
+          "additionalProperties": false,
+          "properties": {
+            "gpg_verify": {
+              "description": "Use gpg to verify swift tool signatures.",
               "type": "boolean"
             }
           }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -187,23 +187,9 @@
           "description": "Use color in mise terminal output",
           "type": "boolean"
         },
-        "config_file": {
-          "description": "Path to the global mise config file. Default is `~/.config/mise/config.toml`. This must be an env var.",
-          "type": "string"
-        },
         "debug": {
           "description": "Sets log level to debug",
           "type": "boolean"
-        },
-        "default_config_filename": {
-          "default": "mise.toml",
-          "description": "The default config filename read. `mise use` and other commands that create new config files will use this value. This must be an env var.",
-          "type": "string"
-        },
-        "default_tool_versions_filename": {
-          "default": ".tool-versions",
-          "description": "The default .tool-versions filename read. `mise use` and other commands that write to new config files will use this if asdf_compat=1. This must be an env var.",
-          "type": "string"
         },
         "disable_backends": {
           "default": [],
@@ -389,22 +375,6 @@
               "description": "Use bun instead of npm if bun is installed and on PATH.",
               "type": "boolean"
             }
-          }
-        },
-        "override_config_filenames": {
-          "default": [],
-          "description": "If set, mise will ignore default config files like `mise.toml` and use these filenames instead. This must be an env var.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "override_tool_versions_filename": {
-          "default": [],
-          "description": "If set, mise will ignore .tool-versions files and use these filename instead. Can be set to `none` to disable .tool-versions. This must be an env var.",
-          "type": "array",
-          "items": {
-            "type": "string"
           }
         },
         "paranoid": {
@@ -612,15 +582,6 @@
             }
           }
         },
-        "swift": {
-          "additionalProperties": false,
-          "properties": {
-            "gpg_verify": {
-              "description": "Use gpg to verify swift tool signatures.",
-              "type": "boolean"
-            }
-          }
-        },
         "task_output": {
           "description": "Change output style when executing tasks.",
           "type": "string",
@@ -664,7 +625,7 @@
           }
         },
         "unix_default_inline_shell_args": {
-          "default": ["sh", "-c"],
+          "default": ["sh", "-c", "-o", "errexit"],
           "description": "List of default shell arguments for unix to be used with inline commands. For example, `sh`, `-c` for sh.",
           "type": "array",
           "items": {

--- a/settings.toml
+++ b/settings.toml
@@ -885,7 +885,7 @@ description = "List of default shell arguments for unix to be used with `file`. 
 env = "MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS"
 type = "ListString"
 rust_type = "Vec<String>"
-default = ["sh", "-c"]
+default = ["sh", "-c", "-o", "errexit"]
 parse_env = "list_by_comma"
 description = "List of default shell arguments for unix to be used with inline commands. For example, `sh`, `-c` for sh."
 

--- a/src/cli/en.rs
+++ b/src/cli/en.rs
@@ -1,0 +1,59 @@
+use crate::cli::exec::Exec;
+use crate::config::Settings;
+use std::path::PathBuf;
+
+use crate::env;
+
+/// [experimental] starts a new shell with the mise environment built from the current configuration
+///
+/// This is an alternative to `mise activate` that allows you to explicitly start a mise session.
+/// It will have the tools and environment variables in the configs loaded.
+/// Note that changing directories will not update the mise environment.
+#[derive(Debug, clap::Args)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+pub struct En {
+    /// Directory to start the shell in
+    #[clap(default_value = ".", verbatim_doc_comment, value_hint = clap::ValueHint::DirPath)]
+    pub dir: PathBuf,
+
+    /// Shell to start
+    ///
+    /// Defaults to $SHELL
+    #[clap(verbatim_doc_comment, long, short = 's', env = "MISE_SHELL")]
+    pub shell: Option<String>,
+}
+
+impl En {
+    pub fn run(self) -> eyre::Result<()> {
+        let settings = Settings::get();
+        settings.ensure_experimental("en")?;
+
+        env::set_current_dir(&self.dir)?;
+        let shell = self.shell.unwrap_or((*env::SHELL).clone());
+        let command = shell_words::split(&shell).map_err(|e| eyre::eyre!(e))?;
+
+        Exec {
+            tool: vec![],
+            raw: false,
+            jobs: None,
+            c: None,
+            command: Some(command),
+        }
+        .run()
+    }
+}
+
+static AFTER_LONG_HELP: &str = color_print::cstr!(
+    r#"<bold><underline>Examples:</underline></bold>
+
+    $ <bold>mise en .</bold>
+    $ <bold>node -v</bold>
+    v20.0.0
+
+    Skip loading bashrc:
+    $ <bold>mise en -s "bash --norc"</bold>
+
+    Skip loading zshrc:
+    $ <bold>mise en -s "zsh -f"</bold>
+"#
+);

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -34,11 +34,11 @@ pub struct Exec {
 
     /// Command string to execute (same as --command)
     #[clap(conflicts_with = "c", required_unless_present = "c", last = true)]
-    pub command: Option<Vec<OsString>>,
+    pub command: Option<Vec<String>>,
 
     /// Command string to execute
     #[clap(short, long = "command", value_hint = ValueHint::CommandString, conflicts_with = "command")]
-    pub c: Option<OsString>,
+    pub c: Option<String>,
 
     /// Number of jobs to run in parallel
     /// [default: 4]
@@ -74,8 +74,27 @@ impl Exec {
             ts.notify_if_versions_missing()
         });
 
-        let (program, args) = parse_command(&env::SHELL, &self.command, &self.c);
+        let (program, mut args) = parse_command(&env::SHELL, &self.command, &self.c);
         let env = measure!("env_with_path", { ts.env_with_path(&CONFIG)? });
+
+        if program.rsplit('/').next() == Some("fish") {
+            let mut cmd = vec![];
+            for (k, v) in env.iter().filter(|(k, _)| *k != "PATH") {
+                cmd.push(format!(
+                    "set -gx {} {}",
+                    shell_escape::escape(k.into()),
+                    shell_escape::escape(v.into())
+                ));
+            }
+            for p in ts.list_final_paths()? {
+                cmd.push(format!(
+                    "fish_add_path -gm {}",
+                    shell_escape::escape(p.to_string_lossy())
+                ));
+            }
+            args.insert(0, cmd.join("\n"));
+            args.insert(0, "-C".into());
+        }
 
         time!("exec");
         self.exec(program, args, env)
@@ -142,9 +161,9 @@ impl Exec {
 
 fn parse_command(
     shell: &str,
-    command: &Option<Vec<OsString>>,
-    c: &Option<OsString>,
-) -> (OsString, Vec<OsString>) {
+    command: &Option<Vec<String>>,
+    c: &Option<String>,
+) -> (String, Vec<String>) {
     match (&command, &c) {
         (Some(command), _) => {
             let (program, args) = command.split_first().unwrap();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -20,6 +20,7 @@ mod current;
 mod deactivate;
 mod direnv;
 mod doctor;
+mod en;
 mod env;
 pub mod exec;
 mod external;
@@ -112,6 +113,8 @@ pub struct Cli {
     /// Set the profile (environment)
     #[clap(short = 'P', long, global = true, hide = true)]
     pub profile: Option<String>,
+    #[clap(long, short, hide = true)]
+    pub shell: Option<String>,
     /// Tool(s) to run in addition to what is in mise.toml files
     /// e.g.: node@20 python@3.10
     #[clap(short, long, hide = true, value_name = "TOOL@VERSION")]
@@ -159,6 +162,7 @@ pub enum Commands {
     Deactivate(deactivate::Deactivate),
     Direnv(direnv::Direnv),
     Doctor(doctor::Doctor),
+    En(en::En),
     Env(env::Env),
     Exec(exec::Exec),
     Generate(generate::Generate),
@@ -219,6 +223,7 @@ impl Commands {
             Self::Deactivate(cmd) => cmd.run(),
             Self::Direnv(cmd) => cmd.run(),
             Self::Doctor(cmd) => cmd.run(),
+            Self::En(cmd) => cmd.run(),
             Self::Env(cmd) => cmd.run(),
             Self::Exec(cmd) => cmd.run(),
             Self::Generate(cmd) => cmd.run(),
@@ -325,6 +330,7 @@ impl Cli {
                         no_timings: self.no_timings,
                         output: run::TaskOutput::Prefix,
                         prefix: self.prefix,
+                        shell: self.shell,
                         quiet: self.quiet,
                         raw: self.raw,
                         timings: self.timings,

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use indoc::formatdoc;
-
 use crate::config::Settings;
 use crate::shell::Shell;
+use indoc::formatdoc;
+use shell_escape::unix::escape;
 
 #[derive(Default)]
 pub struct Fish {}
@@ -107,20 +107,20 @@ impl Shell for Fish {
         "#}
     }
 
-    fn set_env(&self, k: &str, v: &str) -> String {
-        let k = shell_escape::unix::escape(k.into());
-        let v = shell_escape::unix::escape(v.into());
+    fn set_env(&self, key: &str, v: &str) -> String {
+        let k = escape(key.into());
+        let v = escape(v.into());
         format!("set -gx {k} {v}\n")
     }
 
-    fn prepend_env(&self, k: &str, v: &str) -> String {
-        let k = shell_escape::unix::escape(k.into());
-        let v = shell_escape::unix::escape(v.into());
+    fn prepend_env(&self, key: &str, v: &str) -> String {
+        let k = escape(key.into());
+        let v = escape(v.into());
         format!("set -gx {k} {v} ${k}\n")
     }
 
     fn unset_env(&self, k: &str) -> String {
-        format!("set -e {k}\n", k = shell_escape::unix::escape(k.into()))
+        format!("set -e {k}\n", k = escape(k.into()))
     }
 }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -39,6 +39,17 @@ impl ShellType {
             None
         }
     }
+
+    pub fn as_shell(&self) -> Box<dyn Shell> {
+        match self {
+            Self::Bash => Box::<bash::Bash>::default(),
+            Self::Elvish => Box::<elvish::Elvish>::default(),
+            Self::Fish => Box::<fish::Fish>::default(),
+            Self::Nu => Box::<nushell::Nushell>::default(),
+            Self::Xonsh => Box::<xonsh::Xonsh>::default(),
+            Self::Zsh => Box::<zsh::Zsh>::default(),
+        }
+    }
 }
 
 impl Display for ShellType {
@@ -63,13 +74,5 @@ pub trait Shell {
 }
 
 pub fn get_shell(shell: Option<ShellType>) -> Option<Box<dyn Shell>> {
-    match shell.or_else(ShellType::load) {
-        Some(ShellType::Bash) => Some(Box::<bash::Bash>::default()),
-        Some(ShellType::Elvish) => Some(Box::<elvish::Elvish>::default()),
-        Some(ShellType::Fish) => Some(Box::<fish::Fish>::default()),
-        Some(ShellType::Nu) => Some(Box::<nushell::Nushell>::default()),
-        Some(ShellType::Xonsh) => Some(Box::<xonsh::Xonsh>::default()),
-        Some(ShellType::Zsh) => Some(Box::<zsh::Zsh>::default()),
-        _ => None,
-    }
+    shell.or_else(ShellType::load).map(|st| st.as_shell())
 }

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1,6 +1,5 @@
 use crate::exit;
 use std::collections::{BTreeSet, HashSet};
-use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -26,10 +25,11 @@ pub fn handle_shim() -> Result<()> {
         return Ok(());
     }
     logger::init();
-    let args = env::ARGS.read().unwrap();
+    let mut args = env::ARGS.read().unwrap().clone();
     trace!("shim[{bin_name}] args: {}", args.join(" "));
-    let mut args: Vec<OsString> = args.iter().map(OsString::from).collect();
-    args[0] = which_shim(&env::MISE_BIN_NAME)?.into();
+    args[0] = which_shim(&env::MISE_BIN_NAME)?
+        .to_string_lossy()
+        .to_string();
     env::set_var("__MISE_SHIM", "1");
     let exec = Exec {
         tool: vec![],

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -836,6 +836,36 @@ const completionSpec: Fig.Spec = {
         },
         {
             "name": [
+                "en"
+            ],
+            "description": "[experimental] starts a new shell with the mise environment built from the current configuration",
+            "options": [
+                {
+                    "name": [
+                        "-s",
+                        "--shell"
+                    ],
+                    "description": "Shell to start",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "shell",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "dir",
+                    "description": "Directory to start the shell in",
+                    "isOptional": true,
+                    "isVariadic": false,
+                    "template": "folders"
+                }
+            ]
+        },
+        {
+            "name": [
                 "env",
                 "e"
             ],

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1806,6 +1806,19 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                     "name": [
+                        "-s",
+                        "--shell"
+                    ],
+                    "description": "Shell to use to run toml tasks",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "shell",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
                         "-t",
                         "--tool"
                     ],
@@ -2427,6 +2440,19 @@ const completionSpec: Fig.Spec = {
                             ],
                             "description": "Print directly to stdout/stderr instead of by line\nDefaults to true if --jobs == 1\nConfigure with `task_output` config or `MISE_TASK_OUTPUT` env var",
                             "isRepeatable": false
+                        },
+                        {
+                            "name": [
+                                "-s",
+                                "--shell"
+                            ],
+                            "description": "Shell to use to run toml tasks",
+                            "isRepeatable": false,
+                            "args": {
+                                "name": "shell",
+                                "isOptional": false,
+                                "isVariadic": false
+                            }
                         },
                         {
                             "name": [


### PR DESCRIPTION
@booniepepper this isn't working right but I'm curious if you have any ideas.

The problem is that it will still load your rc files, so if you do something like `export PATH="/opt/homebrew/bin:$PATH" in your rc file that will make the mise tools lower priority than homebrew so it won't use mise tools if brew provides any.

One idea I had was running `mise env` when the shell starts but I'm not sure if it's possible to have zsh (for example) load a script like that.

Technically it does _work_ though.