### PR TITLE
Add args to the task prefix

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -136,6 +136,7 @@ impl Debug for EitherStringOrIntOrBool {
     }
 }
 
+
 impl Task {
     pub fn new(path: &Path, prefix: &Path, config_root: &Path) -> Result<Task> {
         Ok(Self {
@@ -243,7 +244,13 @@ impl Task {
     }
 
     pub fn prefix(&self) -> String {
-        format!("[{}]", self.display_name())
+        let args = if !self.args.is_empty(){
+            self.args.join(" ")
+        } else {
+            "".to_string()
+        };
+
+        format!("[{}{}]", self.display_name(), args)
     }
 
     pub fn run(&self) -> &Vec<String> {
@@ -388,7 +395,7 @@ impl Task {
             ]
         });
         let idx = self
-            .display_name()
+            .prefix()
             .chars()
             .map(|c| c as usize)
             .sum::<usize>()


### PR DESCRIPTION
When running the same task with different arguments they are all printed the same.
So make it clear which task ran i propose to add the args to the prefix.

I had a stab at implementing the task dependency args but my rust skills/ knowledge of the project is a bit too limited for that.