### PR TITLE
chore: release 2024.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [2024.10.6](https://github.com/jdx/mise/compare/v2024.10.5..v2024.10.6) - 2024-10-14
+
+### 🚀 Features
+
+- add rustic backup plugin to registry by [@jahands](https://github.com/jahands) in [#2754](https://github.com/jdx/mise/pull/2754)
+- created custom logger by [@jdx](https://github.com/jdx) in [#2758](https://github.com/jdx/mise/pull/2758)
+- render task help via usage by [@jdx](https://github.com/jdx) in [#2760](https://github.com/jdx/mise/pull/2760)
+
+### 🐛 Bug Fixes
+
+- replace asdf-rustic with ubi by [@jdx](https://github.com/jdx) in [#2757](https://github.com/jdx/mise/pull/2757)
+- set trailing_var_arg on `mise run` by [@jdx](https://github.com/jdx) in [b1bb3d2](https://github.com/jdx/mise/commit/b1bb3d2a1e60eaccfc5e24250fc86966b6c9e69a)
+- prevent loading logger multiple times by [@jdx](https://github.com/jdx) in [1b83acd](https://github.com/jdx/mise/commit/1b83acd5cfef954643f3b24519fb51c8531cf59b)
+
+### 📚 Documentation
+
+- http_timeout should be a duration string by [@roele](https://github.com/roele) in [#2755](https://github.com/jdx/mise/pull/2755)
+- added hint about --bump flag for upgrade/outdated by [@jdx](https://github.com/jdx) in [#2761](https://github.com/jdx/mise/pull/2761)
+
+### 🧪 Testing
+
+- reset test by [@jdx](https://github.com/jdx) in [25f172f](https://github.com/jdx/mise/commit/25f172f226766b4e3e78b738bb14bff9a577c51b)
+
 ## [2024.10.5](https://github.com/jdx/mise/compare/v2024.10.4..v2024.10.5) - 2024-10-14
 
 ### 🐛 Bug Fixes
@@ -805,10 +828,6 @@
 
 - Use correct capitalization of GitHub by [@jahands](https://github.com/jahands) in [#2372](https://github.com/jdx/mise/pull/2372)
 - loosen git2 requirements by [@jdx](https://github.com/jdx) in [#2374](https://github.com/jdx/mise/pull/2374)
-
-### New Contributors
-
-- @jahands made their first contribution in [#2372](https://github.com/jdx/mise/pull/2372)
 
 ## [2024.7.2](https://github.com/jdx/mise/compare/v2024.7.1..v2024.7.2) - 2024-07-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.10.5"
+version = "2024.10.6"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -2430,9 +2430,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2441,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2451,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2464,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
 dependencies = [
  "once_cell",
  "pest",
@@ -3060,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.10.5"
+version = "2024.10.6"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.10.5 macos-arm64 (a1b2d3e 2024-10-14)
+2024.10.6 macos-arm64 (a1b2d3e 2024-10-14)
 ```
 
 or install a specific a version:

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.10.5";
+  version = "2024.10.6";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.10.5" 
+.TH mise 1  "mise 2024.10.6" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -192,6 +192,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.10.5
+v2024.10.6
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.10.5
+Version: 2024.10.6
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- add rustic backup plugin to registry by [@jahands](https://github.com/jahands) in [#2754](https://github.com/jdx/mise/pull/2754)
- created custom logger by [@jdx](https://github.com/jdx) in [#2758](https://github.com/jdx/mise/pull/2758)
- render task help via usage by [@jdx](https://github.com/jdx) in [#2760](https://github.com/jdx/mise/pull/2760)

### 🐛 Bug Fixes

- replace asdf-rustic with ubi by [@jdx](https://github.com/jdx) in [#2757](https://github.com/jdx/mise/pull/2757)
- set trailing_var_arg on `mise run` by [@jdx](https://github.com/jdx) in [b1bb3d2](https://github.com/jdx/mise/commit/b1bb3d2a1e60eaccfc5e24250fc86966b6c9e69a)
- prevent loading logger multiple times by [@jdx](https://github.com/jdx) in [1b83acd](https://github.com/jdx/mise/commit/1b83acd5cfef954643f3b24519fb51c8531cf59b)

### 📚 Documentation

- http_timeout should be a duration string by [@roele](https://github.com/roele) in [#2755](https://github.com/jdx/mise/pull/2755)
- added hint about --bump flag for upgrade/outdated by [@jdx](https://github.com/jdx) in [#2761](https://github.com/jdx/mise/pull/2761)

### 🧪 Testing

- reset test by [@jdx](https://github.com/jdx) in [25f172f](https://github.com/jdx/mise/commit/25f172f226766b4e3e78b738bb14bff9a577c51b)