### PR TITLE
chore: release 2024.11.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [2024.11.16](https://github.com/jdx/mise/compare/v2024.11.15..v2024.11.16) - 2024-11-18
+
+### 🐛 Bug Fixes
+
+- **(ruby)** send ruby-install output to stderr by [@jdx](https://github.com/jdx) in [c2918dc](https://github.com/jdx/mise/commit/c2918dc7e6131286442f637fcbd1e60325e727b5)
+- bugs with `mise up` and prefix: versions by [@jdx](https://github.com/jdx) in [#3054](https://github.com/jdx/mise/pull/3054)
+- prefix: on tool dependencies by [@jdx](https://github.com/jdx) in [#3058](https://github.com/jdx/mise/pull/3058)
+- use cargo:cargo-binstall as dependency for cargo-binstall by [@jdx](https://github.com/jdx) in [#3059](https://github.com/jdx/mise/pull/3059)
+- show MRI ruby versions last by [@jdx](https://github.com/jdx) in [#3060](https://github.com/jdx/mise/pull/3060)
+
+### 📚 Documentation
+
+- typo fix in getting-started.md by [@Guria](https://github.com/Guria) in [#3057](https://github.com/jdx/mise/pull/3057)
+- document advantages/disadvantages of aqua/ubi/asdf by [@jdx](https://github.com/jdx) in [09698e7](https://github.com/jdx/mise/commit/09698e74542d3a5f28414b1d2086f22728d711aa)
+
+### ⚡ Performance
+
+- improve init performance by [@jdx](https://github.com/jdx) in [#3065](https://github.com/jdx/mise/pull/3065)
+
+### 🧪 Testing
+
+- improving test-tool on windows by [@jdx](https://github.com/jdx) in [#3056](https://github.com/jdx/mise/pull/3056)
+
+### 🔍 Other Changes
+
+- improve hyperfine PR summary by [@jdx](https://github.com/jdx) in [#3066](https://github.com/jdx/mise/pull/3066)
+
+### New Contributors
+
+- @Guria made their first contribution in [#3057](https://github.com/jdx/mise/pull/3057)
+
 ## [2024.11.15](https://github.com/jdx/mise/compare/v2024.11.14..v2024.11.15) - 2024-11-16
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.15"
+version = "2024.11.16"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -3128,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.15"
+version = "2024.11.16"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.15 macos-arm64 (a1b2d3e 2024-11-16)
+2024.11.16 macos-arm64 (a1b2d3e 2024-11-18)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_15:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_15 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_15;
+  if ( [[ -z "${_usage_spec_mise_2024_11_16:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_16 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_16;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_15 spec
+    _store_cache _usage_spec_mise_2024_11_16 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_15:-} ]]; then
-        _usage_spec_mise_2024_11_15="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_16:-} ]]; then
+        _usage_spec_mise_2024_11_16="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_15}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_16}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_15
-  set -g _usage_spec_mise_2024_11_15 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_16
+  set -g _usage_spec_mise_2024_11_16 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_15" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_16" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.15";
+  version = "2024.11.16";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.15" 
+.TH mise 1  "mise 2024.11.16" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.15
+v2024.11.16
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.15
+Version: 2024.11.16
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(ruby)** send ruby-install output to stderr by [@jdx](https://github.com/jdx) in [c2918dc](https://github.com/jdx/mise/commit/c2918dc7e6131286442f637fcbd1e60325e727b5)
- bugs with `mise up` and prefix: versions by [@jdx](https://github.com/jdx) in [#3054](https://github.com/jdx/mise/pull/3054)
- prefix: on tool dependencies by [@jdx](https://github.com/jdx) in [#3058](https://github.com/jdx/mise/pull/3058)
- use cargo:cargo-binstall as dependency for cargo-binstall by [@jdx](https://github.com/jdx) in [#3059](https://github.com/jdx/mise/pull/3059)
- show MRI ruby versions last by [@jdx](https://github.com/jdx) in [#3060](https://github.com/jdx/mise/pull/3060)

### 📚 Documentation

- typo fix in getting-started.md by [@Guria](https://github.com/Guria) in [#3057](https://github.com/jdx/mise/pull/3057)
- document advantages/disadvantages of aqua/ubi/asdf by [@jdx](https://github.com/jdx) in [09698e7](https://github.com/jdx/mise/commit/09698e74542d3a5f28414b1d2086f22728d711aa)

### ⚡ Performance

- improve init performance by [@jdx](https://github.com/jdx) in [#3065](https://github.com/jdx/mise/pull/3065)

### 🧪 Testing

- improving test-tool on windows by [@jdx](https://github.com/jdx) in [#3056](https://github.com/jdx/mise/pull/3056)

### 🔍 Other Changes

- improve hyperfine PR summary by [@jdx](https://github.com/jdx) in [#3066](https://github.com/jdx/mise/pull/3066)

### New Contributors

- @Guria made their first contribution in [#3057](https://github.com/jdx/mise/pull/3057)