### PR TITLE
feat(status): add setting to control status message truncation

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -862,6 +862,11 @@
             "show_tools": {
               "description": "Show configured tools when entering a directory with a mise.toml file.",
               "type": "boolean"
+            },
+            "truncate": {
+              "default": true,
+              "description": "Truncate status messages.",
+              "type": "boolean"
             }
           }
         },

--- a/settings.toml
+++ b/settings.toml
@@ -1023,6 +1023,12 @@ env = "MISE_STATUS_MESSAGE_SHOW_TOOLS"
 type = "Bool"
 description = "Show configured tools when entering a directory with a mise.toml file."
 
+[status.truncate]
+env = "MISE_STATUS_MESSAGE_TRUNCATE"
+type = "Bool"
+default = true
+description = "Truncate status messages."
+
 [swift.gpg_verify]
 env = "MISE_SWIFT_GPG_VERIFY"
 type = "Bool"


### PR DESCRIPTION
Adds a `.status.truncate` to control the truncation of "show" status messages. 

Defaults to `true` for backward compatibility.

Example: 

With the default value:

```toml
# ~/.config/mise/config.toml
status = { show_env = false, show_tools = true }
```

Navigating to a directory with some mise tools:

```console
cd /to/a/mise/dir

mise +aws@2.26.2 +gcloud@467.0.0 +helm@3.17.2 +helmfile@0.171.0 +jq@1.6 +kubeconform@v0.6.7 +kubectl@1.31.7 +sops@3.9.…
```

When setting `truncate = false`:

```toml
# ~/.config/mise/config.toml
status = { show_env = false, show_tools = true, truncate = false }
```

Navigating to a directory with some mise tools:

```console
cd /to/a/mise/dir

mise +aws@2.26.2 +gcloud@467.0.0 +helm@3.17.2 +helmfile@0.171.0 +jq@1.6 +kubeconform@v0.6.7 +kubectl@1.31.7 +sops@3.9.4 +velero@1.13.0 +yq@4.45.1 +bats@1.11.1 +go@1.24.2 +gomplate@4.3.2 +kind@0.27.0 +kubelogin@1.32.3 +node@23.11.0 +pre-commit@4.2.0 +clusterctl@1.10.0
```
