### PR TITLE
registry: support `.terragrunt-version`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -311,17 +311,18 @@ other developers to use a specific tool like mise or asdf.
 They support aliases, which means you can have an `.nvmrc` file with `lts/hydrogen` and it will work
 in mise and nvm. Here are some of the supported idiomatic version files:
 
-| Plugin    | Idiomatic Files                                    |
-| --------- | -------------------------------------------------- |
-| crystal   | `.crystal-version`                                 |
-| elixir    | `.exenv-version`                                   |
-| go        | `.go-version`                                      |
-| java      | `.java-version`, `.sdkmanrc`                       |
-| node      | `.nvmrc`, `.node-version`                          |
-| python    | `.python-version`, `.python-versions`              |
-| ruby      | `.ruby-version`, `Gemfile`                         |
-| terraform | `.terraform-version`, `.packer-version`, `main.tf` |
-| yarn      | `.yarnrc`                                          |
+| Plugin     | Idiomatic Files                                    |
+| ---------- | -------------------------------------------------- |
+| crystal    | `.crystal-version`                                 |
+| elixir     | `.exenv-version`                                   |
+| go         | `.go-version`                                      |
+| java       | `.java-version`, `.sdkmanrc`                       |
+| node       | `.nvmrc`, `.node-version`                          |
+| python     | `.python-version`, `.python-versions`              |
+| ruby       | `.ruby-version`, `Gemfile`                         |
+| terragrunt | `.terragrunt-version`                              |
+| terraform  | `.terraform-version`, `.packer-version`, `main.tf` |
+| yarn       | `.yarnrc`                                          |
 
 In mise, these are enabled by default. However, in 2025.10.0 they will default to disabled (see <https://github.com/jdx/mise/discussions/4345>).
 

--- a/registry.toml
+++ b/registry.toml
@@ -2678,6 +2678,7 @@ terragrunt.backends = [
     "aqua:gruntwork-io/terragrunt",
     "asdf:gruntwork-io/asdf-terragrunt"
 ]
+terragrunt.idiomatic_files = [".terragrunt-version"]
 terragrunt.test = ["terragrunt --version", "terragrunt version v{{version}}"]
 terramate.description = "Open-source Infrastructure as Code (IaC) orchestration platform: GitOps workflows, orchestration, code generation, observability, drift detection, asset management, policies, Slack notifications, and more. Integrates with Terraform, OpenTofu, Terragrunt, Kubernetes, GitHub Actions, GitLab CI/CD, BitBucket Pipelines, and any other CI/CD platform"
 terramate.backends = [


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/5329.

`.terragrunt-version` is supported by [`tgenv`](https://github.com/tgenv/tgenv).
It doesn't seem to be that common, but I think it would be nice if we support it.