### PR TITLE
chore: Use correct capitalization of GitHub

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -447,9 +447,9 @@ Examples:
 ## `mise generate github-action [OPTIONS]`
 
 ```text
-[experimental] Generate a Github Action workflow file
+[experimental] Generate a GitHub Action workflow file
 
-This command generates a Github Action workflow file that runs a mise task like `mise run ci`
+This command generates a GitHub Action workflow file that runs a mise task like `mise run ci`
 when you push changes to your repository.
 
 Usage: generate github-action [OPTIONS]
@@ -472,7 +472,7 @@ Examples:
 
     $ mise generate github-action --write --task=ci
     $ git commit -m "feat: add new feature"
-    $ git push # runs `mise run ci` on Github
+    $ git push # runs `mise run ci` on GitHub
 ```
 
 ## `mise implode [OPTIONS]`

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -4,7 +4,7 @@ You may install python packages directly from:
 
 - PyPI
 - Git
-- Github
+- GitHub
 - Http
 
 The code for this is inside of the mise repository at [`./src/backend/pipx.rs`](https://github.com/jdx/mise/blob/main/src/backend/pipx.rs).
@@ -45,8 +45,8 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 | ------------------------------------- | ------------------------------------------------------ |
 | PyPI shorthand latest version         | `pipx:black`                                           |
 | PyPI shorthand for specific version   | `pipx:black@24.3.0`                                    |
-| Github shorthand for latest version   | `pipx:psf/black`                                       |
-| Github shorthand for specific version | `pipx:psf/black@24.3.0`                                |
+| GitHub shorthand for latest version   | `pipx:psf/black`                                       |
+| GitHub shorthand for specific version | `pipx:psf/black@24.3.0`                                |
 | Git syntax for latest version         | `pipx:git+https://github.com/psf/black`                |
 | Git syntax for a branch               | `pipx:git+https://github.com/psf/black.git@main`       |
 | Https with zipfile                    | `pipx:https://github.com/psf/black/archive/18.9b0.zip` |

--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -1,6 +1,6 @@
 # SPM Backend <Badge type="warning" text="experimental" />
 
-You may install executables managed by [Swift Package Manager](https://www.swift.org/documentation/package-manager) directly from Github releases.
+You may install executables managed by [Swift Package Manager](https://www.swift.org/documentation/package-manager) directly from GitHub releases.
 
 The code for this is inside of the mise repository at [`./src/backend/spm.rs`](https://github.com/jdx/mise/blob/main/src/backend/spm.rs).
 
@@ -36,9 +36,9 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 
 | Description                                   | Usage                                                     |
 | --------------------------------------------- | --------------------------------------------------------- |
-| Github shorthand for latest release version   | `spm:tuist/tuist`                                         |
-| Github shorthand for specific release version | `spm:tuist/tuist@4.15.0`                                  |
-| Github url for latest release version         | `spm:https://github.com/tuist/tuist.git`                  |
-| Github url for specific release version       | `spm:https://github.com/tuist/tuist.git@4.15.0`           |
+| GitHub shorthand for latest release version   | `spm:tuist/tuist`                                         |
+| GitHub shorthand for specific release version | `spm:tuist/tuist@4.15.0`                                  |
+| GitHub url for latest release version         | `spm:https://github.com/tuist/tuist.git`                  |
+| GitHub url for specific release version       | `spm:https://github.com/tuist/tuist.git@4.15.0`           |
 
 Other syntax may work but is unsupported and untested.

--- a/docs/dev-tools/backends/ubi.md
+++ b/docs/dev-tools/backends/ubi.md
@@ -1,6 +1,6 @@
 # Ubi Backend <Badge type="warning" text="experimental" />
 
-You may install Github Releases and URL packages directly using [ubi](https://github.com/houseabsolute/ubi) backend.
+You may install GitHub Releases and URL packages directly using [ubi](https://github.com/houseabsolute/ubi) backend.
 
 The code for this is inside of the mise repository at [`./src/backend/ubi.rs`](https://github.com/jdx/mise/blob/main/src/backend/ubi.rs).
 
@@ -35,8 +35,8 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 
 | Description                                   | Usage                                                                                                   |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Github shorthand for latest release version   | `ubi:goreleaser/goreleaser`                                                                             |
-| Github shorthand for specific release version | `ubi:goreleaser/goreleaser@1.25.1`                                                                      |
+| GitHub shorthand for latest release version   | `ubi:goreleaser/goreleaser`                                                                             |
+| GitHub shorthand for specific release version | `ubi:goreleaser/goreleaser@1.25.1`                                                                      |
 | URL syntax                                    | `ubi:https://github.com/goreleaser/goreleaser/releases/download/v1.16.2/goreleaser_Darwin_arm64.tar.gz` |
 
 Other syntax may work but is unsupported and untested.

--- a/e2e/style.sh
+++ b/e2e/style.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -n ${GITHUB_ACTION:-} ]]; then
-  # Output Github action annotations
+  # Output GitHub action annotations
   annotate() {
     local parameters=""
     [[ -n ${file:=${TEST_SCRIPT:-}} ]] && parameters="file=${file}"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -328,16 +328,16 @@ when you commit changes to your repository."
         }
         flag "-w --write" help="write to .git/hooks/pre-commit and make it executable"
     }
-    cmd "github-action" help="[experimental] Generate a Github Action workflow file" {
-        long_help r"[experimental] Generate a Github Action workflow file
+    cmd "github-action" help="[experimental] Generate a GitHub Action workflow file" {
+        long_help r"[experimental] Generate a GitHub Action workflow file
 
-This command generates a Github Action workflow file that runs a mise task like `mise run ci`
+This command generates a GitHub Action workflow file that runs a mise task like `mise run ci`
 when you push changes to your repository."
         after_long_help r#"Examples:
 
     $ mise generate github-action --write --task=ci
     $ git commit -m "feat: add new feature"
-    $ git push # runs `mise run ci` on Github
+    $ git push # runs `mise run ci` on GitHub
 "#
         flag "-n --name" help="the name of the workflow to generate" {
             arg "<NAME>"

--- a/scripts/query-top-plugins.fish
+++ b/scripts/query-top-plugins.fish
@@ -5,7 +5,7 @@
 
 if test -n (type -t gh)
 else
-    echo "Github CLI Missing! Aborting!"
+    echo "GitHub CLI Missing! Aborting!"
     exit 1
 end
 

--- a/src/cli/generate/github_action.rs
+++ b/src/cli/generate/github_action.rs
@@ -4,9 +4,9 @@ use crate::config::Settings;
 use crate::file::display_path;
 use crate::git::Git;
 
-/// [experimental] Generate a Github Action workflow file
+/// [experimental] Generate a GitHub Action workflow file
 ///
-/// This command generates a Github Action workflow file that runs a mise task like `mise run ci`
+/// This command generates a GitHub Action workflow file that runs a mise task like `mise run ci`
 /// when you push changes to your repository.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
@@ -78,7 +78,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
     $ <bold>mise generate github-action --write --task=ci</bold>
     $ <bold>git commit -m "feat: add new feature"</bold>
-    $ <bold>git push</bold> <dim># runs `mise run ci` on Github</dim>
+    $ <bold>git push</bold> <dim># runs `mise run ci` on GitHub</dim>
 "#
 );
 


### PR DESCRIPTION
No affiliation with GitHub, this just unreasonably bothers me for some reason 🥲

No code changes, only docs/comment changes.