### PR TITLE
refactor(backend): extract PlatformTarget to separate module

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -14,7 +14,6 @@ use crate::config::{Config, Settings};
 use crate::file::{display_path, remove_all, remove_all_with_warning};
 use crate::install_context::InstallContext;
 use crate::lockfile::PlatformInfo;
-use crate::platform::Platform;
 use crate::plugins::core::CORE_PLUGINS;
 use crate::plugins::{PluginType, VERSION_REGEX};
 use crate::registry::{REGISTRY, tool_enabled};
@@ -49,6 +48,7 @@ pub mod go;
 pub mod http;
 pub mod npm;
 pub mod pipx;
+pub mod platform_target;
 pub mod spm;
 pub mod static_helpers;
 pub mod ubi;
@@ -59,37 +59,7 @@ pub type BackendMap = BTreeMap<String, ABackend>;
 pub type BackendList = Vec<ABackend>;
 pub type VersionCacheManager = CacheManager<Vec<String>>;
 
-/// Represents a target platform for lockfile metadata fetching
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PlatformTarget {
-    pub platform: Platform,
-}
-
-impl PlatformTarget {
-    pub fn new(platform: Platform) -> Self {
-        Self { platform }
-    }
-
-    pub fn from_current() -> Self {
-        Self::new(Platform::current())
-    }
-
-    pub fn os_name(&self) -> &str {
-        &self.platform.os
-    }
-
-    pub fn arch_name(&self) -> &str {
-        &self.platform.arch
-    }
-
-    pub fn qualifier(&self) -> Option<&str> {
-        self.platform.qualifier.as_deref()
-    }
-
-    pub fn to_key(&self) -> String {
-        self.platform.to_key()
-    }
-}
+pub use platform_target::PlatformTarget;
 
 /// Information about a GitHub/GitLab release for platform-specific tools
 #[derive(Debug, Clone)]

--- a/src/backend/platform_target.rs
+++ b/src/backend/platform_target.rs
@@ -1,0 +1,69 @@
+use crate::platform::Platform;
+
+/// Represents a target platform for lockfile metadata fetching
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlatformTarget {
+    pub platform: Platform,
+}
+
+impl PlatformTarget {
+    pub fn new(platform: Platform) -> Self {
+        Self { platform }
+    }
+
+    pub fn from_current() -> Self {
+        Self::new(Platform::current())
+    }
+
+    pub fn os_name(&self) -> &str {
+        &self.platform.os
+    }
+
+    pub fn arch_name(&self) -> &str {
+        &self.platform.arch
+    }
+
+    pub fn qualifier(&self) -> Option<&str> {
+        self.platform.qualifier.as_deref()
+    }
+
+    pub fn to_key(&self) -> String {
+        self.platform.to_key()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_platform_target_creation() {
+        let platform = Platform::parse("linux-x64").unwrap();
+        let target = PlatformTarget::new(platform.clone());
+
+        assert_eq!(target.platform, platform);
+        assert_eq!(target.os_name(), "linux");
+        assert_eq!(target.arch_name(), "x64");
+        assert_eq!(target.qualifier(), None);
+        assert_eq!(target.to_key(), "linux-x64");
+    }
+
+    #[test]
+    fn test_platform_target_with_qualifier() {
+        let platform = Platform::parse("linux-x64-musl").unwrap();
+        let target = PlatformTarget::new(platform);
+
+        assert_eq!(target.os_name(), "linux");
+        assert_eq!(target.arch_name(), "x64");
+        assert_eq!(target.qualifier(), Some("musl"));
+        assert_eq!(target.to_key(), "linux-x64-musl");
+    }
+
+    #[test]
+    fn test_from_current() {
+        let target = PlatformTarget::from_current();
+        let current_platform = Platform::current();
+
+        assert_eq!(target.platform, current_platform);
+    }
+}


### PR DESCRIPTION
Move PlatformTarget struct to its own file for better code organization:
- Create src/backend/platform_target.rs with the struct definition
- Add comprehensive tests for PlatformTarget functionality
- Update mod.rs imports and remove unused Platform import
- Maintain existing API through public re-export

This improves modularity and makes the codebase easier to maintain.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>