### PR TITLE
fix: Example of a NodeJS file task with arguments

### DIFF
--- a/docs/tasks/file-tasks.md
+++ b/docs/tasks/file-tasks.md
@@ -185,12 +185,12 @@ const fs = require("fs");
 const { usage_user, usage_force, usage_output_file } = process.env;
 
 if (usage_force === "true") {
-  fs.rmSync(usage_file, { force: true });
+  fs.rmSync(usage_output_file, { force: true });
 }
 
 const user = usage_user ?? "world";
-fs.appendFileSync(usage_file, `Hello, ${user}\n`);
-console.log(`Greeting written to ${usage_file}`);
+fs.appendFileSync(usage_output_file, `Hello, ${user}\n`);
+console.log(`Greeting written to ${usage_output_file}`);
 ```
 
 Run it with:


### PR DESCRIPTION
The variables didn't quite match up with the usage.