### PR TITLE
feat(registry): add victoriametrics

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2007,6 +2007,11 @@ velero.backends = ["aqua:vmware-tanzu/velero", "asdf:looztra/asdf-velero"]
 vendir.backends = ["aqua:carvel-dev/vendir", "asdf:vmware-tanzu/asdf-carvel"]
 venom.backends = ["aqua:ovh/venom", "asdf:aabouzaid/asdf-venom"]
 vhs.backends = ["aqua:charmbracelet/vhs", "asdf:chessmango/asdf-vhs"]
+victoria-metrics.backends = ["aqua:victoriametrics/victoriametrics/victoria-metrics"]
+victoria-metrics.test = [
+    "victoria-metrics --version | awk -F'-' '{print $6}'",
+    "{{version}}"
+]
 viddy.backends = ["aqua:sachaos/viddy", "asdf:ryodocx/asdf-viddy"]
 vim.backends = ["asdf:mise-plugins/mise-vim"]
 virtualos.backends = ["asdf:mise-plugins/mise-virtualos"]

--- a/registry.toml
+++ b/registry.toml
@@ -2007,7 +2007,9 @@ velero.backends = ["aqua:vmware-tanzu/velero", "asdf:looztra/asdf-velero"]
 vendir.backends = ["aqua:carvel-dev/vendir", "asdf:vmware-tanzu/asdf-carvel"]
 venom.backends = ["aqua:ovh/venom", "asdf:aabouzaid/asdf-venom"]
 vhs.backends = ["aqua:charmbracelet/vhs", "asdf:chessmango/asdf-vhs"]
-victoria-metrics.backends = ["aqua:victoriametrics/victoriametrics/victoria-metrics"]
+victoria-metrics.backends = [
+    "aqua:victoriametrics/victoriametrics/victoria-metrics"
+]
 victoria-metrics.test = [
     "victoria-metrics --version | awk -F'-' '{print $6}'",
     "{{version}}"


### PR DESCRIPTION
Adds VictoriaMetrics: https://github.com/VictoriaMetrics/VictoriaMetrics

VictoriaMetrics is an open-source, cost-effective monitoring solution and time series database.

```
$ cargo run --bin mise -- install victoria-metrics  
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/mise install victoria-metrics`
mise victoria-metrics@1.117.1     ✓ installed 
$ cargo run --bin mise -- tool victoria-metrics
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/mise tool victoria-metrics`
Backend:                                         aqua:victoriametrics/victoriametrics/victoria-metrics                                                           
Description:                                     VictoriaMetrics: fast, cost-effective monitoring solution and time series database                              
Installed Versions:                              1.117.1                                                                                                         
Tool Options:                                    [none]
$ cargo run --bin mise -- uninstall victoria-metrics
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/mise uninstall victoria-metrics`
mise victoria-metrics@1.117.1     ✓ uninstalled
```