### PR TITLE
Suppress redefinition warning of rubygems_plugin.rb

### DIFF
--- a/src/plugins/core/assets/rubygems_plugin.rb
+++ b/src/plugins/core/assets/rubygems_plugin.rb
@@ -1,40 +1,42 @@
 # frozen_string_literal: true
 
-def debug?
-  ENV["MISE_DEBUG"] == "true"
-end
-
-def log_debug(msg)
-  warn "[DEBUG] mise #{msg}" if debug?
-end
-
-def reshim
-  if defined?(RbConfig::CONFIG)
-    log_debug "reshim"
-    `mise reshim`
-  else
-    log_debug "reshim skipped: ruby not found"
-  end
-end
-
 module ReshimInstaller
+  class << self
+    def debug?
+      ENV["MISE_DEBUG"] == "true"
+    end
+
+    def log_debug(msg)
+      warn "[DEBUG] mise #{msg}" if debug?
+    end
+
+    def reshim
+      if defined?(RbConfig::CONFIG)
+        log_debug "reshim"
+        `mise reshim`
+      else
+        log_debug "reshim skipped: ruby not found"
+      end
+    end
+  end
+
   def install(options)
     super
     # We don't know which gems were installed, so always reshim.
-    reshim
+    self.class.reshim
   end
-end
+end unless defined?(ReshimInstaller)
 
 if defined?(Bundler::Installer)
   Bundler::Installer.prepend ReshimInstaller
 else
   Gem.post_install do |installer|
     # Reshim any (potentially) new executables.
-    reshim if installer.spec.executables.any?
+    ReshimInstaller.reshim if installer.spec.executables.any?
   end
   Gem.post_uninstall do |installer|
     # Unfortunately, reshimming just the removed executables or
     # ruby version doesn't work as of 2020/04/23.
-    reshim if installer.spec.executables.any?
+    ReshimInstaller.reshim if installer.spec.executables.any?
   end
 end


### PR DESCRIPTION
👋 Hi, thanks to develop and maintain `mise`.

I'm a Ruby and RubyGems maintainer. I always faced redefinition warnings with RubyGems test suite like:

```
❯ ruby -Ilib:test test/rubygems/test_gem_gem_runner.rb
Loaded suite test/rubygems/test_gem_gem_runner
Started
-/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:3: warning: method redefined; discarding old debug?
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:3: warning: previous definition of debug? was here
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:7: warning: method redefined; discarding old log_debug
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:7: warning: previous definition of log_debug was here
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:11: warning: method redefined; discarding old reshim
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:11: warning: previous definition of reshim was here
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:21: warning: method redefined; discarding old install
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:21: warning: previous definition of install was here
\/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:3: warning: method redefined; discarding old debug?
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:3: warning: previous definition of debug? was here
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:7: warning: method redefined; discarding old log_debug
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:7: warning: previous definition of log_debug was here
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:11: warning: method redefined; discarding old reshim
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:11: warning: previous definition of reshim was here
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:21: warning: method redefined; discarding old install
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:21: warning: previous definition of install was here
|/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:3: warning: method redefined; discarding old debug?
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:3: warning: previous definition of debug? was here
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:7: warning: method redefined; discarding old log_debug
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:7: warning: previous definition of log_debug was here
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:11: warning: method redefined; discarding old reshim
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:11: warning: previous definition of reshim was here
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:21: warning: method redefined; discarding old install
/Users/hsbt/.local/share/mise/installs/ruby/3.4-dev/lib/ruby/site_ruby/rubygems_plugin.rb:21: warning: previous definition of install was here
Finished in 0.064354 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------
7 tests, 32 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------
108.77 tests/s, 497.25 assertions/s
```

It caused to evaluate `rubygems_plugin.rb` in multiple times in test. I made to remove top-level method into `ReshimInstaller` and evaluate only one time.