### PR TITLE
fix(src/path_env.rs): Issue 2504: Fix for JoinPathsError

### DIFF
--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -139,4 +139,20 @@ mod tests {
             format!("/1:/2:/3:/before-1:/before-2:/before-3:/after-1:/after-2:/after-3")
         );
     }
+    #[test]
+    fn test_path_env_with_colon() {
+        reset();
+        let mut path_env = PathEnv::from_iter(
+            [
+                "/before1",
+                "/before2"
+            ]
+            .map(PathBuf::from),
+        );
+        path_env.add("/after1:/after2".into());
+        assert_eq!(
+            path_env.to_string(),
+            format!("/before1:/before2:/after1:/after2")
+        );
+    }
 }

--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -27,7 +27,15 @@ impl PathEnv {
     }
 
     pub fn add(&mut self, path: PathBuf) {
-        self.mise.push(path);
+        let path_string: &str = &path.to_string_lossy();
+        if path_string.contains(':') {
+            let parts: Vec<&str> = path_string.split(':').collect();
+            for part in parts {
+                self.mise.push(PathBuf::from(part));
+            }
+        } else {
+            self.mise.push(path);
+        }
     }
 
     pub fn to_vec(&self) -> Vec<PathBuf> {
@@ -144,15 +152,15 @@ mod tests {
         reset();
         let mut path_env = PathEnv::from_iter(
             [
-                "/before1",
-                "/before2"
+                "/item1",
+                "/item2"
             ]
             .map(PathBuf::from),
         );
-        path_env.add("/after1:/after2".into());
+        path_env.add("/1:/2".into());
         assert_eq!(
             path_env.to_string(),
-            format!("/before1:/before2:/after1:/after2")
+            format!("/1:/2:/item1:/item2")
         );
     }
 }

--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -150,17 +150,8 @@ mod tests {
     #[test]
     fn test_path_env_with_colon() {
         reset();
-        let mut path_env = PathEnv::from_iter(
-            [
-                "/item1",
-                "/item2"
-            ]
-            .map(PathBuf::from),
-        );
+        let mut path_env = PathEnv::from_iter(["/item1", "/item2"].map(PathBuf::from));
         path_env.add("/1:/2".into());
-        assert_eq!(
-            path_env.to_string(),
-            format!("/1:/2:/item1:/item2")
-        );
+        assert_eq!(path_env.to_string(), format!("/1:/2:/item1:/item2"));
     }
 }

--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -1,4 +1,5 @@
 use std::env::join_paths;
+use std::env::split_paths;
 use std::ffi::OsString;
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -27,14 +28,8 @@ impl PathEnv {
     }
 
     pub fn add(&mut self, path: PathBuf) {
-        let path_string: &str = &path.to_string_lossy();
-        if path_string.contains(':') {
-            let parts: Vec<&str> = path_string.split(':').collect();
-            for part in parts {
-                self.mise.push(PathBuf::from(part));
-            }
-        } else {
-            self.mise.push(path);
+        for part in split_paths(&path) {
+            self.mise.push(part);
         }
     }
 


### PR DESCRIPTION
The original submitter of Issue 2504 triggered the JoinPathsError when adding a python env in the [env] section:

    _.python.venv = { path = ".venv", create = true } # create the venv if it doesn't exist

I noticed the same error independently when using the `poetry` plugin and attempting to run `[tasks]`. Consider the following `.mise.toml` file that works fine:

```
[tools]
[tools.poetry]
version = 'latest'
pyproject = 'pyproject.toml'

[tools.python]
version = '3.11'
# Note this is commented out
#virtualenv = '.venv'

[tasks.foo]
run = "echo foo"
```

Running the `foo` task works:

```
❯ mise r foo
[foo] $ echo foo
foo
```

But now if I activate that `virtualenv` config line:

```
[tools]
[tools.poetry]
version = 'latest'
pyproject = 'pyproject.toml'

[tools.python]
version = '3.11'
virtualenv = '.venv'

[tasks.foo]
run = "echo foo"
```

Now running the task triggers the same JoinPathsErr:

```
❯ mise r foo
The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value: JoinPathsError { inner: JoinPathsError }
Location: src/path_env.rs:50

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

In exploring the bug I observed that path_env.add() was being called with two copies of the `.venv` directory concatenated with a colon ":". So my fix is to update the add() function to check for this, split the path argument on ":" and add each element.

My proposed fix is in `./src/path_env.rs`