### PR TITLE
feat(registry): diffoci add

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -541,6 +541,8 @@ difftastic.backends = [
     "ubi:wilfred/difftastic[exe=difft]",
     "asdf:volf52/asdf-difftastic"
 ]
+diffoci.backends = ["aqua:reproducible-containers/diffoci"]
+diffoci.test = ["diffoci --version", "diffoci version v{{version}}"]
 digdag.backends = ["asdf:mise-plugins/mise-digdag"]
 direnv.backends = ["aqua:direnv/direnv", "asdf:asdf-community/asdf-direnv"]
 dive.backends = ["ubi:wagoodman/dive", "asdf:looztra/asdf-dive"]


### PR DESCRIPTION
diffoci compares Docker and OCI container images for helping reproducible builds.

Test
```
10:49:08 ❯ diffoci --version
diffoci version v0.1.6
```

Refs: https://github.com/reproducible-containers/diffoci