### PR TITLE
fix(swift): remove clang bins

### DIFF
--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -1,4 +1,4 @@
-# Rust
+# Rust <Badge type="warning" text="experimental" />
 
 Rust/cargo can be installed which uses rustup under the hood. mise will install rustup if it is not
 already installed and add the requested targets. By default, mise uses the default location of rustup/cargo

--- a/docs/lang/swift.md
+++ b/docs/lang/swift.md
@@ -1,4 +1,4 @@
-# Swift
+# Swift <Badge type="warning" text="experimental" />
 
 Swift is supported for macos and linux.
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -327,6 +327,18 @@ pub fn make_symlink(target: &Path, link: &Path) -> Result<(PathBuf, PathBuf)> {
     Ok((target.to_path_buf(), link.to_path_buf()))
 }
 
+#[cfg(unix)]
+pub fn make_symlink_or_copy(target: &Path, link: &Path) -> Result<()> {
+    make_symlink(target, link)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn make_symlink_or_copy(target: &Path, link: &Path) -> Result<()> {
+    copy(target, link)?;
+    Ok(())
+}
+
 #[cfg(windows)]
 pub fn make_symlink(target: &Path, link: &Path) -> Result<(PathBuf, PathBuf)> {
     if let Err(err) = junction::create(target, link) {

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -73,7 +73,11 @@ impl Backend for RustPlugin {
     }
 
     fn idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec!["rust-toolchain.toml".into()])
+        if SETTINGS.experimental {
+            Ok(vec!["rust-toolchain.toml".into()])
+        } else {
+            Ok(vec![])
+        }
     }
 
     fn parse_idiomatic_file(&self, path: &Path) -> Result<String> {


### PR DESCRIPTION
Also correctly marked rust+swift as experimental. This was the case before but should have been documented.
Fixes #3462
