### PR TITLE
fix: clean up architectures for precompiled binaries

### DIFF
--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -133,13 +133,13 @@ fn os() -> &'static str {
 }
 
 fn arch() -> &'static str {
-    if cfg!(target_arch = "x86_64") || cfg!(target_arch = "amd64") {
+    if cfg!(target_arch = "x86_64") {
         if cfg!(target_feature = "avx2") {
             "x64"
         } else {
             "x64-baseline"
         }
-    } else if cfg!(target_arch = "aarch64") || cfg!(target_arch = "arm64") {
+    } else if cfg!(target_arch = "aarch64") {
         "aarch64"
     } else {
         &ARCH

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -156,9 +156,9 @@ fn os() -> &'static str {
 }
 
 fn arch() -> &'static str {
-    if cfg!(target_arch = "x86_64") || cfg!(target_arch = "amd64") {
+    if cfg!(target_arch = "x86_64") {
         "x86_64"
-    } else if cfg!(target_arch = "aarch64") || cfg!(target_arch = "arm64") {
+    } else if cfg!(target_arch = "aarch64") {
         "aarch64"
     } else {
         &ARCH

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -252,14 +252,11 @@ fn platform() -> &'static str {
 }
 
 fn arch() -> &'static str {
-    if cfg!(target_arch = "x86_64") || cfg!(target_arch = "amd64") {
+    if cfg!(target_arch = "x86_64") {
         "amd64"
-    } else if cfg!(target_arch = "i686") || cfg!(target_arch = "i386") || cfg!(target_arch = "386")
-    {
-        "386"
-    } else if cfg!(target_arch = "armv6l") || cfg!(target_arch = "armv7l") {
+    } else if cfg!(target_arch = "arm") {
         "armv6l"
-    } else if cfg!(target_arch = "aarch64") || cfg!(target_arch = "arm64") {
+    } else if cfg!(target_arch = "aarch64") {
         "arm64"
     } else {
         &ARCH

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -400,11 +400,11 @@ fn os() -> &'static str {
 }
 
 fn arch() -> &'static str {
-    if cfg!(target_arch = "x86_64") || cfg!(target_arch = "amd64") {
+    if cfg!(target_arch = "x86_64") {
         "x86_64"
-    } else if cfg!(target_arch = "armv6l") || cfg!(target_arch = "armv7l") {
+    } else if cfg!(target_arch = "arm") {
         "arm32-vfp-hflt"
-    } else if cfg!(target_arch = "aarch64") || cfg!(target_arch = "arm64") {
+    } else if cfg!(target_arch = "aarch64") {
         "aarch64"
     } else {
         &ARCH

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -389,7 +389,7 @@ fn python_arch(settings: &Settings) -> &str {
     if let Some(arch) = &settings.python_precompiled_arch {
         return arch.as_str();
     }
-    if cfg!(all(os = "linux", target_arch = "x86_64")) {
+    if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
         if cfg!(target_feature = "avx512f") {
             "x86_64_v4"
         } else if cfg!(target_feature = "avx2") {

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -163,14 +163,11 @@ fn os() -> &'static str {
 }
 
 fn arch() -> &'static str {
-    if cfg!(target_arch = "x86_64") || cfg!(target_arch = "amd64") {
+    if cfg!(target_arch = "x86_64") {
         "x86_64"
-    } else if cfg!(target_arch = "i686") || cfg!(target_arch = "i386") || cfg!(target_arch = "386")
-    {
-        "i386"
-    } else if cfg!(target_arch = "aarch64") || cfg!(target_arch = "arm64") {
+    } else if cfg!(target_arch = "aarch64") {
         "aarch64"
-    } else if cfg!(target_arch = "armv7a") {
+    } else if cfg!(target_arch = "arm") {
         "armv7a"
     } else if cfg!(target_arch = "riscv64") {
         "riscv64"


### PR DESCRIPTION
Most of these were incorrect and showing warnings on nightly
