### PR TITLE
docs: fix postinstall typo in nodejs cookbook

### DIFF
--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -87,7 +87,7 @@ node = '22'
 [hooks]
 # Enabling corepack will install the `pnpm` package manager specified in your package.json
 # alternatively, you can also install `pnpm` with mise
-post_install = 'npx corepack enable'
+postinstall = 'npx corepack enable'
 
 [env]
 _.path = ['./node_modules/.bin']


### PR DESCRIPTION
Fix the error in hooks replace `post_install` with `postinstall`