### PR TITLE
fix: use a better completion dir for more compatibility

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -29,7 +29,7 @@ you may source it separately or enable this flag to include it in the script.
 Examples:
 
 ```
-mise completion bash > ~/.local/share/bash-completion/mise
+mise completion bash > ~/.local/share/bash-completion/completions/mise
 mise completion zsh  > /usr/local/share/zsh/site-functions/_mise
 mise completion fish > ~/.config/fish/completions/mise.fish
 ```

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -393,7 +393,7 @@ Then, run the following commands to install the completion script for your shell
 ```sh [bash]
 # This requires bash-completion to be installed
 mkdir -p ~/.local/share/bash-completion/
-mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/mise
+mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise
 ```
 
 ```sh [zsh]

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -154,7 +154,7 @@ cmd "completion" help="Generate shell completions" {
     alias "complete" "completions" hide=true
     after_long_help r"Examples:
 
-    $ mise completion bash > ~/.local/share/bash-completion/mise
+    $ mise completion bash > ~/.local/share/bash-completion/completions/mise
     $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise
     $ mise completion fish > ~/.config/fish/completions/mise.fish
 "

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -143,7 +143,7 @@ cmd cache help="Manage the mise cache" {
 }
 cmd completion help="Generate shell completions" {
     alias complete completions hide=#true
-    after_long_help "Examples:\n\n    $ mise completion bash > ~/.local/share/bash-completion/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n"
+    after_long_help "Examples:\n\n    $ mise completion bash > ~/.local/share/bash-completion/completions/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n"
     flag "-s --shell" help="Shell type to generate completions for" hide=#true {
         arg <SHELL_TYPE> {
             choices bash fish zsh

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -88,7 +88,7 @@ impl Completion {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    $ <bold>mise completion bash > ~/.local/share/bash-completion/mise</bold>
+    $ <bold>mise completion bash > ~/.local/share/bash-completion/completions/mise</bold>
     $ <bold>mise completion zsh  > /usr/local/share/zsh/site-functions/_mise</bold>
     $ <bold>mise completion fish > ~/.config/fish/completions/mise.fish</bold>
 "#


### PR DESCRIPTION
TLDR: Turn out the FAQ of `bash-completion` section is [deprecated compared to the package's code](https://github.com/jdx/mise/discussions/5122#discussioncomment-13280275). Although it stills work on some machines (like mine), the new path would be more aligned with the `bash-completion` code 

This pull request updates the file paths for Bash shell completion scripts to align with standard directory structures for better compatibility and organization. The changes affect documentation, usage examples, and the implementation of the `mise completion` command.

### Documentation updates:
* Updated examples in `docs/cli/completion.md` to save Bash completion scripts under `~/.local/share/bash-completion/completions/` instead of the parent directory.
* Adjusted instructions in `docs/installing-mise.md` to reflect the new path for Bash completion scripts.

### Usage examples:
* Modified examples in `mise.usage.kdl` to use the updated path for Bash completion scripts. [[1]](diffhunk://#diff-234df2d1ab30764d8ba0e8ac010e5489bc5e8f496aa1a9cdea5c56ef60cdcfb0L157-R157) [[2]](diffhunk://#diff-453fee9ce49c9f812a348d5f4414f628785e1463ce4fbec4885ed9108d446a0cL146-R146)

### Code implementation:
* Updated the `AFTER_LONG_HELP` string in `src/cli/completion.rs` to reflect the new file path for Bash completion scripts.