### PR TITLE
docs(backend): fix git url syntax example

### DIFF
--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -64,7 +64,7 @@ mise _should_ do this automatically when using `mise up python`.
 | PyPI shorthand for specific version   | `pipx:black@24.3.0`                                    |
 | GitHub shorthand for latest version   | `pipx:psf/black`                                       |
 | GitHub shorthand for specific version | `pipx:psf/black@24.3.0`                                |
-| Git syntax for latest version         | `pipx:git+https://github.com/psf/black`                |
+| Git syntax for latest version         | `pipx:git+https://github.com/psf/black.git`                |
 | Git syntax for a branch               | `pipx:git+https://github.com/psf/black.git@main`       |
 | Https with zipfile                    | `pipx:https://github.com/psf/black/archive/18.9b0.zip` |
 

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -64,7 +64,7 @@ mise _should_ do this automatically when using `mise up python`.
 | PyPI shorthand for specific version   | `pipx:black@24.3.0`                                    |
 | GitHub shorthand for latest version   | `pipx:psf/black`                                       |
 | GitHub shorthand for specific version | `pipx:psf/black@24.3.0`                                |
-| Git syntax for latest version         | `pipx:git+https://github.com/psf/black.git`                |
+| Git syntax for latest version         | `pipx:git+https://github.com/psf/black.git`            |
 | Git syntax for a branch               | `pipx:git+https://github.com/psf/black.git@main`       |
 | Https with zipfile                    | `pipx:https://github.com/psf/black/archive/18.9b0.zip` |
 


### PR DESCRIPTION
Closes #3403. Assuming it's the docs issue.