### PR TITLE
fix: mise activate not working on powershell v5

### DIFF
--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -50,7 +50,11 @@ impl Shell for Pwsh {
                 }}
 
                 $command = $arguments[0]
-                $remainingArgs = $arguments[1..$($arguments.Length - 1)]
+                if ($arguments.Length -gt 1) {{
+                    $remainingArgs = $arguments[1..($arguments.Length - 1)]
+                }} else {{
+                   $remainingArgs = @()
+                }}
 
                 switch ($command) {{
                     {{ $_ -in 'deactivate', 'shell', 'sh' }} {{

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -50,7 +50,7 @@ impl Shell for Pwsh {
                 }}
 
                 $command = $arguments[0]
-                $remainingArgs = $arguments[1..($arguments.Length)]
+                $remainingArgs = $arguments[1..$($arguments.Length - 1)]
 
                 switch ($command) {{
                     {{ $_ -in 'deactivate', 'shell', 'sh' }} {{

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -50,7 +50,7 @@ impl Shell for Pwsh {
                 }}
 
                 $command = $arguments[0]
-                $remainingArgs = $arguments[1..($arguments.length)]
+                $remainingArgs = $arguments[1..($arguments.Length)]
 
                 switch ($command) {{
                     {{ $_ -in 'deactivate', 'shell', 'sh' }} {{

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -53,7 +53,7 @@ impl Shell for Pwsh {
                 if ($arguments.Length -gt 1) {{
                     $remainingArgs = $arguments[1..($arguments.Length - 1)]
                 }} else {{
-                   $remainingArgs = @()
+                    $remainingArgs = @()
                 }}
 
                 switch ($command) {{

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -65,7 +65,7 @@ impl Shell for Pwsh {
                         }}
                         _reset_output_encoding
                         # Pass down exit code from mise after _mise_hook
-                        if ($PSVersionTable.PSVersion.Major -gt 7) {{
+                        if ($PSVersionTable.PSVersion.Major -ge 7) {{
                             pwsh -NoProfile -Command exit $status
                         }} else {{
                             powershell -NoProfile -Command exit $status
@@ -87,7 +87,7 @@ impl Shell for Pwsh {
             function __enable_mise_chpwd{{
                 if ($PSVersionTable.PSVersion.Major -lt 7) {{
                     if ($env:MISE_PWSH_CHPWD_WARNING -ne '0') {{
-                        Write-Warning 'mise: chpwd functionality requires PowerShell version 7 or higher. Your current version is $($PSVersionTable.PSVersion). You can add `$env:MISE_PWSH_CHPWD_WARNING=0` to your environment to disable this warning.'
+                        Write-Warning "mise: chpwd functionality requires PowerShell version 7 or higher. Your current version is $($PSVersionTable.PSVersion). You can add `$env:MISE_PWSH_CHPWD_WARNING=0` to your environment to disable this warning."
                     }}
                     return
                 }}

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -24,6 +24,12 @@ impl Shell for Pwsh {
             $env:__MISE_ORIG_PATH = $env:PATH
 
             function mise {{
+                [CmdletBinding()]
+                param(
+                    [Parameter(ValueFromRemainingArguments=$true)]  # Allow any number of arguments, including none
+                    [string[]] $arguments
+                )
+
                 $previous_out_encoding = $OutputEncoding
                 $previous_console_out_encoding = [Console]::OutputEncoding
                 $OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
@@ -33,38 +39,37 @@ impl Shell for Pwsh {
                     [Console]::OutputEncoding = $previous_console_out_encoding
                 }}
 
-                # Read line directly from input to workaround powershell input parsing for functions
-                $code = [System.Management.Automation.Language.Parser]::ParseInput($MyInvocation.Statement.Substring($MyInvocation.OffsetInLine - 1), [ref]$null, [ref]$null)
-                $myLine = $code.Find({{ $args[0].CommandElements }}, $true).CommandElements | ForEach-Object {{ $_.ToString() }} | Join-String -Separator ' '
-                $command, [array]$arguments = Invoke-Expression ('Write-Output -- ' + $myLine)
-                
-                if ($null -eq $arguments) {{ 
+                if ($arguments.count -eq 0) {{
                     & {exe}
                     _reset_output_encoding
                     return
                 }} elseif ($arguments -contains '-h' -or $arguments -contains '--help') {{
-                    & {exe} $arguments
+                    & {exe} @arguments
                     _reset_output_encoding
                     return
-                }} 
+                }}
 
                 $command = $arguments[0]
-                $arguments = $arguments[1..$arguments.Length]
+                $remainingArgs = $arguments[1..($arguments.length)]
 
                 switch ($command) {{
                     {{ $_ -in 'deactivate', 'shell', 'sh' }} {{
-                        & {exe} $command $arguments | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+                        & {exe} $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
                         _reset_output_encoding
                     }}
                     default {{
-                        & {exe} $command $arguments
+                        & {exe} $command @remainingArgs
                         $status = $LASTEXITCODE
                         if ($(Test-Path -Path Function:\_mise_hook)){{
                             _mise_hook
                         }}
                         _reset_output_encoding
                         # Pass down exit code from mise after _mise_hook
-                        pwsh -NoProfile -Command exit $status 
+                        if ($PSVersionTable.PSVersion.Major -gt 7) {{
+                            pwsh -NoProfile -Command exit $status
+                        }} else {{
+                            powershell -NoProfile -Command exit $status
+                        }}
                     }}
                 }}
             }}
@@ -80,6 +85,12 @@ impl Shell for Pwsh {
             }}
 
             function __enable_mise_chpwd{{
+                if ($PSVersionTable.PSVersion.Major -lt 7) {{
+                    if ($env:MISE_PWSH_CHPWD_WARNING -ne '0') {{
+                        Write-Warning 'mise: chpwd functionality requires PowerShell version 7 or higher. Your current version is $($PSVersionTable.PSVersion). You can add `$env:MISE_PWSH_CHPWD_WARNING=0` to your environment to disable this warning.'
+                    }}
+                    return
+                }}
                 if (-not $__mise_pwsh_chpwd){{
                     $Global:__mise_pwsh_chpwd= $true
                     $_mise_chpwd_hook = [EventHandler[System.Management.Automation.LocationChangedEventArgs]] {{

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -32,7 +32,7 @@ function mise {
     }
 
     $command = $arguments[0]
-    $remainingArgs = $arguments[1..($arguments.Length)]
+    $remainingArgs = $arguments[1..$($arguments.Length - 1)]
 
     switch ($command) {
         { $_ -in 'deactivate', 'shell', 'sh' } {

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -32,7 +32,11 @@ function mise {
     }
 
     $command = $arguments[0]
-    $remainingArgs = $arguments[1..$($arguments.Length - 1)]
+    if ($arguments.Length -gt 1) {
+        $remainingArgs = $arguments[1..($arguments.Length - 1)]
+    } else {
+         $remainingArgs = @()
+    }
 
     switch ($command) {
         { $_ -in 'deactivate', 'shell', 'sh' } {

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -32,7 +32,7 @@ function mise {
     }
 
     $command = $arguments[0]
-    $remainingArgs = $arguments[1..($arguments.length)]
+    $remainingArgs = $arguments[1..($arguments.Length)]
 
     switch ($command) {
         { $_ -in 'deactivate', 'shell', 'sh' } {
@@ -47,7 +47,7 @@ function mise {
             }
             _reset_output_encoding
             # Pass down exit code from mise after _mise_hook
-            if ($PSVersionTable.PSVersion.Major -gt 7) {
+            if ($PSVersionTable.PSVersion.Major -ge 7) {
                 pwsh -NoProfile -Command exit $status
             } else {
                 powershell -NoProfile -Command exit $status
@@ -65,7 +65,7 @@ function Global:_mise_hook {
 function __enable_mise_chpwd{
     if ($PSVersionTable.PSVersion.Major -lt 7) {
         if ($env:MISE_PWSH_CHPWD_WARNING -ne '0') {
-            Write-Warning 'mise: chpwd functionality requires PowerShell version 7 or higher. Your current version is $($PSVersionTable.PSVersion). You can add `$env:MISE_PWSH_CHPWD_WARNING=0` to your environment to disable this warning.'
+            Write-Warning "mise: chpwd functionality requires PowerShell version 7 or higher. Your current version is $($PSVersionTable.PSVersion). You can add `$env:MISE_PWSH_CHPWD_WARNING=0` to your environment to disable this warning."
         }
         return
     }

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -35,7 +35,7 @@ function mise {
     if ($arguments.Length -gt 1) {
         $remainingArgs = $arguments[1..($arguments.Length - 1)]
     } else {
-         $remainingArgs = @()
+        $remainingArgs = @()
     }
 
     switch ($command) {

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -6,6 +6,12 @@ $env:MISE_SHELL = 'pwsh'
 $env:__MISE_ORIG_PATH = $env:PATH
 
 function mise {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments=$true)]  # Allow any number of arguments, including none
+        [string[]] $arguments
+    )
+
     $previous_out_encoding = $OutputEncoding
     $previous_console_out_encoding = [Console]::OutputEncoding
     $OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
@@ -15,38 +21,37 @@ function mise {
         [Console]::OutputEncoding = $previous_console_out_encoding
     }
 
-    # Read line directly from input to workaround powershell input parsing for functions
-    $code = [System.Management.Automation.Language.Parser]::ParseInput($MyInvocation.Statement.Substring($MyInvocation.OffsetInLine - 1), [ref]$null, [ref]$null)
-    $myLine = $code.Find({ $args[0].CommandElements }, $true).CommandElements | ForEach-Object { $_.ToString() } | Join-String -Separator ' '
-    $command, [array]$arguments = Invoke-Expression ('Write-Output -- ' + $myLine)
-    
-    if ($null -eq $arguments) { 
+    if ($arguments.count -eq 0) {
         & /some/dir/mise
         _reset_output_encoding
         return
     } elseif ($arguments -contains '-h' -or $arguments -contains '--help') {
-        & /some/dir/mise $arguments
+        & /some/dir/mise @arguments
         _reset_output_encoding
         return
-    } 
+    }
 
     $command = $arguments[0]
-    $arguments = $arguments[1..$arguments.Length]
+    $remainingArgs = $arguments[1..($arguments.length)]
 
     switch ($command) {
         { $_ -in 'deactivate', 'shell', 'sh' } {
-            & /some/dir/mise $command $arguments | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+            & /some/dir/mise $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
             _reset_output_encoding
         }
         default {
-            & /some/dir/mise $command $arguments
+            & /some/dir/mise $command @remainingArgs
             $status = $LASTEXITCODE
             if ($(Test-Path -Path Function:\_mise_hook)){
                 _mise_hook
             }
             _reset_output_encoding
             # Pass down exit code from mise after _mise_hook
-            pwsh -NoProfile -Command exit $status 
+            if ($PSVersionTable.PSVersion.Major -gt 7) {
+                pwsh -NoProfile -Command exit $status
+            } else {
+                powershell -NoProfile -Command exit $status
+            }
         }
     }
 }
@@ -58,6 +63,12 @@ function Global:_mise_hook {
 }
 
 function __enable_mise_chpwd{
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+        if ($env:MISE_PWSH_CHPWD_WARNING -ne '0') {
+            Write-Warning 'mise: chpwd functionality requires PowerShell version 7 or higher. Your current version is $($PSVersionTable.PSVersion). You can add `$env:MISE_PWSH_CHPWD_WARNING=0` to your environment to disable this warning.'
+        }
+        return
+    }
     if (-not $__mise_pwsh_chpwd){
         $Global:__mise_pwsh_chpwd= $true
         $_mise_chpwd_hook = [EventHandler[System.Management.Automation.LocationChangedEventArgs]] {


### PR DESCRIPTION
Reworked some portions of the script for `mise activate pwsh` so it works as expected with powershell v5 as well as pwsh v7.

- Now works with Default Powershell Vendored with Windows
- Added an environment variable, `$env:MISE_PWSH_CHPWD_WARNING`, which can be set to disable warning
- Needed to disable chpwd for v5 powershell due to limitations of powershell itself.
- Reworked argument parsing to avoid powershell v5 causing issue where when it tries to get currently issued command, it breaks.

v5 Before:
<img width="1427" height="552" alt="image" src="https://github.com/user-attachments/assets/ac0d0840-d732-451c-b68d-c48b5409142d" />

v5 After:
<img width="1716" height="426" alt="image" src="https://github.com/user-attachments/assets/cf99579a-d04d-48d3-8b11-235933daded2" />


v7 Before:
<img width="1412" height="210" alt="image" src="https://github.com/user-attachments/assets/cee8f34e-5d66-4151-8105-5cdb16021337" />


v7 After
<img width="1635" height="283" alt="image" src="https://github.com/user-attachments/assets/a216cecc-5b17-4baa-89be-35dd88073818" />
