### PR TITLE
fix: spm - cannot install package with null release name field

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -3,11 +3,11 @@ use serde_derive::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct GithubRelease {
     pub tag_name: String,
-    pub name: String,
-    pub body: String,
+    pub name: Option<String>,
+    pub body: Option<String>,
     pub prerelease: bool,
     pub created_at: String,
-    pub published_at: String,
+    pub published_at: Option<String>,
 }
 
 pub fn list_releases(repo: &str) -> eyre::Result<Vec<GithubRelease>> {

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -40,8 +40,7 @@ impl DenoPlugin {
             HTTP_FETCH.json("https://api.github.com/repos/denoland/deno/releases?per_page=100")?;
         let versions = releases
             .into_iter()
-            .map(|r| r.name)
-            .filter(|v| !v.is_empty())
+            .map(|r| r.tag_name)
             .filter(|v| v.starts_with('v'))
             .map(|v| v.trim_start_matches('v').to_string())
             .unique()


### PR DESCRIPTION
Fixes #2401 