### PR TITLE
feat: Add support for generating completions for Amazon CloudWhisperer CLI

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -83,6 +83,13 @@ depends = ["build"]
 env = { NO_COLOR = "1" }
 run = "mise render-mangen"
 
+[tasks."render:q"]
+description = "Generates the Amazon Q spec file for auto completion"
+run = [
+    "mise generate q-spec -o completions/mise.ts",
+    "tsx tasks/render/q.ts"
+]
+
 [tasks."render:help"]
 depends = ["build"]
 env = { NO_COLOR = "1" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a13ab5b8cb13dbe35e68b83f6c12f9293b2f601797b71bc9f23befdb329feb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_complete_fig"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d494102c8ff3951810c72baf96910b980fb065ca5d3101243e6a8dc19747c86b"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2045,8 @@ dependencies = [
  "chrono",
  "ci_info",
  "clap",
+ "clap_complete",
+ "clap_complete_fig",
  "clap_mangen",
  "color-eyre",
  "color-print",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ chrono = { version = "0.4.38", default-features = false, features = [
 ci_info = "0.14.14"
 clap = { version = "4.5.4", features = ["env", "derive", "string"] }
 clap_mangen = { version = "0.2.20", optional = true }
+clap_complete = "4.5.35"
+clap_complete_fig = "4.5.2"
 color-eyre = "0.6.3"
 color-print = "0.3.6"
 confique = { version = "0.2.5", default-features = false }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@tsconfig/node18": "^18.2.4",
+    "@withfig/autocomplete-types": "^1.31.0",
     "handlebars": "^4.7.8",
     "toml": "^3.0.0",
     "ts-pattern": "^5.4.0",

--- a/src/cli/generate/mod.rs
+++ b/src/cli/generate/mod.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 mod git_pre_commit;
 mod github_action;
 mod task_docs;
-
+mod q_spec;
 /// [experimental] Generate files for various tools/services
 #[derive(Debug, clap::Args)]
 #[clap(visible_alias = "g")]
@@ -17,6 +17,7 @@ enum Commands {
     GitPreCommit(git_pre_commit::GitPreCommit),
     GithubAction(github_action::GithubAction),
     TaskDocs(task_docs::TaskDocs),
+    QSpec(q_spec::QSpec),
 }
 
 impl Commands {
@@ -25,6 +26,7 @@ impl Commands {
             Self::GitPreCommit(cmd) => cmd.run(),
             Self::GithubAction(cmd) => cmd.run(),
             Self::TaskDocs(cmd) => cmd.run(),
+            Self::QSpec(cmd) => cmd.run(),
         }
     }
 }

--- a/src/cli/generate/q_spec.rs
+++ b/src/cli/generate/q_spec.rs
@@ -1,0 +1,43 @@
+use crate::cli::Cli;
+use crate::file;
+use std::path::PathBuf;
+use std::fs;
+
+/// [experimental] Generate an Amazon Q spec file
+///
+/// This command generates a Amazon Q spec file that can be compiled to generate autocomplete
+/// for Amazon Q CLI through `@withfig/autocomplete-tools` npm package
+#[derive(Debug, clap::Args)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+pub struct QSpec {
+    /// path to output to
+    #[clap(long, short, default_value = "~/.fig/autocomplete/src/mise.ts")]
+    output: Option<PathBuf>,
+}
+
+impl QSpec {
+    pub fn run(self) -> eyre::Result<()> {
+        let mut out = vec![];
+        clap_complete::generate(
+            clap_complete_fig::Fig,
+            &mut Cli::command(),
+            "mise",
+            &mut out,
+        );
+        if let Some(output) = &self.output {
+            if let Some(parent) = output.parent() { fs::create_dir_all(parent)? };
+            file::write(output, &out)?;
+        }
+
+        // TODO: Add automatically generator object for mise tasks
+        return Ok(());
+    }
+}
+
+static AFTER_LONG_HELP: &str = color_print::cstr!(
+    r#"<bold><underline>Examples:</underline></bold>
+
+    $ <bold>mise generate q-spec -o completions/mise.ts</bold>
+    $ <bold>A new spec file is created that can be used for Amazon CloudWhisperer CLI</bold>
+"#
+);

--- a/tasks/render/q.ts
+++ b/tasks/render/q.ts
@@ -1,0 +1,25 @@
+import path = require('node:path');
+import completion from '../../completions/mise'
+import fsAsync = require('node:fs/promises');
+
+
+const main = async () => {
+  let newSpec = (completion as any);
+  newSpec.subcommands.find((v) => v.name[0] === 'run').args.find(v => v.name === 'task').generators = "$GENERATOR_REPLACE$"
+  const content = `
+const taskGenerator: Fig.Generator = {
+  script: ["sh", "-c", "mise tasks -J"],
+
+  postProcess: (out) => {
+    return JSON.parse(out).map(v => ({ name:v.name, description: v.description, icon: "fig://icon?type=command"} as Fig.Suggestion)) 
+  }
+}
+const completion: Fig.Spec = ${JSON.stringify(newSpec, null, 2).replace(`"$GENERATOR_REPLACE$"`, 'taskGenerator')}
+export default completion;`
+
+  await fsAsync.writeFile('./completions/mise.ts', content);
+
+}
+
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@tsconfig/node18/tsconfig.json",
+    "include": ["**/*"],
+    "exclude": ["node_modules", "az"],
+    "compilerOptions": {
+      "outDir": "./build",
+      "types": ["@withfig/autocomplete-types", "node"]
+    }
+  }


### PR DESCRIPTION
Related to #2804
This PR still has a bit of naming confusion between `Amazon Q`, `Amazon Code Whisperer CLI` and even `Fig` so I'm looking for some guidance on how to keep the naming in the code. 
It's my first attempt at contributing and my first try at Rust as well so feel free to criticize 

This still misses the automated publish step as I'm waiting for feedback before moving forward with that