### PR TITLE
fix: allow installing asdf/vfox plugins by shorthand when overridden by ubi

### DIFF
--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -48,10 +48,12 @@ impl PluginsLs {
         let mut tools = plugins::list2()?;
 
         if self.all {
-            for (plugin, full) in config.get_shorthands() {
-                let mut ep = AsdfPlugin::new(plugin.to_string());
-                ep.repo_url = Some(full_to_url(full));
-                tools.insert(ep.name.clone(), Box::new(ep));
+            for (plugin, backends) in config.get_shorthands() {
+                for full in backends {
+                    let mut ep = AsdfPlugin::new(plugin.to_string());
+                    ep.repo_url = Some(full_to_url(full));
+                    tools.insert(ep.name.clone(), Box::new(ep));
+                }
             }
         } else if self.user && self.core {
         } else if self.core {

--- a/src/cli/plugins/ls_remote.rs
+++ b/src/cli/plugins/ls_remote.rs
@@ -41,15 +41,17 @@ impl PluginsLsRemote {
             warn!("default shorthands are disabled");
         }
 
-        for (plugin, repo) in shorthands {
-            let installed = if !self.only_names && installed_plugins.contains(plugin.as_str()) {
-                "*"
-            } else {
-                " "
-            };
-            let url = if self.urls { repo } else { "" };
-            let plugin = pad_str(plugin, max_plugin_len, Alignment::Left, None);
-            miseprintln!("{} {}{}", plugin, installed, url);
+        for (plugin, backends) in shorthands {
+            for repo in backends {
+                let installed = if !self.only_names && installed_plugins.contains(plugin.as_str()) {
+                    "*"
+                } else {
+                    " "
+                };
+                let url = if self.urls { repo } else { "" };
+                let plugin = pad_str(plugin, max_plugin_len, Alignment::Left, None);
+                miseprintln!("{} {}{}", plugin, installed, url);
+            }
         }
 
         Ok(())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,7 +47,7 @@ pub struct Config {
     env_with_sources: OnceCell<EnvWithSources>,
     all_aliases: OnceLock<AliasMap>,
     repo_urls: HashMap<String, String>,
-    shorthands: OnceLock<HashMap<String, String>>,
+    shorthands: OnceLock<Shorthands>,
     tasks: OnceCell<BTreeMap<String, Task>>,
     tool_request_set: OnceCell<ToolRequestSet>,
 }
@@ -160,7 +160,7 @@ impl Config {
             None => self
                 .get_shorthands()
                 .get(plugin_name)
-                .map(|full| registry::full_to_url(full)),
+                .map(|full| registry::full_to_url(&full[0])),
         }
     }
 

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -2,13 +2,14 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use eyre::Result;
+use itertools::Itertools;
 use toml::Table;
 
 use crate::config::Settings;
 use crate::registry::REGISTRY;
 use crate::{dirs, file};
 
-pub type Shorthands = HashMap<String, String>;
+pub type Shorthands = HashMap<String, Vec<String>>;
 
 pub fn get_shorthands(settings: &Settings) -> Shorthands {
     let mut shorthands = HashMap::new();
@@ -16,11 +17,16 @@ pub fn get_shorthands(settings: &Settings) -> Shorthands {
         shorthands.extend(
             REGISTRY
                 .iter()
-                .filter(|(_, full)| {
-                    let backend = &full[0].split(':').next().unwrap().to_string();
-                    backend == "asdf" || backend == "vfox"
+                .map(|(id, full)| {
+                    (
+                        id.to_string(),
+                        full.iter()
+                            .filter(|f| f.starts_with("asdf:") || f.starts_with("vfox:"))
+                            .map(|f| f.to_string())
+                            .collect_vec(),
+                    )
                 })
-                .map(|(k, v)| (k.to_string(), v[0].to_string())),
+                .filter(|(_, fulls)| !fulls.is_empty()),
         );
     };
     if let Some(f) = &settings.shorthands_file {
@@ -46,7 +52,7 @@ fn parse_shorthands_file(mut f: PathBuf) -> Result<Shorthands> {
     let mut shorthands = HashMap::new();
     for (k, v) in toml {
         if let Some(v) = v.as_str() {
-            shorthands.insert(k, v.to_string());
+            shorthands.insert(k, vec![v.to_string()]);
         }
     }
     Ok(shorthands)
@@ -70,9 +76,9 @@ mod tests {
         let mut settings = Settings::get().deref().clone();
         settings.shorthands_file = Some("../fixtures/shorthands.toml".into());
         let shorthands = get_shorthands(&settings);
-        assert_str_eq!(shorthands["elixir"], "asdf:mise-plugins/mise-elixir");
-        assert_str_eq!(shorthands["node"], "https://node");
-        assert_str_eq!(shorthands["xxxxxx"], "https://xxxxxx");
+        assert_str_eq!(shorthands["elixir"][0], "asdf:mise-plugins/mise-elixir");
+        assert_str_eq!(shorthands["node"][0], "https://node");
+        assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2955
