### PR TITLE
chore: release 2025.7.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2025.7.31](https://github.com/jdx/mise/compare/v2025.7.30..v2025.7.31) - 2025-07-29
+
+### 🚀 Features
+
+- **(tool-stubs)** append to existing tool-stub files instead of overwriting by [@jdx](https://github.com/jdx) in [#5835](https://github.com/jdx/mise/pull/5835)
+- **(tool-stubs)** add auto-platform detection from URLs by [@jdx](https://github.com/jdx) in [#5836](https://github.com/jdx/mise/pull/5836)
+- Add sops.strict setting for non-strict decryption mode by [@pepicrft](https://github.com/pepicrft) in [#5378](https://github.com/jdx/mise/pull/5378)
+
+### 🐛 Bug Fixes
+
+- **(tool-stub)** use URL hash as version for HTTP backend with "latest" by [@jdx](https://github.com/jdx) in [#5828](https://github.com/jdx/mise/pull/5828)
+- **(tool-stubs)** fix -v and --help flags by [@jdx](https://github.com/jdx) in [#5829](https://github.com/jdx/mise/pull/5829)
+- **(tool-stubs)** use 'checksum' field instead of 'blake3' in generated stubs by [@jdx](https://github.com/jdx) in [#5834](https://github.com/jdx/mise/pull/5834)
+- dotnet SearchQueryService fallback by [@acesyde](https://github.com/acesyde) in [#5824](https://github.com/jdx/mise/pull/5824)
+- registry.toml - Specify sbt dependency on java by [@jatcwang](https://github.com/jatcwang) in [#5827](https://github.com/jdx/mise/pull/5827)
+
+### 🧪 Testing
+
+- remove has test which is failing by [@jdx](https://github.com/jdx) in [4aa9cc9](https://github.com/jdx/mise/commit/4aa9cc973acb1bc34df51f27333a226df3256b69)
+
+### New Contributors
+
+- @jatcwang made their first contribution in [#5827](https://github.com/jdx/mise/pull/5827)
+
 ## [2025.7.30](https://github.com/jdx/mise/compare/v2025.7.29..v2025.7.30) - 2025-07-29
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.7.30"
+version = "2025.7.31"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.7.30"
+version = "2025.7.31"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.7.30 macos-arm64 (a1b2d3e 2025-07-29)
+2025.7.31 macos-arm64 (a1b2d3e 2025-07-29)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_7_30:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_30 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_7_30;
+  if ( [[ -z "${_usage_spec_mise_2025_7_31:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_31 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_7_31;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_7_30 spec
+    _store_cache _usage_spec_mise_2025_7_31 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_7_30:-} ]]; then
-        _usage_spec_mise_2025_7_30="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_7_31:-} ]]; then
+        _usage_spec_mise_2025_7_31="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_30}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_31}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_7_30
-  set -g _usage_spec_mise_2025_7_30 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_7_31
+  set -g _usage_spec_mise_2025_7_31 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_30" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_31" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_30" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_31" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.7.30";
+  version = "2025.7.31";
 
   src = lib.cleanSource ./.;
 

--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -8,7 +8,7 @@ This feature is inspired by [dotslash](https://github.com/facebook/dotslash), wh
 
 A tool stub is an executable file that begins with a shebang line pointing to `mise tool-stub` and contains TOML configuration specifying which tool to execute and how to execute it. When the stub is run, mise automatically installs the specified tool version (if needed) and executes it with the provided arguments.
 
-Tool stubs can use any mise backend but because they default to http—and http backend tools have things like urls and don't require a version—the http stubs look a bit different than non-http stubs. 
+Tool stubs can use any mise backend but because they default to http—and http backend tools have things like urls and don't require a version—the http stubs look a bit different than non-http stubs.
 
 ::: tip
 Tool stubs are particularly useful for adding less-commonly used tools to your mise setup. Since tools are only installed when their stub is first executed, you can define many tools without the overhead of installing them all upfront. This is perfect for specialized tools, testing utilities, or project-specific binaries that you might not use every day.

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.7.30
+Version: 2025.7.31
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(tool-stubs)** append to existing tool-stub files instead of overwriting by [@jdx](https://github.com/jdx) in [#5835](https://github.com/jdx/mise/pull/5835)
- **(tool-stubs)** add auto-platform detection from URLs by [@jdx](https://github.com/jdx) in [#5836](https://github.com/jdx/mise/pull/5836)
- Add sops.strict setting for non-strict decryption mode by [@pepicrft](https://github.com/pepicrft) in [#5378](https://github.com/jdx/mise/pull/5378)

### 🐛 Bug Fixes

- **(tool-stub)** use URL hash as version for HTTP backend with "latest" by [@jdx](https://github.com/jdx) in [#5828](https://github.com/jdx/mise/pull/5828)
- **(tool-stubs)** fix -v and --help flags by [@jdx](https://github.com/jdx) in [#5829](https://github.com/jdx/mise/pull/5829)
- **(tool-stubs)** use 'checksum' field instead of 'blake3' in generated stubs by [@jdx](https://github.com/jdx) in [#5834](https://github.com/jdx/mise/pull/5834)
- dotnet SearchQueryService fallback by [@acesyde](https://github.com/acesyde) in [#5824](https://github.com/jdx/mise/pull/5824)
- registry.toml - Specify sbt dependency on java by [@jatcwang](https://github.com/jatcwang) in [#5827](https://github.com/jdx/mise/pull/5827)

### 🧪 Testing

- remove has test which is failing by [@jdx](https://github.com/jdx) in [4aa9cc9](https://github.com/jdx/mise/commit/4aa9cc973acb1bc34df51f27333a226df3256b69)

### New Contributors

- @jatcwang made their first contribution in [#5827](https://github.com/jdx/mise/pull/5827)