### PR TITLE
docs(changelog): automate backend links in changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -68,7 +68,8 @@ footer = """
 trim = true
 postprocessors = [
   { pattern = '\$REPO', replace = "https://github.com/jdx/mise" },
-  { pattern = "'(aqua|github|gitlab|ubi):([^/]+/[^']+)'", replace = "'[$1:$2](https://github.com/$2)'" },
+  { pattern = '\(gitlab:([^/\)]+/[^\)]+)\)', replace = "([gitlab:$1](https://gitlab.com/$1))" },
+  { pattern = '\((aqua|github|ubi):([^/\)]+/[^\)]+)\)', replace = "([$1:$2](https://github.com/$2))" },
 ]
 
 [git]

--- a/cliff.toml
+++ b/cliff.toml
@@ -68,6 +68,7 @@ footer = """
 trim = true
 postprocessors = [
   { pattern = '\$REPO', replace = "https://github.com/jdx/mise" },
+  { pattern = "'(aqua|github|gitlab|ubi):([^/]+/[^']+)'", replace = "'[$1:$2](https://github.com/$2)'" },
 ]
 
 [git]


### PR DESCRIPTION
Add postprocessor to git-cliff config to automatically convert backend references (aqua:, github:, gitlab:, ubi:) to hyperlinks pointing to their respective GitHub repositories.

This ensures that changelog entries like 'add tool via aqua:owner/repo backend' are automatically converted to clickable links.