### PR TITLE
fix: SSH remote tasks do not support organizations in repository path

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -74,10 +74,6 @@ jq-macos-arm64 = "sha256:0bbe619e663e0de2c550be2fe0d240d076799d6f8a652b70fa04aea
 version = "0.44.0"
 backend = "npm:markdownlint-cli"
 
-[tools."npm:pin-github-action"]
-version = "3.3.1"
-backend = "npm:pin-github-action"
-
 [tools."npm:prettier"]
 version = "3.5.3"
 backend = "npm:prettier"

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -81,7 +81,7 @@ impl RemoteTaskGit {
     }
 
     fn detect_ssh(&self, file: &str) -> Result<GitRepoStructure, Box<dyn std::error::Error>> {
-        let re = Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)(?P<host>[^/]+)/(?P<repo>[^/]+)\.git)//(?P<path>[^?]+)(\?ref=(?P<branch>[^?]+))?$").unwrap();
+        let re = Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<branch>[^?]+))?$").unwrap();
 
         if !re.is_match(file) {
             return Err("Invalid SSH URL".into());
@@ -99,7 +99,7 @@ impl RemoteTaskGit {
     }
 
     fn detect_https(&self, file: &str) -> Result<GitRepoStructure, Box<dyn std::error::Error>> {
-        let re = Regex::new(r"^git::(?P<url>https://(?P<host>[^/]+)/(?P<repo>[^/]+(?:/[^/]+)?)\.git)//(?P<path>[^?]+)(\?ref=(?P<branch>[^?]+))?$").unwrap();
+        let re = Regex::new(r"^git::(?P<url>https://(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<branch>[^?]+))?$").unwrap();
 
         if !re.is_match(file) {
             return Err("Invalid HTTPS URL".into());
@@ -182,8 +182,9 @@ mod tests {
         let remote_task_git = RemoteTaskGitBuilder::new().build();
 
         let test_cases = vec![
-            "git::ssh://git@github.com:myorg/example.git//myfile?ref=v1.0.0",
-            "git::ssh://git@github.com:myorg/example.git//terraform/myfile?ref=master",
+            "git::ssh://git@github.com/myorg/example.git//myfile?ref=v1.0.0",
+            "git::ssh://git@github.com/myorg/example.git//terraform/myfile?ref=master",
+            "git::ssh://git@git.acme.com:1222/myorg/example.git//terraform/myfile?ref=master",
             "git::ssh://git@myserver.com/example.git//terraform/myfile",
             "git::ssh://user@myserver.com/example.git//myfile?ref=master",
         ];
@@ -218,6 +219,7 @@ mod tests {
         let test_cases = vec![
             "git::https://github.com/myorg/example.git//myfile?ref=v1.0.0",
             "git::https://github.com/myorg/example.git//terraform/myfile?ref=master",
+            "git::https://git.acme.com:8080/myorg/example.git//terraform/myfile?ref=master",
             "git::https://myserver.com/example.git//terraform/myfile",
             "git::https://myserver.com/example.git//myfile?ref=master",
         ];


### PR DESCRIPTION
Fixes the issue discussed in #5101.

Loosens the constraints around `repo` named capture to allow (sub-)folders (GitLab supports nested folders) for SSH and HTTPS.