### PR TITLE
fix(dotenv): properly escape values in generated dotenv

### DIFF
--- a/e2e/env/test_env_cascading
+++ b/e2e/env/test_env_cascading
@@ -6,7 +6,8 @@ ROOT = "somewhere"
 
 [env]
 KEY = "value"
-CONFIG_ROOT= "{{ vars.ROOT }}/conf.d"
+CONFIG_ROOT = "{{ vars.ROOT }}/conf.d"
+SPECIAL = "#'{\"}"
 
 _.file = [
     "conf.d/secrets.env",
@@ -34,3 +35,4 @@ assert_contains "mise env -s bash" "APP_KEY=value-subvalue"
 assert_contains "mise env -s bash" "CONFIG_ROOT=somewhere/conf.d"
 assert_contains "mise env -s bash" "KEY=value"
 assert_contains "mise env -s bash" "SECRET_FILE=somewhere/conf.d/secret.file"
+assert_contains "mise env -s bash" "SPECIAL='#'\''{\"}'"

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -5,6 +5,7 @@ use crate::{Result, file, sops};
 use eyre::{WrapErr, bail, eyre};
 use indexmap::IndexMap;
 use rops::file::format::{JsonFileFormat, YamlFileFormat};
+use shell_escape::unix::escape;
 use std::path::{Path, PathBuf};
 
 // use indexmap so source is after value for `mise env --json` output
@@ -144,7 +145,7 @@ impl EnvResults {
         // Convert env vars to string format
         let env_as_string = env
             .iter()
-            .map(|(key, value)| format!("{}='{}'", key, value.replace("'", "\\'")))
+            .map(|(key, value)| format!("{}={}", key, escape(value.into())))
             .collect::<Vec<_>>()
             .join("\n");
 


### PR DESCRIPTION
Fix the poor escaping from #4996.

I was trying to avoid adding a new dependency, `shell-escape`, but it is already included, so I just rely on it instead of the poor uncomplete `replace()`

Fix #5008 

