### PR TITLE
fix: github API rate limiting could be handled more explicitly

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -11,8 +11,9 @@ use crate::{cmd, env};
 
 /// Updates mise itself
 ///
-/// Uses the GitHub Releases API to find the latest release and binary
-/// By default, this will also update any installed plugins
+/// Uses the GitHub Releases API to find the latest release and binary.
+/// By default, this will also update any installed plugins.
+/// Uses the `GITHUB_API_TOKEN` environment variable if set for higher rate limits.
 #[derive(Debug, Default, clap::Args)]
 #[clap(verbatim_doc_comment)]
 pub struct SelfUpdate {


### PR DESCRIPTION
Fixes #2263 by adding a hint about GITHUB_API_TOKEN environment variable to the `self-udpate` command.

I don't see an easy way to set a more explicit error message as the underlying `self_update` crate simply throws a generic network error and the status code is lost or rather encoded in the error message.