### PR TITLE
docs: squeeze spaces when migrating from asdf

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -138,7 +138,7 @@ Here is an example script you can use to migrate your global `.tool-versions` fi
 
 ```shell
 mv ~/.tool-versions ~/.tool-versions.bak
-cat ~/.tool-versions.bak | tr ' ' '@' | xargs -n2 mise use -g
+cat ~/.tool-versions.bak | tr -s ' ' | tr ' ' '@' | xargs -n2 mise use -g
 ```
 
 Once you are comfortable with mise, you can remove the `.tool-versions.bak` file and [uninstall `asdf`](https://asdf-vm.com/manage/core.html#uninstall)


### PR DESCRIPTION
The `.tool-versions` file can be indented and contain multiple spaces before the version so we need to replace multiple adjacent spaces by a single space