### PR TITLE
fix: don't skip the latest version fetch

### DIFF
--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -184,12 +184,6 @@ impl ToolVersion {
             }
         }
 
-        let existing = build(v.clone())?;
-        if backend.is_version_installed(&existing, true) {
-            // if the version is already installed, no need to fetch all the remote versions
-            return Ok(existing);
-        }
-
         if v == "latest" {
             if !latest_versions {
                 if let Some(v) = backend.latest_installed_version(None)? {


### PR DESCRIPTION
Removed the code that skips the latest version check if the version is already installed.
I don't know the exact purpose of the code, so please double-check.

The reasoning is this:
* If latest_versions is false, we already don't fetch the remote versions.
* If latest_versions is true, we want the up-to-date version. Due to the fuzzy-matching, we can't be sure that this is the latest version even if the version is present in the installation directory. Thus, we should not skip the remote fetch.

This fixes the bug where the environment variables are not properly set when installing "latest" versions with the vfox backend on windows. (In env_hook, vfox.rs expects the resolved versions like "1.20.0" as the argument, but due to this skip mise is passing "latest". We could fix vfox.rs as jdx maintains this, but IMO this patch makes resolving more correct.)