### PR TITLE
fix: deprecate direnv integration

### DIFF
--- a/docs/.vitepress/cli_commands.ts
+++ b/docs/.vitepress/cli_commands.ts
@@ -80,7 +80,7 @@ export const commands: { [key: string]: Command } = {
     hide: false,
   },
   direnv: {
-    hide: false,
+    hide: true,
     subcommands: {
       envrc: {
         hide: true,
@@ -89,7 +89,7 @@ export const commands: { [key: string]: Command } = {
         hide: true,
       },
       activate: {
-        hide: false,
+        hide: true,
       },
     },
   },

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -63,8 +63,6 @@ Answer yes to all confirmation prompts
 - [`mise config ls [--no-header] [-J --json]`](/cli/config/ls.md)
 - [`mise config set [-f --file <FILE>] [-t --type <TYPE>] <KEY> <VALUE>`](/cli/config/set.md)
 - [`mise deactivate`](/cli/deactivate.md)
-- [`mise direnv <SUBCOMMAND>`](/cli/direnv.md)
-- [`mise direnv activate`](/cli/direnv/activate.md)
 - [`mise doctor`](/cli/doctor.md)
 - [`mise en [-s --shell <SHELL>] [DIR]`](/cli/en.md)
 - [`mise env [FLAGS] [TOOL@VERSION]...`](/cli/env.md)

--- a/docs/direnv.md
+++ b/docs/direnv.md
@@ -1,16 +1,18 @@
-# direnv
+# direnv <Badge type="warning" text="deprecated" />
 
 [direnv](https://direnv.net) and mise both manage environment variables based on directory. Because
 they both analyze
 the current environment variables before and after their respective "hook" commands are run, they
 can sometimes conflict with each other.
 
+::: warning
 The official stance is you should not use direnv with mise. Issues arising
 from incompatibilities are not considered bugs. If mise has feature gaps
 that direnv resolves, please open an issue so we can close those gaps.
 While that's the official stance, the reality is mise and direnv usually
 will work together just fine despite this. It's only more advanced use-cases
 where problems arise.
+:::
 
 If you have an issue, it's likely to do with the ordering of PATH. This means it would
 really only be a problem if you were trying to manage the same tool with direnv and mise. For
@@ -23,7 +25,7 @@ A more typical usage of direnv would be to set some arbitrary environment variab
 unrelated
 binaries to PATH. In these cases, mise will not interfere with direnv.
 
-## mise inside of direnv (`use mise` in `.envrc`) <Badge type="warning" text="deprecated" />
+## mise inside of direnv (`use mise` in `.envrc`)
 
 ::: warning
 `use mise` is deprecated and no longer supported. If `mise activate` does

--- a/docs/direnv.md
+++ b/docs/direnv.md
@@ -5,6 +5,13 @@ they both analyze
 the current environment variables before and after their respective "hook" commands are run, they
 can sometimes conflict with each other.
 
+The official stance is you should not use direnv with mise. Issues arising
+from incompatibilities are not considered bugs. If mise has feature gaps
+that direnv resolves, please open an issue so we can close those gaps.
+While that's the official stance, the reality is mise and direnv usually
+will work together just fine despite this. It's only more advanced use-cases
+where problems arise.
+
 If you have an issue, it's likely to do with the ordering of PATH. This means it would
 really only be a problem if you were trying to manage the same tool with direnv and mise. For
 example,
@@ -16,29 +23,11 @@ A more typical usage of direnv would be to set some arbitrary environment variab
 unrelated
 binaries to PATH. In these cases, mise will not interfere with direnv.
 
-## mise inside of direnv (`use mise` in `.envrc`)
+## mise inside of direnv (`use mise` in `.envrc`) <Badge type="warning" text="deprecated" />
 
 ::: warning
-Update 2024-01-21: after `use mise` has been out for a while, the general impression I have is that
-while it technically functions fine,
-not many people use it because the DX is notably worse than either switching to mise entirely
-or using `mise activate` alongside direnv.
-
-The project direction of mise has changed since this was written and the new direction is for it
-to be capable of replacing direnv completely for any use-case. This likely won't end up as a drop-in
-replacement for direnv like with asdf, but solving the same problems in different ways.
-See [environments](/environments.html)
-for more details.
-
-I have had virtually no reports of problems with `use mise` in the year it has been out.
-This could be because virtually no one is using it, or it has been surprisingly stable. I genuinely
-don't know which. If you try it or use it regularly let me know.
-
-While I have no immediate plans or reasons to do this now, I could see this functionality being
-the target of a future deprecation. Not because it's a maintenance burden, but because it just
-hasn't
-seemed like a particularly useful solution and it may help focus mise on the functionality that does
-work for users.
+`use mise` is deprecated and no longer supported. If `mise activate` does
+not fit your use-case please post an issue.
 :::
 
 If you do encounter issues with `mise activate`, or just want to use direnv in an alternate way,

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -74,9 +74,6 @@ Manage config files
 mise\-deactivate(1)
 Disable mise for current shell session
 .TP
-mise\-direnv(1)
-Output direnv function to use mise inside direnv
-.TP
 mise\-doctor(1)
 Check mise installation for possible problems
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -311,7 +311,7 @@ This can be used to temporarily disable mise in a shell session."
     $ mise deactivate
 "
 }
-cmd "direnv" help="Output direnv function to use mise inside direnv" {
+cmd "direnv" hide=true help="Output direnv function to use mise inside direnv" {
     long_help r"Output direnv function to use mise inside direnv
 
 See https://mise.jdx.dev/direnv.html for more information
@@ -321,7 +321,7 @@ you should run this command after installing new plugins. Otherwise
 direnv may not know to update environment variables when idiomatic file versions change."
     cmd "envrc" hide=true help="[internal] This is an internal command that writes an envrc file\nfor direnv to consume."
     cmd "exec" hide=true help="[internal] This is an internal command that writes an envrc file\nfor direnv to consume."
-    cmd "activate" help="Output direnv function to use mise inside direnv" {
+    cmd "activate" hide=true help="Output direnv function to use mise inside direnv" {
         long_help r"Output direnv function to use mise inside direnv
 
 See https://mise.jdx.dev/direnv.html for more information

--- a/src/cli/direnv/activate.rs
+++ b/src/cli/direnv/activate.rs
@@ -9,7 +9,7 @@ use indoc::indoc;
 /// you should run this command after installing new plugins. Otherwise
 /// direnv may not know to update environment variables when idiomatic file versions change.
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(hide=true, verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct DirenvActivate {}
 
 impl DirenvActivate {

--- a/src/cli/direnv/mod.rs
+++ b/src/cli/direnv/mod.rs
@@ -15,7 +15,7 @@ mod exec;
 /// you should run this command after installing new plugins. Otherwise
 /// direnv may not know to update environment variables when idiomatic file versions change.
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment)]
+#[clap(hide = true, verbatim_doc_comment)]
 pub struct Direnv {
     #[clap(subcommand)]
     command: Option<Commands>,

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -824,20 +824,6 @@ const completionSpec: Fig.Spec = {
         },
         {
             "name": [
-                "direnv"
-            ],
-            "description": "Output direnv function to use mise inside direnv",
-            "subcommands": [
-                {
-                    "name": [
-                        "activate"
-                    ],
-                    "description": "Output direnv function to use mise inside direnv"
-                }
-            ]
-        },
-        {
-            "name": [
                 "doctor",
                 "dr"
             ],


### PR DESCRIPTION
this is not a new decision, this simply documents what has been the actual state of the world for a long time.

If people are still using and liking `use mise` I wouldn't worry, it hasn't had any real changes in a very long time so likely will continue humming along as it does today. I'm probably willing to accept PRs for it too, so it's kind of a "soft" deprecation. I won't be maintaining it myself though so this makes that position clear.

And using direnv with mise together is something I'm going to be more explicit about not supporting. mise may have some lagging feature parity gaps with direnv but I don't think there are very many and certainly not many that are heavily used.