### PR TITLE
chore: release 2024.11.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2024.11.26](https://github.com/jdx/mise/compare/v2024.11.25..v2024.11.26) - 2024-11-23
+
+### 🐛 Bug Fixes
+
+- show ubi versions starting with digit last by [@jdx](https://github.com/jdx) in [#3162](https://github.com/jdx/mise/pull/3162)
+- make built-in aqua cache work on windows by [@jdx](https://github.com/jdx) in [56aae79](https://github.com/jdx/mise/commit/56aae79c97b456cb866c81940519c815e6a67064)
+
+### 🧪 Testing
+
+- added test to check for bad cargo-binstall versions by [@jdx](https://github.com/jdx) in [#3163](https://github.com/jdx/mise/pull/3163)
+
+### 🔍 Other Changes
+
+- bake aqua registry into bin by [@jdx](https://github.com/jdx) in [#3161](https://github.com/jdx/mise/pull/3161)
+
 ## [2024.11.25](https://github.com/jdx/mise/compare/v2024.11.24..v2024.11.25) - 2024-11-23
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2024.11.25"
+version = "2024.11.26"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.11.25"
+version = "2024.11.26"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install mise (other methods [here](https://mise.jdx.dev/getting-started.html)):
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2024.11.25 macos-arm64 (a1b2d3e 2024-11-23)
+2024.11.26 macos-arm64 (a1b2d3e 2024-11-23)
 ```
 
 or install a specific a version:

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2024_11_25:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_25 ) \
-      && ! _retrieve_cache _usage_spec_mise_2024_11_25;
+  if ( [[ -z "${_usage_spec_mise_2024_11_26:-}" ]] || _cache_invalid _usage_spec_mise_2024_11_26 ) \
+      && ! _retrieve_cache _usage_spec_mise_2024_11_26;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2024_11_25 spec
+    _store_cache _usage_spec_mise_2024_11_26 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,12 +6,12 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2024_11_25:-} ]]; then
-        _usage_spec_mise_2024_11_25="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2024_11_26:-} ]]; then
+        _usage_spec_mise_2024_11_26="$(mise usage)"
     fi
 
     # shellcheck disable=SC2207
-    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_25}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
+    COMPREPLY=( $(usage complete-word --shell bash -s "${_usage_spec_mise_2024_11_26}" --cword="$COMP_CWORD" -- "${COMP_WORDS[@]}" ) )
     if [[ $? -ne 0 ]]; then
         unset COMPREPLY
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,7 +6,7 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2024_11_25
-  set -g _usage_spec_mise_2024_11_25 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2024_11_26
+  set -g _usage_spec_mise_2024_11_26 (mise usage | string collect)
 end
-complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_25" -- (commandline -cop) (commandline -t))'
+complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2024_11_26" -- (commandline -cop) (commandline -t))'

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2024.11.25";
+  version = "2024.11.26";
 
   src = lib.cleanSource ./.;
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mise 1  "mise 2024.11.25"
+.TH mise 1  "mise 2024.11.26"
 .SH NAME
 mise \- The front\-end to your dev env
 .SH SYNOPSIS
@@ -189,6 +189,6 @@ Examples:
     $ mise settings                  Show settings in use
     $ mise settings color=0          Disable color by modifying global config file
 .SH VERSION
-v2024.11.25
+v2024.11.26
 .SH AUTHORS
 Jeff Dickey <@jdx>

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2024.11.25
+Version: 2024.11.26
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- show ubi versions starting with digit last by [@jdx](https://github.com/jdx) in [#3162](https://github.com/jdx/mise/pull/3162)
- make built-in aqua cache work on windows by [@jdx](https://github.com/jdx) in [56aae79](https://github.com/jdx/mise/commit/56aae79c97b456cb866c81940519c815e6a67064)

### 🧪 Testing

- added test to check for bad cargo-binstall versions by [@jdx](https://github.com/jdx) in [#3163](https://github.com/jdx/mise/pull/3163)

### 🔍 Other Changes

- bake aqua registry into bin by [@jdx](https://github.com/jdx) in [#3161](https://github.com/jdx/mise/pull/3161)