### PR TITLE
chore: release 2024.11.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2024.11.18](https://github.com/jdx/mise/compare/v2024.11.17..v2024.11.18) - 2024-11-19
+
+### 🚀 Features
+
+- add ripgrep-all by [@yodatak](https://github.com/yodatak) in [#3083](https://github.com/jdx/mise/pull/3083)
+- add vivid by [@swfz](https://github.com/swfz) in [#3089](https://github.com/jdx/mise/pull/3089)
+
+### 🐛 Bug Fixes
+
+- use global mise when running `mise use` in home dir by [@jdx](https://github.com/jdx) in [#3085](https://github.com/jdx/mise/pull/3085)
+- prevent infinite recursion listing dependencies by [@jdx](https://github.com/jdx) in [#3091](https://github.com/jdx/mise/pull/3091)
+- removed duplicate backend specifier from some registry tools by [@syhol](https://github.com/syhol) in [#3090](https://github.com/jdx/mise/pull/3090)
+
+### 🚜 Refactor
+
+- define registry outside of build.rs by [@jdx](https://github.com/jdx) in [e4366ff](https://github.com/jdx/mise/commit/e4366ffc7f8526d57c097dc61387b793b6f7ba3a)
+
+### New Contributors
+
+- @syhol made their first contribution in [#3090](https://github.com/jdx/mise/pull/3090)
+- @swfz made their first contribution in [#3089](https://github.com/jdx/mise/pull/3089)
+
 ## [2024.11.17](https://github.com/jdx/mise/compare/v2024.11.16..v2024.11.17) - 2024-11-19
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.17"
+version = "2024.11.18"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.17"
+version = "2024.11.18"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.17 macos-arm64 (a1b2d3e 2024-11-19)
+2024.11.18 macos-arm64 (a1b2d3e 2024-11-19)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_17:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_17 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_17;
+  if ( [[ -z "${_usage_spec_mise_2024_11_18:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_18 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_18;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_17 spec
+    _store_cache _usage_spec_mise_2024_11_18 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,11 +6,11 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_17:-} ]]; then
-        _usage_spec_mise_2024_11_17="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_18:-} ]]; then
+        _usage_spec_mise_2024_11_18="$(mise usage)"
     fi
 
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_17}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_18}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_17
-  set -g _usage_spec_mise_2024_11_17 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_18
+  set -g _usage_spec_mise_2024_11_18 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_17" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_18" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.17";
+  version = "2024.11.18";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.17" 
+.TH mise 1  "mise 2024.11.18" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings set color 0      Disable color by modifying global config file
 .SH VERSION
-v2024.11.17
+v2024.11.18
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.17
+Version: 2024.11.18
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- add ripgrep-all by [@yodatak](https://github.com/yodatak) in [#3083](https://github.com/jdx/mise/pull/3083)
- add vivid by [@swfz](https://github.com/swfz) in [#3089](https://github.com/jdx/mise/pull/3089)

### 🐛 Bug Fixes

- use global mise when running `mise use` in home dir by [@jdx](https://github.com/jdx) in [#3085](https://github.com/jdx/mise/pull/3085)
- prevent infinite recursion listing dependencies by [@jdx](https://github.com/jdx) in [#3091](https://github.com/jdx/mise/pull/3091)
- removed duplicate backend specifier from some registry tools by [@syhol](https://github.com/syhol) in [#3090](https://github.com/jdx/mise/pull/3090)

### 🚜 Refactor

- define registry outside of build.rs by [@jdx](https://github.com/jdx) in [e4366ff](https://github.com/jdx/mise/commit/e4366ffc7f8526d57c097dc61387b793b6f7ba3a)

### New Contributors

- @syhol made their first contribution in [#3090](https://github.com/jdx/mise/pull/3090)
- @swfz made their first contribution in [#3089](https://github.com/jdx/mise/pull/3089)