### PR TITLE
feat(registry): added astro

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -113,6 +113,8 @@ ast-grep.backends = [
 ast-grep.test = ["sg --version", "ast-grep {{version}}"]
 atlas.backends = ["aqua:ariga/atlas", "asdf:komi1230/asdf-atlas"]
 atmos.backends = ["aqua:cloudposse/atmos", "asdf:cloudposse/asdf-atmos"]
+astro.backends = ["ubi:astronomer/astro-cli[exe=astro]"]
+astro.test = ["astro version", "Astro CLI Version: {{version}}"]
 auto-doc.backends = [
     "ubi:tj-actions/auto-doc",
     "asdf:mise-plugins/mise-auto-doc"

--- a/registry.toml
+++ b/registry.toml
@@ -111,10 +111,10 @@ ast-grep.backends = [
     "pipx:ast-grep-cli"
 ]
 ast-grep.test = ["sg --version", "ast-grep {{version}}"]
-atlas.backends = ["aqua:ariga/atlas", "asdf:komi1230/asdf-atlas"]
-atmos.backends = ["aqua:cloudposse/atmos", "asdf:cloudposse/asdf-atmos"]
 astro.backends = ["ubi:astronomer/astro-cli[exe=astro]"]
 astro.test = ["astro version", "Astro CLI Version: {{version}}"]
+atlas.backends = ["aqua:ariga/atlas", "asdf:komi1230/asdf-atlas"]
+atmos.backends = ["aqua:cloudposse/atmos", "asdf:cloudposse/asdf-atmos"]
 auto-doc.backends = [
     "ubi:tj-actions/auto-doc",
     "asdf:mise-plugins/mise-auto-doc"


### PR DESCRIPTION
[astro](https://github.com/astronomer/astro-cli)
The Astro CLI is a command-line interface for data orchestration. It allows you to get started with Apache Airflow quickly and it can be used with all Astronomer products.

```
$ astro version
Astro CLI Version: 1.34.0
```

Tests:

```sh
$ cargo run --bin mise -- install astro
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/mise install astro`
mise Installed executable into /Users/mnm/.local/share/mise/installs/astro/1.34.0/astro
mise astro@1.34.0    ✓ installed
$ cargo run --bin mise -- tool astro
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/mise tool astro`
Backend:                                             ubi:astronomer/astro-cli[exe=astro]
Installed Versions:                                  1.34.0
Tool Options:                                        exe="astro"
$ cargo run --bin mise -- uninstall astro
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/mise uninstall astro`
mise astro@1.34.0    ✓ uninstalled
```