### PR TITLE
feat(registry): add docker-cli to registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -530,6 +530,8 @@ djinni.backends = [
 ]
 # djinni.test = ["djinni-generator --version", "djinni generator version {{version}}"] # test fails on windows
 dmd.backends = ["asdf:mise-plugins/mise-dmd"]
+docker-cli.backends = ["aqua:docker/cli"]
+docker-cli.test = ["docker --version", "Docker version {{version}}"]
 docker-compose.backends = ["aqua:docker/compose"]
 docker-compose.test = [
     "docker-cli-plugin-docker-compose --version",


### PR DESCRIPTION
Add `docker-cli` to registry.

Tooling is already in Aqua registry: https://github.com/aquaproj/aqua-registry/tree/main/pkgs/docker/cli.