### PR TITLE
chore: release 2024.10.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2024.10.13](https://github.com/jdx/mise/compare/v2024.10.12..v2024.10.13) - 2024-10-28
+
+### 🚀 Features
+
+- bring tasks out of experimental by [@jdx](https://github.com/jdx) in [#2851](https://github.com/jdx/mise/pull/2851)
+
+### 🐛 Bug Fixes
+
+- correct python ls-remote with python.compile option by [@jdx](https://github.com/jdx) in [acfd7f1](https://github.com/jdx/mise/commit/acfd7f13411faf784e585e1e489dccfd97a0de66)
+
+### 📚 Documentation
+
+- added walkthrough by [@jdx](https://github.com/jdx) in [#2848](https://github.com/jdx/mise/pull/2848)
+- added source code links by [@jdx](https://github.com/jdx) in [#2850](https://github.com/jdx/mise/pull/2850)
+
+### 🔍 Other Changes
+
+- Revert "fix: correct python ls-remote with python.compile option" by [@jdx](https://github.com/jdx) in [f65c0b6](https://github.com/jdx/mise/commit/f65c0b67106c22686055f46d81760bb44405d663)
+- fetch mise compressed in standalone installer by [@jdx](https://github.com/jdx) in [62a7aac](https://github.com/jdx/mise/commit/62a7aacae1a2db36d39a4a872b4d83846effa912)
+
 ## [2024.10.12](https://github.com/jdx/mise/compare/v2024.10.11..v2024.10.12) - 2024-10-27
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
+checksum = "a1f72d3e19488cf7d8ea52d2fc0f8754fc933398b337cd3cbdb28aaeb35159ef"
 dependencies = [
  "console",
  "lazy_static",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.10.12"
+version = "2024.10.13"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.10.12"
+version = "2024.10.13"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.10.12 macos-arm64 (a1b2d3e 2024-10-27)
+2024.10.13 macos-arm64 (a1b2d3e 2024-10-28)
 ```
 
 or install a specific a version:

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.10.12";
+  version = "2024.10.13";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.10.12" 
+.TH mise 1  "mise 2024.10.13" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.10.12
+v2024.10.13
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.10.12
+Version: 2024.10.13
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- bring tasks out of experimental by [@jdx](https://github.com/jdx) in [#2851](https://github.com/jdx/mise/pull/2851)

### 🐛 Bug Fixes

- correct python ls-remote with python.compile option by [@jdx](https://github.com/jdx) in [acfd7f1](https://github.com/jdx/mise/commit/acfd7f13411faf784e585e1e489dccfd97a0de66)

### 📚 Documentation

- added walkthrough by [@jdx](https://github.com/jdx) in [#2848](https://github.com/jdx/mise/pull/2848)
- added source code links by [@jdx](https://github.com/jdx) in [#2850](https://github.com/jdx/mise/pull/2850)

### 🔍 Other Changes

- Revert "fix: correct python ls-remote with python.compile option" by [@jdx](https://github.com/jdx) in [f65c0b6](https://github.com/jdx/mise/commit/f65c0b67106c22686055f46d81760bb44405d663)
- fetch mise compressed in standalone installer by [@jdx](https://github.com/jdx) in [62a7aac](https://github.com/jdx/mise/commit/62a7aacae1a2db36d39a4a872b4d83846effa912)