### PR TITLE
fix(schema): fix task schema

### DIFF
--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -161,12 +161,32 @@
               "type": "boolean"
             },
             "outputs": {
-              "description": "files created by this task",
-              "items": {
-                "description": "glob pattern or path to files created by this task",
-                "type": "string"
-              },
-              "type": "array"
+              "oneOf": [
+                {
+                  "description": "files created by this task",
+                  "items": {
+                    "description": "glob pattern or path to files created by this task",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "description": "glob pattern or path to files created by this task",
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "auto": {
+                      "description": "automatically touch an internal tracked file instead of specifying outputs",
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["auto"],
+                  "type": "object"
+                }
+              ]
             },
             "quiet": {
               "description": "do not display mise information for this task",
@@ -213,12 +233,20 @@
               "type": "string"
             },
             "sources": {
-              "description": "files that this task depends on",
-              "items": {
-                "description": "glob pattern or path to files that this task depends on",
-                "type": "string"
-              },
-              "type": "array"
+              "oneOf": [
+                {
+                  "description": "files that this task depends on",
+                  "items": {
+                    "description": "glob pattern or path to files that this task depends on",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "description": "glob pattern or path to files that this task depends on",
+                  "type": "string"
+                }
+              ]
             },
             "shell": {
               "description": "specify a shell command to run the script with",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1110,12 +1110,32 @@
               "type": "boolean"
             },
             "outputs": {
-              "description": "files created by this task",
-              "items": {
-                "description": "glob pattern or path to files created by this task",
-                "type": "string"
-              },
-              "type": "array"
+              "oneOf": [
+                {
+                  "description": "files created by this task",
+                  "items": {
+                    "description": "glob pattern or path to files created by this task",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "description": "glob pattern or path to files created by this task",
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "auto": {
+                      "description": "automatically touch an internal tracked file instead of specifying outputs",
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["auto"],
+                  "type": "object"
+                }
+              ]
             },
             "quiet": {
               "description": "do not display mise information for this task",
@@ -1162,12 +1182,20 @@
               "type": "string"
             },
             "sources": {
-              "description": "files that this task depends on",
-              "items": {
-                "description": "glob pattern or path to files that this task depends on",
-                "type": "string"
-              },
-              "type": "array"
+              "oneOf": [
+                {
+                  "description": "files that this task depends on",
+                  "items": {
+                    "description": "glob pattern or path to files that this task depends on",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "description": "glob pattern or path to files that this task depends on",
+                  "type": "string"
+                }
+              ]
             },
             "shell": {
               "description": "specify a shell command to run the script with",


### PR DESCRIPTION
Updates inconsistency between the schema and the docs.

Not sure whether the description is good for `outputs.auto`.
`automatically touch an internal tracked file instead of specifying outputs`
https://mise.jdx.dev/tasks/task-configuration.html#outputs