### PR TITLE
fix(java): sdkmanrc zulu JVMs are missing in mise

### DIFF
--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -376,7 +376,7 @@ fn fuzzy_match_filter(versions: Vec<String>, query: &str) -> eyre::Result<Vec<St
     if query == "latest" {
         query = "[0-9].*";
     }
-    let query_regex = Regex::new(&format!("^{}([-.].+)?$", query))?;
+    let query_regex = Regex::new(&format!("^{}([+-.].+)?$", query))?;
     let versions = versions
         .into_iter()
         .filter(|v| {

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -376,7 +376,7 @@ fn fuzzy_match_filter(versions: Vec<String>, query: &str) -> eyre::Result<Vec<St
     if query == "latest" {
         query = "[0-9].*";
     }
-    let query_regex = Regex::new(&format!("^{}([+-.].+)?$", query))?;
+    let query_regex = Regex::new(&format!("^{}([-.].+)?$", query))?;
     let versions = versions
         .into_iter()
         .filter(|v| {

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -372,6 +372,7 @@ impl Forge for JavaPlugin {
             let (version, vendor) = version.rsplit_once('-').unwrap_or_default();
             let vendor = match vendor {
                 "amzn" => "corretto",
+                "albba" => "dragonwell",
                 "graalce" => "graalvm-community",
                 "librca" => "liberica",
                 "open" => "openjdk",

--- a/tests/cli/install.rs
+++ b/tests/cli/install.rs
@@ -7,6 +7,7 @@ use test_case::test_case;
 #[test_case("bun", ".bun-version", "1.0.17", &["bun", "-v"], "1.0.17", false)]
 #[test_case("deno", ".deno-version", "1.35.3", &["deno", "-V"], "1.35.3", false)]
 #[test_case("java", ".sdkmanrc", "java=17.0.2", &["java", "-version"], "openjdk version \"17.0.2\"", true)]
+#[test_case("java", ".sdkmanrc", "java=20.0.2-tem", &["java", "-version"], "openjdk version \"20.0.2\"", true)]
 #[test_case("java", ".java-version", "17.0.2", &["java", "-version"], "openjdk version \"17.0.2\"", true)]
 fn test_tool_specific_version_files(
     tool: &str,
@@ -202,7 +203,8 @@ fn python_config_fixture() -> File {
 
             [tools]
             python = "{{exec(command='echo 3.12.0')}}"
-        }.to_string(),
+        }
+        .to_string(),
     }
 }
 


### PR DESCRIPTION
SDKMAN uses a different Java versioning scheme as the core plugin, therefore versions in `.sdkmanrc` are reported missing even if they're installed.

SDKMAN is using `{java-version}` ( e.g. 21.0.2) as opposed to vendor versions and different `{vendor}` strings. In most cases the `{vendor-version}` matches the Java Version with an additional build suffix. SDKMAN also supports vendors (bisheng, dragonwell, graalvm, liberica nik, mandrel, trava) that are not available/mappable in the core plugin.

ASDF: `{vendor}-{vendor-version}` (e.g. zulu-21.30.15)
SDKMAN: `{java-version}-{vendor}` (e.g. 21.0.2-zulu)

This PR is an approach to map the SDKMAN version. In case of "zulu" only the major version could be matched as we dont have the java version while matching. Other option would be to remove support for `.sdkmanrc` files completely.