### PR TITLE
Fix Options example in documentation

### DIFF
--- a/docs/tasks/toml-tasks.md
+++ b/docs/tasks/toml-tasks.md
@@ -91,7 +91,7 @@ Example:
 
 ```toml
 [tasks.test]
-run = 'cargo test {{arg(name="file")}}'
+run = 'cargo test {{option(name="file")}}'
 # execute: mise run test --file my-test-file
 # runs: cargo test my-test-file
 ```


### PR DESCRIPTION
The example in `Options` is using `arg`, this PR fixes it to use the correct `option`