### PR TITLE
feat(aqua): add support for zst compressed assets

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -668,6 +668,10 @@ impl AquaBackend {
             file::create_dir_all(&install_path)?;
             file::un_xz(&tarball_path, &bin_path)?;
             file::make_executable(&bin_path)?;
+        } else if format == "zst" {
+            file::create_dir_all(&install_path)?;
+            file::un_zst(&tarball_path, &bin_path)?;
+            file::make_executable(&bin_path)?;
         } else if format == "bz2" {
             file::create_dir_all(&install_path)?;
             file::un_bz2(&tarball_path, &bin_path)?;

--- a/src/file.rs
+++ b/src/file.rs
@@ -611,6 +611,16 @@ pub fn un_xz(input: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+pub fn un_zst(input: &Path, dest: &Path) -> Result<()> {
+    debug!("zstd -d {} -c > {}", input.display(), dest.display());
+    let f = File::open(input)?;
+    let mut dec = zstd::Decoder::new(f)?;
+    let mut output = File::create(dest)?;
+    std::io::copy(&mut dec, &mut output)
+        .wrap_err_with(|| format!("failed to un-zst: {}", display_path(input)))?;
+    Ok(())
+}
+
 pub fn un_bz2(input: &Path, dest: &Path) -> Result<()> {
     debug!("bzip2 -d {} -c > {}", input.display(), dest.display());
     let f = File::open(input)?;


### PR DESCRIPTION
Thank you for the project! It is my daily driver now.

This change adds support to the aqua backend for assets that are compressed with zst. Aqua already supports that but we miss that compression format.

Note that we already had support for zst compressed tarballs, but not single files.
