### PR TITLE
chore: release 2024.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2024.11.5](https://github.com/jdx/mise/compare/v2024.11.4..v2024.11.5) - 2024-11-09
+
+### 🚀 Features
+
+- show overridden tools in registry by [@jdx](https://github.com/jdx) in [#2974](https://github.com/jdx/mise/pull/2974)
+
+### 🐛 Bug Fixes
+
+- use versions host for core plugins by [@jdx](https://github.com/jdx) in [#2970](https://github.com/jdx/mise/pull/2970)
+- reuse cache when old by [@jdx](https://github.com/jdx) in [#2971](https://github.com/jdx/mise/pull/2971)
+- MISE_PROFILE fixes by [@jdx](https://github.com/jdx) in [#2973](https://github.com/jdx/mise/pull/2973)
+
+### 🧪 Testing
+
+- added win-e2e task test by [@jdx](https://github.com/jdx) in [#2972](https://github.com/jdx/mise/pull/2972)
+
+### 📦️ Dependency Updates
+
+- update dependency vitepress to v1.5.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#2966](https://github.com/jdx/mise/pull/2966)
+
 ## [2024.11.4](https://github.com/jdx/mise/compare/v2024.11.3..v2024.11.4) - 2024-11-06
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.36"
+version = "1.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baee610e9452a8f6f0a1b6194ec09ff9e2d85dea54432acdae41aa0761c95d70"
+checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
 dependencies = [
  "jobserver",
  "libc",
@@ -486,18 +486,18 @@ dependencies = [
 
 [[package]]
 name = "color-print"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee543c60ff3888934877a5671f45494dd27ed4ba25c6670b9a7576b7ed7a8c0"
+checksum = "3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4"
 dependencies = [
  "color-print-proc-macro",
 ]
 
 [[package]]
 name = "color-print-proc-macro"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ff1a80c5f3cb1ca7c06ffdd71b6a6dd6d8f896c42141fbd43f50ed28dcdb93"
+checksum = "692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22"
 dependencies = [
  "nom",
  "proc-macro2",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fiat-crypto"
@@ -1767,9 +1767,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libgit2-sys"
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.4"
+version = "2024.11.5"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -3036,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3488,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3688,9 +3688,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.4"
+version = "2024.11.5"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.4 macos-arm64 (a1b2d3e 2024-11-06)
+2024.11.5 macos-arm64 (a1b2d3e 2024-11-09)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_4:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_4 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_4;
+  if ( [[ -z "${_usage_spec_mise_2024_11_5:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_5 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_5;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_4 spec
+    _store_cache _usage_spec_mise_2024_11_5 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_4:-} ]]; then
-        _usage_spec_mise_2024_11_4="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_5:-} ]]; then
+        _usage_spec_mise_2024_11_5="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_4}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_5}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_4
-  set -U _usage_spec_mise_2024_11_4 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_5
+  set -U _usage_spec_mise_2024_11_5 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_4" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_5" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.4";
+  version = "2024.11.5";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.4" 
+.TH mise 1  "mise 2024.11.5" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.4
+v2024.11.5
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.4
+Version: 2024.11.5
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- show overridden tools in registry by [@jdx](https://github.com/jdx) in [#2974](https://github.com/jdx/mise/pull/2974)

### 🐛 Bug Fixes

- use versions host for core plugins by [@jdx](https://github.com/jdx) in [#2970](https://github.com/jdx/mise/pull/2970)
- reuse cache when old by [@jdx](https://github.com/jdx) in [#2971](https://github.com/jdx/mise/pull/2971)
- MISE_PROFILE fixes by [@jdx](https://github.com/jdx) in [#2973](https://github.com/jdx/mise/pull/2973)

### 🧪 Testing

- added win-e2e task test by [@jdx](https://github.com/jdx) in [#2972](https://github.com/jdx/mise/pull/2972)

### 📦️ Dependency Updates

- update dependency vitepress to v1.5.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#2966](https://github.com/jdx/mise/pull/2966)