### PR TITLE
feat(registry): add cocogitto

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -382,7 +382,7 @@ cockroach.backends = [
 ]
 cockroach.test = ["cockroach version", "v{{version}}"]
 cocoapods.backends = ["asdf:mise-plugins/mise-cocoapods"]
-cocogitto.aliases = ["cog"]
+cocogitto.test = ["cog --version", "cog {{version}}"]
 cocogitto.backends = ["aqua:cocogitto/cocogitto"]
 codefresh.backends = [
     "ubi:codefresh-io/cli[exe=codefresh]",

--- a/registry.toml
+++ b/registry.toml
@@ -382,6 +382,8 @@ cockroach.backends = [
 ]
 cockroach.test = ["cockroach version", "v{{version}}"]
 cocoapods.backends = ["asdf:mise-plugins/mise-cocoapods"]
+cocogitto.aliases = ["cog"]
+cocogitto.backends = ["aqua:cocogitto/cocogitto"]
 codefresh.backends = [
     "ubi:codefresh-io/cli[exe=codefresh]",
     "asdf:gurukulkarni/asdf-codefresh"


### PR DESCRIPTION
Adding [cocogitto/cocogitto](https://github.com/cocogitto/cocogitto) (binary filename: `cog`) to the registry. 

Should (?) work:

```
❯ mise use aqua:cocogitto/cocogitto
mise aqua:cocogitto/cocogitto@6.2.0 ✓ installed                                                                                                                                                            mise ~/code/tools/my-project/.config/mise.toml tools: aqua:cocogitto/cocogitto@6.2.0
```

Hope this counts as obvious. ;) 