### PR TITLE
docs: document new windows installers

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -77,10 +77,12 @@ and `mise deactivate` to work without wrapping them in `eval "$(mise shell)"`.
 
 ## Windows support?
 
-Very basic support for windows is currently available, however because Windows can't support the asdf
-backend, windows can use core, aqua, or vfox backends though.
+While mise runs great in WSL, native Windows is also supported, though via the use of shims until
+someone adds [powershell](https://github.com/jdx/mise/issues/3451) support.
 
-As of this writing, env var management and task execution are not yet supported on Windows.
+As you'll need to use shims, this means you won't have environment variables from mise.toml unless you run mise via
+[`mise x`](/cli/exec) or [`mise run`](/cli/run)—though that's actually how I use mise on my mac so
+for me that's my preferred workflow anyway.
 
 ## How do I use mise with http proxies?
 

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -224,14 +224,36 @@ yum-config-manager --add-repo https://mise.jdx.dev/rpm/mise.repo
 yum install -y mise
 ```
 
-### Windows
+### Windows - scoop
+
+This is the recommended way to install mise on Windows. It will automatically add your shims to PATH.
+
+```sh
+scoop install mise
+```
+
+### Windows - chocolatey
+
+```sh
+choco install mise
+```
+
+### Windows - winget
+
+::: note
+winget is coming soon, follow <https://github.com/microsoft/winget-pkgs/pull/197444>
+:::
+
+```sh
+winget install mise
+```
+
+### Windows - manual
 
 Download the latest release from [GitHub](https://github.com/jdx/mise/releases) and add the binary
 to your PATH.
 
 If your shell does not support `mise activate`, you would want to edit PATH to include the shims directory (by default: `%LOCALAPPDATA%\mise\shims`).
-
-Note that Windows support is very minimal for now.
 
 ## Shells
 


### PR DESCRIPTION
jumping the gun a bit on scoop because the [PR](https://github.com/ScoopInstaller/Main/pull/6374) hasn't landed, but it looks like it should soon enough