### PR TITLE
fix: allow compilation not on macOS, Linux, or Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.12.1"
+version = "2024.12.0"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2024.12.0"
+version = "2024.12.1"
 edition = "2021"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -186,8 +186,5 @@ const ARCH: &str = "unknown";
 #[cfg(macos)]
 const OS: &str = "apple-darwin";
 
-#[cfg(linux)]
-const OS: &str = "unknown";
-
-#[cfg(windows)]
+#[cfg(not(macos))]
 const OS: &str = "unknown";


### PR DESCRIPTION
Allow erlang.rs work if compiled not on Mac, Linux or Windows.