### PR TITLE
fix: resolve GitHub alias tool name parsing and add platform-specific asset support

### DIFF
--- a/e2e/config/test_config_alias_github_edit
+++ b/e2e/config/test_config_alias_github_edit
@@ -1,19 +1,9 @@
 #!/usr/bin/env bash
 
-if [[ "$(uname)" == "Darwin" ]]; then
-  echo "Skipping test_config_alias_github_edit on macOS (no macOS asset available)"
-  exit 0
-fi
-
 cat <<EOF >mise.toml
 [tools.test-edit]
 version = "1.2.0"
-
-[tools.test-edit.platforms]
-linux-aarch64 = { asset_pattern = "edit-1.2.0-aarch64-linux-gnu.tar.zst" }
-windows-aarch64 = { asset_pattern = "edit-1.2.0-aarch64-windows.zip" }
-linux-x64 = { asset_pattern = "edit-1.2.0-x86_64-linux-gnu.tar.zst" }
-windows-x64 = { asset_pattern = "edit-1.2.0-x86_64-windows.zip" }
+asset_pattern = "edit-1.2.0-aarch64-linux-gnu.tar.zst"
 
 [alias]
 test-edit = "github:microsoft/edit"
@@ -21,4 +11,4 @@ EOF
 assert "mise install test-edit"
 
 # Test that the alias works and test-edit command can be executed
-assert_contains "mise x -- edit --version" "edit version"
+assert "mise which edit" ~/.local/share/mise/installs/test-edit/1.2.0/edit

--- a/e2e/config/test_config_alias_github_edit
+++ b/e2e/config/test_config_alias_github_edit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "Skipping test_config_alias_github_edit on macOS (no macOS asset available)"
+  exit 0
+fi
+
+cat <<EOF >mise.toml
+[tools.test-edit]
+version = "1.2.0"
+
+[tools.test-edit.platforms]
+linux-aarch64 = { asset_pattern = "edit-1.2.0-aarch64-linux-gnu.tar.zst" }
+windows-aarch64 = { asset_pattern = "edit-1.2.0-aarch64-windows.zip" }
+linux-x64 = { asset_pattern = "edit-1.2.0-x86_64-linux-gnu.tar.zst" }
+windows-x64 = { asset_pattern = "edit-1.2.0-x86_64-windows.zip" }
+
+[alias]
+test-edit = "github:microsoft/edit"
+EOF
+assert "mise install test-edit"
+
+# Test that the alias works and test-edit command can be executed
+assert_contains "mise x -- edit --version" "edit version"

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -237,7 +237,12 @@ impl UnifiedGitBackend {
         // Template the pattern with actual values
         let templated_pattern = template_string(&pattern, tv);
 
-        let available_assets: Vec<String> = release.assets.links.iter().map(|a| a.name.clone()).collect();
+        let available_assets: Vec<String> = release
+            .assets
+            .links
+            .iter()
+            .map(|a| a.name.clone())
+            .collect();
         // Find matching asset - pattern is already templated by mise.toml parsing
         let asset = release
             .assets


### PR DESCRIPTION
## Summary

This PR fixes a bug where GitHub aliases were not being resolved correctly, causing the wrong repository name to be used when fetching releases.

## Changes

- **Fix BackendArg::tool_name()**: Now extracts the tool name from the resolved alias instead of the original argument
- **Update GitHub backend**: Uses the `tool_name()` method to ensure proper alias resolution
- **Add platform-specific asset patterns**: Test now includes proper TOML configuration for all available assets
- **Skip test on macOS**: Test skips on macOS where no compatible asset is available
- **Improve error messages**: Shows available assets for better debugging

## Testing

- Added comprehensive e2e test that verifies alias resolution works correctly
- Test includes platform-specific asset patterns for all supported platforms
- Test properly skips on macOS where no compatible asset exists

## Example

Before: `test-edit = github:microsoft/edit` would try to fetch from `https://api.github.com/repos/edit/releases`
After: `test-edit = github:microsoft/edit` correctly fetches from `https://api.github.com/repos/microsoft/edit/releases`

This enables users to use aliases with GitHub backends and have them resolve to the correct repository.