### PR TITLE
fix(erlang): add `install_precompiled` for unsupported os

### DIFF
--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -248,6 +248,11 @@ impl ErlangPlugin {
         Ok(Some(tv))
     }
 
+    #[cfg(not(any(linux, macos, windows)))]
+    async fn install_precompiled(&self, ctx: &InstallContext) -> Result<Option<ToolVersion>> {
+        Ok(None)
+    }
+
     async fn install_via_kerl(
         &self,
         _ctx: &InstallContext,


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/5477.

We could also replace `#[cfg(linux)]` with `#[cfg(not(any(macos,windows))]`, but we needed to replace all codes depended by `install_precompiled`, so I just added `install_precompiled` for other OS that returns `Ok(None)`.