### PR TITLE
fix: `mise run` shorthand with options

### DIFF
--- a/e2e/tasks/test_task_options
+++ b/e2e/tasks/test_task_options
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+cat <<EOF >mise.toml
+tasks.mytask = 'echo {{option(name="foo")}}'
+EOF
+
+assert "mise run mytask --foo bar" "bar"
+assert "mise run -- mytask --foo bar" "bar"
+assert "mise run mytask -- --foo bar" "bar"
+assert "mise mytask --foo bar" "bar"
+assert "mise -- mytask --foo bar" "bar"
+assert "mise mytask -- --foo bar" "bar"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -61,7 +61,7 @@ flag "--silent" help="Suppress all task output and mise non-error messages" glob
 flag "--trace" help="Sets log level to trace" hide=true global=true
 flag "-v --verbose" help="Show extra output (use -vv for even more)" var=true global=true count=true
 arg "[TASK]" help="Task to run" help_long="Task to run.\n\nShorthand for `mise task run <TASK>`." required=false
-arg "[TASK_ARGS]..." help="Task arguments" required=false var=true hide=true
+arg "[TASK_ARGS]..." help="Task arguments" required=false double_dash="automatic" var=true hide=true
 cmd "activate" help="Initializes mise in the current shell session" {
     long_help r#"Initializes mise in the current shell session
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -87,7 +87,7 @@ pub struct Cli {
     #[clap(name = "TASK", long_help = LONG_TASK_ABOUT)]
     pub task: Option<String>,
     /// Task arguments
-    #[clap(hide = true)]
+    #[clap(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
     pub task_args: Option<Vec<String>>,
     /// Change directory before running command
     #[clap(short='C', long, global=true, value_name="DIR", value_hint=clap::ValueHint::DirPath)]


### PR DESCRIPTION
Fixes #3717
