### PR TITLE
fix: use config_root for env._.path

### DIFF
--- a/e2e/env/test_env_path_resolution
+++ b/e2e/env/test_env_path_resolution
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+# This test verifies consistent path resolution using config_root for env._.path
+# and current behavior for env._.source as implemented.
+
+echo "=== GitHub Issue #6203: Path Resolution Inconsistency ==="
+echo "This test verifies env._.path uses config_root for relative paths"
+echo "and documents env._.source behavior with .config/mise/config.toml"
+echo ""
+
+# Set up test environment
+mkdir -p .config/mise
+mkdir -p .config/mise/tools/bin
+mkdir -p tools/bin
+
+# Create config file in .config/mise/config.toml
+cat >".config/mise/config.toml" <<EOF
+[env]
+_.source = "script.sh"
+_.path = ["tools/bin"]
+EOF
+
+# Create script in config directory
+cat >".config/mise/script.sh" <<EOF
+export HELLO=CONFIG_DIR
+export PATH="\$HOME/configbin:\$PATH"
+EOF
+
+# Create script in project root
+cat >"script.sh" <<EOF
+export HELLO=PROJECT_ROOT
+export PATH="\$HOME/projectbin:\$PATH"
+EOF
+
+# Create tools in config directory
+echo 'echo "CONFIG_DIR_TOOL"' >.config/mise/tools/bin/test_tool
+chmod +x .config/mise/tools/bin/test_tool
+
+# Create tools in project root
+echo 'echo "PROJECT_ROOT_TOOL"' >tools/bin/test_tool
+chmod +x tools/bin/test_tool
+
+echo "Test setup:"
+echo "  Config file: .config/mise/config.toml"
+echo "  Script in config dir: .config/mise/script.sh (HELLO=CONFIG_DIR)"
+echo "  Script in project root: script.sh (HELLO=PROJECT_ROOT)"
+echo "  Tools in config dir: .config/mise/tools/bin/test_tool"
+echo "  Tools in project root: tools/bin/test_tool"
+echo ""
+
+echo "=== Testing env._.source behavior ==="
+HELLO_VALUE=$(mise env -s bash | grep HELLO | cut -d= -f2)
+echo "HELLO value: $HELLO_VALUE"
+
+if [ "$HELLO_VALUE" = "PROJECT_ROOT" ]; then
+	echo "✓ env._.source resolves relative to PROJECT ROOT (not config file directory)"
+	echo "  This means 'script.sh' refers to ./script.sh, not .config/mise/script.sh"
+elif [ "$HELLO_VALUE" = "CONFIG_DIR" ]; then
+	echo "✓ env._.source resolves relative to CONFIG FILE DIRECTORY"
+	echo "  This means 'script.sh' refers to .config/mise/script.sh"
+else
+	echo "✗ Unexpected behavior: HELLO=$HELLO_VALUE"
+fi
+
+echo ""
+echo "=== Testing env._.path behavior (should use config_root) ==="
+PATH_VALUE=$(mise env -s bash | grep "tools/bin" | head -1)
+echo "PATH contains tools/bin: $(echo "$PATH_VALUE" | grep -o 'tools/bin' | head -1)"
+
+# Test which tool is found
+TOOL_OUTPUT=$(mise exec -- test_tool 2>/dev/null || echo "TOOL_NOT_FOUND")
+echo "test_tool output: $TOOL_OUTPUT"
+
+if [ "$TOOL_OUTPUT" = "PROJECT_ROOT_TOOL" ]; then
+	echo "✓ env._.path resolves relative to CONFIG ROOT (project root for nested configs)"
+	echo "  This means 'tools/bin' refers to ./tools/bin"
+elif [ "$TOOL_OUTPUT" = "CONFIG_DIR_TOOL" ]; then
+	echo "✗ env._.path resolved relative to config file directory (unexpected)"
+else
+	echo "✗ Unexpected behavior: $TOOL_OUTPUT"
+fi
+
+echo ""
+echo "=== Consistency Check ==="
+if [ "$TOOL_OUTPUT" = "PROJECT_ROOT_TOOL" ]; then
+	echo "✓ env._.path is consistent with config_root behavior"
+else
+	echo "✗ env._.path is not consistent with config_root behavior"
+fi
+
+echo ""
+echo "=== GitHub Issue #6203 Summary ==="
+echo "The user's test case in the GitHub issue demonstrates this exact problem:"
+echo "1. They put a config file in .config/mise/config.toml"
+echo "2. They put a script in .config/mise/script.sh"
+echo "3. They expected env._.source = 'script.sh' to find the script in the config directory"
+echo "4. But it actually finds the script in the project root (if it exists there)"
+echo "5. This creates confusion about where to place files"
+echo ""
+echo "env._.path now uses config_root for relative paths (project root for nested configs)."
+
+# Clean up
+rm -rf .config script.sh tools
+
+echo ""
+echo "Test completed. This demonstrates the path resolution inconsistency"
+echo "that is the core issue in GitHub discussion #6203."

--- a/src/config/config_file/config_root.rs
+++ b/src/config/config_file/config_root.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock as Lazy, Mutex};
+
+use path_absolutize::Absolutize;
+use xx::regex;
+
+use crate::config::is_global_config;
+use crate::env;
+
+static CONFIG_ROOT_CACHE: Lazy<Mutex<HashMap<PathBuf, PathBuf>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub fn reset() {
+    CONFIG_ROOT_CACHE.lock().unwrap().clear();
+}
+
+pub fn config_root(path: &Path) -> PathBuf {
+    if is_global_config(path) {
+        return env::MISE_GLOBAL_CONFIG_ROOT.to_path_buf();
+    }
+    let path = path
+        .absolutize()
+        .map(|p| p.to_path_buf())
+        .unwrap_or(path.to_path_buf());
+    if let Some(cached) = CONFIG_ROOT_CACHE.lock().unwrap().get(&path).cloned() {
+        return cached;
+    }
+    let parts = path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    const EMPTY: &str = "";
+    let filename = parts.last().map(|p| p.as_str()).unwrap_or(EMPTY);
+    let parent = parts
+        .iter()
+        .nth_back(1)
+        .map(|p| p.as_str())
+        .unwrap_or(EMPTY);
+    let grandparent = parts
+        .iter()
+        .nth_back(2)
+        .map(|p| p.as_str())
+        .unwrap_or(EMPTY);
+    let great_grandparent = parts
+        .iter()
+        .nth_back(3)
+        .map(|p| p.as_str())
+        .unwrap_or(EMPTY);
+    let parent_path = || path.parent().unwrap().to_path_buf();
+    let grandparent_path = || parent_path().parent().unwrap().to_path_buf();
+    let great_grandparent_path = || grandparent_path().parent().unwrap().to_path_buf();
+    let great_great_grandparent_path = || great_grandparent_path().parent().unwrap().to_path_buf();
+    let is_mise_dir = |d: &str| d == "mise" || d == ".mise";
+    let is_config_filename = |f: &str| {
+        f == "config.toml" || f == "config.local.toml" || regex!(r"config\..+\.toml").is_match(f)
+    };
+    if parent == "conf.d" && is_mise_dir(grandparent) {
+        if great_grandparent == ".config" {
+            let out = great_great_grandparent_path();
+            CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
+            return out;
+        } else {
+            let out = great_grandparent_path();
+            CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
+            return out;
+        }
+    } else if is_mise_dir(parent) && is_config_filename(filename) {
+        if grandparent == ".config" {
+            let out = great_grandparent_path();
+            CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
+            return out;
+        } else {
+            let out = grandparent_path();
+            CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
+            return out;
+        }
+    } else if parent == ".config" {
+        let out = grandparent_path();
+        CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
+        return out;
+    } else {
+        let out = parent_path();
+        CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
+        return out;
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_root() {
+        for p in &[
+            "/foo/bar/.config/mise/conf.d/config.toml",
+            "/foo/bar/.config/mise/conf.d/foo.toml",
+            "/foo/bar/.config/mise/config.local.toml",
+            "/foo/bar/.config/mise/config.toml",
+            "/foo/bar/.config/mise.local.toml",
+            "/foo/bar/.config/mise.toml",
+            "/foo/bar/.mise.env.toml",
+            "/foo/bar/.mise.local.toml",
+            "/foo/bar/.mise.toml",
+            "/foo/bar/.mise/conf.d/config.toml",
+            "/foo/bar/.mise/config.local.toml",
+            "/foo/bar/.mise/config.toml",
+            "/foo/bar/.tool-versions",
+            "/foo/bar/mise.env.toml",
+            "/foo/bar/mise.local.toml",
+            "/foo/bar/mise.toml",
+            "/foo/bar/mise/config.local.toml",
+            "/foo/bar/mise/config.toml",
+            "/foo/bar/.config/mise/config.env.toml",
+            "/foo/bar/.config/mise.env.toml",
+            "/foo/bar/.mise/config.env.toml",
+            "/foo/bar/.mise.env.toml",
+        ] {
+            println!("{p}");
+            assert_eq!(config_root(Path::new(p)), PathBuf::from("/foo/bar"));
+        }
+    }
+}

--- a/src/config/config_file/config_root.rs
+++ b/src/config/config_file/config_root.rs
@@ -55,35 +55,25 @@ pub fn config_root(path: &Path) -> PathBuf {
     let is_config_filename = |f: &str| {
         f == "config.toml" || f == "config.local.toml" || regex!(r"config\..+\.toml").is_match(f)
     };
-    if parent == "conf.d" && is_mise_dir(grandparent) {
+    let out = if parent == "conf.d" && is_mise_dir(grandparent) {
         if great_grandparent == ".config" {
-            let out = great_great_grandparent_path();
-            CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-            out
+            great_great_grandparent_path()
         } else {
-            let out = great_grandparent_path();
-            CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-            out
+            great_grandparent_path()
         }
     } else if is_mise_dir(parent) && is_config_filename(filename) {
         if grandparent == ".config" {
-            let out = great_grandparent_path();
-            CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-            out
+            great_grandparent_path()
         } else {
-            let out = grandparent_path();
-            CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-            out
+            grandparent_path()
         }
     } else if parent == ".config" {
-        let out = grandparent_path();
-        CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-        out
+        grandparent_path()
     } else {
-        let out = parent_path();
-        CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-        out
-    }
+        parent_path()
+    };
+    CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
+    out
 }
 
 #[cfg(test)]

--- a/src/config/config_file/config_root.rs
+++ b/src/config/config_file/config_root.rs
@@ -59,30 +59,30 @@ pub fn config_root(path: &Path) -> PathBuf {
         if great_grandparent == ".config" {
             let out = great_great_grandparent_path();
             CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-            return out;
+            out
         } else {
             let out = great_grandparent_path();
             CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-            return out;
+            out
         }
     } else if is_mise_dir(parent) && is_config_filename(filename) {
         if grandparent == ".config" {
             let out = great_grandparent_path();
             CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-            return out;
+            out
         } else {
             let out = grandparent_path();
             CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-            return out;
+            out
         }
     } else if parent == ".config" {
         let out = grandparent_path();
         CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-        return out;
+        out
     } else {
         let out = parent_path();
         CONFIG_ROOT_CACHE.lock().unwrap().insert(path, out.clone());
-        return out;
+        out
     }
 }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -17,8 +17,8 @@ use toml_edit::{Array, DocumentMut, InlineTable, Item, Key, Value, table, value}
 use versions::Versioning;
 
 use crate::cli::args::{BackendArg, ToolVersionType};
-use crate::config::config_file::toml::deserialize_arr;
 use crate::config::config_file::{ConfigFile, TaskConfig, config_trust_root, trust, trust_check};
+use crate::config::config_file::{config_root, toml::deserialize_arr};
 use crate::config::env_directive::{EnvDirective, EnvDirectiveOptions};
 use crate::config::settings::SettingsPartial;
 use crate::config::{Alias, AliasMap};
@@ -32,7 +32,7 @@ use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource, ToolVersionOptions
 use crate::watch_files::WatchFile;
 use crate::{dirs, file};
 
-use super::{ConfigFileType, config_root};
+use super::ConfigFileType;
 
 #[derive(Default, Deserialize)]
 pub struct MiseToml {
@@ -104,7 +104,10 @@ impl EnvList {
 impl MiseToml {
     pub fn init(path: &Path) -> Self {
         let mut context = BASE_CONTEXT.clone();
-        context.insert("config_root", config_root(path).to_str().unwrap());
+        context.insert(
+            "config_root",
+            config_root::config_root(path).to_str().unwrap(),
+        );
         Self {
             path: path.to_path_buf(),
             context,

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -10,17 +10,15 @@ use std::{
 
 use eyre::{Result, eyre};
 use idiomatic_version::IdiomaticVersionFile;
-use path_absolutize::Absolutize;
 use serde_derive::Deserialize;
 use std::sync::LazyLock as Lazy;
 use tool_versions::ToolVersions;
 use versions::Versioning;
-use xx::regex;
 
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::config_file::mise_toml::MiseToml;
 use crate::config::env_directive::EnvDirective;
-use crate::config::{AliasMap, Settings, is_global_config, settings};
+use crate::config::{AliasMap, Settings, settings};
 use crate::errors::Error::UntrustedConfig;
 use crate::file::display_path;
 use crate::hash::hash_to_str;
@@ -34,6 +32,7 @@ use crate::{backend, config, dirs, env, file, hash};
 
 use super::Config;
 
+pub mod config_root;
 pub mod idiomatic_version;
 pub mod mise_toml;
 pub mod toml;
@@ -72,7 +71,7 @@ pub trait ConfigFile: Debug + Send + Sync {
     }
     fn config_type(&self) -> ConfigFileType;
     fn config_root(&self) -> PathBuf {
-        config_root(self.get_path())
+        config_root::config_root(self.get_path())
     }
     fn plugins(&self) -> Result<HashMap<String, String>> {
         Ok(Default::default())
@@ -259,67 +258,11 @@ pub fn parse(path: &Path) -> Result<Arc<dyn ConfigFile>> {
     }
 }
 
-pub fn config_root(path: &Path) -> PathBuf {
-    if is_global_config(path) {
-        return env::MISE_GLOBAL_CONFIG_ROOT.to_path_buf();
-    }
-    let path = path
-        .absolutize()
-        .map(|p| p.to_path_buf())
-        .unwrap_or(path.to_path_buf());
-    let parts = path
-        .components()
-        .map(|c| c.as_os_str().to_string_lossy().to_string())
-        .collect::<Vec<_>>();
-    const EMPTY: &str = "";
-    let filename = parts.last().map(|p| p.as_str()).unwrap_or(EMPTY);
-    let parent = parts
-        .iter()
-        .nth_back(1)
-        .map(|p| p.as_str())
-        .unwrap_or(EMPTY);
-    let grandparent = parts
-        .iter()
-        .nth_back(2)
-        .map(|p| p.as_str())
-        .unwrap_or(EMPTY);
-    let great_grandparent = parts
-        .iter()
-        .nth_back(3)
-        .map(|p| p.as_str())
-        .unwrap_or(EMPTY);
-    let parent_path = || path.parent().unwrap().to_path_buf();
-    let grandparent_path = || parent_path().parent().unwrap().to_path_buf();
-    let great_grandparent_path = || grandparent_path().parent().unwrap().to_path_buf();
-    let great_great_grandparent_path = || great_grandparent_path().parent().unwrap().to_path_buf();
-    let is_mise_dir = |d: &str| d == "mise" || d == ".mise";
-    let is_config_filename = |f: &str| {
-        f == "config.toml" || f == "config.local.toml" || regex!(r"config\..+\.toml").is_match(f)
-    };
-    if parent == "conf.d" && is_mise_dir(grandparent) {
-        if great_grandparent == ".config" {
-            great_great_grandparent_path()
-        } else {
-            great_grandparent_path()
-        }
-    } else if is_mise_dir(parent) && is_config_filename(filename) {
-        if grandparent == ".config" {
-            great_grandparent_path()
-        } else {
-            grandparent_path()
-        }
-    } else if parent == ".config" {
-        grandparent_path()
-    } else {
-        parent_path()
-    }
-}
-
 pub fn config_trust_root(path: &Path) -> PathBuf {
     if settings::is_loaded() && Settings::get().paranoid {
         path.to_path_buf()
     } else {
-        config_root(path)
+        config_root::config_root(path)
     }
 }
 
@@ -610,36 +553,5 @@ mod tests {
             detect_config_file_type(Path::new("/foo/bar/rust-toolchain.toml")),
             Some(ConfigFileType::IdiomaticVersion)
         );
-    }
-
-    #[test]
-    fn test_config_root() {
-        for p in &[
-            "/foo/bar/.config/mise/conf.d/config.toml",
-            "/foo/bar/.config/mise/conf.d/foo.toml",
-            "/foo/bar/.config/mise/config.local.toml",
-            "/foo/bar/.config/mise/config.toml",
-            "/foo/bar/.config/mise.local.toml",
-            "/foo/bar/.config/mise.toml",
-            "/foo/bar/.mise.env.toml",
-            "/foo/bar/.mise.local.toml",
-            "/foo/bar/.mise.toml",
-            "/foo/bar/.mise/conf.d/config.toml",
-            "/foo/bar/.mise/config.local.toml",
-            "/foo/bar/.mise/config.toml",
-            "/foo/bar/.tool-versions",
-            "/foo/bar/mise.env.toml",
-            "/foo/bar/mise.local.toml",
-            "/foo/bar/mise.toml",
-            "/foo/bar/mise/config.local.toml",
-            "/foo/bar/mise/config.toml",
-            "/foo/bar/.config/mise/config.env.toml",
-            "/foo/bar/.config/mise.env.toml",
-            "/foo/bar/.mise/config.env.toml",
-            "/foo/bar/.mise.env.toml",
-        ] {
-            println!("{p}");
-            assert_eq!(config_root(Path::new(p)), PathBuf::from("/foo/bar"));
-        }
     }
 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -1,4 +1,4 @@
-use crate::config::config_file::{config_root, trust_check};
+use crate::config::config_file::trust_check;
 use crate::dirs;
 use crate::env;
 use crate::env_diff::EnvMap;
@@ -217,7 +217,7 @@ impl EnvResults {
             //     &directive,
             //     &source
             // );
-            let config_root = config_root(&source);
+            let config_root = crate::config::config_file::config_root::config_root(&source);
             ctx.insert("cwd", &*dirs::CWD);
             ctx.insert("config_root", &config_root);
             let env_vars = env
@@ -360,11 +360,9 @@ impl EnvResults {
         // trace!("resolve: paths: {:#?}", &paths);
         // trace!("resolve: ctx.env: {:#?}", &ctx.get("env"));
         for (source, paths) in &paths.iter().chunk_by(|(_, source)| source) {
-            let config_root = source
-                .parent()
-                .map(Path::to_path_buf)
-                .or_else(|| dirs::CWD.clone())
-                .unwrap_or_default();
+            // Use the computed config_root (project root for nested configs) for path resolution
+            // to be consistent with other env directives like _.source and _.file
+            let config_root = crate::config::config_file::config_root::config_root(source);
             let paths = paths.map(|(p, _)| p).collect_vec();
             let mut paths = paths
                 .iter()

--- a/src/config/env_directive/path.rs
+++ b/src/config/env_directive/path.rs
@@ -71,8 +71,8 @@ mod tests {
             @r#"
         [
             "~/foo/1",
-            "~/cwd/rel2/2",
-            "~/cwd/rel/1",
+            "~/rel2/2",
+            "~/rel/1",
             "/path/1",
             "/path/2",
         ]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -335,6 +335,8 @@ impl Settings {
     pub fn reset(cli_settings: Option<SettingsPartial>) {
         *CLI_SETTINGS.lock().unwrap() = cli_settings;
         *BASE_SETTINGS.write().unwrap() = None;
+        // Clear caches that depend on settings and environment
+        crate::config::config_file::config_root::reset();
     }
 
     pub fn ensure_experimental(&self, what: &str) -> Result<()> {


### PR DESCRIPTION
The behavior and docs for env._.path predates config_root as well as config files outside of the root like `.config/mise.toml`. This has been a bug and should have been fixed when support was added for files outside the project root but was not. This change modifies the behavior of env._.path to behave the same as other parts of mise that are relative to config_root and not the parent directory of the config file making mise behave consistently in regards to relative paths.

Fixes https://github.com/jdx/mise/discussions/6203

BREAKING CHANGE: env._.path directories are now relative to the config_root and not the parent directory of the config file. This only affects config files that use env._.path that are outside the config_root (e.g.: `.config/mise.toml` will use `.` and not `.config` like before). To retain compatibility with earlier mise releases, be explicit with `env._.path = "{{config_root}}/bin"` which will behave the same in old and new releases.