### PR TITLE
feat(registry): add `cli53` backend

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -356,6 +356,7 @@ clarinet.backends = ["ubi:hirosystems/clarinet", "asdf:alexgo-io/asdf-clarinet"]
 clarinet.os = ["linux", "macos"]
 clarinet.test = ["clarinet --version", "clarinet {{version}}"]
 cli53.backends = ["aqua:barnybug/cli53"]
+cli53.test = ["cli53 --version", "cli53 version {{version}}"]
 # ubi not working on linux
 # clickhouse.backends = ["ubi:ClickHouse/ClickHouse", "asdf:mise-plugins/mise-clickhouse"]
 # clickhouse.os = ["linux", "macos"]

--- a/registry.toml
+++ b/registry.toml
@@ -355,6 +355,7 @@ clangd.backends = ["asdf:mise-plugins/mise-llvm"]
 clarinet.backends = ["ubi:hirosystems/clarinet", "asdf:alexgo-io/asdf-clarinet"]
 clarinet.os = ["linux", "macos"]
 clarinet.test = ["clarinet --version", "clarinet {{version}}"]
+cli53.backends = ["aqua:barnybug/cli53"]
 # ubi not working on linux
 # clickhouse.backends = ["ubi:ClickHouse/ClickHouse", "asdf:mise-plugins/mise-clickhouse"]
 # clickhouse.os = ["linux", "macos"]


### PR DESCRIPTION
Adding [aqua:barnybug/cli53](https://github.com/garysassano/aqua-registry/tree/main/pkgs/barnybug/cli53) to Mise registry.