### PR TITLE
docs: Removes invalid array in redaction example

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -114,7 +114,7 @@ Variables can be redacted from the output by setting `redact = true`:
 ```toml
 [env]
 SECRET = { value = "my_secret", redact = true }
-_.file = { path = [".env.json"], redact = true }
+_.file = { path = ".env.json", redact = true }
 ```
 
 ## `env._` directives


### PR DESCRIPTION
This commit removes an invalid array declaration from the redactions section in the environments documentation. Including the array as is causes a panic:

```
=== Async Backtrace (panic occurred in tokio runtime) ===                             
  0: Location { name: Some("mise::config::Config::load::{{closure}}"), rest: ("src/config/mod.rs", 106, 5) }

------- TASK DUMP TREE -------
╼ mise::config::Config::load::{{closure}} at src/config/mod.rs:106:5
=== End Async Backtrace ===

The application panicked (crashed).
Message:  called `Option::unwrap()` on a `None` value
Location: src/config/config_file/mise_toml.rs:1238

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Removing the array notation from the `path` definition fixes this issue.