### PR TITLE
feat(registry): added roswell

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1611,6 +1611,7 @@ ripsecrets.backends = [
 # ripsecrets.test = ["ripsecrets --version", "ripsecrets {{version}}"] # broke in CI
 rke.backends = ["aqua:rancher/rke", "asdf:particledecay/asdf-rke"]
 rlwrap.backends = ["asdf:mise-plugins/mise-rlwrap"]
+ros.backends = ["asdf:troydm/asdf-roswell"]
 ruby.backends = ["core:ruby"]
 ruff.backends = [
     "aqua:astral-sh/ruff",


### PR DESCRIPTION
[roswell](https://roswell.github.io/)

Roswell is a Lisp implementation installer/manager, launcher, and much more! It started as a command-line tool with the aim to make installing and managing Common Lisp implementations really simple and easy.

> $ ros --version
> roswell 24.10.115(NO-GIT-REVISION)