### PR TITLE
chore: release 2024.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2024.10.1](https://github.com/jdx/mise/compare/v2024.10.0..v2024.10.1) - 2024-10-07
+
+### 🚀 Features
+
+- added MISE_PIN=1 setting by [@jdx](https://github.com/jdx) in [9f73952](https://github.com/jdx/mise/commit/9f73952ac2a782da6c10ec6a4b36093a74b8e251)
+- add hint about how install missing plugins by [@roele](https://github.com/roele) in [#2706](https://github.com/jdx/mise/pull/2706)
+- task shell by [@roele](https://github.com/roele) in [#2709](https://github.com/jdx/mise/pull/2709)
+
+### 🐛 Bug Fixes
+
+- **(windows)** escape backslash in nu script & use proper csv by [@finalchild](https://github.com/finalchild) in [#2710](https://github.com/jdx/mise/pull/2710)
+- update name of cargo:ubi-cli package by [@jdx](https://github.com/jdx) in [d83fe3f](https://github.com/jdx/mise/commit/d83fe3f0b1eaeb0fc464d8eef589541ddc182673)
+- only upgrade versions if there is a version to upgrade to by [@jdx](https://github.com/jdx) in [8dfc6be](https://github.com/jdx/mise/commit/8dfc6bededf68f747baddd734566074e0fec7773)
+- use npm.cmd on windows by [@finalchild](https://github.com/finalchild) in [#2711](https://github.com/jdx/mise/pull/2711)
+
+### 🧪 Testing
+
+- fix snapshots by [@jdx](https://github.com/jdx) in [e1bc269](https://github.com/jdx/mise/commit/e1bc269b2d40bac21208969f8fb2c744586d8ed1)
+- reset test by [@jdx](https://github.com/jdx) in [b06878d](https://github.com/jdx/mise/commit/b06878dcadfd8a0edc80ea39381f534435f24736)
+
+### New Contributors
+
+* @finalchild made their first contribution in [#2711](https://github.com/jdx/mise/pull/2711)
+
 ## [2024.10.0](https://github.com/jdx/mise/compare/v2024.9.13..v2024.10.0) - 2024-10-03
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "jobserver",
  "libc",
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1146,33 +1146,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.10.0"
+version = "2024.10.1"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -2208,12 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
@@ -2948,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
  "once_cell",
  "ring",
@@ -3022,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.10.0"
+version = "2024.10.1"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.10.0 macos-arm64 (a1b2d3e 2024-10-03)
+2024.10.1 macos-arm64 (a1b2d3e 2024-10-07)
 ```
 
 or install a specific a version:

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.10.0";
+  version = "2024.10.1";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.10.0" 
+.TH mise 1  "mise 2024.10.1" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -192,6 +192,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.10.0
+v2024.10.1
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.10.0
+Version: 2024.10.1
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -554,10 +554,6 @@
                 }
               ]
             },
-            "shell": {
-              "description": "shell command to run script with (e.g. sh -c)",
-              "type": "string"
-            },
             "sources": {
               "description": "files that this task depends on",
               "items": {

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -586,7 +586,7 @@ impl<'de> de::Deserialize<'de> for EnvList {
                                 {
                                     struct ValVisitor;
 
-                                    impl<'de> Visitor<'de> for ValVisitor {
+                                    impl Visitor<'_> for ValVisitor {
                                         type Value = Val;
                                         fn expecting(
                                             &self,
@@ -843,7 +843,7 @@ impl<'de> de::Deserialize<'de> for BackendArg {
     {
         struct BackendArgVisitor;
 
-        impl<'de> Visitor<'de> for BackendArgVisitor {
+        impl Visitor<'_> for BackendArgVisitor {
             type Value = BackendArg;
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter.write_str("backend argument")

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -13,7 +13,7 @@ enum EnvOp<'a> {
     Hide { key: &'a str },
 }
 
-impl<'a> Display for EnvOp<'a> {
+impl Display for EnvOp<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::write_with_newline)]
         match self {


### PR DESCRIPTION
### 🚀 Features

- added MISE_PIN=1 setting by [@jdx](https://github.com/jdx) in [9f73952](https://github.com/jdx/mise/commit/9f73952ac2a782da6c10ec6a4b36093a74b8e251)
- add hint about how install missing plugins by [@roele](https://github.com/roele) in [#2706](https://github.com/jdx/mise/pull/2706)
- task shell by [@roele](https://github.com/roele) in [#2709](https://github.com/jdx/mise/pull/2709)

### 🐛 Bug Fixes

- **(windows)** escape backslash in nu script & use proper csv by [@finalchild](https://github.com/finalchild) in [#2710](https://github.com/jdx/mise/pull/2710)
- update name of cargo:ubi-cli package by [@jdx](https://github.com/jdx) in [d83fe3f](https://github.com/jdx/mise/commit/d83fe3f0b1eaeb0fc464d8eef589541ddc182673)
- only upgrade versions if there is a version to upgrade to by [@jdx](https://github.com/jdx) in [8dfc6be](https://github.com/jdx/mise/commit/8dfc6bededf68f747baddd734566074e0fec7773)
- use npm.cmd on windows by [@finalchild](https://github.com/finalchild) in [#2711](https://github.com/jdx/mise/pull/2711)

### 🧪 Testing

- fix snapshots by [@jdx](https://github.com/jdx) in [e1bc269](https://github.com/jdx/mise/commit/e1bc269b2d40bac21208969f8fb2c744586d8ed1)
- reset test by [@jdx](https://github.com/jdx) in [b06878d](https://github.com/jdx/mise/commit/b06878dcadfd8a0edc80ea39381f534435f24736)

### New Contributors

* @finalchild made their first contribution in [#2711](https://github.com/jdx/mise/pull/2711)