### PR TITLE
fix: add cargo-binstall as dependency of cargo backend

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -14,6 +14,7 @@ python = { version = "latest" }
 shellcheck = "0.10"
 shfmt = "3"
 jq = "latest"
+cargo-binstall = "latest"
 "cargo:cargo-edit" = "latest"
 "cargo:cargo-show" = "latest"
 "cargo:git-cliff" = "latest"

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -38,9 +38,7 @@ Tasks to run
 Can specify multiple tasks by separating with `:::`
 e.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2
 
-#### Default
-
-`default`
+**Default:** `default`
 
 ### `[ARGS]...`
 

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -32,7 +32,7 @@ impl Backend for CargoBackend {
     }
 
     fn get_dependencies(&self, _tvr: &ToolRequest) -> eyre::Result<Vec<BackendArg>> {
-        Ok(vec!["cargo".into(), "rust".into()])
+        Ok(vec!["cargo".into(), "rust".into(), "cargo-binstall".into()])
     }
 
     fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {


### PR DESCRIPTION
This just makes it so mise install cargo-binstall first and then uses it
only if it is already defined in config
