### PR TITLE
doc(config): fix alias section name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,7 +170,7 @@ This is similar
 to [`MISE_SHORTHANDS`](https://github.com/jdx/mise#mise_shorthands_fileconfigmiseshorthandstoml)
 but doesn't require a separate file.
 
-### `[aliases]` - Tool version aliases
+### `[alias]` - Tool version aliases
 
 The following makes `mise install node@my_custom_node` install node-20.x
 this can also be specified in a [plugin](/dev-tools/aliases.md).


### PR DESCRIPTION
`[aliases]` doesn't actually exist according to [the schema](https://github.com/jdx/mise/blob/v2025.7.18/schema/mise.json), but `[alias]` does.