### PR TITLE
refactor: introduce BackendOptions besides ToolVersionOptions

### DIFF
--- a/e2e/backend/test_ubi
+++ b/e2e/backend/test_ubi
@@ -7,12 +7,12 @@ assert_contains "$MISE_DATA_DIR/shims/jc --version" "jc version:  1.25.3"
 
 cat <<EOF >mise.toml
 [tools]
-"ubi:cilium/cilium-cli" = { version = "latest", exe = "cilium" }
+"ubi:cilium/cilium-cli[exe=cilium]" = "latest"
 EOF
 # re-uses tool options
 mise use ubi:cilium/cilium-cli
 assert "cat mise.toml" '[tools]
-"ubi:cilium/cilium-cli" = { version = "latest", exe = "cilium" }'
+"ubi:cilium/cilium-cli[exe=cilium]" = "latest"'
 
 assert "mise x ubi:gitlab-org/cli[exe=glab,provider=gitlab]@1.54.0 -- glab --version | grep -o 1.54.0" "1.54.0"
 

--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -19,11 +19,11 @@ rm .tool-versions
 # ensure options are retained
 mise use "ubi:bazelbuild/buildtools[exe=buildifier,matching=buildifier]@7.1.2"
 assert "cat mise.toml" '[tools]
-"ubi:bazelbuild/buildtools" = { version = "7.1.2", exe = "buildifier", matching = "buildifier" }'
+"ubi:bazelbuild/buildtools[exe=buildifier,matching=buildifier]" = "7.1.2"'
 bazelbuild_latest=$(mise latest ubi:bazelbuild/buildtools)
 mise up --bump ubi:bazelbuild/buildtools
 assert "cat mise.toml" "[tools]
-\"ubi:bazelbuild/buildtools\" = { version = \"$bazelbuild_latest\", exe = \"buildifier\", matching = \"buildifier\" }"
+\"ubi:bazelbuild/buildtools[exe=buildifier,matching=buildififer]\" = \"$bazelbuild_latest\""
 
 rm -f .tool-versions
 echo "tools.dummy = 'prefix:1'" >mise.toml

--- a/e2e/cli/test_use_retain_opts
+++ b/e2e/cli/test_use_retain_opts
@@ -2,7 +2,7 @@
 
 assert "mise use dummy[foo=bar]@1.0.0"
 assert "cat mise.toml" '[tools]
-dummy = { version = "1.0.0", foo = "bar" }'
+"dummy[foo=bar]" = "1.0.0"'
 assert "mise use -g dummy@1.0.0"
 assert "cat ~/.config/mise/config.toml" '[tools]
 dummy = "1.0.0"'

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -50,6 +50,28 @@ pub type VersionCacheManager = CacheManager<Vec<String>>;
 
 static TOOLS: Mutex<Option<Arc<BackendMap>>> = Mutex::new(None);
 
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct BackendOptions {
+    pub os: Option<Vec<String>>,
+    pub install_env: BTreeMap<String, String>,
+    #[serde(flatten)]
+    pub opts: BTreeMap<String, String>,
+}
+
+impl BackendOptions {
+    pub fn is_empty(&self) -> bool {
+        self.install_env.is_empty() && self.opts.is_empty()
+    }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.opts.get(key)
+    }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.opts.contains_key(key)
+    }
+}
+
 fn load_tools() -> Arc<BackendMap> {
     if let Some(memo_tools) = TOOLS.lock().unwrap().clone() {
         return memo_tools;

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -105,7 +105,8 @@ impl Backend for UbiBackend {
         mut tv: ToolVersion,
     ) -> eyre::Result<ToolVersion> {
         let mut v = tv.version.to_string();
-        let opts = tv.request.options();
+        // let opts = tv.request.options();
+        let opts = self.ba.opts();
         let forge = match opts.get("provider") {
             Some(forge) => ForgeType::from_str(forge)?,
             None => ForgeType::default(),

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -125,6 +125,20 @@ impl BackendArg {
         BackendType::Unknown
     }
 
+    pub fn short_opts(&self) -> String {
+        let short_opts = self.short.clone();
+        let opts = self.opts().opts;
+        if !opts.is_empty() {
+            let opts: Vec<String> = opts
+                .iter()
+                .filter(|(_, v)| !v.is_empty())
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect();
+            return format!("{}[{}]", self.short, opts.join(","));
+        }
+        short_opts
+    }
+
     pub fn full(&self) -> String {
         let short = unalias_backend(&self.short);
         if config::is_loaded() {
@@ -175,10 +189,6 @@ impl BackendArg {
                 ToolVersionOptions::default()
             }
         })
-    }
-
-    pub fn set_opts(&mut self, opts: Option<ToolVersionOptions>) {
-        self.opts = opts;
     }
 
     pub fn tool_name(&self) -> String {

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,7 +1,9 @@
 use crate::cli::args::ToolArg;
 use crate::config::Config;
 use crate::hooks::Hooks;
-use crate::toolset::{InstallOptions, ResolveOptions, ToolRequest, ToolSource, Toolset};
+use crate::toolset::{
+    InstallOptions, ResolveOptions, ToolRequest, ToolSource, ToolVersionOptions, Toolset,
+};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{config, env, hooks};
 use eyre::Result;
@@ -114,7 +116,7 @@ impl Install {
                                 let tvr = ToolRequest::Version {
                                     backend: ta.ba.clone(),
                                     version: "latest".into(),
-                                    options: ta.ba.opts(),
+                                    options: ToolVersionOptions::default(),
                                     source: ToolSource::Argument,
                                 };
                                 requests.push(tvr);

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -2,9 +2,10 @@ use eyre::Result;
 use itertools::Itertools;
 use serde_derive::Serialize;
 
+use crate::backend::BackendOptions;
 use crate::cli::args::BackendArg;
 use crate::config::Config;
-use crate::toolset::{ToolSource, ToolVersionOptions, ToolsetBuilder};
+use crate::toolset::{ToolSource, ToolsetBuilder};
 use crate::ui::table;
 
 /// Gets information about a tool
@@ -202,7 +203,7 @@ struct ToolInfo {
     requested_versions: Option<Vec<String>>,
     active_versions: Option<Vec<String>>,
     config_source: Option<ToolSource>,
-    tool_options: ToolVersionOptions,
+    tool_options: BackendOptions,
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -43,7 +43,7 @@ impl Unuse {
                     .collect();
                 for tool in tools_to_remove {
                     removed.push(ta);
-                    cf.remove_tool(&tool.ba())?;
+                    cf.remove_tool(tool.ba())?;
                 }
             }
         }

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -41,9 +41,9 @@ impl Unuse {
                         tv.version() == ta.version.as_ref().map_or("latest", |v| v.as_str())
                     })
                     .collect();
-                for _tool in tools_to_remove {
+                for tool in tools_to_remove {
                     removed.push(ta);
-                    cf.remove_tool(&ta.ba)?;
+                    cf.remove_tool(&tool.ba())?;
                 }
             }
         }

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -313,7 +313,11 @@ impl ConfigFile for MiseToml {
         let doc = self.doc_mut()?;
         if let Some(tools) = doc.get_mut("tools") {
             if let Some(tools) = tools.as_table_like_mut() {
-                tools.remove(&fa.to_string());
+                let keys = tools.iter().map(|(k, _)| k).collect::<Vec<_>>();
+                println!("keys: {keys:?}");
+                println!("removing: {}", fa.short_opts());
+
+                tools.remove(&fa.short_opts());
                 if tools.is_empty() {
                     doc.as_table_mut().remove("tools");
                 }
@@ -353,7 +357,7 @@ impl ConfigFile for MiseToml {
             .unwrap();
 
         // create a key from the short name preserving any decorations like prefix/suffix if the key already exists
-        let key = get_key_with_decor(tools, ba.short.as_str());
+        let key = get_key_with_decor(tools, &ba.short_opts());
 
         // if a short name is used like "node", make sure we remove any long names like "core:node"
         if ba.short != ba.full() {
@@ -439,11 +443,7 @@ impl ConfigFile for MiseToml {
                     for v in options.opts.values_mut() {
                         *v = self.parse_template(v)?;
                     }
-                    let mut ba = ba.clone();
-                    let mut ba_opts = ba.opts().clone();
-                    ba_opts.merge(&options.opts);
-                    ba.set_opts(Some(ba_opts.clone()));
-                    ToolRequest::new_opts(ba, &version, options, source.clone())?
+                    ToolRequest::new_opts(ba.clone(), &version, options, source.clone())?
                 } else {
                     ToolRequest::new(ba.clone(), &version, source.clone())?
                 };

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -13,6 +13,7 @@ use tera::Context as TeraContext;
 use toml_edit::{Array, DocumentMut, InlineTable, Item, Key, Value, table, value};
 use versions::Versioning;
 
+use crate::backend::BackendOptions;
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::config::config_file::toml::deserialize_arr;
 use crate::config::config_file::{ConfigFile, TaskConfig, config_trust_root, trust, trust_check};
@@ -337,12 +338,12 @@ impl ConfigFile for MiseToml {
             if opts.os.is_some() || !opts.install_env.is_empty() {
                 return false;
             }
-            if let Some(reg_ba) = REGISTRY.get(ba.short.as_str()).and_then(|b| b.ba()) {
-                if reg_ba.opts.as_ref().is_some_and(|o| o == opts) {
-                    // in this case the options specified are the same as in the registry so output no options and rely on the defaults
-                    return true;
-                }
-            }
+            // if let Some(reg_ba) = REGISTRY.get(ba.short.as_str()).and_then(|b| b.ba()) {
+            //     if reg_ba.opts.as_ref().is_some_and(|o| o == opts) {
+            //         // in this case the options specified are the same as in the registry so output no options and rely on the defaults
+            //         return true;
+            //     }
+            // }
             opts.is_empty()
         };
         existing.0 = versions

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -13,7 +13,6 @@ use tera::Context as TeraContext;
 use toml_edit::{Array, DocumentMut, InlineTable, Item, Key, Value, table, value};
 use versions::Versioning;
 
-use crate::backend::BackendOptions;
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::config::config_file::toml::deserialize_arr;
 use crate::config::config_file::{ConfigFile, TaskConfig, config_trust_root, trust, trust_check};
@@ -23,7 +22,6 @@ use crate::config::{Alias, AliasMap};
 use crate::file::{create_dir_all, display_path};
 use crate::hooks::{Hook, Hooks};
 use crate::redactions::Redactions;
-use crate::registry::REGISTRY;
 use crate::task::Task;
 use crate::tera::{BASE_CONTEXT, get_tera};
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource, ToolVersionOptions};

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,5 +1,4 @@
 use crate::backend::backend_type::BackendType;
-use crate::cli::args::BackendArg;
 use crate::config::SETTINGS;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env::consts::{ARCH, OS};
@@ -70,12 +69,6 @@ impl RegistryTool {
 
     pub fn is_supported_os(&self) -> bool {
         self.os.is_empty() || self.os.contains(&OS)
-    }
-
-    pub fn ba(&self) -> Option<BackendArg> {
-        self.backends()
-            .first()
-            .map(|f| BackendArg::new(self.short.to_string(), Some(f.to_string())))
     }
 }
 

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -59,14 +59,6 @@ impl ToolVersionOptions {
         self.opts.get(key)
     }
 
-    pub fn merge(&mut self, other: &BTreeMap<String, String>) {
-        for (key, value) in other {
-            self.opts
-                .entry(key.to_string())
-                .or_insert(value.to_string());
-        }
-    }
-
     pub fn contains_key(&self, key: &str) -> bool {
         self.opts.contains_key(key)
     }

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -64,18 +64,6 @@ impl ToolVersionOptions {
     }
 }
 
-pub fn parse_tool_options(s: &str) -> ToolVersionOptions {
-    let mut tvo = ToolVersionOptions::default();
-    for opt in s.split(',') {
-        let (k, v) = opt.split_once('=').unwrap_or((opt, ""));
-        if k.is_empty() {
-            continue;
-        }
-        tvo.opts.insert(k.to_string(), v.to_string());
-    }
-    tvo
-}
-
 #[derive(Debug)]
 pub struct InstallOptions {
     pub force: bool,
@@ -799,43 +787,4 @@ fn get_leaf_dependencies(requests: &[ToolRequest]) -> eyre::Result<Vec<ToolReque
         .map_ok(|tr| tr.clone())
         .collect::<Result<Vec<_>>>()?;
     Ok(leaves)
-}
-
-#[cfg(test)]
-mod tests {
-    use pretty_assertions::assert_eq;
-    use test_log::test;
-
-    use super::ToolVersionOptions;
-    #[test]
-    fn test_tool_version_options() {
-        let t = |input, f| {
-            let opts = super::parse_tool_options(input);
-            assert_eq!(opts, f);
-        };
-        t("", ToolVersionOptions::default());
-        t(
-            "exe=rg",
-            ToolVersionOptions {
-                opts: [("exe".to_string(), "rg".to_string())]
-                    .iter()
-                    .cloned()
-                    .collect(),
-                ..Default::default()
-            },
-        );
-        t(
-            "exe=rg,match=musl",
-            ToolVersionOptions {
-                opts: [
-                    ("exe".to_string(), "rg".to_string()),
-                    ("match".to_string(), "musl".to_string()),
-                ]
-                .iter()
-                .cloned()
-                .collect(),
-                ..Default::default()
-            },
-        );
-    }
 }

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -60,29 +60,34 @@ impl ToolRequest {
             Some((ref_type @ ("ref" | "tag" | "branch" | "rev"), r)) => format!("{ref_type}:{r}"),
             _ => s.to_string(),
         };
+        let opts = ToolVersionOptions {
+            os: backend.opts().os.clone(),
+            install_env: backend.opts().install_env.clone(),
+            ..Default::default()
+        };
         Ok(match s.split_once(':') {
             Some((ref_type @ ("ref" | "tag" | "branch" | "rev"), r)) => Self::Ref {
                 ref_: r.to_string(),
                 ref_type: ref_type.to_string(),
-                options: backend.opts(),
+                options: opts,
                 backend,
                 source,
             },
             Some(("prefix", p)) => Self::Prefix {
                 prefix: p.to_string(),
-                options: backend.opts(),
+                options: opts,
                 backend,
                 source,
             },
             Some(("path", p)) => Self::Path {
                 path: PathBuf::from(p),
-                options: backend.opts(),
+                options: opts,
                 backend,
                 source,
             },
             Some((p, v)) if p.starts_with("sub-") => Self::Sub {
                 sub: p.split_once('-').unwrap().1.to_string(),
-                options: backend.opts(),
+                options: opts,
                 orig_version: v.to_string(),
                 backend,
                 source,
@@ -90,14 +95,14 @@ impl ToolRequest {
             None => {
                 if s == "system" {
                     Self::System {
-                        options: backend.opts(),
+                        options: opts,
                         backend,
                         source,
                     }
                 } else {
                     Self::Version {
                         version: s,
-                        options: backend.opts(),
+                        options: opts,
                         backend,
                         source,
                     }


### PR DESCRIPTION
This is an early draft to split the `ToolVersionOption` which is currently used in the `BackendArg` and `ToolRequest` into a separate `BackendOption`.

When issueing a `mise use ubi:gitlab-org/cli[exe=glab,provider=gitlab]` with backend argument options these are currently copied over to the `ToolRequest`.

```
[tools]
"ubi:gitlab-org/cli" = { version = "latest", exe = "glab", provider = "gitlab" }
```

The new behaviour treats these as separate option variants keeping the backend options in the tool name.

```
[tools]
"ubi:gitlab-org/cli[exe=glab,provider=gitlab]" = "latest"
```
