### PR TITLE
chore: release 2025.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2025.9.9](https://github.com/jdx/mise/compare/v2025.9.8..v2025.9.9) - 2025-09-11
+
+### 🐛 Bug Fixes
+
+- **(backend)** make HTTP installs atomic and serialize with cache lock by @jdx in [#6259](https://github.com/jdx/mise/pull/6259)
+- **(env)** allow nested env._.path directives by @risu729 in [#6160](https://github.com/jdx/mise/pull/6160)
+- **(env)** disallow nested env objects by @risu729 in [#6268](https://github.com/jdx/mise/pull/6268)
+- **(schema)** allow nested arrays in task.depends by @risu729 in [#6265](https://github.com/jdx/mise/pull/6265)
+- **(task)** resolve jobs=1 hang and keep-order panic; improve Ctrl-C handling by @jdx in [#6264](https://github.com/jdx/mise/pull/6264)
+- **(tasks)** stop CLI group after first failure without --continue-on-error by @jdx in [#6270](https://github.com/jdx/mise/pull/6270)
+
+### 📚 Documentation
+
+- fixed toml issues in URL replacements settings documentation by @ThomasSteinbach in [#6269](https://github.com/jdx/mise/pull/6269)
+
+### Chore
+
+- **(schema)** strict oneOf branches and DRY env_directive in schemas by @jdx in [#6271](https://github.com/jdx/mise/pull/6271)
+- add schema linter by @risu729 in [#6267](https://github.com/jdx/mise/pull/6267)
+
 ## [2025.9.8](https://github.com/jdx/mise/compare/v2025.9.7..v2025.9.8) - 2025-09-10
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.9.8"
+version = "2025.9.9"
 dependencies = [
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox"]
 
 [package]
 name = "mise"
-version = "2025.9.8"
+version = "2025.9.9"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.9.8 macos-arm64 (a1b2d3e 2025-09-10)
+2025.9.9 macos-arm64 (a1b2d3e 2025-09-11)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/aqua-registry/pkgs/JanDeDobbeleer/oh-my-posh/pkg.yaml
+++ b/aqua-registry/pkgs/JanDeDobbeleer/oh-my-posh/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: JanDeDobbeleer/oh-my-posh@v26.22.2
+  - name: JanDeDobbeleer/oh-my-posh@v26.23.1
   - name: JanDeDobbeleer/oh-my-posh
     version: v24.10.1
   - name: JanDeDobbeleer/oh-my-posh

--- a/aqua-registry/pkgs/Scalingo/cli/pkg.yaml
+++ b/aqua-registry/pkgs/Scalingo/cli/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: Scalingo/cli@1.38.0
+  - name: Scalingo/cli@1.39.0
   - name: Scalingo/cli
     version: 1.24.1
   - name: Scalingo/cli

--- a/aqua-registry/pkgs/astral-sh/uv/pkg.yaml
+++ b/aqua-registry/pkgs/astral-sh/uv/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: astral-sh/uv@0.8.16
+  - name: astral-sh/uv@0.8.17
   - name: astral-sh/uv
     version: 0.2.21
   - name: astral-sh/uv

--- a/aqua-registry/pkgs/auth0/auth0-cli/pkg.yaml
+++ b/aqua-registry/pkgs/auth0/auth0-cli/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: auth0/auth0-cli@v1.19.0
+  - name: auth0/auth0-cli@v1.20.0
   - name: auth0/auth0-cli
     version: v0.11.8
   - name: auth0/auth0-cli

--- a/aqua-registry/pkgs/aws/aws-sam-cli/pkg.yaml
+++ b/aqua-registry/pkgs/aws/aws-sam-cli/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: aws/aws-sam-cli@v1.143.0
+  - name: aws/aws-sam-cli@v1.144.0
   - name: aws/aws-sam-cli
     version: v1.103.0
   - name: aws/aws-sam-cli

--- a/aqua-registry/pkgs/block/goose/pkg.yaml
+++ b/aqua-registry/pkgs/block/goose/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
-  - name: block/goose@v1.7.0
+  - name: block/goose@v1.8.0
   - name: block/goose
     version: v1.0.0

--- a/aqua-registry/pkgs/buildkite/agent/pkg.yaml
+++ b/aqua-registry/pkgs/buildkite/agent/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: buildkite/agent@v3.104.0
+  - name: buildkite/agent@v3.105.0

--- a/aqua-registry/pkgs/chainguard-dev/apko/pkg.yaml
+++ b/aqua-registry/pkgs/chainguard-dev/apko/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: chainguard-dev/apko@v0.30.9
+  - name: chainguard-dev/apko@v0.30.10
   - name: chainguard-dev/apko
     version: v0.11.0
   - name: chainguard-dev/apko

--- a/aqua-registry/pkgs/cloudquery/cloudquery/pkg.yaml
+++ b/aqua-registry/pkgs/cloudquery/cloudquery/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: cloudquery/cloudquery@cli-v6.28.0
+  - name: cloudquery/cloudquery@cli-v6.28.1
   - name: cloudquery/cloudquery
     version: cli/v0.32.11
   - name: cloudquery/cloudquery

--- a/aqua-registry/pkgs/containers/kubernetes-mcp-server/pkg.yaml
+++ b/aqua-registry/pkgs/containers/kubernetes-mcp-server/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: containers/kubernetes-mcp-server@v0.0.49
+  - name: containers/kubernetes-mcp-server@v0.0.50

--- a/aqua-registry/pkgs/cri-o/cri-o/pkg.yaml
+++ b/aqua-registry/pkgs/cri-o/cri-o/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: cri-o/cri-o@v1.33.4
+  - name: cri-o/cri-o@v1.34.0
   - name: cri-o/cri-o
     version: v1.30.3
   - name: cri-o/cri-o

--- a/aqua-registry/pkgs/daveshanley/vacuum/pkg.yaml
+++ b/aqua-registry/pkgs/daveshanley/vacuum/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: daveshanley/vacuum@v0.17.11
+  - name: daveshanley/vacuum@v0.17.12
   - name: daveshanley/vacuum
     version: v0.8.7
   - name: daveshanley/vacuum

--- a/aqua-registry/pkgs/digitalocean/doctl/pkg.yaml
+++ b/aqua-registry/pkgs/digitalocean/doctl/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: digitalocean/doctl@v1.141.0
+  - name: digitalocean/doctl@v1.142.0

--- a/aqua-registry/pkgs/dolthub/dolt/pkg.yaml
+++ b/aqua-registry/pkgs/dolthub/dolt/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: dolthub/dolt@v1.59.6
+  - name: dolthub/dolt@v1.59.7
   - name: dolthub/dolt
     version: v0.40.15
   - name: dolthub/dolt

--- a/aqua-registry/pkgs/evilmartians/lefthook/pkg.yaml
+++ b/aqua-registry/pkgs/evilmartians/lefthook/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: evilmartians/lefthook@v1.12.4
+  - name: evilmartians/lefthook@v1.13.0
   - name: evilmartians/lefthook
     version: v0.8.0
   - name: evilmartians/lefthook

--- a/aqua-registry/pkgs/firebase/firebase-tools/pkg.yaml
+++ b/aqua-registry/pkgs/firebase/firebase-tools/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: firebase/firebase-tools@v14.15.2
+  - name: firebase/firebase-tools@v14.16.0

--- a/aqua-registry/pkgs/github/copilot-language-server-release/pkg.yaml
+++ b/aqua-registry/pkgs/github/copilot-language-server-release/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
-  - name: github/copilot-language-server-release@1.368.0
+  - name: github/copilot-language-server-release@1.369.0
   - name: github/copilot-language-server-release
     version: 1.276.0

--- a/aqua-registry/pkgs/gotestyourself/gotestsum/pkg.yaml
+++ b/aqua-registry/pkgs/gotestyourself/gotestsum/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: gotestyourself/gotestsum@v1.12.3
+  - name: gotestyourself/gotestsum@v1.13.0
   - name: gotestyourself/gotestsum
     version: v1.10.0
   - name: gotestyourself/gotestsum

--- a/aqua-registry/pkgs/grafana/loki/logcli/pkg.yaml
+++ b/aqua-registry/pkgs/grafana/loki/logcli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: grafana/loki/logcli@v3.5.4
+  - name: grafana/loki/logcli@v3.5.5

--- a/aqua-registry/pkgs/hasura/graphql-engine/pkg.yaml
+++ b/aqua-registry/pkgs/hasura/graphql-engine/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: hasura/graphql-engine@v2.48.4
+  - name: hasura/graphql-engine@v2.48.5

--- a/aqua-registry/pkgs/incu6us/goimports-reviser/pkg.yaml
+++ b/aqua-registry/pkgs/incu6us/goimports-reviser/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: incu6us/goimports-reviser@v3.9.1
+  - name: incu6us/goimports-reviser@v3.10.0
   - name: incu6us/goimports-reviser
     version: v3.9.0
   - name: incu6us/goimports-reviser

--- a/aqua-registry/pkgs/jdx/mise/pkg.yaml
+++ b/aqua-registry/pkgs/jdx/mise/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: jdx/mise@v2025.9.7
+  - name: jdx/mise@v2025.9.8
   - name: jdx/mise
     version: v2024.0.0
   - name: jdx/mise

--- a/aqua-registry/pkgs/kptdev/kpt/pkg.yaml
+++ b/aqua-registry/pkgs/kptdev/kpt/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: kptdev/kpt@v1.0.0-beta.57
+  - name: kptdev/kpt@v1.0.0-beta.58
   - name: kptdev/kpt
     version: v1.0.0-beta.55
   - name: kptdev/kpt

--- a/aqua-registry/pkgs/localstack/localstack-cli/pkg.yaml
+++ b/aqua-registry/pkgs/localstack/localstack-cli/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: localstack/localstack-cli@v4.7.0
+  - name: localstack/localstack-cli@v4.8.0
   - name: localstack/localstack-cli
     version: v3.0.2.post0
   - name: localstack/localstack-cli

--- a/aqua-registry/pkgs/mesosphere/mindthegap/pkg.yaml
+++ b/aqua-registry/pkgs/mesosphere/mindthegap/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: mesosphere/mindthegap@v1.23.0
+  - name: mesosphere/mindthegap@v1.24.0
   - name: mesosphere/mindthegap
     version: v0.13.0
   - name: mesosphere/mindthegap

--- a/aqua-registry/pkgs/mongodb/mongodb-atlas-cli/atlascli/pkg.yaml
+++ b/aqua-registry/pkgs/mongodb/mongodb-atlas-cli/atlascli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: mongodb/mongodb-atlas-cli/atlascli@atlascli/v1.46.4
+  - name: mongodb/mongodb-atlas-cli/atlascli@atlascli/v1.47.0

--- a/aqua-registry/pkgs/namespacelabs/foundation/nsc/pkg.yaml
+++ b/aqua-registry/pkgs/namespacelabs/foundation/nsc/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: namespacelabs/foundation/nsc@v0.0.438
+  - name: namespacelabs/foundation/nsc@v0.0.439
   - name: namespacelabs/foundation/nsc
     version: v0.0.212
   - name: namespacelabs/foundation/nsc

--- a/aqua-registry/pkgs/nodejs/node/pkg.yaml
+++ b/aqua-registry/pkgs/nodejs/node/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: nodejs/node@v24.7.0
+  - name: nodejs/node@v24.8.0

--- a/aqua-registry/pkgs/openai/codex/pkg.yaml
+++ b/aqua-registry/pkgs/openai/codex/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: openai/codex@rust-v0.33.0
+  - name: openai/codex@rust-v0.34.0
   - name: openai/codex
     version: rust-v0.25.0
   - name: openai/codex

--- a/aqua-registry/pkgs/oxc-project/oxc/oxlint/pkg.yaml
+++ b/aqua-registry/pkgs/oxc-project/oxc/oxlint/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: oxc-project/oxc/oxlint@oxlint_v1.14.0
+  - name: oxc-project/oxc/oxlint@oxlint_v1.15.0
   - name: oxc-project/oxc/oxlint
     version: oxlint_v0.2.2
   - name: oxc-project/oxc/oxlint

--- a/aqua-registry/pkgs/pivotal-cf/om/pkg.yaml
+++ b/aqua-registry/pkgs/pivotal-cf/om/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: pivotal-cf/om@7.17.0
+  - name: pivotal-cf/om@7.18.0
   - name: pivotal-cf/om
     version: 7.7.0
   - name: pivotal-cf/om

--- a/aqua-registry/pkgs/planetscale/cli/pkg.yaml
+++ b/aqua-registry/pkgs/planetscale/cli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: planetscale/cli@v0.255.0
+  - name: planetscale/cli@v0.256.0

--- a/aqua-registry/pkgs/speakeasy-api/speakeasy/pkg.yaml
+++ b/aqua-registry/pkgs/speakeasy-api/speakeasy/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: speakeasy-api/speakeasy@v1.615.1
+  - name: speakeasy-api/speakeasy@v1.615.2

--- a/aqua-registry/pkgs/specstoryai/getspecstory/pkg.yaml
+++ b/aqua-registry/pkgs/specstoryai/getspecstory/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: specstoryai/getspecstory@v0.9.0
+  - name: specstoryai/getspecstory@v0.9.1

--- a/aqua-registry/pkgs/sst/opencode/pkg.yaml
+++ b/aqua-registry/pkgs/sst/opencode/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: sst/opencode@v0.7.1
+  - name: sst/opencode@v0.7.2
   - name: sst/opencode
     version: v0.1.61
   - name: sst/opencode

--- a/aqua-registry/pkgs/technicalpickles/envsense/pkg.yaml
+++ b/aqua-registry/pkgs/technicalpickles/envsense/pkg.yaml
@@ -1,0 +1,9 @@
+packages:
+  - name: technicalpickles/envsense@0.3.4
+  - name: technicalpickles/envsense@0.3.1
+  - name: technicalpickles/envsense
+    version: 0.2.2
+  - name: technicalpickles/envsense
+    version: v0.2.1
+  - name: technicalpickles/envsense
+    version: v0.2.0

--- a/aqua-registry/pkgs/technicalpickles/envsense/registry.yaml
+++ b/aqua-registry/pkgs/technicalpickles/envsense/registry.yaml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: technicalpickles
+    repo_name: envsense
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.2.1"
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.2.2")
+        asset: envsense-v0.1.0-universal-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.3.1")
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.bundle"
+          opts:
+            - --certificate-identity-regexp
+            - '^https://github\.com/technicalpickles/envsense/'
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/aqua-registry/pkgs/tombi-toml/tombi/pkg.yaml
+++ b/aqua-registry/pkgs/tombi-toml/tombi/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: tombi-toml/tombi@v0.6.3
+  - name: tombi-toml/tombi@v0.6.4
   - name: tombi-toml/tombi
     version: v0.3.39
   - name: tombi-toml/tombi

--- a/aqua-registry/pkgs/zitadel/zitadel/pkg.yaml
+++ b/aqua-registry/pkgs/zitadel/zitadel/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: zitadel/zitadel@v4.1.3
+  - name: zitadel/zitadel@v4.1.4

--- a/aqua-registry/registry.yaml
+++ b/aqua-registry/registry.yaml
@@ -75293,6 +75293,100 @@ packages:
           - goos: windows
             asset: tealdeer-{{.OS}}-{{.Arch}}-msvc
   - type: github_release
+    repo_owner: technicalpickles
+    repo_name: envsense
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.2.1"
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.2.2")
+        asset: envsense-v0.1.0-universal-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.3.1")
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.bundle"
+          opts:
+            - --certificate-identity-regexp
+            - '^https://github\.com/technicalpickles/envsense/'
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+  - type: github_release
     repo_owner: tektoncd
     repo_name: cli
     description: A CLI for interacting with Tekton

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_9_8:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_8 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_9_8;
+  if ( [[ -z "${_usage_spec_mise_2025_9_9:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_9 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_9_9;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_9_8 spec
+    _store_cache _usage_spec_mise_2025_9_9 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_9_8:-} ]]; then
-        _usage_spec_mise_2025_9_8="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_9_9:-} ]]; then
+        _usage_spec_mise_2025_9_9="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_8}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_9}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_9_8
-  set -g _usage_spec_mise_2025_9_8 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_9_9
+  set -g _usage_spec_mise_2025_9_9 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_8" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_9" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_8" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_9" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.9.8";
+  version = "2025.9.9";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.9.8
+Version: 2025.9.9
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(backend)** make HTTP installs atomic and serialize with cache lock by @jdx in [#6259](https://github.com/jdx/mise/pull/6259)
- **(env)** allow nested env._.path directives by @risu729 in [#6160](https://github.com/jdx/mise/pull/6160)
- **(env)** disallow nested env objects by @risu729 in [#6268](https://github.com/jdx/mise/pull/6268)
- **(schema)** allow nested arrays in task.depends by @risu729 in [#6265](https://github.com/jdx/mise/pull/6265)
- **(task)** resolve jobs=1 hang and keep-order panic; improve Ctrl-C handling by @jdx in [#6264](https://github.com/jdx/mise/pull/6264)
- **(tasks)** stop CLI group after first failure without --continue-on-error by @jdx in [#6270](https://github.com/jdx/mise/pull/6270)

### 📚 Documentation

- fixed toml issues in URL replacements settings documentation by @ThomasSteinbach in [#6269](https://github.com/jdx/mise/pull/6269)

### Chore

- **(schema)** strict oneOf branches and DRY env_directive in schemas by @jdx in [#6271](https://github.com/jdx/mise/pull/6271)
- add schema linter by @risu729 in [#6267](https://github.com/jdx/mise/pull/6267)