### PR TITLE
chore: release 2025.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2025.5.7](https://github.com/jdx/mise/compare/v2025.5.6..v2025.5.7) - 2025-05-18
+
+### 🐛 Bug Fixes
+
+- using custom port with SSH based remote tasks by [@roele](https://github.com/roele) in [#5110](https://github.com/jdx/mise/pull/5110)
+- update rabbitmq backend by [@SerhiiFesenko](https://github.com/SerhiiFesenko) in [#5115](https://github.com/jdx/mise/pull/5115)
+- maven-mvnd does not install with aqua by [@roele](https://github.com/roele) in [#5117](https://github.com/jdx/mise/pull/5117)
+
+### New Contributors
+
+- @SerhiiFesenko made their first contribution in [#5115](https://github.com/jdx/mise/pull/5115)
+
 ## [2025.5.6](https://github.com/jdx/mise/compare/v2025.5.5..v2025.5.6) - 2025-05-17
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.5.6"
+version = "2025.5.7"
 dependencies = [
  "base64 0.22.1",
  "built",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2025.5.6"
+version = "2025.5.7"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.5.6 macos-arm64 (a1b2d3e 2025-05-17)
+2025.5.7 macos-arm64 (a1b2d3e 2025-05-18)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_5_6:-}" ]] || _cache_invalid _usage_spec_mise_2025_5_6 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_5_6;
+  if ( [[ -z "${_usage_spec_mise_2025_5_7:-}" ]] || _cache_invalid _usage_spec_mise_2025_5_7 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_5_7;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_5_6 spec
+    _store_cache _usage_spec_mise_2025_5_7 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_5_6:-} ]]; then
-        _usage_spec_mise_2025_5_6="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_5_7:-} ]]; then
+        _usage_spec_mise_2025_5_7="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_5_6}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_5_7}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_5_6
-  set -g _usage_spec_mise_2025_5_6 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_5_7
+  set -g _usage_spec_mise_2025_5_7 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_6" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_7" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_6" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_7" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.5.6";
+  version = "2025.5.7";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.5.6
+Version: 2025.5.7
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- using custom port with SSH based remote tasks by [@roele](https://github.com/roele) in [#5110](https://github.com/jdx/mise/pull/5110)
- update rabbitmq backend by [@SerhiiFesenko](https://github.com/SerhiiFesenko) in [#5115](https://github.com/jdx/mise/pull/5115)
- maven-mvnd does not install with aqua by [@roele](https://github.com/roele) in [#5117](https://github.com/jdx/mise/pull/5117)

### New Contributors

- @SerhiiFesenko made their first contribution in [#5115](https://github.com/jdx/mise/pull/5115)