### PR TITLE
fix: panic when setting config value

### DIFF
--- a/e2e/cli/test_config_set
+++ b/e2e/cli/test_config_set
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo '[tools.node]
-version = "latest"' > mise.toml
+version = "latest"' >mise.toml
 
 assert "cat mise.toml" '[tools.node]
 version = "latest"'

--- a/e2e/cli/test_config_set
+++ b/e2e/cli/test_config_set
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo '[tools.node]
+version = "latest"' > mise.toml
+
+assert "cat mise.toml" '[tools.node]
+version = "latest"'
+
+mise config set tools.node.postinstall 'corepack enable'
+assert "mise config get tools.node.postinstall" "corepack enable"
+assert "mise config get tools.node.version" "latest"
+mise config set env._.python.venv.path '.venv'
+assert "mise config get env._.python.venv.path" ".venv"
+mise config set env._.python.venv.create true
+assert "mise config get env._.python.venv.create" "true"


### PR DESCRIPTION
Rough draft around the discussion #3820. 

This handles the basic use-case and will behave like the following.
```
# set simple value or nested value
mise config set tools.node 20 --> node = "20"
mise config set tools.node.version 20 --> node = { version = "20" }

# transform version to inline table if its already set
mise config set tools.node 20 --> node = "20"
mise config set tools.node.postinstall 'corepack enable' --> node = { version = "20", postinstall = "corepack enable" }
```