### PR TITLE
fix: removed possible single-point-of-failure while running `mise upgrade` 

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -178,9 +178,7 @@ impl Upgrade {
                 if let Err(e) =
                     cf.replace_versions(o.tool_request.ba(), vec![o.tool_request.clone()])
                 {
-                    had_errors = true;
-                    warn!("Failed to update config for {}: {}", o.name, e);
-                    continue;
+                    return Err(eyre!("Failed to update config for {}: {}", o.name, e));
                 }
 
                 if let Err(e) = cf.save() {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -202,7 +202,7 @@ impl Upgrade {
             }
         }
 
-        config::rebuild_shims_and_runtime_symlinks(&versions)?;
+        config::rebuild_shims_and_runtime_symlinks(&successful_versions)?;
 
         if successful_versions.iter().any(|v| v.short() == "python") {
             PIPXBackend::reinstall_all().unwrap_or_else(|err| {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -178,6 +178,7 @@ impl Upgrade {
                 if let Err(e) =
                     cf.replace_versions(o.tool_request.ba(), vec![o.tool_request.clone()])
                 {
+                    had_errors = true;
                     warn!("Failed to update config for {}: {}", o.name, e);
                     continue;
                 }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -212,7 +212,7 @@ impl Upgrade {
         }
 
         if had_errors {
-            warn!("Some tools failed to upgrade. Check the logs for details.");
+            return Err(eyre!("Some tools failed to upgrade"));
         }
 
         Ok(())

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -183,7 +183,7 @@ impl Upgrade {
                 }
 
                 if let Err(e) = cf.save() {
-                    warn!("Failed to save config for {}: {}", o.name, e);
+                    return Err(eyre!("Failed to save config for {}: {}", o.name, e));
                 }
             }
         }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -202,9 +202,7 @@ impl Upgrade {
             }
         }
 
-        if let Err(e) = config::rebuild_shims_and_runtime_symlinks(&successful_versions) {
-            warn!("Failed to rebuild shims and runtime symlinks: {:?}", e);
-        }
+        config::rebuild_shims_and_runtime_symlinks(&versions)?;
 
         if successful_versions.iter().any(|v| v.short() == "python") {
             PIPXBackend::reinstall_all().unwrap_or_else(|err| {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -202,7 +202,7 @@ impl Upgrade {
         }
 
         if let Err(e) = config::rebuild_shims_and_runtime_symlinks(&successful_versions) {
-            warn!("Failed to rebuild shims and runtime symlinks: {}", e);
+            warn!("Failed to rebuild shims and runtime symlinks: {:?}", e);
         }
 
         if successful_versions.iter().any(|v| v.short() == "python") {


### PR DESCRIPTION
Key changes are as such:

`src/cli/upgrade.rs`
* Modified the upgrade process to update configuration files only for tools that were successfully installed.
* Changed the logic to uninstall old versions of tools only if their new versions were successfully upgraded.
* Adjusted the rebuild of shims and runtime symlinks to occur only for successful upgrades.