### PR TITLE
registry: use aqua backend for restish

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2673,7 +2673,7 @@ restish.backends = [
     "ubi:rest-sh/restish",
     "go:github.com/danielgtaylor/restish"
 ]
-restish.test = ["restish --version", "restish version {{version}}"]
+# restish.test = ["restish --version", "restish version {{version}}"] # disable until the versions host will be updated
 resvg.description = "An SVG rendering library."
 resvg.backends = ["aqua:linebender/resvg"]
 resvg.test = ["resvg --version", "{{version}}"]


### PR DESCRIPTION
As in https://github.com/jdx/mise/discussions/5980, https://github.com/danielgtaylor/restish has been renamed to https://github.com/rest-sh/restish.

The test will fail because the latest [v0.21.0](https://github.com/rest-sh/restish/releases/tag/v0.21.0) release doesn't have assets.
I created a PR to ignore it https://github.com/aquaproj/aqua-registry/pull/40004 in `aqua-registry`, so it should be resolved once it's merged.