### PR TITLE
chore: release 2025.5.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [2025.5.15](https://github.com/jdx/mise/compare/v2025.5.14..v2025.5.15) - 2025-05-28
+
+### 🚀 Features
+
+- **(registry)** add aqua backend for maven by [@ZeroAurora](https://github.com/ZeroAurora) in [#5219](https://github.com/jdx/mise/pull/5219)
+
+### 🐛 Bug Fixes
+
+- **(zig)** **breaking** get tarball url from download index by [@mangkoran](https://github.com/mangkoran) in [#5182](https://github.com/jdx/mise/pull/5182)
+- **(zig)** get version list from download index by [@mangkoran](https://github.com/mangkoran) in [#5217](https://github.com/jdx/mise/pull/5217)
+- use a better completion dir for more compatibility by [@ken-kuro](https://github.com/ken-kuro) in [#5207](https://github.com/jdx/mise/pull/5207)
+- set handler for ctrlc on windows shell by [@L0RD-ZER0](https://github.com/L0RD-ZER0) in [#5209](https://github.com/jdx/mise/pull/5209)
+- prevent go installation failure on go.mod version mismatch by [@roele](https://github.com/roele) in [#5212](https://github.com/jdx/mise/pull/5212)
+- mise run --cd <dir> not working with latest mise by [@roele](https://github.com/roele) in [#5221](https://github.com/jdx/mise/pull/5221)
+
+### 📚 Documentation
+
+- update dependencies section in contributing.md by [@LuckyWindsck](https://github.com/LuckyWindsck) in [#5200](https://github.com/jdx/mise/pull/5200)
+
+### Chore
+
+- disable auto cargo up by [@jdx](https://github.com/jdx) in [3306f6e](https://github.com/jdx/mise/commit/3306f6ef726fe85d71163121497e1d5dd5cd73ca)
+
+### New Contributors
+
+- @L0RD-ZER0 made their first contribution in [#5209](https://github.com/jdx/mise/pull/5209)
+
 ## [2025.5.14](https://github.com/jdx/mise/compare/v2025.5.13..v2025.5.14) - 2025-05-26
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.5.14"
+version = "2025.5.15"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2025.5.14"
+version = "2025.5.15"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.5.14 macos-arm64 (a1b2d3e 2025-05-26)
+2025.5.15 macos-arm64 (a1b2d3e 2025-05-28)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_5_14:-}" ]] || _cache_invalid _usage_spec_mise_2025_5_14 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_5_14;
+  if ( [[ -z "${_usage_spec_mise_2025_5_15:-}" ]] || _cache_invalid _usage_spec_mise_2025_5_15 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_5_15;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_5_14 spec
+    _store_cache _usage_spec_mise_2025_5_15 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_5_14:-} ]]; then
-        _usage_spec_mise_2025_5_14="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_5_15:-} ]]; then
+        _usage_spec_mise_2025_5_15="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_5_14}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_5_15}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_5_14
-  set -g _usage_spec_mise_2025_5_14 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_5_15
+  set -g _usage_spec_mise_2025_5_15 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_14" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_15" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_14" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_5_15" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.5.14";
+  version = "2025.5.15";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.5.14
+Version: 2025.5.15
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(registry)** add aqua backend for maven by [@ZeroAurora](https://github.com/ZeroAurora) in [#5219](https://github.com/jdx/mise/pull/5219)

### 🐛 Bug Fixes

- **(zig)** **breaking** get tarball url from download index by [@mangkoran](https://github.com/mangkoran) in [#5182](https://github.com/jdx/mise/pull/5182)
- **(zig)** get version list from download index by [@mangkoran](https://github.com/mangkoran) in [#5217](https://github.com/jdx/mise/pull/5217)
- use a better completion dir for more compatibility by [@ken-kuro](https://github.com/ken-kuro) in [#5207](https://github.com/jdx/mise/pull/5207)
- set handler for ctrlc on windows shell by [@L0RD-ZER0](https://github.com/L0RD-ZER0) in [#5209](https://github.com/jdx/mise/pull/5209)
- prevent go installation failure on go.mod version mismatch by [@roele](https://github.com/roele) in [#5212](https://github.com/jdx/mise/pull/5212)
- mise run --cd <dir> not working with latest mise by [@roele](https://github.com/roele) in [#5221](https://github.com/jdx/mise/pull/5221)

### 📚 Documentation

- update dependencies section in contributing.md by [@LuckyWindsck](https://github.com/LuckyWindsck) in [#5200](https://github.com/jdx/mise/pull/5200)

### Chore

- disable auto cargo up by [@jdx](https://github.com/jdx) in [3306f6e](https://github.com/jdx/mise/commit/3306f6ef726fe85d71163121497e1d5dd5cd73ca)

### New Contributors

- @L0RD-ZER0 made their first contribution in [#5209](https://github.com/jdx/mise/pull/5209)