### PR TITLE
fix(registry): support editorconfig-checker in windows

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -74,10 +74,6 @@ jq-macos-arm64 = "sha256:0bbe619e663e0de2c550be2fe0d240d076799d6f8a652b70fa04aea
 version = "0.44.0"
 backend = "npm:markdownlint-cli"
 
-[tools."npm:pin-github-action"]
-version = "3.3.1"
-backend = "npm:pin-github-action"
-
 [tools."npm:prettier"]
 version = "3.5.3"
 backend = "npm:prettier"

--- a/registry.toml
+++ b/registry.toml
@@ -610,10 +610,10 @@ earthly.backends = ["aqua:earthly/earthly", "asdf:YR-ZR0/asdf-earthly"]
 ecspresso.backends = ["aqua:kayac/ecspresso", "asdf:kayac/asdf-ecspresso"]
 editorconfig-checker.backends = [
     "aqua:editorconfig-checker/editorconfig-checker",
+    "ubi:editorconfig-checker/editorconfig-checker[exe=ec]",
     "asdf:gabitchov/asdf-editorconfig-checker"
 ]
-editorconfig-checker.os = ["linux", "macos"]
-# editorconfig-checker.test = ["ec --version", "v{{version}}"] # TODO: failing from https://github.com/editorconfig-checker/editorconfig-checker/issues/409
+editorconfig-checker.test = ["ec --version", "v{{version}}"]
 ejson.backends = ["aqua:Shopify/ejson", "asdf:cipherstash/asdf-ejson"]
 eksctl.backends = ["aqua:eksctl-io/eksctl", "asdf:elementalvoid/asdf-eksctl"]
 elasticsearch.backends = ["asdf:mise-plugins/mise-elasticsearch"]


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/5112.

Windows support in aqua-registry added in https://github.com/aquaproj/aqua-registry/pull/30735.