### PR TITLE
fix: parse task run template even if no args/flags

### DIFF
--- a/e2e/tasks/test_task_run_toml
+++ b/e2e/tasks/test_task_run_toml
@@ -11,9 +11,12 @@ run = 'echo "testing!"'
 run = 'echo "{{arg()}} {{flag(name="force")}} {{option(name="user")}}"'
 [tasks.test-with-defaults]
 run = 'echo {{arg(default="arg1")}} {{option(name="user", default="user1")}}'
+[tasks.test-with-template]
+run = 'echo {{1 + 1}}'
 EOF
 
 assert "mise run test arg1 arg2 arg3" "testing! arg1 arg2 arg3"
 assert "mise run test-with-args foo --force --user=user" "foo true user"
 assert "mise run test-with-defaults" "arg1 user1"
 assert "mise run test-with-defaults arg2 --user=user2" "arg2 user2"
+assert "mise run test-with-template" "2"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -217,8 +217,7 @@ impl Task {
                     .collect(),
             )
         } else {
-            Ok(self
-                .run
+            Ok(scripts
                 .iter()
                 .enumerate()
                 .map(|(i, script)| {


### PR DESCRIPTION
Fixes #2902
