### PR TITLE
docs: update `contributing.md` for discussions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,29 +1,25 @@
 ---
 outline: [1, 3]
 ---
+
 # Contributing
 
-Before submitting a PR, unless it's something obvious, consider filing an issue
+Before submitting a PR, unless it's something obvious, consider creating a
+[discussion](https://github.com/jdx/mise/discussions)
 or simply mention what you plan to do in the
 [Discord](https://discord.gg/UBa7pJUN7Z).
 PRs are often either rejected or need to change significantly after submission
 so make sure before you start working on something it won't be a wasted effort.
 
-Issues ideal for contributors can be found with the
-["help wanted"](https://github.com/jdx/mise/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
-and
-["good first issue"](https://github.com/jdx/mise/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
-labels. These are issues that I feel are self-contained therefore don't require
-super in-depth understanding of the codebase or that require knowledge about
-something I don't understand very well myself.
+Do not attempt to open a GitHub issue. New GitHub issues will be automatically closed.
+For context, see [jdx/mise#3859](https://github.com/jdx/mise/issues/3859).
 
 ## Contributing Guidelines
 
-1. **Before starting**: File an issue or discuss in Discord for non-obvious changes
-2. **Look for issues**: Check "help wanted" and "good first issue" labels
-3. **Test thoroughly**: Ensure both unit and E2E tests pass
-4. **Follow conventions**: Use existing code style and patterns
-5. **Update documentation**: Add/update docs for new features
+1. **Before starting**: Create a discussion or discuss in Discord for non-obvious changes
+2. **Test thoroughly**: Ensure both unit and E2E tests pass
+3. **Follow conventions**: Use existing code style and patterns
+4. **Update documentation**: Add/update docs for new features
 
 ### Pull Request Workflow
 


### PR DESCRIPTION
## Description

Thank you for maintaining mise.

The mise repo does not allow creation of new issues by anyone other than @jdx. New issues will be automatically closed.

https://github.com/jdx/mise/blob/67dbc039b5e3dbe4cbd5b77bc1db9b5e19a0d9ab/.github/workflows/issue-closer.yml#L10-L13

However, the contributing docs still recommend opening issues.

https://github.com/jdx/mise/blob/67dbc039b5e3dbe4cbd5b77bc1db9b5e19a0d9ab/docs/contributing.md?plain=1#L6-L12

## Changes

This PR will update `contributing.md` to explain that contributors should create discussions and not issues.

## Related

- https://github.com/jdx/mise/issues/3859
