### PR TITLE
chore: release 2025.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [2025.8.0](https://github.com/jdx/mise/compare/v2025.7.32..v2025.8.0) - 2025-08-01
+
+### 🚀 Features
+
+- **(registry)** use npm backend for yarn by [@mrazauskas](https://github.com/mrazauskas) in [#5745](https://github.com/jdx/mise/pull/5745)
+- **(registry)** add codebuff tool by [@zacheryph](https://github.com/zacheryph) in [#5856](https://github.com/jdx/mise/pull/5856)
+
+### 🐛 Bug Fixes
+
+- **(go)** implement heuristic-based go module find logic by [@risu729](https://github.com/risu729) in [#5851](https://github.com/jdx/mise/pull/5851)
+- **(node)** Add NodeJS maintainer Antoine du Hamel's new GPG key by [@chadlwilson](https://github.com/chadlwilson) in [#5862](https://github.com/jdx/mise/pull/5862)
+- **(pipx)** align HTML backend with PEP 503 registry URL assignment by [@acesyde](https://github.com/acesyde) in [#5853](https://github.com/jdx/mise/pull/5853)
+- **(registry)** fix balena ubi backend options by [@risu729](https://github.com/risu729) in [#5861](https://github.com/jdx/mise/pull/5861)
+- **(registry)** add aqua backends to tools by [@risu729](https://github.com/risu729) in [#5863](https://github.com/jdx/mise/pull/5863)
+
+### 📚 Documentation
+
+- fix uv_venv_create_args reference for python by [@jasonraimondi](https://github.com/jasonraimondi) in [#5854](https://github.com/jdx/mise/pull/5854)
+- expand on env directive examples and formats by [@syhol](https://github.com/syhol) in [#5857](https://github.com/jdx/mise/pull/5857)
+
+### ◀️ Revert
+
+- Revert "docs: fix uv_venv_create_args reference for python" by [@jdx](https://github.com/jdx) in [#5859](https://github.com/jdx/mise/pull/5859)
+
+### New Contributors
+
+- @zacheryph made their first contribution in [#5856](https://github.com/jdx/mise/pull/5856)
+- @chadlwilson made their first contribution in [#5862](https://github.com/jdx/mise/pull/5862)
+- @jasonraimondi made their first contribution in [#5854](https://github.com/jdx/mise/pull/5854)
+
 ## [2025.7.32](https://github.com/jdx/mise/compare/v2025.7.31..v2025.7.32) - 2025-07-31
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.7.32"
+version = "2025.8.0"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.7.32"
+version = "2025.8.0"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.7.32 macos-arm64 (a1b2d3e 2025-07-31)
+2025.8.0 macos-arm64 (a1b2d3e 2025-08-01)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_7_32:-}" ]] || _cache_invalid _usage_spec_mise_2025_7_32 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_7_32;
+  if ( [[ -z "${_usage_spec_mise_2025_8_0:-}" ]] || _cache_invalid _usage_spec_mise_2025_8_0 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_8_0;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_7_32 spec
+    _store_cache _usage_spec_mise_2025_8_0 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_7_32:-} ]]; then
-        _usage_spec_mise_2025_7_32="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_8_0:-} ]]; then
+        _usage_spec_mise_2025_8_0="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_7_32}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_8_0}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_7_32
-  set -g _usage_spec_mise_2025_7_32 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_8_0
+  set -g _usage_spec_mise_2025_8_0 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_32" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_0" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_7_32" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_0" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.7.32";
+  version = "2025.8.0";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.7.32
+Version: 2025.8.0
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(registry)** use npm backend for yarn by [@mrazauskas](https://github.com/mrazauskas) in [#5745](https://github.com/jdx/mise/pull/5745)
- **(registry)** add codebuff tool by [@zacheryph](https://github.com/zacheryph) in [#5856](https://github.com/jdx/mise/pull/5856)

### 🐛 Bug Fixes

- **(go)** implement heuristic-based go module find logic by [@risu729](https://github.com/risu729) in [#5851](https://github.com/jdx/mise/pull/5851)
- **(node)** Add NodeJS maintainer Antoine du Hamel's new GPG key by [@chadlwilson](https://github.com/chadlwilson) in [#5862](https://github.com/jdx/mise/pull/5862)
- **(pipx)** align HTML backend with PEP 503 registry URL assignment by [@acesyde](https://github.com/acesyde) in [#5853](https://github.com/jdx/mise/pull/5853)
- **(registry)** fix balena ubi backend options by [@risu729](https://github.com/risu729) in [#5861](https://github.com/jdx/mise/pull/5861)
- **(registry)** add aqua backends to tools by [@risu729](https://github.com/risu729) in [#5863](https://github.com/jdx/mise/pull/5863)

### 📚 Documentation

- fix uv_venv_create_args reference for python by [@jasonraimondi](https://github.com/jasonraimondi) in [#5854](https://github.com/jdx/mise/pull/5854)
- expand on env directive examples and formats by [@syhol](https://github.com/syhol) in [#5857](https://github.com/jdx/mise/pull/5857)

### ◀️ Revert

- Revert "docs: fix uv_venv_create_args reference for python" by [@jdx](https://github.com/jdx) in [#5859](https://github.com/jdx/mise/pull/5859)

### New Contributors

- @zacheryph made their first contribution in [#5856](https://github.com/jdx/mise/pull/5856)
- @chadlwilson made their first contribution in [#5862](https://github.com/jdx/mise/pull/5862)
- @jasonraimondi made their first contribution in [#5854](https://github.com/jdx/mise/pull/5854)