### PR TITLE
chore: release 2024.11.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2024.11.10](https://github.com/jdx/mise/compare/v2024.11.9..v2024.11.10) - 2024-11-14
+
+### 🚀 Features
+
+- added aliases to registry by [@jdx](https://github.com/jdx) in [#3007](https://github.com/jdx/mise/pull/3007)
+- added more aqua tools by [@jdx](https://github.com/jdx) in [#3008](https://github.com/jdx/mise/pull/3008)
+
+### 🐛 Bug Fixes
+
+- default python to precompiled by [@jdx](https://github.com/jdx) in [dfb13de](https://github.com/jdx/mise/commit/dfb13de8ebc1da2542ab67ba2b81e8b26a085c20)
+
+### 🚜 Refactor
+
+- consolidate tool/plugin loading to install_state.rs by [@jdx](https://github.com/jdx) in [#3015](https://github.com/jdx/mise/pull/3015)
+
+### 🧪 Testing
+
+- remove alias from test-plugins by [@jdx](https://github.com/jdx) in [7d2406b](https://github.com/jdx/mise/commit/7d2406b50e60257937a4476aed4a2a78197771f2)
+
 ## [2024.11.9](https://github.com/jdx/mise/compare/v2024.11.8..v2024.11.9) - 2024-11-13
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "clap_mangen"
@@ -1160,8 +1160,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1996,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.9"
+version = "2024.11.10"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -2637,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -2648,26 +2650,29 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
+ "getrandom",
  "rand",
  "ring",
  "rustc-hash",
  "rustls",
+ "rustls-pki-types",
  "slab",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -2966,6 +2971,9 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.9"
+version = "2024.11.10"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.9 macos-arm64 (a1b2d3e 2024-11-13)
+2024.11.10 macos-arm64 (a1b2d3e 2024-11-14)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_9:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_9 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_9;
+  if ( [[ -z "${_usage_spec_mise_2024_11_10:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_10 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_10;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_9 spec
+    _store_cache _usage_spec_mise_2024_11_10 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_9:-} ]]; then
-        _usage_spec_mise_2024_11_9="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_10:-} ]]; then
+        _usage_spec_mise_2024_11_10="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_9}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_10}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_9
-  set -U _usage_spec_mise_2024_11_9 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_10
+  set -U _usage_spec_mise_2024_11_10 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_9" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_10" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.9";
+  version = "2024.11.10";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.9" 
+.TH mise 1  "mise 2024.11.10" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.9
+v2024.11.10
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.9
+Version: 2024.11.10
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- added aliases to registry by [@jdx](https://github.com/jdx) in [#3007](https://github.com/jdx/mise/pull/3007)
- added more aqua tools by [@jdx](https://github.com/jdx) in [#3008](https://github.com/jdx/mise/pull/3008)

### 🐛 Bug Fixes

- default python to precompiled by [@jdx](https://github.com/jdx) in [dfb13de](https://github.com/jdx/mise/commit/dfb13de8ebc1da2542ab67ba2b81e8b26a085c20)

### 🚜 Refactor

- consolidate tool/plugin loading to install_state.rs by [@jdx](https://github.com/jdx) in [#3015](https://github.com/jdx/mise/pull/3015)

### 🧪 Testing

- remove alias from test-plugins by [@jdx](https://github.com/jdx) in [7d2406b](https://github.com/jdx/mise/commit/7d2406b50e60257937a4476aed4a2a78197771f2)