### PR TITLE
docs: remove go.mod from idiomatic version files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,7 +248,7 @@ in mise and nvm. Here are some of the supported idiomatic version files:
 | --------- | -------------------------------------------------- |
 | crystal   | `.crystal-version`                                 |
 | elixir    | `.exenv-version`                                   |
-| go        | `.go-version`, `go.mod`                            |
+| go        | `.go-version`                                      |
 | java      | `.java-version`, `.sdkmanrc`                       |
 | node      | `.nvmrc`, `.node-version`                          |
 | python    | `.python-version`, `.python-versions`              |


### PR DESCRIPTION
👋  Just noticed that go.mod support was removed in https://github.com/jdx/mise/discussions/4136 but was still mentioned in the docs. This PR removes the mention of go.mod from docs.

Thanks a lot for the project 🙇 !