### PR TITLE
fix(python): Windows OS no longer suffixed with `-shared`

### DIFF
--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -535,7 +535,7 @@ fn python_os(settings: &Settings) -> String {
         return os.clone();
     }
     if cfg!(windows) {
-        "pc-windows-msvc-shared".into()
+        "pc-windows-msvc".into()
     } else if cfg!(target_os = "macos") {
         "apple-darwin".into()
     } else {


### PR DESCRIPTION
For context, see:
* https://github.com/jdx/mise/discussions/4877
  * Linked PR in `python-build-standalone` with explanation: https://github.com/astral-sh/python-build-standalone/pull/554
* Duplicate discussion: https://github.com/jdx/mise/discussions/4962