### PR TITLE
fix: add 'unknown' to the list of OS patterns

### DIFF
--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 // Shared OS/arch patterns used across helpers
 const OS_PATTERNS: &[&str] = &[
     "linux", "darwin", "macos", "windows", "win", "freebsd", "openbsd", "netbsd", "android",
+    "unknown",
 ];
 // Longer arch patterns first to avoid partial matches
 const ARCH_PATTERNS: &[&str] = &[


### PR DESCRIPTION
Fixes `mise install github:coreos/butane` creating a `butane-x86_64-unknown` binary. `mise install ubi:coreos/butane` works as expected, creating a `butane` binary.