### PR TITLE
fix: `aqua` version test

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -87,7 +87,7 @@ apollo-router.backends = [
 ]
 apollo-rover.backends = ["ubi:apollographql/rover"]
 aqua.backends = ["ubi:aquaproj/aqua"]
-# aqua.test = ["aqua version", "{{version}}"]
+aqua.test = ["aqua --version", "aqua version {{version}}"]
 arduino.aliases = ["arduino"]
 arduino.backends = ["aqua:arduino/arduino-cli", "asdf:egnor/asdf-arduino-cli"]
 argc.backends = ["ubi:sigoden/argc"]

--- a/registry.toml
+++ b/registry.toml
@@ -87,7 +87,7 @@ apollo-router.backends = [
 ]
 apollo-rover.backends = ["ubi:apollographql/rover"]
 aqua.backends = ["ubi:aquaproj/aqua"]
-aqua.test = ["aqua --version", "aqua version {{version}}"]
+aqua.test = ["aqua version", "{{version}}"]
 arduino.aliases = ["arduino"]
 arduino.backends = ["aqua:arduino/arduino-cli", "asdf:egnor/asdf-arduino-cli"]
 argc.backends = ["ubi:sigoden/argc"]


### PR DESCRIPTION
It seems that `aqua --version` is the correct command to check the version of `aqua`.

[Issue](https://github.com/aquaproj/aqua/issues/3867) opened with `aqua` for more details.

Also related fa3daa2cab09ba7e0140fcf2112375eef8427a85 and 4f2c0505502c1e3c7bf3478d61a2c352591f281c.

**Edit**: updated back to using the `version` command, now it's fixed in the latest version of `aqua`, [`v2.51.2`](https://github.com/aquaproj/aqua/releases/tag/v2.51.2)