### PR TITLE
fix: dotnet SearchQueryService fallback

### DIFF
--- a/docs/dev-tools/backends/dotnet.md
+++ b/docs/dev-tools/backends/dotnet.md
@@ -2,13 +2,28 @@
 
 The code for this is inside the mise repository at [`./src/backend/dotnet.rs`](https://github.com/jdx/mise/blob/main/src/backend/dotnet.rs).
 
+::: tip Important
+The dotnet backend requires having the .NET runtime installed. You can install it using mise:
+
+```sh
+# Install the latest version
+mise use dotnet
+
+# Or install a specific version (8, 9, etc.)
+mise use dotnet@8
+mise use dotnet@9
+```
+
+This will install the .NET runtime, which is required for dotnet tools to work properly.
+:::
+
 ## Usage
 
 The following installs the latest version of [GitVersion.Tool](https://gitversion.net/) and
 sets it as the active version on PATH:
 
 ```sh
-$ mise use -g dotnet:GitVersion.Tool@5.12.0
+$ mise use dotnet:GitVersion.Tool@5.12.0
 $ dotnet-gitversion /version
 5.12.0+Branch.support-5.x.Sha.3f75764963eb3d7956dcd5a40488c074dd9faf9e
 ```
@@ -21,7 +36,7 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 ```
 
 ```sh
-$ mise use -g dotnet:GitVersion.Tool
+$ mise use dotnet:GitVersion.Tool
 $ dotnet-gitversion /version
 6.1.0+Branch.main.Sha.8856e3041dbb768118a55a31ad4e465ae70c6767
 ```

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -98,7 +98,13 @@ impl DotnetBackend {
             .resources
             .iter()
             .find(|x| x.service_type == "SearchQueryService/3.5.0")
-            .ok_or_else(|| eyre!("No SearchQueryService/3.5.0 found"))?;
+            .or_else(|| {
+                services
+                    .resources
+                    .iter()
+                    .find(|x| x.service_type == "SearchQueryService")
+            })
+            .ok_or_else(|| eyre!("No SearchQueryService found"))?;
 
         Ok(feed.id.clone())
     }


### PR DESCRIPTION
Some NuGet endpoints (like Artifactory) don’t expose the `SearchQueryService/3.5.0` type, just the plain `SearchQueryService`.

I also added a note indicating that the .NET backend requires a compatible .NET runtime to be installed.