### PR TITLE
registry: remove asdf plugin for zoxide

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -3551,10 +3551,7 @@ zola.backends = [
 ]
 zola.test = ["zola --version", "zola {{version}}"]
 zoxide.description = "A smarter cd command. Supports all major shells"
-zoxide.backends = [
-    "aqua:ajeetdsouza/zoxide",
-    "ubi:ajeetdsouza/zoxide"
-]
+zoxide.backends = ["aqua:ajeetdsouza/zoxide", "ubi:ajeetdsouza/zoxide"]
 zoxide.test = ["zoxide --version", "zoxide {{version}}"]
 zprint.description = "Executables, uberjar, and library to beautifully format Clojure and Clojurescript source code and s-expressions"
 zprint.backends = ["asdf:mise-plugins/mise-zprint"]


### PR DESCRIPTION
It seems the author removed the GitHub account.
https://github.com/nyrst

ref: https://github.com/jdx/mise/discussions/6036