### PR TITLE
fix(config): set config_root for tasks defined in included toml files

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -348,7 +348,7 @@ impl Config {
                 p.is_file() && p.extension().unwrap_or_default().to_string_lossy() == "toml"
             })
             .map(|p| {
-                self.load_task_file(p)
+                self.load_task_file(p, dir)
                     .wrap_err_with(|| format!("loading tasks in {}", display_path(p)))
             })
             .collect::<Result<Vec<_>>>()?
@@ -372,7 +372,7 @@ impl Config {
             .collect())
     }
 
-    fn load_task_file(&self, path: &Path) -> Result<Vec<Task>> {
+    fn load_task_file(&self, path: &Path, config_root: &Path) -> Result<Vec<Task>> {
         let raw = file::read_to_string(path)?;
         let mut tasks = toml::from_str::<Tasks>(&raw)
             .wrap_err_with(|| format!("Error parsing task file: {}", display_path(path)))?
@@ -380,6 +380,7 @@ impl Config {
         for (name, task) in &mut tasks {
             task.name = name.clone();
             task.config_source = path.to_path_buf();
+            task.config_root = Some(config_root.to_path_buf());
         }
         Ok(tasks.into_values().collect())
     }


### PR DESCRIPTION
This fixes an error while running tasks defined in toml files specified in `task_config.include`.
`$MISE_CONFIG_ROOT` used to be `None`, and it caused an error when executing tasks with `dir` from non-root directories because the task ran in the current directory instead of `config_root`.

```
[debug:tasks] $ echo $(pwd) 
/home/risu/ghq/github.com/risu729/dotfiles/worker
[debug:tasks] $ echo $MISE_ORIGINAL_CWD 
/home/risu/ghq/github.com/risu729/dotfiles
[debug:tasks] $ echo $MISE_CONFIG_ROOT 

[debug:tasks] $ echo $MISE_PROJECT_ROOT 
/home/risu/ghq/github.com/risu729/dotfiles
[debug:tasks] $ echo $MISE_TASK_DIR 
/home/risu/ghq/github.com/risu729/dotfiles
[debug:tasks] $ echo $MISE_TASK_FILE 
/home/risu/ghq/github.com/risu729/dotfiles/tasks.toml
```