### PR TITLE
fix(go): implement heuristic-based go module find logic

### DIFF
--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -7,6 +7,7 @@ use crate::timeout;
 use crate::toolset::ToolVersion;
 use crate::{backend::Backend, config::Config};
 use async_trait::async_trait;
+use itertools::Itertools;
 use std::{fmt::Debug, sync::Arc};
 use xx::regex;
 
@@ -32,10 +33,31 @@ impl Backend for GoBackend {
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<String>> {
         timeout::run_with_timeout_async(
             async || {
-                let mut mod_path = Some(self.tool_name());
+                let tool_name = self.tool_name();
+                let parts = tool_name.split('/').collect::<Vec<_>>();
+                let module_root_index = if parts[0] == "github.com" {
+                    // Try likely module root index first
+                    if parts.len() >= 3 {
+                        if parts.len() > 3 && regex!(r"^v\d+$").is_match(parts[3]) {
+                            Some(3)
+                        } else {
+                            Some(2)
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                let indices = module_root_index
+                    .into_iter()
+                    .chain((1..parts.len()).rev())
+                    .unique()
+                    .collect::<Vec<_>>();
 
-                while let Some(cur_mod_path) = mod_path {
-                    let res = cmd!("go", "list", "-m", "-versions", "-json", &cur_mod_path)
+                for i in indices {
+                    let mod_path = parts[..=i].join("/");
+                    let res = cmd!("go", "list", "-m", "-versions", "-json", mod_path)
                         .full_env(self.dependency_env(config).await?)
                         .read();
                     if let Ok(raw) = res {
@@ -50,8 +72,6 @@ impl Backend for GoBackend {
                             return Ok(mod_info.versions);
                         }
                     };
-
-                    mod_path = trim_after_last_slash(cur_mod_path);
                 }
 
                 Ok(vec![])
@@ -104,10 +124,6 @@ impl GoBackend {
     pub fn from_arg(ba: BackendArg) -> Self {
         Self { ba: Arc::new(ba) }
     }
-}
-
-fn trim_after_last_slash(s: String) -> Option<String> {
-    s.rsplit_once('/').map(|(new_path, _)| new_path.to_string())
 }
 
 #[derive(Debug, serde::Deserialize)]


### PR DESCRIPTION
This PR refactors https://github.com/jdx/mise/pull/1583 by guessing the root module.
Since many go modules use `github.com/owner/repo` or `github.com/owner/repo/v0`, we can first try them and fall back to the original behaviour.

This will reduce `go list -m -versions -json <module>` call, which is relatively slow.

e.g.

Current behaviour:
```
$ mise ls-remote go:github.com/go-task/task/v3/cmd/task --debug
DEBUG $ go list -m -versions -json github.com/go-task/task/v3/cmd/task
DEBUG $ go list -m -versions -json github.com/go-task/task/v3/cmd
DEBUG $ go list -m -versions -json github.com/go-task/task/v3
```

With this PR:
```
$ mise ls-remote go:github.com/go-task/task/v3/cmd/task --debug
DEBUG $ go list -m -versions -json github.com/go-task/task/v3
```