### PR TITLE
fix: add compression-zip-deflate feature on self_update crate for windows target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7194,10 +7194,12 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
+ "flate2",
  "indexmap 2.9.0",
  "memchr",
  "thiserror 2.0.12",
  "time",
+ "zopfli",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ self_update = { version = "0.42", optional = true, default-features = false, fea
 [target.'cfg(windows)'.dependencies]
 self_update = { version = "0.42", optional = true, default-features = false, features = [
   "archive-zip",
+  "compression-zip-deflate",
   "signatures",
 ] }
 sevenz-rust = "0.6"


### PR DESCRIPTION
Should fix the self-update issue "Compression method not supported" on windows as discussed in #5367.