### PR TITLE
chore: remove rustup update in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,7 @@ jobs:
           key: cargo-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-registry
       - if: matrix.runs-on != 'ubuntu-latest'
-        # TODO: remove rustup update once 1.85.0 is released to images
-        run: rustup update && rustup target add ${{matrix.target}}
+        run: rustup target add ${{matrix.target}}
       - if: matrix.runs-on == 'ubuntu-latest'
         uses: taiki-e/install-action@cross
       - name: build-tarball
@@ -116,8 +115,7 @@ jobs:
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
-      # TODO: remove rustup update once 1.85.0 is released to images
-      - run: rustup update && rustup target add ${{matrix.target}}
+      - run: rustup target add ${{matrix.target}}
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{matrix.arch}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: rustup update # TODO: remove when 1.85.0 is released to build images
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: build
@@ -94,7 +93,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: rustup update # TODO: remove when 1.85.0 is released to build images
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: build
@@ -132,7 +130,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
           submodules: true
-      - run: rustup update # TODO: remove when 1.85.0 is released to build images
       - uses: rui314/setup-mold@v1
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - uses: taiki-e/install-action@v2
@@ -248,7 +245,6 @@ jobs:
       MISE_CACHE_DIR: ~/.cache/mise
     steps:
       - uses: actions/checkout@v4
-      - run: rustup update # TODO: remove when 1.85.0 is released to build images
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: unit


### PR DESCRIPTION
For both `ubuntu-latest` and `macos-latest`, the Rust verison is updated to `1.85.0`.

https://github.com/actions/runner-images/pull/11704
https://github.com/actions/runner-images/pull/11726