### PR TITLE
fix(task): allow args to be used with tera tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6241,9 +6241,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usage-lib"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9370e4a3fddecb4eb9d7fdf059aa1b7fc2e932833faa8defa550a1e66eb616c"
+checksum = "633a305646e76f9fe8149564d1a5eb19a5d3222dd8c3ee9074e8ae5f62fa610f"
 dependencies = [
  "clap",
  "heck 0.5.0",
@@ -6527,7 +6527,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,9 +1,7 @@
 use crate::config::Config;
 use crate::config::config_file::toml::{TomlParser, deserialize_arr};
 use crate::exit::exit;
-use crate::task::task_script_parser::{
-    TaskScriptParser, has_any_args_defined,
-};
+use crate::task::task_script_parser::{TaskScriptParser, has_any_args_defined};
 use crate::tera::get_tera;
 use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::config::config_file::toml::{TomlParser, deserialize_arr};
 use crate::exit::exit;
 use crate::task::task_script_parser::{
-    TaskScriptParser, has_any_args_defined, replace_template_placeholders_with_args,
+    TaskScriptParser, has_any_args_defined,
 };
 use crate::tera::get_tera;
 use crate::ui::tree::TreeItem;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,6 +1,5 @@
 use crate::config::Config;
 use crate::config::config_file::toml::{TomlParser, deserialize_arr};
-use crate::exit::exit;
 use crate::task::task_script_parser::{TaskScriptParser, has_any_args_defined};
 use crate::tera::get_tera;
 use crate::ui::tree::TreeItem;
@@ -356,21 +355,13 @@ impl Task {
     ) -> Result<Vec<(String, Vec<String>)>> {
         let (spec, scripts) = self.parse_usage_spec(cwd.clone(), env)?;
         if has_any_args_defined(&spec) {
-            let args = vec!["".to_string()]
-                .into_iter()
-                .chain(args.iter().cloned())
-                .collect::<Vec<_>>();
-            let m = match usage::parse(&spec, &args) {
-                Ok(m) => m,
-                Err(e) => {
-                    // just print exactly what usage returns so the error output isn't double-wrapped
-                    // this could be displaying help or a parse error
-                    eprintln!("{}", format!("{e}").trim_end());
-                    exit(1);
-                }
-            };
-            let (scripts, _) =
-                TaskScriptParser::new(cwd).parse_run_scripts_with_args(self, self.run(), env, m)?;
+            let scripts = TaskScriptParser::new(cwd).parse_run_scripts_with_args(
+                self,
+                self.run(),
+                env,
+                args,
+                &spec,
+            )?;
             Ok(scripts.into_iter().map(|s| (s, vec![])).collect())
         } else {
             Ok(scripts

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -336,7 +336,6 @@ impl TaskScriptParser {
                 .parse()
                 .ok();
             let escape = {
-                let shell_type = shell_type;
                 move |v: &usage::parse::ParseValue| match v {
                     usage::parse::ParseValue::MultiString(_) => {
                         // these are already escaped

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -362,7 +362,11 @@ impl TaskScriptParser {
                     let mut arg_order = arg_order.lock().unwrap();
                     if arg_order.contains_key(&name) {
                         trace!("already seen {name}");
-                        return Ok(tera::Value::String(template_key(name, &usage_args, &usage_flags)));
+                        return Ok(tera::Value::String(template_key(
+                            name,
+                            &usage_args,
+                            &usage_flags,
+                        )));
                     }
                     arg_order.insert(name.clone(), i);
                     let usage = args.get("usage").map(|r| r.to_string()).unwrap_or_default();
@@ -405,7 +409,11 @@ impl TaskScriptParser {
                     };
                     arg.usage = arg.usage();
                     input_args.lock().unwrap().push(arg);
-                    Ok(tera::Value::String(template_key(name, &usage_args, &usage_flags)))
+                    Ok(tera::Value::String(template_key(
+                        name,
+                        &usage_args,
+                        &usage_flags,
+                    )))
                 }
             }
         });
@@ -498,7 +506,11 @@ impl TaskScriptParser {
                     };
                     flag.usage = flag.usage();
                     input_flags.lock().unwrap().push(flag);
-                    Ok(tera::Value::String(template_key(name, &usage_args, &usage_flags)))
+                    Ok(tera::Value::String(template_key(
+                        name,
+                        &usage_args,
+                        &usage_flags,
+                    )))
                 }
             }
         });
@@ -576,7 +588,11 @@ impl TaskScriptParser {
                     };
                     flag.usage = flag.usage();
                     input_flags.lock().unwrap().push(flag);
-                    Ok(tera::Value::String(template_key(name, &usage_args, &usage_flags)))
+                    Ok(tera::Value::String(template_key(
+                        name,
+                        &usage_args,
+                        &usage_flags,
+                    )))
                 }
             }
         });

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -306,6 +306,312 @@ impl TaskScriptParser {
 
         Ok((scripts, spec))
     }
+
+    pub fn parse_run_scripts_with_args(
+        &self,
+        task: &Task,
+        scripts: &[String],
+        env: &EnvMap,
+        usage_parsed: usage::parse::ParseOutput,
+    ) -> Result<(Vec<String>, usage::Spec)> {
+        let mut tera = self.get_tera();
+        let arg_order = Arc::new(Mutex::new(HashMap::new()));
+        let input_args = Arc::new(Mutex::new(vec![]));
+        let usage_args = usage_parsed
+            .args
+            .iter()
+            .map(|(arg, value)| (arg.name.clone(), value.to_string()))
+            .collect::<HashMap<_, _>>();
+        let usage_flags = usage_parsed
+            .flags
+            .iter()
+            .map(|(flag, value)| (flag.name.clone(), value.to_string()))
+            .collect::<HashMap<_, _>>();
+        let template_key = |name: String,
+                            usage_args: &HashMap<String, String>,
+                            usage_flags: &HashMap<String, String>| {
+            usage_args
+                .get(&name)
+                .or_else(|| usage_flags.get(&name))
+                .unwrap_or(&"false".to_string())
+                .to_string()
+        };
+        tera.register_function("arg", {
+            {
+                let input_args = input_args.clone();
+                let usage_args = usage_args.clone();
+                let usage_flags = usage_flags.clone();
+                let arg_order = arg_order.clone();
+                move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+                    let i = args
+                        .get("i")
+                        .map(|i| i.as_i64().unwrap() as usize)
+                        .unwrap_or_else(|| input_args.lock().unwrap().len());
+                    let required = args
+                        .get("required")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(true);
+                    let var = args
+                        .get("var")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let name = args
+                        .get("name")
+                        .map(|n| n.as_str().unwrap().to_string())
+                        .unwrap_or(i.to_string());
+                    let mut arg_order = arg_order.lock().unwrap();
+                    if arg_order.contains_key(&name) {
+                        trace!("already seen {name}");
+                        return Ok(tera::Value::String(template_key(name, &usage_args, &usage_flags)));
+                    }
+                    arg_order.insert(name.clone(), i);
+                    let usage = args.get("usage").map(|r| r.to_string()).unwrap_or_default();
+                    let help = args.get("help").map(|r| r.to_string());
+                    let help_long = args.get("help_long").map(|r| r.to_string());
+                    let help_md = args.get("help_md").map(|r| r.to_string());
+                    let var_min = args.get("var_min").map(|r| r.as_i64().unwrap() as usize);
+                    let var_max = args.get("var_max").map(|r| r.as_i64().unwrap() as usize);
+                    let hide = args
+                        .get("hide")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let default = args.get("default").map(|d| d.as_str().unwrap().to_string());
+                    let choices = args.get("choices").map(|c| {
+                        let choices = c
+                            .as_array()
+                            .unwrap()
+                            .iter()
+                            .map(|c| c.as_str().unwrap().to_string())
+                            .collect();
+                        usage::SpecChoices { choices }
+                    });
+                    let mut arg = usage::SpecArg {
+                        name: name.clone(),
+                        usage,
+                        help_first_line: help
+                            .clone()
+                            .map(|h| h.lines().next().unwrap().to_string()),
+                        help,
+                        help_long,
+                        help_md,
+                        required,
+                        var,
+                        var_min,
+                        var_max,
+                        hide,
+                        default,
+                        choices,
+                        ..Default::default()
+                    };
+                    arg.usage = arg.usage();
+                    input_args.lock().unwrap().push(arg);
+                    Ok(tera::Value::String(template_key(name, &usage_args, &usage_flags)))
+                }
+            }
+        });
+        let input_flags = Arc::new(Mutex::new(vec![]));
+        tera.register_function("option", {
+            {
+                let input_flags = input_flags.clone();
+                let usage_args = usage_args.clone();
+                let usage_flags = usage_flags.clone();
+                move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+                    let name = args
+                        .get("name")
+                        .map(|n| n.as_str().unwrap().to_string())
+                        .unwrap();
+                    let short = args
+                        .get("short")
+                        .map(|s| s.to_string().chars().collect())
+                        .unwrap_or_default();
+                    let long = args
+                        .get("long")
+                        .map(|l| {
+                            l.as_str()
+                                .unwrap()
+                                .split_whitespace()
+                                .map(|s| s.to_string())
+                                .collect()
+                        })
+                        .unwrap_or_else(|| vec![name.clone()]);
+                    let default = args.get("default").map(|d| d.as_str().unwrap().to_string());
+                    let var = args
+                        .get("var")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let deprecated = args.get("deprecated").map(|r| r.to_string());
+                    let help = args.get("help").map(|r| r.to_string());
+                    let help_long = args.get("help_long").map(|r| r.to_string());
+                    let help_md = args.get("help_md").map(|r| r.to_string());
+                    let hide = args
+                        .get("hide")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let global = args
+                        .get("global")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let count = args
+                        .get("count")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let usage = args.get("usage").map(|r| r.to_string()).unwrap_or_default();
+                    let required = args
+                        .get("required")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let negate = args.get("negate").map(|r| r.to_string());
+                    let choices = args.get("choices").map(|c| {
+                        let choices = c
+                            .as_array()
+                            .unwrap()
+                            .iter()
+                            .map(|c| c.as_str().unwrap().to_string())
+                            .collect();
+                        usage::SpecChoices { choices }
+                    });
+                    let mut flag = usage::SpecFlag {
+                        name: name.clone(),
+                        short,
+                        long,
+                        default,
+                        var,
+                        hide,
+                        global,
+                        count,
+                        deprecated,
+                        help_first_line: help
+                            .clone()
+                            .map(|h| h.lines().next().unwrap().to_string()),
+                        help,
+                        usage,
+                        help_long,
+                        help_md,
+                        required,
+                        negate,
+                        arg: Some(usage::SpecArg {
+                            name: name.clone(),
+                            var,
+                            choices,
+                            ..Default::default()
+                        }),
+                    };
+                    flag.usage = flag.usage();
+                    input_flags.lock().unwrap().push(flag);
+                    Ok(tera::Value::String(template_key(name, &usage_args, &usage_flags)))
+                }
+            }
+        });
+        tera.register_function("flag", {
+            {
+                let input_flags = input_flags.clone();
+                let usage_args = usage_args.clone();
+                let usage_flags = usage_flags.clone();
+                move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+                    let name = args
+                        .get("name")
+                        .map(|n| n.as_str().unwrap().to_string())
+                        .unwrap();
+                    let short = args
+                        .get("short")
+                        .map(|s| s.to_string().chars().collect())
+                        .unwrap_or_default();
+                    let long = args
+                        .get("long")
+                        .map(|l| {
+                            l.as_str()
+                                .unwrap()
+                                .split_whitespace()
+                                .map(|s| s.to_string())
+                                .collect()
+                        })
+                        .unwrap_or_else(|| vec![name.clone()]);
+                    let default = args.get("default").map(|d| d.as_str().unwrap().to_string());
+                    let var = args
+                        .get("var")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let deprecated = args.get("deprecated").map(|r| r.to_string());
+                    let help = args.get("help").map(|r| r.to_string());
+                    let help_long = args.get("help_long").map(|r| r.to_string());
+                    let help_md = args.get("help_md").map(|r| r.to_string());
+                    let hide = args
+                        .get("hide")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let global = args
+                        .get("global")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let count = args
+                        .get("count")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let usage = args.get("usage").map(|r| r.to_string()).unwrap_or_default();
+                    let required = args
+                        .get("required")
+                        .map(|r| r.as_bool().unwrap())
+                        .unwrap_or(false);
+                    let negate = args.get("negate").map(|r| r.to_string());
+                    let mut flag = usage::SpecFlag {
+                        name: name.clone(),
+                        short,
+                        long,
+                        default,
+                        var,
+                        hide,
+                        global,
+                        count,
+                        deprecated,
+                        help_first_line: help
+                            .clone()
+                            .map(|h| h.lines().next().unwrap().to_string()),
+                        help,
+                        usage,
+                        help_long,
+                        help_md,
+                        required,
+                        negate,
+                        arg: None,
+                    };
+                    flag.usage = flag.usage();
+                    input_flags.lock().unwrap().push(flag);
+                    Ok(tera::Value::String(template_key(name, &usage_args, &usage_flags)))
+                }
+            }
+        });
+        let mut tera_ctx = task.tera_ctx()?;
+        tera_ctx.insert("env", &env);
+        let scripts = scripts
+            .iter()
+            .map(|s| {
+                tera.render_str(s.trim(), &tera_ctx)
+                    .wrap_err_with(|| s.to_string())
+            })
+            .collect::<Result<Vec<String>>>()?;
+        let mut cmd = usage::SpecCommand::default();
+        // TODO: ensure no gaps in args, e.g.: 1,2,3,4,5
+        let arg_order = arg_order.lock().unwrap();
+        cmd.args = input_args
+            .lock()
+            .unwrap()
+            .iter()
+            .cloned()
+            .sorted_by_key(|arg| {
+                arg_order
+                    .get(&arg.name)
+                    .unwrap_or_else(|| panic!("missing arg order for {}", arg.name.as_str()))
+            })
+            .collect();
+        cmd.flags = input_flags.lock().unwrap().clone();
+        let mut spec = usage::Spec {
+            cmd,
+            ..Default::default()
+        };
+        spec.merge(task.usage.parse()?);
+
+        Ok((scripts, spec))
+    }
 }
 
 pub fn replace_template_placeholders_with_args(

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -336,7 +336,7 @@ impl TaskScriptParser {
                 .parse()
                 .ok();
             let escape = {
-                let shell_type = shell_type.clone();
+                let shell_type = shell_type;
                 move |v: &usage::parse::ParseValue| match v {
                     usage::parse::ParseValue::MultiString(_) => {
                         // these are already escaped
@@ -370,7 +370,7 @@ impl TaskScriptParser {
                             Ok(tera::Value::String(
                                 usage_args
                                     .iter()
-                                    .find(|(arg, _)| &arg.name == &name)
+                                    .find(|(arg, _)| arg.name == name)
                                     .map(|(_, value)| escape(value))
                                     .unwrap_or("".to_string()),
                             ))
@@ -401,7 +401,7 @@ impl TaskScriptParser {
             let mut tera_ctx = task.tera_ctx()?;
             tera_ctx.insert("env", &env);
             out.push(
-                tera.render_str(&script, &tera_ctx)
+                tera.render_str(script, &tera_ctx)
                     .wrap_err_with(|| script.clone())?,
             );
         }


### PR DESCRIPTION
This PR enables the use of `arg`, `option`, and `flag` in task templates within `if` conditions or similar syntaxes.

### Current Behavior
Currently, placeholders are replaced only after the Tera template is fully rendered. So, expressions like the following:

```toml
[tasks.test]
run = "echo {% if flag(name='test') == 'true' %}test is true{% endif %}"
```
would incorrectly render `mise test --test` as just `echo ` because `'MISE_TASK_ARG:test:MISE_TASK_ARG' != 'true'`.

### Changes
Since we need to parse the usage spec before rendering the full Tera template, this PR adds the second rendering after the usage spec is processed. This ensures that expressions with nest like this are evaluated correctly.

```toml
[tasks.test]
run = "echo {% if flag(name=env.FLAG_NAME) == 'true' %}TRUE{% endif %}"
```

Re-rendering the template might introduce some performance overhead, but I believe it's the simplest solution for this.
Of course, templates with more nests cannot be parsed correctly, but it is impossible if we are using usage to parse args in the template.

~~I still need to fix this PR to avoid code duplication and handle escapes, but I’d like to hear your thoughts on this approach.~~

---

Apologies for creating a PR directly. I was debugging locally and wanted to share the idea.