### PR TITLE
fix(aqua): remove mise-versions aqua registry

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -246,7 +246,7 @@
           "properties": {
             "baked_registry": {
               "default": true,
-              "description": "Use baked-in aqua registry (if compiled in).",
+              "description": "Use baked-in aqua registry.",
               "type": "boolean"
             },
             "cosign": {

--- a/settings.toml
+++ b/settings.toml
@@ -59,7 +59,7 @@ description = "should mise keep install files after installation even if the ins
 env = "MISE_AQUA_BAKED_REGISTRY"
 type = "Bool"
 default = true
-description = "Use baked-in aqua registry (if compiled in)."
+description = "Use baked-in aqua registry."
 
 [aqua.cosign]
 env = "MISE_AQUA_COSIGN"
@@ -88,10 +88,9 @@ description = "URL to fetch aqua registry from."
 docs = """
 URL to fetch aqua registry from. This is used to install tools from the aqua registry.
 
-By default, the official aqua registry is used: https://github.com/aquaproj/aqua-registry
+If this is set, the baked-in aqua registry is not used.
 
-However when this is not specified, instead of cloning the entire registry each individual tool's metadata is fetched
-via HTTP individually.
+By default, the official aqua registry is used: https://github.com/aquaproj/aqua-registry
 """
 
 [aqua.slsa]

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -1,26 +1,22 @@
 use crate::backend::aqua;
 use crate::backend::aqua::{arch, os};
-use crate::duration::{DAILY, WEEKLY};
+use crate::duration::WEEKLY;
 use crate::env;
 use crate::git::{CloneOptions, Git};
 use crate::semver::split_version_prefix;
 use crate::{aqua::aqua_template, config::Settings};
-use crate::{dirs, file, hashmap, http};
+use crate::{dirs, file, hashmap};
 use expr::{Context, Program, Value};
-use eyre::{ContextCompat, Result, eyre};
+use eyre::{ContextCompat, Result, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use serde_derive::Deserialize;
+use std::cmp::PartialEq;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::LazyLock as Lazy;
 use std::sync::LazyLock;
-use std::{
-    cmp::PartialEq,
-    sync::atomic::{AtomicBool, Ordering},
-};
 use tokio::sync::Mutex;
-use url::Url;
 
 #[allow(clippy::invisible_characters)]
 pub static AQUA_STANDARD_REGISTRY_FILES: Lazy<HashMap<&'static str, &'static str>> =
@@ -33,7 +29,7 @@ pub static AQUA_REGISTRY: Lazy<AquaRegistry> = Lazy::new(|| {
     })
 });
 static AQUA_REGISTRY_PATH: Lazy<PathBuf> = Lazy::new(|| dirs::CACHE.join("aqua-registry"));
-
+static AQUA_DEFAULT_REGISTRY_URL: &str = "https://github.com/aquaproj/aqua-registry";
 #[derive(Default)]
 pub struct AquaRegistry {
     path: PathBuf,
@@ -195,15 +191,30 @@ impl AquaRegistry {
     pub fn standard() -> Result<Self> {
         let path = AQUA_REGISTRY_PATH.clone();
         let repo = Git::new(&path);
-        let mut repo_exists = repo.exists();
-        if repo_exists {
-            fetch_latest_repo(&repo)?;
-        } else if let Some(aqua_registry_url) = &Settings::get().aqua.registry_url {
-            info!("cloning aqua registry to {path:?}");
-            repo.clone(aqua_registry_url, CloneOptions::default())?;
-            repo_exists = true;
+        let settings = Settings::get();
+        let registry_url =
+            settings
+                .aqua
+                .registry_url
+                .as_deref()
+                .or(if settings.aqua.baked_registry {
+                    None
+                } else {
+                    Some(AQUA_DEFAULT_REGISTRY_URL)
+                });
+        if let Some(registry_url) = registry_url {
+            if repo.exists() {
+                // TODO: re-clone if remote url doesn't match
+                fetch_latest_repo(&repo)?;
+            } else {
+                info!("cloning aqua registry from {registry_url} to {path:?}");
+                repo.clone(registry_url, CloneOptions::default())?;
+            }
         }
-        Ok(Self { path, repo_exists })
+        Ok(Self {
+            path,
+            repo_exists: repo.exists(),
+        })
     }
 
     pub async fn package(&self, id: &str) -> Result<AquaPackage> {
@@ -232,11 +243,7 @@ impl AquaRegistry {
         Ok(self.package(id).await?.with_version(versions))
     }
 
-    async fn fetch_package_yaml(
-        &self,
-        id: &str,
-        path: &PathBuf,
-    ) -> Result<RegistryYaml> {
+    async fn fetch_package_yaml(&self, id: &str, path: &PathBuf) -> Result<RegistryYaml> {
         let registry = if self.repo_exists {
             trace!("reading aqua-registry for {id} from repo at {path:?}");
             serde_yaml::from_reader(file::open(path)?)?
@@ -246,8 +253,7 @@ impl AquaRegistry {
             trace!("reading baked-in aqua-registry for {id}");
             serde_yaml::from_str(AQUA_STANDARD_REGISTRY_FILES.get(id).unwrap())?
         } else {
-            trace!("reading cached aqua-registry for {id} from {path:?}");
-            serde_yaml::from_reader(file::open(path)?)?
+            bail!("no aqua-registry found for {id}");
         };
         Ok(registry)
     }

--- a/src/aqua/aqua_registry.rs
+++ b/src/aqua/aqua_registry.rs
@@ -30,6 +30,7 @@ pub static AQUA_REGISTRY: Lazy<AquaRegistry> = Lazy::new(|| {
 });
 static AQUA_REGISTRY_PATH: Lazy<PathBuf> = Lazy::new(|| dirs::CACHE.join("aqua-registry"));
 static AQUA_DEFAULT_REGISTRY_URL: &str = "https://github.com/aquaproj/aqua-registry";
+
 #[derive(Default)]
 pub struct AquaRegistry {
     path: PathBuf,

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -549,12 +549,7 @@ fn aqua_registry_count() -> usize {
 }
 
 fn aqua_registry_count_str() -> String {
-    let aqua_count = aqua_registry_count();
-    if aqua_count > 0 {
-        format!("baked in registry tools: {aqua_count}")
-    } else {
-        "baked in registry tools: 0 – aqua registry tools are not compiled into mise, will be fetched dynamically from https://mise-versions.jdx.dev".to_string()
-    }
+    format!("baked in registry tools: {}", aqua_registry_count())
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(


### PR DESCRIPTION
The aqua registry is now always baked in, so the fallback is not required.
https://github.com/jdx/mise/pull/6082