### PR TITLE
fix: mise treats escaped newlines in env files differently than dotenvy

### DIFF
--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -920,6 +920,8 @@ mod tests {
         min_version = "2024.1.1"
         [env]
         foo="bar"
+        foo2='qux\nquux'
+        foo3="qux\nquux"
         "#},
         )
         .unwrap();
@@ -927,7 +929,7 @@ mod tests {
         let dump = cf.dump().unwrap();
         let env = parse_env(file::read_to_string(&p).unwrap());
 
-        assert_debug_snapshot!(env, @r###""foo=bar""###);
+        assert_debug_snapshot!(env, @r###""foo=bar\nfoo2=qux\\nquux\nfoo3=qux\nquux""###);
         let cf: Box<dyn ConfigFile> = Box::new(cf);
         with_settings!({
             assert_snapshot!(dump);
@@ -945,11 +947,18 @@ mod tests {
 
         [[env]]
         bar="baz"
+
+        [[env]]
+        foo2='qux\nquux'
+        bar2="qux\nquux"
         "#});
 
         assert_snapshot!(env, @r###"
         foo=bar
         bar=baz
+        foo2=qux\nquux
+        bar2=qux
+        quux
         "###);
     }
 

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env-2.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env-2.snap
@@ -1,8 +1,9 @@
 ---
 source: src/config/config_file/mise_toml.rs
-expression: cf.dump().unwrap()
+expression: dump
 ---
 min_version = "2024.1.1"
 [env]
 foo="bar"
-
+foo2='qux\nquux'
+foo3="qux\nquux"

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env-4.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env-4.snap
@@ -10,5 +10,13 @@ MiseToml(~/cwd/.test.mise.toml): ToolRequestSet:
             "foo",
             "bar",
         ),
+        Val(
+            "foo2",
+            "qux\\nquux",
+        ),
+        Val(
+            "foo3",
+            "qux\nquux",
+        ),
     ],
 }

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -86,7 +86,6 @@ impl Shell for Bash {
     fn set_env(&self, k: &str, v: &str) -> String {
         let k = shell_escape::unix::escape(k.into());
         let v = shell_escape::unix::escape(v.into());
-        let v = v.replace("\\n", "\n");
         format!("export {k}={v}\n")
     }
 

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -108,7 +108,6 @@ impl Shell for Fish {
     fn set_env(&self, k: &str, v: &str) -> String {
         let k = shell_escape::unix::escape(k.into());
         let v = shell_escape::unix::escape(v.into());
-        let v = v.replace("\\n", "\n");
         format!("set -gx {k} {v}\n")
     }
 

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -90,7 +90,6 @@ impl Shell for Nushell {
     fn set_env(&self, k: &str, v: &str) -> String {
         let k = shell_escape::unix::escape(k.into());
         let v = shell_escape::unix::escape(v.into());
-        let v = v.replace("\\n", "\n");
         let v = v.replace('\'', "");
 
         EnvOp::Set { key: &k, val: &v }.to_string()


### PR DESCRIPTION
Fixes #2453.

A single quoted `foo='line\nbreak'` results in characters `\` and `n`, while a double quoted `foo="line\nbreak"` results in character `\n`. Seems that the replacement of "\\n" in certain shell implementations causes this behaviour.