### PR TITLE
feat: use `machengine.org` for downloading nominated zig versions

### DIFF
--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -62,7 +62,7 @@ impl ZigPlugin {
             )
         } else if regex!(r"^[0-9]+\.[0-9]+\.[0-9]+-dev.[0-9]+\+[0-9a-f]+$").is_match(&tv.version) {
             format!(
-                "https://ziglang.org/builds/zig-{}-{}-{}.{archive_ext}",
+                "https://pkg.machengine.org/zig/zig-{}-{}-{}.{archive_ext}",
                 os(),
                 arch(),
                 tv.version


### PR DESCRIPTION
## Description

This update makes `mise` smarter about finding specific Zig versions! I was personally frustrated trying to use a nominated Zig version and finding that `mise` couldn't grab it with the previous behavior. This change fixes that! Specifically, it improves how `mise` handles those in-between "dev" versions of Zig (like `0.14.0-dev.2577+271452d22`).

The main Zig website (`ziglang.org/download`) doesn't always keep older or development versions around. `machengine.org` does! So, this change tells `mise` to automatically grab those specific "dev" versions from `machengine.org` instead.

**Here's the key thing:** This only applies to Zig versions that look like `0.14.0-dev.2577+271452d22` (a number, then `-dev`, then more numbers and letters). If you're using a regular, stable Zig version (like `0.13.0`), `mise` will still download it from the official Zig website, just like before. **This means it expands the range of Zig versions you can install with `mise` without changing how it works for stable releases.**

This should make it easier to use `mise` with projects that need a very specific Zig development build, and hopefully save others the frustration I experienced!
