### PR TITLE
chore: release 2025.8.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2025.8.12](https://github.com/jdx/mise/compare/v2025.8.11..v2025.8.12) - 2025-08-17
+
+### 📦 Registry
+
+- support tenv idiomatic files by [@risu729](https://github.com/risu729) in [#6050](https://github.com/jdx/mise/pull/6050)
+
+### 🚀 Features
+
+- respect PREFER_OFFLINE for aqua package metadata fetching by [@jdx](https://github.com/jdx) in [#6058](https://github.com/jdx/mise/pull/6058)
+
+### 📚 Documentation
+
+- fix backend_architecture docs by [@risu729](https://github.com/risu729) in [#6027](https://github.com/jdx/mise/pull/6027)
+
+### 📦️ Dependency Updates
+
+- update amannn/action-semantic-pull-request digest to e32d7e6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#6031](https://github.com/jdx/mise/pull/6031)
+- update actions/checkout digest to 08eba0b by [@renovate[bot]](https://github.com/renovate[bot]) in [#6030](https://github.com/jdx/mise/pull/6030)
+- update actions/cache digest to 0400d5f by [@renovate[bot]](https://github.com/renovate[bot]) in [#5957](https://github.com/jdx/mise/pull/5957)
+
+### Chore
+
+- check for warnings in gha with rust stable by [@jdx](https://github.com/jdx) in [#6055](https://github.com/jdx/mise/pull/6055)
+
 ## [2025.8.11](https://github.com/jdx/mise/compare/v2025.8.10..v2025.8.11) - 2025-08-17
 
 ### 📦 Registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.8.11"
+version = "2025.8.12"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.8.11"
+version = "2025.8.12"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.8.11 macos-arm64 (a1b2d3e 2025-08-17)
+2025.8.12 macos-arm64 (a1b2d3e 2025-08-17)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_8_11:-}" ]] || _cache_invalid _usage_spec_mise_2025_8_11 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_8_11;
+  if ( [[ -z "${_usage_spec_mise_2025_8_12:-}" ]] || _cache_invalid _usage_spec_mise_2025_8_12 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_8_12;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_8_11 spec
+    _store_cache _usage_spec_mise_2025_8_12 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_8_11:-} ]]; then
-        _usage_spec_mise_2025_8_11="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_8_12:-} ]]; then
+        _usage_spec_mise_2025_8_12="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_8_11}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_8_12}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_8_11
-  set -g _usage_spec_mise_2025_8_11 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_8_12
+  set -g _usage_spec_mise_2025_8_12 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_11" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_12" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_11" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_12" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.8.11";
+  version = "2025.8.12";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.8.11
+Version: 2025.8.12
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 📦 Registry

- support tenv idiomatic files by [@risu729](https://github.com/risu729) in [#6050](https://github.com/jdx/mise/pull/6050)

### 🚀 Features

- respect PREFER_OFFLINE for aqua package metadata fetching by [@jdx](https://github.com/jdx) in [#6058](https://github.com/jdx/mise/pull/6058)

### 📚 Documentation

- fix backend_architecture docs by [@risu729](https://github.com/risu729) in [#6027](https://github.com/jdx/mise/pull/6027)

### 📦️ Dependency Updates

- update amannn/action-semantic-pull-request digest to e32d7e6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#6031](https://github.com/jdx/mise/pull/6031)
- update actions/checkout digest to 08eba0b by [@renovate[bot]](https://github.com/renovate[bot]) in [#6030](https://github.com/jdx/mise/pull/6030)
- update actions/cache digest to 0400d5f by [@renovate[bot]](https://github.com/renovate[bot]) in [#5957](https://github.com/jdx/mise/pull/5957)

### Chore

- check for warnings in gha with rust stable by [@jdx](https://github.com/jdx) in [#6055](https://github.com/jdx/mise/pull/6055)