### PR TITLE
Release 2024.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ---
-## [2024.3.5](https://github.com/jdx/mise/compare/v2024.3.2..v2024.3.5) - 2024-03-17
+## [2024.3.6](https://github.com/jdx/mise/compare/v2024.3.2..v2024.3.6) - 2024-03-17
 
 ### 🚀 Features
 
@@ -47,6 +47,8 @@ All notable changes to this project will be documented in this file.
 - **(release-plz)** create gh release - ([f9ff369](https://github.com/jdx/mise/commit/f9ff369eb1176e31044fc463fdca08397def5a81)) - jdx
 - **(release-plz)** fixing gpg key - ([8286ded](https://github.com/jdx/mise/commit/8286ded8297b858e7136831e75e4c37fa49e6186)) - jdx
 - **(release-plz)** fixing gpg key - ([abb1dfe](https://github.com/jdx/mise/commit/abb1dfed78e49cf2bee4a137e92879ffd7f2fb03)) - jdx
+- **(release-plz)** do not publish a new release PR immediately - ([b3ae753](https://github.com/jdx/mise/commit/b3ae753fdde1fef17b4f13a1ecc8b23cb1da575c)) - jdx
+- **(release-plz)** prefix versions with "v" - ([3354b55](https://github.com/jdx/mise/commit/3354b551adab7082d5cc533e5d9d0bfe272958b4)) - jdx
 - **(test)** cache mise installed tools - ([0e433b9](https://github.com/jdx/mise/commit/0e433b975a5d8c28ae5c0cbd86d3b19e03146a83)) - jdx
 - cargo update - ([6391239](https://github.com/jdx/mise/commit/639123930eec8e057de7da790cb71d4a2b9e17a2)) - jdx
 - install tools before unit tests - ([f7456eb](https://github.com/jdx/mise/commit/f7456ebc539a4b27ec067bc480bc0aba1466e55b)) - jdx
@@ -54,6 +56,7 @@ All notable changes to this project will be documented in this file.
 - ensure `mise install` is run before lint-fix - ([e8a172f](https://github.com/jdx/mise/commit/e8a172f98ebc837619f3766777e489f3b99f36f4)) - jdx
 - added release-plz workflow (#1787) - ([83fe1ec](https://github.com/jdx/mise/commit/83fe1ecc266caf094fc1cfb251ef1c0cc35afe1b)) - jdx
 - set gpg key - ([467097f](https://github.com/jdx/mise/commit/467097f925053a27f0ede2a506e894562d191a09)) - jdx
+- temporarily disable self-update test - ([5cb39a4](https://github.com/jdx/mise/commit/5cb39a4259f332e5bccec082f1d7cd6127da5f55)) - jdx
 
 ### Outdated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.3.5"
+version = "2024.3.6"
 dependencies = [
  "assert_cmd",
  "base64 0.22.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.3.5"
+version = "2024.3.6"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-mise 2024.3.5
+mise 2024.3.6
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.3.5";
+  version = "2024.3.6";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.3.5" 
+.TH mise 1  "mise 2024.3.6" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -183,6 +183,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.3.5
+v2024.3.6
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.3.5
+Version: 2024.3.6
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
---
## [2024.3.6](https://github.com/jdx/mise/compare/v2024.3.2..v2024.3.6) - 2024-03-17

### 🚀 Features

- very basic dependency support (#1788) - ([7a53a44](https://github.com/jdx/mise/commit/7a53a44c5bbbea7eed281536d869ec4f39de2527)) - jdx

### 🐛 Bug Fixes

- update shorthand for rabbitmq (#1784) - ([d232859](https://github.com/jdx/mise/commit/d232859b5334462a84df8f1f0b4189576712f571)) - roele
- display error message from calling usage (#1786) - ([63fc69b](https://github.com/jdx/mise/commit/63fc69bc751e6ed182243a6021995821d5f4611e)) - jdx
- automatically trust config files in CI (#1791) - ([80b340d](https://github.com/jdx/mise/commit/80b340d8f4a548caa71685a6fca925e2657345dc)) - jdx

### 🚜 Refactor

- move lint tasks from just to mise - ([4f78a8c](https://github.com/jdx/mise/commit/4f78a8cb648246e3f204b426c57662076cc17d5d)) - jdx

### 📚 Documentation

- **(changelog)** use github handles - ([b5ef2f7](https://github.com/jdx/mise/commit/b5ef2f7976e04bf11889062181fc32574eff834a)) - jdx

### 🎨 Styling

- add mise tasks to editorconfig - ([dae8ece](https://github.com/jdx/mise/commit/dae8ece2d891100f86cecea5920bc423e0f4d053)) - jdx
- run lint-fix which has changed slightly - ([6e8dd2f](https://github.com/jdx/mise/commit/6e8dd2fe24adf6d44a17a460c1054738e58f4306)) - jdx
- apply editorconfig changes - ([962bed0](https://github.com/jdx/mise/commit/962bed061ab9218f679f20aa5c53e905981133e0)) - jdx
- new git-cliff format - ([854a4fa](https://github.com/jdx/mise/commit/854a4fae9255968887dc0b0647c993f633666442)) - jdx
- ignore CHANGELOG.md style - ([790cb91](https://github.com/jdx/mise/commit/790cb91a210f5d1d37f4c933798c1802583db753)) - jdx

### 🧪 Testing

- **(mega-linter)** do not use js-standard linter - ([6b63346](https://github.com/jdx/mise/commit/6b63346bdd985964bc824eff03973d2d58d1ad28)) - jdx
- **(mega-linter)** ignore CHANGELOG.md - ([b63b3ac](https://github.com/jdx/mise/commit/b63b3aca3c597ee95db80613b2ea8ca19f0e74c3)) - jdx

### ⚙️ Miscellaneous Tasks

- **(release-plz)** removed some debugging logic - ([f7d7bea](https://github.com/jdx/mise/commit/f7d7bea616c13b31318f2e7da287aa71face8e57)) - jdx
- **(release-plz)** show actual version in PR body - ([e1ef708](https://github.com/jdx/mise/commit/e1ef708745e79bd019c77740820daefca5491b2e)) - jdx
- **(release-plz)** tweaking logic to prevent extra PR - ([8673000](https://github.com/jdx/mise/commit/86730008cd2f60d2767296f97175805225c83951)) - jdx
- **(release-plz)** make logic work for calver - ([890c919](https://github.com/jdx/mise/commit/890c919081f984f3d506c2b1d2712c8cff6f5e6b)) - jdx
- **(release-plz)** make logic work for calver - ([bb5a178](https://github.com/jdx/mise/commit/bb5a178b0642416d0e3dac8a9162a9f0732cf146)) - jdx
- **(release-plz)** fix git diffs - ([6c7e779](https://github.com/jdx/mise/commit/6c7e77944a24b289aaba887f64b7f3c63cb9e5ab)) - jdx
- **(release-plz)** create gh release - ([f9ff369](https://github.com/jdx/mise/commit/f9ff369eb1176e31044fc463fdca08397def5a81)) - jdx
- **(release-plz)** fixing gpg key - ([8286ded](https://github.com/jdx/mise/commit/8286ded8297b858e7136831e75e4c37fa49e6186)) - jdx
- **(release-plz)** fixing gpg key - ([abb1dfe](https://github.com/jdx/mise/commit/abb1dfed78e49cf2bee4a137e92879ffd7f2fb03)) - jdx
- **(release-plz)** do not publish a new release PR immediately - ([b3ae753](https://github.com/jdx/mise/commit/b3ae753fdde1fef17b4f13a1ecc8b23cb1da575c)) - jdx
- **(release-plz)** prefix versions with "v" - ([3354b55](https://github.com/jdx/mise/commit/3354b551adab7082d5cc533e5d9d0bfe272958b4)) - jdx
- **(test)** cache mise installed tools - ([0e433b9](https://github.com/jdx/mise/commit/0e433b975a5d8c28ae5c0cbd86d3b19e03146a83)) - jdx
- cargo update - ([6391239](https://github.com/jdx/mise/commit/639123930eec8e057de7da790cb71d4a2b9e17a2)) - jdx
- install tools before unit tests - ([f7456eb](https://github.com/jdx/mise/commit/f7456ebc539a4b27ec067bc480bc0aba1466e55b)) - jdx
- added git-cliff - ([0ccdf36](https://github.com/jdx/mise/commit/0ccdf36df153ddc3ac1a2714ee9b4a2116dfc918)) - jdx
- ensure `mise install` is run before lint-fix - ([e8a172f](https://github.com/jdx/mise/commit/e8a172f98ebc837619f3766777e489f3b99f36f4)) - jdx
- added release-plz workflow (#1787) - ([83fe1ec](https://github.com/jdx/mise/commit/83fe1ecc266caf094fc1cfb251ef1c0cc35afe1b)) - jdx
- set gpg key - ([467097f](https://github.com/jdx/mise/commit/467097f925053a27f0ede2a506e894562d191a09)) - jdx
- temporarily disable self-update test - ([5cb39a4](https://github.com/jdx/mise/commit/5cb39a4259f332e5bccec082f1d7cd6127da5f55)) - jdx

### Outdated

- add --json flag (#1785) - ([ec8dbdf](https://github.com/jdx/mise/commit/ec8dbdf0659a73ba64ca8a5bd1bf0e021fce0b4b)) - jdx