### PR TITLE
fix: only use mise.toml files with lockfiles

### DIFF
--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -108,7 +108,13 @@ pub fn update_lockfiles(new_versions: &[ToolVersion]) -> Result<()> {
             .insert(backend.short.to_string(), tvl);
     }
 
-    let lockfiles = config.config_files.keys().rev().collect_vec();
+    let lockfiles = config
+        .config_files
+        .iter()
+        .rev()
+        .filter(|(_, cf)| cf.source().is_mise_toml())
+        .map(|(p, _)| p)
+        .collect_vec();
     debug!("updating {} lockfiles", lockfiles.len());
 
     let empty = HashMap::new();
@@ -149,9 +155,10 @@ pub fn update_lockfiles(new_versions: &[ToolVersion]) -> Result<()> {
 fn read_all_lockfiles() -> Lockfile {
     CONFIG
         .config_files
-        .keys()
+        .iter()
         .rev()
-        .map(|cf| read_lockfile_for(cf))
+        .filter(|(_, cf)| cf.source().is_mise_toml())
+        .map(|(p, _)| read_lockfile_for(p))
         .filter_map(|l| match l {
             Ok(l) => Some(l),
             Err(err) => {

--- a/src/toolset/tool_source.rs
+++ b/src/toolset/tool_source.rs
@@ -7,7 +7,7 @@ use indexmap::{indexmap, IndexMap};
 use crate::file::display_path;
 
 /// where a tool version came from (e.g.: .tool-versions)
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, strum::EnumIs)]
 pub enum ToolSource {
     ToolVersions(PathBuf),
     MiseToml(PathBuf),


### PR DESCRIPTION
Fixes #3149
