### PR TITLE
feat(registry): added k9s from aqua registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -977,7 +977,11 @@ k3kcli.backends = [
 k3s.backends = ["asdf:mise-plugins/mise-k3s"]
 k3sup.backends = ["aqua:alexellis/k3sup", "asdf:cgroschupp/asdf-k3sup"]
 k6.backends = ["ubi:grafana/k6", "asdf:gr1m0h/asdf-k6"]
-k9s.backends = ["ubi:derailed/k9s", "asdf:looztra/asdf-k9s"]
+k9s.backends = [
+    "aqua:derailed/k9s",
+    "ubi:derailed/k9s",
+    "asdf:looztra/asdf-k9s"
+]
 kafka.backends = ["asdf:mise-plugins/mise-kafka"]
 kafkactl.backends = [
     "aqua:deviceinsight/kafkactl",


### PR DESCRIPTION
[k9s](https://github.com/derailed/k9s) K9s provides a terminal UI to interact with your Kubernetes clusters

Tests :
```
mise use -g aqua:derailed/k9s
```
```
mise aqua:derailed/k9s@0.40.5 ✓ installed
mise ~/.config/mise/config.toml tools: aqua:derailed/k9s@0.40.5
```