### PR TITLE
fix(aqua): trim prefix before comparing versions

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -9,6 +9,7 @@ use expr::{Context, Parser, Program, Value};
 use eyre::{eyre, ContextCompat, Result};
 use indexmap::IndexSet;
 use itertools::Itertools;
+use regex::Regex;
 use serde_derive::Deserialize;
 use std::cmp::PartialEq;
 use std::collections::HashMap;
@@ -391,7 +392,8 @@ impl AquaPackage {
     }
 
     fn expr_parser(&self, v: &str) -> Parser {
-        let ver = versions::Versioning::new(v.strip_prefix('v').unwrap_or(v));
+        let prefix = Regex::new(r"^[^0-9.]+").unwrap();
+        let ver = versions::Versioning::new(prefix.replace(v, "").to_string());
         let mut expr = Parser::new();
         expr.add_function("semver", move |c| {
             if c.args.len() != 1 {

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -393,7 +393,7 @@ impl AquaPackage {
 
     fn expr_parser(&self, v: &str) -> Parser {
         let prefix = Regex::new(r"^[^0-9.]+").unwrap();
-        let ver = versions::Versioning::new(prefix.replace(v, "").to_string());
+        let ver = versions::Versioning::new(prefix.replace(v, ""));
         let mut expr = Parser::new();
         expr.add_function("semver", move |c| {
             if c.args.len() != 1 {


### PR DESCRIPTION
While I was debugging for #4338, I found that the `versions` crate comparison logic was weird. It treated versions without prefixes larger than versions with prefixes.

As documented in the code, it should be an expected behaviour, but since many GitHub release tags contain prefixes, we should somehow trim them before comparing versions.

>  `nth_lenient` pulls a leading digit from the `Version`'s chunk if it could. If it couldn't, that chunk is some string (perhaps a git hash) and is considered as marking a beta/prerelease version. It is thus considered less than the `SemVer`.
https://github.com/fosskers/rs-versions/blob/efb1b0d16418b17a774e3e5572815367bc813bcd/src/semver.rs#L124-L130

However, we need to parse `version_constraint` to get `version_prefix` from `version_overrides`, so we cannot refer to the aqua registry to determine the prefix of tags. This PR simply trims prefix-ish letters (non-digit characters) from the version before comparison. It only trims the prefix in `semver` function in `expr-lang`, so the effect should be small.

Example of `versions` behaviour:
```rust
use versions::{Requirement, Versioning};
fn main() {
    let v = "test-0.2.0";
    let req = Requirement::new("<=0.1.0").unwrap();
    let ver = Versioning::new(v.strip_prefix('v').unwrap_or(v)).unwrap();
    println!("{:?}", req);
    println!("{:?}", ver);
    println!("{:?}", req.matches(&ver));
}
```
```
Requirement { op: LessEq, version: Some(Ideal(SemVer { major: 0, minor: 1, patch: 0, pre_rel: None, meta: None })) }
General(Version { epoch: None, chunks: Chunks([Alphanum("test")]), release: Some(Release([Numeric(0), Numeric(2), Numeric(0)])), meta: None })
true
```