### PR TITLE
registry: update kubectl aqua alias

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1886,7 +1886,7 @@ kubeconform.backends = [
 ]
 kubectl.description = "kubectl cli"
 kubectl.backends = [
-    "aqua:kubernetes/kubectl",
+    "aqua:kubernetes/kubernetes/kubectl",
     "asdf:asdf-community/asdf-kubectl"
 ]
 kubectl-convert.description = "A plugin for Kubernetes command-line tool kubectl, which allows you to convert manifests between different API versions. This can be particularly helpful to migrate manifests to a non-deprecated api version with newer Kubernetes release"


### PR DESCRIPTION
In https://github.com/aquaproj/aqua-registry/pull/35837, the aqua registry moved the `kubectl` tool from `kubernetes/kubectl` to `kubernetes/kubernetes/kubectl`.

This is a regression as of `v2025.8.17` (`v2025.8.16` works).

The error for the current version (`v2025.8.18` as of the time of this PR creation):

```
❯ mise install kubectl
mise ERROR Failed to install tool: kubectl@latest

kubectl@latest:
   0: failed to install aqua:kubernetes/kubectl@1.33.4
   1: no aqua-registry found for kubernetes/kubectl

Location:
   src/aqua/aqua_registry.rs:257

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
mise mise 2025.8.18 by @jdx –       install
```

`mise install aqua:kubernetes/kubernetes/kubectl` runs fine on `2025.8.18` with no errors.