### PR TITLE
chore: remove git2 from built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
 dependencies = [
  "chrono",
- "git2",
 ]
 
 [[package]]
@@ -1658,19 +1657,6 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
-name = "git2"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
 
 [[package]]
 name = "gix"
@@ -3388,18 +3374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.17.0+1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,18 +3388,6 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ self_update = { version = "0.42", default-features = false, features = [
 sevenz-rust = "0.6"
 
 [build-dependencies]
-built = { version = "0.7", features = ["chrono", "git2"] }
+built = { version = "0.7", features = ["chrono"] }
 cfg_aliases = "0.2"
 heck = "0.5"
 toml = "0.8"

--- a/src/build_time.rs
+++ b/src/build_time.rs
@@ -5,10 +5,6 @@ pub mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
-pub fn git_sha() -> &'static Option<&'static str> {
-    &built_info::GIT_COMMIT_HASH_SHORT
-}
-
 pub static BUILD_TIME: Lazy<DateTime<FixedOffset>> =
     Lazy::new(|| DateTime::parse_from_rfc2822(built_info::BUILT_TIME_UTC).unwrap());
 

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -5,7 +5,7 @@ use eyre::Result;
 use std::sync::LazyLock as Lazy;
 use versions::Versioning;
 
-use crate::build_time::{git_sha, BUILD_TIME};
+use crate::build_time::BUILD_TIME;
 use crate::cli::self_update::SelfUpdate;
 #[cfg(not(test))]
 use crate::config::Settings;
@@ -44,7 +44,6 @@ impl Version {
             "os": *OS,
             "arch": *ARCH,
             "build_time": BUILD_TIME.to_string(),
-            "git_sha": git_sha(),
         });
         println!("{}", serde_json::to_string_pretty(&json)?);
         Ok(())
@@ -67,11 +66,7 @@ pub static VERSION: Lazy<String> = Lazy::new(|| {
         v.push_str("-DEBUG");
     };
     let build_time = BUILD_TIME.format("%Y-%m-%d");
-    let extra = match git_sha() {
-        Some(sha) => format!("({} {})", sha, build_time),
-        _ => format!("({})", build_time),
-    };
-    format!("{v} {os}-{arch} {extra}", os = *OS, arch = *ARCH)
+    format!("{v} {os}-{arch} ({build_time})", os = *OS, arch = *ARCH)
 });
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(


### PR DESCRIPTION
since we switched to gix it isn't worth compiling all of libgit2 for sometimes displaying the git sha in `mise -v`
