### PR TITLE
feat: support extracting 7z archives for static backends

### DIFF
--- a/e2e-win/7z.Tests.ps1
+++ b/e2e-win/7z.Tests.ps1
@@ -15,6 +15,27 @@ Describe '7z' {
 
     It 'executes 7za 25.00' {
         mise install
-        mise x -- 7za | Out-String | Should -Match "7-Zip \(a\) 25\.00"
+        mise x github:ip7z/7zip -- 7za | Out-String | Should -Match "7-Zip \(a\) 25\.00"
+    }
+}
+
+Describe '7z-strip-components' {
+    BeforeAll {
+        $cfg = ".\mise.local.toml"
+        $content = @"
+[tools]
+"http:ip7z/7zip" = { version = "25.00", url = "https://mise.jdx.dev/test-fixtures/7z2500-extra.7z" }
+"@
+        $content | Out-File $cfg
+        Get-Content $cfg
+    }
+
+    AfterAll {
+        Remove-Item $cfg -ErrorAction Ignore
+    }
+
+    It 'executes 7za 25.00' {
+        mise install
+        mise x http:ip7z/7zip -- 7za | Out-String | Should -Match "7-Zip \(a\) 25\.00"
     }
 }

--- a/e2e-win/7z.Tests.ps1
+++ b/e2e-win/7z.Tests.ps1
@@ -1,0 +1,20 @@
+Describe '7z' {
+    BeforeAll {
+        $cfg = ".\mise.local.toml"
+        $content = @"
+[tools]
+"github:ip7z/7zip" = { version = "25.00", asset_pattern = "*-extra.7z" }
+"@
+        $content | Out-File $cfg
+        Get-Content $cfg
+    }
+
+    AfterAll {
+        Remove-Item $cfg -ErrorAction Ignore
+    }
+
+    It 'executes 7za 25.00' {
+        mise install
+        mise x -- 7za | Out-String | Should -Match "7-Zip \(a\) 25\.00"
+    }
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -965,21 +965,16 @@ pub fn inspect_7z_contents(archive: &Path) -> Result<Vec<(String, bool)>> {
     Ok(top_level_components.into_iter().collect())
 }
 
+#[cfg(not(windows))]
+pub fn inspect_7z_contents(_archive: &Path) -> Result<Vec<(String, bool)>> {
+    unimplemented!("7z format not supported on this platform")
+}
+
 /// Determines if strip_components=1 should be applied based on archive structure
 pub fn should_strip_components(archive: &Path, format: TarFormat) -> Result<bool> {
     let top_level_entries = match format {
         TarFormat::Zip => inspect_zip_contents(archive)?,
-        TarFormat::SevenZip => {
-            #[cfg(windows)]
-            {
-                inspect_7z_contents(archive)?
-            }
-
-            #[cfg(not(windows))]
-            {
-                bail!("7z format not supported on this platform");
-            }
-        }
+        TarFormat::SevenZip => inspect_7z_contents(archive)?,
         _ => inspect_tar_contents(archive, format)?,
     };
 

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -134,7 +134,7 @@ impl RubyPlugin {
         let filename = tarball_path.file_name().unwrap().to_string_lossy();
         ctx.pr.set_message(format!("extract {filename}"));
         file::remove_all(tv.install_path())?;
-        file::un7z(tarball_path, &tv.download_path())?;
+        file::un7z(tarball_path, &tv.download_path(), &Default::default())?;
         file::rename(
             tv.download_path()
                 .join(format!("rubyinstaller-{}-1-{arch}", tv.version)),


### PR DESCRIPTION
This update uses file::un7z, which is currently gated behind Windows. ~Another known limitation of this approach is that strip_components is not supported.~