### PR TITLE
feat(registry): Added foundry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -660,6 +660,8 @@ flyctl.backends = [
     "asdf:chessmango/asdf-flyctl"
 ]
 flyway.backends = ["asdf:mise-plugins/mise-flyway"]
+foundry.backends = ["ubi:foundry-rs/foundry[extract_all=true]"]
+foundry.test = ["forge -V", "{{version}}"]
 func-e.backends = ["tetratelabs/func-e", "asdf:mise-plugins/mise-func-e"]
 func-e.test = ["func-e --version", "func-e version {{version}}"]
 furyctl.backends = ["ubi:sighupio/furyctl", "asdf:sighupio/asdf-furyctl"]


### PR DESCRIPTION
https://github.com/foundry-rs/foundry

Foundry has become the de facto standard tool to develop solidity and vyper contracts for EVM blockchains

The package actually consists of a suite of tools: forge, cast, chisel, and anvil. Thus, the `extract_all` flag is needed