### PR TITLE
docs: fixing elvish install instructions

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -334,14 +334,15 @@ make sure they match)
 Add following to your `rc.elv`:
 
 ```shell
-var mise: = (eval &ns=[&] &on-end=$put~ (mise activate elvish | slurp))
+var mise: = (ns [&])
+eval (mise activate elvish | slurp) &ns=$mise: &on-end={|ns| set mise: = $ns }
 mise:activate
 ```
 
 Optionally alias `mise` to `mise:mise` for seamless integration of `mise {activate,deactivate,shell}`:
 
 ```shell
-fn mise {|@args| mise:mise $@args }
+edit:add-var mise~ {|@args| mise:mise $@args }
 ```
 
 ### Something else?


### PR DESCRIPTION
Previous instructions were not working on the latest version of Elvish, giving the following error:

```
Exception: wrong type: need ns, got map
```

I changed it so the namespace is updated in the `eval` callback.

I also changed the alias to use `edit:add-var` since the `fn` syntax is contained to scope, so if the previous code was in, for example, an if statement, it would not export the `mise` alias.