### PR TITLE
fix: only show deprecation if not using 'tools-version'

### DIFF
--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -156,7 +156,10 @@ impl ToolVersion {
             ToolRequest::Path { path: p, .. } => format!("path-{}", hash_to_str(p)),
             ToolRequest::System { .. } => {
                 // Only show deprecation warning if not from .tool-versions file
-                if !matches!(self.request.source(), crate::toolset::ToolSource::ToolVersions(_)) {
+                if !matches!(
+                    self.request.source(),
+                    crate::toolset::ToolSource::ToolVersions(_)
+                ) {
                     deprecated!(
                         "system_tool_version",
                         "@system is deprecated, use MISE_DISABLE_TOOLS instead"

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -155,10 +155,13 @@ impl ToolVersion {
             ToolRequest::Ref { ref_: r, .. } => format!("ref-{r}"),
             ToolRequest::Path { path: p, .. } => format!("path-{}", hash_to_str(p)),
             ToolRequest::System { .. } => {
-                deprecated!(
-                    "system_tool_version",
-                    "@system is deprecated, use MISE_DISABLE_TOOLS instead"
-                );
+                // Only show deprecation warning if not from .tool-versions file
+                if !matches!(self.request.source(), crate::toolset::ToolSource::ToolVersions(_)) {
+                    deprecated!(
+                        "system_tool_version",
+                        "@system is deprecated, use MISE_DISABLE_TOOLS instead"
+                    );
+                }
                 "system".to_string()
             }
         }


### PR DESCRIPTION
## Fix `@system` deprecation warning for .tool-versions files

### Problem
The deprecation warning for `@system` was being shown for every usage, including in `.tool-versions` files where it's still valid for backward compatibility. This caused unnecessary warnings for users who have existing `.tool-versions` files with `@system` entries.

### Solution
Modified the `tv_pathname` method in `src/toolset/tool_version.rs` to check the source of the tool request. The deprecation warning is now suppressed when `@system` is used in `.tool-versions` files, but still shown for other configuration sources like `.mise.toml`.

### Changes
- Updated `ToolRequest::System` handling in `tv_pathname` method
- Added source checking to conditionally show deprecation warning
- Preserved backward compatibility for `.tool-versions` files

### Testing
- Verified that warnings are suppressed for `.tool-versions` 
- Verified that warnings still appear for `.mise.toml` usage

Fixes #5230