### PR TITLE
feat: Install latest nominated zig from https://machengine.org/zig/index.json

### DIFF
--- a/docs/lang/zig.md
+++ b/docs/lang/zig.md
@@ -13,10 +13,13 @@ The following installs zig and makes it the global default:
 
 ```sh
 mise use -g zig@0.13     # install zig 0.13.x
-mise use -g zig@latest  # install latest zig
+mise use -g zig@latest  # install latest zig release
+mise use -g zig@ref:master # instaLL latest nightly from master
+mise use -g zig@ref:mach-latest # install latest nominated zig
+mise use -g zig@0.14.0-dev.2577+271452d22 # install dev version
 ```
 
-See available versions with `mise ls-remote zig`.
+See available stable versions with `mise ls-remote zig`.
 
 ## zig Language Server
 

--- a/e2e-win/zig.Tests.ps1
+++ b/e2e-win/zig.Tests.ps1
@@ -2,4 +2,8 @@ Describe 'zig' {
     It 'executes zig 0.13.0' {
         mise x zig@0.13.0 -- zig version | Should -be "0.13.0"
     }
+
+    It 'executes zig 0.14.0-dev.2577+271452d22' {
+        mise x zig@0.14.0-dev.2577+271452d22 -- zig version | Should -be "0.14.0-dev.2577+271452d22"
+    }
 }

--- a/e2e/core/test_zig
+++ b/e2e/core/test_zig
@@ -2,3 +2,5 @@
 
 assert "mise x zig@0.13.0 -- zig version" "0.13.0"
 assert "mise x zig@ref:master -- zig version"
+assert "mise x zig@0.14.0-dev.2577+271452d22 -- zig version" "0.14.0-dev.2577+271452d22"
+assert "mise x zig@ref:mach-latest -- zig version"


### PR DESCRIPTION
It installs latest nominated zig version from machengine

```
mise use zig@ref:mach-latest
```

I see it requires some improvements over `mise ls-remote zig` to show nightly versions.

We also need to install `zls` related to `zig version` as for now it uses just latest release (0.13) which is wrong