### PR TITLE
feat(registry): add kwokctl

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -455,6 +455,7 @@ You can also specify the full name for a tool using `mise use aqua:1password/cli
 | kubevela | [aqua:kubevela/kubevela](https://github.com/kubevela/kubevela) [asdf:gustavclausen/asdf-kubevela](https://github.com/gustavclausen/asdf-kubevela) |
 | kubie | [aqua:sbstp/kubie](https://github.com/sbstp/kubie) [asdf:johnhamelink/asdf-kubie](https://github.com/johnhamelink/asdf-kubie) |
 | kustomize | [aqua:kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize) [asdf:Banno/asdf-kustomize](https://github.com/Banno/asdf-kustomize) |
+| kwokctl | [aqua:kubernetes-sigs/kwok/kwokctl](https://github.com/kubernetes-sigs/kwok/kwokctl) |
 | kwt | [aqua:carvel-dev/kwt](https://github.com/carvel-dev/kwt) [asdf:vmware-tanzu/asdf-carvel](https://github.com/vmware-tanzu/asdf-carvel) |
 | kyverno | [aqua:kyverno/kyverno](https://github.com/kyverno/kyverno) [asdf:https://github.com/hobaen/asdf-kyverno-cli.git](https://github.com/hobaen/asdf-kyverno-cli) |
 | lab | [aqua:zaquestion/lab](https://github.com/zaquestion/lab) [asdf:particledecay/asdf-lab](https://github.com/particledecay/asdf-lab) |

--- a/registry.toml
+++ b/registry.toml
@@ -1121,6 +1121,8 @@ kustomize.backends = [
     "asdf:Banno/asdf-kustomize"
 ]
 kustomize.test = ["kustomize version", "v{{version}}"]
+kwokctl.backends = ["aqua:kubernetes-sigs/kwok/kwokctl"]
+kwokctl.test = ["kwokctl --version", "kwokctl version v{{version}}"]
 kwt.backends = ["aqua:carvel-dev/kwt", "asdf:vmware-tanzu/asdf-carvel"]
 kyverno.backends = [
     "aqua:kyverno/kyverno",


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/kwok
Ref: https://github.com/aquaproj/aqua-registry/tree/9124d9fb77ded25d95ff22bde80624be5bbadc66/pkgs/kubernetes-sigs/kwok/kwokctl

`kwokctl.test` version template
```
❯ ./kwokctl-linux-amd64 --version
kwokctl version v0.6.1 go1.22.3 (linux/amd64)
```

Note: Please reword my commit message to include the two refs later when merging. Currently it's only one. Thank you.