### PR TITLE
fix: always prefer glibc to musl in mise run

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -42,12 +42,11 @@ get_os() {
 
 get_arch() {
 	musl=""
-	if type ldd >/dev/null 2>/dev/null; then
-		libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
-		if [ -n "$libc" ]; then
-			musl="-musl"
-		fi
-	fi
+	if [ "${MISE_GLIBC-}" = "1" ]; then
+    musl=""
+  elif [ "$(get_os)" = "linux" ]; then
+    musl="-musl"
+  fi
 	arch="$(uname -m)"
 	if [ "$arch" = x86_64 ]; then
 		echo "x64$musl"


### PR DESCRIPTION
Fixes #2276

@autarch says this is a good idea, I suppose we will see
