### PR TITLE
chore: release 2025.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [2025.6.8](https://github.com/jdx/mise/compare/v2025.6.7..v2025.6.8) - 2025-06-26
+
+### 🚀 Features
+
+- **(java)** add support for tar.xz in Java core plugin to support RedHat JDKs by [@roele](https://github.com/roele) in [#5354](https://github.com/jdx/mise/pull/5354)
+- **(registry)** add osv-scanner by [@scop](https://github.com/scop) in [#5413](https://github.com/jdx/mise/pull/5413)
+- **(registry)** add scorecard by [@scop](https://github.com/scop) in [#5410](https://github.com/jdx/mise/pull/5410)
+- **(registry)** add docker cli by [@acesyde](https://github.com/acesyde) in [#5344](https://github.com/jdx/mise/pull/5344)
+- **(registry)** add claude code by [@lelouvincx](https://github.com/lelouvincx) in [#5420](https://github.com/jdx/mise/pull/5420)
+- **(registry)** add aws `cfn-lint` by [@garysassano](https://github.com/garysassano) in [#5434](https://github.com/jdx/mise/pull/5434)
+- added graphite by [@jdx](https://github.com/jdx) in [#5429](https://github.com/jdx/mise/pull/5429)
+
+### 🐛 Bug Fixes
+
+- **(erlang)** use precompiled binaries for linux ubuntu by [@paradox460](https://github.com/paradox460) in [#5402](https://github.com/jdx/mise/pull/5402)
+- **(ubi)** checksum generation might fail if extract_all option is used by [@roele](https://github.com/roele) in [#5394](https://github.com/jdx/mise/pull/5394)
+- `self-update` on MITM firewall by [@joehorsnell](https://github.com/joehorsnell) in [#5387](https://github.com/jdx/mise/pull/5387)
+- lint warning by [@jdx](https://github.com/jdx) in [#5425](https://github.com/jdx/mise/pull/5425)
+- only warn on toolset resolve errors by [@jdx](https://github.com/jdx) in [#5435](https://github.com/jdx/mise/pull/5435)
+
+### 🚜 Refactor
+
+- **(registry)** use pipx for semgrep by [@scop](https://github.com/scop) in [#5423](https://github.com/jdx/mise/pull/5423)
+- **(registry)** add backends and tests by [@risu729](https://github.com/risu729) in [#5388](https://github.com/jdx/mise/pull/5388)
+
+### Ci
+
+- unpin hyperfine by [@risu729](https://github.com/risu729) in [#5411](https://github.com/jdx/mise/pull/5411)
+
+### New Contributors
+
+- @paradox460 made their first contribution in [#5402](https://github.com/jdx/mise/pull/5402)
+- @lelouvincx made their first contribution in [#5420](https://github.com/jdx/mise/pull/5420)
+
 ## [2025.6.7](https://github.com/jdx/mise/compare/v2025.6.6..v2025.6.7) - 2025-06-23
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytecount"
@@ -3481,9 +3481,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags",
  "libc",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.6.7"
+version = "2025.6.8"
 dependencies = [
  "async-backtrace",
  "async-trait",
@@ -4202,9 +4202,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "papergrid"
@@ -6803,9 +6803,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result 0.3.4",
@@ -7104,9 +7104,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
  "rustix 1.0.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2025.6.7"
+version = "2025.6.8"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.6.7 macos-arm64 (a1b2d3e 2025-06-23)
+2025.6.8 macos-arm64 (a1b2d3e 2025-06-26)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_6_7:-}" ]] || _cache_invalid _usage_spec_mise_2025_6_7 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_6_7;
+  if ( [[ -z "${_usage_spec_mise_2025_6_8:-}" ]] || _cache_invalid _usage_spec_mise_2025_6_8 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_6_8;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_6_7 spec
+    _store_cache _usage_spec_mise_2025_6_8 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_6_7:-} ]]; then
-        _usage_spec_mise_2025_6_7="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_6_8:-} ]]; then
+        _usage_spec_mise_2025_6_8="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_6_7}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_6_8}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_6_7
-  set -g _usage_spec_mise_2025_6_7 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_6_8
+  set -g _usage_spec_mise_2025_6_8 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_7" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_8" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_7" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_8" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.6.7";
+  version = "2025.6.8";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.6.7
+Version: 2025.6.8
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(java)** add support for tar.xz in Java core plugin to support RedHat JDKs by [@roele](https://github.com/roele) in [#5354](https://github.com/jdx/mise/pull/5354)
- **(registry)** add osv-scanner by [@scop](https://github.com/scop) in [#5413](https://github.com/jdx/mise/pull/5413)
- **(registry)** add scorecard by [@scop](https://github.com/scop) in [#5410](https://github.com/jdx/mise/pull/5410)
- **(registry)** add docker cli by [@acesyde](https://github.com/acesyde) in [#5344](https://github.com/jdx/mise/pull/5344)
- **(registry)** add claude code by [@lelouvincx](https://github.com/lelouvincx) in [#5420](https://github.com/jdx/mise/pull/5420)
- **(registry)** add aws `cfn-lint` by [@garysassano](https://github.com/garysassano) in [#5434](https://github.com/jdx/mise/pull/5434)
- added graphite by [@jdx](https://github.com/jdx) in [#5429](https://github.com/jdx/mise/pull/5429)

### 🐛 Bug Fixes

- **(erlang)** use precompiled binaries for linux ubuntu by [@paradox460](https://github.com/paradox460) in [#5402](https://github.com/jdx/mise/pull/5402)
- **(ubi)** checksum generation might fail if extract_all option is used by [@roele](https://github.com/roele) in [#5394](https://github.com/jdx/mise/pull/5394)
- `self-update` on MITM firewall by [@joehorsnell](https://github.com/joehorsnell) in [#5387](https://github.com/jdx/mise/pull/5387)
- lint warning by [@jdx](https://github.com/jdx) in [#5425](https://github.com/jdx/mise/pull/5425)
- only warn on toolset resolve errors by [@jdx](https://github.com/jdx) in [#5435](https://github.com/jdx/mise/pull/5435)

### 🚜 Refactor

- **(registry)** use pipx for semgrep by [@scop](https://github.com/scop) in [#5423](https://github.com/jdx/mise/pull/5423)
- **(registry)** add backends and tests by [@risu729](https://github.com/risu729) in [#5388](https://github.com/jdx/mise/pull/5388)

### Ci

- unpin hyperfine by [@risu729](https://github.com/risu729) in [#5411](https://github.com/jdx/mise/pull/5411)

### New Contributors

- @paradox460 made their first contribution in [#5402](https://github.com/jdx/mise/pull/5402)
- @lelouvincx made their first contribution in [#5420](https://github.com/jdx/mise/pull/5420)