### PR TITLE
fix: do not reuse local tool options for `mise use -g`

### DIFF
--- a/e2e/cli/test_use_retain_opts
+++ b/e2e/cli/test_use_retain_opts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+assert "mise use dummy[foo=bar]@1.0.0"
+assert "cat mise.toml" '[tools]
+dummy = { version = "1.0.0", foo = "bar" }'
+assert "mise use -g dummy@1.0.0"
+assert "cat ~/.config/mise/config.toml" '[tools]
+dummy = "1.0.0"'

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -101,7 +101,9 @@ pub struct Use {
 impl Use {
     pub fn run(self) -> Result<()> {
         let config = Config::try_get()?;
-        let mut ts = ToolsetBuilder::new().build(&config)?;
+        let mut ts = ToolsetBuilder::new()
+            .with_global_only(self.global)
+            .build(&config)?;
         let mpr = MultiProgressReport::get();
         let mut cf = self.get_config_file()?;
         let mut resolve_options = ResolveOptions {


### PR DESCRIPTION
Fixes #3442
