### PR TITLE
feat(cli): support scoped packages for all backend types

### DIFF
--- a/src/cli/args/tool_arg.rs
+++ b/src/cli/args/tool_arg.rs
@@ -155,7 +155,7 @@ fn parse_input(s: &str) -> (&str, Option<&str>) {
         return (s, None);
     };
 
-    if left.ends_with(":") {
+    if left.ends_with(':') {
         // Backend format: try to find version in the remaining part
         return right
             .split_once('@')


### PR DESCRIPTION
## What

This PR enables backends other than npm to correctly parse package inputs with scopes and versions, such as '@antfu/ni@1.0.0'.

## Why

I was attempting to add a bun backend via a custom plugin, but discovered that the current parser only handles this format correctly for the npm backend. This change resolves that limitation, allowing other package managers to parse scoped packages properly.