### PR TITLE
fix: remove __MISE_WATCH,__MISE_DIFF env vars on `mise deactivate`

### DIFF
--- a/src/cli/snapshots/mise__cli__deactivate__tests__deactivate-2.snap
+++ b/src/cli/snapshots/mise__cli__deactivate__tests__deactivate-2.snap
@@ -9,3 +9,5 @@ chpwd_functions=( ${chpwd_functions:#_mise_hook} )
 unset -f _mise_hook
 unset -f mise
 unset MISE_SHELL
+unset __MISE_WATCH
+unset __MISE_DIFF

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -80,6 +80,8 @@ impl Shell for Bash {
             unset _mise_hook
             unset mise
             unset MISE_SHELL
+            unset __MISE_DIFF
+            unset __MISE_WATCH
         "#}
     }
 

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -102,6 +102,8 @@ impl Shell for Fish {
           functions --erase __mise_cd_hook
           functions --erase mise
           set -e MISE_SHELL
+          set -e __MISE_DIFF
+          set -e __MISE_WATCH
         "#}
     }
 

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -93,7 +93,12 @@ impl Shell for Nushell {
     }
 
     fn deactivate(&self) -> String {
-        self.unset_env("MISE_SHELL")
+        [
+            self.unset_env("MISE_SHELL"),
+            self.unset_env("__MISE_DIFF"),
+            self.unset_env("__MISE_DIFF"),
+        ]
+        .join("")
     }
 
     fn set_env(&self, k: &str, v: &str) -> String {

--- a/src/shell/snapshots/mise__shell__bash__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__deactivate.snap
@@ -8,3 +8,5 @@ PROMPT_COMMAND="${PROMPT_COMMAND//_mise_hook/}"
 unset _mise_hook
 unset mise
 unset MISE_SHELL
+unset __MISE_DIFF
+unset __MISE_WATCH

--- a/src/shell/snapshots/mise__shell__fish__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__deactivate.snap
@@ -8,3 +8,5 @@ functions --erase __mise_env_eval_2
 functions --erase __mise_cd_hook
 functions --erase mise
 set -e MISE_SHELL
+set -e __MISE_DIFF
+set -e __MISE_WATCH

--- a/src/shell/snapshots/mise__shell__nushell__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__nushell__tests__deactivate.snap
@@ -4,3 +4,5 @@ expression: replace_path(&deactivate)
 snapshot_kind: text
 ---
 hide,MISE_SHELL,
+hide,__MISE_DIFF,
+hide,__MISE_DIFF,

--- a/src/shell/snapshots/mise__shell__xonsh__tests__xonsh_deactivate.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__xonsh_deactivate.snap
@@ -21,3 +21,7 @@ for   hook_type in hooks:
 del XSH.aliases['mise']
 del XSH.env['MISE_SHELL']
 del os.environ['MISE_SHELL']
+del XSH.env['__MISE_DIFF']
+del os.environ['__MISE_DIFF']
+del XSH.env['__MISE_WATCH']
+del os.environ['__MISE_WATCH']

--- a/src/shell/snapshots/mise__shell__zsh__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__deactivate.snap
@@ -8,3 +8,5 @@ chpwd_functions=( ${chpwd_functions:#_mise_hook} )
 unset -f _mise_hook
 unset -f mise
 unset MISE_SHELL
+unset __MISE_WATCH
+unset __MISE_DIFF

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -88,6 +88,10 @@ impl Shell for Xonsh {
             del XSH.aliases['mise']
             del XSH.env['MISE_SHELL']
             del os.environ['MISE_SHELL']
+            del XSH.env['__MISE_DIFF']
+            del os.environ['__MISE_DIFF']
+            del XSH.env['__MISE_WATCH']
+            del os.environ['__MISE_WATCH']
             "#}
     }
 

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -85,6 +85,8 @@ impl Shell for Zsh {
         unset -f _mise_hook
         unset -f mise
         unset MISE_SHELL
+        unset __MISE_WATCH
+        unset __MISE_DIFF
         "#}
     }
 


### PR DESCRIPTION
Fixes #1867
