### PR TITLE
docs: fix http backend tool options example

### DIFF
--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -9,7 +9,7 @@ The code for this is inside of the mise repository at [`./src/backend/http.rs`](
 The following installs a tool from a direct HTTP URL:
 
 ```sh
-mise use -g http:my-tool@1.0.0[url=https://example.com/releases/my-tool-v1.0.0.tar.gz]
+mise use -g http:my-tool[url=https://example.com/releases/my-tool-v1.0.0.tar.gz]@1.0.0
 ```
 
 The version will be set in `~/.config/mise/config.toml` with the following format:
@@ -21,7 +21,7 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 
 ## Supported HTTP Syntax
 
-- **HTTP with URL parameter:** `http:my-tool@1.0.0[url=https://example.com/releases/my-tool-v1.0.0.tar.gz]`
+- **HTTP with URL parameter:** `http:my-tool[url=https://example.com/releases/my-tool-v1.0.0.tar.gz]@1.0.0`
 
 ## Tool Options
 


### PR DESCRIPTION
Fix example commands as tool options should be defined before the `@VERSION`.

For example
```bash
# fails
mise use http:lua@5.4.8[url=http://www.lua.org/ftp/lua-5.4.8.tar.gz]
error: invalid value 'http:lua@5.4.8[url=http://www.lua.org/ftp/lua-5.4.8.tar.gz]' for '[TOOL@VERSION]...': invalid prefix: 5.4.8[url=http

# succeeds
mise use http:lua[url=http://www.lua.org/ftp/lua-5.4.8.tar.gz]@5.4.8
```