### PR TITLE
fix: use fish_add_path when activating mise for fish shell

### DIFF
--- a/src/shell/snapshots/mise__shell__fish__tests__prepend_env.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__prepend_env.snap
@@ -1,6 +1,6 @@
 ---
 source: src/shell/fish.rs
 expression: "replace_path(&sh.prepend_env(\"PATH\", \"/some/dir:/2/dir\"))"
-snapshot_kind: text
 ---
-set -gx PATH '/some/dir:/2/dir' $PATH
+fish_add_path --global --move --path /some/dir
+fish_add_path --global --move --path /2/dir


### PR DESCRIPTION
Fixes issues discussed in #6072. Untested, hence draft.