### PR TITLE
feat(ubi): add option `rename_exe`

### DIFF
--- a/docs/dev-tools/backends/ubi.md
+++ b/docs/dev-tools/backends/ubi.md
@@ -46,6 +46,17 @@ use the `exe` option to specify the executable name:
 "ubi:cli/cli" = { version = "latest", exe = "gh" } # github's cli
 ```
 
+### `rename_exe`
+
+The `rename_exe` option allows you to specify the name of the executable once it has been extracted.
+
+use the `rename_exe` option to specify the target executable name:
+
+```toml
+[tools]
+"ubi:cli/cli" = { version = "latest", exe = "gh", rename_exe = "github" } # github's cli
+```
+
 ### `matching`
 
 Set a string to match against the release filename when there are multiple files for your
@@ -60,7 +71,7 @@ then this will be ignored.
 
 ### `extract_all`
 
-Set to `true` to extract all files in the tarball instead of just the "bin". Not compatible with `exe`.
+Set to `true` to extract all files in the tarball instead of just the "bin". Not compatible with `exe` nor `rename_exe`.
 
 ```toml
 [tools]

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -104,8 +104,13 @@ impl Backend for UbiBackend {
 
             if extract_all {
                 builder = builder.extract_all();
-            } else if let Some(exe) = opts.get("exe") {
-                builder = builder.exe(exe);
+            } else {
+                if let Some(exe) = opts.get("exe") {
+                    builder = builder.exe(exe);
+                }
+                if let Some(rename_exe) = opts.get("rename_exe") {
+                    builder = builder.rename_exe_to(rename_exe)
+                }
             }
             if let Some(matching) = opts.get("matching") {
                 builder = builder.matching(matching);


### PR DESCRIPTION
Add a missing option for ubi backend.

Tested with this :

```bash
$ @mise use --global 'podman[exe=podman-remote-static-linux_amd64,rename_exe=podman]'
mise Installed executable into ~/.local/share/mise/installs/podman/5.4.0/podman
mise podman@5.4.0    ✓ installed
mise ~/.config/mise/config.toml tools: podman@5.4.0
$ which podman
~/.local/share/mise/installs/podman/5.4.0/podman
```
