### PR TITLE
chore: release 2025.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [2025.7.1](https://github.com/jdx/mise/compare/v2025.7.0..v2025.7.1) - 2025-07-06
+
+### 🚀 Features
+
+- **(aqua)** add support for zst compressed assets by [@andreabedini](https://github.com/andreabedini) in [#5495](https://github.com/jdx/mise/pull/5495)
+- **(registry)** import package descriptions from aqua and add os specifier for tuist by [@matracey](https://github.com/matracey) in [#5487](https://github.com/jdx/mise/pull/5487)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** handle hard links in aqua packages (attempt #2) by [@risu729](https://github.com/risu729) in [#5486](https://github.com/jdx/mise/pull/5486)
+- **(aqua)** apply correct `version_override` by [@risu729](https://github.com/risu729) in [#5474](https://github.com/jdx/mise/pull/5474)
+- **(erlang)** fix install_precompiled method signature for unsupported os by [@roele](https://github.com/roele) in [#5503](https://github.com/jdx/mise/pull/5503)
+- **(java)** relax version filter regex for JetBrains builds by [@roele](https://github.com/roele) in [#5508](https://github.com/jdx/mise/pull/5508)
+- **(registry)** use aqua backend for bat by [@risu729](https://github.com/risu729) in [#5490](https://github.com/jdx/mise/pull/5490)
+- **(registry)** use pipx backend for aws-sam on windows by [@risu729](https://github.com/risu729) in [#5491](https://github.com/jdx/mise/pull/5491)
+- enhance self-update for musl targets by [@roele](https://github.com/roele) in [#5502](https://github.com/jdx/mise/pull/5502)
+- include arch and os settings in cache keys by [@risu729](https://github.com/risu729) in [#5504](https://github.com/jdx/mise/pull/5504)
+
+### 🧪 Testing
+
+- **(registry)** enable youtube-dl test by [@risu729](https://github.com/risu729) in [#5492](https://github.com/jdx/mise/pull/5492)
+
+### 📦️ Dependency Updates
+
+- update swatinem/rust-cache digest to 98c8021 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5512](https://github.com/jdx/mise/pull/5512)
+
+### New Contributors
+
+- @matracey made their first contribution in [#5487](https://github.com/jdx/mise/pull/5487)
+- @andreabedini made their first contribution in [#5495](https://github.com/jdx/mise/pull/5495)
+
 ## [2025.7.0](https://github.com/jdx/mise/compare/v2025.6.8..v2025.7.0) - 2025-07-01
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.7.0"
+version = "2025.7.1"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2025.7.0"
+version = "2025.7.1"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.7.0 macos-arm64 (a1b2d3e 2025-07-01)
+2025.7.1 macos-arm64 (a1b2d3e 2025-07-06)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_7_0:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_0 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_7_0;
+  if ( [[ -z "${_usage_spec_mise_2025_7_1:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_1 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_7_1;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_7_0 spec
+    _store_cache _usage_spec_mise_2025_7_1 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_7_0:-} ]]; then
-        _usage_spec_mise_2025_7_0="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_7_1:-} ]]; then
+        _usage_spec_mise_2025_7_1="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_0}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_1}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_7_0
-  set -g _usage_spec_mise_2025_7_0 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_7_1
+  set -g _usage_spec_mise_2025_7_1 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_0" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_1" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_0" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_1" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.7.0";
+  version = "2025.7.1";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.7.0
+Version: 2025.7.1
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(aqua)** add support for zst compressed assets by [@andreabedini](https://github.com/andreabedini) in [#5495](https://github.com/jdx/mise/pull/5495)
- **(registry)** import package descriptions from aqua and add os specifier for tuist by [@matracey](https://github.com/matracey) in [#5487](https://github.com/jdx/mise/pull/5487)

### 🐛 Bug Fixes

- **(aqua)** handle hard links in aqua packages (attempt #2) by [@risu729](https://github.com/risu729) in [#5486](https://github.com/jdx/mise/pull/5486)
- **(aqua)** apply correct `version_override` by [@risu729](https://github.com/risu729) in [#5474](https://github.com/jdx/mise/pull/5474)
- **(erlang)** fix install_precompiled method signature for unsupported os by [@roele](https://github.com/roele) in [#5503](https://github.com/jdx/mise/pull/5503)
- **(java)** relax version filter regex for JetBrains builds by [@roele](https://github.com/roele) in [#5508](https://github.com/jdx/mise/pull/5508)
- **(registry)** use aqua backend for bat by [@risu729](https://github.com/risu729) in [#5490](https://github.com/jdx/mise/pull/5490)
- **(registry)** use pipx backend for aws-sam on windows by [@risu729](https://github.com/risu729) in [#5491](https://github.com/jdx/mise/pull/5491)
- enhance self-update for musl targets by [@roele](https://github.com/roele) in [#5502](https://github.com/jdx/mise/pull/5502)
- include arch and os settings in cache keys by [@risu729](https://github.com/risu729) in [#5504](https://github.com/jdx/mise/pull/5504)

### 🧪 Testing

- **(registry)** enable youtube-dl test by [@risu729](https://github.com/risu729) in [#5492](https://github.com/jdx/mise/pull/5492)

### 📦️ Dependency Updates

- update swatinem/rust-cache digest to 98c8021 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5512](https://github.com/jdx/mise/pull/5512)

### New Contributors

- @matracey made their first contribution in [#5487](https://github.com/jdx/mise/pull/5487)
- @andreabedini made their first contribution in [#5495](https://github.com/jdx/mise/pull/5495)