### PR TITLE
registry: add cfssljson (aqua:cloudflare/cfssl/cfssljson)

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -460,6 +460,7 @@ cfssl.backends = [
 ]
 cfssljson.description = "cfssljson: Takes the JSON output from Cloudflare's cfssl and multirootca programs and writes certificates, keys, CSRs, and bundles to disk."
 cfssljson.backends = ["aqua:cloudflare/cfssl/cfssljson"]
+cfssljson.test = ["cfssljson -version", "Version: {{version}}"]
 chamber.description = "CLI for managing secrets"
 chamber.backends = [
     "aqua:segmentio/chamber",


### PR DESCRIPTION
Adds `cfssljson`, which is a complementary program to `cfssl`, to the mise registry. Both of these programs are developed by Cloudflare here: https://github.com/cloudflare/cfssl