### PR TITLE
docs: add terraform recipe to the cookbook

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -113,6 +113,7 @@ export default defineConfig({
       { text: "FAQs", link: "/faq" },
       { text: "Troubleshooting", link: "/troubleshooting" },
       { text: "Tips & Tricks", link: "/tips-and-tricks" },
+      { text: "Cookbook", link: "/mise-cookbook" },
       {
         text: "About",
         items: [

--- a/docs/mise-cookbook.md
+++ b/docs/mise-cookbook.md
@@ -1,0 +1,47 @@
+# Tasks Cookbook
+
+Here we are sharing a few configurations for tasks that other people have found useful.
+
+## Managing `terraform`/`opentofu` Projects
+
+It is often necessary to have your terraform configuration in a `terraform/` subdirectory.
+This necessitates the use of syntax like `terraform -chdir=terraform plan` to use appropriate
+terraform command. The following config allows you to invoke all of them from `mise`, leveraging
+`mise` tasks.
+
+```toml
+[tools]
+terraform = "1"
+
+[tasks."terraform:init"]
+description = "Initializes a Terraform working directory"
+run = "terraform -chdir=terraform init"
+
+[tasks."terraform:plan"]
+description = "Generates an execution plan for Terraform"
+run = "terraform -chdir=terraform plan"
+
+[tasks."terraform:apply"]
+description = "Applies the changes required to reach the desired state of the configuration"
+run = "terraform -chdir=terraform apply"
+
+[tasks."terraform:destroy"]
+description = "Destroy Terraform-managed infrastructure"
+run = "terraform -chdir=terraform destroy"
+
+[tasks."terraform:validate"]
+description = "Validates the Terraform files"
+run = "terraform -chdir=terraform validate"
+
+[tasks."terraform:format"]
+description = "Formats the Terraform files"
+run = "terraform -chdir=terraform fmt"
+
+[tasks."terraform:check"]
+description = "Checks the Terraform files"
+depends = ["terraform:format", "terraform:validate"]
+
+[env]
+'_'.file = ".env"
+
+```

--- a/docs/mise-cookbook.md
+++ b/docs/mise-cookbook.md
@@ -42,6 +42,6 @@ description = "Checks the Terraform files"
 depends = ["terraform:format", "terraform:validate"]
 
 [env]
-'_'.file = ".env"
+_.file = ".env"
 
 ```

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -142,10 +142,10 @@ Get information about what backend a tool is using and other information with `m
 ```sh
 ❯ mise tool ripgrep
 Backend:            aqua:BurntSushi/ripgrep
-Installed Versions: 14.1.1                 
-Active Version:     14.1.1                 
-Requested Version:  latest                 
-Config Source:      ~/src/mise/mise.toml   
+Installed Versions: 14.1.1
+Active Version:     14.1.1
+Requested Version:  latest
+Config Source:      ~/src/mise/mise.toml
 Tool Options:       [none]
 ```
 
@@ -155,11 +155,11 @@ List the config files mise is reading in a particular directory with `mise cfg`:
 
 ```sh
 ❯ mise cfg
-Path                                    Tools                                   
-~/.config/mise/config.toml              (none)                                  
-~/.mise/config.toml                     (none)                                  
-~/src/mise.toml                         (none)                                  
-~/src/mise/.config/mise/conf.d/foo.toml (none)                                  
+Path                                    Tools
+~/.config/mise/config.toml              (none)
+~/.mise/config.toml                     (none)
+~/src/mise.toml                         (none)
+~/src/mise/.config/mise/conf.d/foo.toml (none)
 ~/src/mise/mise.toml                    actionlint, bun, cargo-binstall, cargo:…
 ~/src/mise/mise.local.toml              (none)
 ```

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -44,7 +44,7 @@ console.log(`Running node: ${process.version}`);
 This can also be useful in environments where mise isn't activated
 (such as a non-interactive session).
 
-You can also download the https://mise.run script to use in a project bootstrap script:
+You can also download the <https://mise.run> script to use in a project bootstrap script:
 
 ```sh
 curl https://mise.run > setup-mise.sh


### PR DESCRIPTION
This pull request adds a new "Cookbook" section to the documentation and provides configurations for managing Terraform projects. The most important changes include adding a link to the new section in the site navigation and creating a detailed mise-cookbook. md file with various Terraform task configurations.

Documentation updates:

* [`docs/.vitepress/config.ts`](diffhunk://#diff-3def678deb1b1d5a53948eb8491817dde4dc881e032e785fc61cc93d334eefcdR116): Added a new link to the "Cookbook" section in the site navigation.

New content:

* [`docs/mise-cookbook.md`](diffhunk://#diff-e126c7bde7dec6ffd7e2bcb21131fe001c70f55b61a4b6c7bde8b5f3b85da962R1-R47): Created a new file with configurations for managing `terraform` projects, including tasks for initialization, planning, applying, destroying, validating, formatting, and checking `terraform` files.