### PR TITLE
fix: prevent go installation failure on go.mod version mismatch

### DIFF
--- a/e2e/core/test_go
+++ b/e2e/core/test_go
@@ -12,5 +12,17 @@ assert_contains "mise x -- go version" "go version go1.20"
 assert "mise x -- go env GOBIN" "${MISE_DATA_DIR}/installs/go/1.20/bin"
 assert_contains "mise x -- go-example" "hello world"
 
+# ensure go.mod does not prevent installation on version mismatch
+mkdir -p "$HOME/go-mod/"
+cd "$HOME/go-mod/" || exit 1
+cat >"go.mod" <<EOF
+package github.com/jdx/go-example
+go 1.22
+EOF
+assert_fail "mise x go@1.21.4 -- go version"
+assert_contains "mise ls go" "go  1.21.4"
+cd -
+rm -rf "$HOME/go-mod/"
+
 # Required to properly cleanup as go installs read-only sources
 chmod -R +w ~/go

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -87,6 +87,8 @@ impl GoPlugin {
     fn test_go(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> eyre::Result<()> {
         pr.set_message("go version".into());
         CmdLineRunner::new(self.go_bin(tv))
+            // run the command in the install path to prevent issues with go.mod version mismatch
+            .current_dir(tv.install_path())
             .with_pr(pr)
             .arg("version")
             .execute()


### PR DESCRIPTION
Fixes an issue (discussed in #5210) where go installation will fail if there is a go.mod file with an incompatible version in the directory where mise is executed.