### PR TITLE
feat: very basic dependency support

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,8 +24,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: unit
-          #save-if: false TODO: add this back later
-          cache-on-failure: true
+          save-if: false
       - run: mkdir -p "$HOME/bin" && echo "$HOME/bin" >> "$GITHUB_PATH"
       - run: |
           set -euxo pipefail

--- a/src/forge/cargo.rs
+++ b/src/forge/cargo.rs
@@ -11,6 +11,7 @@ use crate::file;
 use crate::forge::{Forge, ForgeType};
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
+use crate::toolset::ToolVersion;
 
 #[derive(Debug)]
 pub struct CargoForge {
@@ -25,6 +26,10 @@ impl Forge for CargoForge {
 
     fn fa(&self) -> &ForgeArg {
         &self.fa
+    }
+
+    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+        Ok(vec!["cargo".into(), "rust".into()])
     }
 
     fn list_remote_versions(&self) -> eyre::Result<Vec<String>> {

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -7,6 +7,7 @@ use crate::config::{Config, Settings};
 
 use crate::forge::{Forge, ForgeType};
 use crate::install_context::InstallContext;
+use crate::toolset::ToolVersion;
 
 #[derive(Debug)]
 pub struct GoForge {
@@ -21,6 +22,10 @@ impl Forge for GoForge {
 
     fn fa(&self) -> &ForgeArg {
         &self.fa
+    }
+
+    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+        Ok(vec!["go".into()])
     }
 
     fn list_remote_versions(&self) -> eyre::Result<Vec<String>> {

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -99,6 +99,11 @@ pub trait Forge: Debug + Send + Sync {
     fn get_plugin_type(&self) -> PluginType {
         PluginType::Core
     }
+    /// If any of these tools are installing in parallel, we should wait for them to finish
+    /// before installing this tool.
+    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+        Ok(vec![])
+    }
     fn list_remote_versions(&self) -> eyre::Result<Vec<String>>;
     fn latest_stable_version(&self) -> eyre::Result<Option<String>> {
         self.latest_version(Some("latest".into()))

--- a/src/forge/npm.rs
+++ b/src/forge/npm.rs
@@ -7,6 +7,7 @@ use crate::config::{Config, Settings};
 
 use crate::forge::{Forge, ForgeType};
 use crate::install_context::InstallContext;
+use crate::toolset::ToolVersion;
 use serde_json::Value;
 
 #[derive(Debug)]
@@ -23,6 +24,10 @@ impl Forge for NPMForge {
 
     fn fa(&self) -> &ForgeArg {
         &self.fa
+    }
+
+    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+        Ok(vec!["node".into()])
     }
 
     fn list_remote_versions(&self) -> eyre::Result<Vec<String>> {

--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -444,6 +444,16 @@ impl Forge for ExternalPlugin {
     fn get_plugin_type(&self) -> PluginType {
         PluginType::External
     }
+
+    fn get_dependencies(&self, tv: &ToolVersion) -> Result<Vec<String>> {
+        let out = match tv.forge.name.as_str() {
+            "poetry" | "pipenv" => vec!["python"],
+            "elixir" => vec!["erlang"],
+            _ => vec![],
+        };
+        Ok(out.into_iter().map(|s| s.into()).collect())
+    }
+
     fn list_remote_versions(&self) -> Result<Vec<String>> {
         self.remote_version_cache
             .get_or_try_init(|| self.fetch_remote_versions())


### PR DESCRIPTION
all this does is wait to install things like python before poetry, erlang before elixir, etc. It doesn't include them by default, just waits for them to finish installing if they're in process.

This way if you run `mise install` and have python and poetry, it won't start installing poetry until python is installed and can be used as a dependency. It does require that you put these in order manually, if they're not, it just won't wait.

It's basically just calling "sleep()" if one of its dependencies is currently installing. It's far from a comprehensive dependency solution with versions and things. That said, it's a simple solution not likely to cause any problems and should solve some of the most common issues around this.

cc @travisbhartwell

These are all hardcoded for now but it would be possible to expose it to asdf plugins so they could specify their own dependencies.