### PR TITLE
fix: include arch and os settings in cache keys

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -43,9 +43,12 @@ pub static BASE_CACHE_KEYS: Lazy<Vec<String>> = Lazy::new(|| {
 
 impl CacheManagerBuilder {
     pub fn new(cache_file_path: impl AsRef<Path>) -> Self {
+        let settings = Settings::get();
+        let mut cache_keys = BASE_CACHE_KEYS.clone();
+        cache_keys.extend([settings.os().to_string(), settings.arch().to_string()]);
         Self {
             cache_file_path: cache_file_path.as_ref().to_path_buf(),
-            cache_keys: BASE_CACHE_KEYS.clone(),
+            cache_keys: cache_keys,
             fresh_files: vec![],
             fresh_duration: None,
         }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -48,7 +48,7 @@ impl CacheManagerBuilder {
         cache_keys.extend([settings.os().to_string(), settings.arch().to_string()]);
         Self {
             cache_file_path: cache_file_path.as_ref().to_path_buf(),
-            cache_keys: cache_keys,
+            cache_keys,
             fresh_files: vec![],
             fresh_duration: None,
         }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use serde::ser::Error;
 use serde::{Deserialize, Deserializer};
 use serde_derive::Serialize;
-use std::env::consts::ARCH;
+use std::env::consts::{ARCH, OS};
 use std::fmt::{Debug, Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -446,6 +446,10 @@ impl Settings {
             &self.unix_default_file_shell_args
         };
         Ok(shell_words::split(sa)?)
+    }
+
+    pub fn os(&self) -> &str {
+        self.os.as_deref().unwrap_or(OS)
     }
 
     pub fn arch(&self) -> &str {

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -24,7 +24,6 @@ use itertools::Itertools;
 use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
 use std::sync::LazyLock as Lazy;
-use tabled::settings;
 use versions::Versioning;
 use xx::regex;
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -24,6 +24,7 @@ use itertools::Itertools;
 use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
 use std::sync::LazyLock as Lazy;
+use tabled::settings;
 use versions::Versioning;
 use xx::regex;
 
@@ -38,20 +39,16 @@ impl JavaPlugin {
     pub fn new() -> Self {
         let settings = Settings::get();
         let ba = Arc::new(plugins::core::new_backend_arg("java"));
-        let java_metadata_ga_cache_filename =
-            format!("java_metadata_ga_{}_{}.msgpack.z", os(), arch(&settings));
-        let java_metadata_ea_cache_filename =
-            format!("java_metadata_ea_{}_{}.msgpack.z", os(), arch(&settings));
         Self {
             java_metadata_ea_cache: CacheManagerBuilder::new(
-                ba.cache_path.join(java_metadata_ea_cache_filename),
+                ba.cache_path.join("java_metadata_ea.msgpack.z"),
             )
-            .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
+            .with_fresh_duration(settings.fetch_remote_versions_cache())
             .build(),
             java_metadata_ga_cache: CacheManagerBuilder::new(
-                ba.cache_path.join(java_metadata_ga_cache_filename),
+                ba.cache_path.join("java_metadata_ga.msgpack.z"),
             )
-            .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
+            .with_fresh_duration(settings.fetch_remote_versions_cache())
             .build(),
             ba,
         }


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/5438.

Note that we still need to set `MISE_VERSIONS_HOST=false` to ignore the remote versions host.