### PR TITLE
feat(registry): use ubi backend for youtube-dl nightly releases

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2233,7 +2233,7 @@ youtube-dl.backends = [
     "ubi:ytdl-org/ytdl-nightly[matching_regex=^youtube-dl$,rename_exe=youtube-dl]",
     "asdf:mise-plugins/mise-youtube-dl"
 ]
-youtube-dl.test = ["youtube-dl --version", "{{version}}"]
+# youtube-dl.test = ["youtube-dl --version", "{{version}}"] # disable until the versions host update
 yq.backends = [
     "aqua:mikefarah/yq",
     "ubi:mikefarah/yq",

--- a/registry.toml
+++ b/registry.toml
@@ -2229,7 +2229,8 @@ yazi.test = [
 ] # Version is in format Yazi {{version}} (buildid DATE) so it failed Yazi 0.4.1 (2275719 2024-12-10)
 yj.backends = ["ubi:sclevine/yj", "asdf:ryodocx/asdf-yj"]
 yor.backends = ["aqua:bridgecrewio/yor", "asdf:ordinaryexperts/asdf-yor"]
-youtube-dl.backends = ["asdf:mise-plugins/mise-youtube-dl"]
+youtube-dl.backends = ["ubi:ytdl-org/ytdl-nightly[matching_regex=^youtube-dl$,rename_exe=youtube-dl]","asdf:mise-plugins/mise-youtube-dl"]
+youtube-dl.test = ["youtube-dl --version", "{{version}}"]
 yq.backends = [
     "aqua:mikefarah/yq",
     "ubi:mikefarah/yq",

--- a/registry.toml
+++ b/registry.toml
@@ -2229,7 +2229,10 @@ yazi.test = [
 ] # Version is in format Yazi {{version}} (buildid DATE) so it failed Yazi 0.4.1 (2275719 2024-12-10)
 yj.backends = ["ubi:sclevine/yj", "asdf:ryodocx/asdf-yj"]
 yor.backends = ["aqua:bridgecrewio/yor", "asdf:ordinaryexperts/asdf-yor"]
-youtube-dl.backends = ["ubi:ytdl-org/ytdl-nightly[matching_regex=^youtube-dl$,rename_exe=youtube-dl]","asdf:mise-plugins/mise-youtube-dl"]
+youtube-dl.backends = [
+    "ubi:ytdl-org/ytdl-nightly[matching_regex=^youtube-dl$,rename_exe=youtube-dl]",
+    "asdf:mise-plugins/mise-youtube-dl"
+]
 youtube-dl.test = ["youtube-dl --version", "{{version}}"]
 yq.backends = [
     "aqua:mikefarah/yq",


### PR DESCRIPTION
> This release is old and has many known issues. See "... commits to master since this release" above.
> You almost certainly want the [nightly build release](https://github.com/ytdl-org/ytdl-nightly/releases/), and not this one. The nightly build is created from the master branch of this repo if changes have been committed since the last build. Read about [Installation](https://github.com/ytdl-org/ytdl-nightly#user-content-installation) of the nightly build. Major fixes in the nightly build are listed https://github.com/ytdl-org/youtube-dl/issues/30839.
ref: https://github.com/ytdl-org/youtube-dl/releases/tag/2021.12.17

According to the latest release, we should use `ytdl-org/ytdl-nightly`.
However, the test fails since the versions host don't include the nightly build versions, I disable it for now.