### PR TITLE
docs: fix broken link for `/tasks/task-configuration`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,7 @@ min_version = '2024.11.1'
 
 - You can find the JSON schema for `mise.toml` [here](https://github.com/jdx/mise/blob/main/schema/mise.json) or at <https://mise.jdx.dev/schema/mise.json>.
 - Some editors can load it automatically to provide autocompletion and validation for when editing a `mise.toml` file ([VSCode](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings), [IntelliJ](https://www.jetbrains.com/help/idea/json.html#ws_json_using_schemas), [neovim](https://github.com/b0o/SchemaStore.nvim), etc.). It is also available in the [JSON schema store](https://www.schemastore.org/json/).
-- Note that for `included tasks` (see [task configuration](/tasks/#task-configuration), there is another schema: <https://mise.jdx.dev/schema/mise-task.json>)
+- Note that for `included tasks` (see [task configuration](/task-configuration), there is another schema: <https://mise.jdx.dev/schema/mise-task.json>)
 
 ## Global config: `~/.config/mise/config.toml`
 


### PR DESCRIPTION
fix broken link for `/tasks/#task-configuration`. it should be `tasks/task-configuration`