### PR TITLE
fix(erlang): fix install_precompiled method signature for unsupported os

### DIFF
--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -249,7 +249,7 @@ impl ErlangPlugin {
     }
 
     #[cfg(not(any(linux, macos, windows)))]
-    async fn install_precompiled(&self, ctx: &InstallContext) -> Result<Option<ToolVersion>> {
+    async fn install_precompiled(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<Option<ToolVersion>> {
         Ok(None)
     }
 

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -249,7 +249,11 @@ impl ErlangPlugin {
     }
 
     #[cfg(not(any(linux, macos, windows)))]
-    async fn install_precompiled(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<Option<ToolVersion>> {
+    async fn install_precompiled(
+        &self,
+        ctx: &InstallContext,
+        tv: ToolVersion,
+    ) -> Result<Option<ToolVersion>> {
         Ok(None)
     }
 


### PR DESCRIPTION
Fixes wrong method signature of fix #5479.