### PR TITLE
chore: release 2025.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [2025.8.5](https://github.com/jdx/mise/compare/v2025.8.4..v2025.8.5) - 2025-08-05
+
+### 📦 Registry
+
+- add tlrc ([aqua:tldr-pages/tlrc](https://github.com/tldr-pages/tlrc)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5895](https://github.com/jdx/mise/pull/5895)
+- support `.terragrunt-version` by [@risu729](https://github.com/risu729) in [#5903](https://github.com/jdx/mise/pull/5903)
+- add lnav ([aqua:tstack/lnav](https://github.com/tstack/lnav)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5896](https://github.com/jdx/mise/pull/5896)
+- use aqua backend for yarn by [@risu729](https://github.com/risu729) in [#5902](https://github.com/jdx/mise/pull/5902)
+- add dotenvx ([aqua:dotenvx/dotenvx](https://github.com/dotenvx/dotenvx)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5915](https://github.com/jdx/mise/pull/5915)
+- update kubecolor ([aqua:kubecolor/kubecolor](https://github.com/kubecolor/kubecolor)) by [@Darwiner](https://github.com/Darwiner) in [#5887](https://github.com/jdx/mise/pull/5887)
+- add oxlint ([aqua:oxc-project/oxc/oxlint](https://github.com/oxc-project/oxc/oxlint)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5919](https://github.com/jdx/mise/pull/5919)
+- add container ([aqua:apple/container](https://github.com/apple/container)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5917](https://github.com/jdx/mise/pull/5917)
+- support `.packer-version` by [@risu729](https://github.com/risu729) in [#5900](https://github.com/jdx/mise/pull/5900)
+
+### 🚀 Features
+
+- **(ci)** enhance registry PR validation with strict format checking by [@jdx](https://github.com/jdx) in [#5897](https://github.com/jdx/mise/pull/5897)
+- add Model Context Protocol (MCP) server command by [@jdx](https://github.com/jdx) in [#5920](https://github.com/jdx/mise/pull/5920)
+
+### 🐛 Bug Fixes
+
+- **(elixir)** support `.exenv-version` by [@risu729](https://github.com/risu729) in [#5901](https://github.com/jdx/mise/pull/5901)
+- **(env)** improve PATH handling for env._.path directives by [@jdx](https://github.com/jdx) in [#5922](https://github.com/jdx/mise/pull/5922)
+- allow devcontainer creation without a git repository by [@acesyde](https://github.com/acesyde) in [#5891](https://github.com/jdx/mise/pull/5891)
+
+### Chore
+
+- add synchronize to registry_comment gha by [@jdx](https://github.com/jdx) in [cbb1429](https://github.com/jdx/mise/commit/cbb14294072e9cbd3b0b9f21b2cb0a993a71d5ff)
+- fix registry_comment gha by [@jdx](https://github.com/jdx) in [7ce513b](https://github.com/jdx/mise/commit/7ce513be3efe60372f667f76570e16ce0d4a013f)
+- run registry test only for changed tools by [@risu729](https://github.com/risu729) in [#5905](https://github.com/jdx/mise/pull/5905)
+
+### New Contributors
+
+- @Darwiner made their first contribution in [#5887](https://github.com/jdx/mise/pull/5887)
+- @zekefast made their first contribution in [#5912](https://github.com/jdx/mise/pull/5912)
+
 ## [2025.8.4](https://github.com/jdx/mise/compare/v2025.8.3..v2025.8.4) - 2025-08-03
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.8.4"
+version = "2025.8.5"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.8.4"
+version = "2025.8.5"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.8.4 macos-arm64 (a1b2d3e 2025-08-03)
+2025.8.5 macos-arm64 (a1b2d3e 2025-08-05)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_8_4:-}" ]] || _cache_invalid _usage_spec_mise_2025_8_4 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_8_4;
+  if ( [[ -z "${_usage_spec_mise_2025_8_5:-}" ]] || _cache_invalid _usage_spec_mise_2025_8_5 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_8_5;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_8_4 spec
+    _store_cache _usage_spec_mise_2025_8_5 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_8_4:-} ]]; then
-        _usage_spec_mise_2025_8_4="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_8_5:-} ]]; then
+        _usage_spec_mise_2025_8_5="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_8_4}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_8_5}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_8_4
-  set -g _usage_spec_mise_2025_8_4 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_8_5
+  set -g _usage_spec_mise_2025_8_5 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_4" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_5" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_4" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_5" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.8.4";
+  version = "2025.8.5";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.8.4
+Version: 2025.8.5
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 📦 Registry

- add tlrc ([aqua:tldr-pages/tlrc](https://github.com/tldr-pages/tlrc)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5895](https://github.com/jdx/mise/pull/5895)
- support `.terragrunt-version` by [@risu729](https://github.com/risu729) in [#5903](https://github.com/jdx/mise/pull/5903)
- add lnav ([aqua:tstack/lnav](https://github.com/tstack/lnav)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5896](https://github.com/jdx/mise/pull/5896)
- use aqua backend for yarn by [@risu729](https://github.com/risu729) in [#5902](https://github.com/jdx/mise/pull/5902)
- add dotenvx ([aqua:dotenvx/dotenvx](https://github.com/dotenvx/dotenvx)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5915](https://github.com/jdx/mise/pull/5915)
- update kubecolor ([aqua:kubecolor/kubecolor](https://github.com/kubecolor/kubecolor)) by [@Darwiner](https://github.com/Darwiner) in [#5887](https://github.com/jdx/mise/pull/5887)
- add oxlint ([aqua:oxc-project/oxc/oxlint](https://github.com/oxc-project/oxc/oxlint)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5919](https://github.com/jdx/mise/pull/5919)
- add container ([aqua:apple/container](https://github.com/apple/container)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5917](https://github.com/jdx/mise/pull/5917)
- support `.packer-version` by [@risu729](https://github.com/risu729) in [#5900](https://github.com/jdx/mise/pull/5900)

### 🚀 Features

- **(ci)** enhance registry PR validation with strict format checking by [@jdx](https://github.com/jdx) in [#5897](https://github.com/jdx/mise/pull/5897)
- add Model Context Protocol (MCP) server command by [@jdx](https://github.com/jdx) in [#5920](https://github.com/jdx/mise/pull/5920)

### 🐛 Bug Fixes

- **(elixir)** support `.exenv-version` by [@risu729](https://github.com/risu729) in [#5901](https://github.com/jdx/mise/pull/5901)
- **(env)** improve PATH handling for env._.path directives by [@jdx](https://github.com/jdx) in [#5922](https://github.com/jdx/mise/pull/5922)
- allow devcontainer creation without a git repository by [@acesyde](https://github.com/acesyde) in [#5891](https://github.com/jdx/mise/pull/5891)

### Chore

- add synchronize to registry_comment gha by [@jdx](https://github.com/jdx) in [cbb1429](https://github.com/jdx/mise/commit/cbb14294072e9cbd3b0b9f21b2cb0a993a71d5ff)
- fix registry_comment gha by [@jdx](https://github.com/jdx) in [7ce513b](https://github.com/jdx/mise/commit/7ce513be3efe60372f667f76570e16ce0d4a013f)
- run registry test only for changed tools by [@risu729](https://github.com/risu729) in [#5905](https://github.com/jdx/mise/pull/5905)

### New Contributors

- @Darwiner made their first contribution in [#5887](https://github.com/jdx/mise/pull/5887)
- @zekefast made their first contribution in [#5912](https://github.com/jdx/mise/pull/5912)