### PR TITLE
Change the primary choice for PHP to adwinying/php

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2035,7 +2035,7 @@ periphery.backends = [
 ]
 perl.description = "self-contained, portable perl binaries"
 perl.backends = ["aqua:skaji/relocatable-perl", "asdf:ouest/asdf-perl"]
-php.backends = ["asdf:mise-plugins/asdf-php", "vfox:mise-plugins/vfox-php"]
+php.backends = ["ubi:adwinying/php", "asdf:mise-plugins/asdf-php", "vfox:mise-plugins/vfox-php"]
 pinact.description = "pinact is a CLI to edit GitHub Workflow and Composite action files and pin versions of Actions and Reusable Workflows. pinact can also update their versions and verify version annotations"
 pinact.backends = ["aqua:suzuki-shunsuke/pinact", "ubi:suzuki-shunsuke/pinact"]
 pinact.test = ["pinact version", "{{version}}"]


### PR DESCRIPTION
As per @roele 's suggestion [in this discussion](https://github.com/jdx/mise/discussions/4720#discussioncomment-13812028), I've added my PHP repository as a primary source for PHP. 

This source just takes precompiled binaries from [static-php-cli](https://github.com/crazywhalecc/static-php-cli) and repackage it into Github releases, making it compatible with ubi. No dependencies needed, no compiling need, just good old PHP.

This should solve the other discussions regarding PHP:
- https://github.com/jdx/mise/discussions/5094
- https://github.com/jdx/mise/discussions/4560
- https://github.com/jdx/mise/discussions/4566