### PR TITLE
fix(nushell): fix `get -i` deprecation

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -64,8 +64,9 @@ impl Shell for Nushell {
           }}
 
           def --env add-hook [field: cell-path new_hook: any] {{
+            let field = $field | split cell-path | update optional true | into cell-path
             let old_config = $env.config? | default {{}}
-            let old_hooks = $old_config | get $field --ignore-errors | default []
+            let old_hooks = $old_config | get $field | default []
             $env.config = ($old_config | upsert $field ($old_hooks ++ [$new_hook]))
           }}
 

--- a/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
@@ -1,7 +1,6 @@
 ---
 source: src/shell/nushell.rs
-expression: "nushell.activate(exe, \" --status\".into())"
-snapshot_kind: text
+expression: nushell.activate(opts)
 ---
 export-env {
   $env.MISE_SHELL = "nu"
@@ -14,8 +13,9 @@ export-env {
 }
 
 def --env add-hook [field: cell-path new_hook: any] {
+  let field = $field | split cell-path | update optional true | into cell-path
   let old_config = $env.config? | default {}
-  let old_hooks = $old_config | get $field --ignore-errors | default []
+  let old_hooks = $old_config | get $field | default []
   $env.config = ($old_config | upsert $field ($old_hooks ++ [$new_hook]))
 }
 


### PR DESCRIPTION
Since https://github.com/nushell/nushell/pull/16007, the recommended flag to avoid erroring on missing fields is --optional.

To avoid compatibility issues, a new `cell-path` is built from the provided one, explicitly setting the `optional` prop to `true`.

This makes the change backwards-compatible.

More specifically, this PR fixes `nushell` showing a warning on every launch due to the syntax being deprecated. This deprecation isn't released (yet), but changing this ahead of time in a backward-compatible way should prevent future headaches :)


