### PR TITLE
fix: improve arg parsing for mise watch

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -2,6 +2,7 @@
 /target/
 CHANGELOG.md
 docs/node_modules/
+docs/cli/watch.md
 node_modules/
 test/
 /tasks.md

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -115,6 +115,6 @@ Answer yes to all confirmation prompts
 - [`mise upgrade [FLAGS] [TOOL@VERSION]...`](/cli/upgrade.md)
 - [`mise use [FLAGS] [TOOL@VERSION]...`](/cli/use.md)
 - [`mise version`](/cli/version.md)
-- [`mise watch [-t --task... <TASK>] [-g --glob... <GLOB>] [ARGS]...`](/cli/watch.md)
+- [`mise watch [FLAGS] [TASK] [ARGS]...`](/cli/watch.md)
 - [`mise where <TOOL@VERSION>`](/cli/where.md)
 - [`mise which [FLAGS] <BIN_NAME>`](/cli/which.md)

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -1,6 +1,6 @@
 # `mise watch`
 
-- **Usage**: `mise watch [-t --task... <TASK>] [-g --glob... <GLOB>] [ARGS]...`
+- **Usage**: `mise watch [FLAGS] [TASK] [ARGS]...`
 - **Aliases**: `w`
 - **Source code**: [`src/cli/watch.rs`](https://github.com/jdx/mise/blob/main/src/cli/watch.rs)
 
@@ -11,20 +11,594 @@ It must be installed for this command to work, but you can install it with `mise
 
 ## Arguments
 
+### `[TASK]`
+
+Tasks to run
+Can specify multiple tasks by separating with `:::`
+e.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2
+
 ### `[ARGS]...`
 
-Extra arguments
+Task and arguments to run
 
 ## Flags
 
-### `-t --task... <TASK>`
+### `-w --watch... <PATH>`
 
-Tasks to run
+Watch a specific file or directory
 
-### `-g --glob... <GLOB>`
+By default, Watchexec watches the current directory.
 
-Files to watch
-Defaults to sources from the tasks(s)
+When watching a single file, it's often better to watch the containing directory instead, and filter on the filename. Some editors may replace the file with a new one when saving, and some platforms may not detect that or further changes.
+
+Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help for '--project-origin' for more information.
+
+This option can be specified multiple times to watch multiple files or directories.
+
+The special value '/dev/null', provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used.
+
+### `-W --watch-non-recursive... <PATH>`
+
+Watch a specific directory, non-recursively
+
+Unlike '-w', folders watched with this option are not recursed into.
+
+This option can be specified multiple times to watch multiple directories non-recursively.
+
+### `-F --watch-file <PATH>`
+
+Watch files and directories from a file
+
+Each line in the file will be interpreted as if given to '-w'.
+
+For more complex uses (like watching non-recursively), use the argfile capability: build a file containing command-line options and pass it to watchexec with `@path/to/argfile`.
+
+The special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.
+
+### `-c --clear <MODE>`
+
+Clear screen before running command
+
+If this doesn't completely clear the screen, try '--clear=reset'.
+
+**Choices:**
+
+- `clear`
+- `reset`
+
+### `-o --on-busy-update <MODE>`
+
+What to do when receiving events while the command is running
+
+Default is to 'do-nothing', which ignores events while the command is running, so that changes that occur due to the command are ignored, like compilation outputs. You can also use 'queue' which will run the command once again when the current run has finished if any events occur while it's running, or 'restart', which terminates the running command and starts a new one. Finally, there's 'signal', which only sends a signal; this can be useful with programs that can reload their configuration without a full restart.
+
+The signal can be specified with the '--signal' option.
+
+**Choices:**
+
+- `queue`
+- `do-nothing`
+- `restart`
+- `signal`
+
+### `-r --restart`
+
+Restart the process if it's still running
+
+This is a shorthand for '--on-busy-update=restart'.
+
+### `-s --signal <SIGNAL>`
+
+Send a signal to the process when it's still running
+
+Specify a signal to send to the process when it's still running. This implies '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is controlled by '--stop-signal'.
+
+See the long documentation for '--stop-signal' for syntax.
+
+Signals are not supported on Windows at the moment, and will always be overridden to 'kill'. See '--stop-signal' for more on Windows "signals".
+
+### `--stop-signal <SIGNAL>`
+
+Signal to send to stop the command
+
+This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
+
+The default on unix is "SIGTERM".
+
+Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"), or a signal number (like "15"). All input is case-insensitive.
+
+On Windows this option is technically supported but only supports the "KILL" event, as Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE" events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are respectively mapped to these.
+
+### `--stop-timeout <TIMEOUT>`
+
+Time to wait for the command to exit gracefully
+
+This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time, it is forcefully terminated.
+
+Takes a unit-less value in seconds, or a time span value such as "5min 20s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+
+The default is 10 seconds. Set to 0 to immediately force-kill the command.
+
+This has no practical effect on Windows as the command is always forcefully terminated; see '--stop-signal' for why.
+
+### `--map-signal... <SIGNAL:SIGNAL>`
+
+Translate signals from the OS to signals to send to the command
+
+Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to SIGINT. The first signal is the one received by watchexec, and the second is the one sent to the command. The second can be omitted to discard the first signal, such as "TERM:" to not do anything on SIGTERM.
+
+If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
+
+This option can be specified multiple times to map multiple signals.
+
+Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like "SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot yet deliver other "signals" than a STOP.
+
+### `-d --debounce <TIMEOUT>`
+
+Time to wait for new events before taking action
+
+When an event is received, Watchexec will wait for up to this amount of time before handling it (such as running the command). This is essential as what you might perceive as a single change may actually emit many events, and without this behaviour, Watchexec would run much too often. Additionally, it's not infrequent that file writes are not atomic, and each write may emit an event, so this is a good way to avoid running a command while a file is partially written.
+
+An alternative use is to set a high value (like "30min" or longer), to save power or bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that every accumulated event will build up in memory.
+
+Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+
+The default is 50 milliseconds. Setting to 0 is highly discouraged.
+
+### `--stdin-quit`
+
+Exit when stdin closes
+
+This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is closed. This is used by some process managers to avoid leaving zombie processes around.
+
+### `--no-vcs-ignore`
+
+Don't load gitignores
+
+Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note that Watchexec will detect which of these is in use, if any, and only load the relevant files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
+
+This option is useful if you want to watch files that are ignored by Git.
+
+### `--no-project-ignore`
+
+Don't load project-local ignores
+
+This disables loading of project-local ignore files, like '.gitignore' or '.ignore' in the
+watched project. This is contrasted with '--no-vcs-ignore', which disables loading of Git
+and other VCS ignore files, and with '--no-global-ignore', which disables loading of global
+or user ignore files, like '~/.gitignore' or '~/.config/watchexec/ignore'.
+
+Supported project ignore files:
+
+  - Git: .gitignore at project root and child directories, .git/info/exclude, and the file pointed to by `core.excludesFile` in .git/config.
+  - Mercurial: .hgignore at project root and child directories.
+  - Bazaar: .bzrignore at project root.
+  - Darcs: _darcs/prefs/boring
+  - Fossil: .fossil-settings/ignore-glob
+  - Ripgrep/Watchexec/generic: .ignore at project root and child directories.
+
+VCS ignore files (Git, Mercurial, Bazaar, Darcs, Fossil) are only used if the corresponding
+VCS is discovered to be in use for the project/origin. For example, a .bzrignore in a Git
+repository will be discarded.
+
+### `--no-global-ignore`
+
+Don't load global ignores
+
+This disables loading of global or user ignore files, like '~/.gitignore',
+'~/.config/watchexec/ignore', or '%APPDATA%\Bazzar\2.0\ignore'. Contrast with
+'--no-vcs-ignore' and '--no-project-ignore'.
+
+Supported global ignore files
+
+  - Git (if core.excludesFile is set): the file at that path
+  - Git (otherwise): the first found of $XDG_CONFIG_HOME/git/ignore, %APPDATA%/.gitignore, %USERPROFILE%/.gitignore, $HOME/.config/git/ignore, $HOME/.gitignore.
+  - Bazaar: the first found of %APPDATA%/Bazzar/2.0/ignore, $HOME/.bazaar/ignore.
+  - Watchexec: the first found of $XDG_CONFIG_HOME/watchexec/ignore, %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore, $HOME/.watchexec/ignore.
+
+Like for project files, Git and Bazaar global files will only be used for the corresponding
+VCS as used in the project.
+
+### `--no-default-ignore`
+
+Don't use internal default ignores
+
+Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`, `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and Watchexec log files.
+
+### `--no-discover-ignore`
+
+Don't discover ignore files at all
+
+This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but even more efficient as it will skip all the ignore discovery mechanisms from the get go.
+
+Note that default ignores are still loaded, see '--no-default-ignore'.
+
+### `--ignore-nothing`
+
+Don't ignore anything at all
+
+This is a shorthand for '--no-discover-ignore', '--no-default-ignore'.
+
+Note that ignores explicitly loaded via other command line options, such as '--ignore' or '--ignore-file', will still be used.
+
+### `-p --postpone`
+
+Wait until first change before running command
+
+By default, Watchexec will run the command once immediately. With this option, it will instead wait until an event is detected before running the command as normal.
+
+### `--delay-run <DURATION>`
+
+Sleep before running the command
+
+This option will cause Watchexec to sleep for the specified amount of time before running the command, after an event is detected. This is like using "sleep 5 && command" in a shell, but portable and slightly more efficient.
+
+Takes a unit-less value in seconds, or a time span value such as "2min 5s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+
+### `--poll <INTERVAL>`
+
+Poll for filesystem changes
+
+By default, and where available, Watchexec uses the operating system's native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases.
+
+Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms", to use as the polling interval. If not specified, the default is 30 seconds. Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+
+Aliased as '--force-poll'.
+
+### `--shell <SHELL>`
+
+Use a different shell
+
+By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes, and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec detects is the running shell.
+
+With this option, you can override that and use a different shell, for example one with more features or one which has your custom aliases and functions.
+
+If the value has spaces, it is parsed as a command line, and the first word used as the shell program, with the rest as arguments to the shell.
+
+The command is run with the '-c' flag (except for 'cmd' on Windows, where it's '/C').
+
+The special value 'none' can be used to disable shell use entirely. In that case, the command provided to Watchexec will be parsed, with the first word being the executable and the rest being the arguments, and executed directly. Note that this parsing is rudimentary, and may not work as expected in all cases.
+
+Using 'none' is a little more efficient and can enable a stricter interpretation of the input, but it also means that you can't use shell features like globbing, redirection, control flow, logic, or pipes.
+
+Examples:
+
+Use without shell:
+
+$ watchexec -n -- zsh -x -o shwordsplit scr
+
+Use with powershell core:
+
+$ watchexec --shell=pwsh -- Test-Connection localhost
+
+Use with CMD.exe:
+
+$ watchexec --shell=cmd -- dir
+
+Use with a different unix shell:
+
+$ watchexec --shell=bash -- 'echo $BASH_VERSION'
+
+Use with a unix shell and options:
+
+$ watchexec --shell='zsh -x -o shwordsplit' -- scr
+
+### `-n`
+
+Shorthand for '--shell=none'
+
+### `--emit-events-to <MODE>`
+
+Configure event emission
+
+Watchexec can emit event information when running a command, which can be used by the child
+process to target specific changed files.
+
+One thing to take care with is assuming inherent behaviour where there is only chance.
+Notably, it could appear as if the `RENAMED` variable contains both the original and the new
+path being renamed. In previous versions, it would even appear on some platforms as if the
+original always came before the new. However, none of this was true. It's impossible to
+reliably and portably know which changed path is the old or new, "half" renames may appear
+(only the original, only the new), "unknown" renames may appear (change was a rename, but
+whether it was the old or new isn't known), rename events might split across two debouncing
+boundaries, and so on.
+
+This option controls where that information is emitted. It defaults to 'none', which doesn't
+emit event information at all. The other options are 'environment' (deprecated), 'stdio',
+'file', 'json-stdio', and 'json-file'.
+
+The 'stdio' and 'file' modes are text-based: 'stdio' writes absolute paths to the stdin of
+the command, one per line, each prefixed with `create:`, `remove:`, `rename:`, `modify:`,
+or `other:`, then closes the handle; 'file' writes the same thing to a temporary file, and
+its path is given with the $WATCHEXEC_EVENTS_FILE environment variable.
+
+There are also two JSON modes, which are based on JSON objects and can represent the full
+set of events Watchexec handles. Here's an example of a folder being created on Linux:
+
+```json
+  {
+    "tags": [
+      {
+        "kind": "path",
+        "absolute": "/home/user/your/new-folder",
+        "filetype": "dir"
+      },
+      {
+        "kind": "fs",
+        "simple": "create",
+        "full": "Create(Folder)"
+      },
+      {
+        "kind": "source",
+        "source": "filesystem",
+      }
+    ],
+    "metadata": {
+      "notify-backend": "inotify"
+    }
+  }
+```
+
+The fields are as follows:
+
+  - `tags`, structured event data.
+  - `tags[].kind`, which can be:
+    * 'path', along with:
+      + `absolute`, an absolute path.
+      + `filetype`, a file type if known ('dir', 'file', 'symlink', 'other').
+    * 'fs':
+      + `simple`, the "simple" event type ('access', 'create', 'modify', 'remove', or 'other').
+      + `full`, the "full" event type, which is too complex to fully describe here, but looks like 'General(Precise(Specific))'.
+    * 'source', along with:
+      + `source`, the source of the event ('filesystem', 'keyboard', 'mouse', 'os', 'time', 'internal').
+    * 'keyboard', along with:
+      + `keycode`. Currently only the value 'eof' is supported.
+    * 'process', for events caused by processes:
+      + `pid`, the process ID.
+    * 'signal', for signals sent to Watchexec:
+      + `signal`, the normalised signal name ('hangup', 'interrupt', 'quit', 'terminate', 'user1', 'user2').
+    * 'completion', for when a command ends:
+      + `disposition`, the exit disposition ('success', 'error', 'signal', 'stop', 'exception', 'continued').
+      + `code`, the exit, signal, stop, or exception code.
+  - `metadata`, additional information about the event.
+
+The 'json-stdio' mode will emit JSON events to the standard input of the command, one per
+line, then close stdin. The 'json-file' mode will create a temporary file, write the
+events to it, and provide the path to the file with the $WATCHEXEC_EVENTS_FILE
+environment variable.
+
+Finally, the 'environment' mode was the default until 2.0. It sets environment variables
+with the paths of the affected files, for filesystem events:
+
+$WATCHEXEC_COMMON_PATH is set to the longest common path of all of the below variables,
+and so should be prepended to each path to obtain the full/real path. Then:
+
+  - $WATCHEXEC_CREATED_PATH is set when files/folders were created
+  - $WATCHEXEC_REMOVED_PATH is set when files/folders were removed
+  - $WATCHEXEC_RENAMED_PATH is set when files/folders were renamed
+  - $WATCHEXEC_WRITTEN_PATH is set when files/folders were modified
+  - $WATCHEXEC_META_CHANGED_PATH is set when files/folders' metadata were modified
+  - $WATCHEXEC_OTHERWISE_CHANGED_PATH is set for every other kind of pathed event
+
+Multiple paths are separated by the system path separator, ';' on Windows and ':' on unix.
+Within each variable, paths are deduplicated and sorted in binary order (i.e. neither
+Unicode nor locale aware).
+
+This is the legacy mode, is deprecated, and will be removed in the future. The environment
+is a very restricted space, while also limited in what it can usefully represent. Large
+numbers of files will either cause the environment to be truncated, or may error or crash
+the process entirely. The $WATCHEXEC_COMMON_PATH is also unintuitive, as demonstrated by the
+multiple confused queries that have landed in my inbox over the years.
+
+**Choices:**
+
+- `environment`
+- `stdio`
+- `file`
+- `json-stdio`
+- `json-file`
+- `none`
+
+### `--only-emit-events`
+
+Only emit events to stdout, run no commands.
+
+This is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.
+
+This option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command.
+
+### `-E --env... <KEY=VALUE>`
+
+Add env vars to the command
+
+This is a convenience option for setting environment variables for the command, without setting them for the Watchexec process itself.
+
+Use key=value syntax. Multiple variables can be set by repeating the option.
+
+### `--wrap-process <MODE>`
+
+Configure how the process is wrapped
+
+By default, Watchexec will run the command in a process group in Unix, and in a Job Object in Windows.
+
+Some Unix programs prefer running in a session, while others do not work in a process group.
+
+Use 'group' to use a process group, 'session' to use a process session, and 'none' to run the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
+
+**Choices:**
+
+- `group`
+- `session`
+- `none`
+
+### `-N --notify`
+
+Alert when commands start and end
+
+With this, Watchexec will emit a desktop notification when a command starts and ends, on supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
+
+### `--color <MODE>`
+
+When to use terminal colours
+
+Setting the environment variable `NO_COLOR` to any value is equivalent to `--color=never`.
+
+**Choices:**
+
+- `auto`
+- `always`
+- `never`
+
+### `--timings`
+
+Print how long the command took to run
+
+This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
+
+### `-q --quiet`
+
+Don't print starting and stopping messages
+
+By default Watchexec will print a message when the command starts and stops. This option disables this behaviour, so only the command's output, warnings, and errors will be printed.
+
+### `--bell`
+
+Ring the terminal bell on command completion
+
+### `--project-origin <DIRECTORY>`
+
+Set the project origin
+
+Watchexec will attempt to discover the project's "origin" (or "root") by searching for a variety of markers, like files or directory patterns. It does its best but sometimes gets it it wrong, and you can override that with this option.
+
+The project origin is used to determine the path of certain ignore files, which VCS is being used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
+
+When set, Watchexec will also not bother searching, which can be significantly faster.
+
+### `--workdir <DIRECTORY>`
+
+Set the working directory
+
+By default, the working directory of the command is the working directory of Watchexec. You can change that with this option. Note that paths may be less intuitive to use with this.
+
+### `-e --exts... <EXTENSIONS>`
+
+Filename extensions to filter to
+
+This is a quick filter to only emit events for files with the given extensions. Extensions can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can be given by repeating the option or by separating them with commas.
+
+### `-f --filter... <PATTERN>`
+
+Filename patterns to filter to
+
+Provide a glob-like filter pattern, and only events for files matching the pattern will be emitted. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
+
+### `--filter-file... <PATH>`
+
+Files to load filters from
+
+Provide a path to a file containing filters, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--filter' option.
+
+This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
+
+### `-J --filter-prog... <EXPRESSION>`
+
+[experimental] Filter programs.
+
+/!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
+
+Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
+
+In addition to the jaq stdlib, watchexec adds some custom filter definitions:
+
+- 'path | file_meta' returns file metadata or null if the file does not exist.
+
+- 'path | file_size' returns the size of the file at path, or null if it does not exist.
+
+- 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.
+
+- 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.
+
+- 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.
+
+- 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
+
+All filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.
+
+If the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.
+
+Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!
+
+Find user-contributed programs or submit your own useful ones at &lt;https://github.com/watchexec/watchexec/discussions/592>.
+
+## Examples:
+
+Regexp ignore filter on paths:
+
+'all(.tags[] | select(.kind == "path"); .absolute | test("[.]test[.]js$")) | not'
+
+Pass any event that creates a file:
+
+'any(.tags[] | select(.kind == "fs"); .simple == "create")'
+
+Pass events that touch executable files:
+
+'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+
+Ignore files that start with shebangs:
+
+'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
+
+### `-i --ignore... <PATTERN>`
+
+Filename patterns to filter out
+
+Provide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
+
+### `--ignore-file... <PATH>`
+
+Files to load ignores from
+
+Provide a path to a file containing ignores, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--ignore' option.
+
+This can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.
+
+### `--fs-events... <EVENTS>`
+
+Filesystem events to filter to
+
+This is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.
+
+This may apply filtering at the kernel level when possible, which can be more efficient, but may be more confusing when reading the logs.
+
+**Choices:**
+
+- `access`
+- `create`
+- `remove`
+- `rename`
+- `modify`
+- `metadata`
+
+### `--no-meta`
+
+Don't emit fs events for metadata changes
+
+This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the '--fs-events' option is non-sensical and not allowed.
+
+### `--print-events`
+
+Print events that trigger actions
+
+This prints the events that triggered the action when handling it (after debouncing), in a human readable form. This is useful for debugging filters.
+
+Use '-vvv' instead when you need more diagnostic information.
+
+### `--manual`
+
+Show the manual page
+
+This shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file).
 
 Examples:
 
@@ -36,5 +610,8 @@ Examples:
     Runs the "build" tasks but specify the files to watch with a glob pattern.
     This overrides the "sources" from the tasks definition.
 
-    $ mise run -t build --clear
+    $ mise watch -t build --clear
     Extra arguments are passed to watchexec. See `watchexec --help` for details.
+
+    $ mise watch -t serve --watch src --exts rs --restart
+    Starts an api server, watching for changes to "*.rs" files in "./src" and kills/restarts the server when they change.

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -15,7 +15,7 @@ usage "Usage: mise [OPTIONS] [TASK] [COMMAND]"
 flag "-C --cd" help="Change directory before running command" global=true {
     arg "<DIR>"
 }
-flag "-n --dry-run" help="Dry run, don't actually do anything" hide=true global=true
+flag "-n --dry-run" help="Dry run, don't actually do anything" hide=true
 flag "--debug" help="Sets log level to debug" hide=true global=true
 flag "-E --env" help="Set the environment for loading `mise.<ENV>.toml`" var=true global=true {
     arg "<ENV>"
@@ -1622,16 +1622,186 @@ It must be installed for this command to work, but you can install it with `mise
     Runs the "build" tasks but specify the files to watch with a glob pattern.
     This overrides the "sources" from the tasks definition.
 
-    $ mise run -t build --clear
+    $ mise watch -t build --clear
     Extra arguments are passed to watchexec. See `watchexec --help` for details.
+
+    $ mise watch -t serve --watch src --exts rs --restart
+    Starts an api server, watching for changes to "*.rs" files in "./src" and kills/restarts the server when they change.
 "#
-    flag "-t --task" help="Tasks to run" var=true {
-        arg "<TASK>"
+    flag "-t --task-flag" help="Tasks to run" var=true hide=true {
+        arg "<TASK_FLAG>"
     }
-    flag "-g --glob" help="Files to watch\nDefaults to sources from the tasks(s)" var=true {
+    flag "-g --glob" help="Files to watch\nDefaults to sources from the tasks(s)" var=true hide=true {
         arg "<GLOB>"
     }
-    arg "[ARGS]..." help="Extra arguments" var=true
+    flag "-w --watch" help="Watch a specific file or directory" var=true {
+        long_help "Watch a specific file or directory\n\nBy default, Watchexec watches the current directory.\n\nWhen watching a single file, it's often better to watch the containing directory instead, and filter on the filename. Some editors may replace the file with a new one when saving, and some platforms may not detect that or further changes.\n\nUpon starting, Watchexec resolves a \"project origin\" from the watched paths. See the help for '--project-origin' for more information.\n\nThis option can be specified multiple times to watch multiple files or directories.\n\nThe special value '/dev/null', provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used."
+        arg "<PATH>"
+    }
+    flag "-W --watch-non-recursive" help="Watch a specific directory, non-recursively" var=true {
+        long_help "Watch a specific directory, non-recursively\n\nUnlike '-w', folders watched with this option are not recursed into.\n\nThis option can be specified multiple times to watch multiple directories non-recursively."
+        arg "<PATH>"
+    }
+    flag "-F --watch-file" help="Watch files and directories from a file" {
+        long_help "Watch files and directories from a file\n\nEach line in the file will be interpreted as if given to '-w'.\n\nFor more complex uses (like watching non-recursively), use the argfile capability: build a file containing command-line options and pass it to watchexec with `@path/to/argfile`.\n\nThe special value '-' will read from STDIN; this in incompatible with '--stdin-quit'."
+        arg "<PATH>"
+    }
+    flag "-c --clear" help="Clear screen before running command" {
+        long_help "Clear screen before running command\n\nIf this doesn't completely clear the screen, try '--clear=reset'."
+        arg "<MODE>" {
+            choices "clear" "reset"
+        }
+    }
+    flag "-o --on-busy-update" help="What to do when receiving events while the command is running" {
+        long_help "What to do when receiving events while the command is running\n\nDefault is to 'do-nothing', which ignores events while the command is running, so that changes that occur due to the command are ignored, like compilation outputs. You can also use 'queue' which will run the command once again when the current run has finished if any events occur while it's running, or 'restart', which terminates the running command and starts a new one. Finally, there's 'signal', which only sends a signal; this can be useful with programs that can reload their configuration without a full restart.\n\nThe signal can be specified with the '--signal' option."
+        arg "<MODE>" {
+            choices "queue" "do-nothing" "restart" "signal"
+        }
+    }
+    flag "-r --restart" help="Restart the process if it's still running" {
+        long_help "Restart the process if it's still running\n\nThis is a shorthand for '--on-busy-update=restart'."
+    }
+    flag "-s --signal" help="Send a signal to the process when it's still running" {
+        long_help "Send a signal to the process when it's still running\n\nSpecify a signal to send to the process when it's still running. This implies '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is controlled by '--stop-signal'.\n\nSee the long documentation for '--stop-signal' for syntax.\n\nSignals are not supported on Windows at the moment, and will always be overridden to 'kill'. See '--stop-signal' for more on Windows \"signals\"."
+        arg "<SIGNAL>"
+    }
+    flag "--stop-signal" help="Signal to send to stop the command" {
+        long_help "Signal to send to stop the command\n\nThis is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.\n\nThe default on unix is \"SIGTERM\".\n\nInput is parsed as a full signal name (like \"SIGTERM\"), a short signal name (like \"TERM\"), or a signal number (like \"15\"). All input is case-insensitive.\n\nOn Windows this option is technically supported but only supports the \"KILL\" event, as Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it has termination (here called \"KILL\" or \"STOP\") and \"CTRL+C\", \"CTRL+BREAK\", and \"CTRL+CLOSE\" events. For portability the unix signals \"SIGKILL\", \"SIGINT\", \"SIGTERM\", and \"SIGHUP\" are respectively mapped to these."
+        arg "<SIGNAL>"
+    }
+    flag "--stop-timeout" help="Time to wait for the command to exit gracefully" {
+        long_help "Time to wait for the command to exit gracefully\n\nThis is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time, it is forcefully terminated.\n\nTakes a unit-less value in seconds, or a time span value such as \"5min 20s\". Providing a unit-less value is deprecated and will warn; it will be an error in the future.\n\nThe default is 10 seconds. Set to 0 to immediately force-kill the command.\n\nThis has no practical effect on Windows as the command is always forcefully terminated; see '--stop-signal' for why."
+        arg "<TIMEOUT>"
+    }
+    flag "--map-signal" help="Translate signals from the OS to signals to send to the command" var=true {
+        long_help "Translate signals from the OS to signals to send to the command\n\nTakes a pair of signal names, separated by a colon, such as \"TERM:INT\" to map SIGTERM to SIGINT. The first signal is the one received by watchexec, and the second is the one sent to the command. The second can be omitted to discard the first signal, such as \"TERM:\" to not do anything on SIGTERM.\n\nIf SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also terminating Watchexec and the underlying program with it, e.g. with \"INT:INT\".\n\nThis option can be specified multiple times to map multiple signals.\n\nSignal syntax is case-insensitive for short names (like \"TERM\", \"USR2\") and long names (like \"SIGKILL\", \"SIGHUP\"). Signal numbers are also supported (like \"15\", \"31\"). On Windows, the forms \"STOP\", \"CTRL+C\", and \"CTRL+BREAK\" are also supported to receive, but Watchexec cannot yet deliver other \"signals\" than a STOP."
+        arg "<SIGNAL:SIGNAL>"
+    }
+    flag "-d --debounce" help="Time to wait for new events before taking action" {
+        long_help "Time to wait for new events before taking action\n\nWhen an event is received, Watchexec will wait for up to this amount of time before handling it (such as running the command). This is essential as what you might perceive as a single change may actually emit many events, and without this behaviour, Watchexec would run much too often. Additionally, it's not infrequent that file writes are not atomic, and each write may emit an event, so this is a good way to avoid running a command while a file is partially written.\n\nAn alternative use is to set a high value (like \"30min\" or longer), to save power or bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that every accumulated event will build up in memory.\n\nTakes a unit-less value in milliseconds, or a time span value such as \"5sec 20ms\". Providing a unit-less value is deprecated and will warn; it will be an error in the future.\n\nThe default is 50 milliseconds. Setting to 0 is highly discouraged."
+        arg "<TIMEOUT>"
+    }
+    flag "--stdin-quit" help="Exit when stdin closes" {
+        long_help "Exit when stdin closes\n\nThis watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is closed. This is used by some process managers to avoid leaving zombie processes around."
+    }
+    flag "--no-vcs-ignore" help="Don't load gitignores" {
+        long_help "Don't load gitignores\n\nAmong other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note that Watchexec will detect which of these is in use, if any, and only load the relevant files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.\n\nThis option is useful if you want to watch files that are ignored by Git."
+    }
+    flag "--no-project-ignore" help="Don't load project-local ignores" {
+        long_help "Don't load project-local ignores\n\nThis disables loading of project-local ignore files, like '.gitignore' or '.ignore' in the\nwatched project. This is contrasted with '--no-vcs-ignore', which disables loading of Git\nand other VCS ignore files, and with '--no-global-ignore', which disables loading of global\nor user ignore files, like '~/.gitignore' or '~/.config/watchexec/ignore'.\n\nSupported project ignore files:\n\n  - Git: .gitignore at project root and child directories, .git/info/exclude, and the file pointed to by `core.excludesFile` in .git/config.\n  - Mercurial: .hgignore at project root and child directories.\n  - Bazaar: .bzrignore at project root.\n  - Darcs: _darcs/prefs/boring\n  - Fossil: .fossil-settings/ignore-glob\n  - Ripgrep/Watchexec/generic: .ignore at project root and child directories.\n\nVCS ignore files (Git, Mercurial, Bazaar, Darcs, Fossil) are only used if the corresponding\nVCS is discovered to be in use for the project/origin. For example, a .bzrignore in a Git\nrepository will be discarded."
+    }
+    flag "--no-global-ignore" help="Don't load global ignores" {
+        long_help "Don't load global ignores\n\nThis disables loading of global or user ignore files, like '~/.gitignore',\n'~/.config/watchexec/ignore', or '%APPDATA%\\Bazzar\\2.0\\ignore'. Contrast with\n'--no-vcs-ignore' and '--no-project-ignore'.\n\nSupported global ignore files\n\n  - Git (if core.excludesFile is set): the file at that path\n  - Git (otherwise): the first found of $XDG_CONFIG_HOME/git/ignore, %APPDATA%/.gitignore, %USERPROFILE%/.gitignore, $HOME/.config/git/ignore, $HOME/.gitignore.\n  - Bazaar: the first found of %APPDATA%/Bazzar/2.0/ignore, $HOME/.bazaar/ignore.\n  - Watchexec: the first found of $XDG_CONFIG_HOME/watchexec/ignore, %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore, $HOME/.watchexec/ignore.\n\nLike for project files, Git and Bazaar global files will only be used for the corresponding\nVCS as used in the project."
+    }
+    flag "--no-default-ignore" help="Don't use internal default ignores" {
+        long_help "Don't use internal default ignores\n\nWatchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`, `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and Watchexec log files."
+    }
+    flag "--no-discover-ignore" help="Don't discover ignore files at all" {
+        long_help "Don't discover ignore files at all\n\nThis is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but even more efficient as it will skip all the ignore discovery mechanisms from the get go.\n\nNote that default ignores are still loaded, see '--no-default-ignore'."
+    }
+    flag "--ignore-nothing" help="Don't ignore anything at all" {
+        long_help "Don't ignore anything at all\n\nThis is a shorthand for '--no-discover-ignore', '--no-default-ignore'.\n\nNote that ignores explicitly loaded via other command line options, such as '--ignore' or '--ignore-file', will still be used."
+    }
+    flag "-p --postpone" help="Wait until first change before running command" {
+        long_help "Wait until first change before running command\n\nBy default, Watchexec will run the command once immediately. With this option, it will instead wait until an event is detected before running the command as normal."
+    }
+    flag "--delay-run" help="Sleep before running the command" {
+        long_help "Sleep before running the command\n\nThis option will cause Watchexec to sleep for the specified amount of time before running the command, after an event is detected. This is like using \"sleep 5 && command\" in a shell, but portable and slightly more efficient.\n\nTakes a unit-less value in seconds, or a time span value such as \"2min 5s\". Providing a unit-less value is deprecated and will warn; it will be an error in the future."
+        arg "<DURATION>"
+    }
+    flag "--poll" help="Poll for filesystem changes" {
+        long_help "Poll for filesystem changes\n\nBy default, and where available, Watchexec uses the operating system's native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases.\n\nOptionally takes a unit-less value in milliseconds, or a time span value such as \"2s 500ms\", to use as the polling interval. If not specified, the default is 30 seconds. Providing a unit-less value is deprecated and will warn; it will be an error in the future.\n\nAliased as '--force-poll'."
+        arg "<INTERVAL>"
+    }
+    flag "--shell" help="Use a different shell" {
+        long_help "Use a different shell\n\nBy default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes, and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec detects is the running shell.\n\nWith this option, you can override that and use a different shell, for example one with more features or one which has your custom aliases and functions.\n\nIf the value has spaces, it is parsed as a command line, and the first word used as the shell program, with the rest as arguments to the shell.\n\nThe command is run with the '-c' flag (except for 'cmd' on Windows, where it's '/C').\n\nThe special value 'none' can be used to disable shell use entirely. In that case, the command provided to Watchexec will be parsed, with the first word being the executable and the rest being the arguments, and executed directly. Note that this parsing is rudimentary, and may not work as expected in all cases.\n\nUsing 'none' is a little more efficient and can enable a stricter interpretation of the input, but it also means that you can't use shell features like globbing, redirection, control flow, logic, or pipes.\n\nExamples:\n\nUse without shell:\n\n$ watchexec -n -- zsh -x -o shwordsplit scr\n\nUse with powershell core:\n\n$ watchexec --shell=pwsh -- Test-Connection localhost\n\nUse with CMD.exe:\n\n$ watchexec --shell=cmd -- dir\n\nUse with a different unix shell:\n\n$ watchexec --shell=bash -- 'echo $BASH_VERSION'\n\nUse with a unix shell and options:\n\n$ watchexec --shell='zsh -x -o shwordsplit' -- scr"
+        arg "<SHELL>"
+    }
+    flag "-n" help="Shorthand for '--shell=none'"
+    flag "--emit-events-to" help="Configure event emission" {
+        long_help "Configure event emission\n\nWatchexec can emit event information when running a command, which can be used by the child\nprocess to target specific changed files.\n\nOne thing to take care with is assuming inherent behaviour where there is only chance.\nNotably, it could appear as if the `RENAMED` variable contains both the original and the new\npath being renamed. In previous versions, it would even appear on some platforms as if the\noriginal always came before the new. However, none of this was true. It's impossible to\nreliably and portably know which changed path is the old or new, \"half\" renames may appear\n(only the original, only the new), \"unknown\" renames may appear (change was a rename, but\nwhether it was the old or new isn't known), rename events might split across two debouncing\nboundaries, and so on.\n\nThis option controls where that information is emitted. It defaults to 'none', which doesn't\nemit event information at all. The other options are 'environment' (deprecated), 'stdio',\n'file', 'json-stdio', and 'json-file'.\n\nThe 'stdio' and 'file' modes are text-based: 'stdio' writes absolute paths to the stdin of\nthe command, one per line, each prefixed with `create:`, `remove:`, `rename:`, `modify:`,\nor `other:`, then closes the handle; 'file' writes the same thing to a temporary file, and\nits path is given with the $WATCHEXEC_EVENTS_FILE environment variable.\n\nThere are also two JSON modes, which are based on JSON objects and can represent the full\nset of events Watchexec handles. Here's an example of a folder being created on Linux:\n\n```json\n  {\n    \"tags\": [\n      {\n        \"kind\": \"path\",\n        \"absolute\": \"/home/user/your/new-folder\",\n        \"filetype\": \"dir\"\n      },\n      {\n        \"kind\": \"fs\",\n        \"simple\": \"create\",\n        \"full\": \"Create(Folder)\"\n      },\n      {\n        \"kind\": \"source\",\n        \"source\": \"filesystem\",\n      }\n    ],\n    \"metadata\": {\n      \"notify-backend\": \"inotify\"\n    }\n  }\n```\n\nThe fields are as follows:\n\n  - `tags`, structured event data.\n  - `tags[].kind`, which can be:\n    * 'path', along with:\n      + `absolute`, an absolute path.\n      + `filetype`, a file type if known ('dir', 'file', 'symlink', 'other').\n    * 'fs':\n      + `simple`, the \"simple\" event type ('access', 'create', 'modify', 'remove', or 'other').\n      + `full`, the \"full\" event type, which is too complex to fully describe here, but looks like 'General(Precise(Specific))'.\n    * 'source', along with:\n      + `source`, the source of the event ('filesystem', 'keyboard', 'mouse', 'os', 'time', 'internal').\n    * 'keyboard', along with:\n      + `keycode`. Currently only the value 'eof' is supported.\n    * 'process', for events caused by processes:\n      + `pid`, the process ID.\n    * 'signal', for signals sent to Watchexec:\n      + `signal`, the normalised signal name ('hangup', 'interrupt', 'quit', 'terminate', 'user1', 'user2').\n    * 'completion', for when a command ends:\n      + `disposition`, the exit disposition ('success', 'error', 'signal', 'stop', 'exception', 'continued').\n      + `code`, the exit, signal, stop, or exception code.\n  - `metadata`, additional information about the event.\n\nThe 'json-stdio' mode will emit JSON events to the standard input of the command, one per\nline, then close stdin. The 'json-file' mode will create a temporary file, write the\nevents to it, and provide the path to the file with the $WATCHEXEC_EVENTS_FILE\nenvironment variable.\n\nFinally, the 'environment' mode was the default until 2.0. It sets environment variables\nwith the paths of the affected files, for filesystem events:\n\n$WATCHEXEC_COMMON_PATH is set to the longest common path of all of the below variables,\nand so should be prepended to each path to obtain the full/real path. Then:\n\n  - $WATCHEXEC_CREATED_PATH is set when files/folders were created\n  - $WATCHEXEC_REMOVED_PATH is set when files/folders were removed\n  - $WATCHEXEC_RENAMED_PATH is set when files/folders were renamed\n  - $WATCHEXEC_WRITTEN_PATH is set when files/folders were modified\n  - $WATCHEXEC_META_CHANGED_PATH is set when files/folders' metadata were modified\n  - $WATCHEXEC_OTHERWISE_CHANGED_PATH is set for every other kind of pathed event\n\nMultiple paths are separated by the system path separator, ';' on Windows and ':' on unix.\nWithin each variable, paths are deduplicated and sorted in binary order (i.e. neither\nUnicode nor locale aware).\n\nThis is the legacy mode, is deprecated, and will be removed in the future. The environment\nis a very restricted space, while also limited in what it can usefully represent. Large\nnumbers of files will either cause the environment to be truncated, or may error or crash\nthe process entirely. The $WATCHEXEC_COMMON_PATH is also unintuitive, as demonstrated by the\nmultiple confused queries that have landed in my inbox over the years."
+        arg "<MODE>" {
+            choices "environment" "stdio" "file" "json-stdio" "json-file" "none"
+        }
+    }
+    flag "--only-emit-events" help="Only emit events to stdout, run no commands" {
+        long_help "Only emit events to stdout, run no commands.\n\nThis is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.\n\nThis option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command."
+    }
+    flag "-E --env" help="Add env vars to the command" var=true {
+        long_help "Add env vars to the command\n\nThis is a convenience option for setting environment variables for the command, without setting them for the Watchexec process itself.\n\nUse key=value syntax. Multiple variables can be set by repeating the option."
+        arg "<KEY=VALUE>"
+    }
+    flag "--wrap-process" help="Configure how the process is wrapped" {
+        long_help "Configure how the process is wrapped\n\nBy default, Watchexec will run the command in a process group in Unix, and in a Job Object in Windows.\n\nSome Unix programs prefer running in a session, while others do not work in a process group.\n\nUse 'group' to use a process group, 'session' to use a process session, and 'none' to run the command directly. On Windows, either of 'group' or 'session' will use a Job Object."
+        arg "<MODE>" {
+            choices "group" "session" "none"
+        }
+    }
+    flag "-N --notify" help="Alert when commands start and end" {
+        long_help "Alert when commands start and end\n\nWith this, Watchexec will emit a desktop notification when a command starts and ends, on supported platforms. On unsupported platforms, it may silently do nothing, or log a warning."
+    }
+    flag "--color" help="When to use terminal colours" {
+        long_help "When to use terminal colours\n\nSetting the environment variable `NO_COLOR` to any value is equivalent to `--color=never`."
+        arg "<MODE>" {
+            choices "auto" "always" "never"
+        }
+    }
+    flag "--timings" help="Print how long the command took to run" {
+        long_help "Print how long the command took to run\n\nThis may not be exactly accurate, as it includes some overhead from Watchexec itself. Use the `time` utility, high-precision timers, or benchmarking tools for more accurate results."
+    }
+    flag "-q --quiet" help="Don't print starting and stopping messages" {
+        long_help "Don't print starting and stopping messages\n\nBy default Watchexec will print a message when the command starts and stops. This option disables this behaviour, so only the command's output, warnings, and errors will be printed."
+    }
+    flag "--bell" help="Ring the terminal bell on command completion"
+    flag "--project-origin" help="Set the project origin" {
+        long_help "Set the project origin\n\nWatchexec will attempt to discover the project's \"origin\" (or \"root\") by searching for a variety of markers, like files or directory patterns. It does its best but sometimes gets it it wrong, and you can override that with this option.\n\nThe project origin is used to determine the path of certain ignore files, which VCS is being used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.\n\nWhen set, Watchexec will also not bother searching, which can be significantly faster."
+        arg "<DIRECTORY>"
+    }
+    flag "--workdir" help="Set the working directory" {
+        long_help "Set the working directory\n\nBy default, the working directory of the command is the working directory of Watchexec. You can change that with this option. Note that paths may be less intuitive to use with this."
+        arg "<DIRECTORY>"
+    }
+    flag "-e --exts" help="Filename extensions to filter to" var=true {
+        long_help "Filename extensions to filter to\n\nThis is a quick filter to only emit events for files with the given extensions. Extensions can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can be given by repeating the option or by separating them with commas."
+        arg "<EXTENSIONS>"
+    }
+    flag "-f --filter" help="Filename patterns to filter to" var=true {
+        long_help "Filename patterns to filter to\n\nProvide a glob-like filter pattern, and only events for files matching the pattern will be emitted. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched."
+        arg "<PATTERN>"
+    }
+    flag "--filter-file" help="Files to load filters from" var=true {
+        long_help "Files to load filters from\n\nProvide a path to a file containing filters, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--filter' option.\n\nThis can also be used via the $WATCHEXEC_FILTER_FILES environment variable."
+        arg "<PATH>"
+    }
+    flag "-J --filter-prog" help="[experimental] Filter programs" var=true {
+        long_help "[experimental] Filter programs.\n\n/!\\ This option is EXPERIMENTAL and may change and/or vanish without notice.\n\nProvide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.\n\nIn addition to the jaq stdlib, watchexec adds some custom filter definitions:\n\n- 'path | file_meta' returns file metadata or null if the file does not exist.\n\n- 'path | file_size' returns the size of the file at path, or null if it does not exist.\n\n- 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.\n\n- 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.\n\n- 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.\n\n- 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log(\"debug\") | .[]' will produce a '1' and log '[1]').\n\nAll filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.\n\nIf the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.\n\nJaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!\n\nFind user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.\n\n## Examples:\n\nRegexp ignore filter on paths:\n\n'all(.tags[] | select(.kind == \"path\"); .absolute | test(\"[.]test[.]js$\")) | not'\n\nPass any event that creates a file:\n\n'any(.tags[] | select(.kind == \"fs\"); .simple == \"create\")'\n\nPass events that touch executable files:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | metadata | .executable)'\n\nIgnore files that start with shebangs:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | read(2) == \"#!\") | not'"
+        arg "<EXPRESSION>"
+    }
+    flag "-i --ignore" help="Filename patterns to filter out" var=true {
+        long_help "Filename patterns to filter out\n\nProvide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched."
+        arg "<PATTERN>"
+    }
+    flag "--ignore-file" help="Files to load ignores from" var=true {
+        long_help "Files to load ignores from\n\nProvide a path to a file containing ignores, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--ignore' option.\n\nThis can also be used via the $WATCHEXEC_IGNORE_FILES environment variable."
+        arg "<PATH>"
+    }
+    flag "--fs-events" help="Filesystem events to filter to" var=true {
+        long_help "Filesystem events to filter to\n\nThis is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.\n\nThis may apply filtering at the kernel level when possible, which can be more efficient, but may be more confusing when reading the logs."
+        arg "<EVENTS>" {
+            choices "access" "create" "remove" "rename" "modify" "metadata"
+        }
+    }
+    flag "--no-meta" help="Don't emit fs events for metadata changes" {
+        long_help "Don't emit fs events for metadata changes\n\nThis is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the '--fs-events' option is non-sensical and not allowed."
+    }
+    flag "--print-events" help="Print events that trigger actions" {
+        long_help "Print events that trigger actions\n\nThis prints the events that triggered the action when handling it (after debouncing), in a human readable form. This is useful for debugging filters.\n\nUse '-vvv' instead when you need more diagnostic information."
+    }
+    flag "--manual" help="Show the manual page" {
+        long_help "Show the manual page\n\nThis shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file)."
+    }
+    arg "[TASK]" help="Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2"
+    arg "[ARGS]..." help="Task and arguments to run" var=true
 }
 cmd "where" help="Display the installation path for a tool" {
     long_help r"Display the installation path for a tool

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,7 +90,7 @@ pub struct Cli {
     #[clap(short='C', long, global=true, value_name="DIR", value_hint=clap::ValueHint::DirPath)]
     pub cd: Option<PathBuf>,
     /// Dry run, don't actually do anything
-    #[clap(short = 'n', long, global = true, hide = true)]
+    #[clap(short = 'n', long, hide = true)]
     pub dry_run: bool,
     /// Sets log level to debug
     #[clap(long, global = true, hide = true)]
@@ -201,7 +201,7 @@ pub enum Commands {
     Usage(usage::Usage),
     Use(r#use::Use),
     Version(version::Version),
-    Watch(watch::Watch),
+    Watch(Box<watch::Watch>),
     Where(r#where::Where),
     Which(which::Which),
 

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -12,6 +12,9 @@ use crate::toolset::ToolsetBuilder;
 ///
 /// This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
 /// It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
+///
+/// Because this wraps watchexec, run `watchexec --help` to see what options are available. Arguments
+/// passed to `mise watch` are sent to watchexec. See https://github.com/watchexec/watchexec/tree/main/crates/cli
 #[derive(Debug, clap::Args)]
 #[clap(visible_alias = "w", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Watch {
@@ -134,7 +137,10 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     Runs the "build" tasks but specify the files to watch with a glob pattern.
     This overrides the "sources" from the tasks definition.
 
-    $ <bold>mise run -t build --clear</bold>
+    $ <bold>mise watch -t build --clear</bold>
     Extra arguments are passed to watchexec. See `watchexec --help` for details.
+    
+    $ <bold>mise watch -t serve --watch src --exts rs --restart</bold>
+    Starts an api server, watching for changes to "*.rs" files in "./src" and kills/restarts the server when they change.
 "#
 );

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -1,35 +1,1068 @@
-use crate::exit;
-
-use console::style;
-use eyre::{eyre, Result};
-
 use crate::cli::args::BackendArg;
+use crate::cli::{run, Cli};
 use crate::cmd;
 use crate::config::Config;
+use crate::env;
+use crate::exit::exit;
 use crate::toolset::ToolsetBuilder;
+use crate::Result;
+use clap::{CommandFactory, ValueEnum, ValueHint};
+use console::style;
+use eyre::bail;
+use itertools::Itertools;
+use std::cmp::PartialEq;
+use std::iter::once;
+use std::path::PathBuf;
 
 /// Run task(s) and watch for changes to rerun it
 ///
 /// This command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).
 /// It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
-///
-/// Because this wraps watchexec, run `watchexec --help` to see what options are available. Arguments
-/// passed to `mise watch` are sent to watchexec. See https://github.com/watchexec/watchexec/tree/main/crates/cli
 #[derive(Debug, clap::Args)]
 #[clap(visible_alias = "w", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Watch {
     /// Tasks to run
-    #[clap(short, long, verbatim_doc_comment, default_value = "default")]
-    task: Vec<String>,
+    /// Can specify multiple tasks by separating with `:::`
+    /// e.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2
+    #[clap(allow_hyphen_values = true, verbatim_doc_comment)]
+    task: Option<String>,
 
-    /// Extra arguments
-    #[clap(allow_hyphen_values = true)]
+    /// Tasks to run
+    #[clap(short, long, verbatim_doc_comment, hide = true)]
+    task_flag: Vec<String>,
+
+    /// Task and arguments to run
+    #[clap(allow_hyphen_values = true, trailing_var_arg = true)]
     args: Vec<String>,
 
     /// Files to watch
     /// Defaults to sources from the tasks(s)
-    #[clap(short, long, verbatim_doc_comment)]
+    #[clap(short, long, verbatim_doc_comment, hide = true)]
     glob: Vec<String>,
+
+    #[clap(flatten)]
+    watchexec: WatchexecArgs,
+}
+
+impl Watch {
+    pub fn run(self) -> Result<()> {
+        if let Some(task) = &self.task {
+            if task == "-h" {
+                self.get_clap_command().print_help()?;
+                return Ok(());
+            }
+            if task == "--help" {
+                self.get_clap_command().print_long_help()?;
+                return Ok(());
+            }
+        }
+        let config = Config::try_get()?;
+        let ts = ToolsetBuilder::new().build(&config)?;
+        if let Err(err) = which::which("watchexec") {
+            let watchexec: BackendArg = "watchexec".into();
+            if !ts.versions.contains_key(&watchexec) {
+                eprintln!("{}: {}", style("Error").red().bold(), err);
+                eprintln!("{}: Install watchexec with:", style("Hint").bold());
+                eprintln!("  mise use -g watchexec@latest");
+                exit(1);
+            }
+        }
+        let args = once(self.task)
+            .flatten()
+            .chain(self.task_flag.iter().cloned())
+            .chain(self.args.iter().cloned())
+            .collect::<Vec<_>>();
+        if args.is_empty() {
+            bail!("No tasks specified");
+        }
+        let tasks = run::get_task_lists(&args, false)?;
+        let mut args = vec![];
+        if let Some(delay_run) = self.watchexec.delay_run {
+            args.push("--delay-run".to_string());
+            args.push(delay_run);
+        }
+        if let Some(poll) = self.watchexec.poll {
+            args.push("--poll".to_string());
+            args.push(poll);
+        }
+        if let Some(signal) = self.watchexec.signal {
+            args.push("--signal".to_string());
+            args.push(signal);
+        }
+        if let Some(stop_signal) = self.watchexec.stop_signal {
+            args.push("--stop-signal".to_string());
+            args.push(stop_signal);
+        }
+        if self.watchexec.stop_timeout != "10s" {
+            args.push("--stop-timeout".to_string());
+            args.push(self.watchexec.stop_timeout);
+        }
+        if self.watchexec.debounce != "50ms" {
+            args.push("--debounce".to_string());
+            args.push(self.watchexec.debounce);
+        }
+        if self.watchexec.stdin_quit {
+            args.push("--stdin-quit".to_string());
+        }
+        if self.watchexec.no_vcs_ignore {
+            args.push("--no-vcs-ignore".to_string());
+        }
+        if self.watchexec.no_project_ignore {
+            args.push("--no-project-ignore".to_string());
+        }
+        if self.watchexec.no_global_ignore {
+            args.push("--no-global-ignore".to_string());
+        }
+        if self.watchexec.no_default_ignore {
+            args.push("--no-default-ignore".to_string());
+        }
+        if self.watchexec.no_discover_ignore {
+            args.push("--no-discover-ignore".to_string());
+        }
+        if self.watchexec.ignore_nothing {
+            args.push("--ignore-nothing".to_string());
+        }
+        if self.watchexec.postpone {
+            args.push("--postpone".to_string());
+        }
+        if let Some(screen_clear) = self.watchexec.screen_clear {
+            args.push("--clear".to_string());
+            if let ClearMode::Reset = screen_clear {
+                args.push("reset".to_string());
+            }
+        }
+        if self.watchexec.restart {
+            args.push("--restart".to_string());
+        }
+        if self.watchexec.on_busy_update != OnBusyUpdate::DoNothing {
+            args.push("--on-busy-update".to_string());
+            args.push(self.watchexec.on_busy_update.to_string());
+        }
+        if !self.watchexec.signal_map.is_empty() {
+            for signal_map in &self.watchexec.signal_map {
+                args.push("--map-signal".to_string());
+                args.push(signal_map.to_string());
+            }
+        }
+        if !self.watchexec.recursive_paths.is_empty() {
+            for path in &self.watchexec.recursive_paths {
+                args.push("--watch".to_string());
+                args.push(path.to_string_lossy().to_string());
+            }
+        }
+        if !self.watchexec.non_recursive_paths.is_empty() {
+            for path in &self.watchexec.non_recursive_paths {
+                args.push("--watch-non-recursive".to_string());
+                args.push(path.to_string_lossy().to_string());
+            }
+        }
+        if let Some(watch_file) = &self.watchexec.watch_file {
+            args.push("--watch-file".to_string());
+            args.push(watch_file.to_string_lossy().to_string());
+        }
+        let globs = if self.glob.is_empty() {
+            tasks
+                .iter()
+                .flat_map(|t| t.sources.clone())
+                .collect::<Vec<_>>()
+        } else {
+            self.glob.clone()
+        };
+        if !globs.is_empty() {
+            args.push("-f".to_string());
+            args.extend(itertools::intersperse(globs, "-f".to_string()).collect::<Vec<_>>());
+        }
+        args.extend(["--".to_string(), "mise".to_string(), "run".to_string()]);
+        let task_args = itertools::intersperse(
+            tasks.iter().map(|t| {
+                let mut args = vec![t.name.to_string()];
+                args.extend(t.args.iter().map(|a| a.to_string()));
+                args
+            }),
+            vec![":::".to_string()],
+        )
+        .flatten()
+        .collect_vec();
+        for arg in task_args {
+            args.push(arg);
+        }
+        debug!("$ watchexec {}", args.join(" "));
+        let mut cmd = cmd::cmd("watchexec", &args);
+        for (k, v) in ts.env_with_path(&config)? {
+            cmd = cmd.env(k, v);
+        }
+        cmd.run()?;
+        Ok(())
+    }
+
+    fn get_clap_command(&self) -> clap::Command {
+        Cli::command()
+            .get_subcommands()
+            .find(|s| s.get_name() == "watch")
+            .unwrap()
+            .clone()
+    }
+}
+
+static AFTER_LONG_HELP: &str = color_print::cstr!(
+    r#"<bold><underline>Examples:</underline></bold>
+
+    $ <bold>mise watch -t build</bold>
+    Runs the "build" tasks. Will re-run the tasks when any of its sources change.
+    Uses "sources" from the tasks definition to determine which files to watch.
+
+    $ <bold>mise watch -t build --glob src/**/*.rs</bold>
+    Runs the "build" tasks but specify the files to watch with a glob pattern.
+    This overrides the "sources" from the tasks definition.
+
+    $ <bold>mise watch -t build --clear</bold>
+    Extra arguments are passed to watchexec. See `watchexec --help` for details.
+
+    $ <bold>mise watch -t serve --watch src --exts rs --restart</bold>
+    Starts an api server, watching for changes to "*.rs" files in "./src" and kills/restarts the server when they change.
+"#
+);
+
+//region watchexec
+const OPTSET_FILTERING: &str = "Filtering";
+const OPTSET_COMMAND: &str = "Command";
+const OPTSET_DEBUGGING: &str = "Debugging";
+const OPTSET_OUTPUT: &str = "Output";
+
+#[derive(Debug, clap::Args)]
+pub struct WatchexecArgs {
+    /// Watch a specific file or directory
+    ///
+    /// By default, Watchexec watches the current directory.
+    ///
+    /// When watching a single file, it's often better to watch the containing directory instead,
+    /// and filter on the filename. Some editors may replace the file with a new one when saving,
+    /// and some platforms may not detect that or further changes.
+    ///
+    /// Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help
+    /// for '--project-origin' for more information.
+    ///
+    /// This option can be specified multiple times to watch multiple files or directories.
+    ///
+    /// The special value '/dev/null', provided as the only path watched, will cause Watchexec to
+    /// not watch any paths. Other event sources (like signals or key events) may still be used.
+    #[arg(
+		short = 'w',
+		long = "watch",
+		help_heading = OPTSET_FILTERING,
+		value_hint = ValueHint::AnyPath,
+		value_name = "PATH",
+    )]
+    pub recursive_paths: Vec<PathBuf>,
+
+    /// Watch a specific directory, non-recursively
+    ///
+    /// Unlike '-w', folders watched with this option are not recursed into.
+    ///
+    /// This option can be specified multiple times to watch multiple directories non-recursively.
+    #[arg(
+		short = 'W',
+		long = "watch-non-recursive",
+		help_heading = OPTSET_FILTERING,
+		value_hint = ValueHint::AnyPath,
+		value_name = "PATH",
+    )]
+    pub non_recursive_paths: Vec<PathBuf>,
+
+    /// Watch files and directories from a file
+    ///
+    /// Each line in the file will be interpreted as if given to '-w'.
+    ///
+    /// For more complex uses (like watching non-recursively), use the argfile capability: build a
+    /// file containing command-line options and pass it to watchexec with `@path/to/argfile`.
+    ///
+    /// The special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.
+    #[arg(
+		short = 'F',
+		long,
+		help_heading = OPTSET_FILTERING,
+		value_hint = ValueHint::AnyPath,
+		value_name = "PATH",
+    )]
+    pub watch_file: Option<PathBuf>,
+
+    /// Clear screen before running command
+    ///
+    /// If this doesn't completely clear the screen, try '--clear=reset'.
+    #[arg(
+		short = 'c',
+		long = "clear",
+		help_heading = OPTSET_OUTPUT,
+		num_args = 0..=1,
+		default_missing_value = "clear",
+		value_name = "MODE",
+    )]
+    pub screen_clear: Option<ClearMode>,
+
+    /// What to do when receiving events while the command is running
+    ///
+    /// Default is to 'do-nothing', which ignores events while the command is running, so that
+    /// changes that occur due to the command are ignored, like compilation outputs. You can also
+    /// use 'queue' which will run the command once again when the current run has finished if any
+    /// events occur while it's running, or 'restart', which terminates the running command and starts
+    /// a new one. Finally, there's 'signal', which only sends a signal; this can be useful with
+    /// programs that can reload their configuration without a full restart.
+    ///
+    /// The signal can be specified with the '--signal' option.
+    #[arg(
+        short,
+        long,
+        default_value = "do-nothing",
+        hide_default_value = true,
+        value_name = "MODE"
+    )]
+    pub on_busy_update: OnBusyUpdate,
+
+    /// Restart the process if it's still running
+    ///
+    /// This is a shorthand for '--on-busy-update=restart'.
+    #[arg(
+		short,
+		long,
+		conflicts_with_all = ["on_busy_update"],
+    )]
+    pub restart: bool,
+
+    /// Send a signal to the process when it's still running
+    ///
+    /// Specify a signal to send to the process when it's still running. This implies
+    /// '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is
+    /// controlled by '--stop-signal'.
+    ///
+    /// See the long documentation for '--stop-signal' for syntax.
+    ///
+    /// Signals are not supported on Windows at the moment, and will always be overridden to 'kill'.
+    /// See '--stop-signal' for more on Windows "signals".
+    #[arg(
+		short,
+		long,
+		conflicts_with_all = ["restart"],
+		value_name = "SIGNAL"
+    )]
+    pub signal: Option<String>,
+
+    /// Signal to send to stop the command
+    ///
+    /// This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is
+    /// provided). The restart behaviour is to send the signal, wait for the command to exit, and if
+    /// it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
+    ///
+    /// The default on unix is "SIGTERM".
+    ///
+    /// Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"),
+    /// or a signal number (like "15"). All input is case-insensitive.
+    ///
+    /// On Windows this option is technically supported but only supports the "KILL" event, as
+    /// Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it
+    /// has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE"
+    /// events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are
+    /// respectively mapped to these.
+    #[arg(long, value_name = "SIGNAL")]
+    pub stop_signal: Option<String>,
+
+    /// Time to wait for the command to exit gracefully
+    ///
+    /// This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal
+    /// is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time,
+    /// it is forcefully terminated.
+    ///
+    /// Takes a unit-less value in seconds, or a time span value such as "5min 20s".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    ///
+    /// The default is 10 seconds. Set to 0 to immediately force-kill the command.
+    ///
+    /// This has no practical effect on Windows as the command is always forcefully terminated; see
+    /// '--stop-signal' for why.
+    #[arg(
+        long,
+        default_value = "10s",
+        hide_default_value = true,
+        value_name = "TIMEOUT"
+    )]
+    pub stop_timeout: String,
+
+    /// Translate signals from the OS to signals to send to the command
+    ///
+    /// Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to
+    /// SIGINT. The first signal is the one received by watchexec, and the second is the one sent to
+    /// the command. The second can be omitted to discard the first signal, such as "TERM:" to
+    /// not do anything on SIGTERM.
+    ///
+    /// If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard
+    /// to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also
+    /// terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
+    ///
+    /// This option can be specified multiple times to map multiple signals.
+    ///
+    /// Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like
+    /// "SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the
+    /// forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot
+    /// yet deliver other "signals" than a STOP.
+    #[arg(long = "map-signal", value_name = "SIGNAL:SIGNAL")]
+    pub signal_map: Vec<String>,
+
+    /// Time to wait for new events before taking action
+    ///
+    /// When an event is received, Watchexec will wait for up to this amount of time before handling
+    /// it (such as running the command). This is essential as what you might perceive as a single
+    /// change may actually emit many events, and without this behaviour, Watchexec would run much
+    /// too often. Additionally, it's not infrequent that file writes are not atomic, and each write
+    /// may emit an event, so this is a good way to avoid running a command while a file is
+    /// partially written.
+    ///
+    /// An alternative use is to set a high value (like "30min" or longer), to save power or
+    /// bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that
+    /// every accumulated event will build up in memory.
+    ///
+    /// Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    ///
+    /// The default is 50 milliseconds. Setting to 0 is highly discouraged.
+    #[arg(
+        long,
+        short,
+        default_value = "50ms",
+        hide_default_value = true,
+        value_name = "TIMEOUT"
+    )]
+    pub debounce: String,
+
+    /// Exit when stdin closes
+    ///
+    /// This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is
+    /// closed. This is used by some process managers to avoid leaving zombie processes around.
+    #[arg(long)]
+    pub stdin_quit: bool,
+
+    /// Don't load gitignores
+    ///
+    /// Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note
+    /// that Watchexec will detect which of these is in use, if any, and only load the relevant
+    /// files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
+    ///
+    /// This option is useful if you want to watch files that are ignored by Git.
+    #[arg(
+		long,
+		help_heading = OPTSET_FILTERING,
+    )]
+    pub no_vcs_ignore: bool,
+
+    /// Don't load project-local ignores
+    ///
+    /// This disables loading of project-local ignore files, like '.gitignore' or '.ignore' in the
+    /// watched project. This is contrasted with '--no-vcs-ignore', which disables loading of Git
+    /// and other VCS ignore files, and with '--no-global-ignore', which disables loading of global
+    /// or user ignore files, like '~/.gitignore' or '~/.config/watchexec/ignore'.
+    ///
+    /// Supported project ignore files:
+    ///
+    ///   - Git: .gitignore at project root and child directories, .git/info/exclude, and the file pointed to by `core.excludesFile` in .git/config.
+    ///   - Mercurial: .hgignore at project root and child directories.
+    ///   - Bazaar: .bzrignore at project root.
+    ///   - Darcs: _darcs/prefs/boring
+    ///   - Fossil: .fossil-settings/ignore-glob
+    ///   - Ripgrep/Watchexec/generic: .ignore at project root and child directories.
+    ///
+    /// VCS ignore files (Git, Mercurial, Bazaar, Darcs, Fossil) are only used if the corresponding
+    /// VCS is discovered to be in use for the project/origin. For example, a .bzrignore in a Git
+    /// repository will be discarded.
+    #[arg(
+		long,
+		help_heading = OPTSET_FILTERING,
+		verbatim_doc_comment,
+    )]
+    pub no_project_ignore: bool,
+
+    /// Don't load global ignores
+    ///
+    /// This disables loading of global or user ignore files, like '~/.gitignore',
+    /// '~/.config/watchexec/ignore', or '%APPDATA%\Bazzar\2.0\ignore'. Contrast with
+    /// '--no-vcs-ignore' and '--no-project-ignore'.
+    ///
+    /// Supported global ignore files
+    ///
+    ///   - Git (if core.excludesFile is set): the file at that path
+    ///   - Git (otherwise): the first found of $XDG_CONFIG_HOME/git/ignore, %APPDATA%/.gitignore, %USERPROFILE%/.gitignore, $HOME/.config/git/ignore, $HOME/.gitignore.
+    ///   - Bazaar: the first found of %APPDATA%/Bazzar/2.0/ignore, $HOME/.bazaar/ignore.
+    ///   - Watchexec: the first found of $XDG_CONFIG_HOME/watchexec/ignore, %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore, $HOME/.watchexec/ignore.
+    ///
+    /// Like for project files, Git and Bazaar global files will only be used for the corresponding
+    /// VCS as used in the project.
+    #[arg(
+		long,
+		help_heading = OPTSET_FILTERING,
+		verbatim_doc_comment,
+    )]
+    pub no_global_ignore: bool,
+
+    /// Don't use internal default ignores
+    ///
+    /// Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`,
+    /// `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and
+    /// Watchexec log files.
+    #[arg(
+		long,
+		help_heading = OPTSET_FILTERING,
+    )]
+    pub no_default_ignore: bool,
+
+    /// Don't discover ignore files at all
+    ///
+    /// This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but
+    /// even more efficient as it will skip all the ignore discovery mechanisms from the get go.
+    ///
+    /// Note that default ignores are still loaded, see '--no-default-ignore'.
+    #[arg(
+		long,
+		help_heading = OPTSET_FILTERING,
+    )]
+    pub no_discover_ignore: bool,
+
+    /// Don't ignore anything at all
+    ///
+    /// This is a shorthand for '--no-discover-ignore', '--no-default-ignore'.
+    ///
+    /// Note that ignores explicitly loaded via other command line options, such as '--ignore' or
+    /// '--ignore-file', will still be used.
+    #[arg(
+		long,
+		help_heading = OPTSET_FILTERING,
+    )]
+    pub ignore_nothing: bool,
+
+    /// Wait until first change before running command
+    ///
+    /// By default, Watchexec will run the command once immediately. With this option, it will
+    /// instead wait until an event is detected before running the command as normal.
+    #[arg(long, short)]
+    pub postpone: bool,
+
+    /// Sleep before running the command
+    ///
+    /// This option will cause Watchexec to sleep for the specified amount of time before running
+    /// the command, after an event is detected. This is like using "sleep 5 && command" in a shell,
+    /// but portable and slightly more efficient.
+    ///
+    /// Takes a unit-less value in seconds, or a time span value such as "2min 5s".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    #[arg(long, value_name = "DURATION")]
+    pub delay_run: Option<String>,
+
+    /// Poll for filesystem changes
+    ///
+    /// By default, and where available, Watchexec uses the operating system's native file system
+    /// watching capabilities. This option disables that and instead uses a polling mechanism, which
+    /// is less efficient but can work around issues with some file systems (like network shares) or
+    /// edge cases.
+    ///
+    /// Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms",
+    /// to use as the polling interval. If not specified, the default is 30 seconds.
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    ///
+    /// Aliased as '--force-poll'.
+    #[arg(
+		long,
+		alias = "force-poll",
+		num_args = 0..=1,
+		default_missing_value = "30s",
+		value_name = "INTERVAL",
+    )]
+    pub poll: Option<String>,
+
+    /// Use a different shell
+    ///
+    /// By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes,
+    /// and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec
+    /// detects is the running shell.
+    ///
+    /// With this option, you can override that and use a different shell, for example one with more
+    /// features or one which has your custom aliases and functions.
+    ///
+    /// If the value has spaces, it is parsed as a command line, and the first word used as the
+    /// shell program, with the rest as arguments to the shell.
+    ///
+    /// The command is run with the '-c' flag (except for 'cmd' on Windows, where it's '/C').
+    ///
+    /// The special value 'none' can be used to disable shell use entirely. In that case, the
+    /// command provided to Watchexec will be parsed, with the first word being the executable and
+    /// the rest being the arguments, and executed directly. Note that this parsing is rudimentary,
+    /// and may not work as expected in all cases.
+    ///
+    /// Using 'none' is a little more efficient and can enable a stricter interpretation of the
+    /// input, but it also means that you can't use shell features like globbing, redirection,
+    /// control flow, logic, or pipes.
+    ///
+    /// Examples:
+    ///
+    /// Use without shell:
+    ///
+    ///   $ watchexec -n -- zsh -x -o shwordsplit scr
+    ///
+    /// Use with powershell core:
+    ///
+    ///   $ watchexec --shell=pwsh -- Test-Connection localhost
+    ///
+    /// Use with CMD.exe:
+    ///
+    ///   $ watchexec --shell=cmd -- dir
+    ///
+    /// Use with a different unix shell:
+    ///
+    ///   $ watchexec --shell=bash -- 'echo $BASH_VERSION'
+    ///
+    /// Use with a unix shell and options:
+    ///
+    ///   $ watchexec --shell='zsh -x -o shwordsplit' -- scr
+    #[arg(
+		long,
+		help_heading = OPTSET_COMMAND,
+		value_name = "SHELL",
+    )]
+    pub shell: Option<String>,
+
+    /// Shorthand for '--shell=none'
+    #[arg(
+		short = 'n',
+		help_heading = OPTSET_COMMAND,
+    )]
+    pub no_shell: bool,
+
+    /// Configure event emission
+    ///
+    /// Watchexec can emit event information when running a command, which can be used by the child
+    /// process to target specific changed files.
+    ///
+    /// One thing to take care with is assuming inherent behaviour where there is only chance.
+    /// Notably, it could appear as if the `RENAMED` variable contains both the original and the new
+    /// path being renamed. In previous versions, it would even appear on some platforms as if the
+    /// original always came before the new. However, none of this was true. It's impossible to
+    /// reliably and portably know which changed path is the old or new, "half" renames may appear
+    /// (only the original, only the new), "unknown" renames may appear (change was a rename, but
+    /// whether it was the old or new isn't known), rename events might split across two debouncing
+    /// boundaries, and so on.
+    ///
+    /// This option controls where that information is emitted. It defaults to 'none', which doesn't
+    /// emit event information at all. The other options are 'environment' (deprecated), 'stdio',
+    /// 'file', 'json-stdio', and 'json-file'.
+    ///
+    /// The 'stdio' and 'file' modes are text-based: 'stdio' writes absolute paths to the stdin of
+    /// the command, one per line, each prefixed with `create:`, `remove:`, `rename:`, `modify:`,
+    /// or `other:`, then closes the handle; 'file' writes the same thing to a temporary file, and
+    /// its path is given with the $WATCHEXEC_EVENTS_FILE environment variable.
+    ///
+    /// There are also two JSON modes, which are based on JSON objects and can represent the full
+    /// set of events Watchexec handles. Here's an example of a folder being created on Linux:
+    ///
+    /// ```json
+    ///   {
+    ///     "tags": [
+    ///       {
+    ///         "kind": "path",
+    ///         "absolute": "/home/user/your/new-folder",
+    ///         "filetype": "dir"
+    ///       },
+    ///       {
+    ///         "kind": "fs",
+    ///         "simple": "create",
+    ///         "full": "Create(Folder)"
+    ///       },
+    ///       {
+    ///         "kind": "source",
+    ///         "source": "filesystem",
+    ///       }
+    ///     ],
+    ///     "metadata": {
+    ///       "notify-backend": "inotify"
+    ///     }
+    ///   }
+    /// ```
+    ///
+    /// The fields are as follows:
+    ///
+    ///   - `tags`, structured event data.
+    ///   - `tags[].kind`, which can be:
+    ///     * 'path', along with:
+    ///       + `absolute`, an absolute path.
+    ///       + `filetype`, a file type if known ('dir', 'file', 'symlink', 'other').
+    ///     * 'fs':
+    ///       + `simple`, the "simple" event type ('access', 'create', 'modify', 'remove', or 'other').
+    ///       + `full`, the "full" event type, which is too complex to fully describe here, but looks like 'General(Precise(Specific))'.
+    ///     * 'source', along with:
+    ///       + `source`, the source of the event ('filesystem', 'keyboard', 'mouse', 'os', 'time', 'internal').
+    ///     * 'keyboard', along with:
+    ///       + `keycode`. Currently only the value 'eof' is supported.
+    ///     * 'process', for events caused by processes:
+    ///       + `pid`, the process ID.
+    ///     * 'signal', for signals sent to Watchexec:
+    ///       + `signal`, the normalised signal name ('hangup', 'interrupt', 'quit', 'terminate', 'user1', 'user2').
+    ///     * 'completion', for when a command ends:
+    ///       + `disposition`, the exit disposition ('success', 'error', 'signal', 'stop', 'exception', 'continued').
+    ///       + `code`, the exit, signal, stop, or exception code.
+    ///   - `metadata`, additional information about the event.
+    ///
+    /// The 'json-stdio' mode will emit JSON events to the standard input of the command, one per
+    /// line, then close stdin. The 'json-file' mode will create a temporary file, write the
+    /// events to it, and provide the path to the file with the $WATCHEXEC_EVENTS_FILE
+    /// environment variable.
+    ///
+    /// Finally, the 'environment' mode was the default until 2.0. It sets environment variables
+    /// with the paths of the affected files, for filesystem events:
+    ///
+    /// $WATCHEXEC_COMMON_PATH is set to the longest common path of all of the below variables,
+    /// and so should be prepended to each path to obtain the full/real path. Then:
+    ///
+    ///   - $WATCHEXEC_CREATED_PATH is set when files/folders were created
+    ///   - $WATCHEXEC_REMOVED_PATH is set when files/folders were removed
+    ///   - $WATCHEXEC_RENAMED_PATH is set when files/folders were renamed
+    ///   - $WATCHEXEC_WRITTEN_PATH is set when files/folders were modified
+    ///   - $WATCHEXEC_META_CHANGED_PATH is set when files/folders' metadata were modified
+    ///   - $WATCHEXEC_OTHERWISE_CHANGED_PATH is set for every other kind of pathed event
+    ///
+    /// Multiple paths are separated by the system path separator, ';' on Windows and ':' on unix.
+    /// Within each variable, paths are deduplicated and sorted in binary order (i.e. neither
+    /// Unicode nor locale aware).
+    ///
+    /// This is the legacy mode, is deprecated, and will be removed in the future. The environment
+    /// is a very restricted space, while also limited in what it can usefully represent. Large
+    /// numbers of files will either cause the environment to be truncated, or may error or crash
+    /// the process entirely. The $WATCHEXEC_COMMON_PATH is also unintuitive, as demonstrated by the
+    /// multiple confused queries that have landed in my inbox over the years.
+    #[arg(
+		long,
+		help_heading = OPTSET_COMMAND,
+		verbatim_doc_comment,
+		default_value = "none",
+		hide_default_value = true,
+		value_name = "MODE",
+		required_if_eq("only_emit_events", "true"),
+    )]
+    pub emit_events_to: EmitEvents,
+
+    /// Only emit events to stdout, run no commands.
+    ///
+    /// This is a convenience option for using Watchexec as a file watcher, without running any
+    /// commands. It is almost equivalent to using `cat` as the command, except that it will not
+    /// spawn a new process for each event.
+    ///
+    /// This option requires `--emit-events-to` to be set, and restricts the available modes to
+    /// `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin
+    /// of the command.
+    #[arg(
+		long,
+		help_heading = OPTSET_OUTPUT,
+		conflicts_with_all = ["manual"],
+    )]
+    pub only_emit_events: bool,
+
+    /// Add env vars to the command
+    ///
+    /// This is a convenience option for setting environment variables for the command, without
+    /// setting them for the Watchexec process itself.
+    ///
+    /// Use key=value syntax. Multiple variables can be set by repeating the option.
+    #[arg(
+		long,
+		short = 'E',
+		help_heading = OPTSET_COMMAND,
+		value_name = "KEY=VALUE",
+    )]
+    pub env: Vec<String>,
+
+    /// Configure how the process is wrapped
+    ///
+    /// By default, Watchexec will run the command in a process group in Unix, and in a Job Object
+    /// in Windows.
+    ///
+    /// Some Unix programs prefer running in a session, while others do not work in a process group.
+    ///
+    /// Use 'group' to use a process group, 'session' to use a process session, and 'none' to run
+    /// the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
+    #[arg(
+		long,
+		help_heading = OPTSET_COMMAND,
+		value_name = "MODE",
+		default_value = "group",
+    )]
+    pub wrap_process: WrapMode,
+
+    /// Alert when commands start and end
+    ///
+    /// With this, Watchexec will emit a desktop notification when a command starts and ends, on
+    /// supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
+    #[arg(
+		short = 'N',
+		long,
+		help_heading = OPTSET_OUTPUT,
+    )]
+    pub notify: bool,
+
+    /// When to use terminal colours
+    ///
+    /// Setting the environment variable `NO_COLOR` to any value is equivalent to `--color=never`.
+    #[arg(
+		long,
+		help_heading = OPTSET_OUTPUT,
+		default_value = "auto",
+		value_name = "MODE",
+		alias = "colour",
+    )]
+    pub color: ColourMode,
+
+    /// Print how long the command took to run
+    ///
+    /// This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use
+    /// the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
+    #[arg(
+		long,
+		help_heading = OPTSET_OUTPUT,
+    )]
+    pub timings: bool,
+
+    /// Don't print starting and stopping messages
+    ///
+    /// By default Watchexec will print a message when the command starts and stops. This option
+    /// disables this behaviour, so only the command's output, warnings, and errors will be printed.
+    #[arg(
+		short,
+		long,
+		help_heading = OPTSET_OUTPUT,
+    )]
+    pub quiet: bool,
+
+    /// Ring the terminal bell on command completion
+    #[arg(
+		long,
+		help_heading = OPTSET_OUTPUT,
+    )]
+    pub bell: bool,
+
+    /// Set the project origin
+    ///
+    /// Watchexec will attempt to discover the project's "origin" (or "root") by searching for a
+    /// variety of markers, like files or directory patterns. It does its best but sometimes gets it
+    /// it wrong, and you can override that with this option.
+    ///
+    /// The project origin is used to determine the path of certain ignore files, which VCS is being
+    /// used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
+    ///
+    /// When set, Watchexec will also not bother searching, which can be significantly faster.
+    #[arg(
+		long,
+		value_hint = ValueHint::DirPath,
+		value_name = "DIRECTORY",
+    )]
+    pub project_origin: Option<PathBuf>,
+
+    /// Set the working directory
+    ///
+    /// By default, the working directory of the command is the working directory of Watchexec. You
+    /// can change that with this option. Note that paths may be less intuitive to use with this.
+    #[arg(
+		long,
+		value_hint = ValueHint::DirPath,
+		value_name = "DIRECTORY",
+    )]
+    pub workdir: Option<PathBuf>,
+
+    /// Filename extensions to filter to
+    ///
+    /// This is a quick filter to only emit events for files with the given extensions. Extensions
+    /// can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can
+    /// be given by repeating the option or by separating them with commas.
+    #[arg(
+		long = "exts",
+		short = 'e',
+		help_heading = OPTSET_FILTERING,
+		value_delimiter = ',',
+		value_name = "EXTENSIONS",
+    )]
+    pub filter_extensions: Vec<String>,
+
+    /// Filename patterns to filter to
+    ///
+    /// Provide a glob-like filter pattern, and only events for files matching the pattern will be
+    /// emitted. Multiple patterns can be given by repeating the option. Events that are not from
+    /// files (e.g. signals, keyboard events) will pass through untouched.
+    #[arg(
+		long = "filter",
+		short = 'f',
+		help_heading = OPTSET_FILTERING,
+		value_name = "PATTERN",
+    )]
+    pub filter_patterns: Vec<String>,
+
+    /// Files to load filters from
+    ///
+    /// Provide a path to a file containing filters, one per line. Empty lines and lines starting
+    /// with '#' are ignored. Uses the same pattern format as the '--filter' option.
+    ///
+    /// This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
+    #[arg(
+		long = "filter-file",
+		help_heading = OPTSET_FILTERING,
+		value_delimiter = env::PATH_ENV_SEP,
+		value_hint = ValueHint::FilePath,
+		value_name = "PATH",
+		env = "WATCHEXEC_FILTER_FILES",
+		hide_env = true,
+    )]
+    pub filter_files: Vec<PathBuf>,
+
+    /// [experimental] Filter programs.
+    ///
+    /// /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
+    ///
+    /// Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given
+    /// an event in the same format as described in '--emit-events-to' and must return a boolean.
+    /// Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
+    ///
+    /// In addition to the jaq stdlib, watchexec adds some custom filter definitions:
+    ///
+    ///   - 'path | file_meta' returns file metadata or null if the file does not exist.
+    ///
+    ///   - 'path | file_size' returns the size of the file at path, or null if it does not exist.
+    ///
+    ///   - 'path | file_read(bytes)' returns a string with the first n bytes of the file at path.
+    ///     If the file is smaller than n bytes, the whole file is returned. There is no filter to
+    ///     read the whole file at once to encourage limiting the amount of data read and processed.
+    ///
+    ///   - 'string | hash', and 'path | file_hash' return the hash of the string or file at path.
+    ///     No guarantee is made about the algorithm used: treat it as an opaque value.
+    ///
+    ///   - 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store.
+    ///     Data is kept in memory only, there is no persistence. Consistency is not guaranteed.
+    ///
+    ///   - 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given
+    ///     value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and
+    ///     pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
+    ///
+    /// All filtering done with such programs, and especially those using kv or filesystem access,
+    /// is much slower than the other filtering methods. If filtering is too slow, events will back
+    /// up and stall watchexec. Take care when designing your filters.
+    ///
+    /// If the argument to this option starts with an '@', the rest of the argument is taken to be
+    /// the path to a file containing a jaq program.
+    ///
+    /// Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq
+    /// or not) rejects an event, execution stops there, and no other filters are run. Additionally,
+    /// they stop after outputting the first value, so you'll want to use 'any' or 'all' when
+    /// iterating, otherwise only the first item will be processed, which can be quite confusing!
+    ///
+    /// Find user-contributed programs or submit your own useful ones at
+    /// <https://github.com/watchexec/watchexec/discussions/592>.
+    ///
+    /// ## Examples:
+    ///
+    /// Regexp ignore filter on paths:
+    ///
+    ///   'all(.tags[] | select(.kind == "path"); .absolute | test("[.]test[.]js$")) | not'
+    ///
+    /// Pass any event that creates a file:
+    ///
+    ///   'any(.tags[] | select(.kind == "fs"); .simple == "create")'
+    ///
+    /// Pass events that touch executable files:
+    ///
+    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+    ///
+    /// Ignore files that start with shebangs:
+    ///
+    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
+    #[arg(
+		long = "filter-prog",
+		short = 'J',
+		help_heading = OPTSET_FILTERING,
+		value_name = "EXPRESSION",
+    )]
+    pub filter_programs: Vec<String>,
+
+    /// Filename patterns to filter out
+    ///
+    /// Provide a glob-like filter pattern, and events for files matching the pattern will be
+    /// excluded. Multiple patterns can be given by repeating the option. Events that are not from
+    /// files (e.g. signals, keyboard events) will pass through untouched.
+    #[arg(
+		long = "ignore",
+		short = 'i',
+		help_heading = OPTSET_FILTERING,
+		value_name = "PATTERN",
+    )]
+    pub ignore_patterns: Vec<String>,
+
+    /// Files to load ignores from
+    ///
+    /// Provide a path to a file containing ignores, one per line. Empty lines and lines starting
+    /// with '#' are ignored. Uses the same pattern format as the '--ignore' option.
+    ///
+    /// This can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.
+    #[arg(
+		long = "ignore-file",
+		help_heading = OPTSET_FILTERING,
+		value_delimiter = env::PATH_ENV_SEP,
+		value_hint = ValueHint::FilePath,
+		value_name = "PATH",
+		env = "WATCHEXEC_IGNORE_FILES",
+		hide_env = true,
+    )]
+    pub ignore_files: Vec<PathBuf>,
+
+    /// Filesystem events to filter to
+    ///
+    /// This is a quick filter to only emit events for the given types of filesystem changes. Choose
+    /// from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be
+    /// given by repeating the option or by separating them with commas. By default, this is all
+    /// types except for 'access'.
+    ///
+    /// This may apply filtering at the kernel level when possible, which can be more efficient, but
+    /// may be more confusing when reading the logs.
+    #[arg(
+		long = "fs-events",
+		help_heading = OPTSET_FILTERING,
+		default_value = "create,remove,rename,modify,metadata",
+		value_delimiter = ',',
+		hide_default_value = true,
+		value_name = "EVENTS",
+    )]
+    pub filter_fs_events: Vec<FsEvent>,
+
+    /// Don't emit fs events for metadata changes
+    ///
+    /// This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the
+    /// '--fs-events' option is non-sensical and not allowed.
+    #[arg(
+		long = "no-meta",
+		help_heading = OPTSET_FILTERING,
+		conflicts_with = "filter_fs_events",
+    )]
+    pub filter_fs_meta: bool,
+
+    /// Print events that trigger actions
+    ///
+    /// This prints the events that triggered the action when handling it (after debouncing), in a
+    /// human readable form. This is useful for debugging filters.
+    ///
+    /// Use '-vvv' instead when you need more diagnostic information.
+    #[arg(
+		long,
+		help_heading = OPTSET_DEBUGGING,
+    )]
+    pub print_events: bool,
+
+    /// Show the manual page
+    ///
+    /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program
+    /// is available. If not, the manual page is printed to stdout in ROFF format (suitable for
+    /// writing to a watchexec.1 file).
+    #[arg(
+		long,
+		help_heading = OPTSET_DEBUGGING,
+    )]
+    pub manual: bool,
     // /// Change to this directory before executing the command
     // #[clap(short = 'C', long, value_hint = ValueHint::DirPath, long)]
     // pub cd: Option<PathBuf>,
@@ -71,76 +1104,66 @@ pub struct Watch {
     // pub raw: bool,
 }
 
-impl Watch {
-    pub fn run(self) -> Result<()> {
-        let config = Config::try_get()?;
-        let ts = ToolsetBuilder::new().build(&config)?;
-        if let Err(err) = which::which("watchexec") {
-            let watchexec: BackendArg = "watchexec".into();
-            if !ts.versions.contains_key(&watchexec) {
-                eprintln!("{}: {}", style("Error").red().bold(), err);
-                eprintln!("{}: Install watchexec with:", style("Hint").bold());
-                eprintln!("  mise use -g watchexec@latest");
-                exit(1);
-            }
-        }
-        let tasks = self
-            .task
-            .iter()
-            .map(|t| {
-                config
-                    .tasks_with_aliases()?
-                    .get(t)
-                    .cloned()
-                    .ok_or_else(|| eyre!("Tasks not found: {t}"))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let mut args = vec![];
-        let globs = if self.glob.is_empty() {
-            tasks
-                .iter()
-                .flat_map(|t| t.sources.clone())
-                .collect::<Vec<_>>()
-        } else {
-            self.glob.clone()
-        };
-        if !globs.is_empty() {
-            args.push("-f".to_string());
-            args.extend(itertools::intersperse(globs, "-f".to_string()).collect::<Vec<_>>());
-        }
-        args.extend(self.args.clone());
-        args.extend(["--".to_string(), "mise".to_string(), "run".to_string()]);
-        for arg in itertools::intersperse(tasks.iter().map(|t| t.name.as_str()), ":::") {
-            args.push(arg.to_string());
-        }
-        info!("$ watchexec {}", args.join(" "));
-        let mut cmd = cmd::cmd("watchexec", &args);
-        for (k, v) in ts.env_with_path(&config)? {
-            cmd = cmd.env(k, v);
-        }
-        if let Some(root) = &config.project_root {
-            cmd = cmd.dir(root);
-        }
-        cmd.run()?;
-        Ok(())
-    }
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum EmitEvents {
+    #[default]
+    Environment,
+    Stdio,
+    File,
+    JsonStdio,
+    JsonFile,
+    None,
 }
 
-static AFTER_LONG_HELP: &str = color_print::cstr!(
-    r#"<bold><underline>Examples:</underline></bold>
+#[derive(Clone, Copy, Debug, Default, ValueEnum, PartialEq, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
+pub enum OnBusyUpdate {
+    #[default]
+    Queue,
+    DoNothing,
+    Restart,
+    Signal,
+}
 
-    $ <bold>mise watch -t build</bold>
-    Runs the "build" tasks. Will re-run the tasks when any of its sources change.
-    Uses "sources" from the tasks definition to determine which files to watch.
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum WrapMode {
+    #[default]
+    Group,
+    Session,
+    None,
+}
 
-    $ <bold>mise watch -t build --glob src/**/*.rs</bold>
-    Runs the "build" tasks but specify the files to watch with a glob pattern.
-    This overrides the "sources" from the tasks definition.
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum ClearMode {
+    #[default]
+    Clear,
+    Reset,
+}
 
-    $ <bold>mise watch -t build --clear</bold>
-    Extra arguments are passed to watchexec. See `watchexec --help` for details.
-    
-    $ <bold>mise watch -t serve --watch src --exts rs --restart</bold>
-    Starts an api server, watching for changes to "*.rs" files in "./src" and kills/restarts the server when they change.
-"#
-);
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum FsEvent {
+    Access,
+    Create,
+    Remove,
+    Rename,
+    Modify,
+    Metadata,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum ShellCompletion {
+    Bash,
+    Elvish,
+    Fish,
+    Nu,
+    Powershell,
+    Zsh,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum ColourMode {
+    Auto,
+    Always,
+    Never,
+}
+//endregion

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -3052,36 +3052,513 @@ const completionSpec: Fig.Spec = {
             "options": [
                 {
                     "name": [
-                        "-t",
-                        "--task"
+                        "-w",
+                        "--watch"
                     ],
-                    "description": "Tasks to run",
+                    "description": "Watch a specific file or directory",
                     "isRepeatable": true,
                     "args": {
-                        "name": "task",
+                        "name": "path",
                         "isOptional": false,
                         "isVariadic": false,
-                        "generators": simpleTaskGenerator
+                        "template": "filepaths"
                     }
                 },
                 {
                     "name": [
-                        "-g",
-                        "--glob"
+                        "-W",
+                        "--watch-non-recursive"
                     ],
-                    "description": "Files to watch\nDefaults to sources from the tasks(s)",
+                    "description": "Watch a specific directory, non-recursively",
                     "isRepeatable": true,
                     "args": {
-                        "name": "glob",
+                        "name": "path",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "template": "filepaths"
+                    }
+                },
+                {
+                    "name": [
+                        "-F",
+                        "--watch-file"
+                    ],
+                    "description": "Watch files and directories from a file",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "path",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "template": "filepaths"
+                    }
+                },
+                {
+                    "name": [
+                        "-c",
+                        "--clear"
+                    ],
+                    "description": "Clear screen before running command",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "mode",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "suggestions": [
+                            "clear",
+                            "reset"
+                        ]
+                    }
+                },
+                {
+                    "name": [
+                        "-o",
+                        "--on-busy-update"
+                    ],
+                    "description": "What to do when receiving events while the command is running",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "mode",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "suggestions": [
+                            "queue",
+                            "do-nothing",
+                            "restart",
+                            "signal"
+                        ]
+                    }
+                },
+                {
+                    "name": [
+                        "-r",
+                        "--restart"
+                    ],
+                    "description": "Restart the process if it's still running",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "-s",
+                        "--signal"
+                    ],
+                    "description": "Send a signal to the process when it's still running",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "signal",
                         "isOptional": false,
                         "isVariadic": false
                     }
+                },
+                {
+                    "name": [
+                        "--stop-signal"
+                    ],
+                    "description": "Signal to send to stop the command",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "signal",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "--stop-timeout"
+                    ],
+                    "description": "Time to wait for the command to exit gracefully",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "timeout",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "--map-signal"
+                    ],
+                    "description": "Translate signals from the OS to signals to send to the command",
+                    "isRepeatable": true,
+                    "args": {
+                        "name": "signal:signal",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "-d",
+                        "--debounce"
+                    ],
+                    "description": "Time to wait for new events before taking action",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "timeout",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "--stdin-quit"
+                    ],
+                    "description": "Exit when stdin closes",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--no-vcs-ignore"
+                    ],
+                    "description": "Don't load gitignores",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--no-project-ignore"
+                    ],
+                    "description": "Don't load project-local ignores",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--no-global-ignore"
+                    ],
+                    "description": "Don't load global ignores",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--no-default-ignore"
+                    ],
+                    "description": "Don't use internal default ignores",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--no-discover-ignore"
+                    ],
+                    "description": "Don't discover ignore files at all",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--ignore-nothing"
+                    ],
+                    "description": "Don't ignore anything at all",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "-p",
+                        "--postpone"
+                    ],
+                    "description": "Wait until first change before running command",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--delay-run"
+                    ],
+                    "description": "Sleep before running the command",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "duration",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "--poll"
+                    ],
+                    "description": "Poll for filesystem changes",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "interval",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "--shell"
+                    ],
+                    "description": "Use a different shell",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "shell",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "-n"
+                    ],
+                    "description": "Shorthand for '--shell=none'",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--emit-events-to"
+                    ],
+                    "description": "Configure event emission",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "mode",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "suggestions": [
+                            "environment",
+                            "stdio",
+                            "file",
+                            "json-stdio",
+                            "json-file",
+                            "none"
+                        ]
+                    }
+                },
+                {
+                    "name": [
+                        "--only-emit-events"
+                    ],
+                    "description": "Only emit events to stdout, run no commands",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "-E",
+                        "--env"
+                    ],
+                    "description": "Add env vars to the command",
+                    "isRepeatable": true,
+                    "args": {
+                        "name": "key=value",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "--wrap-process"
+                    ],
+                    "description": "Configure how the process is wrapped",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "mode",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "suggestions": [
+                            "group",
+                            "session",
+                            "none"
+                        ]
+                    }
+                },
+                {
+                    "name": [
+                        "-N",
+                        "--notify"
+                    ],
+                    "description": "Alert when commands start and end",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--color"
+                    ],
+                    "description": "When to use terminal colours",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "mode",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "suggestions": [
+                            "auto",
+                            "always",
+                            "never"
+                        ]
+                    }
+                },
+                {
+                    "name": [
+                        "--timings"
+                    ],
+                    "description": "Print how long the command took to run",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "-q",
+                        "--quiet"
+                    ],
+                    "description": "Don't print starting and stopping messages",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--bell"
+                    ],
+                    "description": "Ring the terminal bell on command completion",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--project-origin"
+                    ],
+                    "description": "Set the project origin",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "directory",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "template": "folders"
+                    }
+                },
+                {
+                    "name": [
+                        "--workdir"
+                    ],
+                    "description": "Set the working directory",
+                    "isRepeatable": false,
+                    "args": {
+                        "name": "directory",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "template": "folders"
+                    }
+                },
+                {
+                    "name": [
+                        "-e",
+                        "--exts"
+                    ],
+                    "description": "Filename extensions to filter to",
+                    "isRepeatable": true,
+                    "args": {
+                        "name": "extensions",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "-f",
+                        "--filter"
+                    ],
+                    "description": "Filename patterns to filter to",
+                    "isRepeatable": true,
+                    "args": {
+                        "name": "pattern",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "--filter-file"
+                    ],
+                    "description": "Files to load filters from",
+                    "isRepeatable": true,
+                    "args": {
+                        "name": "path",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "template": "filepaths"
+                    }
+                },
+                {
+                    "name": [
+                        "-J",
+                        "--filter-prog"
+                    ],
+                    "description": "[experimental] Filter programs",
+                    "isRepeatable": true,
+                    "args": {
+                        "name": "expression",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "-i",
+                        "--ignore"
+                    ],
+                    "description": "Filename patterns to filter out",
+                    "isRepeatable": true,
+                    "args": {
+                        "name": "pattern",
+                        "isOptional": false,
+                        "isVariadic": false
+                    }
+                },
+                {
+                    "name": [
+                        "--ignore-file"
+                    ],
+                    "description": "Files to load ignores from",
+                    "isRepeatable": true,
+                    "args": {
+                        "name": "path",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "template": "filepaths"
+                    }
+                },
+                {
+                    "name": [
+                        "--fs-events"
+                    ],
+                    "description": "Filesystem events to filter to",
+                    "isRepeatable": true,
+                    "args": {
+                        "name": "events",
+                        "isOptional": false,
+                        "isVariadic": false,
+                        "suggestions": [
+                            "access",
+                            "create",
+                            "remove",
+                            "rename",
+                            "modify",
+                            "metadata"
+                        ]
+                    }
+                },
+                {
+                    "name": [
+                        "--no-meta"
+                    ],
+                    "description": "Don't emit fs events for metadata changes",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--print-events"
+                    ],
+                    "description": "Print events that trigger actions",
+                    "isRepeatable": false
+                },
+                {
+                    "name": [
+                        "--manual"
+                    ],
+                    "description": "Show the manual page",
+                    "isRepeatable": false
                 }
             ],
             "args": [
                 {
+                    "name": "task",
+                    "description": "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2",
+                    "isOptional": true,
+                    "isVariadic": false,
+                    "generators": simpleTaskGenerator
+                },
+                {
                     "name": "args",
-                    "description": "Extra arguments",
+                    "description": "Task and arguments to run",
                     "isOptional": true,
                     "isVariadic": true
                 }


### PR DESCRIPTION
lots of improvements to `mise watch`, effectively it works the same as `mise run` now so you don't need to use `-t` anymore. I also added all the watchexec args so they show up in docs/completions.