### PR TITLE
fix(task): Running programs on windows without cmd.exe

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -114,13 +114,7 @@ static RUNNING_PIDS: Lazy<Mutex<HashSet<u32>>> = Lazy::new(Default::default);
 
 impl<'a> CmdLineRunner<'a> {
     pub fn new<P: AsRef<OsStr>>(program: P) -> Self {
-        let mut cmd = if cfg!(windows) {
-            let mut cmd = Command::new("cmd.exe");
-            cmd.arg("/c").arg(program);
-            cmd
-        } else {
-            Command::new(program)
-        };
+        let mut cmd = Command::new(program);
         cmd.stdin(Stdio::null());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());


### PR DESCRIPTION
See discussion #4399

Running a task on windows results in the very confusing command `cmd.exe -c cmd.exe -c command`!

This is caused by getting the configuration `tasks.shell` in `crate::cli::run::Run::get_cmd_program_and_args` and then wrapping the command with `cmd.exe -c` in `crate::cmd::CmdLineRunner::new`. to remove the `cmd.exe -c` wrapper from `new`.

Any other code that uses `crate::cmd::CmdLineRunner::new` should not require `cmd.exe -c` wrapping, so it can be safely removed.