### PR TITLE
chore: release 2024.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2024.11.8](https://github.com/jdx/mise/compare/v2024.11.7..v2024.11.8) - 2024-11-12
+
+### 🚀 Features
+
+- make zig non-experimental by [@jdx](https://github.com/jdx) in [#2999](https://github.com/jdx/mise/pull/2999)
+- aqua backend by [@jdx](https://github.com/jdx) in [#2995](https://github.com/jdx/mise/pull/2995)
+
+### 🔍 Other Changes
+
+- only release fig autocomplete once per month by [@jdx](https://github.com/jdx) in [b86885a](https://github.com/jdx/mise/commit/b86885ab7855b34a776b3119dcb6526b3d8fd814)
+
 ## [2024.11.7](https://github.com/jdx/mise/compare/v2024.11.6..v2024.11.7) - 2024-11-11
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,9 +599,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.7"
+version = "2024.11.8"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -3089,9 +3089,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -3108,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.7"
+version = "2024.11.8"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.7 macos-arm64 (a1b2d3e 2024-11-11)
+2024.11.8 macos-arm64 (a1b2d3e 2024-11-12)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_7:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_7 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_7;
+  if ( [[ -z "${_usage_spec_mise_2024_11_8:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_8 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_8;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_7 spec
+    _store_cache _usage_spec_mise_2024_11_8 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_7:-} ]]; then
-        _usage_spec_mise_2024_11_7="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_8:-} ]]; then
+        _usage_spec_mise_2024_11_8="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_7}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_8}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_7
-  set -U _usage_spec_mise_2024_11_7 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_8
+  set -U _usage_spec_mise_2024_11_8 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_7" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_8" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.7";
+  version = "2024.11.8";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.7" 
+.TH mise 1  "mise 2024.11.8" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.7
+v2024.11.8
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.7
+Version: 2024.11.8
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- make zig non-experimental by [@jdx](https://github.com/jdx) in [#2999](https://github.com/jdx/mise/pull/2999)
- aqua backend by [@jdx](https://github.com/jdx) in [#2995](https://github.com/jdx/mise/pull/2995)

### 🔍 Other Changes

- only release fig autocomplete once per month by [@jdx](https://github.com/jdx) in [b86885a](https://github.com/jdx/mise/commit/b86885ab7855b34a776b3119dcb6526b3d8fd814)