### PR TITLE
chore: release 2025.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [2025.7.2](https://github.com/jdx/mise/compare/v2025.7.1..v2025.7.2) - 2025-07-09
+
+### 🚀 Features
+
+- **(registry)** add zizmor by [@risu729](https://github.com/risu729) in [#5519](https://github.com/jdx/mise/pull/5519)
+- Add `self_update_available` to `mise doctor` output by [@joehorsnell](https://github.com/joehorsnell) in [#5534](https://github.com/jdx/mise/pull/5534)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** use the version in url to verify and install by [@risu729](https://github.com/risu729) in [#5537](https://github.com/jdx/mise/pull/5537)
+- **(registry)** use aqua for numbat, gokey, golines by [@risu729](https://github.com/risu729) in [#5518](https://github.com/jdx/mise/pull/5518)
+- `self-update` on MITM firewall (attempt #2) by [@joehorsnell](https://github.com/joehorsnell) in [#5459](https://github.com/jdx/mise/pull/5459)
+- mise panic in removed directory by [@roele](https://github.com/roele) in [#5532](https://github.com/jdx/mise/pull/5532)
+
+### 📚 Documentation
+
+- update ubi tag_regex syntax by [@grimm26](https://github.com/grimm26) in [#5529](https://github.com/jdx/mise/pull/5529)
+
+### 🧪 Testing
+
+- disable yamlscript test by [@jdx](https://github.com/jdx) in [#5536](https://github.com/jdx/mise/pull/5536)
+
+### New Contributors
+
+- @grimm26 made their first contribution in [#5529](https://github.com/jdx/mise/pull/5529)
+
 ## [2025.7.1](https://github.com/jdx/mise/compare/v2025.7.0..v2025.7.1) - 2025-07-06
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.7.1"
+version = "2025.7.2"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise"
-version = "2025.7.1"
+version = "2025.7.2"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.7.1 macos-arm64 (a1b2d3e 2025-07-06)
+2025.7.2 macos-arm64 (a1b2d3e 2025-07-09)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_7_1:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_1 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_7_1;
+  if ( [[ -z "${_usage_spec_mise_2025_7_2:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_2 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_7_2;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_7_1 spec
+    _store_cache _usage_spec_mise_2025_7_2 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_7_1:-} ]]; then
-        _usage_spec_mise_2025_7_1="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_7_2:-} ]]; then
+        _usage_spec_mise_2025_7_2="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_1}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_2}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_7_1
-  set -g _usage_spec_mise_2025_7_1 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_7_2
+  set -g _usage_spec_mise_2025_7_2 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_1" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_2" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_1" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_2" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.7.1";
+  version = "2025.7.2";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.7.1
+Version: 2025.7.2
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(registry)** add zizmor by [@risu729](https://github.com/risu729) in [#5519](https://github.com/jdx/mise/pull/5519)
- Add `self_update_available` to `mise doctor` output by [@joehorsnell](https://github.com/joehorsnell) in [#5534](https://github.com/jdx/mise/pull/5534)

### 🐛 Bug Fixes

- **(aqua)** use the version in url to verify and install by [@risu729](https://github.com/risu729) in [#5537](https://github.com/jdx/mise/pull/5537)
- **(registry)** use aqua for numbat, gokey, golines by [@risu729](https://github.com/risu729) in [#5518](https://github.com/jdx/mise/pull/5518)
- `self-update` on MITM firewall (attempt #2) by [@joehorsnell](https://github.com/joehorsnell) in [#5459](https://github.com/jdx/mise/pull/5459)
- mise panic in removed directory by [@roele](https://github.com/roele) in [#5532](https://github.com/jdx/mise/pull/5532)

### 📚 Documentation

- update ubi tag_regex syntax by [@grimm26](https://github.com/grimm26) in [#5529](https://github.com/jdx/mise/pull/5529)

### 🧪 Testing

- disable yamlscript test by [@jdx](https://github.com/jdx) in [#5536](https://github.com/jdx/mise/pull/5536)

### New Contributors

- @grimm26 made their first contribution in [#5529](https://github.com/jdx/mise/pull/5529)