### PR TITLE
fix: mise doesn't change the trust hash file

### DIFF
--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -245,10 +245,8 @@ pub fn trust(path: &Path) -> Result<()> {
         file::make_symlink(path, &hashed_path)?;
     }
     let trust_hash_path = hashed_path.with_extension("hash");
-    if !trust_hash_path.exists() {
-        let hash = file_hash_sha256(path)?;
-        file::write(&trust_hash_path, hash)?;
-    }
+    let hash = file_hash_sha256(path)?;
+    file::write(trust_hash_path, hash)?;
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #1746 and fixes #1972.

Trusting a path should update the hash regardless if that file already exists or not. Otherwise changed configurations are never updated which interferes with `MISE_PARANOID`.