### PR TITLE
chore: release 2024.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [2024.4.9](https://github.com/jdx/mise/compare/v2024.4.8..v2024.4.9) - 2024-04-29
+
+### 🚀 Features
+
+- **(node)** support comments in .nvmrc/.node-version by [@jdx](https://github.com/jdx) in [5915ae0](https://github.com/jdx/mise/commit/5915ae0a23d322e37f22847be11638f8ba108c15)
+- cli command for listing backends by [@roele](https://github.com/roele) in [#1989](https://github.com/jdx/mise/pull/1989)
+
+### 🐛 Bug Fixes
+
+- **(ci)** git2 reference by [@jdx](https://github.com/jdx) in [#1961](https://github.com/jdx/mise/pull/1961)
+- **(docker)** Ensure the e2e tests pass in the dev container by [@Adirelle](https://github.com/Adirelle) in [#1942](https://github.com/jdx/mise/pull/1942)
+- **(java)** inconsistent version resolution by [@roele](https://github.com/roele) in [#1957](https://github.com/jdx/mise/pull/1957)
+- **(zig)** can't install zig@master from v2024.4.6 by [@roele](https://github.com/roele) in [#1958](https://github.com/jdx/mise/pull/1958)
+- use mise fork of asdf-maven by [@jdx](https://github.com/jdx) in [5a01c1b](https://github.com/jdx/mise/commit/5a01c1b336a6e0a2ca0167aee6fa865318bd7f81)
+- deal with missing go/cargo/npm/etc in backends by [@jdx](https://github.com/jdx) in [#1976](https://github.com/jdx/mise/pull/1976)
+- mise doesn't change the trust hash file by [@roele](https://github.com/roele) in [#1979](https://github.com/jdx/mise/pull/1979)
+
+### 🚜 Refactor
+
+- converted just tasks in mise tasks. by [@Adirelle](https://github.com/Adirelle) in [#1948](https://github.com/jdx/mise/pull/1948)
+
+### 🧪 Testing
+
+- added cache for docker tests by [@jdx](https://github.com/jdx) in [#1977](https://github.com/jdx/mise/pull/1977)
+
+### 🔍 Other Changes
+
+- **(docker)** removed unused image by [@jdx](https://github.com/jdx) in [4150207](https://github.com/jdx/mise/commit/4150207c3464bf47207ea1c3c0959e7141ab27b8)
+- **(renovate)** ignore changes to registry/ subtree by [@jdx](https://github.com/jdx) in [c556149](https://github.com/jdx/mise/commit/c556149a88e73825306d98e3e3ea5b53692e0900)
+- buildjet by [@jdx](https://github.com/jdx) in [#1953](https://github.com/jdx/mise/pull/1953)
+- make git2 an optional build dependency by [@jdx](https://github.com/jdx) in [#1960](https://github.com/jdx/mise/pull/1960)
+- remove CODEOWNERS by [@jdx](https://github.com/jdx) in [304ba17](https://github.com/jdx/mise/commit/304ba171fd95701c04beb3d2a76bde0463a54209)
+
+### 📦️ Dependency Updates
+
+- update rust crate color-print to 0.3.6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1943](https://github.com/jdx/mise/pull/1943)
+- update amannn/action-semantic-pull-request action to v5.5.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1947](https://github.com/jdx/mise/pull/1947)
+- update rust crate demand to 1.1.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1944](https://github.com/jdx/mise/pull/1944)
+- update rust crate self_update to 0.40.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1954](https://github.com/jdx/mise/pull/1954)
+- update rust crate flate2 to 1.0.29 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1963](https://github.com/jdx/mise/pull/1963)
+- update serde monorepo to 1.0.199 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1964](https://github.com/jdx/mise/pull/1964)
+- update rust crate demand to 1.1.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1965](https://github.com/jdx/mise/pull/1965)
+- update rust crate zip to 1.1.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1985](https://github.com/jdx/mise/pull/1985)
+
+### New Contributors
+
+* @Adirelle made their first contribution in [#1948](https://github.com/jdx/mise/pull/1948)
+
 ## [2024.4.8](https://github.com/jdx/mise/compare/v2024.4.7..v2024.4.8) - 2024-04-23
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
+checksum = "4e9eabd7a98fe442131a17c316bd9349c43695e49e730c3c8e12cfb5f4da2693"
 dependencies = [
  "flate2",
  "futures-core",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fiat-crypto"
@@ -1044,9 +1044,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -1210,7 +1210,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -1337,7 +1337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.4.8"
+version = "2024.4.9"
 dependencies = [
  "assert_cmd",
  "base64 0.22.0",
@@ -2151,7 +2151,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "serde",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -2629,9 +2629,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2790,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -2979,7 +2979,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -3209,9 +3209,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "untrusted"
@@ -3468,11 +3468,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3631,9 +3631,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.4.8"
+version = "2024.4.9"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-mise 2024.4.8
+mise 2024.4.9
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.4.8";
+  version = "2024.4.9";
 
   src = lib.cleanSource ./.;
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -151,6 +151,25 @@ Examples:
     $ mise alias unset node lts-hydrogen
 ```
 
+## `mise backends ls`
+
+**Aliases:** `list`
+
+```text
+List built-in backends
+
+Usage: backends ls
+
+Examples:
+
+  $ mise backends ls
+  cargo
+  go
+  npm
+  pipx
+  ubi
+```
+
 ## `mise bin-paths`
 
 ```text

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.4.8" 
+.TH mise 1  "mise 2024.4.9" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -40,6 +40,9 @@ Initializes mise in the current shell session
 .TP
 mise\-alias(1)
 Manage aliases
+.TP
+mise\-backends(1)
+Manage backends
 .TP
 mise\-bin\-paths(1)
 List all the active runtime bin paths
@@ -183,6 +186,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.4.8
+v2024.4.9
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -122,6 +122,22 @@ This modifies the contents of ~/.config/mise/config.toml"
 cmd "asdf" hide=true help="[internal] simulates asdf for plugins that call \"asdf\" internally" {
     arg "[ARGS]..." help="all arguments" var=true
 }
+cmd "backends" help="Manage backends" {
+    alias "b"
+    alias "backend" "backend-list" hide=true
+    cmd "ls" help="List built-in backends" {
+        alias "list"
+        after_long_help r"Examples:
+
+  $ mise backends ls
+  cargo
+  go
+  npm
+  pipx
+  ubi
+"
+    }
+}
 cmd "bin-paths" help="List all the active runtime bin paths"
 cmd "cache" help="Manage the mise cache" {
     long_help r"Manage the mise cache

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.4.8
+Version: 2024.4.9
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/src/default_shorthands.rs
+++ b/src/default_shorthands.rs
@@ -463,7 +463,7 @@ pub static DEFAULT_SHORTHANDS: Lazy<HashMap<&'static str, &'static str>> =
     ("markdownlint-cli2", "https://github.com/paulo-ferraz-oliveira/asdf-markdownlint-cli2"),
     ("marp-cli", "https://github.com/xataz/asdf-marp-cli"),
     ("mask", "https://github.com/aaaaninja/asdf-mask.git"),
-    ("maven", "https://github.com/halcyon/asdf-maven.git"),
+    ("maven", "https://github.com/mise-plugins/asdf-maven.git"),
     ("mc", "https://github.com/penpyt/asdf-mc.git"),
     ("mdbook", "https://github.com/cipherstash/asdf-mdbook.git"),
     ("mdbook-linkcheck", "https://github.com/cipherstash/asdf-mdbook-linkcheck.git"),


### PR DESCRIPTION
### 🚀 Features

- **(node)** support comments in .nvmrc/.node-version by [@jdx](https://github.com/jdx) in [5915ae0](https://github.com/jdx/mise/commit/5915ae0a23d322e37f22847be11638f8ba108c15)
- cli command for listing backends by [@roele](https://github.com/roele) in [#1989](https://github.com/jdx/mise/pull/1989)

### 🐛 Bug Fixes

- **(ci)** git2 reference by [@jdx](https://github.com/jdx) in [#1961](https://github.com/jdx/mise/pull/1961)
- **(docker)** Ensure the e2e tests pass in the dev container by [@Adirelle](https://github.com/Adirelle) in [#1942](https://github.com/jdx/mise/pull/1942)
- **(java)** inconsistent version resolution by [@roele](https://github.com/roele) in [#1957](https://github.com/jdx/mise/pull/1957)
- **(zig)** can't install zig@master from v2024.4.6 by [@roele](https://github.com/roele) in [#1958](https://github.com/jdx/mise/pull/1958)
- use mise fork of asdf-maven by [@jdx](https://github.com/jdx) in [5a01c1b](https://github.com/jdx/mise/commit/5a01c1b336a6e0a2ca0167aee6fa865318bd7f81)
- deal with missing go/cargo/npm/etc in backends by [@jdx](https://github.com/jdx) in [#1976](https://github.com/jdx/mise/pull/1976)
- mise doesn't change the trust hash file by [@roele](https://github.com/roele) in [#1979](https://github.com/jdx/mise/pull/1979)

### 🚜 Refactor

- converted just tasks in mise tasks. by [@Adirelle](https://github.com/Adirelle) in [#1948](https://github.com/jdx/mise/pull/1948)

### 🧪 Testing

- added cache for docker tests by [@jdx](https://github.com/jdx) in [#1977](https://github.com/jdx/mise/pull/1977)

### 🔍 Other Changes

- **(docker)** removed unused image by [@jdx](https://github.com/jdx) in [4150207](https://github.com/jdx/mise/commit/4150207c3464bf47207ea1c3c0959e7141ab27b8)
- **(renovate)** ignore changes to registry/ subtree by [@jdx](https://github.com/jdx) in [c556149](https://github.com/jdx/mise/commit/c556149a88e73825306d98e3e3ea5b53692e0900)
- buildjet by [@jdx](https://github.com/jdx) in [#1953](https://github.com/jdx/mise/pull/1953)
- make git2 an optional build dependency by [@jdx](https://github.com/jdx) in [#1960](https://github.com/jdx/mise/pull/1960)
- remove CODEOWNERS by [@jdx](https://github.com/jdx) in [304ba17](https://github.com/jdx/mise/commit/304ba171fd95701c04beb3d2a76bde0463a54209)

### 📦️ Dependency Updates

- update rust crate color-print to 0.3.6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1943](https://github.com/jdx/mise/pull/1943)
- update amannn/action-semantic-pull-request action to v5.5.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1947](https://github.com/jdx/mise/pull/1947)
- update rust crate demand to 1.1.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1944](https://github.com/jdx/mise/pull/1944)
- update rust crate self_update to 0.40.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1954](https://github.com/jdx/mise/pull/1954)
- update rust crate flate2 to 1.0.29 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1963](https://github.com/jdx/mise/pull/1963)
- update serde monorepo to 1.0.199 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1964](https://github.com/jdx/mise/pull/1964)
- update rust crate demand to 1.1.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1965](https://github.com/jdx/mise/pull/1965)
- update rust crate zip to 1.1.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1985](https://github.com/jdx/mise/pull/1985)

### New Contributors

* @Adirelle made their first contribution in [#1948](https://github.com/jdx/mise/pull/1948)