### PR TITLE
docs: update ubi tag_regex syntax

### DIFF
--- a/docs/dev-tools/backends/ubi.md
+++ b/docs/dev-tools/backends/ubi.md
@@ -128,7 +128,7 @@ releases.
 
 ```toml
 [tools]
-"ubi:cargo-bins/cargo-binstall" = { version = "latest", tag_regex = "^\d+\." }
+"ubi:cargo-bins/cargo-binstall" = { version = "latest", tag_regex = '^\d+\.' }
 ```
 
 ## Self-hosted GitHub/GitLab


### PR DESCRIPTION
When using double quotes as in the example, mise throws an error:
```
Error loading settings file: TOML parse error at line 21, column 73
   |
21 | "ubi:cargo-bins/cargo-binstall" = { version = "latest", tag_regex = "^\d+\." }
   |                                                                         ^
invalid escape sequence
expected `b`, `f`, `n`, `r`, `t`, `u`, `U`, `\`, `"`
```
