### PR TITLE
fix(aqua): use the version in url to verify and install

### DIFF
--- a/e2e/backend/test_aqua
+++ b/e2e/backend/test_aqua
@@ -12,6 +12,7 @@ test aqua:helm/helm@3.16.3 "helm version" "v3.16.3"
 test aqua:crate-ci/typos@1.27.3 "typos --version" "typos-cli 1.27.3"
 test aqua:biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
 test aqua:biomejs/biome@@biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
+test aqua:gruntwork-io/terragrunt@0.77.22 "terragrunt --version" "terragrunt version v0.77.22"
 
 assert_contains "MISE_USE_VERSIONS_HOST=0 mise ls-remote aqua:sharkdp/hyperfine" "1.9.0
 1.10.0"

--- a/registry.toml
+++ b/registry.toml
@@ -2563,6 +2563,7 @@ terragrunt.backends = [
     "aqua:gruntwork-io/terragrunt",
     "asdf:gruntwork-io/asdf-terragrunt"
 ]
+terragrunt.test = ["terragrunt --version", "terragrunt version v{{version}}"]
 terramate.description = "Open-source Infrastructure as Code (IaC) orchestration platform: GitOps workflows, orchestration, code generation, observability, drift detection, asset management, policies, Slack notifications, and more. Integrates with Terraform, OpenTofu, Terragrunt, Kubernetes, GitHub Actions, GitLab CI/CD, BitBucket Pipelines, and any other CI/CD platform"
 terramate.backends = [
     "aqua:terramate-io/terramate",

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -107,15 +107,17 @@ impl Backend for AquaBackend {
         }
         validate(&pkg)?;
         // try v-prefixed version first because most aqua packages use v-prefixed versions
-        let url = match self
+        let (url, v) = match self
             .fetch_url(&pkg, v_prefixed.as_ref().unwrap_or(&v))
             .await
         {
-            Ok(url) => url,
-            Err(err) if v_prefixed.is_some() => self
-                .fetch_url(&pkg, &v)
-                .await
-                .map_err(|e| err.wrap_err(e))?,
+            Ok(url) => (url, v_prefixed.as_ref().unwrap_or(&v)),
+            Err(err) if v_prefixed.is_some() => (
+                self.fetch_url(&pkg, &v)
+                    .await
+                    .map_err(|e| err.wrap_err(e))?,
+                &v,
+            ),
             Err(err) => return Err(err),
         };
         let filename = url.split('/').next_back().unwrap();

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -122,8 +122,8 @@ impl Backend for AquaBackend {
         };
         let filename = url.split('/').next_back().unwrap();
         self.download(ctx, &tv, &url, filename).await?;
-        self.verify(ctx, &mut tv, &pkg, &v, filename).await?;
-        self.install(ctx, &tv, &pkg, &v, filename)?;
+        self.verify(ctx, &mut tv, &pkg, v, filename).await?;
+        self.install(ctx, &tv, &pkg, v, filename)?;
 
         Ok(tv)
     }


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/5533 and https://github.com/jdx/mise/discussions/5527.

I modified the version resolution in https://github.com/jdx/mise/pull/5474, but I forgot to use the resolved version in the later operations, `verify` and `install`.

This PR fixes that, and also adds a test for `aqua:gruntwork-io/terragrunt@0.77.22`, an older version, as the tag cannot be found in the latest 20 or 30 releases.