### PR TITLE
fix(exec): default to @latest version

### DIFF
--- a/e2e/test_system
+++ b/e2e/test_system
@@ -9,4 +9,4 @@ system_node="$(which node)"
 mise_node="$(mise which node)"
 
 assert "mise x node@system nodejs@system -- which node" "$system_node"
-assert "mise x node -- which node" "$mise_node"
+assert "mise x -- which node" "$mise_node"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -51,7 +51,10 @@ pub struct Exec {
 impl Exec {
     pub fn run(self) -> Result<()> {
         let config = Config::try_get()?;
-        let mut ts = ToolsetBuilder::new().with_args(&self.tool).build(&config)?;
+        let mut ts = ToolsetBuilder::new()
+            .with_args(&self.tool)
+            .with_default_to_latest(true)
+            .build(&config)?;
         let opts = InstallOptions {
             force: false,
             jobs: self.jobs,

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -95,18 +95,18 @@ impl ToolsetBuilder {
                     arg_ts.add_version(tvr.clone(), Default::default());
                 } else {
                     let versions_by_plugin = ts.list_versions_by_plugin();
-                    let set_as_latest = versions_by_plugin
-                    .iter()
-                    .find(|(_ta, fa)|
-                         fa.iter().find(|f|
-                             // Same forget type and same forgeArg name
-                             f.forge.forge_type == arg.forge.forge_type &&
-                             f.forge.name == arg.forge.name
-                        ).is_none()
-                     );
+                    let set_as_latest = versions_by_plugin.iter().find(|(_ta, fa)| {
+                        !fa.iter().any(|f|
+                                // Same forget type and same forgeArg name
+                                f.forge.forge_type == arg.forge.forge_type &&
+                                    f.forge.name == arg.forge.name)
+                    });
 
                     if let Some((_ta, _fa)) = set_as_latest {
-                        arg_ts.add_version(ToolVersionRequest::new(arg.forge.clone(), "latest".into()), Default::default());
+                        arg_ts.add_version(
+                            ToolVersionRequest::new(arg.forge.clone(), "latest"),
+                            Default::default(),
+                        );
                     }
                 }
             }

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -93,9 +93,6 @@ impl ToolsetBuilder {
             for arg in args {
                 if let Some(tvr) = &arg.tvr {
                     arg_ts.add_version(tvr.clone(), Default::default());
-                } else {
-                    let tvr = ToolVersionRequest::new(arg.forge.clone(), "latest".into());
-                    arg_ts.add_version(tvr.clone(), Default::default());
                 }
             }
             ts.merge(arg_ts);

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -93,6 +93,9 @@ impl ToolsetBuilder {
             for arg in args {
                 if let Some(tvr) = &arg.tvr {
                     arg_ts.add_version(tvr.clone(), Default::default());
+                } else {
+                    let tvr = ToolVersionRequest::new(arg.forge.clone(), "latest".into());
+                    arg_ts.add_version(tvr.clone(), Default::default());
                 }
             }
             ts.merge(arg_ts);

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -12,6 +12,7 @@ use crate::{config, env};
 pub struct ToolsetBuilder {
     args: Vec<ToolArg>,
     global_only: bool,
+    default_to_latest: bool,
 }
 
 impl ToolsetBuilder {
@@ -26,6 +27,11 @@ impl ToolsetBuilder {
 
     pub fn with_global_only(mut self, global_only: bool) -> Self {
         self.global_only = global_only;
+        self
+    }
+
+    pub fn with_default_to_latest(mut self, default_to_latest: bool) -> Self {
+        self.default_to_latest = default_to_latest;
         self
     }
 
@@ -93,13 +99,17 @@ impl ToolsetBuilder {
             for arg in args {
                 if let Some(tvr) = &arg.tvr {
                     arg_ts.add_version(tvr.clone(), Default::default());
-                } else {
+                } else if self.default_to_latest {
+                    // TODO: see if there is a cleaner way to handle this scenario
+                    // this logic is required for `mise x` because with that specific command mise
+                    // should default to installing the "latest" version if no version is specified
+                    // in .mise.toml
                     let versions_by_plugin = ts.list_versions_by_plugin();
                     let set_as_latest = versions_by_plugin.iter().find(|(_ta, fa)| {
                         !fa.iter().any(|f|
-                                // Same forget type and same forgeArg name
-                                f.forge.forge_type == arg.forge.forge_type &&
-                                    f.forge.name == arg.forge.name)
+                            // Same forget type and same forgeArg name
+                            f.forge.forge_type == arg.forge.forge_type &&
+                                f.forge.name == arg.forge.name)
                     });
 
                     if let Some((_ta, _fa)) = set_as_latest {

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -93,6 +93,21 @@ impl ToolsetBuilder {
             for arg in args {
                 if let Some(tvr) = &arg.tvr {
                     arg_ts.add_version(tvr.clone(), Default::default());
+                } else {
+                    let versions_by_plugin = ts.list_versions_by_plugin();
+                    let set_as_latest = versions_by_plugin
+                    .iter()
+                    .find(|(_ta, fa)|
+                         fa.iter().find(|f|
+                             // Same forget type and same forgeArg name
+                             f.forge.forge_type == arg.forge.forge_type &&
+                             f.forge.name == arg.forge.name
+                        ).is_none()
+                     );
+
+                    if let Some((_ta, _fa)) = set_as_latest {
+                        arg_ts.add_version(ToolVersionRequest::new(arg.forge.clone(), "latest".into()), Default::default());
+                    }
                 }
             }
             ts.merge(arg_ts);


### PR DESCRIPTION
Addresses a bug with `mise exec` where using an unversioned tool reference causes the underlying binary to not be installed on first use.

Instead we treat an unqualified tool as having tool@latest and handle that in the else clause.

Discord discussion/question:

```
What's the expected behavior for mise backends when the desired tool@version does not exist in a config file and is not installed and mise x tool@version -- ... is run? I assumed it to be like npx behavior of install if missing then run, but it isn't for most backends other than npm.

For example, if I lack cargo:eza in any of my config files nor installed and run mise x cargo:eza -- which -a eza , I see that it does not install cargo:eza + run the --command with eza install folder in the path. In that case the command fails.

But if I run mise x npm:prettier@3.1.0 -- which -a prettier in similar circumstances I see that prettier is available and executed.

The behavior I expect is the npm case and the cargo case is surprising and undesirable for me, because I'm thinking of mise x as being like npx where it will setup dependency if missing then run it.  I see that if I first mise install cargo:eza followed by mise x cargo:eza it works as expected.

Is the npm behavior your expected/desired behavior?

(this is in the context of debugging my PR for a pipx backend and realizing that mise x and mise install followed by mise x have different behavior in my e2e tests)

jdx: I think mise x with any tool on any backend should autoinstall it
```

Closes #1247 