### PR TITLE
chore: release 2024.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [2024.11.6](https://github.com/jdx/mise/compare/v2024.11.5..v2024.11.6) - 2024-11-10
+
+### 🚀 Features
+
+- **(backend)** add a setting to use bun in npm backend by [@risu729](https://github.com/risu729) in [#2899](https://github.com/jdx/mise/pull/2899)
+- **(tasks)** add shell settings for Windows compatibility in tasks by [@rodvieirasilva](https://github.com/rodvieirasilva) in [#2967](https://github.com/jdx/mise/pull/2967)
+
+### 🐛 Bug Fixes
+
+- update tmux plugin by [@drewwells](https://github.com/drewwells) in [#2977](https://github.com/jdx/mise/pull/2977)
+
+### 🚜 Refactor
+
+- remove backend arg from tool-version by [@jdx](https://github.com/jdx) in [#2980](https://github.com/jdx/mise/pull/2980)
+
+### 📚 Documentation
+
+- load core plugins when rendering registry doc by [@jdx](https://github.com/jdx) in [00ef7b4](https://github.com/jdx/mise/commit/00ef7b4d5c59047e795c0fc2476bde386decc363)
+- added core plugins to registry by [@jdx](https://github.com/jdx) in [#2976](https://github.com/jdx/mise/pull/2976)
+
+### 🧪 Testing
+
+- added e2e test with multiple scripts by [@jdx](https://github.com/jdx) in [a89a5ee](https://github.com/jdx/mise/commit/a89a5eec402bf693e274334771d4386c2f752834)
+
+### New Contributors
+
+- @rodvieirasilva made their first contribution in [#2967](https://github.com/jdx/mise/pull/2967)
+- @drewwells made their first contribution in [#2977](https://github.com/jdx/mise/pull/2977)
+
 ## [2024.11.5](https://github.com/jdx/mise/compare/v2024.11.4..v2024.11.5) - 2024-11-09
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.5"
+version = "2024.11.6"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6ddbd668297c46be4bdea6c599dcc1f001a129586272d53170b7ac0a62961e"
+checksum = "0ae9546e4a268c309804e8bbb7526e31cbfdedca7cd60ac1b987d0b212e0d876"
 dependencies = [
  "bstr",
  "either",
@@ -2115,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "mlua-sys"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eebac25c35a13285456c88ee2fde93d9aee8bcfdaf03f9d6d12be3391351ec"
+checksum = "efa6bf1a64f06848749b7e7727417f4ec2121599e2a10ef0a8a3888b0e9a5a0d"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3603,18 +3603,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.5"
+version = "2024.11.6"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.5 macos-arm64 (a1b2d3e 2024-11-09)
+2024.11.6 macos-arm64 (a1b2d3e 2024-11-10)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_5:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_5 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_5;
+  if ( [[ -z "${_usage_spec_mise_2024_11_6:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_6 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_6;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_5 spec
+    _store_cache _usage_spec_mise_2024_11_6 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_5:-} ]]; then
-        _usage_spec_mise_2024_11_5="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_6:-} ]]; then
+        _usage_spec_mise_2024_11_6="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_5}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_6}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_5
-  set -U _usage_spec_mise_2024_11_5 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_6
+  set -U _usage_spec_mise_2024_11_6 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_5" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_6" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.5";
+  version = "2024.11.6";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.5" 
+.TH mise 1  "mise 2024.11.6" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.5
+v2024.11.6
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.5
+Version: 2024.11.6
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(backend)** add a setting to use bun in npm backend by [@risu729](https://github.com/risu729) in [#2899](https://github.com/jdx/mise/pull/2899)
- **(tasks)** add shell settings for Windows compatibility in tasks by [@rodvieirasilva](https://github.com/rodvieirasilva) in [#2967](https://github.com/jdx/mise/pull/2967)

### 🐛 Bug Fixes

- update tmux plugin by [@drewwells](https://github.com/drewwells) in [#2977](https://github.com/jdx/mise/pull/2977)

### 🚜 Refactor

- remove backend arg from tool-version by [@jdx](https://github.com/jdx) in [#2980](https://github.com/jdx/mise/pull/2980)

### 📚 Documentation

- load core plugins when rendering registry doc by [@jdx](https://github.com/jdx) in [00ef7b4](https://github.com/jdx/mise/commit/00ef7b4d5c59047e795c0fc2476bde386decc363)
- added core plugins to registry by [@jdx](https://github.com/jdx) in [#2976](https://github.com/jdx/mise/pull/2976)

### 🧪 Testing

- added e2e test with multiple scripts by [@jdx](https://github.com/jdx) in [a89a5ee](https://github.com/jdx/mise/commit/a89a5eec402bf693e274334771d4386c2f752834)

### New Contributors

- @rodvieirasilva made their first contribution in [#2967](https://github.com/jdx/mise/pull/2967)
- @drewwells made their first contribution in [#2977](https://github.com/jdx/mise/pull/2977)