### PR TITLE
docs(registry): fix links to tools

### DIFF
--- a/docs/components/registry.vue
+++ b/docs/components/registry.vue
@@ -27,9 +27,14 @@
         <td>
           <span v-for="(backend, index) in entry.backends">
             <a
+              v-if="backend.url"
               :href="`${backend.url}`"
               v-html="highlightMatches(backend.name)"
             ></a>
+            <span
+              v-else
+              v-html="highlightMatches(backend.name)"
+            ></span>
             <span v-if="index < entry.backends.length - 1"><br /></span>
           </span>
         </td>

--- a/docs/components/registry.vue
+++ b/docs/components/registry.vue
@@ -27,14 +27,9 @@
         <td>
           <span v-for="(backend, index) in entry.backends">
             <a
-              v-if="backend.url"
               :href="`${backend.url}`"
               v-html="highlightMatches(backend.name)"
             ></a>
-            <span
-              v-else
-              v-html="highlightMatches(backend.name)"
-            ></span>
             <span v-if="index < entry.backends.length - 1"><br /></span>
           </span>
         </td>

--- a/docs/registry.data.ts
+++ b/docs/registry.data.ts
@@ -32,32 +32,56 @@ export default {
     const { tools } = load(raw) as Registry;
     const registry: Record<string, Tool> = {};
 
+    // dotnet, gem, spm backends are not supported
+    const urlBuilders: Record<
+      string,
+      (slug: string, options: string | undefined) => string
+    > = {
+      aqua: (slug) => {
+        const repoName = slug.split("/").slice(0, 2).join("/");
+        return `https://github.com/${repoName}`;
+      },
+      asdf: (slug) =>
+        slug.startsWith("http") ? slug : `https://github.com/${slug}`,
+      cargo: (slug) => `https://crates.io/crates/${slug}`,
+      core: (slug) => `https://mise.jdx.dev/lang/${slug}.html`,
+      go: (slug) => `https://pkg.go.dev/${slug}`,
+      npm: (slug) => `https://www.npmjs.com/package/${slug}`,
+      pipx: (slug) => `https://pypi.org/project/${slug}`,
+      ubi: (slug, options) => {
+        const provider = options
+          ?.split(",")
+          .filter((str) => str.startsWith("provider="))
+          .at(0)
+          ?.replace("provider=", "");
+        const repoName = slug.split("/").slice(0, 2).join("/");
+        return `https://${
+          provider === "gitlab" ? "gitlab.com" : "github.com"
+        }/${repoName}`;
+      },
+      vfox: (slug) => `https://github.com/${slug}`,
+    };
+
+    const nameRegex = /^(?<prefix>.+?):(?<slug>.+?)(?:\[(?<options>.+)\])?$/;
+
     for (const key in tools) {
       const tool = tools[key];
 
       registry[key] = {
         short: key,
         backends: tool.backends.map((backend) => {
-          let name = typeof backend === "string" ? backend : backend.full;
-          // replace selector square brackets
-          name = name.replace(/(.*?)\[.*\]/g, "$1");
-          const parts = name.split(":", 2);
-          const prefix = parts.at(0) ?? "";
-          const slug = parts.at(1) ?? "";
-          const repoName = slug.split("/").slice(0, 1).join("/");
-          const urlMap: { [key: string]: string } = {
-            core: `https://mise.jdx.dev/lang/${slug}.html`,
-            asdf: slug.startsWith("http") ? slug : `https://github.com/${slug}`,
-            aqua: `https://github.com/${repoName}`,
-            cargo: `https://crates.io/crates/${slug}`,
-            go: `https://pkg.go.dev/${slug}`,
-            pipx: `https://pypi.org/project/${slug}`,
-            npm: `https://www.npmjs.com/package/${slug}`,
-          };
-          const url = urlMap[prefix] ?? `https://github.com/${slug}`;
+          const name = typeof backend === "string" ? backend : backend.full;
+          const match = name.match(nameRegex);
+          const prefix = match?.groups?.prefix ?? "";
+          const slug = match?.groups?.slug ?? "";
           return {
-            name,
-            url,
+            name: `${prefix}:${slug}`,
+            url: urlBuilders[prefix]
+              ? urlBuilders[prefix](
+                  slug,
+                  match?.groups?.options ?? "",
+                )
+              : "",
           };
         }),
         aliases: tool.aliases ?? [],

--- a/docs/registry.data.ts
+++ b/docs/registry.data.ts
@@ -77,10 +77,7 @@ export default {
           return {
             name: `${prefix}:${slug}`,
             url: urlBuilders[prefix]
-              ? urlBuilders[prefix](
-                  slug,
-                  match?.groups?.options ?? "",
-                )
+              ? urlBuilders[prefix](slug, match?.groups?.options ?? "")
               : "",
           };
         }),

--- a/registry.toml
+++ b/registry.toml
@@ -1157,7 +1157,7 @@ kubectl.backends = [
     "asdf:asdf-community/asdf-kubectl"
 ]
 kubectl-convert.backends = [
-    "aqua:kubernetes/kubectl-convert",
+    "aqua:kubernetes/kubernetes/kubectl-convert",
     "asdf:iul1an/asdf-kubectl-convert"
 ]
 kubectl-kots.backends = [


### PR DESCRIPTION
My apologies, https://github.com/jdx/mise/pull/5266 didn't work, so this is the follow-up.

I confirmed all links (except for 1password) work with `mise exec lychee -- lychee docs/.vitepress/dist/registry.html` (with https://github.com/jdx/mise/pull/5271 and https://github.com/jdx/mise/pull/5273).

- Since `aqua:1password/cli` uses `http` type, we should link to https://developer.1password.com/ I guess, but didn't know where to declare it.
PR added the package: https://github.com/aquaproj/aqua-registry/pull/26217
https://github.com/aquaproj/aqua-registry/blob/main/pkgs/1password/cli/registry.yaml

- I switched to `kubernetes/kubernetes/kubectl-convert` from its alias `kubernetes/kubectl-convert`, to build the correct url.
https://github.com/aquaproj/aqua-registry/blob/main/pkgs/kubernetes/kubernetes/kubectl-convert/registry.yaml

- `dotnet`, `gem`, `spm` backends are not used in the registry currently, so I ignored them.
I confirmed the page can be rendered even if `url` is an empty string.