### PR TITLE
fix(erlang): use precompiled ubuntu binaries on GHA

### DIFF
--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -99,7 +99,12 @@ impl ErlangPlugin {
 
         let os_ver: String;
         if let Ok(os) = std::env::var("ImageOS") {
-            os_ver = os
+            os_ver = match os.as_str() {
+                "ubuntu24" => "ubuntu-24.04".to_string(),
+                "ubuntu22" => "ubuntu-22.04".to_string(),
+                "ubuntu20" => "ubuntu-20.04".to_string(),
+                _ => os,
+            };
         } else if let Ok(os_release) = &*os_release::OS_RELEASE {
             os_ver = format!("{}-{}", os_release.id, os_release.version_id);
         } else {


### PR DESCRIPTION
My previous PR (https://github.com/jdx/mise/pull/5402) works well on a local Ubuntu runner, but when it comes to the actual github runners, it doesn't work, because Github defines the `ImageOS` as `ubuntu24`, not `ubuntu-24.04`

There are two approaches to solving this issue:

1. Remap `ubuntu24` style strings to `ubuntu-24.04`. That is what I'm doing now
2. Ignore the `ImageOS` envar entirely, and just rely on data from `os_releases`

