### PR TITLE
fix(tool-stubs): remove comment line from tool stub generator

### DIFF
--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -170,7 +170,6 @@ Running the generation command produces an executable stub like:
 
 ```bash
 #!/usr/bin/env -S mise tool-stub
-# gh tool stub
 
 version = "latest"
 bin = "bin/gh"

--- a/e2e/generate/test_generate_tool_stub
+++ b/e2e/generate/test_generate_tool_stub
@@ -18,7 +18,6 @@ assert_succeed "test -x test-tool-basic"
 
 # Verify the generated stub contains expected content
 assert_contains "cat test-tool-basic" "#!/usr/bin/env -S mise tool-stub"
-assert_contains "cat test-tool-basic" "# test-tool-basic tool stub"
 assert_contains "cat test-tool-basic" 'version = "latest"'
 assert_contains "cat test-tool-basic" 'url = "https://httpbin.org/status/200"'
 
@@ -51,7 +50,7 @@ assert_succeed "mise generate tool-stub custom-platform-tool --platform-url 'my-
 
 # Test 8: Verify generated stub content is well-formed TOML
 echo '#!/usr/bin/env -S mise tool-stub
-# simple test stub
+
 version = "1.0.0"
 url = "https://httpbin.org/status/200"' >simple-stub
 chmod +x simple-stub

--- a/e2e/generate/test_generate_tool_stub_archive
+++ b/e2e/generate/test_generate_tool_stub_archive
@@ -15,7 +15,6 @@ assert_succeed "test -x ./bin/node-test"
 
 # Verify the generated stub contains expected content
 assert_contains "cat ./bin/node-test" "#!/usr/bin/env -S mise tool-stub"
-assert_contains "cat ./bin/node-test" "# node-test tool stub"
 assert_contains "cat ./bin/node-test" '[platforms.macos-arm64]'
 assert_contains "cat ./bin/node-test" 'url = "https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz"'
 assert_contains "cat ./bin/node-test" '[platforms.linux-x64]'

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -207,7 +207,6 @@ impl ToolStub {
 
         let mut content = vec![
             "#!/usr/bin/env -S mise tool-stub".to_string(),
-            format!("# {} tool stub", self.get_tool_name()),
             "".to_string(),
         ];
 


### PR DESCRIPTION
## Summary
- Removed automatic comment line generation from tool stub generator
- Updated documentation examples to reflect the cleaner output format
- Updated e2e tests accordingly

## Test plan
- [x] Run `mise run test:e2e test_generate_tool_stub test_generate_tool_stub_archive` - all tests pass
- [x] Manually test tool stub generation to verify comments are removed

🤖 Generated with [Claude Code](https://claude.ai/code)