### PR TITLE
Update getting-started.md for missing shasum command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ See [installing mise](/installing-mise) for other ways to install mise (`macport
 == Linux/macOS
 
 ```shell
-curl https://mise.run | sh
+curl https://mise.run  | sed 's/shasum/sha256sum/' | sh
 ```
 
 By default, mise will be installed to `~/.local/bin` (this is simply a suggestion. `mise` can be installed anywhere).


### PR DESCRIPTION
On AmazonLinux2 (based on CentOS) `shasum` is not available, but there is `sha1sum`, `sha256sum`, etc. I believe sha256sum is required here