### PR TITLE
docs: Update index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,8 @@ features:
 ---
 
 ## Powerful polyglot tool version manager
-Mise can manage multiple tools and runtimes like `node`, `python`, `java`, `go`, `ruby`, `terraform`, etc. in one place. 
+
+Mise can manage multiple tools and runtimes like `node`, `python`, `java`, `go`, `ruby`, `terraform`, etc. in one place.
 
 With a simple configuration file, you can specify which version of each tool to use. `mise` will automatically switch between different versions of tools based on the directory you're in.
 
@@ -41,15 +42,18 @@ With a simple configuration file, you can specify which version of each tool to 
 # mise go@1.x.x ✓ installed
 # mise node@22.x.x ✓ installed
 # mise python@3.x.x ✓ installed
-# mise ~/my-project/mise.toml tools: go@1.x.x, python@3.x.x, node@22.x.x                                                              
+# mise ~/my-project/mise.toml tools: go@1.x.x, python@3.x.x, node@22.x.x
 ```
+
 ::: code-group
+
 ```toml [mise.toml]
 [tools]
 node = "22"
 python = "3"
 go = "latest"
 ```
+
 :::
 
 ```shell
@@ -61,17 +65,21 @@ go = "latest"
 ```
 
 ## Manage environment variables
+
 Mise can manage environment variables for different project directories. Like `direnv`, it will automatically switch between different sets of environment variables as you move between projects.
 
 ```shell
 ~/my-project > mise env set FOO=bar
 ```
+
 ::: code-group
+
 ```toml [mise.toml]
 # ...
 [env]
 FOO = "bar"
 ```
+
 :::
 
 ```shell
@@ -85,6 +93,7 @@ echo $FOO
 Powerful task runner that can replace `make`, `just`, `npm scripts`, etc. leveraging tools and environment variables.
 
 ::: code-group
+
 ```toml [mise.toml]
 # ...
 [task.test]
@@ -94,7 +103,9 @@ run = "echo 'runing tests...'"
 run = "node -e 'console.log(process.version); console.log(process.env.FOO)'"
 depends = ["test"]
 ```
+
 :::
+
 ```shell
 > mise tasks ls
 # my_task     ~/.my-project/mise.toml
@@ -107,23 +118,30 @@ depends = ["test"]
 ```
 
 ## mise works with your existing setup
-You do not need to use `mise` for everything. You can use it only for `tool` or for `tasks`. 
-`mise` interoperates with your extisting setup! 
+
+You do not need to use `mise` for everything. You can use it only for `tool` or for `tasks`.
+`mise` interoperates with your extisting setup!
 
 ### Idiomatic files and asdf compatibility
+
 mise works with idiomatic files like `.nvmrc`, `.python-version`, etc. or asdf `.tool-versions` files.
 
 ::: code-group
+
 ```txt [.nvmrc]
 22
 ```
+
 ```txt [.python-version]
 3.13
 ```
+
 ```txt [.tool-versions]
 go 1.23.4
 ```
+
 :::
+
 ```shell
 > mise install
 # mise go@1.23.4 ✓ installed
@@ -132,14 +150,18 @@ go 1.23.4
 ```
 
 ### `.env` files support
+
 mise can load `.env` files.
+
 ```toml
 [env]
 _.file = ".env"
 ```
 
 ### Standalone file tasks
+
 mise also works with your existing shell scripts. Tasks can be as standalone files!
+
 ```shell
 > cat mise-tasks/build
 | #!/usr/bin/env bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,9 +31,152 @@ features:
     details: mise is a task runner that can replace <a href="https://www.gnu.org/software/make">make</a>, or <a href="https://docs.npmjs.com/cli/v10/using-npm-scripts">npm scripts</a>.
 ---
 
+## Powerful polyglot tool version manager
+Mise can manage multiple tools and runtimes like `node`, `python`, `java`, `go`, `ruby`, `terraform`, etc. in one place. 
+
+With a simple configuration file, you can specify which version of each tool to use. `mise` will automatically switch between different versions of tools based on the directory you're in.
+
+```shell
+~/my-project > mise use node@22 python@3 go@latest
+# mise go@1.x.x ✓ installed
+# mise node@22.x.x ✓ installed
+# mise python@3.x.x ✓ installed
+# mise ~/my-project/mise.toml tools: go@1.x.x, python@3.x.x, node@22.x.x                                                              
+```
+::: code-group
+```toml [mise.toml]
+[tools]
+node = "22"
+python = "3"
+go = "latest"
+```
+:::
+
+```shell
+~/my-project > node -v
+# v22.x.x
+
+~/my-project > which node
+# ~/.local/mise/installs/node/22.x.x/bin/node
+```
+
+## Manage environment variables
+Mise can manage environment variables for different project directories. Like `direnv`, it will automatically switch between different sets of environment variables as you move between projects.
+
+```shell
+~/my-project > mise env set FOO=bar
+```
+::: code-group
+```toml [mise.toml]
+# ...
+[env]
+FOO = "bar"
+```
+:::
+
+```shell
+cd ~/my-project
+echo $FOO
+# bar
+```
+
+## Task runner
+
+Powerful task runner that can replace `make`, `just`, `npm scripts`, etc. leveraging tools and environment variables.
+
+::: code-group
+```toml [mise.toml]
+# ...
+[task.test]
+run = "echo 'runing tests...'"
+
+[tasks.my_task]
+run = "node -e 'console.log(process.version); console.log(process.env.FOO)'"
+depends = ["test"]
+```
+:::
+```shell
+> mise tasks ls
+# my_task     ~/.my-project/mise.toml
+# test        ~/.my-project/mise.toml
+
+> mise run my_task
+# [test] runing tests...
+# [my_task] v22.x.x
+# [my_task] bar
+```
+
+## mise works with your existing setup
+You do not need to use `mise` for everything. You can use it only for `tool` or for `tasks`. 
+`mise` interoperates with your extisting setup! 
+
+### Idiomatic files and asdf compatibility
+mise works with idiomatic files like `.nvmrc`, `.python-version`, etc. or asdf `.tool-versions` files.
+
+::: code-group
+```txt [.nvmrc]
+22
+```
+```txt [.python-version]
+3.13
+```
+```txt [.tool-versions]
+go 1.23.4
+```
+:::
+```shell
+> mise install
+# mise go@1.23.4 ✓ installed
+# mise node@22.12.0 ✓ installed
+# mise python@3.13.1 ✓ installed
+```
+
+### `.env` files support
+mise can load `.env` files.
+```toml
+[env]
+_.file = ".env"
+```
+
+### Standalone file tasks
+mise also works with your existing shell scripts. Tasks can be as standalone files!
+```shell
+> cat mise-tasks/build
+| #!/usr/bin/env bash
+| #MISE description="Build the CLI"
+| cargo build
+```
+
+```shell
+> mise task ls
+# build   Build the CLI   ~/.my-project/mise-tasks
+```
+
+```shell
+> mise run build
+# cargo build
+```
+
+<center style="margin-top: 2em">
+    <a href="/getting-started" class="get-started-button">Getting Started</a>
+</center>
+
 <style>
 .formerly {
     font-size: 0.7em;
     color: #666;
 }
+
+a.get-started-button {
+    display: inline-block;
+    padding: 0.5em 1em;
+    border-radius: 0.25em;
+    color: var(--vp-button-brand-text);
+    text-decoration: none;
+    background-color: var(--vp-button-brand-bg);
+}
+a.get-started-button:hover {
+    color: var(--vp-button-brand-hover-text);
+}
+
 </style>


### PR DESCRIPTION
Just an idea of things which could be added on the home page to get a super quick idea of what `mise` can do.
This is all in Markdown, but it could be possible to build something a bit prettier, more like on the https://vite.dev homepage (obviously not as advanced, but for example, presenting some information into two columns would help)