### PR TITLE
docs: fix typo in contributing commit message prefixes

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -534,7 +534,7 @@ should follow this format:
 - **feat**: New features (🚀 Features)
 - **fix**: Bug fixes (🐛 Bug Fixes)
 - **refactor**: Code refactoring (🚜 Refactor)
-- **doc**: Documentation changes (📚 Documentation)
+- **docs**: Documentation changes (📚 Documentation)
 - **style**: Code style changes (🎨 Styling)
 - **perf**: Performance improvements (⚡ Performance)
 - **test**: Testing changes (🧪 Testing)
@@ -547,7 +547,7 @@ should follow this format:
 feat(cli): add new command for listing plugins
 fix(parser): handle edge case in version parsing
 refactor(config): simplify configuration loading logic
-doc(readme): update installation instructions
+docs(readme): update installation instructions
 test(e2e): add tests for new plugin functionality
 chore(deps): update dependencies to latest versions
 ```


### PR DESCRIPTION
While dealing with https://github.com/jdx/mise/pull/5736 I got mildly confused as to what the documentation conventional commit prefix is used for this repo, as the docs said `doc:` while the PR check said `docs:`. I changed the docs to match the PR check.