### PR TITLE
feat: add the users PATH to `mise doctor`

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -51,6 +51,7 @@ impl Doctor {
         self.analyze_plugins();
 
         info::section("env_vars", mise_env_vars())?;
+        info::section("path", paths())?;
         self.analyze_settings()?;
 
         if let Some(latest) = version::check_for_new_version(duration::HOURLY) {
@@ -244,6 +245,16 @@ fn mise_env_vars() -> String {
         return "(none)".to_string();
     }
     vars.iter().map(|(k, v)| format!("{k}={v}")).join("\n")
+}
+
+fn paths() -> String {
+    if env::PATH_NON_PRISTINE.is_empty() {
+        return "(empty)".to_string();
+    }
+    return env::PATH_NON_PRISTINE
+        .iter()
+        .map(display_path)
+        .join("\n")
 }
 
 fn render_config_files(config: &Config) -> String {

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -251,10 +251,7 @@ fn paths() -> String {
     if env::PATH_NON_PRISTINE.is_empty() {
         return "(empty)".to_string();
     }
-    return env::PATH_NON_PRISTINE
-        .iter()
-        .map(display_path)
-        .join("\n")
+    env::PATH_NON_PRISTINE.iter().map(display_path).join("\n")
 }
 
 fn render_config_files(config: &Config) -> String {


### PR DESCRIPTION
(don't judge me for my double `~/.local/bin` I have reasons)

### New mise doctor output

```console
❯ mise doctor
version: 2024.12.6-DEBUG macos-arm64 (edc962e 2024-12-11)
activated: yes
shims_on_path: no

build_info:
  Target: aarch64-apple-darwin
  Features: CLAP_MANGEN, DEFAULT, NATIVE_TLS, OPENSSL, RUSTLS, RUSTLS_NATIVE_ROOTS
  Built: Wed, 11 Dec 2024 16:29:39 +0000
  Rust Version: rustc 1.83.0 (90b35a623 2024-11-26)
  Profile: debug

shell:
  /opt/homebrew/bin/fish
  fish, version 3.7.1

dirs:
  cache: ~/Library/Caches/mise
  config: ~/.config/mise
  data: ~/.local/share/mise
  shims: ~/.local/share/mise/shims
  state: ~/.local/state/mise

config_files:
  ~/.config/mise/config.toml

backends:
  aqua
  asdf
  cargo
  core
  gem
  go
  npm
  pipx
  spm
  ubi
  vfox

plugins:
  asdf-antiarchitect-asdf-helm              https://github.com/Antiarchitect/asdf-helm.git#085651c
  asdf-https-github-com-virtualstaticvoid-asdf-sonarscanner-git  https://github.com/virtualstaticvoid/asdf-sonarscanner.git#c42dd95
  asdf-https-gitlab-com-wt0f-asdf-kubectx   https://gitlab.com/wt0f/asdf-kubectx#8c0b4aa
  asdfnode                                  https://github.com/asdf-vm/asdf-nodejs.git#93bd217
  awscli                                    https://github.com/MetricMike/asdf-awscli.git#c26bbb4
  flutter                                   https://github.com/oae/asdf-flutter.git#d736066
  helm-diff                                 https://github.com/dex4er/asdf-helm-diff.git#47bb84b
  pdm                                       https://github.com/1oglop1/asdf-pdm.git#0223762
  sonar-scanner                             https://github.com/virtualstaticvoid/asdf-sonarscanner.git#c42dd95
  yarn                                      https://github.com/mise-plugins/asdf-yarn.git#74ea3b9

toolset:
  aqua:astral-sh/uv@0.5.5
  core:bun@1.1.38
  core:deno@2.1.2
  core:go@1.23.3
  core:node@23.3.0
  core:rust@1.83.0
  spm:danger/swift@3.20.2
  ubi:aquaproj/aqua@2.38.1
  ubi:jdx/usage@1.4.0
  ubi:pkgxdev/pkgx@1.3.1

path:
  ~/.local/share/mise/installs/node/23.3.0/bin
  ~/.local/share/mise/installs/deno/2.1.2/bin
  ~/.local/share/mise/installs/deno/2.1.2/.deno/bin
  ~/.local/share/mise/installs/bun/1.1.38/bin
  ~/.local/share/mise/installs/uv/0.5.5/uv-aarch64-apple-darwin
  ~/.local/share/mise/installs/go/1.23.3/bin
  ~/.local/share/mise/installs/usage/1.4.0/bin
  ~/.local/share/mise/installs/ubi-aquaproj-aqua/2.38.1/bin
  ~/.local/share/mise/installs/ubi-pkgxdev-pkgx/1.3.1/bin
  ~/.local/share/mise/installs/danger-swift/3.20.2/bin
  ~/.local/share/cargo/bin
  /opt/homebrew/bin
  /opt/homebrew/sbin
  ~/.local/bin
  ~/.local/bin
  /usr/local/bin
  /System/Cryptexes/App/usr/bin
  /usr/bin
  /bin
  /usr/sbin
  /sbin
  /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin
  /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin
  /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin

env_vars:
  MISE_RUSTUP_HOME=~/.local/share/rustup
  MISE_CARGO_HOME=~/.local/share/cargo

settings:
  experimental  true ~/.config/mise/config.toml
  npm.bun       true ~/.config/mise/config.toml
  pipx.uvx      true ~/.config/mise/config.toml

No problems found

```

### Playing with PATH
Fish no path (note single . at the end)
```console
❯ PATH= mise doctor
...
path:
  ~/.local/share/mise/installs/node/23.3.0/bin
  ~/.local/share/mise/installs/deno/2.1.2/bin
  ~/.local/share/mise/installs/deno/2.1.2/.deno/bin
  ~/.local/share/mise/installs/bun/1.1.38/bin
  ~/.local/share/mise/installs/uv/0.5.5/uv-aarch64-apple-darwin
  ~/.local/share/mise/installs/go/1.23.3/bin
  ~/.local/share/mise/installs/usage/1.4.0/bin
  ~/.local/share/mise/installs/ubi-aquaproj-aqua/2.38.1/bin
  ~/.local/share/mise/installs/ubi-pkgxdev-pkgx/1.3.1/bin
  ~/.local/share/mise/installs/danger-swift/3.20.2/bin
  ~/.local/share/cargo/bin
  .

1 problem found:
...
```
zsh no path
```console
❯ PATH= mise doctor
...
path:
  ~/.local/share/mise/installs/node/23.3.0/bin
  ~/.local/share/mise/installs/deno/2.1.2/bin
  ~/.local/share/mise/installs/deno/2.1.2/.deno/bin
  ~/.local/share/mise/installs/bun/1.1.38/bin
  ~/.local/share/mise/installs/uv/0.5.5/uv-aarch64-apple-darwin
  ~/.local/share/mise/installs/go/1.23.3/bin
  ~/.local/share/mise/installs/usage/1.4.0/bin
  ~/.local/share/mise/installs/ubi-aquaproj-aqua/2.38.1/bin
  ~/.local/share/mise/installs/ubi-pkgxdev-pkgx/1.3.1/bin
  ~/.local/share/mise/installs/danger-swift/3.20.2/bin
  ~/.local/share/cargo/bin

1 problem found:
...
```
bash no path
```console
❯ PATH= mise doctor
...
path:
  ~/.local/share/mise/installs/node/23.3.0/bin
  ~/.local/share/mise/installs/deno/2.1.2/bin
  ~/.local/share/mise/installs/deno/2.1.2/.deno/bin
  ~/.local/share/mise/installs/bun/1.1.38/bin
  ~/.local/share/mise/installs/uv/0.5.5/uv-aarch64-apple-darwin
  ~/.local/share/mise/installs/go/1.23.3/bin
  ~/.local/share/mise/installs/usage/1.4.0/bin
  ~/.local/share/mise/installs/ubi-aquaproj-aqua/2.38.1/bin
  ~/.local/share/mise/installs/ubi-pkgxdev-pkgx/1.3.1/bin
  ~/.local/share/mise/installs/danger-swift/3.20.2/bin
  ~/.local/share/cargo/bin

1 problem found:
...
```
fish 2 fake paths
```console
❯ PATH=foo:bar mise doctor
...
path:
  ~/.local/share/mise/installs/node/23.3.0/bin
  ~/.local/share/mise/installs/deno/2.1.2/bin
  ~/.local/share/mise/installs/deno/2.1.2/.deno/bin
  ~/.local/share/mise/installs/bun/1.1.38/bin
  ~/.local/share/mise/installs/uv/0.5.5/uv-aarch64-apple-darwin
  ~/.local/share/mise/installs/go/1.23.3/bin
  ~/.local/share/mise/installs/usage/1.4.0/bin
  ~/.local/share/mise/installs/ubi-aquaproj-aqua/2.38.1/bin
  ~/.local/share/mise/installs/ubi-pkgxdev-pkgx/1.3.1/bin
  ~/.local/share/mise/installs/danger-swift/3.20.2/bin
  ~/.local/share/cargo/bin
  foo
  bar

2 problems found:
... 
```
