### PR TITLE
fix: concat for nushell script

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -51,7 +51,7 @@ impl Shell for Nushell {
           def --env add-hook [field: cell-path new_hook: any] {{
             let old_config = $env.config? | default {{}}
             let old_hooks = $old_config | get $field --ignore-errors | default []
-            $env.config = ($old_config | upsert $field ($old_hooks ++ $new_hook))
+            $env.config = ($old_config | upsert $field ($old_hooks ++ [$new_hook]))
           }}
 
           def "parse vars" [] {{

--- a/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
@@ -16,7 +16,7 @@ export-env {
 def --env add-hook [field: cell-path new_hook: any] {
   let old_config = $env.config? | default {}
   let old_hooks = $old_config | get $field --ignore-errors | default []
-  $env.config = ($old_config | upsert $field ($old_hooks ++ $new_hook))
+  $env.config = ($old_config | upsert $field ($old_hooks ++ [$new_hook]))
 }
 
 def "parse vars" [] {


### PR DESCRIPTION
Since https://github.com/nushell/nushell/pull/14344 (4d3283e), the `++` (concat) operator does not support appending a bare value to a list.

The current nushell script will result in this error in latest nushell:

```
Error: nu::shell::type_mismatch

  × Type mismatch during operation.
    ╭─[mise.nu:14:47]
 13 │   let old_hooks = $old_config | get $field --ignore-errors | default []
 14 │   $env.config = ($old_config | upsert $field ($old_hooks ++ $new_hook))
    ·                                               ─────┬──── ─┬ ────┬────
    ·                                                    │      │     ╰── record<condition: closure, code: closure>
    ·                                                    │      ╰── type mismatch for operator
    ·                                                    ╰── list<closure>
 15 │ }
    ╰────
```

So here we can fix it, in a backwards compatible manner, by wrapping the `$new_hook` value in brackets
to form a list containing the single item.