### PR TITLE
feat(registry): add git

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,6 +207,7 @@ jobs:
             direnv \
             fd-find \
             fish \
+            gettext \
             pipx \
             python3-venv \
             zsh

--- a/registry.toml
+++ b/registry.toml
@@ -730,6 +730,8 @@ ginkgo.backends = [
     "asdf:mise-plugins/mise-ginkgo"
 ]
 ginkgo.test = ['ginkgo version', 'Ginkgo Version {{version}}']
+git.backends = ["asdf:nishidayuya/asdf-git"]
+git.test = ["git version", "git version {{version}}"]
 git-chglog.backends = [
     "aqua:git-chglog/git-chglog",
     "asdf:GoodwayGroup/asdf-git-chglog"


### PR DESCRIPTION
### Why asdf Backend?

No officially prebuilt Git binaries on the world, so no Aqua backend way and no UBI backend way, I think.

---

I saw following:

- [Download for Linux and Unix](https://git-scm.com/downloads/linux)
- [Releases and Tags page on Git Source Code Mirror on GitHub.com](https://github.com/git/git/releases)
- and other pages on https://git-scm.com/

I could not find officially prebuilt Git binaries. So, we must build Git binaries from source code.

Currently, [Aqua](https://aquaproj.github.io/docs/reference/registry-config/#package-types) and [UBI](https://github.com/houseabsolute/ubi) does not support `./configure && make && make install` style building.

I want to use Git under mise, so I wrote [asdf-git](https://github.com/nishidayuya/asdf-git).

### Test

```console
$ cargo run --bin mise -- tool git
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/mise tool git`
Backend:            asdf:nishidayuya/asdf-git
Installed Versions:
Active Version:     latest
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]

$ cargo run --bin mise -- use -g git
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/mise use -g git`
mise WARN  ⚠️  git is a community-developed plugin – https://github.com/nishidayuya/asdf-git
Would you like to install git? Yes
GIT_VERSION=2.49.0
    * new build flags
    * new link flags
    * new prefix flags
    * new script parameters
    * new perl-specific parameters
...
    * new test suites
mise git@2.49.0      ✓ installed
mise ~/.config/mise/config.toml tools: git@2.49.0

$ cargo run --bin mise -- tool git
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/mise tool git`
Backend:            asdf:git
Installed Versions: 2.49.0
Active Version:     2.49.0
Requested Version:  latest
Config Source:      ~/.config/mise/config.toml
Tool Options:       [none]
```
