### PR TITLE
feat(aqua): use source tag in SLSA verification

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -136,6 +136,7 @@ pub struct AquaSlsaProvenance {
     pub url: Option<String>,
     pub asset: Option<String>,
     pub source_uri: Option<String>,
+    pub source_tag: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -709,6 +710,9 @@ impl AquaSlsaProvenance {
         }
         if let Some(source_uri) = other.source_uri {
             self.source_uri = Some(source_uri);
+        }
+        if let Some(source_tag) = other.source_tag {
+            self.source_tag = Some(source_tag);
         }
     }
 }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -416,6 +416,13 @@ impl AquaBackend {
                     .arg(source_uri)
                     .arg("--provenance-path")
                     .arg(provenance_path);
+                let source_tag = slsa
+                    .source_tag
+                    .clone()
+                    .unwrap_or_else(|| v.to_string());
+                if source_tag != "-" {
+                   cmd = cmd.arg("--source-tag").arg(source_tag);
+                }
                 cmd = cmd.with_pr(&ctx.pr);
                 cmd.execute()?;
             } else {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -416,12 +416,9 @@ impl AquaBackend {
                     .arg(source_uri)
                     .arg("--provenance-path")
                     .arg(provenance_path);
-                let source_tag = slsa
-                    .source_tag
-                    .clone()
-                    .unwrap_or_else(|| v.to_string());
+                let source_tag = slsa.source_tag.clone().unwrap_or_else(|| v.to_string());
                 if source_tag != "-" {
-                   cmd = cmd.arg("--source-tag").arg(source_tag);
+                    cmd = cmd.arg("--source-tag").arg(source_tag);
                 }
                 cmd = cmd.with_pr(&ctx.pr);
                 cmd.execute()?;


### PR DESCRIPTION
For a bit tighter checking. aqua does it too.

Closes https://github.com/jdx/mise/discussions/4791

* https://github.com/aquaproj/aqua/blob/fdfe33db55f25db8d286f38e03a34e488ee15a1b/pkg/slsa/exec.go#L69-L79
* https://github.com/aquaproj/aqua/blob/fdfe33db55f25db8d286f38e03a34e488ee15a1b/pkg/installpackage/verify_slsa.go#L41-L44