### PR TITLE
fix(task): use empty string for the default value of option

### DIFF
--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -584,6 +584,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(parsed_scripts, vec!["echo abc"]);
+
+        let parsed_scripts = parser
+            .parse_run_scripts_with_args(&config, &task, &scripts, &Default::default(), &[], &spec)
+            .await
+            .unwrap();
+        assert_eq!(parsed_scripts, vec!["echo "]);
     }
 
     #[tokio::test]

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -380,7 +380,7 @@ impl TaskScriptParser {
                 }
             });
             let flag_func = {
-                {
+                |default_value: String| {
                     let usage_flags = m.flags.clone();
                     move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
                         let name = args
@@ -392,13 +392,13 @@ impl TaskScriptParser {
                                 .iter()
                                 .find(|(flag, _)| flag.name == name)
                                 .map(|(_, value)| escape(value))
-                                .unwrap_or("false".to_string()),
+                                .unwrap_or(default_value.clone()),
                         ))
                     }
                 }
             };
-            tera.register_function("option", flag_func.clone());
-            tera.register_function("flag", flag_func);
+            tera.register_function("option", flag_func("".to_string()));
+            tera.register_function("flag", flag_func(false.to_string()));
             let mut tera_ctx = task.tera_ctx(config).await?;
             tera_ctx.insert("env", &env);
             out.push(


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/5308.

Uses `""` instead of `false` for the default value of `option` in tasks.