### PR TITLE
fix(python): install python when pip is disabled outside virtualenv

### DIFF
--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -165,6 +165,7 @@ impl PythonPlugin {
             .with_pr(ctx.pr.as_ref())
             .arg(ctx.tv.version.as_str())
             .arg(&ctx.tv.install_path())
+            .env("PIP_REQUIRE_VIRTUALENV", "false")
             .envs(config.env()?);
         if settings.verbose {
             cmd = cmd.arg("--verbose");
@@ -209,6 +210,7 @@ impl PythonPlugin {
             .arg("--upgrade")
             .arg("-r")
             .arg(packages_file)
+            .env("PIP_REQUIRE_VIRTUALENV", "false")
             .envs(config.env()?)
             .execute()
     }


### PR DESCRIPTION
Hey :wave:

As many users, I disabled pip when outside of virtual environments, to avoid messing with my global installs, using this ~/.pip/pip.conf
```ini
[global]
require-virtualenv = true
```

Unfortunately, it means I must always install Python with `PIP_REQUIRE_VIRTUALENV=false mise install`, as pip is invoked when setting up Python with mise.

This small PR adds the environment variable in the mise command invocations.

__Before__
```
➜ mise install python@3.12.0
Downloading Python-3.12.0.tar.xz...
-> https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tar.xz
Installing Python-3.12.0...
Installed Python-3.12.0 to /Users/gabdug/.local/share/mise/installs/python/3.12.0
ERROR: Could not find an activated virtualenv (required).
mise ~/.local/share/mise/installs/python/3.12.0/bin/python failed
ERROR: Could not find an activated virtualenv (required).
mise ~/.local/share/mise/installs/python/3.12.0/bin/python exited with non-zero status: exit code 3
mise Run with --verbose or MISE_VERBOSE=1 for more information
```

__After__
```
➜ mise install python@3.12.0
Downloading Python-3.12.0.tar.xz...
-> https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tar.xz
Installing Python-3.12.0...
Installed Python-3.12.0 to /Users/gabdug/.local/share/mise/installs/python/3.12.0
[notice] A new release of pip is available: 23.2.1 -> 24.0
[notice] To update, run: /Users/gabdug/.local/share/mise/installs/python/3.12.0/bin/python -m pip install --upgrade pip
mise python@3.12.0 ✓ installed 
```

I can try and modify the E2E test cases if you feel this would warrant a regression check.

Thanks, and have a great day!