### PR TITLE
docs: Fix path to tracked-configs

### DIFF
--- a/docs/cli/prune.md
+++ b/docs/cli/prune.md
@@ -6,7 +6,7 @@
 
 Delete unused versions of tools
 
-mise tracks which config files have been used in ~/.local/share/mise/tracked_config_files
+mise tracks which config files have been used in ~/.local/state/mise/tracked-configs
 Versions which are no longer the latest specified in any of those configs are deleted.
 Versions installed only with environment variables `MISE_<PLUGIN>_VERSION` will be deleted,
 as will versions only referenced on the command line `mise exec <PLUGIN>@<VERSION>`.

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -713,7 +713,7 @@ note: this updates the plugin itself, not the runtime versions"
 cmd "prune" help="Delete unused versions of tools" {
     long_help r"Delete unused versions of tools
 
-mise tracks which config files have been used in ~/.local/share/mise/tracked_config_files
+mise tracks which config files have been used in ~/.local/state/mise/tracked-configs
 Versions which are no longer the latest specified in any of those configs are deleted.
 Versions installed only with environment variables (`MISE_<PLUGIN>_VERSION`) will be deleted,
 as will versions only referenced on the command line (`mise exec <PLUGIN>@<VERSION>`)."

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -814,7 +814,7 @@ note: this updates the plugin itself, not the runtime versions"
 cmd "prune" help="Delete unused versions of tools" {
     long_help r"Delete unused versions of tools
 
-mise tracks which config files have been used in ~/.local/share/mise/tracked_config_files
+mise tracks which config files have been used in ~/.local/state/mise/tracked-configs
 Versions which are no longer the latest specified in any of those configs are deleted.
 Versions installed only with environment variables `MISE_<PLUGIN>_VERSION` will be deleted,
 as will versions only referenced on the command line `mise exec <PLUGIN>@<VERSION>`."

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -16,7 +16,7 @@ use super::trust::Trust;
 
 /// Delete unused versions of tools
 ///
-/// mise tracks which config files have been used in ~/.local/share/mise/tracked_config_files
+/// mise tracks which config files have been used in ~/.local/state/mise/tracked-configs
 /// Versions which are no longer the latest specified in any of those configs are deleted.
 /// Versions installed only with environment variables `MISE_<PLUGIN>_VERSION` will be deleted,
 /// as will versions only referenced on the command line `mise exec <PLUGIN>@<VERSION>`.


### PR DESCRIPTION
```
$ mise prune --help
Delete unused versions of tools

mise tracks which config files have been used in ~/.local/share/mise/tracked_config_files
[…]
```

That path hasn't been used since cf4ed1f9567e.