### PR TITLE
Use HTTPS for downloading precompiled pythons

### DIFF
--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -104,8 +104,7 @@ impl PythonPlugin {
     fn fetch_precompiled_remote_versions(&self) -> eyre::Result<&Vec<(String, String, String)>> {
         self.precompiled_cache.get_or_try_init(|| {
             let settings = Settings::get();
-            // using http is not a security concern and enabling tls makes mise significantly slower
-            let raw = HTTP_FETCH.get_text("http://mise-versions.jdx.dev/python-precompiled")?;
+            let raw = HTTP_FETCH.get_text("https://mise-versions.jdx.dev/python-precompiled")?;
             let platform = format!("{}-{}", python_arch(&settings), python_os(&settings));
             let versions = raw
                 .lines()


### PR DESCRIPTION
In this day and age _not_ using TLS is just begging for malicious actors to inject malware. This fixes that by adding an `s` (and removing the comment).

I couldn't measure any real difference between HTTP and HTTPS (~10 ms), so I wonder how you, @jdx, came to that conclusion?