### PR TITLE
fix(aqua,github): make asset name matching case-insensitive

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -328,7 +328,10 @@ impl AquaBackend {
         let asset = gh_release
             .assets
             .iter()
-            .find(|a| asset_strs_lower.contains(&a.name.to_lowercase()))
+            .find(|a| {
+                // First try exact match, then case-insensitive
+                asset_strs.contains(&a.name) || asset_strs_lower.contains(&a.name.to_lowercase())
+            })
             .wrap_err_with(|| {
                 format!(
                     "no asset found: {}\nAvailable assets:\n{}",

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -320,10 +320,15 @@ impl AquaBackend {
     ) -> Result<String> {
         let gh_id = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
         let gh_release = github::get_release(&gh_id, v).await?;
+
+        // Convert expected asset names to lowercase once for case-insensitive matching
+        let asset_strs_lower: IndexSet<String> =
+            asset_strs.iter().map(|s| s.to_lowercase()).collect();
+
         let asset = gh_release
             .assets
             .iter()
-            .find(|a| asset_strs.contains(&a.name))
+            .find(|a| asset_strs_lower.contains(&a.name.to_lowercase()))
             .wrap_err_with(|| {
                 format!(
                     "no asset found: {}\nAvailable assets:\n{}",

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -322,11 +322,13 @@ impl UnifiedGitBackend {
 
         // Fall back to auto-detection
         let asset_name = self.auto_detect_asset(&available_assets)?;
-        let asset_name_lower = asset_name.to_lowercase();
         let asset = release
             .assets
-            .into_iter()
-            .find(|a| a.name.to_lowercase() == asset_name_lower)
+            .iter()
+            .find(|a| {
+                // First try exact match, then case-insensitive
+                a.name == asset_name || a.name.to_lowercase() == asset_name.to_lowercase()
+            })
             .ok_or_else(|| {
                 eyre::eyre!(
                     "Auto-detected asset not found: {}\nAvailable assets: {}",
@@ -335,7 +337,7 @@ impl UnifiedGitBackend {
                 )
             })?;
 
-        Ok(asset.browser_download_url)
+        Ok(asset.browser_download_url.clone())
     }
 
     async fn resolve_gitlab_asset_url(
@@ -381,12 +383,14 @@ impl UnifiedGitBackend {
 
         // Fall back to auto-detection
         let asset_name = self.auto_detect_asset(&available_assets)?;
-        let asset_name_lower = asset_name.to_lowercase();
         let asset = release
             .assets
             .links
-            .into_iter()
-            .find(|a| a.name.to_lowercase() == asset_name_lower)
+            .iter()
+            .find(|a| {
+                // First try exact match, then case-insensitive
+                a.name == asset_name || a.name.to_lowercase() == asset_name.to_lowercase()
+            })
             .ok_or_else(|| {
                 eyre::eyre!(
                     "Auto-detected asset not found: {}\nAvailable assets: {}",
@@ -395,7 +399,7 @@ impl UnifiedGitBackend {
                 )
             })?;
 
-        Ok(asset.direct_asset_url)
+        Ok(asset.direct_asset_url.clone())
     }
 
     fn auto_detect_asset(&self, available_assets: &[String]) -> Result<String> {

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -501,4 +501,57 @@ mod tests {
         assert_eq!(backend.strip_version_prefix("release-1.0.0"), "1.0.0");
         assert_eq!(backend.strip_version_prefix("1.0.0"), "1.0.0");
     }
+
+    #[test]
+    fn test_find_asset_case_insensitive() {
+        let backend = create_test_backend();
+
+        // Mock asset structs for testing
+        struct TestAsset {
+            name: String,
+        }
+
+        let assets = vec![
+            TestAsset {
+                name: "tool-1.0.0-linux-x86_64.tar.gz".to_string(),
+            },
+            TestAsset {
+                name: "tool-1.0.0-Darwin-x86_64.tar.gz".to_string(),
+            },
+            TestAsset {
+                name: "tool-1.0.0-Windows-x86_64.zip".to_string(),
+            },
+        ];
+
+        // Test exact match (should find immediately)
+        let result =
+            backend.find_asset_case_insensitive(&assets, "tool-1.0.0-linux-x86_64.tar.gz", |a| {
+                &a.name
+            });
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "tool-1.0.0-linux-x86_64.tar.gz");
+
+        // Test case-insensitive match for Darwin (capital D)
+        let result = backend.find_asset_case_insensitive(
+            &assets,
+            "tool-1.0.0-darwin-x86_64.tar.gz", // lowercase 'd'
+            |a| &a.name,
+        );
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "tool-1.0.0-Darwin-x86_64.tar.gz");
+
+        // Test case-insensitive match for Windows (capital W)
+        let result = backend.find_asset_case_insensitive(
+            &assets,
+            "tool-1.0.0-windows-x86_64.zip", // lowercase 'w'
+            |a| &a.name,
+        );
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "tool-1.0.0-Windows-x86_64.zip");
+
+        // Test no match
+        let result =
+            backend.find_asset_case_insensitive(&assets, "nonexistent-asset.tar.gz", |a| &a.name);
+        assert!(result.is_none());
+    }
 }

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -322,10 +322,11 @@ impl UnifiedGitBackend {
 
         // Fall back to auto-detection
         let asset_name = self.auto_detect_asset(&available_assets)?;
+        let asset_name_lower = asset_name.to_lowercase();
         let asset = release
             .assets
             .into_iter()
-            .find(|a| a.name == asset_name)
+            .find(|a| a.name.to_lowercase() == asset_name_lower)
             .ok_or_else(|| {
                 eyre::eyre!(
                     "Auto-detected asset not found: {}\nAvailable assets: {}",
@@ -380,11 +381,12 @@ impl UnifiedGitBackend {
 
         // Fall back to auto-detection
         let asset_name = self.auto_detect_asset(&available_assets)?;
+        let asset_name_lower = asset_name.to_lowercase();
         let asset = release
             .assets
             .links
             .into_iter()
-            .find(|a| a.name == asset_name)
+            .find(|a| a.name.to_lowercase() == asset_name_lower)
             .ok_or_else(|| {
                 eyre::eyre!(
                     "Auto-detected asset not found: {}\nAvailable assets: {}",


### PR DESCRIPTION
## Summary
Makes aqua and github backend asset matching case-insensitive to handle GitHub releases with inconsistent capitalization.

## Problem
Some GitHub releases use inconsistent capitalization in asset names. For example, lazygit uses "Linux" (capital L) in their asset names while mise's aqua backend expects "linux" (lowercase).

This causes installation failures:
```
Error: failed to install aqua:jesseduffield/lazygit@0.54.0
no asset found: lazygit_0.54.0_Linux_x86_64.tar.gz
Available assets:
...
lazygit_0.54.0_linux_x86_64.tar.gz
...
```

## Solution
Changed the asset matching logic in both the aqua and github backends to use case-insensitive comparison.

### Implementation details:
- **Aqua backend**: Convert expected asset names to lowercase once before matching (optimization)
- **GitHub backend**: Use case-insensitive comparison for auto-detected assets

## Test
```bash
mise install -f lazygit
# Now works successfully
```

🤖 Generated with [Claude Code](https://claude.ai/code)