### PR TITLE
chore: release 2025.7.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
+## [2025.7.14](https://github.com/jdx/mise/compare/v2025.7.13..v2025.7.14) - 2025-07-18
+
+### 📦️ Dependency Updates
+
+- update rust crate tabled to 0.20 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5688](https://github.com/jdx/mise/pull/5688)
+- update rust crate indicatif to 0.18 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5687](https://github.com/jdx/mise/pull/5687)
+
 ## [2025.7.13](https://github.com/jdx/mise/compare/v2025.7.12..v2025.7.13) - 2025-07-18
 
 ### 🚀 Features
 
 - https://mise.run/{bash,zsh,fish} by [@jdx](https://github.com/jdx) in [#5677](https://github.com/jdx/mise/pull/5677)
+- add opencode tool with description, backends, and test command by [@nipuna-perera](https://github.com/nipuna-perera) in [#5679](https://github.com/jdx/mise/pull/5679)
 
 ### 🐛 Bug Fixes
 
@@ -25,6 +33,7 @@
 
 ### New Contributors
 
+- @nipuna-perera made their first contribution in [#5679](https://github.com/jdx/mise/pull/5679)
 - @hsbt made their first contribution in [#5678](https://github.com/jdx/mise/pull/5678)
 - @anderso made their first contribution in [#5673](https://github.com/jdx/mise/pull/5673)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,8 +3248,21 @@ dependencies = [
  "console 0.15.11",
  "number_prefix",
  "portable-atomic",
+ "unicode-width 0.2.1",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console 0.16.0",
+ "portable-atomic",
  "unicode-segmentation",
  "unicode-width 0.2.1",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -3779,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.7.13"
+version = "2025.7.14"
 dependencies = [
  "async-backtrace",
  "async-trait",
@@ -3820,7 +3833,7 @@ dependencies = [
  "homedir",
  "indenter",
  "indexmap 2.10.0",
- "indicatif",
+ "indicatif 0.18.0",
  "indoc",
  "insta",
  "itertools 0.14.0",
@@ -5255,7 +5268,7 @@ dependencies = [
  "either",
  "flate2",
  "hyper",
- "indicatif",
+ "indicatif 0.17.11",
  "log",
  "quick-xml",
  "regex",
@@ -6410,6 +6423,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.7.13"
+version = "2025.7.14"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.7.13 macos-arm64 (a1b2d3e 2025-07-18)
+2025.7.14 macos-arm64 (a1b2d3e 2025-07-18)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_7_13:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_13 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_7_13;
+  if ( [[ -z "${_usage_spec_mise_2025_7_14:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_14 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_7_14;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_7_13 spec
+    _store_cache _usage_spec_mise_2025_7_14 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_7_13:-} ]]; then
-        _usage_spec_mise_2025_7_13="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_7_14:-} ]]; then
+        _usage_spec_mise_2025_7_14="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_13}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_14}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_7_13
-  set -g _usage_spec_mise_2025_7_13 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_7_14
+  set -g _usage_spec_mise_2025_7_14 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_13" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_14" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_13" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_14" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.7.13";
+  version = "2025.7.14";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.7.13
+Version: 2025.7.14
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 📦️ Dependency Updates

- update rust crate tabled to 0.20 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5688](https://github.com/jdx/mise/pull/5688)
- update rust crate indicatif to 0.18 by [@renovate[bot]](https://github.com/renovate[bot]) in [#5687](https://github.com/jdx/mise/pull/5687)