### PR TITLE
fix: some fixes for new tera template helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,7 +1978,6 @@ dependencies = [
  "openssl",
  "path-absolutize",
  "petgraph",
- "platform-info",
  "predicates",
  "pretty_assertions",
  "rand",
@@ -2547,16 +2546,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platform-info"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ff316b9c4642feda973c18f0decd6c8b0919d4722566f6e4337cce0dd88217"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,12 +74,11 @@ indicatif = { version = "0.17.8", features = ["default", "improved_unicode"] }
 indoc = "2.0.5"
 itertools = "0.13"
 log = "0.4.21"
-num_cpus = "1.16.0" # gets cross-platform the number of CPU
+num_cpus = "1"
 once_cell = "1.19.0"
 openssl = { version = "0.10.66", optional = true }
 path-absolutize = "3.1.1"
 petgraph = "0.6.4"
-platform-info = "2.0.3" # cross-platform platform information
 rand = "0.8.5"
 rayon = "1.10.0"
 regex = "1.10.4"

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -9,11 +9,49 @@ Templates are used in the following locations:
 The following context objects are available inside templates:
 
 - `env: HashMap<String, String>` – current environment variables
-- `config_root: PathBuf` – directory containing the `.mise.toml` file
+- `cwd: PathBuf` – current working directory
+- `config_root: PathBuf` – directory containing the `mise.toml` file or directory containing
+  `.mise` directory with config file.
 
 As well as these functions:
 
-- `exec(command: &str) -> String` – execute a command and return the output
+- `exec(command) -> String` – execute a command and return the output
+- `arch() -> String` – return the system architecture, e.g. `x86_64`, `arm64`
+- `os() -> String` – return the operating system, e.g. `linux`, `macos`, `windows`
+- `os_family() -> String` – return the operating system family, e.g. `unix`, `windows`
+- `num_cpus() -> usize` – return the number of CPUs on the system
+
+And these filters:
+
+- `str | hash -> String` – return the SHA256 hash of the input string
+- `str | hash(len=usize) -> String` – return the SHA256 hash of the input string truncated to `len`
+  characters
+- `path | hash_file -> String` – return the SHA256 hash of the file at the input path
+- `path | hash_file(len=usize) -> String` – return the SHA256 hash of the file at the input path
+  truncated to `len` characters
+- `path | canonicalize -> String` – return the canonicalized path
+- `path | dirname -> String` – return the directory path for a file, e.g. `/foo/bar/baz.txt` ->
+  `/foo/bar`
+- `path | basename -> String` – return the base name of a file, e.g. `/foo/bar/baz.txt` -> `baz.txt`
+- `path | extname -> String` – return the extension of a file, e.g. `/foo/bar/baz.txt` -> `.txt`
+- `path | file_stem -> String` – return the file name without the extension, e.g.
+  `/foo/bar/baz.txt` -> `baz`
+- `path | file_size -> String` – return the size of a file in bytes
+- `path | last_modified -> String` – return the last modified time of a file
+- `path[] | join_path -> String` – join an array of paths into a single path
+- `str | quote -> String` – quote a string
+- `str | kebabcase -> String` – convert a string to kebab-case
+- `str | lowercamelcase -> String` – convert a string to lowerCamelCase
+- `str | uppercamelcase -> String` – convert a string to UpperCamelCase
+- `str | shoutycamelcase -> String` – convert a string to ShoutyCamelCase
+- `str | snakecase -> String` – convert a string to snake_case
+- `str | shoutysnakecase -> String` – convert a string to SHOUTY_SNAKE_CASE
+
+And these testers:
+
+- `if path is dir` – if the path is a directory
+- `if path is file` – if the path is a file
+- `if path is exists` – if the path exists
 
 Templates are parsed with [tera](https://keats.github.io/tera/docs/)—which is quite powerful. For
 example, this snippet will get the directory name of the project:

--- a/src/config/env_directive.rs
+++ b/src/config/env_directive.rs
@@ -97,6 +97,7 @@ impl EnvResults {
                 .map(Path::to_path_buf)
                 .or_else(|| dirs::CWD.clone())
                 .unwrap_or_default();
+            ctx.insert("cwd", &*dirs::CWD);
             ctx.insert("config_root", &config_root);
             let env_vars = env
                 .iter()

--- a/src/file.rs
+++ b/src/file.rs
@@ -22,6 +22,12 @@ use zip::ZipArchive;
 
 use crate::{dirs, env};
 
+pub fn open<P: AsRef<Path>>(path: P) -> Result<File> {
+    let path = path.as_ref();
+    trace!("open {}", display_path(path));
+    File::open(path).wrap_err_with(|| format!("failed open: {}", display_path(path)))
+}
+
 pub fn remove_all<P: AsRef<Path>>(path: P) -> Result<()> {
     let path = path.as_ref();
     match path.metadata().map(|m| m.file_type()) {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,16 +1,15 @@
 use std::collections::HashMap;
-use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::io::{Read, Write};
 use std::path::Path;
 
+use crate::file;
+use crate::file::display_path;
+use crate::ui::progress_report::SingleReport;
 use eyre::{ensure, Result};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use siphasher::sip::SipHasher;
-
-use crate::file::display_path;
-use crate::ui::progress_report::SingleReport;
 
 pub fn hash_to_str<T: Hash>(t: &T) -> String {
     let mut s = SipHasher::new();
@@ -18,12 +17,18 @@ pub fn hash_to_str<T: Hash>(t: &T) -> String {
     format!("{:x}", s.finish())
 }
 
+pub fn hash_sha256_to_str(s: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(s);
+    format!("{:x}", hasher.finalize())
+}
+
 pub fn file_hash_sha256(path: &Path) -> Result<String> {
     file_hash_sha256_prog(path, None)
 }
 
 pub fn file_hash_sha256_prog(path: &Path, pr: Option<&dyn SingleReport>) -> Result<String> {
-    let mut file = File::open(path)?;
+    let mut file = file::open(path)?;
     if let Some(pr) = pr {
         pr.set_length(file.metadata()?.len());
     }


### PR DESCRIPTION
in mise I try to stick to "x64/arm64" consistently because tools, rust, operating systems all name these things differently.

I think "invocation_directory" is already available somewhere but I need to find what it is and also standardize some of the naming of directories like "project_root" and "config_root".