### PR TITLE
docs: mark code block for dnf5 install as shell code

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -162,7 +162,7 @@ dnf install -y mise
 
 Fedora 41+ (dnf5)
 
-```
+```sh
 dnf install -y dnf-plugins-core
 dnf config-manager addrepo --from-repofile=https://mise.jdx.dev/rpm/mise.repo
 dnf install -y mise


### PR DESCRIPTION
This fixes a simple omission when documenting the new dnf5 syntax for adding the mise repository to Fedora.