### PR TITLE
fix: properly iterate over depends_post entries to retrieve tasks

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -291,9 +291,10 @@ impl Task {
             .flatten_ok()
             .filter_ok(|t| tasks_to_run.contains(t))
             .collect_vec();
-        let depends_post = tasks_to_run
+        let depends_post = self
+            .depends_post
             .iter()
-            .flat_map(|t| t.depends_post.iter().map(|td| match_tasks(&tasks, td)))
+            .map(|td| match_tasks(&tasks, td))
             .flatten_ok()
             .filter_ok(|t| t.name != self.name)
             .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
This is an attempt to fix: https://github.com/jdx/mise/discussions/4398 and https://github.com/jdx/mise/discussions/4222 
I am not familiar with Rust or the code base here. However, this change seems to fix the issue for my case. When running `mise task deps` I get the expected result from the setup in: https://github.com/jdx/mise/discussions/4398
When running the various tasks I get the proper output as well. Happy to get feedback and guidance here.