### PR TITLE
fix: only run not_found_auto_install if non-tty in shims

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -381,8 +381,9 @@ default = true
 description = "Set to false to disable the \"command not found\" handler to autoinstall missing tool versions."
 docs = """
 Set to false to disable the "command not found" handler to autoinstall missing tool versions.
-Disable this if experiencing strange behavior in your shell when a command is not found—but please submit a
-ticket to help diagnose problems.
+Disable this if experiencing strange behavior in your shell when a command is not found.
+
+This also runs in shims if the terminal is interactive.
 """
 
 [paranoid]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -54,7 +54,7 @@ fn which_shim(bin_name: &str) -> Result<PathBuf> {
             return Ok(bin);
         }
     }
-    if SETTINGS.not_found_auto_install {
+    if SETTINGS.not_found_auto_install && console::user_attended() {
         for tv in ts.install_missing_bin(bin_name)?.unwrap_or_default() {
             let p = tv.get_backend();
             if let Some(bin) = p.which(&tv, bin_name)? {


### PR DESCRIPTION
Fixes #2858
