### PR TITLE
feat(registry): added skeema

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1691,6 +1691,8 @@ skaffold.backends = [
     "asdf:nklmilojevic/asdf-skaffold"
 ]
 skate.backends = ["aqua:charmbracelet/skate", "asdf:chessmango/asdf-skate"]
+skeema.backends = ["aqua:skeema/skeema", "ubi:skeema/skeema"]
+skeema.tests = ["skeema version | awk -F, '{print $1}'", "skeema version {{version}}-community"]
 sloth.backends = ["aqua:slok/sloth", "asdf:slok/asdf-sloth"]
 slsa-verifier.backends = ["ubi:slsa-framework/slsa-verifier"]
 slsa-verifier.test = ["slsa-verifier version", "{{version}}"]

--- a/registry.toml
+++ b/registry.toml
@@ -1692,7 +1692,10 @@ skaffold.backends = [
 ]
 skate.backends = ["aqua:charmbracelet/skate", "asdf:chessmango/asdf-skate"]
 skeema.backends = ["aqua:skeema/skeema", "ubi:skeema/skeema"]
-skeema.tests = ["skeema version | awk -F, '{print $1}'", "skeema version {{version}}-community"]
+skeema.tests = [
+    "skeema version | awk -F, '{print $1}'",
+    "skeema version {{version}}-community"
+]
 sloth.backends = ["aqua:slok/sloth", "asdf:slok/asdf-sloth"]
 slsa-verifier.backends = ["ubi:slsa-framework/slsa-verifier"]
 slsa-verifier.test = ["slsa-verifier version", "{{version}}"]


### PR DESCRIPTION
[skeema](https://github.com/skeema/skeema)
Skeema is a tool for managing MySQL and MariaDB schema changes in a declarative fashion using pure SQL.

For the `skeema.tests`, the skeema version is a bit bloat-some.
```
$ skeema version
skeema version 1.12.3-community, commit 085259b2f833beb0588e72f9085c1f51bdfd5879, released 2025-02-27T22:12:38Z
```
I saw `doggo.test` used `awk`, so I did the same to pair it down
```
$ skeema version | awk -F, '{print $1}'
skeema version 1.12.3-community
```

Tests (using both aqua and ubi backends):

```
$ cargo run --bin mise -- install skeema
   Compiling mise v2025.4.0 (/Users/mnm/mise)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.69s
     Running `target/debug/mise install skeema`
mise skeema@1.12.3   ✓ installed

$ cargo run --bin mise -- tool skeema
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.53s
     Running `target/debug/mise tool skeema`
Backend:            aqua:skeema/skeema
Description:        Declarative pure-SQL schema management for MySQL and MariaDB (Community Edition)
Installed Versions: 1.12.3
Tool Options:       [none]

$ cargo run --bin mise -- uninstall skeema
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
     Running `target/debug/mise uninstall skeema`
mise skeema@1.12.3   ✓ uninstalled

$ MISE_DISABLE_BACKENDS=aqua cargo run --bin mise -- install skeema
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/mise install skeema`
mise Installed executable into /Users/mnm/.local/share/mise/installs/skeema/1.12.3/skeema
mise skeema@1.12.3   ✓ installed

$ cargo run --bin mise -- tool skeema
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/mise tool skeema`
Backend:            ubi:skeema/skeema
Installed Versions: 1.12.3
Tool Options:       [none]

$ cargo run --bin mise -- uninstall skeema
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/mise uninstall skeema`
mise skeema@1.12.3   ✓ uninstalled
```