### PR TITLE
docs: use sudo for apt

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -102,7 +102,7 @@ For installation on Ubuntu/Debian:
 ::: code-group
 
 ```sh [amd64]
-apt update -y && apt install -y gpg sudo wget curl
+sudo apt update -y && sudo apt install -y gpg sudo wget curl
 sudo install -dm 755 /etc/apt/keyrings
 wget -qO - https://mise.jdx.dev/gpg-key.pub | gpg --dearmor | sudo tee /etc/apt/keyrings/mise-archive-keyring.gpg 1> /dev/null
 echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=amd64] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list


### PR DESCRIPTION
Correct doc to run bootstrapping apt statements under sudo