### PR TITLE
feat(backend): improve http error when platform url missing; list available platforms

### DIFF
--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -59,6 +59,10 @@ impl ToolVersionOptions {
         self.get_nested_value_exists(key)
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
+        self.opts.iter()
+    }
+
     // Check if a nested value exists without returning a reference
     fn get_nested_value_exists(&self, key: &str) -> bool {
         // Split the key by dots to navigate nested structure


### PR DESCRIPTION
- Improve error when no 'url' and no matching platform URL
- Show available platforms detected from options
- Helper moved to backend/static_helpers.rs and reused

This enhances UX by pointing users to valid platform keys when the current platform is unsupported.