### PR TITLE
fix: Task resolve_depends for multiple depends_post values

### DIFF
--- a/e2e/tasks/test_task_depends_post_multiple
+++ b/e2e/tasks/test_task_depends_post_multiple
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# ensures depends_post and depends can be used on separate tasks
+cat <<EOF >mise.toml
+[tasks.one]
+run = "echo one"
+
+[tasks.two]
+depends_post = ["one"]
+run = "echo two"
+
+[tasks.three]
+depends_post = ["one", "two"]
+run = "echo three"
+EOF
+assert "mise task deps" "one
+├── three
+└── two
+    └── three
+three
+two
+└── three"
+assert "mise run three"
+
+# TODO: this does not work with how mise is designed currently. Tasks can only ever be run once per run session. This will require hefty refactoring if it is ever supported
+# uses depends and depends_post on the same task
+#cat <<EOF >mise.toml
+#tasks."util:donothing" = ""
+#[tasks.hi]
+#depends = "util:donothing"
+#run = "echo hi"
+#depends_post = "util:donothing"
+#EOF
+#assert "mise run hi"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -304,9 +304,9 @@ impl Task {
             .flatten_ok()
             .filter_ok(|t| tasks_to_run.contains(t))
             .collect_vec();
-        let depends_post = tasks_to_run
+        let depends_post = self.depends_post
             .iter()
-            .flat_map(|t| t.depends_post.iter().map(|td| match_tasks(&tasks, td)))
+            .map(|td| match_tasks(&tasks, td))
             .flatten_ok()
             .filter_ok(|t| t.name != self.name)
             .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
`Task::resolve_depends` was iterating over all tasks for traversal when processing `depends_post`. When a task had a single `depends_post`, this was mostly fine. However the issue was most visible with multiple `depends_post` values, where an infinite loop in the graph was generated, however the actual dependencies were not generated leaving the tasks listed in `depends_post` un-executed.

This lead to the following error:

```
[a] panic in task: panicked at src/task/deps.rs:101:13: Infinitive loop detected, all tasks are finished but the graph isn't empty
```

By initially iterating over `self.depends_post` we properly resolve the dependencies

```
>>> E2E tasks/test_task_depends_post_multiple
$ mise task deps
[mise task deps] output is equal to 'one
├── three
└── two
    └── three
three
two
└── three'
$ mise run three
[three] $ echo three
[two] $ echo two
[one] $ echo one
Finished in 9.2ms
[mise run three]
tasks/test_task_depends_post_multiple: 0s
```

Fixes #4398 