### PR TITLE
feat: add hint about how install missing plugins

### DIFF
--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -82,6 +82,11 @@ impl Current {
                         "{}@{} is specified in {}, but not installed",
                         &tv.backend, &tv.version, &source
                     );
+                    hint!(
+                        "tools_missing",
+                        "install missing tools with",
+                        "mise install"
+                    );
                 }
             }
             miseprintln!(


### PR DESCRIPTION
* Add hint with install instruction for missing tools

Fixes #2587 