### PR TITLE
chore(release): require GitHub Actions environment for release-plz script

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -2,6 +2,13 @@
 #MISE description="Release with release-plz"
 set -euxo pipefail
 
+# Ensure this script is only run in GitHub Actions
+if [[ -z ${GITHUB_ACTIONS:-} ]]; then
+	echo "Error: This script must be run in GitHub Actions"
+	echo "The release-plz script should only be executed in the CI/CD pipeline"
+	exit 1
+fi
+
 git config user.name mise-en-dev
 git config user.email release@mise.jdx.dev
 


### PR DESCRIPTION
## Summary
- Added a safety check to the release-plz script to ensure it only runs in GitHub Actions
- Prevents accidental local execution of the release process

## Changes
The `xtasks/release-plz` script now checks for the `GITHUB_ACTIONS` environment variable at the start and exits with an error message if it's not set. This ensures that releases can only be created through the proper CI/CD pipeline.

## Test plan
- [ ] The release-plz workflow continues to work in GitHub Actions
- [ ] Running `./xtasks/release-plz` locally now fails with a clear error message

🤖 Generated with [Claude Code](https://claude.ai/code)