### PR TITLE
registry: revert back to plugin for yarn to bring back v1 compat

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -3057,7 +3057,6 @@ yarn.backends = [
     "aqua:yarnpkg/berry",
     "npm:@yarnpkg/cli-dist"
 ]
-yarn.idiomatic_files = [".yvmrc"]
 yarn.test = ["yarn --version", "{{version}}"]
 yay.backends = ["asdf:mise-plugins/mise-yay"]
 yazi.description = "Blazing fast terminal file manager written in Rust, based on async I/O"

--- a/registry.toml
+++ b/registry.toml
@@ -3053,10 +3053,8 @@ yamlscript.backends = [
 ]
 yamlscript.test = ["ys --version", "{{version}}"]
 yarn.backends = [
-    {full = "aqua:yarnpkg/berry", platforms = [
-        "windows"
-    ]},
     "asdf:mise-plugins/mise-yarn",
+    "aqua:yarnpkg/berry",
     "npm:@yarnpkg/cli-dist"
 ]
 yarn.idiomatic_files = [".yvmrc"]

--- a/registry.toml
+++ b/registry.toml
@@ -3053,9 +3053,11 @@ yamlscript.backends = [
 ]
 yamlscript.test = ["ys --version", "{{version}}"]
 yarn.backends = [
-    "aqua:yarnpkg/berry",
-    "npm:@yarnpkg/cli-dist",
-    "asdf:mise-plugins/mise-yarn"
+    {full = "aqua:yarnpkg/berry", platforms = [
+        "windows"
+    ]},
+    "asdf:mise-plugins/mise-yarn",
+    "npm:@yarnpkg/cli-dist"
 ]
 yarn.idiomatic_files = [".yvmrc"]
 yarn.test = ["yarn --version", "{{version}}"]


### PR DESCRIPTION
convert back to plugin for yarn. I'm working on making this a vfox plugin so windows support will come back

Fixes https://github.com/mise-plugins/mise-yarn/issues/14