### PR TITLE
fix: do not default to writing to mise.$MISE_ENV.toml

### DIFF
--- a/e2e/cli/test_use_env
+++ b/e2e/cli/test_use_env
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+mise use -e local dummy@1
+assert "cat mise.local.toml" '[tools]
+dummy = "1"'
+assert "rm mise.local.toml"
+
+MISE_ENV=local mise use dummy@1 # doesn't imply `-e local` for writing
+assert "cat mise.toml" '[tools]
+dummy = "1"'

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -211,9 +211,6 @@ impl Use {
             } else {
                 cwd.join(format!("mise.{env}.toml"))
             }
-        } else if !env::MISE_ENV.is_empty() {
-            let env = env::MISE_ENV.last().unwrap();
-            config_file_from_dir(&cwd.join(format!("mise.{env}.toml")))
         } else if env::in_home_dir() {
             MISE_GLOBAL_CONFIG_FILE.clone()
         } else {

--- a/src/env.rs
+++ b/src/env.rs
@@ -110,7 +110,6 @@ pub static MISE_DEFAULT_CONFIG_FILENAME: Lazy<String> = Lazy::new(|| {
     var("MISE_DEFAULT_CONFIG_FILENAME")
         .ok()
         .or(MISE_OVERRIDE_CONFIG_FILENAMES.first().cloned())
-        .or(MISE_ENV.last().map(|env| format!("mise.{env}.toml")))
         .unwrap_or_else(|| "mise.toml".into())
 });
 pub static MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES: Lazy<Option<IndexSet<String>>> =


### PR DESCRIPTION
I just hit a situation where I had set `MISE_ENV=macos` globally. This meant that `mise use` started writing to `mise.macos.toml` which I did not want.

I am not sure why I had this logic in the first place but it doesn't seem ideal. It seems to me if you specify `mise use -E macos` _that_ should write to `mise.macos.toml` but not if it's just an env var.

@roele I know you worked on this code a bit in https://github.com/jdx/mise/pull/4249 but I think it was more about making the `--path` flag work correctly. Any concerns about this change?