### PR TITLE
fix: skip last modified time test for nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,7 +39,8 @@ rustPlatform.buildRustPackage {
   # is excluded by default from Nix.
   checkPhase = ''
     RUST_BACKTRACE=full cargo test --all-features -- \
-      --skip cli::plugins::ls::tests::test_plugin_list_urls
+      --skip cli::plugins::ls::tests::test_plugin_list_urls \
+      --skip tera::tests::test_last_modified
   '';
 
   meta = with lib; {


### PR DESCRIPTION
File timestamps in nix are set to 00:00:01 1/1/1970 UTC so the test won't pass in nix.