### PR TITLE
chore: Upgrade ubi dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 toml = { version = "0.8", features = ["parse"] }
 toml_edit = { version = "0.22", features = ["parse"] }
-ubi = { version = "0.7.1", default-features = false }
+ubi = { version = "0.7.3", default-features = false }
 url = "2"
 urlencoding = "2.1.3"
 usage-lib = { version = "2", features = ["clap", "docs"] }


### PR DESCRIPTION
Required to support deep nested namespaces in GitLab.

See https://github.com/houseabsolute/ubi/issues/114 and https://github.com/houseabsolute/ubi/pull/115.

