### PR TITLE
feat(tool-stubs): Add human readable comments to stub sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3831,6 +3831,7 @@ dependencies = [
  "globset",
  "heck",
  "homedir",
+ "humansize",
  "indenter",
  "indexmap 2.10.0",
  "indicatif 0.18.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ gix = { version = "<1", features = ["worktree-mutation"] }
 glob = "0.3"
 globset = "0.4"
 heck = "0.5"
+humansize = "2"
 indenter = "0.3"
 indexmap = { version = "2", features = ["serde"] }
 indicatif = { version = "0.18", features = ["default", "improved_unicode"] }

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -155,7 +155,7 @@ impl ToolStub {
                     doc["checksum"] = toml_edit::value(&checksum);
                     
                     // Create size entry with human-readable comment
-                    let mut size_item = toml_edit::Item::Value(toml_edit::value(size as i64));
+                    let mut size_item = toml_edit::value(size as i64);
                     if let Some(value) = size_item.as_value_mut() {
                         let formatted_comment = format_size_comment(size);
                         value.decor_mut().set_suffix(formatted_comment);
@@ -208,7 +208,7 @@ impl ToolStub {
                         platform_table["checksum"] = toml_edit::value(&checksum);
                         
                         // Create size entry with human-readable comment
-                        let mut size_item = toml_edit::Item::Value(toml_edit::value(size as i64));
+                        let mut size_item = toml_edit::value(size as i64);
                         if let Some(value) = size_item.as_value_mut() {
                             let formatted_comment = format_size_comment(size);
                             value.decor_mut().set_suffix(formatted_comment);

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -9,7 +9,7 @@ use crate::ui::progress_report::SingleReport;
 use clap::ValueHint;
 use color_eyre::eyre::bail;
 use indexmap::IndexMap;
-use number_prefix::NumberPrefix;
+use humansize::{BINARY, format_size};
 use std::path::PathBuf;
 use toml_edit::DocumentMut;
 use xx::file::display_path;
@@ -443,10 +443,7 @@ impl ToolStub {
 }
 
 fn format_size_comment(bytes: u64) -> String {
-    match NumberPrefix::binary(bytes as f64) {
-        NumberPrefix::Standalone(bytes) => format!(" # {} bytes", bytes),
-        NumberPrefix::Prefixed(prefix, n) => format!(" # {:.1} {}B", n, prefix),
-    }
+    format!(" # {}", format_size(bytes, BINARY))
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -8,8 +8,8 @@ use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
 use clap::ValueHint;
 use color_eyre::eyre::bail;
-use indexmap::IndexMap;
 use humansize::{BINARY, format_size};
+use indexmap::IndexMap;
 use std::path::PathBuf;
 use toml_edit::DocumentMut;
 use xx::file::display_path;
@@ -153,7 +153,7 @@ impl ToolStub {
                 let mpr = MultiProgressReport::get();
                 if let Ok((checksum, size, bin_path)) = self.analyze_url(url, &mpr).await {
                     doc["checksum"] = toml_edit::value(&checksum);
-                    
+
                     // Create size entry with human-readable comment
                     let mut size_item = toml_edit::value(size as i64);
                     if let Some(value) = size_item.as_value_mut() {
@@ -161,7 +161,7 @@ impl ToolStub {
                         value.decor_mut().set_suffix(formatted_comment);
                     }
                     doc["size"] = size_item;
-                    
+
                     if self.bin.is_none() && bin_path.is_some() {
                         doc["bin"] = toml_edit::value(bin_path.as_ref().unwrap());
                     }
@@ -206,7 +206,7 @@ impl ToolStub {
                 if !self.skip_download {
                     if let Ok((checksum, size, _)) = self.analyze_url(&url, &mpr).await {
                         platform_table["checksum"] = toml_edit::value(&checksum);
-                        
+
                         // Create size entry with human-readable comment
                         let mut size_item = toml_edit::value(size as i64);
                         if let Some(value) = size_item.as_value_mut() {


### PR DESCRIPTION
Add human-readable size comments to tool stubs to improve readability of file sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ff306e6-b916-4eaf-9760-04c70457720c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ff306e6-b916-4eaf-9760-04c70457720c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>