### PR TITLE
chore: release 2025.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [2025.7.11](https://github.com/jdx/mise/compare/v2025.7.10..v2025.7.11) - 2025-07-16
+
+### 🚀 Features
+
+- support extracting 7z archives for static backends by [@yjoer](https://github.com/yjoer) in [#5632](https://github.com/jdx/mise/pull/5632)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** improve warnings for packages without repo_owner and repo_name by [@risu729](https://github.com/risu729) in [#5644](https://github.com/jdx/mise/pull/5644)
+- **(generate)** fix task docs inject by [@risu729](https://github.com/risu729) in [#5651](https://github.com/jdx/mise/pull/5651)
+- **(static)** support `strip_components` for zip files by [@risu729](https://github.com/risu729) in [#5631](https://github.com/jdx/mise/pull/5631)
+- private forges by [@hamnis](https://github.com/hamnis) in [#5650](https://github.com/jdx/mise/pull/5650)
+
+### 🚜 Refactor
+
+- **(aqua)** move no_aset and error_message checks into validate by [@risu729](https://github.com/risu729) in [#5649](https://github.com/jdx/mise/pull/5649)
+
+### 📚 Documentation
+
+- **(vfox)** replace deprecated asdf and vfox settings with disable_backends by [@risu729](https://github.com/risu729) in [#5652](https://github.com/jdx/mise/pull/5652)
+- tweak static backend docs by [@jdx](https://github.com/jdx) in [#5627](https://github.com/jdx/mise/pull/5627)
+
+### 🧪 Testing
+
+- **(e2e)** move test_github_auto_detect to correct directory by [@risu729](https://github.com/risu729) in [#5640](https://github.com/jdx/mise/pull/5640)
+
+### New Contributors
+
+- @hamnis made their first contribution in [#5650](https://github.com/jdx/mise/pull/5650)
+
 ## [2025.7.10](https://github.com/jdx/mise/compare/v2025.7.9..v2025.7.10) - 2025-07-14
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.7.10"
+version = "2025.7.11"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.7.10"
+version = "2025.7.11"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.7.10 macos-arm64 (a1b2d3e 2025-07-14)
+2025.7.11 macos-arm64 (a1b2d3e 2025-07-16)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_7_10:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_10 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_7_10;
+  if ( [[ -z "${_usage_spec_mise_2025_7_11:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_11 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_7_11;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_7_10 spec
+    _store_cache _usage_spec_mise_2025_7_11 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_7_10:-} ]]; then
-        _usage_spec_mise_2025_7_10="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_7_11:-} ]]; then
+        _usage_spec_mise_2025_7_11="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_10}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_11}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_7_10
-  set -g _usage_spec_mise_2025_7_10 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_7_11
+  set -g _usage_spec_mise_2025_7_11 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_10" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_11" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_10" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_11" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.7.10";
+  version = "2025.7.11";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.7.10
+Version: 2025.7.11
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- support extracting 7z archives for static backends by [@yjoer](https://github.com/yjoer) in [#5632](https://github.com/jdx/mise/pull/5632)

### 🐛 Bug Fixes

- **(aqua)** improve warnings for packages without repo_owner and repo_name by [@risu729](https://github.com/risu729) in [#5644](https://github.com/jdx/mise/pull/5644)
- **(generate)** fix task docs inject by [@risu729](https://github.com/risu729) in [#5651](https://github.com/jdx/mise/pull/5651)
- **(static)** support `strip_components` for zip files by [@risu729](https://github.com/risu729) in [#5631](https://github.com/jdx/mise/pull/5631)
- private forges by [@hamnis](https://github.com/hamnis) in [#5650](https://github.com/jdx/mise/pull/5650)

### 🚜 Refactor

- **(aqua)** move no_aset and error_message checks into validate by [@risu729](https://github.com/risu729) in [#5649](https://github.com/jdx/mise/pull/5649)

### 📚 Documentation

- **(vfox)** replace deprecated asdf and vfox settings with disable_backends by [@risu729](https://github.com/risu729) in [#5652](https://github.com/jdx/mise/pull/5652)
- tweak static backend docs by [@jdx](https://github.com/jdx) in [#5627](https://github.com/jdx/mise/pull/5627)

### 🧪 Testing

- **(e2e)** move test_github_auto_detect to correct directory by [@risu729](https://github.com/risu729) in [#5640](https://github.com/jdx/mise/pull/5640)

### New Contributors

- @hamnis made their first contribution in [#5650](https://github.com/jdx/mise/pull/5650)