### PR TITLE
fix: hide missing runtime warning in shim context

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -85,6 +85,9 @@ pub static MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
 
 pub static __USAGE: Lazy<Option<String>> = Lazy::new(|| var("__USAGE").ok());
 
+// true if running inside a shim
+pub static __MISE_SHIM: Lazy<bool> = Lazy::new(|| var_is_true("__MISE_SHIM"));
+
 #[cfg(test)]
 pub static TERM_WIDTH: Lazy<usize> = Lazy::new(|| 80);
 

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -32,6 +32,7 @@ pub fn handle_shim() -> Result<()> {
     trace!("shim[{bin_name}] args: {}", args.join(" "));
     let mut args: Vec<OsString> = args.iter().map(OsString::from).collect();
     args[0] = which_shim(&env::MISE_BIN_NAME)?.into();
+    env::set_var("__MISE_SHIM", "1");
     let exec = Exec {
         tool: vec![],
         c: None,

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -471,7 +471,7 @@ impl Toolset {
                     .is_ok_and(|f| !f.is_empty()),
             })
             .collect_vec();
-        if missing.is_empty() {
+        if missing.is_empty() || *env::__MISE_SHIM {
             return;
         }
         let versions = missing


### PR DESCRIPTION
Fixes #2101
