### PR TITLE
fix(schema): add missing `settings` type

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -223,6 +223,7 @@
       "type": "object"
     },
     "settings": {
+      "type": "object",
       "properties": {
         "activate_aggressive": {
           "description": "Pushes tools' bin-paths to the front of PATH instead of allowing modifications of PATH after activation to take precedence.",


### PR DESCRIPTION
## Description

The JSON schema is missing a type for the `settings` key.

https://github.com/jdx/mise/blob/57c2b1c0eb5fd1f277f2dab10ce65ed45d2eb999/schema/mise.json#L225

To reproduce this, create a `mise.toml` with a `[settings]` key and lint the file using the JSON schema.

```sh
printf '[settings]\n' >mise.toml
uvx --from "tombi>=0.5,<0.6" tombi lint --no-cache mise.toml
```

```text
Error: invalid json pointer: #/$defs/settings,
schema_uri: https://mise.jdx.dev/schema/mise.json
```

## Changes

This PR will add `"type": "object"` to the `settings` key in the JSON schema.

## Related

- https://github.com/tombi-toml/tombi/issues/858
