### PR TITLE
chore: release 2024.10.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Changelog
 
-## [2024.10.9](https://github.com/jdx/mise/compare/v2024.10.8..v2024.10.9) - 2024-10-23
+## [2024.10.10](https://github.com/jdx/mise/compare/v2024.10.9..v2024.10.10) - 2024-10-25
+
+### 🚀 Features
+
+- automatically hide hints after displayed once by [@jdx](https://github.com/jdx) in [#2807](https://github.com/jdx/mise/pull/2807)
+- add ubi installers for various tools by [@BurnerWah](https://github.com/BurnerWah) in [#2801](https://github.com/jdx/mise/pull/2801)
+
+### 🐛 Bug Fixes
+
+- upgrade --bump with non-semver versions by [@jdx](https://github.com/jdx) in [#2809](https://github.com/jdx/mise/pull/2809)
+- parsing default task arg/flags by [@jdx](https://github.com/jdx) in [#2810](https://github.com/jdx/mise/pull/2810)
+- attempt ubi installs with/without "v" prefix if they fail by [@jdx](https://github.com/jdx) in [#2813](https://github.com/jdx/mise/pull/2813)
+- add cargo-binstall as dependency of cargo backend by [@jdx](https://github.com/jdx) in [#2811](https://github.com/jdx/mise/pull/2811)
+- use GITHUB_API_TOKEN or GITHUB_TOKEN by [@jdx](https://github.com/jdx) in [#2815](https://github.com/jdx/mise/pull/2815)
+- bug with ls-remote and "sub-" prefixes by [@jdx](https://github.com/jdx) in [#2814](https://github.com/jdx/mise/pull/2814)
+- autoinstalling on `mise x` when the tool is in the config by [@jdx](https://github.com/jdx) in [#2816](https://github.com/jdx/mise/pull/2816)
+
+### 📚 Documentation
+
+- hide outdated_bump message if already using --bump by [@jdx](https://github.com/jdx) in [#2808](https://github.com/jdx/mise/pull/2808)
+
+### 🔍 Other Changes
+
+- loosen versions in Cargo.toml by [@jdx](https://github.com/jdx) in [8253059](https://github.com/jdx/mise/commit/825305999683dc4121eefeb61a7399545e167001)
+- resolve regex loop clippy warning by [@jdx](https://github.com/jdx) in [#2812](https://github.com/jdx/mise/pull/2812)
+
+### 📦️ Dependency Updates
+
+- update rust crate confique to 0.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#2803](https://github.com/jdx/mise/pull/2803)
+
+## [2024.10.9](https://github.com/jdx/mise/compare/v2024.10.8..v2024.10.9) - 2024-10-24
 
 ### 🚀 Features
 
@@ -22,7 +52,6 @@
 ### New Contributors
 
 - @yodatak made their first contribution in [#2792](https://github.com/jdx/mise/pull/2792)
-- @BurnerWah made their first contribution in [#2794](https://github.com/jdx/mise/pull/2794)
 - @rgeraskin made their first contribution in [#2790](https://github.com/jdx/mise/pull/2790)
 
 ## [2024.10.8](https://github.com/jdx/mise/compare/v2024.10.7..v2024.10.8) - 2024-10-22

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -107,36 +107,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "confique"
@@ -945,9 +945,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.10.9"
+version = "2024.10.10"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -2116,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "mlua-sys"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe026d6bd1583a9cf9080e189030ddaea7e6f5f0deb366a8e26f8a26c4135b8"
+checksum = "e9eebac25c35a13285456c88ee2fde93d9aee8bcfdaf03f9d6d12be3391351ec"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2566,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2825,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.10.9"
+version = "2024.10.10"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.10.9 macos-arm64 (a1b2d3e 2024-10-23)
+2024.10.10 macos-arm64 (a1b2d3e 2024-10-25)
 ```
 
 or install a specific a version:

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.10.9";
+  version = "2024.10.10";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.10.9" 
+.TH mise 1  "mise 2024.10.10" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -192,6 +192,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.10.9
+v2024.10.10
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.10.9
+Version: 2024.10.10
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- automatically hide hints after displayed once by [@jdx](https://github.com/jdx) in [#2807](https://github.com/jdx/mise/pull/2807)
- add ubi installers for various tools by [@BurnerWah](https://github.com/BurnerWah) in [#2801](https://github.com/jdx/mise/pull/2801)

### 🐛 Bug Fixes

- upgrade --bump with non-semver versions by [@jdx](https://github.com/jdx) in [#2809](https://github.com/jdx/mise/pull/2809)
- parsing default task arg/flags by [@jdx](https://github.com/jdx) in [#2810](https://github.com/jdx/mise/pull/2810)
- attempt ubi installs with/without "v" prefix if they fail by [@jdx](https://github.com/jdx) in [#2813](https://github.com/jdx/mise/pull/2813)
- add cargo-binstall as dependency of cargo backend by [@jdx](https://github.com/jdx) in [#2811](https://github.com/jdx/mise/pull/2811)
- use GITHUB_API_TOKEN or GITHUB_TOKEN by [@jdx](https://github.com/jdx) in [#2815](https://github.com/jdx/mise/pull/2815)
- bug with ls-remote and "sub-" prefixes by [@jdx](https://github.com/jdx) in [#2814](https://github.com/jdx/mise/pull/2814)
- autoinstalling on `mise x` when the tool is in the config by [@jdx](https://github.com/jdx) in [#2816](https://github.com/jdx/mise/pull/2816)

### 📚 Documentation

- hide outdated_bump message if already using --bump by [@jdx](https://github.com/jdx) in [#2808](https://github.com/jdx/mise/pull/2808)

### 🔍 Other Changes

- loosen versions in Cargo.toml by [@jdx](https://github.com/jdx) in [8253059](https://github.com/jdx/mise/commit/825305999683dc4121eefeb61a7399545e167001)
- resolve regex loop clippy warning by [@jdx](https://github.com/jdx) in [#2812](https://github.com/jdx/mise/pull/2812)

### 📦️ Dependency Updates

- update rust crate confique to 0.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#2803](https://github.com/jdx/mise/pull/2803)