### PR TITLE
feat: Allows control of config_root for global config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,6 +342,12 @@ Default: `$MISE_CONFIG_DIR/config.toml` (Usually ~/.config/mise/config.toml)
 
 This is the path to the config file.
 
+### `MISE_GLOBAL_CONFIG_ROOT`
+
+Default: `$HOME`
+
+This is the path which is used as `{{config_root}}` for the global config file.
+
 ### `MISE_ENV_FILE`
 
 Set to a filename to read from env from a dotenv file. e.g.: `MISE_ENV_FILE=.env`.

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -407,6 +407,10 @@
           "description": "Path to the global mise config file. Default is `~/.config/mise/config.toml`. This must be an env var.",
           "type": "string"
         },
+        "global_config_root": {
+          "description": "Path which is used as `{{config_root}}` for the global config file. Default is `$HOME`. This must be an env var.",
+          "type": "string"
+        },
         "go_default_packages_file": {
           "default": "~/.default-go-packages",
           "description": "Path to a file containing default go packages to install when installing go",

--- a/settings.toml
+++ b/settings.toml
@@ -330,6 +330,12 @@ type = "Path"
 optional = true
 description = "Path to the global mise config file. Default is `~/.config/mise/config.toml`. This must be an env var."
 
+[global_config_root]
+env = "MISE_GLOBAL_CONFIG_ROOT"
+type = "Path"
+optional = true
+description = "Path which is used as `{{config_root}}` for the global config file. Default is `$HOME`. This must be an env var."
+
 [go_default_packages_file]
 env = "MISE_GO_DEFAULT_PACKAGES_FILE"
 type = "Path"

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -242,7 +242,7 @@ pub fn parse(path: &Path) -> Result<Box<dyn ConfigFile>> {
 
 pub fn config_root(path: &Path) -> PathBuf {
     if is_global_config(path) {
-        return env::HOME.to_path_buf();
+        return env::MISE_GLOBAL_CONFIG_ROOT.to_path_buf();
     }
     let path = path
         .absolutize()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -909,7 +909,10 @@ pub fn load_config_paths(config_filenames: &[String], include_ignored: bool) -> 
     config_files
         .into_iter()
         .unique_by(|p| file::desymlink_path(p))
-        .filter(|p| include_ignored || !(config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(&p)))
+        .filter(|p| {
+            include_ignored
+                || !(config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(p))
+        })
         .collect()
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -909,7 +909,7 @@ pub fn load_config_paths(config_filenames: &[String], include_ignored: bool) -> 
     config_files
         .into_iter()
         .unique_by(|p| file::desymlink_path(p))
-        .filter(|p| include_ignored || !config_file::is_ignored(&config_trust_root(p)))
+        .filter(|p| include_ignored || !(config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(&p)))
         .collect()
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -114,6 +114,10 @@ pub static MISE_GLOBAL_CONFIG_FILE: Lazy<PathBuf> = Lazy::new(|| {
         .or_else(|| var_path("MISE_CONFIG_FILE"))
         .unwrap_or_else(|| MISE_CONFIG_DIR.join("config.toml"))
 });
+pub static MISE_GLOBAL_CONFIG_ROOT: Lazy<PathBuf> = Lazy::new(|| {
+    var_path("MISE_GLOBAL_CONFIG_ROOT")
+        .unwrap_or_else(|| HOME.to_path_buf())
+});
 pub static MISE_SYSTEM_CONFIG_FILE: Lazy<PathBuf> = Lazy::new(|| {
     var_path("MISE_SYSTEM_CONFIG_FILE").unwrap_or_else(|| MISE_SYSTEM_DIR.join("config.toml"))
 });

--- a/src/env.rs
+++ b/src/env.rs
@@ -114,10 +114,8 @@ pub static MISE_GLOBAL_CONFIG_FILE: Lazy<PathBuf> = Lazy::new(|| {
         .or_else(|| var_path("MISE_CONFIG_FILE"))
         .unwrap_or_else(|| MISE_CONFIG_DIR.join("config.toml"))
 });
-pub static MISE_GLOBAL_CONFIG_ROOT: Lazy<PathBuf> = Lazy::new(|| {
-    var_path("MISE_GLOBAL_CONFIG_ROOT")
-        .unwrap_or_else(|| HOME.to_path_buf())
-});
+pub static MISE_GLOBAL_CONFIG_ROOT: Lazy<PathBuf> =
+    Lazy::new(|| var_path("MISE_GLOBAL_CONFIG_ROOT").unwrap_or_else(|| HOME.to_path_buf()));
 pub static MISE_SYSTEM_CONFIG_FILE: Lazy<PathBuf> = Lazy::new(|| {
     var_path("MISE_SYSTEM_CONFIG_FILE").unwrap_or_else(|| MISE_SYSTEM_DIR.join("config.toml"))
 });


### PR DESCRIPTION
- Adds `MISE_GLOBAL_CONFIG_ROOT` to control config_root for global config file which previously was always `env::HOME` (which remains the default, when unconfigured)
- Allows `MISE_IGNORED_CONFIG_PATHS` to specify explicit paths of config files to ignore