### PR TITLE
fix(task): use terminal width instead of hardcoded 60-char limit for task display

### DIFF
--- a/e2e/tasks/test_task_display_truncation
+++ b/e2e/tasks/test_task_display_truncation
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Test for task display truncation fix
+# This test verifies that task names/commands are not truncated at 60 characters
+# and instead use proper width calculations
+
+cat <<EOF >mise.toml
+[tasks.short]
+run = 'echo "short task"'
+
+[tasks.medium-length-task-name]
+run = 'echo "medium length task with some reasonable command length here"'
+
+[tasks.very-long-task-name-that-exceeds-sixty-characters-to-test-truncation]
+run = 'echo "this is a very long command that should not be immediately truncated"'
+
+[tasks.super-duper-ultra-mega-extremely-long-task-name-that-definitely-exceeds-the-old-sixty-character-hard-limit]
+run = 'echo "super long command text that should show more than just the command name before truncation"'
+EOF
+
+# Test task listing shows full names (not truncated at 60 chars)
+assert_contains "mise task ls" "short"
+assert_contains "mise task ls" "medium-length-task-name"
+assert_contains "mise task ls" "very-long-task-name-that-exceeds-sixty-characters-to-test-truncation"
+assert_contains "mise task ls" "super-duper-ultra-mega-extremely-long-task-name-that-definitely-exceeds-the-old-sixty-character-hard-limit"
+
+# Test that we can still run tasks with long names
+assert_succeed "mise run short"
+assert_succeed "mise run medium-length-task-name"
+
+# Verify the task runs successfully (main functionality not affected)
+output=$(mise run short 2>&1)
+if [[ $output == *"short task"* ]]; then
+  ok "[task execution] short task runs correctly"
+else
+  fail "[task execution] expected 'short task' in output, got: $output"
+fi
+
+echo "Task display truncation test completed successfully"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1454,7 +1454,10 @@ pub enum TaskOutput {
 fn trunc(prefix: &str, msg: &str) -> String {
     let prefix_len = console::measure_text_width(prefix);
     let msg = msg.lines().next().unwrap_or_default();
-    console::truncate_str(msg, *env::TERM_WIDTH - prefix_len - 1, "…").to_string()
+    // Ensure we have at least 20 characters for the message, even with very long prefixes
+    let available_width = (*env::TERM_WIDTH).saturating_sub(prefix_len + 1);
+    let max_width = available_width.max(20); // Always show at least 20 chars of message
+    console::truncate_str(msg, max_width, "…").to_string()
 }
 
 async fn err_no_task(config: &Config, name: &str) -> Result<()> {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -8,7 +8,7 @@ use crate::task::task_script_parser::{TaskScriptParser, has_any_args_defined};
 use crate::tera::get_tera;
 use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};
-use console::{Color, truncate_str};
+use console::{Color, measure_text_width, truncate_str};
 use either::Either;
 use eyre::{Result, eyre};
 use globset::GlobBuilder;
@@ -777,7 +777,13 @@ impl Display for Task {
 
         if let Some(cmd) = cmd {
             let cmd = cmd.lines().next().unwrap_or_default();
-            write!(f, "{} {}", self.prefix(), truncate_str(cmd, 60, "…"))
+            let prefix = self.prefix();
+            let prefix_len = measure_text_width(&prefix);
+            // Ensure we have at least 20 characters for the command, even with very long prefixes
+            let available_width = (*env::TERM_WIDTH).saturating_sub(prefix_len + 4); // 4 chars buffer for spacing and ellipsis
+            let max_width = available_width.max(20); // Always show at least 20 chars of command
+            let truncated_cmd = truncate_str(cmd, max_width, "…");
+            write!(f, "{} {}", prefix, truncated_cmd)
         } else {
             write!(f, "{}", self.prefix())
         }


### PR DESCRIPTION
Replace hardcoded 60-character truncation limit in Task Display implementation
with terminal-width-based calculation. This fixes premature truncation of task
commands in CI environments and wide terminals.

- Use console::measure_text_width() to properly handle ANSI color codes
- Calculate max width based on TERM_WIDTH minus prefix length and buffer
- Maintains consistent truncation behavior with runtime task execution
- Fixes issue where long commands were truncated at 60 chars regardless of terminal size

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
