### PR TITLE
feat(registry): added tusd

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -103,7 +103,7 @@ backend = "aqua:BurntSushi/ripgrep"
 
 [tools.shellcheck]
 version = "0.10.0"
-backend = "aqua:koalaman/shellcheck"
+backend = "ubi:koalaman/shellcheck"
 
 [tools.shellcheck.checksums]
 "shellcheck-v0.10.0.darwin.aarch64.tar.xz" = "sha256:bbd2f14826328eee7679da7221f2bc3afb011f6a928b848c80c321f6046ddf81"

--- a/registry.toml
+++ b/registry.toml
@@ -1906,6 +1906,8 @@ tsuru.backends = [
 ]
 ttyd.backends = ["aqua:tsl0922/ttyd", "asdf:ivanvc/asdf-ttyd"]
 tuist.backends = ["asdf:mise-plugins/mise-tuist"]
+tusd.backends = ["ubi:tus/tusd"]
+tusd.tests = ["tusd --version | head -n1", "Version: v{{version}}"]
 typos.backends = ["aqua:crate-ci/typos", "asdf:aschiavon91/asdf-typos"]
 typst.backends = ["aqua:typst/typst", "asdf:stephane-klein/asdf-typst"]
 uaa.aliases = ["uaa-cli"]


### PR DESCRIPTION
[tusd](https://github.com/tus/tusd)
Reference server implementation in Go of tus: the open protocol for resumable file uploads.

```
$ tusd --version
Version: v2.8.0
Commit: 0e52ad650abed02ec961353bb0c3c8bc36650d2c
Date: Wed Apr  2 07:49:21 UTC 2025
```

Tests:

```
$ cargo run --bin mise -- install tusd
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/mise install tusd`
mise Installed executable into /Users/mnm/.local/share/mise/installs/tusd/2.8.0/tusd
mise tusd@2.8.0      ✓ installed
$ cargo run --bin mise -- tool tusd
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/mise tool tusd`
Backend:            ubi:tus/tusd
Installed Versions: 2.8.0
Tool Options:       [none]
$ cargo run --bin mise -- uninstall tusd
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/mise uninstall tusd`
mise tusd@2.8.0      ✓ uninstalled
```