### PR TITLE
docs: fix uv_venv_create_args reference for python

### DIFF
--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -61,7 +61,7 @@ The venv will need to be created manually with `python -m venv /path/to/venv` un
 
 If you have installed `uv` (for example, with `mise use -g uv@latest`), `mise` will use it to create virtual environments. Otherwise, it will use the built-in `python -m venv` command.
 
-Note that `uv` does not include `pip` by default (as `uv` provides `uv pip` instead). If you need the `pip` package, add the `uv_create_args = ['--seed']` option.
+Note that `uv` does not include `pip` by default (as `uv` provides `uv pip` instead). If you need the `pip` package, add the `uv_venv_create_args = ['--seed']` option.
 
 See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for more examples.
 


### PR DESCRIPTION
Hey, disclaimer is I am a noob with `uv`, but when setting uv up following the mise + uv configurations, I kept having errors with `uv_create_args`, it appears to me that it is a typo and should actually be `uv_venv_create_args`.

Hopefully this is helpful for others. Feel free to merge or close if this is incorrect, no worries.

Thanks for this awesome tool. Been using since the rtx days. 