### PR TITLE
feat: add interactive task inputs

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -244,6 +244,42 @@
               "description": "do not display this task",
               "type": "boolean"
             },
+            "inputs": {
+              "description": "inputs for this task",
+              "type": "array",
+              "items": {
+                "description": "confirmation input",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "description": "unique identifier for this input",
+                    "type": "string"
+                  },
+                  "input_type": {
+                    "description": "confirmation input",
+                    "type": "string",
+                    "enum": ["confirm", "input", "password", "select"],
+                    "default": "confirm"
+                  },
+                  "title": {
+                    "description": "title of the input",
+                    "type": "string"
+                  },
+                  "description": {
+                    "description": "description of the input",
+                    "type": "string"
+                  },
+                  "options": {
+                    "description": "options for select input",
+                    "type": "array",
+                    "items": {
+                      "description": "option for select input",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
             "quiet": {
               "description": "do not display mise information for this task",
               "type": "boolean"

--- a/src/task.rs
+++ b/src/task.rs
@@ -22,6 +22,20 @@ use crate::tera::{get_tera, BASE_CONTEXT};
 use crate::ui::tree::TreeItem;
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize)]
+pub struct TaskInput {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub input_type: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub options: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize)]
 pub struct Task {
     #[serde(skip)]
     pub name: String,
@@ -39,6 +53,8 @@ pub struct Task {
     pub dir: Option<PathBuf>,
     #[serde(default)]
     pub hide: bool,
+    #[serde(default)]
+    pub inputs: Vec<TaskInput>,
     #[serde(default)]
     pub raw: bool,
     #[serde(default)]


### PR DESCRIPTION
Rough draft to add support for interactive task inputs.

Open topics up for discussion are:
* TOML schema
  * do we need specific schema types for each input?
* parallel tasks
  * only support linear tasks or job=1?
* handling for non-interactive usage 
  * skip inputs if `-y` is passed?
  * scripts could fallback to default values if environment variable is not set