### PR TITLE
fix: Fixes infinite loop in auto install not found bash function

### DIFF
--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -71,7 +71,7 @@ impl Shell for Bash {
                 fi
 
                 command_not_found_handle() {{
-                    if [ "$1" != "mise" ] && {exe} hook-not-found -s bash -- "$1"; then
+                    if [[ "$1" != "mise" && "$1" != "mise-"* ]] && {exe} hook-not-found -s bash -- "$1"; then
                       _mise_hook
                       "$@"
                     elif [ -n "$(declare -f _command_not_found_handle)" ]; then

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -56,7 +56,7 @@ impl Shell for Bash {
             {chpwd_load}
             chpwd_functions+=(_mise_hook)
             _mise_hook
-            "#, 
+            "#,
             chpwd_functions = include_str!("../assets/bash_zsh_support/chpwd/function.sh"),
             chpwd_load = include_str!("../assets/bash_zsh_support/chpwd/load.sh")
             });
@@ -71,7 +71,7 @@ impl Shell for Bash {
                 fi
 
                 command_not_found_handle() {{
-                    if {exe} hook-not-found -s bash -- "$1"; then
+                    if [ "$1" != "mise" ] && {exe} hook-not-found -s bash -- "$1"; then
                       _mise_hook
                       "$@"
                     elif [ -n "$(declare -f _command_not_found_handle)" ]; then

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -56,7 +56,7 @@ impl Shell for Fish {
 
         if !opts.no_hook_env {
             out.push_str(&formatdoc! {r#"
-            
+
             function __mise_env_eval --on-event fish_prompt --description {description};
                 {exe} hook-env{flags} -s fish | source;
 
@@ -92,7 +92,8 @@ impl Shell for Fish {
             end
 
             function fish_command_not_found
-                if {exe} hook-not-found -s fish -- $argv[1]
+                if test "$argv[1]" != "mise" -a "$argv[1]" != "mise-"*
+                    and {exe} hook-not-found -s fish -- $argv[1]
                     {exe} hook-env{flags} -s fish | source
                 else if functions -q __mise_fish_command_not_found
                     __mise_fish_command_not_found $argv

--- a/src/shell/snapshots/mise__shell__bash__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__activate.snap
@@ -73,7 +73,7 @@ if [ -z "${_mise_cmd_not_found:-}" ]; then
     fi
 
     command_not_found_handle() {
-        if /some/dir/mise hook-not-found -s bash -- "$1"; then
+        if [ "$1" != "mise" ] && /some/dir/mise hook-not-found -s bash -- "$1"; then
           _mise_hook
           "$@"
         elif [ -n "$(declare -f _command_not_found_handle)" ]; then

--- a/src/shell/snapshots/mise__shell__bash__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__activate.snap
@@ -73,7 +73,7 @@ if [ -z "${_mise_cmd_not_found:-}" ]; then
     fi
 
     command_not_found_handle() {
-        if [ "$1" != "mise" ] && /some/dir/mise hook-not-found -s bash -- "$1"; then
+        if [[ "$1" != "mise" && "$1" != "mise-"* ]] && /some/dir/mise hook-not-found -s bash -- "$1"; then
           _mise_hook
           "$@"
         elif [ -n "$(declare -f _command_not_found_handle)" ]; then

--- a/src/shell/snapshots/mise__shell__fish__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__activate.snap
@@ -66,7 +66,8 @@ if functions -q fish_command_not_found; and not functions -q __mise_fish_command
 end
 
 function fish_command_not_found
-    if /some/dir/mise hook-not-found -s fish -- $argv[1]
+    if test "$argv[1]" != "mise" -a "$argv[1]" != "mise-"*
+        and /some/dir/mise hook-not-found -s fish -- $argv[1]
         /some/dir/mise hook-env --status -s fish | source
     else if functions -q __mise_fish_command_not_found
         __mise_fish_command_not_found $argv

--- a/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
@@ -45,7 +45,7 @@ if [ -z "${_mise_cmd_not_found:-}" ]; then
     [ -n "$(declare -f command_not_found_handler)" ] && eval "${$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}"
 
     function command_not_found_handler() {
-        if /some/dir/mise hook-not-found -s zsh -- "$1"; then
+        if [[ "$1" != "mise" && "$1" != "mise-"* ]] && /some/dir/mise hook-not-found -s zsh -- "$1"; then
           _mise_hook
           "$@"
         elif [ -n "$(declare -f _command_not_found_handler)" ]; then

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -48,7 +48,7 @@ impl Shell for Zsh {
 
         if !opts.no_hook_env {
             out.push_str(&formatdoc! {r#"
-            
+
             _mise_hook() {{
               eval "$({exe} hook-env{flags} -s zsh)";
             }}
@@ -71,7 +71,7 @@ impl Shell for Zsh {
                 [ -n "$(declare -f command_not_found_handler)" ] && eval "${{$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}}"
 
                 function command_not_found_handler() {{
-                    if {exe} hook-not-found -s zsh -- "$1"; then
+                    if [[ "$1" != "mise" && "$1" != "mise-"* ]] && {exe} hook-not-found -s zsh -- "$1"; then
                       _mise_hook
                       "$@"
                     elif [ -n "$(declare -f _command_not_found_handler)" ]; then


### PR DESCRIPTION
This infinite loop bug is triggered when `mise` itself becomes not found, e.g., by deleting the directory `mise` is in.

Here's some output of the shell with `set -x` on when doing `rm -rf` on the directory (`workspace/`) containing `mise` in some subpath:
```
+ rm -rf workspace/
++ _mise_hook
++ local previous_exit_status=0
+++ mise hook-env -s bash
+++ local command
+++ command=hook-env
+++ '[' 3 = 0 ']'
+++ shift
+++ case "$command" in
+++ command mise hook-env -s bash
+++ mise hook-not-found -s bash -- mise
+++ local command
+++ command=hook-not-found
+++ '[' 5 = 0 ']'
+++ shift
+++ case "$command" in
+++ command mise hook-not-found -s bash -- mise
+++ mise hook-not-found -s bash -- mise
+++ local command
+++ command=hook-not-found
+++ '[' 5 = 0 ']'
+++ shift
+++ case "$command" in
+++ command mise hook-not-found -s bash -- mise
+++ mise hook-not-found -s bash -- mise
+++ local command
+++ command=hook-not-found
+++ '[' 5 = 0 ']'
+++ shift
+++ case "$command" in
+++ command mise hook-not-found -s bash -- mise
+++ mise hook-not-found -s bash -- mise
+++ local command
+++ command=hook-not-found
+++ '[' 5 = 0 ']'
+++ shift
+++ case "$command" in
+++ command mise hook-not-found -s bash -- mise
+++ mise hook-not-found -s bash -- mise
```