### PR TITLE
fix: check lib64 directories for .disable-self-update file

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -110,6 +110,10 @@ impl SelfUpdate {
                         .join("mise")
                         .join(".disable-self-update")
                         .exists()
+                    || p.join("lib64")
+                        .join("mise")
+                        .join(".disable-self-update")
+                        .exists()
             })
             .unwrap_or_default()
     }


### PR DESCRIPTION
## Summary
- Added check for `.disable-self-update` file in `lib64` directories
- Fixes self-update detection on 64-bit Linux systems where packages are installed to `/usr/lib64`
- Maintains backward compatibility with existing `lib` directory checks

## Test plan
- [x] On a 64-bit Linux system with mise installed via package manager (e.g., Fedora COPR), verify that `mise doctor` correctly shows `self_update_available: no` when `/usr/lib64/mise/.disable-self-update` exists
- [x] Verify that existing functionality for checking `/usr/lib/mise/.disable-self-update` still works
- [x] Test that self-update is properly disabled when the file exists in either location

🤖 Generated with [Claude Code](https://claude.ai/code)