### PR TITLE
chore: release 2024.11.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [2024.11.17](https://github.com/jdx/mise/compare/v2024.11.16..v2024.11.17) - 2024-11-19
+
+### 🚀 Features
+
+- **(bun)** windows support by [@jdx](https://github.com/jdx) in [#3075](https://github.com/jdx/mise/pull/3075)
+- added more aqua tools by [@jdx](https://github.com/jdx) in [#3079](https://github.com/jdx/mise/pull/3079)
+- added more aqua tools by [@jdx](https://github.com/jdx) in [#3081](https://github.com/jdx/mise/pull/3081)
+- added `key` option for `settings ls` by [@jdx](https://github.com/jdx) in [#3084](https://github.com/jdx/mise/pull/3084)
+- added more aqua tools by [@jdx](https://github.com/jdx) in [#3082](https://github.com/jdx/mise/pull/3082)
+
+### 🐛 Bug Fixes
+
+- reuse tool options on `mise use` from config file by [@jdx](https://github.com/jdx) in [#3076](https://github.com/jdx/mise/pull/3076)
+- move a warning to debug in aqua by [@jdx](https://github.com/jdx) in [a0c8446](https://github.com/jdx/mise/commit/a0c84460fa05a36e5562652cc8549f8af8902d61)
+
+### 📚 Documentation
+
+- added GoatCounter by [@jdx](https://github.com/jdx) in [9ab42fa](https://github.com/jdx/mise/commit/9ab42fab8f1e9fa8550a8512f65c13a951776c19)
+- use mise tasks for publishing by [@jdx](https://github.com/jdx) in [4b6a780](https://github.com/jdx/mise/commit/4b6a7804fe0c6073237c330b82701a5a15179d49)
+- use mise tasks for publishing by [@jdx](https://github.com/jdx) in [#3073](https://github.com/jdx/mise/pull/3073)
+
+### ⚡ Performance
+
+- improve init performance by [@jdx](https://github.com/jdx) in [#3074](https://github.com/jdx/mise/pull/3074)
+
+### 🔍 Other Changes
+
+- only add PR comment for PRs by [@jdx](https://github.com/jdx) in [5499bfb](https://github.com/jdx/mise/commit/5499bfb362f9a0f32dcad4c676e7085b3ce6cca3)
+
 ## [2024.11.16](https://github.com/jdx/mise/compare/v2024.11.15..v2024.11.16) - 2024-11-18
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,9 +1353,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.16"
+version = "2024.11.17"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -2920,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno 0.3.9",
@@ -3010,9 +3010,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.16"
+version = "2024.11.17"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.16 macos-arm64 (a1b2d3e 2024-11-18)
+2024.11.17 macos-arm64 (a1b2d3e 2024-11-19)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_16:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_16 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_16;
+  if ( [[ -z "${_usage_spec_mise_2024_11_17:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_17 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_17;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_16 spec
+    _store_cache _usage_spec_mise_2024_11_17 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_16:-} ]]; then
-        _usage_spec_mise_2024_11_16="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_17:-} ]]; then
+        _usage_spec_mise_2024_11_17="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_16}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_17}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_16
-  set -g _usage_spec_mise_2024_11_16 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_17
+  set -g _usage_spec_mise_2024_11_17 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_16" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_17" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.16";
+  version = "2024.11.17";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.16" 
+.TH mise 1  "mise 2024.11.17" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.16
+v2024.11.17
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.16
+Version: 2024.11.17
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(bun)** windows support by [@jdx](https://github.com/jdx) in [#3075](https://github.com/jdx/mise/pull/3075)
- added more aqua tools by [@jdx](https://github.com/jdx) in [#3079](https://github.com/jdx/mise/pull/3079)
- added more aqua tools by [@jdx](https://github.com/jdx) in [#3081](https://github.com/jdx/mise/pull/3081)
- added `key` option for `settings ls` by [@jdx](https://github.com/jdx) in [#3084](https://github.com/jdx/mise/pull/3084)
- added more aqua tools by [@jdx](https://github.com/jdx) in [#3082](https://github.com/jdx/mise/pull/3082)

### 🐛 Bug Fixes

- reuse tool options on `mise use` from config file by [@jdx](https://github.com/jdx) in [#3076](https://github.com/jdx/mise/pull/3076)
- move a warning to debug in aqua by [@jdx](https://github.com/jdx) in [a0c8446](https://github.com/jdx/mise/commit/a0c84460fa05a36e5562652cc8549f8af8902d61)

### 📚 Documentation

- added GoatCounter by [@jdx](https://github.com/jdx) in [9ab42fa](https://github.com/jdx/mise/commit/9ab42fab8f1e9fa8550a8512f65c13a951776c19)
- use mise tasks for publishing by [@jdx](https://github.com/jdx) in [4b6a780](https://github.com/jdx/mise/commit/4b6a7804fe0c6073237c330b82701a5a15179d49)
- use mise tasks for publishing by [@jdx](https://github.com/jdx) in [#3073](https://github.com/jdx/mise/pull/3073)

### ⚡ Performance

- improve init performance by [@jdx](https://github.com/jdx) in [#3074](https://github.com/jdx/mise/pull/3074)

### 🔍 Other Changes

- only add PR comment for PRs by [@jdx](https://github.com/jdx) in [5499bfb](https://github.com/jdx/mise/commit/5499bfb362f9a0f32dcad4c676e7085b3ce6cca3)