### PR TITLE
chore: release 2024.5.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,11 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest,cargo-deny,cargo-msrv,cargo-machete,usage-cli
-      - name: Install direnv
-        run: sudo apt-get update; sudo apt-get install direnv
       - run: |
           cargo build --all-features
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
-      - run: cargo nextest run --all-features
+      - run: mise install
+      - run: mise x -- cargo nextest run --all-features
       - run: cargo deny check
       - run: cargo msrv verify
       - run: cargo machete --with-metadata
@@ -50,11 +49,11 @@ jobs:
       - run: mise settings set experimental true
       - uses: actions/cache@v4
         with:
+          key: mise-tools-${{ hashFiles('.mise.toml') }}
+          restore-keys: mise-tools
           path: |
             ~/.local/share/mise/installs
             ~/.local/share/mise/plugins
-          key: mise-tools-${{ hashFiles('.mise.toml') }}
-          restore-keys: mise-tools
       - run: mise install
       - run: mise run render
       - if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'jdx/mise'
@@ -74,11 +73,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with: { toolchain: nightly, components: rustfmt, rustflags: "" }
-      - run: sudo apt-get update; sudo apt-get install direnv
+        with:
+          { toolchain: nightly, components: "rustfmt, clippy", rustflags: "" }
       - run: |
           cargo build --all-features
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
+      - uses: actions/cache@v4
+        with:
+          key: mise-tools-${{ hashFiles('.mise.toml') }}
+          restore-keys: mise-tools
+          path: |
+            ~/.local/share/mise/installs
+            ~/.local/share/mise/plugins
+      - run: mise install
       - run: mise run test:shuffle
       - if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'jdx/mise'
         run: mise run lint-fix && git diff HEAD

--- a/.mise.toml
+++ b/.mise.toml
@@ -20,6 +20,7 @@ shfmt = "3"
 "cargo:git-cliff" = "latest"
 "npm:markdownlint-cli" = "0.38"
 "npm:prettier" = "3"
+direnv = "latest"
 #python = { version = "latest", virtualenv = "{{env.HOME}}/.cache/venv" }
 #ruby = "3.1"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [2024.5.18](https://github.com/jdx/mise/compare/v2024.5.17..v2024.5.18) - 2024-05-19
+
+### 🚀 Features
+
+- added plugin registry to docs by [@jdx](https://github.com/jdx) in [#2138](https://github.com/jdx/mise/pull/2138)
+- added registry command by [@jdx](https://github.com/jdx) in [#2147](https://github.com/jdx/mise/pull/2147)
+- pre-commit and github action generate commands by [@jdx](https://github.com/jdx) in [#2144](https://github.com/jdx/mise/pull/2144)
+
+### 🐛 Bug Fixes
+
+- raise error if resolve fails and is a CLI argument by [@jdx](https://github.com/jdx) in [#2136](https://github.com/jdx/mise/pull/2136)
+- clean up architectures for precompiled binaries by [@jdx](https://github.com/jdx) in [#2137](https://github.com/jdx/mise/pull/2137)
+- add target and other configs to cache key logic by [@jdx](https://github.com/jdx) in [#2141](https://github.com/jdx/mise/pull/2141)
+
+### 🚜 Refactor
+
+- remove cmd_forge by [@jdx](https://github.com/jdx) in [#2142](https://github.com/jdx/mise/pull/2142)
+
+### 🧪 Testing
+
+- separate nightly into its own job by [@jdx](https://github.com/jdx) in [#2145](https://github.com/jdx/mise/pull/2145)
+- lint in nightly job by [@jdx](https://github.com/jdx) in [b5a3d08](https://github.com/jdx/mise/commit/b5a3d0884655f884319b23924d06566d597a4abe)
+
 ## [2024.5.17](https://github.com/jdx/mise/compare/v2024.5.16..v2024.5.17) - 2024-05-18
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
@@ -346,7 +346,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -398,7 +398,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -547,7 +547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -616,7 +616,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -649,7 +649,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -982,7 +982,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.5.17"
+version = "2024.5.18"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -1804,7 +1804,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1921,7 +1921,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2063,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
@@ -2472,7 +2472,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2655,7 +2655,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2677,9 +2677,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.64"
+version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
+checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2831,7 +2831,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2842,7 +2842,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
  "test-case-core",
 ]
 
@@ -2865,7 +2865,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2885,7 +2885,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3348,7 +3348,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
  "wasm-bindgen-shared",
 ]
 
@@ -3382,7 +3382,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3487,7 +3487,7 @@ checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3498,7 +3498,7 @@ checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.5.17"
+version = "2024.5.18"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-mise 2024.5.17
+mise 2024.5.18
 ```
 
 or install a specific a version:
@@ -44,7 +44,7 @@ or install a specific a version:
 ```sh-session
 $ curl https://mise.run | MISE_VERSION=v2024.5.16 sh
 $ ~/.local/bin/mise --version
-mise 2024.5.17
+mise 2024.5.18
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.5.17";
+  version = "2024.5.18";
 
   src = lib.cleanSource ./.;
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -85,6 +85,7 @@ editLink: false
 | calendarsync | [asdf:FeryET/asdf-calendarsync](https://github.com/FeryET/asdf-calendarsync) |
 | calicoctl | [asdf:TheCubicleJockey/asdf-calicoctl](https://github.com/TheCubicleJockey/asdf-calicoctl) |
 | camunda-modeler | [asdf:barmac/asdf-camunda-modeler](https://github.com/barmac/asdf-camunda-modeler) |
+| cargo-binstall | [cargo:cargo-binstall](https://crates.io/crates/cargo-binstall) |
 | cargo-make | [asdf:mise-plugins/asdf-cargo-make](https://github.com/mise-plugins/asdf-cargo-make) |
 | carp | [asdf:susurri/asdf-carp](https://github.com/susurri/asdf-carp) |
 | carthage | [asdf:younke/asdf-carthage](https://github.com/younke/asdf-carthage) |

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.5.17" 
+.TH mise 1  "mise 2024.5.18" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -192,6 +192,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.5.17
+v2024.5.18
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.5.17
+Version: 2024.5.18
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/scripts/render-registry.js
+++ b/scripts/render-registry.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-const {execSync} = require("node:child_process");
-const fs = require('node:fs');
+const { execSync } = require("node:child_process");
+const fs = require("node:fs");
 
-const stdout = execSync("mise registry", {encoding: "utf-8"});
+const stdout = execSync("mise registry", { encoding: "utf-8" });
 // Regular expression to match plugin name and repository URL
 // e.g.: zprint asdf:carlduevel/asdf-zprint
 const regex = /^(.+?) +(.+?):(.+?) *$/gm;
@@ -13,24 +13,32 @@ let output = ["---\neditLink: false\n---"];
 
 output.push("| Short | Full |\n| ----------- | --------------- |");
 while ((match = regex.exec(stdout)) !== null) {
-    if (match[2] === "asdf") {
-        let repoUrl = match[3].replace(/\.git$/, "");
-        if (!repoUrl.startsWith("http")) {
-            repoUrl = `https://github.com/${repoUrl}`;
-        }
-        output.push(`| ${match[1]} | [${match[2]}:${match[3]}](${repoUrl}) |`);
-    } else if (match[2] === 'core') {
-        output.push(`| ${match[1]} | [${match[2]}:${match[3]}](https://mise.jdx.dev/lang/${match[2]}.html) |`);
-    } else if (match[2] === 'cargo') {
-        output.push(`| ${match[1]} | [${match[2]}:${match[3]}](https://crates.io/crates/${match[3]}) |`);
-    } else if (match[2] === 'npm') {
-        output.push(`| ${match[1]} | [${match[2]}:${match[3]}](https://www.npmjs.com/package/${match[3]}) |`);
-    } else if (match[2] === 'pipx') {
-        output.push(`| ${match[1]} | [${match[2]}:${match[3]}](https://pypi.org/project/${match[3]}) |`);
-    } else {
-        output.push(`| ${match[1]} | ${match[2]}:${match[3]} |`);
+  if (match[2] === "asdf") {
+    let repoUrl = match[3].replace(/\.git$/, "");
+    if (!repoUrl.startsWith("http")) {
+      repoUrl = `https://github.com/${repoUrl}`;
     }
+    output.push(`| ${match[1]} | [${match[2]}:${match[3]}](${repoUrl}) |`);
+  } else if (match[2] === "core") {
+    output.push(
+      `| ${match[1]} | [${match[2]}:${match[3]}](https://mise.jdx.dev/lang/${match[2]}.html) |`,
+    );
+  } else if (match[2] === "cargo") {
+    output.push(
+      `| ${match[1]} | [${match[2]}:${match[3]}](https://crates.io/crates/${match[3]}) |`,
+    );
+  } else if (match[2] === "npm") {
+    output.push(
+      `| ${match[1]} | [${match[2]}:${match[3]}](https://www.npmjs.com/package/${match[3]}) |`,
+    );
+  } else if (match[2] === "pipx") {
+    output.push(
+      `| ${match[1]} | [${match[2]}:${match[3]}](https://pypi.org/project/${match[3]}) |`,
+    );
+  } else {
+    output.push(`| ${match[1]} | ${match[2]}:${match[3]} |`);
+  }
 }
-output.push('');
+output.push("");
 
-fs.writeFileSync("docs/registry.md", output.join('\n'));
+fs.writeFileSync("docs/registry.md", output.join("\n"));

--- a/src/forge/cargo.rs
+++ b/src/forge/cargo.rs
@@ -30,7 +30,7 @@ impl Forge for CargoForge {
     }
 
     fn get_dependencies(&self, _tvr: &ToolRequest) -> eyre::Result<Vec<ForgeArg>> {
-        Ok(vec!["cargo".into(), "cargo-binstall".into(), "rust".into()])
+        Ok(vec!["cargo".into(), "rust".into()])
     }
 
     fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -6,6 +6,7 @@ use crate::plugins::core::CORE_PLUGINS;
 
 const _REGISTRY: &[(&str, &str)] = &[
     ("ubi", "cargo:ubi"),
+    ("cargo-binstall", "cargo:cargo-binstall"),
     // ("elixir", "asdf:mise-plugins/mise-elixir"),
 ];
 


### PR DESCRIPTION
### 🚀 Features

- added plugin registry to docs by [@jdx](https://github.com/jdx) in [#2138](https://github.com/jdx/mise/pull/2138)
- added registry command by [@jdx](https://github.com/jdx) in [#2147](https://github.com/jdx/mise/pull/2147)
- pre-commit and github action generate commands by [@jdx](https://github.com/jdx) in [#2144](https://github.com/jdx/mise/pull/2144)

### 🐛 Bug Fixes

- raise error if resolve fails and is a CLI argument by [@jdx](https://github.com/jdx) in [#2136](https://github.com/jdx/mise/pull/2136)
- clean up architectures for precompiled binaries by [@jdx](https://github.com/jdx) in [#2137](https://github.com/jdx/mise/pull/2137)
- add target and other configs to cache key logic by [@jdx](https://github.com/jdx) in [#2141](https://github.com/jdx/mise/pull/2141)

### 🚜 Refactor

- remove cmd_forge by [@jdx](https://github.com/jdx) in [#2142](https://github.com/jdx/mise/pull/2142)

### 🧪 Testing

- separate nightly into its own job by [@jdx](https://github.com/jdx) in [#2145](https://github.com/jdx/mise/pull/2145)
- lint in nightly job by [@jdx](https://github.com/jdx) in [b5a3d08](https://github.com/jdx/mise/commit/b5a3d0884655f884319b23924d06566d597a4abe)