### PR TITLE
fix: update completions

### DIFF
--- a/completions/_mise
+++ b/completions/_mise
@@ -15,7 +15,7 @@ _mise() {
   typeset -A opt_args
   local curcontext="$curcontext" spec cache_policy
 
-  if ! command usage &> /dev/null; then
+  if ! command -v usage &> /dev/null; then
       echo >&2
       echo "Error: usage CLI not found. This is required for completions to work in mise." >&2
       echo "See https://usage.jdx.dev for more information." >&2
@@ -34,7 +34,7 @@ _mise() {
     _store_cache _usage_spec_mise_2025_7_12 spec
   fi
 
-  _arguments "*: :(($(command usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
+  _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
   return 0
 }
 

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -1,5 +1,5 @@
 _mise() {
-    if ! command usage &> /dev/null; then
+    if ! command -v usage &> /dev/null; then
         echo >&2
         echo "Error: usage CLI not found. This is required for completions to work in mise." >&2
         echo "See https://usage.jdx.dev for more information." >&2
@@ -13,7 +13,7 @@ _mise() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(command usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_12}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_12}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -1,5 +1,5 @@
 # if "usage" is not installed show an error
-if ! command usage &> /dev/null
+if ! command -v usage &> /dev/null
     echo >&2
     echo "Error: usage CLI not found. This is required for completions to work in mise." >&2
     echo "See https://usage.jdx.dev for more information." >&2
@@ -11,7 +11,7 @@ if ! set -q _usage_spec_mise_2025_7_12
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(command usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_12" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_12" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(command usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_12" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_12" -- (commandline -opc) (commandline -t))'
 end

--- a/mise.lock
+++ b/mise.lock
@@ -40,7 +40,7 @@ version = "0.2.3"
 backend = "cargo:toml-cli"
 
 [tools."cargo:usage-cli"]
-version = "2.2.1"
+version = "2.2.2"
 backend = "cargo:usage-cli"
 
 [tools.cosign]


### PR DESCRIPTION
Sorry, I missed updating `usage` version in `mise.toml` in https://github.com/jdx/mise/pull/5657.
Since `mise completion` calls `usage` via CLI, it didn't fix the completions.
Resolves https://github.com/jdx/mise/discussions/5659.