### PR TITLE
fix: sort pipx forge remote versions semantically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "self_update",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ self_update = { version = "<0.40.0", default-features = false, features = [
     "compression-flate2",
     "signatures",
 ] }
+semver = "1.0.23"
 serde = "1.0.199"
 serde_derive = "1.0.199"
 serde_json = { version = "1.0.116", features = [] }

--- a/src/forge/pipx.rs
+++ b/src/forge/pipx.rs
@@ -10,6 +10,9 @@ use crate::github;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolRequest;
 
+use itertools::Itertools;
+use semver::Version;
+
 #[derive(Debug)]
 pub struct PIPXForge {
     fa: ForgeArg,
@@ -45,7 +48,9 @@ impl Forge for PIPXForge {
                         .as_object()
                         .ok_or_else(|| eyre::eyre!("Invalid pypi response"))?
                         .keys()
-                        .map(|k| k.to_string())
+                        .map(|k| Version::parse(k).unwrap())
+                        .sorted()
+                        .map(|v| v.to_string())
                         .collect();
                     Ok(versions)
                 }


### PR DESCRIPTION
Seems pypi sorts `releases` lexically which can result in the wrong version being selected for `latest` in the pipx forge. [Example](https://pypi.org/pypi/magic-wormhole/json)

Noticed this when attempting to use `pipx:magic-wormhole` which would install `v0.9.2` instead of `v0.14.0`.

Just like the last time I was in here, I'm not a rust person and just kinda fumbled my way through (and didn't write any tests!) so please destroy at will.

Previous behavior:
```
$ mise x pipx:magic-wormhole -- wormhole --version
creating virtual environment...
creating shared libraries...
upgrading shared libraries...
installing magic-wormhole from spec 'magic-wormhole==0.9.2'...
done! ✨ 🌟 ✨
mise pipx:magic-wormhole@0.9.2 ✓ installed                                                                                                                                                                                         magic-wormhole 0.9.2
```

New behavior:
```
$ cargo run x pipx:magic-wormhole -- wormhole --version
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `/tmp/mise/target/debug/mise x 'pipx:magic-wormhole' -- wormhole --version`
creating virtual environment...
creating shared libraries...
upgrading shared libraries...
installing magic-wormhole from spec 'magic-wormhole==0.14.0'...
done! ✨ 🌟 ✨
mise pipx:magic-wormhole@0.14.0 ✓ installed
magic-wormhole 0.14.0
```