### PR TITLE
docs: remove experimental badge from cargo and npm backends

### DIFF
--- a/docs/dev-tools/backends/index.md
+++ b/docs/dev-tools/backends/index.md
@@ -3,9 +3,9 @@
 In addition to asdf plugins, you can also directly install CLIs with some package managers.
 
 * [asdf](/dev-tools/backends/asdf)
-* [Cargo](/dev-tools/backends/cargo) <Badge type="warning" text="experimental" />
+* [Cargo](/dev-tools/backends/cargo)
 * [Go](/dev-tools/backends/go) <Badge type="warning" text="experimental" />
-* [NPM](/dev-tools/backends/npm) <Badge type="warning" text="experimental" />
+* [NPM](/dev-tools/backends/npm)
 * [Pipx](/dev-tools/backends/pipx) <Badge type="warning" text="experimental" />
 * [SPM](/dev-tools/backends/spm) <Badge type="warning" text="experimental" />
 * [Ubi](/dev-tools/backends/ubi) <Badge type="warning" text="experimental" />


### PR DESCRIPTION
`cargo` and `npm` are no longer experimental features, so I think it's okay to remove the badge.
