### PR TITLE
feat(aqua): support SLSA source_uri setting

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -135,6 +135,7 @@ pub struct AquaSlsaProvenance {
     pub repo_name: Option<String>,
     pub url: Option<String>,
     pub asset: Option<String>,
+    pub source_uri: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -705,6 +706,9 @@ impl AquaSlsaProvenance {
         }
         if let Some(asset) = other.asset {
             self.asset = Some(asset);
+        }
+        if let Some(source_uri) = other.source_uri {
+            self.source_uri = Some(source_uri);
         }
     }
 }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -403,13 +403,17 @@ impl AquaBackend {
                         return Ok(());
                     }
                 };
+                let source_uri = slsa
+                    .source_uri
+                    .clone()
+                    .unwrap_or_else(|| format!("github.com/{repo}"));
                 let mut cmd = CmdLineRunner::new(slsa_bin)
                     .arg("verify-artifact")
                     .arg(tv.download_path().join(filename))
                     .arg("--provenance-repository")
                     .arg(&repo)
                     .arg("--source-uri")
-                    .arg(format!("github.com/{repo}"))
+                    .arg(source_uri)
                     .arg("--provenance-path")
                     .arg(provenance_path);
                 cmd = cmd.with_pr(&ctx.pr);


### PR DESCRIPTION
https://github.com/aquaproj/aqua/blob/fdfe33db55f25db8d286f38e03a34e488ee15a1b/json-schema/registry.json#L625-L627

Only one corner case in the registry for now, `aqua:aquaproj/example-go-slsa-provenance@v0.1.0`