### PR TITLE
fix: pre-commit hook temporary file

### DIFF
--- a/docs/cli/generate/git-pre-commit.md
+++ b/docs/cli/generate/git-pre-commit.md
@@ -9,7 +9,7 @@
 This command generates a git pre-commit hook that runs a mise task like `mise run pre-commit`
 when you commit changes to your repository.
 
-Staged files are passed to the task as `STAGED`.
+Staged files are passed to the task via appended arguments.
 
 ## Flags
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -522,7 +522,7 @@ This is designed to be used in a project where contributors may not have mise in
 This command generates a git pre-commit hook that runs a mise task like `mise run pre-commit`
 when you commit changes to your repository.
 
-Staged files are passed to the task as `STAGED`."
+Staged files are passed to the task via appended arguments."
         after_long_help r#"Examples:
 
     $ mise generate git-pre-commit --write --task=pre-commit


### PR DESCRIPTION
- Create temporary files in correct location (`${TMPDIR}`) and make `mktemp` usage cross-platform
- Fix cleanup of temporary file (`exec` doesn't allow `trap` to be triggered)
- Allow pre-commit for the first commit (i.e. where `HEAD` isn't valid yet)