### PR TITLE
fix: lowercase desired shim names

### DIFF
--- a/src/shims.rs
+++ b/src/shims.rs
@@ -267,6 +267,9 @@ fn get_desired_shims(toolset: &Toolset) -> Result<HashSet<String>> {
                         ]
                     })
                     .collect()
+            } else if cfg!(macos) {
+                // some bins might be uppercased but on mac APFS is case insensitive
+                bins.into_iter().map(|b| b.to_lowercase()).collect()
             } else {
                 bins
             }


### PR DESCRIPTION
This fixes a bug on macOS where we are searching for a shim name with one or more characters uppercased, e.g. Python. But on macOS the APFS (default file system) is case insensitive, so `mise doctor` will always report an error in this case.

See https://github.com/jdx/mise/discussions/4332