### PR TITLE
fix(docs): broken path example

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -120,7 +120,7 @@ This example makes CLIs installed with `npm` available:
 
 ```toml
 [env]
-_.PATH = "./node_modules/.bin"
+_.path = "./node_modules/.bin"
 ```
 
 This will add `./node_modules/.bin` to the PATH for the project—with "." here referring to the directory


### PR DESCRIPTION
The `PATH` example from the walkthrough does not work on macos 15.x.

every shell command ends with:

```
mise ERROR Plugin directory not found: "/Users/<USERNAME>/.local/share/mise/plugins/PATH"                                                                                                                                                                                             
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```

using lowercase `path` like described [here](https://mise.jdx.dev/environments.html#env-path) fixes that.