### PR TITLE
fix(registry): use full version of taplo

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1810,7 +1810,7 @@ talosctl.backends = [
 tanka.backends = ["aqua:grafana/tanka", "asdf:trotttrotttrott/asdf-tanka"]
 tanzu.backends = ["asdf:mise-plugins/tanzu-plug-in-for-asdf"]
 taplo.backends = [
-    "aqua:tamasfe/taplo",
+    "aqua:tamasfe/taplo/full",
     "ubi:tamasfe/taplo[matching=full]",
     "cargo:taplo-cli"
 ]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -500,6 +500,7 @@
           "default": [],
           "description": "Specific tools to disable idiomatic version files for.",
           "type": "array",
+          "deprecated": true,
           "items": {
             "type": "string"
           }


### PR DESCRIPTION
Fixes a regression with my previous PR to use aqua for taplo.
https://github.com/jdx/mise/pull/4991#issuecomment-2856241179