### PR TITLE
fix: infinite sourcing loop on bash-completion

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -29,7 +29,7 @@ you may source it separately or enable this flag to include it in the script.
 Examples:
 
 ```
-mise completion bash > /etc/bash_completion.d/mise
+mise completion bash > ~/local/share/bash-completion/mise
 mise completion zsh  > /usr/local/share/zsh/site-functions/_mise
 mise completion fish > ~/.config/fish/completions/mise.fish
 ```

--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -29,7 +29,7 @@ you may source it separately or enable this flag to include it in the script.
 Examples:
 
 ```
-mise completion bash > ~/local/share/bash-completion/mise
+mise completion bash > ~/.local/share/bash-completion/mise
 mise completion zsh  > /usr/local/share/zsh/site-functions/_mise
 mise completion fish > ~/.config/fish/completions/mise.fish
 ```

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -392,8 +392,8 @@ Then, run the following commands to install the completion script for your shell
 
 ```sh [bash]
 # This requires bash-completion to be installed
-mkdir -p /etc/bash_completion.d/
-mise completion bash --include-bash-completion-lib | sudo tee /etc/bash_completion.d/mise > /dev/null
+mkdir -p ~/local/share/bash-completion/
+mise completion bash --include-bash-completion-lib > ~/local/share/bash-completion/mise
 ```
 
 ```sh [zsh]

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -392,8 +392,8 @@ Then, run the following commands to install the completion script for your shell
 
 ```sh [bash]
 # This requires bash-completion to be installed
-mkdir -p ~/local/share/bash-completion/
-mise completion bash --include-bash-completion-lib > ~/local/share/bash-completion/mise
+mkdir -p ~/.local/share/bash-completion/
+mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/mise
 ```
 
 ```sh [zsh]

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -154,7 +154,7 @@ cmd "completion" help="Generate shell completions" {
     alias "complete" "completions" hide=true
     after_long_help r"Examples:
 
-    $ mise completion bash > /etc/bash_completion.d/mise
+    $ mise completion bash > ~/local/share/bash-completion/mise
     $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise
     $ mise completion fish > ~/.config/fish/completions/mise.fish
 "

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -154,7 +154,7 @@ cmd "completion" help="Generate shell completions" {
     alias "complete" "completions" hide=true
     after_long_help r"Examples:
 
-    $ mise completion bash > ~/local/share/bash-completion/mise
+    $ mise completion bash > ~/.local/share/bash-completion/mise
     $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise
     $ mise completion fish > ~/.config/fish/completions/mise.fish
 "

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -143,7 +143,7 @@ cmd cache help="Manage the mise cache" {
 }
 cmd completion help="Generate shell completions" {
     alias complete completions hide=#true
-    after_long_help "Examples:\n\n    $ mise completion bash > ~/local/share/bash-completion/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n"
+    after_long_help "Examples:\n\n    $ mise completion bash > ~/.local/share/bash-completion/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n"
     flag "-s --shell" help="Shell type to generate completions for" hide=#true {
         arg <SHELL_TYPE> {
             choices bash fish zsh

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -143,7 +143,7 @@ cmd cache help="Manage the mise cache" {
 }
 cmd completion help="Generate shell completions" {
     alias complete completions hide=#true
-    after_long_help "Examples:\n\n    $ mise completion bash > /etc/bash_completion.d/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n"
+    after_long_help "Examples:\n\n    $ mise completion bash > ~/local/share/bash-completion/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n"
     flag "-s --shell" help="Shell type to generate completions for" hide=#true {
         arg <SHELL_TYPE> {
             choices bash fish zsh

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -87,7 +87,7 @@ impl Completion {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    $ <bold>mise completion bash > /etc/bash_completion.d/mise</bold>
+    $ <bold>mise completion bash > ~/local/share/bash-completion/mise</bold>
     $ <bold>mise completion zsh  > /usr/local/share/zsh/site-functions/_mise</bold>
     $ <bold>mise completion fish > ~/.config/fish/completions/mise.fish</bold>
 "#

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -87,7 +87,7 @@ impl Completion {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    $ <bold>mise completion bash > ~/local/share/bash-completion/mise</bold>
+    $ <bold>mise completion bash > ~/.local/share/bash-completion/mise</bold>
     $ <bold>mise completion zsh  > /usr/local/share/zsh/site-functions/_mise</bold>
     $ <bold>mise completion fish > ~/.config/fish/completions/mise.fish</bold>
 "#


### PR DESCRIPTION
_Further information can be found [here](https://github.com/jdx/mise/discussions/5122)_

This pull request updates the default installation path for Bash shell completion scripts generated by the `mise` CLI tool. The changes ensure that the scripts are placed in user-specific directories instead of system-wide locations, improving compatibility and avoiding the need for elevated permissions.

### Updates to documentation:

* Updated examples in `docs/cli/completion.md` to redirect Bash completion scripts to `~/.local/share/bash-completion/mise` instead of `/etc/bash_completion.d/mise`.
* Modified installation instructions in `docs/installing-mise.md` to reflect the new user-specific path for Bash completion scripts.

### Updates to usage examples:

* Adjusted examples in `mise.usage.kdl` to use the updated Bash completion script path. [[1]](diffhunk://#diff-234df2d1ab30764d8ba0e8ac010e5489bc5e8f496aa1a9cdea5c56ef60cdcfb0L157-R157) [[2]](diffhunk://#diff-453fee9ce49c9f812a348d5f4414f628785e1463ce4fbec4885ed9108d446a0cL146-R146)

### Updates to source code:

* Updated the `AFTER_LONG_HELP` constant in `src/cli/completion.rs` to reflect the new default path for Bash completion scripts.