### PR TITLE
fix: confusing error in fish_command_not_found

### DIFF
--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -92,7 +92,7 @@ impl Shell for Fish {
             end
 
             function fish_command_not_found
-                if string match -qrv '^(?:mise$|mise-)' $argv[1] &&
+                if string match -qrv -- '^(?:mise$|mise-)' $argv[1] &&
                     {exe} hook-not-found -s fish -- $argv[1]
                     {exe} hook-env{flags} -s fish | source
                 else if functions -q __mise_fish_command_not_found

--- a/src/shell/snapshots/mise__shell__fish__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__activate.snap
@@ -66,7 +66,7 @@ if functions -q fish_command_not_found; and not functions -q __mise_fish_command
 end
 
 function fish_command_not_found
-    if string match -qrv '^(?:mise$|mise-)' $argv[1] &&
+    if string match -qrv -- '^(?:mise$|mise-)' $argv[1] &&
         /some/dir/mise hook-not-found -s fish -- $argv[1]
         /some/dir/mise hook-env --status -s fish | source
     else if functions -q __mise_fish_command_not_found


### PR DESCRIPTION
When a user enters a command starting with a dash (for example `-la`) they got an error like this.

```fish
string match: -la: unknown option

- (line 64): 
    if string match -qrv '^(?:mise$|mise-)' $argv[1] &&
       ^
in function 'fish_command_not_found' with arguments '-ad'
in event handler: handler for generic event “fish_command_not_found”

(Type 'help string' for related documentation)
fish: Unknown command: -ad
```

For me this happened accidentally and no command will/should start with a dash. It just looked confusing. Now a clear separation between options to `string match` and the two strings to be matched is made.

For reference this is what vanilla fish shows:
```
❯ -ad
fish: Unknown command: -ad
```