### PR TITLE
Add Zig language plugin

### DIFF
--- a/src/default_shorthands.rs
+++ b/src/default_shorthands.rs
@@ -791,7 +791,7 @@ pub static DEFAULT_SHORTHANDS: Lazy<HashMap<&'static str, &'static str>> =
     ("zbctl", "https://github.com/camunda-community-hub/asdf-zbctl.git"),
     ("zellij", "https://github.com/chessmango/asdf-zellij.git"),
     ("zephyr", "https://github.com/nsaunders/asdf-zephyr.git"),
-    ("zig", "https://github.com/cheetah/asdf-zig.git"),
+    // ("zig", "https://github.com/cheetah/asdf-zig.git"),
     ("zigmod", "https://github.com/kachick/asdf-zigmod.git"),
     ("zola", "https://github.com/salasrod/asdf-zola.git"),
     ("zoxide", "https://github.com/nyrst/asdf-zoxide"),

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -21,6 +21,7 @@ use crate::plugins::core::go::GoPlugin;
 use crate::plugins::core::java::JavaPlugin;
 use crate::plugins::core::node::NodePlugin;
 use crate::plugins::core::ruby::RubyPlugin;
+use crate::plugins::core::zig::ZigPlugin;
 use crate::timeout::run_with_timeout;
 use crate::toolset::ToolVersion;
 
@@ -32,6 +33,7 @@ mod java;
 mod node;
 mod python;
 mod ruby;
+mod zig;
 
 pub static CORE_PLUGINS: Lazy<ForgeList> = Lazy::new(|| {
     let mut plugins: Vec<Arc<dyn Forge>> = vec![
@@ -42,6 +44,8 @@ pub static CORE_PLUGINS: Lazy<ForgeList> = Lazy::new(|| {
         Arc::new(NodePlugin::new()),
         Arc::new(PythonPlugin::new()),
         Arc::new(RubyPlugin::new()),
+        Arc::new(ZigPlugin::new()),
+
     ];
     let settings = Settings::get();
     if settings.experimental {

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -45,7 +45,6 @@ pub static CORE_PLUGINS: Lazy<ForgeList> = Lazy::new(|| {
         Arc::new(PythonPlugin::new()),
         Arc::new(RubyPlugin::new()),
         Arc::new(ZigPlugin::new()),
-
     ];
     let settings = Settings::get();
     if settings.experimental {

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -16,7 +16,6 @@ use crate::plugins::core::CorePlugin;
 use crate::toolset::{ToolVersion, ToolVersionRequest};
 use crate::ui::progress_report::SingleReport;
 
-
 #[derive(Debug)]
 pub struct ZigPlugin {
     core: CorePlugin,
@@ -30,7 +29,6 @@ impl ZigPlugin {
     fn zig_bin(&self, tv: &ToolVersion) -> PathBuf {
         tv.install_path().join("zig")
     }
-
 
     fn test_zig(&self, ctx: &InstallContext) -> Result<()> {
         ctx.pr.set_message("zig version".into());
@@ -52,15 +50,21 @@ impl ZigPlugin {
             HTTP_FETCH.json("https://api.github.com/repos/ziglang/zig/releases?per_page=100")?;
         let versions = releases
             .into_iter()
-            .map(|r| r.tag_name).unique()
+            .map(|r| r.tag_name)
+            .unique()
             .sorted_by_cached_key(|s| (Versioning::new(s), s.to_string()))
             .collect();
         Ok(versions)
     }
 
     fn downlaod(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
-        let url = format!("https://ziglang.org/download/{}/zig-{}-{}-{}.tar.xz", tv.version, os(), arch(), tv.version);
-
+        let url = format!(
+            "https://ziglang.org/download/{}/zig-{}-{}-{}.tar.xz",
+            tv.version,
+            os(),
+            arch(),
+            tv.version
+        );
 
         let filename = url.split('/').last().unwrap();
         let tarball_path = tv.download_path().join(filename);
@@ -82,17 +86,18 @@ impl ZigPlugin {
             ctx.tv.install_path(),
         )?;
         file::create_dir_all(ctx.tv.install_path().join("bin"))?;
-        file::make_symlink(self.zig_bin(&ctx.tv).as_path(), &ctx.tv.install_path().join("bin/zig"))?;
+        file::make_symlink(
+            self.zig_bin(&ctx.tv).as_path(),
+            &ctx.tv.install_path().join("bin/zig"),
+        )?;
 
         Ok(())
     }
-
 
     fn verify(&self, ctx: &InstallContext) -> Result<()> {
         self.test_zig(ctx)
     }
 }
-
 
 impl Forge for ZigPlugin {
     fn fa(&self) -> &ForgeArg {
@@ -106,7 +111,6 @@ impl Forge for ZigPlugin {
             .cloned()
     }
 
-
     fn legacy_filenames(&self) -> Result<Vec<String>> {
         Ok(vec![".zig-version".into()])
     }
@@ -119,7 +123,6 @@ impl Forge for ZigPlugin {
     }
 }
 
-
 fn os() -> &'static str {
     if cfg!(target_os = "macos") {
         "macos"
@@ -131,7 +134,6 @@ fn os() -> &'static str {
         &OS
     }
 }
-
 
 fn arch() -> &'static str {
     if cfg!(target_arch = "x86_64") || cfg!(target_arch = "amd64") {
@@ -150,10 +152,13 @@ fn arch() -> &'static str {
     }
 }
 
-
 pub fn untar_xy(archive: &Path, dest: &Path) -> Result<()> {
-    let archive = archive.to_str().ok_or(eyre::eyre!("Failed to read archive path"))?;
-    let dest = dest.to_str().ok_or(eyre::eyre!("Failed to read destination path"))?;
+    let archive = archive
+        .to_str()
+        .ok_or(eyre::eyre!("Failed to read archive path"))?;
+    let dest = dest
+        .to_str()
+        .ok_or(eyre::eyre!("Failed to read destination path"))?;
 
     let output = std::process::Command::new("tar")
         .arg("-xf")

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -1,0 +1,171 @@
+use std::path::{Path, PathBuf};
+
+use eyre::Result;
+use itertools::Itertools;
+use versions::Versioning;
+
+use crate::cli::args::ForgeArg;
+use crate::cli::version::{ARCH, OS};
+use crate::cmd::CmdLineRunner;
+use crate::file;
+use crate::forge::Forge;
+use crate::github::GithubRelease;
+use crate::http::{HTTP, HTTP_FETCH};
+use crate::install_context::InstallContext;
+use crate::plugins::core::CorePlugin;
+use crate::toolset::{ToolVersion, ToolVersionRequest};
+use crate::ui::progress_report::SingleReport;
+
+
+#[derive(Debug)]
+pub struct ZigPlugin {
+    core: CorePlugin,
+}
+
+impl ZigPlugin {
+    pub fn new() -> Self {
+        let core = CorePlugin::new("zig");
+        Self { core }
+    }
+    fn zig_bin(&self, tv: &ToolVersion) -> PathBuf {
+        tv.install_path().join("zig")
+    }
+
+
+    fn test_zig(&self, ctx: &InstallContext) -> Result<()> {
+        ctx.pr.set_message("zig version".into());
+        CmdLineRunner::new(self.zig_bin(&ctx.tv))
+            .with_pr(ctx.pr.as_ref())
+            .arg("version")
+            .execute()
+    }
+
+    fn fetch_remote_versions(&self) -> Result<Vec<String>> {
+        // let json = HTTP_FETCH.get_text("https://ziglang.org/download/index.json")?;
+        match self.core.fetch_remote_versions_from_mise() {
+            Ok(Some(versions)) => return Ok(versions),
+            Ok(None) => {}
+            Err(e) => warn!("failed to fetch remote versions: {}", e),
+        }
+
+        let releases: Vec<GithubRelease> =
+            HTTP_FETCH.json("https://api.github.com/repos/ziglang/zig/releases?per_page=100")?;
+        let versions = releases
+            .into_iter()
+            .map(|r| r.tag_name).unique()
+            .sorted_by_cached_key(|s| (Versioning::new(s), s.to_string()))
+            .collect();
+        Ok(versions)
+    }
+
+    fn downlaod(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
+        let url = format!("https://ziglang.org/download/{}/zig-{}-{}-{}.tar.xz", tv.version, os(), arch(), tv.version);
+
+
+        let filename = url.split('/').last().unwrap();
+        let tarball_path = tv.download_path().join(filename);
+
+        pr.set_message(format!("downloading {filename}"));
+        HTTP.download_file(&url, &tarball_path, Some(pr))?;
+
+        Ok(tarball_path)
+    }
+    fn install(&self, ctx: &InstallContext, tarball_path: &Path) -> Result<()> {
+        let filename = tarball_path.file_name().unwrap().to_string_lossy();
+        ctx.pr.set_message(format!("installing {filename}"));
+        file::remove_all(ctx.tv.install_path())?;
+        untar_xy(tarball_path, &ctx.tv.download_path())?;
+        file::rename(
+            ctx.tv
+                .download_path()
+                .join(format!("zig-{}-{}-{}", os(), arch(), ctx.tv.version)),
+            ctx.tv.install_path(),
+        )?;
+        file::create_dir_all(ctx.tv.install_path().join("bin"))?;
+        file::make_symlink(self.zig_bin(&ctx.tv).as_path(), &ctx.tv.install_path().join("bin/zig"))?;
+
+        Ok(())
+    }
+
+
+    fn verify(&self, ctx: &InstallContext) -> Result<()> {
+        self.test_zig(ctx)
+    }
+}
+
+
+impl Forge for ZigPlugin {
+    fn fa(&self) -> &ForgeArg {
+        &self.core.fa
+    }
+
+    fn list_remote_versions(&self) -> Result<Vec<String>> {
+        self.core
+            .remote_version_cache
+            .get_or_try_init(|| self.fetch_remote_versions())
+            .cloned()
+    }
+
+
+    fn legacy_filenames(&self) -> Result<Vec<String>> {
+        Ok(vec![".zig-version".into()])
+    }
+    #[requires(matches ! (ctx.tv.request, ToolVersionRequest::Version { .. } | ToolVersionRequest::Prefix { .. }), "unsupported tool version request type")]
+    fn install_version_impl(&self, ctx: &InstallContext) -> Result<()> {
+        let tarball_path = self.downlaod(&ctx.tv, ctx.pr.as_ref())?;
+        self.install(ctx, &tarball_path)?;
+        self.verify(ctx)?;
+        Ok(())
+    }
+}
+
+
+fn os() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "freebsd") {
+        "freebsd"
+    } else {
+        &OS
+    }
+}
+
+
+fn arch() -> &'static str {
+    if cfg!(target_arch = "x86_64") || cfg!(target_arch = "amd64") {
+        "x86_64"
+    } else if cfg!(target_arch = "i686") || cfg!(target_arch = "i386") || cfg!(target_arch = "386")
+    {
+        "i386"
+    } else if cfg!(target_arch = "aarch64") || cfg!(target_arch = "arm64") {
+        "aarch64"
+    } else if cfg!(target_arch = "armv7a") {
+        "armv7a"
+    } else if cfg!(target_arch = "riscv64") {
+        "riscv64"
+    } else {
+        &ARCH
+    }
+}
+
+
+pub fn untar_xy(archive: &Path, dest: &Path) -> Result<()> {
+    let archive = archive.to_str().ok_or(eyre::eyre!("Failed to read archive path"))?;
+    let dest = dest.to_str().ok_or(eyre::eyre!("Failed to read destination path"))?;
+
+    let output = std::process::Command::new("tar")
+        .arg("-xf")
+        .arg(archive)
+        .arg("-C")
+        .arg(dest)
+        .output()?;
+
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        return Err(eyre::eyre!("Failed to extract tar: {}", err));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Integrated Zig into the list of supported languages. This new addition includes functionality for fetching remote versions, downloading, installing, and verifying the Zig installation. A new `zig.rs` file was created specifically for managing Zig related tasks. The reference to this ZigPlugin was included in the core plugins list.