### PR TITLE
Include post about Mise secrets in the context of Swift app dev

### DIFF
--- a/docs/external-resources.md
+++ b/docs/external-resources.md
@@ -2,6 +2,7 @@
 
 Links to articles, videos, and other resources that are relevant to mise.
 
+- 2025-04-09 - Keeping your Swift apps' sensitive data secret  - <https://tuist.dev/blog/2025/04/09/secrets>
 - 2025-02-17 - hk: git hook manager that pairs well with mise - <https://hk.jdx.dev>
 - 2025-02-04 - A Mise guide for Swift developers - <https://tuist.dev/blog/2025/02/04/mise>
 - 2025-01-26 - devtools.fm: Jeff Dickey - Mise, Usage, and Pitchfork and the Future of Polyglot Tools - <https://www.devtools.fm/episode/129>

--- a/docs/external-resources.md
+++ b/docs/external-resources.md
@@ -2,7 +2,7 @@
 
 Links to articles, videos, and other resources that are relevant to mise.
 
-- 2025-04-09 - Keeping your Swift apps' sensitive data secret  - <https://tuist.dev/blog/2025/04/09/secrets>
+- 2025-04-09 - Keeping your Swift apps' sensitive data secret - <https://tuist.dev/blog/2025/04/09/secrets>
 - 2025-02-17 - hk: git hook manager that pairs well with mise - <https://hk.jdx.dev>
 - 2025-02-04 - A Mise guide for Swift developers - <https://tuist.dev/blog/2025/02/04/mise>
 - 2025-01-26 - devtools.fm: Jeff Dickey - Mise, Usage, and Pitchfork and the Future of Polyglot Tools - <https://www.devtools.fm/episode/129>


### PR DESCRIPTION
I wrote a blog post about using Mise secrets' capability to encrypt secrets in Swift app repositories and obfuscate them into the app binary at build time.