### PR TITLE
fix: include full env in toolset tera_ctx

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -603,7 +603,8 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     fn dependency_env(&self) -> eyre::Result<BTreeMap<String, String>> {
-        self.dependency_toolset()?.full_env()
+        let config = Config::get();
+        self.dependency_toolset()?.full_env(&config)
     }
 
     fn fuzzy_match_filter(&self, versions: Vec<String>, query: &str) -> eyre::Result<Vec<String>> {

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -67,7 +67,8 @@ impl Completion {
         if self.include_bash_completion_lib {
             args.push("--include-bash-completion-lib".into());
         }
-        let output = cmd("usage", args).full_env(toolset.full_env()?).read()?;
+        let config = Config::get();
+        let output = cmd("usage", args).full_env(toolset.full_env(&config)?).read()?;
         Ok(output)
     }
 

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -68,7 +68,9 @@ impl Completion {
             args.push("--include-bash-completion-lib".into());
         }
         let config = Config::get();
-        let output = cmd("usage", args).full_env(toolset.full_env(&config)?).read()?;
+        let output = cmd("usage", args)
+            .full_env(toolset.full_env(&config)?)
+            .read()?;
         Ok(output)
     }
 

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -373,7 +373,8 @@ impl Doctor {
     }
 
     fn paths(&mut self, ts: &Toolset) -> eyre::Result<Vec<PathBuf>> {
-        let env = ts.full_env()?;
+        let config = Config::get();
+        let env = ts.full_env(&config)?;
         let path = env
             .get(&*PATH_KEY)
             .ok_or_else(|| eyre::eyre!("Path not found"))?;

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -161,7 +161,8 @@ fn execute(ts: &Toolset, root: &Path, hook: &Hook) -> Result<()> {
         .map(|s| s.as_str())
         .chain(once(hook.script.as_str()))
         .collect_vec();
-    let mut env = ts.full_env()?;
+    let config = Config::get();
+    let mut env = ts.full_env(&config)?;
     if let Some(cwd) = dirs::CWD.as_ref() {
         env.insert(
             "MISE_ORIGINAL_CWD".to_string(),

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -463,9 +463,9 @@ impl Toolset {
             .collect()
     }
     /// returns env_with_path but also with the existing env vars from the system
-    pub fn full_env(&self) -> Result<EnvMap> {
+    pub fn full_env(&self, config: &Config) -> Result<EnvMap> {
         let mut env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
-        env.extend(self.env_with_path(&Config::get())?.clone());
+        env.extend(self.env_with_path(config)?.clone());
         Ok(env)
     }
     /// the full mise environment including all tool paths
@@ -590,7 +590,7 @@ impl Toolset {
     pub fn tera_ctx(&self) -> Result<&tera::Context> {
         self.tera_ctx.get_or_try_init(|| {
             let config = Config::get();
-            let env = self.env_with_path(&config)?;
+            let env = self.full_env(&config)?;
             let mut ctx = config.tera_ctx.clone();
             ctx.insert("env", &env);
             Ok(ctx)

--- a/src/watch_files.rs
+++ b/src/watch_files.rs
@@ -67,7 +67,8 @@ fn execute(ts: &Toolset, root: &Path, run: &str, files: Vec<&PathBuf>) -> Result
         .map(|s| s.as_str())
         .chain(once(run))
         .collect_vec();
-    let mut env = ts.full_env()?;
+    let config = Config::get();
+    let mut env = ts.full_env(&config)?;
     env.insert("MISE_WATCH_FILES_MODIFIED".to_string(), modified_files_var);
     if let Some(cwd) = &*dirs::CWD {
         env.insert(


### PR DESCRIPTION
This fixes a bug that we cannot use the pristine env in `tasks.*.run` templates. The bug is caused by #3708, which started using toolset's `tera_ctx` instead of that of task itself.

I added config to the args of `full_env`. If it's better to make it `Option<&Config>`, I will refactor it.

https://github.com/risu729/mise/blob/130b3e1cf8a924ddf28ce94d7cb01e52a00ea09e/src/toolset/mod.rs#L466