### PR TITLE
Remove os limitation for editorconfig-checker

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -612,7 +612,6 @@ editorconfig-checker.backends = [
     "aqua:editorconfig-checker/editorconfig-checker",
     "asdf:gabitchov/asdf-editorconfig-checker"
 ]
-editorconfig-checker.os = ["linux", "macos"]
 # editorconfig-checker.test = ["ec --version", "v{{version}}"] # TODO: failing from https://github.com/editorconfig-checker/editorconfig-checker/issues/409
 ejson.backends = ["aqua:Shopify/ejson", "asdf:cipherstash/asdf-ejson"]
 eksctl.backends = ["aqua:eksctl-io/eksctl", "asdf:elementalvoid/asdf-eksctl"]


### PR DESCRIPTION
so it can be used on windows.

See also https://github.com/jdx/mise/discussions/5112