### PR TITLE
feat: Modify install_rubygems_hook to place plugin in site_ruby directory

### DIFF
--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -15,7 +15,7 @@ use crate::install_context::InstallContext;
 use crate::lock_file::LockFile;
 use crate::toolset::{ToolVersion, Toolset};
 use crate::ui::progress_report::SingleReport;
-use crate::{cmd, env, file, plugins, timeout};
+use crate::{cmd, file, plugins, timeout};
 use eyre::{Result, WrapErr};
 use itertools::Itertools;
 use xx::regex;
@@ -244,15 +244,11 @@ impl RubyPlugin {
     }
 
     fn install_rubygems_hook(&self, tv: &ToolVersion) -> Result<()> {
-        let d = self.rubygems_plugins_path(tv);
-        let f = d.join("rubygems_plugin.rb");
-        file::create_dir_all(d)?;
+        let site_ruby_path = tv.install_path().join("lib/ruby/site_ruby");
+        let f = site_ruby_path.join("rubygems_plugin.rb");
+        file::create_dir_all(site_ruby_path)?;
         file::write(f, include_str!("assets/rubygems_plugin.rb"))?;
         Ok(())
-    }
-
-    fn rubygems_plugins_path(&self, tv: &ToolVersion) -> PathBuf {
-        tv.install_path().join("lib/rubygems_plugin")
     }
 
     fn install_cmd<'a>(
@@ -406,20 +402,10 @@ impl Backend for RubyPlugin {
         &self,
         _config: &Config,
         _ts: &Toolset,
-        tv: &ToolVersion,
+        _tv: &ToolVersion,
     ) -> eyre::Result<BTreeMap<String, String>> {
-        // TODO: is there a way to avoid needing to set RUBYLIB?
-        // is there a directory I can put rubygems_plugin.rb in that will be automatically loaded?
-        let rubygems_plugin_path = self.rubygems_plugins_path(tv);
-        let mut map = BTreeMap::new();
-        if rubygems_plugin_path.exists() {
-            let rubygems_plugin_path = rubygems_plugin_path.to_string_lossy().to_string();
-            let rubylib = match env::PRISTINE_ENV.get("RUBYLIB") {
-                Some(rubylib) => format!("{}:{}", rubylib, rubygems_plugin_path),
-                None => rubygems_plugin_path,
-            };
-            map.insert("RUBYLIB".to_string(), rubylib);
-        }
+        let map = BTreeMap::new();
+        // No modification to RUBYLIB
         Ok(map)
     }
 }


### PR DESCRIPTION
To avoid setting the RUBYLIB environment variable, the rubygems_plugin.rb file is now placed in the site_ruby directory within the Ruby installation. This change ensures that Ruby automatically loads the plugin.

- Updated install_rubygems_hook method to place the plugin in the site_ruby directory.
- Created the necessary directory structure if it does not exist.
- Wrote the rubygems_plugin.rb file to the site_ruby directory.