### PR TITLE
fix: issue with non-default backends not getting tool options

### DIFF
--- a/e2e/backend/test_ubi
+++ b/e2e/backend/test_ubi
@@ -15,3 +15,11 @@ assert "cat mise.toml" '[tools]
 "ubi:cilium/cilium-cli" = { version = "latest", exe = "cilium" }'
 
 MISE_USE_VERSIONS_HOST=0 assert_not_contains "mise ls-remote cargo-binstall" "binstalk"
+
+# the following tests that tool options from ubi are still retained even if the default backend changes to aqua
+assert "MISE_DISABLE_BACKENDS=aqua mise use gh"
+cat "$MISE_DATA_DIR/installs/gh/.mise.backend"
+assert_contains "mise tool gh" "ubi:cli/cli[exe=gh]"
+assert "mise i -f gh"
+cat "$MISE_DATA_DIR/installs/gh/.mise.backend"
+assert_contains "mise tool gh" "ubi:cli/cli[exe=gh]"

--- a/mise.lock
+++ b/mise.lock
@@ -65,6 +65,12 @@ version = "3.3.3"
 [tools."pipx:toml-sort"]
 version = "0.24.2"
 
+[tools.pre-commit]
+version = "4.0.1"
+
+[tools.pre-commit.checksums]
+"pre-commit-4.0.1.pyz" = "sha256:f3e65c943795be7879e7ea2beda248321b6c8ae851dabc785522a432fb8ce003"
+
 [tools.ripgrep]
 version = "14.1.1"
 

--- a/mise.toml
+++ b/mise.toml
@@ -18,6 +18,7 @@ cosign = "latest"
 "npm:markdownlint-cli" = "latest"
 "npm:prettier" = "3"
 "pipx:toml-sort" = "latest"
+pre-commit = "latest"
 #"python" = { version = "latest", virtualenv = "{{env.HOME}}/.cache/venv" }
 "ripgrep" = "latest"
 "shellcheck" = "0.10"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -142,6 +142,8 @@ impl BackendArg {
         }
         if let Some(full) = &self.full {
             full.clone()
+        } else if let Some(full) = install_state::get_tool_full(short).unwrap_or_default() {
+            full
         } else if let Some(pt) = install_state::get_plugin_type(short).unwrap_or_default() {
             match pt {
                 PluginType::Asdf => format!("asdf:{short}"),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -344,11 +344,11 @@ impl Config {
                 p.is_file() && p.extension().unwrap_or_default().to_string_lossy() == "toml"
             })
             .map(|p| {
-                self.load_task_file(p).unwrap_or_else(|err| {
-                    warn!("loading tasks in {}: {err}", display_path(p));
-                    vec![]
-                })
+                self.load_task_file(p)
+                    .wrap_err_with(|| format!("loading tasks in {}", display_path(p)))
             })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
             .flatten()
             .collect::<Vec<_>>();
         let file_tasks = includes

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -126,6 +126,15 @@ pub fn list_plugins() -> Result<BTreeMap<String, PluginType>> {
     Ok(plugins.as_ref().unwrap().clone())
 }
 
+pub fn get_tool_full(short: &str) -> Result<Option<String>> {
+    let tools = init_tools()?;
+    Ok(tools
+        .as_ref()
+        .unwrap()
+        .get(short)
+        .and_then(|t| t.full.clone()))
+}
+
 pub fn get_plugin_type(short: &str) -> Result<Option<PluginType>> {
     let plugins = init_plugins()?;
     Ok(plugins.as_ref().unwrap().get(short).cloned())

--- a/xtasks/lint-fix
+++ b/xtasks/lint-fix
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 #MISE alias=["format"]
-#MISE wait_for=["build", "render:settings"]
+#MISE wait_for=["render:settings"]
 set -euxo pipefail
 
 # Used for shellcheck which needs explicit args
 scripts=("$PWD"/scripts/*.sh "$PWD"/e2e/{test_,run_}* "$PWD"/e2e/*.sh)
 # Used for shfmt which will run only on files it can
 scripts_dirs=("$PWD"/scripts "$PWD"/e2e)
-cargo clippy --all-features --fix --allow-staged --allow-dirty -- -Dwarnings
 shellcheck -x "${scripts[@]}"
 shfmt -w  -i 2 -ci -bn "${scripts_dirs[@]}"
 # shellcheck disable=SC2046
@@ -24,3 +23,4 @@ imports_granularity = "Module"
 EOF
 cargo fmt --all
 rm rustfmt.toml
+cargo clippy --all-features --fix --allow-staged --allow-dirty -- -Dwarnings


### PR DESCRIPTION
In the case where you had installed a tool with one backend and that backend changes, mise was not passing the registry tool options to the old backend.

Fixes #3262
