### PR TITLE
test(registry): fix test of lazyjournal

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1192,7 +1192,7 @@ lazygit.backends = [
     "asdf:nklmilojevic/asdf-lazygit"
 ]
 lazyjournal.backends = ["aqua:Lifailon/lazyjournal", "ubi:Lifailon/lazyjournal"]
-lazyjournal.test = ["lazyjournal --version", "Version: {{version}}"]
+lazyjournal.test = ["lazyjournal --version", "{{version}}"]
 lean.backends = ["asdf:mise-plugins/mise-lean"]
 lefthook.backends = [
     "aqua:evilmartians/lefthook",


### PR DESCRIPTION
> #18 Added new flag -a/--audit to get summary and diagnostic information and the ability to load into the brew package manager. Now the flag -v/--version returns only the version without unnecessary text.

https://github.com/Lifailon/lazyjournal/releases/tag/0.7.5