### PR TITLE
docs: update link to faq in use_versions_host

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -1122,7 +1122,7 @@ a quick way for mise to query for new versions. This host regularly grabs all th
 latest versions of core and community plugins. It's faster than running a plugin's
 `list-all` command and gets around GitHub rate limiting problems when using it.
 
-See [FAQ](/faq.html#new-version-of-a-tool-is-not-available) for more information.
+See [Troubleshooting](/troubleshooting.html#new-version-of-a-tool-is-not-available) for more information.
 """
 
 [verbose]


### PR DESCRIPTION
The link was broken because of this commit https://github.com/jdx/mise/commit/5bba86b03e7dd652a0958aa584e0a7322483f3e1.