### PR TITLE
fix: use task display_name in more places

### DIFF
--- a/e2e/tasks/test_task_deps
+++ b/e2e/tasks/test_task_deps
@@ -49,3 +49,10 @@ Depends on: hello:*
 Usage Spec:
   name "hello:all"
   bin "hello:all"'
+
+echo '' >mise.toml
+
+mkdir -p mise-tasks && echo "" > mise-tasks/build.sh && chmod +x mise-tasks/build.sh
+assert "mise task deps build" "build"
+assert "mise task deps build.sh" "build"
+

--- a/e2e/tasks/test_task_deps
+++ b/e2e/tasks/test_task_deps
@@ -52,7 +52,6 @@ Usage Spec:
 
 echo '' >mise.toml
 
-mkdir -p mise-tasks && echo "" > mise-tasks/build.sh && chmod +x mise-tasks/build.sh
+mkdir -p mise-tasks && echo "" >mise-tasks/build.sh && chmod +x mise-tasks/build.sh
 assert "mise task deps build" "build"
 assert "mise task deps build.sh" "build"
-

--- a/e2e/tasks/test_task_info
+++ b/e2e/tasks/test_task_info
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-mkdir -p mise-tasks && echo "" > mise-tasks/build.sh && chmod +x mise-tasks/build.sh
+mkdir -p mise-tasks && echo "" >mise-tasks/build.sh && chmod +x mise-tasks/build.sh
 assert "mise task info build" 'Task: build
 Description:
 Source: ~/workdir/mise-tasks/build.sh

--- a/e2e/tasks/test_task_info
+++ b/e2e/tasks/test_task_info
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+mkdir -p mise-tasks && echo "" > mise-tasks/build.sh && chmod +x mise-tasks/build.sh
+assert "mise task info build" 'Task: build
+Description:
+Source: ~/workdir/mise-tasks/build.sh
+File: ~/workdir/mise-tasks/build.sh
+
+Usage Spec:
+  name "build"
+  bin "build"'
+
+assert_contains "mise task info build.sh --json" '"name": "build"'

--- a/e2e/tasks/test_task_ls
+++ b/e2e/tasks/test_task_ls
@@ -29,12 +29,19 @@ cat <<'EOF' >mytasks/filetask2
 EOF
 chmod +x mytasks/filetask2
 
+cat <<'EOF' >mytasks/filetask3.sh
+#!/usr/bin/env bash
+EOF
+chmod +x mytasks/filetask3.sh
+
 assert "mise task ls" "filetask2
+filetask3
 lint
 test
 test-with-args"
 
 assert "mise task -x ls" "filetask2          ./mytasks/filetask2
+filetask3          ./mytasks/filetask3.sh
 lint               ./mise.toml
 test               ./tasks.toml
 test-with-args     ./tasks.toml"

--- a/mise.lock
+++ b/mise.lock
@@ -4,6 +4,7 @@ backend = "aqua:rhysd/actionlint"
 
 [tools.actionlint.checksums]
 "actionlint_1.7.6_darwin_arm64.tar.gz" = "sha256:9a7c9cb2b627bb137ef68742eead2dd5b78f3ddc44876e84c37d323ba28b4710"
+"actionlint_1.7.6_linux_amd64.tar.gz" = "sha256:5d1a70d9de15fee5371e6f9e20cc29b284e814d6ee1b882f9749e91caf716eba"
 
 [tools.bun]
 version = "1.1.42"

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -142,11 +142,7 @@ impl TasksDeps {
         let config = Config::get();
         let tasks = config
             .tasks()
-            .map(|t| {
-                t.iter()
-                    .map(|(_, v)| v.display_name())
-                    .collect::<Vec<_>>()
-            })
+            .map(|t| t.iter().map(|(_, v)| v.display_name()).collect::<Vec<_>>())
             .unwrap_or_default();
         let task_names = tasks.into_iter().map(style::ecyan).join(", ");
         let t = style(&t).yellow().for_stderr();

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -57,16 +57,19 @@ impl TasksDeps {
         let tasks = config.tasks()?;
         let tasks = self.tasks.as_ref().map(|t| {
             t.iter()
-              .map(|tn| {
-                  tasks.get(tn)
-                    .cloned()
-                    .or_else(|| {
-                        tasks.values().find(|task| task.display_name().as_str() == tn.as_str())
-                          .cloned()
-                    })
-                    .ok_or_else(|| self.err_no_task(tn.as_str()))
-              })
-              .collect::<Result<Vec<Task>>>()
+                .map(|tn| {
+                    tasks
+                        .get(tn)
+                        .cloned()
+                        .or_else(|| {
+                            tasks
+                                .values()
+                                .find(|task| task.display_name().as_str() == tn.as_str())
+                                .cloned()
+                        })
+                        .ok_or_else(|| self.err_no_task(tn.as_str()))
+                })
+                .collect::<Result<Vec<Task>>>()
         });
         match tasks {
             Some(Ok(tasks)) => Ok(tasks),
@@ -74,7 +77,7 @@ impl TasksDeps {
             None => Ok(vec![]),
         }
     }
-    
+
     ///
     /// Print dependencies as a tree
     ///
@@ -139,10 +142,11 @@ impl TasksDeps {
         let config = Config::get();
         let tasks = config
             .tasks()
-            .map(|t| t
-              .into_iter()
-              .map(|(_, v)| v.display_name())
-              .collect::<Vec<_>>())
+            .map(|t| {
+                t.iter()
+                    .map(|(_, v)| v.display_name())
+                    .collect::<Vec<_>>()
+            })
             .unwrap_or_default();
         let task_names = tasks.into_iter().map(style::ecyan).join(", ");
         let t = style(&t).yellow().for_stderr();

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -23,7 +23,12 @@ pub struct TasksInfo {
 impl TasksInfo {
     pub fn run(self) -> Result<()> {
         let config = Config::get();
-        let task = config.tasks()?.get(&self.task);
+        let tasks = config.tasks()?;
+
+        let task = tasks.get(&self.task)
+          .or_else(|| {
+              tasks.values().find(|task| task.display_name().as_str() == self.task.as_str())
+          });
 
         if let Some(task) = task {
             let ts = config.get_toolset()?;
@@ -44,7 +49,7 @@ impl TasksInfo {
     }
 
     fn display(&self, task: &Task, env: &EnvMap) -> Result<()> {
-        info::inline_section("Task", &task.name)?;
+        info::inline_section("Task", &task.display_name())?;
         if !task.aliases.is_empty() {
             info::inline_section("Aliases", task.aliases.join(", "))?;
         }
@@ -95,7 +100,7 @@ impl TasksInfo {
     fn display_json(&self, task: &Task, env: &EnvMap) -> Result<()> {
         let (spec, _) = task.parse_usage_spec(None, env)?;
         let o = json!({
-            "name": task.name.to_string(),
+            "name": task.display_name(),
             "aliases": task.aliases.join(", "),
             "description": task.description.to_string(),
             "source": task.config_source,

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -25,10 +25,11 @@ impl TasksInfo {
         let config = Config::get();
         let tasks = config.tasks()?;
 
-        let task = tasks.get(&self.task)
-          .or_else(|| {
-              tasks.values().find(|task| task.display_name().as_str() == self.task.as_str())
-          });
+        let task = tasks.get(&self.task).or_else(|| {
+            tasks
+                .values()
+                .find(|task| task.display_name().as_str() == self.task.as_str())
+        });
 
         if let Some(task) = task {
             let ts = config.get_toolset()?;
@@ -49,7 +50,7 @@ impl TasksInfo {
     }
 
     fn display(&self, task: &Task, env: &EnvMap) -> Result<()> {
-        info::inline_section("Task", &task.display_name())?;
+        info::inline_section("Task", task.display_name())?;
         if !task.aliases.is_empty() {
             info::inline_section("Aliases", task.aliases.join(", "))?;
         }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -640,7 +640,7 @@ impl TreeItem for (&Graph<Task, ()>, NodeIndex) {
 
     fn write_self(&self) -> std::io::Result<()> {
         if let Some(w) = self.0.node_weight(self.1) {
-            miseprint!("{}", w.name)?;
+            miseprint!("{}", w.display_name())?;
         }
         Ok(())
     }


### PR DESCRIPTION
Related to https://github.com/jdx/mise/discussions/3980

I am not sure if these changes are correct but, I think we should either use `display_name` everywhere or report both `name` and `display_name` in the json. I prefer just reporting `display_name` while also supporting `name` internally?

This will make the following commands work
```sh
cargo run -- t deps aqua-tester
cargo run -- t info aqua-tester
```
which is consistent with what the autocompletion displays: (or `mise tasks ls`)
![image](https://github.com/user-attachments/assets/121f2038-b138-4e62-bb21-d97ada25512f)

without this change, one will get:
```
mise tasks info aqua-tester 
mise ERROR Task not found: aqua-tester, use `mise tasks ls` to list all tasks
```
