### PR TITLE
fix: Fixes fish_command_not_found glob error

### DIFF
--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -92,8 +92,8 @@ impl Shell for Fish {
             end
 
             function fish_command_not_found
-                if test "$argv[1]" != "mise" -a "$argv[1]" != "mise-"*
-                    and {exe} hook-not-found -s fish -- $argv[1]
+                if string match -qrv '^(?:mise$|mise-)' $argv[1] &&
+                    {exe} hook-not-found -s fish -- $argv[1]
                     {exe} hook-env{flags} -s fish | source
                 else if functions -q __mise_fish_command_not_found
                     __mise_fish_command_not_found $argv

--- a/src/shell/snapshots/mise__shell__fish__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__activate.snap
@@ -66,8 +66,8 @@ if functions -q fish_command_not_found; and not functions -q __mise_fish_command
 end
 
 function fish_command_not_found
-    if test "$argv[1]" != "mise" -a "$argv[1]" != "mise-"*
-        and /some/dir/mise hook-not-found -s fish -- $argv[1]
+    if string match -qrv '^(?:mise$|mise-)' $argv[1] &&
+        /some/dir/mise hook-not-found -s fish -- $argv[1]
         /some/dir/mise hook-env --status -s fish | source
     else if functions -q __mise_fish_command_not_found
         __mise_fish_command_not_found $argv


### PR DESCRIPTION
An error for `fish_command_not_found` was introduce in #4094 because
glob misses do not work the same in fish as in other shells. As such,
we are getting the following error on an unknown function:

```
- (line 64): No matches for wildcard '"mise-"*'. See `help wildcards-globbing`.
    if test "$argv[1]" != "mise" -a "$argv[1]" != "mise-"*
```

This has been replaced with a fish-specific implementation test that
prevents the error and is somewhat more idiomatic as well.
