### PR TITLE
refactor: migrate humantime to jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ dependencies = [
  "gix-date",
  "gix-object",
  "gix-worktree-stream",
- "jiff",
+ "jiff 0.1.29",
  "thiserror 2.0.12",
 ]
 
@@ -1871,7 +1871,7 @@ checksum = "c57c477b645ee248b173bb1176b52dd528872f12c50375801a58aaf5ae91113f"
 dependencies = [
  "bstr",
  "itoa",
- "jiff",
+ "jiff 0.1.29",
  "thiserror 2.0.12",
 ]
 
@@ -2747,12 +2747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,6 +3274,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "jiff-tzdb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,13 +3692,13 @@ dependencies = [
  "globset",
  "heck 0.5.0",
  "homedir",
- "humantime",
  "indenter",
  "indexmap 2.7.1",
  "indicatif",
  "indoc",
  "insta",
  "itertools 0.14.0",
+ "jiff 0.2.4",
  "junction",
  "log",
  "md-5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ fslock = "0.2.1"
 glob = "0.3"
 globset = "0.4"
 heck = "0.5"
-humantime = "2"
 indenter = "0.3"
 indexmap = { version = "2", features = ["serde"] }
 indicatif = { version = "0.17", features = ["default", "improved_unicode"] }
@@ -151,6 +150,7 @@ xz2 = "0.1"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 zstd = "0.13"
 gix = { version = "<1", features = ["worktree-mutation"] }
+jiff = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 exec = "0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,6 @@ feature-depth = 1
 ignore = [
   { id = "RUSTSEC-2024-0370", reason = "subdependency cannot be updated" },
   { id = "RUSTSEC-2024-0436", reason = "subdependency cannot be updated" },
-  { id = "RUSTSEC-2025-0014", reason = "humantime is unmaintained" },
   #"RUSTSEC-0000-0000",
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -2,7 +2,7 @@ use eyre::{Result, bail, eyre};
 use toml_edit::DocumentMut;
 
 use crate::config::settings::{SETTINGS_META, SettingsFile, SettingsType};
-use crate::{config, file};
+use crate::{config, duration, file};
 
 /// Add/update a setting
 ///
@@ -107,7 +107,7 @@ fn parse_i64(value: &str) -> Result<toml_edit::Value> {
 }
 
 fn parse_duration(value: &str) -> Result<toml_edit::Value> {
-    humantime::parse_duration(value)?;
+    duration::parse_duration(value)?;
     Ok(value.into())
 }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,5 +1,6 @@
 use crate::cli::Cli;
 use crate::config::ALL_TOML_CONFIG_FILES;
+use crate::duration;
 use crate::file::FindUp;
 use crate::{dirs, env, file};
 #[allow(unused_imports)]
@@ -364,14 +365,12 @@ impl Settings {
     }
 
     pub fn cache_prune_age_duration(&self) -> Option<Duration> {
-        if self.cache_prune_age == "0" {
-            return None;
-        }
-        Some(humantime::parse_duration(&self.cache_prune_age).unwrap())
+        let age = duration::parse_duration(&self.cache_prune_age).unwrap();
+        if age.as_secs() == 0 { None } else { Some(age) }
     }
 
     pub fn fetch_remote_versions_timeout(&self) -> Duration {
-        humantime::parse_duration(&self.fetch_remote_versions_timeout).unwrap()
+        duration::parse_duration(&self.fetch_remote_versions_timeout).unwrap()
     }
 
     /// duration that remote version cache is kept for
@@ -383,8 +382,12 @@ impl Settings {
         if *env::PREFER_STALE {
             None
         } else {
-            Some(humantime::parse_duration(&self.fetch_remote_versions_cache).unwrap())
+            Some(duration::parse_duration(&self.fetch_remote_versions_cache).unwrap())
         }
+    }
+
+    pub fn http_timeout(&self) -> Duration {
+        duration::parse_duration(&self.http_timeout).unwrap()
     }
 
     pub fn log_level(&self) -> log::LevelFilter {

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,5 +1,22 @@
 pub use std::time::Duration;
 
+use eyre::{Result, bail};
+use jiff::{Span, civil::date};
+
 pub const HOURLY: Duration = Duration::from_secs(60 * 60);
 pub const DAILY: Duration = Duration::from_secs(60 * 60 * 24);
 pub const WEEKLY: Duration = Duration::from_secs(60 * 60 * 24 * 7);
+
+pub fn parse_duration(s: &str) -> Result<Duration> {
+    match s.parse::<Span>() {
+        Ok(span) => {
+            // we must provide a relative date to determine the duration with months and years
+            let duration = span.to_duration(date(2025, 1, 1))?;
+            if duration.is_negative() {
+                bail!("duration must not be negative: {}", s);
+            }
+            Ok(duration.unsigned_abs())
+        }
+        Err(_) => Ok(Duration::from_secs(s.parse()?)),
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,16 +19,11 @@ use crate::{env, file};
 pub static HTTP_VERSION_CHECK: Lazy<Client> =
     Lazy::new(|| Client::new(Duration::from_secs(3)).unwrap());
 
-pub static HTTP: Lazy<Client> = Lazy::new(|| {
-    let duration = humantime::parse_duration(&SETTINGS.http_timeout)
-        .unwrap_or_else(|_| Duration::from_secs(SETTINGS.http_timeout.parse().unwrap()));
-    Client::new(duration).unwrap()
-});
+pub static HTTP: Lazy<Client> =
+    Lazy::new(|| Client::new(SETTINGS.fetch_remote_versions_timeout()).unwrap());
 
-pub static HTTP_FETCH: Lazy<Client> = Lazy::new(|| {
-    Client::new(humantime::parse_duration(&SETTINGS.fetch_remote_versions_timeout).unwrap())
-        .unwrap()
-});
+pub static HTTP_FETCH: Lazy<Client> =
+    Lazy::new(|| Client::new(SETTINGS.fetch_remote_versions_timeout()).unwrap());
 
 #[derive(Debug)]
 pub struct Client {

--- a/src/http.rs
+++ b/src/http.rs
@@ -20,7 +20,7 @@ pub static HTTP_VERSION_CHECK: Lazy<Client> =
     Lazy::new(|| Client::new(Duration::from_secs(3)).unwrap());
 
 pub static HTTP: Lazy<Client> =
-    Lazy::new(|| Client::new(SETTINGS.fetch_remote_versions_timeout()).unwrap());
+    Lazy::new(|| Client::new(SETTINGS.http_timeout()).unwrap());
 
 pub static HTTP_FETCH: Lazy<Client> =
     Lazy::new(|| Client::new(SETTINGS.fetch_remote_versions_timeout()).unwrap());

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,8 +19,7 @@ use crate::{env, file};
 pub static HTTP_VERSION_CHECK: Lazy<Client> =
     Lazy::new(|| Client::new(Duration::from_secs(3)).unwrap());
 
-pub static HTTP: Lazy<Client> =
-    Lazy::new(|| Client::new(SETTINGS.http_timeout()).unwrap());
+pub static HTTP: Lazy<Client> = Lazy::new(|| Client::new(SETTINGS.http_timeout()).unwrap());
 
 pub static HTTP_FETCH: Lazy<Client> =
     Lazy::new(|| Client::new(SETTINGS.fetch_remote_versions_timeout()).unwrap());

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -13,7 +13,7 @@ use versions::{Requirement, Versioning};
 use crate::cache::CacheManagerBuilder;
 use crate::cmd::cmd;
 use crate::env_diff::EnvMap;
-use crate::{dirs, env, hash};
+use crate::{dirs, duration, env, hash};
 
 pub static BASE_CONTEXT: Lazy<Context> = Lazy::new(|| {
     let mut context = Context::new();
@@ -314,7 +314,7 @@ pub fn tera_exec(
             _ => return Err("exec cache_key must be a string".into()),
         };
         let cache_duration = match args.get("cache_duration") {
-            Some(Value::String(duration)) => match humantime::parse_duration(&duration.to_string())
+            Some(Value::String(duration)) => match duration::parse_duration(&duration.to_string())
             {
                 Ok(duration) => Some(duration),
                 Err(e) => return Err(format!("exec cache_duration: {}", e).into()),

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -314,11 +314,12 @@ pub fn tera_exec(
             _ => return Err("exec cache_key must be a string".into()),
         };
         let cache_duration = match args.get("cache_duration") {
-            Some(Value::String(duration)) => match duration::parse_duration(&duration.to_string())
-            {
-                Ok(duration) => Some(duration),
-                Err(e) => return Err(format!("exec cache_duration: {}", e).into()),
-            },
+            Some(Value::String(duration)) => {
+                match duration::parse_duration(&duration.to_string()) {
+                    Ok(duration) => Some(duration),
+                    Err(e) => return Err(format!("exec cache_duration: {}", e).into()),
+                }
+            }
             None => None,
             _ => return Err("exec cache_duration must be an integer".into()),
         };


### PR DESCRIPTION
Follow up of #4612. `humantime` crate is now outdated, so migrate to [jiff](https://crates.io/crates/jiff) instead as `cargo-deny` suggests.

`jiff` is almost compatible with `humantime`, but is not 100% compatible as documented.
https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html#comparison-with-the-humantime-crate
Notably, `1M` is parsed as `1 month` by `humantime` but cannot be parsed by `jiff`.

I used `2025-01-01` when converting `Span` to `SignedDuration` since we need a relative date to convert `months` or `years`, in which the duration differs depending on dates.
https://docs.rs/jiff/latest/jiff/struct.Span.html#integration-with-stdtimeduration-and-signedduration