### PR TITLE
feat(registry): added kubeone

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1139,6 +1139,8 @@ kubent.backends = [
     "asdf:virtualstaticvoid/asdf-kubent"
 ]
 kubent.test = ["kubent --version 2>&1", "version {{version}}"]
+kubeone.backends = ["aqua:kubermatic/kubeone", "aqua:kubermatic/kubeone"]
+kubeone.test = ["kubeone version | jq -r '.kubeone.gitVersion'", "{{version}}"]
 kubergrunt.backends = [
     "aqua:gruntwork-io/kubergrunt",
     "asdf:NeoHsu/asdf-kubergrunt"


### PR DESCRIPTION
kubeone automate cluster operations on all your cloud, on-prem, edge, and IoT environments

Test
```
$ cargo run --bin mise -- tool kubeone
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.71s
     Running `target/debug/mise tool kubeone`
Backend:            aqua:kubermatic/kubeone
Installed Versions:
Tool Options:       [none]

$ cargo run --bin mise -- use -g kubeone
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
     Running `target/debug/mise use -g kubeone`
mise kubeone@1.8.6      install
mise kubeone@1.8.6      download kubeone_1.8.6_darwin_arm64.zip
mise kubeone@1.8.6      checksum kubeone_1.8.6_darwin_arm64.zip
mise kubeone@1.8.6      extract kubeone_1.8.6_darwin_arm64.zip
mise kubeone@1.8.6    ✓ installed
mise ~/.config/mise/config.toml tools: kubeone@1.8.6

$ cargo run --bin mise -- tool kubeone
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.90s
     Running `target/debug/mise tool kubeone`
Backend:            aqua:kubermatic/kubeone
Description:        Kubermatic KubeOne automate cluster operations on all your cloud, on-prem, edge, and IoT environments
Installed Versions: 1.8.6
Active Version:     1.8.6
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```