### PR TITLE
docs: fix incorrect examples that were causing 'expected a sequence' error

### DIFF
--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -137,8 +137,8 @@ _.python.venv = "/root/.venv" # can be absolute
 _.python.venv = "{{env.HOME}}/.cache/venv/myproj" # can use templates
 _.python.venv = { path = ".venv", create = true } # create the venv if it doesn't exist
 _.python.venv = { path = ".venv", create = true, python = "3.10" } # use a specific python version
-_.python.venv = { path = ".venv", create = true, python_create_args = "--without-pip" } # pass args to python -m venv
-_.python.venv = { path = ".venv", create = true, uv_create_args = "--system-site-packages" } # pass args to uv venv
+_.python.venv = { path = ".venv", create = true, python_create_args = ["--without-pip"] } # pass args to python -m venv
+_.python.venv = { path = ".venv", create = true, uv_create_args = ["--system-site-packages"] } # pass args to uv venv
 ```
 
 The venv will need to be created manually with `python -m venv /path/to/venv` unless `create=true`.

--- a/mise.lock
+++ b/mise.lock
@@ -73,6 +73,9 @@ jq-macos-arm64 = "sha256:0bbe619e663e0de2c550be2fe0d240d076799d6f8a652b70fa04aea
 version = "0.11"
 backend = "aqua:jedisct1/minisign"
 
+[tools.minisign.checksums]
+"minisign-0.11-linux.tar.gz" = "sha256:f0a0954413df8531befed169e447a66da6868d79052ed7e892e50a4291af7ae0"
+
 [tools."npm:markdownlint-cli"]
 version = "0.43.0"
 backend = "npm:markdownlint-cli"


### PR DESCRIPTION
As `python_create_args` and `uv_create_args` options only allow list of strings and not simple strings, we correct the examples. Current examples were causing a config loading error like:

```
invalid type: string "--without-pip", expected a sequence
```

In the future it might prove useful to only include examples snippets that are also used during testing, so they do not diverge from mise usage. With mkdocs this is possible as I did it on one or two other projects.