### PR TITLE
fix(aqua): fix 403 forbidden error for aqua:gitea.com/gitea/tea

### DIFF
--- a/e2e/backend/test_aqua
+++ b/e2e/backend/test_aqua
@@ -13,6 +13,7 @@ test aqua:crate-ci/typos@1.27.3 "typos --version" "typos-cli 1.27.3"
 test aqua:biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
 test aqua:biomejs/biome@@biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
 test aqua:gruntwork-io/terragrunt@0.77.22 "terragrunt --version" "terragrunt version v0.77.22"
+test aqua:gitea.com/gitea/tea@0.9.2 "tea --version" "Version: 0.9.2"
 
 assert_contains "MISE_USE_VERSIONS_HOST=0 mise ls-remote aqua:sharkdp/hyperfine" "1.9.0
 1.10.0"

--- a/e2e/backend/test_aqua
+++ b/e2e/backend/test_aqua
@@ -13,7 +13,7 @@ test aqua:crate-ci/typos@1.27.3 "typos --version" "typos-cli 1.27.3"
 test aqua:biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
 test aqua:biomejs/biome@@biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
 test aqua:gruntwork-io/terragrunt@0.77.22 "terragrunt --version" "terragrunt version v0.77.22"
-test aqua:gitea.com/gitea/tea@0.9.2 "tea --version" $'Version: \e[1m0.9.2\e[0m'
+test aqua:gitea.com/gitea/tea@0.9.2 "tea --version" "Version: \\e[1m0.9.2\\e[0m"
 
 assert_contains "MISE_USE_VERSIONS_HOST=0 mise ls-remote aqua:sharkdp/hyperfine" "1.9.0
 1.10.0"

--- a/e2e/backend/test_aqua
+++ b/e2e/backend/test_aqua
@@ -13,7 +13,7 @@ test aqua:crate-ci/typos@1.27.3 "typos --version" "typos-cli 1.27.3"
 test aqua:biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
 test aqua:biomejs/biome@@biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
 test aqua:gruntwork-io/terragrunt@0.77.22 "terragrunt --version" "terragrunt version v0.77.22"
-test aqua:gitea.com/gitea/tea@0.9.2 "tea --version" "Version: \\e[1m0.9.2\\e[0m"
+test aqua:gitea.com/gitea/tea@0.9.2 "tea --version" 'Version: \e[1m0.9.2\e[0m'
 
 assert_contains "MISE_USE_VERSIONS_HOST=0 mise ls-remote aqua:sharkdp/hyperfine" "1.9.0
 1.10.0"

--- a/e2e/backend/test_aqua
+++ b/e2e/backend/test_aqua
@@ -13,7 +13,7 @@ test aqua:crate-ci/typos@1.27.3 "typos --version" "typos-cli 1.27.3"
 test aqua:biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
 test aqua:biomejs/biome@@biomejs/biome@2.0.0 "biome --version" "Version: 2.0.0"
 test aqua:gruntwork-io/terragrunt@0.77.22 "terragrunt --version" "terragrunt version v0.77.22"
-test aqua:gitea.com/gitea/tea@0.9.2 "tea --version" "Version: 0.9.2"
+test aqua:gitea.com/gitea/tea@0.9.2 "tea --version" $'Version: \e[1m0.9.2\e[0m'
 
 assert_contains "MISE_USE_VERSIONS_HOST=0 mise ls-remote aqua:sharkdp/hyperfine" "1.9.0
 1.10.0"

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -263,7 +263,8 @@ impl AquaBackend {
             }
             AquaPackageType::Http => {
                 let url = pkg.url(v)?;
-                HTTP.head(&url).await?;
+                // should use HEAD, but some servers do not support it (e.g. Gitea Attachments)
+                HTTP.get_async(&url).await?;
                 Ok(url)
             }
             AquaPackageType::Cargo => {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -263,7 +263,12 @@ impl AquaBackend {
             }
             AquaPackageType::Http => {
                 let url = pkg.url(v)?;
-                HTTP.head(&url).await?;
+                // Gitea doesn't support HEAD requests for attachments, so use GET instead
+                if url.contains("gitea.com") {
+                    HTTP.get_async(&url).await?;
+                } else {
+                    HTTP.head(&url).await?;
+                }
                 Ok(url)
             }
             AquaPackageType::Cargo => {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -263,8 +263,7 @@ impl AquaBackend {
             }
             AquaPackageType::Http => {
                 let url = pkg.url(v)?;
-                // should use HEAD, but some servers do not support it (e.g. Gitea Attachments)
-                HTTP.get_async(&url).await?;
+                HTTP.head(&url).await?;
                 Ok(url)
             }
             AquaPackageType::Cargo => {


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/5643.
However, since this is a patch only for `aqua:gitea.com/gitea/tea`, as it's the only package using Gitea, I don't think we should fix this on our end.

I opened an issue https://github.com/go-gitea/gitea/issues/35086.