### PR TITLE
feat(registry): added lazyjournal

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1191,6 +1191,8 @@ lazygit.backends = [
     "aqua:jesseduffield/lazygit",
     "asdf:nklmilojevic/asdf-lazygit"
 ]
+lazyjournal.backends = ["aqua:Lifailon/lazyjournal", "ubi:Lifailon/lazyjournal"]
+lazyjournal.test = ["lazyjournal --version", "Version: {{version}}"]
 lean.backends = ["asdf:mise-plugins/mise-lean"]
 lefthook.backends = [
     "aqua:evilmartians/lefthook",


### PR DESCRIPTION
Lazyjournal - A TUI for reading logs from journalctl, file system, Docker and Podman containers, as well Kubernetes pods for quick viewing and filtering with fuzzy find, regex support and coloring the output, written in Go with the gocui.

```
$ cargo run --bin mise -- tool lazyjournal                                                                                       *1 (lazyjournal) 13:43:04
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.76s
     Running `target/debug/mise tool lazyjournal`
Backend:            aqua:Lifailon/lazyjournal
Installed Versions:
Tool Options:       [none]

$ cargo run --bin mise -- use -g lazyjournal                                                                                     *1 (lazyjournal) 13:43:13
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.81s
     Running `target/debug/mise use -g lazyjournal`
mise lazyjournal@0.7.4 install
mise lazyjournal@0.7.4 download lazyjournal-0.7.4-darwin-arm64
mise lazyjournal@0.7.4 generate checksum lazyjournal-0.7.4-darwin-arm64
mise lazyjournal@0.7.4 extract lazyjournal-0.7.4-darwin-arm64
mise lazyjournal@0.7.4 ✓ installed
mise ~/.config/mise/config.toml tools: lazyjournal@0.7.4

$ cargo run --bin mise -- tool lazyjournal                                                                                       *1 (lazyjournal) 13:44:22
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.05s
     Running `target/debug/mise tool lazyjournal`
Backend:            aqua:Lifailon/lazyjournal
Description:        TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering with fuzzy find, regex support (like fzf and g
                    rep) and coloring the output, written in Go with the gocui library
Installed Versions: 0.7.4
Active Version:     0.7.4
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```