### PR TITLE
feat(pipx): add support for specifying package extras

### DIFF
--- a/e2e/backend/test_pipx_extras
+++ b/e2e/backend/test_pipx_extras
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+require_cmd python3
+
+# Create a system pipx that always fail and push it to the front of PATH
+cat >"$HOME/bin/pipx" <<'EOF'
+#!/usr/bin/env bash
+echo "CALL TO SYSTEM pipx! args: $*" >&2
+exit 1
+EOF
+chmod +x "$HOME"/bin/pipx
+export PATH="$HOME/bin:$PATH"
+
+# Just to be sure...
+assert_fail "pipx"
+
+# Use precompiled python
+export MISE_PYTHON_COMPILE=0
+
+# Set up a 2-step installation: pipx@1.5.0 > pipx:mkdocs@1.6.0
+cat >.mise.toml <<EOF
+[tools]
+pipx = "1.5.0"
+"pipx:harlequin" = {version = "1.24.0", extras = "s3"}
+EOF
+
+# Install the tools
+mise install
+
+assert_contains "mise x -- harlequin --version" "1.24.0"

--- a/e2e/backend/test_pipx_slow
+++ b/e2e/backend/test_pipx_slow
@@ -4,3 +4,4 @@ require_cmd pipx
 assert_contains "mise x pipx:black@22.6.0 -- black --version" "22.6.0"
 assert_contains "mise x pipx:psf/black@24.3.0 -- black --version" "24.3.0"
 assert_contains "mise x pipx:git+https://github.com/psf/black.git@24.2.0 -- black --version" "24.2.0"
+assert_contains "mise x pipx:harlequin[s3]@1.24.0 -- harlequin --version" "1.24.0"

--- a/e2e/backend/test_pipx_slow
+++ b/e2e/backend/test_pipx_slow
@@ -4,4 +4,3 @@ require_cmd pipx
 assert_contains "mise x pipx:black@22.6.0 -- black --version" "22.6.0"
 assert_contains "mise x pipx:psf/black@24.3.0 -- black --version" "24.3.0"
 assert_contains "mise x pipx:git+https://github.com/psf/black.git@24.2.0 -- black --version" "24.2.0"
-assert_contains "mise x pipx:harlequin[s3]@1.24.0 -- harlequin --version" "1.24.0"

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -21,7 +21,6 @@ pub struct PIPXBackend {
     latest_version_cache: CacheManager<Option<String>>,
 }
 
-
 impl Backend for PIPXBackend {
     fn get_type(&self) -> BackendType {
         BackendType::Pipx
@@ -153,7 +152,7 @@ impl PipxRequest {
         if v == "latest" {
             match self {
                 PipxRequest::Git(url) => format!("git+{url}.git"),
-                PipxRequest::Pypi(package) => format!("{}{}", package.to_string(), extras),
+                PipxRequest::Pypi(package) => format!("{}{}", package, extras),
             }
         } else {
             match self {


### PR DESCRIPTION
Closes #2491

Some Python tools support optional features upon package installation, via `pipx install package[feature,…]`. This is used, for example, by [Harlequin](https://harlequin.sh/docs/getting-started).

This PR adds support for specifying extras via

```toml
mytool = { version = '3.10', extras = 'foo,bar' }
```

NOTE: It only works for tools published to a registry (e.g PyPI), git-based tools require a different syntax than the one already implemented. (`git+...#egg=project[...]`).

NOTE: I had some issues setting up the local docker environment (unrelated to this project), so I couldn't run the e2e tests. There may be other parts of the code that could complain if using `[, ]` in the tool name, but the PyPI resolution error is the first one that popped up when trying to use package extras.