### PR TITLE
feat(registry): added localstack

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1255,6 +1255,8 @@ litestream.backends = [
 ]
 llvm-objcopy.backends = ["asdf:mise-plugins/mise-llvm"]
 llvm-objdump.backends = ["asdf:mise-plugins/mise-llvm"]
+localstack.backends = ["ubi:localstack/localstack-cli[exe=localstack]"]
+localstack.test = ["localstack --version", "LocalStack CLI {{version}}"]
 logtalk.backends = ["asdf:mise-plugins/mise-logtalk"]
 loki-logcli.backends = [
     "aqua:grafana/loki/logcli",


### PR DESCRIPTION
[localstack](https://github.com/localstack/localstack) LocalStack is a cloud software development framework to develop and test your AWS applications locally.

Tests:
```
$ cargo run --bin mise -- install localstack
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
     Running `target/debug/mise install localstack`
mise Installed executable into /Users/mnm/.local/share/mise/installs/localstack/4.3.0/localstack
mise localstack@4.3.0 ✓ installed

$ cargo run --bin mise -- tool localstack
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
     Running `target/debug/mise tool localstack`
Backend:            ubi:localstack/localstack-cli[exe=localstack]
Installed Versions: 4.3.0
Tool Options:       exe="localstack"

$ cargo run --bin mise -- uninstall localstack
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/mise uninstall localstack`
mise localstack@4.3.0 ✓ uninstalled
```