### PR TITLE
fix(registry): use aqua backend for bat

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -188,13 +188,9 @@ bashbot.backends = [
     "asdf:mathew-fleisch/asdf-bashbot"
 ]
 bashly.backends = ["asdf:mise-plugins/mise-bashly"]
-# aqua is available but uses cargo
 bat.backends = [
-    {full = "ubi:sharkdp/bat", platforms = [
-        "linux",
-        "macos",
-        "windows"
-    ]},
+    "aqua:sharkdp/bat",
+    "ubi:sharkdp/bat",
     "cargo:bat",
     "asdf:https://gitlab.com/wt0f/asdf-bat"
 ]


### PR DESCRIPTION
`package_type: cargo` is removed in https://github.com/aquaproj/aqua-registry/pull/30801.
Also, `platforms` for the ubi backend seem not to be required as other tools use `platforms`.
