### PR TITLE
feat/add-trunk-metalinter-to-registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2685,6 +2685,8 @@ tridentctl.backends = [
 ]
 trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in containers, Kubernetes, code repositories, clouds and more"
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
+trunk.backends = ["aqua:trunk-io/launcher"]
+trunk.description = "The Trunk metalinter (https://trunk.io)"
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"

--- a/registry.toml
+++ b/registry.toml
@@ -2687,6 +2687,7 @@ trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in c
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
 trunk.backends = ["aqua:trunk-io/launcher"]
 trunk.description = "Trunk is a comprehensive code quality tool that runs linters, formatters, and security scanners to help maintain high-quality codebases (https://trunk.io)"
+trunk.test = ["trunk --version", "trunk {{version}}"]
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"

--- a/registry.toml
+++ b/registry.toml
@@ -2686,7 +2686,7 @@ tridentctl.backends = [
 trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in containers, Kubernetes, code repositories, clouds and more"
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
 trunk.backends = ["aqua:trunk-io/launcher"]
-trunk.description = "The Trunk metalinter (https://trunk.io)"
+trunk.description = "Trunk is a comprehensive code quality tool that runs linters, formatters, and security scanners to help maintain high-quality codebases (https://trunk.io)"
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"


### PR DESCRIPTION
Add trunk.io metalinter support with aqua backend, description, and test.
The trunk metalinter provides comprehensive code quality checks via various sub-linters.