### PR TITLE
docs: add tip for conditional shims using TERM_PROGRAM

### DIFF
--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -41,12 +41,13 @@ This assumes that `mise` is on PATH. If it is not, you'll need to use the absolu
 e.g.: `eval "$($HOME/.local/bin/mise activate zsh)"`).
 
 :::: tip
-Conditionally using shims is also possible. Some programs will set a `TERM_PROGRAM` environment 
+Conditionally using shims is also possible. Some programs will set a `TERM_PROGRAM` environment
 variable, which may be used to determine which activation strategy to use.
 
 Here is an example using VSCode:
 
 ::: code-group
+
 ```zsh
 # ~/.zprofile
 if [[ "$TERM_PROGRAM" == "vscode" ]]; then
@@ -64,6 +65,7 @@ elif; then
   eval "$($HOME/.local/bin/mise activate bash)"
 fi
 ```
+
 :::
 ::::
 

--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -40,6 +40,33 @@ end
 This assumes that `mise` is on PATH. If it is not, you'll need to use the absolute path (
 e.g.: `eval "$($HOME/.local/bin/mise activate zsh)"`).
 
+:::: tip
+Conditionally using shims is also possible. Some programs will set a `TERM_PROGRAM` environment 
+variable, which may be used to determine which activation strategy to use.
+
+Here is an example using VSCode:
+
+::: code-group
+```zsh
+# ~/.zprofile
+if [[ "$TERM_PROGRAM" == "vscode" ]]; then
+  eval "$($HOME/.local/bin/mise activate zsh --shims)"
+elif; then
+  eval "$($HOME/.local/bin/mise activate zsh)"
+fi
+```
+
+```bash
+# ~/.bash_profile or ~/.bash_login or ~/.profile
+if [[ "$TERM_PROGRAM" == "vscode" ]]; then
+  eval "$($HOME/.local/bin/mise activate bash --shims)"
+elif; then
+  eval "$($HOME/.local/bin/mise activate bash)"
+fi
+```
+:::
+::::
+
 This won't work for all of mise's functionality. For example, arbitrary env vars in `[env]` will
 only be set
 if a shim is executed. For this we need tighter integration with the IDE and a custom plugin. If you


### PR DESCRIPTION
I added a tip explaining how to use the `TERM_PROGRAM` environment variable to conditionally use shim-based activation. 

---

For background, I use zsh and have my `.zprofile` configured to activate mise like so:

```zsh
eval "$($HOME/.local/bin/mise activate zsh)"
```

However, as these docs already mention, IDEs such as VSCode don't always function as expected unless mise is activated with `--shims`.

To get the best of both worlds, mise activation can be conditionally modified if terminal detection is used, which is what I added to the docs:

```zsh
# ~/.zprofile
if [[ "$TERM_PROGRAM" == "vscode" ]]; then
  eval "$($HOME/.local/bin/mise activate zsh --shims)"
elif; then
  eval "$($HOME/.local/bin/mise activate zsh)"
fi
```