### PR TITLE
fix(registry): use pipx backend for aws-sam on windows

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -138,11 +138,11 @@ aws-iam-authenticator.backends = [
 aws-nuke.backends = ["aqua:ekristen/aws-nuke", "asdf:bersalazar/asdf-aws-nuke"]
 aws-sam.aliases = ["aws-sam-cli"]
 aws-sam.backends = [
-    "aqua:aws/aws-sam-cli",
+    {full="aqua:aws/aws-sam-cli",platforms=["linux","macos"]},
     "pipx:aws-sam-cli",
     "asdf:mise-plugins/mise-pyapp"
 ]
-# aws-sam.test = ["sam --version", "SAM CLI, version {{version}}"] # takes forever on windows in CI
+aws-sam.test = ["sam --version", "SAM CLI, version {{version}}"]
 aws-sso.backends = [
     "aqua:synfinatic/aws-sso-cli",
     "asdf:adamcrews/asdf-aws-sso-cli"


### PR DESCRIPTION
They release `.msi` for Windows, but aqua doesn't support it.
https://github.com/aws/aws-sam-cli/releases/tag/v1.142.0

I confirmed the test passes in Windows with the pipx backend.