### PR TITLE
fix: panic when directory name contains japanese characters

### DIFF
--- a/src/backend/external_plugin_cache.rs
+++ b/src/backend/external_plugin_cache.rs
@@ -84,7 +84,7 @@ fn render_cache_key(config: &Config, tv: &ToolVersion, cache_key: &[String]) -> 
             let s = s.trim().to_string();
             trace!("cache key element: {} -> {}", tmpl.trim(), s);
             let mut s = hash_to_str(&s);
-            s.truncate(10);
+            s = s.chars().take(10).collect();
             s
         })
         .collect::<Vec<String>>();

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -467,7 +467,7 @@ fn hashed_path_filename(path: &Path) -> String {
     let hash = hash_to_str(&canonicalized_path);
     let trunc_str = |s: &OsStr| {
         let mut s = s.to_str().unwrap().to_string();
-        s.truncate(20);
+        s = s.chars().take(20).collect();
         s
     };
     let trust_path = dirs::TRUSTED_CONFIGS.join(hash_to_str(&hash));


### PR DESCRIPTION
Fixes #4071 

`String::truncate` seems to work on byte level which can cause issues with multi-byte characters. `String::chars() `handles multi-byte characters properly though.