### PR TITLE
fix(task): more flexible parsing around `#MISE alias(es)=`, changed prefix from `# mise` to `#MISE`

### DIFF
--- a/.mise/tasks/filetask
+++ b/.mise/tasks/filetask
@@ -5,12 +5,13 @@
 #USAGE arg "<file>" help="The file to write" default="file.txt"
 #USAGE arg "<arg_with_default>" help="An arg with a default" default="mydefault"
 
-# mise description="This is a test build script"
-# mise depends=["lint", "build"]
-# mise sources=[".test-tool-versions"]
-# mise outputs=["$MISE_PROJECT_ROOT/test/test-build-output.txt"]
-# mise env={TEST_BUILDSCRIPT_ENV_VAR = "VALID"}
-# mise dir="{{config_root}}"
+#MISE description="This is a test build script"
+#MISE depends=["lint", "build"]
+#MISE sources=[".test-tool-versions"]
+#MISE outputs=["$MISE_PROJECT_ROOT/test/test-build-output.txt"]
+#MISE env={TEST_BUILDSCRIPT_ENV_VAR = "VALID"}
+#MISE dir="{{config_root}}"
+#MISE alias="ft"
 
 set -exo pipefail
 cd "$MISE_PROJECT_ROOT" || exit 1

--- a/.mise/tasks/lint-fix
+++ b/.mise/tasks/lint-fix
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise alias=["format"]
+#MISE alias=["format"]
 set -euxo pipefail
 
 # Used for shellcheck which needs explicit args

--- a/.mise/tasks/test/coverage
+++ b/.mise/tasks/test/coverage
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="run all tests with coverage report"
+#MISE description="run all tests with coverage report"
 
 echo "::group::Setup"
 set -euxo pipefail

--- a/.mise/tasks/test/e2e
+++ b/.mise/tasks/test/e2e
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# mise depends=["build"]
-# mise alias="e"
-# mise description="run end-to-end tests"
+#MISE depends=["build"]
+#MISE alias="e"
+#MISE description="run end-to-end tests"
 set -euo pipefail
 
 export RUST_TEST_THREADS=1

--- a/docs/tasks/file-tasks.md
+++ b/docs/tasks/file-tasks.md
@@ -12,7 +12,7 @@ Here is an example of a file task that builds a Rust CLI:
 
 ```bash
 #!/usr/bin/env bash
-# mise description="Build the CLI"
+#MISE description="Build the CLI"
 cargo build
 ```
 
@@ -24,11 +24,11 @@ The other configuration for "script" tasks is supported in this format so you ca
 following-note that this is parsed a TOML table:
 
 ```bash
-# mise alias="b"
-# mise sources=["Cargo.toml", "src/**/*.rs"]
-# mise outputs=["target/debug/mycli"]
-# mise env={RUST_BACKTRACE = "1"}
-# mise depends=["lint", "test"]
+#MISE alias="b"
+#MISE sources=["Cargo.toml", "src/**/*.rs"]
+#MISE outputs=["target/debug/mycli"]
+#MISE env={RUST_BACKTRACE = "1"}
+#MISE depends=["lint", "test"]
 ```
 
 Assuming that file was located in `.mise/tasks/build`, it can then be run with `mise run build` (or with its alias: `mise run b`).

--- a/e2e/tasks/test_task_run
+++ b/e2e/tasks/test_task_run
@@ -14,11 +14,11 @@ EOF
 mkdir -p .mise/tasks
 cat <<'EOF' >.mise/tasks/filetask
 #!/usr/bin/env bash
-# mise description="This is a test build script"
-# mise depends=["lint", "test"]
-# mise sources=[".test-tool-versions"]
-# mise outputs=["$MISE_PROJECT_ROOT/test-e2e/test-build-output.txt"]
-# mise env={TEST_BUILDSCRIPT_ENV_VAR = "VALID"}
+#MISE description="This is a test build script"
+#MISE depends=["lint", "test"]
+#MISE sources=[".test-tool-versions"]
+#MISE outputs=["$MISE_PROJECT_ROOT/test-e2e/test-build-output.txt"]
+#MISE env={TEST_BUILDSCRIPT_ENV_VAR = "VALID"}
 
 set -euxo pipefail
 cd "$MISE_PROJECT_ROOT" || exit 1

--- a/src/test.rs
+++ b/src/test.rs
@@ -103,12 +103,12 @@ pub fn reset() {
     file::write(
         ".mise/tasks/filetask",
         indoc! {r#"#!/usr/bin/env bash
-        # mise alias=["ft"]
-        # mise description="This is a test build script"
-        # mise depends=["lint", "test"]
-        # mise sources=[".test-tool-versions"]
-        # mise outputs=["$MISE_PROJECT_ROOT/test/test-build-output.txt"]
-        # mise env={TEST_BUILDSCRIPT_ENV_VAR = "VALID", BOOLEAN_VAR = true}
+        #MISE alias="ft"
+        #MISE description="This is a test build script"
+        #MISE depends=["lint", "test"]
+        #MISE sources=[".test-tool-versions"]
+        #MISE outputs=["$MISE_PROJECT_ROOT/test/test-build-output.txt"]
+        #MISE env={TEST_BUILDSCRIPT_ENV_VAR = "VALID", BOOLEAN_VAR = true}
         
         #USAGE flag "--user <user>" help="The user to run as"
 

--- a/tasks.md
+++ b/tasks.md
@@ -72,6 +72,8 @@ run a command inside of development docker container
 
 **Usage**: `filetask [-f --force] [-u --user <user>] <file> <arg_with_default>`
 
+**Aliases**: ft
+
 This is a test build script
 
 ### Arguments
@@ -243,6 +245,8 @@ run all tests with coverage report
 * Depends: build
 
 **Usage**: `test:e2e`
+
+**Aliases**: e
 
 run end-to-end tests
 


### PR DESCRIPTION
`# mise` style will still be accepted for now but will likely be deprecated and removed in the future

Fixes #2692
Fixes #2693
