### PR TITLE
fix: elixir installation failed

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -49,7 +49,10 @@ impl Install {
     pub fn run(self) -> Result<()> {
         let config = Config::try_get()?;
         match &self.tool {
-            Some(runtime) => self.install_runtimes(&config, runtime)?,
+            Some(runtime) => {
+                crate::env::TOOL_ARGS.write().unwrap().clone_from(&runtime);
+                self.install_runtimes(&config, runtime)?
+            }
             None => self.install_missing_runtimes(&config)?,
         };
         Ok(())

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -50,7 +50,7 @@ impl Install {
         let config = Config::try_get()?;
         match &self.tool {
             Some(runtime) => {
-                crate::env::TOOL_ARGS.write().unwrap().clone_from(&runtime);
+                crate::env::TOOL_ARGS.write().unwrap().clone_from(runtime);
                 self.install_runtimes(&config, runtime)?
             }
             None => self.install_missing_runtimes(&config)?,

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -101,6 +101,10 @@ impl Use {
         if self.tool.is_empty() && self.remove.is_empty() {
             self.tool = vec![self.tool_selector()?];
         }
+        crate::env::TOOL_ARGS
+            .write()
+            .unwrap()
+            .clone_from(&self.tool);
         let config = Config::try_get()?;
         let mut ts = ToolsetBuilder::new()
             .with_global_only(self.global)

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,4 +1,4 @@
-use crate::cli::args::{ENV_ARG, PROFILE_ARG};
+use crate::cli::args::{ToolArg, ENV_ARG, PROFILE_ARG};
 use crate::env_diff::{EnvDiff, EnvDiffOperation, EnvDiffPatches, EnvMap};
 use crate::file::replace_path;
 use crate::shell::ShellType;
@@ -14,6 +14,7 @@ use std::sync::RwLock;
 use std::{path, process};
 
 pub static ARGS: RwLock<Vec<String>> = RwLock::new(vec![]);
+pub static TOOL_ARGS: RwLock<Vec<ToolArg>> = RwLock::new(vec![]);
 #[cfg(unix)]
 pub static SHELL: Lazy<String> = Lazy::new(|| var("SHELL").unwrap_or_else(|_| "sh".into()));
 #[cfg(windows)]

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -227,6 +227,22 @@ impl ToolRequestSetBuilder {
             }
             merge(trs, arg_ts);
         }
+
+        let tool_args = env::TOOL_ARGS.read().unwrap();
+        let mut arg_trs = ToolRequestSet::new();
+        for arg in tool_args.iter() {
+            if let Some(tvr) = &arg.tvr {
+                arg_trs.add_version(tvr.clone(), &ToolSource::Argument);
+            } else {
+                if !trs.tools.contains_key(&arg.ba) {
+                    // no active version, so use "latest"
+                    let tr = ToolRequest::new(arg.ba.clone(), "latest", ToolSource::Argument)?;
+                    arg_trs.add_version(tr, &ToolSource::Argument);
+                }
+            }
+        }
+        merge(trs, arg_trs);
+
         Ok(())
     }
 }

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -233,12 +233,10 @@ impl ToolRequestSetBuilder {
         for arg in tool_args.iter() {
             if let Some(tvr) = &arg.tvr {
                 arg_trs.add_version(tvr.clone(), &ToolSource::Argument);
-            } else {
-                if !trs.tools.contains_key(&arg.ba) {
-                    // no active version, so use "latest"
-                    let tr = ToolRequest::new(arg.ba.clone(), "latest", ToolSource::Argument)?;
-                    arg_trs.add_version(tr, &ToolSource::Argument);
-                }
+            } else if !trs.tools.contains_key(&arg.ba) {
+                // no active version, so use "latest"
+                let tr = ToolRequest::new(arg.ba.clone(), "latest", ToolSource::Argument)?;
+                arg_trs.add_version(tr, &ToolSource::Argument);
             }
         }
         merge(trs, arg_trs);


### PR DESCRIPTION
Fixes #4114 

The `dependency_toolset` function should not rely on dependencies in the Config to build the environment for the CmdLineRunner, especially when used with `install`.

Since this seems specific to Elixir so far and the method is used in other contexts, its probably best to keep the solution exclusive to elixir. If necessary we can move it up to the trait later. WDYT?