### PR TITLE
fix(go): go backend supports versions prefixed with 'v'

### DIFF
--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -57,7 +57,8 @@ impl Forge for GoForge {
         settings.ensure_experimental("go backend")?;
 
         // if the (semantic) version has no v prefix, add it
-        let version = if regex!(r"^\d+(\.\d+)*([+-.].+)?$").is_match(&ctx.tv.version) {
+        // we allow max. 6 digits for the major version to prevent clashes with Git commit hashes
+        let version = if regex!(r"^\d{1,6}(\.\d+)*([+-.].+)?$").is_match(&ctx.tv.version) {
             format!("v{}", ctx.tv.version)
         } else {
             ctx.tv.version.clone()

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -1,7 +1,5 @@
 use std::fmt::Debug;
 
-use regex::Regex;
-
 use crate::cache::CacheManager;
 use crate::cli::args::ForgeArg;
 use crate::cmd::CmdLineRunner;
@@ -59,8 +57,7 @@ impl Forge for GoForge {
         settings.ensure_experimental("go backend")?;
 
         // if the (semantic) version has no v prefix, add it
-        let version_regex = Regex::new(r"^\d+(\.\d+)*([+-.].+)?$").unwrap();
-        let version = if version_regex.is_match(&ctx.tv.version) {
+        let version = if regex!(r"^\d+(\.\d+)*([+-.].+)?$").is_match(&ctx.tv.version) {
             format!("v{}", ctx.tv.version)
         } else {
             ctx.tv.version.clone()

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -30,6 +30,9 @@ pub static VERSION_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
         .unwrap()
 });
 
+pub static VERSION_V_PREFIX_REGEX: Lazy<regex::Regex> =
+    Lazy::new(|| Regex::new(r"^v(\d+(\.\d+)*([+-.].+)?)$").unwrap());
+
 pub fn get(name: &str) -> Arc<dyn Forge> {
     let fa = ForgeArg::new(ForgeType::Asdf, name);
     forge::get(&fa)

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -30,9 +30,6 @@ pub static VERSION_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
         .unwrap()
 });
 
-pub static VERSION_V_PREFIX_REGEX: Lazy<regex::Regex> =
-    Lazy::new(|| Regex::new(r"^v(\d+(\.\d+)*([+-.].+)?)$").unwrap());
-
 pub fn get(name: &str) -> Arc<dyn Forge> {
     let fa = ForgeArg::new(ForgeType::Asdf, name);
     forge::get(&fa)

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use console::style;
 use eyre::Result;
+use regex::Captures;
 use versions::{Chunk, Version};
 
 use crate::cli::args::ForgeArg;
@@ -13,6 +14,7 @@ use crate::config::Config;
 use crate::forge;
 use crate::forge::{AForge, Forge};
 use crate::hash::hash_to_str;
+use crate::plugins::VERSION_V_PREFIX_REGEX;
 use crate::toolset::{ToolVersionOptions, ToolVersionRequest};
 
 /// represents a single version of a tool for a particular plugin
@@ -33,7 +35,9 @@ impl ToolVersion {
     ) -> Self {
         ToolVersion {
             forge: tool.fa().clone(),
-            version,
+            version: VERSION_V_PREFIX_REGEX
+                .replace(&version, |caps: &Captures| format!("{}", &caps[1]))
+                .to_string(),
             request,
             opts,
         }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -14,7 +14,6 @@ use crate::config::Config;
 use crate::forge;
 use crate::forge::{AForge, Forge};
 use crate::hash::hash_to_str;
-use crate::plugins::VERSION_V_PREFIX_REGEX;
 use crate::toolset::{ToolVersionOptions, ToolVersionRequest};
 
 /// represents a single version of a tool for a particular plugin
@@ -35,7 +34,7 @@ impl ToolVersion {
     ) -> Self {
         ToolVersion {
             forge: tool.fa().clone(),
-            version: VERSION_V_PREFIX_REGEX
+            version: regex!(r"^v(\d+(\.\d+)*([+-.].+)?)$")
                 .replace(&version, |caps: &Captures| format!("{}", &caps[1]))
                 .to_string(),
             request,


### PR DESCRIPTION
Attempt to fix #1637 by removing the `v` prefix (if its the only character before the semantic version) from the `ToolVersion::version`.

For Go the prefix is stripped in `GoForge::list_remote_versions` and added for installation in `GoForge::install_version_impl`  since its required for installation.