### PR TITLE
feat: use registry shortname for mise.toml/install dirs

### DIFF
--- a/src/backend/backend_meta.rs
+++ b/src/backend/backend_meta.rs
@@ -7,6 +7,7 @@ use super::BackendType;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct BackendMeta {
+    pub short: String,
     pub id: String,
     pub name: String,
     pub backend_type: String,
@@ -26,7 +27,8 @@ impl BackendMeta {
             return Ok(());
         }
         let meta = BackendMeta {
-            id: fa.id.clone(),
+            short: fa.short.clone(),
+            id: fa.full.clone(),
             name: fa.name.clone(),
             backend_type: fa.backend_type.as_ref().to_string(),
         };
@@ -45,12 +47,14 @@ impl BackendMeta {
                 let name = Self::name_for_type(name.to_string(), backend_type);
                 let id = format!("{}:{}", backend_type, name);
                 BackendMeta {
+                    short: id.clone(),
                     id,
                     name,
                     backend_type: backend_type.to_string(),
                 }
             }
             None => BackendMeta {
+                short: id.clone(),
                 id: id.to_string(),
                 name: id.to_string(),
                 backend_type: BackendType::Asdf.as_ref().to_string(),

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -18,7 +18,7 @@ use crate::toolset::ToolRequest;
 
 #[derive(Debug)]
 pub struct CargoBackend {
-    fa: BackendArg,
+    ba: BackendArg,
     remote_version_cache: CacheManager<Vec<String>>,
 }
 
@@ -28,7 +28,7 @@ impl Backend for CargoBackend {
     }
 
     fn fa(&self) -> &BackendArg {
-        &self.fa
+        &self.ba
     }
 
     fn get_dependencies(&self, _tvr: &ToolRequest) -> eyre::Result<Vec<BackendArg>> {
@@ -102,13 +102,12 @@ impl Backend for CargoBackend {
 }
 
 impl CargoBackend {
-    pub fn new(name: String) -> Self {
-        let fa = BackendArg::new(BackendType::Cargo, &name);
+    pub fn from_arg(ba: BackendArg) -> Self {
         Self {
             remote_version_cache: CacheManager::new(
-                fa.cache_path.join("remote_versions-$KEY.msgpack.z"),
+                ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
             ),
-            fa,
+            ba,
         }
     }
 

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -10,7 +10,7 @@ use crate::toolset::ToolRequest;
 
 #[derive(Debug)]
 pub struct GoBackend {
-    fa: BackendArg,
+    ba: BackendArg,
     remote_version_cache: CacheManager<Vec<String>>,
 }
 
@@ -20,7 +20,7 @@ impl Backend for GoBackend {
     }
 
     fn fa(&self) -> &BackendArg {
-        &self.fa
+        &self.ba
     }
 
     fn get_dependencies(&self, _tvr: &ToolRequest) -> eyre::Result<Vec<BackendArg>> {
@@ -83,13 +83,12 @@ impl Backend for GoBackend {
 }
 
 impl GoBackend {
-    pub fn new(name: String) -> Self {
-        let fa = BackendArg::new(BackendType::Go, &name);
+    pub fn from_arg(ba: BackendArg) -> Self {
         Self {
             remote_version_cache: CacheManager::new(
-                fa.cache_path.join("remote_versions-$KEY.msgpack.z"),
+                ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
             ),
-            fa,
+            ba,
         }
     }
 }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -12,7 +12,7 @@ use crate::toolset::ToolRequest;
 
 #[derive(Debug)]
 pub struct NPMBackend {
-    fa: BackendArg,
+    ba: BackendArg,
     remote_version_cache: CacheManager<Vec<String>>,
     latest_version_cache: CacheManager<Option<String>>,
 }
@@ -23,7 +23,7 @@ impl Backend for NPMBackend {
     }
 
     fn fa(&self) -> &BackendArg {
-        &self.fa
+        &self.ba
     }
 
     fn get_dependencies(&self, _tvr: &ToolRequest) -> eyre::Result<Vec<BackendArg>> {
@@ -77,16 +77,15 @@ impl Backend for NPMBackend {
 }
 
 impl NPMBackend {
-    pub fn new(name: String) -> Self {
-        let fa = BackendArg::new(BackendType::Npm, &name);
+    pub fn from_arg(ba: BackendArg) -> Self {
         Self {
             remote_version_cache: CacheManager::new(
-                fa.cache_path.join("remote_versions-$KEY.msgpack.z"),
+                ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
             ),
             latest_version_cache: CacheManager::new(
-                fa.cache_path.join("latest_version-$KEY.msgpack.z"),
+                ba.cache_path.join("latest_version-$KEY.msgpack.z"),
             ),
-            fa,
+            ba,
         }
     }
 }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -16,7 +16,7 @@ use crate::toolset::ToolRequest;
 
 #[derive(Debug)]
 pub struct PIPXBackend {
-    fa: BackendArg,
+    ba: BackendArg,
     remote_version_cache: CacheManager<Vec<String>>,
     latest_version_cache: CacheManager<Option<String>>,
 }
@@ -27,7 +27,7 @@ impl Backend for PIPXBackend {
     }
 
     fn fa(&self) -> &BackendArg {
-        &self.fa
+        &self.ba
     }
 
     fn get_dependencies(&self, _tvr: &ToolRequest) -> eyre::Result<Vec<BackendArg>> {
@@ -101,16 +101,15 @@ impl Backend for PIPXBackend {
 }
 
 impl PIPXBackend {
-    pub fn new(name: String) -> Self {
-        let fa = BackendArg::new(BackendType::Pipx, &name);
+    pub fn from_arg(ba: BackendArg) -> Self {
         Self {
             remote_version_cache: CacheManager::new(
-                fa.cache_path.join("remote_versions-$KEY.msgpack.z"),
+                ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
             ),
             latest_version_cache: CacheManager::new(
-                fa.cache_path.join("latest_version-$KEY.msgpack.z"),
+                ba.cache_path.join("latest_version-$KEY.msgpack.z"),
             ),
-            fa,
+            ba,
         }
     }
 }

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -19,7 +19,7 @@ use crate::{file, github};
 
 #[derive(Debug)]
 pub struct SPMBackend {
-    fa: BackendArg,
+    ba: BackendArg,
     remote_version_cache: CacheManager<Vec<String>>,
 }
 
@@ -30,7 +30,7 @@ impl Backend for SPMBackend {
     }
 
     fn fa(&self) -> &BackendArg {
-        &self.fa
+        &self.ba
     }
 
     fn get_dependencies(
@@ -85,13 +85,12 @@ impl Backend for SPMBackend {
 }
 
 impl SPMBackend {
-    pub fn new(name: String) -> Self {
-        let fa = BackendArg::new(BackendType::Spm, &name);
+    pub fn from_arg(ba: BackendArg) -> Self {
         Self {
             remote_version_cache: CacheManager::new(
-                fa.cache_path.join("remote_versions-$KEY.msgpack.z"),
+                ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
             ),
-            fa,
+            ba,
         }
     }
 

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -12,7 +12,7 @@ use crate::toolset::ToolRequest;
 
 #[derive(Debug)]
 pub struct UbiBackend {
-    fa: BackendArg,
+    ba: BackendArg,
     remote_version_cache: CacheManager<Vec<String>>,
 }
 
@@ -24,7 +24,7 @@ impl Backend for UbiBackend {
     }
 
     fn fa(&self) -> &BackendArg {
-        &self.fa
+        &self.ba
     }
 
     fn get_dependencies(&self, _tvr: &ToolRequest) -> eyre::Result<Vec<BackendArg>> {
@@ -78,13 +78,12 @@ impl Backend for UbiBackend {
 }
 
 impl UbiBackend {
-    pub fn new(name: String) -> Self {
-        let fa = BackendArg::new(BackendType::Ubi, &name);
+    pub fn from_arg(ba: BackendArg) -> Self {
         Self {
             remote_version_cache: CacheManager::new(
-                fa.cache_path.join("remote_versions-$KEY.msgpack.z"),
+                ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
             ),
-            fa,
+            ba,
         }
     }
 }

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -6,16 +6,17 @@ use std::path::PathBuf;
 
 use once_cell::sync::Lazy;
 
+use crate::backend::backend_meta::BackendMeta;
 use crate::backend::{unalias_backend, BackendType};
 use crate::dirs;
 use crate::registry::REGISTRY;
 
 #[derive(Clone, PartialOrd, Ord)]
 pub struct BackendArg {
-    /// user-specified identifier, "node", "npm:prettier", "cargo:eza", "vfox:version-fox/vfox-nodejs"
-    /// multiple ids may point to a single tool, e.g.: "node", "core:node" or "vfox:version-fox/vfox-nodejs"
-    /// and "vfox:https://github.com/version-fox/vfox-nodejs"
-    pub id: String,
+    /// short or full identifier (what the user specified), "node", "prettier", "npm:prettier", "cargo:eza"
+    pub short: String,
+    /// full identifier, "core:node", "npm:prettier", "cargo:eza", "vfox:version-fox/vfox-nodejs"
+    pub full: String,
     /// the name of the tool within the backend, e.g.: "node", "prettier", "eza", "vfox-nodejs"
     pub name: String,
     /// type of backend, "asdf", "cargo", "core", "npm", "vfox"
@@ -31,30 +32,36 @@ pub struct BackendArg {
 impl<A: AsRef<str>> From<A> for BackendArg {
     fn from(s: A) -> Self {
         let s = s.as_ref();
-        if let Some(fa) = FORGE_MAP.get(s) {
-            return fa.clone();
+        if let Some(fa) = REGISTRY_BACKEND_MAP.get(s) {
+            fa.clone()
+        } else {
+            Self::new(s, s)
         }
-        if let Some((backend_type, name)) = s.split_once(':') {
-            if let Ok(backend_type) = backend_type.parse() {
-                return Self::new(backend_type, name);
-            }
-        }
-        Self::new(BackendType::Asdf, s)
+    }
+}
+
+impl From<BackendMeta> for BackendArg {
+    fn from(meta: BackendMeta) -> Self {
+        meta.short.into()
     }
 }
 
 impl BackendArg {
-    pub fn new(backend_type: BackendType, name: &str) -> Self {
-        let name = unalias_backend(name).to_string();
-        let id = match backend_type {
-            BackendType::Asdf | BackendType::Core => name.clone(),
+    pub fn new(short: &str, full: &str) -> Self {
+        let short = unalias_backend(short).to_string();
+        let (backend, name) = full.split_once(':').unwrap_or(("", full));
+        let backend = unalias_backend(backend);
+        let backend_type = backend.parse().unwrap_or(BackendType::Asdf);
+        let full = match backend_type {
+            BackendType::Asdf | BackendType::Core => short.clone(),
             backend_type => format!("{backend_type}:{name}"),
         };
-        let pathname = id.to_kebab_case();
+        let pathname = short.to_kebab_case();
         Self {
-            name,
+            name: name.to_string(),
             backend_type,
-            id,
+            short,
+            full,
             cache_path: dirs::CACHE.join(&pathname),
             installs_path: dirs::INSTALLS.join(&pathname),
             downloads_path: dirs::DOWNLOADS.join(&pathname),
@@ -64,19 +71,23 @@ impl BackendArg {
 
 impl Display for BackendArg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.id)
+        write!(f, "{}", self.short)
     }
 }
 
 impl Debug for BackendArg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, r#"BackendArg("{}")"#, self.id)
+        if self.short != self.full {
+            write!(f, r#"BackendArg("{}" -> "{}")"#, self.short, self.full)
+        } else {
+            write!(f, r#"BackendArg("{}")"#, self.short)
+        }
     }
 }
 
 impl PartialEq for BackendArg {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.short == other.short
     }
 }
 
@@ -84,19 +95,14 @@ impl Eq for BackendArg {}
 
 impl Hash for BackendArg {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
+        self.short.hash(state);
     }
 }
 
-static FORGE_MAP: Lazy<HashMap<&'static str, BackendArg>> = Lazy::new(|| {
+static REGISTRY_BACKEND_MAP: Lazy<HashMap<&'static str, BackendArg>> = Lazy::new(|| {
     REGISTRY
         .iter()
-        .map(|(short, full)| {
-            let (backend_type, name) = full.split_once(':').unwrap();
-            let backend_type = backend_type.parse().unwrap();
-            let fa = BackendArg::new(backend_type, name);
-            (*short, fa)
-        })
+        .map(|(short, full)| (*short, BackendArg::new(short, full)))
         .collect()
 });
 
@@ -110,7 +116,7 @@ mod tests {
     fn test_backend_arg() {
         let t = |s: &str, id, name, t| {
             let fa: BackendArg = s.into();
-            assert_str_eq!(fa.id, id);
+            assert_str_eq!(fa.full, id);
             assert_str_eq!(fa.name, name);
             assert_eq!(fa.backend_type, t);
         };
@@ -119,7 +125,7 @@ mod tests {
         // let core = |s, id, name| t(s, id, name, BackendType::Core);
         let npm = |s, id, name| t(s, id, name, BackendType::Npm);
 
-        asdf("asdf:poetry", "poetry", "poetry");
+        asdf("asdf:poetry", "asdf:poetry", "poetry");
         asdf("poetry", "poetry", "poetry");
         asdf("", "", "");
         cargo("cargo:eza", "cargo:eza", "eza");
@@ -136,7 +142,7 @@ mod tests {
             let expected = dirs::INSTALLS.join(expected);
             assert_str_eq!(actual, expected.to_string_lossy());
         };
-        t("asdf:node", "node");
+        t("asdf:node", "asdf-node");
         t("node", "node");
         t("", "");
         t("cargo:eza", "cargo-eza");

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -162,7 +162,7 @@ impl Ls {
         //     .map(|(plugin, tv, source)| (plugin.to_string(), tv.to_string()))
         //     .collect_vec();
         let rows = runtimes.into_iter().map(|(p, tv, source)| Row {
-            plugin: p.clone(),
+            tool: p.clone(),
             version: (p.as_ref(), &tv, &source).into(),
             requested: match source.is_some() {
                 true => Some(tv.request.version()),
@@ -258,8 +258,8 @@ type RuntimeRow = (Arc<dyn Backend>, ToolVersion, Option<ToolSource>);
 #[derive(Tabled)]
 #[tabled(rename_all = "PascalCase")]
 struct Row {
-    #[tabled(display_with = "Self::display_plugin")]
-    plugin: Arc<dyn Backend>,
+    #[tabled(display_with = "Self::display_tool")]
+    tool: Arc<dyn Backend>,
     version: VersionStatus,
     #[tabled(rename = "Config Source", display_with = "Self::display_source")]
     source: Option<ToolSource>,
@@ -274,8 +274,8 @@ impl Row {
             None => String::new(),
         }
     }
-    fn display_plugin(plugin: &Arc<dyn Backend>) -> String {
-        style(plugin).blue().to_string()
+    fn display_tool(tool: &Arc<dyn Backend>) -> String {
+        style(tool).blue().to_string()
     }
     fn display_source(source: &Option<ToolSource>) -> String {
         match source {

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -68,7 +68,8 @@ pub struct Use {
 
     /// Specify a path to a config file or directory
     /// If a directory is specified, it will look for .mise.toml (default) or .tool-versions
-    #[clap(short, long, overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
+    #[clap(short, long, overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath
+    )]
     path: Option<PathBuf>,
 
     /// Save exact version to config file

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -286,14 +286,17 @@ impl ConfigFile for MiseToml {
             .as_table_mut()
             .unwrap();
 
+        // if a short name is used like "node", make sure we remove any long names like "core:node"
+        tools.remove(&fa.full.to_string());
+
         if versions.len() == 1 {
-            tools.insert(&fa.to_string(), value(versions[0].clone()));
+            tools.insert(&fa.short, value(versions[0].clone()));
         } else {
             let mut arr = Array::new();
             for v in versions {
                 arr.push(v);
             }
-            tools.insert(&fa.to_string(), Item::Value(Value::Array(arr)));
+            tools.insert(&fa.short, Item::Value(Value::Array(arr)));
         }
 
         Ok(())

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -79,7 +79,7 @@ impl ToolVersions {
         self.plugins
             .entry(fa.clone())
             .or_insert_with(|| ToolVersionPlugin {
-                orig_name: fa.to_string(),
+                orig_name: fa.short.to_string(),
                 versions: vec![],
                 post: "".into(),
             })

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -34,7 +34,7 @@ pub static VERSION_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
 });
 
 pub fn get(name: &str) -> ABackend {
-    BackendArg::new(BackendType::Asdf, name).into()
+    BackendArg::new(name, name).into()
 }
 
 pub fn list() -> BackendList {
@@ -143,7 +143,7 @@ mod tests {
     fn test_exact_match() {
         reset();
         assert_cli!("plugin", "add", "tiny");
-        let plugin = AsdfBackend::new(String::from("tiny"));
+        let plugin = AsdfBackend::from_arg("tiny".into());
         let version = plugin
             .latest_version(Some("1.0.0".into()))
             .unwrap()
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn test_latest_stable() {
         reset();
-        let plugin = AsdfBackend::new(String::from("dummy"));
+        let plugin = AsdfBackend::from_arg("dummy".into());
         let version = plugin.latest_version(None).unwrap().unwrap();
         assert_str_eq!(version, "2.0.0");
     }

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -125,7 +125,7 @@ mod tests {
         reset();
         assert_cli!("install", "tiny@2");
         let config = Config::load().unwrap();
-        let plugin = AsdfBackend::new(String::from("tiny"));
+        let plugin = AsdfBackend::from_arg("tiny".into());
         let plugin = Arc::new(plugin);
         let symlinks = list_symlinks(&config, plugin).unwrap();
         assert_debug_snapshot!(symlinks);

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -94,7 +94,7 @@ impl ToolVersion {
     pub fn style(&self) -> String {
         format!(
             "{}{}",
-            style(&self.backend.id).blue().for_stderr(),
+            style(&self.backend.full).blue().for_stderr(),
             style(&format!("@{}", &self.version)).for_stderr()
         )
     }
@@ -239,13 +239,13 @@ impl ToolVersion {
 
 impl Display for ToolVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}@{}", &self.backend.id, &self.version)
+        write!(f, "{}@{}", &self.backend.full, &self.version)
     }
 }
 
 impl PartialEq for ToolVersion {
     fn eq(&self, other: &Self) -> bool {
-        self.backend.id == other.backend.id && self.version == other.version
+        self.backend.full == other.backend.full && self.version == other.version
     }
 }
 
@@ -259,7 +259,7 @@ impl PartialOrd for ToolVersion {
 
 impl Ord for ToolVersion {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.backend.id.cmp(&other.backend.id) {
+        match self.backend.full.cmp(&other.backend.full) {
             Ordering::Equal => self.version.cmp(&other.version),
             o => o,
         }
@@ -268,7 +268,7 @@ impl Ord for ToolVersion {
 
 impl Hash for ToolVersion {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.backend.id.hash(state);
+        self.backend.full.hash(state);
         self.version.hash(state);
     }
 }


### PR DESCRIPTION
This change makes it so when you run `mise use ubi` it saves `ubi` not `cargo:ubi` to mise.toml. It also uses ~/.local/share/mise/installs/ubi as the install path.

This is a prereq for vfox/windows support
