### PR TITLE
feat: cleanup invalid symlinks in .local/state/mise/(tracked|trusted)-configs

### DIFF
--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -1,3 +1,4 @@
+use std::fs::read_dir;
 use std::path::PathBuf;
 
 use clap::ValueHint;
@@ -5,6 +6,8 @@ use eyre::Result;
 
 use crate::config;
 use crate::config::{config_file, DEFAULT_CONFIG_FILENAMES};
+use crate::dirs::TRUSTED_CONFIGS;
+use crate::file::remove_file;
 
 /// Marks a config file as trusted
 ///
@@ -43,6 +46,17 @@ impl Trust {
         } else {
             self.trust()
         }
+    }
+    pub fn clean() -> Result<()> {
+        if TRUSTED_CONFIGS.is_dir() {
+            for path in read_dir(&*TRUSTED_CONFIGS)? {
+                let path = path?.path();
+                if !path.exists() {
+                    remove_file(&path)?;
+                }
+            }
+        }
+        Ok(())
     }
     fn untrust(&self) -> Result<()> {
         let path = match &self.config_file {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,7 +29,7 @@ use crate::{dirs, env, file, forge};
 pub mod config_file;
 mod env_directive;
 pub mod settings;
-mod tracking;
+pub mod tracking;
 
 type AliasMap = BTreeMap<ForgeArg, BTreeMap<String, String>>;
 type ConfigMap = IndexMap<PathBuf, Box<dyn ConfigFile>>;

--- a/src/config/tracking.rs
+++ b/src/config/tracking.rs
@@ -21,7 +21,6 @@ impl Tracker {
     }
 
     pub fn list_all() -> Result<Vec<PathBuf>> {
-        Self::clean()?;
         let mut output = vec![];
         for path in read_dir(&*TRACKED_CONFIGS)? {
             let path = path?.path();
@@ -37,10 +36,12 @@ impl Tracker {
     }
 
     pub fn clean() -> Result<()> {
-        for path in read_dir(&*TRACKED_CONFIGS)? {
-            let path = path?.path();
-            if !path.exists() {
-                remove_file(&path)?;
+        if TRACKED_CONFIGS.is_dir() {
+            for path in read_dir(&*TRACKED_CONFIGS)? {
+                let path = path?.path();
+                if !path.exists() {
+                    remove_file(&path)?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Fixes #2020 by introducing an experimental `mise config prune` command to prune invalid config file references from `.local/state/mise/(tracked|trusted)-configs`.