### PR TITLE
feat: pipx custom repository url

### DIFF
--- a/e2e/backend/test_pipx_custom_registry
+++ b/e2e/backend/test_pipx_custom_registry
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+require_cmd python3
+
+# Create a system pipx that always fail and push it to the front of PATH
+cat >"$HOME/bin/pipx" <<'EOF'
+#!/usr/bin/env bash
+echo "CALL TO SYSTEM pipx! args: $*" >&2
+exit 1
+EOF
+chmod +x "$HOME"/bin/pipx
+export PATH="$HOME/bin:$PATH"
+
+# Just to be sure...
+assert_fail "pipx"
+
+# Use precompiled python
+export MISE_PYTHON_COMPILE=0
+export MISE_PIPX_REGISTRY_URL="https://pypi.org/simple/{}"
+
+# Set up a 2-step installation: pipx@1.5.0 > pipx:mkdocs@1.6.0
+cat >.mise.toml <<EOF
+[tools]
+pipx = "1.5.0"
+"pipx:mkdocs" = "1.6.0"
+EOF
+
+mise install
+
+# Assert that mkdocs 1.6.0 has been installed with pipx
+# (mkdocs conveniently returns its installation path in with --version)
+assert_contains "mise x -- mkdocs --version" "/mise/installs/pipx-mkdocs/1.6.0/"
+
+# Test invalid MISE_PIPX_REGISTRY_URL format (missing {} placeholder)
+mise uninstall pipx:mkdocs
+mise cache clear
+export MISE_PIPX_REGISTRY_URL="https://invalid-registry.example/simple"
+
+# This should fail with an error about the registry URL format
+assert_fail "mise install" "Registry URL must be a valid URL and contain a {} placeholder"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -617,6 +617,11 @@
         "pipx": {
           "additionalProperties": false,
           "properties": {
+            "registry_url": {
+              "default": "https://pypi.org/pypi/{}/json",
+              "description": "URL to use for pipx registries.",
+              "type": "string"
+            },
             "uvx": {
               "description": "Use uvx instead of pipx if uv is installed and on PATH.",
               "type": "boolean"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -619,7 +619,7 @@
           "properties": {
             "registry_url": {
               "default": "https://pypi.org/pypi/{}/json",
-              "description": "URL to use for pipx registries.",
+              "description": "URL to use for pipx registry.",
               "type": "string"
             },
             "uvx": {

--- a/settings.toml
+++ b/settings.toml
@@ -646,6 +646,22 @@ This sets `--pin` by default when running `mise use` in mise.toml files. This ca
 passing `--fuzzy` on the command line.
 """
 
+[pipx.registry_url]
+env = "MISE_PIPX_REGISTRY_URL"
+type = "String"
+default = "https://pypi.org/pypi/{}/json"
+description = "URL to use for pipx registries."
+docs = """
+URL to use for pipx registries.
+
+This is used to fetch the latest version of a package from the pypi registry.
+
+The default is `https://pypi.org/pypi/{}/json` which is the JSON endpoint for the pypi
+registry.
+
+You can also use the HTML endpoint by setting this to `https://pypi.org/simple/{}/`.
+"""
+
 [pipx.uvx]
 env = "MISE_PIPX_UVX"
 type = "Bool"

--- a/settings.toml
+++ b/settings.toml
@@ -650,9 +650,9 @@ passing `--fuzzy` on the command line.
 env = "MISE_PIPX_REGISTRY_URL"
 type = "String"
 default = "https://pypi.org/pypi/{}/json"
-description = "URL to use for pipx registries."
+description = "URL to use for pipx registry."
 docs = """
-URL to use for pipx registries.
+URL to use for pipx registry.
 
 This is used to fetch the latest version of a package from the pypi registry.
 

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -51,7 +51,7 @@ impl Backend for PIPXBackend {
             PipxRequest::Pypi(package) => {
                 let registry_url = self.get_registry_url()?;
                 if registry_url.contains("/json") {
-                    debug!("Fetching JSON from {}", package);
+                    debug!("Fetching JSON for {}", package);
                     let url = format!("https://pypi.org/pypi/{}/json", package);
                     let data: PypiPackage = HTTP_FETCH.json(url)?;
                     let versions = data
@@ -63,7 +63,7 @@ impl Backend for PIPXBackend {
 
                     Ok(versions)
                 } else {
-                    debug!("Fetching HTML from {}", package);
+                    debug!("Fetching HTML for {}", package);
                     let url = format!("https://pypi.org/simple/{}/", package);
                     let html = HTTP_FETCH.get_html(url)?;
 
@@ -99,12 +99,12 @@ impl Backend for PIPXBackend {
                 PipxRequest::Pypi(package) => {
                     let registry_url = self.get_registry_url()?;
                     if registry_url.contains("/json") {
-                        debug!("Fetching JSON from {}", package);
+                        debug!("Fetching JSON for {}", package);
                         let url = format!("https://pypi.org/pypi/{}/json", package);
                         let pkg: PypiPackage = HTTP_FETCH.json(url)?;
                         Ok(Some(pkg.info.version))
                     } else {
-                        debug!("Fetching HTML from {}", package);
+                        debug!("Fetching HTML for {}", package);
                         let url = format!("https://pypi.org/simple/{}/", package);
                         let html = HTTP_FETCH.get_html(url)?;
 

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -126,7 +126,7 @@ impl Backend for PIPXBackend {
                                     && !v.contains("rc")
                             })
                             .sorted_by_cached_key(|v| Versioning::new(v))
-                            .last();
+                            .next_back();
 
                         Ok(version)
                     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -150,6 +150,18 @@ impl Client {
         Ok(text)
     }
 
+    pub fn get_html<U: IntoUrl>(&self, url: U) -> Result<String> {
+        let url = url.into_url().unwrap();
+        let html = RUNTIME.block_on(async {
+            let resp = self.get_async(url.clone()).await?;
+            Ok::<String, eyre::Error>(resp.text().await?)
+        })?;
+        if !html.starts_with("<!DOCTYPE html>") {
+            bail!("Got non-HTML text from {}", url);
+        }
+        Ok(html)
+    }
+
     pub fn json_headers<T, U: IntoUrl>(&self, url: U) -> Result<(T, HeaderMap)>
     where
         T: serde::de::DeserializeOwned,


### PR DESCRIPTION
- Add new settings to configure a custom repository url
- Support of https://peps.python.org/pep-0503/ and https://peps.python.org/pep-0691/

#4938 