### PR TITLE
fix(aqua): support `AND` operator in semver

### DIFF
--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -474,7 +474,7 @@ impl AquaPackage {
                 .unwrap()
                 .replace(' ', "")
                 .split(',')
-                .flat_map(|s| versions::Requirement::new(s))
+                .flat_map(versions::Requirement::new)
                 .collect::<Vec<_>>();
             if requirements.is_empty() {
                 return Err("invalid semver".to_string().into());

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -474,13 +474,16 @@ impl AquaPackage {
                 .unwrap()
                 .replace(' ', "")
                 .split(',')
-                .flat_map(versions::Requirement::new)
+                .map(versions::Requirement::new)
                 .collect::<Vec<_>>();
-            if requirements.is_empty() {
-                return Err("invalid semver".to_string().into());
+            if requirements.iter().any(|r| r.is_none()) {
+                return Err("invalid semver requirement".to_string().into());
             }
             if let Some(ver) = &ver {
-                Ok(requirements.iter().all(|r| r.matches(ver)).into())
+                Ok(requirements
+                    .iter()
+                    .all(|r| r.clone().is_some_and(|r| r.matches(ver)))
+                    .into())
             } else {
                 Err("invalid version".to_string().into())
             }


### PR DESCRIPTION
Aqua supports multiple constraints in `semver` separated with `,`.
https://aquaproj.github.io/docs/reference/upgrade-guide/v2/change-semver/

However, [`versions`](https://github.com/fosskers/rs-versions) crate doesn't support it.
[`semver`](https://github.com/dtolnay/semver) crate supports it, but since we depend on the fuzzy parse of messed semvers, I couldn't migrate to it.

e.g.

```
DEBUG error parsing semver("<= 7.4.7") || (semver(">= 7.5.0-preview.1, <= 7.5.1")) || (semver(">= 7.6.0-preview.1, <= 7.6.0-preview.4")): invalid semver
```
https://github.com/risu729/aqua-registry/blob/main/pkgs/PowerShell/PowerShell/registry.yaml