### PR TITLE
fix: Xonsh integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,6 +203,7 @@ jobs:
             pipx \
             python3-venv \
             zsh
+          sudo pip3 install xonsh
       - run: |
           mkdir -p "$HOME/.local/bin"
           ln -s "$(which fdfind)" "$HOME/.local/bin/fd"

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -240,7 +240,7 @@ The obvious downside is that anytime one wants to use `mise` they need to prefix
 
 ## Hook on `cd` {#hook-on-cd}
 
-For some shells (`bash`, `zsh`, `fish`), `mise` hooks into the `cd` command, while in others, it only runs when the prompt is displayed. This relies on `chpwd` in `zsh`, `PROMPT_COMMAND` in `bash`, and `fish_prompt` in `fish`.
+For some shells (`bash`, `zsh`, `fish`, `xonsh`), `mise` hooks into the `cd` command, while in others, it only runs when the prompt is displayed. This relies on `chpwd` in `zsh`, `PROMPT_COMMAND` in `bash`, `fish_prompt` in `fish`, and `on_chdir` in `xonsh`.
 
 The upside is that it doesn't run as frequently but since mise is written in Rust the cost for executing
 mise is negligible (a few ms).

--- a/e2e/shell/test_xonsh
+++ b/e2e/shell/test_xonsh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+require_cmd xonsh
+exec /home/joe/.pyenv/versions/3.12.0/bin/xonsh --no-rc "$TEST_DIR/xonsh_script"

--- a/e2e/shell/test_xonsh
+++ b/e2e/shell/test_xonsh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 require_cmd xonsh
-exec /home/joe/.pyenv/versions/3.12.0/bin/xonsh --no-rc "$TEST_DIR/xonsh_script"
+exec xonsh --no-rc "$TEST_DIR/xonsh_script"

--- a/e2e/shell/xonsh_script
+++ b/e2e/shell/xonsh_script
@@ -17,23 +17,24 @@ mise install node@20.0.0 node@18.0.0
 
 # shellcheck disable=SC1073,SC1065,SC1064,SC1072
 execx($(mise activate -s xonsh))
-events.on_pre_prompt.fire() # event handlers don't fire in non-interactive mode, so do it manually
 
 # check that mise was activated at all
 assert 'mise' in aliases
-assert list(events.on_pre_prompt)[0].__name__ == 'listen_prompt'
+assert list(events.on_pre_prompt)[0].__name__ == 'mise_hook'
+assert list(events.on_chdir)[0].__name__ == 'mise_hook'
 
 # check that correct node version is being used
+events.on_pre_prompt.fire() # prompt doesn't render in non-interactive mode, so do this manually
 assert $(node -v) == 'v20.0.0'
 
-# check that config file in subdir is respected
-cd 18 && events.on_pre_prompt.fire()
+# check that on_chdir hook is firing
+cd 18
 assert $(node -v) == 'v18.0.0'
-
-# check that subdir is correctly forgotten when moving back up to parent dir
-cd .. && events.on_pre_prompt.fire()
+cd ..
 assert $(node -v) == 'v20.0.0'
 
+# check that mise is correctly deactivated
 mise deactivate
 assert 'mise' not in aliases
 assert len(list(events.on_pre_prompt)) == 0
+assert len(list(events.on_chdir)) == 0

--- a/e2e/shell/xonsh_script
+++ b/e2e/shell/xonsh_script
@@ -26,6 +26,14 @@ assert list(events.on_pre_prompt)[0].__name__ == 'listen_prompt'
 # check that correct node version is being used
 assert $(node -v) == 'v20.0.0'
 
-cd 18
-events.on_pre_prompt.fire()
+# check that config file in subdir is respected
+cd 18 && events.on_pre_prompt.fire()
 assert $(node -v) == 'v18.0.0'
+
+# check that subdir is correctly forgotten when moving back up to parent dir
+cd .. && events.on_pre_prompt.fire()
+assert $(node -v) == 'v20.0.0'
+
+mise deactivate
+assert 'mise' not in aliases
+assert len(list(events.on_pre_prompt)) == 0

--- a/e2e/shell/xonsh_script
+++ b/e2e/shell/xonsh_script
@@ -1,0 +1,28 @@
+$XONSH_SHOW_TRACEBACK = True
+
+node20 = """
+[tools]
+node = "20.0.0"
+"""
+echo @(node20) > .mise.toml
+
+node18 = """
+[tools]
+node = "18.0.0"
+"""
+mkdir -p 18
+echo @(node18) > 18/.mise.toml
+
+execx($(mise activate -s xonsh))
+events.on_pre_prompt.fire() # event handlers don't fire in non-interactive mode, so do it manually
+
+# check that mise was activated at all
+assert 'mise' in aliases
+assert list(events.on_pre_prompt)[0].__name__ == 'listen_prompt'
+
+# check that correct node version is being used
+assert $(node -v) == 'v20.0.0'
+
+cd 18
+events.on_pre_prompt.fire()
+assert $(node -v) == 'v18.0.0'

--- a/e2e/shell/xonsh_script
+++ b/e2e/shell/xonsh_script
@@ -13,6 +13,8 @@ node = "18.0.0"
 mkdir -p 18
 echo @(node18) > 18/.mise.toml
 
+mise install node@20.0.0 node@18.0.0
+
 execx($(mise activate -s xonsh))
 events.on_pre_prompt.fire() # event handlers don't fire in non-interactive mode, so do it manually
 

--- a/e2e/shell/xonsh_script
+++ b/e2e/shell/xonsh_script
@@ -15,6 +15,7 @@ echo @(node18) > 18/.mise.toml
 
 mise install node@20.0.0 node@18.0.0
 
+# shellcheck disable=SC1073,SC1065,SC1064,SC1072
 execx($(mise activate -s xonsh))
 events.on_pre_prompt.fire() # event handlers don't fire in non-interactive mode, so do it manually
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -2,7 +2,7 @@ amends "package://github.com/jdx/hk/releases/download/v1.0.0/hk@1.0.0#/Config.pk
 import "package://github.com/jdx/hk/releases/download/v1.0.0/hk@1.0.0#/Builtins.pkl"
 
 local bash_glob = List("*.sh", "xtasks/**", "scripts/**", "e2e/**")
-local bash_exclude = List("*.ps1", "*.fish", "*.ts", "*.js", "*.json", "*.bat", "**/.*", "src/assets/bash_zsh_support/**")
+local bash_exclude = List("*.ps1", "*.fish", "*.ts", "*.js", "*.json", "*.bat", "**/.*", "src/assets/bash_zsh_support/**", "e2e/shell/xonsh_script")
 local linters = new Mapping<String, Step> {
     // uses builtin prettier linter config
     ["prettier"] = (Builtins.prettier) {

--- a/src/shell/snapshots/mise__shell__xonsh__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__hook_init.snap
@@ -17,7 +17,7 @@ import shlex
 import subprocess
 
 extra_args = shlex.split(' --status')
-def listen_prompt(): # Hook Events
+def mise_hook(**kwargs): # Hook Events
     script = subprocess.run(
         ['/some/dir/mise', 'hook-env', *extra_args, '-s', 'xonsh'],
         env=XSH.env.detype(),
@@ -25,4 +25,5 @@ def listen_prompt(): # Hook Events
     ).stdout.decode()
     execx(script)
 
-XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
+XSH.builtins.events.on_pre_prompt(mise_hook) # Activate hook: before showing the prompt
+XSH.builtins.events.on_chdir(mise_hook) # Activate hook: when the working directory changes

--- a/src/shell/snapshots/mise__shell__xonsh__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__hook_init.snap
@@ -3,22 +3,26 @@ source: src/shell/xonsh.rs
 expression: "xonsh.activate(exe, \" --status\".into())"
 snapshot_kind: text
 ---
-from os               import environ
-import subprocess
-from xonsh.built_ins  import XSH
-
-def listen_prompt(): # Hook Events
-  execx($(/some/dir/mise hook-env --status -s xonsh))
-
-envx = XSH.env
-envx[   'MISE_SHELL'] = 'xonsh'
-environ['MISE_SHELL'] = envx.get_detyped('MISE_SHELL')
-XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
+from xonsh.built_ins import XSH
 
 def _mise(args):
   if args and args[0] in ('deactivate', 'shell', 'sh'):
-    execx(subprocess.run(['command', 'mise', *args], stdout=subprocess.PIPE).stdout.decode())
+    execx($(mise @(args)))
   else:
-    subprocess.run(['command', 'mise', *args])
+    mise @(args)
 
+XSH.env['MISE_SHELL'] = 'xonsh'
 XSH.aliases['mise'] = _mise
+import shlex
+import subprocess
+
+extra_args = shlex.split(' --status')
+def listen_prompt(): # Hook Events
+    script = subprocess.run(
+        ['/some/dir/mise', 'hook-env', *extra_args, '-s', 'xonsh'],
+        env=XSH.env.detype(),
+        stdout=subprocess.PIPE,
+    ).stdout.decode()
+    execx(script)
+
+XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt

--- a/src/shell/snapshots/mise__shell__xonsh__tests__prepend_env.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__prepend_env.snap
@@ -3,9 +3,5 @@ source: src/shell/xonsh.rs
 expression: "replace_path(&sh.prepend_env(\"PATH\", \"/some/dir:/2/dir\"))"
 snapshot_kind: text
 ---
-from os               import environ
-from xonsh.built_ins  import XSH
-
-envx = XSH.env
-envx[   'PATH'].add('/some/dir:/2/dir', front=True)
-environ['PATH'] = envx.get_detyped('PATH')
+from xonsh.built_ins import XSH
+XSH.env['PATH'].add('/some/dir:/2/dir', front=True)

--- a/src/shell/snapshots/mise__shell__xonsh__tests__set_env.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__set_env.snap
@@ -3,9 +3,5 @@ source: src/shell/xonsh.rs
 expression: "Xonsh::default().set_env(\"FOO\", \"1\")"
 snapshot_kind: text
 ---
-from os               import environ
-from xonsh.built_ins  import XSH
-
-envx = XSH.env
-envx[   'FOO'] = '1'
-environ['FOO'] = envx.get_detyped('FOO')
+from xonsh.built_ins import XSH
+XSH.env['FOO'] = '1'

--- a/src/shell/snapshots/mise__shell__xonsh__tests__unset_env.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__unset_env.snap
@@ -3,9 +3,5 @@ source: src/shell/xonsh.rs
 expression: "Xonsh::default().unset_env(\"FOO\")"
 snapshot_kind: text
 ---
-from os               import environ
-from xonsh.built_ins  import XSH
-
-envx = XSH.env
-envx.pop(   'FOO',None)
-environ.pop('FOO',None)
+from xonsh.built_ins import XSH
+XSH.env.pop('FOO',None)

--- a/src/shell/snapshots/mise__shell__xonsh__tests__xonsh_deactivate.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__xonsh_deactivate.snap
@@ -4,14 +4,13 @@ expression: replace_path(&deactivate)
 snapshot_kind: text
 ---
 import os
-from xonsh.built_ins  import XSH
+from xonsh.built_ins import XSH
 
 hooks = {
   'on_pre_prompt' : ['listen_prompt'],
 }
-for   hook_type in hooks:
-  hook_fns = hooks[hook_type]
-  for hook_fn   in hook_fns:
+for hook_type, hook_fns in hooks.items():
+  for hook_fn in hook_fns:
     hndl = getattr(XSH.builtins.events, hook_type)
     for fn in hndl:
       if fn.__name__ == hook_fn:
@@ -20,8 +19,5 @@ for   hook_type in hooks:
 
 del XSH.aliases['mise']
 del XSH.env['MISE_SHELL']
-del os.environ['MISE_SHELL']
 del XSH.env['__MISE_DIFF']
-del os.environ['__MISE_DIFF']
 del XSH.env['__MISE_SESSION']
-del os.environ['__MISE_SESSION']

--- a/src/shell/snapshots/mise__shell__xonsh__tests__xonsh_deactivate.snap
+++ b/src/shell/snapshots/mise__shell__xonsh__tests__xonsh_deactivate.snap
@@ -7,7 +7,8 @@ import os
 from xonsh.built_ins import XSH
 
 hooks = {
-  'on_pre_prompt' : ['listen_prompt'],
+  'on_pre_prompt' : ['mise_hook'],
+  'on_chdir': ['mise_hook'],
 }
 for hook_type, hook_fns in hooks.items():
   for hook_fn in hook_fns:

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -67,7 +67,7 @@ impl Shell for Xonsh {
                 import subprocess
 
                 extra_args = shlex.split('{flags}')
-                def listen_prompt(): # Hook Events
+                def mise_hook(**kwargs): # Hook Events
                     script = subprocess.run(
                         ['{exe}', 'hook-env', *extra_args, '-s', 'xonsh'],
                         env=XSH.env.detype(),
@@ -75,7 +75,8 @@ impl Shell for Xonsh {
                     ).stdout.decode()
                     execx(script)
 
-                XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
+                XSH.builtins.events.on_pre_prompt(mise_hook) # Activate hook: before showing the prompt
+                XSH.builtins.events.on_chdir(mise_hook) # Activate hook: when the working directory changes
             "#});
         }
         out
@@ -87,7 +88,8 @@ impl Shell for Xonsh {
             from xonsh.built_ins import XSH
 
             hooks = {{
-              'on_pre_prompt' : ['listen_prompt'],
+              'on_pre_prompt' : ['mise_hook'],
+              'on_chdir': ['mise_hook'],
             }}
             for hook_type, hook_fns in hooks.items():
               for hook_fn in hook_fns:

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -107,23 +107,25 @@ impl Shell for Xonsh {
     }
 
     fn set_env(&self, k: &str, v: &str) -> String {
-        let k = shell_escape::unix::escape(k.into()); // todo: drop illegal chars, not escape?
         formatdoc!(
             r#"
             from xonsh.built_ins import XSH
             XSH.env['{k}'] = '{v}'
         "#,
-            k = shell_escape::unix::escape(k), // todo: drop illegal chars, not escape?
+            k = shell_escape::unix::escape(k.into()), // todo: drop illegal chars, not escape?
             v = xonsh_escape_sq(v)
         )
     }
 
     fn prepend_env(&self, k: &str, v: &str) -> String {
-        let v = xonsh_escape_sq(v);
-        formatdoc! {r#"
+        formatdoc!(
+            r#"
             from xonsh.built_ins import XSH
             XSH.env['{k}'].add('{v}', front=True)
-        "#}
+        "#,
+            k = shell_escape::unix::escape(k.into()),
+            v = xonsh_escape_sq(v)
+        )
     }
 
     fn unset_env(&self, k: &str) -> String {

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -47,47 +47,50 @@ impl Shell for Xonsh {
         let mut out = String::new();
         out.push_str(&self.format_activate_prelude(&opts.prelude));
 
-        // todo: xonsh doesn't update the environment that mise relies on with $PATH.add even with $UPDATE_OS_ENVIRON (github.com/xonsh/xonsh/issues/3207)
-        // with envx.swap(UPDATE_OS_ENVIRON=True): # ← use when ↑ fixed before PATH.add; remove environ
-        // meanwhile, save variables twice: in shell env + in os env
         // use xonsh API instead of $.xsh to allow use inside of .py configs, which start faster due to being compiled to .pyc
-        // todo: subprocess instead of $() is a bit faster, but lose auto-color detection (use $FORCE_COLOR)
         out.push_str(&formatdoc! {r#"
-            from os               import environ
-            import subprocess
-            from xonsh.built_ins  import XSH
-
-            def listen_prompt(): # Hook Events
-              execx($({exe} hook-env{flags} -s xonsh))
-
-            envx = XSH.env
-            envx[   'MISE_SHELL'] = 'xonsh'
-            environ['MISE_SHELL'] = envx.get_detyped('MISE_SHELL')
-            XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
+            from xonsh.built_ins import XSH
 
             def _mise(args):
               if args and args[0] in ('deactivate', 'shell', 'sh'):
-                execx(subprocess.run(['command', 'mise', *args], stdout=subprocess.PIPE).stdout.decode())
+                execx($(mise @(args)))
               else:
-                subprocess.run(['command', 'mise', *args])
+                mise @(args)
 
+            XSH.env['MISE_SHELL'] = 'xonsh'
             XSH.aliases['mise'] = _mise
         "#});
 
+        if !opts.no_hook_env {
+            out.push_str(&formatdoc! {r#"
+                import shlex
+                import subprocess
+
+                extra_args = shlex.split('{flags}')
+                def listen_prompt(): # Hook Events
+                    script = subprocess.run(
+                        ['{exe}', 'hook-env', *extra_args, '-s', 'xonsh'],
+                        env=XSH.env.detype(),
+                        stdout=subprocess.PIPE,
+                    ).stdout.decode()
+                    execx(script)
+
+                XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
+            "#});
+        }
         out
     }
 
     fn deactivate(&self) -> String {
         formatdoc! {r#"
             import os
-            from xonsh.built_ins  import XSH
+            from xonsh.built_ins import XSH
 
             hooks = {{
               'on_pre_prompt' : ['listen_prompt'],
             }}
-            for   hook_type in hooks:
-              hook_fns = hooks[hook_type]
-              for hook_fn   in hook_fns:
+            for hook_type, hook_fns in hooks.items():
+              for hook_fn in hook_fns:
                 hndl = getattr(XSH.builtins.events, hook_type)
                 for fn in hndl:
                   if fn.__name__ == hook_fn:
@@ -96,11 +99,8 @@ impl Shell for Xonsh {
 
             del XSH.aliases['mise']
             del XSH.env['MISE_SHELL']
-            del os.environ['MISE_SHELL']
             del XSH.env['__MISE_DIFF']
-            del os.environ['__MISE_DIFF']
             del XSH.env['__MISE_SESSION']
-            del os.environ['__MISE_SESSION']
             "#}
     }
 
@@ -108,12 +108,8 @@ impl Shell for Xonsh {
         let k = shell_escape::unix::escape(k.into()); // todo: drop illegal chars, not escape?
         formatdoc!(
             r#"
-            from os               import environ
-            from xonsh.built_ins  import XSH
-
-            envx = XSH.env
-            envx[   '{k}'] = '{v}'
-            environ['{k}'] = envx.get_detyped('{k}')
+            from xonsh.built_ins import XSH
+            XSH.env['{k}'] = '{v}'
         "#,
             k = shell_escape::unix::escape(k), // todo: drop illegal chars, not escape?
             v = xonsh_escape_sq(v)
@@ -123,24 +119,16 @@ impl Shell for Xonsh {
     fn prepend_env(&self, k: &str, v: &str) -> String {
         let v = xonsh_escape_sq(v);
         formatdoc! {r#"
-            from os               import environ
-            from xonsh.built_ins  import XSH
-
-            envx = XSH.env
-            envx[   '{k}'].add('{v}', front=True)
-            environ['{k}'] = envx.get_detyped('{k}')
+            from xonsh.built_ins import XSH
+            XSH.env['{k}'].add('{v}', front=True)
         "#}
     }
 
     fn unset_env(&self, k: &str) -> String {
         formatdoc!(
             r#"
-            from os               import environ
-            from xonsh.built_ins  import XSH
-
-            envx = XSH.env
-            envx.pop(   '{k}',None)
-            environ.pop('{k}',None)
+            from xonsh.built_ins import XSH
+            XSH.env.pop('{k}',None)
         "#,
             k = shell_escape::unix::escape(k.into()) // todo: drop illegal chars, not escape?
         )


### PR DESCRIPTION
The Xonsh integration is currently broken. It doesn't output any errors when running `execx($(mise activate -s xonsh))`, but calling `mise` after doing so will raise an error:

```
joe@vingilot ~/Documents/code/mise main @ execx($(mise activate xonsh))
joe@vingilot ~/Documents/code/mise main @ mise
xonsh: For full traceback set: $XONSH_SHOW_TRACEBACK = True
Exception in thread {'cls': 'ProcProxyThread', 'name': 'Thread-33', 'func': FuncAlias({'name': 'mise', 'func': '_mise', 'return_what': 'result'}), 'alias': 'mise', 'pid': None}
FileNotFoundError: [Errno 2] No such file or directory: 'command'
```

Ultimately this error is due to the activating script trying to execute `command mise ...`, and `command` isn't a proper executable. `command` is a Bash builtin (and maybe exists in other more bash-like shells as well?), so I'm guessing what happened was that some logic was ported over from other shells and doesn't work here.

Fixing this issue is straightforward, but doing so reveals a second issue. The pre-prompt hook attempts to capture the output of `mise hook-env` via `$(...)`, but this doesn't work because `mise` has been replaced with an alias that runs it using `subprocess.run()`, which bypasses Xonsh's output-capturing mechanics.

To fix these issues I suggest the following changes:
  * Use normal `xonsh` subprocess semantics in the main `mise` alias, which fixes output capturing
  * Since the original motivation for using `subprocess.run()` was to speed up execution, but we really only care about this in the pre-prompt hook, we will use `subprocess.run()` only in the pre-prompt hook.
  * Switch to passing in the Xonsh environment via `XSH.env.detype()`. This avoids the added complexity of having to set env vars in both `XSH.env` and `os.environ`, which significantly cleans up the implementation.
  * Add an `e2e` test for Xonsh, at least for the basic behavior. I modeled this one mostly after the e2e test for Zsh.

If that seems reasonable, I have a couple of additional questions:
1. There's [a section in the docs](https://mise.jdx.dev/dev-tools/shims.html#hook-on-cd) that talks about hooking into `cd`, rather than just running every time the prompt is displayed. This makes sense to me - the PATH manipulation that mise does should only need to be updated when the working directory changes - but I'm not sure if it means what I think it means. At least, the docs claim that this happens in Bash and Zsh, but looking at those implementations it appears that they are still running on prompt as well as on `cd`, so I'm not sure what's going on. If my original intuition is right and the hook only really needs to fire when the directory is changed, this would be easy to do in Xonsh as well. We'd just need to hook into the `on_chdir` event instead of `on_pre_prompt`.
2. `shfmt` doesn't like the Xonsh test script, which is understandable since Xonsh syntax can get pretty far from regular shell (all valid Python is also valid Xonsh.) Unfortunately it's causing some checks to fail in CI, and I can't find a way to tell it to ignore this file, or just mark it as an expected fail. Is that possible?