### PR TITLE
feat(task): allow more #MISE comments patterns

### DIFF
--- a/docs/tasks/file-tasks.md
+++ b/docs/tasks/file-tasks.md
@@ -49,6 +49,12 @@ You can provide additional configuration for file tasks by adding `#MISE` commen
 
 Assuming that file was located in `mise-tasks/build`, it can then be run with `mise run build` (or with its alias: `mise run b`).
 
+:::tip
+Beware of formatters changing `#MISE` to `# MISE`.
+It's intentionally ignored by mise to avoid unintentional configuration.
+To workaround this, use the alternative: `# [MISE]`.
+:::
+
 ## Shebang
 
 The shebang line is optional, but if it is present, it will be used to determine the shell to run the script with.

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -165,6 +165,10 @@ impl Task {
         let info = file::read_to_string(path)?
             .lines()
             .filter_map(|line| {
+                debug_assert!(
+                    !VERSION.starts_with("2026.3"),
+                    "remove old syntax `# mise`"
+                );
                 if let Some(captures) =
                     regex!(r"^(?:#|//|::)(?:MISE| ?\[MISE\]) ([a-z_]+=.+)$").captures(line)
                 {
@@ -172,10 +176,6 @@ impl Task {
                 } else if let Some(captures) = regex!(r"^(?:#|//) mise ([a-z_]+=.+)$")
                     .captures(line)
                 {
-                     debug_assert!(
-                        !VERSION.starts_with("2026.3"),
-                        "remove old syntax `# mise`"
-                    );
                     deprecated!(
                         "file_task_headers_old_syntax",
                         "The `# mise ...` syntax for task headers is deprecated and will be removed in mise 2026.3.0. Use the new `#MISE ...` syntax instead."

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,3 +1,4 @@
+use crate::cli::version::VERSION;
 use crate::config::config_file::mise_toml::EnvList;
 use crate::config::config_file::toml::{TomlParser, deserialize_arr};
 use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
@@ -171,6 +172,10 @@ impl Task {
                 } else if let Some(captures) = regex!(r"^(?:#|//) mise ([a-z_]+=.+)$")
                     .captures(line)
                 {
+                     debug_assert!(
+                        !VERSION.starts_with("2026.3"),
+                        "remove old syntax `# mise`"
+                    );
                     deprecated!(
                         "file_task_headers_old_syntax",
                         "The `# mise ...` syntax for task headers is deprecated and will be removed in mise 2026.3.0. Use the new `#MISE ...` syntax instead."

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -164,7 +164,7 @@ impl Task {
         let info = file::read_to_string(path)?
             .lines()
             .filter_map(|line| {
-                regex!(r"^(?:#|//|::) (?:MISE|mise) ([a-z_]+=.+)$")
+                regex!(r"^(?:#|//|::) ?(?:MISE|mise) ([a-z_]+=.+)$")
                     .captures(line)
             })
             .map(|captures| captures.extract().1)

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -168,7 +168,7 @@ impl Task {
                     regex!(r"^(?:#|//|::)(?:MISE| ?\[MISE\]) ([a-z_]+=.+)$").captures(line)
                 {
                     Some(captures)
-                } else if let Some(captures) = regex!(r"^(?:#|//) mise ([a-z_]+=.+)$") // old deprecated syntax
+                } else if let Some(captures) = regex!(r"^(?:#|//) mise ([a-z_]+=.+)$")
                     .captures(line)
                 {
                     deprecated!(

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -824,10 +824,8 @@ mod tests {
             &task_path,
             r#"#!/bin/bash
 #MISE description="Build the CLI"
-#MISE alias="b"
-#MISE sources=["Cargo.toml", "src/**/*.rs"]
-#MISE env={RUST_BACKTRACE = "1"}
-#MISE depends=["lint", "test"]
+# MISE alias="b"
+# [MISE] sources=["Cargo.toml", "src/**/*.rs"]
 echo "hello world"
 "#,
         )
@@ -838,10 +836,6 @@ echo "hello world"
         expected.description = "Build the CLI".to_string();
         expected.aliases = vec!["b".to_string()];
         expected.sources = vec!["Cargo.toml".to_string(), "src/**/*.rs".to_string()];
-        expected.env = vec![("RUST_BACKTRACE".to_string(), "1".to_string())]
-            .into_iter()
-            .collect();
-        expected.depends = vec!["lint".to_string(), "test".to_string()];
         assert_eq!(result.unwrap(), expected);
     }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -163,10 +163,7 @@ impl Task {
         let mut task = Task::new(path, prefix, config_root)?;
         let info = file::read_to_string(path)?
             .lines()
-            .filter_map(|line| {
-                regex!(r"^(?:#|//|::) ?(?:MISE|mise) ([a-z_]+=.+)$")
-                    .captures(line)
-            })
+            .filter_map(|line| regex!(r"^(?:#|//|::) ?(?:MISE|mise) ([a-z_]+=.+)$").captures(line))
             .map(|captures| captures.extract().1)
             .map(|[toml]| {
                 toml.parse::<toml::Value>()

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -164,12 +164,11 @@ impl Task {
         let info = file::read_to_string(path)?
             .lines()
             .filter_map(|line| {
-                regex!(r"^(#|//) mise ([a-z_]+=.+)$")
+                regex!(r"^(?:#|//|::) (?:MISE|mise) ([a-z_]+=.+)$")
                     .captures(line)
-                    .or_else(|| regex!(r"^(#|//|::)MISE ([a-z_]+=.+)$").captures(line))
             })
             .map(|captures| captures.extract().1)
-            .map(|[_, toml]| {
+            .map(|[toml]| {
                 toml.parse::<toml::Value>()
                     .map_err(|e| eyre::eyre!("failed to parse task header TOML '{}': {}", toml, e))
             })


### PR DESCRIPTION
Resovles https://github.com/jdx/mise/discussions/5499.

mise currently supports:
- `# mise`
- `// mise`
- `#MISE`
- `//MISE`
- `::MISE`

This PR supports more patterns by making a space between `#` and `mise` optional for both cases.
- `#mise`
- `//mise`
- `::mise`
- `:: mise`
- `# MISE`
- `// MISE`
- `:: MISE`

---

Sorry, I found `# mise` is now deprecated. Was it because spaces caused problems?
https://github.com/jdx/mise/pull/2694