### PR TITLE
feat(registry): add harper-ls and harper-cli

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -865,6 +865,11 @@ hadolint.backends = [
     "asdf:devlincashman/asdf-hadolint"
 ]
 hamler.backends = ["asdf:mise-plugins/mise-hamler"]
+harper-cli.backends = ["aqua:Automattic/harper/harper-cli"]
+# harper-cli intentionally prints different version. See https://github.com/Automattic/harper/issues/557#issuecomment-2635037944
+# harper-cli.test = ["harper-cli --version", "harper-cli {{version}}"]
+harper-ls.backends = ["aqua:Automattic/harper/harper-ls"]
+harper-ls.test = ["harper-ls --version", "harper-ls {{version}}"]
 has.backends = ["aqua:kdabir/has", "asdf:sylvainmetayer/asdf-has"]
 has.os = ["linux", "macos"]
 has.test = ["has --version", "v{{version}}"]


### PR DESCRIPTION
Add harper-ls and harper-cli released by [harper](https://github.com/Automattic/harper) to registry using aqua backend.
I comment out the test for harper-cli, because harper-cli intentionally prints diffrent version. (see https://github.com/Automattic/harper/issues/557#issuecomment-2635037944)