### PR TITLE
feat(registry): add trunk metalinter

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2745,6 +2745,9 @@ tridentctl.backends = [
 ]
 trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in containers, Kubernetes, code repositories, clouds and more"
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
+trunk.backends = ["aqua:trunk-io/launcher"]
+trunk.description = "Trunk is a comprehensive code quality tool that runs linters, formatters, and security scanners to help maintain high-quality codebases (https://trunk.io)"
+trunk.test = ["trunk --version", "trunk 1.3.4 --version"]
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"


### PR DESCRIPTION
Add trunk code quality tool configuration to the registry with aqua backend support from trunk-io/launcher. Includes description and version test commands to ensure proper installation and functionality.

This pull request adds a new backend configuration for the `trunk` tool in the `registry.toml` file. The changes include specifying the backend source, a description of the tool, and a test command to verify its installation.

### Added `trunk` tool configuration:

* [`registry.toml`](diffhunk://#diff-853107e163a6cc7805cb4166459f02f5478bc3772365b80add9e3f779097c14fR2748-R2750): Added `trunk.backends` with the source `aqua:trunk-io/launcher`, a description of the tool, and test commands (`trunk --version`, `trunk 1.3.4 --version`) to validate its setup.