### PR TITLE
fix(tera): use default inline shell to parse exec template

### DIFF
--- a/src/tera.rs
+++ b/src/tera.rs
@@ -333,7 +333,6 @@ pub fn tera_exec(
                 let args = shell
                     .iter()
                     .skip(1)
-                    .map(|s| s)
                     .chain(once(command))
                     .collect::<Vec<&String>>();
                 let mut cmd: duct::Expression = cmd(&shell[0], args).full_env(&env);


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/4607.

I used `SETTINGS.default_inline_shell()` because the parsed scripts are executed with it, but `env::SHELL` should also be fine for this case.