### PR TITLE
fix: Update fish.rs for activation of mise

### DIFF
--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -75,7 +75,7 @@ impl Shell for Fish {
         "#});
         if Settings::get().not_found_auto_install {
             out.push_str(&formatdoc! {r#"
-            if functions -q fish_command_not_found and not functions -q __mise_fish_command_not_found
+            if functions -q fish_command_not_found; and not functions -q __mise_fish_command_not_found
                 functions -e __mise_fish_command_not_found
                 functions -c fish_command_not_found __mise_fish_command_not_found
             end

--- a/src/shell/snapshots/mise__shell__fish__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__activate.snap
@@ -57,7 +57,7 @@ function __mise_env_eval_2 --on-event fish_preexec --description 'Update mise en
 
     functions --erase __mise_cd_hook;
 end;
-if functions -q fish_command_not_found and not functions -q __mise_fish_command_not_found
+if functions -q fish_command_not_found; and not functions -q __mise_fish_command_not_found
     functions -e __mise_fish_command_not_found
     functions -c fish_command_not_found __mise_fish_command_not_found
 end
@@ -71,4 +71,3 @@ function fish_command_not_found
         __fish_default_command_not_found_handler $argv
     end
 end
-


### PR DESCRIPTION
The if statement syntax is wrong due to which __mise_fish_command_not_found function not created.

As shown in this screenshot.
![image](https://github.com/user-attachments/assets/83ddb369-bb3a-494b-bce5-a7adb7850d6f)
