### PR TITLE
fix: `parse_command` passing `-c` flag to cmd.exe

### DIFF
--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -214,7 +214,13 @@ fn parse_command(
             let (program, args) = command.split_first().unwrap();
             (program.clone(), args.into())
         }
-        _ => (shell.into(), vec!["-c".into(), c.clone().unwrap()]),
+        _ => {
+            #[cfg(unix)]
+            let command_flag = "-c";
+            #[cfg(windows)]
+            let command_flag = "/c";
+            (shell.into(), vec![command_flag.into(), c.clone().unwrap()])
+        }
     }
 }
 


### PR DESCRIPTION
- `parse_command` passes `-c` flag to cmd.exe (Windows) instead of `/c`.
- Using `#cfg(...)` because that's what `env::SHELL` depends upon.