### PR TITLE
feat: Add `--json-extended` option to settings ls 

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -31,6 +31,10 @@ List all settings
 
 Output in JSON format
 
+### `--json-extended`
+
+Output in JSON format with sources
+
 ### `-T --toml`
 
 Output in TOML format

--- a/docs/cli/settings/ls.md
+++ b/docs/cli/settings/ls.md
@@ -31,6 +31,10 @@ Use the local config file instead of the global one
 
 Output in JSON format
 
+### `--json-extended`
+
+Output in JSON format with sources
+
 ### `-T --toml`
 
 Output in TOML format

--- a/e2e/cli/test_settings_ls
+++ b/e2e/cli/test_settings_ls
@@ -1,7 +1,36 @@
 #!/usr/bin/env bash
 
 echo "settings.all_compile = false" >mise.toml
-assert_contains "mise settings" "all_compile  false"
+echo "settings.disable_backends = [\"rust\", \"java\"]" >>mise.toml
+
+assert_contains "mise settings" 'all_compile       false            ~/workdir/mise.toml
+disable_backends  ["rust", "java"] ~/workdir/mise.toml'
+
+assert_contains "mise settings --json" '{
+  "all_compile": false,
+  "disable_backends": [
+    "rust",
+    "java"
+  ]
+}'
+
+assert_contains "mise settings --toml" 'all_compile = false
+disable_backends = ["rust", "java"]'
+
+assert_contains "mise settings --json-extended" '{
+  "all_compile": {
+    "source": "~/workdir/mise.toml",
+    "value": false
+  },
+  "disable_backends": {
+    "source": "~/workdir/mise.toml",
+    "value": [
+      "rust",
+      "java"
+    ]
+  }
+}'
+
 assert_contains "mise settings ls -T" "all_compile = false"
 echo "settings.python.venv_auto_create = false" >>mise.toml
 assert_contains "mise settings ls python" "venv_auto_create  false"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1062,6 +1062,7 @@ cmd "settings" help="Manage settings" {
     flag "-a --all" help="List all settings"
     flag "-l --local" help="Use the local config file instead of the global one" global=true
     flag "-J --json" help="Output in JSON format"
+    flag "--json-extended" help="Output in JSON format with sources"
     flag "-T --toml" help="Output in TOML format"
     arg "[KEY]" help="Setting name to get/set"
     arg "[VALUE]" help="Setting value to set"
@@ -1114,6 +1115,7 @@ but managed separately with `mise aliases`"
         flag "-a --all" help="Display settings set to the default"
         flag "-l --local" help="Use the local config file instead of the global one"
         flag "-J --json" help="Output in JSON format"
+        flag "--json-extended" help="Output in JSON format with sources"
         flag "-T --toml" help="Output in TOML format"
         arg "[KEY]" help="List keys under this key"
     }

--- a/src/cli/settings/mod.rs
+++ b/src/cli/settings/mod.rs
@@ -30,11 +30,15 @@ pub struct Settings {
     local: bool,
 
     /// Output in JSON format
-    #[clap(long, short = 'J')]
+    #[clap(long, short = 'J', group = "output")]
     pub json: bool,
 
+    /// Output in JSON format with sources
+    #[clap(long, group = "output")]
+    pub json_extended: bool,
+
     /// Output in TOML format
-    #[clap(long, short = 'T')]
+    #[clap(long, short = 'T', group = "output")]
     pub toml: bool,
 }
 
@@ -87,6 +91,7 @@ impl Settings {
                     key: None,
                     local: self.local,
                     json: self.json,
+                    json_extended: self.json_extended,
                     toml: self.toml,
                 })
             }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -2041,6 +2041,13 @@ const completionSpec: Fig.Spec = {
                         },
                         {
                             "name": [
+                                "--json-extended"
+                            ],
+                            "description": "Output in JSON format with sources",
+                            "isRepeatable": false
+                        },
+                        {
+                            "name": [
                                 "-T",
                                 "--toml"
                             ],
@@ -2140,6 +2147,13 @@ const completionSpec: Fig.Spec = {
                         "--json"
                     ],
                     "description": "Output in JSON format",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--json-extended"
+                    ],
+                    "description": "Output in JSON format with sources",
                     "isRepeatable": false
                 },
                 {


### PR DESCRIPTION
Fix #3301
- Add `--json-extended` output option to `mise settings ls`
- Update `--json` output to print arrays as json arrays
- ensure only one output option can be set