### PR TITLE
feat: implement a few tera functions for mise toml config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,6 +1978,7 @@ dependencies = [
  "openssl",
  "path-absolutize",
  "petgraph",
+ "platform-info",
  "predicates",
  "pretty_assertions",
  "rand",
@@ -2546,6 +2547,16 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "platform-info"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5ff316b9c4642feda973c18f0decd6c8b0919d4722566f6e4337cce0dd88217"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ once_cell = "1.19.0"
 openssl = { version = "0.10.66", optional = true }
 path-absolutize = "3.1.1"
 petgraph = "0.6.4"
+platform-info = "2.0.3" # cross-platform platform information
 rand = "0.8.5"
 rayon = "1.10.0"
 regex = "1.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ indicatif = { version = "0.17.8", features = ["default", "improved_unicode"] }
 indoc = "2.0.5"
 itertools = "0.13"
 log = "0.4.21"
-num_cpus = "1.16.0"
+num_cpus = "1.16.0" # gets cross-platform the number of CPU
 once_cell = "1.19.0"
 openssl = { version = "0.10.66", optional = true }
 path-absolutize = "3.1.1"

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -75,7 +75,7 @@ pub fn get_tera(dir: Option<&Path>) -> Tera {
     tera.register_function(
         "invocation_directory",
         move |_args: &HashMap<String, Value>| -> tera::Result<Value> {
-            let path = env::current_dir().unwrap_or(PathBuf::default());
+            let path = env::current_dir().unwrap_or_default();
 
             let result = String::from(path.to_string_lossy());
 
@@ -128,7 +128,7 @@ pub fn get_tera(dir: Option<&Path>) -> Tera {
         "quote",
         move |input: &Value, _args: &HashMap<String, Value>| match input {
             Value::String(s) => {
-                let result = format!("'{}'", s.replace("'", "\'"));
+                let result = format!("'{}'", s.replace("'", "\\'"));
 
                 Ok(Value::String(result))
             }

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1,7 +1,12 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use heck::{
+    ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase,
+    ToUpperCamelCase,
+};
 use once_cell::sync::Lazy;
+use platform_info::{PlatformInfo, PlatformInfoAPI, UNameAPI};
 use tera::{Context, Tera, Value};
 
 use crate::cmd::cmd;
@@ -34,6 +39,47 @@ pub fn get_tera(dir: Option<&Path>) -> Tera {
                 }
                 _ => Err("exec command must be a string".into()),
             }
+        },
+    );
+    tera.register_function(
+        "arch",
+        move |_args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let info = PlatformInfo::new().expect("unable to determine platform info");
+            let result = String::from(info.machine().to_string_lossy()); // ignore potential UTF-8 convension error
+            Ok(Value::String(result))
+        },
+    );
+    tera.register_function(
+        "num_cpus",
+        move |_args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let num = num_cpus::get();
+            Ok(Value::String(num.to_string()))
+        },
+    );
+    tera.register_function(
+        "os",
+        move |_args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let info = PlatformInfo::new().expect("unable to determine platform info");
+            let result = String::from(info.osname().to_string_lossy()); // ignore potential UTF-8 convension error
+            Ok(Value::String(result))
+        },
+    );
+    tera.register_function(
+        "os_family",
+        move |_args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let info = PlatformInfo::new().expect("unable to determine platform info");
+            let result = String::from(info.sysname().to_string_lossy()); // ignore potential UTF-8 convension error
+            Ok(Value::String(result))
+        },
+    );
+    tera.register_function(
+        "invocation_directory",
+        move |_args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let path = env::current_dir().unwrap_or(PathBuf::default());
+
+            let result = String::from(path.to_string_lossy());
+
+            Ok(Value::String(result))
         },
     );
     tera.register_filter(
@@ -78,6 +124,59 @@ pub fn get_tera(dir: Option<&Path>) -> Tera {
             _ => Err("join_path input must be an array of strings".into()),
         },
     );
+    tera.register_filter(
+        "quote",
+        move |input: &Value, _args: &HashMap<String, Value>| match input {
+            Value::String(s) => {
+                let result = format!("'{}'", s.replace("'", "\'"));
+
+                Ok(Value::String(result))
+            }
+            _ => Err("quote input must be a string".into()),
+        },
+    );
+    tera.register_filter(
+        "kebabcase",
+        move |input: &Value, _args: &HashMap<String, Value>| match input {
+            Value::String(s) => Ok(Value::String(s.to_kebab_case())),
+            _ => Err("kebabcase input must be a string".into()),
+        },
+    );
+    tera.register_filter(
+        "lowercamelcase",
+        move |input: &Value, _args: &HashMap<String, Value>| match input {
+            Value::String(s) => Ok(Value::String(s.to_lower_camel_case())),
+            _ => Err("lowercamelcase input must be a string".into()),
+        },
+    );
+    tera.register_filter(
+        "shoutykebabcase",
+        move |input: &Value, _args: &HashMap<String, Value>| match input {
+            Value::String(s) => Ok(Value::String(s.to_shouty_kebab_case())),
+            _ => Err("shoutykebabcase input must be a string".into()),
+        },
+    );
+    tera.register_filter(
+        "shoutysnakecase",
+        move |input: &Value, _args: &HashMap<String, Value>| match input {
+            Value::String(s) => Ok(Value::String(s.to_shouty_snake_case())),
+            _ => Err("shoutysnakecase input must be a string".into()),
+        },
+    );
+    tera.register_filter(
+        "snakecase",
+        move |input: &Value, _args: &HashMap<String, Value>| match input {
+            Value::String(s) => Ok(Value::String(s.to_snake_case())),
+            _ => Err("snakecase input must be a string".into()),
+        },
+    );
+    tera.register_filter(
+        "uppercamelcase",
+        move |input: &Value, _args: &HashMap<String, Value>| match input {
+            Value::String(s) => Ok(Value::String(s.to_upper_camel_case())),
+            _ => Err("uppercamelcase input must be a string".into()),
+        },
+    );
     tera.register_tester(
         "file_exists",
         move |input: Option<&Value>, _args: &[Value]| match input {
@@ -85,5 +184,197 @@ pub fn get_tera(dir: Option<&Path>) -> Tera {
             _ => Err("file_exists input must be a string".into()),
         },
     );
+
     tera
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_render_with_custom_function_arch_x86_64() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ arch() }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("x86_64", result);
+    }
+
+    #[test]
+    #[cfg(target_arch = "aarch64")]
+    fn test_render_with_custom_function_arch_arm64() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ arch() }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("aarch64", result);
+    }
+
+    #[test]
+    fn test_render_with_custom_function_num_cpus() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ num_cpus() }}", &Context::default())
+            .unwrap();
+
+        let num = result.parse::<u32>().unwrap();
+        assert!(num > 0);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_render_with_custom_function_os_linux() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera.render_str("{{ os() }}", &Context::default()).unwrap();
+
+        assert_eq!("GNU/Linux", result);
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_render_with_custom_function_os_windows() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera.render_str("{{ os() }}", &Context::default()).unwrap();
+
+        assert_eq!("Windows", result);
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn test_render_with_custom_function_os_family_unix() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ os_family() }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("Linux", result);
+    }
+
+    #[test]
+    #[cfg(target_family = "windows")]
+    fn test_render_with_custom_function_os_windows() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ os_family() }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("Windows", result);
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn test_render_with_custom_function_invocation_directory() {
+        let a = env::set_current_dir("/tmp").is_ok();
+        let mut tera = get_tera(Option::default());
+        assert!(a);
+        println!("{:?}", env::current_dir().unwrap());
+
+        let result = tera
+            .render_str("{{ invocation_directory() }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("/tmp", result);
+    }
+
+    #[test]
+    #[cfg(target_family = "windows")]
+    fn test_render_with_custom_function_invocation_directory() {
+        let a = env::set_current_dir("C:\\").is_ok();
+        let mut tera = get_tera(Option::default());
+        assert!(a);
+
+        let result = tera
+            .render_str("{{ invocation_directory() }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("C:\\", result);
+    }
+
+    #[test]
+    fn test_render_with_custom_filter_quote() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ \"quoted'str\" | quote }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("'quoted\'str'", result);
+    }
+
+    #[test]
+    fn test_render_with_custom_filter_kebabcase() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ \"thisFilter\" | kebabcase }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("this-filter", result);
+    }
+
+    #[test]
+    fn test_render_with_custom_filter_lowercamelcase() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ \"Camel-case\" | lowercamelcase }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("camelCase", result);
+    }
+
+    #[test]
+    fn test_render_with_custom_filter_shoutykebabcase() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ \"kebabCase\" | shoutykebabcase }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("KEBAB-CASE", result);
+    }
+
+    #[test]
+    fn test_render_with_custom_filter_shoutysnakecase() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ \"snakeCase\" | shoutysnakecase }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("SNAKE_CASE", result);
+    }
+
+    #[test]
+    fn test_render_with_custom_filter_snakecase() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ \"snakeCase\" | snakecase }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("snake_case", result);
+    }
+
+    #[test]
+    fn test_render_with_custom_filter_uppercamelcase() {
+        let mut tera = get_tera(Option::default());
+
+        let result = tera
+            .render_str("{{ \"CamelCase\" | uppercamelcase }}", &Context::default())
+            .unwrap();
+
+        assert_eq!("CamelCase", result);
+    }
 }

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -309,7 +309,7 @@ mod tests {
             .render_str("{{ \"quoted'str\" | quote }}", &Context::default())
             .unwrap();
 
-        assert_eq!("'quoted\'str'", result);
+        assert_eq!("'quoted\\'str'", result);
     }
 
     #[test]


### PR DESCRIPTION
I implemented these functions:
- arch
- num_cpus
- os
- os_family
- invocation_directory
- quote
- kebabcase
- lowercamelcase
- shoutykebabcase
- shoutysnakecase
- snakecase

Since there are difference from `just`, I figure it's good to check in before I continue implementing more and add documentation.

1. `PlatformInfo` provides "runtime" information as `uname`. `just` returns `target` information. I don't agree on correctness since it will break if you cross-compile. It's always a hassle for package managers. So `PlatformInfo` API provides a different output than `just`'s.
   I took inspiration from [YADM's template design](https://yadm.io/docs/templates). I provide the result of `arch`, `os`, ... as is. This behavior aligns with `direnv` where `direnv` exposes no arch information. It's `direnv`'s users job to parse platform information. And for mise, users can use tera filter to transform text.
   What do you think of this?
3. `invocation_directory` is annoying to fix. `BASE_CONTEXT` is initialized lazily so I have difficulty testing other functions (I wrote one test per one custom function). We can come back to this later or refactor the context a bit. I prefer skipping inconsistency for now.
4. `just` implements functions like `kebabcase` as function. I implement them as tera filters. Any objections?
5. Where should I add documentation? Also, any other thoughts?

Part of #2049 