### PR TITLE
Update ruby.md: clarify how to enable ideomatic version file reading

### DIFF
--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -49,6 +49,12 @@ Create a `.ruby-version` file for the current version of ruby:
 ruby -v > .ruby-version
 ```
 
+Enable ideomatic version file reading for ruby:
+
+```sh
+mise settings add idiomatic_version_file_enable_tools ruby
+```
+
 See [idiomatic version files](/configuration.html#idiomatic-version-files) for more information.
 
 ## Manually updating ruby-build


### PR DESCRIPTION
Add information from command line to documentation as it becomes more critical before changing default behavior.