### PR TITLE
feat: pass github token to UBI and cargo-binstall backends.

### DIFF
--- a/e2e/forge/test_cargo_binstall_token
+++ b/e2e/forge/test_cargo_binstall_token
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+
+unset GITHUB_TOKEN GITHUB_API_TOKEN
+
+# Create an cargo-binstall stub that just output the value of GITHUB_TOKEN
+cat >~/bin/cargo-binstall <<'EOF'
+#!/usr/bin/env bash
+echo "token=$GITHUB_TOKEN"
+EOF
+chmod u+x ~/bin/cargo-binstall
+export PATH="$HOME/bin:$PATH"
+
+# This should reuse the existing GITHUB_TOKEN variable
+assert_contains "GITHUB_TOKEN=foobar mise install -f cargo:eza@0.17.0 2>&1" "token=foobar"
+
+# This should use the GITHUB_API_TOKEN variable
+assert_contains "GITHUB_API_TOKEN=foobar mise install -f cargo:eza@0.17.0 2>&1" "token=foobar"
+
+# This should prefer GITHUB_API_TOKEN
+assert_contains "GITHUB_TOKEN=foobar GITHUB_API_TOKEN=barquz mise install -f cargo:eza@0.17.0 2>&1" "token=foobar"

--- a/e2e/forge/test_ubi_token
+++ b/e2e/forge/test_ubi_token
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+
+unset GITHUB_TOKEN GITHUB_API_TOKEN
+
+# Create an ubi stub that just output the value of GITHUB_TOKEN
+cat >~/bin/ubi <<'EOF'
+#!/usr/bin/env bash
+echo "token=$GITHUB_TOKEN"
+EOF
+chmod u+x ~/bin/ubi
+export PATH="$HOME/bin:$PATH"
+
+# This should reuse the existing GITHUB_TOKEN variable
+assert_contains "GITHUB_TOKEN=foobar mise install -f ubi:goreleaser/goreleaser@v1.25.0 2>&1" "token=foobar"
+
+# This should use the GITHUB_API_TOKEN variable
+assert_contains "GITHUB_API_TOKEN=foobar mise install -f ubi:goreleaser/goreleaser@v1.25.0 2>&1" "token=foobar"
+
+# This should prefer GITHUB_API_TOKEN
+assert_contains "GITHUB_TOKEN=foobar GITHUB_API_TOKEN=barquz mise install -f ubi:goreleaser/goreleaser@v1.25.0 2>&1" "token=foobar"

--- a/src/env.rs
+++ b/src/env.rs
@@ -141,6 +141,11 @@ pub static PATH_NON_PRISTINE: Lazy<Vec<PathBuf>> = Lazy::new(|| match var("PATH"
 pub static DIRENV_DIFF: Lazy<Option<String>> = Lazy::new(|| var("DIRENV_DIFF").ok());
 #[allow(unused)]
 pub static GITHUB_API_TOKEN: Lazy<Option<String>> = Lazy::new(|| var("GITHUB_API_TOKEN").ok());
+pub static GITHUB_TOKEN: Lazy<Option<String>> = Lazy::new(|| {
+    var("GITHUB_TOKEN")
+        .or_else(|_| var("GITHUB_API_TOKEN"))
+        .ok()
+});
 
 pub static MISE_USE_VERSIONS_HOST: Lazy<bool> =
     Lazy::new(|| !var_is_false("MISE_USE_VERSIONS_HOST"));

--- a/src/forge/cargo.rs
+++ b/src/forge/cargo.rs
@@ -7,6 +7,7 @@ use crate::cache::CacheManager;
 use crate::cli::args::ForgeArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
+use crate::env::GITHUB_TOKEN;
 use crate::file;
 use crate::forge::{Forge, ForgeType};
 use crate::http::HTTP_FETCH;
@@ -54,7 +55,11 @@ impl Forge for CargoForge {
         let settings = Settings::get();
         settings.ensure_experimental("cargo backend")?;
         let cmd = if self.is_binstall_enabled() {
-            CmdLineRunner::new("cargo-binstall").arg("-y")
+            let mut runner = CmdLineRunner::new("cargo-binstall").arg("-y");
+            if let Some(token) = &*GITHUB_TOKEN {
+                runner = runner.env("GITHUB_TOKEN", token)
+            }
+            runner
         } else {
             CmdLineRunner::new("cargo").arg("install")
         };

--- a/src/forge/ubi.rs
+++ b/src/forge/ubi.rs
@@ -4,6 +4,7 @@ use crate::cache::CacheManager;
 use crate::cli::args::ForgeArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
+use crate::env::GITHUB_TOKEN;
 use crate::forge::{Forge, ForgeType};
 use crate::github;
 use crate::install_context::InstallContext;
@@ -63,6 +64,10 @@ impl Forge for UbiForge {
             .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path(&config)?)
             .prepend_path(ctx.ts.list_paths())?;
+
+        if let Some(token) = &*GITHUB_TOKEN {
+            cmd = cmd.env("GITHUB_TOKEN", token);
+        }
 
         if version != "latest" {
             cmd = cmd.arg("--tag").arg(version);


### PR DESCRIPTION
The environment variable GITHUB_TOKEN is passed through calls to ubi and cargo-binstall. If GITHUB_TOKEN is not defined but GITHUB_API_TOKEN is, it is passed GITHUB_TOKEN .

Resolves #2067.