### PR TITLE
chore: release 2025.7.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2025.7.12](https://github.com/jdx/mise/compare/v2025.7.11..v2025.7.12) - 2025-07-17
+
+### 🐛 Bug Fixes
+
+- **(npm)** run bun in install_path instead of using --cwd flag of bun by [@risu729](https://github.com/risu729) in [#5656](https://github.com/jdx/mise/pull/5656)
+- **(nushell)** fix `get -i` deprecation by [@JoaquinTrinanes](https://github.com/JoaquinTrinanes) in [#5666](https://github.com/jdx/mise/pull/5666)
+
+### ◀️ Revert
+
+- Revert "fix(aqua): improve warnings for packages without repo_owner and repo_name " by [@jdx](https://github.com/jdx) in [#5668](https://github.com/jdx/mise/pull/5668)
+
+### Chore
+
+- update deps by [@risu729](https://github.com/risu729) in [#5657](https://github.com/jdx/mise/pull/5657)
+- update usage by [@risu729](https://github.com/risu729) in [#5661](https://github.com/jdx/mise/pull/5661)
+
+### New Contributors
+
+- @JoaquinTrinanes made their first contribution in [#5666](https://github.com/jdx/mise/pull/5666)
+
 ## [2025.7.11](https://github.com/jdx/mise/compare/v2025.7.10..v2025.7.11) - 2025-07-16
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.7.11"
+version = "2025.7.12"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.7.11"
+version = "2025.7.12"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.7.11 macos-arm64 (a1b2d3e 2025-07-16)
+2025.7.12 macos-arm64 (a1b2d3e 2025-07-17)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_7_11:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_11 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_7_11;
+  if ( [[ -z "${_usage_spec_mise_2025_7_12:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_12 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_7_12;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_7_11 spec
+    _store_cache _usage_spec_mise_2025_7_12 spec
   fi
 
   _arguments "*: :(($(command usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_7_11:-} ]]; then
-        _usage_spec_mise_2025_7_11="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_7_12:-} ]]; then
+        _usage_spec_mise_2025_7_12="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(command usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_11}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(command usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_12}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_7_11
-  set -g _usage_spec_mise_2025_7_11 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_7_12
+  set -g _usage_spec_mise_2025_7_12 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(command usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_11" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(command usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_12" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(command usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_11" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(command usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_12" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.7.11";
+  version = "2025.7.12";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.7.11
+Version: 2025.7.12
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(npm)** run bun in install_path instead of using --cwd flag of bun by [@risu729](https://github.com/risu729) in [#5656](https://github.com/jdx/mise/pull/5656)
- **(nushell)** fix `get -i` deprecation by [@JoaquinTrinanes](https://github.com/JoaquinTrinanes) in [#5666](https://github.com/jdx/mise/pull/5666)

### ◀️ Revert

- Revert "fix(aqua): improve warnings for packages without repo_owner and repo_name " by [@jdx](https://github.com/jdx) in [#5668](https://github.com/jdx/mise/pull/5668)

### Chore

- update deps by [@risu729](https://github.com/risu729) in [#5657](https://github.com/jdx/mise/pull/5657)
- update usage by [@risu729](https://github.com/risu729) in [#5661](https://github.com/jdx/mise/pull/5661)

### New Contributors

- @JoaquinTrinanes made their first contribution in [#5666](https://github.com/jdx/mise/pull/5666)