### PR TITLE
feat(aqua): make bin paths executable

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1225,11 +1225,7 @@ gitsign.backends = ["aqua:sigstore/gitsign", "asdf:spencergilbert/asdf-gitsign"]
 gitsign.os = ["linux", "macos"]
 gitsign.test = ["gitsign --version", "gitsign version v{{version}}"]
 gitu.description = "A TUI Git client inspired by Magit"
-gitu.backends = [
-    "aqua:altsem/gitu",
-    "ubi:altsem/gitu",
-    "cargo:gitu"
-]
+gitu.backends = ["aqua:altsem/gitu", "ubi:altsem/gitu", "cargo:gitu"]
 gitu.test = ["gitu --version", "gitu v{{version}}"]
 gitui.description = "Blazing 💥 fast terminal-ui for git written in rust"
 gitui.backends = ["aqua:extrawurst/gitui", "asdf:looztra/asdf-gitui"]

--- a/registry.toml
+++ b/registry.toml
@@ -2504,6 +2504,7 @@ powershell-core.backends = [
     "aqua:PowerShell/PowerShell",
     "asdf:daveneeley/asdf-powershell-core"
 ]
+powershell-core.test = ["pwsh --version", "PowerShell {{version}}"]
 pre-commit.description = "A framework for managing and maintaining multi-language pre-commit hooks"
 pre-commit.backends = [
     "aqua:pre-commit/pre-commit",

--- a/registry.toml
+++ b/registry.toml
@@ -331,7 +331,7 @@ black.backends = ["aqua:psf/black"]
 black.test = ["black --version", "black, {{version}}"]
 bob.description = "A version manager for neovim"
 bob.backends = [
-    # "aqua:MordechaiHadad/bob",  # +x permission not set
+    "aqua:MordechaiHadad/bob",
     "ubi:MordechaiHadad/bob[matching_regex=bob-(linux|macos|windows)-(arm|x86_64)\\.zip$]",
     "cargo:bob-nvim"
 ]
@@ -1226,7 +1226,7 @@ gitsign.os = ["linux", "macos"]
 gitsign.test = ["gitsign --version", "gitsign version v{{version}}"]
 gitu.description = "A TUI Git client inspired by Magit"
 gitu.backends = [
-    # "aqua:altsem/gitu", # +x permission not set
+    "aqua:altsem/gitu",
     "ubi:altsem/gitu",
     "cargo:gitu"
 ]
@@ -2181,7 +2181,7 @@ mint.description = "🍃 A refreshing programming language for the front-end web
 mint.backends = ["ubi:mint-lang/mint", "asdf:mint-lang/asdf-mint"]
 mirrord.description = "Connect your local process and your cloud environment, and run local code in cloud conditions"
 mirrord.backends = [
-    # "aqua:metalbear-co/mirrord", # +x permission not set
+    "aqua:metalbear-co/mirrord",
     "ubi:metalbear-co/mirrord",
     "asdf:metalbear-co/asdf-mirrord"
 ]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -726,7 +726,7 @@ impl AquaBackend {
                 }
             })
             .collect();
-        let first_bin_path = bin_paths.first().unwrap();
+        let first_bin_path = bin_paths.first().expect("at least one bin path should exist");
         let mut tar_opts = TarOptions {
             format: format.parse().unwrap_or_default(),
             pr: Some(&ctx.pr),

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -698,7 +698,7 @@ impl AquaBackend {
         let install_path = tv.install_path();
         file::remove_all(&install_path)?;
         let format = pkg.format(v)?;
-        let bin_names: Vec<Cow<str>> = if pkg.files.is_empty() {
+        let bin_names = if pkg.files.is_empty() {
             let fallback_name = pkg
                 .name
                 .as_deref()

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -726,7 +726,9 @@ impl AquaBackend {
                 }
             })
             .collect();
-        let first_bin_path = bin_paths.first().expect("at least one bin path should exist");
+        let first_bin_path = bin_paths
+            .first()
+            .expect("at least one bin path should exist");
         let mut tar_opts = TarOptions {
             format: format.parse().unwrap_or_default(),
             pr: Some(&ctx.pr),

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -777,6 +777,8 @@ impl AquaBackend {
                 // bin_path should exist, but doesn't when the registry is outdated
                 if bin_path.exists() {
                     file::make_executable(bin_path)?;
+                } else {
+                    warn!("bin path does not exist: {}", bin_path.display());
                 }
             }
         }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -732,6 +732,7 @@ impl AquaBackend {
         } else if format == "raw" {
             file::create_dir_all(&install_path)?;
             file::copy(&tarball_path, first_bin_path)?;
+            file::make_executable(first_bin_path)?;
         } else if format.starts_with("tar") {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
             for bin_path in &bin_paths {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -701,14 +701,11 @@ impl AquaBackend {
             let fallback_name = pkg
                 .name
                 .as_deref()
-                .and_then(|n| n.split('/').last())
+                .and_then(|n| n.split('/').next_back())
                 .unwrap_or(&pkg.repo_name);
             vec![fallback_name]
         } else {
-            pkg.files
-                .iter()
-                .map(|file| file.name.as_str())
-                .collect()
+            pkg.files.iter().map(|file| file.name.as_str()).collect()
         };
         let bin_paths: Vec<_> = bin_names
             .iter()
@@ -733,7 +730,7 @@ impl AquaBackend {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
         } else if format == "raw" {
             file::create_dir_all(&install_path)?;
-            file::copy(&tarball_path, &bin_paths.first().unwrap())?;
+            file::copy(&tarball_path, bin_paths.first().unwrap())?;
         } else if format.starts_with("tar") {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
             for bin_path in &bin_paths {
@@ -746,20 +743,20 @@ impl AquaBackend {
             }
         } else if format == "gz" {
             file::create_dir_all(&install_path)?;
-            file::un_gz(&tarball_path, &bin_paths.first().unwrap())?;
-            file::make_executable(&bin_paths.first().unwrap())?;
+            file::un_gz(&tarball_path, bin_paths.first().unwrap())?;
+            file::make_executable(bin_paths.first().unwrap())?;
         } else if format == "xz" {
             file::create_dir_all(&install_path)?;
-            file::un_xz(&tarball_path, &bin_paths.first().unwrap())?;
-            file::make_executable(&bin_paths.first().unwrap())?;
+            file::un_xz(&tarball_path, bin_paths.first().unwrap())?;
+            file::make_executable(bin_paths.first().unwrap())?;
         } else if format == "zst" {
             file::create_dir_all(&install_path)?;
-            file::un_zst(&tarball_path, &bin_paths.first().unwrap())?;
-            file::make_executable(&bin_paths.first().unwrap())?;
+            file::un_zst(&tarball_path, bin_paths.first().unwrap())?;
+            file::make_executable(bin_paths.first().unwrap())?;
         } else if format == "bz2" {
             file::create_dir_all(&install_path)?;
-            file::un_bz2(&tarball_path, &bin_paths.first().unwrap())?;
-            file::make_executable(&bin_paths.first().unwrap())?;
+            file::un_bz2(&tarball_path, bin_paths.first().unwrap())?;
+            file::make_executable(bin_paths.first().unwrap())?;
         } else if format == "dmg" {
             file::un_dmg(&tarball_path, &install_path)?;
         } else if format == "pkg" {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -708,8 +708,13 @@ impl AquaBackend {
         } else {
             pkg.files
                 .iter()
-                .filter_map(|file| file.src(pkg, v).ok().flatten())
-                .map(Cow::Owned)
+                .filter_map(|file| {
+                    match file.src(pkg, v) {
+                        Ok(Some(s)) => Some(Cow::Owned(s)),
+                        Ok(None) => Some(Cow::Borrowed(file.name.as_str())),
+                        Err(_) => None,
+                    }
+                })
                 .collect()
         };
         let bin_paths: Vec<_> = bin_names

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -708,12 +708,10 @@ impl AquaBackend {
         } else {
             pkg.files
                 .iter()
-                .filter_map(|file| {
-                    match file.src(pkg, v) {
-                        Ok(Some(s)) => Some(Cow::Owned(s)),
-                        Ok(None) => Some(Cow::Borrowed(file.name.as_str())),
-                        Err(_) => None,
-                    }
+                .filter_map(|file| match file.src(pkg, v) {
+                    Ok(Some(s)) => Some(Cow::Owned(s)),
+                    Ok(None) => Some(Cow::Borrowed(file.name.as_str())),
+                    Err(_) => None,
                 })
                 .collect()
         };

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -709,7 +709,7 @@ impl AquaBackend {
             pkg.files
                 .iter()
                 .filter_map(|file| file.src(pkg, v).ok().flatten())
-                .map(|s| Cow::Owned(s))
+                .map(Cow::Owned)
                 .collect()
         };
         let bin_paths: Vec<_> = bin_names

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -718,6 +718,7 @@ impl AquaBackend {
                 }
             })
             .collect();
+        let first_bin_path = bin_paths.first().unwrap();
         let mut tar_opts = TarOptions {
             format: format.parse().unwrap_or_default(),
             pr: Some(&ctx.pr),
@@ -730,7 +731,7 @@ impl AquaBackend {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
         } else if format == "raw" {
             file::create_dir_all(&install_path)?;
-            file::copy(&tarball_path, bin_paths.first().unwrap())?;
+            file::copy(&tarball_path, first_bin_path)?;
         } else if format.starts_with("tar") {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
             for bin_path in &bin_paths {
@@ -743,20 +744,20 @@ impl AquaBackend {
             }
         } else if format == "gz" {
             file::create_dir_all(&install_path)?;
-            file::un_gz(&tarball_path, bin_paths.first().unwrap())?;
-            file::make_executable(bin_paths.first().unwrap())?;
+            file::un_gz(&tarball_path, first_bin_path)?;
+            file::make_executable(first_bin_path)?;
         } else if format == "xz" {
             file::create_dir_all(&install_path)?;
-            file::un_xz(&tarball_path, bin_paths.first().unwrap())?;
-            file::make_executable(bin_paths.first().unwrap())?;
+            file::un_xz(&tarball_path, first_bin_path)?;
+            file::make_executable(first_bin_path)?;
         } else if format == "zst" {
             file::create_dir_all(&install_path)?;
-            file::un_zst(&tarball_path, bin_paths.first().unwrap())?;
-            file::make_executable(bin_paths.first().unwrap())?;
+            file::un_zst(&tarball_path, first_bin_path)?;
+            file::make_executable(first_bin_path)?;
         } else if format == "bz2" {
             file::create_dir_all(&install_path)?;
-            file::un_bz2(&tarball_path, bin_paths.first().unwrap())?;
-            file::make_executable(bin_paths.first().unwrap())?;
+            file::un_bz2(&tarball_path, first_bin_path)?;
+            file::make_executable(first_bin_path)?;
         } else if format == "dmg" {
             file::un_dmg(&tarball_path, &install_path)?;
         } else if format == "pkg" {


### PR DESCRIPTION
Reapplies https://github.com/jdx/mise/pull/5998 (reverted in https://github.com/jdx/mise/pull/6004) with some changes.

Some tools don't set `+x` permissions to their executable files in the archives:

- [`powershell`](https://github.com/PowerShell/PowerShell) (https://github.com/jdx/mise/discussions/5552)
- [`bob`](https://github.com/MordechaiHadad/bob)
- [`gitu`](https://github.com/altsem/gitu)
- [`mirrord`](https://github.com/metalbear-co/mirrord)
- [`CQLabs/homebrew-dcm`](https://github.com/CQLabs/homebrew-dcm) (#5998)

Since both `.tar` and `.zip` can include permissions in the archive, this is not a mise bug, but their issues.
However, I think supporting them would be beneficial for some users.

`aqua` supports this because they use shims. `ubi` backend also supports this but I'm not sure why.