### PR TITLE
feat(shim): Windows shim add hardlink & symlink mode

### DIFF
--- a/e2e-win/shim.Tests.ps1
+++ b/e2e-win/shim.Tests.ps1
@@ -13,6 +13,10 @@ Describe 'shim_mode' {
         $shimPath = Join-Path -Path $env:MISE_DATA_DIR -ChildPath "shims"
     }
 
+    AfterAll {
+        mise settings unset windows_shim_mode
+    }
+
     It 'run on symlink' {
         changeShimMode "symlink"
 

--- a/e2e-win/shim.Tests.ps1
+++ b/e2e-win/shim.Tests.ps1
@@ -1,0 +1,43 @@
+Describe 'shim_mode' {
+
+    function changeShimMode {
+        param (
+            [string]$mode,
+        )
+
+        mise settings windows_shim_mode $mode
+        mise reshim --force
+
+    }
+
+    BeforeAll {
+         $shimPath = Join-Path -Path $env:MISE_DATA_DIR -ChildPath "shims"
+    }
+
+    It 'run on symlink' {
+        changeShimMode "symlink"
+
+        mise x go@1.23.3 -- where go
+        mise x go@1.23.3 -- go version | Should -BeLike "go version go1.23.3 windows/*"
+        
+        (Get-Item -Path (Join-Path -Path $shimPath -ChildPath go.exe)).LinkType | Should -Be "SymbolicLink"
+    }
+
+    It 'run on file' {
+        changeShimMode "file"
+
+        mise x go@1.23.3 -- where go
+        mise x go@1.23.3 -- go version | Should -BeLike "go version go1.23.3 windows/*"
+
+        (Get-Item -Path  (Join-Path -Path $shimPath -ChildPath go.cmd)) | Should -Be ""
+    }
+
+    It 'run on hardlink' {
+        changeShimMode "hardlink"
+
+        mise x go@1.23.3 -- where go
+        mise x go@1.23.3 -- go version | Should -BeLike "go version go1.23.3 windows/*"
+
+        (Get-Item -Path (Join-Path -Path $shimPath -ChildPath go.exe)).LinkType | Should -Be "HardLink"
+    }
+}

--- a/e2e-win/shim.Tests.ps1
+++ b/e2e-win/shim.Tests.ps1
@@ -8,7 +8,6 @@ Describe 'shim_mode' {
 
             mise settings windows_shim_mode $mode
             mise reshim --force
-
         }
 
         $shimPath = Join-Path -Path $env:MISE_DATA_DIR -ChildPath "shims"
@@ -33,10 +32,19 @@ Describe 'shim_mode' {
     }
 
     It 'run on hardlink' {
-        changeShimMode "hardlink"
+        mise settings windows_shim_mode "hardlink"
 
-        mise x go@1.23.3 -- where go
-        mise x go@1.23.3 -- go version | Should -BeLike "go version go1.23.3 windows/*"
+        # make mise is on same filesystem
+        $misePath = (Get-Command -Type Application mise -all | Select-Object -First 1).Source
+        $binPath = (Join-Path -Path $env:MISE_DATA_DIR -ChildPath "bin")
+        $newMisePath = (Join-Path -Path $binPath -ChildPath "mise.exe")
+        New-Item -ItemType Directory -Path $binPath -Force
+        Copy-Item  $misePath $newMisePath
+
+        &$newMisePath reshim --force
+
+        &$newMisePath x go@1.23.3 -- where go
+        &$newMisePath x go@1.23.3 -- go version | Should -BeLike "go version go1.23.3 windows/*"
 
         (Get-Item -Path (Join-Path -Path $shimPath -ChildPath go.exe)).LinkType | Should -Be "HardLink"
     }

--- a/e2e-win/shim.Tests.ps1
+++ b/e2e-win/shim.Tests.ps1
@@ -1,17 +1,17 @@
 Describe 'shim_mode' {
 
-    function changeShimMode {
-        param (
-            [string]$mode,
-        )
-
-        mise settings windows_shim_mode $mode
-        mise reshim --force
-
-    }
-
     BeforeAll {
-         $shimPath = Join-Path -Path $env:MISE_DATA_DIR -ChildPath "shims"
+        function changeShimMode {
+            param (
+                [string]$mode
+            )
+
+            mise settings windows_shim_mode $mode
+            mise reshim --force
+
+        }
+
+        $shimPath = Join-Path -Path $env:MISE_DATA_DIR -ChildPath "shims"
     }
 
     It 'run on symlink' {
@@ -29,7 +29,7 @@ Describe 'shim_mode' {
         mise x go@1.23.3 -- where go
         mise x go@1.23.3 -- go version | Should -BeLike "go version go1.23.3 windows/*"
 
-        (Get-Item -Path  (Join-Path -Path $shimPath -ChildPath go.cmd)) | Should -Be ""
+        (Get-Item -Path  (Join-Path -Path $shimPath -ChildPath go.cmd)).LinkType | Should -Be $null
     }
 
     It 'run on hardlink' {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -969,6 +969,11 @@
             "type": "string"
           }
         },
+        "windows_shim_mode": {
+          "default": "file",
+          "description": "Shim file mode for Windows. Options: `file`, `hardlink`, `symlink`.",
+          "type": "string"
+        },
         "yes": {
           "description": "This will automatically answer yes or no to prompts. This is useful for scripting.",
           "type": "boolean"

--- a/settings.toml
+++ b/settings.toml
@@ -1159,6 +1159,17 @@ default = ["exe", "bat", "cmd", "com", "ps1", "vbs"]
 parse_env = "list_by_comma"
 description = "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on."
 
+[windows_shim_mode]
+env = "MISE_WINDOWS_SHIM_MODE"
+type = "String"
+default = "file"
+description = "Shim file mode for Windows. Options: `file`, `hardlink`, `symlink`."
+docs = """
+`file`: Creates a file with the content `mise exec`.
+`hardlink`: Uses Windows NTFS Hardlink, required on same filesystems. Need run `mise reshim --force` after upgrade mise
+`symlink`: Uses Windows NTFS SymbolicLink. Requires Windows Vista or later with admin privileges or enabling "Developer Mode" in Windows 10/11.
+"""
+
 [yes]
 env = "MISE_YES"
 type = "Bool"


### PR DESCRIPTION
https://github.com/jdx/mise/discussions/4360

add setting `windows_shim_mode`
1. `file` default, current implement 
2. `hardlink`, require on same filesystem
3. `symlink`: Requires Windows Vista or later with admin privileges or enabling "Developer Mode" in Windows 10/11.


I am not familiar with Rust or the code base here

test on windows 11 24h2 with "Devloper Mode"