### PR TITLE
docs: remove outdated note about automatic shim activation with Scoop

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -177,7 +177,6 @@ $newPath = $currentPath + ";" + $shimPath
 [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
 ```
 
-- When using `scoop`, mise is automatically activated
 - If not using powershell, add `<homedir>\AppData\Local\mise\shims` to `PATH`.
 
 == Other package managers


### PR DESCRIPTION
This PR removes an outdated statement that said installing mise with Scoop would automatically activate it

As of ScoopInstaller/Main#6677 (April 23, 2025), the Scoop manifest for mise no longer:
- Forces `MISE_DATA_DIR` into Scoop-managed paths
- Automatically adds mise’s internal shims to the PATH

Users now must manually configure shell activation by adding `%LOCALAPPDATA%\mise\shims` to PATH or using `mise activate <shell>` as documented elsewhere.

This brings the installation instructions up-to-date with the current Scoop behavior.

Reference: https://github.com/ScoopInstaller/Main/pull/6677