### PR TITLE
fix(aqua): update victoria-metrics package name casing

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2134,7 +2134,7 @@ vendir.backends = ["aqua:carvel-dev/vendir", "asdf:vmware-tanzu/asdf-carvel"]
 venom.backends = ["aqua:ovh/venom", "asdf:aabouzaid/asdf-venom"]
 vhs.backends = ["aqua:charmbracelet/vhs", "asdf:chessmango/asdf-vhs"]
 victoria-metrics.backends = [
-    "aqua:victoriametrics/victoriametrics/victoria-metrics"
+    "aqua:VictoriaMetrics/VictoriaMetrics/victoria-metrics"
 ]
 # victoria-metrics.test = [
 # "victoria-metrics --version | awk -F'-' '{print $6}'",


### PR DESCRIPTION
About 3 weeks ago, aqua updated the casing for the victoria-metrics package here: https://github.com/aquaproj/aqua-registry/pull/37504/files

Updating the reference in `registry.toml`. Should fix the issue in #5250, although I wasn't able to get `cargo run` to use the updated registry locally, for some reason.