### PR TITLE
fix(windows): escape backslash in nu script & use proper csv

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -374,7 +374,7 @@ Install Mise by appending `env.nu` and `config.nu`:
 let mise_path = $nu.default-config-dir | path join mise.nu
 ^mise activate nu | save $mise_path --force
 ' | save $nu.env-path --append
-"\nuse mise.nu" | save $nu.config-path --append
+"\nuse ($nu.default-config-dir | path join mise.nu)" | save $nu.config-path --append
 ```
 
 If you prefer to keep your dotfiles clean you can save it to a different directory then

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -330,9 +330,10 @@ yum install -y mise
 
 ### Windows
 
-Download the latest release from [GitHub](https://github.com/jdx/mise/releases). Add the binary
-to your PATH and edit PATH to include the shims directory (by default:
-`%LOCALAPPDATA%\mise\shims`).
+Download the latest release from [GitHub](https://github.com/jdx/mise/releases) and add the binary
+to your PATH.
+
+If your shell does not support `mise activate`, you would want to edit PATH to include the shims directory (by default: `%LOCALAPPDATA%\mise\shims`).
 
 Note that Windows support is very minimal for now.
 

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -23,9 +23,19 @@ impl<'a> Display for EnvOp<'a> {
     }
 }
 
+impl Nushell {
+    fn escape_csv_value(s: &str) -> String {
+        if s.contains(['\r', '\n', '"', ',']) {
+            format!("\"{}\"", s.replace('"', "\"\""))
+        } else {
+            s.to_owned()
+        }
+    }
+}
+
 impl Shell for Nushell {
     fn activate(&self, exe: &Path, flags: String) -> String {
-        let exe = exe.display();
+        let exe = exe.to_string_lossy().replace('\\', r#"\\"#);
 
         formatdoc! {r#"
           export-env {{
@@ -45,7 +55,7 @@ impl Shell for Nushell {
           }}
 
           def "parse vars" [] {{
-            $in | lines | parse "{{op}},{{name}},{{value}}"
+            $in | from csv --noheaders --no-infer | rename 'op' 'name' 'value'
           }}
 
           export def --env --wrapped main [command?: string, --help, ...rest: string] {{
@@ -88,9 +98,8 @@ impl Shell for Nushell {
     }
 
     fn set_env(&self, k: &str, v: &str) -> String {
-        let k = shell_escape::unix::escape(k.into());
-        let v = shell_escape::unix::escape(v.into());
-        let v = v.replace('\'', "");
+        let k = Nushell::escape_csv_value(k);
+        let v = Nushell::escape_csv_value(v);
 
         EnvOp::Set { key: &k, val: &v }.to_string()
     }
@@ -100,7 +109,7 @@ impl Shell for Nushell {
     }
 
     fn unset_env(&self, k: &str) -> String {
-        let k = shell_escape::unix::escape(k.into());
+        let k = Nushell::escape_csv_value(k);
         EnvOp::Hide { key: k.as_ref() }.to_string()
     }
 }

--- a/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
@@ -19,7 +19,7 @@ def --env add-hook [field: cell-path new_hook: any] {
 }
 
 def "parse vars" [] {
-  $in | lines | parse "{op},{name},{value}"
+  $in | from csv --noheaders --no-infer | rename 'op' 'name' 'value'
 }
 
 export def --env --wrapped main [command?: string, --help, ...rest: string] {


### PR DESCRIPTION
1. The mise exe location often includes backslashes in windows, which must be escaped in nushell.
2. Nushell has a csv parser, so we can use this standardized format to pass data.
3. On my setup, "use mise.nu" doesn't work. (Module not found error) I have to be explicit about the location of mise.nu.