### PR TITLE
chore: release 2025.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2025.7.9](https://github.com/jdx/mise/compare/v2025.7.8..v2025.7.9) - 2025-07-14
+
+### 🚀 Features
+
+- **(shim)** prevent mise-specific flags from interfering with shim execution by [@jdx](https://github.com/jdx) in [#5616](https://github.com/jdx/mise/pull/5616)
+- github asset auto-detection by [@jdx](https://github.com/jdx) in [#5622](https://github.com/jdx/mise/pull/5622)
+
+### 🐛 Bug Fixes
+
+- resolve GitHub alias tool name parsing and add platform-specific asset support by [@jdx](https://github.com/jdx) in [#5621](https://github.com/jdx/mise/pull/5621)
+
 ## [2025.7.8](https://github.com/jdx/mise/compare/v2025.7.7..v2025.7.8) - 2025-07-13
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.7.8"
+version = "2025.7.9"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.7.8"
+version = "2025.7.9"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.7.8 macos-arm64 (a1b2d3e 2025-07-13)
+2025.7.9 macos-arm64 (a1b2d3e 2025-07-14)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_7_8:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_8 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_7_8;
+  if ( [[ -z "${_usage_spec_mise_2025_7_9:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_9 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_7_9;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_7_8 spec
+    _store_cache _usage_spec_mise_2025_7_9 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_7_8:-} ]]; then
-        _usage_spec_mise_2025_7_8="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_7_9:-} ]]; then
+        _usage_spec_mise_2025_7_9="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_8}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_9}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_7_8
-  set -g _usage_spec_mise_2025_7_8 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_7_9
+  set -g _usage_spec_mise_2025_7_9 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_8" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_9" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_8" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_9" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.7.8";
+  version = "2025.7.9";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.7.8
+Version: 2025.7.9
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(shim)** prevent mise-specific flags from interfering with shim execution by [@jdx](https://github.com/jdx) in [#5616](https://github.com/jdx/mise/pull/5616)
- github asset auto-detection by [@jdx](https://github.com/jdx) in [#5622](https://github.com/jdx/mise/pull/5622)

### 🐛 Bug Fixes

- resolve GitHub alias tool name parsing and add platform-specific asset support by [@jdx](https://github.com/jdx) in [#5621](https://github.com/jdx/mise/pull/5621)