### PR TITLE
fix(nu): Gracefully handle missing `$env.config`

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -27,20 +27,18 @@ impl Shell for Nushell {
         formatdoc! {r#"
           export-env {{
             $env.MISE_SHELL = "nu"
-            add-hook pre_prompt {{
+            let mise_hook = {{
               condition: {{ "MISE_SHELL" in $env }}
               code: {{ mise_hook }}
             }}
-            add-hook env_change.PWD {{
-              condition: {{ "MISE_SHELL" in $env }}
-              code: {{ mise_hook }}
-            }}
+            add-hook hooks.pre_prompt $mise_hook
+            add-hook hooks.env_change.PWD $mise_hook
           }}
 
-          def --env add-hook [field hook] {{
-            let field = $field | split row . | prepend hooks | into cell-path
-            let hooks = $env.config | get --ignore-errors $field | default []
-            $env.config = ($env.config | upsert $field ($hooks ++ $hook))
+          def --env add-hook [field: cell-path new_hook: any] {{
+            let old_config = $env.config? | default {{}}
+            let old_hooks = $old_config | get $field --ignore-errors | default []
+            $env.config = ($old_config | upsert $field ($old_hooks ++ $new_hook))
           }}
 
           def "parse vars" [] {{

--- a/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
@@ -4,20 +4,18 @@ expression: "nushell.activate(exe, \" --status\".into())"
 ---
 export-env {
   $env.MISE_SHELL = "nu"
-  add-hook pre_prompt {
+  let mise_hook = {
     condition: { "MISE_SHELL" in $env }
     code: { mise_hook }
   }
-  add-hook env_change.PWD {
-    condition: { "MISE_SHELL" in $env }
-    code: { mise_hook }
-  }
+  add-hook hooks.pre_prompt $mise_hook
+  add-hook hooks.env_change.PWD $mise_hook
 }
 
-def --env add-hook [field hook] {
-  let field = $field | split row . | prepend hooks | into cell-path
-  let hooks = $env.config | get --ignore-errors $field | default []
-  $env.config = ($env.config | upsert $field ($hooks ++ $hook))
+def --env add-hook [field: cell-path new_hook: any] {
+  let old_config = $env.config? | default {}
+  let old_hooks = $old_config | get $field --ignore-errors | default []
+  $env.config = ($old_config | upsert $field ($old_hooks ++ $new_hook))
 }
 
 def "parse vars" [] {


### PR DESCRIPTION
Fixes error when `$env.config` is null. Nu implements default behavior for missing configurations enabling minimal customization in config files.

Additional simplifications:
- save hook to variable vs repeat it
- annotate `cell-path` type vs create it with `into cell-path`

Sorry for such a quick sequel to #1763 😅