### PR TITLE
docs: update Fedora install cmd to reflect dnf5 config-manager

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ sudo apt install -y mise
 
 ```sh
 sudo dnf install -y dnf-plugins-core
-sudo dnf config-manager --add-repo https://mise.jdx.dev/rpm/mise.repo
+sudo dnf config-manager addrepo --from-repofile=https://mise.jdx.dev/rpm/mise.repo
 sudo dnf install -y mise
 ```
 


### PR DESCRIPTION
Executing `sudo dnf config-manager --add-repo https://mise.jdx.dev/rpm/mise.repo` in the latest Fedora release (v41) with dnf throws the following error (probably due to dnf5):
> Unknown argument "--add-repo" for command "config-manager". Add "--help" for more information about the arguments.