### PR TITLE
chore: release 2025.8.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2025.8.19](https://github.com/jdx/mise/compare/v2025.8.18..v2025.8.19) - 2025-08-22
+
+### 📦 Registry
+
+- update kubectl aqua alias by [@malept](https://github.com/malept) in [#6107](https://github.com/jdx/mise/pull/6107)
+- remove asdf plugin for watchexec by [@risu729](https://github.com/risu729) in [#6106](https://github.com/jdx/mise/pull/6106)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** bake in aliased registries by [@risu729](https://github.com/risu729) in [#6105](https://github.com/jdx/mise/pull/6105)
+
 ## [2025.8.18](https://github.com/jdx/mise/compare/v2025.8.17..v2025.8.18) - 2025-08-22
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.8.18"
+version = "2025.8.19"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.8.18"
+version = "2025.8.19"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.8.18 macos-arm64 (a1b2d3e 2025-08-22)
+2025.8.19 macos-arm64 (a1b2d3e 2025-08-22)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/aqua-registry/.github/workflows/count-pkgs.yaml
+++ b/aqua-registry/.github/workflows/count-pkgs.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: asdf-vm/actions/setup@1902764435ca0dd2f3388eea723a4f92a4eb8302 # v4.0.0
-      - uses: jdx/mise-action@c0b8518a9f5e56c720e9545c993b77ff15dc7b27 # v3.0.2
+      - uses: jdx/mise-action@ca0c5fc9c8a8386dae8ba5d37608a083a307991c # v3.1.0
       - run: |
           set -euo pipefail
           n=$(find pkgs -name registry.yaml | wc -l)

--- a/aqua-registry/pkgs/Songmu/maltmill/pkg.yaml
+++ b/aqua-registry/pkgs/Songmu/maltmill/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: Songmu/maltmill@v1.1.0
+  - name: Songmu/maltmill@v1.2.0

--- a/aqua-registry/pkgs/cargo-bins/cargo-binstall/pkg.yaml
+++ b/aqua-registry/pkgs/cargo-bins/cargo-binstall/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: cargo-bins/cargo-binstall@v1.14.4
+  - name: cargo-bins/cargo-binstall@v1.15.0
   - name: cargo-bins/cargo-binstall
     version: v1.3.1
   - name: cargo-bins/cargo-binstall

--- a/aqua-registry/pkgs/crates.io/cargo-deb/pkg.yaml
+++ b/aqua-registry/pkgs/crates.io/cargo-deb/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: crates.io/cargo-deb@3.5.1
+  - name: crates.io/cargo-deb@3.6.0

--- a/aqua-registry/pkgs/dag-andersen/argocd-diff-preview/pkg.yaml
+++ b/aqua-registry/pkgs/dag-andersen/argocd-diff-preview/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: dag-andersen/argocd-diff-preview@v0.1.14
+  - name: dag-andersen/argocd-diff-preview@v0.1.15
   - name: dag-andersen/argocd-diff-preview
     version: v0.0.35
   - name: dag-andersen/argocd-diff-preview

--- a/aqua-registry/pkgs/ekristen/aws-nuke/pkg.yaml
+++ b/aqua-registry/pkgs/ekristen/aws-nuke/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: ekristen/aws-nuke@v3.56.2
+  - name: ekristen/aws-nuke@v3.56.4
   - name: ekristen/aws-nuke
     version: v3.0.0-beta.7
   - name: ekristen/aws-nuke

--- a/aqua-registry/pkgs/github/github-mcp-server/pkg.yaml
+++ b/aqua-registry/pkgs/github/github-mcp-server/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
-  - name: github/github-mcp-server@v0.12.1
+  - name: github/github-mcp-server@v0.13.0
   - name: github/github-mcp-server
     version: v0.1.1

--- a/aqua-registry/pkgs/google/wire/pkg.yaml
+++ b/aqua-registry/pkgs/google/wire/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: google/wire@v0.6.0
+  - name: google/wire@v0.7.0

--- a/aqua-registry/pkgs/jdx/hk/pkg.yaml
+++ b/aqua-registry/pkgs/jdx/hk/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
-  - name: jdx/hk@v1.9.2
+  - name: jdx/hk@v1.10.1
   - name: jdx/hk
     version: v0.1.9

--- a/aqua-registry/pkgs/jdx/mise/pkg.yaml
+++ b/aqua-registry/pkgs/jdx/mise/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: jdx/mise@v2025.8.17
+  - name: jdx/mise@v2025.8.18
   - name: jdx/mise
     version: v2024.0.0
   - name: jdx/mise

--- a/aqua-registry/pkgs/okteto/okteto/pkg.yaml
+++ b/aqua-registry/pkgs/okteto/okteto/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: okteto/okteto@3.10.0
+  - name: okteto/okteto@3.10.1
   - name: okteto/okteto
     version: 1.10.5
   - name: okteto/okteto

--- a/aqua-registry/pkgs/ziglang/zig/pkg.yaml
+++ b/aqua-registry/pkgs/ziglang/zig/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
-  - name: ziglang/zig@0.15.0
+  - name: ziglang/zig@0.15.1
   - name: ziglang/zig
     version: 0.14.0

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_8_18:-}" ]] || _cache_invalid _usage_spec_mise_2025_8_18 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_8_18;
+  if ( [[ -z "${_usage_spec_mise_2025_8_19:-}" ]] || _cache_invalid _usage_spec_mise_2025_8_19 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_8_19;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_8_18 spec
+    _store_cache _usage_spec_mise_2025_8_19 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_8_18:-} ]]; then
-        _usage_spec_mise_2025_8_18="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_8_19:-} ]]; then
+        _usage_spec_mise_2025_8_19="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_8_18}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_8_19}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_8_18
-  set -g _usage_spec_mise_2025_8_18 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_8_19
+  set -g _usage_spec_mise_2025_8_19 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_18" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_19" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_18" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_8_19" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.8.18";
+  version = "2025.8.19";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.8.18
+Version: 2025.8.19
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 📦 Registry

- update kubectl aqua alias by [@malept](https://github.com/malept) in [#6107](https://github.com/jdx/mise/pull/6107)
- remove asdf plugin for watchexec by [@risu729](https://github.com/risu729) in [#6106](https://github.com/jdx/mise/pull/6106)

### 🐛 Bug Fixes

- **(aqua)** bake in aliased registries by [@risu729](https://github.com/risu729) in [#6105](https://github.com/jdx/mise/pull/6105)