### PR TITLE
feat(registry): added octosql

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1332,6 +1332,8 @@ oapi-codegen.backends = [
 oc.backends = ["asdf:mise-plugins/mise-oc"]
 ocaml.backends = ["asdf:mise-plugins/mise-ocaml"]
 oci.backends = ["asdf:mise-plugins/mise-oci"]
+octosql.backends = ["ubi:cube2222/octosql"]
+octosql.text = ["octosql --version", "octosql version {{version}}"]
 odin.backends = ["ubi:odin-lang/Odin[exe=odin]", "asdf:jtakakura/asdf-odin"]
 odo.backends = ["aqua:redhat-developer/odo", "asdf:rm3l/asdf-odo"]
 okta-aws.aliases = ["okta-aws-cli"]


### PR DESCRIPTION
octosql - a query tool that allows you to join, analyse and transform data from multiple databases and file formats using SQL.

Test
```
$ cargo run --bin mise -- tool octosql
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.08s
     Running `target/debug/mise tool octosql`
Backend:            ubi:cube2222/octosql
Installed Versions:
Tool Options:       [none]

$ cargo run --bin mise -- use -g octosql
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.80s
     Running `target/debug/mise use -g octosql`
mise octosql@0.13.0     install
mise Installed executable into /Users/tony/.local/share/mise/installs/octosql/0.13.0/octosql
mise octosql@0.13.0     checksum generate octosql-macos-aarch64
mise octosql@0.13.0   ✓ installed
mise ~/.config/mise/config.toml tools: octosql@0.13.0

$ cargo run --bin mise -- tool octosql
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.89s
     Running `target/debug/mise tool octosql`
Backend:            ubi:cube2222/octosql
Installed Versions: 0.13.0
Active Version:     0.13.0
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```