### PR TITLE
feat(registry): add protoc-gen-validate

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1489,6 +1489,11 @@ protoc-gen-js.backends = [
     "ubi:protocolbuffers/protobuf-javascript[exe=protoc-gen-js]",
     "asdf:pbr0ck3r/asdf-protoc-gen-js"
 ]
+protoc-gen-validate.backends = [
+    "aqua:bufbuild/protoc-gen-validate",
+    "go:github.com/envoyproxy/protoc-gen-validate"
+]
+protoc-gen-validate.test = ["which protoc-gen-validate", "protoc-gen-validate"]
 protolint.backends = [
     "aqua:yoheimuta/protolint",
     "asdf:spencergilbert/asdf-protolint"


### PR DESCRIPTION
Adds [protoc-gen-validate tool](https://github.com/bufbuild/protoc-gen-validate). As it is a protoc plugin, there's not a great way to test it off the bat.

```
mise use go:github.com/bufbuild/protoc-gen-validate 
go: downloading github.com/bufbuild/protoc-gen-validate v1.2.1
go: downloading github.com/iancoleman/strcase v0.3.0
go: downloading google.golang.org/protobuf v1.36.3
go: downloading github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4
go: downloading github.com/spf13/afero v1.10.0
go: downloading golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
go: downloading golang.org/x/mod v0.17.0
mise go:github.com/bufbuild/protoc-gen-validate@1.2.1 ✓ installed
mise ~/test/.mise.toml tools: go:github.com/bufbuild/protoc-gen-validate@1.2.1
```

```
mise use aqua:bufbuild/protoc-gen-validate
mise aqua:bufbuild/protoc-gen-validate@1.2.1 ✓ installed
mise ~/test/.mise.toml tools: aqua:bufbuild/protoc-gen-validate@1.2.1
```