### PR TITLE
chore: release 2024.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2024.10.4](https://github.com/jdx/mise/compare/v2024.10.3..v2024.10.4) - 2024-10-14
+
+### 🐛 Bug Fixes
+
+- some bugs with vfox by [@jdx](https://github.com/jdx) in [0c90062](https://github.com/jdx/mise/commit/0c90062cf9e148bcae4f85262bd6e4883496f385)
+
+### 🚜 Refactor
+
+- use ci_info to determine if running on CI by [@jdx](https://github.com/jdx) in [ac9a35b](https://github.com/jdx/mise/commit/ac9a35bc762e5679ea56b02a4ee278a88d358f78)
+
+### 🔍 Other Changes
+
+- enable more colors for tasks by [@jdx](https://github.com/jdx) in [f3b0e33](https://github.com/jdx/mise/commit/f3b0e33071376172142e89c010663add8365524b)
+
 ## [2024.10.3](https://github.com/jdx/mise/compare/v2024.10.2..v2024.10.3) - 2024-10-14
 
 ### 🚀 Features
@@ -40,6 +54,7 @@
 - bump usage-lib by [@jdx](https://github.com/jdx) in [f3a2e5f](https://github.com/jdx/mise/commit/f3a2e5f098b957a5a5745c7879cf98e27e32e403)
 - bump usage-lib by [@jdx](https://github.com/jdx) in [60f942d](https://github.com/jdx/mise/commit/60f942ddf3f3bc64f5f49015eb8c4093d616787b)
 - upgrade ubuntu version by [@jdx](https://github.com/jdx) in [978ea1a](https://github.com/jdx/mise/commit/978ea1a80a32574611d66aed552b34f7a10430d7)
+- added registry.toml to crate by [@jdx](https://github.com/jdx) in [be641ca](https://github.com/jdx/mise/commit/be641ca235b5b3ff944dfc5851206aa396bdfb09)
 
 ### New Contributors
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.10.3"
+version = "2024.10.4"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -4226,9 +4226,9 @@ dependencies = [
 
 [[package]]
 name = "vfox"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8122f37f0a8573ca23fd2be7cede3809ee8634a35421f2862d63cbe13679c7"
+checksum = "9d1986b1c92f01935d738b0ea408d7524af35fa922afdfda4f1f315b978dabe6"
 dependencies = [
  "homedir",
  "indexmap 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.10.3"
+version = "2024.10.4"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.10.3 macos-arm64 (a1b2d3e 2024-10-14)
+2024.10.4 macos-arm64 (a1b2d3e 2024-10-14)
 ```
 
 or install a specific a version:

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.10.3";
+  version = "2024.10.4";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.10.3" 
+.TH mise 1  "mise 2024.10.4" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -192,6 +192,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.10.3
+v2024.10.4
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.10.3
+Version: 2024.10.4
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- some bugs with vfox by [@jdx](https://github.com/jdx) in [0c90062](https://github.com/jdx/mise/commit/0c90062cf9e148bcae4f85262bd6e4883496f385)

### 🚜 Refactor

- use ci_info to determine if running on CI by [@jdx](https://github.com/jdx) in [ac9a35b](https://github.com/jdx/mise/commit/ac9a35bc762e5679ea56b02a4ee278a88d358f78)

### 🔍 Other Changes

- enable more colors for tasks by [@jdx](https://github.com/jdx) in [f3b0e33](https://github.com/jdx/mise/commit/f3b0e33071376172142e89c010663add8365524b)