### PR TITLE
fix(registry): use aqua for numbat, gokey, golines

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1081,6 +1081,7 @@ gojq.backends = [
     "go:github.com/itchyny/gojq/cmd/gojq"
 ]
 gojq.test = ["gojq --version", "gojq {{version}}"]
+gokey.description = "A simple vaultless password manager in Go"
 gokey.backends = [
     "aqua:cloudflare/gokey",
     "ubi:cloudflare/gokey"
@@ -1102,6 +1103,7 @@ golangci-lint-langserver.test = [
     "which golangci-lint-langserver",
     "golangci-lint-langserver"
 ]
+golines.description = "A golang formatter that fixes long lines"
 golines.backends = [
     "aqua:segmentio/golines",
     "ubi:segmentio/golines",
@@ -1897,6 +1899,7 @@ notation.backends = ["aqua:notaryproject/notation", "asdf:bodgit/asdf-notation"]
 nova.description = "Find outdated or deprecated Helm charts running in your cluster"
 nova.backends = ["aqua:FairwindsOps/nova", "asdf:elementalvoid/asdf-nova"]
 nsc.backends = ["ubi:nats-io/nsc", "asdf:dex4er/asdf-nsc"]
+numbat.description = "A statically typed programming language for scientific computations with first class support for physical dimensions and units"
 numbat.backends = ["aqua:sharkdp/numbat", "ubi:sharkdp/numbat"]
 numbat.test = ["numbat --version", "numbat {{version}}"]
 oapi-codegen.backends = [

--- a/registry.toml
+++ b/registry.toml
@@ -1082,10 +1082,7 @@ gojq.backends = [
 ]
 gojq.test = ["gojq --version", "gojq {{version}}"]
 gokey.description = "A simple vaultless password manager in Go"
-gokey.backends = [
-    "aqua:cloudflare/gokey",
-    "ubi:cloudflare/gokey"
-]
+gokey.backends = ["aqua:cloudflare/gokey", "ubi:cloudflare/gokey"]
 gokey.test = ["gokey -p master -r realm -l 8", "hJ2gXSy["]
 golangci-lint.description = "Fast linters Runner for Go"
 golangci-lint.backends = [
@@ -1105,8 +1102,14 @@ golangci-lint-langserver.test = [
 ]
 golines.description = "A golang formatter that fixes long lines"
 golines.backends = [
-    {full="aqua:segmentio/golines", platforms=["linux", "macos"]},
-    {full="ubi:segmentio/golines", platforms=["linux", "macos"]},
+    {full = "aqua:segmentio/golines", platforms = [
+        "linux",
+        "macos"
+    ]},
+    {full = "ubi:segmentio/golines", platforms = [
+        "linux",
+        "macos"
+    ]},
     "go:github.com/segmentio/golines"
 ]
 golines.test = ["golines --version", "golines v{{version}}"]

--- a/registry.toml
+++ b/registry.toml
@@ -1105,8 +1105,8 @@ golangci-lint-langserver.test = [
 ]
 golines.description = "A golang formatter that fixes long lines"
 golines.backends = [
-    "aqua:segmentio/golines",
-    "ubi:segmentio/golines",
+    {full="aqua:segmentio/golines", platforms=["linux", "macos"]},
+    {full="ubi:segmentio/golines", platforms=["linux", "macos"]},
     "go:github.com/segmentio/golines"
 ]
 golines.test = ["golines --version", "golines v{{version}}"]

--- a/registry.toml
+++ b/registry.toml
@@ -1082,7 +1082,7 @@ gojq.backends = [
 ]
 gojq.test = ["gojq --version", "gojq {{version}}"]
 gokey.backends = [
-    # "aqua:cloudflare/gokey", # package type go_install not supported
+    "aqua:cloudflare/gokey",
     "ubi:cloudflare/gokey"
 ]
 gokey.test = ["gokey -p master -r realm -l 8", "hJ2gXSy["]
@@ -1103,7 +1103,7 @@ golangci-lint-langserver.test = [
     "golangci-lint-langserver"
 ]
 golines.backends = [
-    # "aqua:segmentio/golines", # package type go_install not supported
+    "aqua:segmentio/golines",
     "ubi:segmentio/golines",
     "go:github.com/segmentio/golines"
 ]
@@ -1897,7 +1897,7 @@ notation.backends = ["aqua:notaryproject/notation", "asdf:bodgit/asdf-notation"]
 nova.description = "Find outdated or deprecated Helm charts running in your cluster"
 nova.backends = ["aqua:FairwindsOps/nova", "asdf:elementalvoid/asdf-nova"]
 nsc.backends = ["ubi:nats-io/nsc", "asdf:dex4er/asdf-nsc"]
-numbat.backends = ["ubi:sharkdp/numbat"]
+numbat.backends = ["aqua:sharkdp/numbat", "ubi:sharkdp/numbat"]
 numbat.test = ["numbat --version", "numbat {{version}}"]
 oapi-codegen.backends = [
     "go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen",


### PR DESCRIPTION
Added numbat in  https://github.com/aquaproj/aqua-registry/pull/38316.

Updated the registry to use the GitHub release assets in https://github.com/aquaproj/aqua-registry/pull/38317, https://github.com/aquaproj/aqua-registry/pull/38318.
