### PR TITLE
docs(cursor): fix conventional commits rule formatting

### DIFF
--- a/.cursor/rules/conventional_commits.mdc
+++ b/.cursor/rules/conventional_commits.mdc
@@ -1,3 +1,8 @@
+---
+alwaysApply: false
+description: how to write commit and PR titles
+---
+
 ## Conventional Commits (REQUIRED)
 
 All commit messages and PR titles MUST follow conventional commit format:
@@ -11,7 +16,7 @@ All commit messages and PR titles MUST follow conventional commit format:
 - `feat:` - New features
 - `fix:` - Bug fixes  
 - `refactor:` - Code refactoring
-- `doc:` - Documentation
+- `docs:` - Documentation
 - `style:` - Code style/formatting
 - `perf:` - Performance improvements
 - `test:` - Testing changes


### PR DESCRIPTION
Fix the formatting issues in the conventional commits cursor rule file, including proper frontmatter and removing line break issues.