### PR TITLE
feat: mise search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,6 +3666,7 @@ dependencies = [
  "filetime",
  "flate2",
  "fslock",
+ "fuzzy-matcher",
  "gix",
  "glob",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ zstd = "0.13"
 gix = { version = "<1", features = ["worktree-mutation"] }
 jiff = "0.2"
 urlencoding = "2.1.3"
+fuzzy-matcher = "0.3.7"
 
 [target.'cfg(unix)'.dependencies]
 exec = "0.3"

--- a/docs/.vitepress/cli_commands.ts
+++ b/docs/.vitepress/cli_commands.ts
@@ -216,6 +216,9 @@ export const commands: { [key: string]: Command } = {
   run: {
     hide: false,
   },
+  search: {
+    hide: false,
+  },
   "self-update": {
     hide: false,
   },

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -110,6 +110,7 @@ Can also use `MISE_NO_CONFIG=1`
 - [`mise registry [-b --backend <BACKEND>] [--hide-aliased] [NAME]`](/cli/registry.md)
 - [`mise reshim [-f --force]`](/cli/reshim.md)
 - [`mise run [FLAGS]`](/cli/run.md)
+- [`mise search [FLAGS] [NAME]`](/cli/search.md)
 - [`mise self-update [FLAGS] [VERSION]`](/cli/self-update.md)
 - [`mise set [--file <FILE>] [-g --global] [ENV_VAR]…`](/cli/set.md)
 - [`mise settings [FLAGS] [SETTING] [VALUE] <SUBCOMMAND>`](/cli/settings.md)

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -1,0 +1,58 @@
+# `mise search`
+
+- **Usage**: `mise search [FLAGS] [NAME]`
+- **Source code**: [`src/cli/search.rs`](https://github.com/jdx/mise/blob/main/src/cli/search.rs)
+
+Search for tools in the registry
+
+This command searches a tool in the registry.
+
+By default, it will show all tools that fuzzy match the search term. For
+non-fuzzy matches, use the `--match-type` flag.
+
+## Arguments
+
+### `[NAME]`
+
+The tool to search for
+
+## Flags
+
+### `-i --interactive`
+
+Show interactive search
+
+### `-m --match-type <MATCH_TYPE>`
+
+Match type: equal, contains, or fuzzy
+
+**Choices:**
+
+- `equal`
+- `contains`
+- `fuzzy`
+
+### `--no-header`
+
+Don't display headers
+
+Examples:
+
+```
+$ mise search jq
+Tool  Description
+jq    Command-line JSON processor. https://github.com/jqlang/jq
+jqp   https://github.com/noahgorstein/jqp
+jiq   https://github.com/fiatjaf/jiq
+gojq  https://github.com/itchyny/gojq
+
+$ mise search --interactive
+Tool
+Search a tool
+❯ jq    Command-line JSON processor. https://github.com/jqlang/jq
+  jqp   https://github.com/noahgorstein/jqp
+  jiq   https://github.com/fiatjaf/jiq
+  gojq  https://github.com/itchyny/gojq
+/jq 
+esc clear filter • enter confirm
+```

--- a/e2e/cli/test_search
+++ b/e2e/cli/test_search
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+assert "mise search jq" "jq    Command-line JSON processor. https://github.com/jqlang/jq
+jqp   https://github.com/noahgorstein/jqp
+jiq   https://github.com/fiatjaf/jiq
+gojq  https://github.com/itchyny/gojq"
+
+assert "mise search --match-type contains jq" "gojq  https://github.com/itchyny/gojq
+jq    Command-line JSON processor. https://github.com/jqlang/jq
+jqp   https://github.com/noahgorstein/jqp"
+
+assert "mise search --match-type equal jq" "jq  Command-line JSON processor. https://github.com/jqlang/jq"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -134,6 +134,9 @@ Creates new shims based on bin paths from currently installed tools.
 mise\-run(1)
 Run task(s)
 .TP
+mise\-search(1)
+Search for tools in the registry
+.TP
 mise\-self\-update(1)
 Updates mise itself.
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -621,6 +621,18 @@ cmd run help="Run task(s)" {
     flag --no-cache
     mount run="mise tasks --usage"
 }
+cmd search help="Search for tools in the registry" {
+    long_help "Search for tools in the registry\n\nThis command searches a tool in the registry.\n\nBy default, it will show all tools that fuzzy match the search term. For\nnon-fuzzy matches, use the `--match-type` flag."
+    after_long_help "Examples:\n\n    $ mise search jq\n    Tool  Description\n    jq    Command-line JSON processor. https://github.com/jqlang/jq\n    jqp   https://github.com/noahgorstein/jqp\n    jiq   https://github.com/fiatjaf/jiq\n    gojq  https://github.com/itchyny/gojq\n\n    $ mise search --interactive\n    Tool\n    Search a tool\n    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq\n      jqp   https://github.com/noahgorstein/jqp\n      jiq   https://github.com/fiatjaf/jiq\n      gojq  https://github.com/itchyny/gojq\n    /jq \n    esc clear filter • enter confirm\n"
+    flag "-i --interactive" help="Show interactive search"
+    flag "-m --match-type" help="Match type: equal, contains, or fuzzy" {
+        arg <MATCH_TYPE> {
+            choices equal contains fuzzy
+        }
+    }
+    flag --no-header help="Don't display headers"
+    arg "[NAME]" help="The tool to search for" required=#false
+}
 cmd self-update help="Updates mise itself." {
     long_help "Updates mise itself.\n\nUses the GitHub Releases API to find the latest release and binary.\nBy default, this will also update any installed plugins.\nUses the `GITHUB_API_TOKEN` environment variable if set for higher rate limits.\n\nThis command is not available if mise is installed via a package manager."
     flag "-f --force" help="Update even if already up to date"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,6 +49,7 @@ mod render_help;
 mod render_mangen;
 mod reshim;
 pub mod run;
+mod search;
 #[cfg_attr(not(feature = "self_update"), path = "self_update_stub.rs")]
 pub mod self_update;
 mod set;
@@ -221,6 +222,7 @@ pub enum Commands {
     Registry(registry::Registry),
     Reshim(reshim::Reshim),
     Run(run::Run),
+    Search(search::Search),
     #[cfg(feature = "self_update")]
     SelfUpdate(self_update::SelfUpdate),
     Set(set::Set),
@@ -286,6 +288,7 @@ impl Commands {
             Self::Registry(cmd) => cmd.run(),
             Self::Reshim(cmd) => cmd.run(),
             Self::Run(cmd) => cmd.run(),
+            Self::Search(cmd) => cmd.run(),
             #[cfg(feature = "self_update")]
             Self::SelfUpdate(cmd) => cmd.run(),
             Self::Set(cmd) => cmd.run(),

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -1,0 +1,220 @@
+use std::sync::LazyLock as Lazy;
+
+use clap::ValueEnum;
+use demand::DemandOption;
+use demand::Select;
+use eyre::Result;
+use eyre::bail;
+use eyre::eyre;
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use itertools::Itertools;
+use xx::regex;
+
+use crate::registry::RegistryTool;
+use crate::{
+    config::SETTINGS,
+    registry::{REGISTRY, tool_enabled},
+    ui::table::MiseTable,
+};
+
+static FUZZY_MATCHER: Lazy<SkimMatcherV2> =
+    Lazy::new(|| SkimMatcherV2::default().use_cache(true).smart_case());
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum MatchType {
+    Equal,
+    Contains,
+    Fuzzy,
+}
+
+/// Search for tools in the registry
+///
+/// This command searches a tool in the registry.
+///
+/// By default, it will show all tools that fuzzy match the search term. For
+/// non-fuzzy matches, use the `--match-type` flag.
+#[derive(Debug, clap::Args)]
+#[clap(after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
+pub struct Search {
+    /// The tool to search for
+    name: Option<String>,
+
+    /// Show interactive search
+    #[clap(long, short, conflicts_with_all = &["match_type", "no_header"])]
+    interactive: bool,
+
+    /// Match type: equal, contains, or fuzzy
+    #[clap(long, short, value_enum, default_value = "fuzzy")]
+    match_type: MatchType,
+
+    /// Don't display headers
+    #[clap(long, alias = "no-headers")]
+    no_header: bool,
+}
+
+impl Search {
+    pub fn run(self) -> Result<()> {
+        if self.interactive {
+            self.interactive()?;
+        } else {
+            self.display_table()?;
+        }
+        Ok(())
+    }
+
+    fn interactive(&self) -> Result<()> {
+        let tools = self.get_tools();
+        let mut s = Select::new("Tool")
+            .description("Search a tool")
+            .filtering(true)
+            .filterable(true);
+        for t in tools.iter() {
+            let short = t.0.as_str();
+            let description = get_description(t.1);
+            s = s.option(
+                DemandOption::new(short)
+                    .label(short)
+                    .description(&description),
+            );
+        }
+        match s.run() {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    // user interrupted, exit gracefully
+                    Ok(())
+                } else {
+                    Err(eyre!(err))
+                }
+            }
+        }
+    }
+
+    fn display_table(&self) -> Result<()> {
+        let tools = self
+            .get_matches()
+            .into_iter()
+            .map(|(short, description)| vec![short, description])
+            .collect_vec();
+        if tools.is_empty() {
+            bail!("tool {} not found in registry", self.name.as_ref().unwrap());
+        }
+
+        let mut table = MiseTable::new(self.no_header, &["Tool", "Description"]);
+        for row in tools {
+            table.add_row(row);
+        }
+        table.print()
+    }
+
+    fn get_matches(&self) -> Vec<(String, String)> {
+        self.get_tools()
+            .iter()
+            .filter_map(|(short, rt)| {
+                let name = self.name.as_deref().unwrap_or("");
+                if name.is_empty() {
+                    Some((0, short, rt))
+                } else {
+                    match self.match_type {
+                        MatchType::Equal => {
+                            if *short == name {
+                                Some((0, short, rt))
+                            } else {
+                                None
+                            }
+                        }
+                        MatchType::Contains => {
+                            if short.contains(name) {
+                                Some((0, short, rt))
+                            } else {
+                                None
+                            }
+                        }
+                        MatchType::Fuzzy => FUZZY_MATCHER
+                            .fuzzy_match(&short.to_lowercase(), name.to_lowercase().as_str())
+                            .map(|score| (score, short, rt)),
+                    }
+                }
+            })
+            .sorted_by_key(|(score, _short, _rt)| -1 * *score)
+            .map(|(_score, short, rt)| (short.to_string(), get_description(rt)))
+            .collect()
+    }
+
+    fn get_tools(&self) -> Vec<(String, &'static RegistryTool)> {
+        REGISTRY
+            .iter()
+            .filter(|(short, _)| filter_enabled(short))
+            .map(|(short, rt)| (short.to_string(), rt))
+            .sorted_by(|(a, _), (b, _)| a.cmp(b))
+            .collect_vec()
+    }
+}
+
+static AFTER_LONG_HELP: &str = color_print::cstr!(
+    r#"<bold><underline>Examples:</underline></bold>
+
+    $ <bold>mise search jq</bold>
+    Tool  Description
+    jq    Command-line JSON processor. https://github.com/jqlang/jq
+    jqp   https://github.com/noahgorstein/jqp
+    jiq   https://github.com/fiatjaf/jiq
+    gojq  https://github.com/itchyny/gojq
+
+    $ <bold>mise search --interactive</bold>
+    Tool
+    Search a tool
+    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq
+      jqp   https://github.com/noahgorstein/jqp
+      jiq   https://github.com/fiatjaf/jiq
+      gojq  https://github.com/itchyny/gojq
+    /jq 
+    esc clear filter • enter confirm
+"#
+);
+
+fn filter_enabled(short: &str) -> bool {
+    tool_enabled(
+        &SETTINGS.enable_tools,
+        &SETTINGS.disable_tools,
+        &short.to_string(),
+    )
+}
+
+fn get_description(tool: &RegistryTool) -> String {
+    let description = tool.description.unwrap_or_default();
+    let backend = get_backends(tool.backends())
+        .iter()
+        .filter(|b| !SETTINGS.disable_backends.contains(b))
+        .map(|b| b.to_string())
+        .next()
+        .unwrap_or_default();
+    if description.is_empty() {
+        format!("{backend}")
+    } else {
+        format!("{description}. {backend}")
+    }
+}
+
+fn get_backends(backends: Vec<&'static str>) -> Vec<String> {
+    if backends.is_empty() {
+        return vec!["".to_string()];
+    }
+    backends
+        .iter()
+        .map(|backend| {
+            let prefix = backend.split(':').next().unwrap_or("");
+            let slug = backend.split(':').last().unwrap_or("");
+            let slug = regex!(r"^(.*?)\[.*\]$").replace_all(slug, "$1");
+            match prefix {
+                "core" => format!("https://mise.jdx.dev/lang/{slug}.html"),
+                "cargo" => format!("https://crates.io/crates/{slug}"),
+                "go" => format!("https://pkg.go.dev/{slug}"),
+                "pipx" => format!("https://pypi.org/project/{slug}"),
+                "npm" => format!("https://www.npmjs.com/package/{slug}"),
+                _ => format!("https://github.com/{slug}"),
+            }
+        })
+        .collect()
+}

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -191,7 +191,7 @@ fn get_description(tool: &RegistryTool) -> String {
         .next()
         .unwrap_or_default();
     if description.is_empty() {
-        format!("{backend}")
+        backend.to_string()
     } else {
         format!("{description}. {backend}")
     }
@@ -205,7 +205,7 @@ fn get_backends(backends: Vec<&'static str>) -> Vec<String> {
         .iter()
         .map(|backend| {
             let prefix = backend.split(':').next().unwrap_or("");
-            let slug = backend.split(':').last().unwrap_or("");
+            let slug = backend.split(':').next_back().unwrap_or("");
             let slug = regex!(r"^(.*?)\[.*\]$").replace_all(slug, "$1");
             match prefix {
                 "core" => format!("https://mise.jdx.dev/lang/{slug}.html"),

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1816,6 +1816,36 @@ const completionSpec: Fig.Spec = {
       cache: false,
     },
     {
+      name: "search",
+      description: "Search for tools in the registry",
+      options: [
+        {
+          name: ["-i", "--interactive"],
+          description: "Show interactive search",
+          isRepeatable: false,
+        },
+        {
+          name: ["-m", "--match-type"],
+          description: "Match type: equal, contains, or fuzzy",
+          isRepeatable: false,
+          args: {
+            name: "match_type",
+            suggestions: ["equal", "contains", "fuzzy"],
+          },
+        },
+        {
+          name: "--no-header",
+          description: "Don't display headers",
+          isRepeatable: false,
+        },
+      ],
+      args: {
+        name: "name",
+        description: "The tool to search for",
+        isOptional: true,
+      },
+    },
+    {
       name: "self-update",
       description: "Updates mise itself.",
       options: [


### PR DESCRIPTION
Fixes #5084 

Adds a new `search` command to search the registry for tools. By default it matches the search term with a `fuzzy` match (to match the interactive behaviour) and displays the `tool` and `description` in a table. If no search term is provided all tools are listed. 

The `description` also contains the RegistryTool description and the preferred URL to the tool similar to https://mise.jdx.dev/registry.html. Backends that are disabled are filtered out beforehand.

```
❯ mise search jq
Tool  Description
jq    Command-line JSON processor. https://github.com/jqlang/jq
jqp   https://github.com/noahgorstein/jqp
jiq   https://github.com/fiatjaf/jiq
gojq  https://github.com/itchyny/gojq
```

Following arguments are supported.
* `--interactive` - Interactive mode using a filterable Select
* `--no-header` - Don't  display the table header
* `--match-type` - Match type, either fuzzy (default), equal or contains

/cc @jdx, @hverlin Any comments on this approach?
