### PR TITLE
registry: use aqua backend for yarn

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,7 +321,7 @@ in mise and nvm. Here are some of the supported idiomatic version files:
 | python    | `.python-version`, `.python-versions`              |
 | ruby      | `.ruby-version`, `Gemfile`                         |
 | terraform | `.terraform-version`, `.packer-version`, `main.tf` |
-| yarn      | `.yvmrc`                                          |
+| yarn      | `.yvmrc`                                           |
 
 In mise, these are enabled by default. However, in 2025.10.0 they will default to disabled (see <https://github.com/jdx/mise/discussions/4345>).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,7 +321,7 @@ in mise and nvm. Here are some of the supported idiomatic version files:
 | python    | `.python-version`, `.python-versions`              |
 | ruby      | `.ruby-version`, `Gemfile`                         |
 | terraform | `.terraform-version`, `.packer-version`, `main.tf` |
-| yarn      | `.yarnrc`                                          |
+| yarn      | `.yvmrc`                                          |
 
 In mise, these are enabled by default. However, in 2025.10.0 they will default to disabled (see <https://github.com/jdx/mise/discussions/4345>).
 

--- a/registry.toml
+++ b/registry.toml
@@ -2981,7 +2981,8 @@ yamlscript.backends = [
     "asdf:mise-plugins/mise-yamlscript"
 ]
 yamlscript.test = ["ys --version", "{{version}}"]
-yarn.backends = ["npm:@yarnpkg/cli-dist", "asdf:mise-plugins/mise-yarn"]
+yarn.backends = ["aqua:yarnpkg/berry", "npm:@yarnpkg/cli-dist", "asdf:mise-plugins/mise-yarn"]
+yarn.idiomatic_files = [".yvmrc"]
 yarn.test = ["yarn --version", "{{version}}"]
 yay.backends = ["asdf:mise-plugins/mise-yay"]
 yazi.description = "Blazing fast terminal file manager written in Rust, based on async I/O"

--- a/registry.toml
+++ b/registry.toml
@@ -2981,7 +2981,11 @@ yamlscript.backends = [
     "asdf:mise-plugins/mise-yamlscript"
 ]
 yamlscript.test = ["ys --version", "{{version}}"]
-yarn.backends = ["aqua:yarnpkg/berry", "npm:@yarnpkg/cli-dist", "asdf:mise-plugins/mise-yarn"]
+yarn.backends = [
+    "aqua:yarnpkg/berry",
+    "npm:@yarnpkg/cli-dist",
+    "asdf:mise-plugins/mise-yarn"
+]
 yarn.idiomatic_files = [".yvmrc"]
 yarn.test = ["yarn --version", "{{version}}"]
 yay.backends = ["asdf:mise-plugins/mise-yay"]


### PR DESCRIPTION
Sorry, I didn't notice the author hadn't updated the PR to use the aqua backend in https://github.com/jdx/mise/pull/5745.

I didn't notice that the registry supports `idiomatic_files`, but it does, so `.yvmrc` will still be supported.
`.yarnrc` was in the docs, but it had never been supported by the asdf plugin, so I guess it was a mistake.

yarn v1 is no longer supported since https://github.com/jdx/mise/pull/5745, but we can still install it with `asdf:yarn` (not on Windows).