### PR TITLE
feat(registry): add lychee to registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1193,6 +1193,8 @@ lua-language-server.backends = [
     "asdf:bellini666/asdf-lua-language-server"
 ]
 luajit.backends = ["asdf:mise-plugins/mise-luaJIT"]
+lychee.backends = ["aqua:lycheeverse/lychee"]
+lychee.test = ["lychee --version", "lychee {{version}}"]
 maestro.backends = [
     "ubi:mobile-dev-inc/maestro",
     "asdf:dotanuki-labs/asdf-maestro"


### PR DESCRIPTION
Adds `lychee` (https://github.com/lycheeverse/lychee) to the `mise` registry.

`lychee` is already in the aqua registry: https://github.com/aquaproj/aqua-registry/tree/main/pkgs/lycheeverse/lychee