### PR TITLE
registry: fix os specific backends for usage

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -3272,9 +3272,9 @@ upx.backends = ["aqua:upx/upx", "asdf:jimmidyson/asdf-upx"]
 usage.description = "A specification for CLIs"
 usage.backends = [
     # prebuilt binaries are not available for FreeBSD
-    {full = "aqua:jdx/usage", os = ["linux", "macos"]},
-    {full = "ubi:jdx/usage", os = ["linux", "macos"]},
-    {full = "asdf:mise-plugins/mise-usage", os = ["linux", "macos"]},
+    {full = "aqua:jdx/usage", platforms = ["linux", "macos"]},
+    {full = "ubi:jdx/usage", platforms = ["linux", "macos"]},
+    {full = "asdf:mise-plugins/mise-usage", platforms = ["linux", "macos"]},
     "cargo:usage-cli"
 ]
 usage.os = ["linux", "macos", "freebsd"]


### PR DESCRIPTION
Follow up for https://github.com/jdx/mise/pull/5973.

Sorry, I didn't remember we need to use `platforms` instead of `os` here.