### PR TITLE
fix: handle error when getting modified duration in file::modified_duration

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -259,7 +259,7 @@ pub fn touch_dir(dir: &Path) -> Result<()> {
 pub fn modified_duration(path: &Path) -> Result<Duration> {
     let metadata = path.metadata()?;
     let modified = metadata.modified()?;
-    let duration = modified.elapsed()?;
+    let duration = modified.elapsed().unwrap_or_default();
     Ok(duration)
 }
 


### PR DESCRIPTION
Fixes a bug that surfaced with #4623 