### PR TITLE
feat(registry): added ast-grep

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -100,6 +100,13 @@ argocd.backends = [
 ]
 asciidoctorj.backends = ["asdf:mise-plugins/mise-asciidoctorj"]
 assh.backends = ["asdf:mise-plugins/mise-assh"]
+ast-grep.backends = [
+    "aqua:ast-grep/ast-grep",
+    "cargo:ast-grep",
+    "npm:@ast-grep/cli",
+    "pipx:ast-grep-cli"
+]
+ast-grep.test = ["sg --version", "ast-grep {{version}}"]
 atlas.backends = ["aqua:ariga/atlas", "asdf:komi1230/asdf-atlas"]
 atmos.backends = ["aqua:cloudposse/atmos", "asdf:cloudposse/asdf-atmos"]
 auto-doc.backends = ["asdf:mise-plugins/mise-auto-doc"]


### PR DESCRIPTION
[ast-grep](https://github.com/ast-grep/ast-grep) A CLI tool for code structural search, lint and rewriting

Tests :
```
$ cargo run --bin mise -- tool ast-grep                                                                                                  *1 [main] 12:19:10
   Compiling mise v2025.2.7 (/Users/tony/Projects/oss/mise)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.47s
     Running `target/debug/mise tool ast-grep`
Backend:            aqua:ast-grep/ast-grep
Installed Versions:
Tool Options:       [none]

$ cargo run --bin mise -- use -g ast-grep                                                                                                *1 [main] 12:19:34
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.94s
     Running `target/debug/mise use -g ast-grep`
mise ast-grep@0.35.0    install
mise ast-grep@0.35.0    download app-aarch64-apple-darwin.zip
mise ast-grep@0.35.0    generate checksum app-aarch64-apple-darwin.zip
mise ast-grep@0.35.0    extract app-aarch64-apple-darwin.zip
mise ast-grep@0.35.0  ✓ installed
mise ~/.config/mise/config.toml tools: ast-grep@0.35.0

$ cargo run --bin mise -- tool ast-grep                                                                                                  *1 [main] 12:25:42
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.80s
     Running `target/debug/mise tool ast-grep`
Backend:            aqua:ast-grep/ast-grep
Description:        A CLI tool for code structural search, lint and rewriting. Written in Rust
Installed Versions: 0.35.0
Active Version:     0.35.0
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```