### PR TITLE
chore: add libbz2-dev to e2e test dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
         with:
           submodules: true
       - name: Install zsh/fish/direnv/fd
-        run: sudo apt-get update; sudo apt-get install zsh fish direnv fd-find liblzma-dev
+        run: sudo apt-get update; sudo apt-get install zsh fish direnv fd-find liblzma-dev libbz2-dev
       - name: Install fd-find
         run: |
           mkdir -p "$HOME/.local/bin"


### PR DESCRIPTION
Add libbz2-dev and liblzma-dev packages to the e2e test environment
to support Python builds that require these compression libraries.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
