### PR TITLE
fix(aqua): add executable permissions for zip-extracted binaries

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -713,6 +713,7 @@ impl AquaBackend {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
         } else if format == "zip" {
             file::unzip(&tarball_path, &install_path, &Default::default())?;
+            file::make_executable(&bin_path)?;
         } else if format == "gz" {
             file::create_dir_all(&install_path)?;
             file::un_gz(&tarball_path, &bin_path)?;


### PR DESCRIPTION
When extracting binaries from zip archives in the aqua backend, the files were not being marked as executable. This caused tools like [CQLabs/homebrew-dcm](https://github.com/CQLabs/homebrew-dcm) to fail with permission errors when trying to execute them.

This fix adds a call to file::make_executable() after extracting zip files, matching the behavior of other archive formats (gz, xz, zst, bz2) which already set executable permissions.

Fixes permission denied errors when using aqua backend with zip-packaged tools.

Current mise:
```bash
% mise exec aqua:CQLabs/homebrew-dcm -- dcm --version
mise aqua:CQLabs/homebrew-dcm@1.30.1 ✓ installed
mise ERROR "dcm" couldn't exec process: Permission denied
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```

This PR changes:
```bash
% mise uninstall aqua:CQLabs/homebrew-dcm
% @mise exec aqua:CQLabs/homebrew-dcm -- dcm --version
mise aqua:CQLabs/homebrew-dcm@1.30.1 ✓ installed
DCM version: 1.30.1
```