### PR TITLE
fix: python nested venv path order

### DIFF
--- a/e2e/env/test_env_path
+++ b/e2e/env/test_env_path
@@ -14,3 +14,14 @@ _.path = ['a', 'b']
 EOF
 assert "mise dr path" "$PWD/a
 $PWD/b"
+
+mkdir -p sub_dir
+cd sub_dir
+cat <<'EOF' >mise.toml
+[env]
+_.path = ['c', 'd']
+EOF
+assert "mise dr path" "$PWD/c
+$PWD/d
+${PWD%/*}/a
+${PWD%/*}/b"

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -366,16 +366,17 @@ impl EnvResults {
                 .or_else(|| dirs::CWD.clone())
                 .unwrap_or_default();
             let paths = paths.map(|(p, _)| p).collect_vec();
-            let paths = paths
+            let mut paths = paths
                 .iter()
                 .rev()
                 .flat_map(|path| env::split_paths(path))
                 .map(|s| normalize_path(&config_root, s))
                 .collect::<Vec<_>>();
-            r.env_paths.extend(paths);
+            // r.env_paths is already reversed and paths should prepend r.env_paths
+            paths.reverse();
+            paths.extend(r.env_paths);
+            r.env_paths = paths;
         }
-
-        r.env_paths.reverse();
 
         Ok(r)
     }


### PR DESCRIPTION
As discovered  https://github.com/jdx/mise/discussions/4510 and https://github.com/jdx/mise/issues/4515 , the nested python venv path is incorrect.

I locate the code below, the code origin target is prepend reversed paths to `r. env_paths`, but the `r. env_paths` is already reversed outside.