### PR TITLE
ci(test): run `apt-get update` before `apt-get install`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,6 +196,7 @@ jobs:
           sudo apt-get install \
             bison \
             build-essential \
+            direnv \
             fd-find \
             fish \
             pipx \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,6 @@ jobs:
           sudo apt-get install \
             bison \
             build-essential \
-            direnv \
             fd-find \
             fish \
             pipx \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,6 +193,7 @@ jobs:
           fetch-depth: 0
       - name: Install build and test dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install \
             bison \
             build-essential \


### PR DESCRIPTION
~~I'm not sure why `direnv` was installed, as it seems unused. https://github.com/jdx/mise/commit/d5bbfa42fc9e2747af3ca767005bb66fb2ec961c~~

~~Since it threw an error, maybe because the packages list is outdated, I just removed `direnv`.~~
If `direnv` is required, I think we need `sudo apt-get update` beforehand.

```
  sudo apt-get install \
    bison \
    build-essential \
    direnv \
    fd-find \
    fish \
    pipx \
    python3-venv \
    zsh
  shell: /usr/bin/bash -e {0}
  env:
    CARGO_TERM_COLOR: always
    MISE_TRUSTED_CONFIG_PATHS: /home/runner/work/mise/mise
    MISE_EXPERIMENTAL: 1
    MISE_LOCKFILE: 1
    RUST_BACKTRACE: 1
    GITHUB_TOKEN: ***
Reading package lists...
Building dependency tree...
Reading state information...
bison is already the newest version (2:3.8.2+dfsg-1build2).
python3-venv is already the newest version (3.12.3-0ubuntu2).
The following additional packages will be installed:
  fish-common python3-argcomplete python3-platformdirs python3-psutil
  python3-userpath xsel zsh-common
Suggested packages:
  doc-base zsh-doc
The following NEW packages will be installed:
  build-essential direnv fd-find fish fish-common pipx python3-argcomplete
  python3-platformdirs python3-psutil python3-userpath xsel zsh zsh-common
0 upgraded, 13 newly installed, 0 to remove and 21 not upgraded.
Need to get 13.6 MB of archives.
After this operation, 50.9 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 build-essential amd64 12.10ubuntu1 [4928 B]
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 direnv amd64 2.32.1-2ubuntu0.24.04.2
Get:4 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fd-find amd64 9.0.0-1 [1356 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fish-common all 3.7.0-1 [2261 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fish amd64 3.7.0-1 [1306 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 python3-argcomplete all 3.1.4-1ubuntu0.1 [33.8 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 python3-platformdirs all 4.2.0-1 [16.1 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 python3-userpath all 1.9.1-1 [9416 B]
Get:10 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 pipx all 1.4.3-1 [787 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 python3-psutil amd64 5.9.8-2build2 [195 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 xsel amd64 1.2.1-1 [20.5 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 zsh-common all 5.9-6ubuntu2 [4173 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 zsh amd64 5.9-6ubuntu2 [812 kB]
Ign:3 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 direnv amd64 2.32.1-2ubuntu0.24.04.2
Ign:3 https://security.ubuntu.com/ubuntu noble-updates/universe amd64 direnv amd64 2.32.1-2ubuntu0.24.04.2
Err:3 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/universe amd64 direnv amd64 2.32.1-2ubuntu0.24.04.2
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/universe/d/direnv/direnv_2.32.1-2ubuntu0.24.04.2_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
Fetched 11.0 MB in 1s (10.4 MB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```