### PR TITLE
feat(registry): added sops from aqua registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1610,7 +1610,11 @@ sonobuoy.backends = [
     "ubi:vmware-tanzu/sonobuoy",
     "asdf:Nick-Triller/asdf-sonobuoy"
 ]
-sops.backends = ["ubi:getsops/sops", "asdf:mise-plugins/mise-sops"]
+sops.backends = [
+    "aqua:getsops/sops",
+    "ubi:getsops/sops",
+    "asdf:mise-plugins/mise-sops"
+]
 sopstool.backends = ["aqua:ibotta/sopstool", "asdf:elementalvoid/asdf-sopstool"]
 soracom.backends = ["ubi:soracom/soracom-cli", "asdf:gr1m0h/asdf-soracom"]
 sourcery.backends = ["asdf:mise-plugins/mise-sourcery"]


### PR DESCRIPTION
[sops](https://github.com/getsops/sops) SOPS is an editor of encrypted files that supports YAML, JSON, ENV, INI and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault, age, and PGP


Tests :
```
mise use -g aqua:getsops/sops
```
```
mise aqua:getsops/sops@3.9.4 ✓ installed
mise ~/.config/mise/config.toml tools: aqua:getsops/sops@3.9.4
```