### PR TITLE
fix: ls-remote doesn't support @sub-X style versions

### DIFF
--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 use crate::backend;
 use crate::backend::Backend;
 use crate::cli::args::ToolArg;
-use crate::toolset::ToolRequest;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::ui::multi_progress_report::MultiProgressReport;
 
 /// List runtime versions available for install
@@ -45,6 +45,10 @@ impl LsRemote {
         let prefix = match &self.plugin {
             Some(tool_arg) => match &tool_arg.tvr {
                 Some(ToolRequest::Version { version: v, .. }) => Some(v.clone()),
+                Some(ToolRequest::Sub { .. }) => match tool_arg.clone().tvr {
+                    Some(tvr) => Some(ToolVersion::resolve(plugin.as_ref(), tvr, false)?.version),
+                    None => None,
+                },
                 _ => self.prefix.clone(),
             },
             _ => self.prefix.clone(),
@@ -128,5 +132,6 @@ mod tests {
     fn test_ls_remote_prefix() {
         assert_cli_snapshot!("list-remote", "dummy", "1");
         assert_cli_snapshot!("list-remote", "dummy@2");
+        assert_cli_snapshot!("list-remote", "dummy@sub-1:2");
     }
 }

--- a/src/cli/snapshots/mise__cli__ls_remote__tests__ls_remote_prefix-3.snap
+++ b/src/cli/snapshots/mise__cli__ls_remote__tests__ls_remote_prefix-3.snap
@@ -1,0 +1,5 @@
+---
+source: src/cli/ls_remote.rs
+expression: output
+---
+1.1.0


### PR DESCRIPTION
Fixes #2494