### PR TITLE
docs: Fix 'mise x' command snippet in the Continuous Integration section

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -17,7 +17,7 @@ To ensure you run the version of the tools installed by Mise, make sure you run 
 
 ```yaml
 script: |
-  mise x npm -- test
+  mise x -- npm test
 ```
 
 Alternatively, you can add the [shims](/dev-tools/shims.md) directory to your `PATH`, if the CI provider allows it.


### PR DESCRIPTION
This pull request fixes 'mise x' command snippet in the Continuous Integration documentation section. 

The link to the original documentation:
* https://mise.jdx.dev/continuous-integration.html#any-ci-provider
