### PR TITLE
fix(release): clean up extra newlines in release notes formatting

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -29,25 +29,24 @@ body = """
     | filter(attribute="scope")
     | sort(attribute="scope") -%}
         {% if commit.scope -%}
-        - {{self::commit(commit=commit)}}\
+    - {{self::commit(commit=commit)}}\
         {% endif -%}
     {% endfor -%}
     {% for commit in commits -%}
         {% if commit.scope -%}
         {% else -%}
-          - {{self::commit(commit=commit)}}\
+    - {{self::commit(commit=commit)}}\
         {% endif -%}
     {% endfor -%}
 {% endfor %}
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 -%}
+{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
 ### New Contributors
 {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
   - @{{ contributor.username }} made their first contribution
     {%- if contributor.pr_number %} in \
       [#{{ contributor.pr_number }}]($REPO/pull/{{ contributor.pr_number }})\
     {% endif %}\
-{% endfor %}
-
+{% endfor -%}
 {% endif -%}
 {% macro commit(commit) -%}
 {% if commit.scope %}**({{commit.scope}})** {% endif -%}


### PR DESCRIPTION
## Summary
- Fixed the git-cliff template to remove extra blank lines in release notes
- Adjusted bullet point indentation for better formatting
- Cleaned up template control flow to eliminate unnecessary whitespace

## Problem
The GitHub releases had ugly formatting with extra blank lines between commits and sections. This was caused by the git-cliff template having improper indentation and an extra blank line before the endif statement in the New Contributors section.

Example of the issue: https://github.com/jdx/mise/releases/tag/v2025.9.1

## Solution
Updated the `cliff.toml` template to:
1. Fix indentation of bullet points (removed extra spaces before `-`)
2. Removed the blank line before `{% endif -%}` in the New Contributors section
3. Adjusted the template control flow tags to prevent extra whitespace

## Test plan
- [ ] The next release should have clean, compact release notes without extra blank lines
- [ ] Verify the changelog generation works correctly with `git cliff`
- [ ] Check that both single and multi-commit releases format properly

🤖 Generated with [Claude Code](https://claude.ai/code)