### PR TITLE
chore: release 2025.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2025.6.3](https://github.com/jdx/mise/compare/v2025.6.2..v2025.6.3) - 2025-06-13
+
+### 🚀 Features
+
+- support matching_regex from the ubi backend by [@yjoer](https://github.com/yjoer) in [#5320](https://github.com/jdx/mise/pull/5320)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** parse templates in version_filter by [@risu729](https://github.com/risu729) in [#5341](https://github.com/jdx/mise/pull/5341)
+- **(registry)** use extract_all for docker-slim by [@risu729](https://github.com/risu729) in [#5342](https://github.com/jdx/mise/pull/5342)
+
+### 🚜 Refactor
+
+- **(getting-started)** update powershell profile instructions by [@Armaldio](https://github.com/Armaldio) in [#5340](https://github.com/jdx/mise/pull/5340)
+
+### 📦️ Dependency Updates
+
+- update docker/build-push-action digest to 2634353 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5338](https://github.com/jdx/mise/pull/5338)
+- update jdx/mise-action digest to 13abe50 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5339](https://github.com/jdx/mise/pull/5339)
+
+### New Contributors
+
+- @yjoer made their first contribution in [#5320](https://github.com/jdx/mise/pull/5320)
+
 ## [2025.6.2](https://github.com/jdx/mise/compare/v2025.6.1..v2025.6.2) - 2025-06-12
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.6.2"
+version = "2025.6.3"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2025.6.2"
+version = "2025.6.3"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.6.2 macos-arm64 (a1b2d3e 2025-06-12)
+2025.6.3 macos-arm64 (a1b2d3e 2025-06-13)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_6_2:-}" ]] || _cache_invalid _usage_spec_mise_2025_6_2 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_6_2;
+  if ( [[ -z "${_usage_spec_mise_2025_6_3:-}" ]] || _cache_invalid _usage_spec_mise_2025_6_3 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_6_3;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_6_2 spec
+    _store_cache _usage_spec_mise_2025_6_3 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_6_2:-} ]]; then
-        _usage_spec_mise_2025_6_2="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_6_3:-} ]]; then
+        _usage_spec_mise_2025_6_3="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_6_2}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_6_3}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_6_2
-  set -g _usage_spec_mise_2025_6_2 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_6_3
+  set -g _usage_spec_mise_2025_6_3 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_2" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_3" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_2" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_3" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.6.2";
+  version = "2025.6.3";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.6.2
+Version: 2025.6.3
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- support matching_regex from the ubi backend by [@yjoer](https://github.com/yjoer) in [#5320](https://github.com/jdx/mise/pull/5320)

### 🐛 Bug Fixes

- **(aqua)** parse templates in version_filter by [@risu729](https://github.com/risu729) in [#5341](https://github.com/jdx/mise/pull/5341)
- **(registry)** use extract_all for docker-slim by [@risu729](https://github.com/risu729) in [#5342](https://github.com/jdx/mise/pull/5342)

### 🚜 Refactor

- **(getting-started)** update powershell profile instructions by [@Armaldio](https://github.com/Armaldio) in [#5340](https://github.com/jdx/mise/pull/5340)

### 📦️ Dependency Updates

- update docker/build-push-action digest to 2634353 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5338](https://github.com/jdx/mise/pull/5338)
- update jdx/mise-action digest to 13abe50 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5339](https://github.com/jdx/mise/pull/5339)

### New Contributors

- @yjoer made their first contribution in [#5320](https://github.com/jdx/mise/pull/5320)