### PR TITLE
feat(registry): add `jsonschema` CLI tool

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1410,7 +1410,10 @@ jsonnet-bundler.backends = [
 ]
 jsonnet-bundler.test = ["jb --version 2>&1", "v{{version}}"]
 jsonschema.description = "The CLI for working with JSON Schema. Covers formatting, linting, testing, bundling, and more for both local development and CI/CD pipelines"
-jsonschema.backends = ["aqua:sourcemeta/jsonschema", "ubi:sourcemeta/jsonschema"]
+jsonschema.backends = [
+    "aqua:sourcemeta/jsonschema",
+    "ubi:sourcemeta/jsonschema"
+]
 jsonschema.test = ["jsonschema version", "{{version}}"]
 julia.backends = ["asdf:mise-plugins/mise-julia"]
 just.description = "Just a command runner"

--- a/registry.toml
+++ b/registry.toml
@@ -1409,6 +1409,9 @@ jsonnet-bundler.backends = [
     "asdf:beardix/asdf-jb"
 ]
 jsonnet-bundler.test = ["jb --version 2>&1", "v{{version}}"]
+jsonschema.description = "The CLI for working with JSON Schema. Covers formatting, linting, testing, bundling, and more for both local development and CI/CD pipelines"
+jsonschema.backends = ["aqua:sourcemeta/jsonschema", "ubi:sourcemeta/jsonschema"]
+jsonschema.test = ["jsonschema version", "{{version}}"]
 julia.backends = ["asdf:mise-plugins/mise-julia"]
 just.description = "Just a command runner"
 just.backends = [


### PR DESCRIPTION
Please add the `jsonschema` CLI tool. It was just included to the aqua registry: https://github.com/aquaproj/aqua-registry/pull/39066