### PR TITLE
fix: misidentifying built-in backend as a plugin backend 

### DIFF
--- a/e2e/backend/test_pipx_custom_registry
+++ b/e2e/backend/test_pipx_custom_registry
@@ -36,5 +36,4 @@ mise cache clear
 export MISE_PIPX_REGISTRY_URL="https://invalid-registry.example/simple"
 
 # This should fail with an error about the registry URL format
-# TODO: this is showing a warning, should be an error but I can't figure out why right now
-assert_contains "mise install 2>&1" "Registry URL must be a valid URL and contain a {} placeholder"
+assert_fail "mise install" "Registry URL must be a valid URL and contain a {} placeholder"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -205,7 +205,10 @@ impl BackendArg {
             full
         } else if let Some((plugin_name, _tool_name)) = short.split_once(':') {
             // Check if this is a plugin:tool format
-            if let Some(pt) = install_state::get_plugin_type(plugin_name) {
+            if BackendType::guess(short) != BackendType::Unknown {
+                // Handle built-in backends
+                short.to_string()
+            } else if let Some(pt) = install_state::get_plugin_type(plugin_name) {
                 match pt {
                     PluginType::Asdf => {
                         // For asdf plugins, plugin:tool format is invalid


### PR DESCRIPTION
Fixes: https://github.com/jdx/mise/discussions/5646

Issue introduced here:

https://github.com/jdx/mise/compare/v2025.7.7..v2025.7.8#diff-666bb9d34c6ca6727005c50be93f02d720e77f525dcef4d8d286344c1f0d21f1R101-R126

The new backend logic was causing the `versions_hash` in `get_leaf_dependencies` to always include "pipx" when testing with a pipx tool. This causes issues when pipx is not part of the requested tools to install. It essentialy prevented the tool from being considered a leaf dependency.