### PR TITLE
feat(aqua): support no_asset and error_message

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -142,4 +142,5 @@ version = "1.0.0"
 backend = "ubi:jdx/wait-for-gh-rate-limit"
 
 [tools.wait-for-gh-rate-limit.checksums]
+wait-for-gh-rate-limit-linux-x86_64 = "sha256:fd8bb89c91936cf530e1da2699810c9a3793922315611b6938c89c9364ee2e76"
 wait-for-gh-rate-limit-macos-aarch64 = "sha256:a3a12519075fdb18eb933e8c369e78a6c27d2e17575fdd6a86ab26dbeba34247"

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -80,6 +80,8 @@ pub struct AquaPackage {
     overrides: Vec<AquaOverride>,
     version_constraint: String,
     version_overrides: Vec<AquaPackage>,
+    pub no_asset: bool,
+    pub error_message: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -582,6 +584,12 @@ fn apply_override(mut orig: AquaPackage, avo: &AquaPackage) -> AquaPackage {
         minisign.merge(avo_minisign);
         orig.minisign = Some(minisign);
     }
+    if avo.no_asset {
+        orig.no_asset = true;
+    }
+    if let Some(error_message) = avo.error_message.clone() {
+        orig.error_message = Some(error_message);
+    }
     orig
 }
 
@@ -842,6 +850,8 @@ impl Default for AquaPackage {
             overrides: vec![],
             version_constraint: "".to_string(),
             version_overrides: vec![],
+            no_asset: false,
+            error_message: None,
         }
     }
 }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -72,6 +72,9 @@ impl Backend for AquaBackend {
                         }
                     }
                     let pkg = pkg.clone().with_version(v);
+                    if pkg.no_asset || pkg.error_message.is_some() {
+                        return None;
+                    }
                     if let Some(prefix) = &pkg.version_prefix {
                         if let Some(_v) = v.strip_prefix(prefix) {
                             v = _v
@@ -97,6 +100,12 @@ impl Backend for AquaBackend {
     ) -> Result<ToolVersion> {
         let mut v = format!("v{}", tv.version);
         let pkg = AQUA_REGISTRY.package_with_version(&self.id, &v).await?;
+        if pkg.no_asset {
+            bail!("no asset released");
+        }
+        if pkg.error_message.is_some() {
+            bail!(pkg.error_message.unwrap());
+        }
         if let Some(prefix) = &pkg.version_prefix {
             v = format!("{prefix}{v}");
         }


### PR DESCRIPTION
Adds support for [`no_asset`](https://aquaproj.github.io/docs/reference/registry-config/no_asset/) and [`error_message`](https://aquaproj.github.io/docs/reference/registry-config/error_message) of aqua registry.

Fixes https://github.com/jdx/mise/discussions/5274