### PR TITLE
chore: release 2025.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2025.4.5](https://github.com/jdx/mise/compare/v2025.4.4..v2025.4.5) - 2025-04-18
+
+### 🐛 Bug Fixes
+
+- **(ubi)** API URL for GitHub should not have /repos segement by [@roele](https://github.com/roele) in [#4848](https://github.com/jdx/mise/pull/4848)
+- **(ubi)** URL syntax fails by [@roele](https://github.com/roele) in [#4859](https://github.com/jdx/mise/pull/4859)
+- allow to install non-numeric elixir versions by [@roele](https://github.com/roele) in [#4850](https://github.com/jdx/mise/pull/4850)
+- removed possible single-point-of-failure while running `mise upgrade` by [@hitblast](https://github.com/hitblast) in [#4847](https://github.com/jdx/mise/pull/4847)
+- `#MISE tools=` in task header by [@jdx](https://github.com/jdx) in [#4860](https://github.com/jdx/mise/pull/4860)
+
+### 🧪 Testing
+
+- fix aqua tool test by [@jdx](https://github.com/jdx) in [4f2c050](https://github.com/jdx/mise/commit/4f2c0505502c1e3c7bf3478d61a2c352591f281c)
+
+### New Contributors
+
+- @hitblast made their first contribution in [#4847](https://github.com/jdx/mise/pull/4847)
+
 ## [2025.4.4](https://github.com/jdx/mise/compare/v2025.4.3..v2025.4.4) - 2025-04-15
 
 ### 🧪 Testing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,9 +3419,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.4.4"
+version = "2025.4.5"
 dependencies = [
  "base64 0.22.1",
  "built",
@@ -3737,7 +3737,7 @@ dependencies = [
  "path-absolutize",
  "petgraph",
  "pretty_assertions",
- "rand 0.9.0",
+ "rand 0.9.1",
  "rayon",
  "regex",
  "reqwest",
@@ -3846,7 +3846,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.0",
+ "rand 0.9.1",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -4473,9 +4473,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -4529,7 +4529,7 @@ checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -4583,13 +4583,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2025.4.4"
+version = "2025.4.5"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.4.4 macos-arm64 (a1b2d3e 2025-04-15)
+2025.4.5 macos-arm64 (a1b2d3e 2025-04-18)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_4_4:-}" ]] || _cache_invalid _usage_spec_mise_2025_4_4 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_4_4;
+  if ( [[ -z "${_usage_spec_mise_2025_4_5:-}" ]] || _cache_invalid _usage_spec_mise_2025_4_5 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_4_5;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_4_4 spec
+    _store_cache _usage_spec_mise_2025_4_5 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_4_4:-} ]]; then
-        _usage_spec_mise_2025_4_4="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_4_5:-} ]]; then
+        _usage_spec_mise_2025_4_5="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_4_4}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_4_5}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_4_4
-  set -g _usage_spec_mise_2025_4_4 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_4_5
+  set -g _usage_spec_mise_2025_4_5 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_4_4" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_4_5" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_4_4" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_4_5" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.4.4";
+  version = "2025.4.5";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.4.4
+Version: 2025.4.5
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(ubi)** API URL for GitHub should not have /repos segement by [@roele](https://github.com/roele) in [#4848](https://github.com/jdx/mise/pull/4848)
- **(ubi)** URL syntax fails by [@roele](https://github.com/roele) in [#4859](https://github.com/jdx/mise/pull/4859)
- allow to install non-numeric elixir versions by [@roele](https://github.com/roele) in [#4850](https://github.com/jdx/mise/pull/4850)
- removed possible single-point-of-failure while running `mise upgrade` by [@hitblast](https://github.com/hitblast) in [#4847](https://github.com/jdx/mise/pull/4847)
- `#MISE tools=` in task header by [@jdx](https://github.com/jdx) in [#4860](https://github.com/jdx/mise/pull/4860)

### 🧪 Testing

- fix aqua tool test by [@jdx](https://github.com/jdx) in [4f2c050](https://github.com/jdx/mise/commit/4f2c0505502c1e3c7bf3478d61a2c352591f281c)

### New Contributors

- @hitblast made their first contribution in [#4847](https://github.com/jdx/mise/pull/4847)