### PR TITLE
fix(schema): allow array of objects for hooks

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1414,6 +1414,24 @@
               }
             },
             "type": "object"
+          },
+          {
+            "description": "scripts to run",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "script": {
+                  "description": "script to run",
+                  "type": "string"
+                },
+                "shell": {
+                  "description": "specify the shell to run the script inside of",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
           }
         ]
       }


### PR DESCRIPTION
ref: https://github.com/jdx/mise/discussions/4423

Allows an array of objects in `hooks`.
e.g.
```
[[hooks.cd]]
script = "echo 'I changed directories'"
[[hooks.cd]]
script = "echo 'I also directories'"
```