### PR TITLE
docs(settings): clarify the usage of disable_default_registry

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -353,7 +353,7 @@
           }
         },
         "disable_default_registry": {
-          "description": "Disable the default mapping of short tool names like `go` -> `vfox:version-fox/vfox-golang`",
+          "description": "Disable the default mapping of short tool names like `go` -> `vfox:version-fox/vfox-golang`. This parameter disables only for the backends `vfox` and `asdf`.",
           "type": "boolean"
         },
         "disable_default_shorthands": {

--- a/settings.toml
+++ b/settings.toml
@@ -229,7 +229,7 @@ description = "Backends to disable such as `asdf` or `pipx`"
 [disable_default_registry]
 env = "MISE_DISABLE_DEFAULT_REGISTRY"
 type = "Bool"
-description = "Disable the default mapping of short tool names like `go` -> `vfox:version-fox/vfox-golang`"
+description = "Disable the default mapping of short tool names like `go` -> `vfox:version-fox/vfox-golang`. This parameter disables only for the backends `vfox` and `asdf`."
 
 [disable_default_shorthands]
 env = "MISE_DISABLE_DEFAULT_SHORTHANDS"


### PR DESCRIPTION
This PR improves the usage of `disable_default_registry` as explained in the discussion [4581](https://github.com/jdx/mise/discussions/4581)
