### PR TITLE
feat(registry): added sampler

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1567,6 +1567,8 @@ saml2aws.backends = [
     "aqua:Versent/saml2aws",
     "asdf:elementalvoid/asdf-saml2aws"
 ]
+sampler.backends = ["aqua:sqshq/sampler", "ubi:sqshq/sampler"]
+sampler.test = ["sampler --version 2>&1", "{{version}}"]
 sbcl.backends = ["asdf:mise-plugins/mise-sbcl"]
 sbt.backends = ["asdf:mise-plugins/mise-sbt"]
 scala.backends = [


### PR DESCRIPTION
Test
```
$ cargo run --bin mise -- tool sampler                                                                                               *1 (sampler) 18:20:14
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.12s
     Running `target/debug/mise tool sampler`
Backend:            aqua:sqshq/sampler
Installed Versions:
Tool Options:       [none]

$ cargo run --bin mise -- use -g sampler                                                                                             *1 (sampler) 18:22:18
   Compiling mise v2025.3.0 (/Users/tony/Projects/oss/mise)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.76s
     Running `target/debug/mise use -g sampler`
mise sampler@1.1.0   install
mise sampler@1.1.0   download sampler-1.1.0-darwin-amd64
mise sampler@1.1.0   generate checksum sampler-1.1.0-darwin-amd64
mise sampler@1.1.0   extract sampler-1.1.0-darwin-amd64
mise sampler@1.1.0 ✓ installed
mise ~/.config/mise/config.toml tools: sampler@1.1.0

$ cargo run --bin mise -- tool sampler                                                                                               *1 (sampler) 18:23:15
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.07s
     Running `target/debug/mise tool sampler`
Backend:            aqua:sqshq/sampler
Description:        Tool for shell commands execution, visualization and alerting. Configured with a simple YAML file
Installed Versions: 1.1.0
Active Version:     1.1.0
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```