### PR TITLE
fix: npm backend not finding updates

### DIFF
--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -10,7 +10,7 @@ use crate::cache::CacheManager;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
-use crate::env::GITHUB_TOKEN;
+use crate::env::{self, GITHUB_TOKEN};
 use crate::file;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
@@ -106,7 +106,8 @@ impl CargoBackend {
         Self {
             remote_version_cache: CacheManager::new(
                 ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
-            ),
+            )
+            .with_fresh_duration(*env::MISE_FETCH_REMOTE_VERSIONS_CACHE),
             ba,
         }
     }

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -5,6 +5,7 @@ use crate::cache::CacheManager;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::Settings;
+use crate::env;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolRequest;
 
@@ -87,7 +88,8 @@ impl GoBackend {
         Self {
             remote_version_cache: CacheManager::new(
                 ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
-            ),
+            )
+            .with_fresh_duration(*env::MISE_FETCH_REMOTE_VERSIONS_CACHE),
             ba,
         }
     }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -7,6 +7,7 @@ use crate::cache::CacheManager;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
+use crate::env;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolRequest;
 
@@ -81,10 +82,12 @@ impl NPMBackend {
         Self {
             remote_version_cache: CacheManager::new(
                 ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
-            ),
+            )
+            .with_fresh_duration(*env::MISE_FETCH_REMOTE_VERSIONS_CACHE),
             latest_version_cache: CacheManager::new(
                 ba.cache_path.join("latest_version-$KEY.msgpack.z"),
-            ),
+            )
+            .with_fresh_duration(*env::MISE_FETCH_REMOTE_VERSIONS_CACHE),
             ba,
         }
     }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -10,10 +10,10 @@ use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::file;
-use crate::github;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolRequest;
+use crate::{env, github};
 
 #[derive(Debug)]
 pub struct PIPXBackend {
@@ -125,10 +125,12 @@ impl PIPXBackend {
         Self {
             remote_version_cache: CacheManager::new(
                 ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
-            ),
+            )
+            .with_fresh_duration(*env::MISE_FETCH_REMOTE_VERSIONS_CACHE),
             latest_version_cache: CacheManager::new(
                 ba.cache_path.join("latest_version-$KEY.msgpack.z"),
-            ),
+            )
+            .with_fresh_duration(*env::MISE_FETCH_REMOTE_VERSIONS_CACHE),
             ba,
         }
     }

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -15,7 +15,7 @@ use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::Settings;
 use crate::install_context::InstallContext;
-use crate::{file, github};
+use crate::{env, file, github};
 
 #[derive(Debug)]
 pub struct SPMBackend {
@@ -89,7 +89,8 @@ impl SPMBackend {
         Self {
             remote_version_cache: CacheManager::new(
                 ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
-            ),
+            )
+            .with_fresh_duration(*env::MISE_FETCH_REMOTE_VERSIONS_CACHE),
             ba,
         }
     }

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -5,7 +5,7 @@ use crate::cache::CacheManager;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
-use crate::env::GITHUB_TOKEN;
+use crate::env::{self, GITHUB_TOKEN};
 use crate::github;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolRequest;
@@ -82,7 +82,8 @@ impl UbiBackend {
         Self {
             remote_version_cache: CacheManager::new(
                 ba.cache_path.join("remote_versions-$KEY.msgpack.z"),
-            ),
+            )
+            .with_fresh_duration(*env::MISE_FETCH_REMOTE_VERSIONS_CACHE),
             ba,
         }
     }


### PR DESCRIPTION
It seems that most backends do not respect the `MISE_FETCH_REMOTE_VERSIONS_CACHE` yet which leads to non-detected outdated tools as mentioned in #2503.

Fixes #2503.