### PR TITLE
docs: fix doc for MISE_GLOBAL_CONFIG_ROOT got interpolated

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -346,7 +346,9 @@ This is the path to the config file.
 
 Default: `$HOME`
 
+::: v-pre
 This is the path which is used as `{{config_root}}` for the global config file.
+:::
 
 ### `MISE_ENV_FILE`
 


### PR DESCRIPTION
Inline code in vitepress still got interpolated as vue template (ref: https://github.com/vuejs/vuepress/issues/2377). Wrap the paragraph with `::: v-pre` to avoid this.