### PR TITLE
docs: Small documentation improvements

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ node = "https://github.com/my-org/mise-node.git#DEADBEEF" # supports specific gi
 ```
 
 If you simply want to install a plugin from a specific URL once, it's better to use
-`mise plugin install plugin <GIT_URL>`. Add this section to `.mise.toml` if you want
+`mise plugin install plugin <GIT_URL>`. Add this section to `mise.toml` if you want
 to share the plugin location/revision with other developers in your project.
 
 This is similar
@@ -146,13 +146,13 @@ min_version = '2024.11.1'
 
 ### `mise.toml` schema
 
-- You can find the JSON schema for `.mise.toml` [here](https://github.com/jdx/mise/blob/main/schema/mise.json) or at <https://mise.jdx.dev/schema/mise.json>.
+- You can find the JSON schema for `mise.toml` [here](https://github.com/jdx/mise/blob/main/schema/mise.json) or at <https://mise.jdx.dev/schema/mise.json>.
 - Some editors can load it automatically to provide autocompletion and validation for when editing a `mise.toml` file ([VSCode](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings), [IntelliJ](https://www.jetbrains.com/help/idea/json.html#ws_json_using_schemas), [neovim](https://github.com/b0o/SchemaStore.nvim), etc.). It is also available in the [JSON schema store](https://www.schemastore.org/json/).
 - Note that for `included tasks` (see [task configuration](/tasks/#task-configuration), there is another schema: <https://mise.jdx.dev/schema/mise-task.json>)
 
 ## Global config: `~/.config/mise/config.toml`
 
-mise can be configured in `~/.config/mise/config.toml`. It's like local `.mise.toml` files except
+mise can be configured in `~/.config/mise/config.toml`. It's like local `mise.toml` files except
 that
 it is used for all directories.
 
@@ -216,8 +216,8 @@ setting defaults for all users.
 
 ## `.tool-versions`
 
-The `.tool-versions` file is asdf's config file and it can be used in mise just like `.mise.toml`.
-It isn't as flexible so it's recommended to use `.mise.toml` instead. It can be useful if you
+The `.tool-versions` file is asdf's config file and it can be used in mise just like `mise.toml`.
+It isn't as flexible so it's recommended to use `mise.toml` instead. It can be useful if you
 already have a lot of `.tool-versions` files or work on a team that uses asdf.
 
 Here is an example with all the supported syntax:
@@ -241,7 +241,7 @@ this file format.
 
 ## Scopes
 
-Both `.mise.toml` and `.tool-versions` support "scopes" which modify the behavior of the version:
+Both `mise.toml` and `.tool-versions` support "scopes" which modify the behavior of the version:
 
 - `ref:<SHA>` - compile from a vcs (usually git) ref
 - `prefix:<PREFIX>` - use the latest version that matches the prefix. Useful for Go since `1.20`
@@ -350,7 +350,7 @@ Uses [dotenvy](https://crates.io/crates/dotenvy) under the hood.
 ### `MISE_${PLUGIN}_VERSION`
 
 Set the version for a runtime. For example, `MISE_NODE_VERSION=20` will use <node@20.x> regardless
-of what is set in `.tool-versions`/`.mise.toml`.
+of what is set in `mise.toml`/`.tool-versions`.
 
 ### `MISE_TRUSTED_CONFIG_PATHS`
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -45,14 +45,14 @@ jobs:
           version: 2023.12.0 # [default: latest] mise version to install
           install: true # [default: true] run `mise install`
           cache: true # [default: true] cache mise using GitHub's cache
-          # automatically write this .tool-versions file
           experimental: true # [default: false] enable experimental features
-          tool_versions: |
-            shellcheck 0.9.0
-          # or, if you prefer mise.toml format:
+          # automatically write this mise.toml file
           mise_toml: |
             [tools]
             shellcheck = "0.9.0"
+          # or, if you prefer .tool-versions:
+          tool_versions: |
+            shellcheck 0.9.0
       - run: shellcheck scripts/*.sh
 ```
 

--- a/docs/dev-tools/aliases.md
+++ b/docs/dev-tools/aliases.md
@@ -15,7 +15,7 @@ erlang = 'asdf:https://github.com/company/our-custom-erlang'
 
 mise supports aliasing the versions of runtimes. One use-case for this is to define aliases for LTS
 versions of runtimes. For example, you may want to specify `lts-hydrogen` as the version for <node@20.x>
-so you can use set it with `node lts-hydrogen` in `.tool-versions`/`mise.toml`.
+so you can use set it with `node lts-hydrogen` in `mise.toml`/`.tool-versions`.
 
 User aliases can be created by adding an `alias.<PLUGIN>` section to `~/.config/mise/config.toml`:
 

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -118,7 +118,7 @@ $ which node
 ### Env vars and shims
 
 A downside of shims is the "mise environment" is only loaded when a shim is called. This means if you
-set an environment variable in `.mise.toml`, it will only be run when a shim is called. So the following
+set an environment variable in `mise.toml`, it will only be run when a shim is called. So the following
 only works under `mise activate`:
 
 ```sh
@@ -155,7 +155,7 @@ this isn't a problem.
 
 Some version managers modify the behavior of `cd`. That might seem like the ideal method of making a version
 manager, it has tons of gaps. It doesn't work if you use `pushd|popd` or other commands that modify PWD—though
-some shells have a "chpwd" hook that would. It doesn't run if you modify the `.mise.toml` file.
+some shells have a "chpwd" hook that would. It doesn't run if you modify the `mise.toml` file.
 
 The upside is that it doesn't run as frequently but since mise is written in rust the cost for executing
 mise is negligible (~4-5ms).

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,7 +1,7 @@
 # Environments
 
 > Like [direnv](https://github.com/direnv/direnv) it
-manages [environment variables](/configuration#env---arbitrary-environment-variables) for
+manages *environment variables* for
 different project directories.
 
 Use mise to specify environment variables used for different projects. Create a `mise.toml` file

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,18 +1,18 @@
 # FAQs
 
-## I don't want to put a `.tool-versions`/`mise.toml` file into my project since git shows it as an untracked file
+## I don't want to put a `mise.toml`/`.tool-versions` file into my project since git shows it as an untracked file
 
 Use [`mise.local.toml`](https://mise.jdx.dev/configuration.html#mise-toml) and put that into your global gitignore file. This file should never be committed.
 
-Or you can make git ignore these files in 3 different ways:
+If you really want to use a `mise.toml` or `.tool-versions`, here are 3 ways to make git ignore these files:
 
-- Adding `.tool-versions` to project's `.gitignore` file. This has the downside that you need to
-  commit the change to the ignore file.
-- Adding `.tool-versions` to project's `.git/info/exclude`. This file is local to your project so
+- Adding `mise.toml` to project's `.git/info/exclude`. This file is local to your project so
   there is no need to commit it.
-- Adding `.tool-versions` to global gitignore (`core.excludesFile`). This will cause git to
-  ignore `.tool-versions` files in all projects. You can explicitly add one to a project if needed
-  with `git add --force .tool-versions`.
+- Adding `mise.toml` to project's `.gitignore` file. This has the downside that you need to
+  commit the change to the ignore file.
+- Adding `mise.toml` to global gitignore (`core.excludesFile`). This will cause git to
+  ignore `mise.toml` files in all projects. You can explicitly add one to a project if needed
+  with `git add --force mise.toml`.
 
 ## What is the difference between "nodejs" and "node" (or "golang" and "go")?
 

--- a/docs/lang/go.md
+++ b/docs/lang/go.md
@@ -97,5 +97,5 @@ github.com/jesseduffield/lazygit
 
 ## `.go-version` file support
 
-mise uses a `.tool-versions` or `mise.toml` file for auto-switching between software versions.
+mise uses a `mise.toml` or `.tool-versions` file for auto-switching between software versions.
 However it can also read go-specific version files named `.go-version`.

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -59,7 +59,7 @@ You can specify a non-default location of this file by setting a `MISE_NODE_DEFA
 
 ## `.nvmrc` and `.node-version` support
 
-mise uses a `.tool-versions` or `mise.toml` file for auto-switching between software versions. To ease migration, you can have also have it read an existing `.nvmrc` or `.node-version` file to find out what version of Node.js should be used. This will be used if `node` isn't defined in `.tool-versions`/`.mise.toml`.
+mise uses a `mise.toml` or `.tool-versions` file for auto-switching between software versions. To ease migration, you can have also have it read an existing `.nvmrc` or `.node-version` file to find out what version of Node.js should be used. This will be used if `node` isn't defined in `mise.toml`/`.tool-versions`.
 
 ## "nodejs" -> "node" Alias
 

--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -50,7 +50,7 @@ rubocop --pre # install prerelease version
 
 ## `.ruby-version` and `Gemfile` support
 
-mise uses a `.tool-versions` or `mise.toml` file for auto-switching between software versions.
+mise uses a `mise.toml` or `.tool-versions` file for auto-switching between software versions.
 However it can also read ruby-specific version files `.ruby-version` or `Gemfile`
 (if it specifies a ruby version).
 

--- a/docs/rtx.md
+++ b/docs/rtx.md
@@ -17,7 +17,7 @@ and `~/.config/rtx` to `~/.config/mise` (if the destination does not exist). Pyt
 installs will need to be reinstalled with `mise install`.
 
 `mise` will continue reading `.rtx.toml` files for some time but that eventually will
-be deprecated so please rename them to `.mise.toml`. `mise` will not read from `RTX_*`
+be deprecated so please rename them to `mise.toml`. `mise` will not read from `RTX_*`
 env vars so those will need to be changed to `MISE_*`. Anything using a local `.rtx` or
 `.config/rtx` directory will need to be moved to `.mise`/`.config/mise`.
 

--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -1,6 +1,6 @@
 # Tasks
 
-> Like [make](https://www.gnu.org/software/make/manual/make.html) it manages [tasks](/tasks/) used
+> Like [make](https://www.gnu.org/software/make/manual/make.html) it manages _tasks_ used
 > to build and test projects.
 
 You can define tasks in `mise.toml` files or as standalone shell scripts. These are useful for

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -4,9 +4,9 @@ Templates in mise provide a powerful way to configure different aspects of
 your environment and project settings.
 You can define and use templates in the following locations:
 
-- `.tool-versions` files
 - Most `mise.toml` configuration values
   - The `mise.toml` file itself is not templated and must be valid toml
+- `.tool-versions` files
 - _(Submit a ticket if you want to see it used elsewhere!)_
 
 ## Template Rendering
@@ -107,7 +107,7 @@ These variables offer key information about the current environment:
 - `env: HashMap<String, String>` – Accesses current environment variables as
   a key-value map.
 - `cwd: PathBuf` – Points to the current working directory.
-- `config_root: PathBuf` – Locates the directory containing your `.mise.toml` file
+- `config_root: PathBuf` – Locates the directory containing your `mise.toml` file
   or the `.mise` configuration folder.
 - `mise_bin: String` - Points to the path to the current mise executable
 - `mise_pid: String` - Points to the pid of the current mise process
@@ -252,7 +252,6 @@ PROJECT_CONFIG = "{{ config_root | concat(with='bar.txt') | join_path }}"
 - `str | kebabcase -> String` – Converts a string to kebab-case
 - `str | lowercamelcase -> String` – Converts a string to lowerCamelCase
 - `str | uppercamelcase -> String` – Converts a string to UpperCamelCase
-- `str | shoutycamelcase -> String` – Converts a string to ShoutyCamelCase
 - `str | snakecase -> String` – Converts a string to snake_case
 - `str | shoutysnakecase -> String` – Converts a string to SHOUTY_SNAKE_CASE
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -33,7 +33,7 @@ mise-x64 use -g node@20
 ## Shebang
 
 You can specify a tool and its version in a shebang without needing to first
-setup `.tool-versions`/`mise.toml` config:
+set up a `mise.toml`/`.tool-versions` config:
 
 ```typescript
 #!/usr/bin/env -S mise x node@20 -- node


### PR DESCRIPTION
- remove wrong links in environment variables & tasks overview
- re-order `.tool-versions`/`mise.toml` to `mise.toml`/`.tool-versions`
- remove `shoutycamelcase` from `template` page as it's not implemented
- `.mise.toml` -> `mise.toml`