### PR TITLE
fix: mise deactivate zsh does not work, but mise deactivate does

### DIFF
--- a/docs/cli/deactivate.md
+++ b/docs/cli/deactivate.md
@@ -9,8 +9,5 @@ Usage: deactivate
 
 Examples:
 
-    $ mise deactivate bash
-    $ mise deactivate zsh
-    $ mise deactivate fish
-    $ execx($(mise deactivate xonsh))
+    $ mise deactivate
 ```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -289,10 +289,7 @@ Usage: deactivate
 
 Examples:
 
-    $ mise deactivate bash
-    $ mise deactivate zsh
-    $ mise deactivate fish
-    $ execx($(mise deactivate xonsh))
+    $ mise deactivate
 ```
 
 ## `mise direnv activate`

--- a/src/cli/deactivate.rs
+++ b/src/cli/deactivate.rs
@@ -41,10 +41,7 @@ fn err_inactive() -> Result<()> {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    $ <bold>mise deactivate bash</bold>
-    $ <bold>mise deactivate zsh</bold>
-    $ <bold>mise deactivate fish</bold>
-    $ <bold>execx($(mise deactivate xonsh))</bold>
+    $ <bold>mise deactivate</bold>
 "#
 );
 


### PR DESCRIPTION
Fixes #2546 