### PR TITLE
fix: remove missing symlinks on unuse when pruning

### DIFF
--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -5,6 +5,7 @@ use crate::backend::Backend;
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::tracking::Tracker;
 use crate::config::{Config, SETTINGS};
+use crate::runtime_symlinks;
 use crate::toolset::{ToolVersion, Toolset, ToolsetBuilder};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::prompt;
@@ -107,6 +108,7 @@ fn delete(dry_run: bool, to_delete: Vec<(Arc<dyn Backend>, ToolVersion)>) -> Res
         let pr = mpr.add(&prefix);
         if dry_run || SETTINGS.yes || prompt::confirm_with_all(format!("remove {} ?", &tv))? {
             p.uninstall_version(&tv, &pr, dry_run)?;
+            runtime_symlinks::remove_missing_symlinks(p)?;
             pr.finish();
         }
     }

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -29,8 +29,6 @@ pub fn rebuild(config: &Config) -> Result<()> {
             make_symlink_or_file(&to, &from)?;
         }
         remove_missing_symlinks(backend.clone())?;
-        // remove install dir if empty (ignore metadata)
-        file::remove_dir_ignore(installs_dir, vec![".mise.backend.json", ".mise.backend"])?;
     }
     Ok(())
 }
@@ -86,7 +84,7 @@ fn installed_versions(backend: &Arc<dyn Backend>) -> Result<Vec<String>> {
     Ok(versions)
 }
 
-fn remove_missing_symlinks(backend: Arc<dyn Backend>) -> Result<()> {
+pub fn remove_missing_symlinks(backend: Arc<dyn Backend>) -> Result<()> {
     let installs_dir = &backend.ba().installs_path;
     if !installs_dir.exists() {
         return Ok(());
@@ -99,6 +97,8 @@ fn remove_missing_symlinks(backend: Arc<dyn Backend>) -> Result<()> {
             file::remove_file(path)?;
         }
     }
+    // remove install dir if empty (ignore metadata)
+    file::remove_dir_ignore(installs_dir, vec![".mise.backend.json", ".mise.backend"])?;
     Ok(())
 }
 


### PR DESCRIPTION
Currently after pruning on `unuse`, non-working symlinks are leftover.

```
mise use ubi:gitlab-org/cli[provider=gitlab,exe=glab]@latest

ls ~/.local/share/mise/installs/ubi-gitlab-org-cli
1@      1.56@   1.56.0/ latest@

mise unuse ubi:gitlab-org/cli

ls ~/.local/share/mise/installs/ubi-gitlab-org-cli
1@  1.56@  latest@
```