### PR TITLE
Revert "fix(java): inconsistent version resolution"

### DIFF
--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -415,17 +415,7 @@ fn fuzzy_match_filter(versions: Vec<String>, query: &str) -> eyre::Result<Vec<St
     if query == "latest" {
         query = "[0-9].*";
     }
-
-    // check for major versions (e.g. openjdk-17)
-    // for which we fuzzy match the exact version without minor/patch (see #1887)
-    let major_version_regex = Regex::new(r"[a-z]-\d{1,}$")?;
-    let query_regex_str = if major_version_regex.is_match(query) {
-        format!("^{}([+-].+)?$", query)
-    } else {
-        format!("^{}([+-.].+)?$", query)
-    };
-
-    let query_regex = Regex::new(&query_regex_str)?;
+    let query_regex = Regex::new(&format!("^{}([+-.].+)?$", query))?;
     let versions = versions
         .into_iter()
         .filter(|v| {


### PR DESCRIPTION
Reverts jdx/mise#1957

caused a bug:

```
$ mise install java@corretto-8 --verbose
[DEBUG] ARGS: target/debug/mise i java@corretto-8 --verbose
[DEBUG] Config {
    Config Files: [
        "~/src/mise/.mise.local.toml",
        "~/src/mise/.mise.toml",
        "~/src/mise/.mise/config.toml",
        "~/src/mise/.tool-versions",
        "~/src/mise/.node-version",
        "~/.mise/config.toml",
        "~/.config/mise/config.toml",
        "~/.tool-versions",
    ],
    Env: {
        "FOO_FROM_FILE": "foo_from_file",
        "FOO": ".mise.local.toml",
        "FOO_NUM": "1",
        "THIS_PROJECT": "/Users/jdx/src/mise-/Users/jdx/src/mise",
    },
    Path Dirs: [
        "/Users/jdx/src/mise/target/debug",
    ],
    Aliases: {
        ForgeArg("tiny"): {
            "abc": "1",
        },
    },
}
[DEBUG] Toolset: tiny@1, go@prefix:1.21, python@latest, shellcheck@0.10, shfmt@3, cargo:cargo-edit@latest, cargo:cargo-show@latest, cargo:git-cliff@latest, npm:markdownlint-cli@0.38, npm:prettier@3, jq@latest, node@lts/hydrogen, ruby@latest, java@22
Error: 
   0: no metadata found for version corretto-8

Location:
   src/plugins/core/java.rs:276

Version:
   2024.4.8-DEBUG macos-arm64 (1060234 2024-04-29)

Suggestion: Run with --verbose or MISE_VERBOSE=1 for more information.
```