### PR TITLE
fix(registry): use extract_all for docker-slim

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -551,7 +551,10 @@ docker-compose.test = [
     "docker-cli-plugin-docker-compose --version",
     "Docker Compose version"
 ]
-docker-slim.backends = ["ubi:slimtoolkit/slim[extract_all=true]", "asdf:xataz/asdf-docker-slim"]
+docker-slim.backends = [
+    "ubi:slimtoolkit/slim[extract_all=true]",
+    "asdf:xataz/asdf-docker-slim"
+]
 docker-slim.os = ["linux", "macos"]
 # docker-slim.test = ["slim --version", ""] # prints out weird version of mint or something
 dockle.backends = [

--- a/registry.toml
+++ b/registry.toml
@@ -551,7 +551,7 @@ docker-compose.test = [
     "docker-cli-plugin-docker-compose --version",
     "Docker Compose version"
 ]
-docker-slim.backends = ["ubi:slimtoolkit/slim", "asdf:xataz/asdf-docker-slim"]
+docker-slim.backends = ["ubi:slimtoolkit/slim[extract_all=true]", "asdf:xataz/asdf-docker-slim"]
 docker-slim.os = ["linux", "macos"]
 # docker-slim.test = ["slim --version", ""] # prints out weird version of mint or something
 dockle.backends = [


### PR DESCRIPTION
As described in https://github.com/houseabsolute/ubi/issues/124, ubi throws an error while installing `slimtoolkit/slim`.
We need to use `extract_all` because it contains symlinks, and also requires `mint-sensor` to be extracted.

Regarding the output of `slim --version`, I found that [slimtoolkit/slim](https://github.com/slimtoolkit/slim) has moved to [mintoolkit/mint](https://github.com/mintoolkit/mint), but `mint` was already mapped to [mint-lang/mint](https://github.com/mint-lang/mint).