### PR TITLE
chore(registry): declare copier

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -431,6 +431,8 @@ cookiecutter.backends = [
     "pipx:cookiecutter",
     "asdf:shawon-crosen/asdf-cookiecutter"
 ]
+copier.backends = ["pipx:copier", "asdf:looztra/asdf-copier"]
+copier.test = ["copier --version", "copier {{version}}"]
 copper.backends = ["ubi:cloud66-oss/copper", "asdf:vladlosev/asdf-copper"]
 copper.os = ["linux", "macos"]
 copper.test = ["copper version", ""]


### PR DESCRIPTION
# Description

- chore(registry): declare copier with pipx/uvx backend and asdf plugin

## Note

- if there is a way to test this kind of PR locally, I'd be happy to do it (did not find something related to the registry PRs in the doc)