### PR TITLE
fix(aqua): handle hard links in aqua packages

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -225,10 +225,8 @@ biome.backends = [
 ]
 biome.test = ["biome --version", "Version: {{version}}"]
 bitwarden.backends = ["aqua:bitwarden/clients", "asdf:vixus0/asdf-bitwarden"]
-bitwarden.test = [
-    "bw --version",
-    ""
-] # TODO: change version_filter to version_prefix in aqua registry
+# TODO: change version_filter to version_prefix in aqua registry
+# bitwarden.test = ["bw --version", ""] # latest version doesn't contain sha256
 bitwarden-secrets-manager.backends = [
     "ubi:bitwarden/sdk[tag_regex=^bws,exe=bws]",
     "asdf:asdf-community/asdf-bitwarden-secrets-manager"

--- a/registry.toml
+++ b/registry.toml
@@ -819,6 +819,10 @@ github-markdown-toc.backends = [
     "aqua:ekalinin/github-markdown-toc",
     "asdf:skyzyx/asdf-github-markdown-toc"
 ]
+github-markdown-toc.test = [
+    "github-markdown-toc --version",
+    "{{version}}"
+]
 gitleaks.backends = ["aqua:gitleaks/gitleaks", "asdf:jmcvetta/asdf-gitleaks"]
 gitleaks.test = ["gitleaks --version", "gitleaks version {{version}}"]
 gitsign.backends = ["aqua:sigstore/gitsign", "asdf:spencergilbert/asdf-gitsign"]
@@ -1323,6 +1327,7 @@ license-plist.backends = [
     "asdf:MacPaw/asdf-license-plist"
 ]
 lima.backends = ["aqua:lima-vm/lima", "asdf:CrouchingMuppet/asdf-lima"]
+lima.test = ["lima --version", "limactl version {{version}}"]
 linkerd.backends = ["aqua:linkerd/linkerd2", "asdf:kforsthoevel/asdf-linkerd"]
 liqoctl.backends = ["aqua:liqotech/liqo", "asdf:pdemagny/asdf-liqoctl"]
 liquibase.backends = ["asdf:mise-plugins/mise-liquibase"]

--- a/registry.toml
+++ b/registry.toml
@@ -819,7 +819,7 @@ github-markdown-toc.backends = [
     "aqua:ekalinin/github-markdown-toc",
     "asdf:skyzyx/asdf-github-markdown-toc"
 ]
-github-markdown-toc.test = ["github-markdown-toc --version", "{{version}}"]
+github-markdown-toc.test = ["gh-md-toc --version", "{{version}}"]
 gitleaks.backends = ["aqua:gitleaks/gitleaks", "asdf:jmcvetta/asdf-gitleaks"]
 gitleaks.test = ["gitleaks --version", "gitleaks version {{version}}"]
 gitsign.backends = ["aqua:sigstore/gitsign", "asdf:spencergilbert/asdf-gitsign"]

--- a/registry.toml
+++ b/registry.toml
@@ -819,10 +819,7 @@ github-markdown-toc.backends = [
     "aqua:ekalinin/github-markdown-toc",
     "asdf:skyzyx/asdf-github-markdown-toc"
 ]
-github-markdown-toc.test = [
-    "github-markdown-toc --version",
-    "{{version}}"
-]
+github-markdown-toc.test = ["github-markdown-toc --version", "{{version}}"]
 gitleaks.backends = ["aqua:gitleaks/gitleaks", "asdf:jmcvetta/asdf-gitleaks"]
 gitleaks.test = ["gitleaks --version", "gitleaks version {{version}}"]
 gitsign.backends = ["aqua:sigstore/gitsign", "asdf:spencergilbert/asdf-gitsign"]

--- a/registry.toml
+++ b/registry.toml
@@ -225,8 +225,10 @@ biome.backends = [
 ]
 biome.test = ["biome --version", "Version: {{version}}"]
 bitwarden.backends = ["aqua:bitwarden/clients", "asdf:vixus0/asdf-bitwarden"]
-# TODO: change version_filter to version_prefix in aqua registry
-# bitwarden.test = ["bw --version", ""] # latest version doesn't contain sha256
+bitwarden.test = [
+    "bw --version",
+    ""
+] # TODO: change version_filter to version_prefix in aqua registry
 bitwarden-secrets-manager.backends = [
     "ubi:bitwarden/sdk[tag_regex=^bws,exe=bws]",
     "asdf:asdf-community/asdf-bitwarden-secrets-manager"

--- a/src/file.rs
+++ b/src/file.rs
@@ -16,7 +16,6 @@ use eyre::bail;
 use filetime::{FileTime, set_file_times};
 use flate2::read::GzDecoder;
 use itertools::Itertools;
-use path_absolutize::Absolutize;
 use std::sync::LazyLock as Lazy;
 use tar::Archive;
 use walkdir::WalkDir;
@@ -164,7 +163,7 @@ pub fn copy_dir_all<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()
     let from = from.as_ref();
     let to = to.as_ref();
     trace!("cp -r {} {}", from.display(), to.display());
-    recursive_ls(from)?.into_iter().try_for_each(|path| {
+    recursive_ls(from, false)?.into_iter().try_for_each(|path| {
         let relative = path.strip_prefix(from)?;
         let dest = to.join(relative);
         create_dir_all(dest.parent().unwrap())?;
@@ -329,7 +328,7 @@ pub fn ls(dir: &Path) -> Result<BTreeSet<PathBuf>> {
     Ok(output)
 }
 
-pub fn recursive_ls(dir: &Path) -> Result<BTreeSet<PathBuf>> {
+pub fn recursive_ls(dir: &Path, include_dirs: bool) -> Result<BTreeSet<PathBuf>> {
     if !dir.is_dir() {
         return Ok(Default::default());
     }
@@ -337,7 +336,7 @@ pub fn recursive_ls(dir: &Path) -> Result<BTreeSet<PathBuf>> {
     Ok(WalkDir::new(dir)
         .follow_links(true)
         .into_iter()
-        .filter_ok(|e| e.file_type().is_file())
+        .filter_ok(|e| e.file_type().is_file() || (include_dirs && e.file_type().is_dir()))
         .map_ok(|e| e.path().to_path_buf())
         .try_collect()?)
 }
@@ -713,22 +712,42 @@ pub fn untar(archive: &Path, dest: &Path, opts: &TarOptions) -> Result<()> {
     //         pr.set_length(total);
     //     }
     // }
+    create_dir_all(dest).wrap_err_with(err)?;
     for entry in Archive::new(tar).entries().wrap_err_with(err)? {
         let mut entry = entry.wrap_err_with(err)?;
-        let path: PathBuf = entry
-            .path()
-            .wrap_err_with(err)?
-            .components()
-            .skip(opts.strip_components)
-            .filter(|c| c.as_os_str() != ".")
-            .collect::<PathBuf>()
-            .absolutize_virtually(dest)?
-            .to_path_buf();
-        create_dir_all(path.parent().unwrap()).wrap_err_with(err)?;
-        trace!("extracting {}", display_path(&path));
-        entry.unpack(&path).wrap_err_with(err)?;
+        trace!("extracting {}", entry.path()?.display());
+        entry.unpack_in(&dest).wrap_err_with(err)?;
         if let Some(pr) = &opts.pr {
             pr.set_length(entry.raw_file_position());
+        }
+    }
+    if opts.strip_components > 0 {
+        debug!(
+            "moving files with strip-components={}",
+            opts.strip_components
+        );
+        let entries = recursive_ls(dest, true).wrap_err_with(err)?;
+        for entry in entries.into_iter().rev() {
+            if entry.is_dir() {
+                if is_empty_dir(&entry).wrap_err_with(err)? {
+                    fs::remove_dir(&entry).wrap_err_with(err)?;
+                }
+                continue;
+            }
+            let relative = entry
+                .strip_prefix(dest)
+                .wrap_err_with(err)?
+                .components()
+                .skip(opts.strip_components)
+                .collect::<PathBuf>();
+            if relative.is_empty() {
+                // remove the file if the path components are all stripped
+                fs::remove_file(&entry).wrap_err_with(err)?;
+                continue;
+            }
+            let stripped = dest.join(relative);
+            create_dir_all(stripped.parent().unwrap()).wrap_err_with(err)?;
+            fs::rename(&entry, &stripped).wrap_err_with(err)?;
         }
     }
     // if let Some(pr) = &opts.pr {

--- a/src/file.rs
+++ b/src/file.rs
@@ -716,7 +716,7 @@ pub fn untar(archive: &Path, dest: &Path, opts: &TarOptions) -> Result<()> {
     for entry in Archive::new(tar).entries().wrap_err_with(err)? {
         let mut entry = entry.wrap_err_with(err)?;
         trace!("extracting {}", entry.path().wrap_err_with(err)?.display());
-        entry.unpack_in(&dest).wrap_err_with(err)?;
+        entry.unpack_in(dest).wrap_err_with(err)?;
         if let Some(pr) = &opts.pr {
             pr.set_length(entry.raw_file_position());
         }

--- a/src/file.rs
+++ b/src/file.rs
@@ -715,7 +715,7 @@ pub fn untar(archive: &Path, dest: &Path, opts: &TarOptions) -> Result<()> {
     create_dir_all(dest).wrap_err_with(err)?;
     for entry in Archive::new(tar).entries().wrap_err_with(err)? {
         let mut entry = entry.wrap_err_with(err)?;
-        trace!("extracting {}", entry.path()?.display());
+        trace!("extracting {}", entry.path().wrap_err_with(err)?.display());
         entry.unpack_in(&dest).wrap_err_with(err)?;
         if let Some(pr) = &opts.pr {
             pr.set_length(entry.raw_file_position());


### PR DESCRIPTION
Resolves #5419.

This PR fixes a bug that caused a `No such file or directory` error when extracting tar archives containing hard links.

### Cause

The issue is caused by [`tar::Entry::unpack`](https://docs.rs/tar/latest/tar/struct.Entry.html#method.unpack), which resolves hard link paths relative to the current working directory instead of the intended destination directory.
When `Entry::unpack` calls the internal `EntryFields::unpack` method, it passes `None` as the `target_base`, so the hard links are resolved to the current working directory.

This resulted in `std::fs::hard_link` being called with an incorrect source path (implementation [here](https://github.com/alexcrichton/tar-rs/blob/a1c3036af48fa02437909112239f0632e4cfcfae/src/entry.rs#L509)), leading to the following error:

```
No such file or directory (os error 2) when hard linking ./share/lima/templates/_images/ubuntu-24.04.yaml to /home/ryan/.local/share/mise/installs/lima/1.1.1/share/lima/templates/_images/ubuntu-lts.yaml
```

### Solution

The fix is to replace `Entry::unpack` with [`Entry::unpack_in`](https://docs.rs/tar/latest/tar/struct.Entry.html#method.unpack_in).

This method correctly uses the destination path as the base for unpacking contents, including hard links, ensuring that `std::fs::hard_link` receives the correct source path.

While `Archive::unpack` could also solve this issue, sticking with `Entry::unpack_in` on a per-entry basis allows us to retain the existing progress bar functionality.

However, `opts.strip_components` cannot be parsed directly, so I added logic to move the entries to upper directories.
This might slow down the process, but I couldn't find other solutions for this.

### Notes

- We might be able to use `std::env::set_current_dir` to change the current working directory, but that would be a global change and could cause issues in other parts of the code.

- The use of `Entry::unpack_in` mitigates the security issues that `absolutize_virtually` was introduced in #5279 to prevent, so it is no longer necessary.