### PR TITLE
fix: maven-mvnd does not install with aqua

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -322,7 +322,13 @@ impl AquaPackage {
     }
 
     pub fn asset(&self, v: &str) -> Result<String> {
-        self.parse_aqua_str(&self.asset, v, &Default::default())
+        // derive asset from url if not set and url contains a path
+        if self.asset.is_empty() && self.url.split("/").count() > "//".len() {
+            let asset = self.url.rsplit("/").next().unwrap_or("");
+            self.parse_aqua_str(asset, v, &Default::default())
+        } else {
+            self.parse_aqua_str(&self.asset, v, &Default::default())
+        }
     }
 
     pub fn asset_strs(&self, v: &str) -> Result<IndexSet<String>> {


### PR DESCRIPTION
Fixes #3977 

The [registry.yml](https://mise-versions.jdx.dev/aqua-registry/apache/maven-mvnd/registry.yaml) does not contain a field `asset` like the current code assumes. Instead a `url` is provided which can be used to derive the asset pattern from.
Could not find much information about the registry.yml format on https://aquaproj.github.io/docs/reference/registry-config though so i'm not sure if this fix might cause potential other issues and is the correct approach.