### PR TITLE
chore: release 2024.10.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [2024.10.12](https://github.com/jdx/mise/compare/v2024.10.11..v2024.10.12) - 2024-10-27
+
+### 🚀 Features
+
+- **(registry)** Use ubi for delta, fd, gohugo, hyperfine, just, tokei, xh by [@vrslev](https://github.com/vrslev) in [#2836](https://github.com/jdx/mise/pull/2836)
+- accept argument for `mise registry` by [@jdx](https://github.com/jdx) in [#2841](https://github.com/jdx/mise/pull/2841)
+- allow listing all versions from github by [@jdx](https://github.com/jdx) in [#2844](https://github.com/jdx/mise/pull/2844)
+- lockfiles by [@jdx](https://github.com/jdx) in [#2839](https://github.com/jdx/mise/pull/2839)
+
+### 🐛 Bug Fixes
+
+- allow passing ubi:[exe=] on the command line by [@jdx](https://github.com/jdx) in [#2843](https://github.com/jdx/mise/pull/2843)
+- pass ubi config from mise.toml by [@jdx](https://github.com/jdx) in [#2842](https://github.com/jdx/mise/pull/2842)
+
+### 🚜 Refactor
+
+- added ToolSource to ToolRequest by [@jdx](https://github.com/jdx) in [#2846](https://github.com/jdx/mise/pull/2846)
+
+### 📚 Documentation
+
+- added anchor tags for settings by [@jdx](https://github.com/jdx) in [#2845](https://github.com/jdx/mise/pull/2845)
+
+### 🔍 Other Changes
+
+- Disable ruby plugin test as no network access to GitHub in derivation by [@laozc](https://github.com/laozc) in [#2835](https://github.com/jdx/mise/pull/2835)
+- remove extra code coverage comment by [@jdx](https://github.com/jdx) in [2c83dff](https://github.com/jdx/mise/commit/2c83dfff4f9b98a9efeede022dc6948b8f6be764)
+- updated ubi by [@jdx](https://github.com/jdx) in [#2847](https://github.com/jdx/mise/pull/2847)
+
 ## [2024.10.11](https://github.com/jdx/mise/compare/v2024.10.10..v2024.10.11) - 2024-10-27
 
 ### 🚀 Features
@@ -1317,10 +1345,6 @@
 ### 🔍 Other Changes
 
 - add rustfmt to release-plz by [@jdx](https://github.com/jdx) in [2d530f6](https://github.com/jdx/mise/commit/2d530f645b6263c6162380684ab7914efc3dce39)
-
-### New Contributors
-
-- @vrslev made their first contribution in [#2116](https://github.com/jdx/mise/pull/2116)
 
 ## [2024.5.15](https://github.com/jdx/mise/compare/v2024.5.14..v2024.5.15) - 2024-05-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.10.11"
+version = "2024.10.12"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -2977,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags",
  "errno 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.10.11"
+version = "2024.10.12"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.10.11 macos-arm64 (a1b2d3e 2024-10-27)
+2024.10.12 macos-arm64 (a1b2d3e 2024-10-27)
 ```
 
 or install a specific a version:

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.10.11";
+  version = "2024.10.12";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.10.11" 
+.TH mise 1  "mise 2024.10.12" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.10.11
+v2024.10.12
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.10.11
+Version: 2024.10.12
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(registry)** Use ubi for delta, fd, gohugo, hyperfine, just, tokei, xh by [@vrslev](https://github.com/vrslev) in [#2836](https://github.com/jdx/mise/pull/2836)
- accept argument for `mise registry` by [@jdx](https://github.com/jdx) in [#2841](https://github.com/jdx/mise/pull/2841)
- allow listing all versions from github by [@jdx](https://github.com/jdx) in [#2844](https://github.com/jdx/mise/pull/2844)
- lockfiles by [@jdx](https://github.com/jdx) in [#2839](https://github.com/jdx/mise/pull/2839)

### 🐛 Bug Fixes

- allow passing ubi:[exe=] on the command line by [@jdx](https://github.com/jdx) in [#2843](https://github.com/jdx/mise/pull/2843)
- pass ubi config from mise.toml by [@jdx](https://github.com/jdx) in [#2842](https://github.com/jdx/mise/pull/2842)

### 🚜 Refactor

- added ToolSource to ToolRequest by [@jdx](https://github.com/jdx) in [#2846](https://github.com/jdx/mise/pull/2846)

### 📚 Documentation

- added anchor tags for settings by [@jdx](https://github.com/jdx) in [#2845](https://github.com/jdx/mise/pull/2845)

### 🔍 Other Changes

- Disable ruby plugin test as no network access to GitHub in derivation by [@laozc](https://github.com/laozc) in [#2835](https://github.com/jdx/mise/pull/2835)
- remove extra code coverage comment by [@jdx](https://github.com/jdx) in [2c83dff](https://github.com/jdx/mise/commit/2c83dfff4f9b98a9efeede022dc6948b8f6be764)
- updated ubi by [@jdx](https://github.com/jdx) in [#2847](https://github.com/jdx/mise/pull/2847)