### PR TITLE
feat: add --local flag for ls

### DIFF
--- a/docs/cli/ls.md
+++ b/docs/cli/ls.md
@@ -28,6 +28,10 @@ Only show tool versions currently specified in a mise.toml
 
 Only show tool versions currently specified in the global mise.toml
 
+### `-l --local`
+
+Only show tool versions currently specified in the local mise.toml
+
 ### `-i --installed`
 
 Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)

--- a/e2e/cli/test_ls
+++ b/e2e/cli/test_ls
@@ -11,6 +11,8 @@ assert_contains "mise ls --prefix=3 tiny" "3.1.0"
 assert_not_contains "mise ls --prefix=2 tiny" "3.1.0"
 assert_contains "mise ls --global" "dummy"
 assert_not_contains "mise ls --global" "tiny"
+assert_contains "mise ls --local" "tiny"
+assert_not_contains "mise ls --local" "dummy"
 
 mise ls tiny --json >json
 assert "cat json | jq -r '.[0].installed'" "true"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -461,6 +461,7 @@ cmd ls help="List installed and active tool versions" {
     }
     flag "-c --current" help="Only show tool versions currently specified in a mise.toml"
     flag "-g --global" help="Only show tool versions currently specified in the global mise.toml"
+    flag "-l --local" help="Only show tool versions currently specified in the local mise.toml"
     flag "-i --installed" help="Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)"
     flag "-o --offline" help="Don't fetch information such as outdated versions"
     flag --outdated help="Display whether a version is outdated"

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1356,6 +1356,12 @@ const completionSpec: Fig.Spec = {
           isRepeatable: false,
         },
         {
+          name: ["-l", "--local"],
+          description:
+            "Only show tool versions currently specified in the local mise.toml",
+          isRepeatable: false,
+        },
+        {
           name: ["-i", "--installed"],
           description:
             "Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)",


### PR DESCRIPTION
Related to https://github.com/jdx/mise/discussions/4411 

Allow to get tools list, defined only in local mise.toml

```
~/Projects/oss/mise ✔ $ cargo run --bin mise -- ls                                                                                      (ls-local) 17:27:58
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/mise ls`
Tool                    Version            Source                            Requested
bat                     0.25.0             ~/.config/mise/config.toml        latest
bun                     1.2.2 (missing)    ~/Projects/oss/mise/mise.toml     latest
cargo-binstall          1.10.22 (missing)  ~/Projects/oss/mise/mise.toml     latest
cargo:cargo-edit        0.13.1 (missing)   ~/Projects/oss/mise/mise.toml     latest
cargo:cargo-insta       1.42.1 (missing)   ~/Projects/oss/mise/mise.toml     latest
cargo:git-cliff         2.8.0 (missing)    ~/Projects/oss/mise/mise.toml     latest
cargo:toml-cli          0.2.3 (missing)    ~/Projects/oss/mise/mise.toml     latest
cargo:usage-cli         2.0.4 (missing)    ~/Projects/oss/mise/mise.toml     latest
doggo                   1.0.5              ~/.config/mise/config.toml        latest
fd                      10.2.0             ~/.config/mise/config.toml        latest
fzf                     0.60.2             ~/.config/mise/config.toml        latest
go                      1.24.0             ~/.config/mise/config.toml        latest
helm                    3.17.1             ~/.config/mise/config.toml        latest
jq                      1.7.1 (missing)    ~/Projects/oss/mise/mise.toml     latest
krew                    0.4.4              ~/.config/mise/config.toml        latest
kubectl                 1.32.2             ~/.config/mise/config.toml        latest
lua                     5.1.5              ~/.config/mise/config.toml        latest
neovim                  0.10.4             ~/.config/mise/config.local.toml  latest
node                    23.9.0             ~/.config/mise/config.toml        latest
npm:markdownlint-cli    0.44.0 (missing)   ~/Projects/oss/mise/mise.toml     latest
npm:prettier            3.4.2 (missing)    ~/Projects/oss/mise/mise.toml     3
pipx:toml-sort          0.24.2 (missing)   ~/Projects/oss/mise/mise.toml     latest
pnpm                    10.5.2             ~/.config/mise/config.toml        latest
poetry                  2.1.1              ~/.config/mise/config.toml        latest
pre-commit              4.1.0 (missing)    ~/Projects/oss/mise/mise.toml     latest
rg                      14.1.1             ~/.config/mise/config.toml        latest
ripgrep                 14.1.1 (missing)   ~/Projects/oss/mise/mise.toml     latest
ruby                    3.4.2 (missing)    ~/.config/mise/config.toml        latest
rust                    1.85.0 (symlink)   ~/.config/mise/config.toml        latest
shellcheck              0.10.0 (missing)   ~/Projects/oss/mise/mise.toml     latest
shfmt                   3.10.0 (missing)   ~/Projects/oss/mise/mise.toml     latest
slsa-verifier           2.6.0 (missing)    ~/Projects/oss/mise/mise.toml     latest
taplo                   0.9.3 (missing)    ~/Projects/oss/mise/mise.toml     latest
task                    3.41.0             ~/.config/mise/config.toml        latest
usage                   2.0.5              ~/.config/mise/config.toml        latest
wait-for-gh-rate-limit  0.1.8 (missing)    ~/Projects/oss/mise/mise.toml     latest
yq                      4.45.1             ~/.config/mise/config.toml        latest

~/Projects/oss/mise ✔ $ cargo run --bin mise -- ls --local                                                                              (ls-local) 17:27:49
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/mise ls --local`
Tool                    Version            Source                         Requested
actionlint              1.7.7 (missing)    ~/Projects/oss/mise/mise.toml  latest
bun                     1.2.2 (missing)    ~/Projects/oss/mise/mise.toml  latest
cargo-binstall          1.10.22 (missing)  ~/Projects/oss/mise/mise.toml  latest
cargo:cargo-edit        0.13.1 (missing)   ~/Projects/oss/mise/mise.toml  latest
cargo:cargo-insta       1.42.1 (missing)   ~/Projects/oss/mise/mise.toml  latest
cargo:git-cliff         2.8.0 (missing)    ~/Projects/oss/mise/mise.toml  latest
cargo:toml-cli          0.2.3 (missing)    ~/Projects/oss/mise/mise.toml  latest
cargo:usage-cli         2.0.4 (missing)    ~/Projects/oss/mise/mise.toml  latest
cosign                  2.4.1 (missing)    ~/Projects/oss/mise/mise.toml  latest
jq                      1.7.1 (missing)    ~/Projects/oss/mise/mise.toml  latest
npm:markdownlint-cli    0.44.0 (missing)   ~/Projects/oss/mise/mise.toml  latest
npm:prettier            3.4.2 (missing)    ~/Projects/oss/mise/mise.toml  3
pipx:toml-sort          0.24.2 (missing)   ~/Projects/oss/mise/mise.toml  latest
pre-commit              4.1.0 (missing)    ~/Projects/oss/mise/mise.toml  latest
ripgrep                 14.1.1 (missing)   ~/Projects/oss/mise/mise.toml  latest
shellcheck              0.10.0 (missing)   ~/Projects/oss/mise/mise.toml  latest
shfmt                   3.10.0 (missing)   ~/Projects/oss/mise/mise.toml  latest
slsa-verifier           2.6.0 (missing)    ~/Projects/oss/mise/mise.toml  latest
taplo                   0.9.3 (missing)    ~/Projects/oss/mise/mise.toml  latest
wait-for-gh-rate-limit  0.1.8 (missing)    ~/Projects/oss/mise/mise.toml  latest

~/Projects/oss/mise ✔ $ cargo run --bin mise -- ls --global --local                                                                     (ls-local) 17:28:24
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running `target/debug/mise ls --global --local`
error: the argument '--global' cannot be used with '--local'

Usage: mise ls --global [INSTALLED_TOOL]...

For more information, try '--help'.
~/Projects/oss/mise ✘ $ cargo run --bin mise -- ls --local --global                                                                   (ls-local) 2 17:31:54
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/mise ls --local --global`
error: the argument '--local' cannot be used with '--global'

Usage: mise ls --local [INSTALLED_TOOL]...

For more information, try '--help'.
```