### PR TITLE
docs: add SPM backend page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
               { text: 'go', link: '/dev-tools/backends/go' },
               { text: 'npm', link: '/dev-tools/backends/npm' },
               { text: 'pipx', link: '/dev-tools/backends/pipx' },
+              { text: 'spm', link: '/dev-tools/backends/spm' },
               { text: 'ubi', link: '/dev-tools/backends/ubi' },
             ]
           }

--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -3,7 +3,7 @@
 You may install packages directly from [Cargo Crates](https://crates.io/) even if there
 isn't an asdf plugin for it.
 
-The code for this is inside of the mise repository at [`./src/forge/cargo.rs`](https://github.com/jdx/mise/blob/main/src/forge/cargo.rs).
+The code for this is inside of the mise repository at [`./src/backend/cargo.rs`](https://github.com/jdx/mise/blob/main/src/backend/cargo.rs).
 
 ## Dependencies
 

--- a/docs/dev-tools/backends/go.md
+++ b/docs/dev-tools/backends/go.md
@@ -3,7 +3,7 @@
 You may install packages directly via [go install](https://go.dev/doc/install) even if there
 isn't an asdf plugin for it.
 
-The code for this is inside of the mise repository at [`./src/forge/go.rs`](https://github.com/jdx/mise/blob/main/src/forge/go.rs).
+The code for this is inside of the mise repository at [`./src/backend/go.rs`](https://github.com/jdx/mise/blob/main/src/backend/go.rs).
 
 ## Dependencies
 

--- a/docs/dev-tools/backends/index.md
+++ b/docs/dev-tools/backends/index.md
@@ -7,6 +7,7 @@ In addition to asdf plugins, you can also directly install CLIs with some packag
 * [Go](/dev-tools/backends/go) <Badge type="warning" text="experimental" />
 * [NPM](/dev-tools/backends/npm) <Badge type="warning" text="experimental" />
 * [Pipx](/dev-tools/backends/pipx) <Badge type="warning" text="experimental" />
+* [SPM](/dev-tools/backends/spm) <Badge type="warning" text="experimental" />
 * [Ubi](/dev-tools/backends/ubi) <Badge type="warning" text="experimental" />
 * [More coming soon!](https://github.com/jdx/mise/discussions/1250)
 

--- a/docs/dev-tools/backends/index.md
+++ b/docs/dev-tools/backends/index.md
@@ -13,5 +13,5 @@ In addition to asdf plugins, you can also directly install CLIs with some packag
 
 ::: tip
 If you'd like to contribute a new backend to mise, they're not difficult to write.
-See [`./src/forge/`](https://github.com/jdx/mise/tree/main/src/forge) for examples.
+See [`./src/backend/`](https://github.com/jdx/mise/tree/main/src/backend) for examples.
 :::

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -3,7 +3,7 @@
 You may install packages directly from [npmjs.org](https://npmjs.org/) even if there
 isn't an asdf plugin for it.
 
-The code for this is inside of the mise repository at [`./src/forge/npm.rs`](https://github.com/jdx/mise/blob/main/src/forge/npm.rs).
+The code for this is inside of the mise repository at [`./src/backend/npm.rs`](https://github.com/jdx/mise/blob/main/src/backend/npm.rs).
 
 ## Dependencies
 

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -7,7 +7,7 @@ You may install python packages directly from:
 - Github
 - Http
 
-The code for this is inside of the mise repository at [`./src/forge/pipx.rs`](https://github.com/jdx/mise/blob/main/src/forge/pipx.rs).
+The code for this is inside of the mise repository at [`./src/backend/pipx.rs`](https://github.com/jdx/mise/blob/main/src/backend/pipx.rs).
 
 ## Dependencies
 

--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -29,13 +29,13 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 "spm:tuist/tuist" = "latest"
 ```
 
-### Supported Ubi Syntax
+### Supported Syntax
 
-| Description                                   | Usage                                                                                                   |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Github shorthand for latest release version   | `spm:tuist/tuist`                                                                                       |
-| Github shorthand for specific release version | `spm:tuist/tuist@4.15.0`                                                                                |
-| Github url for latest release version         | `spm:https://github.com/tuist/tuist.git`                                                                |
-| Github url for specific release version       | `spm:https://github.com/tuist/tuist.git@4.15.0`                                                         |
+| Description                                   | Usage                                                     |
+| --------------------------------------------- | --------------------------------------------------------- |
+| Github shorthand for latest release version   | `spm:tuist/tuist`                                         |
+| Github shorthand for specific release version | `spm:tuist/tuist@4.15.0`                                  |
+| Github url for latest release version         | `spm:https://github.com/tuist/tuist.git`                  |
+| Github url for specific release version       | `spm:https://github.com/tuist/tuist.git@4.15.0`           |
 
 Other syntax may work but is unsupported and untested.

--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -1,0 +1,41 @@
+# SPM Backend <Badge type="warning" text="experimental" />
+
+You may install executables managed by [Swift Package Manager](https://www.swift.org/documentation/package-manager) directly from Github releases.
+
+The code for this is inside of the mise repository at [`./src/backend/spm.rs`](https://github.com/jdx/mise/blob/main/src/backend/spm.rs).
+
+## Dependencies
+
+This relies on having `swift` installed. You can install it according to the [instructions](https://www.swift.org/install).
+
+## Usage
+
+The following installs the latest version of `tuist`
+and sets it as the active version on PATH:
+
+```sh
+$ mise use -g spm:tuist/tuist
+$ tuist --help
+OVERVIEW: Generate, build and test your Xcode projects.
+
+USAGE: tuist <subcommand>
+...
+```
+
+The version will be set in `~/.config/mise/config.toml` with the following format:
+
+```toml
+[tools]
+"spm:tuist/tuist" = "latest"
+```
+
+### Supported Ubi Syntax
+
+| Description                                   | Usage                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Github shorthand for latest release version   | `spm:tuist/tuist`                                                                                       |
+| Github shorthand for specific release version | `spm:tuist/tuist@4.15.0`                                                                                |
+| Github url for latest release version         | `spm:https://github.com/tuist/tuist.git`                                                                |
+| Github url for specific release version       | `spm:https://github.com/tuist/tuist.git@4.15.0`                                                         |
+
+Other syntax may work but is unsupported and untested.

--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -8,6 +8,9 @@ The code for this is inside of the mise repository at [`./src/backend/spm.rs`](h
 
 This relies on having `swift` installed. You can install it according to the [instructions](https://www.swift.org/install).
 
+> [!NOTE]
+> If you have Xcode installed and selected in your system via `xcode-select`, Swift is already available through the toolchain embedded in the Xcode installation.
+
 ## Usage
 
 The following installs the latest version of `tuist`

--- a/docs/dev-tools/backends/ubi.md
+++ b/docs/dev-tools/backends/ubi.md
@@ -2,7 +2,7 @@
 
 You may install Github Releases and URL packages directly using [ubi](https://github.com/houseabsolute/ubi) backend.
 
-The code for this is inside of the mise repository at [`./src/forge/ubi.rs`](https://github.com/jdx/mise/blob/main/src/forge/ubi.rs).
+The code for this is inside of the mise repository at [`./src/backend/ubi.rs`](https://github.com/jdx/mise/blob/main/src/backend/ubi.rs).
 
 ## Dependencies
 


### PR DESCRIPTION
1. Added document to SPM backend
2. Fix backend src path in dock: `src/forge` -> `src/backend`