### PR TITLE
fix: reuse cache when old

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -807,7 +807,6 @@ editLink: false
 | zbctl | [asdf:camunda-community-hub/asdf-zbctl](https://github.com/camunda-community-hub/asdf-zbctl) |
 | zellij | [ubi:zellij-org/zellij](https://github.com/zellij-org/zellij) |
 | zephyr | [asdf:nsaunders/asdf-zephyr](https://github.com/nsaunders/asdf-zephyr) |
-| zig | [asdf:cheetah/asdf-zig](https://github.com/cheetah/asdf-zig) |
 | zigmod | [asdf:mise-plugins/asdf-zigmod](https://github.com/mise-plugins/asdf-zigmod) |
 | zola | [ubi:getzola/zola](https://github.com/getzola/zola) |
 | zoxide | [ubi:ajeetdsouza/zoxide](https://github.com/ajeetdsouza/zoxide) |

--- a/e2e/cli/test_ls_cache
+++ b/e2e/cli/test_ls_cache
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# verify that cache is reused for `mise ls`
+# see https://github.com/jdx/mise/issues/2961
+
+assert_contains "mise -v use bat 2>&1" "GET http://mise-versions.jdx.dev/bat 200 OK"
+touch -t 202001010000 "$MISE_CACHE_DIR/bat/"*
+assert_not_contains "mise -v ls bat 2>&1" "GET http://mise-versions.jdx.dev/bat 200 OK"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -45,7 +45,7 @@ impl CacheManagerBuilder {
         Self {
             cache_file_path: cache_file_path.as_ref().to_path_buf(),
             cache_keys: BASE_CACHE_KEYS.clone(),
-            fresh_files: vec![dirs::DATA.to_path_buf()],
+            fresh_files: vec![],
             fresh_duration: None,
         }
     }


### PR DESCRIPTION
Verified with: `touch -t 201007162310 ~/.mise/cache/bat/remote_versions-* ~/.mise/cache/ && m ls -v bat`
Fixes #2961
