### PR TITLE
feat(http): show retry after for github rate limit

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -294,7 +294,7 @@ fn display_github_rate_limit(resp: &Response) {
             }
             return;
         }
-        // retry-after header should be ignored if x-ratelimit-remaining is 0
+        // retry-after header is processed only if x-ratelimit-remaining is not 0 or is missing
         if let Some(retry_after) = resp.headers().get("retry-after") {
             let retry_after = retry_after.to_str().unwrap_or_default();
             warn!(

--- a/src/http.rs
+++ b/src/http.rs
@@ -281,7 +281,7 @@ fn display_github_rate_limit(resp: &Response) {
             .and_then(|r| r.to_str().ok());
         if remaining.is_some_and(|r| r == "0") {
             if let Some(reset) = resp.headers().get("x-ratelimit-reset") {
-                let reset = reset.to_str().map(|r| r.to_string()).unwrap_or_default();
+                let reset = reset.to_str().unwrap_or_default();
                 if let Some(reset) = chrono::DateTime::from_timestamp(reset.parse().unwrap(), 0) {
                     warn!(
                         "GitHub rate limit exceeded. Resets at {}",


### PR DESCRIPTION
> If the `retry-after` response header is present, you should not retry your request until after that many seconds has elapsed. If the `x-ratelimit-remaining` header is `0`, you should not retry your request until after the time, in UTC epoch seconds, specified by the `x-ratelimit-reset` header. Otherwise, wait for at least one minute before retrying.
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit