### PR TITLE
fix: use correct python path for venv creation in windows

### DIFF
--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -1,4 +1,3 @@
-use crate::backend;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::config_file::trust_check;
@@ -8,6 +7,7 @@ use crate::env_diff::EnvMap;
 use crate::file::{display_path, which_non_pristine};
 use crate::toolset::ToolsetBuilder;
 use crate::Result;
+use crate::{backend, plugins};
 use indexmap::IndexMap;
 use std::path::{Path, PathBuf};
 
@@ -48,9 +48,7 @@ impl EnvResults {
                 }
             });
             let python_path = tv.map(|tv| {
-                tv.install_path()
-                    .join("bin")
-                    .join("python")
+                plugins::core::python::python_path(tv)
                     .to_string_lossy()
                     .to_string()
             });

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -18,7 +18,7 @@ mod erlang;
 mod go;
 mod java;
 mod node;
-mod python;
+pub(crate) mod python;
 #[cfg_attr(windows, path = "ruby_windows.rs")]
 mod ruby;
 mod rust;


### PR DESCRIPTION
Python installations on windows do not have a bin directory. This is already taken into account in different places, but when automatically creating venvs bin is always used.

This change was my attempt to fix this as a non-rust developer with minimal code changes and reusing the existing python_path function. I had to make the python plugin public, which is probably not the way to do it. 😄 

So I am open to suggestions on how to properly fix this.

https://github.com/jdx/mise/discussions/4152