### PR TITLE
Handle errors from the underlying plugin updates

### DIFF
--- a/src/cli/plugins/update.rs
+++ b/src/cli/plugins/update.rs
@@ -1,6 +1,5 @@
 use console::style;
-use eyre::Result;
-use itertools::Itertools;
+use eyre::{Report, Result};
 use rayon::prelude::*;
 use std::sync::Mutex;
 
@@ -47,32 +46,37 @@ impl Update {
         // let queue = Mutex::new(plugins);
         let settings = Settings::try_get()?;
         let mpr = MultiProgressReport::get();
+
         rayon::ThreadPoolBuilder::new()
             .num_threads(self.jobs.unwrap_or(settings.jobs))
             .build()?
             .install(|| {
-                let errors = Mutex::new(Vec::new());
-
+                let results = Mutex::new(Vec::new());
                 plugins.into_par_iter().for_each(|(plugin, ref_)| {
                     let prefix = format!("plugin:{}", style(plugin.id()).blue().for_stderr());
                     let pr = mpr.add(&prefix);
-                    match plugin.update(pr.as_ref(), ref_) {
-                        Ok(_) => (),
-                        Err(e) => {
-                            let plugin_name = plugin.name().to_owned();
-                            let mut errs = errors.lock().unwrap();
-                            errs.push((plugin_name, e))
-                        }
-                    }
+                    let mut results = results.lock().unwrap();
+                    let result = plugin.update(pr.as_ref(), ref_);
+                    results.push(result)
                 });
 
-                let locked_errors = errors.lock().unwrap();
-                if locked_errors.is_empty() {
-                    Ok(())
-                } else {
-                    let names = locked_errors.iter().map(|(name, _)| name).join(", ");
-                    Err(eyre::eyre!("Failed to update plugins: {}", names))
+                let locked_results = results.lock().unwrap();
+                if locked_results.iter().all(|r| r.is_ok()) {
+                    return Ok(());
                 }
+
+                let errors: Vec<&Report> = locked_results
+                    .iter()
+                    .filter_map(|r| r.as_ref().err())
+                    .collect();
+
+                let report = errors
+                    .into_iter()
+                    .fold(eyre!("encountered errors during update"), |report, e| {
+                        report.wrap_err(e)
+                    });
+
+                Err(report)
             })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn handle_err(err: Report) -> eyre::Result<()> {
         display_friendly_err(err);
         exit(1);
     }
-    Err(err).suggestion("Run with --verbose or MISE_VERBOSE=1 for more information.")
+    Err(err)
 }
 
 fn display_friendly_err(err: Report) {


### PR DESCRIPTION
This wraps things up so there's no panic when the plugin update fails.

This isn't perfect; it'd be nice to find a way to report the underlying
cause, if possible, but it beats a panic.

## The exception

``` 
The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value:
   0: git failed: Cmd(["git", "-C", "/Users/offby1/.local/share/mise/plugins/action-validator", "-c", "safe.directory=/Users/offby1/.local/share/mise/plugins/action-validator", "fetch", "--prune", "--update-head-ok", "origin", "main:main"]) From https://github.com/mpalmer/action-validator
       ! [rejected]        main       -> main  (non-fast-forward)
   0:

Location:
   src/git.rs:41

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
Location: src/cli/plugins/update.rs:55
```

Note that this change loses the _cause_, but survives without a crash. I'm open to suggestions about how to format the error.