### PR TITLE
feat(registry): added Signadot

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1686,6 +1686,8 @@ shellspec.backends = [
 shfmt.backends = ["aqua:mvdan/sh", "asdf:luizm/asdf-shfmt"]
 shfmt.os = ["linux", "macos"]
 shorebird.backends = ["asdf:mise-plugins/mise-shorebird"]
+signadot.backends = ["ubi:signadot/cli[exe=signadot]"]
+signadot.test = ["signadot --version", "signadot version v{{version}}"]
 sinker.backends = ["aqua:plexsystems/sinker", "asdf:elementalvoid/asdf-sinker"]
 skaffold.backends = [
     "aqua:GoogleContainerTools/skaffold",


### PR DESCRIPTION
[Signadot](https://www.signadot.com/) is Microservices testing platform.

[Signadot CLI reference](https://www.signadot.com/docs/reference/cli/overview).

Tests:

```
❯ cargo run --bin mise -- install signadot
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.77s
     Running `target/debug/mise install signadot`
mise Installed executable into /Users/joe/.local/share/mise/installs/signadot/0.9.0/signadot
mise signadot@0.9.0  ✓ installed

❯ cargo run --bin mise -- tool signadot
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.35s
     Running `target/debug/mise tool signadot`
Backend:            ubi:signadot/cli[exe=signadot]
Installed Versions: 0.9.0
Tool Options:       exe="signadot"

❯ cargo run --bin mise -- uninstall signadot
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.95s
     Running `target/debug/mise uninstall signadot`
mise signadot@0.9.0  ✓ uninstalled
```