### PR TITLE
fix: add `:` escaping for tasks with multiple colons

### DIFF
--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2060,7 +2060,7 @@ complete "plugin" run="mise plugins --core --user"
 complete "prefix" run="mise ls-remote {{words[PREV]}}"
 complete "setting" run="mise settings | awk '{print $1}'"
 complete "task" run=r#"
-mise tasks --json | jq -r '.[] | (.name | sub(":"; "\\:")) + ":" + (.description | sub(":"; "\\:"))'
+mise tasks --json | jq -r '.[] | (.name | gsub(":"; "\\:")) + ":" + (.description | gsub(":"; "\\:"))'
 "# descriptions=true
 
 complete "tool@version" run=r#"

--- a/src/assets/mise-extra.usage.kdl
+++ b/src/assets/mise-extra.usage.kdl
@@ -7,7 +7,7 @@ complete "plugin" run="mise plugins --core --user"
 complete "prefix" run="mise ls-remote {{words[PREV]}}"
 complete "setting" run="mise settings | awk '{print $1}'"
 complete "task" run=r#"
-mise tasks --json | jq -r '.[] | (.name | sub(":"; "\\:")) + ":" + (.description | sub(":"; "\\:"))'
+mise tasks --json | jq -r '.[] | (.name | gsub(":"; "\\:")) + ":" + (.description | gsub(":"; "\\:"))'
 "# descriptions=true
 
 complete "tool@version" run=r#"


### PR DESCRIPTION
This PR fixes the colon escaping substitution, done for tasks completion, to apply to all colons rather than just the first one, by using `gsub` instead of `sub`.
To replicate:
```sh
$ mise tasks add "be:api:build" -- echo hello
$ mise be<TAB>  # completes as "be:api" with the description "build:" (even though none was provided)
``` 
*This, of course, doesn't change the manually added colon.*