### PR TITLE
feat(zig): make dev builds installable

### DIFF
--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -145,7 +145,7 @@ impl ZigPlugin {
     }
 
     fn get_zig_dev_version_regex() -> regex::Regex {
-        return Regex::new(r"^[0-9]+\.[0-9]+\.[0-9]+-dev.[0-9]+\+[0-9a-f]+$").unwrap();
+        Regex::new(r"^[0-9]+\.[0-9]+\.[0-9]+-dev.[0-9]+\+[0-9a-f]+$").unwrap()
     }
 
     fn get_master_version(&self) -> Result<String> {


### PR DESCRIPTION
Hello, I need to switch between dev builds of `zig` because of the compatibility issues. I made dev-builds not listed on `ls-remote` command since there are many of them. I don't have rust experience, sorry if I mutated some function that I should not.

You can see the commands I executed for testing purposes below.
![image](https://github.com/user-attachments/assets/c2489cf0-1f77-479c-b96e-0fe78638d052)
