### PR TITLE
fix(spm): install from annotated tag

### DIFF
--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -98,7 +98,7 @@ impl SPMBackend {
             repo.clone(package_repo.url.as_str(), Some(&ctx.pr))?;
         }
         debug!("Checking out revision: {revision}");
-        repo.update(Some(revision.to_string()))?;
+        repo.update_tag(revision.to_string())?;
 
         Ok(repo.dir)
     }


### PR DESCRIPTION
See https://github.com/jdx/mise/discussions/4042

Installs using spm backend works with some repos, but fails for other. For example
`mise install spm:nicklockwood/SwiftFormat@0.54.3` - ok
`mise install spm:realm/SwiftLint@0.57.1` - fails:

```
ERROR git failed: Cmd(["git", "-C", "/home/vscode/.cache/mise/spm-realm-swift-lint/0.57.1/repo", "-c", "safe.directory=/home/vscode/.cache/mise/spm-realm-swift-lint/0.57.1/repo", "fetch", "--prune", "--update-head-ok", "origin", "0.57.1:0.57.1"]) error: cannot update ref 'refs/heads/0.57.1': trying to write non-commit object bf3f358f09ca74dc7f031ed44f185fd7a874efe4 to branch 'refs/heads/0.57.1'
```

Looks like it does not work with annotated tags:
```sh
swiftlint (main)> git cat-file -t 0.57.1
tag

SwiftFormat (main)> git cat-file -t 0.54.3
commit
```

The command:
```sh
swiftlint (main)> git fetch --prune --update-head-ok origin '0.57.1:0.57.1'
error: cannot update ref 'refs/heads/0.57.1': trying to write non-commit object bf3f358f09ca74dc7f031ed44f185fd7a874efe4 to branch 'refs/heads/0.57.1'
From github.com:realm/SwiftLint
 ! [new tag]             0.57.1     -> 0.57.1  (unable to update local ref)
```

is trying to create branch from annotated tag and fails. For tags we could use:
```
git fetch --prune --update-head-ok origin 'refs/tags/0.57.1:refs/tags/0.57.1'
or
git fetch --prune --update-head-ok origin tag 0.57.1
```