### PR TITLE
fix(java): treat freebsd as linux (assuming linux compatability)

### DIFF
--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -484,6 +484,8 @@ impl Backend for JavaPlugin {
 fn os() -> &'static str {
     if cfg!(target_os = "macos") {
         "macosx"
+    } else if OS.as_str() == "freebsd" {
+        "linux"
     } else {
         &OS
     }


### PR DESCRIPTION
Addresses the installation issue with FreeBSD mentioned in #6135.
Executing Linux binaries on FreeBSD requires Linux compatibility to be enabled. Guess this is save to take for granted given `mise` is run on FreeBSD (without a specific build).