### PR TITLE
docs: update example with `pnpm`

### DIFF
--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -117,6 +117,10 @@ node = '22'
 # alternatively, you can also install `pnpm` with mise
 postinstall = 'npx corepack enable'
 
+[settings]
+# This must be enabled to make the hooks work
+experimental = true
+
 [env]
 _.path = ['./node_modules/.bin']
 


### PR DESCRIPTION
This is updating a `pnpm` recipe.

---

To be honest, I was looking at it while putting together a CI workflow for Yarn. It did not work without `experimental = true`.

Another problem, adding `yarn` to the `tools` did not work on Windows. Therefore I had to fall back to `corepack` as suggested in the recipe. The whole point why I wanted to use `mise` was to avoid using `corepack`. Why? Because `miss` is way better! I love it. But the CI has to pass on Ubuntu, macOS, and uff.. Windows.

Hopefully, I complain in the right place. See: https://github.com/mise-plugins/mise-yarn/issues/12