### PR TITLE
chore: release 2025.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2025.8.8](https://github.com/jdx/mise/compare/v2025.8.7..v2025.8.8) - 2025-08-11
+
+### 📦 Registry
+
+- add bob ([aqua:MordechaiHadad/bob](https://github.com/MordechaiHadad/bob)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5914](https://github.com/jdx/mise/pull/5914)
+- support usage on FreeBSD by [@risu729](https://github.com/risu729) in [#5973](https://github.com/jdx/mise/pull/5973)
+- filter out installer for podman by [@risu729](https://github.com/risu729) in [#5974](https://github.com/jdx/mise/pull/5974)
+- use pipx aqua backend by [@itochan](https://github.com/itochan) in [#5971](https://github.com/jdx/mise/pull/5971)
+
+### 📚 Documentation
+
+- add documentation for os field in tool configuration by [@jdx](https://github.com/jdx) in [#5947](https://github.com/jdx/mise/pull/5947)
+
+### Chore
+
+- **(ci)** accept @ in regular expressions for new registry PR titles by [@mst-mkt](https://github.com/mst-mkt) in [#5969](https://github.com/jdx/mise/pull/5969)
+- fix registry test filter by [@risu729](https://github.com/risu729) in [#5942](https://github.com/jdx/mise/pull/5942)
+- fix registry test by [@risu729](https://github.com/risu729) in [#5953](https://github.com/jdx/mise/pull/5953)
+
+### New Contributors
+
+- @itochan made their first contribution in [#5971](https://github.com/jdx/mise/pull/5971)
+- @mst-mkt made their first contribution in [#5969](https://github.com/jdx/mise/pull/5969)
+
 ## [2025.8.7](https://github.com/jdx/mise/compare/v2025.8.6..v2025.8.7) - 2025-08-06
 
 ### 📦 Registry
@@ -8,6 +32,7 @@
 
 ### 🐛 Bug Fixes
 
+- **(lockfile)** fix multiple lockfile issues with version management by [@jdx](https://github.com/jdx) in [#5907](https://github.com/jdx/mise/pull/5907)
 - **(toolset)** properly handle MISE_ADD_PATH from plugins by [@jdx](https://github.com/jdx) in [#5937](https://github.com/jdx/mise/pull/5937)
 
 ## [2025.8.6](https://github.com/jdx/mise/compare/v2025.8.5..v2025.8.6) - 2025-08-06

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.8.7"
+version = "2025.8.8"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.8.7"
+version = "2025.8.8"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.8.7 macos-arm64 (a1b2d3e 2025-08-06)
+2025.8.8 macos-arm64 (a1b2d3e 2025-08-11)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_8_7:-}" ]] || _cache_invalid _usage_spec_mise_2025_8_7 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_8_7;
+  if ( [[ -z "${_usage_spec_mise_2025_8_8:-}" ]] || _cache_invalid _usage_spec_mise_2025_8_8 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_8_8;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_8_7 spec
+    _store_cache _usage_spec_mise_2025_8_8 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_8_7:-} ]]; then
-        _usage_spec_mise_2025_8_7="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_8_8:-} ]]; then
+        _usage_spec_mise_2025_8_8="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_8_7}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_8_8}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_8_7
-  set -g _usage_spec_mise_2025_8_7 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_8_8
+  set -g _usage_spec_mise_2025_8_8 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_7" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_8" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_7" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_8" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.8.7";
+  version = "2025.8.8";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.8.7
+Version: 2025.8.8
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 📦 Registry

- add bob ([aqua:MordechaiHadad/bob](https://github.com/MordechaiHadad/bob)) by [@TyceHerrman](https://github.com/TyceHerrman) in [#5914](https://github.com/jdx/mise/pull/5914)
- support usage on FreeBSD by [@risu729](https://github.com/risu729) in [#5973](https://github.com/jdx/mise/pull/5973)
- filter out installer for podman by [@risu729](https://github.com/risu729) in [#5974](https://github.com/jdx/mise/pull/5974)
- use pipx aqua backend by [@itochan](https://github.com/itochan) in [#5971](https://github.com/jdx/mise/pull/5971)

### 📚 Documentation

- add documentation for os field in tool configuration by [@jdx](https://github.com/jdx) in [#5947](https://github.com/jdx/mise/pull/5947)

### Chore

- **(ci)** accept @ in regular expressions for new registry PR titles by [@mst-mkt](https://github.com/mst-mkt) in [#5969](https://github.com/jdx/mise/pull/5969)
- fix registry test filter by [@risu729](https://github.com/risu729) in [#5942](https://github.com/jdx/mise/pull/5942)
- fix registry test by [@risu729](https://github.com/risu729) in [#5953](https://github.com/jdx/mise/pull/5953)

### New Contributors

- @itochan made their first contribution in [#5971](https://github.com/jdx/mise/pull/5971)
- @mst-mkt made their first contribution in [#5969](https://github.com/jdx/mise/pull/5969)