### PR TITLE
fix: `self-update` on MITM firewall (attempt #2)

### DIFF
--- a/scripts/build-tarball.ps1
+++ b/scripts/build-tarball.ps1
@@ -6,7 +6,7 @@ $Version = ./scripts/get-version.ps1
 $BaseName = "mise-v$Version-$Env:OS-$Env:ARCH"
 
 # TODO: use "serious" feature
-cargo build --release --features openssl/vendored --target "$Target"
+cargo build --release --features rustls-native-roots,openssl/vendored --target "$Target"
 mkdir -p dist/mise/bin
 cp "target/$Target/release/mise.exe" dist/mise/bin/mise.exe
 cp README.md dist/mise/README.md

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -71,11 +71,11 @@ linux-arm*)
 esac
 
 if command -v cross >/dev/null; then
-	cross build --profile=serious --target "$RUST_TRIPLE" --features openssl/vendored
+	cross build --profile=serious --target "$RUST_TRIPLE" --features rustls-native-roots,openssl/vendored
 elif command -v zig >/dev/null; then
-	cargo zigbuild --profile=serious --target "$RUST_TRIPLE" --features openssl/vendored
+	cargo zigbuild --profile=serious --target "$RUST_TRIPLE" --features rustls-native-roots,openssl/vendored
 else
-	cargo build --profile=serious --target "$RUST_TRIPLE" --features openssl/vendored
+	cargo build --profile=serious --target "$RUST_TRIPLE" --features rustls-native-roots,openssl/vendored
 fi
 mkdir -p dist/mise/bin
 mkdir -p dist/mise/man/man1


### PR DESCRIPTION
This is a follow-up to jdx/mise#5387, to fix the `self-update` command when using a traffic-inspecting/MITM firewall, such as Cloudflare WARP.

The previous PR broke the release build, so had to be reverted. I didn't realise that the [`reqwest`](https://crates.io/crates/reqwest) crate requirements are different on Linux (I use macOS), so OpenSSL is still needed.

I tried removing OpenSSL as a dependency completely, but it appears to not be straightforward, as many other crates also depend on `reqwest`.

The simplest thing I think is just to leave OpenSSL and add the `rustls-native-roots` feature.

I've tested `build-tarball.sh` locally on both macOS and Linux (using a VM) and verified that the resulting binaries can self-update correctly.

I don't have an easy way to test on Windows, but the `reqwest` docs suggest that it behaves the same as on macOS.