### PR TITLE
fix: mise panics if CI env var isn't a boolean

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -218,6 +218,12 @@ pub struct Settings {"#
                     parse_env.as_str().unwrap().to_string(),
                 );
             }
+            if let Some(deserialize_with) = props.get("deserialize_with") {
+                opts.insert(
+                    "deserialize_with".to_string(),
+                    deserialize_with.as_str().unwrap().to_string(),
+                );
+            }
             lines.push(format!(
                 "    #[config({})]",
                 opts.iter()

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -326,6 +326,7 @@
           "type": "string"
         },
         "ci": {
+          "default": "false",
           "description": "Set to true if running in a CI environment",
           "type": "boolean"
         },

--- a/settings.toml
+++ b/settings.toml
@@ -204,6 +204,8 @@ hide = true
 [ci]
 env = "CI"
 type = "Bool"
+default = "false"
+deserialize_with = "bool_string"
 description = "Set to true if running in a CI environment"
 hide = true
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -10,7 +10,8 @@ use eyre::{Result, bail};
 use indexmap::{IndexMap, indexmap};
 use itertools::Itertools;
 use serde::ser::Error;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer};
+use serde_derive::Serialize;
 use std::collections::{BTreeSet, HashSet};
 use std::env::consts::ARCH;
 use std::fmt::{Debug, Display, Formatter};
@@ -465,5 +466,18 @@ impl SettingsNode {
 impl SettingsStatus {
     pub fn missing_tools(&self) -> SettingsStatusMissingTools {
         SettingsStatusMissingTools::from_str(&self.missing_tools).unwrap()
+    }
+}
+
+/// Deserialize a string to a boolean, accepting "false", "no", "0"
+/// and their case-insensitive variants as `false`. Any other value (incl. "") is considered `true`.
+fn bool_string<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    match s.to_lowercase().as_str() {
+        "false" | "no" | "0" => Ok(false),
+        _ => Ok(true),
     }
 }


### PR DESCRIPTION
Fixes issues with string to boolean conversion for `CI` as discussed in #5053.