### PR TITLE
feat(registry): added doggo

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -535,6 +535,8 @@ docuum.backends = [
     "cargo:docuum",
     "asdf:bradym/asdf-docuum"
 ]
+doggo.backends = ["aqua:mr-karan/doggo", "ubi:mr-karan/doggo"]
+doggo.test = ["doggo --version | awk '{print $1}'", "v{{version}}"]
 dome.backends = ["asdf:mise-plugins/mise-dome"]
 doppler.backends = [
     "ubi:DopplerHQ/cli[exe=doppler]",


### PR DESCRIPTION
doggo - Command-line DNS Client for Humans. Written in Golang

Test

```
$ cargo run --bin mise -- tool doggo
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.77s
     Running `target/debug/mise tool doggo`
Backend:            aqua:mr-karan/doggo
Installed Versions:
Tool Options:       [none]

$ cargo run --bin mise -- use -g doggo
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.94s
     Running `target/debug/mise use -g doggo`
mise doggo@1.0.5        install
mise doggo@1.0.5        download doggo_1.0.5_Darwin_arm64.tar.gz
mise doggo@1.0.5        checksum doggo_1.0.5_Darwin_arm64.tar.gz
mise doggo@1.0.5        extract doggo_1.0.5_Darwin_arm64.tar.gz
mise doggo@1.0.5      ✓ installed
mise ~/.config/mise/config.toml tools: doggo@1.0.5

$ cargo run --bin mise -- tool doggo                                                                                                   *1 (doggo) 19:03:44
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.87s
     Running `target/debug/mise tool doggo`
Backend:            aqua:mr-karan/doggo
Description:        :dog: Command-line DNS Client for Humans. Written in Golang
Installed Versions: 1.0.5
Active Version:     1.0.5
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```