### PR TITLE
ci: use pinnable tag of taiki-e/install-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,8 @@ jobs:
       - if: matrix.runs-on != 'ubuntu-latest'
         run: rustup target add ${{matrix.target}}
       - if: matrix.runs-on == 'ubuntu-latest'
-        uses: taiki-e/install-action@cross
+        uses: taiki-e/install-action@v2
+        with: { tool: cross }
       - name: build-tarball
         uses: nick-fields/retry@v3
         with:


### PR DESCRIPTION
`taiki-e/install-action@cross` cannot be pinned by Renovate.

Since Renovate fails to update the branch, it cannot pin GitHub Actions even though pinning has been enabled since https://github.com/jdx/mise/commit/b80d8e3ffe73d315c4214f77dedcf4cce7a54032.

```
DEBUG: Value is not updated (branch="renovate/pin-dependencies")
{
  "depName": "taiki-e/install-action"
  "manager": "github-actions"
  "packageFile": ".github/workflows/release.yml"
  "expectedValue": "cross"
}

WARN: Error updating branch: update failure (branch="renovate/pin-dependencies")
```