### PR TITLE
fix: suppress hint on 'cargo search mise' command

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -5,7 +5,7 @@ git config user.name mise-en-dev
 git config user.email release@mise.jdx.dev
 
 cur_version="$(cargo pkgid mise | cut -d# -f2)"
-latest_version="$(cargo search mise --limit 1 | grep '^mise = "' | cut -d'"' -f2)"
+latest_version="$(cargo search mise --limit 1 -q | grep '^mise = "' | cut -d'"' -f2)"
 if [[ $cur_version != "$latest_version" ]]; then
 	echo "Releasing $cur_version"
 	cargo publish


### PR DESCRIPTION
According to the action log output it seems that the `cargo search mise --limit 1` command breaks/fails to a new hint/note in stdout.

```
[release-plz] $ ~/work/mise/mise/xtasks/release-plz
+ git config user.name mise-en-dev
+ git config user.email release@mise.jdx.dev
++ cargo pkgid mise
++ cut -d# -f2
+ cur_version=2025.6.5
++ cargo search mise --limit 1
++ grep '^mise = "'
++ cut '-d"' -f2
note: to learn more about a package, run `cargo info <name>`
+ latest_version=
[release-plz] ERROR task failed
Error: Process completed with exit code 1.
```