### PR TITLE
docs: continuous-integration.md: fix gitlab caching example

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -99,7 +99,7 @@ build-job:
   stage: build
   image: mise-debian-slim # Use the image you created
   variables:
-    MISE_DATA_DIR: .mise/mise-data
+    MISE_DATA_DIR: $CI_PROJECT_DIR/.mise/mise-data
   cache:
     - key:
         prefix: mise-


### PR DESCRIPTION
It seems MISE_DATA_DIR needs to be absolute, as per https://github.com/jdx/mise/discussions/4313

This change fixed it in my CI so perhaps the docs need to be updated.