### PR TITLE
refactor: move opts from ToolVersion to ToolVersionRequest struct

### DIFF
--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -30,7 +30,7 @@ impl Latest {
         let config = Config::try_get()?;
         let mut prefix = match self.tool.tvr {
             None => self.asdf_version,
-            Some(ToolVersionRequest::Version(_, version)) => Some(version),
+            Some(ToolVersionRequest::Version { version, .. }) => Some(version),
             _ => bail!("invalid version: {}", self.tool.style()),
         };
 

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -43,7 +43,7 @@ impl LsRemote {
     fn run_single(self, plugin: Arc<dyn Forge>) -> Result<()> {
         let prefix = match &self.plugin {
             Some(tool_arg) => match &tool_arg.tvr {
-                Some(ToolVersionRequest::Version(_, v)) => Some(v.clone()),
+                Some(ToolVersionRequest::Version { version: v, .. }) => Some(v.clone()),
                 _ => self.prefix.clone(),
             },
             _ => self.prefix.clone(),

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -100,15 +100,12 @@ impl Uninstall {
                     .into_iter()
                     .map(|v| {
                         let tvr = ToolVersionRequest::new(tool.fa().clone(), v);
-                        let tv = ToolVersion::new(tool.as_ref(), tvr, Default::default(), v.into());
+                        let tv = ToolVersion::new(tool.as_ref(), tvr, v.into());
                         (tool.clone(), tv)
                     })
                     .collect::<Vec<_>>();
                 if let Some(tvr) = &a.tvr {
-                    tvs.push((
-                        tool.clone(),
-                        tvr.resolve(tool.as_ref(), Default::default(), false)?,
-                    ));
+                    tvs.push((tool.clone(), tvr.resolve(tool.as_ref(), false)?));
                 }
                 if tvs.is_empty() {
                     warn!("no versions found for {}", style(&tool).blue().for_stderr());

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -78,7 +78,7 @@ impl Upgrade {
                 tv.version.clone_from(latest);
                 tv
             })
-            .collect();
+            .collect::<Vec<_>>();
 
         let to_remove = outdated
             .into_iter()
@@ -101,6 +101,7 @@ impl Upgrade {
             raw: self.raw,
             latest_versions: true,
         };
+        let new_versions = new_versions.into_iter().map(|tv| tv.request).collect();
         ts.install_versions(config, new_versions, &mpr, &opts)?;
         for (tool, tv) in to_remove {
             let pr = mpr.add(&tv.style());

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -41,7 +41,7 @@ impl Where {
                         .versions
                         .get(&self.tool.forge)
                         .and_then(|v| v.requests.first())
-                        .map(|(r, _)| r.version());
+                        .map(|r| r.version());
                     self.tool.with_version(&v.unwrap_or(String::from("latest")))
                 }
             },
@@ -53,7 +53,7 @@ impl Where {
         match runtime
             .tvr
             .as_ref()
-            .map(|tvr| tvr.resolve(plugin.as_ref(), Default::default(), false))
+            .map(|tvr| tvr.resolve(plugin.as_ref(), false))
         {
             Some(Ok(tv)) if plugin.is_version_installed(&tv) => {
                 miseprintln!("{}", tv.install_path().to_string_lossy());

--- a/src/config/config_file/legacy_version.rs
+++ b/src/config/config_file/legacy_version.rs
@@ -20,10 +20,7 @@ impl LegacyVersionFile {
         for plugin in plugins {
             let version = plugin.parse_legacy_file(&path)?;
             for version in version.split_whitespace() {
-                toolset.add_version(
-                    ToolVersionRequest::new(plugin.fa().clone(), version),
-                    Default::default(),
-                );
+                toolset.add_version(ToolVersionRequest::new(plugin.fa().clone(), version));
             }
         }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -308,12 +308,12 @@ impl ConfigFile for MiseToml {
                     trust_check(&self.path)?;
                 }
                 let version = self.parse_template(&tool.tt.to_string())?;
-                let tvr = ToolVersionRequest::new(fa.clone(), &version);
                 let mut options = tool.options.clone();
                 for v in options.values_mut() {
                     *v = self.parse_template(v)?;
                 }
-                toolset.add_version(tvr, options);
+                let tvr = ToolVersionRequest::new_opts(fa.clone(), &version, options);
+                toolset.add_version(tvr);
             }
         }
         Ok(toolset)

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -100,7 +100,7 @@ impl dyn ConfigFile {
         for (fa, versions) in &plugins_to_update {
             let mut tvl = ToolVersionList::new(fa.clone(), ts.source.as_ref().unwrap().clone());
             for tv in versions {
-                tvl.requests.push(((*tv).clone(), Default::default()));
+                tvl.requests.push((*tv).clone());
             }
             ts.versions.insert(fa.clone(), tvl);
         }
@@ -111,7 +111,7 @@ impl dyn ConfigFile {
                 .map(|tvr| {
                     if pin {
                         let plugin = forge::get(&fa);
-                        let tv = tvr.resolve(plugin.as_ref(), Default::default(), false)?;
+                        let tv = tvr.resolve(plugin.as_ref(), false)?;
                         Ok(tv.version)
                     } else {
                         Ok(tvr.version())
@@ -144,7 +144,7 @@ impl dyn ConfigFile {
                 })?
                 .requests
                 .iter()
-                .map(|(tvr, _)| tvr.version())
+                .map(|tvr| tvr.version())
                 .collect::<Vec<_>>();
             miseprintln!("{}", tvl.join(" "));
             return Ok(true);

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-3.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-3.snap
@@ -8,13 +8,11 @@ Toolset {
             forge: ForgeArg("terraform"),
             versions: [],
             requests: [
-                (
-                    Version(
-                        ForgeArg("terraform"),
-                        "1.0.0",
-                    ),
-                    {},
-                ),
+                Version {
+                    forge: ForgeArg("terraform"),
+                    version: "1.0.0",
+                    options: {},
+                },
             ],
             source: MiseToml(
                 "~/fixtures/.mise.toml",
@@ -24,33 +22,24 @@ Toolset {
             forge: ForgeArg("node"),
             versions: [],
             requests: [
-                (
-                    Version(
-                        ForgeArg("node"),
-                        "18",
-                    ),
-                    {},
-                ),
-                (
-                    Prefix(
-                        ForgeArg("node"),
-                        "20",
-                    ),
-                    {},
-                ),
-                (
-                    Ref(
-                        ForgeArg("node"),
-                        "master",
-                    ),
-                    {},
-                ),
-                (
-                    Path(
-                        ForgeArg("node"),
-                        "~/.nodes/18",
-                    ),
-                    {},
+                Version {
+                    forge: ForgeArg("node"),
+                    version: "18",
+                    options: {},
+                },
+                Prefix {
+                    forge: ForgeArg("node"),
+                    prefix: "20",
+                    options: {},
+                },
+                Ref {
+                    forge: ForgeArg("node"),
+                    ref_: "master",
+                    options: {},
+                },
+                Path(
+                    ForgeArg("node"),
+                    "~/.nodes/18",
                 ),
             ],
             source: MiseToml(
@@ -61,13 +50,11 @@ Toolset {
             forge: ForgeArg("jq"),
             versions: [],
             requests: [
-                (
-                    Prefix(
-                        ForgeArg("jq"),
-                        "1.6",
-                    ),
-                    {},
-                ),
+                Prefix {
+                    forge: ForgeArg("jq"),
+                    prefix: "1.6",
+                    options: {},
+                },
             ],
             source: MiseToml(
                 "~/fixtures/.mise.toml",
@@ -77,13 +64,11 @@ Toolset {
             forge: ForgeArg("shellcheck"),
             versions: [],
             requests: [
-                (
-                    Version(
-                        ForgeArg("shellcheck"),
-                        "0.9.0",
-                    ),
-                    {},
-                ),
+                Version {
+                    forge: ForgeArg("shellcheck"),
+                    version: "0.9.0",
+                    options: {},
+                },
             ],
             source: MiseToml(
                 "~/fixtures/.mise.toml",
@@ -93,22 +78,18 @@ Toolset {
             forge: ForgeArg("python"),
             versions: [],
             requests: [
-                (
-                    Version(
-                        ForgeArg("python"),
-                        "3.10.0",
-                    ),
-                    {
+                Version {
+                    forge: ForgeArg("python"),
+                    version: "3.10.0",
+                    options: {
                         "venv": ".venv",
                     },
-                ),
-                (
-                    Version(
-                        ForgeArg("python"),
-                        "3.9.0",
-                    ),
-                    {},
-                ),
+                },
+                Version {
+                    forge: ForgeArg("python"),
+                    version: "3.9.0",
+                    options: {},
+                },
             ],
             source: MiseToml(
                 "~/fixtures/.mise.toml",

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__replace_versions.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__replace_versions.snap
@@ -8,20 +8,16 @@ Toolset {
             forge: ForgeArg("node"),
             versions: [],
             requests: [
-                (
-                    Version(
-                        ForgeArg("node"),
-                        "16.0.1",
-                    ),
-                    {},
-                ),
-                (
-                    Version(
-                        ForgeArg("node"),
-                        "18.0.1",
-                    ),
-                    {},
-                ),
+                Version {
+                    forge: ForgeArg("node"),
+                    version: "16.0.1",
+                    options: {},
+                },
+                Version {
+                    forge: ForgeArg("node"),
+                    version: "18.0.1",
+                    options: {},
+                },
             ],
             source: MiseToml(
                 "/tmp/.mise.toml",

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -128,7 +128,7 @@ impl ToolVersions {
         for (plugin, tvp) in &self.plugins {
             for version in &tvp.versions {
                 let tvr = ToolVersionRequest::new(plugin.clone(), version);
-                self.toolset.add_version(tvr, Default::default())
+                self.toolset.add_version(tvr)
             }
         }
     }

--- a/src/forge/cargo.rs
+++ b/src/forge/cargo.rs
@@ -11,7 +11,7 @@ use crate::file;
 use crate::forge::{Forge, ForgeType};
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::ToolVersionRequest;
 
 #[derive(Debug)]
 pub struct CargoForge {
@@ -28,7 +28,7 @@ impl Forge for CargoForge {
         &self.fa
     }
 
-    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+    fn get_dependencies(&self, _tvr: &ToolVersionRequest) -> eyre::Result<Vec<String>> {
         Ok(vec!["cargo".into(), "rust".into()])
     }
 

--- a/src/forge/go.rs
+++ b/src/forge/go.rs
@@ -8,7 +8,7 @@ use crate::file;
 
 use crate::forge::{Forge, ForgeType};
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::ToolVersionRequest;
 
 #[derive(Debug)]
 pub struct GoForge {
@@ -25,7 +25,7 @@ impl Forge for GoForge {
         &self.fa
     }
 
-    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+    fn get_dependencies(&self, _tvr: &ToolVersionRequest) -> eyre::Result<Vec<String>> {
         Ok(vec!["go".into()])
     }
 
@@ -112,7 +112,7 @@ fn trim_after_last_slash(s: &str) -> Option<&str> {
 }
 
 fn is_go_installed() -> bool {
-    file::which("go").is_some()
+    file::which_non_pristine("go").is_some()
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -145,7 +145,7 @@ pub trait Forge: Debug + Send + Sync {
     }
     /// If any of these tools are installing in parallel, we should wait for them to finish
     /// before installing this tool.
-    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+    fn get_dependencies(&self, _tvr: &ToolVersionRequest) -> eyre::Result<Vec<String>> {
         Ok(vec![])
     }
     fn list_remote_versions(&self) -> eyre::Result<Vec<String>> {

--- a/src/forge/npm.rs
+++ b/src/forge/npm.rs
@@ -8,7 +8,7 @@ use crate::config::{Config, Settings};
 use crate::file;
 use crate::forge::{Forge, ForgeType};
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::ToolVersionRequest;
 use serde_json::Value;
 
 #[derive(Debug)]
@@ -27,7 +27,7 @@ impl Forge for NPMForge {
         &self.fa
     }
 
-    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+    fn get_dependencies(&self, _tvr: &ToolVersionRequest) -> eyre::Result<Vec<String>> {
         Ok(vec!["node".into()])
     }
 

--- a/src/forge/pipx.rs
+++ b/src/forge/pipx.rs
@@ -8,7 +8,7 @@ use crate::file;
 
 use crate::forge::{Forge, ForgeType};
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::ToolVersionRequest;
 
 #[derive(Debug)]
 pub struct PIPXForge {
@@ -26,7 +26,7 @@ impl Forge for PIPXForge {
         &self.fa
     }
 
-    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+    fn get_dependencies(&self, _tvr: &ToolVersionRequest) -> eyre::Result<Vec<String>> {
         Ok(vec!["pipx".into()])
     }
 

--- a/src/forge/ubi.rs
+++ b/src/forge/ubi.rs
@@ -9,7 +9,7 @@ use crate::file;
 use crate::forge::{Forge, ForgeType};
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::ToolVersionRequest;
 use serde_json::Value;
 use url::Url;
 
@@ -32,7 +32,7 @@ impl Forge for UbiForge {
         &self.fa
     }
 
-    fn get_dependencies(&self, _tv: &ToolVersion) -> eyre::Result<Vec<String>> {
+    fn get_dependencies(&self, _tvr: &ToolVersionRequest) -> eyre::Result<Vec<String>> {
         Ok(vec!["cargo:ubi".into()])
     }
 
@@ -56,16 +56,6 @@ impl Forge for UbiForge {
         }
     }
 
-    fn ensure_dependencies_installed(&self) -> eyre::Result<()> {
-        if !is_ubi_installed() {
-            bail!(
-                "ubi is not installed. Please install it in order to install {}",
-                self.name()
-            );
-        }
-        Ok(())
-    }
-
     fn latest_stable_version(&self) -> eyre::Result<Option<String>> {
         if name_is_url(self.name()) {
             Ok(Some("latest".to_string()))
@@ -74,6 +64,16 @@ impl Forge for UbiForge {
                 .get_or_try_init(|| Ok(Some(self.list_remote_versions()?.last().unwrap().into())))
                 .cloned()
         }
+    }
+
+    fn ensure_dependencies_installed(&self) -> eyre::Result<()> {
+        if !is_ubi_installed() {
+            bail!(
+                "ubi is not installed. Please install it in order to install {}",
+                self.name()
+            );
+        }
+        Ok(())
     }
 
     fn install_version_impl(&self, ctx: &InstallContext) -> eyre::Result<()> {

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -108,7 +108,7 @@ impl Forge for ErlangPlugin {
 
         file::remove_all(ctx.tv.install_path())?;
         match &ctx.tv.request {
-            ToolVersionRequest::Ref(..) => {
+            ToolVersionRequest::Ref { .. } => {
                 unimplemented!("erlang does not yet support refs");
             }
             _ => {

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -247,7 +247,8 @@ impl JavaPlugin {
     }
 
     fn tv_release_type(&self, tv: &ToolVersion) -> String {
-        tv.opts
+        tv.request
+            .options()
             .get("release_type")
             .cloned()
             .unwrap_or(String::from("ga"))

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -161,7 +161,7 @@ impl PythonPlugin {
         let config = Config::get();
         let settings = Settings::get();
         self.install_or_update_python_build()?;
-        if matches!(&ctx.tv.request, ToolVersionRequest::Ref(..)) {
+        if matches!(&ctx.tv.request, ToolVersionRequest::Ref { .. }) {
             return Err(eyre!("Ref versions not supported for python"));
         }
         ctx.pr.set_message("Running python-build".into());
@@ -225,7 +225,7 @@ impl PythonPlugin {
         tv: &ToolVersion,
         pr: Option<&dyn SingleReport>,
     ) -> eyre::Result<Option<PathBuf>> {
-        if let Some(virtualenv) = tv.opts.get("virtualenv") {
+        if let Some(virtualenv) = tv.request.options().get("virtualenv") {
             let settings = Settings::try_get()?;
             if !settings.experimental {
                 warn!(

--- a/src/plugins/external_plugin_cache.rs
+++ b/src/plugins/external_plugin_cache.rs
@@ -94,7 +94,7 @@ fn render_cache_key(config: &Config, tv: &ToolVersion, cache_key: &[String]) -> 
 fn parse_template(config: &Config, tv: &ToolVersion, tmpl: &str) -> Result<String> {
     let mut ctx = BASE_CONTEXT.clone();
     ctx.insert("project_root", &config.project_root);
-    ctx.insert("opts", &tv.opts);
+    ctx.insert("opts", &tv.request.options());
     get_tera(
         config
             .project_root

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -83,7 +83,7 @@ impl ToolsetBuilder {
                 let mut env_ts = Toolset::new(source);
                 for v in v.split_whitespace() {
                     let tvr = ToolVersionRequest::new(fa.clone(), v);
-                    env_ts.add_version(tvr, Default::default());
+                    env_ts.add_version(tvr);
                 }
                 ts.merge(env_ts);
             }
@@ -98,7 +98,7 @@ impl ToolsetBuilder {
             let mut arg_ts = Toolset::new(ToolSource::Argument);
             for arg in args {
                 if let Some(tvr) = &arg.tvr {
-                    arg_ts.add_version(tvr.clone(), Default::default());
+                    arg_ts.add_version(tvr.clone());
                 } else if self.default_to_latest {
                     // TODO: see if there is a cleaner way to handle this scenario
                     // this logic is required for `mise x` because with that specific command mise
@@ -113,10 +113,7 @@ impl ToolsetBuilder {
                     });
 
                     if let Some((_ta, _fa)) = set_as_latest {
-                        arg_ts.add_version(
-                            ToolVersionRequest::new(arg.forge.clone(), "latest"),
-                            Default::default(),
-                        );
+                        arg_ts.add_version(ToolVersionRequest::new(arg.forge.clone(), "latest"));
                     }
                 }
             }

--- a/src/toolset/tool_version_list.rs
+++ b/src/toolset/tool_version_list.rs
@@ -1,14 +1,14 @@
 use crate::cli::args::ForgeArg;
 use crate::forge;
 use crate::toolset::tool_version_request::ToolVersionRequest;
-use crate::toolset::{ToolSource, ToolVersion, ToolVersionOptions};
+use crate::toolset::{ToolSource, ToolVersion};
 
 /// represents several versions of a tool for a particular plugin
 #[derive(Debug, Clone)]
 pub struct ToolVersionList {
     pub forge: ForgeArg,
     pub versions: Vec<ToolVersion>,
-    pub requests: Vec<(ToolVersionRequest, ToolVersionOptions)>,
+    pub requests: Vec<ToolVersionRequest>,
     pub source: ToolSource,
 }
 
@@ -24,8 +24,8 @@ impl ToolVersionList {
     pub fn resolve(&mut self, latest_versions: bool) {
         self.versions.clear();
         let plugin = forge::get(&self.forge);
-        for (tvr, opts) in &mut self.requests {
-            match tvr.resolve(plugin.as_ref(), opts.clone(), latest_versions) {
+        for tvr in &mut self.requests {
+            match tvr.resolve(plugin.as_ref(), latest_versions) {
                 Ok(v) => self.versions.push(v),
                 Err(err) => {
                     let source = self.source.to_string();
@@ -46,10 +46,7 @@ mod tests {
     fn test_tool_version_list() {
         let fa: ForgeArg = "tiny".parse().unwrap();
         let mut tvl = ToolVersionList::new(fa.clone(), ToolSource::Argument);
-        tvl.requests.push((
-            ToolVersionRequest::new(fa, "latest"),
-            ToolVersionOptions::default(),
-        ));
+        tvl.requests.push(ToolVersionRequest::new(fa, "latest"));
         tvl.resolve(true);
         assert_eq!(tvl.versions.len(), 1);
     }
@@ -61,10 +58,7 @@ mod tests {
         file::remove_all(dirs::CACHE.join("dummy")).unwrap();
         let fa: ForgeArg = "dummy".parse().unwrap();
         let mut tvl = ToolVersionList::new(fa.clone(), ToolSource::Argument);
-        tvl.requests.push((
-            ToolVersionRequest::new(fa, "latest"),
-            ToolVersionOptions::default(),
-        ));
+        tvl.requests.push(ToolVersionRequest::new(fa, "latest"));
         tvl.resolve(true);
         assert_eq!(tvl.versions.len(), 0);
         env::remove_var("MISE_FAILURE");


### PR DESCRIPTION
This will make it possible to delay resolving the version until after dependencies are installed.

Relates to #2053 
Relates to #2046 
Relates to #2029 
Relates to #2028
Relates to #2000
Relates to #1999 