### PR TITLE
fix(rubygems_plugin):  Replace which ruby check for Windows compatibility

### DIFF
--- a/src/plugins/core/assets/rubygems_plugin.rb
+++ b/src/plugins/core/assets/rubygems_plugin.rb
@@ -9,7 +9,7 @@ def log_debug(msg)
 end
 
 def reshim
-  if `which ruby`.strip != ""
+  if defined?(RbConfig::CONFIG)
     log_debug "reshim"
     `mise reshim`
   else


### PR DESCRIPTION
Replace which ruby command with `RbConfig::CONFIG` check to ensure cross-platform compatibility, particularly for Windows environments where which is not available.

When running `bundle update` on Windows, the following error occurs:

```
❯ bundle update
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
--- ERROR REPORT TEMPLATE -------------------------------------------------------
Errno::ENOENT: No such file or directory - which ruby
<path_to_mise>/mise/current/mise/installs/ruby/3.4.1/lib/ruby/site_ruby/rubygems_plugin.rb:12:in 'Kernel#`'
```

The error occurs because the `which` command does not exist on Windows systems. This PR replaces the command with `RbConfig::CONFIG` check to make the Ruby detection more platform-agnostic.