### PR TITLE
fix(registry): update glab ubi provider

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -779,7 +779,7 @@ gitu.backends = ["ubi:altsem/gitu", "cargo:gitu"]
 gitui.backends = ["aqua:extrawurst/gitui", "asdf:looztra/asdf-gitui"]
 gitversion.backends = ["aqua:gittools/gitversion", "ubi:gittools/gitversion"]
 glab.backends = [
-    "ubi:gitlab-org/cli[forge=gitlab,exe=glab]",
+    "ubi:gitlab-org/cli[provider=gitlab,exe=glab]",
     "asdf:mise-plugins/mise-glab"
 ]
 # glab.test = ["glab version", "Current glab version: {{version}}"]


### PR DESCRIPTION
Updates the `glab` ubi backend from `forge` to `provider`

Brings this in line with the documented api in https://mise.jdx.dev/dev-tools/backends/ubi.html#provider

I didn't find any other instances of `forge` in the registry

