### PR TITLE
fix: allow cosign opts to be empty in aqua

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -123,6 +123,7 @@ pub struct AquaCosign {
     pub signature: Option<AquaCosignSignature>,
     pub key: Option<AquaCosignSignature>,
     pub certificate: Option<AquaCosignSignature>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     opts: Vec<String>,
 }
 


### PR DESCRIPTION
The opts attribute on cosign check for aqua is optional. If not provided it will make the package resolution fail. This patch makes it optional and provide an empty array if key is not found.

This address the issue described here: https://github.com/jdx/mise/discussions/4092