### PR TITLE
feat(go): support build tags

### DIFF
--- a/docs/dev-tools/backends/go.md
+++ b/docs/dev-tools/backends/go.md
@@ -28,3 +28,18 @@ $ mise use -g go:github.com/DarthSim/hivemind
 $ hivemind --help
 Hivemind version 1.1.0
 ```
+
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `go` backend—these
+go in `[tools]` in `mise.toml`.
+
+### `tags``
+
+The `tags` option allow you to specify go build tags. This is useful for tools that need specific
+build tags, like the following:
+
+```toml
+[tools]
+"go:github.com/golang-migrate/migrate/v4/cmd/migrate" = { version = "latest", tags = "postgres" }
+```

--- a/docs/dev-tools/backends/go.md
+++ b/docs/dev-tools/backends/go.md
@@ -36,8 +36,7 @@ go in `[tools]` in `mise.toml`.
 
 ### `tags``
 
-The `tags` option allow you to specify go build tags. This is useful for tools that need specific
-build tags, like the following:
+Specify go build tags (passed as `go install --tags`):
 
 ```toml
 [tools]

--- a/e2e/backend/test_go_install_slow
+++ b/e2e/backend/test_go_install_slow
@@ -31,5 +31,7 @@ assert "mise x go:github.com/go-task/task/v3/cmd/task@3.34.1 -- task --version" 
 # See https://github.com/jdx/mise/issues/1667
 assert "mise x go:github.com/jdx/go-example@e16a340 -- go-example" "hello world"
 
+assert_contains "mise x go:github.com/golang-migrate/migrate/v4/cmd/migrate[tags=postgres]@4.18.2 -- bash -c 'migrate --help 2>&1'" "postgres"
+
 # Required to properly cleanup as go installs read-only sources
 chmod -R +w ~/go

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -60,11 +60,16 @@ impl Backend for GoBackend {
 
     fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> eyre::Result<ToolVersion> {
         SETTINGS.ensure_experimental("go backend")?;
+        let opts = self.ba.opts();
 
         let install = |v| {
-            CmdLineRunner::new("go")
-                .arg("install")
-                .arg(format!("{}@{v}", self.tool_name()))
+            let mut cmd = CmdLineRunner::new("go").arg("install");
+
+            if let Some(tags) = opts.get("tags") {
+                cmd = cmd.arg("-tags").arg(tags);
+            }
+
+            cmd.arg(format!("{}@{v}", self.tool_name()))
                 .with_pr(&ctx.pr)
                 .envs(self.dependency_env()?)
                 .env("GOBIN", tv.install_path().join("bin"))


### PR DESCRIPTION
## What

Allow installing tools like golang migrate that require people to pass -tags to work with specific databases.

## Reasonale

I've been working on a go project and we managed to install all our tools with mise with the exception of golang migrate. The reason being that installing it to work in our setup required passing `-tags postgres`. I recently saw how `ubi` allow some specific tags for specifying the binary to extract and I realized I could do something similar for go. 

Hopefully you like it 😄 