### PR TITLE
fix: make mise exec work again with unknown tool entries

### DIFF
--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -185,12 +185,11 @@ impl Toolset {
 
         self.versions = successful_versions;
 
-        match errors.is_empty() {
-            true => Ok(()),
-            false => {
-                let err = eyre::eyre!("error resolving versions");
-                Err(errors.into_iter().fold(err, |e, x| e.wrap_err(x)))
-            }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            let err = eyre::eyre!("error resolving versions");
+            Err(errors.into_iter().fold(err, |e, x| e.wrap_err(x)))
         }
     }
     #[async_backtrace::framed]


### PR DESCRIPTION
With the switch from Rayon (parallel processing) to Tokio (async) in https://github.com/jdx/mise/pull/5172, `mise exec` no longer correctly resolves tool versions if `.tool-versions` contains an unknown entry.

This occurred because a single failure would cause a hard faliure in the `resolve()` method in `src/toolset/mod.rs`. Fix this by setting successful tool resolutions while returning the errors, which can be ignored by the caller.

Relates to https://github.com/jdx/mise/discussions/5282