### PR TITLE
feat: mise hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ package-lock.json
 
 megalinter-reports/
 .dev/
+
+.vscode/

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -314,6 +314,14 @@
           "description": "disables built-in shorthands",
           "type": "boolean"
         },
+        "disable_hints": {
+          "description": "disable hints for mise commands",
+          "type": "array",
+          "items": {
+            "description": "command name or * for all commands",
+            "type": "string"
+          }
+        },
         "disable_tools": {
           "description": "tools that should not be used",
           "items": {

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -31,6 +31,14 @@
       "description": "disables built-in shorthands",
       "type": "boolean"
     },
+    "disable_hints": {
+      "description": "disable hints for mise commands",
+      "type": "array",
+      "items": {
+        "description": "command name or * for all commands",
+        "type": "string"
+      }
+    },
     "disable_tools": {
       "description": "tools that should not be used",
       "items": {
@@ -42,6 +50,34 @@
     "experimental": {
       "description": "enable experimental features",
       "type": "boolean"
+    },
+    "go_default_packages_file": {
+      "description": "path to file containing default go packages",
+      "type": "string"
+    },
+    "go_download_mirror": {
+      "description": "url to use as a mirror for go downloads",
+      "type": "string"
+    },
+    "go_repo": {
+      "description": "url to use as a mirror for go modules",
+      "type": "string"
+    },
+    "go_set_gopath": {
+      "description": "set GOPATH to the directory containing the go tool",
+      "type": "boolean"
+    },
+    "go_set_goroot": {
+      "description": "set GOROOT to the directory containing the go tool",
+      "type": "boolean"
+    },
+    "go_skip_checksum": {
+      "description": "skip checksum verification for go downloads",
+      "type": "boolean"
+    },
+    "http_timeout": {
+      "description": "timeout for http requests in seconds",
+      "type": "integer"
     },
     "jobs": {
       "description": "number of tools to install in parallel, default is 4",
@@ -58,6 +94,11 @@
         "type": "string"
       },
       "type": "array"
+    },
+    "libgit2": {
+      "description": "use libgit2 for git operations",
+      "type": "boolean",
+      "default": true
     },
     "node_compile": {
       "description": "do not use precompiled binaries for node",
@@ -80,8 +121,16 @@
       "description": "do not use precompiled binaries for python",
       "type": "boolean"
     },
+    "python_default_packages_file": {
+      "description": "path to file containing default python packages",
+      "type": "string"
+    },
     "python_venv_auto_create": {
       "description": "automatically create a virtualenv for python tools",
+      "type": "boolean"
+    },
+    "quiet": {
+      "description": "suppress all non-error output",
       "type": "boolean"
     },
     "raw": {
@@ -91,6 +140,27 @@
     "shorthands_file": {
       "description": "path to file containing shorthand mappings",
       "type": "string"
+    },
+    "status": {
+      "description": "configure messages displayed when changing directories or executing tools",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "missing_tools": {
+          "description": "display warning when a tool is not installed",
+          "type": "string",
+          "enum": ["if_other_versions_installed", "always", "never"],
+          "default": "if_other_versions_installed"
+        },
+        "show_env": {
+          "description": "display configured mise environment variables",
+          "type": "boolean"
+        },
+        "show_tools": {
+          "description": "display active tools",
+          "type": "boolean"
+        }
+      }
     },
     "task_output": {
       "default": "prefix",
@@ -105,10 +175,6 @@
         "type": "string"
       },
       "type": "array"
-    },
-    "quiet": {
-      "description": "suppress all non-error output",
-      "type": "boolean"
     },
     "verbose": {
       "description": "display extra output",

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -49,12 +49,19 @@ impl Install {
     pub fn run(self) -> Result<()> {
         let config = Config::try_get()?;
         match &self.tool {
-            Some(runtime) => self.install_runtimes(&config, runtime)?,
+            Some(runtime) => {
+                hint!(
+                    "install",
+                    "install multiple versions simultaneously with",
+                    "mise install python@3.8 python@3.9"
+                );
+                self.install_runtimes(&config, runtime)?
+            }
             None => self.install_missing_runtimes(&config)?,
         };
-
         Ok(())
     }
+
     fn install_runtimes(&self, config: &Config, runtimes: &[ToolArg]) -> Result<Vec<ToolVersion>> {
         let mpr = MultiProgressReport::get();
         let tools: HashSet<BackendArg> = runtimes.iter().map(|ta| ta.backend.clone()).collect();

--- a/src/cli/plugins/link.rs
+++ b/src/cli/plugins/link.rs
@@ -90,6 +90,7 @@ mod tests {
         dummy
         tiny
         tiny-link
+        mise hint see available plugins with mise registry
         "###);
         assert_cli_snapshot!("plugin", "uninstall", "tiny-link", @"");
     }

--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -92,6 +92,7 @@ impl PluginsLs {
             table::default_style(&mut table, false);
             miseprintln!("{table}");
         } else {
+            hint!("plugins", "see available plugins with", "mise registry");
             for tool in tools.values() {
                 miseprintln!("{tool}");
             }

--- a/src/cli/plugins/snapshots/mise__cli__plugins__ls__tests__plugin_list.snap
+++ b/src/cli/plugins/snapshots/mise__cli__plugins__ls__tests__plugin_list.snap
@@ -4,3 +4,4 @@ expression: output
 ---
 dummy
 tiny
+mise hint see available plugins with mise registry

--- a/src/cli/settings/ls.rs
+++ b/src/cli/settings/ls.rs
@@ -68,6 +68,7 @@ mod tests {
         cargo_binstall = true
         color = true
         disable_default_shorthands = false
+        disable_hints = []
         disable_tools = []
         experimental = true
         go_default_packages_file = "~/.default-go-packages"
@@ -116,6 +117,7 @@ mod tests {
         cargo_binstall
         color
         disable_default_shorthands
+        disable_hints
         disable_tools
         experimental
         go_default_packages_file

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -29,6 +29,7 @@ impl SettingsSet {
             "cargo_binstall" => parse_bool(&self.value)?,
             "color" => parse_bool(&self.value)?,
             "disable_default_shorthands" => parse_bool(&self.value)?,
+            "disable_hints" => self.value.split(',').map(|s| s.to_string()).collect(),
             "disable_tools" => self.value.split(',').map(|s| s.to_string()).collect(),
             "experimental" => parse_bool(&self.value)?,
             "go_default_packages_file" => self.value.into(),
@@ -143,6 +144,7 @@ pub mod tests {
         cargo_binstall = true
         color = true
         disable_default_shorthands = false
+        disable_hints = []
         disable_tools = []
         experimental = true
         go_default_packages_file = "~/.default-go-packages"

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -59,6 +59,7 @@ mod tests {
         cargo_binstall = true
         color = true
         disable_default_shorthands = false
+        disable_hints = []
         disable_tools = []
         experimental = true
         go_default_packages_file = "~/.default-go-packages"

--- a/src/cli/snapshots/mise__cli__install__tests__install_nothing.snap
+++ b/src/cli/snapshots/mise__cli__install__tests__install_nothing.snap
@@ -2,4 +2,4 @@
 source: src/cli/install.rs
 expression: output
 ---
-
+mise hint install multiple versions simultaneously with mise install python@3.8 python@3.9

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -81,6 +81,11 @@ pub struct Use {
 
 impl Use {
     pub fn run(self) -> Result<()> {
+        hint!(
+            "use",
+            "install multiple versions simultaneously with",
+            "mise use python@3.8 python@3.9"
+        );
         let config = Config::try_get()?;
         let mut ts = ToolsetBuilder::new().build(&config)?;
         let mpr = MultiProgressReport::get();
@@ -240,32 +245,47 @@ mod tests {
         let cf_path = env::current_dir().unwrap().join(".test.mise.toml");
         file::write(&cf_path, "").unwrap();
 
-        assert_cli_snapshot!("use", "tiny@2", @"mise ~/cwd/.test.mise.toml tools: tiny@2.1.0");
+        assert_cli_snapshot!("use", "tiny@2", @r###"
+        mise ~/cwd/.test.mise.toml tools: tiny@2.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
         [tools]
         tiny = "2"
         "###);
 
-        assert_cli_snapshot!("use", "tiny@1", "tiny@2", "tiny@3", @"mise ~/cwd/.test.mise.toml tools: tiny@1.0.1, tiny@2.1.0, tiny@3.1.0");
+        assert_cli_snapshot!("use", "tiny@1", "tiny@2", "tiny@3", @r###"
+        mise ~/cwd/.test.mise.toml tools: tiny@1.0.1, tiny@2.1.0, tiny@3.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
         [tools]
         tiny = ["1", "2", "3"]
         "###);
 
-        assert_cli_snapshot!("use", "--pin", "tiny", @"mise ~/cwd/.test.mise.toml tools: tiny@3.1.0");
+        assert_cli_snapshot!("use", "--pin", "tiny", @r###"
+        mise ~/cwd/.test.mise.toml tools: tiny@3.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
         [tools]
         tiny = "3.1.0"
         "###);
 
-        assert_cli_snapshot!("use", "--fuzzy", "tiny@2", @"mise ~/cwd/.test.mise.toml tools: tiny@2.1.0");
+        assert_cli_snapshot!("use", "--fuzzy", "tiny@2", @r###"
+        mise ~/cwd/.test.mise.toml tools: tiny@2.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
         [tools]
         tiny = "2"
         "###);
 
         let p = cf_path.to_string_lossy().to_string();
-        assert_cli_snapshot!("use", "--rm", "tiny", "--path", &p, @"mise ~/cwd/.test.mise.toml tools:");
+        assert_cli_snapshot!("use", "--rm", "tiny", "--path", &p, @r###"
+        mise ~/cwd/.test.mise.toml tools:
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @"");
 
         let _ = file::remove_file(&cf_path);
@@ -277,32 +297,47 @@ mod tests {
         let _ = file::remove_file(env::current_dir().unwrap().join(".test-tool-versions"));
         let cf_path = env::current_dir().unwrap().join(".test.mise.toml");
 
-        assert_cli_snapshot!("use", "tiny@2", @"mise ~/cwd/.test.mise.toml tools: tiny@2.1.0");
+        assert_cli_snapshot!("use", "tiny@2", @r###"
+        mise ~/cwd/.test.mise.toml tools: tiny@2.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
       [tools]
       tiny = "2"
       "###);
 
-        assert_cli_snapshot!("use", "tiny@1", "tiny@2", "tiny@3", @"mise ~/cwd/.test.mise.toml tools: tiny@1.0.1, tiny@2.1.0, tiny@3.1.0");
+        assert_cli_snapshot!("use", "tiny@1", "tiny@2", "tiny@3", @r###"
+        mise ~/cwd/.test.mise.toml tools: tiny@1.0.1, tiny@2.1.0, tiny@3.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
       [tools]
       tiny = ["1", "2", "3"]
       "###);
 
-        assert_cli_snapshot!("use", "--pin", "tiny", @"mise ~/cwd/.test.mise.toml tools: tiny@3.1.0");
+        assert_cli_snapshot!("use", "--pin", "tiny", @r###"
+        mise ~/cwd/.test.mise.toml tools: tiny@3.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
       [tools]
       tiny = "3.1.0"
       "###);
 
-        assert_cli_snapshot!("use", "--fuzzy", "tiny@2", @"mise ~/cwd/.test.mise.toml tools: tiny@2.1.0");
+        assert_cli_snapshot!("use", "--fuzzy", "tiny@2", @r###"
+        mise ~/cwd/.test.mise.toml tools: tiny@2.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
       [tools]
       tiny = "2"
       "###);
 
         let p = cf_path.to_string_lossy().to_string();
-        assert_cli_snapshot!("use", "--rm", "tiny", "--path", &p, @"mise ~/cwd/.test.mise.toml tools:");
+        assert_cli_snapshot!("use", "--rm", "tiny", "--path", &p, @r###"
+        mise ~/cwd/.test.mise.toml tools:
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @"");
 
         let _ = file::remove_file(&cf_path);
@@ -314,7 +349,10 @@ mod tests {
         let cf_path = env::current_dir().unwrap().join(".test-tool-versions");
         file::write(&cf_path, "").unwrap();
 
-        assert_cli_snapshot!("use", "tiny@3", @"mise ~/cwd/.test-tool-versions tools: tiny@3.1.0");
+        assert_cli_snapshot!("use", "tiny@3", @r###"
+        mise ~/cwd/.test-tool-versions tools: tiny@3.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
         tiny 3
         "###);
@@ -327,7 +365,10 @@ mod tests {
         reset();
         let cf_path = env::current_dir().unwrap().join(".test-tool-versions");
 
-        assert_cli_snapshot!("use", "tiny@3", @"mise ~/cwd/.test-tool-versions tools: tiny@3.1.0");
+        assert_cli_snapshot!("use", "tiny@3", @r###"
+        mise ~/cwd/.test-tool-versions tools: tiny@3.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
+        "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"
         tiny 3
         "###);
@@ -343,6 +384,7 @@ mod tests {
 
         assert_cli_snapshot!("use", "-g", "tiny@2", @r###"
         mise ~/config/config.toml tools: tiny@2.1.0
+        mise hint install multiple versions simultaneously with mise use python@3.8 python@3.9
         mise tiny is defined in ~/cwd/.test-tool-versions which overrides the global config (~/config/config.toml)
         "###);
         assert_snapshot!(file::read_to_string(&cf_path).unwrap(), @r###"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -47,6 +47,8 @@ pub struct Settings {
     pub color: bool,
     #[config(env = "MISE_DISABLE_DEFAULT_SHORTHANDS", default = false)]
     pub disable_default_shorthands: bool,
+    #[config(env = "MISE_DISABLE_HINTS", default = [], parse_env = list_by_comma)]
+    pub disable_hints: BTreeSet<String>,
     #[config(env = "MISE_DISABLE_TOOLS", default = [], parse_env = list_by_comma)]
     pub disable_tools: BTreeSet<String>,
     #[config(env = "MISE_EXPERIMENTAL", default = false)]

--- a/src/output.rs
+++ b/src/output.rs
@@ -42,6 +42,24 @@ macro_rules! miseprint {
 
 #[cfg(test)]
 #[macro_export]
+macro_rules! hint {
+    ($arg1:expr, $arg2:expr, $arg3:expr) => {{
+        let mut stderr = $crate::output::tests::STDERR.lock().unwrap();
+        if !$crate::config::Settings::get()
+            .disable_hints
+            .iter()
+            .any(|hint| hint == $arg1 || hint == "*")
+            || !console::user_attended()
+        {
+            let prefix = console::style("mise hint").dim().for_stderr();
+            let cmd = console::style($arg3).bold().for_stderr();
+            stderr.push(format!("{} {} {}", prefix, format!($arg2), cmd));
+        }
+    }};
+}
+
+#[cfg(test)]
+#[macro_export]
 macro_rules! info {
         ($($arg:tt)*) => {{
             let mut stderr = $crate::output::tests::STDERR.lock().unwrap();
@@ -85,6 +103,36 @@ macro_rules! trace {
 macro_rules! debug {
     ($($arg:tt)*) => {{
         log::debug!($($arg)*);
+    }};
+}
+
+#[cfg(not(test))]
+#[macro_export]
+macro_rules! hint {
+    ($arg1:expr, $arg2:expr, $arg3:expr) => {{
+        if !$crate::config::Settings::get()
+            .disable_hints
+            .iter()
+            .any(|hint| hint == $arg1 || hint == "*")
+            || !console::user_attended()
+        {
+            let prefix = console::style("mise hint").dim().for_stderr();
+            let cmd = console::style($arg3).bold().for_stderr();
+            let disable_single =
+                console::style(format!("mise settings set disable_hints {}", $arg1))
+                    .bold()
+                    .for_stderr();
+            let disable_all = console::style("mise settings set disable_hints \"*\"")
+                .bold()
+                .for_stderr();
+            info_unprefix!("{} {} {}", prefix, format!($arg2), cmd);
+            info_unprefix!(
+                "{} disable this hint with {} or all with {}",
+                prefix,
+                disable_single,
+                disable_all
+            );
+        }
     }};
 }
 

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -139,9 +139,13 @@ impl PythonPlugin {
             Some((_, tag, filename)) => (tag, filename),
             None => {
                 if cfg!(windows) || Settings::get().python_compile == Some(false) {
+                    hint!(
+                        "install",
+                        "To compile python from source, run",
+                        "mise settings set python_compile 1"
+                    );
                     bail!(
-                        "no precompiled python found for {} on {}-{}.\n\
-                        To compile python from source, run: mise settings set python_compile 1",
+                        "no precompiled python found for {} on {}-{}",
                         ctx.tv.version,
                         python_arch(&Settings::get()),
                         python_os(&Settings::get()),
@@ -154,9 +158,12 @@ impl PythonPlugin {
             }
         };
 
-        warn!("installing precompiled python from indygreg/python-build-standalone");
-        warn!("if you experience issues with this python (e.g.: running poetry), switch to python-build");
-        warn!("by running: mise settings set python_compile 1");
+        hint!(
+            "install",
+            "installing precompiled python from indygreg/python-build-standalone\n\
+            if you experience issues with this python (e.g.: running poetry), switch to python-build by running",
+            "mise settings set python_compile 1"
+        );
 
         let url = format!(
             "https://github.com/indygreg/python-build-standalone/releases/download/{tag}/{filename}"

--- a/tests/cli/data/configs/.mise.toml
+++ b/tests/cli/data/configs/.mise.toml
@@ -2,6 +2,8 @@
 [env]
 FOO = "bar"
 
+[settings]
+
 [tools]
 tiny = "latest"
 #golang = {version="1.19.5", foo="bar"}


### PR DESCRIPTION
First draft for a very pragmatic approach on mise hints. Just adds a simple `hint!` macro with static args which respects the setting. Since i wasn't able to figure out yet how to have a multi-type setting i thought it might be handy to use `disable_hints= ["*"] ` as a way to disable all commands (IIRC we use `*` for running all tasks as well?)

It might be nicer to have something which we could pin to the run method such as `#[hint(...)]` (derive, proc_macro?). Not sure if Rust has something similar to Aspects in Java which allows you to run stuff after/before method calls etc.

Still a bit undecided about the styling. We probably should stick to a `dim` prefix like info messages but should highlight the command somehow with `bold`?

<img width="654" alt="Screenshot 2024-08-20 at 00 25 26" src="https://github.com/user-attachments/assets/ffd0e59d-6fe5-4d76-9055-76837a2a9867">

Fixes #2460 
