### PR TITLE
chore: eliminate .tool-versions only used for jq

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -14,6 +14,7 @@ tiny = { version = "1", foo = "bar" }
 python = { version = "latest" }
 shellcheck = "0.10"
 shfmt = "3"
+jq = "latest"
 "cargo:cargo-edit" = "latest"
 "cargo:cargo-show" = "latest"
 "cargo:git-cliff" = "latest"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,0 @@
-shellcheck 0.9.0
-shfmt      sub-1:4
-jq         latest
-tiny       2 1 3


### PR DESCRIPTION
Pretty self-explanatory.

After an initial clone, I thought it was odd that I got:

```shell
$ mise ls --current
Plugin                Version   Config Source                             Requested
actionlint            1.7.0     ~/Code/github.com/jdx/mise/.mise.toml     latest
cargo:cargo-edit      0.12.2    ~/Code/github.com/jdx/mise/.mise.toml     latest
cargo:cargo-show      0.6.0     ~/Code/github.com/jdx/mise/.mise.toml     latest
cargo:git-cliff       2.2.2     ~/Code/github.com/jdx/mise/.mise.toml     latest
direnv                2.34.0    ~/Code/github.com/jdx/mise/.mise.toml     latest
jq                    1.7.1     ~/Code/github.com/jdx/mise/.tool-versions latest
npm:markdownlint-cli  0.38.0    ~/Code/github.com/jdx/mise/.mise.toml     0.38
npm:prettier          3.2.5     ~/Code/github.com/jdx/mise/.mise.toml     3
python                3.12.3    ~/Code/github.com/jdx/mise/.mise.toml     latest
ruby                  3.3.1     ~/.config/mise/config.toml                3.3.1
shellcheck            0.10.0    ~/Code/github.com/jdx/mise/.mise.toml     0.10
shfmt                 3.8.0     ~/Code/github.com/jdx/mise/.mise.toml     3
tiny                  1.1.0     ~/Code/github.com/jdx/mise/.mise.toml     1
usage                 0.2.1     ~/.config/mise/config.toml                latest
```

so I removed the (main) outlier [it also seems odd and possibly like a bug that globals are included in a `--current` output (because this is a child of my home directory?) but that's for another issue or PR]