### PR TITLE
fix: bugs with grep in tar_supports_zstd in mise.run script

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -79,7 +79,7 @@ tar_supports_zstd() {
   # tar is bsdtar or version is >= 1.31
   if tar --version | grep -q 'bsdtar' && command -v zstd >/dev/null 2>&1; then
     true
-  elif tar --version | grep -q '1.(3[1-9]|{4-9}\d)'; then
+  elif tar --version | grep -q '1\.(3[1-9]|[4-9][0-9]'; then
     true
   else
     false


### PR DESCRIPTION
Fix three issues with the tar version check in mise.run:

- period should be escaped in order to only match periods
- the 4-9 range needs to be put in `[]` not `{}`
- GNU grep (common on Linux) does not support `\d`