### PR TITLE
fix(aqua): respect order of asset_strs

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -338,12 +338,8 @@ impl AquaBackend {
         let asset = asset_strs
             .iter()
             .find_map(|expected| {
-                gh_release.assets.iter().find_map(|a| {
-                    if a.name == *expected || a.name.to_lowercase() == expected.to_lowercase() {
-                        Some(a)
-                    } else {
-                        None
-                    }
+                gh_release.assets.iter().find(|a| {
+                    a.name == *expected || a.name.to_lowercase() == expected.to_lowercase()
                 })
             })
             .wrap_err_with(|| {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -334,16 +334,17 @@ impl AquaBackend {
         let gh_id = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
         let gh_release = github::get_release(&gh_id, v).await?;
 
-        // Convert expected asset names to lowercase once for case-insensitive matching
-        let asset_strs_lower: IndexSet<String> =
-            asset_strs.iter().map(|s| s.to_lowercase()).collect();
-
-        let asset = gh_release
-            .assets
+        // Prioritize order of asset_strs
+        let asset = asset_strs
             .iter()
-            .find(|a| {
-                // First try exact match, then case-insensitive
-                asset_strs.contains(&a.name) || asset_strs_lower.contains(&a.name.to_lowercase())
+            .find_map(|expected| {
+                gh_release.assets.iter().find_map(|a| {
+                    if a.name == *expected || a.name.to_lowercase() == expected.to_lowercase() {
+                        Some(a)
+                    } else {
+                        None
+                    }
+                })
             })
             .wrap_err_with(|| {
                 format!(


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/6132

The bug was caused by prioritising `universal` over `x86_64`. We should use `universal` as a fallback, not the first choice.