### PR TITLE
feat(aqua): support cosign bundle option

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1593,6 +1593,7 @@ psc-package.backends = [
 ]
 psqldef.backends = ["aqua:sqldef/sqldef/psqldef"]
 pulumi.backends = ["aqua:pulumi/pulumi", "asdf:canha/asdf-pulumi"]
+pulumi.test = ["pulumi version", "v{{version}}"]
 purerl.backends = ["ubi:purerl/purerl", "asdf:GoNZooo/asdf-purerl"]
 purescript.backends = [
     "ubi:purescript/purescript[exe=purs]",

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -137,6 +137,7 @@ pub struct AquaCosign {
     pub signature: Option<AquaCosignSignature>,
     pub key: Option<AquaCosignSignature>,
     pub certificate: Option<AquaCosignSignature>,
+    pub bundle: Option<AquaCosignSignature>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     opts: Vec<String>,
 }
@@ -687,6 +688,12 @@ impl AquaCosign {
                 self.certificate = Some(certificate.clone());
             }
             self.certificate.as_mut().unwrap().merge(certificate);
+        }
+        if let Some(bundle) = other.bundle.clone() {
+            if self.bundle.is_none() {
+                self.bundle = Some(bundle.clone());
+            }
+            self.bundle.as_mut().unwrap().merge(bundle);
         }
         if !other.opts.is_empty() {
             self.opts = other.opts.clone();


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/5287. Basically re-implements https://github.com/aquaproj/aqua/pull/3711.

Since `bundle` option doesn't allow URL as an arg, it downloads the file and verifies using the file.
ref: https://github.com/sigstore/cosign/issues/4119