### PR TITLE
fix(schema): broken $schema ref

### DIFF
--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://mise.jdx.dev/schema/mise-task.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "mise-task-schema",
   "type": "object",
   "$defs": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://mise.jdx.dev/schema/mise.json",
-  "$schema": "http://json-schema.org/2019-09/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema#",
   "title": "mise",
   "type": "object",
   "$defs": {


### PR DESCRIPTION
Fixed a broken `$schema` ref for the mise JSON schema. (The previous URL was a 404.)

Also upgraded 2 $schema refs to use https.

(Thanks so much for this tool by the way - this is easily one of the best pieces of FOSS in existence IMO.)