### PR TITLE
feat(registry): add docker cli

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -552,6 +552,11 @@ djinni.backends = [
 ]
 # djinni.test = ["djinni-generator --version", "djinni generator version {{version}}"] # test fails on windows
 dmd.backends = ["asdf:mise-plugins/mise-dmd"]
+docker-cli.backends = ["aqua:docker/cli"]
+docker-cli.test = [
+    "docker --version | awk '{print $3}' | tr -d ','",
+    "{{version}}"
+]
 docker-compose.backends = ["aqua:docker/compose"]
 docker-compose.test = [
     "docker-cli-plugin-docker-compose --version",


### PR DESCRIPTION
- feat: add docker cli in the registry

`cargo run --bin mise -- tool docker-cli`

```shell
Backend:            aqua:docker/cli
Description:        Docker CE CLI  
Installed Versions: 28.2.2        
Tool Options:       [none] 
```

#4832