### PR TITLE
fix: mise fails to install kubectl on windows from aqua registry

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -532,6 +532,11 @@ impl AquaBackend {
         for (src, dst) in self.srcs(pkg, tv)? {
             if src != dst && src.exists() && !dst.exists() {
                 if cfg!(windows) {
+                    let dst = if dst.extension().is_none() {
+                        dst.with_extension("exe")
+                    } else {
+                        dst
+                    };
                     file::copy(&src, &dst)?;
                 } else {
                     let src = PathBuf::from(".").join(src.file_name().unwrap().to_str().unwrap());


### PR DESCRIPTION
Fixes #3890 

Note; Untested since i don't have a Windows machine.