### PR TITLE
fix(ubi): API URL for GitHub should not have /repos segement

### DIFF
--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -46,7 +46,7 @@ impl Backend for UbiBackend {
                 None => ForgeType::default(),
             };
             let api_url = match opts.get("api_url") {
-                Some(api_url) => api_url,
+                Some(api_url) => api_url.strip_suffix("/").unwrap_or(api_url),
                 None => match forge {
                     ForgeType::GitHub => github::API_URL,
                     ForgeType::GitLab => gitlab::API_URL,
@@ -111,7 +111,7 @@ impl Backend for UbiBackend {
             None => ForgeType::default(),
         };
         let api_url = match opts.get("api_url") {
-            Some(api_url) => api_url,
+            Some(api_url) => api_url.strip_suffix("/").unwrap_or(api_url),
             None => match forge {
                 ForgeType::GitHub => github::API_URL,
                 ForgeType::GitLab => gitlab::API_URL,
@@ -172,7 +172,7 @@ impl Backend for UbiBackend {
 
             if let Some(api_url) = opts.get("api_url") {
                 if !api_url.contains("github.com") && !api_url.contains("gitlab.com") {
-                    builder = builder.api_base_url(api_url);
+                    builder = builder.api_base_url(api_url.strip_suffix("/").unwrap_or(api_url));
                     builder = set_enterprise_token(builder, &forge);
                 }
             }

--- a/src/github.rs
+++ b/src/github.rs
@@ -43,7 +43,7 @@ static RELEASE_CACHE: Lazy<RwLock<CacheGroup<GithubRelease>>> = Lazy::new(Defaul
 
 static TAGS_CACHE: Lazy<RwLock<CacheGroup<Vec<String>>>> = Lazy::new(Default::default);
 
-pub static API_URL: &str = "https://api.github.com/repos";
+pub static API_URL: &str = "https://api.github.com";
 
 fn get_tags_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<Vec<String>>> {
     TAGS_CACHE
@@ -103,7 +103,7 @@ pub fn list_releases_from_url(api_url: &str, repo: &str) -> Result<Vec<GithubRel
 }
 
 fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GithubRelease>> {
-    let url = format!("{api_url}/{repo}/releases");
+    let url = format!("{api_url}/repos/{repo}/releases");
     let headers = get_headers(&url);
     let (mut releases, mut headers) = crate::http::HTTP_FETCH
         .json_headers_with_headers::<Vec<GithubRelease>, _>(url, &headers)?;
@@ -140,7 +140,7 @@ pub fn list_tags_from_url(api_url: &str, repo: &str) -> Result<Vec<String>> {
 }
 
 fn list_tags_(api_url: &str, repo: &str) -> Result<Vec<String>> {
-    let url = format!("{api_url}/{repo}/tags");
+    let url = format!("{api_url}/repos/{repo}/tags");
     let headers = get_headers(&url);
     let (mut tags, mut headers) =
         crate::http::HTTP_FETCH.json_headers_with_headers::<Vec<GithubTag>, _>(url, &headers)?;
@@ -176,7 +176,7 @@ pub fn get_release_for_url(api_url: &str, repo: &str, tag: &str) -> Result<Githu
 }
 
 fn get_release_(api_url: &str, repo: &str, tag: &str) -> Result<GithubRelease> {
-    let url = format!("{api_url}/{repo}/releases/tags/{tag}");
+    let url = format!("{api_url}/repos/{repo}/releases/tags/{tag}");
     let headers = get_headers(&url);
     crate::http::HTTP_FETCH.json_with_headers(url, &headers)
 }


### PR DESCRIPTION
As discussed in #4020