### PR TITLE
docs: update Fedora install for dnf5

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -154,11 +154,19 @@ cargo install mise --git https://github.com/jdx/mise --branch main
 
 ### dnf
 
-For Fedora, CentOS, Amazon Linux, RHEL and other dnf-based distributions:
+For Fedora 40, CentOS, Amazon Linux, RHEL and other dnf-based distributions:
 
 ```sh
 dnf install -y dnf-plugins-core
 dnf config-manager --add-repo https://mise.jdx.dev/rpm/mise.repo
+dnf install -y mise
+```
+
+Fedora 41+ (dnf5)
+
+```
+dnf install -y dnf-plugins-core
+dnf config-manager addrepo --from-repofile=https://mise.jdx.dev/rpm/mise.repo
 dnf install -y mise
 ```
 


### PR DESCRIPTION
Fedora 41+ is using `dnf5` which has slightly different commands.