### PR TITLE
refactor(ci): separate Alpine release into its own workflow

### DIFF
--- a/.github/workflows/release-alpine.yml
+++ b/.github/workflows/release-alpine.yml
@@ -1,0 +1,42 @@
+name: release-alpine
+
+on:
+  workflow_run:
+    workflows: ["release"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., v1.0.0)"
+        required: true
+
+concurrency:
+  group: release-alpine-${{ github.ref_name }}
+
+env:
+  GITHUB_API_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  bump-alpine:
+    runs-on: ubuntu-latest
+    container: ghcr.io/jdx/mise:alpine
+    timeout-minutes: 30
+    if: |
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v') && 
+       endsWith(github.event.workflow_run.head_branch, '0')) ||
+      (github.event_name == 'workflow_dispatch')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Bump APKBUILD
+        run: sudo -Eu packager ./scripts/release-alpine.sh
+        env:
+          ALPINE_GITLAB_TOKEN: ${{ secrets.ALPINE_GITLAB_TOKEN }}
+          ALPINE_KEY_ID: ${{ secrets.ALPINE_KEY_ID }}
+          ALPINE_PRIV_KEY: ${{ secrets.ALPINE_PRIV_KEY }}
+          ALPINE_PUB_KEY: ${{ secrets.ALPINE_PUB_KEY }}

--- a/.github/workflows/release-alpine.yml
+++ b/.github/workflows/release-alpine.yml
@@ -1,14 +1,12 @@
 name: release-alpine
 
 on:
-  workflow_run:
-    workflows: ["release"]
-    types:
-      - completed
+  release:
+    types: [released]
   workflow_dispatch:
 
 concurrency:
-  group: release-alpine-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
+  group: release-alpine-${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
 
 env:
   GITHUB_API_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -21,10 +19,9 @@ jobs:
     container: ghcr.io/jdx/mise:alpine
     timeout-minutes: 30
     if: |
-      (github.event_name == 'workflow_run' && 
-       github.event.workflow_run.conclusion == 'success' &&
-       startsWith(github.event.workflow_run.head_branch, 'v') && 
-       endsWith(github.event.workflow_run.head_branch, '0')) ||
+      (github.event_name == 'release' && 
+       startsWith(github.event.release.tag_name, 'v') && 
+       endsWith(github.event.release.tag_name, '0')) ||
       (github.event_name == 'workflow_dispatch')
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-alpine.yml
+++ b/.github/workflows/release-alpine.yml
@@ -9,6 +9,7 @@ concurrency:
   group: release-alpine-${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
 
 env:
+  DRY_RUN: ${{ github.event_name == 'release' && '0' || '1' }}
   GITHUB_API_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
   GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-alpine.yml
+++ b/.github/workflows/release-alpine.yml
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/jdx/mise:alpine
     timeout-minutes: 30
+    if: |
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v') && 
+       endsWith(github.event.workflow_run.head_branch, '0')) ||
+      (github.event_name == 'workflow_dispatch')
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/release-alpine.yml
+++ b/.github/workflows/release-alpine.yml
@@ -6,13 +6,9 @@ on:
     types:
       - completed
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to release (e.g., v1.0.0)"
-        required: true
 
 concurrency:
-  group: release-alpine-${{ github.ref_name }}
+  group: release-alpine-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
 
 env:
   GITHUB_API_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -24,12 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/jdx/mise:alpine
     timeout-minutes: 30
-    if: |
-      (github.event_name == 'workflow_run' && 
-       github.event.workflow_run.conclusion == 'success' &&
-       startsWith(github.event.workflow_run.head_branch, 'v') && 
-       endsWith(github.event.workflow_run.head_branch, '0')) ||
-      (github.event_name == 'workflow_dispatch')
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/release-alpine.yml
+++ b/.github/workflows/release-alpine.yml
@@ -15,7 +15,7 @@ concurrency:
   group: release-alpine-${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
 
 env:
-  DRY_RUN: ${{ github.event_name == 'release' && '0' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.dry_run == 'true' && '1' || '0') || '1') }}
+  DRY_RUN: ${{ github.event_name == 'release' && '0' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.dry_run && '1' || '0')) || '1' }}
   GITHUB_API_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
   GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-alpine.yml
+++ b/.github/workflows/release-alpine.yml
@@ -4,12 +4,18 @@ on:
   release:
     types: [released]
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run in dry-run mode (no actual changes)"
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: release-alpine-${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
 
 env:
-  DRY_RUN: ${{ github.event_name == 'release' && '0' || '1' }}
+  DRY_RUN: ${{ github.event_name == 'release' && '0' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.dry_run == 'true' && '1' || '0') || '1') }}
   GITHUB_API_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
   GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,19 +292,3 @@ jobs:
           token: ${{ secrets.RTX_GITHUB_BOT_TOKEN }}
       - run: gh release edit --draft=false "$(./scripts/get-version.sh)"
         if: startsWith(github.event.ref, 'refs/tags/v')
-  bump-alpine:
-    runs-on: ubuntu-latest
-    container: ghcr.io/jdx/mise:alpine
-    timeout-minutes: 30
-    needs: [release]
-    if: startsWith(github.event.ref, 'refs/tags/v') && endsWith(github.event.ref, '0')
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Bump APKBUILD
-        run: sudo -Eu packager ./scripts/release-alpine.sh
-        env:
-          ALPINE_GITLAB_TOKEN: ${{ secrets.ALPINE_GITLAB_TOKEN }}
-          ALPINE_KEY_ID: ${{ secrets.ALPINE_KEY_ID }}
-          ALPINE_PRIV_KEY: ${{ secrets.ALPINE_PRIV_KEY }}
-          ALPINE_PUB_KEY: ${{ secrets.ALPINE_PUB_KEY }}


### PR DESCRIPTION
## Summary
- Move the Alpine package release job from the main release workflow into a dedicated workflow file
- Improves workflow organization and reduces complexity in the main release workflow
- Alpine releases now trigger automatically after successful main releases or can be run manually

## Changes
- **New file**: `.github/workflows/release-alpine.yml` - Dedicated Alpine release workflow
- **Modified**: `.github/workflows/release.yml` - Removed the `bump-alpine` job

## Benefits  
- Better separation of concerns between main releases and Alpine packaging
- Independent Alpine release process that doesn't block or complicate main releases
- Easier to maintain and debug Alpine-specific release issues

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>