### PR TITLE
fix: bug when using mise use -g when MISE_ENV is filled

### DIFF
--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -75,6 +75,13 @@ assert "cat ~/.config/mise/config.toml" '[tools]
 gh = "2"'
 rm -f ~/.config/mise/config.toml
 
+export MISE_ENV=test
+mise use -g dummy@1
+assert "cat ~/.config/mise/config.toml" '[tools]
+dummy = "1"'
+rm -f ~/.config/mise/config.toml
+unset MISE_ENV
+
 mise uninstall dummy --all
 mise use dummy@system
 assert "mise ls dummy" "dummy  system  ~/workdir/mise.toml  system"

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -195,7 +195,9 @@ impl Use {
 
     fn get_config_file(&self) -> Result<Box<dyn ConfigFile>> {
         let cwd = env::current_dir()?;
-        let path = if let Some(p) = &self.path {
+        let path = if self.global {
+            MISE_GLOBAL_CONFIG_FILE.clone()
+        } else if let Some(p) = &self.path {
             let from_dir = config_file_from_dir(p).absolutize()?.to_path_buf();
             if from_dir.starts_with(&cwd) {
                 from_dir
@@ -212,7 +214,7 @@ impl Use {
         } else if !env::MISE_ENV.is_empty() {
             let env = env::MISE_ENV.last().unwrap();
             config_file_from_dir(&cwd.join(format!("mise.{env}.toml")))
-        } else if self.global || env::in_home_dir() {
+        } else if env::in_home_dir() {
             MISE_GLOBAL_CONFIG_FILE.clone()
         } else {
             config_file_from_dir(&cwd)


### PR DESCRIPTION
Fixes #4490 

Using `MISE_ENV` circumvents the option overrides, so `global`, `path` and `env` options should come before `MISE_ENV` in the loading priority.