### PR TITLE
fix(backend): include backend dependencies in paths

### DIFF
--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -31,11 +31,10 @@ impl Backend for GoBackend {
         self.remote_version_cache
             .get_or_try_init(|| {
                 let mut mod_path = Some(self.name());
-                let env = self.dependency_env()?;
 
                 while let Some(cur_mod_path) = mod_path {
                     let res = cmd!("go", "list", "-m", "-versions", "-json", cur_mod_path)
-                        .full_env(&env)
+                        .full_env(self.dependency_env()?)
                         .read();
                     if let Ok(raw) = res {
                         let res = serde_json::from_str::<GoModInfo>(&raw);

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -34,7 +34,9 @@ impl Backend for NPMBackend {
     fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
         self.remote_version_cache
             .get_or_try_init(|| {
-                let raw = cmd!(PROGRAM, "view", self.name(), "versions", "--json").read()?;
+                let raw = cmd!(PROGRAM, "view", self.name(), "versions", "--json")
+                    .full_env(self.dependency_env()?)
+                    .read()?;
                 let versions: Vec<String> = serde_json::from_str(&raw)?;
                 Ok(versions)
             })

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -126,6 +126,7 @@ impl SPMBackend {
             "--package-path",
             &repo_dir
         )
+        .full_env(self.dependency_env()?)
         .read()?;
         let executables = serde_json::from_str::<PackageDescription>(&package_json)
             .wrap_err("Failed to parse package description")?
@@ -153,7 +154,8 @@ impl SPMBackend {
             .arg(executable)
             .arg("--package-path")
             .arg(repo_dir)
-            .with_pr(ctx.pr.as_ref());
+            .with_pr(ctx.pr.as_ref())
+            .prepend_path(self.dependency_toolset()?.list_paths())?;
         build_cmd.execute()?;
         let bin_path = cmd!(
             "swift",
@@ -166,6 +168,7 @@ impl SPMBackend {
             &repo_dir,
             "--show-bin-path"
         )
+        .full_env(self.dependency_env()?)
         .read()?;
         Ok(PathBuf::from(bin_path.trim().to_string()))
     }

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -29,7 +29,6 @@ pub fn handle_shim() -> Result<()> {
     let args = env::ARGS.read().unwrap();
     trace!("shim[{bin_name}] args: {}", args.join(" "));
     let mut args: Vec<OsString> = args.iter().map(OsString::from).collect();
-    remove_shim_dir_from_path();
     args[0] = which_shim(&env::MISE_BIN_NAME)?.into();
     env::set_var("__MISE_SHIM", "1");
     let exec = Exec {
@@ -270,22 +269,6 @@ fn make_shim(target: &Path, shim: &Path) -> Result<()> {
         shim.display()
     );
     Ok(())
-}
-
-/// prevent shims from being called in a loop
-fn remove_shim_dir_from_path() {
-    let path = env::var_os(&*env::PATH_KEY).unwrap_or_default();
-    let paths = env::split_paths(&path).filter(|p| {
-        p != *dirs::SHIMS
-            && !p
-                .canonicalize()
-                .is_ok_and(|p| p == dirs::SHIMS.canonicalize().unwrap_or_default())
-    });
-    let path = env::join_paths(paths)
-        .unwrap()
-        .to_string_lossy()
-        .to_string();
-    env::set_var(&*env::PATH_KEY, &path);
 }
 
 fn err_no_version_set(ts: Toolset, bin_name: &str, tvs: Vec<ToolVersion>) -> Result<PathBuf> {


### PR DESCRIPTION
Fixes #2260.

From #2745, there is no need to remove the shims directory from `PATH` beforehand (#2376).

I tested the infinite loop repro and it seems working fine. This should resolve the issue, but I will revert the removal commit if it's better to preserve it just in case.