### PR TITLE
docs: add documentation for os field in tool configuration

### DIFF
--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -142,7 +142,34 @@ port = 6379
 
 Internally, nested options are flattened to dot notation (e.g., `platforms.macos-x64.url`, `database.host`, `cache.redis.port`) for backend access.
 
-### Caching and Performance
+## OS-Specific Tools
+
+You can restrict tools to specific operating systems using the `os` field:
+
+```toml
+[tools]
+# Only install on Linux and macOS
+ripgrep = { version = "latest", os = ["linux", "macos"] }
+
+# Only install on Windows
+"npm:windows-terminal" = { version = "latest", os = ["windows"] }
+
+# Works with other options
+"cargo:usage-cli" = { 
+    version = "latest", 
+    os = ["linux", "macos"],
+    install_env = { RUST_BACKTRACE = "1" }
+}
+```
+
+The `os` field accepts an array of operating system identifiers:
+- `"linux"` - All Linux distributions
+- `"macos"` - macOS (Darwin)
+- `"windows"` - Windows
+
+If a tool specifies an `os` restriction and the current operating system is not in the list, mise will skip installing and using that tool.
+
+## Caching and Performance
 
 mise uses intelligent caching to minimize overhead:
 


### PR DESCRIPTION
## Summary
- Added documentation for the `os` field in tool configuration
- Explains how to restrict tools to specific operating systems

## Details
This PR adds a new section "OS-Specific Tools" to the dev-tools documentation that explains how to use the `os` field to restrict tool installation to specific operating systems (linux, macos, windows).

The documentation includes:
- Basic usage examples
- List of supported OS identifiers
- How it works with other tool options
- Clear explanation of the behavior when OS restrictions are applied

Fixes the issue where the `os` field was being used in mise.toml files but was not documented in the user-facing documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)