### PR TITLE
fix(elixir): support `.exenv-version`

### DIFF
--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -110,6 +110,10 @@ impl Backend for ElixirPlugin {
         Ok(versions)
     }
 
+    fn idiomatic_filenames(&self) -> eyre::Result<Vec<String>> {
+        Ok(vec![".exenv-version".into()])
+    }
+
     fn get_dependencies(&self) -> Result<Vec<&str>> {
         Ok(vec!["erlang"])
     }


### PR DESCRIPTION
It has been documented but was not supported by the core.

https://github.com/jdx/mise/blob/11529f77d9eeae9fed2bfc086fd1bd3ba1771885/docs/configuration.md#L317