### PR TITLE
fix: `.` in `list-bin-paths` was taken as is to form `PATH`

### DIFF
--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -296,7 +296,16 @@ impl ExternalPlugin {
             //     }
             // }
             let output = sm.cmd(&Script::ListBinPaths).read()?;
-            output.split_whitespace().map(|f| f.to_string()).collect()
+            output
+                .split_whitespace()
+                .map(|f| {
+                    if f == "." {
+                        String::new()
+                    } else {
+                        f.to_string()
+                    }
+                })
+                .collect()
         } else {
             vec!["bin".into()]
         };


### PR DESCRIPTION
`PATH` generated from this was like `/Users/user/.local/share/mise/installs/dotnet/8.0.204/.:/Users/user/.local/share/mise/installs/dotnet/8.0.204/shared:other-stuff...` which lead to executable not found.

Now with the fix, the `PATH` becomes `/Users/user/.local/share/mise/installs/dotnet/8.0.204/:/Users/user/.local/share/mise/installs/dotnet/8.0.204/shared:other-stuff...`, and the executable can be found.

This should fix #2076.