### PR TITLE
feat: add shims in REMOTE ENV

### DIFF
--- a/e2e/generate/test_generate_devcontainer
+++ b/e2e/generate/test_generate_devcontainer
@@ -47,6 +47,9 @@ assert_json_partial_object "mise generate devcontainer --mount-mise-data" "name,
     \"containerEnv\": {
       \"MISE_DATA_DIR\": \"/mnt/mise-data\"
     },
+    \"remoteEnv\": {
+      \"PATH\": \"\${containerEnv:PATH}:/mnt/mise-data/shims\"
+    },
     \"postCreateCommand\": \"sudo chown -R vscode:vscode /mnt/mise-data\"
   }
 "

--- a/src/cli/generate/devcontainer.rs
+++ b/src/cli/generate/devcontainer.rs
@@ -37,6 +37,8 @@ struct DevcontainerTemplate {
     mounts: Vec<DevcontainerMount>,
     #[serde(rename = "containerEnv")]
     container_env: HashMap<String, String>,
+    #[serde(rename = "remoteEnv")]
+    remote_env: HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "postCreateCommand")]
     post_create_command: Option<String>,
@@ -77,6 +79,7 @@ impl Devcontainer {
         let mut post_create_command: Option<String> = None;
         let mut mounts = vec![];
         let mut container_env = HashMap::new();
+        let mut remote_env = HashMap::new();
         if self.mount_mise_data {
             mounts.push(DevcontainerMount {
                 source: "mise-data-volume".to_string(),
@@ -84,6 +87,10 @@ impl Devcontainer {
                 type_field: "volume".to_string(),
             });
             container_env.insert("MISE_DATA_DIR".to_string(), "/mnt/mise-data".to_string());
+            remote_env.insert(
+                "PATH".to_string(),
+                "${containerEnv:PATH}:/mnt/mise-data/shims".to_string(),
+            );
             post_create_command = Some("sudo chown -R vscode:vscode /mnt/mise-data".to_string());
         }
 
@@ -110,6 +117,7 @@ impl Devcontainer {
             customizations,
             mounts,
             container_env,
+            remote_env,
             post_create_command,
         };
 


### PR DESCRIPTION
Some VS Code extensions (e.g., Terraform) do not function properly within the DevContainer environment. Specifically, they do not provide an option to configure the path to the tool's binary, which leads to issues when the tool is installed in non-standard locations (e.g., via a version manager like mise).