### PR TITLE
fix(nushell/windows): Fix $env.PATH getting converted to a string

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -94,7 +94,7 @@ impl Shell for Nushell {
           def --env "update-env" [] {{
             for $var in $in {{
               if $var.op == "set" {{
-                if $var.name == 'PATH' {{
+                if ($var.name | str upcase) == 'PATH' {{
                   $env.PATH = ($var.value | split row (char esep))
                 }} else {{
                   load-env {{($var.name): $var.value}}

--- a/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
@@ -43,7 +43,7 @@ export def --env --wrapped main [command?: string, --help, ...rest: string] {
 def --env "update-env" [] {
   for $var in $in {
     if $var.op == "set" {
-      if $var.name == 'PATH' {
+      if ($var.name | str upcase) == 'PATH' {
         $env.PATH = ($var.value | split row (char esep))
       } else {
         load-env {($var.name): $var.value}


### PR DESCRIPTION
This addresses the issue in discussion #5472.

Mise on nushell on windows doesn't properly convert the path to a nushell-native list. Most of the time this works fine, as long as the path stays a string. However, if anything else adds a value to the path (like manually activating a python venv), you end up with a list of 2 items: the big, `;` delimited string that was $env.PATH, and one entry for whatever was just added (now the only valid item in the path list).

The problem comes from this function in the activate script:

```nu
def --env "update-env" [] {
     # ...
     if $var.name == 'PATH' {
        $env.PATH = ($var.value | split row (char esep))
     } else {
    # ...
}
```

`$env.PATH` is case-insensitive in nushell [1] (actually, all environment variables are, regardless of OS [2]). Mise matches whatever capitalization is in use at run time [3], which for windows is `Path`. For the sake of the update hook though, in case something changes the capitalization of `$env.PATH` between activating mise and some later run of the hook, it's probably just better to do this comparison in a case-insensitive way.

[1]: https://www.nushell.sh/book/configuration.html#path-configuration
[2]: https://www.nushell.sh/book/environment.html#case-sensitivity
[3]: https://github.com/jdx/mise/blob/b7583ea9cc43c78e60d044640d149958e71261e4/src/env.rs#L225C1-L231C4