### PR TITLE
fix: NoMethodError with Bundler::Installer

### DIFF
--- a/src/plugins/core/assets/rubygems_plugin.rb
+++ b/src/plugins/core/assets/rubygems_plugin.rb
@@ -23,7 +23,7 @@ module ReshimInstaller
   def install(options)
     super
     # We don't know which gems were installed, so always reshim.
-    self.class.reshim
+    ReshimInstaller.reshim
   end
 end unless defined?(ReshimInstaller)
 


### PR DESCRIPTION
Sorry, I introduced new issue with https://github.com/jdx/mise/pull/5676

```
NoMethodError: undefined method 'reshim' for an instance of Bundler::Installer
```

This PR fixed that. Thanks!