### PR TITLE
✨ Add trunk tool to registry with aqua backend support

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2745,6 +2745,9 @@ tridentctl.backends = [
 ]
 trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in containers, Kubernetes, code repositories, clouds and more"
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
+trunk.backends = ["aqua:trunk-io/launcher"]
+trunk.description = "Trunk is a comprehensive code quality tool that runs linters, formatters, and security scanners to help maintain high-quality codebases (https://trunk.io)"
+trunk.test = ["trunk --version", "trunk 1.3.4 --version"]
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"

--- a/registry.toml
+++ b/registry.toml
@@ -2745,9 +2745,9 @@ tridentctl.backends = [
 ]
 trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in containers, Kubernetes, code repositories, clouds and more"
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
-trunk.backends = ["aqua:trunk-io/launcher"]
+trunk.backends = ["npm:@trunkio/launcher"]
 trunk.description = "Trunk is a comprehensive code quality tool that runs linters, formatters, and security scanners to help maintain high-quality codebases (https://trunk.io)"
-trunk.test = ["trunk --version", "trunk 1.3.4 --version"]
+trunk.test = ["trunk --version", "{{version}}"]
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"

--- a/registry.toml
+++ b/registry.toml
@@ -2747,7 +2747,7 @@ trivy.description = "Find vulnerabilities, misconfigurations, secrets, SBOM in c
 trivy.backends = ["aqua:aquasecurity/trivy", "asdf:zufardhiyaulhaq/asdf-trivy"]
 trunk.backends = ["npm:@trunkio/launcher"]
 trunk.description = "Trunk is a comprehensive code quality tool that runs linters, formatters, and security scanners to help maintain high-quality codebases (https://trunk.io)"
-trunk.test = ["trunk --version", "{{version}}"]
+trunk.test = ["trunk --help", "trunk [flags] [subcommand]"] # --version can't be used because we know the launcher version, but we get the binary version
 tsuru.backends = [
     "ubi:tsuru/tsuru-client[exe=tsuru]",
     "asdf:virtualstaticvoid/asdf-tsuru"


### PR DESCRIPTION
Add trunk code quality tool configuration to the registry with aqua
backend support from trunk-io/launcher. Includes description and
version test commands to ensure proper installation and functionality.