### PR TITLE
Revert "fix(aqua): add executable permissions for zip-extracted binaries"

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -713,7 +713,6 @@ impl AquaBackend {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
         } else if format == "zip" {
             file::unzip(&tarball_path, &install_path, &Default::default())?;
-            file::make_executable(&bin_path)?;
         } else if format == "gz" {
             file::create_dir_all(&install_path)?;
             file::un_gz(&tarball_path, &bin_path)?;


### PR DESCRIPTION
Reverts jdx/mise#5998

this breaks zip files that contain multiple files