### PR TITLE
fix(settings): respect os in settings

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -285,9 +285,9 @@ impl AquaPackage {
         self = apply_override(self.clone(), self.version_override(v));
         if let Some(avo) = self.overrides.clone().into_iter().find(|o| {
             if let (Some(goos), Some(goarch)) = (&o.goos, &o.goarch) {
-                goos == aqua::os() && goarch == aqua::arch()
+                goos == &aqua::os() && goarch == aqua::arch()
             } else if let Some(goos) = &o.goos {
-                goos == aqua::os()
+                goos == &aqua::os()
             } else if let Some(goarch) = &o.goarch {
                 goarch == aqua::arch()
             } else {
@@ -376,11 +376,12 @@ impl AquaPackage {
 
     pub fn asset_strs(&self, v: &str) -> Result<IndexSet<String>> {
         let mut strs = IndexSet::from([self.asset(v)?]);
-        if cfg!(macos) {
+        let settings = Settings::get();
+        if settings.is_macos() {
             let mut ctx = HashMap::default();
             ctx.insert("Arch".to_string(), "universal".to_string());
             strs.insert(self.parse_aqua_str(&self.asset, v, &ctx)?);
-        } else if cfg!(windows) {
+        } else if settings.is_windows() {
             let mut ctx = HashMap::default();
             let asset = self.parse_aqua_str(&self.asset, v, &ctx)?;
             if self.complete_windows_ext && self.format(v)? == "raw" {
@@ -405,7 +406,7 @@ impl AquaPackage {
 
     pub fn url(&self, v: &str) -> Result<String> {
         let mut url = self.url.clone();
-        if cfg!(windows) && self.complete_windows_ext && self.format(v)? == "raw" {
+        if Settings::get().is_windows() && self.complete_windows_ext && self.format(v)? == "raw" {
             url.push_str(".exe");
         }
         self.parse_aqua_str(&url, v, &Default::default())
@@ -439,8 +440,8 @@ impl AquaPackage {
         let mut ctx = hashmap! {
             "Version".to_string() => replace(v),
             "SemVer".to_string() => replace(semver),
-            "OS".to_string() => replace(os),
-            "GOOS".to_string() => replace(os),
+            "OS".to_string() => replace(&os),
+            "GOOS".to_string() => replace(&os),
             "GOARCH".to_string() => replace(arch),
             "Arch".to_string() => replace(arch),
             "Format".to_string() => replace(&self.format),

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1,6 +1,6 @@
 use crate::backend::backend_type::BackendType;
 use crate::cli::args::BackendArg;
-use crate::cli::version::{ARCH, OS};
+use crate::cli::version::{ARCH};
 use crate::cmd::CmdLineRunner;
 use crate::config::Settings;
 use crate::file::TarOptions;
@@ -746,7 +746,7 @@ fn validate(pkg: &AquaPackage) -> Result<()> {
     let os = os();
     let arch = arch();
     let os_arch = format!("{os}/{arch}");
-    let mut myself: HashSet<&str> = ["all", os, arch, os_arch.as_str()].into();
+    let mut myself: HashSet<&str> = ["all", &os, arch, os_arch.as_str()].into();
     if os == "windows" && arch == "arm64" {
         // assume windows/arm64 is supported
         myself.insert("windows/amd64");
@@ -758,11 +758,11 @@ fn validate(pkg: &AquaPackage) -> Result<()> {
     Ok(())
 }
 
-pub fn os() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "darwin"
-    } else {
-        &OS
+pub fn os() -> String {
+    let os = Settings::get().os().to_string();
+    match os.as_str() {
+        "macos" => "darwin".into(),
+        _ => os,
     }
 }
 

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1,6 +1,6 @@
 use crate::backend::backend_type::BackendType;
 use crate::cli::args::BackendArg;
-use crate::cli::version::{ARCH};
+use crate::cli::version::ARCH;
 use crate::cmd::CmdLineRunner;
 use crate::config::Settings;
 use crate::file::TarOptions;

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -639,7 +639,8 @@ impl AquaBackend {
                 .or_else(|| pkg.name.as_ref().and_then(|n| n.split('/').next_back()))
                 .unwrap_or(&pkg.repo_name),
         );
-        if cfg!(windows) && pkg.complete_windows_ext {
+        let settings = Settings::get();
+        if settings.is_windows() && pkg.complete_windows_ext {
             bin_path = bin_path.with_extension("exe");
         }
         let mut tar_opts = TarOptions {
@@ -682,7 +683,7 @@ impl AquaBackend {
 
         for (src, dst) in self.srcs(pkg, tv)? {
             if src != dst && src.exists() && !dst.exists() {
-                if cfg!(windows) {
+                if settings.is_windows() {
                     file::copy(&src, &dst)?;
                 } else {
                     let src = PathBuf::from(".").join(src.file_name().unwrap().to_str().unwrap());

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -571,7 +571,7 @@ pub trait Backend: Debug + Send + Sync {
             .into_iter()
             .filter(|p| p.parent().is_some());
         for bin_path in bin_paths {
-            let paths_with_ext = if cfg!(windows) {
+            let paths_with_ext = if Settings::get().is_windows() {
                 vec![
                     bin_path.clone(),
                     bin_path.join(bin_name).with_extension("exe"),

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -168,7 +168,7 @@ impl Backend for UbiBackend {
                 .cloned()
                 .unwrap_or(tv.ba().short.to_string()),
         ];
-        if cfg!(windows) {
+        if Settings::get().is_windows() {
             possible_exes.push(format!("{}.exe", possible_exes[0]));
         }
         let full_binary_path = if let Some(bin_file) = possible_exes

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -224,6 +224,7 @@ impl Backend for UbiBackend {
         tv: &mut ToolVersion,
         file: &Path,
     ) -> eyre::Result<()> {
+        let settings = Settings::get();
         let mut checksum_key = file.file_name().unwrap().to_string_lossy().to_string();
         if let Some(exe) = tv.request.options().get("exe") {
             checksum_key = format!("{checksum_key}-{exe}");
@@ -231,7 +232,7 @@ impl Backend for UbiBackend {
         if let Some(matching) = tv.request.options().get("matching") {
             checksum_key = format!("{checksum_key}-{matching}");
         }
-        checksum_key = format!("{}-{}-{}", checksum_key, env::consts::OS, env::consts::ARCH);
+        checksum_key = format!("{}-{}-{}", checksum_key, settings.os(), env::consts::ARCH);
         if let Some(checksum) = &tv.checksums.get(&checksum_key) {
             ctx.pr
                 .set_message(format!("checksum verify {checksum_key}"));
@@ -240,7 +241,7 @@ impl Backend for UbiBackend {
             } else {
                 bail!("Invalid checksum: {checksum_key}");
             }
-        } else if Settings::get().lockfile && Settings::get().experimental {
+        } else if settings.lockfile && settings.experimental {
             ctx.pr
                 .set_message(format!("checksum generate {checksum_key}"));
             let hash = hash::file_hash_sha256(file, Some(&ctx.pr))?;

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use crate::config::Settings;
 use crate::env::PATH_KEY;
 use crate::file::touch_dir;
 use crate::path_env::PathEnv;
@@ -71,7 +72,7 @@ impl Activate {
         // touch ROOT to allow hook-env to run
         let _ = touch_dir(&dirs::DATA);
 
-        let mise_bin = if cfg!(target_os = "linux") {
+        let mise_bin = if Settings::get().is_linux() {
             // linux dereferences symlinks, so use argv0 instead
             PathBuf::from(&*env::ARGV0)
         } else {

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -7,7 +7,7 @@ use crate::backend::backend_type::BackendType;
 use crate::build_time::built_info;
 use crate::cli::version;
 use crate::cli::version::VERSION;
-use crate::config::{Config, IGNORED_CONFIG_FILES};
+use crate::config::{Config, IGNORED_CONFIG_FILES, Settings};
 use crate::env::PATH_KEY;
 use crate::file::display_path;
 use crate::git::Git;
@@ -280,7 +280,7 @@ impl Doctor {
 
         if !env::is_activated() && !shims_on_path() {
             let shims = style::ncyan(display_path(*dirs::SHIMS));
-            if cfg!(windows) {
+            if Settings::try_get().is_ok_and(|s| s.is_windows()) {
                 self.errors.push(formatdoc!(
                     r#"mise shims are not on PATH
                     Add this directory to PATH: {shims}"#

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -1,4 +1,5 @@
 use crate::cli::Cli;
+use crate::config::Settings;
 use crate::file;
 use clap::CommandFactory;
 use eyre::Result;
@@ -15,7 +16,7 @@ impl RenderHelp {
         xx::file::mkdirp("docs/.vitepress")?;
 
         file::write("docs/.vitepress/cli_commands.ts", render_command_ts())?;
-        if cfg!(windows) {
+        if Settings::get().is_windows() {
             cmd!("prettier.cmd", "--write", "docs/.vitepress/cli_commands.ts").run()?;
         } else {
             cmd!("prettier", "--write", "docs/.vitepress/cli_commands.ts").run()?;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -555,8 +555,9 @@ impl Run {
         args: &[String],
     ) -> Result<(String, Vec<String>)> {
         let display = file.display().to_string();
-        if file::is_executable(file) && !Settings::get().use_file_shell_for_executable_tasks {
-            if cfg!(windows) && file.extension().is_some_and(|e| e == "ps1") {
+        let settings = Settings::get();
+        if file::is_executable(file) && !settings.use_file_shell_for_executable_tasks {
+            if settings.is_windows() && file.extension().is_some_and(|e| e == "ps1") {
                 let args = vec!["-File".to_string(), display]
                     .into_iter()
                     .chain(args.iter().cloned())
@@ -1189,7 +1190,7 @@ async fn err_no_task(config: &Config, name: &str) -> Result<()> {
             .map(|d| d.join(name))
             .find(|d| d.is_file() && !file::is_executable(d));
         if let Some(path) = path {
-            if !cfg!(windows) {
+            if !Settings::get().is_windows() {
                 warn!(
                     "no task {} found, but a non-executable file exists at {}",
                     style::ered(name),

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -4,7 +4,7 @@ use console::style;
 use self_update::backends::github::Update;
 use self_update::{Status, cargo_crate_version};
 
-use crate::cli::version::{ARCH};
+use crate::cli::version::ARCH;
 use crate::config::Settings;
 use crate::{cmd, env};
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -4,7 +4,7 @@ use console::style;
 use self_update::backends::github::Update;
 use self_update::{Status, cargo_crate_version};
 
-use crate::cli::version::{ARCH, OS};
+use crate::cli::version::{ARCH};
 use crate::config::Settings;
 use crate::{cmd, env};
 
@@ -70,7 +70,7 @@ impl SelfUpdate {
             .current_version(cargo_crate_version!())
             .bin_path_in_archive(bin_path_in_archive);
 
-        let settings = Settings::try_get();
+        let settings = Settings::get();
         let v = self
             .version
             .clone()
@@ -79,7 +79,7 @@ impl SelfUpdate {
                 Ok,
             )
             .map(|v| format!("v{v}"))?;
-        let target = format!("{}-{}", *OS, *ARCH);
+        let target = format!("{}-{}", settings.os(), *ARCH);
         if self.force || self.version.is_some() {
             update.target_version_tag(&v);
         }
@@ -91,7 +91,7 @@ impl SelfUpdate {
             .verifying_keys([*include_bytes!("../../zipsign.pub")])
             .show_download_progress(true)
             .target(&target)
-            .no_confirm(settings.is_ok_and(|s| s.yes) || self.yes)
+            .no_confirm(settings.yes || self.yes)
             .build()?
             .update()?;
         Ok(status)

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -1,7 +1,8 @@
 use eyre::Result;
 use itertools::sorted;
-use std::env::consts::{ARCH, OS};
+use std::env::consts::ARCH;
 
+use crate::config::Settings;
 use crate::{backend, config, dirs, env, file};
 use crate::{config::Config, env::PYENV_ROOT};
 
@@ -94,7 +95,7 @@ impl SyncPython {
             }
             // ~/.local/share/uv/python/cpython-3.10.16-macos-aarch64-none
             // ~/.local/share/uv/python/cpython-3.13.0-linux-x86_64-gnu
-            let os = OS;
+            let os = Settings::get().os().to_string();
             let arch = if cfg!(target_arch = "x86_64") {
                 "x86_64-gnu"
             } else if cfg!(target_arch = "aarch64") {

--- a/src/cli/test_tool.rs
+++ b/src/cli/test_tool.rs
@@ -1,5 +1,5 @@
 use crate::cli::args::ToolArg;
-use crate::config::Config;
+use crate::config::{Config, Settings};
 use crate::file::display_path;
 use crate::registry::REGISTRY;
 use crate::tera::get_tera;
@@ -164,12 +164,13 @@ impl TestTool {
             .which(config, &tv, cmd)
             .await?
             .unwrap_or(PathBuf::from(cmd));
-        if cfg!(windows) && which_cmd == PathBuf::from("which") {
+        let settings = Settings::get();
+        if settings.is_windows() && which_cmd == PathBuf::from("which") {
             which_cmd = PathBuf::from("where");
         }
         let cmd = format!("{} {}", which_cmd.display(), which_parts.join(" "));
         info!("$ {cmd}");
-        let mut cmd = if cfg!(windows) {
+        let mut cmd = if settings.is_windows() {
             cmd!("cmd", "/C", cmd)
         } else {
             cmd!("sh", "-c", cmd)

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -126,8 +126,14 @@ impl EnvResults {
         }
         drop(venv_lock);
         if venv.exists() {
-            r.env_paths
-                .insert(0, venv.join(if cfg!(windows) { "Scripts" } else { "bin" }));
+            r.env_paths.insert(
+                0,
+                venv.join(if Settings::get().is_windows() {
+                    "Scripts"
+                } else {
+                    "bin"
+                }),
+            );
             env.insert(
                 "VIRTUAL_ENV".into(),
                 (

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -24,6 +24,7 @@ use std::{
     sync::atomic::Ordering,
 };
 use url::Url;
+use crate::cli::version::OS;
 
 // settings are generated from settings.toml in the project root
 // make sure you run `mise run render` after updating settings.toml
@@ -446,6 +447,10 @@ impl Settings {
             &self.unix_default_file_shell_args
         };
         Ok(shell_words::split(sa)?)
+    }
+
+    pub fn os(&self) -> &str {
+        self.os.as_deref().unwrap_or(&OS)
     }
 
     pub fn arch(&self) -> &str {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -432,7 +432,7 @@ impl Settings {
     }
 
     pub fn default_inline_shell(&self) -> Result<Vec<String>> {
-        let sa = if cfg!(windows) {
+        let sa = if self.is_windows() {
             &self.windows_default_inline_shell_args
         } else {
             &self.unix_default_inline_shell_args
@@ -441,7 +441,7 @@ impl Settings {
     }
 
     pub fn default_file_shell(&self) -> Result<Vec<String>> {
-        let sa = if cfg!(windows) {
+        let sa = if self.is_windows() {
             &self.windows_default_file_shell_args
         } else {
             &self.unix_default_file_shell_args
@@ -451,6 +451,23 @@ impl Settings {
 
     pub fn os(&self) -> &str {
         self.os.as_deref().unwrap_or(&OS)
+    }
+
+    // derive the OS family from `os` field as `os_family` cannot be modified by the user
+    pub fn is_unix(&self) -> bool {
+        !self.is_windows()
+    }
+
+    pub fn is_linux(&self) -> bool {
+        self.os() == "linux"
+    }
+
+    pub fn is_macos(&self) -> bool {
+        self.os() == "macos"
+    }
+
+    pub fn is_windows(&self) -> bool {
+        self.os() == "windows"
     }
 
     pub fn arch(&self) -> &str {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,4 +1,5 @@
 use crate::cli::Cli;
+use crate::cli::version::OS;
 use crate::config::ALL_TOML_CONFIG_FILES;
 use crate::duration;
 use crate::file::FindUp;
@@ -24,7 +25,6 @@ use std::{
     sync::atomic::Ordering,
 };
 use url::Url;
-use crate::cli::version::OS;
 
 // settings are generated from settings.toml in the project root
 // make sure you run `mise run render` after updating settings.toml

--- a/src/config/tracking.rs
+++ b/src/config/tracking.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use eyre::Result;
 
+use crate::config::Settings;
 use crate::dirs::TRACKED_CONFIGS;
 use crate::file::{create_dir_all, make_symlink_or_file};
 use crate::hash::hash_to_str;
@@ -29,7 +30,7 @@ impl Tracker {
             let mut path = path?.path();
             if path.is_symlink() {
                 path = fs::read_link(path)?;
-            } else if cfg!(target_os = "windows") {
+            } else if Settings::get().is_windows() {
                 path = PathBuf::from(fs::read_to_string(&path)?.trim());
             } else {
                 continue;

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,5 +1,3 @@
-use crate::config::Settings;
-use crate::path::{Path, PathBuf, PathExt};
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Display;
 use std::fs;
@@ -22,8 +20,8 @@ use tar::Archive;
 use walkdir::WalkDir;
 use zip::ZipArchive;
 
-#[cfg(windows)]
 use crate::config::Settings;
+use crate::path::{Path, PathBuf, PathExt};
 use crate::ui::progress_report::SingleReport;
 use crate::{dirs, env};
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,3 +1,4 @@
+use crate::config::Settings;
 use crate::path::{Path, PathBuf, PathExt};
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Display;
@@ -845,9 +846,10 @@ pub fn desymlink_path(p: &Path) -> PathBuf {
 }
 
 pub fn clone_dir(from: &PathBuf, to: &PathBuf) -> Result<()> {
-    if cfg!(macos) {
+    let settings = Settings::get();
+    if settings.is_macos() {
         cmd!("cp", "-cR", from, to).run()?;
-    } else if cfg!(windows) {
+    } else if settings.is_windows() {
         cmd!("robocopy", from, to, "/MIR").run()?;
     } else {
         cmd!("cp", "--reflink=auto", "-r", from, to).run()?;

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,6 +1,6 @@
 pub use std::path::*;
 
-use crate::dirs;
+use crate::{config::Settings, dirs};
 
 pub trait PathExt {
     /// replaces $HOME with "~"
@@ -12,7 +12,7 @@ pub trait PathExt {
 impl PathExt for Path {
     fn display_user(&self) -> String {
         let home = dirs::HOME.to_string_lossy();
-        match cfg!(unix) && self.starts_with(home.as_ref()) && home != "/" {
+        match Settings::get().is_unix() && self.starts_with(home.as_ref()) && home != "/" {
             true => self.to_string_lossy().replacen(home.as_ref(), "~", 1),
             false => self.to_string_lossy().to_string(),
         }

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -8,8 +8,8 @@ use eyre::Result;
 use itertools::Itertools;
 use versions::Versioning;
 
-use crate::cli::args::BackendArg;
-use crate::cli::version::{ARCH, OS};
+use crate::{cli::args::BackendArg, config::Settings};
+use crate::cli::version::{ARCH};
 use crate::cmd::CmdLineRunner;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
@@ -118,13 +118,11 @@ impl Backend for BunPlugin {
     }
 }
 
-fn os() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "darwin"
-    } else if cfg!(target_os = "linux") {
-        "linux"
-    } else {
-        &OS
+fn os() -> String {
+    let os = Settings::get().os().to_string();
+    match os.as_str() {
+        "macos" => "darwin".into(),
+        _ => os,
     }
 }
 

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -8,14 +8,14 @@ use eyre::Result;
 use itertools::Itertools;
 use versions::Versioning;
 
-use crate::{cli::args::BackendArg, config::Settings};
-use crate::cli::version::{ARCH};
+use crate::cli::version::ARCH;
 use crate::cmd::CmdLineRunner;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolVersion;
 use crate::ui::progress_report::SingleReport;
 use crate::{backend::Backend, config::Config};
+use crate::{cli::args::BackendArg, config::Settings};
 use crate::{file, github, plugins};
 
 #[derive(Debug)]
@@ -153,5 +153,9 @@ fn arch() -> &'static str {
 }
 
 fn bun_bin_name() -> &'static str {
-    if Settings::get().is_windows() { "bun.exe" } else { "bun" }
+    if Settings::get().is_windows() {
+        "bun.exe"
+    } else {
+        "bun"
+    }
 }

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -70,7 +70,7 @@ impl BunPlugin {
                 .join(bun_bin_name()),
             self.bun_bin(tv),
         )?;
-        if cfg!(unix) {
+        if Settings::get().is_unix() {
             file::make_executable(self.bun_bin(tv))?;
             file::make_symlink(Path::new("./bun"), &tv.install_path().join("bin/bunx"))?;
         }
@@ -142,7 +142,7 @@ fn arch() -> &'static str {
     } else if cfg!(target_arch = "aarch64") {
         if cfg!(target_env = "musl") {
             "aarch64-musl"
-        } else if cfg!(windows) {
+        } else if Settings::get().is_windows() {
             "x64"
         } else {
             "aarch64"
@@ -153,5 +153,5 @@ fn arch() -> &'static str {
 }
 
 fn bun_bin_name() -> &'static str {
-    if cfg!(windows) { "bun.exe" } else { "bun" }
+    if Settings::get().is_windows() { "bun.exe" } else { "bun" }
 }

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -33,7 +33,7 @@ impl DenoPlugin {
     }
 
     fn deno_bin(&self, tv: &ToolVersion) -> PathBuf {
-        tv.install_path().join(if cfg!(target_os = "windows") {
+        tv.install_path().join(if Settings::get().is_windows() {
             "bin/deno.exe"
         } else {
             "bin/deno"
@@ -79,7 +79,7 @@ impl DenoPlugin {
         file::create_dir_all(tv.install_path().join("bin"))?;
         file::unzip(tarball_path, &tv.download_path())?;
         file::rename(
-            tv.download_path().join(if cfg!(target_os = "windows") {
+            tv.download_path().join(if Settings::get().is_windows() {
                 "deno.exe"
             } else {
                 "deno"

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -12,7 +12,6 @@ use versions::Versioning;
 
 use crate::backend::Backend;
 use crate::cli::args::BackendArg;
-use crate::cli::version::OS;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::http::{HTTP, HTTP_FETCH};
@@ -161,15 +160,13 @@ impl Backend for DenoPlugin {
     }
 }
 
-fn os() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "apple-darwin"
-    } else if cfg!(target_os = "linux") {
-        "unknown-linux-gnu"
-    } else if cfg!(target_os = "windows") {
-        "pc-windows-msvc"
-    } else {
-        &OS
+fn os() -> String {
+    let os = Settings::get().os().to_string();
+    match os.as_str() {
+        "macos" => "apple-darwin".into(),
+        "linux" => "unknown-linux-gnu".into(),
+        "windows" => "pc-windows-msvc".into(),
+        _ => os,
     }
 }
 

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -3,7 +3,6 @@ use std::{
     sync::Arc,
 };
 
-use crate::{cli::args::BackendArg, config::Settings};
 use crate::cmd::CmdLineRunner;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
@@ -11,6 +10,7 @@ use crate::plugins::VERSION_REGEX;
 use crate::toolset::ToolVersion;
 use crate::ui::progress_report::SingleReport;
 use crate::{backend::Backend, config::Config};
+use crate::{cli::args::BackendArg, config::Settings};
 use crate::{file, plugins};
 use async_trait::async_trait;
 use eyre::Result;

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::cli::args::BackendArg;
+use crate::{cli::args::BackendArg, config::Settings};
 use crate::cmd::CmdLineRunner;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
@@ -139,7 +139,7 @@ impl Backend for ElixirPlugin {
 }
 
 fn elixir_bin_name() -> &'static str {
-    if cfg!(windows) {
+    if Settings::get().is_windows() {
         "elixir.bat"
     } else {
         "elixir"

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -4,7 +4,6 @@ use std::{collections::BTreeMap, sync::Arc};
 use crate::Result;
 use crate::backend::Backend;
 use crate::cli::args::BackendArg;
-use crate::cli::version::OS;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::file::{TarFormat, TarOptions};
@@ -266,11 +265,11 @@ impl Backend for GoPlugin {
     }
 }
 
-fn platform() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "darwin"
-    } else {
-        &OS
+fn platform() -> String {
+    let os = Settings::get().os().to_string();
+    match os.as_str() {
+        "macos" => "darwin".into(),
+        _ => os,
     }
 }
 

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -287,5 +287,9 @@ fn arch(settings: &Settings) -> &str {
 }
 
 fn ext() -> &'static str {
-    if Settings::get().is_windows() { "zip" } else { "tar.gz" }
+    if Settings::get().is_windows() {
+        "zip"
+    } else {
+        "tar.gz"
+    }
 }

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -137,7 +137,7 @@ impl GoPlugin {
             .to_string_lossy();
         pr.set_message(format!("extract {tarball}"));
         let tmp_extract_path = tempdir_in(tv.install_path().parent().unwrap())?;
-        if cfg!(windows) {
+        if Settings::get().is_windows() {
             file::unzip(tarball_path, tmp_extract_path.path())?;
         } else {
             file::untar(
@@ -287,5 +287,5 @@ fn arch(settings: &Settings) -> &str {
 }
 
 fn ext() -> &'static str {
-    if cfg!(windows) { "zip" } else { "tar.gz" }
+    if Settings::get().is_windows() { "zip" } else { "tar.gz" }
 }

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -163,7 +163,7 @@ impl JavaPlugin {
             file::rename(entry.path(), dest)?;
         }
 
-        if cfg!(target_os = "macos") {
+        if os() == "macosx" {
             self.handle_macos_integration(&contents_dir, tv, m)?;
         }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use crate::backend::Backend;
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
-use crate::cli::version::OS;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::file::{TarFormat, TarOptions};
@@ -442,11 +441,11 @@ impl Backend for JavaPlugin {
     }
 }
 
-fn os() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "macosx"
-    } else {
-        &OS
+fn os() -> String {
+    let os = Settings::get().os().to_string();
+    match os.as_str() {
+        "macos" => "macosx".into(),
+        _ => os,
     }
 }
 

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -544,12 +544,10 @@ fn python_os(settings: &Settings) -> String {
     match os {
         "windows" => "pc-windows-msvc-shared".into(),
         "macos" => "apple-darwin".into(),
-        _ => {
-            ["unknown", os, built_info::CFG_ENV]
-                .iter()
-                .filter(|s| !s.is_empty())
-                .join("-")
-        }
+        _ => ["unknown", os, built_info::CFG_ENV]
+            .iter()
+            .filter(|s| !s.is_empty())
+            .join("-"),
     }
 }
 

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -199,7 +199,11 @@ impl Backend for SwiftPlugin {
 }
 
 fn swift_bin_name() -> &'static str {
-    if Settings::get().is_windows() { "swift.exe" } else { "swift" }
+    if Settings::get().is_windows() {
+        "swift.exe"
+    } else {
+        "swift"
+    }
 }
 
 fn platform_directory(settings: &Settings) -> String {

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -35,7 +35,7 @@ impl ZigPlugin {
     }
 
     fn zig_bin(&self, tv: &ToolVersion) -> PathBuf {
-        if cfg!(windows) {
+        if Settings::get().is_windows() {
             tv.install_path().join("zig.exe")
         } else {
             tv.install_path().join("bin").join("zig")
@@ -103,7 +103,7 @@ impl ZigPlugin {
             },
         )?;
 
-        if cfg!(unix) {
+        if Settings::get().is_unix() {
             file::create_dir_all(tv.install_path().join("bin"))?;
             file::make_symlink(Path::new("../zig"), &tv.install_path().join("bin/zig"))?;
         }
@@ -170,7 +170,7 @@ impl Backend for ZigPlugin {
         _config: &Arc<Config>,
         tv: &ToolVersion,
     ) -> Result<Vec<PathBuf>> {
-        if cfg!(windows) {
+        if Settings::get().is_windows() {
             Ok(vec![tv.install_path()])
         } else {
             Ok(vec![tv.install_path().join("bin")])

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -6,7 +6,6 @@ use std::{
 
 use crate::backend::Backend;
 use crate::cli::args::BackendArg;
-use crate::cli::version::OS;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::file::TarOptions;
@@ -63,7 +62,7 @@ impl ZigPlugin {
                 indexes["mach"],
                 tv.version.as_str(),
                 arch(&settings),
-                os(),
+                &os(),
             )
             .await?
         } else {
@@ -71,7 +70,7 @@ impl ZigPlugin {
                 indexes["zig"],
                 tv.version.as_str(),
                 arch(&settings),
-                os(),
+                &os(),
             )
             .await?
         };
@@ -195,16 +194,8 @@ impl Backend for ZigPlugin {
     }
 }
 
-fn os() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "macos"
-    } else if cfg!(target_os = "linux") {
-        "linux"
-    } else if cfg!(target_os = "freebsd") {
-        "freebsd"
-    } else {
-        &OS
-    }
+fn os() -> String {
+    Settings::get().os().to_string()
 }
 
 fn arch(settings: &Settings) -> &str {

--- a/src/plugins/script_manager.rs
+++ b/src/plugins/script_manager.rs
@@ -168,8 +168,9 @@ impl ScriptManager {
         let path = self.get_script_path(script);
         pr.set_message(display_path(&path));
         let mut cmd = CmdLineRunner::new(path.clone());
-        if let Some(arch) = &Settings::get().arch {
-            if arch == "x86_64" && cfg!(macos) {
+        let settings = Settings::get();
+        if let Some(arch) = &settings.arch {
+            if arch == "x86_64" && settings.is_macos() {
                 cmd = CmdLineRunner::new("/usr/bin/arch")
                     .arg("-x86_64")
                     .arg(path.clone());

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -2,7 +2,7 @@ use crate::backend::backend_type::BackendType;
 use crate::cli::args::BackendArg;
 use crate::config::Settings;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::env::consts::{ARCH, OS};
+use std::env::consts::{ARCH};
 use std::fmt::Display;
 use std::iter::Iterator;
 use std::sync::LazyLock as Lazy;
@@ -48,7 +48,7 @@ impl RegistryTool {
             }
             backend_types
         });
-        let os = Settings::get().os.clone().unwrap_or(OS.to_string());
+        let os = Settings::get().os().to_string();
         let arch = Settings::get().arch.clone().unwrap_or(ARCH.to_string());
         let platform = format!("{os}-{arch}");
         self.backends
@@ -69,7 +69,7 @@ impl RegistryTool {
     }
 
     pub fn is_supported_os(&self) -> bool {
-        self.os.is_empty() || self.os.contains(&OS)
+        self.os.is_empty() || self.os.contains(&Settings::get().os())
     }
 
     pub fn ba(&self) -> Option<BackendArg> {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -2,7 +2,7 @@ use crate::backend::backend_type::BackendType;
 use crate::cli::args::BackendArg;
 use crate::config::Settings;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::env::consts::{ARCH};
+use std::env::consts::ARCH;
 use std::fmt::Display;
 use std::iter::Iterator;
 use std::sync::LazyLock as Lazy;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -43,7 +43,7 @@ impl RegistryTool {
                 backend_types.remove(backend);
             }
             time!("disable_backends");
-            if cfg!(windows) {
+            if Settings::get().is_windows() {
                 backend_types.remove("asdf");
             }
             backend_types

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -293,10 +293,11 @@ async fn get_desired_shims(config: &Arc<Config>, toolset: &Toolset) -> Result<Ha
                 warn!("Error listing bin paths for {}: {:#}", tv, e);
                 Vec::new()
             });
-        if cfg!(windows) {
+            let settings = Settings::get();
+        if settings.is_windows() {
             shims.extend(bins.into_iter().flat_map(|b| {
                 let p = PathBuf::from(&b);
-                match Settings::get().windows_shim_mode.as_ref() {
+                match settings.windows_shim_mode.as_ref() {
                     "hardlink" | "symlink" => {
                         vec![p.with_extension("exe").to_string_lossy().to_string()]
                     }
@@ -309,7 +310,7 @@ async fn get_desired_shims(config: &Arc<Config>, toolset: &Toolset) -> Result<Ha
                     _ => panic!("Unknown shim mode"),
                 }
             }));
-        } else if cfg!(macos) {
+        } else if settings.is_macos() {
             // some bins might be uppercased but on mac APFS is case insensitive
             shims.extend(bins.into_iter().map(|b| b.to_lowercase()));
         } else {

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -293,7 +293,7 @@ async fn get_desired_shims(config: &Arc<Config>, toolset: &Toolset) -> Result<Ha
                 warn!("Error listing bin paths for {}: {:#}", tv, e);
                 Vec::new()
             });
-            let settings = Settings::get();
+        let settings = Settings::get();
         if settings.is_windows() {
             shims.extend(bins.into_iter().flat_map(|b| {
                 let p = PathBuf::from(&b);

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,5 +1,5 @@
 use crate::config::config_file::toml::{TomlParser, deserialize_arr};
-use crate::config::{self, Config};
+use crate::config::{self, Config, Settings};
 use crate::task::task_script_parser::{TaskScriptParser, has_any_args_defined};
 use crate::tera::get_tera;
 use crate::ui::tree::TreeItem;
@@ -259,7 +259,7 @@ impl Task {
     }
 
     pub fn run(&self) -> &Vec<String> {
-        if cfg!(windows) && !self.run_windows.is_empty() {
+        if Settings::get().is_windows() && !self.run_windows.is_empty() {
             &self.run_windows
         } else {
             &self.run

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -60,7 +60,7 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
     tera.register_function(
         "os",
         move |_args: &HashMap<String, Value>| -> tera::Result<Value> {
-            Ok(Value::String(env::consts::OS.to_string()))
+            Ok(Value::String(Settings::get().os().to_string()))
         },
     );
     tera.register_function(

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -66,7 +66,11 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
     tera.register_function(
         "os_family",
         move |_args: &HashMap<String, Value>| -> tera::Result<Value> {
-            Ok(Value::String(env::consts::FAMILY.to_string()))
+            Ok(Value::String(if Settings::get().is_unix() {
+                "unix".into()
+            } else {
+                "windows".into()
+            }))
         },
     );
     tera.register_function(

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -9,6 +9,7 @@ use versions::{Chunk, Version};
 use xx::file;
 
 use crate::cli::args::BackendArg;
+use crate::config::Settings;
 use crate::lockfile::LockfileTool;
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::tool_version::ResolveOptions;
@@ -292,7 +293,7 @@ impl ToolRequest {
 
     pub fn is_os_supported(&self) -> bool {
         if let Some(os) = self.os() {
-            if !os.contains(&crate::cli::version::OS) {
+            if !os.contains(&Settings::get().os().to_string()) {
                 return false;
             }
         }

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -179,7 +179,7 @@ impl ToolRequestSetBuilder {
     fn is_disabled(&self, ba: &BackendArg) -> bool {
         let backend_type = ba.backend_type();
         backend_type == BackendType::Unknown
-            || (cfg!(windows) && backend_type == BackendType::Asdf)
+            || (Settings::get().is_windows() && backend_type == BackendType::Asdf)
             || !ba.is_os_supported()
             || !tool_enabled(&self.enable_tools, &self.disable_tools, ba)
     }


### PR DESCRIPTION
`MISE_OS` or `settings.os` is added in https://github.com/jdx/mise/pull/4224, but only `test-tool` respected it.

This PR replaces `env::consts::OS` or `cfg!(target_os)` with `settings.os()`.

Since this will move the os detection from compile-time to runtime, it might slow down the execution.
Also, in most cases, setting `MISE_OS` doesn't work as expected.

This PR aims only to make the code consistent.
It might make OS-dependent tests a bit easier locally.