### PR TITLE
docs: add hint about environment variable parsing

### DIFF
--- a/docs/components/setting.vue
+++ b/docs/components/setting.vue
@@ -26,6 +26,7 @@ defineProps(["setting", "level"]);
     </li>
     <li v-if="setting.env">
       Env: <code>{{ setting.env }}</code>
+      <span v-if="setting.parseEnv">({{setting.parseEnv}} separated)</span>
     </li>
     <li>
       Default: <code>{{ setting.default }}</code>

--- a/docs/components/setting.vue
+++ b/docs/components/setting.vue
@@ -26,7 +26,7 @@ defineProps(["setting", "level"]);
     </li>
     <li v-if="setting.env">
       Env: <code>{{ setting.env }}</code>
-      <span v-if="setting.parseEnv">({{setting.parseEnv}} separated)</span>
+      <span v-if="setting.parseEnv">({{ setting.parseEnv }} separated)</span>
     </li>
     <li>
       Default: <code>{{ setting.default }}</code>

--- a/docs/settings.data.ts
+++ b/docs/settings.data.ts
@@ -11,6 +11,16 @@ export default {
     const raw = fs.readFileSync("./settings.toml", "utf-8");
     const doc = toml.parse(raw);
 
+    function getParseEnv(parseEnv) {
+      if (parseEnv === "list_by_comma") {
+        return "comma";
+      }
+      if (parseEnv === "list_by_colon") {
+        return "colon";
+      }
+      return undefined;
+    }
+
     function buildElement(key, props) {
       let type = props.type;
       type = type.replaceAll("PathBuf", "String");
@@ -42,6 +52,7 @@ export default {
         deprecated: props.deprecated,
         enum: props.enum,
         env: props.env,
+        parseEnv: getParseEnv(props.parse_env),
         optional: !props.default_docs && props.optional,
         type,
       };


### PR DESCRIPTION
The docs currently don't mentions how array values are parsed. This PR is adding a hint about either comma or colon separated string array values.