### PR TITLE
fix: go backend naming inconsistency (in mise ls and mise prune)

### DIFF
--- a/src/cli/args/forge_arg.rs
+++ b/src/cli/args/forge_arg.rs
@@ -49,7 +49,18 @@ impl ForgeArg {
     }
 
     pub fn from_pathname(name: &str) -> Self {
-        let fa_name = name.replacen('-', ":", 1);
+        let mut fa_name = name.replacen('-', ":", 1);
+        let forge_type = name.split('-').next().unwrap_or_default();
+        // Go packages cannot have dashes in their name.
+        // - Simply replace dashes with slashes
+        if ForgeType::Go.as_ref() == forge_type {
+            fa_name = fa_name.replace('-', "/");
+        }
+        // NPM packages can have dashes and slashes in their name.
+        // - If scoped, replace first dash after the @ with a slash. Will not work for scopes using dashes
+        if ForgeType::Npm.as_ref() == forge_type && fa_name.contains('@') {
+            fa_name = fa_name.replacen('-', "/", 1);
+        }
         ForgeArg::from_str(&fa_name).unwrap()
     }
 }


### PR DESCRIPTION
Mitigates #1904 which was introduced with #1885. 

- Cargo crates use kebab-case (or snake_case?) to they should not cause issues.
- Go packages cannot have dashes so reverting `-` to `/` fixes the issue.
- NPM backend is still problematic as scopes can have `-` and end with `/`, so reverting from for example `npm-@adobe-aio-cli` to `npm:@adobe/aio-cli` can only happen on best guess replacing first dash after the `@`.