### PR TITLE
fix: ls command does not respect MISE_COLOR value

### DIFF
--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -52,8 +52,8 @@ impl MiseTable {
         table
             .load_preset(comfy_table::presets::NOTHING)
             .set_content_arrangement(ContentArrangement::Dynamic);
-        if console::colors_enabled() {
-            table.enforce_styling();
+        if !console::colors_enabled() {
+            table.force_no_tty();
         }
         if !no_header && console::user_attended() {
             let headers = headers.iter().map(Self::header).collect_vec();


### PR DESCRIPTION
Fixes `MISE_COLOR=false` for the `ls` command as discussed in #5315. Crate `comfy_table` requires a `force_no_tty` method call to disable colors.