### PR TITLE
fix: SwiftPM backend not working with the Swift 6 toolchain

### DIFF
--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -353,9 +353,9 @@ impl PackageDescriptionProductType {
                         "type" => {
                             let value: String = map.next_value()?;
                             if value == "executable" {
-                                return Ok(PackageDescriptionProductType::Executable);
+                                Ok(PackageDescriptionProductType::Executable)
                             } else {
-                                return Ok(PackageDescriptionProductType::Other);
+                                Ok(PackageDescriptionProductType::Other)
                             }
                         }
                         "executable" => {

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -291,6 +291,17 @@ impl PackageDescriptionProductType {
         matches!(self, Self::Executable)
     }
 
+    /// Swift determines the toolchain to use with a given package using a comment in the Package.swift file at the top.
+    /// For example:
+    ///   // swift-tools-version: 6.0
+    ///
+    /// The version of the toolchain can be older than the Swift version used to build the package. This versioning gives
+    /// Apple the flexibility to introduce and flag breaking changes in the toolchain.
+    ///
+    /// How to determine the product type is something that might change across different versions of Swift.
+    ///
+    /// ## Swift 5.x
+    ///
     /// Product type is a key in the map with an undocumented value that we are not interested in and can be easily skipped.
     ///
     /// Example:
@@ -307,6 +318,17 @@ impl PackageDescriptionProductType {
     ///     ]
     /// }
     /// ```
+    ///
+    /// ## Swift 6.x
+    ///
+    /// The product type is directly the value under the key "type"
+    ///
+    /// Example:
+    ///
+    /// ```json
+    /// "type": "executable"
+    /// ```
+    ///
     fn deserialize_product_type_field<'de, D>(
         deserializer: D,
     ) -> Result<PackageDescriptionProductType, D::Error>
@@ -328,6 +350,14 @@ impl PackageDescriptionProductType {
             {
                 if let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
+                        "type" => {
+                            let value: String = map.next_value()?;
+                            if value == "executable" {
+                                return Ok(PackageDescriptionProductType::Executable);
+                            } else {
+                                return Ok(PackageDescriptionProductType::Other);
+                            }
+                        }
                         "executable" => {
                             // Skip the value by reading it into a dummy serde_json::Value
                             let _value: serde_json::Value = map.next_value()?;


### PR DESCRIPTION
Addresses [this discussion](https://github.com/jdx/mise/discussions/4613)

Swift introduced a breaking change in the package manifest dumped through stdout from the Swift toolchain version 6.0. That's causing the installation of packages through the `spm` backend to fail.

This PR fixes it.