### PR TITLE
chore: release 2025.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2025.9.5](https://github.com/jdx/mise/compare/v2025.9.4..v2025.9.5) - 2025-09-06
+
+### 🚀 Features
+
+- **(task)** add timeout support for task execution by @jdx in [#6216](https://github.com/jdx/mise/pull/6216)
+- **(task)** sub-tasks in run lists by @jdx in [#6212](https://github.com/jdx/mise/pull/6212)
+
+### Chore
+
+- fix npm publish action by @jdx in [14f4b09](https://github.com/jdx/mise/commit/14f4b09982cfa09139f172f302939f46d2cb0872)
+- fix cloudflare release action by @jdx in [00afa25](https://github.com/jdx/mise/commit/00afa2563d4368963bcacce11ebddbe05f45b4d7)
+- fix git-cliff for release notes by @jdx in [15a9aed](https://github.com/jdx/mise/commit/15a9aede95c8ad953842c206df3b6c9a3960100f)
+
 ## [2025.9.4](https://github.com/jdx/mise/compare/v2025.9.3..v2025.9.4) - 2025-09-06
 
 ### Chore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.9.4"
+version = "2025.9.5"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.9.4"
+version = "2025.9.5"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.9.4 macos-arm64 (a1b2d3e 2025-09-06)
+2025.9.5 macos-arm64 (a1b2d3e 2025-09-06)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/aqua-registry/pkgs/cargo-bins/cargo-binstall/pkg.yaml
+++ b/aqua-registry/pkgs/cargo-bins/cargo-binstall/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: cargo-bins/cargo-binstall@v1.15.3
+  - name: cargo-bins/cargo-binstall@v1.15.4
   - name: cargo-bins/cargo-binstall
     version: v1.3.1
   - name: cargo-bins/cargo-binstall

--- a/aqua-registry/pkgs/cloudfoundry/bosh-cli/pkg.yaml
+++ b/aqua-registry/pkgs/cloudfoundry/bosh-cli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: cloudfoundry/bosh-cli@v7.9.10
+  - name: cloudfoundry/bosh-cli@v7.9.11

--- a/aqua-registry/pkgs/realm/SwiftLint/pkg.yaml
+++ b/aqua-registry/pkgs/realm/SwiftLint/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: realm/SwiftLint@0.60.0
+  - name: realm/SwiftLint@0.61.0
   - name: realm/SwiftLint
     version: 0.59.1
   - name: realm/SwiftLint

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_9_4:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_4 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_9_4;
+  if ( [[ -z "${_usage_spec_mise_2025_9_5:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_5 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_9_5;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_9_4 spec
+    _store_cache _usage_spec_mise_2025_9_5 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_9_4:-} ]]; then
-        _usage_spec_mise_2025_9_4="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_9_5:-} ]]; then
+        _usage_spec_mise_2025_9_5="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_4}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_5}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_9_4
-  set -g _usage_spec_mise_2025_9_4 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_9_5
+  set -g _usage_spec_mise_2025_9_5 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_4" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_5" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_4" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_5" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.9.4";
+  version = "2025.9.5";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.9.4
+Version: 2025.9.5
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🚀 Features

- **(task)** add timeout support for task execution by @jdx in [#6216](https://github.com/jdx/mise/pull/6216)
- **(task)** sub-tasks in run lists by @jdx in [#6212](https://github.com/jdx/mise/pull/6212)

### Chore

- fix npm publish action by @jdx in [14f4b09](https://github.com/jdx/mise/commit/14f4b09982cfa09139f172f302939f46d2cb0872)
- fix cloudflare release action by @jdx in [00afa25](https://github.com/jdx/mise/commit/00afa2563d4368963bcacce11ebddbe05f45b4d7)
- fix git-cliff for release notes by @jdx in [15a9aed](https://github.com/jdx/mise/commit/15a9aede95c8ad953842c206df3b6c9a3960100f)