### PR TITLE
docs: add doc about github access token permissions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -229,6 +229,6 @@ See [autocompletion](/installing-mise.html#autocompletion) to learn how to set u
 Many tools in mise require the use of the GitHub API. Unauthenticated requests to the GitHub API are
 often rate limited. If you see 4xx errors while using mise, you can set `MISE_GITHUB_TOKEN` or `GITHUB_TOKEN`
 to a token [generated from here](https://github.com/settings/tokens/new?description=MISE_GITHUB_TOKEN) which
-will likely fix the issue. The token usually does not require any scopes, however some installations 
+will likely fix the issue. The token usually does not require any scopes, however some installations
 (notably asdf:clang) require the `repo/public_repo` access permission to be enabled.
 :::


### PR DESCRIPTION
Some installations, notably asdf:clang (try `mise use -g clang@latest` with a github token set) require additional token permissions (notably public repo access to be checked/enabled).

This PR suggests editing the doc to explain that. Please change the text as you see fit.

Before the change: 
* `mise use -g clang@latest` succeeds if no gh token is set
* `mise use -g clang@latest` fails if gh token is set (with 404 when trying to download `https://github.com/llvm/llvm-project/archive/llvmorg-<version>.tar.gz`)

After the change:
* `mise use -g clang@latest` succeeds if no gh token is set
* `mise use -g clang@latest` succeeds if gh token is set

How to set it:
![image](https://github.com/user-attachments/assets/b30aa579-d85c-4d41-9ffc-a60e727f1061)
