### PR TITLE
chore: enable clearing screen for confirm and dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1032,14 +1032,13 @@ checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "demand"
-version = "1.6.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abeb34924c8d59be6428a07f63a0bf5f9d5c15ccb6fd9ef4f4e8cd7f422abfe"
+checksum = "081fee97d4d3dfb2baf0333ccf376b5cae24448afe5c5652861bb987853d685c"
 dependencies = [
  "console",
  "fuzzy-matcher",
  "itertools 0.14.0",
- "once_cell",
  "signal-hook",
  "termcolor",
 ]
@@ -1311,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3311,7 +3310,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4551,7 +4550,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4921,7 +4920,7 @@ dependencies = [
  "errno 0.3.11",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4934,7 +4933,7 @@ dependencies = [
  "errno 0.3.11",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5708,7 +5707,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6612,7 +6611,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -16,7 +16,7 @@ pub fn confirm<S: Into<String>>(message: S) -> eyre::Result<bool> {
     if !console::user_attended_stderr() || env::__USAGE.is_some() {
         return Ok(false);
     }
-    let result = Confirm::new(message).run()?;
+    let result = Confirm::new(message).clear_screen(true).run()?;
     Ok(result)
 }
 
@@ -40,6 +40,7 @@ pub fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<bool> {
             DialogButton::new("All"),
         ])
         .selected_button(1)
+        .clear_screen(true)
         .run()?;
 
     let result = match answer.as_str() {


### PR DESCRIPTION
Set new `clear_screen` flag on confirm and dialog. 

Confirmation dialogs displayed in tasks might be overwritten by other tasks output running in parallel which leads to broken dialog renditions. Clearing the screen helps mitigate this.