### PR TITLE
fix(registry): update kubecolor to use kubecolor/kubecolor

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1638,8 +1638,9 @@ kubebuilder.backends = [
 ]
 kubecm.description = "Manage your kubeconfig more easily"
 kubecm.backends = ["aqua:sunny0826/kubecm", "asdf:samhvw8/asdf-kubecm"]
-kubecolor.description = "colorizes kubectl output"
-kubecolor.backends = ["aqua:hidetatz/kubecolor", "asdf:dex4er/asdf-kubecolor"]
+kubecolor.description = "Colorize your kubectl output"
+kubecolor.backends = ["aqua:kubecolor/kubecolor", "asdf:dex4er/asdf-kubecolor"]
+kubecolor.test = ["kubecolor version --client=true", "Client Version: v"]
 kubeconform.description = "A FAST Kubernetes manifests validator, with support for Custom Resources"
 kubeconform.backends = [
     "aqua:yannh/kubeconform",


### PR DESCRIPTION
* Change `kubecolor` to use to https://github.com/kubecolor/kubecolor instead of https://github.com/hidetatz/kubecolor as that project has been archived/deprecated.
* The aqua package entry exists in aqua at https://github.com/aquaproj/aqua-registry/blob/main/pkgs/kubecolor/kubecolor/registry.yaml and a `mise install aqua:kubecolor/kubecolor` runs successfully.