### PR TITLE
feat: `mise fmt` (renamed from `mise format`)

### DIFF
--- a/docs/cli/format.md
+++ b/docs/cli/format.md
@@ -1,7 +1,6 @@
 # `mise format`
 
 - **Usage**: `mise format [-a --all]`
-- **Aliases**: `fmt`
 - **Source code**: [`src/cli/format.rs`](https://github.com/jdx/mise/blob/main/src/cli/format.rs)
 
 Formats mise.toml

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -425,7 +425,6 @@ The "--" separates runtimes from the commands to pass along to the subprocess."#
     arg "[COMMAND]..." help="Command string to execute (same as --command)" var=true
 }
 cmd "format" help="Formats mise.toml" {
-    alias "fmt"
     after_long_help r"Examples:
 
     $ mise format

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -5,14 +5,14 @@ use taplo::formatter::Options;
 
 /// Formats mise.toml
 #[derive(Debug, clap::Args)]
-#[clap(visible_alias="fmt", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
-pub struct Format {
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+pub struct Fmt {
     /// Format all files from the current directory
     #[clap(short, long)]
     pub all: bool,
 }
 
-impl Format {
+impl Fmt {
     pub fn run(self) -> eyre::Result<()> {
         let cwd = dirs::CWD.clone().unwrap_or_default();
         let configs = if self.all {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,7 +24,7 @@ mod en;
 mod env;
 pub mod exec;
 mod external;
-mod format;
+mod fmt;
 mod generate;
 mod global;
 mod hook_env;
@@ -168,7 +168,7 @@ pub enum Commands {
     En(en::En),
     Env(env::Env),
     Exec(exec::Exec),
-    Format(format::Format),
+    Format(fmt::Fmt),
     Generate(generate::Generate),
     Global(global::Global),
     HookEnv(hook_env::HookEnv),

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -980,8 +980,7 @@ const completionSpec: Fig.Spec = {
         },
         {
             "name": [
-                "format",
-                "fmt"
+                "format"
             ],
             "description": "Formats mise.toml",
             "options": [


### PR DESCRIPTION
This will avoid conflicting with using `mise format` as shorthand for `mise run format`
