### PR TITLE
fix: mise settings add idiomatic_version_file_enable_tools stores duplicates in config

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -195,6 +195,7 @@ pub struct Settings {"#
                 "Duration" => "String",
                 "ListString" => "Vec<String>",
                 "ListPath" => "Vec<PathBuf>",
+                "SetString" => "BTreeSet<String>",
                 t => panic!("Unknown type: {}", t),
             }));
         if let Some(type_) = type_ {

--- a/docs/cli/config/set.md
+++ b/docs/cli/config/set.md
@@ -33,6 +33,7 @@ If not provided, the nearest mise.toml file will be used
 - `float`
 - `bool`
 - `list`
+- `set`
 
 Examples:
 

--- a/e2e/cli/test_settings_add
+++ b/e2e/cli/test_settings_add
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# mise should ignore identical values which have been passed using `add`
 assert "mise settings add disable_hints a" ""
 assert "mise settings add disable_hints b" ""
 assert "mise settings get disable_hints" '["a", "b"]'
+assert "mise settings add disable_hints a" ""
+assert "grep disable_hints ~/.config/mise/config.toml" 'disable_hints = ["a", "b"]'
+
+assert "mise settings add idiomatic_version_file_enable_tools python" ""
+assert "mise settings add idiomatic_version_file_enable_tools rust" ""
+assert "mise settings get idiomatic_version_file_enable_tools" '["python", "rust"]'
+assert "mise settings add idiomatic_version_file_enable_tools python,rust,zig" ""
+assert "grep idiomatic_version_file_enable_tools ~/.config/mise/config.toml" 'idiomatic_version_file_enable_tools = ["python", "rust", "zig"]'

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -199,7 +199,7 @@ cmd config help="Manage config files" {
         }
         flag "-t --type" {
             arg <TYPE> {
-                choices infer string integer float bool list
+                choices infer string integer float bool list set
             }
         }
         arg <KEY> help="The path of the config to display"

--- a/settings.toml
+++ b/settings.toml
@@ -260,18 +260,18 @@ installing plugins, e.g.: `mise plugin install node https://github.com/asdf-vm/a
 
 [disable_hints]
 env = "MISE_DISABLE_HINTS"
-type = "ListString"
+type = "SetString"
 rust_type = "BTreeSet<String>"
 default = []
-parse_env = "list_by_comma"
+parse_env = "set_by_comma"
 description = "Turns off helpful hints when using different mise features"
 
 [disable_tools]
 env = "MISE_DISABLE_TOOLS"
-type = "ListString"
+type = "SetString"
 rust_type = "BTreeSet<String>"
 default = []
-parse_env = "list_by_comma"
+parse_env = "set_by_comma"
 description = "Tools defined in mise.toml that should be ignored"
 
 [dotnet.package_flags]
@@ -304,10 +304,10 @@ However, you can set this to a different URL if you have a custom feed or want t
 
 [enable_tools]
 env = "MISE_ENABLE_TOOLS"
-type = "ListString"
+type = "SetString"
 rust_type = "BTreeSet<String>"
 default = []
-parse_env = "list_by_comma"
+parse_env = "set_by_comma"
 description = "Tools defined in mise.toml that should be used - all other tools are ignored"
 
 [env]
@@ -480,18 +480,18 @@ Set to "false" to disable idiomatic version file parsing.
 
 [idiomatic_version_file_disable_tools]
 env = "MISE_IDIOMATIC_VERSION_FILE_DISABLE_TOOLS"
-type = "ListString"
+type = "SetString"
 rust_type = "BTreeSet<String>"
 default = []
-parse_env = "list_by_comma"
+parse_env = "set_by_comma"
 deprecated = "This has been replaced with the idiomatic_version_file_enable_tools setting."
 description = "Specific tools to disable idiomatic version files for."
 
 [idiomatic_version_file_enable_tools]
 env = "MISE_IDIOMATIC_VERSION_FILE_ENABLE_TOOLS"
-type = "ListString"
+type = "SetString"
 rust_type = "Option<BTreeSet<String>>"
-parse_env = "list_by_comma"
+parse_env = "set_by_comma"
 description = "Specific tools to enable idiomatic version files for like .node-version, .ruby-version, etc."
 
 [ignored_config_paths]
@@ -519,10 +519,10 @@ hide = true
 
 [legacy_version_file_disable_tools]
 env = "MISE_LEGACY_VERSION_FILE_DISABLE_TOOLS"
-type = "ListString"
+type = "SetString"
 rust_type = "BTreeSet<String>"
 default = []
-parse_env = "list_by_comma"
+parse_env = "set_by_comma"
 deprecated = "Use idiomatic_version_file_disable_tools instead."
 description = "Specific tools to disable idiomatic version files for."
 hide = true
@@ -1121,10 +1121,10 @@ description = "Automatically install missing tools when executing tasks."
 
 [task_skip]
 env = "MISE_TASK_SKIP"
-type = "ListString"
+type = "SetString"
 rust_type = "BTreeSet<String>"
 default = []
-parse_env = "list_by_comma"
+parse_env = "set_by_comma"
 description = "Tasks to skip when running `mise run`."
 
 [task_timings]

--- a/src/cli/config/set.rs
+++ b/src/cli/config/set.rs
@@ -1,6 +1,7 @@
 use crate::config::config_file::mise_toml::MiseToml;
 use crate::config::settings::{SETTINGS_META, SettingsType};
 use crate::config::top_toml_config;
+use crate::toml::dedup_toml_array;
 use clap::ValueEnum;
 use eyre::bail;
 use std::path::PathBuf;
@@ -39,6 +40,8 @@ pub enum TomlValueTypes {
     Bool,
     #[value()]
     List,
+    #[value()]
+    Set,
 }
 
 impl ConfigSet {
@@ -91,6 +94,7 @@ impl ConfigSet {
                         SettingsType::Url => TomlValueTypes::String,
                         SettingsType::ListString => TomlValueTypes::List,
                         SettingsType::ListPath => TomlValueTypes::List,
+                        SettingsType::SetString => TomlValueTypes::Set,
                     },
                     None => match self.value.as_str() {
                         "true" | "false" => TomlValueTypes::Bool,
@@ -112,6 +116,10 @@ impl ConfigSet {
                     list.push(item);
                 }
                 toml_edit::Item::Value(toml_edit::Value::Array(list))
+            }
+            TomlValueTypes::Set => {
+                let set = toml_edit::Array::new();
+                toml_edit::Item::Value(toml_edit::Value::Array(dedup_toml_array(&set)))
             }
             TomlValueTypes::Infer => bail!("Type not found"),
         };

--- a/src/cli/settings/ls.rs
+++ b/src/cli/settings/ls.rs
@@ -54,6 +54,7 @@ fn settings_type_to_string(st: &SettingsType) -> String {
         SettingsType::Url => "string".to_string(),
         SettingsType::ListString => "array".to_string(),
         SettingsType::ListPath => "array".to_string(),
+        SettingsType::SetString => "array".to_string(),
     }
 }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -37,6 +37,7 @@ pub enum SettingsType {
     Url,
     ListString,
     ListPath,
+    SetString,
 }
 
 pub struct SettingsMeta {
@@ -487,4 +488,17 @@ where
         "false" | "no" | "0" => Ok(false),
         _ => Ok(true),
     }
+}
+
+fn set_by_comma<T, C>(input: &str) -> Result<C, <T as FromStr>::Err>
+where
+    T: FromStr + Eq + Ord,
+    C: FromIterator<T>,
+{
+    input
+        .split(',')
+        .map(T::from_str)
+        // collect into HashSet to remove duplicates
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map(|set| set.into_iter().collect())
 }

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 #[macro_export]
 macro_rules! parse_error {
     ($key:expr, $val:expr, $t:expr) => {{
@@ -10,4 +12,15 @@ macro_rules! parse_error {
             $crate::ui::style::eblue($val.to_string().trim()),
         )
     }};
+}
+
+pub fn dedup_toml_array(array: &toml_edit::Array) -> toml_edit::Array {
+    let mut seen = HashSet::new();
+    let mut deduped = toml_edit::Array::new();
+    for item in array.iter() {
+        if seen.insert(item.as_str()) {
+            deduped.push(item.clone());
+        }
+    }
+    deduped
 }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -810,6 +810,7 @@ const completionSpec: Fig.Spec = {
                   "float",
                   "bool",
                   "list",
+                  "set",
                 ],
               },
             },

--- a/xtasks/render/settings.ts
+++ b/xtasks/render/settings.ts
@@ -43,6 +43,7 @@ function buildElement(key: string, props: Props): Element {
     .with("Integer", () => "number")
     .with("ListString", () => "string[]")
     .with("ListPath", () => "string[]")
+    .with("SetString", () => "string[]")
     .otherwise(() => {
       throw new Error(`Unknown type: ${type}`);
     });


### PR DESCRIPTION
Fixes #4919 and replaces #4925