### PR TITLE
feat: respect PREFER_OFFLINE for aqua package metadata fetching

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -37,7 +37,7 @@ impl log::Log for Logger {
             ui::multi_progress_report::MultiProgressReport::suspend_if_active(|| {
                 let out = self.render(record, term_level);
                 if !out.is_empty() {
-                    eprintln!("{}", self.render(record, term_level));
+                    eprintln!("{out}");
                 }
             });
         }


### PR DESCRIPTION
- Add PREFER_OFFLINE check in fetch_latest_repo to skip aqua registry updates
- Add PREFER_OFFLINE check in fetch_package_yaml to skip downloading individual package metadata
- When PREFER_OFFLINE is set, use cached metadata even if it's older than DAILY threshold
- Return error if no cached metadata exists and PREFER_OFFLINE is set
