### PR TITLE
fix: mise watch forward --exts and --filter to watchexec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3750,7 +3750,7 @@ dependencies = [
  "shell-words",
  "signal-hook",
  "siphasher",
- "strum 0.26.3",
+ "strum 0.27.1",
  "sys-info",
  "tabled",
  "taplo",

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -156,6 +156,18 @@ impl Watch {
                 args.push(path.to_string_lossy().to_string());
             }
         }
+        if !self.watchexec.filter_extensions.is_empty() {
+            for ext in &self.watchexec.filter_extensions {
+                args.push("--exts".to_string());
+                args.push(ext.to_string());
+            }
+        }
+        if !self.watchexec.filter_patterns.is_empty() {
+            for pattern in &self.watchexec.filter_patterns {
+                args.push("--filter".to_string());
+                args.push(pattern.to_string());
+            }
+        }
         if let Some(watch_file) = &self.watchexec.watch_file {
             args.push("--watch-file".to_string());
             args.push(watch_file.to_string_lossy().to_string());


### PR DESCRIPTION
mise watch not forward --exts and --filter args to watchexec