### PR TITLE
feat(registry): add 'marksman' via 'aqua:artempyanykh/marksman' backend

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1202,6 +1202,8 @@ markdownlint-cli2.backends = [
     "npm:markdownlint-cli2",
     "asdf:paulo-ferraz-oliveira/asdf-markdownlint-cli2"
 ]
+marksman.backends = ["aqua:artempyanykh/marksman"]
+marksman.test = ["marksman --version", "{{version}}"]
 marp-cli.backends = ["aqua:marp-team/marp-cli", "asdf:xataz/asdf-marp-cli"]
 mask.backends = ["aqua:jacobdeichert/mask", "asdf:aaaaninja/asdf-mask"]
 mask.test = ["mask --version", "mask {{version}}"]

--- a/registry.toml
+++ b/registry.toml
@@ -1203,7 +1203,7 @@ markdownlint-cli2.backends = [
     "asdf:paulo-ferraz-oliveira/asdf-markdownlint-cli2"
 ]
 marksman.backends = ["aqua:artempyanykh/marksman"]
-marksman.test = ["marksman --version", "{{version}}"]
+marksman.test = ["marksman --version", ""]
 marp-cli.backends = ["aqua:marp-team/marp-cli", "asdf:xataz/asdf-marp-cli"]
 mask.backends = ["aqua:jacobdeichert/mask", "asdf:aaaaninja/asdf-mask"]
 mask.test = ["mask --version", "mask {{version}}"]


### PR DESCRIPTION
This PR adds [marksman](https://github.com/artempyanykh/marksman) to the Mise registry via the Aqua backend (see PR [#31906](https://github.com/aquaproj/aqua-registry/pull/31906), merged as of yesterday).

Marksman implements the Language Server Protocol for Markdown to be used in terminal- and non-terminal-based text editors. Marksman is developed in F# and distributed as a single binary for Linux, MacOS, and Windows. Installation using `mise` was tested successfully on Fedora and Ubuntu.
