### PR TITLE
chore: release 2024.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2024.4.11](https://github.com/jdx/mise/compare/v2024.4.10..v2024.4.11) - 2024-04-30
+
+### 🐛 Bug Fixes
+
+- **(self-update)** always use rustls by [@jdx](https://github.com/jdx) in [93a9c57](https://github.com/jdx/mise/commit/93a9c57ae895f1772a5ae8146d83713f631c77f1)
+
+### 🧪 Testing
+
+- **(java)** added e2e test for corretto-8 shorthand by [@jdx](https://github.com/jdx) in [#1995](https://github.com/jdx/mise/pull/1995)
+
+### 🔍 Other Changes
+
+- **(release)** fix cache by [@jdx](https://github.com/jdx) in [b54b25d](https://github.com/jdx/mise/commit/b54b25d06c49b5116ed37dda4c08005dfe7e6e11)
+- fix clippy warnings in latest rust beta by [@jdx](https://github.com/jdx) in [#1994](https://github.com/jdx/mise/pull/1994)
+
+### 📦️ Dependency Updates
+
+- update rust crate flate2 to 1.0.30 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1997](https://github.com/jdx/mise/pull/1997)
+
 ## [2024.4.10](https://github.com/jdx/mise/compare/v2024.4.9..v2024.4.10) - 2024-04-29
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 dependencies = [
  "jobserver",
  "libc",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.4.10"
+version = "2024.4.11"
 dependencies = [
  "assert_cmd",
  "base64 0.22.0",
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938a142ab806f18b88a97b0dea523d39e0fd730a064b035726adcfc58a8a5188"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
 dependencies = [
  "byteorder",
  "rmp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.4.10"
+version = "2024.4.11"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-mise 2024.4.10
+mise 2024.4.11
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.4.10";
+  version = "2024.4.11";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.4.10" 
+.TH mise 1  "mise 2024.4.11" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -186,6 +186,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.4.10
+v2024.4.11
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.4.10
+Version: 2024.4.11
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(self-update)** always use rustls by [@jdx](https://github.com/jdx) in [93a9c57](https://github.com/jdx/mise/commit/93a9c57ae895f1772a5ae8146d83713f631c77f1)

### 🧪 Testing

- **(java)** added e2e test for corretto-8 shorthand by [@jdx](https://github.com/jdx) in [#1995](https://github.com/jdx/mise/pull/1995)

### 🔍 Other Changes

- **(release)** fix cache by [@jdx](https://github.com/jdx) in [b54b25d](https://github.com/jdx/mise/commit/b54b25d06c49b5116ed37dda4c08005dfe7e6e11)
- fix clippy warnings in latest rust beta by [@jdx](https://github.com/jdx) in [#1994](https://github.com/jdx/mise/pull/1994)

### 📦️ Dependency Updates

- update rust crate flate2 to 1.0.30 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1997](https://github.com/jdx/mise/pull/1997)