### PR TITLE
refactor: use a metadata file for forges

### DIFF
--- a/src/cli/args/forge_arg.rs
+++ b/src/cli/args/forge_arg.rs
@@ -1,4 +1,4 @@
-use crate::dirs;
+use crate::{dirs, file};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::path::PathBuf;
@@ -46,6 +46,21 @@ impl ForgeArg {
             installs_path: dirs::INSTALLS.join(&pathname),
             downloads_path: dirs::DOWNLOADS.join(&pathname),
         }
+    }
+
+    pub fn from_metadata(dirname: &str) -> Self {
+        let id = dirname.replacen('-', ":", 1);
+        let meta_path = &dirs::INSTALLS.join(dirname).join(".mise.metadata");
+        let meta_id = file::read_to_string(meta_path).unwrap_or(id);
+        ForgeArg::from_str(&meta_id).unwrap()
+    }
+
+    pub fn write_metadata(&self) -> eyre::Result<()> {
+        if self.forge_type != ForgeType::Asdf {
+            let meta_path = &self.installs_path.join(".mise.metadata");
+            return file::write(meta_path, &self.id);
+        }
+        Ok(())
     }
 }
 

--- a/src/cli/args/forge_arg.rs
+++ b/src/cli/args/forge_arg.rs
@@ -47,22 +47,6 @@ impl ForgeArg {
             downloads_path: dirs::DOWNLOADS.join(&pathname),
         }
     }
-
-    pub fn from_pathname(name: &str) -> Self {
-        let mut fa_name = name.replacen('-', ":", 1);
-        let forge_type = name.split('-').next().unwrap_or_default();
-        // Go packages cannot have dashes in their name.
-        // - Simply replace dashes with slashes
-        if ForgeType::Go.as_ref() == forge_type {
-            fa_name = fa_name.replace('-', "/");
-        }
-        // NPM packages can have dashes and slashes in their name.
-        // - If scoped, replace first dash after the @ with a slash. Will not work for scopes using dashes
-        if ForgeType::Npm.as_ref() == forge_type && fa_name.contains('@') {
-            fa_name = fa_name.replacen('-', "/", 1);
-        }
-        ForgeArg::from_str(&fa_name).unwrap()
-    }
 }
 
 impl Display for ForgeArg {

--- a/src/cli/args/forge_arg.rs
+++ b/src/cli/args/forge_arg.rs
@@ -1,4 +1,4 @@
-use crate::{dirs, file};
+use crate::dirs;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::path::PathBuf;
@@ -46,21 +46,6 @@ impl ForgeArg {
             installs_path: dirs::INSTALLS.join(&pathname),
             downloads_path: dirs::DOWNLOADS.join(&pathname),
         }
-    }
-
-    pub fn from_metadata(dirname: &str) -> Self {
-        let id = dirname.replacen('-', ":", 1);
-        let meta_path = &dirs::INSTALLS.join(dirname).join(".mise.metadata");
-        let meta_id = file::read_to_string(meta_path).unwrap_or(id);
-        ForgeArg::from_str(&meta_id).unwrap()
-    }
-
-    pub fn write_metadata(&self) -> eyre::Result<()> {
-        if self.forge_type != ForgeType::Asdf {
-            let meta_path = &self.installs_path.join(".mise.metadata");
-            return file::write(meta_path, &self.id);
-        }
-        Ok(())
     }
 }
 

--- a/src/forge/cargo.rs
+++ b/src/forge/cargo.rs
@@ -82,10 +82,6 @@ impl CargoForge {
             fa,
         }
     }
-
-    pub fn from_dirname(dirname: String) -> Self {
-        CargoForge::new(dirname)
-    }
 }
 
 fn get_crate_url(n: &str) -> eyre::Result<Url> {

--- a/src/forge/cargo.rs
+++ b/src/forge/cargo.rs
@@ -73,13 +73,18 @@ impl Forge for CargoForge {
 }
 
 impl CargoForge {
-    pub fn new(fa: ForgeArg) -> Self {
+    pub fn new(name: String) -> Self {
+        let fa = ForgeArg::new(ForgeType::Cargo, &name);
         Self {
             remote_version_cache: CacheManager::new(
                 fa.cache_path.join("remote_versions.msgpack.z"),
             ),
             fa,
         }
+    }
+
+    pub fn from_dirname(dirname: String) -> Self {
+        CargoForge::new(dirname)
     }
 }
 

--- a/src/forge/forge_meta.rs
+++ b/src/forge/forge_meta.rs
@@ -8,15 +8,16 @@ use super::ForgeType;
 pub struct ForgeMeta {
     pub id: String,
     pub name: String,
+    pub forge_type: String,
 }
 
-const FORGE_META_FILENAME: &str = ".mise.forge.toml";
+const FORGE_META_FILENAME: &str = ".mise.forge.json";
 
 impl ForgeMeta {
     pub fn read(dirname: &str) -> ForgeMeta {
         let meta_path = &dirs::INSTALLS.join(dirname).join(FORGE_META_FILENAME);
-        let toml = file::read_to_string(meta_path).unwrap_or_default();
-        toml::from_str(&toml).unwrap_or(Self::default_meta(dirname))
+        let json = file::read_to_string(meta_path).unwrap_or_default();
+        serde_json::from_str(&json).unwrap_or(Self::default_meta(dirname))
     }
 
     pub fn write(fa: &ForgeArg) -> eyre::Result<()> {
@@ -26,29 +27,37 @@ impl ForgeMeta {
         let meta = ForgeMeta {
             id: fa.id.clone(),
             name: fa.name.clone(),
+            forge_type: fa.forge_type.as_ref().to_string(),
         };
-        let toml = toml::to_string(&meta).expect("Could not encode TOML value");
+
+        let json = serde_json::to_string(&meta).expect("Could not encode JSON value");
         let meta_path = fa.installs_path.join(FORGE_META_FILENAME);
-        file::write(meta_path, toml)?;
+        file::write(meta_path, json)?;
         Ok(())
     }
 
-    // Returns a ForgeMeta with id and name derived from the dirname for backends without a .mise.forge.toml file
+    // Returns a ForgeMeta derived from the dirname for forges without a meta file
     fn default_meta(dirname: &str) -> ForgeMeta {
         let id = dirname.replacen('-', ":", 1);
         match id.split_once(':') {
             Some((forge_type, name)) => {
                 let name = Self::name_for_type(name.to_string(), forge_type);
                 let id = format!("{}:{}", forge_type, name);
-                ForgeMeta { id, name }
+                ForgeMeta {
+                    id,
+                    name,
+                    forge_type: forge_type.to_string(),
+                }
             }
             None => ForgeMeta {
                 id: id.to_string(),
                 name: id.to_string(),
+                forge_type: ForgeType::Asdf.as_ref().to_string(),
             },
         }
     }
 
+    // TODO: remove this when backends come out of experimental
     fn name_for_type(name: String, forge_type: &str) -> String {
         match forge_type {
             "go" => name.replace('-', "/"),

--- a/src/forge/forge_meta.rs
+++ b/src/forge/forge_meta.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{cli::args::ForgeArg, dirs, file};
+
+use super::ForgeType;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ForgeMeta {
+    pub id: String,
+    pub name: String,
+}
+
+const FORGE_META_FILENAME: &str = ".mise.forge.toml";
+
+impl ForgeMeta {
+    pub fn read(dirname: &str) -> ForgeMeta {
+        let meta_path = &dirs::INSTALLS.join(dirname).join(FORGE_META_FILENAME);
+        let toml = file::read_to_string(meta_path).unwrap_or_default();
+        toml::from_str(&toml).unwrap_or(Self::default_meta(dirname))
+    }
+
+    pub fn write(fa: &ForgeArg) -> eyre::Result<()> {
+        if fa.forge_type == ForgeType::Asdf {
+            return Ok(());
+        }
+        let meta = ForgeMeta {
+            id: fa.id.clone(),
+            name: fa.name.clone(),
+        };
+        let toml = toml::to_string(&meta).expect("Could not encode TOML value");
+        let meta_path = fa.installs_path.join(FORGE_META_FILENAME);
+        file::write(meta_path, toml)?;
+        Ok(())
+    }
+
+    // Returns a ForgeMeta with id and name derived from the dirname for backends without a .mise.forge.toml file
+    fn default_meta(dirname: &str) -> ForgeMeta {
+        let id = dirname.replacen('-', ":", 1);
+        match id.split_once(':') {
+            Some((forge_type, name)) => {
+                let name = Self::name_for_type(name.to_string(), forge_type);
+                let id = format!("{}:{}", forge_type, name);
+                ForgeMeta { id, name }
+            }
+            None => ForgeMeta {
+                id: id.to_string(),
+                name: id.to_string(),
+            },
+        }
+    }
+
+    fn name_for_type(name: String, forge_type: &str) -> String {
+        match forge_type {
+            "go" => name.replace('-', "/"),
+            "npm" => {
+                if name.contains('@') {
+                    return name.replacen('-', "/", 1).to_string();
+                }
+                name.to_string()
+            }
+            _ => name.to_string(),
+        }
+    }
+}

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -91,14 +91,6 @@ impl GoForge {
             fa,
         }
     }
-
-    pub fn from_dirname(dirname: String) -> Self {
-        GoForge::new(un_dirname(dirname))
-    }
-}
-
-fn un_dirname(dirname: String) -> String {
-    dirname.replace('-', "/")
 }
 
 fn trim_after_last_slash(s: &str) -> Option<&str> {
@@ -112,22 +104,4 @@ fn trim_after_last_slash(s: &str) -> Option<&str> {
 #[serde(rename_all = "PascalCase")]
 pub struct GoModInfo {
     versions: Vec<String>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_from_dirname() {
-        let dirnames = vec![
-            ("github.com-user-repo", "github.com/user/repo"),
-            ("github.com-user-repo-new", "github.com/user/repo/new"),
-        ];
-        for (dirname, name) in dirnames {
-            let npm_forge = GoForge::from_dirname(dirname.to_string());
-            assert_eq!(npm_forge.fa().forge_type, ForgeType::Go);
-            assert_eq!(npm_forge.fa().name, name);
-        }
-    }
 }

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -82,7 +82,8 @@ impl Forge for GoForge {
 }
 
 impl GoForge {
-    pub fn new(fa: ForgeArg) -> Self {
+    pub fn new(name: String) -> Self {
+        let fa = ForgeArg::new(ForgeType::Go, &name);
         Self {
             remote_version_cache: CacheManager::new(
                 fa.cache_path.join("remote_versions.msgpack.z"),
@@ -90,6 +91,14 @@ impl GoForge {
             fa,
         }
     }
+
+    pub fn from_dirname(dirname: String) -> Self {
+        GoForge::new(un_dirname(dirname))
+    }
+}
+
+fn un_dirname(dirname: String) -> String {
+    dirname.replace('-', "/")
 }
 
 fn trim_after_last_slash(s: &str) -> Option<&str> {
@@ -103,4 +112,22 @@ fn trim_after_last_slash(s: &str) -> Option<&str> {
 #[serde(rename_all = "PascalCase")]
 pub struct GoModInfo {
     versions: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_dirname() {
+        let dirnames = vec![
+            ("github.com-user-repo", "github.com/user/repo"),
+            ("github.com-user-repo-new", "github.com/user/repo/new"),
+        ];
+        for (dirname, name) in dirnames {
+            let npm_forge = GoForge::from_dirname(dirname.to_string());
+            assert_eq!(npm_forge.fa().forge_type, ForgeType::Go);
+            assert_eq!(npm_forge.fa().name, name);
+        }
+    }
 }

--- a/src/forge/npm.rs
+++ b/src/forge/npm.rs
@@ -85,35 +85,4 @@ impl NPMForge {
             fa,
         }
     }
-
-    pub fn from_dirname(dirname: String) -> Self {
-        NPMForge::new(un_dirname(dirname))
-    }
-}
-
-// NPM packages can have dashes and slashes in their name.
-// - If scoped, replace first dash after the @ with a slash. Will not work for scopes using dashes
-fn un_dirname(dirname: String) -> String {
-    if dirname.contains('@') {
-        return dirname.replacen('-', "/", 1);
-    }
-    dirname
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_from_dirname() {
-        let dirnames = vec![
-            ("@scope-my-package", "@scope/my-package"),
-            ("my-package", "my-package"),
-        ];
-        for (dirname, name) in dirnames {
-            let npm_forge = NPMForge::from_dirname(dirname.to_string());
-            assert_eq!(npm_forge.fa().forge_type, ForgeType::Npm);
-            assert_eq!(npm_forge.fa().name, name);
-        }
-    }
 }

--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -89,6 +89,11 @@ impl ExternalPlugin {
             fa,
         }
     }
+
+    pub fn from_dirname(dirname: String) -> Self {
+        ExternalPlugin::new(dirname)
+    }
+
     pub fn list() -> Result<ForgeList> {
         Ok(file::dir_subdirs(&dirs::PLUGINS)?
             .into_par_iter()

--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -90,10 +90,6 @@ impl ExternalPlugin {
         }
     }
 
-    pub fn from_dirname(dirname: String) -> Self {
-        ExternalPlugin::new(dirname)
-    }
-
     pub fn list() -> Result<ForgeList> {
         Ok(file::dir_subdirs(&dirs::PLUGINS)?
             .into_par_iter()


### PR DESCRIPTION
This is a follow up on #1905 attempting to move the "un-dirname" logic out of the `ForgeArg` into the `Forge` implementations.

Additionally it seems for `Go` while package names cannot have `-`, module names can and often do. So the logic for `Go` will also not work reliably. For example https://pkg.go.dev/search?q=http reveals all sorts of exceptions.

Using a `+` as separator would yield better results but i'm afraid thats not easy to change now is it?