### PR TITLE
feat(registry): added hexyl

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -894,6 +894,8 @@ helmwave.backends = ["aqua:helmwave/helmwave", "ubi:helmwave/helmwave"]
 helmwave.test = ["helmwave version", "{{version}}"]
 heroku.aliases = ["heroku-cli"]
 heroku.backends = ["asdf:mise-plugins/mise-heroku-cli"]
+hexyl.backends = ["aqua:sharkdp/hexyl", "ubi:sharkdp/hexyl"]
+hexyl.test = ["hexyl --version", "hexyl {{version}}"]
 hey.backends = ["asdf:mise-plugins/mise-hey"]
 hishtory.backends = [
     "ubi:ddworken/hishtory",


### PR DESCRIPTION
hexyl - A command-line hex viewer

Test
```
$ cargo run --bin mise -- tool hexyl
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.76s
     Running `target/debug/mise tool hexyl`
Backend:            aqua:sharkdp/hexyl
Installed Versions:
Tool Options:       [none]

$ cargo run --bin mise -- use -g hexyl
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.00s
     Running `target/debug/mise use -g hexyl`
mise hexyl@0.16.0       install
mise hexyl@0.16.0       download hexyl-v0.16.0-x86_64-apple-darwin.tar.gz
mise hexyl@0.16.0       generate checksum hexyl-v0.16.0-x86_64-apple-darwin.tar.gz
mise hexyl@0.16.0       extract hexyl-v0.16.0-x86_64-apple-darwin.tar.gz
mise hexyl@0.16.0     ✓ installed
mise ~/.config/mise/config.toml tools: hexyl@0.16.0

$ cargo run --bin mise -- tool hexyl
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.78s
     Running `target/debug/mise tool hexyl`
Backend:            aqua:sharkdp/hexyl
Description:        A command-line hex viewer
Installed Versions: 0.16.0
Active Version:     0.16.0
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```