### PR TITLE
Fix the `shell` subcommand for xonsh

### DIFF
--- a/src/shell/snapshots/mise__shell__xonsh__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__hook_init.snap
@@ -2,10 +2,22 @@
 source: src/shell/xonsh.rs
 expression: "xonsh.activate(exe, \" --status\".into())"
 ---
+from os               import environ
+import subprocess
 from xonsh.built_ins  import XSH
 
 def listen_prompt(): # Hook Events
   execx($(/some/dir/mise hook-env --status -s xonsh))
 
+envx = XSH.env
+envx[   'MISE_SHELL'] = 'xonsh'
+environ['MISE_SHELL'] = envx.get_detyped('MISE_SHELL')
 XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
 
+def _mise(args):
+  if args and args[0] in ('deactivate', 'shell', 'sh'):
+    execx(subprocess.run(['command', 'mise', *args], stdout=subprocess.PIPE).stdout.decode())
+  else:
+    subprocess.run(['command', 'mise', *args])
+
+XSH.aliases['mise'] = _mise

--- a/src/shell/snapshots/mise__shell__xonsh__tests__xonsh_deactivate.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__xonsh_deactivate.snap
@@ -2,6 +2,7 @@
 source: src/shell/xonsh.rs
 expression: replace_path(&deactivate)
 ---
+import os
 from xonsh.built_ins  import XSH
 
 hooks = {
@@ -16,3 +17,6 @@ for   hook_type in hooks:
         hndl.remove(fn)
         break
 
+del XSH.aliases['mise']
+del XSH.env['MISE_SHELL']
+del os.environ['MISE_SHELL']

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -44,17 +44,31 @@ impl Shell for Xonsh {
         // use xonsh API instead of $.xsh to allow use inside of .py configs, which start faster due to being compiled to .pyc
         // todo: subprocess instead of $() is a bit faster, but lose auto-color detection (use $FORCE_COLOR)
         formatdoc! {r#"
+            from os               import environ
+            import subprocess
             from xonsh.built_ins  import XSH
 
             def listen_prompt(): # Hook Events
               execx($({exe} hook-env{flags} -s xonsh))
 
+            envx = XSH.env
+            envx[   'MISE_SHELL'] = 'xonsh'
+            environ['MISE_SHELL'] = envx.get_detyped('MISE_SHELL')
             XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
+
+            def _mise(args):
+              if args and args[0] in ('deactivate', 'shell', 'sh'):
+                execx(subprocess.run(['command', 'mise', *args], stdout=subprocess.PIPE).stdout.decode())
+              else:
+                subprocess.run(['command', 'mise', *args])
+
+            XSH.aliases['mise'] = _mise
         "#}
     }
 
     fn deactivate(&self) -> String {
         formatdoc! {r#"
+            import os
             from xonsh.built_ins  import XSH
 
             hooks = {{
@@ -68,6 +82,10 @@ impl Shell for Xonsh {
                   if fn.__name__ == hook_fn:
                     hndl.remove(fn)
                     break
+
+            del XSH.aliases['mise']
+            del XSH.env['MISE_SHELL']
+            del os.environ['MISE_SHELL']
             "#}
     }
 


### PR DESCRIPTION
This fixes https://github.com/jdx/mise/issues/425 by porting the shell function that shadows the `mise` binary from bash/zsh to xonsh.