### PR TITLE
feat(registry): add aqua backend for maven

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1325,6 +1325,7 @@ maven.backends = [
     "asdf:mise-plugins/mise-maven",
     "vfox:mise-plugins/vfox-maven"
 ]
+maven.test = ["mvn --version", "Apache Maven {{version}}"]
 mc.backends = ["asdf:mise-plugins/mise-mc"]
 mdbook.backends = ["aqua:rust-lang/mdBook", "asdf:cipherstash/asdf-mdbook"]
 mdbook.test = ["mdbook --version", "mdbook v{{version}}"]

--- a/registry.toml
+++ b/registry.toml
@@ -1321,6 +1321,7 @@ marp-cli.backends = ["aqua:marp-team/marp-cli", "asdf:xataz/asdf-marp-cli"]
 mask.backends = ["aqua:jacobdeichert/mask", "asdf:aaaaninja/asdf-mask"]
 mask.test = ["mask --version", "mask {{version}}"]
 maven.backends = [
+    "aqua:apache/maven",
     "asdf:mise-plugins/mise-maven",
     "vfox:mise-plugins/vfox-maven"
 ]


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/blob/main/pkgs/apache/maven/pkg.yaml
Tested locally using alias:
![图片](https://github.com/user-attachments/assets/2bbed21b-dafa-42e5-b0be-c154c04f0214)

mise checks latest versions from GitHub, so `@latest` works well. Verified not working with versions `<3.0.0 || >= 4.0.0` (need aqua-side changes)