### PR TITLE
refactor: remove backend arg from tool-version

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,7 @@ feature-depth = 1
 # output a note when they are encountered.
 ignore = [
     { id = "RUSTSEC-2024-0370", reason = "subdependency cannot be updated" },
+    { id = "RUSTSEC-2024-0384", reason = "subdependency cannot be updated" },
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -289,8 +289,8 @@ pub trait Backend: Debug + Send + Sync {
             }
         }
     }
-    fn is_version_outdated(&self, tv: &ToolVersion, p: &dyn Backend) -> bool {
-        let latest = match tv.latest_version(p) {
+    fn is_version_outdated(&self, tv: &ToolVersion) -> bool {
+        let latest = match tv.latest_version() {
             Ok(latest) => latest,
             Err(e) => {
                 debug!(
@@ -407,7 +407,7 @@ pub trait Backend: Debug + Send + Sync {
         None
     }
 
-    #[requires(ctx.tv.backend.backend_type == self.get_type())]
+    #[requires(ctx.tv.backend().backend_type == self.get_type())]
     fn install_version(&self, ctx: InstallContext) -> eyre::Result<()> {
         if let Some(plugin) = self.plugin() {
             plugin.is_installed_err()?;
@@ -433,7 +433,7 @@ pub trait Backend: Debug + Send + Sync {
             )));
         }
 
-        BackendMeta::write(&ctx.tv.backend)?;
+        BackendMeta::write(ctx.tv.backend())?;
 
         self.cleanup_install_dirs(&ctx.tv);
         // attempt to touch all the .tool-version files to trigger updates in hook-env

--- a/src/cli/asdf.rs
+++ b/src/cli/asdf.rs
@@ -53,12 +53,12 @@ fn list_versions(config: &Config, args: &[String]) -> Result<()> {
         _ => None,
     };
     if let Some(plugin) = plugin {
-        versions.retain(|(_, v)| &v.backend.to_string() == plugin);
+        versions.retain(|(_, v)| &v.backend().to_string() == plugin);
         for (_, version) in versions {
             miseprintln!("{}", version.version);
         }
     } else {
-        for (plugin, versions) in &versions.into_iter().chunk_by(|(_, v)| v.backend.clone()) {
+        for (plugin, versions) in &versions.into_iter().chunk_by(|(_, v)| v.backend().clone()) {
             miseprintln!("{}", plugin);
             for (_, tv) in versions {
                 miseprintln!("  {}", tv.version);

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -77,10 +77,12 @@ impl Current {
             }
             for tv in versions {
                 if !plugin.is_version_installed(tv, true) {
-                    let source = ts.versions.get(&tv.backend).unwrap().source.clone();
+                    let source = ts.versions.get(tv.backend()).unwrap().source.clone();
                     warn!(
                         "{}@{} is specified in {}, but not installed",
-                        &tv.backend, &tv.version, &source
+                        &tv.backend(),
+                        &tv.version,
+                        &source
                     );
                     hint!(
                         "tools_missing",

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -42,7 +42,7 @@ impl Latest {
             plugin.ensure_installed(&mpr, false)?;
         }
         if let Some(v) = prefix {
-            prefix = Some(config.resolve_alias(backend.as_ref(), &v)?);
+            prefix = Some(config.resolve_alias(&backend, &v)?);
         }
 
         let latest_version = if self.installed {

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -155,7 +155,7 @@ impl Ls {
                 // only displaying 1 plugin so only show the version
                 miseprintln!("{}", tv.version);
             } else {
-                miseprintln!("{} {}", &tv.backend, tv.version);
+                miseprintln!("{} {}", tv.backend(), tv.version);
             }
         }
         Ok(())
@@ -228,7 +228,7 @@ impl Ls {
             })
             .map(|(k, (p, tv))| {
                 let source = match &active.get(&k) {
-                    Some((_, tv)) => ts.versions.get(&tv.backend).map(|tv| tv.source.clone()),
+                    Some((_, tv)) => ts.versions.get(tv.backend()).map(|tv| tv.source.clone()),
                     None => None,
                 };
                 (self, p, tv, source)
@@ -326,7 +326,7 @@ impl From<(&Ls, &dyn Backend, &ToolVersion, &Option<ToolSource>)> for VersionSta
             let outdated = if ls.offline {
                 false
             } else {
-                p.is_version_outdated(tv, p)
+                p.is_version_outdated(tv)
             };
             VersionStatus::Active(tv.version.clone(), outdated)
         } else {

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -72,7 +72,7 @@ impl Prune {
             .collect::<BTreeMap<String, (Arc<dyn Backend>, ToolVersion)>>();
 
         if let Some(backends) = &self.plugin {
-            to_delete.retain(|_, (_, tv)| backends.contains(&tv.backend));
+            to_delete.retain(|_, (_, tv)| backends.contains(tv.backend()));
         }
 
         for cf in config.get_tracked_config_files()?.values() {

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -107,15 +107,12 @@ impl Uninstall {
                     .into_iter()
                     .map(|v| {
                         let tvr = ToolRequest::new(tool.fa().clone(), v, ToolSource::Unknown)?;
-                        let tv = ToolVersion::new(tool.as_ref(), tvr, v.into());
+                        let tv = ToolVersion::new(tvr, v.into());
                         Ok((tool.clone(), tv))
                     })
                     .collect::<Result<Vec<_>>>()?;
                 if let Some(tvr) = &a.tvr {
-                    tvs.push((
-                        tool.clone(),
-                        tvr.resolve(tool.as_ref(), &Default::default())?,
-                    ));
+                    tvs.push((tool.clone(), tvr.resolve(&Default::default())?));
                 }
                 if tvs.is_empty() {
                     warn!("no versions found for {}", style(&tool).blue().for_stderr());

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -64,7 +64,7 @@ impl Upgrade {
             outdated.retain(|o| {
                 self.tool
                     .iter()
-                    .any(|t| t.backend == o.tool_version.backend)
+                    .any(|t| &t.backend == o.tool_version.backend())
             });
         }
         if outdated.is_empty() {

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -116,7 +116,7 @@ impl Use {
         let mut cf = self.get_config_file()?;
         let pin = self.pin || !self.fuzzy && (SETTINGS.pin || SETTINGS.asdf_compat);
 
-        for (fa, tvl) in &versions.iter().chunk_by(|tv| &tv.backend) {
+        for (fa, tvl) in &versions.iter().chunk_by(|tv| tv.backend()) {
             let versions: Vec<_> = tvl
                 .into_iter()
                 .map(|tv| {

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -46,7 +46,7 @@ impl Where {
 
         let ba = tvr.backend();
         let backend = backend::get(ba);
-        let tv = tvr.resolve(backend.as_ref(), &Default::default())?;
+        let tv = tvr.resolve(&Default::default())?;
 
         if backend.is_version_installed(&tv, true) {
             miseprintln!("{}", tv.install_path().to_string_lossy());

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -123,8 +123,7 @@ impl dyn ConfigFile {
                 .into_iter()
                 .map(|tvr| {
                     if pin {
-                        let plugin = backend::get(&fa);
-                        let tv = tvr.resolve(plugin.as_ref(), &Default::default())?;
+                        let tv = tvr.resolve(&Default::default())?;
                         Ok((tv.version, tv.request.options()))
                     } else {
                         Ok((tvr.version(), tvr.options()))

--- a/src/config/env_directive.rs
+++ b/src/config/env_directive.rs
@@ -262,7 +262,7 @@ impl EnvResults {
                         if ts
                             .list_missing_versions()
                             .iter()
-                            .any(|tv| tv.backend.name == "python")
+                            .any(|tv| tv.backend().name == "python")
                         {
                             debug!("python not installed, skipping venv creation");
                         } else {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,7 +12,7 @@ use rayon::prelude::*;
 pub use settings::Settings;
 use walkdir::WalkDir;
 
-use crate::backend::Backend;
+use crate::backend::ABackend;
 use crate::cli::args::BackendArg;
 use crate::cli::version;
 use crate::config::config_file::legacy_version::LegacyVersionFile;
@@ -186,7 +186,7 @@ impl Config {
             .collect())
     }
 
-    pub fn resolve_alias(&self, backend: &dyn Backend, v: &str) -> Result<String> {
+    pub fn resolve_alias(&self, backend: &ABackend, v: &str) -> Result<String> {
         if let Some(plugin_aliases) = self.aliases.get(backend.fa()) {
             if let Some(alias) = plugin_aliases.get(v) {
                 return Ok(alias.clone());

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -59,7 +59,7 @@ pub fn update_lockfiles(new_versions: &[ToolVersion]) -> Result<()> {
     }
 
     // add versions added within this session such as from `mise use` or `mise up`
-    for (backend, group) in &new_versions.iter().chunk_by(|tv| &tv.backend) {
+    for (backend, group) in &new_versions.iter().chunk_by(|tv| tv.backend()) {
         let tvs = group.cloned().collect_vec();
         let source = tvs[0].request.source().clone();
         let mut tvl = ToolVersionList::new(backend.clone(), source.clone());

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -275,17 +275,17 @@ fn err_no_version_set(ts: Toolset, bin_name: &str, tvs: Vec<ToolVersion>) -> Res
     if tvs.is_empty() {
         bail!("{} is not a valid shim", bin_name);
     }
-    let missing_plugins = tvs.iter().map(|tv| &tv.backend).collect::<HashSet<_>>();
+    let missing_plugins = tvs.iter().map(|tv| tv.backend()).collect::<HashSet<_>>();
     let mut missing_tools = ts
         .list_missing_versions()
         .into_iter()
-        .filter(|t| missing_plugins.contains(&t.backend))
+        .filter(|t| missing_plugins.contains(t.backend()))
         .collect_vec();
     if missing_tools.is_empty() {
         let mut msg = format!("No version is set for shim: {}\n", bin_name);
         msg.push_str("Set a global default version with one of the following:\n");
         for tv in tvs {
-            msg.push_str(&format!("mise use -g {}@{}\n", tv.backend, tv.version));
+            msg.push_str(&format!("mise use -g {}@{}\n", tv.backend(), tv.version));
         }
         Err(eyre!(msg.trim().to_string()))
     } else {

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -141,7 +141,7 @@ impl Toolset {
             .into_iter()
             .filter(|(p, tv)| opts.force || !p.is_version_installed(tv, true))
             .map(|(_, tv)| tv)
-            .filter(|tv| matches!(self.versions[&tv.backend].source, ToolSource::Argument))
+            .filter(|tv| matches!(self.versions[tv.backend()].source, ToolSource::Argument))
             .map(|tv| tv.request)
             .collect_vec();
         let versions = self.install_versions(config, versions, &mpr, opts)?;
@@ -225,7 +225,7 @@ impl Toolset {
                                         sleep(Duration::from_millis(100));
                                     }
                                 }
-                                let tv = tr.resolve(t.as_ref(), &opts.resolve_options)?;
+                                let tv = tr.resolve(&opts.resolve_options)?;
                                 let ctx = InstallContext {
                                     ts,
                                     pr: mpr.add(&tv.style()),
@@ -284,7 +284,7 @@ impl Toolset {
                             Some((p, tv)) => Ok((p.clone(), tv.clone())),
                             None => {
                                 let tv = ToolRequest::new(p.fa().clone(), &v, ToolSource::Unknown)?
-                                    .resolve(p.as_ref(), &Default::default())
+                                    .resolve(&Default::default())
                                     .unwrap();
                                 Ok((p.clone(), tv))
                             }
@@ -333,7 +333,7 @@ impl Toolset {
                                 source: v.request.source().clone(),
                             };
                             let version = format!("ref:{r}");
-                            ToolVersion::new(p.as_ref(), request, version)
+                            ToolVersion::new(request, version)
                         }
                         _ => v.clone(),
                     };
@@ -364,7 +364,7 @@ impl Toolset {
                 let latest_result = if bump {
                     t.latest_version(prefix.clone())
                 } else {
-                    tv.latest_version(t.as_ref()).map(Option::from)
+                    tv.latest_version().map(Option::from)
                 };
                 let mut out = OutdatedInfo::new(tv.clone(), tv.request.source().clone());
                 out.current = if t.is_version_installed(&tv, true) {
@@ -523,7 +523,7 @@ impl Toolset {
             let versions = self
                 .list_missing_versions()
                 .into_iter()
-                .filter(|tv| &tv.backend == plugin.fa())
+                .filter(|tv| tv.backend() == plugin.fa())
                 .map(|tv| tv.request)
                 .collect_vec();
             if !versions.is_empty() {
@@ -731,7 +731,7 @@ pub struct OutdatedInfo {
 impl OutdatedInfo {
     fn new(tv: ToolVersion, source: ToolSource) -> Self {
         Self {
-            name: tv.backend.short.to_string(),
+            name: tv.backend().short.to_string(),
             current: None,
             requested: tv.request.version(),
             tool_request: tv.request.clone(),

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -5,7 +5,6 @@ use eyre::{bail, Result};
 use versions::{Chunk, Version};
 use xx::file;
 
-use crate::backend::Backend;
 use crate::cli::args::BackendArg;
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::tool_version::ResolveOptions;
@@ -161,7 +160,7 @@ impl ToolRequest {
 
     pub fn is_installed(&self) -> bool {
         let backend = backend::get(self.backend());
-        let tv = ToolVersion::new(backend.as_ref(), self.clone(), self.version());
+        let tv = ToolVersion::new(self.clone(), self.version());
 
         backend.is_version_installed(&tv, false)
     }
@@ -226,8 +225,8 @@ impl ToolRequest {
         Ok(None)
     }
 
-    pub fn resolve(&self, plugin: &dyn Backend, opts: &ResolveOptions) -> Result<ToolVersion> {
-        ToolVersion::resolve(plugin, self.clone(), opts)
+    pub fn resolve(&self, opts: &ResolveOptions) -> Result<ToolVersion> {
+        ToolVersion::resolve(self.clone(), opts)
     }
 }
 

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -5,7 +5,7 @@ use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 use crate::backend;
-use crate::backend::{ABackend, Backend};
+use crate::backend::ABackend;
 use crate::cli::args::BackendArg;
 use crate::config::Config;
 #[cfg(windows)]
@@ -21,54 +21,48 @@ use path_absolutize::Absolutize;
 #[derive(Debug, Clone)]
 pub struct ToolVersion {
     pub request: ToolRequest,
-    pub backend: BackendArg,
     pub version: String,
 }
 
 impl ToolVersion {
-    pub fn new(tool: &dyn Backend, request: ToolRequest, version: String) -> Self {
-        ToolVersion {
-            backend: tool.fa().clone(),
-            version,
-            request,
-        }
+    pub fn new(request: ToolRequest, version: String) -> Self {
+        ToolVersion { request, version }
     }
 
-    pub fn resolve(
-        backend: &dyn Backend,
-        request: ToolRequest,
-        opts: &ResolveOptions,
-    ) -> Result<Self> {
+    pub fn resolve(request: ToolRequest, opts: &ResolveOptions) -> Result<Self> {
+        let backend = backend::get(request.backend());
         if opts.use_locked_version {
             if let Some(v) = request.lockfile_resolve()? {
-                let tv = Self::new(backend, request.clone(), v);
+                let tv = Self::new(request.clone(), v);
                 return Ok(tv);
             }
         }
         if let Some(plugin) = backend.plugin() {
             if !plugin.is_installed() {
-                let tv = Self::new(backend, request.clone(), request.version());
+                let tv = Self::new(request.clone(), request.version());
                 return Ok(tv);
             }
         }
         let tv = match request.clone() {
-            ToolRequest::Version { version: v, .. } => {
-                Self::resolve_version(backend, request, &v, opts)?
-            }
-            ToolRequest::Prefix { prefix, .. } => Self::resolve_prefix(backend, request, &prefix)?,
+            ToolRequest::Version { version: v, .. } => Self::resolve_version(request, &v, opts)?,
+            ToolRequest::Prefix { prefix, .. } => Self::resolve_prefix(request, &prefix)?,
             ToolRequest::Sub {
                 sub, orig_version, ..
-            } => Self::resolve_sub(backend, request, &sub, &orig_version, opts)?,
+            } => Self::resolve_sub(request, &sub, &orig_version, opts)?,
             _ => {
                 let version = request.version();
-                Self::new(backend, request, version)
+                Self::new(request, version)
             }
         };
         Ok(tv)
     }
 
+    pub fn backend(&self) -> &BackendArg {
+        self.request.backend()
+    }
+
     pub fn get_backend(&self) -> ABackend {
-        backend::get(&self.backend)
+        backend::get(self.backend())
     }
 
     pub fn install_path(&self) -> PathBuf {
@@ -76,14 +70,14 @@ impl ToolVersion {
             ToolRequest::Path(_, p, ..) => p.to_string_lossy().to_string(),
             _ => self.tv_pathname(),
         };
-        let path = self.backend.installs_path.join(pathname);
+        let path = self.backend().installs_path.join(pathname);
 
         // handle non-symlinks on windows
         // TODO: make this a utility function in xx
         #[cfg(windows)]
         if path.is_file() {
             if let Ok(p) = file::read_to_string(&path).map(PathBuf::from) {
-                let path = self.backend.installs_path.join(p);
+                let path = self.backend().installs_path.join(p);
                 if path.exists() {
                     return path
                         .absolutize()
@@ -95,17 +89,20 @@ impl ToolVersion {
         path
     }
     pub fn cache_path(&self) -> PathBuf {
-        self.backend.cache_path.join(self.tv_pathname())
+        self.backend().cache_path.join(self.tv_pathname())
     }
     pub fn download_path(&self) -> PathBuf {
-        self.backend.downloads_path.join(self.tv_pathname())
+        self.request
+            .backend()
+            .downloads_path
+            .join(self.tv_pathname())
     }
-    pub fn latest_version(&self, tool: &dyn Backend) -> Result<String> {
+    pub fn latest_version(&self) -> Result<String> {
         let opts = ResolveOptions {
             latest_versions: true,
             use_locked_version: false,
         };
-        let tv = self.request.resolve(tool, &opts)?;
+        let tv = self.request.resolve(&opts)?;
         // map cargo backend specific prefixes to ref
         let version = match tv.request.version().split_once(':') {
             Some((_ref_type @ ("tag" | "branch" | "rev"), r)) => {
@@ -118,7 +115,7 @@ impl ToolVersion {
     pub fn style(&self) -> String {
         format!(
             "{}{}",
-            style(&self.backend.full).blue().for_stderr(),
+            style(&self.backend().full).blue().for_stderr(),
             style(&format!("@{}", &self.version)).for_stderr()
         )
     }
@@ -134,17 +131,16 @@ impl ToolVersion {
         .replace([':', '/'], "-")
     }
     fn resolve_version(
-        backend: &dyn Backend,
         request: ToolRequest,
         v: &str,
         opts: &ResolveOptions,
     ) -> Result<ToolVersion> {
         let config = Config::get();
-        let v = config.resolve_alias(backend, v)?;
+        let backend = backend::get(request.backend());
+        let v = config.resolve_alias(&backend, v)?;
         match v.split_once(':') {
             Some((ref_type @ ("ref" | "tag" | "branch" | "rev"), r)) => {
                 return Ok(Self::resolve_ref(
-                    backend,
                     r.to_string(),
                     ref_type.to_string(),
                     request.options(),
@@ -152,19 +148,19 @@ impl ToolVersion {
                 ));
             }
             Some(("path", p)) => {
-                return Self::resolve_path(backend, PathBuf::from(p), &request);
+                return Self::resolve_path(PathBuf::from(p), &request);
             }
             Some(("prefix", p)) => {
-                return Self::resolve_prefix(backend, request, p);
+                return Self::resolve_prefix(request, p);
             }
             Some((part, v)) if part.starts_with("sub-") => {
                 let sub = part.split_once('-').unwrap().1;
-                return Self::resolve_sub(backend, request, sub, v, opts);
+                return Self::resolve_sub(request, sub, v, opts);
             }
             _ => (),
         }
 
-        let build = |v| Ok(Self::new(backend, request.clone(), v));
+        let build = |v| Ok(Self::new(request.clone(), v));
 
         if let Some(plugin) = backend.plugin() {
             if !plugin.is_installed() {
@@ -195,70 +191,70 @@ impl ToolVersion {
         if matches.contains(&v) {
             return build(v);
         }
-        Self::resolve_prefix(backend, request, &v)
+        Self::resolve_prefix(request, &v)
     }
 
     /// resolve a version like `sub-1:12.0.0` which becomes `11.0.0`, `sub-0.1:12.1.0` becomes `12.0.0`
     fn resolve_sub(
-        tool: &dyn Backend,
         request: ToolRequest,
         sub: &str,
         v: &str,
         opts: &ResolveOptions,
     ) -> Result<Self> {
+        let backend = backend::get(request.backend());
         let v = match v {
-            "latest" => tool.latest_version(None)?.unwrap(),
-            _ => Config::get().resolve_alias(tool, v)?,
+            "latest" => backend.latest_version(None)?.unwrap(),
+            _ => Config::get().resolve_alias(&backend, v)?,
         };
         let v = tool_request::version_sub(&v, sub);
-        Self::resolve_version(tool, request, &v, opts)
+        Self::resolve_version(request, &v, opts)
     }
 
-    fn resolve_prefix(tool: &dyn Backend, request: ToolRequest, prefix: &str) -> Result<Self> {
-        let matches = tool.list_versions_matching(prefix)?;
+    fn resolve_prefix(request: ToolRequest, prefix: &str) -> Result<Self> {
+        let backend = backend::get(request.backend());
+        let matches = backend.list_versions_matching(prefix)?;
         let v = match matches.last() {
             Some(v) => v,
             None => prefix,
             // None => Err(VersionNotFound(plugin.name.clone(), prefix.to_string()))?,
         };
-        Ok(Self::new(tool, request, v.to_string()))
+        Ok(Self::new(request, v.to_string()))
     }
 
     fn resolve_ref(
-        tool: &dyn Backend,
         ref_: String,
         ref_type: String,
         opts: ToolVersionOptions,
         tr: &ToolRequest,
     ) -> Self {
         let request = ToolRequest::Ref {
-            backend: tool.fa().clone(),
+            backend: tr.backend().clone(),
             ref_,
             ref_type,
             options: opts.clone(),
             source: tr.source().clone(),
         };
         let version = request.version();
-        Self::new(tool, request, version)
+        Self::new(request, version)
     }
 
-    fn resolve_path(tool: &dyn Backend, path: PathBuf, tr: &ToolRequest) -> Result<ToolVersion> {
+    fn resolve_path(path: PathBuf, tr: &ToolRequest) -> Result<ToolVersion> {
         let path = fs::canonicalize(path)?;
-        let request = ToolRequest::Path(tool.fa().clone(), path, tr.source().clone());
+        let request = ToolRequest::Path(tr.backend().clone(), path, tr.source().clone());
         let version = request.version();
-        Ok(Self::new(tool, request, version))
+        Ok(Self::new(request, version))
     }
 }
 
 impl Display for ToolVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}@{}", &self.backend.full, &self.version)
+        write!(f, "{}@{}", &self.backend().full, &self.version)
     }
 }
 
 impl PartialEq for ToolVersion {
     fn eq(&self, other: &Self) -> bool {
-        self.backend.full == other.backend.full && self.version == other.version
+        self.backend().full == other.backend().full && self.version == other.version
     }
 }
 
@@ -272,7 +268,7 @@ impl PartialOrd for ToolVersion {
 
 impl Ord for ToolVersion {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.backend.full.cmp(&other.backend.full) {
+        match self.request.backend().full.cmp(&other.backend().full) {
             Ordering::Equal => self.version.cmp(&other.version),
             o => o,
         }
@@ -281,7 +277,7 @@ impl Ord for ToolVersion {
 
 impl Hash for ToolVersion {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.backend.full.hash(state);
+        self.backend().full.hash(state);
         self.version.hash(state);
     }
 }

--- a/src/toolset/tool_version_list.rs
+++ b/src/toolset/tool_version_list.rs
@@ -1,4 +1,3 @@
-use crate::backend;
 use crate::cli::args::BackendArg;
 use crate::errors::Error;
 use crate::toolset::tool_request::ToolRequest;
@@ -25,9 +24,8 @@ impl ToolVersionList {
     }
     pub fn resolve(&mut self, opts: &ResolveOptions) -> eyre::Result<()> {
         self.versions.clear();
-        let plugin = backend::get(&self.backend);
         for tvr in &mut self.requests {
-            match tvr.resolve(plugin.as_ref(), opts) {
+            match tvr.resolve(opts) {
                 Ok(v) => self.versions.push(v),
                 Err(err) => {
                     return Err(Error::FailedToResolveVersion {
@@ -48,7 +46,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use crate::test::reset;
-    use crate::{dirs, env, file};
+    use crate::{backend, dirs, env, file};
 
     use super::*;
 


### PR DESCRIPTION
Prerequisite for #2979. Because backend arg will change during TV resolving, this allows me to modify backend_arg.full during resolving
