### PR TITLE
chore(ci): accept @ in regular expressions for new registry PR titles

### DIFF
--- a/.github/workflows/registry_comment.yml
+++ b/.github/workflows/registry_comment.yml
@@ -99,7 +99,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Check if PR title follows the exact format: registry: add [TOOL] ([FULL])
-          if [[ ! "$PR_TITLE" =~ ^registry:\ add\ [a-zA-Z0-9_-]+\ \([a-zA-Z0-9:/-]+\)$ ]]; then
+          if [[ ! "$PR_TITLE" =~ ^registry:\ add\ [a-zA-Z0-9_-]+\ \([a-zA-Z0-9@:/-]+\)$ ]]; then
             echo "❌ Error: PR title must follow the exact format when adding new tools"
             echo "Current title: $PR_TITLE"
             echo "Expected format: registry: add [TOOL] ([FULL])"


### PR DESCRIPTION
## description

Currently, PRs that add new registries are checked by github actions for their titles, but the current check fails because npm's scoped modules contain `@` (like `npm:@anthropic-ai/claude-code`).

This PR adds `@` to the regex pattern to fix the validation.

You can see this failed action in #5967, which I created
(this PR has been closed as it was unnecessary).