### PR TITLE
docs: fix typo in RUSTUP_TOOLCHAIN env variable name

### DIFF
--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -7,7 +7,7 @@ not set. You can change this by setting the `MISE_RUSTUP_HOME` and `MISE_CARGO_H
 to isolate mise's rustup/cargo from your other rustup/cargo installations.
 
 Unlike most tools, these won't exist inside of `~/.local/share/mise/installs` because they are managed by rustup.
-All mise does is set the `RUST_TOOLCHAIN` environment variable to the requested version and rustup will
+All mise does is set the `RUSTUP_TOOLCHAIN` environment variable to the requested version and rustup will
 automatically install it if it doesn't exist.
 
 ## Usage


### PR DESCRIPTION
See:
- https://rust-lang.github.io/rustup/environment-variables.html#environment-variables
- https://github.com/jdx/mise/blob/c49082d1097e5cd65334f61254e6315ceefd225d/src/plugins/core/rust.rs#L170