### PR TITLE
fix: maven-mvnd does not install with aqua

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -322,13 +322,7 @@ impl AquaPackage {
     }
 
     pub fn asset(&self, v: &str) -> Result<String> {
-        // derive asset from url if not set and url contains a path
-        if self.asset.is_empty() && self.url.split("/").count() > "//".len() {
-            let asset = self.url.rsplit("/").next().unwrap_or("");
-            self.parse_aqua_str(asset, v, &Default::default())
-        } else {
-            self.parse_aqua_str(&self.asset, v, &Default::default())
-        }
+        self.parse_aqua_str(&self.asset, v, &Default::default())
     }
 
     pub fn asset_strs(&self, v: &str) -> Result<IndexSet<String>> {
@@ -450,6 +444,9 @@ impl AquaFile {
 }
 
 fn apply_override(mut orig: AquaPackage, avo: &AquaPackage) -> AquaPackage {
+    if orig.r#type != avo.r#type {
+        orig.r#type = avo.r#type.clone();
+    }
     if !avo.repo_owner.is_empty() {
         orig.repo_owner = avo.repo_owner.clone();
     }


### PR DESCRIPTION
Follow up on PR #3982 

The main issue of #3977 is that the package type resolves to `github_release` as indicated in the top definition which gets overridden by the `version_overrides` to `http`. So the proper fix would be to adapt the `apply_overrides` function to take the type into account.

Sorry for the inconvenience. Jumped to conclusions to fast, only slowly starting to understand how aqua's package schema is supposed to work.