### PR TITLE
fix: allow interactive upgrade to select nothing

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -227,8 +227,7 @@ impl Upgrade {
         ui::ctrlc::show_cursor_after_ctrl_c();
         let mut ms = demand::MultiSelect::new("mise upgrade")
             .description("Select tools to upgrade")
-            .filterable(true)
-            .min(1);
+            .filterable(true);
         for out in outdated {
             ms = ms.option(DemandOption::new(out.clone()));
         }


### PR DESCRIPTION
Fixes #4869.

This change allows users to proceed without selecting any options, but it doesn’t introduce a dedicated cancel operation.