### PR TITLE
docs(schema): fix description of task.dir default

### DIFF
--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -91,7 +91,7 @@
             },
             "dir": {
               "default": "{{ config_root }}",
-              "description": "directory to run script in",
+              "description": "directory to run script in, default is current working directory",
               "type": "string"
             },
             "env": {

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -91,7 +91,7 @@
             },
             "dir": {
               "default": "{{ config_root }}",
-              "description": "directory to run script in, default is current working directory",
+              "description": "directory to run script in, default is the project's base directory",
               "type": "string"
             },
             "env": {

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -91,7 +91,7 @@
             },
             "dir": {
               "default": "{{ config_root }}",
-              "description": "directory to run script in, default is current working directory",
+              "description": "directory to run script in",
               "type": "string"
             },
             "env": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1066,7 +1066,7 @@
             },
             "dir": {
               "default": "{{ config_root }}",
-              "description": "directory to run script in, default is current working directory",
+              "description": "directory to run script in",
               "type": "string"
             },
             "env": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1066,7 +1066,7 @@
             },
             "dir": {
               "default": "{{ config_root }}",
-              "description": "directory to run script in",
+              "description": "directory to run script in, default is the project's base directory",
               "type": "string"
             },
             "env": {


### PR DESCRIPTION
Resolves #4323. Since the default is explained by `default` property, just remove it from the `description`.