### PR TITLE
Fix mise github discussion 6039

### DIFF
--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -76,15 +76,17 @@ impl BunPlugin {
             fallback_root
         } else {
             // As a last resort, search recursively for a file named bun/bun.exe
-            let found = file::recursive_ls(&tv.download_path())?
+            
+            file::recursive_ls(&tv.download_path())?
                 .into_iter()
                 .find(|p| p.file_name().map(|f| f == bun_bin_name()).unwrap_or(false))
-                .ok_or_else(|| eyre::eyre!(
-                    "bun binary not found after extracting {} to {}",
-                    filename,
-                    file::display_path(&tv.download_path())
-                ))?;
-            found
+                .ok_or_else(|| {
+                    eyre::eyre!(
+                        "bun binary not found after extracting {} to {}",
+                        filename,
+                        file::display_path(tv.download_path())
+                    )
+                })?
         };
         file::rename(&src_bun, self.bun_bin(tv))?;
         if cfg!(unix) {

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -76,7 +76,7 @@ impl BunPlugin {
             fallback_root
         } else {
             // As a last resort, search recursively for a file named bun/bun.exe
-            
+
             file::recursive_ls(&tv.download_path())?
                 .into_iter()
                 .find(|p| p.file_name().map(|f| f == bun_bin_name()).unwrap_or(false))


### PR DESCRIPTION
Fix `mise install bun` on Alpine/Edge CI by making the bun plugin robust to varying archive layouts.

---
<a href="https://cursor.com/background-agent?bcId=bc-b484b115-8753-491a-8422-75133ee2c686">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b484b115-8753-491a-8422-75133ee2c686">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

