### PR TITLE
fix(docs): correct syntax error in IDE integration examples

### DIFF
--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -52,7 +52,7 @@ Here is an example using VSCode:
 # ~/.zprofile
 if [[ "$TERM_PROGRAM" == "vscode" ]]; then
   eval "$($HOME/.local/bin/mise activate zsh --shims)"
-elif; then
+else
   eval "$($HOME/.local/bin/mise activate zsh)"
 fi
 ```
@@ -61,7 +61,7 @@ fi
 # ~/.bash_profile or ~/.bash_login or ~/.profile
 if [[ "$TERM_PROGRAM" == "vscode" ]]; then
   eval "$($HOME/.local/bin/mise activate bash --shims)"
-elif; then
+else
   eval "$($HOME/.local/bin/mise activate bash)"
 fi
 ```


### PR DESCRIPTION
This pull request includes changes to the `docs/ide-integration.md` code snippets. The changes replace incorrect `elif` statements with `else` statements to ensure correct syntax.

Changes in `docs/ide-integration.md`:

* Corrected the conditional statement for activating the environment in zsh by replacing `elif` with `else`.
* Corrected the conditional statement for activating the environment in bash by replacing `elif` with `else`.