### PR TITLE
fix(ci): set required environment variables for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,6 +300,9 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags/v')
         run: |
           if [[ ${DRY_RUN:-0} != 1 ]]; then
+            MISE_VERSION="$(./scripts/get-version.sh)"
+            export MISE_VERSION
+            export RELEASE_DIR="releases"
             NPM_PREFIX=@jdxcode/mise ./scripts/release-npm.sh
           fi
         env:


### PR DESCRIPTION
## Summary
- Fixed the failing npm publishing step in the release workflow
- Added required environment variables `MISE_VERSION` and `RELEASE_DIR` that the `release-npm.sh` script depends on

## Problem
The npm publishing step was failing in CI because the `release-npm.sh` script requires `MISE_VERSION` and `RELEASE_DIR` environment variables to be set. These variables were previously set in the `release.sh` script which runs in an earlier workflow step, but environment variables don't persist across GitHub Actions workflow steps.

## Solution
Explicitly export these required variables in the npm publishing step:
- `MISE_VERSION` - obtained from `scripts/get-version.sh`
- `RELEASE_DIR` - set to "releases" (the directory where release artifacts are stored)

## Test plan
- [ ] The next release should successfully publish npm packages without errors
- [ ] Verify npm packages are published to registry after merge and next release

Fixes: https://github.com/jdx/mise/actions/runs/17495121479/job/49696552525

🤖 Generated with [Claude Code](https://claude.ai/code)