### PR TITLE
chore: release 2024.11.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [2024.11.14](https://github.com/jdx/mise/compare/v2024.11.13..v2024.11.14) - 2024-11-16
+
+### 🚀 Features
+
+- improve progress bar during tarball extraction by [@jdx](https://github.com/jdx) in [#3030](https://github.com/jdx/mise/pull/3030)
+- added more aqua tools by [@jdx](https://github.com/jdx) in [#3031](https://github.com/jdx/mise/pull/3031)
+- added `wait_for` option for tasks by [@jdx](https://github.com/jdx) in [#3046](https://github.com/jdx/mise/pull/3046)
+- added `os` option to mise.toml by [@jdx](https://github.com/jdx) in [#3047](https://github.com/jdx/mise/pull/3047)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** allow environment validation for arch-only matches by [@risu729](https://github.com/risu729) in [#3037](https://github.com/jdx/mise/pull/3037)
+- **(java)** show verifying message on progress bar by [@jdx](https://github.com/jdx) in [8f8fc64](https://github.com/jdx/mise/commit/8f8fc64e6ca57fd24ac3ee6cd9e4a506eeca51c2)
+- mise use -p . panics by [@roele](https://github.com/roele) in [#3038](https://github.com/jdx/mise/pull/3038)
+- some bugs with aqua by [@jdx](https://github.com/jdx) in [#3041](https://github.com/jdx/mise/pull/3041)
+- sort files returned by ls by [@jdx](https://github.com/jdx) in [#3043](https://github.com/jdx/mise/pull/3043)
+- add os opts to shellcheck by [@jdx](https://github.com/jdx) in [#3045](https://github.com/jdx/mise/pull/3045)
+
+### 🧪 Testing
+
+- improve coverage perf by [@jdx](https://github.com/jdx) in [#3042](https://github.com/jdx/mise/pull/3042)
+- added `mise test-tool` to test tools from registry by [@jdx](https://github.com/jdx) in [#3039](https://github.com/jdx/mise/pull/3039)
+
+### 🔍 Other Changes
+
+- Add missing word to node.md by [@AlecRust](https://github.com/AlecRust) in [#3036](https://github.com/jdx/mise/pull/3036)
+- remove unneeded "timings" feature by [@jdx](https://github.com/jdx) in [#3044](https://github.com/jdx/mise/pull/3044)
+- increase windows-unit timeout by [@jdx](https://github.com/jdx) in [5fa3530](https://github.com/jdx/mise/commit/5fa3530c2bde75a87e9f6c8c5f16ef55f666a1c8)
+
+### 📦️ Dependency Updates
+
+- update dawidd6/action-homebrew-bump-formula action to v4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#3034](https://github.com/jdx/mise/pull/3034)
+
 ## [2024.11.13](https://github.com/jdx/mise/compare/v2024.11.12..v2024.11.13) - 2024-11-14
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.13"
+version = "2024.11.14"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -4039,9 +4039,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usage-lib"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b238b4a9af42e204521677c28babe3659ab430aaf9067b9ab08d2f1bdf6b1"
+checksum = "92a5a09b800c368c08956eae3c15a4bcb3d24f5a2e9ae406684bea35354ea5fc"
 dependencies = [
  "clap",
  "heck 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.13"
+version = "2024.11.14"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.13 macos-arm64 (a1b2d3e 2024-11-14)
+2024.11.14 macos-arm64 (a1b2d3e 2024-11-16)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_13:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_13 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_13;
+  if ( [[ -z "${_usage_spec_mise_2024_11_14:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_14 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_14;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_13 spec
+    _store_cache _usage_spec_mise_2024_11_14 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_13:-} ]]; then
-        _usage_spec_mise_2024_11_13="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_14:-} ]]; then
+        _usage_spec_mise_2024_11_14="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_13}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_14}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_13
-  set -g _usage_spec_mise_2024_11_13 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_14
+  set -g _usage_spec_mise_2024_11_14 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_13" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_14" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.13";
+  version = "2024.11.14";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.13" 
+.TH mise 1  "mise 2024.11.14" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.13
+v2024.11.14
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.13
+Version: 2024.11.14
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- improve progress bar during tarball extraction by [@jdx](https://github.com/jdx) in [#3030](https://github.com/jdx/mise/pull/3030)
- added more aqua tools by [@jdx](https://github.com/jdx) in [#3031](https://github.com/jdx/mise/pull/3031)
- added `wait_for` option for tasks by [@jdx](https://github.com/jdx) in [#3046](https://github.com/jdx/mise/pull/3046)
- added `os` option to mise.toml by [@jdx](https://github.com/jdx) in [#3047](https://github.com/jdx/mise/pull/3047)

### 🐛 Bug Fixes

- **(aqua)** allow environment validation for arch-only matches by [@risu729](https://github.com/risu729) in [#3037](https://github.com/jdx/mise/pull/3037)
- **(java)** show verifying message on progress bar by [@jdx](https://github.com/jdx) in [8f8fc64](https://github.com/jdx/mise/commit/8f8fc64e6ca57fd24ac3ee6cd9e4a506eeca51c2)
- mise use -p . panics by [@roele](https://github.com/roele) in [#3038](https://github.com/jdx/mise/pull/3038)
- some bugs with aqua by [@jdx](https://github.com/jdx) in [#3041](https://github.com/jdx/mise/pull/3041)
- sort files returned by ls by [@jdx](https://github.com/jdx) in [#3043](https://github.com/jdx/mise/pull/3043)
- add os opts to shellcheck by [@jdx](https://github.com/jdx) in [#3045](https://github.com/jdx/mise/pull/3045)

### 🧪 Testing

- improve coverage perf by [@jdx](https://github.com/jdx) in [#3042](https://github.com/jdx/mise/pull/3042)
- added `mise test-tool` to test tools from registry by [@jdx](https://github.com/jdx) in [#3039](https://github.com/jdx/mise/pull/3039)

### 🔍 Other Changes

- Add missing word to node.md by [@AlecRust](https://github.com/AlecRust) in [#3036](https://github.com/jdx/mise/pull/3036)
- remove unneeded "timings" feature by [@jdx](https://github.com/jdx) in [#3044](https://github.com/jdx/mise/pull/3044)
- increase windows-unit timeout by [@jdx](https://github.com/jdx) in [5fa3530](https://github.com/jdx/mise/commit/5fa3530c2bde75a87e9f6c8c5f16ef55f666a1c8)

### 📦️ Dependency Updates

- update dawidd6/action-homebrew-bump-formula action to v4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#3034](https://github.com/jdx/mise/pull/3034)