### PR TITLE
docs: fix git examples for cargo backend

### DIFF
--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -47,13 +47,13 @@ install a particular tag, branch, or commit revision:
 
 ```sh
 # Install a specific tag
-mise use cargo:github.com/username/demo@tag:<release_tag>
+mise use cargo:https://github.com/username/demo@tag:<release_tag>
 
 # Install the latest from a branch
-mise use cargo:github.com/username/demo@branch:<branch_name>
+mise use cargo:https://github.com/username/demo@branch:<branch_name>
 
 # Install a specific commit revision
-mise use cargo:github.com/username/demo@rev:<commit_hash>
+mise use cargo:https://github.com/username/demo@rev:<commit_hash>
 ```
 
 This will execute a `cargo install` command with the corresponding Git options.


### PR DESCRIPTION
If not specified, `mise` will prepend `https://github.com` automatically as demonstrated below:

```text
❯ mise use -g cargo:github.com/dummy/package@branch:main
    Updating git repository `https://github.com/github.com/dummy/package.git`
warning: spurious network error (3 tries remaining): unexpected http status code: 404; class=Http (34)
warning: spurious network error (2 tries remaining): unexpected http status code: 404; class=Http (34)
warning: spurious network error (1 tries remaining): unexpected http status code: 404; class=Http (34)
error: failed to clone into: /home/tmeijn/.cargo/git/db/package-01981305c4472e03
Caused by:
  network failure seems to have happened
  if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
Caused by:
  unexpected http status code: 404; class=Http (34)
mise ERROR cargo failed
    Updating git repository `https://github.com/github.com/dummy/package.git`
warning: spurious network error (3 tries remaining): unexpected http status code: 404; class=Http (34)
warning: spurious network error (2 tries remaining): unexpected http status code: 404; class=Http (34)
warning: spurious network error (1 tries remaining): unexpected http status code: 404; class=Http (34)
error: failed to clone into: /home/tmeijn/.cargo/git/db/package-01981305c4472e03

Caused by:
  network failure seems to have happened
  if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  unexpected http status code: 404; class=Http (34)
mise ERROR failed to install cargo:github.com/dummy/package@branch:main
mise ERROR cargo exited with non-zero status: exit code 101
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information

-------------------------------------------------------------------------------------------------------------------------------------------
~ took 11s 
-------------------------------------------------------------------------------------------------------------------------------------------
❯ mise use -g cargo:https://github.com/dummy/package@branch:main
    Updating git repository `https://github.com/dummy/package`
error: failed to clone into: /home/tmeijn/.cargo/git/db/package-aa5c65e2f15c8492
Caused by:
  failed to authenticate when downloading repository
  * attempted to find username/password via git's `credential.helper` support, but failed
  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
Caused by:
  failed to acquire username/password from local configuration
mise ERROR cargo failed
    Updating git repository `https://github.com/dummy/package`
error: failed to clone into: /home/tmeijn/.cargo/git/db/package-aa5c65e2f15c8492

Caused by:
  failed to authenticate when downloading repository

  * attempted to find username/password via git's `credential.helper` support, but failed

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  failed to acquire username/password from local configuration
mise ERROR failed to install cargo:https://github.com/dummy/package@branch:main
mise ERROR cargo exited with non-zero status: exit code 101
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```