### PR TITLE
fix: upgrade all urls to https

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "$id": "https://mise.jdx.dev/schema/mise.json",
   "title": "mise",
   "description": "config file for mise version manager (.mise.toml)",

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://mise.jdx.dev/schema/settings.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "mise settings schema",
   "description": "settings file for mise-en-place (~/.config/mise/settings.toml)",
   "type": "object",

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -150,7 +150,7 @@ impl Asdf {
             return Ok(None);
         }
         let versions =
-            match HTTP_FETCH.get_text(format!("http://mise-versions.jdx.dev/{}", self.name)) {
+            match HTTP_FETCH.get_text(format!("https://mise-versions.jdx.dev/{}", self.name)) {
                 Err(err) if http::error_code(&err) == Some(404) => return Ok(None),
                 res => res?,
             };

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -108,7 +108,7 @@ fn get_latest_version_call() -> Option<String> {
 
 #[cfg(not(test))]
 fn get_latest_version_call() -> Option<String> {
-    const URL: &str = "http://mise.jdx.dev/VERSION";
+    const URL: &str = "https://mise.jdx.dev/VERSION";
     debug!("checking mise version from {}", URL);
     match crate::http::HTTP_VERSION_CHECK.get_text(URL) {
         Ok(text) => {

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -97,7 +97,8 @@ impl CorePlugin {
         if !*env::MISE_USE_VERSIONS_HOST {
             return Ok(None);
         }
-        let raw = HTTP_FETCH.get_text(format!("http://mise-versions.jdx.dev/{}", &self.fa.name))?;
+        let raw =
+            HTTP_FETCH.get_text(format!("https://mise-versions.jdx.dev/{}", &self.fa.name))?;
         let versions = raw
             .lines()
             .map(|v| v.trim().to_string())

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -100,7 +100,7 @@ impl PythonPlugin {
     fn fetch_precompiled_remote_versions(&self) -> eyre::Result<&Vec<(String, String, String)>> {
         self.precompiled_cache.get_or_try_init(|| {
             let settings = Settings::get();
-            let raw = HTTP_FETCH.get_text("http://mise-versions.jdx.dev/python-precompiled")?;
+            let raw = HTTP_FETCH.get_text("https://mise-versions.jdx.dev/python-precompiled")?;
             let platform = format!("{}-{}", python_arch(&settings), python_os(&settings));
             let versions = raw
                 .lines()


### PR DESCRIPTION
Fixes #2311 

Changes all http urls to their https equivalent

I fired this up in the devcontainer. `cargo test` works, but I couldn't get the e2e test running (from [here](https://mise.jdx.dev/contributing.html#setup))