### PR TITLE
chore: release 2025.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [2025.7.0](https://github.com/jdx/mise/compare/v2025.6.8..v2025.7.0) - 2025-07-01
+
+### 🚀 Features
+
+- **(registry)** adds gemini-cli by [@risu729](https://github.com/risu729) in [#5447](https://github.com/jdx/mise/pull/5447)
+- **(registry)** adds npm backended tools by [@risu729](https://github.com/risu729) in [#5446](https://github.com/jdx/mise/pull/5446)
+- **(registry)** add powershell alias by [@risu729](https://github.com/risu729) in [#5449](https://github.com/jdx/mise/pull/5449)
+- **(registry)** add dagu by [@yottahmd](https://github.com/yottahmd) in [#5476](https://github.com/jdx/mise/pull/5476)
+- **(registry)** update aws-sam backends to include aqua source by [@yashikota](https://github.com/yashikota) in [#5461](https://github.com/jdx/mise/pull/5461)
+- **(registry)** use ubi backend for youtube-dl nightly releases by [@risu729](https://github.com/risu729) in [#5466](https://github.com/jdx/mise/pull/5466)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** update victoria-metrics package name casing by [@shikharbhardwaj](https://github.com/shikharbhardwaj) in [#5483](https://github.com/jdx/mise/pull/5483)
+- **(aqua)** handle hard links in aqua packages by [@risu729](https://github.com/risu729) in [#5463](https://github.com/jdx/mise/pull/5463)
+- **(bun)** enhance architecture detection for musl targets by [@roele](https://github.com/roele) in [#5450](https://github.com/jdx/mise/pull/5450)
+- **(erlang)** use precompiled ubuntu binaries on GHA by [@paradox460](https://github.com/paradox460) in [#5439](https://github.com/jdx/mise/pull/5439)
+- **(erlang)** add `install_precompiled` for unsupported os by [@risu729](https://github.com/risu729) in [#5479](https://github.com/jdx/mise/pull/5479)
+- **(registry)** use aqua backend for cargo-make by [@risu729](https://github.com/risu729) in [#5465](https://github.com/jdx/mise/pull/5465)
+- **(registry)** use aqua backends for all available tools by [@risu729](https://github.com/risu729) in [#5467](https://github.com/jdx/mise/pull/5467)
+- `parse_command` passing `-c` flag to cmd.exe by [@IMXEren](https://github.com/IMXEren) in [#5441](https://github.com/jdx/mise/pull/5441)
+
+### 🧪 Testing
+
+- **(registry)** disable bitwarden test by [@risu729](https://github.com/risu729) in [#5468](https://github.com/jdx/mise/pull/5468)
+
+### 📦️ Dependency Updates
+
+- pin dependencies by [@renovate[bot]](https://github.com/renovate[bot]) in [#5443](https://github.com/jdx/mise/pull/5443)
+- update jdx/mise-action digest to 5cb1df6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5444](https://github.com/jdx/mise/pull/5444)
+
+### Chore
+
+- disable automatic cargo up due to windows build failure in homedir crate by [@jdx](https://github.com/jdx) in [7570d0a](https://github.com/jdx/mise/commit/7570d0a95498d7b5626645fe3065429e19d0b26e)
+
+### Ci
+
+- **(test)** run `apt-get update` before `apt-get install` by [@risu729](https://github.com/risu729) in [#5448](https://github.com/jdx/mise/pull/5448)
+
+### New Contributors
+
+- @yashikota made their first contribution in [#5461](https://github.com/jdx/mise/pull/5461)
+- @yottahmd made their first contribution in [#5476](https://github.com/jdx/mise/pull/5476)
+- @IMXEren made their first contribution in [#5441](https://github.com/jdx/mise/pull/5441)
+
 ## [2025.6.8](https://github.com/jdx/mise/compare/v2025.6.7..v2025.6.8) - 2025-06-26
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.6.8"
+version = "2025.7.0"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2025.6.8"
+version = "2025.7.0"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.6.8 macos-arm64 (a1b2d3e 2025-06-26)
+2025.7.0 macos-arm64 (a1b2d3e 2025-07-01)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_6_8:-}" ]] || _cache_invalid _usage_spec_mise_2025_6_8 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_6_8;
+  if ( [[ -z "${_usage_spec_mise_2025_7_0:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_0 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_7_0;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_6_8 spec
+    _store_cache _usage_spec_mise_2025_7_0 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_6_8:-} ]]; then
-        _usage_spec_mise_2025_6_8="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_7_0:-} ]]; then
+        _usage_spec_mise_2025_7_0="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_6_8}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_0}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_6_8
-  set -g _usage_spec_mise_2025_6_8 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_7_0
+  set -g _usage_spec_mise_2025_7_0 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_8" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_0" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_6_8" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_0" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.6.8";
+  version = "2025.7.0";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.6.8
+Version: 2025.7.0
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(registry)** adds gemini-cli by [@risu729](https://github.com/risu729) in [#5447](https://github.com/jdx/mise/pull/5447)
- **(registry)** adds npm backended tools by [@risu729](https://github.com/risu729) in [#5446](https://github.com/jdx/mise/pull/5446)
- **(registry)** add powershell alias by [@risu729](https://github.com/risu729) in [#5449](https://github.com/jdx/mise/pull/5449)
- **(registry)** add dagu by [@yottahmd](https://github.com/yottahmd) in [#5476](https://github.com/jdx/mise/pull/5476)
- **(registry)** update aws-sam backends to include aqua source by [@yashikota](https://github.com/yashikota) in [#5461](https://github.com/jdx/mise/pull/5461)
- **(registry)** use ubi backend for youtube-dl nightly releases by [@risu729](https://github.com/risu729) in [#5466](https://github.com/jdx/mise/pull/5466)

### 🐛 Bug Fixes

- **(aqua)** update victoria-metrics package name casing by [@shikharbhardwaj](https://github.com/shikharbhardwaj) in [#5483](https://github.com/jdx/mise/pull/5483)
- **(aqua)** handle hard links in aqua packages by [@risu729](https://github.com/risu729) in [#5463](https://github.com/jdx/mise/pull/5463)
- **(bun)** enhance architecture detection for musl targets by [@roele](https://github.com/roele) in [#5450](https://github.com/jdx/mise/pull/5450)
- **(erlang)** use precompiled ubuntu binaries on GHA by [@paradox460](https://github.com/paradox460) in [#5439](https://github.com/jdx/mise/pull/5439)
- **(erlang)** add `install_precompiled` for unsupported os by [@risu729](https://github.com/risu729) in [#5479](https://github.com/jdx/mise/pull/5479)
- **(registry)** use aqua backend for cargo-make by [@risu729](https://github.com/risu729) in [#5465](https://github.com/jdx/mise/pull/5465)
- **(registry)** use aqua backends for all available tools by [@risu729](https://github.com/risu729) in [#5467](https://github.com/jdx/mise/pull/5467)
- `parse_command` passing `-c` flag to cmd.exe by [@IMXEren](https://github.com/IMXEren) in [#5441](https://github.com/jdx/mise/pull/5441)

### 🧪 Testing

- **(registry)** disable bitwarden test by [@risu729](https://github.com/risu729) in [#5468](https://github.com/jdx/mise/pull/5468)

### 📦️ Dependency Updates

- pin dependencies by [@renovate[bot]](https://github.com/renovate[bot]) in [#5443](https://github.com/jdx/mise/pull/5443)
- update jdx/mise-action digest to 5cb1df6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5444](https://github.com/jdx/mise/pull/5444)

### Chore

- disable automatic cargo up due to windows build failure in homedir crate by [@jdx](https://github.com/jdx) in [7570d0a](https://github.com/jdx/mise/commit/7570d0a95498d7b5626645fe3065429e19d0b26e)

### Ci

- **(test)** run `apt-get update` before `apt-get install` by [@risu729](https://github.com/risu729) in [#5448](https://github.com/jdx/mise/pull/5448)

### New Contributors

- @yashikota made their first contribution in [#5461](https://github.com/jdx/mise/pull/5461)
- @yottahmd made their first contribution in [#5476](https://github.com/jdx/mise/pull/5476)
- @IMXEren made their first contribution in [#5441](https://github.com/jdx/mise/pull/5441)