### PR TITLE
feat(registry): Add btop

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -94,6 +94,7 @@ You can also specify the full name for a tool using `mise use aqua:1password/cli
 | boundary | [aqua:hashicorp/boundary](https://github.com/hashicorp/boundary) [asdf:asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp) |
 | bpkg | [asdf:bpkg/asdf-bpkg](https://github.com/bpkg/asdf-bpkg) |
 | brig | [aqua:brigadecore/brigade](https://github.com/brigadecore/brigade) [asdf:Ibotta/asdf-brig](https://github.com/Ibotta/asdf-brig) |
+| btop | [ubi:aristocratos/btop](https://github.com/aristocratos/btop) |
 | btrace | [asdf:joschi/asdf-btrace](https://github.com/joschi/asdf-btrace) |
 | buf | [aqua:bufbuild/buf](https://github.com/bufbuild/buf) [ubi:bufbuild/buf](https://github.com/bufbuild/buf) [asdf:truepay/asdf-buf](https://github.com/truepay/asdf-buf) |
 | buildpack | [aqua:buildpacks/pack](https://github.com/buildpacks/pack) [asdf:johnlayton/asdf-buildpack](https://github.com/johnlayton/asdf-buildpack) |

--- a/registry.toml
+++ b/registry.toml
@@ -228,6 +228,8 @@ boundary.backends = [
 bpkg.backends = ["asdf:bpkg/asdf-bpkg"]
 brig.backends = ["aqua:brigadecore/brigade", "asdf:Ibotta/asdf-brig"]
 brig.test = ["brig version", "Brigade client: version v{{version}}"]
+btop.backends = ['ubi:aristocratos/btop']
+btop.test = ["btop --version", "btop version: {{version}}"]
 btrace.backends = ["asdf:joschi/asdf-btrace"]
 buf.backends = [
     "aqua:bufbuild/buf",


### PR DESCRIPTION
https://github.com/aristocratos/btop

```sh
docker run -it --rm jdxcode/mise:latest mise exec ubi:aristocratos/btop -- btop --utf-force
```


Tried with aqua as wellbut it does not work:
```sh
❯ mise use -g aqua:aristocratos/btop
mise ERROR failed to install aqua:aristocratos/btop@1.4.0
mise ERROR unsupported format: tbz
```