### PR TITLE
fix: mise fails to install kubectl on windows from aqua registry

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -350,12 +350,8 @@ impl AquaPackage {
 
     pub fn url(&self, v: &str) -> Result<String> {
         let mut url = self.url.clone();
-        if cfg!(windows) {
-            if Path::new(&url).extension().is_none()
-                && (self.format.is_empty() || self.format == "raw")
-            {
-                url.push_str(".exe");
-            }
+        if cfg!(windows) && Path::new(&url).extension().is_none() && (self.format.is_empty() || self.format == "raw") {
+            url.push_str(".exe");
         }
         self.parse_aqua_str(&url, v, &Default::default())
     }

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -350,7 +350,10 @@ impl AquaPackage {
 
     pub fn url(&self, v: &str) -> Result<String> {
         let mut url = self.url.clone();
-        if cfg!(windows) && Path::new(&url).extension().is_none() && (self.format.is_empty() || self.format == "raw") {
+        if cfg!(windows)
+            && Path::new(&url).extension().is_none()
+            && (self.format.is_empty() || self.format == "raw")
+        {
             url.push_str(".exe");
         }
         self.parse_aqua_str(&url, v, &Default::default())

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use serde_derive::Deserialize;
 use std::cmp::PartialEq;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock as Lazy;
 use url::Url;
 
@@ -349,7 +349,15 @@ impl AquaPackage {
     }
 
     pub fn url(&self, v: &str) -> Result<String> {
-        self.parse_aqua_str(&self.url, v, &Default::default())
+        let mut url = self.url.clone();
+        if cfg!(windows) {
+            if Path::new(&url).extension().is_none()
+                && (self.format.is_empty() || self.format == "raw")
+            {
+                url.push_str(".exe");
+            }
+        }
+        self.parse_aqua_str(&url, v, &Default::default())
     }
 
     fn parse_aqua_str(

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -533,11 +533,6 @@ impl AquaBackend {
         for (src, dst) in self.srcs(pkg, tv)? {
             if src != dst && src.exists() && !dst.exists() {
                 if cfg!(windows) {
-                    let dst = if dst.extension().is_none() {
-                        dst.with_extension("exe")
-                    } else {
-                        dst
-                    };
                     file::copy(&src, &dst)?;
                 } else {
                     let src = PathBuf::from(".").join(src.file_name().unwrap().to_str().unwrap());


### PR DESCRIPTION
Another follow up for #3890

It seems for `http` package types with a `raw` format we might need to add the `.exe` extension in some cases (e.g kubernetes/kubectl). Correct approach would be to fix the registry and provide an override for the windows OS with proper url but since aqua has fixed this in code we might have to follow this approach i assume.

TODO: needs to be tested on a Windows machine