### PR TITLE
fix: installed_tool@version complete script doesn't list installed tools, but plugins

### DIFF
--- a/src/assets/mise-extra.usage.kdl
+++ b/src/assets/mise-extra.usage.kdl
@@ -47,7 +47,7 @@ case $cur in
     done
     ;;
   *)
-    plugins=$(mise plugins --core --user)
+    plugins=$(mise ls --installed | awk '{print $1}' | sed '1!G;h;$!d')
     for plugin in $plugins; do
       echo "$plugin@"
     done


### PR DESCRIPTION
The complete script of `installed_tool@version` runs `mise plugins --core --user` which displays plugins instead of installed tools&versions. Considering this complete is only used by `mise uninstall` currently, I don't think it makes sense.
`mise plugins --user` also doesn't seem to make sense to me here since we want to uninstall tool versions, not plugins itself as per [uninstall documentation](https://mise.jdx.dev/cli/uninstall.html)