### PR TITLE
docs: update actions/checkout version

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -39,7 +39,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
         with:
           version: 2023.12.0 # [default: latest] mise version to install


### PR DESCRIPTION
The latest version of [actions/checkout](https://github.com/actions/checkout) is 4 and jdx/mise-action@v2 works fine, so I have updated the documentation.