### PR TITLE
fix: mise run --cd <dir> not working with latest mise

### DIFF
--- a/e2e/cli/test_chdir
+++ b/e2e/cli/test_chdir
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+mkdir -p ./test
+cat <<EOF >./test/mise.toml
+[tasks.hello]
+run = 'echo "Hello, World!"'
+EOF
+
+assert_contains "mise config --cd $PWD/test ls" "test/mise.toml"
+
+assert_contains "mise run --cd $PWD/test hello" "Hello, World!"
+assert_contains "mise run --cd ./test hello" "Hello, World!"
+assert_contains "mise run --cd test hello" "Hello, World!"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -990,9 +990,7 @@ impl Run {
     }
 
     async fn cwd(&self, task: &Task, config: &Arc<Config>) -> Result<PathBuf> {
-        if let Some(d) = &self.cd {
-            Ok(d.clone())
-        } else if let Some(d) = task.dir(config).await? {
+        if let Some(d) = task.dir(config).await? {
             Ok(d)
         } else {
             Ok(config

--- a/src/file.rs
+++ b/src/file.rs
@@ -486,7 +486,8 @@ pub async fn make_executable_async<P: AsRef<Path>>(_path: P) -> Result<()> {
 
 pub fn all_dirs() -> Result<Vec<PathBuf>> {
     let mut output = vec![];
-    let mut cwd = dirs::CWD.as_ref().map(|p| p.as_path());
+    let dir = env::current_dir().ok();
+    let mut cwd = dir.as_deref();
     while let Some(dir) = cwd {
         output.push(dir.to_path_buf());
         cwd = dir.parent();


### PR DESCRIPTION
Fixes #5214 and should also address absolute/relative as discussed in #4582.