### PR TITLE
feat: Add sops.strict setting for non-strict decryption mode

### DIFF
--- a/e2e/secrets/test_secrets_non_strict
+++ b/e2e/secrets/test_secrets_non_strict
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -x
+
+# Test that with sops.strict=false, mise continues when age key is not available
+
+mise use sops age
+
+# Create an encrypted file but don't set age key
+age="$(mise x -- age-keygen 2>&1)"
+age_pub="$(echo "$age" | grep "# public key:" | awk '{print $4}')"
+
+# json test with strict=false
+echo '{ "SECRET": "mysecret" }' >.env.json
+mise x -- sops encrypt -i --age "$age_pub" .env.json
+
+# Set non-strict mode
+mise settings set sops.strict false
+
+# Clear age key to simulate missing key
+export MISE_SOPS_AGE_KEY=
+rm -f ~/.config/mise/age.txt
+
+# Should continue without failing and not include the secret
+assert "mise set _.file=.env.json"
+# The env should not contain the decrypted secret since key is missing
+assert_not_contains "mise env" "export SECRET=mysecret"
+
+# Test with strict=true (default behavior)
+mise settings set sops.strict true
+
+# This should fail
+assert_fail "mise env"
+
+# Test with yaml files too
+age_pub="$(mise x -- age-keygen -o ~/age.txt 2>&1 | awk '{print $3}')"
+echo 'SECRET: mysecret' >.env.yaml
+mise x -- sops encrypt -i --age "$age_pub" .env.yaml
+
+# Remove the key file
+rm -f ~/age.txt
+export MISE_SOPS_AGE_KEY=
+
+# Set non-strict mode
+mise settings set sops.strict false
+
+# Should work with non-strict mode
+assert "mise set _.file=.env.yaml"
+assert_not_contains "mise env" "export SECRET=mysecret"
+
+# Reset to strict mode and verify it fails
+mise settings set sops.strict true
+assert_fail "mise env"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -863,6 +863,11 @@
               "default": true,
               "description": "Use rops to decrypt sops files. Disable to shell out to `sops` which will slow down mise but sops may offer features not available in rops.",
               "type": "boolean"
+            },
+            "strict": {
+              "default": true,
+              "description": "If true, fail when sops decryption fails. If false, skip encrypted secrets and continue when key is not available.",
+              "type": "boolean"
             }
           }
         },

--- a/settings.toml
+++ b/settings.toml
@@ -1019,6 +1019,12 @@ type = "Bool"
 default = true
 description = "Use rops to decrypt sops files. Disable to shell out to `sops` which will slow down mise but sops may offer features not available in rops."
 
+[sops.strict]
+env = "MISE_SOPS_STRICT"
+type = "Bool"
+default = true
+description = "If true, fail when sops decryption fails. If false, skip encrypted secrets and continue when key is not available."
+
 [status.missing_tools]
 env = "MISE_STATUS_MESSAGE_MISSING_TOOLS"
 type = "String"


### PR DESCRIPTION
## Summary
- Add new `sops.strict` setting (default: `true`) to control sops decryption failure behavior
- When `sops.strict=false`, mise continues and skips encrypted content when decryption fails
- When `sops.strict=true`, mise fails when decryption fails (current behavior)

## Problem
Currently, mise fails to load environments when sops-encrypted files are present but the required age key is not available. This prevents users from working with repositories containing encrypted secrets unless they have access to the decryption keys.

## Solution
This feature adds a new setting `sops.strict` that allows users to opt into a non-strict mode where:
- Missing sops keys won't cause mise to fail
- Encrypted content is skipped and logged as a warning
- Unencrypted environment variables continue to work normally

## Test plan
- [x] Unit tests pass (`cargo test`)
- [x] Code compiles successfully (`cargo build`)  
- [x] Linting and formatting passes (`mise run lint`)
- [x] Added integration test for non-strict mode behavior
- [x] Verified backward compatibility (strict mode is default)

## Usage
```bash
# Enable non-strict mode
mise settings set sops.strict false

# Or via environment variable
export MISE_SOPS_STRICT=false
```

🤖 Generated with [Claude Code](https://claude.ai/code)