### PR TITLE
chore: release 2024.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2024.5.0](https://github.com/jdx/mise/compare/v2024.4.12..v2024.5.0) - 2024-05-01
+
+### 🐛 Bug Fixes
+
+- **(release)** use target/release dir by [@jdx](https://github.com/jdx) in [e6448b3](https://github.com/jdx/mise/commit/e6448b335cf99db6fb2bdfd4c3f49ba255c2d8de)
+- **(release)** fixed the "serious" profile by [@jdx](https://github.com/jdx) in [487a1a0](https://github.com/jdx/mise/commit/487a1a0d336fed180123659ac59d1106d79f2d60)
+
+### 🔍 Other Changes
+
+- **(release)** added "serious" profile by [@jdx](https://github.com/jdx) in [f8ce139](https://github.com/jdx/mise/commit/f8ce139c1d0b41006dbbf1707801bf665f201ec6)
+
+### 📦️ Dependency Updates
+
+- update rust crate rmp-serde to 1.3.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#2007](https://github.com/jdx/mise/pull/2007)
+- update rust crate base64 to 0.22.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#2006](https://github.com/jdx/mise/pull/2006)
+
 ## [2024.4.12](https://github.com/jdx/mise/compare/v2024.4.11..v2024.4.12) - 2024-04-30
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.4.12"
+version = "2024.5.0"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -1729,9 +1729,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1740,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -2279,18 +2279,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.4.12"
+version = "2024.5.0"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-mise 2024.4.12
+mise 2024.5.0
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.4.12";
+  version = "2024.5.0";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.4.12" 
+.TH mise 1  "mise 2024.5.0" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -186,6 +186,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.4.12
+v2024.5.0
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.4.12
+Version: 2024.5.0
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(release)** use target/release dir by [@jdx](https://github.com/jdx) in [e6448b3](https://github.com/jdx/mise/commit/e6448b335cf99db6fb2bdfd4c3f49ba255c2d8de)
- **(release)** fixed the "serious" profile by [@jdx](https://github.com/jdx) in [487a1a0](https://github.com/jdx/mise/commit/487a1a0d336fed180123659ac59d1106d79f2d60)

### 🔍 Other Changes

- **(release)** added "serious" profile by [@jdx](https://github.com/jdx) in [f8ce139](https://github.com/jdx/mise/commit/f8ce139c1d0b41006dbbf1707801bf665f201ec6)

### 📦️ Dependency Updates

- update rust crate rmp-serde to 1.3.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#2007](https://github.com/jdx/mise/pull/2007)
- update rust crate base64 to 0.22.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#2006](https://github.com/jdx/mise/pull/2006)