### PR TITLE
fix(registry): use mintoolkit/mint for docker-slim

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -556,7 +556,8 @@ docker-compose.test = [
     "Docker Compose version"
 ]
 docker-slim.backends = [
-    "ubi:slimtoolkit/slim[extract_all=true]",
+    "aqua:mintoolkit/mint",
+    "ubi:mintoolkit/mint[extract_all=true]",
     "asdf:xataz/asdf-docker-slim"
 ]
 docker-slim.os = ["linux", "macos"]


### PR DESCRIPTION
Follow up of https://github.com/jdx/mise/pull/5342.

`aqua:mintoolkit/mint` is added in
https://github.com/aquaproj/aqua-registry/pull/37629.

Also, `slim --version` still prints weird mint version.
```
$ slim --version
mint version linux/amd64|ALP|x.1.42.2|29e62e7836de7b1004607c51c502537ffe1969f0|2025-01-16_07:48:54AM|x
```

The test should fail because `aqua-registry` in mise is not updated yet.