### PR TITLE
feat: Set usage arguments and flag as environment variables before running the command

### DIFF
--- a/e2e/tasks/test_task_usage
+++ b/e2e/tasks/test_task_usage
@@ -75,3 +75,78 @@ chmod +x mise-tasks/test-args.js
 # assert_fail "mise run test-args --grower 1 -g 2" "Missing required flag: --packer <packer>"
 assert "mise run --trace test-args --grower 1 -g 2 --packer 3" "grower: 1 2
 packer: 3"
+
+cat <<'EOF' >mise.toml
+[tasks.usage-env]
+usage = '''
+arg "myarg" "myarg description" default="foo"
+'''
+run = 'echo myarg=$usage_myarg'
+EOF
+
+assert "mise run usage-env" "myarg=foo"
+assert "mise run usage-env bar" "myarg=bar"
+
+cat <<'EOF' >mise.toml
+[tasks.usage-env]
+usage = '''
+flag "-m --myflag <myflag>" default="foo"
+'''
+run = 'echo myflag=$usage_myflag'
+EOF
+
+assert "mise run usage-env" "myflag=foo"
+assert "mise run usage-env -m bar" "myflag=bar"
+assert "mise run usage-env --myflag bar" "myflag=bar"
+
+cat <<'EOF' >mise.toml
+[tasks.usage-env]
+usage = '''
+arg "myarg" "myarg description" default="foo"
+'''
+run = [
+'echo "Command 1: $usage_myarg"',
+'echo "Command 2: {{arg(name="myarg", default="bar")}} $usage_myarg"',
+]
+EOF
+
+assert "mise run usage-env" "\
+Command 1: foo
+Command 2: foo foo"
+assert "mise run usage-env baz" "\
+Command 1: baz
+Command 2: baz baz"
+
+cat <<'EOF' >mise.toml
+[tasks.usage-env]
+usage = '''
+flag "-m --myflag <myflag>" default="false"
+'''
+run = [
+'echo "Command 1: $usage_myflag"',
+'echo "Command 2: {{flag(name="myflag", default="false")}} $usage_myflag"',
+]
+EOF
+
+assert "mise run usage-env" "\
+Command 1: false
+Command 2: false false"
+assert "mise run usage-env -m true" "\
+Command 1: true
+Command 2: true true"
+assert "mise run usage-env --myflag true" "\
+Command 1: true
+Command 2: true true"
+
+cat <<'EOF' >mise.toml
+[tasks.usage-env]
+usage = '''
+arg "myarg" "myarg description"
+'''
+run = [
+'echo "Command 1: $usage_myarg"',
+'echo "Command 2: {{arg(name="myarg", default="bar")}} $usage_myarg"',
+]
+EOF
+
+assert_fail "mise run usage-env"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -479,9 +479,19 @@ impl Run {
         if let Some(file) = &task.file {
             self.exec_file(file, task, &env, &prefix)?;
         } else {
-            for (script, args) in
-                task.render_run_scripts_with_args(self.cd.clone(), &task.args, &env)?
-            {
+            let rendered_run_scripts =
+                task.render_run_scripts_with_args(self.cd.clone(), &task.args, &env)?;
+
+            let get_args = || {
+                [String::new()]
+                    .iter()
+                    .chain(task.args.iter())
+                    .cloned()
+                    .collect()
+            };
+            self.parse_usage_spec_and_init_env(task, &mut env, get_args)?;
+
+            for (script, args) in rendered_run_scripts {
                 self.exec_script(&script, &args, task, &env, &prefix)?;
             }
         }
@@ -596,14 +606,8 @@ impl Run {
         let mut env = env.clone();
         let command = file.to_string_lossy().to_string();
         let args = task.args.iter().cloned().collect_vec();
-        let (spec, _) = task.parse_usage_spec(self.cd.clone(), &env)?;
-        if !spec.cmd.args.is_empty() || !spec.cmd.flags.is_empty() {
-            let args = once(command.clone()).chain(args.clone()).collect_vec();
-            let po = usage::parse(&spec, &args).map_err(|err| eyre!(err))?;
-            for (k, v) in po.as_env() {
-                env.insert(k, v);
-            }
-        }
+        let get_args = || once(command.clone()).chain(args.clone()).collect_vec();
+        self.parse_usage_spec_and_init_env(task, &mut env, get_args)?;
 
         if !self.quiet(Some(task)) {
             let cmd = format!("{} {}", display_path(file), args.join(" "))
@@ -804,6 +808,28 @@ impl Run {
                 }
             }
         }
+        Ok(())
+    }
+
+    fn parse_usage_spec_and_init_env(
+        &self,
+        task: &Task,
+        env: &mut EnvMap,
+        get_args: impl Fn() -> Vec<String>,
+    ) -> Result<()> {
+        let (spec, _) = task.parse_usage_spec(self.cd.clone(), env)?;
+        if !spec.cmd.args.is_empty() || !spec.cmd.flags.is_empty() {
+            let args: Vec<String> = get_args();
+            debug!("Parsing usage spec for {:?}", args);
+            let po = usage::parse(&spec, &args).map_err(|err| eyre!(err))?;
+            for (k, v) in po.as_env() {
+                debug!("Adding key {} value {} in env", k, v);
+                env.insert(k, v);
+            }
+        } else {
+            debug!("Usage spec has no args or flags");
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/issues/4070

Toml tasks with an array of commands in their `run` section are now supported.
