### PR TITLE
fix(aqua): bake in aliased registries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,7 @@ cfg_aliases = "0.2"
 heck = "0.5"
 toml = "0.8"
 indexmap = "2"
+serde_yaml = "0.9"
 
 [dev-dependencies]
 ctor = "0.4"


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/6102.

`aqua.registry_url` doesn't work with aliases, but I'll fix it later.