### PR TITLE
fix: couldn't download node binary in Alpine, even if it exists in the mirror url

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -78,8 +78,13 @@ static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static DEFAULT_SETTINGS: Lazy<SettingsPartial> = Lazy::new(|| {
     let mut s = SettingsPartial::empty();
     s.python.default_packages_file = Some(env::HOME.join(".default-python-packages"));
-    if let Some("alpine" | "nixos") = env::LINUX_DISTRO.as_ref().map(|s| s.as_str()) {
+    let distro = env::LINUX_DISTRO.as_ref().map(|s| s.as_str());
+    if let Some("alpine" | "nixos") = distro {
         if !cfg!(test) {
+            info!(
+                "activating settings.all_compile as the {:?} distro default",
+                distro
+            );
             s.all_compile = Some(true);
         }
     }
@@ -176,7 +181,9 @@ impl Settings {
             settings.yes = true;
         }
         if settings.all_compile {
-            settings.node.compile = Some(true);
+            if settings.node.compile.is_none() {
+                settings.node.compile = Some(true);
+            }
             if settings.python.compile.is_none() {
                 settings.python.compile = Some(true);
             }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -78,13 +78,8 @@ static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static DEFAULT_SETTINGS: Lazy<SettingsPartial> = Lazy::new(|| {
     let mut s = SettingsPartial::empty();
     s.python.default_packages_file = Some(env::HOME.join(".default-python-packages"));
-    let distro = env::LINUX_DISTRO.as_ref().map(|s| s.as_str());
-    if let Some("alpine" | "nixos") = distro {
+    if let Some("alpine" | "nixos") = env::LINUX_DISTRO.as_ref().map(|s| s.as_str()) {
         if !cfg!(test) {
-            info!(
-                "activating settings.all_compile as the {:?} distro default",
-                distro
-            );
             s.all_compile = Some(true);
         }
     }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -57,9 +57,7 @@ impl NodePlugin {
                 &opts.binary_tarball_path,
                 &opts.version,
             )
-            .await
-            .map_err(eyre::Report::from)
-        {
+            .await{
             Ok(()) => {
                 debug!("We successfully downloaded precompiled node archive");
             }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -57,7 +57,8 @@ impl NodePlugin {
                 &opts.binary_tarball_path,
                 &opts.version,
             )
-            .await{
+            .await
+        {
             Ok(()) => {
                 debug!("We successfully downloaded precompiled node archive");
             }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -46,7 +46,7 @@ impl NodePlugin {
         opts: &BuildOpts,
         extract: impl FnOnce() -> Result<()>,
     ) -> Result<FetchOutcome> {
-        debug!("We will fetch a precompiled version");
+        debug!("{:?}: we will fetch a precompiled version", self);
 
         match self
             .fetch_tarball(
@@ -60,10 +60,10 @@ impl NodePlugin {
             .await
         {
             Ok(()) => {
-                debug!("We successfully downloaded precompiled node archive");
+                debug!("{:?}: successfully downloaded node archive", self);
             }
             Err(e) if matches!(http::error_code(&e), Some(404)) => {
-                debug!("precompiled node archive not found {e}");
+                debug!("{:?}: precompiled node archive not found {e}", self);
                 return Ok(FetchOutcome::NotFound);
             }
             Err(e) => return Err(e),
@@ -71,14 +71,14 @@ impl NodePlugin {
 
         let tarball_name = &opts.binary_tarball_name;
         ctx.pr.set_message(format!("extract {tarball_name}"));
-        debug!("extracting precompiled node");
+        debug!("{:?}: extracting precompiled node", self);
 
         if let Err(e) = extract() {
-            debug!("extraction failed: {e}");
+            debug!("{:?}: extraction failed: {e}", self);
             return Err(e);
         }
 
-        debug!("precompiled node extraction was successful");
+        debug!("{:?}: precompiled node extraction was successful", self);
         Ok(FetchOutcome::Downloaded)
     }
 
@@ -90,7 +90,7 @@ impl NodePlugin {
         strip_components: usize,
     ) -> Result<()> {
         file::remove_all(dest_path).map_err(|e| {
-            debug!("Failed to remove {:?}: {e}", dest_path);
+            debug!("{:?}: Failed to remove {:?}: {e}", self, dest_path);
             e
         })?;
         file::untar(
@@ -169,7 +169,7 @@ impl NodePlugin {
         tv: &mut ToolVersion,
         opts: &BuildOpts,
     ) -> Result<()> {
-        debug!("We will fetch the source and compile");
+        debug!("{:?}: we will fetch the source and compile", self);
         let tarball_name = &opts.source_tarball_name;
         self.fetch_tarball(
             ctx,
@@ -504,7 +504,7 @@ impl Backend for NodePlugin {
         } else {
             self.install_precompiled(ctx, &mut tv, &opts).await?;
         }
-        debug!("Checking if the installation is working as expected");
+        debug!("{:?}: checking installation is working as expected", self);
         self.test_node(&ctx.config, &tv, &ctx.pr).await?;
         if !cfg!(windows) {
             self.install_npm_shim(&tv)?;

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -89,10 +89,6 @@ impl NodePlugin {
         ctx: &InstallContext,
         strip_components: usize,
     ) -> Result<()> {
-        file::remove_all(dest_path).map_err(|e| {
-            debug!("{:?}: Failed to remove {:?}: {e}", self, dest_path);
-            e
-        })?;
         file::untar(
             tarball_path,
             dest_path,
@@ -128,6 +124,10 @@ impl NodePlugin {
     ) -> Result<()> {
         match self
             .fetch_binary(ctx, tv, opts, || {
+                file::remove_all(&opts.install_path).map_err(|e| {
+                    debug!("{:?}: Failed to remove {:?}: {e}", self, &opts.install_path);
+                    e
+                })?;
                 self.extract_tarball(
                     &opts.binary_tarball_path,
                     &opts.install_path,
@@ -181,6 +181,10 @@ impl NodePlugin {
         )
         .await?;
         ctx.pr.set_message(format!("extract {tarball_name}"));
+        file::remove_all(&opts.build_dir).map_err(|e| {
+            debug!("{:?}: Failed to remove {:?}: {e}", self, &opts.build_dir);
+            e
+        })?;
         self.extract_tarball(
             &opts.source_tarball_path,
             opts.build_dir.parent().unwrap(),

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -89,7 +89,6 @@ impl NodePlugin {
         ctx: &InstallContext,
         strip_components: usize,
     ) -> Result<()> {
-        debug!("Removing destination before extraction: {:?}", dest_path);
         file::remove_all(dest_path).map_err(|e| {
             debug!("Failed to remove {:?}: {e}", dest_path);
             e
@@ -501,7 +500,6 @@ impl Backend for NodePlugin {
         if cfg!(windows) {
             self.install_windows(ctx, &mut tv, &opts).await?;
         } else if settings.node.compile == Some(true) {
-            info!("node.compile true so we won't fetch a precompiled version");
             self.install_compiling(ctx, &mut tv, &opts).await?;
         } else {
             self.install_precompiled(ctx, &mut tv, &opts).await?;


### PR DESCRIPTION
I was trying to use in Alpine the following build:

https://unofficial-builds.nodejs.org/download/release/v24.5.0/node-v24.5.0-linux-x64-musl.tar.gz

So I set:

```sh
export MISE_NODE_MIRROR_URL=https://unofficial-builds.nodejs.org/download/release/
export MISE_NODE_FLAVOR=musl
export MISE_NODE_COMPILE=false

# and/or

mise settings set node.mirror_url https://unofficial-builds.nodejs.org/download/release/
mise settings set node.flavor musl
mise settings set node.compile 0
```

But `mise install` would **always** fail trying to download `https://unofficial-builds.nodejs.org/download/release/v24.5.0/node-v24.5.0.tar.gz` that don't exist.

The main issue was that my `settings.node.compile false` was being overridden by the distro `all_compile` override, and it would then try to download the source code for compilation, and fail, took me a long while to figure that out. The real fix was just avoiding the `all_compile` override if  `node.compile` was set by the user manually. Added a `info` log to avoid future issues with not understand where this behavior came from.

The rest of the changes in `plugins/core/node.rs` are not necessary to solve the bug, but I would like to try pushing too:
 - I made a `fetch_binary` to reuse/deduplicate code for posix and windows, while at it made the logic about Ok explicit and about the NotFound case too; (_while the diff looks horrible, imho the final code is clearer to reason and safer now, for someone new to the codebase_)
 - it now makes explicitly clear when "precompiled node archive not found and compilation is disabled" happens.
 - Renamed `install_compiled` to `install_compiling` to make the intent of the method really clear, the first time I read the code I was confusing `install_compiled` and `install_precompiled`
 - Made the unarchiving logic reusable, I was thinking in moving to another place to let other packages use something like this, but it's just that for now;
 - ~~Made sure the errors where not encapsulated by using `Report::from` (I had a bug because of it while testing stuff that shouldn't ever happen, making an `Ok(())` be tested and treated as 404 somehow, but the previous flow allowed it when I made my broken test changes, so this could eventually cause a bug to some bad change in the future)~~ removed by autofix
 - Added 2 `info` logs that would've been crucial to understand this issue.
 - Added more `debug` logging around the areas that eventually led me to discover the issue, and areas I was under the impression could be potential troublemakers.
 
 
 The new install_precompiled and install_windows method bodies here for faster reading than the diff, just to try to defend my "unnecessary" changes easier 😆:
 ```rust
    async fn install_precompiled(
        &self,
        ctx: &InstallContext,
        tv: &mut ToolVersion,
        opts: &BuildOpts,
    ) -> Result<()> {
        match self
            .fetch_binary(ctx, tv, opts, || {
                self.extract_tarball(
                    &opts.binary_tarball_path,
                    &opts.install_path,
                    ctx,
                    1, // strip_components for binary tarball
                )
            })
            .await?
        {
            FetchOutcome::Downloaded => Ok(()),
            FetchOutcome::NotFound => {
                if Settings::get().node.compile != Some(false) {
                    self.install_compiling(ctx, tv, opts).await
                } else {
                    bail!("precompiled node archive not found and compilation is disabled")
                }
            }
        }
    }

    async fn install_windows(
        &self,
        ctx: &InstallContext,
        tv: &mut ToolVersion,
        opts: &BuildOpts,
    ) -> Result<()> {
        match self
            .fetch_binary(ctx, tv, opts, || self.extract_zip(opts, ctx))
            .await?
        {
            FetchOutcome::Downloaded => Ok(()),
            FetchOutcome::NotFound => bail!("precompiled node archive not found (404)"),
        }
    }
```