### PR TITLE
registry: add python to gcloud dependencies

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1011,6 +1011,7 @@ gator.test = ["gator --version", "gator version v{{version}}"]
 gauche.backends = ["asdf:mise-plugins/mise-gauche"]
 gcc-arm-none-eabi.backends = ["asdf:mise-plugins/mise-gcc-arm-none-eabi"]
 gcloud.backends = ["asdf:mise-plugins/mise-gcloud"]
+gcloud.depends = ["python"]
 gdu.description = "Fast disk usage analyzer with console interface written in Go"
 gdu.backends = ["aqua:dundee/gdu"]
 gemini-cli.aliases = ["gemini"]


### PR DESCRIPTION
`python` is required by `mise-gcloud` asdf plugin.
https://github.com/mise-plugins/mise-gcloud/blob/main/lib/dependencies.txt