### PR TITLE
fix(e2e): allow running tests by full, relative, or filename path

### DIFF
--- a/e2e/run_test
+++ b/e2e/run_test
@@ -7,7 +7,14 @@ ROOT="$(cd "$SCRIPT_DIR"/.. && pwd)"
 source "$SCRIPT_DIR/style.sh"
 
 TEST="$1"
-TEST_SCRIPT="$SCRIPT_DIR/$TEST"
+# Handle both relative and absolute paths
+if [[ $TEST == /* ]] || [[ $TEST == e2e/* ]]; then
+	# If it's an absolute path or already contains e2e/, use it as is
+	TEST_SCRIPT="$TEST"
+else
+	# Otherwise, treat it as relative to the e2e directory
+	TEST_SCRIPT="$SCRIPT_DIR/$TEST"
+fi
 
 setup_isolated_env() {
 	TEST_ISOLATED_DIR="$(mktemp --tmpdir --directory "$(basename "$TEST").XXXXXX")"

--- a/xtasks/test/e2e
+++ b/xtasks/test/e2e
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE depends=["build"]
-#MISE alias="e"
+#MISE alias=["e", "e2e"]
 #MISE description="run end-to-end tests"
 set -euo pipefail
 
@@ -9,14 +9,27 @@ export RUST_TEST_THREADS=1
 if [[ ${1:-all} == all ]]; then
 	./e2e/run_all_tests
 else
-	pushd e2e
-	FILES="$(fd -tf "$1" --and "^test_")"
-	popd
+	PATTERN="$1"
+	if [[ $PATTERN == e2e/* ]]; then
+		PATTERN="${PATTERN#e2e/}"
+	fi
+	# Debug output
+	echo "[xtask:e2e] Searching for test pattern: $PATTERN" >&2
+	pushd e2e >/dev/null
+	if [[ -f $PATTERN ]]; then
+		FILES="$PATTERN"
+	elif [[ $PATTERN == */* ]]; then
+		FILES="$(fd -tf "$(basename "$PATTERN")")"
+	else
+		FILES="$(fd -tf "$PATTERN" --and "^test_")"
+	fi
+	popd >/dev/null
 	if [[ -z $FILES ]]; then
 		echo "Not test matches $1" >&2
 		exit 1
 	fi
 	for FILE in $FILES; do
+		echo "[xtask:e2e] Running test: $FILE" >&2
 		./e2e/run_test "$FILE"
 	done
 fi


### PR DESCRIPTION
## What does this PR do?

This PR improves the e2e test runner to support multiple ways of specifying test files:

- **Full path**: \`mise run e2e -- e2e/cli/test_activate_aggressive\`
- **Relative path**: \`mise run e2e -- cli/test_activate_aggressive\` 
- **Filename only**: \`mise run e2e -- test_activate_aggressive\`

## Why is this needed?

Previously, only the filename approach worked reliably. Users who tried to use full paths (like \`e2e/cli/test_activate_aggressive\`) would get "No test matches" errors because the test discovery logic didn't handle path-based lookups correctly.

## Changes made

- Updated \`xtasks/test/e2e\` to strip \`e2e/\` prefix when present
- Added direct file existence check for path-based arguments
- Improved fallback logic to search by filename when path doesn't exist
- Added debug output to help troubleshoot test discovery issues

## Testing

All three invocation patterns now work correctly:
✅ \`mise run e2e -- e2e/cli/test_activate_aggressive\`
✅ \`mise run e2e -- cli/test_activate_aggressive\`
✅ \`mise run e2e -- test_activate_aggressive\`