### PR TITLE
feat(registry): added oxipng

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1377,6 +1377,7 @@ overmind.backends = [
     "ubi:DarthSim/overmind",
     "go:github.com/DarthSim/overmind/v2"
 ]
+oxipng.backends = ["aqua:shssoichiro/oxipng"]
 pachctl.backends = ["aqua:pachyderm/pachyderm", "asdf:abatilo/asdf-pachctl"]
 # pachctl.test = ["pachctl version", "{{version}}"] # test fails on ci but seems to work locally
 packer.backends = ["aqua:hashicorp/packer", "asdf:mise-plugins/mise-hashicorp"]


### PR DESCRIPTION
[Oxipng](https://github.com/shssoichiro/oxipng) is a multithreaded lossless PNG/APNG compression optimizer


Tests :
```
mise use -g aqua:shssoichiro/oxipng
```
```
mise aqua:shssoichiro/oxipng@9.1.4 ✓ installed
mise ~/.config/mise/config.toml tools: aqua:shssoichiro/oxipng@9.1.4
```