### PR TITLE
feat: allow set/unset backend aliases

### DIFF
--- a/docs/cli/alias.md
+++ b/docs/cli/alias.md
@@ -21,4 +21,4 @@ Don't show table header
 - [`mise alias get <PLUGIN> <ALIAS>`](/cli/alias/get.md)
 - [`mise alias ls [--no-header] [TOOL]`](/cli/alias/ls.md)
 - [`mise alias set <ARGS>…`](/cli/alias/set.md)
-- [`mise alias unset <PLUGIN> <ALIAS>`](/cli/alias/unset.md)
+- [`mise alias unset <PLUGIN> [ALIAS]`](/cli/alias/unset.md)

--- a/docs/cli/alias/set.md
+++ b/docs/cli/alias/set.md
@@ -4,7 +4,7 @@
 - **Aliases**: `add`, `create`
 - **Source code**: [`src/cli/alias/set.rs`](https://github.com/jdx/mise/blob/main/src/cli/alias/set.rs)
 
-Add/update an alias for a plugin
+Add/update an alias for a backend/plugin
 
 This modifies the contents of ~/.config/mise/config.toml
 
@@ -12,18 +12,19 @@ This modifies the contents of ~/.config/mise/config.toml
 
 ### `<PLUGIN>`
 
-The plugin to set the alias for
+The backend/plugin to set the alias for
 
 ### `<ALIAS>`
 
 The alias to set
 
-### `<VALUE>`
+### `[VALUE]`
 
 The value to set the alias to
 
 Examples:
 
 ```
+mise alias set maven asdf:mise-plugins/mise-maven
 mise alias set node lts-jod 22.0.0
 ```

--- a/docs/cli/alias/unset.md
+++ b/docs/cli/alias/unset.md
@@ -1,10 +1,10 @@
 # `mise alias unset`
 
-- **Usage**: `mise alias unset <PLUGIN> <ALIAS>`
+- **Usage**: `mise alias unset <PLUGIN> [ALIAS]`
 - **Aliases**: `rm`, `remove`, `delete`, `del`
 - **Source code**: [`src/cli/alias/unset.rs`](https://github.com/jdx/mise/blob/main/src/cli/alias/unset.rs)
 
-Clears an alias for a plugin
+Clears an alias for a backend/plugin
 
 This modifies the contents of ~/.config/mise/config.toml
 
@@ -12,14 +12,15 @@ This modifies the contents of ~/.config/mise/config.toml
 
 ### `<PLUGIN>`
 
-The plugin to remove the alias from
+The backend/plugin to remove the alias from
 
-### `<ALIAS>`
+### `[ALIAS]`
 
 The alias to remove
 
 Examples:
 
 ```
+mise alias unset maven
 mise alias unset node lts-jod
 ```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -63,7 +63,7 @@ Can also use `MISE_NO_CONFIG=1`
 - [`mise alias get <PLUGIN> <ALIAS>`](/cli/alias/get.md)
 - [`mise alias ls [--no-header] [TOOL]`](/cli/alias/ls.md)
 - [`mise alias set <ARGS>…`](/cli/alias/set.md)
-- [`mise alias unset <PLUGIN> <ALIAS>`](/cli/alias/unset.md)
+- [`mise alias unset <PLUGIN> [ALIAS]`](/cli/alias/unset.md)
 - [`mise backends <SUBCOMMAND>`](/cli/backends.md)
 - [`mise backends ls`](/cli/backends/ls.md)
 - [`mise bin-paths [TOOL@VERSION]…`](/cli/bin-paths.md)

--- a/e2e/cli/test_alias
+++ b/e2e/cli/test_alias
@@ -5,5 +5,5 @@ assert_contains "mise alias ls tiny" "tiny  xxx 2"
 assert "mise alias unset tiny xxx"
 assert_not_contains "mise alias ls" "tiny  xxx"
 
-assert "mise config set alias.nushell aqua:nushell/nushell"
+assert "mise alias set nushell aqua:nushell/nushell"
 assert "mise x nushell -- nu --version"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -95,20 +95,20 @@ cmd alias help="Manage version aliases." {
         flag --no-header help="Don't show table header"
         arg "[TOOL]" help="Show aliases for <TOOL>" required=#false
     }
-    cmd set help="Add/update an alias for a plugin" {
+    cmd set help="Add/update an alias for a backend/plugin" {
         alias add create
-        long_help "Add/update an alias for a plugin\n\nThis modifies the contents of ~/.config/mise/config.toml"
-        after_long_help "Examples:\n\n    $ mise alias set node lts-jod 22.0.0\n"
-        arg <PLUGIN> help="The plugin to set the alias for"
+        long_help "Add/update an alias for a backend/plugin\n\nThis modifies the contents of ~/.config/mise/config.toml"
+        after_long_help "Examples:\n\n    $ mise alias set maven asdf:mise-plugins/mise-maven\n    $ mise alias set node lts-jod 22.0.0\n"
+        arg <PLUGIN> help="The backend/plugin to set the alias for"
         arg <ALIAS> help="The alias to set"
-        arg <VALUE> help="The value to set the alias to"
+        arg "[VALUE]" help="The value to set the alias to" required=#false
     }
-    cmd unset help="Clears an alias for a plugin" {
+    cmd unset help="Clears an alias for a backend/plugin" {
         alias rm remove delete del
-        long_help "Clears an alias for a plugin\n\nThis modifies the contents of ~/.config/mise/config.toml"
-        after_long_help "Examples:\n\n    $ mise alias unset node lts-jod\n"
-        arg <PLUGIN> help="The plugin to remove the alias from"
-        arg <ALIAS> help="The alias to remove"
+        long_help "Clears an alias for a backend/plugin\n\nThis modifies the contents of ~/.config/mise/config.toml"
+        after_long_help "Examples:\n\n    $ mise alias unset maven\n    $ mise alias unset node lts-jod\n"
+        arg <PLUGIN> help="The backend/plugin to remove the alias from"
+        arg "[ALIAS]" help="The alias to remove" required=#false
     }
 }
 cmd asdf hide=#true help="[internal] simulates asdf for plugins that call \"asdf\" internally" {

--- a/src/cli/alias/set.rs
+++ b/src/cli/alias/set.rs
@@ -4,24 +4,27 @@ use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::config_file::ConfigFile;
 
-/// Add/update an alias for a plugin
+/// Add/update an alias for a backend/plugin
 ///
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Debug, clap::Args)]
 #[clap(visible_aliases = ["add", "create"], after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
 pub struct AliasSet {
-    /// The plugin to set the alias for
+    /// The backend/plugin to set the alias for
     pub plugin: BackendArg,
     /// The alias to set
     pub alias: String,
     /// The value to set the alias to
-    pub value: String,
+    pub value: Option<String>,
 }
 
 impl AliasSet {
     pub async fn run(self) -> Result<()> {
         let mut global_config = Config::get().await?.global_config()?;
-        global_config.set_alias(&self.plugin, &self.alias, &self.value)?;
+        match &self.value {
+            None => global_config.set_backend_alias(&self.plugin, &self.alias)?,
+            Some(val) => global_config.set_alias(&self.plugin, &self.alias, val)?,
+        }
         global_config.save()
     }
 }
@@ -29,6 +32,7 @@ impl AliasSet {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
+    $ <bold>mise alias set maven asdf:mise-plugins/mise-maven</bold>
     $ <bold>mise alias set node lts-jod 22.0.0</bold>
 "#
 );

--- a/src/cli/alias/unset.rs
+++ b/src/cli/alias/unset.rs
@@ -4,22 +4,29 @@ use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::config_file::ConfigFile;
 
-/// Clears an alias for a plugin
+/// Clears an alias for a backend/plugin
 ///
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Debug, clap::Args)]
 #[clap(visible_aliases = ["rm", "remove", "delete", "del"], after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
 pub struct AliasUnset {
-    /// The plugin to remove the alias from
+    /// The backend/plugin to remove the alias from
     pub plugin: BackendArg,
     /// The alias to remove
-    pub alias: String,
+    pub alias: Option<String>,
 }
 
 impl AliasUnset {
     pub async fn run(self) -> Result<()> {
         let mut global_config = Config::get().await?.global_config()?;
-        global_config.remove_alias(&self.plugin, &self.alias)?;
+        match self.alias {
+            None => {
+                global_config.remove_backend_alias(&self.plugin)?;
+            }
+            Some(ref alias) => {
+                global_config.remove_alias(&self.plugin, alias)?;
+            }
+        }
         global_config.save()
     }
 }
@@ -27,6 +34,7 @@ impl AliasUnset {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
+    $ <bold>mise alias unset maven</bold>
     $ <bold>mise alias unset node lts-jod</bold>
 "#
 );

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -153,6 +153,18 @@ impl MiseToml {
         Ok(self.doc.lock().unwrap())
     }
 
+    pub fn set_backend_alias(&mut self, fa: &BackendArg, to: &str) -> eyre::Result<()> {
+        self.doc_mut()?
+            .get_mut()
+            .unwrap()
+            .entry("alias")
+            .or_insert_with(table)
+            .as_table_like_mut()
+            .unwrap()
+            .insert(&fa.short, value(to));
+        Ok(())
+    }
+
     pub fn set_alias(&mut self, fa: &BackendArg, from: &str, to: &str) -> eyre::Result<()> {
         self.alias
             .entry(fa.short.to_string())
@@ -175,6 +187,18 @@ impl MiseToml {
             .as_table_like_mut()
             .unwrap()
             .insert(from, value(to));
+        Ok(())
+    }
+
+    pub fn remove_backend_alias(&mut self, fa: &BackendArg) -> eyre::Result<()> {
+        let mut doc = self.doc_mut()?;
+        let doc = doc.get_mut().unwrap();
+        if let Some(aliases) = doc.get_mut("alias").and_then(|v| v.as_table_mut()) {
+            aliases.remove(&fa.short);
+            if aliases.is_empty() {
+                doc.as_table_mut().remove("alias");
+            }
+        }
         Ok(())
     }
 

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -579,11 +579,11 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: ["set", "add", "create"],
-          description: "Add/update an alias for a plugin",
+          description: "Add/update an alias for a backend/plugin",
           args: [
             {
               name: "plugin",
-              description: "The plugin to set the alias for",
+              description: "The backend/plugin to set the alias for",
               generators: pluginGenerator,
               debounce: true,
             },
@@ -596,22 +596,24 @@ const completionSpec: Fig.Spec = {
             {
               name: "value",
               description: "The value to set the alias to",
+              isOptional: true,
             },
           ],
         },
         {
           name: ["unset", "rm", "remove", "delete", "del"],
-          description: "Clears an alias for a plugin",
+          description: "Clears an alias for a backend/plugin",
           args: [
             {
               name: "plugin",
-              description: "The plugin to remove the alias from",
+              description: "The backend/plugin to remove the alias from",
               generators: pluginGenerator,
               debounce: true,
             },
             {
               name: "alias",
               description: "The alias to remove",
+              isOptional: true,
               generators: aliasGenerator,
               debounce: true,
             },


### PR DESCRIPTION
I was just trying to set a backend alias for `maven` (since aqua is mostly behind with latest versions) and figured that i am not able to do so with the `alias set` command. While `config set` works, it is not obvious and does not allow for removal.