### PR TITLE
docs: fix add_predicate handler in neovim cookbook

### DIFF
--- a/docs/mise-cookbook/neovim.md
+++ b/docs/mise-cookbook/neovim.md
@@ -67,7 +67,7 @@ For example, using [`lazy.nvim`](https://github.com/folke/lazy.nvim):
     require("vim.treesitter.query").add_predicate("is-mise?", function(_, _, bufnr, _)
       local filepath = vim.api.nvim_buf_get_name(tonumber(bufnr) or 0)
       local filename = vim.fn.fnamemodify(filepath, ":t")
-      return string.match(filename, ".*mise.*%.toml$")
+      return string.match(filename, ".*mise.*%.toml$") ~= nil
     end, { force = true, all = false })
   end,
 },


### PR DESCRIPTION
According to [the documentation](https://neovim.io/doc/user/treesitter.html#vim.treesitter.query.add_predicate()), the TS predicate handler function is supposed to return boolean (or nil). It previously returned either a string or nil depending on whether the filename matched the predicate or not. This caused the example to not work (at least on my machine running nvim 0.11).

Fixed it by adding a nil check for the `string.match` return value.