### PR TITLE
chore(release): mark a release as draft until assets are added

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,6 +288,7 @@ jobs:
           files: releases/${{github.ref_name}}/*
           generate_release_notes: true
           token: ${{ secrets.RTX_GITHUB_BOT_TOKEN }}
+      - run: gh release edit --draft=false $(./scripts/get-version.sh)
   bump-alpine:
     runs-on: ubuntu-latest
     container: ghcr.io/jdx/mise:alpine

--- a/mise.lock
+++ b/mise.lock
@@ -54,6 +54,7 @@ backend = "aqua:jdx/hk"
 
 [tools.hk.checksums]
 "hk-aarch64-apple-darwin.tar.gz" = "sha256:acaae0f68b20838a68b48014dd8aa79a46a748ff9e11f472d33b9413f36f98f3"
+"hk-x86_64-unknown-linux-gnu.tar.gz" = "sha256:1cf3749b28958acb2697935bf5566414024a67ad44d53339f16501dfd8f7a72d"
 
 [tools.jq]
 version = "1.8.1"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -89,6 +89,6 @@ if [[ $DRY_RUN != 1 ]]; then
 	#  NPM_PREFIX=mise-cli ./scripts/release-npm.sh
 	echo "::group::Publish r2"
 	./scripts/publish-r2.sh
-	echo "::group::Publish GitHub releases"
-	gh release edit --draft=false "$MISE_VERSION"
+	echo "::group::Publish GitHub releases as draft"
+	gh release edit --draft=true "$MISE_VERSION"
 fi


### PR DESCRIPTION
This marks the release as a draft until the assets are successfully added.

However, since `release-r2.sh` runs before it, `https://mise.run` will still fail.
I think we need to move it to `post-release.sh` and run it after the assets creation.