### PR TITLE
fix: Can not find the bin files when using python venv on windows

### DIFF
--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -113,7 +113,8 @@ impl EnvResults {
             }
         }
         if venv.exists() {
-            r.env_paths.insert(0, venv.join("bin"));
+            r.env_paths
+                .insert(0, venv.join(if cfg!(windows) { "Scripts" } else { "bin" }));
             env.insert(
                 "VIRTUAL_ENV".into(),
                 (


### PR DESCRIPTION
Activating python venv on windows uses the `venv/bin` directory, but it should actually be the `venv/Scripts` path on windows.

```console
# mise hook-env -s pwsh
# ...
$Env:VIRTUAL_ENV='C:\Users\xxx\.local\share\chezmoi\.venv'
$Env:Path='C:\Users\xxx\.local\share\chezmoi\.venv\bin;...'

# l .\.venv\Scripts\python.exe
Mode  Size Date Modified    Name
-a--- 257k 2024-12-11 11:39 .\.venv\Scripts\python.exe
```
