### PR TITLE
fix(zig): get tarball url from download index

### DIFF
--- a/e2e-win/zig.Tests.ps1
+++ b/e2e-win/zig.Tests.ps1
@@ -3,7 +3,7 @@ Describe 'zig' {
         mise x zig@0.13.0 -- zig version | Should -be "0.13.0"
     }
 
-    It 'executes zig 0.14.0-dev.2577+271452d22' {
-        mise x zig@0.14.0-dev.2577+271452d22 -- zig version | Should -be "0.14.0-dev.2577+271452d22"
+    It 'executes zig 2024.11.0-mach' {
+        mise x zig@2024.11.0-mach -- zig version | Should -be "0.14.0-dev.2577+271452d22"
     }
 }

--- a/e2e/core/test_zig
+++ b/e2e/core/test_zig
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 assert "mise x zig@0.13.0 -- zig version" "0.13.0"
-# TODO: enable this later when 0.15 is working
-# assert "mise x zig@ref:master -- zig version"
+assert "mise x zig@ref:master -- zig version"
 assert "mise x zig@0.14.0-dev.2577+271452d22 -- zig version" "0.14.0-dev.2577+271452d22"
 assert "mise x zig@ref:mach-latest -- zig version"

--- a/e2e/core/test_zig
+++ b/e2e/core/test_zig
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 assert "mise x zig@0.13.0 -- zig version" "0.13.0"
-assert "mise x zig@ref:master -- zig version"
+assert "mise x zig@master -- zig version"
 assert "mise x zig@2024.11.0-mach -- zig version" "0.14.0-dev.2577+271452d22"
-assert "mise x zig@ref:mach-latest -- zig version"
+assert "mise x zig@mach-latest -- zig version"

--- a/e2e/core/test_zig
+++ b/e2e/core/test_zig
@@ -2,5 +2,5 @@
 
 assert "mise x zig@0.13.0 -- zig version" "0.13.0"
 assert "mise x zig@ref:master -- zig version"
-assert "mise x zig@0.14.0-dev.2577+271452d22 -- zig version" "0.14.0-dev.2577+271452d22"
+assert "mise x zig@2024.11.0-mach -- zig version" "0.14.0-dev.2577+271452d22"
 assert "mise x zig@ref:mach-latest -- zig version"

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -54,13 +54,7 @@ impl ZigPlugin {
         let zig_download_index = "https://ziglang.org/download/index.json";
         let machengine_download_index = "https://machengine.org/zig/index.json";
 
-        let url = if tv.version == "ref:master" {
-            self.get_tarball_url_from_json(zig_download_index, "master", arch(), os())
-                .await?
-        } else if tv.version == "ref:mach-latest" {
-            self.get_tarball_url_from_json(machengine_download_index, "mach-latest", arch(), os())
-                .await?
-        } else if regex!(r"-mach$").is_match(&tv.version) {
+        let url = if regex!(r"^mach-|-mach$").is_match(&tv.version) {
             self.get_tarball_url_from_json(
                 machengine_download_index,
                 tv.version.as_str(),

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -51,41 +51,40 @@ impl ZigPlugin {
     }
 
     async fn download(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<PathBuf> {
-        let archive_ext = if cfg!(target_os = "windows") {
-            "zip"
-        } else {
-            "tar.xz"
-        };
+        let zig_download_index = "https://ziglang.org/download/index.json";
+        let machengine_download_index = "https://machengine.org/zig/index.json";
 
         let url = if tv.version == "ref:master" {
-            format!(
-                "https://ziglang.org/builds/zig-{}-{}-{}.{archive_ext}",
-                os(),
+            self.get_tarball_url_from_json(
+                zig_download_index,
+                self.get_version_from_json(zig_download_index, "master")
+                    .await?
+                    .as_str(),
                 arch(),
-                self.get_version_from_json("master").await?
+                os(),
             )
+            .await?
         } else if tv.version == "ref:mach-latest" {
-            format!(
-                "https://pkg.machengine.org/zig/zig-{}-{}-{}.{archive_ext}",
-                os(),
+            self.get_tarball_url_from_json(
+                machengine_download_index,
+                self.get_version_from_json(machengine_download_index, "mach-latest")
+                    .await?
+                    .as_str(),
                 arch(),
-                self.get_version_from_json("mach-latest").await?
+                os(),
             )
+            .await?
         } else if regex!(r"^[0-9]+\.[0-9]+\.[0-9]+-dev.[0-9]+\+[0-9a-f]+$").is_match(&tv.version) {
-            format!(
-                "https://pkg.machengine.org/zig/zig-{}-{}-{}.{archive_ext}",
-                os(),
+            self.get_tarball_url_from_json(
+                machengine_download_index,
+                tv.version.as_str(),
                 arch(),
-                tv.version
+                os(),
             )
+            .await?
         } else {
-            format!(
-                "https://ziglang.org/download/{}/zig-{}-{}-{}.{archive_ext}",
-                tv.version,
-                os(),
-                arch(),
-                tv.version
-            )
+            self.get_tarball_url_from_json(zig_download_index, tv.version.as_str(), arch(), os())
+                .await?
         };
 
         let filename = url.split('/').next_back().unwrap();
@@ -128,22 +127,28 @@ impl ZigPlugin {
         self.test_zig(ctx, tv)
     }
 
-    async fn get_version_from_json(&self, key: &str) -> Result<String> {
-        let json_url: &str = if key == "master" {
-            "https://ziglang.org/download/index.json"
-        } else if key == "mach-latest" {
-            "https://machengine.org/zig/index.json"
-        } else {
-            // Left blank for future sources just in case
-            ""
-        };
-
+    async fn get_version_from_json(&self, json_url: &str, key: &str) -> Result<String> {
         let version_json: serde_json::Value = HTTP_FETCH.json(json_url).await?;
         let zig_version = version_json
             .pointer(&format!("/{key}/version"))
             .and_then(|v| v.as_str())
             .ok_or_else(|| eyre::eyre!("Failed to get zig version from {:?}", json_url))?;
         Ok(zig_version.to_string())
+    }
+
+    async fn get_tarball_url_from_json(
+        &self,
+        json_url: &str,
+        version: &str,
+        arch: &str,
+        os: &str,
+    ) -> Result<String> {
+        let version_json: serde_json::Value = HTTP_FETCH.json(json_url).await?;
+        let zig_tarball_url = version_json
+            .pointer(&format!("/{version}/{arch}-{os}/tarball"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| eyre::eyre!("Failed to get zig tarball url from {:?}", json_url))?;
+        Ok(zig_tarball_url.to_string())
     }
 }
 

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -55,25 +55,11 @@ impl ZigPlugin {
         let machengine_download_index = "https://machengine.org/zig/index.json";
 
         let url = if tv.version == "ref:master" {
-            self.get_tarball_url_from_json(
-                zig_download_index,
-                self.get_version_from_json(zig_download_index, "master")
-                    .await?
-                    .as_str(),
-                arch(),
-                os(),
-            )
-            .await?
+            self.get_tarball_url_from_json(zig_download_index, "master", arch(), os())
+                .await?
         } else if tv.version == "ref:mach-latest" {
-            self.get_tarball_url_from_json(
-                machengine_download_index,
-                self.get_version_from_json(machengine_download_index, "mach-latest")
-                    .await?
-                    .as_str(),
-                arch(),
-                os(),
-            )
-            .await?
+            self.get_tarball_url_from_json(machengine_download_index, "mach-latest", arch(), os())
+                .await?
         } else if regex!(r"^[0-9]+\.[0-9]+\.[0-9]+-dev.[0-9]+\+[0-9a-f]+$").is_match(&tv.version) {
             self.get_tarball_url_from_json(
                 machengine_download_index,
@@ -125,15 +111,6 @@ impl ZigPlugin {
 
     fn verify(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
         self.test_zig(ctx, tv)
-    }
-
-    async fn get_version_from_json(&self, json_url: &str, key: &str) -> Result<String> {
-        let version_json: serde_json::Value = HTTP_FETCH.json(json_url).await?;
-        let zig_version = version_json
-            .pointer(&format!("/{key}/version"))
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| eyre::eyre!("Failed to get zig version from {:?}", json_url))?;
-        Ok(zig_version.to_string())
     }
 
     async fn get_tarball_url_from_json(

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -60,7 +60,7 @@ impl ZigPlugin {
         } else if tv.version == "ref:mach-latest" {
             self.get_tarball_url_from_json(machengine_download_index, "mach-latest", arch(), os())
                 .await?
-        } else if regex!(r"^[0-9]+\.[0-9]+\.[0-9]+-dev.[0-9]+\+[0-9a-f]+$").is_match(&tv.version) {
+        } else if regex!(r"-mach$").is_match(&tv.version) {
             self.get_tarball_url_from_json(
                 machengine_download_index,
                 tv.version.as_str(),


### PR DESCRIPTION
Fix: #5173
BREAKING CHANGE: To match mach version index, `*-mach` version schema is now used instead of `*-dev.*` e.g. `2024.11.0-mach` instead of `0.14.0-dev.2577+271452d22`
Co-authored-by: Julius Alphonso <12978899+JadeMaveric@users.noreply.github.com>