### PR TITLE
fix: installing tools with postinstall hooks fails

### DIFF
--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -179,6 +179,8 @@ impl BackendArg {
             let opts_str = opts
                 .opts
                 .iter()
+                // filter out global options that are only relevant for initial installation
+                .filter(|(k, _)| !["postinstall", "install_env"].contains(&k.as_str()))
                 .map(|(k, v)| format!("{k}={v}"))
                 .collect::<Vec<_>>()
                 .join(",");

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -222,10 +222,16 @@ fn read_backend_meta(short: &str) -> Option<Vec<String>> {
 }
 
 pub fn write_backend_meta(ba: &BackendArg) -> Result<()> {
-    // do not write options for core plugins
-    let full = match ba.full().starts_with("core:") {
-        true => ba.full(),
-        false => ba.full_with_opts(),
+    // only use full_with_opts for specific plugin prefixes
+    let full = match ba.full() {
+        full if full.starts_with("cargo:")
+            || full.starts_with("go:")
+            || full.starts_with("pipx:")
+            || full.starts_with("ubi:") =>
+        {
+            ba.full_with_opts()
+        }
+        _ => ba.full(),
     };
     let doc = format!("{}\n{}", ba.short, full);
     file::write(backend_meta_path(&ba.short), doc.trim())?;


### PR DESCRIPTION
According to the discussion #5001 the change #4960 to support GH Enterprise/GitLab is causing a regression for certain tools (e.g. aqua) because of the global ToolOption argument `postinstall`. To address this we should filter the global once on install arguments and only store ToolOptions for certain backends (`cargo`, `go`, `pipx`, `ubi`)