### PR TITLE
chore: release 2024.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2024.11.3](https://github.com/jdx/mise/compare/v2024.11.2..v2024.11.3) - 2024-11-06
+
+### 🐛 Bug Fixes
+
+- support multiple versions in lockfile by [@jdx](https://github.com/jdx) in [#2923](https://github.com/jdx/mise/pull/2923)
+- use mise.toml instead of .mise.toml by default in `mise use` by [@jdx](https://github.com/jdx) in [#2818](https://github.com/jdx/mise/pull/2818)
+- explode backend dependencies by [@jdx](https://github.com/jdx) in [#2945](https://github.com/jdx/mise/pull/2945)
+- show install prefix in output by [@jdx](https://github.com/jdx) in [#2946](https://github.com/jdx/mise/pull/2946)
+- make vfox/vendored-lua optional by [@jdx](https://github.com/jdx) in [acc674b](https://github.com/jdx/mise/commit/acc674b00c307241fb8b87ba7e27fba1f08a1a22)
+
+### 🔍 Other Changes
+
+- Revert "perf(shell/zsh.rs): avoid hook-env execution on Enter without command " by [@jdx](https://github.com/jdx) in [7e19251](https://github.com/jdx/mise/commit/7e1925188eff61a4d93657d15c23bef4b5c55424)
+
 ## [2024.11.2](https://github.com/jdx/mise/compare/v2024.11.1..v2024.11.2) - 2024-11-06
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arbitrary"
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.2"
+version = "2024.11.3"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.2"
+version = "2024.11.3"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.2 macos-arm64 (a1b2d3e 2024-11-06)
+2024.11.3 macos-arm64 (a1b2d3e 2024-11-06)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_2:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_2 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_2;
+  if ( [[ -z "${_usage_spec_mise_2024_11_3:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_3 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_3;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_2 spec
+    _store_cache _usage_spec_mise_2024_11_3 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_2:-} ]]; then
-        _usage_spec_mise_2024_11_2="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_3:-} ]]; then
+        _usage_spec_mise_2024_11_3="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_2}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_3}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_2
-  set -U _usage_spec_mise_2024_11_2 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_3
+  set -U _usage_spec_mise_2024_11_3 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_2" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_3" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.2";
+  version = "2024.11.3";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.2" 
+.TH mise 1  "mise 2024.11.3" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.2
+v2024.11.3
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.2
+Version: 2024.11.3
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- support multiple versions in lockfile by [@jdx](https://github.com/jdx) in [#2923](https://github.com/jdx/mise/pull/2923)
- use mise.toml instead of .mise.toml by default in `mise use` by [@jdx](https://github.com/jdx) in [#2818](https://github.com/jdx/mise/pull/2818)
- explode backend dependencies by [@jdx](https://github.com/jdx) in [#2945](https://github.com/jdx/mise/pull/2945)
- show install prefix in output by [@jdx](https://github.com/jdx) in [#2946](https://github.com/jdx/mise/pull/2946)
- make vfox/vendored-lua optional by [@jdx](https://github.com/jdx) in [acc674b](https://github.com/jdx/mise/commit/acc674b00c307241fb8b87ba7e27fba1f08a1a22)

### 🔍 Other Changes

- Revert "perf(shell/zsh.rs): avoid hook-env execution on Enter without command " by [@jdx](https://github.com/jdx) in [7e19251](https://github.com/jdx/mise/commit/7e1925188eff61a4d93657d15c23bef4b5c55424)