### PR TITLE
feat: ubi forge option support

### DIFF
--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -14,8 +14,9 @@ use regex::Regex;
 use std::env;
 use std::fmt::Debug;
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::OnceLock;
-use ubi::UbiBuilder;
+use ubi::{ForgeType, UbiBuilder};
 use xx::regex;
 
 #[derive(Debug)]
@@ -114,6 +115,9 @@ impl Backend for UbiBackend {
             }
             if let Some(matching) = opts.get("matching") {
                 builder = builder.matching(matching);
+            }
+            if let Some(forge) = opts.get("forge") {
+                builder = builder.forge(ForgeType::from_str(forge)?);
             }
 
             let mut ubi = builder.build().map_err(|e| eyre::eyre!(e))?;


### PR DESCRIPTION
https://docs.rs/ubi/0.5.2/ubi/struct.UbiBuilder.html#method.forge

Without this, gitlab.com projects can be installed by specifying the full URL, but that's a bit unwieldy and doesn't work for other GitLab instances besides the gitlab.com one.