### PR TITLE
fix(registry): fix balena ubi backend options

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -213,10 +213,10 @@ babashka.backends = [
 babashka.test = ["bb --version", "babashka v{{version}}"]
 balena.aliases = ["balena-cli"]
 balena.backends = [
-    "ubi:balena-io/balena-cli[exe=balena]",
-    "asdf:boatkit-io/asdf-balena-cli"
+    "ubi:balena-io/balena-cli[extract_all=true,bin_path=bin]",
+    "asdf:jaredallard/asdf-balena-cli"
 ]
-# balena.test = ["balena -v", "{{version}}"] # times out on windows in CI
+balena.test = ["balena --version", "{{version}}"]
 bashbot.description = "A slack-bot written in golang for infrastructure/devops teams"
 bashbot.backends = [
     "aqua:mathew-fleisch/bashbot",


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/5855.

However, the `bin` directory contains `node` itself, so it might override other `node` installations.
See https://github.com/jdx/mise/pull/5788#issuecomment-3119966306 and https://github.com/jdx/mise/discussions/4675.

We can use `npm:balena-cli` instead, but it didn't work with `npm.bun=true`.
I think adding a tool option to override it per tool would be a solution, as in https://github.com/jdx/mise/discussions/4816, but it would cause another issue in `list_bin_paths`.

For the asdf plugin, they transffered the repository from an organization to an indivisual, so I followed it.