### PR TITLE
refactor: provide ToolRequest for some backend operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,6 +3731,7 @@ dependencies = [
  "nix",
  "num_cpus",
  "number_prefix",
+ "numeric-sort",
  "once_cell",
  "openssl",
  "os-release",
@@ -4016,6 +4017,12 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "numeric-sort"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f218700a47ff14f06bb676b97e63a6fb2fd25db3bf05d6f369971188e303f7f"
 
 [[package]]
 name = "object"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ zstd = "0.13"
 gix = { version = "<1", features = ["worktree-mutation"] }
 jiff = "0.2"
 urlencoding = "2.1.3"
+numeric-sort = "0.1.4"
 
 [target.'cfg(unix)'.dependencies]
 exec = "0.3"

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -10,7 +10,7 @@ use crate::http::HTTP;
 use crate::install_context::InstallContext;
 use crate::plugins::VERSION_REGEX;
 use crate::registry::REGISTRY;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{file, github, minisign};
 use eyre::{ContextCompat, Result, bail};
 use indexmap::IndexSet;
@@ -46,7 +46,7 @@ impl Backend for AquaBackend {
         Ok(vec!["cosign", "slsa-verifier"])
     }
 
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         let pkg = AQUA_REGISTRY.package(&self.id)?;
         if !pkg.repo_owner.is_empty() && !pkg.repo_name.is_empty() {
             let versions = get_versions(&pkg)?;

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -236,15 +236,15 @@ impl Backend for AsdfBackend {
         Some(PluginType::Asdf)
     }
 
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         self.plugin.fetch_remote_versions()
     }
 
-    fn latest_stable_version(&self) -> Result<Option<String>> {
+    fn latest_stable_version(&self, tr: Option<ToolRequest>) -> Result<Option<String>> {
         run_with_timeout(
             || {
                 if !self.plugin.has_latest_stable_script() {
-                    return self.latest_version(Some("latest".into()));
+                    return self.latest_version(tr, Some("latest".into()));
                 }
                 self.latest_stable_cache
                     .get_or_try_init(|| self.plugin.fetch_latest_stable())

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -13,7 +13,7 @@ use crate::config::{Config, SETTINGS};
 use crate::env::GITHUB_TOKEN;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{env, file};
 
 #[derive(Debug)]
@@ -38,7 +38,7 @@ impl Backend for CargoBackend {
         Ok(vec!["cargo-binstall", "sccache"])
     }
 
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         if self.git_url().is_some() {
             // TODO: maybe fetch tags/branches from git?
             return Ok(vec!["HEAD".into()]);

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -4,6 +4,7 @@ use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::SETTINGS;
 use crate::http::HTTP_FETCH;
+use crate::toolset::ToolRequest;
 use eyre::eyre;
 
 #[derive(Debug)]
@@ -24,7 +25,7 @@ impl Backend for DotnetBackend {
         Ok(vec!["dotnet"])
     }
 
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         let feed_url = self.get_search_url()?;
 
         let feed: NugetFeedSearch = HTTP_FETCH.json(format!(

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -6,7 +6,7 @@ use crate::config::SETTINGS;
 use crate::file;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use indoc::formatdoc;
 use std::fmt::Debug;
 use url::Url;
@@ -29,7 +29,7 @@ impl Backend for GemBackend {
         Ok(vec!["ruby"])
     }
 
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         // The `gem list` command does not supporting listing versions as json output
         // so we use the rubygems.org api to get the list of versions.
         let raw = HTTP_FETCH.get_text(get_gem_url(&self.tool_name())?)?;

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -5,7 +5,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::SETTINGS;
 use crate::install_context::InstallContext;
 use crate::timeout;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use std::fmt::Debug;
 use xx::regex;
 
@@ -27,7 +27,7 @@ impl Backend for GoBackend {
         Ok(vec!["go"])
     }
 
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         timeout::run_with_timeout(
             || {
                 let mut mod_path = Some(self.tool_name());

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -6,7 +6,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::{Config, SETTINGS};
 use crate::install_context::InstallContext;
 use crate::timeout;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use serde_json::Value;
 use std::fmt::Debug;
 
@@ -31,7 +31,7 @@ impl Backend for NPMBackend {
         Ok(vec!["node", "bun"])
     }
 
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         timeout::run_with_timeout(
             || {
                 let raw = cmd!(NPM_PROGRAM, "view", self.tool_name(), "versions", "--json")
@@ -44,7 +44,7 @@ impl Backend for NPMBackend {
         )
     }
 
-    fn latest_stable_version(&self) -> eyre::Result<Option<String>> {
+    fn latest_stable_version(&self, tr: Option<ToolRequest>) -> eyre::Result<Option<String>> {
         timeout::run_with_timeout(
             || {
                 self.latest_version_cache
@@ -56,7 +56,7 @@ impl Backend for NPMBackend {
                         let dist_tags: Value = serde_json::from_str(&raw)?;
                         let latest = match dist_tags["latest"] {
                             Value::String(ref s) => Some(s.clone()),
-                            _ => self.latest_version(Some("latest".into())).unwrap(),
+                            _ => self.latest_version(tr, Some("latest".into())).unwrap(),
                         };
                         Ok(latest)
                     })

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -7,7 +7,7 @@ use crate::config::{Config, SETTINGS};
 use crate::github;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
-use crate::toolset::{ToolVersion, ToolVersionOptions, Toolset, ToolsetBuilder};
+use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset, ToolsetBuilder};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
 use eyre::Result;
@@ -45,7 +45,7 @@ impl Backend for PIPXBackend {
      * Pipx doesn't have a remote version concept across its backends, so
      * we return a single version.
      */
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         match self.tool_name().parse()? {
             PipxRequest::Pypi(package) => {
                 let url = format!("https://pypi.org/pypi/{}/json", package);
@@ -67,7 +67,7 @@ impl Backend for PIPXBackend {
         }
     }
 
-    fn latest_stable_version(&self) -> eyre::Result<Option<String>> {
+    fn latest_stable_version(&self, tr: Option<ToolRequest>) -> eyre::Result<Option<String>> {
         self.latest_version_cache
             .get_or_try_init(|| match self.tool_name().parse()? {
                 PipxRequest::Pypi(package) => {
@@ -75,7 +75,7 @@ impl Backend for PIPXBackend {
                     let pkg: PypiPackage = HTTP_FETCH.json(url)?;
                     Ok(Some(pkg.info.version))
                 }
-                _ => self.latest_version(Some("latest".into())),
+                _ => self.latest_version(tr, Some("latest".into())),
             })
             .cloned()
     }

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -5,7 +5,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::Settings;
 use crate::git::{CloneOptions, Git};
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{dirs, file, github};
 use eyre::WrapErr;
 use serde::Deserializer;
@@ -35,7 +35,7 @@ impl Backend for SPMBackend {
         Ok(vec!["swift"])
     }
 
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         let repo = SwiftPackageRepo::new(&self.tool_name())?;
         Ok(github::list_releases(repo.shorthand.as_str())?
             .into_iter()
@@ -50,7 +50,7 @@ impl Backend for SPMBackend {
 
         let repo = SwiftPackageRepo::new(&self.tool_name())?;
         let revision = if tv.version == "latest" {
-            self.latest_stable_version()?
+            self.latest_stable_version(Some(tv.request.clone()))?
                 .ok_or_else(|| eyre::eyre!("No stable versions found"))?
         } else {
             tv.version.clone()

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -8,7 +8,7 @@ use crate::env::{
 use crate::install_context::InstallContext;
 use crate::plugins::VERSION_REGEX;
 use crate::tokio::RUNTIME;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{file, github, gitlab, hash};
 use eyre::bail;
 use itertools::Itertools;
@@ -35,12 +35,11 @@ impl Backend for UbiBackend {
     fn ba(&self) -> &BackendArg {
         &self.ba
     }
-
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         if name_is_url(&self.tool_name()) {
             Ok(vec!["latest".to_string()])
         } else {
-            let opts = self.ba.opts();
+            let opts = self._get_tool_version_opts(tr);
             let forge = match opts.get("provider") {
                 Some(forge) => ForgeType::from_str(forge)?,
                 None => ForgeType::default(),

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -17,7 +17,7 @@ use crate::install_context::InstallContext;
 use crate::plugins::vfox_plugin::VfoxPlugin;
 use crate::plugins::{Plugin, PluginType};
 use crate::tokio::RUNTIME;
-use crate::toolset::{ToolVersion, Toolset};
+use crate::toolset::{ToolRequest, ToolVersion, Toolset};
 use crate::ui::multi_progress_report::MultiProgressReport;
 
 #[derive(Debug)]
@@ -41,7 +41,7 @@ impl Backend for VfoxBackend {
         Some(PluginType::Vfox)
     }
 
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         timeout::run_with_timeout(
             || {
                 let (vfox, _log_rx) = self.plugin.vfox();

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -29,6 +29,7 @@ pub struct Latest {
 impl Latest {
     pub fn run(self) -> Result<()> {
         let config = Config::try_get()?;
+        let tr = self.tool.tvr.clone();
         let mut prefix = match self.tool.tvr {
             None => self.asdf_version,
             Some(ToolRequest::Version { version, .. }) => Some(version),
@@ -47,7 +48,7 @@ impl Latest {
         let latest_version = if self.installed {
             backend.latest_installed_version(prefix)?
         } else {
-            backend.latest_version(prefix)?
+            backend.latest_version(tr, prefix)?
         };
         if let Some(version) = latest_version {
             miseprintln!("{}", version);

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -52,7 +52,12 @@ impl LsRemote {
             _ => self.prefix.clone(),
         };
 
-        let versions = plugin.list_remote_versions()?;
+        let tr: Option<ToolRequest> = match &self.plugin {
+            Some(tool_arg) => tool_arg.tvr.clone(),
+            None => None,
+        };
+
+        let versions = plugin.list_remote_versions(tr)?;
         let versions = match prefix {
             Some(prefix) => versions
                 .into_iter()
@@ -72,7 +77,7 @@ impl LsRemote {
         let versions = backend::list()
             .into_par_iter()
             .map(|p| {
-                let versions = p.list_remote_versions()?;
+                let versions = p.list_remote_versions(None)?;
                 Ok((p, versions))
             })
             .collect::<Result<Vec<_>>>()?

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -61,6 +61,7 @@ impl Tool {
         let tv = tvl.map(|tvl| tvl.versions.first().unwrap());
         let ba = tv.map(|tv| tv.ba()).unwrap_or_else(|| &self.tool);
         let backend = ba.backend().ok();
+        let tvo = tv.map_or(ba.opts(), |tv| tv.request.options());
         let info = ToolInfo {
             backend: ba.full(),
             description: backend.and_then(|b| b.description()),
@@ -83,7 +84,7 @@ impl Tool {
                     .collect::<Vec<_>>()
             }),
             config_source: tvl.map(|tvl| tvl.source.clone()),
-            tool_options: ba.opts(),
+            tool_options: tvo,
         };
 
         if self.json {

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -353,7 +353,7 @@ impl ConfigFile for MiseToml {
             .unwrap();
 
         // create a key from the short name preserving any decorations like prefix/suffix if the key already exists
-        let key = get_key_with_decor(tools, ba.short.as_str());
+        let key = get_key_with_decor(tools, &ba.short);
 
         // if a short name is used like "node", make sure we remove any long names like "core:node"
         if ba.short != ba.full() {
@@ -439,11 +439,7 @@ impl ConfigFile for MiseToml {
                     for v in options.opts.values_mut() {
                         *v = self.parse_template(v)?;
                     }
-                    let mut ba = ba.clone();
-                    let mut ba_opts = ba.opts().clone();
-                    ba_opts.merge(&options.opts);
-                    ba.set_opts(Some(ba_opts.clone()));
-                    ToolRequest::new_opts(ba, &version, options, source.clone())?
+                    ToolRequest::new_opts(ba.clone(), &version, options, source.clone())?
                 } else {
                     ToolRequest::new(ba.clone(), &version, source.clone())?
                 };

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -10,7 +10,7 @@ use crate::cli::version::{ARCH, OS};
 use crate::cmd::CmdLineRunner;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::ui::progress_report::SingleReport;
 use crate::{file, github, plugins};
 
@@ -83,7 +83,7 @@ impl Backend for BunPlugin {
         &self.ba
     }
 
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         let versions = github::list_releases("oven-sh/bun")?
             .into_iter()
             .map(|r| r.tag_name)

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -96,7 +96,7 @@ impl Backend for DenoPlugin {
         &self.ba
     }
 
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         let versions: DenoVersions = HTTP_FETCH.json("https://deno.com/versions.json")?;
         let versions = versions
             .cli

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -6,7 +6,7 @@ use crate::cmd::CmdLineRunner;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::plugins::VERSION_REGEX;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::ui::progress_report::SingleReport;
 use crate::{file, plugins};
 use eyre::Result;
@@ -78,7 +78,7 @@ impl Backend for ElixirPlugin {
         &self.ba
     }
 
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         let versions: Vec<String> = HTTP_FETCH
             .get_text("https://builds.hex.pm/builds/elixir/builds.txt")?
             .lines()

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -175,7 +175,7 @@ impl Backend for ErlangPlugin {
     fn ba(&self) -> &BackendArg {
         &self.ba
     }
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         let versions = if SETTINGS.erlang.compile == Some(false) {
             github::list_releases("erlef/otp_builds")?
                 .into_iter()

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -180,7 +180,7 @@ impl Backend for GoPlugin {
     fn ba(&self) -> &BackendArg {
         &self.ba
     }
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         plugins::core::run_fetch_task_with_timeout(move || {
             let output = cmd!("git", "ls-remote", "--tags", &SETTINGS.go_repo, "go*").read()?;
             let lines = output.split('\n');

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -8,7 +8,7 @@ use crate::config::{Config, Settings};
 use crate::file::{TarFormat, TarOptions};
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::ui::progress_report::SingleReport;
 use crate::{env, file, gpg, hash, http, plugins};
 use eyre::{Result, bail, ensure};
@@ -337,7 +337,7 @@ impl Backend for NodePlugin {
         &self.ba
     }
 
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         let base = SETTINGS.node.mirror_url();
         let versions = HTTP_FETCH
             .json::<Vec<NodeVersion>, _>(base.join("index.json")?)?
@@ -448,7 +448,7 @@ impl Backend for NodePlugin {
         Ok(vec![tv.install_path()])
     }
 
-    fn get_remote_version_cache(&self) -> Arc<VersionCacheManager> {
+    fn get_remote_version_cache(&self, _tr: Option<ToolRequest>) -> Arc<VersionCacheManager> {
         static CACHE: OnceLock<Arc<VersionCacheManager>> = OnceLock::new();
         CACHE
             .get_or_init(|| {

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -390,7 +390,7 @@ impl Backend for PythonPlugin {
         &self.ba
     }
 
-    fn _list_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> eyre::Result<Vec<String>> {
         if cfg!(windows) || SETTINGS.python.compile == Some(false) {
             Ok(self
                 .fetch_precompiled_remote_versions()?
@@ -465,7 +465,7 @@ impl Backend for PythonPlugin {
         Ok(hm)
     }
 
-    fn get_remote_version_cache(&self) -> Arc<VersionCacheManager> {
+    fn get_remote_version_cache(&self, _tr: Option<ToolRequest>) -> Arc<VersionCacheManager> {
         static CACHE: OnceLock<Arc<VersionCacheManager>> = OnceLock::new();
         CACHE
             .get_or_init(|| {

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -13,7 +13,7 @@ use crate::github::GithubRelease;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lock_file::LockFile;
-use crate::toolset::{ToolVersion, Toolset};
+use crate::toolset::{ToolRequest, ToolVersion, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{cmd, file, plugins, timeout};
 use eyre::{Result, WrapErr};
@@ -311,7 +311,7 @@ impl Backend for RubyPlugin {
     fn ba(&self) -> &BackendArg {
         &self.ba
     }
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         timeout::run_with_timeout(
             || {
                 if let Err(err) = self.update_build_tool(None) {

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -9,7 +9,7 @@ use crate::env::PATH_KEY;
 use crate::github::GithubRelease;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
-use crate::toolset::{ToolVersion, Toolset};
+use crate::toolset::{ToolRequest, ToolVersion, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{file, github, plugins};
 use eyre::Result;
@@ -138,7 +138,7 @@ impl Backend for RubyPlugin {
     fn ba(&self) -> &BackendArg {
         &self.ba
     }
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         // TODO: use windows set of versions
         //  match self.core.fetch_remote_versions_from_mise() {
         //      Ok(Some(versions)) => return Ok(versions),
@@ -257,19 +257,19 @@ mod tests {
     fn test_list_versions_matching() {
         let plugin = RubyPlugin::new();
         assert!(
-            !plugin.list_versions_matching("3").unwrap().is_empty(),
+            !plugin.list_versions_matching(None, "3").unwrap().is_empty(),
             "versions for 3 should not be empty"
         );
         assert!(
             !plugin
-                .list_versions_matching("truffleruby-24")
+                .list_versions_matching(None, "truffleruby-24")
                 .unwrap()
                 .is_empty(),
             "versions for truffleruby-24 should not be empty"
         );
         assert!(
             !plugin
-                .list_versions_matching("truffleruby+graalvm-24")
+                .list_versions_matching(None, "truffleruby+graalvm-24")
                 .unwrap()
                 .is_empty(),
             "versions for truffleruby+graalvm-24 should not be empty"

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -10,7 +10,7 @@ use crate::http::HTTP;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolSource::IdiomaticVersionFile;
 use crate::toolset::outdated_info::OutdatedInfo;
-use crate::toolset::{ToolVersion, Toolset};
+use crate::toolset::{ToolRequest, ToolVersion, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{dirs, env, file, github, plugins};
 use eyre::Result;
@@ -67,7 +67,7 @@ impl Backend for RustPlugin {
         &self.ba
     }
 
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         let versions = github::list_releases("rust-lang/rust")?
             .into_iter()
             .map(|r| r.tag_name)

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -4,7 +4,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::SETTINGS;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::ui::progress_report::SingleReport;
 use crate::{file, github, gpg, plugins};
 use eyre::Result;
@@ -151,7 +151,7 @@ impl Backend for SwiftPlugin {
         &self.ba
     }
 
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         let versions = github::list_releases("swiftlang/swift")?
             .into_iter()
             .map(|r| r.tag_name)

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -149,7 +149,7 @@ impl Backend for ZigPlugin {
         &self.ba
     }
 
-    fn _list_remote_versions(&self) -> Result<Vec<String>> {
+    fn _list_remote_versions(&self, _tr: Option<ToolRequest>) -> Result<Vec<String>> {
         let versions: Vec<String> = github::list_releases("ziglang/zig")?
             .into_iter()
             .map(|r| r.tag_name)

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -52,7 +52,7 @@ impl OutdatedInfo {
             .find(&tv.request.version())
             .map(|m| m.as_str().to_string());
         let latest_result = if bump {
-            t.latest_version(prefix.clone())
+            t.latest_version(Some(tv.request.clone()), prefix.clone())
         } else {
             tv.latest_version().map(Option::from)
         };

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -193,7 +193,7 @@ impl ToolVersion {
                     return build(v);
                 }
             }
-            if let Some(v) = backend.latest_version(None)? {
+            if let Some(v) = backend.latest_version(Some(request.clone()), None)? {
                 return build(v);
             }
         }
@@ -206,7 +206,7 @@ impl ToolVersion {
                 return build(v.clone());
             }
         }
-        let matches = backend.list_versions_matching(&v)?;
+        let matches = backend.list_versions_matching(Some(request.clone()), &v)?;
         if matches.contains(&v) {
             return build(v);
         }
@@ -222,7 +222,9 @@ impl ToolVersion {
     ) -> Result<Self> {
         let backend = request.backend()?;
         let v = match v {
-            "latest" => backend.latest_version(None)?.unwrap(),
+            "latest" => backend
+                .latest_version(Some(request.clone()), None)?
+                .unwrap(),
             _ => Config::get().resolve_alias(&backend, v)?,
         };
         let v = tool_request::version_sub(&v, sub);
@@ -236,7 +238,7 @@ impl ToolVersion {
                 return Ok(Self::new(request, v.to_string()));
             }
         }
-        let matches = backend.list_versions_matching(prefix)?;
+        let matches = backend.list_versions_matching(Some(request.clone()), prefix)?;
         let v = match matches.last() {
             Some(v) => v,
             None => prefix,


### PR DESCRIPTION
This is ~draft for~ a slight refactor to address issues with tool options for operations such as `ls-remote`, `outdated` or `upgrade` (see #4020)

This alters some Backend trait methods to take a `Option<ToolRequest>` argument which can be used for example in `list_remote_versions` to get the ToolOptions. Currently this happens via `BackendArg` (`self.ba().opts()`) which is not the correct approach since the backend might not have any tool options for a certain version. This also led to code in `mise_toml.rs` which copies the tool options to the `BackendArg` which now could be removed.

Additionally this partially solves another issues with tool options recently reported. Java EA releases cannot be discovered via `ls-remote`. With this fix this would be possible via `mise ls-remote java[release_type=ea]@openjdk-25` (versions host interferes here so an additional method allows to disable the usage)