### PR TITLE
fix(python): reduce network usage for python precompiled manifests

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -60,7 +60,7 @@ impl Client {
             Ok(resp.bytes().await?)
         })
     }
-    
+
     pub async fn get_async<U: IntoUrl>(&self, url: U) -> Result<Response> {
         let get = |url: Url| async move {
             debug!("GET {}", &url);

--- a/src/http.rs
+++ b/src/http.rs
@@ -53,7 +53,15 @@ impl Client {
             .zstd(true)
     }
 
-    pub async fn get<U: IntoUrl>(&self, url: U) -> Result<Response> {
+    pub fn get_bytes<U: IntoUrl>(&self, url: U) -> Result<impl AsRef<[u8]>> {
+        let url = url.into_url().unwrap();
+        RUNTIME.block_on(async {
+            let resp = self.get_async(url.clone()).await?;
+            Ok(resp.bytes().await?)
+        })
+    }
+    
+    pub async fn get_async<U: IntoUrl>(&self, url: U) -> Result<Response> {
         let get = |url: Url| async move {
             debug!("GET {}", &url);
             let mut req = self.reqwest.get(url.clone());
@@ -113,7 +121,7 @@ impl Client {
     pub fn get_text<U: IntoUrl>(&self, url: U) -> Result<String> {
         let mut url = url.into_url().unwrap();
         let text = RUNTIME.block_on(async {
-            let resp = self.get(url.clone()).await?;
+            let resp = self.get_async(url.clone()).await?;
             Ok::<String, eyre::Error>(resp.text().await?)
         })?;
         if text.starts_with("<!DOCTYPE html>") {
@@ -133,7 +141,7 @@ impl Client {
     {
         let url = url.into_url().unwrap();
         let (json, headers) = RUNTIME.block_on(async {
-            let resp = self.get(url).await?;
+            let resp = self.get_async(url).await?;
             let headers = resp.headers().clone();
             Ok::<(T, HeaderMap), eyre::Error>((resp.json().await?, headers))
         })?;
@@ -157,7 +165,7 @@ impl Client {
         debug!("GET Downloading {} to {}", &url, display_path(path));
 
         RUNTIME.block_on(async {
-            let mut resp = self.get(url).await?;
+            let mut resp = self.get_async(url).await?;
             if let Some(length) = resp.content_length() {
                 if let Some(pr) = pr {
                     pr.set_length(length);

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -12,13 +12,13 @@ use crate::toolset::{ToolRequest, ToolVersion, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{cmd, dirs, file, plugins};
 use eyre::{bail, eyre};
+use flate2::read::GzDecoder;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
-use std::io::{Read};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
-use flate2::read::GzDecoder;
 use versions::Versioning;
 use xx::regex;
 


### PR DESCRIPTION
this should make version fetching with python _way_ faster

```
❯ curl -s http://mise-versions.jdx.dev/python-precompiled | wc -c | numfmt --to iec
    482K
❯ curl -s http://mise-versions.jdx.dev/python-precompiled-aarch64-apple-darwin.gz | wc -c | numfmt --to iec
    1.9K
```