### PR TITLE
fix(registry): remove full from taplo

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -131,7 +131,7 @@ slsa-verifier-macos-aarch64 = "sha256:84d9122ce12e0c79080844285fd5c4976407ed3463
 
 [tools.taplo]
 version = "0.9.3"
-backend = "aqua:tamasfe/taplo/full"
+backend = "aqua:tamasfe/taplo"
 
 [tools.taplo.checksums]
 taplo-full-linux-aarch64 = "sha256:9ffa2a799ff0ca601a0e7ff93dcae64a34c81c677916e6f0d3c81d62e0670d83"

--- a/registry.toml
+++ b/registry.toml
@@ -1847,8 +1847,8 @@ talosctl.backends = [
 tanka.backends = ["aqua:grafana/tanka", "asdf:trotttrotttrott/asdf-tanka"]
 tanzu.backends = ["asdf:mise-plugins/tanzu-plug-in-for-asdf"]
 taplo.backends = [
-    "aqua:tamasfe/taplo/full",
-    "ubi:tamasfe/taplo[matching=full]",
+    "aqua:tamasfe/taplo",
+    "ubi:tamasfe/taplo",
     "cargo:taplo-cli"
 ]
 taplo.test = ["taplo --version", "taplo {{version}}"]

--- a/registry.toml
+++ b/registry.toml
@@ -1846,11 +1846,7 @@ talosctl.backends = [
 ]
 tanka.backends = ["aqua:grafana/tanka", "asdf:trotttrotttrott/asdf-tanka"]
 tanzu.backends = ["asdf:mise-plugins/tanzu-plug-in-for-asdf"]
-taplo.backends = [
-    "aqua:tamasfe/taplo",
-    "ubi:tamasfe/taplo",
-    "cargo:taplo-cli"
-]
+taplo.backends = ["aqua:tamasfe/taplo", "ubi:tamasfe/taplo", "cargo:taplo-cli"]
 taplo.test = ["taplo --version", "taplo {{version}}"]
 task.backends = ["ubi:go-task/task", "asdf:particledecay/asdf-task"]
 tctl.backends = ["aqua:temporalio/tctl", "asdf:eko/asdf-tctl"]


### PR DESCRIPTION
The latest taplo release, [0.10.0](https://github.com/tamasfe/taplo/releases/tag/0.10.0), no longer provides a full version. The lsp feature is now enabled by default in the standard release.

This change impacts users using `taplo@0.9.3` or older.
Previously, mise would fetch the full version for 0.9.3, but with this PR, `taplo@0.9.3` will now resolve to the non-full version.
This would cause a problem like https://github.com/jdx/mise/pull/5017.

However, the installation of `taplo@0.10.0` is currently failing, so I think we need to update the registry.

For users who require the full version of `taplo@0.9.3`, they will need to explicitly specify `aqua:tamasfe/taplo/full@0.9.3` in their configuration.

