### PR TITLE
ci: use cargo info to retrieve latest mise version

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -5,7 +5,7 @@ git config user.name mise-en-dev
 git config user.email release@mise.jdx.dev
 
 cur_version="$(cargo pkgid mise | cut -d# -f2)"
-latest_version="$(cargo search mise --limit 1 -q | grep '^mise = "' | cut -d'"' -f2)"
+latest_version="$(cargo info --registry "crates-io" --color never --quiet mise | grep "^version:" | cut -d' ' -f2)"
 if [[ $cur_version != "$latest_version" ]]; then
 	echo "Releasing $cur_version"
 	cargo publish


### PR DESCRIPTION
I'm not sure if this will work, but it might work.
`--registry "crates-io"` avoids printing the local mise verison, and `--color never` avoids printing ANSI color codes.

```
cargo info --registry "crates-io" --color never --quiet mise | grep "^version:" | cut -d' ' -f2
```