### PR TITLE
fix: ensure `mise install` installs missing runtimes listed in `mise ls`

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -219,13 +219,15 @@ pub trait Backend: Debug + Send + Sync {
             false => vec![],
         })
     }
-    fn is_version_installed(&self, tv: &ToolVersion) -> bool {
+    fn is_version_installed(&self, tv: &ToolVersion, check_symlink: bool) -> bool {
         match tv.request {
             ToolRequest::System(_) => true,
             _ => {
-                tv.install_path().exists()
-                    && !self.incomplete_file_path(tv).exists()
-                    && !is_runtime_symlink(&tv.install_path())
+                let is_installed = tv.install_path().exists();
+                let is_not_incomplete = !self.incomplete_file_path(tv).exists();
+                let is_valid_symlink = !check_symlink || !is_runtime_symlink(&tv.install_path());
+
+                is_installed && is_not_incomplete && is_valid_symlink
             }
         }
     }
@@ -241,7 +243,7 @@ pub trait Backend: Debug + Send + Sync {
                 return false;
             }
         };
-        !self.is_version_installed(tv) || tv.version != latest
+        !self.is_version_installed(tv, true) || tv.version != latest
     }
     fn symlink_path(&self, tv: &ToolVersion) -> Option<PathBuf> {
         match tv.install_path() {
@@ -352,7 +354,7 @@ pub trait Backend: Debug + Send + Sync {
         }
         let config = Config::get();
         let settings = Settings::try_get()?;
-        if self.is_version_installed(&ctx.tv) {
+        if self.is_version_installed(&ctx.tv, true) {
             if ctx.force {
                 self.uninstall_version(&ctx.tv, ctx.pr.as_ref(), false)?;
                 ctx.pr.set_message("installing".into());

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -76,7 +76,7 @@ impl Current {
                 continue;
             }
             for tv in versions {
-                if !plugin.is_version_installed(tv) {
+                if !plugin.is_version_installed(tv, true) {
                     let source = ts.versions.get(&tv.backend).unwrap().source.clone();
                     warn!(
                         "{}@{} is specified in {}, but not installed",

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -140,7 +140,7 @@ impl Doctor {
         let tools = ts
             .list_current_versions()
             .into_iter()
-            .map(|(f, tv)| match f.is_version_installed(&tv) {
+            .map(|(f, tv)| match f.is_version_installed(&tv, true) {
                 true => (tv.to_string(), style::nstyle("")),
                 false => (tv.to_string(), style::ndim("(missing)")),
             })

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -84,10 +84,10 @@ impl Ls {
             runtimes.retain(|(_, _, source)| source.is_some());
         }
         if self.installed {
-            runtimes.retain(|(p, tv, _)| p.is_version_installed(tv));
+            runtimes.retain(|(p, tv, _)| p.is_version_installed(tv, true));
         }
         if self.missing {
-            runtimes.retain(|(p, tv, _)| !p.is_version_installed(tv));
+            runtimes.retain(|(p, tv, _)| !p.is_version_installed(tv, true));
         }
         if let Some(prefix) = &self.prefix {
             runtimes.retain(|(_, tv, _)| tv.version.starts_with(prefix));
@@ -143,7 +143,7 @@ impl Ls {
         let tvs = runtimes
             .into_iter()
             .map(|(p, tv, _)| (p, tv))
-            .filter(|(p, tv)| p.is_version_installed(tv))
+            .filter(|(p, tv)| p.is_version_installed(tv, true))
             .map(|(_, tv)| tv);
         for tv in tvs {
             if self.plugin.is_some() {
@@ -226,7 +226,7 @@ impl Ls {
                 (p, tv, source)
             })
             // if it isn't installed and it's not specified, don't show it
-            .filter(|(p, tv, source)| source.is_some() || p.is_version_installed(tv))
+            .filter(|(p, tv, source)| source.is_some() || p.is_version_installed(tv, true))
             .filter(|(p, _, _)| match &self.plugin {
                 Some(backend) => backend.contains(p.fa()),
                 None => true,
@@ -312,7 +312,7 @@ impl From<(&dyn Backend, &ToolVersion, &Option<ToolSource>)> for VersionStatus {
     fn from((p, tv, source): (&dyn Backend, &ToolVersion, &Option<ToolSource>)) -> Self {
         if p.symlink_path(tv).is_some() {
             VersionStatus::Symlink(tv.version.clone(), source.is_some())
-        } else if !p.is_version_installed(tv) {
+        } else if !p.is_version_installed(tv, true) {
             VersionStatus::Missing(tv.version.clone())
         } else if source.is_some() {
             VersionStatus::Active(tv.version.clone(), p.is_version_outdated(tv, p))

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -57,7 +57,7 @@ impl Outdated {
         let currents = outdated
             .iter()
             .map(|(t, tv, _)| {
-                if t.is_version_installed(tv) {
+                if t.is_version_installed(tv, true) {
                     tv.version.clone()
                 } else {
                     "MISSING".to_string()

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -48,7 +48,7 @@ impl Uninstall {
 
         let mpr = MultiProgressReport::get();
         for (plugin, tv) in tool_versions {
-            if !plugin.is_version_installed(&tv) {
+            if !plugin.is_version_installed(&tv, true) {
                 warn!("{} is not installed", tv.style());
                 continue;
             }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -81,7 +81,7 @@ impl Upgrade {
 
         let to_remove = outdated
             .into_iter()
-            .filter(|(tool, tv, _)| tool.is_version_installed(tv))
+            .filter(|(tool, tv, _)| tool.is_version_installed(tv, true))
             .map(|(tool, tv, _)| (tool, tv))
             .collect::<Vec<_>>();
 

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -55,7 +55,7 @@ impl Where {
             .as_ref()
             .map(|tvr| tvr.resolve(plugin.as_ref(), false))
         {
-            Some(Ok(tv)) if plugin.is_version_installed(&tv) => {
+            Some(Ok(tv)) if plugin.is_version_installed(&tv, true) => {
                 miseprintln!("{}", tv.install_path().to_string_lossy());
                 Ok(())
             }

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -127,7 +127,7 @@ impl Toolset {
         let versions = self
             .list_current_versions()
             .into_iter()
-            .filter(|(p, tv)| opts.force || !p.is_version_installed(tv))
+            .filter(|(p, tv)| opts.force || !p.is_version_installed(tv, true))
             .map(|(_, tv)| tv)
             .filter(|tv| matches!(self.versions[&tv.backend].source, ToolSource::Argument))
             .map(|tv| tv.request)
@@ -249,7 +249,7 @@ impl Toolset {
     pub fn list_missing_versions(&self) -> Vec<ToolVersion> {
         self.list_current_versions()
             .into_iter()
-            .filter(|(p, tv)| !p.is_version_installed(tv))
+            .filter(|(p, tv)| !p.is_version_installed(tv, true))
             .map(|(_, tv)| tv)
             .collect()
     }
@@ -312,7 +312,7 @@ impl Toolset {
     pub fn list_current_installed_versions(&self) -> Vec<(Arc<dyn Backend>, ToolVersion)> {
         self.list_current_versions()
             .into_iter()
-            .filter(|(p, v)| p.is_version_installed(v))
+            .filter(|(p, v)| p.is_version_installed(v, true))
             .collect()
     }
     pub fn list_outdated_versions(&self) -> Vec<(Arc<dyn Backend>, ToolVersion, String)> {
@@ -330,7 +330,7 @@ impl Toolset {
                         return None;
                     }
                 };
-                if !t.is_version_installed(&tv)
+                if !t.is_version_installed(&tv, true)
                     || is_outdated_version(tv.version.as_str(), latest.as_str())
                 {
                     Some((t, tv, latest))

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -128,11 +128,10 @@ impl ToolRequest {
     }
 
     pub fn is_installed(&self) -> bool {
-        // TODO: dispatch to backend
-        match self {
-            Self::System(_) => true,
-            _ => self.install_path().is_some_and(|p| p.exists()),
-        }
+        let backend = backend::get(self.backend());
+        let tv = ToolVersion::new(backend.as_ref(), self.clone(), self.version());
+
+        backend.is_version_installed(&tv, false)
     }
 
     pub fn install_path(&self) -> Option<PathBuf> {

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -174,7 +174,7 @@ impl ToolVersion {
         }
 
         let existing = build(v.clone())?;
-        if backend.is_version_installed(&existing) {
+        if backend.is_version_installed(&existing, true) {
             // if the version is already installed, no need to fetch all the remote versions
             return Ok(existing);
         }


### PR DESCRIPTION
Previously `mise ls` could show missing runtimes, but `mise install` would report all runtimes were installed. The latter only checked if the install directory existed, which could be present if `mise install` aborted early. However, the former also checked the existence of the runtime symlink and the `incomplete` file in the cache.

To make this behavior consistent, dispatch the tool request to the backend. Exclude the runtime symlink check since this breaks the install check for `node@latest`.

Closes https://github.com/jdx/mise/issues/2257