### PR TITLE
docs: update dependencies section in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,7 +40,6 @@ pwsh e2e-win\run.ps1 task # run tests matching `*task*`
 ## Dependencies
 
 - [rust](https://www.rust-lang.org/) latest stable
-- [just](https://github.com/casey/just) this should be removed in favor of mise tasks but it's still used for some things.
 - `pipx` or `uv`
 - bash newer than the 20-year-old version macOS provides
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,6 +40,7 @@ pwsh e2e-win\run.ps1 task # run tests matching `*task*`
 ## Dependencies
 
 - [rust](https://www.rust-lang.org/) latest stable
+- `node`
 - `pipx` or `uv`
 - bash newer than the 20-year-old version macOS provides
 


### PR DESCRIPTION
I was trying to setup mise locally, and found `contributing.md` outdated, so I updated it.

1. remove [`just`](https://github.com/casey/just)
    - The usage of `just` is removed in https://github.com/jdx/mise/pull/1948 
2. add [`node`](https://nodejs.org/ja)
    - I guess that it's the npm part in `mise.toml` that required Node.js
        https://github.com/jdx/mise/blob/ffb47799c69607ebc17e5dc9f2f0aa3bfaf80797/mise.toml#L19-L20
    - I've received error about `npm:prettier` when I didn't have node available.