### PR TITLE
docs: Install on Windows - Update doc on install on Windows with Scoop and WinGet + fix NOTE section

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -229,7 +229,7 @@ yum install -y mise
 > [!NOTE]
 > We're currently waiting for mise to be merged to the Scoop main bucket:
 >
-> * <https://github.com/ScoopInstaller/Main/pull/6374>
+> - <https://github.com/ScoopInstaller/Main/pull/6374>
 
 This is the recommended way to install mise on Windows. It will automatically add your shims to PATH.
 
@@ -248,7 +248,7 @@ choco install mise
 > [!NOTE]
 > We're currently waiting for mise to be merged to WinGet-pkgs:
 >
-> * <https://github.com/microsoft/winget-pkgs/pull/197444>
+> - <https://github.com/microsoft/winget-pkgs/pull/197444>
 
 ```sh
 winget install mise

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -224,7 +224,12 @@ yum-config-manager --add-repo https://mise.jdx.dev/rpm/mise.repo
 yum install -y mise
 ```
 
-### Windows - scoop
+### Windows - Scoop
+
+> [!NOTE]
+> We're currently waiting for mise to be merged to the Scoop main bucket:
+>
+> * <https://github.com/ScoopInstaller/Main/pull/6374>
 
 This is the recommended way to install mise on Windows. It will automatically add your shims to PATH.
 
@@ -232,17 +237,18 @@ This is the recommended way to install mise on Windows. It will automatically ad
 scoop install mise
 ```
 
-### Windows - chocolatey
+### Windows - Chocolatey
 
 ```sh
 choco install mise
 ```
 
-### Windows - winget
+### Windows - WinGet
 
-::: note
-winget is coming soon, follow <https://github.com/microsoft/winget-pkgs/pull/197444>
-:::
+> [!NOTE]
+> We're currently waiting for mise to be merged to WinGet-pkgs:
+>
+> * <https://github.com/microsoft/winget-pkgs/pull/197444>
 
 ```sh
 winget install mise


### PR DESCRIPTION
VitePress does not support `:::note`:

* <https://vitepress.dev/guide/markdown#custom-containers>
* <https://github.com/vuejs/vitepress/issues/4427>

<img width="816" alt="image" src="https://github.com/user-attachments/assets/b6512b6b-2263-4515-b65e-781e1f3f2c0e" />

But it supports GitHub flavored alerts, which supports `> [!NOTE]`, so I used that instead:

* <https://vitepress.dev/guide/markdown#github-flavored-alerts>
