### PR TITLE
fix(zig): get version list from download index

### DIFF
--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -51,19 +51,14 @@ impl ZigPlugin {
     }
 
     async fn download(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<PathBuf> {
-        let zig_download_index = "https://ziglang.org/download/index.json";
-        let machengine_download_index = "https://machengine.org/zig/index.json";
+        let zig_index = "https://ziglang.org/download/index.json";
+        let mach_index = "https://machengine.org/zig/index.json";
 
         let url = if regex!(r"^mach-|-mach$").is_match(&tv.version) {
-            self.get_tarball_url_from_json(
-                machengine_download_index,
-                tv.version.as_str(),
-                arch(),
-                os(),
-            )
-            .await?
+            self.get_tarball_url_from_json(mach_index, tv.version.as_str(), arch(), os())
+                .await?
         } else {
-            self.get_tarball_url_from_json(zig_download_index, tv.version.as_str(), arch(), os())
+            self.get_tarball_url_from_json(zig_index, tv.version.as_str(), arch(), os())
                 .await?
         };
 

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -51,14 +52,16 @@ impl ZigPlugin {
     }
 
     async fn download(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<PathBuf> {
-        let zig_index = "https://ziglang.org/download/index.json";
-        let mach_index = "https://machengine.org/zig/index.json";
+        let indexes = HashMap::from([
+            ("zig", "https://ziglang.org/download/index.json"),
+            ("mach", "https://machengine.org/zig/index.json"),
+        ]);
 
         let url = if regex!(r"^mach-|-mach$").is_match(&tv.version) {
-            self.get_tarball_url_from_json(mach_index, tv.version.as_str(), arch(), os())
+            self.get_tarball_url_from_json(indexes["mach"], tv.version.as_str(), arch(), os())
                 .await?
         } else {
-            self.get_tarball_url_from_json(zig_index, tv.version.as_str(), arch(), os())
+            self.get_tarball_url_from_json(indexes["zig"], tv.version.as_str(), arch(), os())
                 .await?
         };
 


### PR DESCRIPTION
Follow up of https://github.com/jdx/mise/pull/5182

I also did small refactor of that PR by using HashMap for download index to make it a bit cleaner :)


Tested in local
```
14:01:04 ❯ mise ls-remote zig
0.11.0
0.12.0
0.12.1
0.13.0
0.14.0
0.14.1

14:01:04 ❯ mise cache clean
mise cache cleared

14:01:14 ❯ MISE_USE_VERSIONS_HOST=false cargo run --bin mise -- ls-remote zig
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.73s
     Running `target/debug/mise ls-remote zig`
mach-latest
master
0.1.1
0.2.0
0.3.0-mach
0.3.0
0.4.0-mach
0.4.0
0.5.0
0.6.0
0.7.0
0.7.1
0.8.0
0.8.1
0.9.0
0.9.1
0.10.0
0.10.1
0.11.0
0.12.0
0.12.1
0.13.0
0.14.0
0.14.1
2024.1.0-mach
2024.3.0-mach
2024.5.0-mach
2024.10.0-mach
2024.11.0-mach
```

I'm not sure if the ordering should be like this (non semver e.g. master at top) or it should be the other way.