### PR TITLE
fix: trim "v" prefix for ubi backend tools

### DIFF
--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -1,8 +1,5 @@
 use std::fmt::Debug;
 
-use eyre::eyre;
-use ubi::UbiBuilder;
-
 use crate::backend::{Backend, BackendType};
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
@@ -11,6 +8,9 @@ use crate::env::GITHUB_TOKEN;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolRequest;
 use crate::{github, http};
+use eyre::eyre;
+use ubi::UbiBuilder;
+use xx::regex;
 
 #[derive(Debug)]
 pub struct UbiBackend {
@@ -41,6 +41,11 @@ impl Backend for UbiBackend {
                     Ok(github::list_releases(self.name())?
                         .into_iter()
                         .map(|r| r.tag_name)
+                        // trim 'v' prefixes if they exist
+                        .map(|t| match regex!(r"^v[0-9]").is_match(&t) {
+                            true => t[1..].to_string(),
+                            false => t,
+                        })
                         .rev()
                         .collect())
                 })

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ pub(crate) mod timeout;
 mod toml;
 mod toolset;
 mod ui;
+mod versions_host;
 
 pub use crate::exit::exit;
 

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -213,6 +213,10 @@ impl Plugin for AsdfPlugin {
         &self.name
     }
 
+    fn path(&self) -> PathBuf {
+        self.plugin_path.clone()
+    }
+
     fn get_plugin_type(&self) -> PluginType {
         PluginType::Asdf
     }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -69,13 +69,13 @@ impl ErlangPlugin {
         file::make_executable(self.kerl_path())?;
         Ok(())
     }
+}
 
-    fn fetch_remote_versions(&self) -> Result<Vec<String>> {
-        match self.core.fetch_remote_versions_from_mise() {
-            Ok(Some(versions)) => return Ok(versions),
-            Ok(None) => {}
-            Err(e) => warn!("failed to fetch remote versions: {}", e),
-        }
+impl Backend for ErlangPlugin {
+    fn fa(&self) -> &BackendArg {
+        &self.core.fa
+    }
+    fn _list_remote_versions(&self) -> Result<Vec<String>> {
         self.update_kerl()?;
         let versions = CorePlugin::run_fetch_task_with_timeout(move || {
             let output = cmd!(self.kerl_path(), "list", "releases", "all")
@@ -89,18 +89,6 @@ impl ErlangPlugin {
             Ok(versions)
         })?;
         Ok(versions)
-    }
-}
-
-impl Backend for ErlangPlugin {
-    fn fa(&self) -> &BackendArg {
-        &self.core.fa
-    }
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
-        self.core
-            .remote_version_cache
-            .get_or_try_init(|| self.fetch_remote_versions())
-            .cloned()
     }
 
     fn install_version_impl(&self, ctx: &InstallContext) -> Result<()> {

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -77,42 +77,6 @@ impl JavaPlugin {
         })
     }
 
-    fn fetch_remote_versions(&self) -> Result<Vec<String>> {
-        // TODO: find out how to get this to work for different os/arch
-        // See https://github.com/jdx/mise/issues/1196
-        // match self.core.fetch_remote_versions_from_mise() {
-        //     Ok(Some(versions)) => return Ok(versions),
-        //     Ok(None) => {}
-        //     Err(e) => warn!("failed to fetch remote versions: {}", e),
-        // }
-        let versions = self
-            .fetch_java_metadata("ga")?
-            .iter()
-            .sorted_by_cached_key(|(v, m)| {
-                let is_shorthand = regex!(r"^\d").is_match(v);
-                let vendor = &m.vendor;
-                let is_jdk = m
-                    .image_type
-                    .as_ref()
-                    .is_some_and(|image_type| image_type == "jdk");
-                let features = 10 - m.features.len();
-                let version = Versioning::new(v);
-                (
-                    is_shorthand,
-                    vendor,
-                    is_jdk,
-                    features,
-                    version,
-                    v.to_string(),
-                )
-            })
-            .map(|(v, _)| v.clone())
-            .unique()
-            .collect();
-
-        Ok(versions)
-    }
-
     fn java_bin(&self, tv: &ToolVersion) -> PathBuf {
         tv.install_path().join("bin/java")
     }
@@ -306,10 +270,39 @@ impl Backend for JavaPlugin {
     }
 
     fn _list_remote_versions(&self) -> Result<Vec<String>> {
-        self.core
-            .remote_version_cache
-            .get_or_try_init(|| self.fetch_remote_versions())
-            .cloned()
+        // TODO: find out how to get this to work for different os/arch
+        // See https://github.com/jdx/mise/issues/1196
+        // match self.core.fetch_remote_versions_from_mise() {
+        //     Ok(Some(versions)) => return Ok(versions),
+        //     Ok(None) => {}
+        //     Err(e) => warn!("failed to fetch remote versions: {}", e),
+        // }
+        let versions = self
+            .fetch_java_metadata("ga")?
+            .iter()
+            .sorted_by_cached_key(|(v, m)| {
+                let is_shorthand = regex!(r"^\d").is_match(v);
+                let vendor = &m.vendor;
+                let is_jdk = m
+                    .image_type
+                    .as_ref()
+                    .is_some_and(|image_type| image_type == "jdk");
+                let features = 10 - m.features.len();
+                let version = Versioning::new(v);
+                (
+                    is_shorthand,
+                    vendor,
+                    is_jdk,
+                    features,
+                    version,
+                    v.to_string(),
+                )
+            })
+            .map(|(v, _)| v.clone())
+            .unique()
+            .collect();
+
+        Ok(versions)
     }
 
     fn list_installed_versions_matching(&self, query: &str) -> eyre::Result<Vec<String>> {

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -31,29 +31,6 @@ impl RubyPlugin {
         }
     }
 
-    fn fetch_remote_versions(&self) -> Result<Vec<String>> {
-        // TODO: use windows set of versions
-        //  match self.core.fetch_remote_versions_from_mise() {
-        //      Ok(Some(versions)) => return Ok(versions),
-        //      Ok(None) => {}
-        //      Err(e) => warn!("failed to fetch remote versions: {}", e),
-        //  }
-        let releases: Vec<GithubRelease> = github::list_releases("oneclick/rubyinstaller2")?;
-        let versions = releases
-            .into_iter()
-            .map(|r| r.tag_name)
-            .filter_map(|v| {
-                regex!(r"RubyInstaller-([0-9.]+)-.*")
-                    .replace(&v, "$1")
-                    .parse()
-                    .ok()
-            })
-            .unique()
-            .sorted_by_cached_key(|s: &String| (Versioning::new(s), s.to_string()))
-            .collect();
-        Ok(versions)
-    }
-
     fn ruby_path(&self, tv: &ToolVersion) -> PathBuf {
         tv.install_path().join("bin").join("ruby.exe")
     }
@@ -164,10 +141,26 @@ impl Backend for RubyPlugin {
         &self.core.fa
     }
     fn _list_remote_versions(&self) -> Result<Vec<String>> {
-        self.core
-            .remote_version_cache
-            .get_or_try_init(|| self.fetch_remote_versions())
-            .cloned()
+        // TODO: use windows set of versions
+        //  match self.core.fetch_remote_versions_from_mise() {
+        //      Ok(Some(versions)) => return Ok(versions),
+        //      Ok(None) => {}
+        //      Err(e) => warn!("failed to fetch remote versions: {}", e),
+        //  }
+        let releases: Vec<GithubRelease> = github::list_releases("oneclick/rubyinstaller2")?;
+        let versions = releases
+            .into_iter()
+            .map(|r| r.tag_name)
+            .filter_map(|v| {
+                regex!(r"RubyInstaller-([0-9.]+)-.*")
+                    .replace(&v, "$1")
+                    .parse()
+                    .ok()
+            })
+            .unique()
+            .sorted_by_cached_key(|s: &String| (Versioning::new(s), s.to_string()))
+            .collect();
+        Ok(versions)
     }
 
     fn legacy_filenames(&self) -> Result<Vec<String>> {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -14,6 +14,7 @@ use regex::Regex;
 pub use script_manager::{Script, ScriptManager};
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display};
+use std::path::PathBuf;
 use std::vec;
 
 pub mod asdf_plugin;
@@ -84,6 +85,7 @@ pub type PluginList = Vec<APlugin>;
 
 pub trait Plugin: Debug + Send {
     fn name(&self) -> &str;
+    fn path(&self) -> PathBuf;
     fn get_plugin_type(&self) -> PluginType;
     fn get_remote_url(&self) -> eyre::Result<Option<String>>;
     fn current_abbrev_ref(&self) -> eyre::Result<Option<String>>;

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -84,6 +84,10 @@ impl Plugin for VfoxPlugin {
         &self.name
     }
 
+    fn path(&self) -> PathBuf {
+        self.plugin_path.clone()
+    }
+
     fn get_plugin_type(&self) -> PluginType {
         PluginType::Vfox
     }

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -1,0 +1,60 @@
+use crate::cli::args::BackendArg;
+use crate::config::SETTINGS;
+use crate::http::HTTP_FETCH;
+use crate::registry::REGISTRY;
+use crate::{backend, http, registry};
+use url::Url;
+
+pub fn list_versions(ba: &BackendArg) -> eyre::Result<Option<Vec<String>>> {
+    if !SETTINGS.use_versions_host || ba.short.contains(':') {
+        return Ok(None);
+    }
+    // ensure that we're using a default shorthand plugin
+    if let Some(plugin) = backend::get(ba).plugin() {
+        if let Ok(Some(remote_url)) = plugin.get_remote_url() {
+            let normalized_remote = normalize_remote(&remote_url).unwrap_or("INVALID_URL".into());
+            let shorthand_remote = REGISTRY
+                .get(plugin.name())
+                .map(|s| registry::full_to_url(s))
+                .unwrap_or_default();
+            if normalized_remote != normalize_remote(&shorthand_remote).unwrap_or_default() {
+                trace!(
+                    "Skipping versions host check for {} because it has a non-default remote",
+                    ba.short
+                );
+                return Ok(None);
+            }
+        }
+    }
+    let response = match SETTINGS.paranoid {
+        true => HTTP_FETCH.get_text(format!("https://mise-versions.jdx.dev/{}", &ba.short)),
+        false => HTTP_FETCH.get_text(format!("http://mise-versions.jdx.dev/{}", &ba.short)),
+    };
+    let versions =
+        // using http is not a security concern and enabling tls makes mise significantly slower
+        match response {
+            Err(err) if http::error_code(&err) == Some(404) => return Ok(None),
+            res => res?,
+        };
+    let versions = versions
+        .lines()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .collect::<Vec<String>>();
+    trace!(
+        "got {} {} versions from versions host",
+        versions.len(),
+        &ba.short
+    );
+    match versions.is_empty() {
+        true => Ok(None),
+        false => Ok(Some(versions)),
+    }
+}
+
+fn normalize_remote(remote: &str) -> eyre::Result<String> {
+    let url = Url::parse(remote)?;
+    let host = url.host_str().unwrap();
+    let path = url.path().trim_end_matches(".git");
+    Ok(format!("{host}{path}"))
+}


### PR DESCRIPTION
before:

```
❯ mise ls-remote ubi:jdx/usage
v0.1.5
v0.1.6
v0.1.7
v0.1.8
v0.1.9
v0.1.16
v0.1.17
v0.1.18
v0.2.0
v0.2.1
v0.3.0
v0.3.1
v0.4.0
v0.5.0
v0.5.1
v0.6.0
v0.7.0
v0.7.1
v0.7.2
v0.7.3
v0.7.4
v0.8.0
v0.8.1
v0.8.2
v0.8.3
v0.8.4
v0.9.0
v0.10.0
v0.11.0
```

to make things simpler for the user, we avoid "v" prefixes whenever possible so users don't need to remember which tools have the prefix and which don't