### PR TITLE
fix: maven-mvnd does not install with aqua

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -327,7 +327,13 @@ impl AquaPackage {
     }
 
     pub fn asset(&self, v: &str) -> Result<String> {
-        self.parse_aqua_str(&self.asset, v, &Default::default())
+        // derive asset from url if not set and url contains a path
+        if self.asset.is_empty() && self.url.split("/").count() > "//".len() {
+            let asset = self.url.rsplit("/").next().unwrap_or("");
+            self.parse_aqua_str(asset, v, &Default::default())
+        } else {
+            self.parse_aqua_str(&self.asset, v, &Default::default())
+        }
     }
 
     pub fn asset_strs(&self, v: &str) -> Result<IndexSet<String>> {


### PR DESCRIPTION
There seems to be still an issue with `mvnd` installed via Aqua not deriving the asset properly (see https://github.com/jdx/mise/issues/3977#issuecomment-2888291964). This should restore the proper behaviour.

Thanks @artemy for reporting this!