### PR TITLE
docs: example with required version

### DIFF
--- a/docs/dev-tools/backends/ubi.md
+++ b/docs/dev-tools/backends/ubi.md
@@ -43,7 +43,7 @@ use the `exe` option to specify the executable name:
 
 ```toml
 [tools]
-"ubi:cli/cli" = { exe = "gh" } # github's cli
+"ubi:cli/cli" = { version = "latest", exe = "gh" } # github's cli
 ```
 
 ### `matching`


### PR DESCRIPTION
Not supplying the version results in the following error:

    mise ERROR error parsing config file: ~/.config/mise/config.toml
    mise ERROR TOML parse error at line 5, column 17
      |
    5 | "ubi:cli/cli" = { exe = "gh" }
      |                 ^^^^^^^^^^^^^^
    missing version

    mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information