### PR TITLE
feat: Allow PATH to be configured as array

### DIFF
--- a/src/config/env_directive/path.rs
+++ b/src/config/env_directive/path.rs
@@ -19,7 +19,7 @@ impl EnvResults {
 #[cfg(unix)]
 mod tests {
     use super::*;
-    use crate::config::env_directive::{EnvDirective, EnvResolveOptions};
+    use crate::config::env_directive::{EnvDirective, EnvResolveOptions, PathOrPaths};
     use crate::env_diff::EnvMap;
     use crate::tera::BASE_CONTEXT;
     use crate::test::replace_path;
@@ -36,20 +36,23 @@ mod tests {
             &env,
             vec![
                 (
-                    EnvDirective::Path("/path/1".into(), Default::default()),
+                    EnvDirective::Path(PathOrPaths::Path("/path/1".into()), Default::default()),
                     PathBuf::from("/config"),
                 ),
                 (
-                    EnvDirective::Path("/path/2".into(), Default::default()),
+                    EnvDirective::Path(PathOrPaths::Path("/path/2".into()), Default::default()),
                     PathBuf::from("/config"),
                 ),
                 (
-                    EnvDirective::Path("~/foo/{{ env.A }}".into(), Default::default()),
+                    EnvDirective::Path(
+                        PathOrPaths::Path("~/foo/{{ env.A }}".into()),
+                        Default::default(),
+                    ),
                     Default::default(),
                 ),
                 (
                     EnvDirective::Path(
-                        "./rel/{{ env.A }}:./rel2/{{env.B}}".into(),
+                        PathOrPaths::Path("./rel/{{ env.A }}:./rel2/{{env.B}}".into()),
                         Default::default(),
                     ),
                     Default::default(),


### PR DESCRIPTION
In TOML config files, `env` was previously allowed to contain TOML arrays at the `[[env]]` level, but that leads to a fair amount of repetition when configuring certain things, as alluded to on the [Environments -> Multiple `env._` Directives][Documented-by] section of the docs site when configuring multiple `env._.source` directives.

For `env._.path` specifically, this leads to a lot of repetition when configuring multiple paths that need to specify `tools` or `redact` values:

```toml
[[env]]
RAILS_ENV = "development"
RUBY_VERSION = { value = "{{exec command='ruby -e \"print RUBY_VERSION\"')}}, tools = true }

[[env]]
_.path = { path = "{{env.GEM_HOME}}/bin", tools = true }

[[env]]
_.path = { path = "{{exec(command=\"gem env user_gemhome\")}}/bin", tools = true }

[[env]]
_.file = ".env"
```

If we instead enable arrays at the `env._.path.path` level, the above can be rewritten more concisely, resulting in an easier-to-maintain config that doesn't need to repeat the `tools = true` directive in an inline table for each entry:

```toml
[env]
RAILS_ENV = "development"
RUBY_VERSION = { value = "{{exec command='ruby -e \"print RUBY_VERSION\"')}}, tools = true }
_.file = ".env"

[env._.path]
path = [
    "{{env.GEM_HOME}}/bin",
    "{{exec(command=\"gem env user_gemhome\")}}/bin",
]
tools = true
```

[Documented-by]: <https://mise.jdx.dev/environments/#multiple-env-directives>

Conventional: feat(config)