### PR TITLE
chore: fix shim PATH for windows in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -332,7 +332,7 @@ yum install -y mise
 
 Download the latest release from [GitHub](https://github.com/jdx/mise/releases). Add the binary
 to your PATH and edit PATH to include the shims directory (by default:
-`%USERPROFILE%\.local\share\mise\shims`).
+`%LOCALAPPDATA%\mise\shims`).
 
 Note that Windows support is very minimal for now.
 


### PR DESCRIPTION
This seems to have changed in #2653

Related: The defaults now seem to be:
```
dirs:
  data: ~\AppData\Local\mise
  config: ~\.config\mise
  cache: ~\AppData\Local\Temp\mise
  state: ~\.local\state\mise
  shims: ~\AppData\Local\mise\shims
```

which seems to be a healthy mix between Windows defaults and XDG. OTOH I never knew where to put config files on Windows...