### PR TITLE
chore: update kerl to 4.1.1

### DIFF
--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -17,7 +17,7 @@ pub struct ErlangPlugin {
     core: CorePlugin,
 }
 
-const KERL_VERSION: &str = "4.0.0";
+const KERL_VERSION: &str = "4.1.1";
 
 impl ErlangPlugin {
     pub fn new() -> Self {


### PR DESCRIPTION
4.1.1 supports the new OTP 27, including changes to building docs: https://github.com/kerl/kerl/releases/tag/4.1.1