### PR TITLE
fix: enable templates for shell of hooks

### DIFF
--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -510,6 +510,9 @@ impl ConfigFile for MiseToml {
                 let mut hooks = Hook::from_toml(*hook, val.clone())?;
                 for hook in hooks.iter_mut() {
                     hook.script = self.parse_template(&hook.script)?;
+                    if let Some(shell) = &hook.shell {
+                        hook.shell = Some(self.parse_template(shell)?);
+                    }
                 }
                 eyre::Ok(hooks)
             })


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/4846.