### PR TITLE
Update java.rs to change symlink dir

### DIFF
--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -228,8 +228,8 @@ impl JavaPlugin {
                 "{}",
                 formatdoc! {r#"
                 To enable macOS integration, run the following commands:
-                sudo mkdir /Library/Java/JavaVirtualMachines/{version}.jdk
-                sudo ln -s {path}/Contents /Library/Java/JavaVirtualMachines/{version}.jdk/Contents
+                sudo mkdir ~/Library/Java/JavaVirtualMachines/{version}.jdk
+                sudo ln -s {path}/Contents ~/Library/Java/JavaVirtualMachines/{version}.jdk/Contents
                 "#,
                     version = tv.version,
                     path = tv.install_path().display(),


### PR DESCRIPTION
Change symlink comment to add a symlink to users home directory instead of globally on mac since mise will usually install the languages at the users home directory when installed through brew 
![Screenshot 2024-03-02 at 8 54 45 PM](https://github.com/jdx/mise/assets/87888006/e534fd54-ea52-4d69-82d1-f4c3c6c3abf3)

Now this should showup: `sudo ln -s /Users/notlaggy/.local/share/mise/installs/java/latest/Contents ~/Library/Java/JavaVirtualMachines/latest.jdk/Contents/`