### PR TITLE
feat(registry): add trunk metalinter

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2745,6 +2745,9 @@ tridentctl.backends = [
 ]
 trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in containers, Kubernetes, code repositories, clouds and more"
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
+trunk.backends = ["aqua:trunk-io/launcher"]
+trunk.description = "Trunk is a comprehensive code quality tool that runs linters, formatters, and security scanners to help maintain high-quality codebases (https://trunk.io)"
+trunk.test = ["trunk --version", "trunk 1.3.4 --version"]
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"

--- a/registry.toml
+++ b/registry.toml
@@ -2745,9 +2745,9 @@ tridentctl.backends = [
 ]
 trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in containers, Kubernetes, code repositories, clouds and more"
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
-trunk.backends = ["aqua:trunk-io/launcher"]
+trunk.backends = ["npm:@trunkio/launcher"]
 trunk.description = "Trunk is a comprehensive code quality tool that runs linters, formatters, and security scanners to help maintain high-quality codebases (https://trunk.io)"
-trunk.test = ["trunk --version", "trunk 1.3.4 --version"]
+trunk.test = ["trunk --version", "{{version}}"]
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"

--- a/registry.toml
+++ b/registry.toml
@@ -2747,7 +2747,7 @@ trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in c
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
 trunk.backends = ["npm:@trunkio/launcher"]
 trunk.description = "Trunk is a comprehensive code quality tool that runs linters, formatters, and security scanners to help maintain high-quality codebases (https://trunk.io)"
-trunk.test = ["trunk --version", "{{version}}"]
+trunk.test = ["trunk --help", "trunk [flags] [subcommand]"] # --version can't be used because we know the launcher version, but we get the binary version
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"


### PR DESCRIPTION
Add trunk code quality tool configuration to the registry with aqua
backend support from trunk-io/launcher. Includes description and
version test commands to ensure proper installation and functionality.

Sorry to have opened and closed this PR a few times. Now we're using the `npm` backend, CI should pass and we can consider this final from my end.

---

This pull request updates the `registry.toml` file to add a new backend configuration for Trunk, a code quality tool. The changes include its description, backend source, and a test command.

### Added Trunk backend configuration:
* [`trunk.backends`](diffhunk://#diff-853107e163a6cc7805cb4166459f02f5478bc3772365b80add9e3f779097c14fR2748-R2750): Added Trunk as a new backend with the source `"npm:@trunkio/launcher"`.
* [`trunk.description`](diffhunk://#diff-853107e163a6cc7805cb4166459f02f5478bc3772365b80add9e3f779097c14fR2748-R2750): Included a description for Trunk, highlighting its role as a comprehensive code quality tool.
* [`trunk.test`](diffhunk://#diff-853107e163a6cc7805cb4166459f02f5478bc3772365b80add9e3f779097c14fR2748-R2750): Added a test command to verify the Trunk installation with `"trunk --version"`.