### PR TITLE
chore: release 2025.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2025.5.11](https://github.com/jdx/mise/compare/v2025.5.10..v2025.5.11) - 2025-05-23
+
+### 🚀 Features
+
+- **(registry)** add victoriametrics by [@shikharbhardwaj](https://github.com/shikharbhardwaj) in [#5161](https://github.com/jdx/mise/pull/5161)
+
+### 🐛 Bug Fixes
+
+- **(registry)** remove full from taplo by [@risu729](https://github.com/risu729) in [#5160](https://github.com/jdx/mise/pull/5160)
+- mise registry links for ubi with exe selector by [@mnm364](https://github.com/mnm364) in [#5156](https://github.com/jdx/mise/pull/5156)
+- mise settings add idiomatic_version_file_enable_tools stores duplicates in config by [@roele](https://github.com/roele) in [#5162](https://github.com/jdx/mise/pull/5162)
+- infinite sourcing loop on bash-completion by [@ken-kuro](https://github.com/ken-kuro) in [#5150](https://github.com/jdx/mise/pull/5150)
+
+### 🧪 Testing
+
+- disable mockolo since linux does not work anymore by [@jdx](https://github.com/jdx) in [5387d70](https://github.com/jdx/mise/commit/5387d7012d65b3da3dde12cd0a0eb07288b2d8f6)
+
+### New Contributors
+
+- @ken-kuro made their first contribution in [#5150](https://github.com/jdx/mise/pull/5150)
+- @shikharbhardwaj made their first contribution in [#5161](https://github.com/jdx/mise/pull/5161)
+
 ## [2025.5.10](https://github.com/jdx/mise/compare/v2025.5.9..v2025.5.10) - 2025-05-22
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.5.10"
+version = "2025.5.11"
 dependencies = [
  "base64 0.22.1",
  "built",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2025.5.10"
+version = "2025.5.11"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.5.10 macos-arm64 (a1b2d3e 2025-05-22)
+2025.5.11 macos-arm64 (a1b2d3e 2025-05-23)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_5_10:-}" ]] || _cache_invalid _usage_spec_mise_2025_5_10 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_5_10;
+  if ( [[ -z "${_usage_spec_mise_2025_5_11:-}" ]] || _cache_invalid _usage_spec_mise_2025_5_11 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_5_11;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_5_10 spec
+    _store_cache _usage_spec_mise_2025_5_11 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_5_10:-} ]]; then
-        _usage_spec_mise_2025_5_10="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_5_11:-} ]]; then
+        _usage_spec_mise_2025_5_11="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_5_10}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_5_11}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_5_10
-  set -g _usage_spec_mise_2025_5_10 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_5_11
+  set -g _usage_spec_mise_2025_5_11 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_10" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_11" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_10" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_11" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.5.10";
+  version = "2025.5.11";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.5.10
+Version: 2025.5.11
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(registry)** add victoriametrics by [@shikharbhardwaj](https://github.com/shikharbhardwaj) in [#5161](https://github.com/jdx/mise/pull/5161)

### 🐛 Bug Fixes

- **(registry)** remove full from taplo by [@risu729](https://github.com/risu729) in [#5160](https://github.com/jdx/mise/pull/5160)
- mise registry links for ubi with exe selector by [@mnm364](https://github.com/mnm364) in [#5156](https://github.com/jdx/mise/pull/5156)
- mise settings add idiomatic_version_file_enable_tools stores duplicates in config by [@roele](https://github.com/roele) in [#5162](https://github.com/jdx/mise/pull/5162)
- infinite sourcing loop on bash-completion by [@ken-kuro](https://github.com/ken-kuro) in [#5150](https://github.com/jdx/mise/pull/5150)

### 🧪 Testing

- disable mockolo since linux does not work anymore by [@jdx](https://github.com/jdx) in [5387d70](https://github.com/jdx/mise/commit/5387d7012d65b3da3dde12cd0a0eb07288b2d8f6)

### New Contributors

- @ken-kuro made their first contribution in [#5150](https://github.com/jdx/mise/pull/5150)
- @shikharbhardwaj made their first contribution in [#5161](https://github.com/jdx/mise/pull/5161)