### PR TITLE
feat(install): add --dry-run flag to show what would be installed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ heck = "0.5"
 humansize = "2"
 indenter = "0.3"
 indexmap = { version = "2", features = ["serde"] }
-indicatif = { version = "0.18", features = ["default", "improved_unicode"] }
+indicatif = { version = "0.18", features = ["improved_unicode"] }
 indoc = "2"
 itertools = "0.14"
 jiff = "0.2"

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -22,6 +22,10 @@ Tool(s) to install e.g.: node@20
 
 ## Flags
 
+### `-n --dry-run`
+
+Show what would be installed without actually installing
+
 ### `-f --force`
 
 Force reinstall even if already installed
@@ -48,4 +52,6 @@ mise install node@20.0.0  # install specific node version
 mise install node@20      # install fuzzy node version
 mise install node         # install version specified in mise.toml
 mise install              # installs everything specified in mise.toml
+mise install --dry-run     # show what would be installed
+mise install -n node@20   # show what would be installed (short form)
 ```

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -52,6 +52,4 @@ mise install node@20.0.0  # install specific node version
 mise install node@20      # install fuzzy node version
 mise install node         # install version specified in mise.toml
 mise install              # installs everything specified in mise.toml
-mise install --dry-run     # show what would be installed
-mise install -n node@20   # show what would be installed (short form)
 ```

--- a/docs/cli/use.md
+++ b/docs/cli/use.md
@@ -51,6 +51,10 @@ this is the default behavior unless `MISE_PIN=1`
 
 Use the global config file (`~/.config/mise/config.toml`) instead of the local one
 
+### `-n --dry-run`
+
+Perform a dry run, showing what would be installed and modified without making changes
+
 ### `-e --env <ENV>`
 
 Create/modify an environment-specific config file like .mise.&lt;env>.toml

--- a/e2e/cli/test_install_dry_run
+++ b/e2e/cli/test_install_dry_run
@@ -4,35 +4,17 @@
 set -euo pipefail
 
 # Test: Dry-run should show what would be installed without actually installing
-output=$(mise install tiny@3.1.0 --dry-run 2>&1 || true)
-if [[ ! $output =~ "would install" ]]; then
-	echo "ERROR: Expected 'would install' in output: $output"
-	exit 1
-fi
+assert_contains "mise install tiny@3.1.0 --dry-run 2>&1" "would install"
 
-# Verify tiny is NOT actually installed (should exit with non-zero)
-if mise which tiny 2>/dev/null; then
-	echo "ERROR: tiny should not be installed after dry-run"
-	exit 1
-fi
+# Verify tiny is NOT actually installed
+assert_fail "mise which tiny"
 
 # Test: Dry-run should show already installed for existing tools
 mise install jq@latest --force
-output=$(mise install jq@latest --dry-run 2>&1 || true)
-if [[ ! $output =~ "already installed" ]]; then
-	echo "ERROR: Expected 'already installed' in output: $output"
-	exit 1
-fi
+assert_contains "mise install jq@latest --dry-run 2>&1" "already installed"
 
 # Test: Dry-run should work with multiple tools
-output=$(mise install tiny@3.1.0 shfmt@3.10.0 --dry-run 2>&1 || true)
-if [[ ! $output =~ "would install" ]]; then
-	echo "ERROR: Expected 'would install' in output: $output"
-	exit 1
-fi
+assert_contains "mise install tiny@3.1.0 shfmt@3.10.0 --dry-run 2>&1" "would install"
 
 # Verify neither tool was actually installed
-if mise which tiny 2>/dev/null; then
-	echo "ERROR: tiny should not be installed after dry-run"
-	exit 1
-fi
+assert_fail "mise which tiny"

--- a/e2e/cli/test_install_dry_run
+++ b/e2e/cli/test_install_dry_run
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Test install --dry-run functionality
+
+set -euo pipefail
+
+# Test: Dry-run should show what would be installed without actually installing
+output=$(mise install tiny@3.1.0 --dry-run 2>&1 || true)
+if [[ ! $output =~ "would install" ]]; then
+	echo "ERROR: Expected 'would install' in output: $output"
+	exit 1
+fi
+
+# Verify tiny is NOT actually installed (should exit with non-zero)
+if mise which tiny 2>/dev/null; then
+	echo "ERROR: tiny should not be installed after dry-run"
+	exit 1
+fi
+
+# Test: Dry-run should show already installed for existing tools
+mise install jq@latest --force
+output=$(mise install jq@latest --dry-run 2>&1 || true)
+if [[ ! $output =~ "already installed" ]]; then
+	echo "ERROR: Expected 'already installed' in output: $output"
+	exit 1
+fi
+
+# Test: Dry-run should work with multiple tools
+output=$(mise install tiny@3.1.0 shfmt@3.10.0 --dry-run 2>&1 || true)
+if [[ ! $output =~ "would install" ]]; then
+	echo "ERROR: Expected 'would install' in output: $output"
+	exit 1
+fi
+
+# Verify neither tool was actually installed
+if mise which tiny 2>/dev/null; then
+	echo "ERROR: tiny should not be installed after dry-run"
+	exit 1
+fi

--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -8,7 +8,7 @@ assert "mise current dummy" "1.0.0"
 assert_contains "mise use dummy@2" "dummy@2."
 assert "mise current dummy" "2.0.0"
 
-assert_not_contains "mise use --rm dummy" "dummy"
+assert_contains "mise use --rm dummy" "removed: dummy"
 assert "mise current dummy" ""
 
 assert_contains "mise use --env local dummy@2" "dummy@2."

--- a/e2e/cli/test_use_dry_run
+++ b/e2e/cli/test_use_dry_run
@@ -8,7 +8,8 @@ TEST_DIR=$(mktemp -d)
 cd "$TEST_DIR"
 
 # Test: Dry-run should show what would be added without actually modifying the file
-assert_contains "mise use tiny@3.1.0 --dry-run 2>&1" "would install"
+assert_contains "mise use tiny@3.1.0 --dry-run 2>&1" "would update"
+assert_contains "mise use tiny@3.1.0 --dry-run 2>&1" "add: tiny@3.1.0"
 # Config file should not exist after dry-run
 assert_fail "test -f mise.toml"
 
@@ -20,7 +21,8 @@ mise use tiny@3.1.0
 assert_contains "cat mise.toml" "tiny"
 
 # Test: Dry-run for removing a tool
-assert_contains "mise use --remove tiny --dry-run 2>&1" "would remove tiny"
+assert_contains "mise use --remove tiny --dry-run 2>&1" "would update"
+assert_contains "mise use --remove tiny --dry-run 2>&1" "remove: tiny"
 assert_contains "cat mise.toml" "tiny" # Should still be there
 
 # Test: Actually remove the tool
@@ -29,7 +31,8 @@ assert_not_contains "cat mise.toml" "tiny"
 
 # Test: Dry-run with multiple tools
 rm -f mise.toml # Start fresh
-assert_contains "mise use jq@latest shfmt@3.10.0 --dry-run 2>&1" "would install"
+assert_contains "mise use jq@latest shfmt@3.10.0 --dry-run 2>&1" "would update"
+assert_contains "mise use jq@latest shfmt@3.10.0 --dry-run 2>&1" "add: jq@"
 assert_fail "test -f mise.toml" # File should not be created
 
 # Clean up

--- a/e2e/cli/test_use_dry_run
+++ b/e2e/cli/test_use_dry_run
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Test use --dry-run functionality
+
+set -euo pipefail
+
+# Create a temporary directory for testing
+TEST_DIR=$(mktemp -d)
+cd "$TEST_DIR"
+
+# Test: Dry-run should show what would be added without actually modifying the file
+assert_contains "mise use tiny@3.1.0 --dry-run 2>&1" "would install"
+# Config file should not exist after dry-run
+assert_fail "test -f mise.toml"
+
+# Test: Tool should not be installed after dry-run
+assert_fail "mise which tiny"
+
+# Test: Regular use should actually add the tool
+mise use tiny@3.1.0
+assert_contains "cat mise.toml" "tiny"
+
+# Test: Dry-run for removing a tool
+assert_contains "mise use --remove tiny --dry-run 2>&1" "would remove tiny"
+assert_contains "cat mise.toml" "tiny" # Should still be there
+
+# Test: Actually remove the tool
+mise use --remove tiny
+assert_not_contains "cat mise.toml" "tiny"
+
+# Test: Dry-run with multiple tools
+rm -f mise.toml # Start fresh
+assert_contains "mise use jq@latest shfmt@3.10.0 --dry-run 2>&1" "would install"
+assert_fail "test -f mise.toml" # File should not be created
+
+# Clean up
+cd /
+rm -rf "$TEST_DIR"

--- a/e2e/cli/test_use_dry_run
+++ b/e2e/cli/test_use_dry_run
@@ -31,8 +31,10 @@ assert_not_contains "cat mise.toml" "tiny"
 
 # Test: Dry-run with multiple tools
 rm -f mise.toml # Start fresh
-assert_contains "mise use jq@latest shfmt@3.10.0 --dry-run 2>&1" "would update"
-assert_contains "mise use jq@latest shfmt@3.10.0 --dry-run 2>&1" "add: jq@"
+output=$(mise use jq@latest shfmt@3.10.0 --dry-run 2>&1)
+assert_contains "echo '$output'" "would update"
+assert_contains "echo '$output'" "jq@"
+assert_contains "echo '$output'" "shfmt@"
 assert_fail "test -f mise.toml" # File should not be created
 
 # Clean up

--- a/mise.lock
+++ b/mise.lock
@@ -105,18 +105,13 @@ size = 12793347
 url = "https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_macOS_arm64.zip"
 
 [tools.hk]
-version = "1.7.0"
+version = "1.9.2"
 backend = "aqua:jdx/hk"
 
 [tools.hk.platforms.linux-x64]
-checksum = "blake3:168aec65edfc5b29f7dd15d24b63000b54eba42b05b4029ad8f846cb81a0a796"
-size = 6642933
-url = "https://github.com/jdx/hk/releases/download/v1.7.0/hk-x86_64-unknown-linux-gnu.tar.gz"
-
-[tools.hk.platforms.macos-arm64]
-checksum = "blake3:e7e7c5f105d87dd8f5c477efa0fa31281c29df9ac7d13deac748b29fb6a734d9"
-size = 5727200
-url = "https://github.com/jdx/hk/releases/download/v1.7.0/hk-aarch64-apple-darwin.tar.gz"
+checksum = "blake3:d036e27885addbb47b9c41ef590827fbc5f407708092bf142f1f69ef76707f33"
+size = 6811131
+url = "https://github.com/jdx/hk/releases/download/v1.9.2/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [tools.jq]
 version = "1.8.1"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -440,7 +440,7 @@ cmd implode help="Removes mise CLI and all related data" {
 cmd install help="Install a tool version" {
     alias i
     long_help "Install a tool version\n\nInstalls a tool version to `~/.local/share/mise/installs/<PLUGIN>/<VERSION>`\nInstalling alone will not activate the tools so they won't be in PATH.\nTo install and/or activate in one command, use `mise use` which will create a `mise.toml` file\nin the current directory to activate this tool when inside the directory.\nAlternatively, run `mise exec <TOOL>@<VERSION> -- <COMMAND>` to execute a tool without creating config files.\n\nTools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`"
-    after_long_help "Examples:\n\n    $ mise install node@20.0.0  # install specific node version\n    $ mise install node@20      # install fuzzy node version\n    $ mise install node         # install version specified in mise.toml\n    $ mise install              # installs everything specified in mise.toml\n    $ mise install --dry-run     # show what would be installed\n    $ mise install -n node@20   # show what would be installed (short form)\n"
+    after_long_help "Examples:\n\n    $ mise install node@20.0.0  # install specific node version\n    $ mise install node@20      # install fuzzy node version\n    $ mise install node         # install version specified in mise.toml\n    $ mise install              # installs everything specified in mise.toml\n"
     flag "-n --dry-run" help="Show what would be installed without actually installing"
     flag "-f --force" help="Force reinstall even if already installed"
     flag "-j --jobs" help="Number of jobs to run in parallel\n[default: 4]" {

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -440,7 +440,8 @@ cmd implode help="Removes mise CLI and all related data" {
 cmd install help="Install a tool version" {
     alias i
     long_help "Install a tool version\n\nInstalls a tool version to `~/.local/share/mise/installs/<PLUGIN>/<VERSION>`\nInstalling alone will not activate the tools so they won't be in PATH.\nTo install and/or activate in one command, use `mise use` which will create a `mise.toml` file\nin the current directory to activate this tool when inside the directory.\nAlternatively, run `mise exec <TOOL>@<VERSION> -- <COMMAND>` to execute a tool without creating config files.\n\nTools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`"
-    after_long_help "Examples:\n\n    $ mise install node@20.0.0  # install specific node version\n    $ mise install node@20      # install fuzzy node version\n    $ mise install node         # install version specified in mise.toml\n    $ mise install              # installs everything specified in mise.toml\n"
+    after_long_help "Examples:\n\n    $ mise install node@20.0.0  # install specific node version\n    $ mise install node@20      # install fuzzy node version\n    $ mise install node         # install version specified in mise.toml\n    $ mise install              # installs everything specified in mise.toml\n    $ mise install --dry-run     # show what would be installed\n    $ mise install -n node@20   # show what would be installed (short form)\n"
+    flag "-n --dry-run" help="Show what would be installed without actually installing"
     flag "-f --force" help="Force reinstall even if already installed"
     flag "-j --jobs" help="Number of jobs to run in parallel\n[default: 4]" {
         arg <JOBS>
@@ -1028,6 +1029,7 @@ cmd use help="Installs a tool and adds the version to mise.toml." {
         long_help "Save fuzzy version to config file\n\ne.g.: `mise use --fuzzy node@20` will save 20 as the version\nthis is the default behavior unless `MISE_PIN=1`"
     }
     flag "-g --global" help="Use the global config file (`~/.config/mise/config.toml`) instead of the local one"
+    flag "-n --dry-run" help="Perform a dry run, showing what would be installed and modified without making changes"
     flag "-e --env" help="Create/modify an environment-specific config file like .mise.<env>.toml" {
         arg <ENV>
     }

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -279,7 +279,7 @@ impl VfoxBackend {
 
     async fn ensure_plugin_installed(&self, config: &Arc<Config>) -> eyre::Result<()> {
         self.plugin
-            .ensure_installed(config, &MultiProgressReport::get(), false)
+            .ensure_installed(config, &MultiProgressReport::get(), false, false)
             .await
     }
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -208,7 +208,5 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise install node@20</bold>      # install fuzzy node version
     $ <bold>mise install node</bold>         # install version specified in mise.toml
     $ <bold>mise install</bold>              # installs everything specified in mise.toml
-    $ <bold>mise install --dry-run</bold>     # show what would be installed
-    $ <bold>mise install -n node@20</bold>   # show what would be installed (short form)
 "#
 );

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -25,6 +25,10 @@ pub struct Install {
     #[clap(value_name = "TOOL@VERSION")]
     tool: Option<Vec<ToolArg>>,
 
+    /// Show what would be installed without actually installing
+    #[clap(long, short = 'n', verbatim_doc_comment)]
+    dry_run: bool,
+
     /// Force reinstall even if already installed
     #[clap(long, short, requires = "tool")]
     force: bool,
@@ -94,7 +98,11 @@ impl Install {
         let current_versions = ts.list_current_versions();
         // ensure that only current versions are sent to lockfile rebuild
         versions.retain(|tv| current_versions.iter().any(|(_, cv)| tv == cv));
-        config::rebuild_shims_and_runtime_symlinks(&config, ts, &versions).await?;
+
+        // Skip rebuilding shims and symlinks in dry-run mode
+        if !self.dry_run {
+            config::rebuild_shims_and_runtime_symlinks(&config, ts, &versions).await?;
+        }
         Ok(())
     }
 
@@ -108,6 +116,7 @@ impl Install {
                 use_locked_version: true,
                 latest_versions: true,
             },
+            dry_run: self.dry_run,
             ..Default::default()
         }
     }
@@ -181,10 +190,13 @@ impl Install {
                     .await?
             })
         };
-        measure!("rebuild_shims_and_runtime_symlinks", {
-            let ts = config.get_toolset().await?;
-            config::rebuild_shims_and_runtime_symlinks(&config, ts, &versions).await?;
-        });
+        // Skip rebuilding shims and symlinks in dry-run mode
+        if !self.dry_run {
+            measure!("rebuild_shims_and_runtime_symlinks", {
+                let ts = config.get_toolset().await?;
+                config::rebuild_shims_and_runtime_symlinks(&config, ts, &versions).await?;
+            });
+        }
         Ok(())
     }
 }
@@ -196,5 +208,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise install node@20</bold>      # install fuzzy node version
     $ <bold>mise install node</bold>         # install version specified in mise.toml
     $ <bold>mise install</bold>              # installs everything specified in mise.toml
+    $ <bold>mise install --dry-run</bold>     # show what would be installed
+    $ <bold>mise install -n node@20</bold>   # show what would be installed (short form)
 "#
 );

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -47,6 +47,7 @@ impl InstallInto {
             ts: ts.clone(),
             pr: mpr.add(&tv.style()),
             force: true,
+            dry_run: false,
         };
         tv.install_path = Some(self.path.clone());
         backend.install_version(install_ctx, tv).await?;

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -38,7 +38,7 @@ impl Latest {
         let backend = self.tool.ba.backend()?;
         let mpr = MultiProgressReport::get();
         if let Some(plugin) = backend.plugin() {
-            plugin.ensure_installed(&config, &mpr, false).await?;
+            plugin.ensure_installed(&config, &mpr, false, false).await?;
         }
         if let Some(v) = prefix {
             prefix = Some(config.resolve_alias(&backend, &v).await?);

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -87,7 +87,7 @@ impl LsRemote {
                 let backend = tool_arg.ba.backend()?;
                 let mpr = MultiProgressReport::get();
                 if let Some(plugin) = backend.plugin() {
-                    plugin.ensure_installed(config, &mpr, false).await?;
+                    plugin.ensure_installed(config, &mpr, false, false).await?;
                 }
                 Ok(Some(backend))
             }

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -143,7 +143,9 @@ impl PluginsInstall {
             warn!("Use --force to install anyway");
         } else {
             let mpr = MultiProgressReport::get();
-            plugin.ensure_installed(config, &mpr, self.force).await?;
+            plugin
+                .ensure_installed(config, &mpr, self.force, false)
+                .await?;
         }
         Ok(())
     }

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -8,4 +8,5 @@ pub struct InstallContext {
     pub ts: Arc<Toolset>,
     pub pr: Box<dyn SingleReport>,
     pub force: bool,
+    pub dry_run: bool,
 }

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -232,6 +232,7 @@ impl Plugin for AsdfPlugin {
         config: &Arc<Config>,
         mpr: &MultiProgressReport,
         force: bool,
+        dry_run: bool,
     ) -> Result<()> {
         let settings = Settings::try_get()?;
         if !force {
@@ -262,8 +263,12 @@ impl Plugin for AsdfPlugin {
         }
         let prefix = format!("plugin:{}", style(&self.name).blue().for_stderr());
         let pr = mpr.add(&prefix);
-        let _lock = lock_file::get(&self.plugin_path, force)?;
-        self.install(config, &pr).await
+        if !dry_run {
+            let _lock = lock_file::get(&self.plugin_path, force)?;
+            self.install(config, &pr).await
+        } else {
+            Ok(())
+        }
     }
 
     async fn update(&self, pr: &Box<dyn SingleReport>, gitref: Option<String>) -> Result<()> {

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -262,7 +262,7 @@ impl Plugin for AsdfPlugin {
             }
         }
         let prefix = format!("plugin:{}", style(&self.name).blue().for_stderr());
-        let pr = mpr.add(&prefix);
+        let pr = mpr.add_with_options(&prefix, dry_run);
         if !dry_run {
             let _lock = lock_file::get(&self.plugin_path, force)?;
             self.install(config, &pr).await

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -165,11 +165,14 @@ impl PluginEnum {
         config: &Arc<Config>,
         mpr: &MultiProgressReport,
         force: bool,
+        dry_run: bool,
     ) -> eyre::Result<()> {
         match self {
-            PluginEnum::Asdf(plugin) => plugin.ensure_installed(config, mpr, force).await,
-            PluginEnum::Vfox(plugin) => plugin.ensure_installed(config, mpr, force).await,
-            PluginEnum::VfoxBackend(plugin) => plugin.ensure_installed(config, mpr, force).await,
+            PluginEnum::Asdf(plugin) => plugin.ensure_installed(config, mpr, force, dry_run).await,
+            PluginEnum::Vfox(plugin) => plugin.ensure_installed(config, mpr, force, dry_run).await,
+            PluginEnum::VfoxBackend(plugin) => {
+                plugin.ensure_installed(config, mpr, force, dry_run).await
+            }
         }
     }
 }
@@ -251,6 +254,7 @@ pub trait Plugin: Debug + Send {
         _config: &Arc<Config>,
         _mpr: &MultiProgressReport,
         _force: bool,
+        _dry_run: bool,
     ) -> eyre::Result<()> {
         Ok(())
     }

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -135,7 +135,7 @@ impl Plugin for VfoxPlugin {
         if !self.plugin_path.exists() {
             let url = self.get_repo_url()?;
             trace!("Cloning vfox plugin: {url}");
-            let pr = mpr.add(&format!("clone vfox plugin {url}"));
+            let pr = mpr.add_with_options(&format!("clone vfox plugin {url}"), dry_run);
             if !dry_run {
                 self.repo()
                     .clone(url.as_str(), CloneOptions::default().pr(&pr))?;

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -130,13 +130,16 @@ impl Plugin for VfoxPlugin {
         _config: &Arc<Config>,
         mpr: &MultiProgressReport,
         _force: bool,
+        dry_run: bool,
     ) -> Result<()> {
         if !self.plugin_path.exists() {
             let url = self.get_repo_url()?;
             trace!("Cloning vfox plugin: {url}");
             let pr = mpr.add(&format!("clone vfox plugin {url}"));
-            self.repo()
-                .clone(url.as_str(), CloneOptions::default().pr(&pr))?;
+            if !dry_run {
+                self.repo()
+                    .clone(url.as_str(), CloneOptions::default().pr(&pr))?;
+            }
         }
         Ok(())
     }

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -220,7 +220,7 @@ impl Toolset {
         } else {
             opts.reason.clone()
         };
-        mpr.init_header(&header_reason, versions.len());
+        mpr.init_header(opts.dry_run, &header_reason, versions.len());
 
         // Skip hooks in dry-run mode
         if !opts.dry_run {
@@ -304,7 +304,9 @@ impl Toolset {
         }
 
         // Finish the global header
-        mpr.header_finish();
+        if !opts.dry_run {
+            mpr.header_finish();
+        }
         Ok(installed)
     }
 

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -341,9 +341,7 @@ impl Toolset {
             }
         };
 
-        // Initialize global header progress (overall tools)
-        let mpr = MultiProgressReport::get();
-        mpr.init_header("install", versions_clone.len());
+        // Don't initialize header here - it's already done in install_all_versions
 
         // Track plugin installation errors to avoid early returns
         let mut plugin_errors = Vec::new();

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -55,6 +55,8 @@ impl MultiProgressReport {
             _ if self.quiet => Box::new(QuietReport::new()),
             Some(mp) if !dry_run => {
                 let mut pr = ProgressReport::new(prefix.into());
+                // Always use add() to append progress bars
+                // The header should already be at position 0 if it exists
                 pr.pb = mp.add(pr.pb);
                 Box::new(pr)
             }
@@ -94,6 +96,7 @@ impl MultiProgressReport {
                     style::edim(format!("{version} by @jdx –")),
                 );
                 let mut header = HeaderReport::new(prefix, total_tools as u64, message.to_string());
+                // Use add() instead of insert() to avoid potential duplicates
                 header.pb = mp.add(header.pb);
                 *hdr = Some(header);
             }

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -66,34 +66,41 @@ impl MultiProgressReport {
             return;
         }
 
-        // Always print header as static text at the beginning
-        // This ensures it stays visible and appears at the top
-        let version = &*VERSION_PLAIN;
-        let icon = if message.contains("(dry-run)") {
-            style::eyellow("○")
-        } else {
-            style::egreen("✓").bright()
-        };
-        eprintln!(
-            "{} {} {} {}",
-            style::emagenta("mise").bold(),
-            style::edim(format!("{version} by @jdx –")),
-            icon,
-            message
-        );
+        // Print header for non-tty mode
+        if self.mp.is_none() {
+            let version = &*VERSION_PLAIN;
+            let icon = if message.contains("(dry-run)") {
+                style::eyellow("○")
+            } else {
+                style::egreen("✓").bright()
+            };
+            eprintln!(
+                "{} {} {} {}",
+                style::emagenta("mise").bold(),
+                style::edim(format!("{version} by @jdx –")),
+                icon,
+                message
+            );
+            return;
+        }
 
-        // For TTY mode with MultiProgress, still create the header for tracking
-        // but it won't be displayed as a progress bar
-        if self.mp.is_some() {
-            let mut hdr = self.header.lock().unwrap();
-            if hdr.is_none() {
-                // Create a dummy header just for tracking state
-                // We won't actually add it to the MultiProgress
-                let prefix = String::new();
-                let header = HeaderReport::new(prefix, total_tools as u64, message.to_string());
-                // Don't add to mp - just track it internally
+        let mut hdr = self.header.lock().unwrap();
+        match (&self.mp, hdr.as_ref()) {
+            (Some(mp), None) => {
+                let version = &*VERSION_PLAIN;
+                let prefix = format!(
+                    "{} {}",
+                    style::emagenta("mise").bold(),
+                    style::edim(format!("{version} by @jdx –")),
+                );
+                let mut header = HeaderReport::new(prefix, total_tools as u64, message.to_string());
+                header.pb = mp.add(header.pb);
                 *hdr = Some(header);
             }
+            (_, Some(_h)) => {
+                // header already initialized; do not change total
+            }
+            _ => {}
         }
     }
     pub fn header_inc(&self, n: usize) {
@@ -105,11 +112,11 @@ impl MultiProgressReport {
         }
     }
     pub fn header_finish(&self) {
-        // The header is now printed as static text in init_header
-        // so we don't need to call finish on a progress bar
-        // Just clear our internal tracking
-        let mut hdr = self.header.lock().unwrap();
-        *hdr = None;
+        if let Some(h) = &*self.header.lock().unwrap() {
+            h.finish();
+        }
+        // Note: For non-tty mode, the header was already printed with the final icon
+        // in init_header, so we don't need to do anything here
     }
     pub fn suspend_if_active<F: FnOnce() -> R, R>(f: F) -> R {
         match Self::try_get() {

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -47,14 +47,18 @@ impl MultiProgressReport {
         }
     }
     pub fn add(&self, prefix: &str) -> Box<dyn SingleReport> {
+        self.add_with_options(prefix, false)
+    }
+
+    pub fn add_with_options(&self, prefix: &str, dry_run: bool) -> Box<dyn SingleReport> {
         match &self.mp {
             _ if self.quiet => Box::new(QuietReport::new()),
-            Some(mp) => {
+            Some(mp) if !dry_run => {
                 let mut pr = ProgressReport::new(prefix.into());
                 pr.pb = mp.add(pr.pb);
                 Box::new(pr)
             }
-            None => Box::new(VerboseReport::new(prefix.to_string())),
+            _ => Box::new(VerboseReport::new(prefix.to_string())),
         }
     }
     pub fn init_header(&self, message: &str, total_tools: usize) {

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -2,7 +2,9 @@ use std::sync::{Arc, Mutex};
 
 use indicatif::MultiProgress;
 
-use crate::ui::progress_report::{ProgressReport, QuietReport, SingleReport, VerboseReport};
+use crate::ui::progress_report::{
+    HeaderReport, ProgressReport, QuietReport, SingleReport, VerboseReport,
+};
 use crate::ui::style;
 use crate::{cli::version::VERSION_PLAIN, config::Settings};
 
@@ -10,6 +12,7 @@ use crate::{cli::version::VERSION_PLAIN, config::Settings};
 pub struct MultiProgressReport {
     mp: Option<MultiProgress>,
     quiet: bool,
+    header: Mutex<Option<HeaderReport>>,
 }
 
 static INSTANCE: Mutex<Option<Arc<MultiProgressReport>>> = Mutex::new(None);
@@ -40,6 +43,7 @@ impl MultiProgressReport {
         MultiProgressReport {
             mp,
             quiet: settings.quiet,
+            header: Mutex::new(None),
         }
     }
     pub fn add(&self, prefix: &str) -> Box<dyn SingleReport> {
@@ -57,13 +61,12 @@ impl MultiProgressReport {
             _ => Box::new(VerboseReport::new(prefix.to_string())),
         }
     }
-    pub fn init_header(&self, message: &str, _total_tools: usize) {
+    pub fn init_header(&self, message: &str, total_tools: usize) {
         if self.quiet {
             return;
         }
 
-        // Only print header for non-tty mode
-        // In TTY mode with progress bars, the header gets buried and doesn't display properly
+        // Print header for non-tty mode
         if self.mp.is_none() {
             let version = &*VERSION_PLAIN;
             let icon = if message.contains("(dry-run)") {
@@ -78,14 +81,42 @@ impl MultiProgressReport {
                 icon,
                 message
             );
+            return;
         }
-        // Don't create a header progress bar for TTY mode
+
+        let mut hdr = self.header.lock().unwrap();
+        match (&self.mp, hdr.as_ref()) {
+            (Some(mp), None) => {
+                let version = &*VERSION_PLAIN;
+                let prefix = format!(
+                    "{} {}",
+                    style::emagenta("mise").bold(),
+                    style::edim(format!("{version} by @jdx –")),
+                );
+                let mut header = HeaderReport::new(prefix, total_tools as u64, message.to_string());
+                header.pb = mp.add(header.pb);
+                *hdr = Some(header);
+            }
+            (_, Some(_h)) => {
+                // header already initialized; do not change total
+            }
+            _ => {}
+        }
     }
-    pub fn header_inc(&self, _n: usize) {
-        // No header in TTY mode, so nothing to increment
+    pub fn header_inc(&self, n: usize) {
+        if n == 0 {
+            return;
+        }
+        if let Some(h) = &*self.header.lock().unwrap() {
+            h.inc(n as u64);
+        }
     }
     pub fn header_finish(&self) {
-        // No header to finish - it was already printed in non-TTY mode
+        if let Some(h) = &*self.header.lock().unwrap() {
+            h.finish();
+        }
+        // Note: For non-tty mode, the header was already printed with the final icon
+        // in init_header, so we don't need to do anything here
     }
     pub fn suspend_if_active<F: FnOnce() -> R, R>(f: F) -> R {
         match Self::try_get() {

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -137,8 +137,15 @@ impl SingleReport for ProgressReport {
     fn finish(&self) {
         self.pb.finish_and_clear();
     }
-    fn finish_with_message(&self, message: String) {
-        self.pb.finish_with_message(message);
+    fn finish_with_message(&self, _message: String) {
+        // Keep existing behavior - clear the progress bar
+        self.pb.finish_and_clear();
+    }
+
+    fn finish_with_icon(&self, _message: String, _icon: ProgressIcon) {
+        // For ProgressReport (indicatif), we still clear since it's a progress bar
+        // The message would be transient anyway
+        self.pb.finish_and_clear();
     }
 }
 

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -99,7 +99,8 @@ impl ProgressReport {
 
 impl SingleReport for ProgressReport {
     fn println(&self, message: String) {
-        self.pb.suspend(|| {
+        // Suspend the entire MultiProgress to prevent header duplication
+        crate::ui::multi_progress_report::MultiProgressReport::suspend_if_active(|| {
             eprintln!("{message}");
         });
     }
@@ -222,7 +223,8 @@ impl HeaderReport {
 
 impl SingleReport for HeaderReport {
     fn println(&self, message: String) {
-        self.pb.suspend(|| {
+        // Suspend the entire MultiProgress to prevent header duplication
+        crate::ui::multi_progress_report::MultiProgressReport::suspend_if_active(|| {
             eprintln!("{message}");
         });
     }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1333,6 +1333,12 @@ const completionSpec: Fig.Spec = {
       description: "Install a tool version",
       options: [
         {
+          name: ["-n", "--dry-run"],
+          description:
+            "Show what would be installed without actually installing",
+          isRepeatable: false,
+        },
+        {
           name: ["-f", "--force"],
           description: "Force reinstall even if already installed",
           isRepeatable: false,
@@ -3009,6 +3015,12 @@ const completionSpec: Fig.Spec = {
           name: ["-g", "--global"],
           description:
             "Use the global config file (`~/.config/mise/config.toml`) instead of the local one",
+          isRepeatable: false,
+        },
+        {
+          name: ["-n", "--dry-run"],
+          description:
+            "Perform a dry run, showing what would be installed and modified without making changes",
           isRepeatable: false,
         },
         {

--- a/xtasks/test/perf
+++ b/xtasks/test/perf
@@ -2,7 +2,7 @@
 #MISE depends=["test:build-perf-workspace"]
 #MISE description="Run performance tests"
 # shellcheck disable=SC2086,SC2129
-set -xeuo pipefail
+set -euo pipefail
 
 runs="${RUNS:-1}"
 cd perf-workspace


### PR DESCRIPTION
## Summary

This PR adds a `--dry-run` flag to the `mise install` command, allowing users to preview what would be installed without actually performing the installation.

## Changes

- **CLI**: Added `--dry-run` flag with short form `-n` to the install command
- **Logic**: Skip actual installation, plugin installation, and post-install hooks in dry-run mode
- **Display**: 
  - Shows "would install" for new tools and "already installed" for existing ones
  - Uses circle icon (○) instead of checkmark (✓) to indicate skipped actions
  - Fixed TTY display issues by forcing verbose text output for dry-run mode
- **Progress Icons**: Added `ProgressIcon` enum with Success, Skipped, Warning, and Error variants
- **Tests**: Added comprehensive e2e tests for dry-run functionality
- **Documentation**: Updated help text with dry-run examples

## Key Implementation Details

- Early return in `install_version` when dry-run is enabled to avoid plugin installation
- Skip config reloading and shim rebuilding in dry-run mode  
- Use `VerboseReport` for dry-run to ensure output remains visible in TTY
- Added `finish_with_icon` method to `SingleReport` trait for custom status icons

## Testing

```bash
# Test with uninstalled tool
mise install tiny@3.1.0 --dry-run
# Output: mise tiny@3.1.0                  ○ would install

# Test with installed tool  
mise install node --dry-run
# Output: mise node@24.6.0                 ○ already installed

# Test with multiple tools
mise install -n node@20 tiny@3.1.0
# Output shows both tools with appropriate status
```

## Examples

```bash
mise install --dry-run        # show what would be installed from mise.toml
mise install -n node@20       # show what would be installed (short form)
```

Closes #6084