### PR TITLE
ci(registry): increaset timeout to 30 mins

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   test-tool:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`registry` workflow sometimes fails due to a timeout, even on the first attempt.
This PR increases the timeout from 20 mins to 30 mins to avoid failures.

Workflow logs: https://github.com/jdx/mise/actions/workflows/registry.yml