### PR TITLE
fix: mise up node fails

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -35,7 +35,7 @@ impl Client {
     fn new(timeout: Duration) -> Result<Self> {
         Ok(Self {
             reqwest: Self::_new()
-                .timeout(timeout)
+                .read_timeout(timeout)
                 .connect_timeout(timeout)
                 .build()?,
         })


### PR DESCRIPTION
Fixes #2240 by using [read_timeout](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.read_timeout) rather than [timeout](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout)