### PR TITLE
docs(registry): fix links of registry

### DIFF
--- a/docs/registry.data.ts
+++ b/docs/registry.data.ts
@@ -31,11 +31,14 @@ export default {
           let name = typeof backend === "string" ? backend : backend.full;
           // replace selector square brackets
           name = name.replace(/(.*?)\[.*\]/g, "$1");
-          const parts = name.toString().split(":");
+          const parts = name.split(":", 2);
           const prefix = parts[0];
           const slug = parts[1];
+          const repoName = slug.split("/").slice(0,1).join("/");
           const urlMap: { [key: string]: string } = {
             core: `https://mise.jdx.dev/lang/${slug}.html`,
+            asdf: slug.startsWith("http") ? slug : `https://github.com/${slug}`,
+            aqua: `https://github.com/${repoName}`,
             cargo: `https://crates.io/crates/${slug}`,
             go: `https://pkg.go.dev/${slug}`,
             pipx: `https://pypi.org/project/${slug}`,

--- a/docs/registry.data.ts
+++ b/docs/registry.data.ts
@@ -31,7 +31,7 @@ export default {
           let name = typeof backend === "string" ? backend : backend.full;
           // replace selector square brackets
           name = name.replace(/(.*?)\[.*\]/g, "$1");
-          const parts = name.split(":", 2);
+          const parts = name.toString().split(":", 2);
           const prefix = parts[0];
           const slug = parts[1];
           const repoName = slug.split("/").slice(0,1).join("/");

--- a/docs/registry.data.ts
+++ b/docs/registry.data.ts
@@ -34,7 +34,7 @@ export default {
           const parts = name.toString().split(":", 2);
           const prefix = parts[0];
           const slug = parts[1];
-          const repoName = slug.split("/").slice(0,1).join("/");
+          const repoName = slug.split("/").slice(0, 1).join("/");
           const urlMap: { [key: string]: string } = {
             core: `https://mise.jdx.dev/lang/${slug}.html`,
             asdf: slug.startsWith("http") ? slug : `https://github.com/${slug}`,


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/5265.

`aqua:pipe-cd/pipecd/pipectl` linked to https://github.com/pipe-cd/pipecd/pipectl, so fixed it to only use the repo name instead of the full aqua package name: https://github.com/pipe-cd/pipecd
(This doesn't support aqua packages starting with `gitlab.com`, but there are no such packages in the registry now.)

Also, `asdf:https://gitlab.com/td7x/asdf/adr-tools` pointed https://github.com/https, so use `slug` as is if it's a url (starting with `http`).