### PR TITLE
chore: loosen git2 requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ eyre = "0.6.12"
 filetime = "0.2.23"
 flate2 = "1.0.30"
 fslock = "0.2.1"
-git2 = "0.19.0"
+git2 = "<1"
 glob = "0.3.1"
 globset = "0.4.14"
 heck = "0.5"
@@ -127,7 +127,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 exec = "0.3.1"
 
 [build-dependencies]
-built = { version = "0.7.4", features = ["chrono", "git2"] }
+built = { version = "0.7", features = ["chrono", "git2"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"


### PR DESCRIPTION
this (might) make mise work with homebrew to fix https://github.com/jdx/mise/issues/2371 but I'm not sure if it will work. It shouldn't _hurt_ anything though since cargo should use the latest version of git2 if it's available