### PR TITLE
feat(registry): added helmwave

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -883,10 +883,7 @@ helm-docs.backends = [
 ]
 helmfile.backends = ["ubi:helmfile/helmfile", "asdf:feniix/asdf-helmfile"]
 helmsman.backends = ["ubi:Praqma/helmsman", "asdf:luisdavim/asdf-helmsman"]
-helmwave.backends = [
-    "aqua:helmwave/helmwave",
-    "ubi:helmwave/helmwave",
-]
+helmwave.backends = ["aqua:helmwave/helmwave", "ubi:helmwave/helmwave"]
 helmwave.test = ["helmwave version", "{{version}}"]
 heroku.aliases = ["heroku-cli"]
 heroku.backends = ["asdf:mise-plugins/mise-heroku-cli"]

--- a/registry.toml
+++ b/registry.toml
@@ -883,6 +883,11 @@ helm-docs.backends = [
 ]
 helmfile.backends = ["ubi:helmfile/helmfile", "asdf:feniix/asdf-helmfile"]
 helmsman.backends = ["ubi:Praqma/helmsman", "asdf:luisdavim/asdf-helmsman"]
+helmwave.backends = [
+    "aqua:helmwave/helmwave",
+    "ubi:helmwave/helmwave",
+]
+helmwave.test = ["helmwave version", "{{version}}"]
 heroku.aliases = ["heroku-cli"]
 heroku.backends = ["asdf:mise-plugins/mise-heroku-cli"]
 hey.backends = ["asdf:mise-plugins/mise-hey"]


### PR DESCRIPTION
Helmwave is helm3-native tool for deploy your Helm Charts. HelmWave is like docker-compose for helm.

```
$ cargo run --bin mise -- tool helmwave
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/mise tool helmwave`
Backend:            aqua:helmwave/helmwave
Installed Versions:
Active Version:     0.41.8
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]

$ cargo run --bin mise -- use -g helmwave
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.83s
     Running `target/debug/mise use -g helmwave`
mise helmwave@0.41.8    install
mise helmwave@0.41.8    download helmwave_0.41.8_darwin_arm64.tar.gz
mise helmwave@0.41.8    checksum helmwave_0.41.8_darwin_arm64.tar.gz
mise helmwave@0.41.8    extract helmwave_0.41.8_darwin_arm64.tar.gz
mise helmwave@0.41.8  ✓ installed
mise ~/.config/mise/config.toml tools: helmwave@0.41.8

$ cargo run --bin mise -- tool helmwave
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
     Running `target/debug/mise tool helmwave`
Backend:            aqua:helmwave/helmwave
Description:        New  wave for @helm
Installed Versions: 0.41.8
Active Version:     0.41.8
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```