### PR TITLE
feat: show bump in mise outdated and upgrade --interactive

### DIFF
--- a/e2e/cli/test_outdated
+++ b/e2e/cli/test_outdated
@@ -11,7 +11,7 @@ assert_not_contains "mise ls --installed dummy" "1.1.0"
 #assert_not_contains "mise ls --installed dummy" "1.0.0"
 
 assert "mise outdated dummy" "dummy  1  1.0.0  1.1.0 ~/workdir/.tool-versions"
-assert "mise outdated dummy --bump" "dummy  1  1.0.0  2.0.0 ~/workdir/.tool-versions"
+assert "mise outdated dummy --bump" "dummy  1  1.0.0  2  2.0.0 ~/workdir/.tool-versions"
 
 assert "mise outdated dummy --json | jq -r '.dummy.latest'" "1.1.0"
 assert "mise outdated dummy --bump --json | jq -r '.dummy.latest'" "2.0.0"

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -6,6 +6,8 @@ use crate::toolset::{OutdatedInfo, ToolsetBuilder};
 use crate::ui::table;
 use eyre::Result;
 use indexmap::IndexMap;
+use tabled::settings::location::ByColumnName;
+use tabled::settings::Disable;
 
 /// Shows outdated tool versions
 ///
@@ -67,6 +69,9 @@ impl Outdated {
 
     fn display(&self, outdated: Vec<OutdatedInfo>) -> Result<()> {
         let mut table = tabled::Table::new(outdated);
+        if !self.bump {
+            table.with(Disable::column(ByColumnName::new("bump")));
+        }
         table::default_style(&mut table, self.no_header);
         miseprintln!("{table}");
         Ok(())

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -722,7 +722,7 @@ pub struct OutdatedInfo {
     pub requested: String,
     #[tabled(display_with("Self::display_current", self))]
     pub current: Option<String>,
-    #[tabled(skip)]
+    #[tabled(display_with("Self::display_bump", self))]
     pub bump: Option<String>,
     pub latest: String,
     pub source: ToolSource,
@@ -749,23 +749,29 @@ impl OutdatedInfo {
             "[MISSING]".to_string()
         }
     }
+
+    fn display_bump(&self) -> String {
+        if let Some(bump) = &self.bump {
+            bump.clone()
+        } else {
+            "[NONE]".to_string()
+        }
+    }
 }
 
 impl Display for OutdatedInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:<20} ", self.name)?;
         if let Some(current) = &self.current {
-            write!(
-                f,
-                "{:<20} {:<10} -> {:<10} ({})",
-                self.name, current, self.latest, self.source
-            )
+            write!(f, "{:<20} ", current)?;
         } else {
-            write!(
-                f,
-                "{:<20} {:<10} -> {:<10} ({})",
-                self.name, "MISSING", self.latest, self.source
-            )
+            write!(f, "{:<20} ", "MISSING")?;
         }
+        write!(f, "-> {:<10} (", self.latest)?;
+        if let Some(bump) = &self.bump {
+            write!(f, "bump to {} in ", bump)?;
+        }
+        write!(f, "{})", self.source)
     }
 }
 


### PR DESCRIPTION
Since --bump is currently a bit unreliable, it's helpful to show early what exactly it's about to do.
