### PR TITLE
feat(http): auto-clean OS/arch suffixes from binary names

### DIFF
--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -137,6 +137,20 @@ Number of directory components to strip when extracting archives:
 If `strip_components` is not explicitly set, mise will automatically detect when to apply `strip_components = 1`. This happens when the extracted archive contains exactly one directory at the root level and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `ripgrep-14.1.0-x86_64-unknown-linux-musl/rg`). The auto-detection ensures the binary is placed directly in the install path where mise expects it.
 :::
 
+### `bin`
+
+Rename the downloaded binary to a specific name. This is useful when downloading single binaries that have platform-specific names:
+
+```toml
+[tools."github:docker/compose"]
+version = "2.29.1"
+bin = "docker-compose"  # Rename the downloaded binary to docker-compose
+```
+
+::: info
+When downloading single binaries (not archives), mise automatically removes OS/arch suffixes from the filename. For example, `docker-compose-linux-x86_64` becomes `docker-compose` automatically. Use the `bin` option only when you need a specific custom name.
+:::
+
 ### `bin_path`
 
 Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports templating with `{name}`, `{version}`, `{os}`, `{arch}`, and `{ext}`:

--- a/docs/dev-tools/backends/gitlab.md
+++ b/docs/dev-tools/backends/gitlab.md
@@ -151,6 +151,21 @@ Number of directory components to strip when extracting archives:
 If `strip_components` is not explicitly set, mise will automatically detect when to apply `strip_components = 1`. This happens when the extracted archive contains exactly one directory at the root level and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `ripgrep-14.1.0-x86_64-unknown-linux-musl/rg`). The auto-detection ensures the binary is placed directly in the install path where mise expects it.
 :::
 
+### `bin`
+
+Rename the downloaded binary to a specific name. This is useful when downloading single binaries that have platform-specific names:
+
+```toml
+[tools."gitlab:myorg/mytool"]
+version = "1.0.0"
+asset_pattern = "mytool-linux-x86_64"
+bin = "mytool"  # Rename from mytool-linux-x86_64 to mytool
+```
+
+::: info
+When downloading single binaries (not archives), mise automatically removes OS/arch suffixes from the filename. For example, `mytool-linux-x86_64` becomes `mytool` automatically. Use the `bin` option only when you need a specific custom name.
+:::
+
 ### `bin_path`
 
 Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports templating with `{name}`, `{version}`, `{os}`, `{arch}`, and `{ext}`:

--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -132,6 +132,21 @@ strip_components = 1
 If `strip_components` is not explicitly set, mise will automatically detect when to apply `strip_components = 1`. This happens when the extracted archive contains exactly one directory at the root level and no files. This is common with tools like ripgrep that package their binaries in a versioned directory (e.g., `ripgrep-14.1.0-x86_64-unknown-linux-musl/rg`). The auto-detection ensures the binary is placed directly in the install path where mise expects it.
 :::
 
+### `bin`
+
+Rename the downloaded binary to a specific name. This is useful when downloading single binaries that have platform-specific names:
+
+```toml
+[tools."http:docker-compose"]
+version = "2.29.1"
+url = "https://github.com/docker/compose/releases/download/v{version}/docker-compose-linux-x86_64"
+bin = "docker-compose"  # Rename from docker-compose-linux-x86_64 to docker-compose
+```
+
+::: info
+When downloading single binaries (not archives), mise automatically removes OS/arch suffixes from the filename. For example, `docker-compose-linux-x86_64` becomes `docker-compose` automatically. Use the `bin` option only when you need a specific custom name.
+:::
+
 ### `bin_path`
 
 Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports templating with `{{version}}`:

--- a/e2e-win/backend/test_github_docker_compose.ps1
+++ b/e2e-win/backend/test_github_docker_compose.ps1
@@ -1,0 +1,18 @@
+# Test GitHub backend with docker-compose on Windows
+
+$ErrorActionPreference = "Stop"
+
+# Test: Install docker-compose via GitHub backend
+@"
+[tools]
+"github:docker/compose" = "2.29.1"
+"@ | Set-Content -Path "mise.toml"
+
+mise install -f github:docker/compose
+if ($LASTEXITCODE -ne 0) { throw "Failed to install github:docker/compose" }
+
+# Verify it's executable
+mise exec github:docker/compose -- docker-compose version
+if ($LASTEXITCODE -ne 0) { throw "Failed to execute docker-compose" }
+
+Write-Host "GitHub backend docker-compose test passed!" -ForegroundColor Green

--- a/e2e-win/backend/test_http_binary_clean.ps1
+++ b/e2e-win/backend/test_http_binary_clean.ps1
@@ -1,0 +1,20 @@
+# Test HTTP backend binary name cleaning with docker-compose on Windows
+
+$ErrorActionPreference = "Stop"
+$env:MISE_EXPERIMENTAL = "1"
+
+# Test: Install docker-compose via HTTP backend
+# The binary name should be automatically cleaned from docker-compose-windows-x86_64.exe to docker-compose
+@"
+[tools]
+"http:docker-compose" = { version = "2.29.1", url = "https://github.com/docker/compose/releases/download/v{version}/docker-compose-windows-x86_64.exe" }
+"@ | Set-Content -Path "mise.toml"
+
+mise install -f http:docker-compose
+if ($LASTEXITCODE -ne 0) { throw "Failed to install http:docker-compose" }
+
+# Verify it's executable
+mise exec http:docker-compose -- docker-compose version
+if ($LASTEXITCODE -ne 0) { throw "Failed to execute docker-compose" }
+
+Write-Host "HTTP backend binary cleaning test passed!" -ForegroundColor Green

--- a/e2e/backend/test_github_docker_compose
+++ b/e2e/backend/test_github_docker_compose
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Test GitHub backend with docker-compose
+
+set -euo pipefail
+
+# Test: Install docker-compose via GitHub backend
+cat >mise.toml <<EOF
+[tools]
+"github:docker/compose" = "2.29.1"
+EOF
+
+assert_succeed "mise install -f github:docker/compose"
+
+# Verify it's executable
+assert_succeed "mise exec github:docker/compose -- docker-compose version"
+assert "mise x github:docker/compose -- which docker-compose" "$MISE_DATA_DIR/installs/github-docker-compose/2.29.1/docker-compose"

--- a/e2e/backend/test_http_binary_clean
+++ b/e2e/backend/test_http_binary_clean
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Test HTTP backend binary name cleaning with docker-compose
+
+set -euo pipefail
+export MISE_EXPERIMENTAL=1
+
+# Test: Install docker-compose via HTTP backend
+# The binary name should be automatically cleaned from docker-compose-linux-x86_64 to docker-compose
+cat >mise.toml <<EOF
+[tools]
+"http:docker-compose" = { version = "2.29.1", url = "https://github.com/docker/compose/releases/download/v{version}/docker-compose-linux-x86_64" }
+EOF
+
+assert_succeed "mise install -f http:docker-compose"
+
+# Verify it's executable
+assert_succeed "mise exec http:docker-compose -- docker-compose version"
+
+# The binary should be cleaned to just "docker-compose" in the cache
+assert_succeed "test -f $HOME/.cache/mise/http-tarballs/*/docker-compose"

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -1,7 +1,7 @@
 use crate::backend::Backend;
 use crate::backend::backend_type::BackendType;
 use crate::backend::static_helpers::{
-    get_filename_from_url, lookup_platform_key, template_string, verify_artifact,
+    clean_binary_name, get_filename_from_url, lookup_platform_key, template_string, verify_artifact,
 };
 use crate::cli::args::BackendArg;
 use crate::config::Config;
@@ -152,10 +152,12 @@ impl HttpBackend {
                 // If bin is specified, rename the file to this name
                 (cache_path.to_path_buf(), std::ffi::OsString::from(bin_name))
             } else {
-                // Default behavior: place file directly in cache root with original name
+                // Always auto-clean binary names by removing OS/arch suffixes
+                let original_name = file_path.file_name().unwrap().to_string_lossy();
+                let cleaned_name = clean_binary_name(&original_name, Some(&self.ba.tool_name));
                 (
                     cache_path.to_path_buf(),
-                    file_path.file_name().unwrap().to_os_string(),
+                    std::ffi::OsString::from(cleaned_name),
                 )
             };
 


### PR DESCRIPTION
## Summary

This PR makes the HTTP, GitHub, and GitLab backends automatically remove OS/arch suffixes from downloaded binary names. For example, `docker-compose-linux-x86_64` becomes `docker-compose`, making tool names predictable across platforms.

## Problem

When installing tools like docker-compose via the HTTP backend, the binary name would include platform-specific suffixes (e.g., `docker-compose-linux-x86_64`), making it difficult to use the tool consistently across different platforms.

## Solution

- Added `clean_binary_name()` function that intelligently removes common OS and architecture patterns from binary names
- HTTP backend now always cleans binary names for single file downloads
- GitHub/GitLab backends inherit this behavior via the shared `install_artifact()` function
- Added `bin` option to allow manual override if a specific name is needed
- Binary cleaning is automatic and enabled by default

## Changes

- **New function**: `clean_binary_name()` in `static_helpers.rs` removes OS/arch suffixes
- **HTTP backend**: Modified to auto-clean binary names
- **GitHub/GitLab backends**: Inherit cleaning via `install_artifact()`
- **Documentation**: Added `bin` option docs for all three backends
- **Tests**: Added e2e tests for Linux/macOS and Windows

## Test Plan

- [x] Unit tests for `clean_binary_name()` function
- [x] E2E test installing docker-compose via HTTP backend
- [x] E2E test installing docker-compose via GitHub backend
- [x] Manual testing with various binary naming patterns

## Example

```toml
# Before: binary would be named docker-compose-linux-x86_64
# After: binary is named docker-compose
[tools]
"http:docker-compose" = { version = "2.29.1", url = "https://github.com/docker/compose/releases/download/v{version}/docker-compose-linux-x86_64" }
```

Fixes #6075

🤖 Generated with [Claude Code](https://claude.ai/code)