### PR TITLE
fix: tools installed via cargo:a/b@rev:012 immediately pruned

### DIFF
--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -111,7 +111,14 @@ impl ToolVersion {
     }
     pub fn latest_version(&self, tool: &dyn Backend) -> Result<String> {
         let tv = self.request.resolve(tool, true)?;
-        Ok(tv.version)
+        // map cargo backend specific prefixes to ref
+        let version = match tv.request.version().split_once(':') {
+            Some((_ref_type @ ("tag" | "branch" | "rev"), r)) => {
+                format!("ref:{r}")
+            }
+            _ => tv.version,
+        };
+        Ok(version)
     }
     pub fn style(&self) -> String {
         format!(


### PR DESCRIPTION
Fixes #2583 

@jdx First thought i had was, why not setting the `ref: ` in the TOML file but the cargo tool could not infer the type for installation. So i guess we're stuck with mapping these prefixes back and forth, or do you have any other ideas?

A a small side-effect Version/Requested will differ but that is not unusual as it already does for `latest`.

```
mise-debug ls
Tool                     Version                           Config Source               Requested                      
cargo:eza-community/eza  ref:a3b0c8b40ed1f4f1a12c23242bbe  ~/Downloads/mise/.mise.toml rev:a3b0c8b40ed1f4f1a12c23242bb
                         780c391812f3                                                  e780c391812f3                  
cargo:eza-community/eza  ref:main                                                                                     
cargo:eza-community/eza  ref:v0.20.0                                                                                  
go                       1.23.1                            ~/.config/mise/config.toml  latest                         
```