### PR TITLE
refactor(aqua): move no_aset and error_message checks into validate

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -99,12 +99,6 @@ impl Backend for AquaBackend {
                 v_prefixed = v_prefixed.map(|v| format!("{prefix}{v}"));
             }
         }
-        if pkg.no_asset {
-            bail!("no asset released");
-        }
-        if pkg.error_message.is_some() {
-            bail!(pkg.error_message.unwrap());
-        }
         validate(&pkg)?;
         // try v-prefixed version first because most aqua packages use v-prefixed versions
         let (url, v) = match self
@@ -770,6 +764,12 @@ async fn get_tags(pkg: &AquaPackage) -> Result<Vec<String>> {
 }
 
 fn validate(pkg: &AquaPackage) -> Result<()> {
+    if pkg.no_asset {
+        bail!("no asset released");
+    }
+    if let Some(message) = &pkg.error_message {
+        bail!("{}", message);
+    }
     let envs: HashSet<&str> = pkg.supported_envs.iter().map(|s| s.as_str()).collect();
     let os = os();
     let arch = arch();


### PR DESCRIPTION
I'm sorry I didn't notice that `validate` handles such things. Follow up of https://github.com/jdx/mise/pull/5303.