### PR TITLE
fix: remove `root` env var in tasks

### DIFF
--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -53,7 +53,7 @@ The following environment variables are passed to the task:
 
 - `MISE_ORIGINAL_CWD`: The original working directory from where the task was run.
 - `MISE_CONFIG_ROOT`: The directory containing the `mise.toml` file where the task was defined or if the config path is something like `~/src/myproj/.config/mise.toml`, it will be `~/src/myproj`.
-- `MISE_PROJECT_ROOT` or `root`: The root of the project.
+- `MISE_PROJECT_ROOT`: The root of the project.
 - `MISE_TASK_NAME`: The name of the task being run.
 - `MISE_TASK_DIR`: The directory containing the task script.
 - `MISE_TASK_FILE`: The full path to the task script.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -445,7 +445,6 @@ impl Run {
         }
         if let Some(root) = config.project_root.clone().or(task.config_root.clone()) {
             env.insert("MISE_PROJECT_ROOT".into(), root.display().to_string());
-            env.insert("root".into(), root.display().to_string());
         }
         env.insert("MISE_TASK_NAME".into(), task.name.clone());
         let task_file = task.file.as_ref().unwrap_or(&task.config_source);


### PR DESCRIPTION
I believe the intention here was for templates but for some reason this was added to env vars. Removing as it can obviously conflict with other env vars.

Fixes https://github.com/jdx/mise/issues/3883

BREAKING CHANGE: you will need to use `{{root}}` or MISE_PROJECT_ROOT after this change.
