### PR TITLE
fix: flaky keep-order e2e test

### DIFF
--- a/e2e/tasks/test_task_keep_order
+++ b/e2e/tasks/test_task_keep_order
@@ -15,5 +15,4 @@ tasks.a = "echo a"
 tasks.b = "echo b ; exit 1"
 tasks.all.depends = ['a', 'b']
 EOF
-assert_fail "mise run -o keep-order all" "[a] a
-[b] b"
+assert_fail "mise run -o keep-order all" "[b] b"


### PR DESCRIPTION
Fix flaky test introduced in #5175 (sorry!) where task b can fail before task a has a chance to run so a has no output.