### PR TITLE
feat(registry): add carapace

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -294,6 +294,8 @@ calicoctl.backends = [
     "aqua:projectcalico/calico/calicoctl",
     "asdf:TheCubicleJockey/asdf-calicoctl"
 ]
+carapace.backends = ["aqua:carapace-sh/carapace-bin"]
+carapace.test = ["carapace --version", "carapace-bin {{version}}"]
 cargo-binstall.backends = [
     "aqua:cargo-bins/cargo-binstall",
     'ubi:cargo-bins/cargo-binstall[tag_regex=^\\d\\.]',


### PR DESCRIPTION
This is a nice shell completion tool: https://github.com/carapace-sh/carapace-bin

It has support for many tools: https://carapace-sh.github.io/carapace-bin/completers.html

And a completion format that's easier to use than typical zsh completions: https://carapace-sh.github.io/carapace-bin/spec.html

![CleanShot_2025-06-19T06-37-48_CleanShot@2x](https://github.com/user-attachments/assets/53f50915-1f5c-40b8-8d22-b9babf0b2a54)
