### PR TITLE
docs(task): remove word "additional" to avoid confusions

### DIFF
--- a/docs/tasks/file-tasks.md
+++ b/docs/tasks/file-tasks.md
@@ -8,7 +8,7 @@ In addition to defining tasks through the configuration, they can also be define
 - `.mise/tasks/:task_name`
 - `.config/mise/tasks/:task_name`
 
-Note that you can include additional directories using the [task_config](/tasks/task-configuration.html#task-config-options) section.
+Note that you can configure directories using the [task_config](/tasks/task-configuration.html#task-config-options) section.
 
 Here is an example of a file task that builds a Rust CLI:
 


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/6151.

I read the implementation and confirmed it overrode the default.
It seems it's the intended behaviour since the initial PR https://github.com/jdx/mise/pull/1571.