### PR TITLE
feat: add mise_env tera variable for templates

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -128,6 +128,7 @@ These variables offer key information about the current environment:
 - `config_root: PathBuf` – Locates the directory containing your `mise.toml` file, or in the case of something like `~/src/myproj/.config/mise.toml`, it will point to `~/src/myproj`.
 - `mise_bin: String` - Points to the path to the current mise executable
 - `mise_pid: String` - Points to the pid of the current mise process
+- `mise_env: String` - The configuration environment as specified by `MISE_ENV`, `-E`, or `--env`
 - `xdg_cache_home: PathBuf` - Points to the directory of XDG cache home
 - `xdg_config_home: PathBuf` - Points to the directory of XDG config home
 - `xdg_data_home: PathBuf` - Points to the directory of XDG data home

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -128,7 +128,7 @@ These variables offer key information about the current environment:
 - `config_root: PathBuf` – Locates the directory containing your `mise.toml` file, or in the case of something like `~/src/myproj/.config/mise.toml`, it will point to `~/src/myproj`.
 - `mise_bin: String` - Points to the path to the current mise executable
 - `mise_pid: String` - Points to the pid of the current mise process
-- `mise_env: String` - The configuration environment as specified by `MISE_ENV`, `-E`, or `--env`
+- `mise_env: String` - The configuration environment as specified by `MISE_ENV`, `-E`, or `--env`. Will be undefined if the configuration environment is not set.
 - `xdg_cache_home: PathBuf` - Points to the directory of XDG cache home
 - `xdg_config_home: PathBuf` - Points to the directory of XDG config home
 - `xdg_data_home: PathBuf` - Points to the directory of XDG data home

--- a/e2e/env/test_env_profiles
+++ b/e2e/env/test_env_profiles
@@ -15,3 +15,5 @@ EOF
 assert "mise run print" ""
 MISE_ENV=env1 assert "mise run print" "[env1]"
 MISE_ENV=env1,env2 assert "mise run print" "[env1, env2]"
+assert "mise --env env3 run print" "[env3]"
+assert "mise -E env3,env4 run print" "[env3, env4]"

--- a/e2e/env/test_env_profiles
+++ b/e2e/env/test_env_profiles
@@ -7,3 +7,11 @@ echo 'env.AAA = "override-2"' >mise.override2.toml
 assert "mise env --json | jq -r .AAA" "main"
 MISE_ENV=override1 assert "mise env --json | jq -r .AAA" "override-1"
 MISE_ENV=override1,override2 assert "mise env --json | jq -r .AAA" "override-2"
+
+cat <<EOF >mise.toml
+[tasks.print]
+run = 'echo {{mise_env}}'
+EOF
+assert "mise run print" ""
+MISE_ENV=env1 assert "mise run print" "[env1]"
+MISE_ENV=env1,env2 assert "mise run print" "[env1, env2]"

--- a/e2e/env/test_env_profiles
+++ b/e2e/env/test_env_profiles
@@ -10,7 +10,7 @@ MISE_ENV=override1,override2 assert "mise env --json | jq -r .AAA" "override-2"
 
 cat <<EOF >mise.toml
 [tasks.print]
-run = 'echo {{mise_env}}'
+run = '{% if mise_env %}echo {{mise_env}}{% endif %}'
 EOF
 assert "mise run print" ""
 MISE_ENV=env1 assert "mise run print" "[env1]"

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -22,7 +22,9 @@ pub static BASE_CONTEXT: Lazy<Context> = Lazy::new(|| {
     context.insert("env", &*env::PRISTINE_ENV);
     context.insert("mise_bin", &*env::MISE_BIN);
     context.insert("mise_pid", &*env::MISE_PID);
-    context.insert("mise_env", &*env::MISE_ENV);
+    if !(&*env::MISE_ENV).is_empty() {
+        context.insert("mise_env", &*env::MISE_ENV);
+    }
     if let Ok(dir) = env::current_dir() {
         context.insert("cwd", &dir);
     }
@@ -384,7 +386,7 @@ mod tests {
 
     #[test]
     fn test_mise_env() {
-        assert_eq!(render("{{mise_env}}"), "[]");
+        assert_eq!(render("{% if mise_env %}{{mise_env}}{% endif %}"), "");
     }
 
     #[test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -22,6 +22,7 @@ pub static BASE_CONTEXT: Lazy<Context> = Lazy::new(|| {
     context.insert("env", &*env::PRISTINE_ENV);
     context.insert("mise_bin", &*env::MISE_BIN);
     context.insert("mise_pid", &*env::MISE_PID);
+    context.insert("mise_env", &*env::MISE_ENV);
     if let Ok(dir) = env::current_dir() {
         context.insert("cwd", &dir);
     }
@@ -379,6 +380,11 @@ mod tests {
     #[test]
     fn test_config_root() {
         assert_eq!(render("{{config_root}}"), "/");
+    }
+
+    #[test]
+    fn test_mise_env() {
+        assert_eq!(render("{{mise_env}}"), "[]");
     }
 
     #[test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -22,7 +22,7 @@ pub static BASE_CONTEXT: Lazy<Context> = Lazy::new(|| {
     context.insert("env", &*env::PRISTINE_ENV);
     context.insert("mise_bin", &*env::MISE_BIN);
     context.insert("mise_pid", &*env::MISE_PID);
-    if !(&*env::MISE_ENV).is_empty() {
+    if !(*env::MISE_ENV).is_empty() {
         context.insert("mise_env", &*env::MISE_ENV);
     }
     if let Ok(dir) = env::current_dir() {


### PR DESCRIPTION
Allows the user to query in a template what configuration environment a task is running in:

```bash
cat <<EOF >mise.toml
[tasks.print]
run = '{% if mise_env %}echo {{mise_env}}{% endif %}'
EOF
mise run print # output:
MISE_ENV=env1 mise run print # output: env1
mise --env env1,env2 run print # output: env1,env2
```

This can be useful when you want to `mise set` an environment variable for the current configuration environment:

```toml
[tasks.test]
run = "mise set --file mise.{{ mise_env | split(pat=',') | last }}.yaml KEY={{arg(name='value')}}"
```