### PR TITLE
docs: Add default description to github token link

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,7 +140,7 @@ HTTP status client error (403 Forbidden) for url
 This can happen if the tool is hosted on GitHub, and you've hit the API rate limit. This is especially
 common running mise in a CI environment like GitHub Actions. If you don't have a `GITHUB_TOKEN`
 set, the rate limit is quite low. You can fix this by creating a GitHub token (which needs no scopes)
-by going to <https://github.com/settings/tokens> and setting it as an environment variable. You can
+by going to [https://github.com/settings/tokens/new](https://github.com/settings/tokens/new?description=MISE_GITHUB_TOKEN) and setting it as an environment variable. You can
 use any of the following (in order of preference):
 
 - `MISE_GITHUB_TOKEN`


### PR DESCRIPTION
This way, it goes directly to the new GitHub classic token page with a prefilled description

![image](https://github.com/user-attachments/assets/4a82d3d4-0534-497a-9aee-c34f095587af)
