### PR TITLE
fix(task): script tasks don't pick up alias from comments

### DIFF
--- a/.mise/tasks/lint-fix
+++ b/.mise/tasks/lint-fix
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise aliases=["lint:fix"]
+# mise alias=["lint:fix"]
 set -euxo pipefail
 
 scripts=("$PWD"/scripts/*.sh "$PWD"/e2e/{test_,run_}* "$PWD"/e2e/*.sh)

--- a/src/task.rs
+++ b/src/task.rs
@@ -102,6 +102,9 @@ impl Task {
 
         let task = Task {
             hide: !file::is_executable(path) || p.parse_bool("hide").unwrap_or_default(),
+            aliases: p
+                .parse_array("alias")?
+                .unwrap_or(vec![p.parse_str("alias")?.unwrap_or_default()]),
             description: p.parse_str("description")?.unwrap_or_default(),
             sources: p.parse_array("sources")?.unwrap_or_default(),
             outputs: p.parse_array("outputs")?.unwrap_or_default(),
@@ -371,7 +374,20 @@ where
 mod tests {
     use std::path::Path;
 
+    use crate::task::Task;
+
     use super::{config_root, name_from_path};
+
+    #[test]
+    fn test_from_path() {
+        let test_cases = [(".mise/tasks/filetask", "filetask", vec!["ft"])];
+
+        for (path, name, aliases) in test_cases {
+            let t = Task::from_path(Path::new(path)).unwrap();
+            assert_eq!(t.name, name);
+            assert_eq!(t.aliases, aliases);
+        }
+    }
 
     #[test]
     fn test_name_from_path() {

--- a/test/cwd/.mise/tasks/filetask
+++ b/test/cwd/.mise/tasks/filetask
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# mise alias=["ft"]
 # mise description="This is a test build script"
 # mise depends=["lint", "test"]
 # mise sources=[".test-tool-versions"]


### PR DESCRIPTION
Fixes #1802 