### PR TITLE
chore: fix registry test filter

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -57,12 +57,14 @@ jobs:
       - id: diff
         shell: bash # -eo pipefail
         run: |
+          set -x
           changed_tools=$( \
             mise x jd -- jd -f merge \
               <(git show ${{ github.event.pull_request.base.sha }}:registry.toml | mise x yj -- yj -t) \
               <(mise x yj -- yj -t < registry.toml) \
             | jq -r '[.tools // {} | keys[]] | join(" ")' \
           )
+          echo $changed_tools
           echo "tools=$changed_tools" >> $GITHUB_OUTPUT
 
   test-tool:

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           fetch-depth: 0
           sparse-checkout: registry.toml
+          sparse-checkout-cone-mode: false
+          fetch-tags: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           log_level: debug

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -55,11 +55,12 @@ jobs:
           fetch-depth: 0
           sparse-checkout: registry.toml
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          log_level: debug
       - id: diff
         shell: bash # -eo pipefail
         run: |
           set -x
-          mise x yj -- yj -t < registry.toml
           changed_tools=$( \
             mise x jd -- jd -f merge \
               <(git show ${{ github.event.pull_request.base.sha }}:registry.toml | mise x yj -- yj -t) \

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -53,12 +53,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-          sparse-checkout: registry.toml
-          sparse-checkout-cone-mode: false
-          fetch-tags: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
-          log_level: debug
+          install_args: jd yj
       - id: diff
         shell: bash # -eo pipefail
         run: |

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -53,11 +53,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+          sparse-checkout: registry.toml
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
       - id: diff
         shell: bash # -eo pipefail
         run: |
           set -x
+          cat registry.toml | head -n 10
+          mise x yj -- yj -t < registry.toml
           changed_tools=$( \
             mise x jd -- jd -f merge \
               <(git show ${{ github.event.pull_request.base.sha }}:registry.toml | mise x yj -- yj -t) \

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -59,7 +59,6 @@ jobs:
         shell: bash # -eo pipefail
         run: |
           set -x
-          cat registry.toml | head -n 10
           mise x yj -- yj -t < registry.toml
           changed_tools=$( \
             mise x jd -- jd -f merge \

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -59,7 +59,6 @@ jobs:
       - id: diff
         shell: bash # -eo pipefail
         run: |
-          set -x
           changed_tools=$( \
             mise x jd -- jd -f merge \
               <(git show ${{ github.event.pull_request.base.sha }}:registry.toml | mise x yj -- yj -t) \

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -55,6 +55,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
       - id: diff
+        shell: bash # -eo pipefail
         run: |
           changed_tools=$( \
             mise x jd -- jd -f merge \


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/pull/5914#issuecomment-3160707479.

It failed with a mise error, and I didn't set `pipefail`, so it continued with an error.

The mise error seems to occur when `mise exec` is called with a `<` redirect, or `mise exec` is called twice in a row.
I don't have any ideas what's happening and I don't think it's a common problem, so I fix the workflow by installing the tools before `mise exec`, which works fine as a workaround.

<details>

<summary>action log</summary>

```
+++ mise x yj -- yj -t
DEBUG Version: 2025.8.7 linux-x64 (2025-08-06)
DEBUG Version: 2025.8.7 linux-x64 (2025-08-06)
DEBUG Version: 2025.8.7 linux-x64 (2025-08-06)
DEBUG ARGS: mise x yj -- yj -t
DEBUG ARGS: mise x jd -- jd -f merge /dev/fd/63 /dev/fd/62
DEBUG ARGS: mise x yj -- yj -t
DEBUG config: ~/work/mise/mise/mise.toml
DEBUG config: ~/work/mise/mise/mise.toml
DEBUG config: ~/work/mise/mise/mise.toml
DEBUG config: ~/work/mise/mise/mise.toml
DEBUG EnvResults { env_paths: ["/home/runner/work/mise/mise/target/debug", "/home/runner/work/mise/mise/node_modules/.bin"] }
DEBUG GET http://mise-versions.jdx.dev/yj
DEBUG starting new connection: http://mise-versions.jdx.dev/
DEBUG GET http://mise-versions.jdx.dev/yj
DEBUG starting new connection: http://mise-versions.jdx.dev/
DEBUG GET http://mise-versions.jdx.dev/jd
DEBUG starting new connection: http://mise-versions.jdx.dev/
DEBUG GET http://mise-versions.jdx.dev/yj 200 OK
DEBUG install_some_versions: yj@latest
INFO  yj@5.1.0               install
DEBUG GET https://api.github.com/repos/sclevine/yj/releases
DEBUG starting new connection: https://api.github.com/
DEBUG GET http://mise-versions.jdx.dev/jd 200 OK
DEBUG install_some_versions: jd@latest
INFO  jd@2.2.3               install
DEBUG GET https://api.github.com/repos/josephburnett/jd/releases
DEBUG starting new connection: https://api.github.com/
DEBUG GET http://mise-versions.jdx.dev/yj 200 OK
DEBUG install_some_versions: yj@latest
INFO  yj@5.1.0               install
DEBUG waiting for lock on ~/.cache/mise/lockfiles/5d784cf5eb0ef75e
DEBUG GET https://api.github.com/repos/sclevine/yj/releases 200 OK
DEBUG GET https://api.github.com/repos/sclevine/yj/releases/tags/v5.1.0
DEBUG GET https://api.github.com/repos/josephburnett/jd/releases 200 OK
DEBUG GET https://api.github.com/repos/josephburnett/jd/releases/tags/v2.2.3
DEBUG GET https://api.github.com/repos/sclevine/yj/releases/tags/v5.1.0 200 OK
INFO  yj@5.1.0               download yj-linux-amd64
DEBUG GET Downloading https://github.com/sclevine/yj/releases/download/v5.1.0/yj-linux-amd64 to ~/.local/share/mise/downloads/yj/5.1.0/yj-linux-amd64
DEBUG GET https://github.com/sclevine/yj/releases/download/v5.1.0/yj-linux-amd64
DEBUG starting new connection: https://github.com/
DEBUG GET https://api.github.com/repos/josephburnett/jd/releases/tags/v2.2.3 200 OK
INFO  jd@2.2.3               download jd-amd64-linux
DEBUG GET Downloading https://github.com/josephburnett/jd/releases/download/v2.2.3/jd-amd64-linux to ~/.local/share/mise/downloads/jd/2.2.3/jd-amd64-linux
DEBUG GET https://github.com/josephburnett/jd/releases/download/v2.2.3/jd-amd64-linux
DEBUG starting new connection: https://github.com/
DEBUG starting new connection: https://release-assets.githubusercontent.com/
DEBUG GET https://github.com/sclevine/yj/releases/download/v5.1.0/yj-linux-amd64 200 OK
INFO  yj@5.1.0               generate checksum yj-linux-amd64
INFO  yj@5.1.0               record size yj-linux-amd64
INFO  yj@5.1.0               extract yj-linux-amd64
INFO  yj@5.1.0             ✓ installed
INFO  yj@5.1.0               download yj-linux-amd64
DEBUG config: ~/work/mise/mise/mise.toml
DEBUG [aqua:sclevine/yj@5.1.0] list_bin_paths: ["/home/runner/.local/share/mise/installs/yj/5.1.0"]
DEBUG GET Downloading https://github.com/sclevine/yj/releases/download/v5.1.0/yj-linux-amd64 to ~/.local/share/mise/downloads/yj/5.1.0/yj-linux-amd64
DEBUG GET https://github.com/sclevine/yj/releases/download/v5.1.0/yj-linux-amd64
DEBUG starting new connection: https://github.com/
DEBUG updating 1 lockfiles
WARN  missing: yj@5.1.0
DEBUG EnvResults { env_paths: ["/home/runner/work/mise/mise/target/debug", "/home/runner/work/mise/mise/node_modules/.bin"] }
Error: 
   0: "yj" couldn't exec process: No such file or directory

Location:
   src/cli/exec.rs:128

Version:
   2025.8.7 linux-x64 (2025-08-06)

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 2 frames hidden ⋮                               
   3: mise::cli::exec::Exec::run::{{closure}}::{{closure}}::h1c9b1ce63df8dc51
      at <unknown source file>:<unknown line>
   4: <async_backtrace::framed::Framed<F> as core::future::future::Future>::poll::hfbf1dfa1c7124c54
      at <unknown source file>:<unknown line>
   5: mise::cli::exec::Exec::run::{{closure}}::hc16abb7e85b66888.49755<unknown>
      at <unknown source file>:<unknown line>
   6: mise::cli::Commands::run::{{closure}}::h83731c52b0c1d2f1.49732<unknown>
      at <unknown source file>:<unknown line>
   7: mise::cli::Cli::run::{{closure}}::ha0cdb2b6709825cd.49694<unknown>
      at <unknown source file>:<unknown line>
   8: tokio::runtime::runtime::Runtime::block_on::h1670429a1ee5f4e5
      at <unknown source file>:<unknown line>
   9: mise::main::h5952510e40af4251
      at <unknown source file>:<unknown line>
  10: std::sys::backtrace::__rust_begin_short_backtrace::h397b2a66038df40e
      at <unknown source file>:<unknown line>
  11: main<unknown>
      at <unknown source file>:<unknown line>
  12: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>
  13: _start<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
Run with RUST_BACKTRACE=full to include source snippets.
DEBUG starting new connection: https://release-assets.githubusercontent.com/
DEBUG starting new connection: https://release-assets.githubusercontent.com/
DEBUG GET https://github.com/sclevine/yj/releases/download/v5.1.0/yj-linux-amd64 200 OK
DEBUG GET https://github.com/josephburnett/jd/releases/download/v2.2.3/jd-amd64-linux 200 OK
INFO  yj@5.1.0               generate checksum yj-linux-amd64
INFO  yj@5.1.0               record size yj-linux-amd64
INFO  yj@5.1.0               extract yj-linux-amd64
INFO  yj@5.1.0             ✓ installed
DEBUG config: ~/work/mise/mise/mise.toml
DEBUG [aqua:sclevine/yj@5.1.0] list_bin_paths: ["/home/runner/.local/share/mise/installs/yj/5.1.0"]
DEBUG updating 1 lockfiles
DEBUG EnvResults { env_paths: ["/home/runner/work/mise/mise/target/debug", "/home/runner/work/mise/mise/node_modules/.bin"] }
INFO  jd@2.2.3               generate checksum jd-amd64-linux
INFO  jd@2.2.3               record size jd-amd64-linux
INFO  jd@2.2.3               extract jd-amd64-linux
INFO  jd@2.2.3             ✓ installed
DEBUG config: ~/work/mise/mise/mise.toml
DEBUG [aqua:josephburnett/jd@2.2.3] list_bin_paths: ["/home/runner/.local/share/mise/installs/jd/2.2.3"]
DEBUG updating 1 lockfiles
DEBUG EnvResults { env_paths: ["/home/runner/work/mise/mise/target/debug", "/home/runner/work/mise/mise/node_modules/.bin"] }
```

</details>