### PR TITLE
chore: make some gh workflows only run on jdx/mise

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   release:
+    if: github.repository == 'jdx/mise'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   release-plz:
+    if: github.repository == 'jdx/mise'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -20,6 +20,9 @@ env:
 
 jobs:
   build-linux:
+    if: >
+      github.event_name == 'workflow_dispatch'
+      || github.repository == 'jdx/mise'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
My fork was giving me daily error messages of the release-plz job.

I went through the workflows and pinned some of the automatic stuff to just your repo. And where it seemed to make sense kept the possibility to request a manual run from a fork.

PS: When making this PR, I noticed tests are run too, even though I haven't touched any code. Maybe I can make those path dependant, if you like.