### PR TITLE
feat: Add flag to fmt command to read from stdin

### DIFF
--- a/docs/cli/fmt.md
+++ b/docs/cli/fmt.md
@@ -1,6 +1,6 @@
 # `mise fmt`
 
-- **Usage**: `mise fmt [-a --all]`
+- **Usage**: `mise fmt [-a --all] [-s --stdin]`
 - **Source code**: [`src/cli/fmt.rs`](https://github.com/jdx/mise/blob/main/src/cli/fmt.rs)
 
 Formats mise.toml
@@ -15,7 +15,7 @@ Format all files from the current directory
 
 ### `-s --stdin`
 
-Read config from `stdin` and write its formatted version into `stdout`
+Read config from stdin and write its formatted version into stdout
 
 Examples:
 

--- a/docs/cli/fmt.md
+++ b/docs/cli/fmt.md
@@ -13,6 +13,10 @@ Sorts keys and cleans up whitespace in mise.toml
 
 Format all files from the current directory
 
+### `-s --stdin`
+
+Read config from `stdin` and write its formatted version into `stdout`
+
 Examples:
 
 ```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -82,7 +82,7 @@ Can also use `MISE_NO_CONFIG=1`
 - [`mise en [-s --shell <SHELL>] [DIR]`](/cli/en.md)
 - [`mise env [FLAGS] [TOOL@VERSION]...`](/cli/env.md)
 - [`mise exec [FLAGS] [TOOL@VERSION]... [-- COMMAND]...`](/cli/exec.md)
-- [`mise fmt [-a --all]`](/cli/fmt.md)
+- [`mise fmt [-a --all] [-s --stdin]`](/cli/fmt.md)
 - [`mise generate <SUBCOMMAND>`](/cli/generate.md)
 - [`mise generate bootstrap [FLAGS]`](/cli/generate/bootstrap.md)
 - [`mise generate config [-t --tool-versions <TOOL_VERSIONS>] [-o --output <OUTPUT>]`](/cli/generate/config.md)

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -275,6 +275,7 @@ cmd fmt help="Formats mise.toml" {
     long_help "Formats mise.toml\n\nSorts keys and cleans up whitespace in mise.toml"
     after_long_help "Examples:\n\n    $ mise fmt\n"
     flag "-a --all" help="Format all files from the current directory"
+    flag "-s --stdin" help="Read config from stdin and write its formatted version into stdout"
 }
 cmd generate subcommand_required=#true help="[experimental] Generate files for various tools/services" {
     alias gen

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -2,6 +2,7 @@ use crate::Result;
 use crate::config::ALL_TOML_CONFIG_FILES;
 use crate::{config, dirs, file};
 use eyre::bail;
+use std::io::{self, Read, Write};
 use taplo::formatter::Options;
 
 /// Formats mise.toml
@@ -13,10 +14,27 @@ pub struct Fmt {
     /// Format all files from the current directory
     #[clap(short, long)]
     pub all: bool,
+
+    /// Read config from stdin and write its formatted version into
+    /// stdout
+    #[clap(short, long)]
+    pub stdin: bool,
 }
 
 impl Fmt {
     pub fn run(self) -> eyre::Result<()> {
+        if self.stdin {
+            let mut toml = String::new();
+            io::stdin().read_to_string(&mut toml)?;
+
+            let toml = sort(toml)?;
+            let toml = format(toml)?;
+            let mut stdout = io::stdout();
+            write!(stdout, "{}", toml)?;
+
+            return Ok(());
+        }
+
         let cwd = dirs::CWD.clone().unwrap_or_default();
         let configs = if self.all {
             ALL_TOML_CONFIG_FILES.clone()
@@ -35,30 +53,7 @@ impl Fmt {
             }
             let toml = file::read_to_string(&p)?;
             let toml = sort(toml)?;
-            let toml = taplo::formatter::format(
-                &toml,
-                Options {
-                    align_entries: false,
-                    align_comments: true,
-                    align_single_comments: true,
-                    array_trailing_comma: true,
-                    array_auto_expand: true,
-                    inline_table_expand: true,
-                    array_auto_collapse: true,
-                    compact_arrays: true,
-                    compact_inline_tables: false,
-                    compact_entries: false,
-                    column_width: 80,
-                    indent_tables: false,
-                    indent_entries: false,
-                    indent_string: "  ".to_string(),
-                    trailing_newline: true,
-                    reorder_keys: false,
-                    reorder_arrays: false,
-                    allowed_blank_lines: 2,
-                    crlf: false,
-                },
-            );
+            let toml = format(toml)?;
             file::write(&p, &toml)?;
         }
 
@@ -88,6 +83,35 @@ fn sort(toml: String) -> Result<String> {
     };
     doc.sort_values_by(|a, _, b, _| order(a.to_string()).cmp(&order(b.to_string())));
     Ok(doc.to_string())
+}
+
+fn format(toml: String) -> Result<String> {
+    let tmp = taplo::formatter::format(
+        &toml,
+        Options {
+            align_entries: false,
+            align_comments: true,
+            align_single_comments: true,
+            array_trailing_comma: true,
+            array_auto_expand: true,
+            inline_table_expand: true,
+            array_auto_collapse: true,
+            compact_arrays: true,
+            compact_inline_tables: false,
+            compact_entries: false,
+            column_width: 80,
+            indent_tables: false,
+            indent_entries: false,
+            indent_string: "  ".to_string(),
+            trailing_newline: true,
+            reorder_keys: false,
+            reorder_arrays: false,
+            allowed_blank_lines: 2,
+            crlf: false,
+        },
+    );
+
+    Ok(tmp)
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -993,6 +993,11 @@ const completionSpec: Fig.Spec = {
           description: "Format all files from the current directory",
           isRepeatable: false,
         },
+        {
+          name: ["-s", "--stdin"],
+          description: "Read config from stdin and write its formatted version into stdout",
+          isRepeatable: false,
+        },
       ],
     },
     {

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -995,7 +995,8 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: ["-s", "--stdin"],
-          description: "Read config from stdin and write its formatted version into stdout",
+          description:
+            "Read config from stdin and write its formatted version into stdout",
           isRepeatable: false,
         },
       ],


### PR DESCRIPTION
This allow to take input from stdin so it can be integrated in editors or shell pipelines

Also move format process into a function to be reusable for stdin process and regular file based process