### PR TITLE
fix: don't follow symlink to ignore symlinks from deletion

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -784,7 +784,7 @@ fn strip_archive_path_components(dir: &Path, strip_depth: usize) -> Result<()> {
         fs::rename(entry, new_dir)?;
     }
     for path in top_level_paths {
-        if path.metadata()?.is_dir() {
+        if path.symlink_metadata()?.is_dir() {
             remove_dir(path)?;
         }
     }


### PR DESCRIPTION
Follow up of https://github.com/jdx/mise/pull/5662.
The copilot suggestion was wrong; `path.metadata()` follows symlinks, so use [`path.symlink_metadata()`](https://doc.rust-lang.org/beta/std/fs/fn.symlink_metadata.html) to return the metadata of the path itself.