### PR TITLE
docs: Mention the fish shell's automatic activation in the Quickstart section

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,11 @@ Now that `mise` is installed, you can optionally activate it or add its [shims](
 For interactive shells, `mise activate` is recommended. In non-interactive sessions, like CI/CD, IDEs, and scripts, using `shims` might work best. You can also not use any and call `mise exec/run` directly instead.
 See [this guide](dev-tools/shims.md) for more information.
 
+:::info
+Activation may be handled automatically if you use fish shell and installed via homebrew. This
+can be disabled with `set -Ux MISE_FISH_AUTO_ACTIVATE 0`.
+:::
+
 ::: code-group
 
 ```sh [bash]


### PR DESCRIPTION
Since folks might not read the whole page before they start following the steps in the Quickstart section, I think it's helpful to mention this detail sooner.