### PR TITLE
fix: jq Installed Using x86_64 on Apple Silicon using mise

### DIFF
--- a/src/default_shorthands.rs
+++ b/src/default_shorthands.rs
@@ -344,7 +344,7 @@ pub static DEFAULT_SHORTHANDS: Lazy<HashMap<&'static str, &'static str>> =
     ("jless", "https://github.com/jc00ke/asdf-jless.git"),
     ("jmespath", "https://github.com/skyzyx/asdf-jmespath.git"),
     ("jmeter", "https://github.com/comdotlinux/asdf-jmeter"),
-    ("jq", "https://github.com/lsanwick/asdf-jq.git"),
+    ("jq", "https://github.com/mise-plugins/asdf-jq.git"),
     ("jqp", "https://gitlab.com/wt0f/asdf-jqp.git"),
     ("jreleaser", "https://github.com/joschi/asdf-jreleaser.git"),
     ("jsonnet", "https://github.com/Banno/asdf-jsonnet.git"),


### PR DESCRIPTION
This fixes #1767 and fixes #1762 by referencing the forked and adapted repository for `jq`.