### PR TITLE
feat(registry): added hadolint from aqua registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -837,6 +837,7 @@ gwvault.backends = [
     "asdf:GoodwayGroup/asdf-gwvault"
 ]
 hadolint.backends = [
+    "aqua:hadolint/hadolint",
     "ubi:hadolint/hadolint",
     "asdf:devlincashman/asdf-hadolint"
 ]


### PR DESCRIPTION
[hadolint](https://github.com/hadolint/hadolint) ContainerFile linter 


Tests :
```
mise use -g aqua:hadolint/hadolint
```
```
mise aqua:hadolint/hadolint@2.12.0 ✓ installed
mise ~/.config/mise/config.toml tools: aqua:hadolint/hadolint@2.12.0
```