### PR TITLE
docs: Split run command so that copy button is useful

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -14,8 +14,11 @@ file, mise will automatically add itself to `PATH`.
 
 ```sh
 curl https://mise.run | sh
+```
 
-# or with options
+or with options
+
+```sh
 curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
 ```
 


### PR DESCRIPTION
I tend to hit the copy button, but it pulls in both the commands whereas I need just one. Split the code block in two.