### PR TITLE
feat(registry): added gokey

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -787,6 +787,9 @@ goconvey.backends = [
 gocryptfs.backends = ["aqua:rfjakob/gocryptfs", "ubi:rfjakob/gocryptfs"]
 gofumpt.backends = ["ubi:mvdan/gofumpt", "asdf:looztra/asdf-gofumpt"]
 gojq.backends = ["aqua:itchyny/gojq", "asdf:jimmidyson/asdf-gojq"]
+# "aqua:cloudflare/gokey" exists, but can't be used due to "unsupported aqua package type: go_install"
+gokey.backends = ["ubi:cloudflare/gokey"]
+gokey.test = ["gokey -p master -r realm -l 8", "hJ2gXSy["]
 golangci-lint.backends = [
     "aqua:golangci/golangci-lint",
     "ubi:golangci/golangci-lint",


### PR DESCRIPTION
gokey - A simple vaultless password manager in Go

Test
```
$ cargo run --bin mise -- tool gokey
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.75s
     Running `target/debug/mise tool gokey`
Backend:            ubi:cloudflare/gokey
Installed Versions:
Tool Options:       [none]

$ cargo run --bin mise -- use -g gokey
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.87s
     Running `target/debug/mise use -g gokey`
mise gokey@0.1.3        install
mise Installed executable into /Users/anton.solovev/.local/share/mise/installs/gokey/0.1.3/gokey
mise gokey@0.1.3        checksum generate gokey-macos-aarch64
mise gokey@0.1.3      ✓ installed
mise ~/.config/mise/config.toml tools: gokey@0.1.3

$ cargo run --bin mise -- tool gokey
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
     Running `target/debug/mise tool gokey`
Backend:            ubi:cloudflare/gokey
Installed Versions: 0.1.3
Active Version:     0.1.3
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```