### PR TITLE
fix(npm): run bun in install_path instead of using --cwd flag of bun

### DIFF
--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -80,8 +80,6 @@ impl Backend for NPMBackend {
             CmdLineRunner::new("bun")
                 .arg("install")
                 .arg(format!("{}@{}", self.tool_name(), tv.version))
-                .arg("--cwd")
-                .arg(tv.install_path())
                 .arg("--global")
                 .arg("--trust")
                 .with_pr(&ctx.pr)
@@ -95,6 +93,7 @@ impl Backend for NPMBackend {
                         .list_paths(&ctx.config)
                         .await,
                 )?
+                .current_dir(tv.install_path())
                 .execute()?;
         } else {
             CmdLineRunner::new(NPM_PROGRAM)


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/5654.

Even if `--cwd` is used, bun seems to read `bun.lock` in the current directory, which is `~` by default.
To avoid this, run `bun` in the `tv.install_path()` directly.