### PR TITLE
include symlink error context in error message

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -205,7 +205,8 @@ pub fn make_symlink(target: &Path, link: &Path) -> Result<()> {
     if link.is_file() || link.is_symlink() {
         fs::remove_file(link)?;
     }
-    symlink(target, link)?;
+    symlink(target, link)
+        .wrap_err_with(|| format!("failed to ln -sf {} {}", target.display(), link.display()))?;
     Ok(())
 }
 


### PR DESCRIPTION
this change updates this error message

```bash
mise tracking config: Permission denied (os error 13)
```

to this:

```bash
mise tracking config: failed to ln -sf .../mise/.mise.local.toml ~/pule/.local/state/mise/tracked-configs/35d795b4e6c9a289: Permission denied (os error 13)
```

in my case there was a permission error on the destination link, which triggered an error for each 5 config files it was trying to link on every command. I was seeing this in my terminal, which on its own provides no context for debugging and is very noisy:

```bash
$ mise --version
2024.4.8 macos-arm64 (2024-04-23)
mise tracking config: Permission denied (os error 13)
mise tracking config: Permission denied (os error 13)
mise tracking config: Permission denied (os error 13)
mise tracking config: Permission denied (os error 13)
mise tracking config: Permission denied (os error 13)
```

the permission error on its own is an easy fix, I just needed to run mise with this debug info to figure out where the problem was