### PR TITLE
fix(env): fix dotenv files cascading (fix #4688)

### DIFF
--- a/e2e/env/test_env_cascading
+++ b/e2e/env/test_env_cascading
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+cat >mise.toml <<EOF
+[vars]
+ROOT = "somewhere"
+
+[env]
+KEY = "value"
+CONFIG_ROOT= "{{ vars.ROOT }}/conf.d"
+
+_.file = [
+    "conf.d/secrets.env",
+    "conf.d/app.env",
+]
+EOF
+
+mkdir -p conf.d
+
+cat >conf.d/secrets.env <<EOF
+API_KEY=my-api-key
+SECRET_FILE=\${CONFIG_ROOT}/secret.file
+EOF
+
+cat >conf.d/app.env <<EOF
+APP_CONF=\${CONFIG_ROOT}/app.yaml
+APP_KEY=\${KEY}-subvalue
+APP_API_KEY=\${API_KEY}
+EOF
+
+assert_contains "mise env -s bash" "API_KEY=my-api-key"
+assert_contains "mise env -s bash" "APP_API_KEY=my-api-key"
+assert_contains "mise env -s bash" "APP_CONF=somewhere/conf.d/app.yaml"
+assert_contains "mise env -s bash" "APP_KEY=value-subvalue"
+assert_contains "mise env -s bash" "CONFIG_ROOT=somewhere/conf.d"
+assert_contains "mise env -s bash" "KEY=value"
+assert_contains "mise env -s bash" "SECRET_FILE=somewhere/conf.d/secret.file"

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -1,4 +1,5 @@
 use crate::config::env_directive::EnvResults;
+use crate::env_diff;
 use crate::file::display_path;
 use crate::{Result, file, sops};
 use eyre::{WrapErr, bail, eyre};
@@ -26,23 +27,26 @@ impl EnvResults {
         normalize_path: fn(&Path, PathBuf) -> PathBuf,
         source: &Path,
         config_root: &Path,
+        env_vars: &env_diff::EnvMap,
         input: String,
     ) -> Result<IndexMap<PathBuf, EnvMap>> {
         let mut out = IndexMap::new();
         let s = r.parse_template(ctx, tera, source, &input)?;
+        let mut tmpenv = env_vars.clone();
         for p in xx::file::glob(normalize_path(config_root, s.into())).unwrap_or_default() {
-            let env = out.entry(p.clone()).or_insert_with(IndexMap::new);
+            let new_env = out.entry(p.clone()).or_insert_with(IndexMap::new);
             let parse_template = |s: String| r.parse_template(ctx, tera, source, &s);
             let ext = p
                 .extension()
                 .map(|e| e.to_string_lossy().to_string())
                 .unwrap_or_default();
-            *env = match ext.as_str() {
+            *new_env = match ext.as_str() {
                 "json" => Self::json(&p, parse_template)?,
                 "yaml" => Self::yaml(&p, parse_template)?,
                 "toml" => Self::toml(&p)?,
-                _ => Self::dotenv(&p)?,
+                _ => Self::dotenv(&p, &tmpenv)?,
             };
+            tmpenv.extend(new_env.clone());
         }
         Ok(out)
     }
@@ -132,15 +136,35 @@ impl EnvResults {
         }
     }
 
-    fn dotenv(p: &Path) -> Result<EnvMap> {
+    fn dotenv(p: &Path, env: &env_diff::EnvMap) -> Result<EnvMap> {
         let errfn = || eyre!("failed to parse dotenv file: {}", display_path(p));
-        let mut env = EnvMap::new();
+        let mut full_env = EnvMap::new();
+        let mut new_env = EnvMap::new();
+
+        // Convert env vars to string format
+        let env_as_string = env
+            .iter()
+            .map(|(key, value)| format!("{}='{}'", key, value.replace("'", "\\'")))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Read the file content and concatenate with env_as_string
+        let file_content = file::read_to_string(p).unwrap_or_default();
+        let combined_content = format!("{}\n{}", env_as_string, file_content);
+
+        for item in dotenvy::from_read_iter(combined_content.as_bytes()) {
+            let (k, v) = item.wrap_err_with(errfn)?;
+            full_env.insert(k, v);
+        }
+        // A 2nd pass is needed to only keep new values
         if let Ok(dotenv) = dotenvy::from_path_iter(p) {
             for item in dotenv {
-                let (k, v) = item.wrap_err_with(errfn)?;
-                env.insert(k, v);
+                let (k, _) = item.wrap_err_with(errfn)?;
+                let value = full_env.get(&k).cloned().unwrap_or_default();
+                new_env.insert(k, value);
             }
         }
-        Ok(env)
+
+        Ok(new_env)
     }
 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -251,6 +251,7 @@ impl EnvResults {
                         normalize_path,
                         &source,
                         &config_root,
+                        &env_vars,
                         input,
                     )?;
                     for (f, new_env) in files {


### PR DESCRIPTION
Hi 👋🏼 

I posted an issue I had in #4688 and never had a response, so I gave a try at fixing it.

The test case is simple and covers 2 broken use-cases:
- dotenv file referencing a variable declared in the `env` section
- dotenv file referencing a variable declared in a previous dotenv file

In both cases, the referenced variables were replaced by an empty string.

Given `dotenvy` doesn't allow providing an initial substitution map ([I created an issue for that](https://github.com/allan2/dotenvy/issues/149)), I used the only workaround I found as of today: concatenate the initial environment with the dotenv file to load.
