### PR TITLE
fix(config): project root for files in .config/ or mise/

### DIFF
--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -263,10 +263,11 @@ impl ConfigFile for MiseToml {
                 dir if dir.starts_with(*dirs::CONFIG) => None,
                 dir if dir.starts_with(*dirs::SYSTEM) => None,
                 dir if dir == *dirs::HOME => None,
-                dir if !filename.starts_with('.') && dir.ends_with(".mise") => dir.parent(),
+                dir if !filename.starts_with('.') && (dir.ends_with(".mise") || dir.ends_with(".config")) => dir.parent(),
                 dir if !filename.starts_with('.') && dir.ends_with(".config/mise") => {
                     dir.parent().unwrap().parent()
                 }
+                dir if !filename.starts_with('.') && dir.ends_with("mise") => dir.parent(),
                 dir => Some(dir),
             },
             None => None,

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -263,7 +263,11 @@ impl ConfigFile for MiseToml {
                 dir if dir.starts_with(*dirs::CONFIG) => None,
                 dir if dir.starts_with(*dirs::SYSTEM) => None,
                 dir if dir == *dirs::HOME => None,
-                dir if !filename.starts_with('.') && (dir.ends_with(".mise") || dir.ends_with(".config")) => dir.parent(),
+                dir if !filename.starts_with('.')
+                    && (dir.ends_with(".mise") || dir.ends_with(".config")) =>
+                {
+                    dir.parent()
+                }
                 dir if !filename.starts_with('.') && dir.ends_with(".config/mise") => {
                     dir.parent().unwrap().parent()
                 }


### PR DESCRIPTION
Closes https://github.com/jdx/mise/discussions/4620, see the failing `PROJECT_ROOT/.config/` and `PROJECT_ROOT/mise/` cases detailed in it.