### PR TITLE
fix:  Swift on Ubuntu 24.04 arm64 generates the incorrect download URL

### DIFF
--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -197,18 +197,16 @@ fn platform_directory() -> String {
         "xcode".into()
     } else if cfg!(windows) {
         "windows10".into()
-    } else {
-        if let Ok(os_release) = &*os_release::OS_RELEASE {
-            let arch = SETTINGS.arch();
-            if os_release.id == "ubuntu" && arch == "aarch64" {
-                let retval = format!("{}{}-{}", os_release.id, os_release.version_id, arch);
-                retval.replace(".", "")
-            } else {
-                platform().replace(".", "")
-            }
+    } else if let Ok(os_release) = &*os_release::OS_RELEASE {
+        let arch = SETTINGS.arch();
+        if os_release.id == "ubuntu" && arch == "aarch64" {
+            let retval = format!("{}{}-{}", os_release.id, os_release.version_id, arch);
+            retval.replace(".", "")
         } else {
             platform().replace(".", "")
         }
+    } else {
+        platform().replace(".", "")
     }
 }
 

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -198,7 +198,17 @@ fn platform_directory() -> String {
     } else if cfg!(windows) {
         "windows10".into()
     } else {
-        platform().replace(".", "")
+        if let Ok(os_release) = &*os_release::OS_RELEASE {
+            let arch = SETTINGS.arch();
+            if os_release.id == "ubuntu" && arch == "aarch64" {
+                let retval = format!("{}{}-{}", os_release.id, os_release.version_id, arch);
+                retval.replace(".", "")
+            } else {
+                platform().replace(".", "")
+            }
+        } else {
+            platform().replace(".", "")
+        }
     }
 }
 


### PR DESCRIPTION
The wrong download path is generated: 

The correct format is: 

```https://download.swift.org/swift-6.0.2-release/ubuntu2404-aarch64/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE-ubuntu24.04-aarch64.tar.gz```

but mise was using:
```https://download.swift.org/swift-6.0.2-release/ubuntu2404/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE-ubuntu24.04-aarch64.tar.gz```