### PR TITLE
fix: zstd detection false positive on MacOS

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -73,6 +73,9 @@ jq-macos-arm64 = "sha256:0bbe619e663e0de2c550be2fe0d240d076799d6f8a652b70fa04aea
 version = "0.11"
 backend = "aqua:jedisct1/minisign"
 
+[tools.minisign.checksums]
+"minisign-0.11-linux.tar.gz" = "sha256:f0a0954413df8531befed169e447a66da6868d79052ed7e892e50a4291af7ae0"
+
 [tools."npm:markdownlint-cli"]
 version = "0.43.0"
 backend = "npm:markdownlint-cli"

--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -77,7 +77,7 @@ get_ext() {
 
 tar_supports_zstd() {
   # tar is bsdtar or version is >= 1.31
-  if tar --version | grep -q 'bsdtar'; then
+  if tar --version | grep -q 'bsdtar' && command -v zstd >/dev/null 2>&1; then
     true
   elif tar --version | grep -q '1.(3[1-9]|{4-9}\d)'; then
     true


### PR DESCRIPTION
Fixes #3827 

It seems `bsdtar` on macOS requires the binary `zstd` for its support to work (as opposed to GNU tar). Unfortunately he man pages do not make that clear.