### PR TITLE
fix(static): support `strip_components` for zip files

### DIFF
--- a/e2e/backend/test_github_ripgrep
+++ b/e2e/backend/test_github_ripgrep
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-assert "mise use github:BurntSushi/ripgrep@14.1.0"
-assert "mise which rg"
-assert_contains "mise x -- rg --version" "ripgrep 14.1.0"

--- a/e2e/backend/test_github_tools
+++ b/e2e/backend/test_github_tools
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+assert "mise use github:BurntSushi/ripgrep@14.1.0"
+assert "mise which rg"
+assert_contains "mise x -- rg --version" "ripgrep 14.1.0"
+
+# zip file with strip_components=1
+assert "mise use github:nats-io/natscli@0.2.3"
+assert "mise which nats"
+assert_contains "mise x -- nats --version" "0.2.3"

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -683,7 +683,7 @@ impl AquaBackend {
         } else if format.starts_with("tar") {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
         } else if format == "zip" {
-            file::unzip(&tarball_path, &install_path)?;
+            file::unzip(&tarball_path, &install_path, &Default::default())?;
         } else if format == "gz" {
             file::create_dir_all(&install_path)?;
             file::un_gz(&tarball_path, &bin_path)?;

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -95,7 +95,10 @@ pub fn install_artifact(
     let ext = file_path.extension().and_then(|s| s.to_str()).unwrap_or("");
     let format = file::TarFormat::from_ext(ext);
     if format == file::TarFormat::Zip {
-        file::unzip(file_path, &install_path)?;
+        let zip_opts = file::ZipOptions {
+            strip_components: strip_components.unwrap_or(0),
+        };
+        file::unzip(file_path, &install_path, &zip_opts)?;
     } else if format == file::TarFormat::Raw {
         // Copy the file directly to the bin_path directory or install_path
         if let Some(bin_path_template) = opts.get("bin_path") {

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -94,12 +94,7 @@ pub fn install_artifact(
     // Use TarFormat for format detection
     let ext = file_path.extension().and_then(|s| s.to_str()).unwrap_or("");
     let format = file::TarFormat::from_ext(ext);
-    if format == file::TarFormat::Zip {
-        let zip_opts = file::ZipOptions {
-            strip_components: strip_components.unwrap_or(0),
-        };
-        file::unzip(file_path, &install_path, &zip_opts)?;
-    } else if format == file::TarFormat::Raw {
+    if format == file::TarFormat::Raw {
         // Copy the file directly to the bin_path directory or install_path
         if let Some(bin_path_template) = opts.get("bin_path") {
             let bin_path = template_string(bin_path_template, tv);

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -63,7 +63,7 @@ impl BunPlugin {
         ctx.pr.set_message(format!("extract {filename}"));
         file::remove_all(tv.install_path())?;
         file::create_dir_all(tv.install_path().join("bin"))?;
-        file::unzip(tarball_path, &tv.download_path())?;
+        file::unzip(tarball_path, &tv.download_path(), &Default::default())?;
         file::rename(
             tv.download_path()
                 .join(format!("bun-{}-{}", os(), arch()))

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -78,7 +78,7 @@ impl DenoPlugin {
         pr.set_message(format!("extract {filename}"));
         file::remove_all(tv.install_path())?;
         file::create_dir_all(tv.install_path().join("bin"))?;
-        file::unzip(tarball_path, &tv.download_path())?;
+        file::unzip(tarball_path, &tv.download_path(), &Default::default())?;
         file::rename(
             tv.download_path().join(if cfg!(target_os = "windows") {
                 "deno.exe"

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -72,7 +72,7 @@ impl ElixirPlugin {
         let filename = tarball_path.file_name().unwrap().to_string_lossy();
         ctx.pr.set_message(format!("extract {filename}"));
         file::remove_all(tv.install_path())?;
-        file::unzip(tarball_path, &tv.install_path())?;
+        file::unzip(tarball_path, &tv.install_path(), &Default::default())?;
 
         Ok(())
     }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -244,7 +244,7 @@ impl ErlangPlugin {
             .await?;
         self.verify_checksum(ctx, &mut tv, &zip_path)?;
         ctx.pr.set_message(format!("Extracting {}", zip_name));
-        file::unzip(&zip_path, &tv.install_path())?;
+        file::unzip(&zip_path, &tv.install_path(), &Default::default())?;
         Ok(Some(tv))
     }
 

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -139,7 +139,7 @@ impl GoPlugin {
         pr.set_message(format!("extract {tarball}"));
         let tmp_extract_path = tempdir_in(tv.install_path().parent().unwrap())?;
         if cfg!(windows) {
-            file::unzip(tarball_path, tmp_extract_path.path())?;
+            file::unzip(tarball_path, tmp_extract_path.path(), &Default::default())?;
         } else {
             file::untar(
                 tarball_path,

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -130,7 +130,7 @@ impl JavaPlugin {
         let filename = tarball_path.file_name().unwrap().to_string_lossy();
         pr.set_message(format!("extract {filename}"));
         match m.file_type.as_deref() {
-            Some("zip") => file::unzip(tarball_path, &tv.download_path())?,
+            Some("zip") => file::unzip(tarball_path, &tv.download_path(), &Default::default())?,
             _ => file::untar(
                 tarball_path,
                 &tv.download_path(),

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -101,7 +101,11 @@ impl NodePlugin {
         let tarball_name = &opts.binary_tarball_name;
         ctx.pr.set_message(format!("extract {tarball_name}"));
         let tmp_extract_path = tempdir_in(opts.install_path.parent().unwrap())?;
-        file::unzip(&opts.binary_tarball_path, tmp_extract_path.path(), &Default::default())?;
+        file::unzip(
+            &opts.binary_tarball_path,
+            tmp_extract_path.path(),
+            &Default::default(),
+        )?;
         file::remove_all(&opts.install_path)?;
         file::rename(
             tmp_extract_path.path().join(slug(&opts.version)),

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -101,7 +101,7 @@ impl NodePlugin {
         let tarball_name = &opts.binary_tarball_name;
         ctx.pr.set_message(format!("extract {tarball_name}"));
         let tmp_extract_path = tempdir_in(opts.install_path.parent().unwrap())?;
-        file::unzip(&opts.binary_tarball_path, tmp_extract_path.path())?;
+        file::unzip(&opts.binary_tarball_path, tmp_extract_path.path(), &Default::default())?;
         file::remove_all(&opts.install_path)?;
         file::rename(
             tmp_extract_path.path().join(slug(&opts.version)),


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/5604#discussioncomment-13750422.

~~It's a bit weird, but only `file::untar` supports `strip_components` option.
It internally calls `file::unzip`, so some codes call `file::untar` even for `.zip`.~~

~~However, `inspect_tar_contents`, or `open_tar` in it, doesn't support `.zip`, so the auto detection doesn't work.~~

~~Can I refactor it to support `strip_components` by `file::unzip`?~~