### PR TITLE
fix: disable reverse uv syncing

### DIFF
--- a/docs/cli/sync/python.md
+++ b/docs/cli/sync/python.md
@@ -17,7 +17,7 @@ Get tool versions from pyenv
 
 ### `--uv`
 
-Sync tool versions with uv (2-way sync)
+Sync tool versions from uv
 
 Examples:
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1268,7 +1268,7 @@ This won't overwrite any existing installs but will overwrite any existing symli
     $ uv run -p 3.10.0 -- python -V - uses mise-provided python
 "
         flag "--pyenv" help="Get tool versions from pyenv"
-        flag "--uv" help="Sync tool versions with uv (2-way sync)"
+        flag "--uv" help="Sync tool versions from uv"
     }
     cmd "ruby" help="Symlinks all ruby tool versions from an external tool into mise" {
         after_long_help r"Examples:

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -1,6 +1,5 @@
 use eyre::Result;
 use itertools::sorted;
-use std::env::consts::{ARCH, OS};
 
 use crate::env::PYENV_ROOT;
 use crate::{backend, config, dirs, env, file};

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -17,7 +17,7 @@ pub struct SyncPython {
     #[clap(long)]
     pyenv: bool,
 
-    /// Sync tool versions with uv (2-way sync)
+    /// Sync tool versions from uv
     #[clap(long)]
     uv: bool,
 }
@@ -80,31 +80,36 @@ impl SyncPython {
             }
         }
 
-        let subdirs = file::dir_subdirs(&installed_python_versions_path)?;
-        for v in sorted(subdirs) {
-            if v.starts_with(".") {
-                continue;
-            }
-            let src = installed_python_versions_path.join(&v);
-            if src.is_symlink() {
-                continue;
-            }
-            // ~/.local/share/uv/python/cpython-3.10.16-macos-aarch64-none
-            // ~/.local/share/uv/python/cpython-3.13.0-linux-x86_64-gnu
-            let os = OS;
-            let arch = if cfg!(target_arch = "x86_64") {
-                "x86_64-gnu"
-            } else if cfg!(target_arch = "aarch64") {
-                "aarch64-none"
-            } else {
-                ARCH
-            };
-            let dst = uv_versions_path.join(format!("cpython-{v}-{os}-{arch}"));
-            if !dst.exists() {
-                file::make_symlink(&src, &dst)?;
-                miseprintln!("Synced python@{v} from mise to uv");
-            }
-        }
+        // TODO: disable reverse syncing until there is a way to deal with these 2 files that uv needs:
+        // ❯ diff -rq uv mise
+        // Only in uv/lib/python3.11: EXTERNALLY-MANAGED
+        // Files uv/lib/python3.11/_sysconfigdata__darwin_darwin.py and mise/lib/python3.11/_sysconfigdata__darwin_darwin.py differ
+        // See https://github.com/jdx/mise/issues/3654
+        //let subdirs = file::dir_subdirs(&installed_python_versions_path)?;
+        //for v in sorted(subdirs) {
+        //    if v.starts_with(".") {
+        //        continue;
+        //    }
+        //    let src = installed_python_versions_path.join(&v);
+        //    if src.is_symlink() {
+        //        continue;
+        //    }
+        //    // ~/.local/share/uv/python/cpython-3.10.16-macos-aarch64-none
+        //    // ~/.local/share/uv/python/cpython-3.13.0-linux-x86_64-gnu
+        //    let os = OS;
+        //    let arch = if cfg!(target_arch = "x86_64") {
+        //        "x86_64-gnu"
+        //    } else if cfg!(target_arch = "aarch64") {
+        //        "aarch64-none"
+        //    } else {
+        //        ARCH
+        //    };
+        //    let dst = uv_versions_path.join(format!("cpython-{v}-{os}-{arch}"));
+        //    if !dst.exists() {
+        //        file::make_symlink(&src, &dst)?;
+        //        miseprintln!("Synced python@{v} from mise to uv");
+        //    }
+        //}
         Ok(())
     }
 }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -2398,7 +2398,7 @@ const completionSpec: Fig.Spec = {
                             "name": [
                                 "--uv"
                             ],
-                            "description": "Sync tool versions with uv (2-way sync)",
+                            "description": "Sync tool versions from uv",
                             "isRepeatable": false
                         }
                     ]


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/issues/3654

it does not appear this is going to be possible right now at least without a bunch of work modifying sysconfig. If someone really wants this they'll need to figure out how to get mise to patch sysconfig the same way uv does: https://github.com/astral-sh/uv/blob/main/crates/uv-python/src/sysconfig/mod.rs#L217

it is rust though, so maybe we could just copy their code? Funnily enough it seems that's what they did reading the license information in the header.

It's probably also worth pinging the uv team and asking if they have any plans around the indygreg binaries that would make this easier for mise.