### PR TITLE
fix: Update ZLS registry.yaml

### DIFF
--- a/aqua-registry/pkgs/zigtools/zls/registry.yaml
+++ b/aqua-registry/pkgs/zigtools/zls/registry.yaml
@@ -27,7 +27,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "0.10.0"
+      - version_constraint: semver("< 0.15.0")
         url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:
@@ -46,12 +46,12 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
-        url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+     - version_constraint: "true"
+        url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:
           type: http
-          url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
+          url: https://builds.zigtools.org/zls}-{{.Arch}}-{{.OS}-{{.Version}}.{{.Format}}.minisig
           public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
         replacements:
           darwin: macos


### PR DESCRIPTION
https://zigtools.org/zls/releases/0.15.0/

> Release filenames have changed
> The operating system and cpu archtecture in the filename have been swapped to match the equivalent change that happened in Zig’s tarballs. armv7a also has been renamed to arm for the same reason.