### PR TITLE
fix: transform `master` to `ref:master` in ls-remote for zig

### DIFF
--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -42,7 +42,18 @@ impl ZigPlugin {
 
     fn fetch_remote_versions(&self) -> Result<Vec<String>> {
         match self.core.fetch_remote_versions_from_mise() {
-            Ok(Some(versions)) => return Ok(versions),
+            Ok(Some(versions)) => {
+                return Ok(versions
+                    .into_iter()
+                    .map(|r| {
+                        if r == "master" {
+                            "ref:master".to_string()
+                        } else {
+                            r
+                        }
+                    })
+                    .collect())
+            }
             Ok(None) => {}
             Err(e) => warn!("failed to fetch remote versions: {}", e),
         }
@@ -52,6 +63,13 @@ impl ZigPlugin {
         let versions = releases
             .into_iter()
             .map(|r| r.tag_name)
+            .map(|r| {
+                if r == "master" {
+                    "ref:master".to_string()
+                } else {
+                    r
+                }
+            })
             .unique()
             .sorted_by_cached_key(|s| (Versioning::new(s), s.to_string()))
             .collect();


### PR DESCRIPTION
Currently ls-remote zig shows `master` as a valid version but this isn't actually accepted by mise and throws a somewhat cryptic error. The correct version to specify if you want nightly is ref:master so this adds a simple transformation to direct the user to the correct value.

Fixes #2403 