### PR TITLE
chore: release 2025.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2025.9.2](https://github.com/jdx/mise/compare/v2025.9.1..v2025.9.2) - 2025-09-05
+
+### 🐛 Bug Fixes
+
+- **(ci)** set required environment variables for npm publishing by [@jdx](https://github.com/jdx) in [#6189](https://github.com/jdx/mise/pull/6189)
+- **(release)** clean up extra newlines in release notes formatting by [@jdx](https://github.com/jdx) in [#6190](https://github.com/jdx/mise/pull/6190)
+- **(release)** add proper newline after New Contributors section in cliff template by [@jdx](https://github.com/jdx) in [#6194](https://github.com/jdx/mise/pull/6194)
+- **(release)** fix changelog formatting to remove extra blank lines by [@jdx](https://github.com/jdx) in [#6195](https://github.com/jdx/mise/pull/6195)
+- **(release)** restore proper newline after New Contributors section by [@jdx](https://github.com/jdx) in [#6196](https://github.com/jdx/mise/pull/6196)
+
+### 🚜 Refactor
+
+- **(ci)** split release workflow into separate specialized workflows by [@jdx](https://github.com/jdx) in [#6193](https://github.com/jdx/mise/pull/6193)
+
+### Chore
+
+- **(release)** require GitHub Actions environment for release-plz script by [@jdx](https://github.com/jdx) in [#6191](https://github.com/jdx/mise/pull/6191)
+
+### New Contributors
+
+- @jdx made their first contribution in [#6196](https://github.com/jdx/mise/pull/6196)
+
 ## [2025.9.1](https://github.com/jdx/mise/compare/v2025.9.0..v2025.9.1) - 2025-09-05
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.9.1"
+version = "2025.9.2"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.9.1"
+version = "2025.9.2"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.9.1 macos-arm64 (a1b2d3e 2025-09-05)
+2025.9.2 macos-arm64 (a1b2d3e 2025-09-05)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/aqua-registry/pkgs/crazywhalecc/static-php-cli/pkg.yaml
+++ b/aqua-registry/pkgs/crazywhalecc/static-php-cli/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: crazywhalecc/static-php-cli@2.7.2
+  - name: crazywhalecc/static-php-cli@2.7.3
   - name: crazywhalecc/static-php-cli
     version: 2.1.0-beta.2
   - name: crazywhalecc/static-php-cli

--- a/aqua-registry/pkgs/gruntwork-io/terragrunt/pkg.yaml
+++ b/aqua-registry/pkgs/gruntwork-io/terragrunt/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: gruntwork-io/terragrunt@v0.86.2
+  - name: gruntwork-io/terragrunt@v0.86.3

--- a/aqua-registry/pkgs/speakeasy-api/speakeasy/pkg.yaml
+++ b/aqua-registry/pkgs/speakeasy-api/speakeasy/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: speakeasy-api/speakeasy@v1.609.0
+  - name: speakeasy-api/speakeasy@v1.610.0

--- a/aqua-registry/pkgs/weaviate/weaviate/pkg.yaml
+++ b/aqua-registry/pkgs/weaviate/weaviate/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: weaviate/weaviate@v1.32.5
+  - name: weaviate/weaviate@v1.32.6
   - name: weaviate/weaviate
     version: v1.30.3
   - name: weaviate/weaviate

--- a/cliff.toml
+++ b/cliff.toml
@@ -47,7 +47,6 @@ body = """
       [#{{ contributor.pr_number }}]($REPO/pull/{{ contributor.pr_number }})\
     {% endif %}\
 {% endfor %}
-
 {% endif %}
 {% macro commit(commit) -%}
 {% if commit.scope %}**({{commit.scope}})** {% endif -%}

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_9_1:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_1 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_9_1;
+  if ( [[ -z "${_usage_spec_mise_2025_9_2:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_2 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_9_2;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_9_1 spec
+    _store_cache _usage_spec_mise_2025_9_2 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_9_1:-} ]]; then
-        _usage_spec_mise_2025_9_1="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_9_2:-} ]]; then
+        _usage_spec_mise_2025_9_2="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_1}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_2}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_9_1
-  set -g _usage_spec_mise_2025_9_1 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_9_2
+  set -g _usage_spec_mise_2025_9_2 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_1" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_2" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_1" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_2" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.9.1";
+  version = "2025.9.2";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.9.1
+Version: 2025.9.2
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(ci)** set required environment variables for npm publishing by [@jdx](https://github.com/jdx) in [#6189](https://github.com/jdx/mise/pull/6189)
- **(release)** clean up extra newlines in release notes formatting by [@jdx](https://github.com/jdx) in [#6190](https://github.com/jdx/mise/pull/6190)
- **(release)** add proper newline after New Contributors section in cliff template by [@jdx](https://github.com/jdx) in [#6194](https://github.com/jdx/mise/pull/6194)
- **(release)** fix changelog formatting to remove extra blank lines by [@jdx](https://github.com/jdx) in [#6195](https://github.com/jdx/mise/pull/6195)
- **(release)** restore proper newline after New Contributors section by [@jdx](https://github.com/jdx) in [#6196](https://github.com/jdx/mise/pull/6196)

### 🚜 Refactor

- **(ci)** split release workflow into separate specialized workflows by [@jdx](https://github.com/jdx) in [#6193](https://github.com/jdx/mise/pull/6193)

### Chore

- **(release)** require GitHub Actions environment for release-plz script by [@jdx](https://github.com/jdx) in [#6191](https://github.com/jdx/mise/pull/6191)