### PR TITLE
fix(aqua): fix bin_path of tools in monorepo

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -54,6 +54,7 @@ backend = "aqua:jdx/hk"
 
 [tools.hk.checksums]
 hk-macos-aarch64 = "sha256:878e12593fdaba5838cf5084afe6d019b0872d338558571475a581d722d00529"
+"hk-x86_64-unknown-linux-gnu.tar.gz" = "sha256:b98919d9045786d34afa61b7d34d84d5a13988e1f25fd3c1e188deda7f1acf31"
 
 [tools.jq]
 version = "1.7.1"
@@ -64,6 +65,10 @@ jq-linux-amd64 = "sha256:5942c9b0934e510ee61eb3e30273f1b3fe2590df93933a93d7c58b8
 jq-linux-arm64 = "sha256:4dd2d8a0661df0b22f1bb9a1f9830f06b6f3b8f7d91211a1ef5d7c4f06a8b4a5"
 jq-macos-arm64 = "sha256:0bbe619e663e0de2c550be2fe0d240d076799d6f8a652b70fa04aea8a8362e8a"
 "jq-windows-amd64.exe" = "sha256:7451fbbf37feffb9bf262bd97c54f0da558c63f0748e64152dd87b0a07b6d6ab"
+
+[tools.mimirtool]
+version = "2.15.2"
+backend = "aqua:grafana/mimir/mimirtool"
 
 [tools."npm:markdownlint-cli"]
 version = "0.44.0"

--- a/mise.lock
+++ b/mise.lock
@@ -66,10 +66,6 @@ jq-linux-arm64 = "sha256:4dd2d8a0661df0b22f1bb9a1f9830f06b6f3b8f7d91211a1ef5d7c4
 jq-macos-arm64 = "sha256:0bbe619e663e0de2c550be2fe0d240d076799d6f8a652b70fa04aea8a8362e8a"
 "jq-windows-amd64.exe" = "sha256:7451fbbf37feffb9bf262bd97c54f0da558c63f0748e64152dd87b0a07b6d6ab"
 
-[tools.mimirtool]
-version = "2.15.2"
-backend = "aqua:grafana/mimir/mimirtool"
-
 [tools."npm:markdownlint-cli"]
 version = "0.44.0"
 backend = "npm:markdownlint-cli"

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -51,10 +51,10 @@ pub enum AquaPackageType {
 #[derive(Debug, Deserialize, Default, Clone)]
 #[serde(default)]
 pub struct AquaPackage {
-    pub name: String,
     pub r#type: AquaPackageType,
     pub repo_owner: String,
     pub repo_name: String,
+    pub name: Option<String>,
     pub asset: String,
     pub url: String,
     pub description: Option<String>,

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -51,6 +51,7 @@ pub enum AquaPackageType {
 #[derive(Debug, Deserialize, Default, Clone)]
 #[serde(default)]
 pub struct AquaPackage {
+    pub name: String,
     pub r#type: AquaPackageType,
     pub repo_owner: String,
     pub repo_name: String,

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -530,7 +530,8 @@ impl AquaBackend {
             pkg.files
                 .first()
                 .map(|f| f.name.as_str())
-                .unwrap_or_else(|| pkg.name.split('/').last().unwrap()),
+                .or_else(|| pkg.name.as_ref().and_then(|n| n.split('/').last()))
+                .unwrap_or(&pkg.repo_name),
         );
         if cfg!(windows) && bin_path.extension().is_none() {
             bin_path = bin_path.with_extension("exe");

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -530,7 +530,7 @@ impl AquaBackend {
             pkg.files
                 .first()
                 .map(|f| f.name.as_str())
-                .or_else(|| pkg.name.as_ref().and_then(|n| n.split('/').last()))
+                .or_else(|| pkg.name.as_ref().and_then(|n| n.split('/').next_back()))
                 .unwrap_or(&pkg.repo_name),
         );
         if cfg!(windows) && bin_path.extension().is_none() {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -526,8 +526,12 @@ impl AquaBackend {
         let install_path = tv.install_path();
         file::remove_all(&install_path)?;
         let format = pkg.format(v)?;
-        let mut bin_path =
-            install_path.join(pkg.files.first().map(|f| &f.name).unwrap_or(&pkg.repo_name));
+        let mut bin_path = install_path.join(
+            pkg.files
+                .first()
+                .map(|f| f.name.as_str())
+                .unwrap_or_else(|| pkg.name.split('/').last().unwrap()),
+        );
         if cfg!(windows) && bin_path.extension().is_none() {
             bin_path = bin_path.with_extension("exe");
         }


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/4904.

For tools in a monorepo, we need to use the directory name instead of the repo name for `bin_path`.

e.g. `mimirtool`
```
# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
packages:
  - name: grafana/mimir/mimirtool
    type: github_release
    repo_owner: grafana
    repo_name: mimir
    description: Grafana Mimir provides horizontally scalable, highly available, multi-tenant, long-term storage for Prometheus
    asset: mimirtool-{{.OS}}-{{.Arch}}
    format: raw
    version_prefix: mimir-
    supported_envs:
      - linux
      - darwin
```
https://mise-versions.jdx.dev/aqua-registry/grafana/mimir/mimirtool/registry.yaml