### PR TITLE
fix: do not overwrite github tokens environment variables

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -205,62 +205,28 @@ pub static PATH_NON_PRISTINE: Lazy<Vec<PathBuf>> = Lazy::new(|| match var(&*PATH
 });
 pub static DIRENV_DIFF: Lazy<Option<String>> = Lazy::new(|| var("DIRENV_DIFF").ok());
 pub static GITHUB_TOKEN: Lazy<Option<String>> = Lazy::new(|| {
-    let token = var("MISE_GITHUB_TOKEN")
+    var("MISE_GITHUB_TOKEN")
         .or_else(|_| var("GITHUB_API_TOKEN"))
         .or_else(|_| var("GITHUB_TOKEN"))
         .ok()
-        .and_then(|v| if v.is_empty() { None } else { Some(v) });
-
-    // set or unset the token for plugins+ubi
-    if let Some(token) = token.as_ref() {
-        set_var("MISE_GITHUB_TOKEN", token);
-        set_var("GITHUB_TOKEN", token);
-        set_var("GITHUB_API_TOKEN", token);
-    } else {
-        remove_var("MISE_GITHUB_TOKEN");
-        remove_var("GITHUB_TOKEN");
-        remove_var("GITHUB_API_TOKEN");
-    }
-
-    token
+        .and_then(|v| if v.is_empty() { None } else { Some(v) })
 });
-pub static MISE_GITHUB_ENTERPRISE_TOKEN: Lazy<Option<String>> =
-    Lazy::new(|| match var("MISE_GITHUB_ENTERPRISE_TOKEN") {
-        Ok(v) if v.trim() != "" => {
-            set_var("MISE_GITHUB_ENTERPRISE_TOKEN", &v);
-            Some(v)
-        }
-        _ => {
-            remove_var("MISE_GITHUB_ENTERPRISE_TOKEN");
-            None
-        }
-    });
-pub static GITLAB_TOKEN: Lazy<Option<String>> =
-    Lazy::new(
-        || match var("MISE_GITLAB_TOKEN").or_else(|_| var("GITLAB_TOKEN")) {
-            Ok(v) if v.trim() != "" => {
-                set_var("MISE_GITLAB_TOKEN", &v);
-                set_var("GITLAB_TOKEN", &v);
-                Some(v)
-            }
-            _ => {
-                remove_var("MISE_GITLAB_TOKEN");
-                remove_var("GITLAB_TOKEN");
-                None
-            }
-        },
-    );
-pub static MISE_GITLAB_ENTERPRISE_TOKEN: Lazy<Option<String>> =
-    Lazy::new(|| match var("MISE_GITLAB_ENTERPRISE_TOKEN") {
-        Ok(v) if v.trim() != "" => {
-            set_var("MISE_GITLAB_ENTERPRISE_TOKEN", &v);
-            Some(v)
-        }
-        _ => {
-            remove_var("MISE_GITLAB_ENTERPRISE_TOKEN");
-            None
-        }
-    });
+pub static MISE_GITHUB_ENTERPRISE_TOKEN: Lazy<Option<String>> = Lazy::new(|| {
+    var("MISE_GITHUB_ENTERPRISE_TOKEN")
+        .ok()
+        .and_then(|v| if v.trim().is_empty() { None } else { Some(v) })
+});
+pub static GITLAB_TOKEN: Lazy<Option<String>> = Lazy::new(|| {
+    var("MISE_GITLAB_TOKEN")
+        .or_else(|_| var("GITLAB_API_TOKEN"))
+        .ok()
+        .and_then(|v| if v.is_empty() { None } else { Some(v) })
+});
+pub static MISE_GITLAB_ENTERPRISE_TOKEN: Lazy<Option<String>> = Lazy::new(|| {
+    var("MISE_GITLAB_ENTERPRISE_TOKEN")
+        .ok()
+        .and_then(|v| if v.trim().is_empty() { None } else { Some(v) })
+});
 
 pub static TEST_TRANCHE: Lazy<usize> = Lazy::new(|| var_u8("TEST_TRANCHE") as usize);
 pub static TEST_TRANCHE_COUNT: Lazy<usize> = Lazy::new(|| var_u8("TEST_TRANCHE_COUNT") as usize);

--- a/src/env.rs
+++ b/src/env.rs
@@ -209,7 +209,7 @@ pub static GITHUB_TOKEN: Lazy<Option<String>> = Lazy::new(|| {
         .or_else(|_| var("GITHUB_API_TOKEN"))
         .or_else(|_| var("GITHUB_TOKEN"))
         .ok()
-        .and_then(|v| if v.is_empty() { None } else { Some(v) })
+        .and_then(|v| if v.trim().is_empty() { None } else { Some(v) })
 });
 pub static MISE_GITHUB_ENTERPRISE_TOKEN: Lazy<Option<String>> = Lazy::new(|| {
     var("MISE_GITHUB_ENTERPRISE_TOKEN")
@@ -220,7 +220,7 @@ pub static GITLAB_TOKEN: Lazy<Option<String>> = Lazy::new(|| {
     var("MISE_GITLAB_TOKEN")
         .or_else(|_| var("GITLAB_API_TOKEN"))
         .ok()
-        .and_then(|v| if v.is_empty() { None } else { Some(v) })
+        .and_then(|v| if v.trim().is_empty() { None } else { Some(v) })
 });
 pub static MISE_GITLAB_ENTERPRISE_TOKEN: Lazy<Option<String>> = Lazy::new(|| {
     var("MISE_GITLAB_ENTERPRISE_TOKEN")

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -420,8 +420,10 @@ fn build_script_man(name: &str, plugin_path: &Path) -> ScriptManager {
         .with_env("MISE_PLUGIN_PATH", plugin_path)
         .with_env("MISE_SHIMS_DIR", *dirs::SHIMS);
     if let Some(token) = &*env::GITHUB_TOKEN {
-        // asdf plugins often use GITHUB_API_TOKEN as the env var for GitHub API token
-        sm = sm.with_env("GITHUB_API_TOKEN", token.to_string());
+        sm = sm
+            .with_env("GITHUB_TOKEN", token.to_string())
+            // asdf plugins often use GITHUB_API_TOKEN as the env var for GitHub API token
+            .with_env("GITHUB_API_TOKEN", token.to_string());
     }
     sm
 }

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -411,19 +411,16 @@ Plugins could support local directories in the future but for now a symlink is r
 
 fn build_script_man(name: &str, plugin_path: &Path) -> ScriptManager {
     let plugin_path_s = plugin_path.to_string_lossy().to_string();
-    let mut sm = ScriptManager::new(plugin_path.to_path_buf())
+    let token = env::GITHUB_TOKEN.as_deref().unwrap_or("");
+    ScriptManager::new(plugin_path.to_path_buf())
         .with_env("ASDF_PLUGIN_PATH", plugin_path_s.clone())
         .with_env("RTX_PLUGIN_PATH", plugin_path_s.clone())
         .with_env("RTX_PLUGIN_NAME", name.to_string())
         .with_env("RTX_SHIMS_DIR", *dirs::SHIMS)
         .with_env("MISE_PLUGIN_NAME", name.to_string())
         .with_env("MISE_PLUGIN_PATH", plugin_path)
-        .with_env("MISE_SHIMS_DIR", *dirs::SHIMS);
-    if let Some(token) = &*env::GITHUB_TOKEN {
-        sm = sm
-            .with_env("GITHUB_TOKEN", token.to_string())
-            // asdf plugins often use GITHUB_API_TOKEN as the env var for GitHub API token
-            .with_env("GITHUB_API_TOKEN", token.to_string());
-    }
-    sm
+        .with_env("MISE_SHIMS_DIR", *dirs::SHIMS)
+        .with_env("GITHUB_TOKEN", token)
+        // asdf plugins often use GITHUB_API_TOKEN as the env var for GitHub API token
+        .with_env("GITHUB_API_TOKEN", token)
 }


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/issues/5524.

https://github.com/jdx/mise/pull/3114 introduced the overwrite behaviour to resolve https://github.com/jdx/mise/issues/2910 and https://github.com/jdx/mise/issues/3070.
It was to ignore an invalid `GITHUB_TOKEN` if `MISE_GITHUB_TOKEN` is set to an empty string, but it was necessary only because we used to call `ubi` from the CLI.

For asdf plugins, this should be enough to overwrite `GITHUB_TOKEN`.
https://github.com/jdx/mise/blob/ce78f04bfb338d218df90301a093b01b1d67d13a/src/plugins/asdf_plugin.rs#L426

I'm not sure about vfox plugins, but I don't think this PR will change any behaviours because it seems `vfox.rs` not using the tokens.