### PR TITLE
chore: resolve macros/derived-traits from crates w/ scopes rather than globally

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -158,6 +158,8 @@ static KEY: Lazy<String> = Lazy::new(|| {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]

--- a/src/cli/alias/get.rs
+++ b/src/cli/alias/get.rs
@@ -41,6 +41,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::test::reset;
 
     #[test]

--- a/src/cli/args/env_var_arg.rs
+++ b/src/cli/args/env_var_arg.rs
@@ -26,9 +26,12 @@ impl FromStr for EnvVarArg {
 
 #[cfg(test)]
 mod tests {
-    use super::EnvVarArg;
-    use crate::test::reset;
+    use pretty_assertions::assert_eq;
     use test_log::test;
+
+    use crate::test::reset;
+
+    use super::EnvVarArg;
 
     #[test]
     fn valid_values() {

--- a/src/cli/args/forge_arg.rs
+++ b/src/cli/args/forge_arg.rs
@@ -97,6 +97,8 @@ static FORGE_MAP: Lazy<HashMap<&'static str, ForgeArg>> = Lazy::new(|| {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::{assert_eq, assert_str_eq};
+
     use super::*;
 
     #[test]

--- a/src/cli/args/tool_arg.rs
+++ b/src/cli/args/tool_arg.rs
@@ -163,6 +163,8 @@ fn parse_input(s: &str) -> (&str, Option<&str>) {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]

--- a/src/cli/args/tool_arg.rs
+++ b/src/cli/args/tool_arg.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use console::style;
+use eyre::bail;
 use regex::Regex;
 
 use crate::cli::args::ForgeArg;

--- a/src/cli/asdf.rs
+++ b/src/cli/asdf.rs
@@ -71,6 +71,8 @@ fn list_versions(config: &Config, args: &[String]) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::test::reset;
 
     #[test]

--- a/src/cli/cache/mod.rs
+++ b/src/cli/cache/mod.rs
@@ -43,6 +43,8 @@ impl Cache {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_str_eq;
+
     use crate::env;
 
     #[test]

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -1,6 +1,7 @@
 use clap::builder::PossibleValue;
 use clap::ValueEnum;
 use eyre::Result;
+use strum::EnumString;
 
 /// Generate shell completions
 #[derive(Debug, clap::Args)]
@@ -73,7 +74,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 "#
 );
 
-#[derive(Debug, Clone, Copy, EnumString, Display)]
+#[derive(Debug, Clone, Copy, EnumString, strum::Display)]
 #[strum(serialize_all = "snake_case")]
 enum Shell {
     Bash,

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -1,5 +1,5 @@
 use console::style;
-use eyre::Result;
+use eyre::{bail, Result};
 
 use crate::cli::args::ForgeArg;
 use crate::config::Config;

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -102,10 +102,10 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     shfmt 3.6.0
     shellcheck 0.9.0
     node 20.0.0
-  
+
     $ <bold>mise current node</bold>
     20.0.0
-  
+
     # can output multiple versions
     $ <bold>mise current python</bold>
     3.11.0 3.10.0

--- a/src/cli/deactivate.rs
+++ b/src/cli/deactivate.rs
@@ -50,6 +50,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::config::Config;
     use crate::env;
     use crate::test::reset;

--- a/src/cli/deactivate.rs
+++ b/src/cli/deactivate.rs
@@ -1,4 +1,5 @@
 use eyre::{eyre, Result};
+use indoc::formatdoc;
 
 use crate::shell::get_shell;
 use crate::ui::style;

--- a/src/cli/deactivate.rs
+++ b/src/cli/deactivate.rs
@@ -1,4 +1,4 @@
-use eyre::Result;
+use eyre::{eyre, Result};
 
 use crate::shell::get_shell;
 use crate::ui::style;

--- a/src/cli/direnv/activate.rs
+++ b/src/cli/direnv/activate.rs
@@ -1,4 +1,5 @@
 use eyre::Result;
+use indoc::indoc;
 
 /// Output direnv function to use mise inside direnv
 ///

--- a/src/cli/direnv/envrc.rs
+++ b/src/cli/direnv/envrc.rs
@@ -57,6 +57,9 @@ impl Envrc {
 
 #[cfg(test)]
 mod tests {
+
+    use insta::assert_snapshot;
+
     use crate::test::reset;
     use crate::{dirs, file};
 

--- a/src/cli/direnv/exec.rs
+++ b/src/cli/direnv/exec.rs
@@ -50,6 +50,8 @@ fn env_cmd() -> Expression {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_str_eq;
+
     use crate::cli::tests::grep;
     use crate::test::reset;
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -3,6 +3,7 @@ use std::process::exit;
 
 use console::{pad_str, style, Alignment};
 use indenter::indented;
+use indoc::formatdoc;
 use itertools::Itertools;
 use rayon::prelude::*;
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -71,6 +71,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 mod tests {
     use std::env;
 
+    use pretty_assertions::assert_str_eq;
+
     use crate::cli::tests::grep;
     use crate::dirs;
     use crate::test::reset;

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -142,9 +142,12 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::reset;
     use std::env;
+
+    use insta::assert_snapshot;
     use test_log::test;
+
+    use crate::test::reset;
 
     #[test]
     fn test_exec_ok() {

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -3,7 +3,10 @@ use std::ffi::{OsStr, OsString};
 
 use clap::ValueHint;
 use duct::IntoExecutablePath;
-use eyre::Result;
+#[cfg(not(any(test, windows)))]
+use eyre::{bail, Result};
+#[cfg(any(test, windows))]
+use eyre::{eyre, Result};
 
 use crate::cli::args::ToolArg;
 #[cfg(any(test, windows))]

--- a/src/cli/generate/git_pre_commit.rs
+++ b/src/cli/generate/git_pre_commit.rs
@@ -66,6 +66,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use test_log::test;
 
     use crate::file;

--- a/src/cli/generate/github_action.rs
+++ b/src/cli/generate/github_action.rs
@@ -84,6 +84,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use test_log::test;
 
     use crate::file;

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -76,6 +76,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_str_eq;
+
     use crate::test::reset;
     use crate::{dirs, file};
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -142,6 +142,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_str_eq;
+
     use crate::dirs;
     use crate::test::reset;
 

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -66,6 +66,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use pretty_assertions::assert_str_eq;
     use test_log::test;
 

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -66,8 +66,10 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::reset;
+    use pretty_assertions::assert_str_eq;
     use test_log::test;
+
+    use crate::test::reset;
 
     #[test]
     fn test_latest() {

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{bail, Result};
 
 use crate::cli::args::ToolArg;
 use crate::config::Config;

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -92,9 +92,9 @@ mod tests {
         create_dir_all("../data/tmp/tiny").unwrap();
         assert_cli!("link", "tiny@9.8.7", "../data/tmp/tiny");
         assert_cli_snapshot!("ls", "tiny", @r###"
-        tiny  1.0.1                                       
-        tiny  2.1.0                                       
-        tiny  3.0.1                                       
+        tiny  1.0.1
+        tiny  2.1.0
+        tiny  3.0.1
         tiny  3.1.0            ~/cwd/.test-tool-versions 3
         tiny  9.8.7 (symlink)
         "###);

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::ValueHint;
 use color_eyre::eyre::{eyre, Result};
 use console::style;
+use eyre::bail;
 use path_absolutize::Absolutize;
 
 use crate::cli::args::ToolArg;

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -160,6 +160,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 mod tests {
     use std::panic;
 
+    use insta::assert_snapshot;
     use pretty_assertions::assert_str_eq;
 
     use crate::cli::tests::grep;

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -160,6 +160,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 mod tests {
     use std::panic;
 
+    use pretty_assertions::assert_str_eq;
+
     use crate::cli::tests::grep;
     use crate::test::{cleanup, reset};
     use crate::{dirs, forge};

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -409,14 +409,14 @@ mod tests {
         assert_cli!("install", "tiny@2.0.0");
         assert_cli_snapshot!("list", @r###"
         dummy  ref:master  ~/.test-tool-versions     ref:master
-        tiny   2.0.0                                           
+        tiny   2.0.0
         tiny   3.1.0       ~/cwd/.test-tool-versions 3
         "###);
 
         assert_cli!("uninstall", "tiny@3.1.0");
         assert_cli_snapshot!("list", @r###"
         dummy  ref:master       ~/.test-tool-versions     ref:master
-        tiny   2.0.0                                                
+        tiny   2.0.0
         tiny   3.1.0 (missing)  ~/cwd/.test-tool-versions 3
         "###);
 

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -392,6 +392,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_str_eq;
+
     use crate::dirs;
     use crate::file::remove_all;
     use crate::test::reset;

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use console::style;
-use eyre::Result;
+use eyre::{ensure, Result};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use serde_derive::Serialize;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use clap::{FromArgMatches, Subcommand};
 use color_eyre::Result;
+use indoc::indoc;
 
 use crate::config::Settings;
 use crate::{logger, migrate, shims};

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -167,9 +167,10 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::reset;
+    use insta::assert_snapshot;
     use test_log::test;
 
+    use crate::test::reset;
     #[test]
     fn test_plugin_install_invalid_url() {
         reset();

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::{eyre, Result};
+use color_eyre::eyre::{bail, eyre, Result};
 use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
 use url::Url;

--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -114,9 +114,11 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+    use test_log::test;
+
     use crate::cli::tests::grep;
     use crate::test::reset;
-    use test_log::test;
 
     #[test]
     fn test_plugin_list() {

--- a/src/cli/plugins/update.rs
+++ b/src/cli/plugins/update.rs
@@ -1,5 +1,5 @@
 use console::style;
-use eyre::{Report, Result};
+use eyre::{eyre, Report, Result};
 use rayon::prelude::*;
 
 use crate::config::Settings;

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -64,6 +64,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use test_log::test;
 
     use crate::cli::tests::grep;

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -1,6 +1,7 @@
 use clap::builder::StyledStr;
 use console::strip_ansi_codes;
 use eyre::Result;
+use indoc::formatdoc;
 use itertools::Itertools;
 
 use crate::cli::Cli;
@@ -113,11 +114,13 @@ fn remove_trailing_spaces(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::reset;
     use std::fs;
 
-    use crate::file;
+    use indoc::indoc;
     use test_log::test;
+
+    use crate::file;
+    use crate::test::reset;
 
     #[test]
     fn test_render_help() {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -14,7 +14,7 @@ use console::Color;
 use demand::{DemandOption, Select};
 use duct::IntoExecutablePath;
 use either::Either;
-use eyre::Result;
+use eyre::{bail, ensure, eyre, Result};
 use globwalk::GlobWalkerBuilder;
 use itertools::Itertools;
 use once_cell::sync::Lazy;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -589,6 +589,8 @@ fn format_duration(dur: std::time::Duration) -> String {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::file;
     use crate::test::reset;
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -557,7 +557,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 "#
 );
 
-#[derive(Debug, PartialEq, EnumString)]
+#[derive(Debug, PartialEq, strum::EnumString)]
 #[strum(serialize_all = "snake_case")]
 enum TaskOutput {
     Prefix,

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1,4 +1,4 @@
-use color_eyre::Result;
+use color_eyre::{eyre::bail, Result};
 use console::style;
 use self_update::backends::github::{ReleaseList, Update};
 use self_update::update::Release;

--- a/src/cli/set.rs
+++ b/src/cli/set.rs
@@ -128,6 +128,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 mod tests {
     use std::path::PathBuf;
 
+    use insta::assert_snapshot;
+
     use crate::test::reset;
     use crate::{env, file};
 

--- a/src/cli/set.rs
+++ b/src/cli/set.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use eyre::Result;
+use eyre::{bail, Result};
 use tabled::Tabled;
 
 use crate::config::config_file::mise_toml::MiseToml;

--- a/src/cli/settings/get.rs
+++ b/src/cli/settings/get.rs
@@ -1,4 +1,5 @@
 use crate::config::Settings;
+use eyre::bail;
 
 /// Show a current setting
 ///

--- a/src/cli/settings/get.rs
+++ b/src/cli/settings/get.rs
@@ -48,6 +48,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 #[cfg(test)]
 mod tests {
     use crate::test::reset;
+    use insta::assert_snapshot;
 
     #[test]
     fn test_settings_get() {

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -1,4 +1,4 @@
-use eyre::Result;
+use eyre::{eyre, Result};
 use toml_edit::DocumentMut;
 
 use crate::config::settings::SettingsFile;

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -1,5 +1,6 @@
 use color_eyre::eyre::{eyre, Result};
 use console::style;
+use indoc::formatdoc;
 
 use crate::cli::args::ToolArg;
 use crate::config::Config;

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -94,8 +94,11 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::reset;
     use std::env;
+
+    use insta::assert_snapshot;
+
+    use crate::test::reset;
 
     #[test]
     fn test_shell() {

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -1,5 +1,5 @@
 use console::style;
-use eyre::Result;
+use eyre::{eyre, Result};
 use itertools::Itertools;
 use petgraph::dot::Dot;
 

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -122,7 +122,7 @@ impl Uninstall {
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
-    
+
     $ <bold>mise uninstall node@18.0.0</bold> # will uninstall specific version
     $ <bold>mise uninstall node</bold>        # will uninstall current node version
     $ <bold>mise uninstall --all node@18.0.0</bold> # will uninstall all node versions

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use console::style;
-use eyre::{Result, WrapErr};
+use eyre::{bail, eyre, Result, WrapErr};
 use itertools::Itertools;
 use rayon::prelude::*;
 

--- a/src/cli/unset.rs
+++ b/src/cli/unset.rs
@@ -58,6 +58,8 @@ fn get_mise_toml(filename: &Path) -> Result<MiseToml> {
 mod tests {
     use std::path::PathBuf;
 
+    use insta::assert_snapshot;
+
     use crate::{env, file};
 
     fn remove_config_file(filename: &str) -> PathBuf {

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -216,6 +216,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::test::reset;
     use crate::{dirs, env, file};
 

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -1,7 +1,7 @@
 use std::process::exit;
 
 use console::style;
-use eyre::Result;
+use eyre::{eyre, Result};
 
 use crate::cli::args::ForgeArg;
 use crate::cmd;

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -83,6 +83,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use pretty_assertions::assert_str_eq;
     use test_log::test;
 

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -83,9 +83,11 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_str_eq;
+    use test_log::test;
+
     use crate::dirs;
     use crate::test::reset;
-    use test_log::test;
 
     #[test]
     fn test_where() {

--- a/src/cli/which.rs
+++ b/src/cli/which.rs
@@ -1,4 +1,4 @@
-use eyre::Result;
+use eyre::{bail, Result};
 
 use crate::cli::args::ToolArg;
 use crate::config::Config;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -409,6 +409,8 @@ enum ChildProcessOutput {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use crate::cmd;
 
     #[test]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -863,11 +863,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use dirs::CWD;
     use indoc::formatdoc;
-
-    use crate::test::{replace_path, reset};
+    use insta::{assert_debug_snapshot, assert_snapshot};
     use test_log::test;
+
+    use crate::dirs::CWD;
+    use crate::test::{replace_path, reset};
 
     use super::*;
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -864,6 +864,7 @@ where
 #[cfg(test)]
 mod tests {
     use dirs::CWD;
+    use indoc::formatdoc;
 
     use crate::test::{replace_path, reset};
     use test_log::test;

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Formatter};
 use std::path::{Path, PathBuf};
 
-use eyre::WrapErr;
+use eyre::{eyre, WrapErr};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -350,6 +350,8 @@ pub fn reset() {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
+use eyre::eyre;
 use once_cell::sync::Lazy;
 use serde_derive::Deserialize;
 use versions::Versioning;

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -206,6 +206,7 @@ impl ConfigFile for ToolVersions {
 #[cfg(test)]
 pub(crate) mod tests {
     use indoc::indoc;
+    use insta::assert_snapshot;
     use pretty_assertions::assert_eq;
     use test_log::test;
 

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -205,13 +205,14 @@ impl ConfigFile for ToolVersions {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
+    use test_log::test;
 
     use crate::env;
     use crate::test::reset;
 
     use super::*;
-    use test_log::test;
 
     #[test]
     fn test_parse() {

--- a/src/config/env_directive.rs
+++ b/src/config/env_directive.rs
@@ -237,10 +237,12 @@ impl EnvResults {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_debug_snapshot;
+    use test_log::test;
+
     use crate::test::{replace_path, reset};
 
     use super::*;
-    use test_log::test;
 
     #[test]
     fn test_env_path() {

--- a/src/config/env_directive.rs
+++ b/src/config/env_directive.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
 
-use eyre::Context;
+use eyre::{eyre, Context};
 use indexmap::IndexMap;
 
 use crate::cmd::CmdLineRunner;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ use std::iter::once;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock, RwLock};
 
-use eyre::{Context, Result};
+use eyre::{ensure, eyre, Context, Result};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use once_cell::sync::{Lazy, OnceCell};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -654,8 +654,11 @@ fn default_task_includes() -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use insta::assert_debug_snapshot;
+
     use crate::test::reset;
+
+    use super::*;
 
     #[test]
     fn test_load() {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex, RwLock};
 #[allow(unused_imports)]
 use confique::env::parse::{list_by_colon, list_by_comma};
 use confique::{Config, Partial};
-use eyre::Result;
+use eyre::{bail, Result};
 use once_cell::sync::Lazy;
 use serde::ser::Error;
 use serde_derive::{Deserialize, Serialize};

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -155,7 +155,9 @@ pub struct SettingsStatus {
     pub show_tools: bool,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, EnumString, Display)]
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, Default, strum::EnumString, strum::Display,
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum SettingsStatusMissingTools {

--- a/src/direnv.rs
+++ b/src/direnv.rs
@@ -111,6 +111,8 @@ impl Display for DirenvDiff {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use super::*;
 
     #[test]

--- a/src/env.rs
+++ b/src/env.rs
@@ -385,9 +385,12 @@ pub fn is_activated() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test::reset;
+    use pretty_assertions::assert_eq;
     use test_log::test;
+
+    use crate::test::reset;
+
+    use super::*;
 
     #[test]
     fn test_apply_patches() {

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -251,6 +251,7 @@ fn normalize_escape_sequences(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use indexmap::indexmap;
+    use pretty_assertions::assert_str_eq;
 
     use crate::dirs;
 

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -251,6 +251,7 @@ fn normalize_escape_sequences(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use indexmap::indexmap;
+    use insta::assert_debug_snapshot;
     use pretty_assertions::assert_str_eq;
 
     use crate::dirs;

--- a/src/fake_asdf.rs
+++ b/src/fake_asdf.rs
@@ -4,6 +4,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 use color_eyre::eyre::ErrReport;
+use indoc::formatdoc;
 use once_cell::sync::OnceCell;
 
 use crate::{env, file};

--- a/src/file.rs
+++ b/src/file.rs
@@ -409,6 +409,8 @@ pub fn unzip(archive: &Path, dest: &Path) -> Result<()> {
 mod tests {
     use std::ops::Deref;
 
+    use pretty_assertions::assert_eq;
+
     use crate::test::reset;
 
     use super::*;

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -43,7 +43,17 @@ pub type ForgeMap = BTreeMap<ForgeArg, AForge>;
 pub type ForgeList = Vec<AForge>;
 
 #[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Copy, EnumString, EnumIter, AsRefStr, Ord, PartialOrd,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Copy,
+    strum::EnumString,
+    strum::EnumIter,
+    strum::AsRefStr,
+    Ord,
+    PartialOrd,
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum ForgeType {

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -7,6 +7,8 @@ use std::sync::{Arc, Mutex};
 
 use clap::Command;
 use console::style;
+
+use contracts::requires;
 use eyre::WrapErr;
 use itertools::Itertools;
 use rayon::prelude::*;

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -7,9 +7,8 @@ use std::sync::{Arc, Mutex};
 
 use clap::Command;
 use console::style;
-
 use contracts::requires;
-use eyre::WrapErr;
+use eyre::{bail, ensure, eyre, WrapErr};
 use itertools::Itertools;
 use rayon::prelude::*;
 use regex::Regex;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -72,6 +72,7 @@ pub fn parse_shasums(text: &str) -> HashMap<String, String> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use pretty_assertions::assert_eq;
     use test_log::test;
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -5,7 +5,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{Read, Write};
 use std::path::Path;
 
-use eyre::Result;
+use eyre::{ensure, Result};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -72,9 +72,12 @@ pub fn parse_shasums(text: &str) -> HashMap<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test::reset;
+    use pretty_assertions::assert_eq;
     use test_log::test;
+
+    use crate::test::reset;
+
+    use super::*;
 
     #[test]
     fn test_hash_to_str() {

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -166,11 +166,14 @@ pub fn build_env_commands(shell: &dyn Shell, patches: &EnvDiffPatches) -> String
 
 #[cfg(test)]
 mod tests {
-    use crate::test::reset;
     use std::time::UNIX_EPOCH;
 
-    use super::*;
+    use pretty_assertions::{assert_eq, assert_str_eq};
     use test_log::test;
+
+    use crate::test::reset;
+
+    use super::*;
 
     #[test]
     fn test_have_config_files_been_modified() {

--- a/src/http.rs
+++ b/src/http.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::Path;
 use std::time::Duration;
 
-use eyre::{Report, Result};
+use eyre::{bail, Report, Result};
 use once_cell::sync::Lazy;
 use reqwest::{ClientBuilder, IntoUrl, Response};
 use tokio::runtime::Runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,4 @@
 #[macro_use]
-extern crate contracts;
-extern crate core;
-#[macro_use]
 extern crate eyre;
 #[macro_use]
 extern crate indoc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#[macro_use]
-extern crate indoc;
 #[cfg(test)]
 #[macro_use]
 extern crate insta;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,6 @@ extern crate insta;
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
-#[macro_use]
-extern crate strum;
 
 use std::process::exit;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,3 @@
-#[cfg(test)]
-#[macro_use]
-extern crate insta;
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
 use std::process::exit;
 
 use color_eyre::{Section, SectionExt};
@@ -15,6 +8,9 @@ use crate::cli::version::VERSION;
 use crate::cli::Cli;
 use crate::ui::style;
 
+#[cfg(test)]
+#[macro_use]
+extern crate insta;
 #[cfg(test)]
 #[macro_use]
 mod test;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,6 @@ use crate::ui::style;
 
 #[cfg(test)]
 #[macro_use]
-extern crate insta;
-#[cfg(test)]
-#[macro_use]
 mod test;
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate eyre;
-#[macro_use]
 extern crate indoc;
 #[cfg(test)]
 #[macro_use]

--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -83,9 +83,12 @@ impl FromIterator<PathBuf> for PathEnv {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test::reset;
+    use pretty_assertions::assert_eq;
     use test_log::test;
+
+    use crate::test::reset;
+
+    use super::*;
 
     #[test]
     fn test_path_env() {

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use contracts::requires;
 use eyre::Result;
 use itertools::Itertools;
 use versions::Versioning;

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use contracts::requires;
 use eyre::Result;
 use itertools::Itertools;
 use versions::Versioning;

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -4,6 +4,7 @@ use std::fs::{self};
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{eyre, Result};
+use contracts::requires;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{eyre, Result};
 use contracts::requires;
+use indoc::formatdoc;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use eyre::{bail, eyre};
 use itertools::Itertools;
 
 use crate::build_time::built_info;

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -427,6 +427,8 @@ fn parse_gemfile(body: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
+
     use super::*;
 
     #[test]

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -428,6 +428,7 @@ fn parse_gemfile(body: &str) -> String {
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use pretty_assertions::assert_eq;
 
     use super::*;
 

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::env::temp_dir;
 use std::path::{Path, PathBuf};
 
+use contracts::requires;
 use eyre::{Result, WrapErr};
 
 use crate::cli::args::ForgeArg;

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use contracts::requires;
 use eyre::Result;
 use itertools::Itertools;
 use versions::Versioning;

--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -8,7 +8,7 @@ use std::process::exit;
 use std::sync::Arc;
 
 use clap::Command;
-use color_eyre::eyre::{eyre, Result, WrapErr};
+use color_eyre::eyre::{bail, eyre, Result, WrapErr};
 use console::style;
 use itertools::Itertools;
 use rayon::prelude::*;

--- a/src/plugins/mise_plugin_toml.rs
+++ b/src/plugins/mise_plugin_toml.rs
@@ -102,6 +102,7 @@ impl MisePluginToml {
 #[cfg(test)]
 mod tests {
     use crate::dirs;
+    use indoc::formatdoc;
 
     use super::*;
 

--- a/src/plugins/mise_plugin_toml.rs
+++ b/src/plugins/mise_plugin_toml.rs
@@ -101,8 +101,10 @@ impl MisePluginToml {
 
 #[cfg(test)]
 mod tests {
-    use crate::dirs;
     use indoc::formatdoc;
+    use insta::assert_debug_snapshot;
+
+    use crate::dirs;
 
     use super::*;
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -49,10 +49,13 @@ pub fn list_external() -> ForgeList {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use pretty_assertions::assert_str_eq;
+    use test_log::test;
+
     use crate::forge::Forge;
     use crate::test::reset;
-    use test_log::test;
+
+    use super::*;
 
     #[test]
     fn test_exact_match() {

--- a/src/plugins/script_manager.rs
+++ b/src/plugins/script_manager.rs
@@ -183,6 +183,8 @@ impl ScriptManager {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -113,6 +113,8 @@ pub fn is_runtime_symlink(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_debug_snapshot;
+
     use crate::plugins::ExternalPlugin;
     use crate::test::reset;
 

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -101,8 +101,10 @@ impl Shell for Bash {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::{replace_path, reset};
+    use insta::assert_snapshot;
     use test_log::test;
+
+    use crate::test::{replace_path, reset};
 
     use super::*;
 

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use indoc::formatdoc;
+
 use crate::config::Settings;
 use crate::shell::Shell;
 

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use indoc::formatdoc;
+
 use crate::config::Settings;
 use crate::shell::Shell;
 

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -125,8 +125,11 @@ impl Shell for Fish {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use insta::assert_snapshot;
+
     use crate::test::replace_path;
+
+    use super::*;
 
     #[test]
     fn test_activate() {

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -108,6 +108,8 @@ impl Shell for Nushell {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::test::replace_path;
 
     use super::*;

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 use std::path::Path;
 
+use indoc::formatdoc;
+
 use crate::shell::Shell;
 
 #[derive(Default)]

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 use std::path::Path;
 
+use indoc::formatdoc;
+
 use crate::shell::Shell;
 
 #[derive(Default)]

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -136,8 +136,11 @@ impl Shell for Xonsh {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use pretty_assertions::assert_eq;
+
     use crate::test::replace_path;
+
+    use super::*;
 
     #[test]
     fn test_hook_init() {

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -136,6 +136,7 @@ impl Shell for Xonsh {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use pretty_assertions::assert_eq;
 
     use crate::test::replace_path;

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -103,6 +103,8 @@ impl Shell for Zsh {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::test::replace_path;
 
     use super::*;

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use indoc::formatdoc;
+
 use crate::config::Settings;
 use crate::shell::bash::Bash;
 use crate::shell::Shell;

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use color_eyre::eyre::{bail, eyre, Result};
 use eyre::WrapErr;
+use indoc::formatdoc;
 use itertools::Itertools;
 use rayon::prelude::*;
 

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::sync::Arc;
 
-use color_eyre::eyre::{eyre, Result};
+use color_eyre::eyre::{bail, eyre, Result};
 use eyre::WrapErr;
 use itertools::Itertools;
 use rayon::prelude::*;

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -50,11 +50,14 @@ fn parse_shorthands_file(mut f: PathBuf) -> Result<Shorthands> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::reset;
     use std::ops::Deref;
 
-    use super::*;
+    use pretty_assertions::assert_str_eq;
     use test_log::test;
+
+    use crate::test::reset;
+
+    use super::*;
 
     #[test]
     fn test_get_shorthands() {

--- a/src/task.rs
+++ b/src/task.rs
@@ -372,6 +372,8 @@ where
 mod tests {
     use std::path::Path;
 
+    use pretty_assertions::assert_eq;
+
     use crate::task::Task;
     use crate::test::reset;
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -277,6 +277,7 @@ impl Deps {
         rx
     }
 
+    // use contracts::{ensures, requires};
     // #[requires(self.graph.node_count() > 0)]
     // #[ensures(self.graph.node_count() == old(self.graph.node_count()) - 1)]
     pub fn remove(&mut self, task: &Task) {

--- a/src/task.rs
+++ b/src/task.rs
@@ -9,7 +9,7 @@ use std::{ffi, fmt, path};
 
 use console::truncate_str;
 use either::Either;
-use eyre::Result;
+use eyre::{eyre, Result};
 use globset::Glob;
 use itertools::Itertools;
 use petgraph::prelude::*;

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,6 +2,7 @@ use std::env::join_paths;
 use std::path::PathBuf;
 
 use color_eyre::{Help, SectionExt};
+use indoc::indoc;
 
 use crate::cli::Cli;
 use crate::config::{config_file, Config};

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -1,6 +1,8 @@
 #[macro_export]
 macro_rules! parse_error {
     ($key:expr, $val:expr, $t:expr) => {{
+        use eyre::bail;
+
         bail!(
             r#"expected value of {} to be a {}, got: {}"#,
             $crate::ui::style::eyellow($key),

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use std::{panic, thread};
 
 use console::truncate_str;
-use eyre::Result;
+use eyre::{eyre, Result};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rayon::prelude::*;

--- a/src/toolset/tool_source.rs
+++ b/src/toolset/tool_source.rs
@@ -57,6 +57,8 @@ impl ToolSource {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::{assert_eq, assert_str_eq};
+
     use super::*;
 
     #[test]

--- a/src/toolset/tool_version_list.rs
+++ b/src/toolset/tool_version_list.rs
@@ -44,6 +44,8 @@ impl ToolVersionList {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use crate::test::reset;
     use crate::{dirs, env, file};
 

--- a/src/toolset/tool_version_request.rs
+++ b/src/toolset/tool_version_request.rs
@@ -196,6 +196,7 @@ impl Display for ToolRequest {
 #[cfg(test)]
 mod tests {
     use super::version_sub;
+    use pretty_assertions::assert_str_eq;
 
     #[test]
     fn test_version_sub() {

--- a/src/toolset/tool_version_request.rs
+++ b/src/toolset/tool_version_request.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
-use eyre::Result;
+use eyre::{bail, Result};
 use versions::{Chunk, Version};
 use xx::file;
 


### PR DESCRIPTION
i.e. remove depreciated use of `#[macro_import] extern crate`

to make this more sane for reviewing, I did commits by crate.

I'm pretty sure the `contracts`, `eyre`, `indoc`, and `strum` ones are worth taking for overall clarity-of-provenance.

---

I have more mixed feelings on the utility of scoping `pretty_assertions` and `insta` assertions.

I, in fact, tried (at least) doing:

```rust
pub use pretty_assertions::{assert_eq, assert_ne, assert_str_eq};
```

in `src/test.rs` and then it was gonna e.g. `use crate::test::*` or similar (`crate::test::assertions::*`?), but that made stuff angry about possible ambiguity (based on implications/expansion of `#[test]`?)

The "correct" way to do this, I think, then is to rather overrider/replace the `#[test]` attribute itself with e.g. a `#[mise_test]` (for the insta ones maybe a `#[snapshot_test]`) or similar

---

I was working on a larger refactor 

(trying to disentangle the `cli`— in particular `ForgeArg`, `ToolArg`, `ToolVersionType` (to limit down cli-layer usage to the FromStr-ing?); `ui` (`SingleReport` and `TreeItem` traits) and most of the `env` crates from the rest, with a view towards maybe doing a separate `lib.rs` and minimal `main.rs`) 

but I wore myself out and stepped back to start with offering this [and now probably lose interest for at least several days]

¯\\_(ツ)_/¯ 