### PR TITLE
fix: wrong version in the README example when install specific version

### DIFF
--- a/.mise/tasks/release-plz
+++ b/.mise/tasks/release-plz
@@ -31,7 +31,7 @@ version="$(cargo pkgid mise | cut -d# -f2)"
 git cliff --tag "v$version" -o CHANGELOG.md
 changelog="$(git cliff --tag "v$version" --unreleased --strip all)"
 changelog="$(echo "$changelog" | tail -n +3)"
-sed -i.bak "s/^mise [0-9]\+\.[0-9]\+\.[0-9]\+\(-rc\.[0-9]\+\)\?$/mise $version/" README.md
+sed -i.bak "s/^[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc\.[0-9]\+\)\? macos-arm64 (a1b2d3e [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})$/$version macos-arm64 (a1b2d3e $date)/" README.md
 sed -i.bak "s/^Version: [0-9]\+\.[0-9]\+\.[0-9]\+\(-rc\.[0-9]\+\)\?$/Version: $version/" packaging/rpm/mise.spec
 sed -i.bak "s/version = \"[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc\.[0-9]\+\)\?\";$/version = \"$version\";/" default.nix
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-mise 2024.9.3
+2024.9.3 macos-arm64 (a1b2d3e 2024-09-12)
 ```
 
 or install a specific a version:
@@ -44,7 +44,7 @@ or install a specific a version:
 ```sh-session
 $ curl https://mise.run | MISE_VERSION=v2024.5.16 sh
 $ ~/.local/bin/mise --version
-mise 2024.9.3
+2024.5.16 macos-arm64 (8838098 2024-05-14)
 ```
 
 Hook mise into your shell (pick the right one for your shell):


### PR DESCRIPTION
* Removed `mise` prefix and added hash and date (whereas hash for latest version is bogus as it is not known at that time)
* Specific version has been adapted and is not replaced by the release-plz task anymore.

Fixes #2495