### PR TITLE
feat(registry): use ubi backend for func-e

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -718,7 +718,7 @@ flyctl.backends = [
 flyway.backends = ["asdf:mise-plugins/mise-flyway"]
 foundry.backends = ["ubi:foundry-rs/foundry[extract_all=true]"]
 foundry.test = ["forge -V", "{{version}}"]
-func-e.backends = ["tetratelabs/func-e", "asdf:mise-plugins/mise-func-e"]
+func-e.backends = ["ubi:tetratelabs/func-e", "asdf:mise-plugins/mise-func-e"]
 func-e.test = ["func-e --version", "func-e version {{version}}"]
 furyctl.backends = ["ubi:sighupio/furyctl", "asdf:sighupio/asdf-furyctl"]
 furyctl.os = ["linux", "macos"]


### PR DESCRIPTION
In https://github.com/jdx/mise/pull/5266, `tetratelabs/func-e` was added, but it didn't have the backend.
Since `aqua-registry` doesn't contain it, I guess it was meant to use `ubi`.
I confirmed it can be installed.