### PR TITLE
Fix cargo install examples

### DIFF
--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -96,7 +96,7 @@ Select the CLI bin name to install when multiple are available (passed as `cargo
 
 ```toml
 [tools]
-"cargo:github.com/username/demo" = { version = "tag:v1.0.0", bin = "demo" }
+"cargo:https://github.com/username/demo" = { version = "tag:v1.0.0", bin = "demo" }
 ```
 
 ### `crate`
@@ -106,7 +106,7 @@ Select the crate name to install when multiple are available (passed as
 
 ```toml
 [tools]
-"cargo:github.com/username/demo" = { version = "tag:v1.0.0", crate = "demo" }
+"cargo:https://github.com/username/demo" = { version = "tag:v1.0.0", crate = "demo" }
 ```
 
 ### `locked`
@@ -116,5 +116,5 @@ pass `false` to disable:
 
 ```toml
 [tools]
-"cargo:github.com/username/demo" = { version = "latest", locked = false }
+"cargo:https://github.com/username/demo" = { version = "latest", locked = false }
 ```


### PR DESCRIPTION
Using these examples results in an error - it's appending the path to `https://github.com`, resulting in `https://github.com/github.com/cross-rs/cross.git`:

```
DEBUG $ cargo install --git=https://github.com/github.com/cross-rs/cross.git --branch=main --locked cross --root /Users/tomforbes/.local/share/mise/installs/cargo-github-com-cross-rs-cross/ref-main
    Updating git repository `https://github.com/github.com/cross-rs/cross.git`
```

Not sure if this is intended or not, but I figured I'd fix the examples.