### PR TITLE
fix(aqua): improve warnings for packages without repo_owner and repo_name

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -58,15 +58,19 @@ impl Backend for AquaBackend {
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<String>> {
-        let version_tags = self.get_version_tags().await?;
+        let version_tags = self.get_version_tags().await;
         let mut versions = Vec::new();
-        for (v, tag) in version_tags.iter() {
-            let pkg = AQUA_REGISTRY
-                .package_with_version(&self.id, &[tag])
-                .await
-                .unwrap_or_default();
-            if !pkg.no_asset && pkg.error_message.is_none() {
-                versions.push(v.clone());
+        match version_tags {
+            Ok(tags) => {
+                for (version, tag) in tags.iter() {
+                    if !version.starts_with('v') {
+                        versions.push(version.clone());
+                    }
+                    versions.push(tag.clone());
+                }
+            }
+            Err(e) => {
+                warn!("Remote versions cannot be fetched: {}", e);
             }
         }
         Ok(versions)
@@ -79,8 +83,10 @@ impl Backend for AquaBackend {
     ) -> Result<ToolVersion> {
         let tag = self
             .get_version_tags()
-            .await?
-            .iter()
+            .await
+            .ok()
+            .into_iter()
+            .flatten()
             .find(|(version, _)| version == &tv.version)
             .map(|(_, tag)| tag);
         let mut v = tag.cloned().unwrap_or_else(|| tv.version.clone());
@@ -248,7 +254,10 @@ impl AquaBackend {
                         versions.push((version.to_string(), tag));
                     }
                 } else {
-                    warn!("no aqua registry found for {}", self.ba());
+                    bail!(
+                        "aqua package {} does not have repo_owner and/or repo_name.",
+                        self.id
+                    );
                 }
                 Ok(versions)
             })


### PR DESCRIPTION
Fix inaccurate warning message `no aqua registry found for aqua:gitea.com/gitea/tea`.
`repo_owner` and/or `repo_name` are sometimes missing for `type: http` packages.

The warnings used to be:
```
DEBUG ARGS: mise install aqua:gitea.com/gitea/tea@0.10.1 --debug
DEBUG config: ~/.config/mise/mise.local.toml
DEBUG config: ~/.config/mise/config.toml
DEBUG install_some_versions: aqua:gitea.com/gitea/tea@0.10.1
WARN  no aqua registry found for aqua:gitea.com/gitea/tea
WARN  No versions found for aqua:gitea.com/gitea/tea
INFO  aqua:gitea.com/gitea/tea@0.10.1     install
```

With this change, it will be:
```
DEBUG ARGS: target/debug/mise install aqua:gitea.com/gitea/tea@0.10.1 --debug
DEBUG $ /home/risu/.local/share/mise/plugins/asdf-maven/bin/list-legacy-filenames 
DEBUG $ /home/risu/.local/share/mise/plugins/yarn/bin/list-legacy-filenames 
DEBUG config: ~/.ghr/github.com/risu729/mise/mise.local.toml
DEBUG config: ~/.ghr/github.com/risu729/mise/mise.toml
DEBUG config: ~/.config/mise/mise.local.toml
DEBUG config: ~/.config/mise/config.toml
DEBUG install_some_versions: aqua:gitea.com/gitea/tea@0.10.1
WARN  remote versions cannot be fetched: aqua package gitea.com/gitea/tea does not have repo_owner and/or repo_name.
WARN  No versions found for aqua:gitea.com/gitea/tea
INFO  aqua:gitea.com/gitea/tea@0.10.1     install
```