### PR TITLE
fix: backend install directory not removed if empty

### DIFF
--- a/src/forge/forge_meta.rs
+++ b/src/forge/forge_meta.rs
@@ -11,7 +11,7 @@ pub struct ForgeMeta {
     pub forge_type: String,
 }
 
-const FORGE_META_FILENAME: &str = ".mise.forge.json";
+pub const FORGE_META_FILENAME: &str = ".mise.forge.json";
 
 impl ForgeMeta {
     pub fn read(dirname: &str) -> ForgeMeta {

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -32,7 +32,7 @@ use crate::{dirs, file};
 use self::forge_meta::ForgeMeta;
 
 mod cargo;
-mod forge_meta;
+pub mod forge_meta;
 mod go;
 mod npm;
 mod pipx;

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -9,7 +9,7 @@ use versions::Versioning;
 
 use crate::config::Config;
 use crate::file::make_symlink;
-use crate::forge::Forge;
+use crate::forge::{forge_meta, Forge};
 use crate::plugins::VERSION_REGEX;
 use crate::{file, forge};
 
@@ -30,8 +30,11 @@ pub fn rebuild(config: &Config) -> Result<()> {
             make_symlink(&to, &from)?;
         }
         remove_missing_symlinks(forge.clone())?;
-        // remove install dir if empty
-        file::remove_dir(installs_dir)?;
+        // remove install dir if empty (ignore metadata)
+        file::remove_dir_ignore(
+            installs_dir,
+            vec![forge_meta::FORGE_META_FILENAME.to_string()],
+        )?;
     }
     Ok(())
 }


### PR DESCRIPTION
Adds some new functions to remove a directory passing in a list of files to ignore for the empty dir check. This allows to remove the (empty) backend directory despite the new hidden `.mise.forge.json` file.

Fixes #2017 