### PR TITLE
Introducing Mise Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 <a href="https://github.com/jdx/mise/actions/workflows/test.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/jdx/mise/test.yml?style=for-the-badge"></a>
 <a href="https://app.codacy.com/gh/jdx/mise/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage"><img alt="Codacy coverage (branch)" src="https://img.shields.io/codacy/coverage/af322e1f36ca41f0a296f49733a705f5/main?color=%2344CC11&style=for-the-badge"></a>
 <a href="https://discord.gg/mABnUDvP57"><img alt="Discord" src="https://img.shields.io/discord/1066429325269794907?color=%23738ADB&style=for-the-badge"></a>
+<a href="https://gurubase.io/g/mise"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Mise%20Guru-006BFF?style=for-the-badge"></a>
 <p><em>The front-end to your dev env.</em></p>
 </div>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Mise Guru](https://gurubase.io/g/mise) to Gurubase. Mise Guru uses the data from this repo and data from the [docs](https://mise.jdx.dev) to answer questions by leveraging the LLM.

In this PR, I showcased the "Mise Guru", which highlights that Mise now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Mise Guru in Gurubase, just let me know that's totally fine.
