### PR TITLE
fix(cli): remove empty [platforms] section from generated tool stubs

### DIFF
--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -165,7 +165,9 @@ impl ToolStub {
 
             // Ensure platforms table exists
             if doc.get("platforms").is_none() {
-                doc["platforms"] = toml_edit::table();
+                let mut platforms_table = toml_edit::Table::new();
+                platforms_table.set_implicit(true);
+                doc["platforms"] = toml_edit::Item::Table(platforms_table);
             }
             let platforms = doc["platforms"].as_table_mut().unwrap();
 


### PR DESCRIPTION
## Summary
- Uses toml_edit's `set_implicit(true)` to prevent rendering of empty `[platforms]` table header in generated tool stubs
- Results in cleaner TOML output without the redundant empty section

## Test plan
- [x] Run `mise run test:e2e test_generate_tool_stub test_generate_tool_stub_archive` - all tests pass
- [x] Manual testing shows clean output without empty `[platforms]` section

## Example

Before:
```toml
#\!/usr/bin/env -S mise tool-stub

version = "latest"

[platforms]

[platforms.linux-x64]
url = "https://example.com/tool.tar.gz"
```

After:
```toml
#\!/usr/bin/env -S mise tool-stub

version = "latest"

[platforms.linux-x64]
url = "https://example.com/tool.tar.gz"
```

🤖 Generated with [Claude Code](https://claude.ai/code)