### PR TITLE
docs: fix some broken anchor links

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -227,7 +227,7 @@ outputs = { auto = true }
 - **Note**: Only applies to toml-tasks.
 
 The shell to use to run the task. This is useful if you want to run a task with a different shell than
-the default such as `fish`, `zsh`, or `pwsh`. Generally though, it's recommended to use a [shebang](/tasks/toml-tasks.html#shell-shebang) instead
+the default such as `fish`, `zsh`, or `pwsh`. Generally though, it's recommended to use a [shebang](./toml-tasks#shell-shebang) instead
 because that will allow IDEs with mise support to show syntax highlighting and linting for the script.
 
 ```toml

--- a/docs/tasks/toml-tasks.md
+++ b/docs/tasks/toml-tasks.md
@@ -168,7 +168,7 @@ outputs = ['target/debug/mycli']
 
 You can use `sources` alone if with [`mise watch`](/cli/watch.html) to run the task when the sources change.
 
-## Specifying a shell or an interpreter
+## Specifying a shell or an interpreter {#shell-shebang}
 
 Tasks are executed with `set -e` (`set -o erropt`) if the shell is `sh`, `bash`, or `zsh`. This means that the script
 will exit if any command fails. You can disable this by running `set +e` in the script.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -97,7 +97,7 @@ As of this writing, env var management and task execution are not yet supported 
 
 `mise activate` will not update PATH until the shell prompt is displayed. So if you need to access a
 tool provided by mise before the prompt is displayed you can either
-[add the shims to your PATH](getting-started.html#2-add-mise-shims-to-path) e.g.
+[add the shims to your PATH](/dev-tools/shims.html#how-to-add-mise-shims-to-path) e.g.
 
 ```bash
 export PATH="$HOME/.local/share/mise/shims:$PATH"

--- a/settings.toml
+++ b/settings.toml
@@ -395,7 +395,7 @@ default = true
 description = "Set to false to disable the idiomatic version files such as .node-version, .ruby-version, etc."
 docs = """
 Plugins can read the versions files used by other version managers (if enabled by the plugin)
-for example, `.nvmrc` in the case of node's nvm. See [idiomatic version files](#idiomatic-version-files)
+for example, `.nvmrc` in the case of node's nvm. See [idiomatic version files](/configuration.html#idiomatic-version-files)
 for more
 information.
 
@@ -619,7 +619,7 @@ optional = true
 description = "If true, compile python from source. If false, use precompiled binaries. If not set, use precompiled binaries if available."
 docs = """
 * Values:
-  * `true` - always compile with python-build instead of downloading [precompiled binaries](#precompiled-python-binaries).
+  * `true` - always compile with python-build instead of downloading [precompiled binaries](/python.html#precompiled-python-binaries).
   * `false` - always download precompiled binaries.
   * [undefined] - use precompiled binary if one is available for the current platform, compile otherwise.
 """


### PR DESCRIPTION
`vitepress` already checks for links but does not check for anchors. `lychee` seems to be able to catch some of the issues.
```sh
cd docs/.vitepress/dist
mise x ubi:lycheeverse/lychee -- lychee .  --include-fragments --offline  
#  3613/3613 ━━━━━━━━━━━━━━━━━━━━ Finished extracting links 
# 🔍 3613 Total (in 0s) ✅ 1300 OK 🚫 0 Errors 💤 2313 Excluded
```