### PR TITLE
fix: tool-stub generation with archive downloads

### DIFF
--- a/e2e/generate/test_generate_tool_stub_archive
+++ b/e2e/generate/test_generate_tool_stub_archive
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2103
+
+# Test mise generate tool-stub command with archive downloads and extraction
+
+# Enable experimental features for http backend
+export MISE_EXPERIMENTAL=true
+
+# Test 1: Tool stub generation with real Node.js tar.gz archive
+echo "Testing tool-stub generation with Node.js tar.gz archive..."
+assert_succeed "mise generate tool-stub ./bin/node-test --platform 'macos-arm64:https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz' --platform 'linux-x64:https://nodejs.org/dist/v22.17.1/node-v22.17.1-linux-x64.tar.gz'"
+
+# Verify the generated stub exists and is executable
+assert_succeed "test -x ./bin/node-test"
+
+# Verify the generated stub contains expected content
+assert_contains "cat ./bin/node-test" "#!/usr/bin/env -S mise tool-stub"
+assert_contains "cat ./bin/node-test" "# node-test tool stub"
+assert_contains "cat ./bin/node-test" '[platforms.macos-arm64]'
+assert_contains "cat ./bin/node-test" 'url = "https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz"'
+assert_contains "cat ./bin/node-test" '[platforms.linux-x64]'
+assert_contains "cat ./bin/node-test" 'url = "https://nodejs.org/dist/v22.17.1/node-v22.17.1-linux-x64.tar.gz"'
+
+# Check that it detected checksums and sizes
+assert_contains "cat ./bin/node-test" 'blake3 = "'
+assert_contains "cat ./bin/node-test" 'size = '
+
+# Check that it detected the binary path (should be something like bin/node)
+assert_contains "cat ./bin/node-test" 'bin = "'
+
+echo "node-test stub content:"
+cat ./bin/node-test
+
+# Test that the stub actually works by executing it
+echo "Testing that the generated node-test stub actually works..."
+assert "./bin/node-test --version" "v22.17.1"

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -205,7 +205,7 @@ impl ToolStub {
         let archive_path = temp_dir.path().join(&filename);
 
         // Create one progress reporter for the entire operation
-        let pr = mpr.add(&format!("download {}", filename));
+        let pr = mpr.add(&format!("download {filename}"));
 
         // Download using mise's HTTP client
         HTTP.download_file(url, &archive_path, Some(&pr)).await?;
@@ -218,7 +218,7 @@ impl ToolStub {
         // Detect binary path if this is an archive
         let bin_path = if self.is_archive_format(url) {
             // Update progress message for extraction and reuse the same progress reporter
-            pr.set_message(format!("extract {}", filename));
+            pr.set_message(format!("extract {filename}"));
             match self
                 .extract_and_find_binary(&archive_path, &temp_dir, &filename, &pr)
                 .await
@@ -258,7 +258,7 @@ impl ToolStub {
             strip_components: 0,
             pr: Some(pr),
         };
-        file::untar(&archive_path, &extracted_dir, &tar_opts)?;
+        file::untar(archive_path, &extracted_dir, &tar_opts)?;
 
         // Check if strip_components would be applied during actual installation
         let format = TarFormat::from_ext(

--- a/src/file.rs
+++ b/src/file.rs
@@ -675,7 +675,11 @@ pub struct TarOptions<'a> {
 pub fn untar(archive: &Path, dest: &Path, opts: &TarOptions) -> Result<()> {
     let format = match opts.format {
         TarFormat::Auto => {
-            TarFormat::from_ext(archive.extension().unwrap().to_string_lossy().as_ref())
+            // Handle missing extension gracefully, default to Raw (which will be treated as tar.gz)
+            match archive.extension() {
+                Some(ext) => TarFormat::from_ext(&ext.to_string_lossy()),
+                None => TarFormat::Raw,
+            }
         }
         _ => opts.format,
     };


### PR DESCRIPTION
## Summary

Fixes tool-stub generation failures when using archive URLs like .tar.gz files.

## Issues Fixed

- **Filename preservation**: Archive temporary files now retain original filenames with extensions, enabling proper format detection
- **Duplicate downloads**: Combined checksum detection and binary path detection into single download operation
- **Progress reporting**: Unified download and extraction into one continuous progress indicator
- **Binary path detection**: Fixed paths to account for automatic \`strip_components=1\` application
- **HTTP infrastructure**: Replaced direct reqwest usage with mise's HTTP client for consistency

## Changes

### Core Fixes
- Modified \`analyze_url()\` to download once and return checksum, size, and binary path
- Enhanced \`extract_and_find_binary()\` to predict \`strip_components\` behavior and adjust binary paths accordingly
- Fixed \`untar()\` to handle missing file extensions gracefully  
- Unified progress reporting across download and extraction phases

### Testing
- Added \`test_generate_tool_stub_archive\` e2e test that:
  - Generates tool stubs from real Node.js tar.gz archives
  - Verifies correct checksums, sizes, and binary paths are detected
  - **Actually executes the generated stub** to ensure it works end-to-end

## Example

Before (failed):
\`\`\`bash
mise g tool-stub ./bin/node --platform 'macos-arm64:https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz'
# Error: called Option::unwrap() on a None value
\`\`\`

After (works):
\`\`\`bash
mise g tool-stub ./bin/node --platform 'macos-arm64:https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz'
# ✓ Generated tool stub with correct binary path: bin/node
./bin/node --version  # v22.17.1
\`\`\`

## Testing

- [x] E2E test passes with real archive downloads
- [x] Generated stubs execute correctly 
- [x] All linting and formatting checks pass