### PR TITLE
chore: release 2024.11.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [2024.11.24](https://github.com/jdx/mise/compare/v2024.11.23..v2024.11.24) - 2024-11-23
+
+### 🚀 Features
+
+- ignore config files after not trusting them by [@jdx](https://github.com/jdx) in [#3128](https://github.com/jdx/mise/pull/3128)
+- task vars by [@jdx](https://github.com/jdx) in [#3130](https://github.com/jdx/mise/pull/3130)
+- verify aqua packages with cosign and/or slsa when available by [@jdx](https://github.com/jdx) in [#3151](https://github.com/jdx/mise/pull/3151)
+- added `task_skip` setting by [@jdx](https://github.com/jdx) in [#3154](https://github.com/jdx/mise/pull/3154)
+- allow calling `mise settings foo=bar` as shorthand by [@jdx](https://github.com/jdx) in [#3155](https://github.com/jdx/mise/pull/3155)
+
+### 🐛 Bug Fixes
+
+- **(cargo)** added extra tool opts by [@jdx](https://github.com/jdx) in [#3144](https://github.com/jdx/mise/pull/3144)
+- hide MISE_GITHUB_TOKEN from `mise dr` by [@jdx](https://github.com/jdx) in [#3135](https://github.com/jdx/mise/pull/3135)
+- show password prompt when cloning and libgit2 is disabled by [@jdx](https://github.com/jdx) in [#3138](https://github.com/jdx/mise/pull/3138)
+- keep tools sorted by [@jdx](https://github.com/jdx) in [#3148](https://github.com/jdx/mise/pull/3148)
+- only use mise.toml files with lockfiles by [@jdx](https://github.com/jdx) in [#3150](https://github.com/jdx/mise/pull/3150)
+
+### 📚 Documentation
+
+- add more detail about task vars by [@jdx](https://github.com/jdx) in [#3136](https://github.com/jdx/mise/pull/3136)
+
+### 🧪 Testing
+
+- move ls tests to e2e by [@jdx](https://github.com/jdx) in [#3146](https://github.com/jdx/mise/pull/3146)
+
+### 🔍 Other Changes
+
+- Add note about how config values are template but not the file itself by [@syhol](https://github.com/syhol) in [#3137](https://github.com/jdx/mise/pull/3137)
+- bump usage by [@jdx](https://github.com/jdx) in [#3139](https://github.com/jdx/mise/pull/3139)
+- simplify render:settings task by [@jdx](https://github.com/jdx) in [#3142](https://github.com/jdx/mise/pull/3142)
+- use versions host more to avoid rate limiting by [@jdx](https://github.com/jdx) in [#3145](https://github.com/jdx/mise/pull/3145)
+- simplify release-plz output by [@mise-en-dev](https://github.com/mise-en-dev) in [b5bdf53](https://github.com/jdx/mise/commit/b5bdf537549433dacb6f6df0fd3f01f3190dd276)
+- disable versions host for `mise test-tool` by [@mise-en-dev](https://github.com/mise-en-dev) in [c4d487e](https://github.com/jdx/mise/commit/c4d487e7dd59e85eeeb3c0c3082c250590339188)
+- cache mise tools by [@jdx](https://github.com/jdx) in [#3147](https://github.com/jdx/mise/pull/3147)
+- ran `pre-commit run --all-files` against codebase by [@jdx](https://github.com/jdx) in [#3141](https://github.com/jdx/mise/pull/3141)
+- run autofix on windows by [@jdx](https://github.com/jdx) in [#3153](https://github.com/jdx/mise/pull/3153)
+
 ## [2024.11.23](https://github.com/jdx/mise/compare/v2024.11.22..v2024.11.23) - 2024-11-21
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,9 +609,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.23"
+version = "2024.11.24"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -2956,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "once_cell",
  "ring",
@@ -3937,9 +3937,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ubi"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142b3c47969de63fa38283962c08273cc06fec0de2e7425da9003d14ed0a05fa"
+checksum = "513462ea178a80eb0c05583d577ea13dba7e891bf6f14360bdb231ab014bea7e"
 dependencies = [
  "anyhow",
  "binstall-tar",
@@ -4056,9 +4056,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.23"
+version = "2024.11.24"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.23 macos-arm64 (a1b2d3e 2024-11-21)
+2024.11.24 macos-arm64 (a1b2d3e 2024-11-23)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_23:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_23 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_23;
+  if ( [[ -z "${_usage_spec_mise_2024_11_24:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_24 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_24;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_23 spec
+    _store_cache _usage_spec_mise_2024_11_24 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,12 +6,12 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_23:-} ]]; then
-        _usage_spec_mise_2024_11_23="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_24:-} ]]; then
+        _usage_spec_mise_2024_11_24="$(mise usage)"
     fi
 
     # shellcheck disable=SC2207
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_23}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_24}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_23
-  set -g _usage_spec_mise_2024_11_23 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_24
+  set -g _usage_spec_mise_2024_11_24 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_23" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_24" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.23";
+  version = "2024.11.24";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.23" 
+.TH mise 1  "mise 2024.11.24" 
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings color=0          Disable color by modifying global config file
 .SH VERSION
-v2024.11.23
+v2024.11.24
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.23
+Version: 2024.11.24
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- ignore config files after not trusting them by [@jdx](https://github.com/jdx) in [#3128](https://github.com/jdx/mise/pull/3128)
- task vars by [@jdx](https://github.com/jdx) in [#3130](https://github.com/jdx/mise/pull/3130)
- verify aqua packages with cosign and/or slsa when available by [@jdx](https://github.com/jdx) in [#3151](https://github.com/jdx/mise/pull/3151)
- added `task_skip` setting by [@jdx](https://github.com/jdx) in [#3154](https://github.com/jdx/mise/pull/3154)
- allow calling `mise settings foo=bar` as shorthand by [@jdx](https://github.com/jdx) in [#3155](https://github.com/jdx/mise/pull/3155)

### 🐛 Bug Fixes

- **(cargo)** added extra tool opts by [@jdx](https://github.com/jdx) in [#3144](https://github.com/jdx/mise/pull/3144)
- hide MISE_GITHUB_TOKEN from `mise dr` by [@jdx](https://github.com/jdx) in [#3135](https://github.com/jdx/mise/pull/3135)
- show password prompt when cloning and libgit2 is disabled by [@jdx](https://github.com/jdx) in [#3138](https://github.com/jdx/mise/pull/3138)
- keep tools sorted by [@jdx](https://github.com/jdx) in [#3148](https://github.com/jdx/mise/pull/3148)
- only use mise.toml files with lockfiles by [@jdx](https://github.com/jdx) in [#3150](https://github.com/jdx/mise/pull/3150)

### 📚 Documentation

- add more detail about task vars by [@jdx](https://github.com/jdx) in [#3136](https://github.com/jdx/mise/pull/3136)

### 🧪 Testing

- move ls tests to e2e by [@jdx](https://github.com/jdx) in [#3146](https://github.com/jdx/mise/pull/3146)

### 🔍 Other Changes

- Add note about how config values are template but not the file itself by [@syhol](https://github.com/syhol) in [#3137](https://github.com/jdx/mise/pull/3137)
- bump usage by [@jdx](https://github.com/jdx) in [#3139](https://github.com/jdx/mise/pull/3139)
- simplify render:settings task by [@jdx](https://github.com/jdx) in [#3142](https://github.com/jdx/mise/pull/3142)
- use versions host more to avoid rate limiting by [@jdx](https://github.com/jdx) in [#3145](https://github.com/jdx/mise/pull/3145)
- simplify release-plz output by [@mise-en-dev](https://github.com/mise-en-dev) in [b5bdf53](https://github.com/jdx/mise/commit/b5bdf537549433dacb6f6df0fd3f01f3190dd276)
- disable versions host for `mise test-tool` by [@mise-en-dev](https://github.com/mise-en-dev) in [c4d487e](https://github.com/jdx/mise/commit/c4d487e7dd59e85eeeb3c0c3082c250590339188)
- cache mise tools by [@jdx](https://github.com/jdx) in [#3147](https://github.com/jdx/mise/pull/3147)
- ran `pre-commit run --all-files` against codebase by [@jdx](https://github.com/jdx) in [#3141](https://github.com/jdx/mise/pull/3141)
- run autofix on windows by [@jdx](https://github.com/jdx) in [#3153](https://github.com/jdx/mise/pull/3153)