### PR TITLE
fix: Ensure dependencies are available for alternative backends

### DIFF
--- a/e2e/backend/test_npm
+++ b/e2e/backend/test_npm
@@ -6,3 +6,4 @@ export NPM_CONFIG_FUND=false
 mise use node
 assert "mise x npm:prettier@3.1.0 -- prettier -v" "3.1.0"
 assert "FORCE_COLOR=0 mise x npm:@antfu/ni@0.21.12 -- ni -v 2>/dev/null | head -n1" "@antfu/ni  v0.21.12"
+assert "mise install npm:tldr"

--- a/e2e/backend/test_npm
+++ b/e2e/backend/test_npm
@@ -6,4 +6,4 @@ export NPM_CONFIG_FUND=false
 mise use node
 assert "mise x npm:prettier@3.1.0 -- prettier -v" "3.1.0"
 assert "FORCE_COLOR=0 mise x npm:@antfu/ni@0.21.12 -- ni -v 2>/dev/null | head -n1" "@antfu/ni  v0.21.12"
-assert "mise install npm:tldr"
+assert "mise install npm:tldr@3.4.0" "mise npm:tldr@3.4.0 ✓ installed"

--- a/e2e/backend/test_npm
+++ b/e2e/backend/test_npm
@@ -6,4 +6,4 @@ export NPM_CONFIG_FUND=false
 mise use node
 assert "mise x npm:prettier@3.1.0 -- prettier -v" "3.1.0"
 assert "FORCE_COLOR=0 mise x npm:@antfu/ni@0.21.12 -- ni -v 2>/dev/null | head -n1" "@antfu/ni  v0.21.12"
-assert "mise install npm:tldr@3.4.0" "mise npm:tldr@3.4.0 ✓ installed"
+assert_succeed "mise install npm:tldr@3.4.0"

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -105,6 +105,7 @@ impl Backend for CargoBackend {
             .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path(&config)?)
             .prepend_path(ctx.ts.list_paths())?
+            .prepend_path(self.depedency_toolset()?.list_paths())?
             .execute()?;
 
         Ok(())

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -476,7 +476,7 @@ pub trait Backend: Debug + Send + Sync {
         tv.cache_path().join("incomplete")
     }
 
-    fn dependency_env(&self) -> eyre::Result<BTreeMap<String, String>> {
+    fn depedency_toolset(&self) -> eyre::Result<Toolset> {
         let config = Config::get();
         let dependencies = self
             .get_all_dependencies(&ToolRequest::System(self.name().into()))?
@@ -487,7 +487,11 @@ pub trait Backend: Debug + Send + Sync {
             .filter_by_tool(&dependencies)
             .into();
         ts.resolve()?;
-        ts.full_env()
+        Ok(ts)
+    }
+
+    fn dependency_env(&self) -> eyre::Result<BTreeMap<String, String>> {
+        self.depedency_toolset()?.full_env()
     }
 }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -71,6 +71,7 @@ impl Backend for NPMBackend {
             .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path(&config)?)
             .prepend_path(ctx.ts.list_paths())?
+            .prepend_path(self.depedency_toolset()?.list_paths())?
             .execute()?;
 
         Ok(())

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -96,6 +96,7 @@ impl Backend for PIPXBackend {
                 .prepend_path(ctx.ts.list_paths())?
                 // Prepend install path so pipx doesn't issue a warning about missing path
                 .prepend_path(vec![ctx.tv.install_path().join("bin")])?
+                .prepend_path(self.depedency_toolset()?.list_paths())?
                 .execute()?;
         } else {
             CmdLineRunner::new("pipx")
@@ -108,6 +109,7 @@ impl Backend for PIPXBackend {
                 .prepend_path(ctx.ts.list_paths())?
                 // Prepend install path so pipx doesn't issue a warning about missing path
                 .prepend_path(vec![ctx.tv.install_path().join("bin")])?
+                .prepend_path(self.depedency_toolset()?.list_paths())?
                 .execute()?;
         }
         Ok(())

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -63,7 +63,8 @@ impl Backend for UbiBackend {
             .arg(self.name())
             .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path(&config)?)
-            .prepend_path(ctx.ts.list_paths())?;
+            .prepend_path(ctx.ts.list_paths())?
+            .prepend_path(self.depedency_toolset()?.list_paths())?;
 
         if let Some(token) = &*GITHUB_TOKEN {
             cmd = cmd.env("GITHUB_TOKEN", token);


### PR DESCRIPTION
When installing a tool via one of the experimental backends (`npm`, `pipx`, etc), the install would fail if the backend was managed by `mise` itself. 

When setting up the paths for the installation command (`npm install tldr`) to run, `mise` wasn't making the backends specified in `get_dependencies` available to the subshell. So, they'd fail with a cryptic error:

```
No such file or directory (os error 2)
```

This was because `npm` wasn't in the path, despite it being installed. 

I restructured some existing code to make creating a Toolset for a backend's dependents simple, then prepended those paths to the resulting command. I've confirmed locally that installations commands that fail without the

I also added a line to an e2e test, but I wasn't able to get those running locally in docker, so it's worth double checking that works as intended before merge.

---

fixes https://github.com/jdx/mise/issues/2174 
fixes https://github.com/jdx/mise/issues/2315
fixes https://github.com/jdx/mise/issues/2457
fixes https://github.com/jdx/mise/issues/2458