### PR TITLE
docs: warn that mise is not a dependency manager

### DIFF
--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -1,5 +1,10 @@
 # Cargo Backend
 
+::: warning
+Mise is not a replacement for a project dependency manager. Please continue to use `cargo`
+to manage your project's package dependencies.
+:::
+
 You may install packages directly from [Cargo Crates](https://crates.io/) even if there
 isn't an asdf plugin for it.
 

--- a/docs/dev-tools/backends/dotnet.md
+++ b/docs/dev-tools/backends/dotnet.md
@@ -1,5 +1,10 @@
 # Dotnet backend
 
+::: warning
+Mise is not a replacement for a project dependency manager. Please continue to use `nuget`
+or another tool to manage your project's package dependencies.
+:::
+
 The code for this is inside the mise repository at [`./src/backend/dotnet.rs`](https://github.com/jdx/mise/blob/main/src/backend/dotnet.rs).
 
 ## Usage

--- a/docs/dev-tools/backends/gem.md
+++ b/docs/dev-tools/backends/gem.md
@@ -1,5 +1,10 @@
 # gem Backend
 
+::: warning
+Mise is not a replacement for a project dependency manager. Please continue to use `gem`
+to manage your project's package dependencies.
+:::
+
 mise can be used to install CLIs from RubyGems. The code for this is inside of the mise repository at [`./src/backend/gem.rs`](https://github.com/jdx/mise/blob/main/src/backend/pipx.rs).
 
 ## Dependencies

--- a/docs/dev-tools/backends/go.md
+++ b/docs/dev-tools/backends/go.md
@@ -1,5 +1,10 @@
 # Go Backend <Badge type="warning" text="experimental" />
 
+::: warning
+Mise is not a replacement for a project dependency manager. Please continue to use `go mod`
+to manage your project's package dependencies.
+:::
+
 You may install packages directly via [go install](https://go.dev/doc/install) even if there
 isn't an asdf plugin for it.
 

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -1,6 +1,11 @@
 # npm Backend
 
-You may install packages directly from [npmjs.org](https://npmjs.org/) even if there
+::: warning
+Mise is not a replacement for a project dependency manager. Please continue to use `npm`, `yarn`,
+`pnpm`, `bun`, or another tool to manage your project's package dependencies.
+:::
+
+You may install tools directly from [npmjs.org](https://npmjs.org/) even if there
 isn't an asdf plugin for it.
 
 The code for this is inside of the mise repository at [`./src/backend/npm.rs`](https://github.com/jdx/mise/blob/main/src/backend/npm.rs).

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -1,5 +1,10 @@
 # pipx Backend
 
+::: warning
+Mise is not a replacement for a project dependency manager. Please continue to use `pip`, `uv`,
+`poetry`, or another tool to manage your project's package dependencies.
+:::
+
 pipx is a tool for running Python CLIs in isolated virtualenvs. This is necessary for Python CLIs
 because it prevents conflicting dependencies between CLIs or between a CLI and Python projects. In essence,
 this backend lets you add Python CLIs to mise.

--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -1,5 +1,10 @@
 # SPM Backend <Badge type="warning" text="experimental" />
 
+::: warning
+Mise is not a replacement for a project dependency manager. Please continue to `swift` 
+to manage your project's package dependencies.
+:::
+
 You may install executables managed by [Swift Package Manager](https://www.swift.org/documentation/package-manager) directly from GitHub releases.
 
 The code for this is inside of the mise repository at [`./src/backend/spm.rs`](https://github.com/jdx/mise/blob/main/src/backend/spm.rs).

--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -1,7 +1,7 @@
 # SPM Backend <Badge type="warning" text="experimental" />
 
 ::: warning
-Mise is not a replacement for a project dependency manager. Please continue to `swift` 
+Mise is not a replacement for a project dependency manager. Please continue to `swift`
 to manage your project's package dependencies.
 :::
 


### PR DESCRIPTION
## Summary

- A response to https://github.com/jdx/mise/discussions/4043
- An extension of https://github.com/jdx/mise/commit/42dcb3bc5a6547d3d148c391ceccfd9228e34669
- Renaming `package` -> `tool`
- Adding warnings

### Warnings

Perhaps these warnings are too loud, we could either move them somewhere else in the page or convert them to normal paragraphs. But for now this is how they look:

![image](https://github.com/user-attachments/assets/b11a63db-9d10-4a92-8678-cc1bf18b7724)

![image](https://github.com/user-attachments/assets/2dabf651-5337-4bc3-92b6-ca02616cd428)

![image](https://github.com/user-attachments/assets/453fac8a-b3fe-4345-8f53-a5e5d83dbc05)

![image](https://github.com/user-attachments/assets/44b496c2-cd03-46f4-8efe-dbd0889bbad2)

![image](https://github.com/user-attachments/assets/43d7275e-2fa1-4c84-b127-a2f9283e871c)

![image](https://github.com/user-attachments/assets/82218fd4-418e-458d-96ba-ad71258b2c0b)
