### PR TITLE
chore: release 2024.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [2024.11.2](https://github.com/jdx/mise/compare/v2024.11.1..v2024.11.2) - 2024-11-06
+
+### 🐛 Bug Fixes
+
+- **(backend)** include backend dependencies in paths by [@risu729](https://github.com/risu729) in [#2893](https://github.com/jdx/mise/pull/2893)
+- **(completions)** set usage cache-key by [@jdx](https://github.com/jdx) in [#2937](https://github.com/jdx/mise/pull/2937)
+- **(ls)** only show symlink_path when not runtime-symlink by [@jdx](https://github.com/jdx) in [#2927](https://github.com/jdx/mise/pull/2927)
+- upgrade vfox.rs with http module by [@jdx](https://github.com/jdx) in [#2934](https://github.com/jdx/mise/pull/2934)
+- hide extra "mise" prefix when installing by [@jdx](https://github.com/jdx) in [#2935](https://github.com/jdx/mise/pull/2935)
+- only show actual cargo-binstall versions by [@jdx](https://github.com/jdx) in [#2936](https://github.com/jdx/mise/pull/2936)
+- use project_root for task execution by [@jdx](https://github.com/jdx) in [#2942](https://github.com/jdx/mise/pull/2942)
+- upgrade with options by [@jdx](https://github.com/jdx) in [#2925](https://github.com/jdx/mise/pull/2925)
+- remove duplicate "mise" in logs by [@jdx](https://github.com/jdx) in [693f39b](https://github.com/jdx/mise/commit/693f39b8b9d7506c035e5fa9cdb77be7287ac7e1)
+
+### 📚 Documentation
+
+- move alternative ways to install mise to a separate page by [@hverlin](https://github.com/hverlin) in [#2930](https://github.com/jdx/mise/pull/2930)
+- show information about github rate limits when erroring due to 403 by [@jdx](https://github.com/jdx) in [#2856](https://github.com/jdx/mise/pull/2856)
+
+### ⚡ Performance
+
+- **(shell/zsh.rs)** avoid hook-env execution on Enter without command by [@powerman](https://github.com/powerman) in [#2861](https://github.com/jdx/mise/pull/2861)
+- skip reading backend-meta files if they do not exist by [@jdx](https://github.com/jdx) in [#2941](https://github.com/jdx/mise/pull/2941)
+
+### 🧪 Testing
+
+- move use tests to e2e by [@jdx](https://github.com/jdx) in [#2924](https://github.com/jdx/mise/pull/2924)
+
+### 🔍 Other Changes
+
+- Update installing-mise.md by [@jdx](https://github.com/jdx) in [c8cd667](https://github.com/jdx/mise/commit/c8cd667c15b7d0ba25bbe475c5f11dc142496a18)
+
+### New Contributors
+
+- @powerman made their first contribution in [#2861](https://github.com/jdx/mise/pull/2861)
+
 ## [2024.11.1](https://github.com/jdx/mise/compare/v2024.11.0..v2024.11.1) - 2024-11-05
 
 ### 🚀 Features
@@ -48,7 +84,6 @@
 
 ### New Contributors
 
-- @hverlin made their first contribution in [#2891](https://github.com/jdx/mise/pull/2891)
 - @liskin made their first contribution in [#2892](https://github.com/jdx/mise/pull/2892)
 - @SolitudeSF made their first contribution in [#2857](https://github.com/jdx/mise/pull/2857)
 - @glasser made their first contribution in [#2872](https://github.com/jdx/mise/pull/2872)
@@ -377,10 +412,6 @@
 ### 🔍 Other Changes
 
 - move /.mise/tasks to /tasks by [@jdx](https://github.com/jdx) in [#2728](https://github.com/jdx/mise/pull/2728)
-
-### New Contributors
-
-- @risu729 made their first contribution in [#2729](https://github.com/jdx/mise/pull/2729)
 
 ## [2024.10.1](https://github.com/jdx/mise/compare/v2024.10.0..v2024.10.1) - 2024-10-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775a8770d29db3dadcb858482cc240af7b2ffde4ac4de67d1d4955728103f0e2"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.34"
+version = "1.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
+checksum = "baee610e9452a8f6f0a1b6194ec09ff9e2d85dea54432acdae41aa0761c95d70"
 dependencies = [
  "jobserver",
  "libc",
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d475dfebcb4854d596b17b09f477616f80f17a550517f2b3615d8c205d5c802b"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.1"
+version = "2024.11.2"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -2679,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.1"
+version = "2024.11.2"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.1 macos-arm64 (a1b2d3e 2024-11-05)
+2024.11.2 macos-arm64 (a1b2d3e 2024-11-06)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_1:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_1 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_1;
+  if ( [[ -z "${_usage_spec_mise_2024_11_2:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_2 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_2;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_1 spec
+    _store_cache _usage_spec_mise_2024_11_2 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_1:-} ]]; then
-        _usage_spec_mise_2024_11_1="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_2:-} ]]; then
+        _usage_spec_mise_2024_11_2="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_1}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_2}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_1
-  set -U _usage_spec_mise_2024_11_1 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_2
+  set -U _usage_spec_mise_2024_11_2 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_1" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_2" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.1";
+  version = "2024.11.2";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.1" 
+.TH mise 1  "mise 2024.11.2" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.1
+v2024.11.2
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.1
+Version: 2024.11.2
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(backend)** include backend dependencies in paths by [@risu729](https://github.com/risu729) in [#2893](https://github.com/jdx/mise/pull/2893)
- **(completions)** set usage cache-key by [@jdx](https://github.com/jdx) in [#2937](https://github.com/jdx/mise/pull/2937)
- **(ls)** only show symlink_path when not runtime-symlink by [@jdx](https://github.com/jdx) in [#2927](https://github.com/jdx/mise/pull/2927)
- upgrade vfox.rs with http module by [@jdx](https://github.com/jdx) in [#2934](https://github.com/jdx/mise/pull/2934)
- hide extra "mise" prefix when installing by [@jdx](https://github.com/jdx) in [#2935](https://github.com/jdx/mise/pull/2935)
- only show actual cargo-binstall versions by [@jdx](https://github.com/jdx) in [#2936](https://github.com/jdx/mise/pull/2936)
- use project_root for task execution by [@jdx](https://github.com/jdx) in [#2942](https://github.com/jdx/mise/pull/2942)
- upgrade with options by [@jdx](https://github.com/jdx) in [#2925](https://github.com/jdx/mise/pull/2925)
- remove duplicate "mise" in logs by [@jdx](https://github.com/jdx) in [693f39b](https://github.com/jdx/mise/commit/693f39b8b9d7506c035e5fa9cdb77be7287ac7e1)

### 📚 Documentation

- move alternative ways to install mise to a separate page by [@hverlin](https://github.com/hverlin) in [#2930](https://github.com/jdx/mise/pull/2930)
- show information about github rate limits when erroring due to 403 by [@jdx](https://github.com/jdx) in [#2856](https://github.com/jdx/mise/pull/2856)

### ⚡ Performance

- **(shell/zsh.rs)** avoid hook-env execution on Enter without command by [@powerman](https://github.com/powerman) in [#2861](https://github.com/jdx/mise/pull/2861)
- skip reading backend-meta files if they do not exist by [@jdx](https://github.com/jdx) in [#2941](https://github.com/jdx/mise/pull/2941)

### 🧪 Testing

- move use tests to e2e by [@jdx](https://github.com/jdx) in [#2924](https://github.com/jdx/mise/pull/2924)

### 🔍 Other Changes

- Update installing-mise.md by [@jdx](https://github.com/jdx) in [c8cd667](https://github.com/jdx/mise/commit/c8cd667c15b7d0ba25bbe475c5f11dc142496a18)

### New Contributors

- @powerman made their first contribution in [#2861](https://github.com/jdx/mise/pull/2861)