### PR TITLE
fix(ubi): update ubi identifiers

### DIFF
--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -28,7 +28,7 @@ impl Backend for UbiBackend {
     }
 
     fn get_dependencies(&self, _tvr: &ToolRequest) -> eyre::Result<Vec<BackendArg>> {
-        Ok(vec!["cargo:ubi".into()])
+        Ok(vec!["ubi".into()])
     }
 
     // TODO: v0.0.3 is stripped of 'v' such that it reports incorrectly in tool :-/

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -37,7 +37,7 @@ const _REGISTRY_VFOX: &[(&str, &str)] = &[
     // ("ruby", "vfox:yanecc/vfox-ruby"),
     ("scala", "vfox:version-fox/vfox-scala"),
     ("terraform", "vfox:enochchau/vfox-terraform"),
-    ("ubi", "cargo:ubi"),
+    ("ubi", "cargo:ubi-cli"),
     ("vlang", "vfox:ahai-code/vfox-vlang"),
     ("zig", "vfox:version-fox/vfox-zig"),
 ];


### PR DESCRIPTION
follow up of d83fe3f0b1eaeb0fc464d8eef589541ddc182673

---

While reading the code, I found `cargo:ubi-cli` and `cargo:cargo-binstall` are duplicated in `_REGISTRY` and `_REGISTRY_VFOX`.

As `_REGISTRY_VFOX` is merged with `_REGISTRY` here.
https://github.com/jdx/mise/blob/e34788b803b0f4817e2b8481c4ed7d94ed308d66/src/registry.rs#L48-L50

And, it seems it is assumed to contain only `vfox:` prefixed identifiers here.
https://github.com/jdx/mise/blob/e34788b803b0f4817e2b8481c4ed7d94ed308d66/src/backend/vfox.rs#L91-L101

I think these duplicates are unnecessary, so if my guess is correct, I will create a new PR to remove them.