### PR TITLE
chore: release 2024.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [2024.11.4](https://github.com/jdx/mise/compare/v2024.11.3..v2024.11.4) - 2024-11-06
+
+### 🚀 Features
+
+- added --offline flag to ls by [@jdx](https://github.com/jdx) in [#2954](https://github.com/jdx/mise/pull/2954)
+- added MISE_TASK_TIMINGS setting by [@jdx](https://github.com/jdx) in [#2957](https://github.com/jdx/mise/pull/2957)
+
+### 🐛 Bug Fixes
+
+- **(go)** remove old GOPATH bin dir by [@jdx](https://github.com/jdx) in [#2959](https://github.com/jdx/mise/pull/2959)
+- allow installing asdf/vfox plugins by shorthand when overridden by ubi by [@jdx](https://github.com/jdx) in [#2956](https://github.com/jdx/mise/pull/2956)
+- set docs directory in release-docs task by [@jdx](https://github.com/jdx) in [6efac79](https://github.com/jdx/mise/commit/6efac7976b2d1ebdb988baf6e50f8faa8218053b)
+
+### 🔍 Other Changes
+
+- added hidden --outdate option for cache clear by [@jdx](https://github.com/jdx) in [9535aa1](https://github.com/jdx/mise/commit/9535aa15ceb0ad43e1ca0f2623a7cbbde59ce6f0)
+
 ## [2024.11.3](https://github.com/jdx/mise/compare/v2024.11.2..v2024.11.3) - 2024-11-06
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.3"
+version = "2024.11.4"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.3"
+version = "2024.11.4"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.3 macos-arm64 (a1b2d3e 2024-11-06)
+2024.11.4 macos-arm64 (a1b2d3e 2024-11-06)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_3:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_3 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_3;
+  if ( [[ -z "${_usage_spec_mise_2024_11_4:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_4 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_4;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_3 spec
+    _store_cache _usage_spec_mise_2024_11_4 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_3:-} ]]; then
-        _usage_spec_mise_2024_11_3="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_4:-} ]]; then
+        _usage_spec_mise_2024_11_4="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_3}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_4}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_3
-  set -U _usage_spec_mise_2024_11_3 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_4
+  set -U _usage_spec_mise_2024_11_4 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_3" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_4" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.3";
+  version = "2024.11.4";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.3" 
+.TH mise 1  "mise 2024.11.4" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.3
+v2024.11.4
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.3
+Version: 2024.11.4
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- added --offline flag to ls by [@jdx](https://github.com/jdx) in [#2954](https://github.com/jdx/mise/pull/2954)
- added MISE_TASK_TIMINGS setting by [@jdx](https://github.com/jdx) in [#2957](https://github.com/jdx/mise/pull/2957)

### 🐛 Bug Fixes

- **(go)** remove old GOPATH bin dir by [@jdx](https://github.com/jdx) in [#2959](https://github.com/jdx/mise/pull/2959)
- allow installing asdf/vfox plugins by shorthand when overridden by ubi by [@jdx](https://github.com/jdx) in [#2956](https://github.com/jdx/mise/pull/2956)
- set docs directory in release-docs task by [@jdx](https://github.com/jdx) in [6efac79](https://github.com/jdx/mise/commit/6efac7976b2d1ebdb988baf6e50f8faa8218053b)

### 🔍 Other Changes

- added hidden --outdate option for cache clear by [@jdx](https://github.com/jdx) in [9535aa1](https://github.com/jdx/mise/commit/9535aa15ceb0ad43e1ca0f2623a7cbbde59ce6f0)