### PR TITLE
Ensure the e2e tests pass in the dev container

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -112,7 +112,7 @@ run = 'docker build $root -f $root/packaging/dev/Dockerfile -t ghcr.io/jdx/mise:
 
 [tasks."docker:cargo"]
 description = "run cargo inside of development docker container"
-run = 'docker run -ti --rm -v $root:/mise -w /mise ghcr.io/jdx/mise:dev cargo'
+run = 'docker run -ti --rm -e "GITHUB_API_TOKEN=${GITHUB_API_TOKEN:-}" -v $root:/mise -w /mise ghcr.io/jdx/mise:dev cargo'
 
 [tasks."docker:mise"]
 description = "run mise inside of development docker container"

--- a/packaging/dev/Dockerfile
+++ b/packaging/dev/Dockerfile
@@ -20,6 +20,7 @@ RUN    apt-get update \
        direnv \
        fd-find \
        fish \
+       python3-venv \
     && ln -s /usr/bin/{fdfind,fd} \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
@@ -44,6 +45,7 @@ RUN    apt-get update \
     && cargo -V \
     && node -v \
     && npm -v \
+    && python3 -v \
     && just --version
 #    && mkdir -p $dev/cargo \
 #    && mv "$CARGO_HOME/registry" $dev/cargo/registry && ln -s $dev/cargo/registry "$CARGO_HOME/registry" \


### PR DESCRIPTION
This is an early, draft pull request.

As discussed on discord, its purpose is to have the e2e tests passing in the dev container, and also to use this container to run all the e2e tests in CI.