### PR TITLE
feat(env): supports glob patterns in `env._.file` and `env._.source`

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -11,3 +11,5 @@ Library
 /pyproject.toml
 /poetry.lock
 /test-e2e/
+env.d
+source.d

--- a/e2e/test_env_file_glob
+++ b/e2e/test_env_file_glob
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "$0")/assert.sh"
+
+cat >.e2e.mise.toml <<EOF
+[env]
+_.file = "env.d/*.env"
+EOF
+
+mkdir -p env.d
+
+echo "VAR1=1" >env.d/1.env
+echo "VAR2=2" >env.d/2.env
+
+# mise trust --verbose
+mise env -s bash
+assert_contains "mise env -s bash" "VAR1=1"
+assert_contains "mise env -s bash" "VAR2=2"

--- a/e2e/test_env_source_glob
+++ b/e2e/test_env_source_glob
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "$0")/assert.sh"
+
+export MISE_EXPERIMENTAL=1
+
+cat >.e2e.mise.toml <<EOF
+[env]
+_.source = "source.d/*.sh"
+EOF
+
+mkdir -p source.d
+
+cat >source.d/1.sh <<EOF
+#!/usr/bin/env bash
+export SOURCE1=1
+EOF
+
+cat >source.d/2.sh <<EOF
+#!/usr/bin/env bash
+export SOURCE2=2
+EOF
+
+assert_contains "mise env -s bash" "SOURCE1=1"
+assert_contains "mise env -s bash" "SOURCE2=2"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -57,6 +57,7 @@ fn init_term_logger(level: LevelFilter) -> Box<dyn SharedLogger> {
             .set_thread_level(trace_level)
             .set_location_level(trace_level)
             .set_target_level(trace_level)
+            .add_filter_ignore(String::from("globset")) // debug!() statements break outputs
             .build(),
         TerminalMode::Stderr,
         ColorChoice::Auto,


### PR DESCRIPTION
This PR adds support for glob patterns in `env._.file` and `env._.source`.

Implements and fixes #1916

> [!Note] 
> I had to [explicitely disable `globset` logger](https://github.com/jdx/mise/pull/2016/files#diff-6658812715089c8241f20814aaf257dbd94a5448e01cf0010a0a2da54406f844R60) because of [this statement](https://github.com/BurntSushi/ripgrep/blob/master/crates/globset/src/lib.rs#L453-L463).
> Any `print` statement (`println!()`, `trace!()`, `debug()!()`...) called [inside the `std::fmt::Debug::fmt()` call of `Config`](https://github.com/jdx/mise/blob/main/src/config/mod.rs#L592-L620) just deadlock `mise`.
> Given [this line](https://github.com/jdx/mise/blob/main/src/config/mod.rs#L94) on init triggers a `Debug::fmt`, it triggers a deadlock on the first print. Disabling the `globset` logging in the TermLogger and removing the `trace!()` statements I initally added to both directives fixed [this deadlocked test](https://github.com/jdx/mise/actions/runs/8958121344/job/24602008803?pr=2016#step:6:129).
> I don't know if this is expected, but it was very hard to understand (given any print was just triggering the deadlock earlier).