### PR TITLE
feat: add bunch of tools and tests

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -138,6 +138,7 @@ backend = "aqua:tamasfe/taplo/full"
 [tools.taplo.checksums]
 taplo-full-linux-aarch64 = "sha256:9ffa2a799ff0ca601a0e7ff93dcae64a34c81c677916e6f0d3c81d62e0670d83"
 taplo-full-linux-x86_64 = "sha256:e89d2303ea9a5ec07971feec807fa493dc9ab6624c19b313ff90fdede247ee08"
+"taplo-full-linux-x86_64.gz" = "sha256:71d655dc3f69ce30454cfade92fdbe846c0ba4aa3afa68f3ff0d216966d0d3c2"
 taplo-full-macos-aarch64 = "sha256:cf55aa3e4c9b631c1fbb3f8a4adac59ca2ecc7898d26e749cd9b62d5ed858fce"
 "taplo-linux-x86_64.gz" = "sha256:889efcfa067b179fda488427d3b13ce2d679537da8b9ed8138ba415db7da2a5e"
 "taplo.exe-full-windows-aarch64" = "sha256:13eaa7f30f321a02a43bcc476450b9a79307f12addc25df132613cbb76d03f86"

--- a/registry.toml
+++ b/registry.toml
@@ -1532,9 +1532,8 @@ pre-commit.backends = [
     "asdf:jonathanmorley/asdf-pre-commit"
 ]
 pre-commit.description = "A framework for managing and maintaining multi-language pre-commit hooks"
-probe-rs.aliases = ["probe-rs-tools"]
-probe-rs.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall[exe=probe-rs]"]
-probe-rs.test = [
+probe-rs-tools.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall[exe=probe-rs]"]
+probe-rs-tools.test = [
     "probe-rs --version",
     "probe-rs {{version}} (git commit: crates.io)"
 ]
@@ -2076,7 +2075,7 @@ zig.backends = ["core:zig"]
 zigmod.backends = ["ubi:nektro/zigmod", "asdf:mise-plugins/asdf-zigmod"]
 zigmod.test = ["zigmod version", "{{version}}"]
 zizmor.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
-zizmor.test = ["zizmor --version", "zizmor {{version}}"]
+# zizmor.test = ["zizmor --version", "zizmor {{version}}"] # 1.7.0 unavailable for CI's x86_64-unknown-linux-gnu
 zls.backends = ["aqua:zigtools/zls", "ubi:zigtools/zls"]
 zls.test = ["zls --version", "{{version}}"]
 zola.backends = ["ubi:getzola/zola", "asdf:salasrod/asdf-zola"]

--- a/registry.toml
+++ b/registry.toml
@@ -170,6 +170,8 @@ babashka.backends = [
     "asdf:pitch-io/asdf-babashka"
 ]
 babashka.test = ["bb --version", "babashka v{{version}}"]
+bacon.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
+bacon.test = ["bacon --version", "bacon {{version}}"]
 balena.aliases = ["balena-cli"]
 balena.backends = [
     "ubi:balena-io/balena-cli[exe=balena]",
@@ -292,6 +294,9 @@ calicoctl.backends = [
     "aqua:projectcalico/calico/calicoctl",
     "asdf:TheCubicleJockey/asdf-calicoctl"
 ]
+carapace.aliases = ["carapace-bin"]
+carapace.backends = ["asdf:vic1707/asdf-carapace-bin[exe=carapace]"]
+carapace.tests = ["carapace --version", "carapace-bin {{version}}"]
 cargo-binstall.backends = [
     "aqua:cargo-bins/cargo-binstall",
     'ubi:cargo-bins/cargo-binstall[tag_regex=^\\d\\.]',
@@ -532,6 +537,8 @@ difftastic.backends = [
 ]
 digdag.backends = ["asdf:mise-plugins/mise-digdag"]
 direnv.backends = ["aqua:direnv/direnv", "asdf:asdf-community/asdf-direnv"]
+diskonaut.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
+diskonaut.test = ["diskonaut --version", "diskonaut {{version}}"]
 dive.backends = ["ubi:wagoodman/dive", "asdf:looztra/asdf-dive"]
 djinni.backends = [
     "ubi:cross-language-cpp/djinni-generator",
@@ -668,6 +675,8 @@ fission.backends = [
     "aqua:fission/fission",
     "asdf:virtualstaticvoid/asdf-fission"
 ]
+flamegraph.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
+flamegraph.test = ["flamegraph --version", "flamegraph {{version}}"]
 flamingo.backends = [
     "ubi:flux-subsystem-argo/flamingo",
     "asdf:log2/asdf-flamingo"
@@ -1523,6 +1532,11 @@ pre-commit.backends = [
     "asdf:jonathanmorley/asdf-pre-commit"
 ]
 pre-commit.description = "A framework for managing and maintaining multi-language pre-commit hooks"
+probe-rs.aliases = ["probe-rs-tools"]
+probe-rs.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall[exe=probe-rs]"]
+probe-rs.test = ["probe-rs --version", "probe-rs {{version}} (git commit: crates.io)"]
+procs.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
+procs.test = ["procs --version", "procs {{version}}"]
 promtool.backends = [
     "aqua:prometheus/prometheus",
     "asdf:asdf-community/asdf-promtool"

--- a/registry.toml
+++ b/registry.toml
@@ -1532,7 +1532,9 @@ pre-commit.backends = [
     "asdf:jonathanmorley/asdf-pre-commit"
 ]
 pre-commit.description = "A framework for managing and maintaining multi-language pre-commit hooks"
-probe-rs-tools.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall[exe=probe-rs]"]
+probe-rs-tools.backends = [
+    "asdf:vic1707/asdf-any-cargo-quickinstall[exe=probe-rs]"
+]
 probe-rs-tools.test = [
     "probe-rs --version",
     "probe-rs {{version}} (git commit: crates.io)"

--- a/registry.toml
+++ b/registry.toml
@@ -278,6 +278,8 @@ buildpack.backends = ["aqua:buildpacks/pack", "asdf:johnlayton/asdf-buildpack"]
 buildpack.test = ["pack --version", "{{version}}"]
 bun.backends = ["core:bun"]
 bun.test = ["bun --version", "{{version}}"]
+butane.backends = ["asdf:Okeanos/asdf-butane"]
+butane.test = ["butane --version", "Butane {{version}}"]
 cabal.backends = ["aqua:haskell/cabal/cabal-install"]
 # cabal.test = ["cabal --version", "cabal-install version {{version}}"]
 caddy.backends = ["aqua:caddyserver/caddy", "asdf:salasrod/asdf-caddy"]
@@ -842,8 +844,9 @@ gomigrate.backends = [
 gomigrate.test = ["migrate --version 2>&1", "{{version}}"]
 gomplate.backends = [
     "aqua:hairyhenderson/gomplate",
-    "asdf:sneakybeaky/asdf-gomplate"
+    "asdf:tapih/asdf-gomplate"
 ]
+gomplate.test = ["gomplate --version", "gomplate version {{version}}"]
 gopass.backends = ["aqua:gopasspw/gopass", "asdf:trallnag/asdf-gopass"]
 goreleaser.backends = [
     "aqua:goreleaser/goreleaser",
@@ -917,6 +920,9 @@ haxe.backends = ["ubi:HaxeFoundation/haxe", "asdf:mise-plugins/mise-haxe"]
 haxe.test = ["haxe --version", "{{version}}"]
 hcl2json.backends = ["aqua:tmccombs/hcl2json", "asdf:dex4er/asdf-hcl2json"]
 hcloud.backends = ["aqua:hetznercloud/cli", "asdf:chessmango/asdf-hcloud"]
+hcloud.test = ["hcloud version", "hcloud {{version}}"]
+hcloud-upload-image.backends = ["asdf:vic1707/asdf-hcloud-upload-image"]
+hcloud-upload-image.test = ["hcloud-upload-image --version", "hcloud-upload-image version {{version}}"]
 helix.backends = ["ubi:helix-editor/helix[extract_all=true]"]
 helm.backends = ["aqua:helm/helm", "asdf:Antiarchitect/asdf-helm"]
 helm-cr.backends = [
@@ -2052,6 +2058,8 @@ zephyr.backends = ["ubi:MaybeJustJames/zephyr", "asdf:nsaunders/asdf-zephyr"]
 zig.backends = ["core:zig"]
 zigmod.backends = ["ubi:nektro/zigmod", "asdf:mise-plugins/asdf-zigmod"]
 zigmod.test = ["zigmod version", "{{version}}"]
+zizmor.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
+zizmor.test = ["zizmor --version", "zizmor {{version}}"]
 zls.backends = ["aqua:zigtools/zls", "ubi:zigtools/zls"]
 zls.test = ["zls --version", "{{version}}"]
 zola.backends = ["ubi:getzola/zola", "asdf:salasrod/asdf-zola"]

--- a/registry.toml
+++ b/registry.toml
@@ -1534,7 +1534,10 @@ pre-commit.backends = [
 pre-commit.description = "A framework for managing and maintaining multi-language pre-commit hooks"
 probe-rs.aliases = ["probe-rs-tools"]
 probe-rs.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall[exe=probe-rs]"]
-probe-rs.test = ["probe-rs --version", "probe-rs {{version}} (git commit: crates.io)"]
+probe-rs.test = [
+    "probe-rs --version",
+    "probe-rs {{version}} (git commit: crates.io)"
+]
 procs.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
 procs.test = ["procs --version", "procs {{version}}"]
 promtool.backends = [

--- a/registry.toml
+++ b/registry.toml
@@ -171,7 +171,7 @@ babashka.backends = [
 ]
 babashka.test = ["bb --version", "babashka v{{version}}"]
 bacon.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
-bacon.test = ["bacon --version", "bacon {{version}}"]
+# bacon.test = ["bacon --version", "bacon {{version}}"] # 3.13.0 unavailable for CI's x86_64-unknown-linux-gnu
 balena.aliases = ["balena-cli"]
 balena.backends = [
     "ubi:balena-io/balena-cli[exe=balena]",
@@ -676,7 +676,7 @@ fission.backends = [
     "asdf:virtualstaticvoid/asdf-fission"
 ]
 flamegraph.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
-flamegraph.test = ["flamegraph --version", "flamegraph {{version}}"]
+# flamegraph.test = ["flamegraph --version", "flamegraph {{version}}"] # 0.11.0 unavailable for CI's x86_64-unknown-linux-gnu
 flamingo.backends = [
     "ubi:flux-subsystem-argo/flamingo",
     "asdf:log2/asdf-flamingo"
@@ -1539,7 +1539,7 @@ probe-rs.test = [
     "probe-rs {{version}} (git commit: crates.io)"
 ]
 procs.backends = ["asdf:vic1707/asdf-any-cargo-quickinstall"]
-procs.test = ["procs --version", "procs {{version}}"]
+# procs.test = ["procs --version", "procs {{version}}"] # 0.11.0 unavailable for CI's x86_64-unknown-linux-gnu
 promtool.backends = [
     "aqua:prometheus/prometheus",
     "asdf:asdf-community/asdf-promtool"

--- a/registry.toml
+++ b/registry.toml
@@ -842,10 +842,7 @@ gomigrate.backends = [
     "asdf:joschi/asdf-gomigrate"
 ]
 gomigrate.test = ["migrate --version 2>&1", "{{version}}"]
-gomplate.backends = [
-    "aqua:hairyhenderson/gomplate",
-    "asdf:tapih/asdf-gomplate"
-]
+gomplate.backends = ["aqua:hairyhenderson/gomplate", "asdf:tapih/asdf-gomplate"]
 gomplate.test = ["gomplate --version", "gomplate version {{version}}"]
 gopass.backends = ["aqua:gopasspw/gopass", "asdf:trallnag/asdf-gopass"]
 goreleaser.backends = [
@@ -922,7 +919,10 @@ hcl2json.backends = ["aqua:tmccombs/hcl2json", "asdf:dex4er/asdf-hcl2json"]
 hcloud.backends = ["aqua:hetznercloud/cli", "asdf:chessmango/asdf-hcloud"]
 hcloud.test = ["hcloud version", "hcloud {{version}}"]
 hcloud-upload-image.backends = ["asdf:vic1707/asdf-hcloud-upload-image"]
-hcloud-upload-image.test = ["hcloud-upload-image --version", "hcloud-upload-image version {{version}}"]
+hcloud-upload-image.test = [
+    "hcloud-upload-image --version",
+    "hcloud-upload-image version {{version}}"
+]
 helix.backends = ["ubi:helix-editor/helix[extract_all=true]"]
 helm.backends = ["aqua:helm/helm", "asdf:Antiarchitect/asdf-helm"]
 helm-cr.backends = [


### PR DESCRIPTION
Hi 👋 
*If you prefer this PR to be split for each tools feel free to ask !*

This PR does
**new tools supported**
1. [butane](https://github.com/coreos/butane) through https://github.com/Okeanos/asdf-butane
2. [bacon](https://github.com/Canop/bacon) through https://github.com/vic1707/asdf-any-cargo-quickinstall
3. [carapace](https://github.com/carapace-sh/carapace-bin) through https://github.com/vic1707/asdf-carapace-bin
4. [diskonaut](https://github.com/imsnif/diskonaut) through https://github.com/vic1707/asdf-any-cargo-quickinstall
5. [flamegraph](https://github.com/flamegraph-rs/flamegraph) through https://github.com/vic1707/asdf-any-cargo-quickinstall
6. [probe-rs](https://github.com/probe-rs/probe-rs) through https://github.com/vic1707/asdf-any-cargo-quickinstall
7. [procs](https://github.com/dalance/procs) through https://github.com/vic1707/asdf-any-cargo-quickinstall
8. [hcloud-upload-image](https://github.com/apricote/hcloud-upload-image) through https://github.com/vic1707/asdf-hcloud-upload-image
9. [zizmor](https://github.com/zizmorcore/zizmor) through https://github.com/vic1707/asdf-any-cargo-quickinstall
<img width="504" alt="image" src="https://github.com/user-attachments/assets/db6463f5-4726-4f43-abaa-ed8cb5cdfabb" />

**Adds tests**
1. [gomplate](https://github.com/hairyhenderson/gomplate)
2. [hcloud](https://github.com/hetznercloud/cli)
<img width="504" alt="image" src="https://github.com/user-attachments/assets/5f898cc1-a526-458d-a9d9-3cefcc4e8d83" />

**Updates asdf repo**
1. [gomplate](https://github.com/hairyhenderson/gomplate) to https://github.com/tapih/asdf-gomplate because the current one expects `v` prefix for versions, doesn't support aarch on mac