### PR TITLE
docs: improve treesitter queries in neovim cookbook

### DIFF
--- a/docs/mise-cookbook/neovim.md
+++ b/docs/mise-cookbook/neovim.md
@@ -18,7 +18,7 @@ In your neovim config, create a `after/queries/toml/injections.scm` file with th
   (string) @injection.content @injection.language
 
   (#is-mise?)
-  (#match? @injection.language "^\"\"\"\n*#!(/\\w+)+/env\\s+\\w+") ; multiline shebang using env
+  (#match? @injection.language "^['\"]{3}\n*#!(/\\w+)+/env\\s+\\w+") ; multiline shebang using env
   (#gsub! @injection.language "^.*#!/.*/env%s+([^%s]+).*" "%1") ; extract lang
   (#offset! @injection.content 0 3 0 -3) ; rm quotes
 )
@@ -28,7 +28,7 @@ In your neovim config, create a `after/queries/toml/injections.scm` file with th
   (string) @injection.content @injection.language
 
   (#is-mise?)
-  (#match? @injection.language "^\"\"\"\n*#!(/\\w+)+\s*\n") ; multiline shebang
+  (#match? @injection.language "^['\"]{3}\n*#!(/\\w+)+\s*\n") ; multiline shebang
   (#gsub! @injection.language "^.*#!/.*/([^/%s]+).*" "%1") ; extract lang
   (#offset! @injection.content 0 3 0 -3) ; rm quotes
 )
@@ -38,8 +38,8 @@ In your neovim config, create a `after/queries/toml/injections.scm` file with th
   (string) @injection.content
 
   (#is-mise?)
-  (#match? @injection.content "^\"\"\"\n*.*") ; multiline
-  (#not-match? @injection.content "^\"\"\"\n*#!") ; no shebang
+  (#match? @injection.content "^['\"]{3}\n*.*") ; multiline
+  (#not-match? @injection.content "^['\"]{3}\n*#!") ; no shebang
   (#offset! @injection.content 0 3 0 -3) ; rm quotes
   (#set! injection.language "bash") ; default to bash
 )
@@ -49,7 +49,7 @@ In your neovim config, create a `after/queries/toml/injections.scm` file with th
   (string) @injection.content
 
   (#is-mise?)
-  (#not-match? @injection.content "^\"\"\"") ; not multiline
+  (#not-match? @injection.content "^['\"]{3}") ; not multiline
   (#offset! @injection.content 0 1 0 -1) ; rm quotes
   (#set! injection.language "bash") ; default to bash
 )


### PR DESCRIPTION
The original queries only supported double quotes. Since `mise` supports using both single and double quotes in TOML tasks the queries should support them as well.

You might notice these regexes aren't technically correct as they would also allow quotations like '"' and '"" and other such nonsense. But since TOML parser will freak out if you try to mix and match quotation marks in funny ways it doesn't really matter.