### PR TITLE
refactor: simplify ForgeArg building

### DIFF
--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -24,7 +24,7 @@ pub struct BunPlugin {
 
 impl BunPlugin {
     pub fn new() -> Self {
-        let core = CorePlugin::new("bun");
+        let core = CorePlugin::new("bun".into());
         Self { core }
     }
 

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -26,7 +26,7 @@ pub struct DenoPlugin {
 
 impl DenoPlugin {
     pub fn new() -> Self {
-        let core = CorePlugin::new("deno");
+        let core = CorePlugin::new("deno".into());
         Self { core }
     }
 

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -22,7 +22,7 @@ const KERL_VERSION: &str = "4.1.1";
 impl ErlangPlugin {
     pub fn new() -> Self {
         Self {
-            core: CorePlugin::new("erlang"),
+            core: CorePlugin::new("erlang".into()),
         }
     }
 

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -26,7 +26,7 @@ pub struct GoPlugin {
 impl GoPlugin {
     pub fn new() -> Self {
         Self {
-            core: CorePlugin::new("go"),
+            core: CorePlugin::new("go".into()),
         }
     }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -35,7 +35,7 @@ pub struct JavaPlugin {
 
 impl JavaPlugin {
     pub fn new() -> Self {
-        let core = CorePlugin::new("java");
+        let core = CorePlugin::new("java".into());
         let java_metadata_ga_cache_filename =
             format!("java_metadata_ga_{}_{}-$KEY.msgpack.z", os(), arch());
         let java_metadata_ea_cache_filename =

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -11,7 +11,7 @@ use crate::cache::CacheManager;
 use crate::cli::args::ForgeArg;
 use crate::config::Settings;
 use crate::env;
-use crate::forge::{Forge, ForgeList, ForgeType};
+use crate::forge::{Forge, ForgeList};
 use crate::http::HTTP_FETCH;
 use crate::plugins::core::bun::BunPlugin;
 use crate::plugins::core::deno::DenoPlugin;
@@ -55,15 +55,12 @@ pub static CORE_PLUGINS: Lazy<ForgeList> = Lazy::new(|| {
 #[derive(Debug)]
 pub struct CorePlugin {
     pub fa: ForgeArg,
-    pub name: &'static str,
     pub remote_version_cache: CacheManager<Vec<String>>,
 }
 
 impl CorePlugin {
-    pub fn new(name: &'static str) -> Self {
-        let fa = ForgeArg::new(ForgeType::Asdf, name);
+    pub fn new(fa: ForgeArg) -> Self {
         Self {
-            name,
             remote_version_cache: CacheManager::new(
                 fa.cache_path.join("remote_versions-$KEY.msgpack.z"),
             )
@@ -90,7 +87,7 @@ impl CorePlugin {
         if !*env::MISE_USE_VERSIONS_HOST {
             return Ok(None);
         }
-        let raw = HTTP_FETCH.get_text(format!("http://mise-versions.jdx.dev/{}", &self.name))?;
+        let raw = HTTP_FETCH.get_text(format!("http://mise-versions.jdx.dev/{}", &self.fa.name))?;
         let versions = raw
             .lines()
             .map(|v| v.trim().to_string())

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -27,7 +27,7 @@ pub struct NodePlugin {
 impl NodePlugin {
     pub fn new() -> Self {
         Self {
-            core: CorePlugin::new("node"),
+            core: CorePlugin::new("node".into()),
         }
     }
 

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -27,7 +27,7 @@ pub struct PythonPlugin {
 
 impl PythonPlugin {
     pub fn new() -> Self {
-        let core = CorePlugin::new("python");
+        let core = CorePlugin::new("python".into());
         Self {
             precompiled_cache: CacheManager::new(
                 core.fa.cache_path.join("precompiled-$KEY.msgpack.z"),

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -28,7 +28,7 @@ pub struct RubyPlugin {
 impl RubyPlugin {
     pub fn new() -> Self {
         Self {
-            core: CorePlugin::new("ruby"),
+            core: CorePlugin::new("ruby".into()),
         }
     }
 

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -24,7 +24,7 @@ pub struct ZigPlugin {
 
 impl ZigPlugin {
     pub fn new() -> Self {
-        let core = CorePlugin::new("zig");
+        let core = CorePlugin::new("zig".into());
         Self { core }
     }
 


### PR DESCRIPTION
my long-term goal here is to get rid of `ForgeArg::new()` and just use the FromStr version and the longer-still goal is to help support #2187 by allowing the forges to dispatch between asdf, core, and vfox plugins