### PR TITLE
registry: add prek (aqua:j178/prek)

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2531,6 +2531,8 @@ pre-commit.backends = [
     "pipx:pre-commit"
 ]
 pre-commit.test = ["pre-commit --version", "pre-commit {{version}}"]
+prek.backends = ["aqua:j178/prek"]
+prek.test = ["prek --version", "prek {{version}}"]
 prettier.description = "Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary"
 prettier.backends = ["npm:prettier"]
 prettier.test = ["prettier --version", "{{version}}"]


### PR DESCRIPTION
I've added prek to aqua-registry, so I will use it with mise.

[aquaproj/aqua-registry#39978](https://github.com/aquaproj/aqua-registry/pull/39978)