### PR TITLE
fix: trim run scripts whitespace

### DIFF
--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -269,7 +269,7 @@ impl TaskScriptParser {
         }
         let scripts = scripts
             .iter()
-            .map(|s| tera.render_str(s, &ctx).unwrap())
+            .map(|s| tera.render_str(s.trim(), &ctx).unwrap())
             .collect();
         let mut cmd = usage::SpecCommand::default();
         // TODO: ensure no gaps in args, e.g.: 1,2,3,4,5


### PR DESCRIPTION
Fixes #3444
