### PR TITLE
fix: Always use env::MISE_BIN when calling mise from itself (#4141)

### DIFF
--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -122,3 +122,45 @@ This may change in the future.)
 Tasks can be run with `mise run <TASK>` or `mise <TASK>`—if the name doesn't conflict with a mise command.
 Because mise may later add a command with a conflicting name, it's recommended to use `mise run <TASK>` in
 scripts and documentation.
+
+## Execution order
+
+You can use [depends](/tasks/task-configuration.html#depends), [wait_for](/tasks/task-configuration.html#wait-for) and [depends_post](/tasks/task-configuration.html#depends-post) to control the order of execution.
+
+```toml
+[tasks.build]
+run = "echo 'build'"
+
+[tasks.test]
+run = "echo 'test'"
+depends = ["build"]
+```
+
+This will ensure that the `build` task is run before the `test` task.
+
+You can also define a mise task to run other tasks sequentially (or in series).
+You can do this by calling `mise run <task>` in the `run` property of a task.
+
+```toml
+[tasks.example1]
+run = "echo 'example1'"
+
+[tasks.example2]
+run = "mise example2"
+
+[tasks.one_by_one]
+run = [
+    'mise run example1',
+    'mise run example2',
+]
+```
+
+This assumes that `mise` is in your `PATH`. If you are using [mise generate bootstrap](/cli/generate/bootstrap.html) or if `mise` is not on `PATH`, it's better to use <span v-pre>[`{{mise_bin}}`](/templates.html#variables)</span> instead of `mise` in the task definition.
+
+```toml
+[tasks.one_by_one]
+run = [
+    '{{mise_bin}} run example1',
+    '{{mise_bin}} run example2',
+]
+```

--- a/e2e/cli/test_doctor
+++ b/e2e/cli/test_doctor
@@ -3,6 +3,8 @@
 mise use dummy@latest
 
 eval "$(mise activate bash)" && _mise_hook
+assert "PATH="" $(which mise) doctor --json"
+
 mise p add uv
 mise use uv
 assert_contains "mise doctor" "asdf:uv@"

--- a/e2e/cli/test_watch
+++ b/e2e/cli/test_watch
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+mise use dummy@latest
+mise use -g watchexec@latest
+
+mise tasks add example -- echo 'running example'
+
+test_mise_watch() {
+  local mise_path="$1"
+  output_file=.watch_output
+
+  rm -f "${output_file}"
+
+  $mise_path watch example -e '.aaa' >"${output_file}" &
+  PID_TO_KILL=$!
+
+  while ! grep -q "running example" "${output_file}"; do
+    sleep 0.5
+  done
+
+  kill -SIGINT $PID_TO_KILL
+
+  assert_contains "cat ${output_file}" "running example"
+}
+
+# Test with original mise
+test_mise_watch "mise"
+
+# Test when mise is not in PATH
+original_mise="$(which mise)"
+mkdir -p ./bin && mv "$original_mise" ./bin/mise
+test_mise_watch "./bin/mise"
+mv ./bin/mise "$original_mise"

--- a/e2e/generate/test_generate_bootstrap
+++ b/e2e/generate/test_generate_bootstrap
@@ -8,6 +8,23 @@ assert "mise generate task-stubs --mise-bin ./bin/mise"
 assert "./bin/xxx" "running xxx"
 
 assert "mise generate bootstrap -l -w"
+
+# ensure that that the commands don't rely on the global mise bin
+orginal_mise="$(which mise)"
+mv "$orginal_mise" "orginal_mise"
+
 assert_contains "./bin/mise tasks ls" "xxx"
 
 assert_not_contains "MISE_IGNORED_CONFIG_PATHS=$(pwd) ./bin/mise tasks ls" "xxx"
+
+echo '
+[tasks.other_task]
+run = "echo running other_task"
+
+[tasks.my_task]
+run = ["{{mise_bin}} run other_task"]
+' >mise.toml
+
+assert_contains "./bin/mise run my_task" "running other_task"
+
+mv "orginal_mise" "$orginal_mise"

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -96,7 +96,7 @@ impl Doctor {
         data.insert("env_vars".into(), mise_env_vars().into_iter().collect());
         data.insert(
             "settings".into(),
-            serde_json::from_str(&cmd!("mise", "settings", "-J").read()?)?,
+            serde_json::from_str(&cmd!(&*env::MISE_BIN, "settings", "-J").read()?)?,
         );
 
         let config = Config::get();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 use crate::cli::args::ToolArg;
 use crate::cli::run::TaskOutput;
 use crate::config::{Config, Settings};
+use crate::env::MISE_BIN;
 use crate::exit::exit;
 use crate::ui::ctrlc;
 use crate::{logger, migrate, shims};
@@ -334,6 +335,7 @@ impl Cli {
         }
 
         debug!("ARGS: {}", &args.join(" "));
+        trace!("MISE_BIN: {}", MISE_BIN.to_string_lossy().to_string());
         if print_version {
             version::show_latest();
             exit(0);

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -184,7 +184,11 @@ impl Watch {
             args.push("-f".to_string());
             args.extend(itertools::intersperse(globs, "-f".to_string()).collect::<Vec<_>>());
         }
-        args.extend(["--".to_string(), "mise".to_string(), "run".to_string()]);
+        args.extend([
+            "--".to_string(),
+            env::MISE_BIN.to_string_lossy().to_string(),
+            "run".to_string(),
+        ]);
         let task_args = itertools::intersperse(
             tasks.iter().map(|t| {
                 let mut args = vec![t.name.to_string()];


### PR DESCRIPTION
- Update two places where `mise` assumed that `mise` is on `PATH` (in `mise dr --json` and `mise watch`).
- Update documentation to indicate how one might run tasks in series and mention that using `{{mise_bin}}` might be a good idea in this case.
- Add tests

Related discussion: https://github.com/jdx/mise/discussions/4141