### PR TITLE
fix(uv): avoid deadlocks while initializing UV_VENV

### DIFF
--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -519,7 +519,7 @@ impl Toolset {
             env.insert(PATH_KEY.to_string(), add_paths);
         }
         env.extend(config.env()?.clone());
-        if let Some(venv) = &*UV_VENV {
+        if let Ok(Some(venv)) = UV_VENV.try_lock().as_deref() {
             for (k, v) in &venv.env {
                 env.insert(k.clone(), v.clone());
             }
@@ -573,7 +573,7 @@ impl Toolset {
         for p in config.path_dirs()?.clone() {
             paths.insert(p);
         }
-        if let Some(venv) = &*UV_VENV {
+        if let Ok(Some(venv)) = UV_VENV.try_lock().as_deref() {
             paths.insert(venv.venv_path.clone());
         }
         if let Some(path) = self.env(config)?.get(&*PATH_KEY) {

--- a/src/uv.rs
+++ b/src/uv.rs
@@ -14,6 +14,8 @@ pub struct Venv {
     pub env: HashMap<String, String>,
 }
 
+// use a mutex to prevent deadlocks that may occur due to recursive initialization
+// when resolving the venv path or env vars
 pub static UV_VENV: Lazy<Mutex<Option<Venv>>> = Lazy::new(|| {
     if !SETTINGS.python.uv_venv_auto {
         return Mutex::new(None);


### PR DESCRIPTION
Fixes #4600.

`UV_VENV` initialization somtimes cause a deadlock in some cases because it requires loading `path` or `env` to get the toolset.

This PR avoids the deadlock by using `Mutex` and returning `None` while initializing itself.