### PR TITLE
docs getting started backends and tasks

### DIFF
--- a/docs/asdf-legacy-plugins.md
+++ b/docs/asdf-legacy-plugins.md
@@ -324,14 +324,15 @@ Consider migrating from asdf plugins to modern alternatives:
 
 1. **Check if tool is available in [aqua registry](https://aquaproj.github.io/aqua-registry/)**
 2. **Use [ubi backend](dev-tools/backends/ubi.md) for simple GitHub releases**
-3. **Create a [mise plugin](tool-plugin-development.md) for complex tools**
+3. **Create a [mise plugin](tool-plugin-development.md) for complex tools** - use the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) for a quick start
 4. **Use language-specific package managers** (npm, pipx, cargo, gem)
 
 ## Community Resources
 
 - **[asdf Plugin List](https://github.com/asdf-vm/asdf-plugins)** - Official asdf plugin registry
 - **[mise-plugins Organization](https://github.com/mise-plugins)** - Community-maintained plugins
-- **[Plugin Template](https://github.com/asdf-vm/asdf-plugin-template)** - Template for creating new plugins
+- **[Plugin Template (asdf)](https://github.com/asdf-vm/asdf-plugin-template)** - Template for creating asdf plugins
+- **[Plugin Template (mise)](https://github.com/jdx/mise-tool-plugin-template)** - Modern template for creating mise plugins with Lua
 
 ## Security Considerations
 

--- a/docs/backend-plugin-development.md
+++ b/docs/backend-plugin-development.md
@@ -74,12 +74,30 @@ end
 
 ## Creating a Backend Plugin
 
+### Using the Template Repository
+
+While the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) is primarily designed for tool plugins, you can adapt it for backend plugins:
+
+```bash
+# Clone the template
+git clone https://github.com/jdx/mise-tool-plugin-template my-backend-plugin
+cd my-backend-plugin
+
+# Remove the template's git history
+rm -rf .git
+git init
+
+# Replace tool plugin hooks with backend hooks
+rm hooks/*.lua
+# Create backend_list_versions.lua, backend_install.lua, backend_exec_env.lua
+```
+
 ### 1. Plugin Structure
 
 Create a directory with this structure:
 
 ```
-vfox-npm/
+my-backend-plugin/
 ├── metadata.lua                    # Plugin metadata
 ├── hooks/
 │   ├── backend_list_versions.lua   # BackendListVersions hook
@@ -395,7 +413,8 @@ TODO: We need caching support for [Shared Lua modules](plugin-lua-modules.md).
 
 ## Next Steps
 
+- [Start with the plugin template](https://github.com/jdx/mise-tool-plugin-template)
 - [Learn about Tool Plugin Development](tool-plugin-development.md)
-- [Explore available Lua modules](plugin-lua-modules.md)  
+- [Explore available Lua modules](plugin-lua-modules.md)
 - [Publishing your plugin](plugin-publishing.md)
 - [View the vfox-npm plugin source](https://github.com/jdx/vfox-npm)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -738,7 +738,7 @@ If you need a custom backend:
    creating a [discussion](https://github.com/jdx/mise/discussions)
 2. **Consider if existing backends** (ubi, aqua, npm, pipx, etc.) can meet your
    needs
-3. **Create a plugin** - use the [plugin system](tool-plugin-development.md) to create plugins for private/custom tools without core changes
+3. **Create a plugin** - use the [plugin system](tool-plugin-development.md) to create plugins for private/custom tools without core changes. Start with the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) for a quick setup
 
 Most tool installation needs can be met by existing backends, especially
 [ubi](dev-tools/backends/ubi.md) for GitHub releases and

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -81,3 +81,4 @@ For more information, see:
 
 - [Using Plugins](../../plugin-usage.md) - End-user guide
 - [Plugin Development](../../tool-plugin-development.md) - Developer guide
+- [Plugin Template](https://github.com/jdx/mise-tool-plugin-template) - Quick start template for creating plugins

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -223,11 +223,124 @@ Note that when you ran `mise use --global node@22`, `mise` updated the global `m
 node = "22"
 ```
 
-## 4. Next steps {#next-steps}
+## 4. Use tools from backends (npm, pipx, core, aqua, github) {#tool-backends}
+
+```mermaid
+flowchart LR
+  subgraph Backends
+    core
+    aqua
+    github
+    npm
+    pipx
+  end
+
+  core --> node["core:node"]
+  core --> python["core:python"]
+  aqua -->gh["aqua:cli/cli"]
+  github -->ripgrep["github:BurntSushi/ripgrep"]
+  github -->ruff["github:astral-sh/ruff"]
+  npm --> prettier["npm:prettier"]
+  npm --> claude_code["npm:@anthropic-ai/claude-code"]
+  pipx -->black["pipx:black"]
+  pipx -->pycowsay["pipx:pycowsay"]
+  aqua -->terraform["aqua:hashicorp/terraform"]
+
+  subgraph Tools
+    node
+    python
+    gh
+    ripgrep
+    ruff
+    prettier
+    claude_code
+    black
+    pycowsay
+    terraform
+  end
+```
+
+Backends are ecosystems or package managers that mise uses to install tools. With `mise use`, you can install multiple tools from each backend.
+
+For example, to install [claude-code](https://www.npmjs.com/package/@anthropic-ai/claude-code) with the npm backend:
+
+```sh
+# run claude-code via mise x|exec
+mise exec npm:@anthropic-ai/claude-code -- claude-code --version
+
+# or if mise is activated in your shell
+mise use --global npm:@anthropic-ai/claude-code
+claude-code --version
+```
+
+Install [black](https://github.com/psf/black) with the pipx backend:
+
+```sh
+# run black via mise x|exec
+mise exec pipx:black -- black --version
+
+# or if mise is activated in your shell
+mise use --global pipx:black
+black --version
+```
+
+mise can also install tools directly from github with the github backend:
+
+```sh
+# run ripgrep via mise x|exec
+mise exec github:BurntSushi/ripgrep -- ripgrep --version
+
+# or if mise is activated in your shell
+mise use --global github:BurntSushi/ripgrep
+ripgrep --version
+```
+
+See [Backends](/dev-tools/backends/) for more ecosystems and details.
+
+### 4. Setting environment variables {#environment-variables}
+
+You can set environment variables in `mise.toml` which will be set if mise is activated or if `mise x|exec` is used in a directory:
+
+```toml [mise.toml]
+[env]
+NODE_ENV = "production"
+```
+
+```sh
+mise exec -- node --eval 'console.log(process.env.NODE_ENV)'
+
+# or if mise is activated in your shell
+echo "node env: $NODE_ENV"
+# node env: production
+```
+
+### 6. Run a task {#run-a-task}
+
+You can define simple tasks in `mise.toml` and run them with `mise run`:
+
+```toml [mise.toml]
+[tasks]
+hello = "echo hello from mise"
+```
+
+Run it:
+
+```sh
+mise run hello
+# hello from mise
+```
+
+:::tip
+mise tasks will automatically install all of the tools from `mise.toml` before running the task.
+:::
+
+See [tasks](/tasks/) for more information on how to define and use tasks.
+
+## 7. Next steps {#next-steps}
 
 Follow the [walkthrough](/walkthrough) for more examples on how to use mise.
 
-### Set up the autocompletion {#autocompletion}
+### Set up autocompletion {#autocompletion}
 
 See [autocompletion](/installing-mise.html#autocompletion) to learn how to set up autocompletion for your shell.
 

--- a/docs/plugin-publishing.md
+++ b/docs/plugin-publishing.md
@@ -22,7 +22,23 @@ Before publishing your plugin, ensure you have:
 
 ### 1. Initialize Repository
 
-Create a Git repository for your plugin:
+The easiest way to start is with the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template):
+
+```bash
+# Clone the template
+git clone https://github.com/jdx/mise-tool-plugin-template my-plugin
+cd my-plugin
+
+# Remove template history and set up your own repository
+rm -rf .git
+git init
+git remote add origin https://github.com/username/my-plugin.git
+
+# Customize for your plugin
+# Edit metadata.lua, hooks/*.lua, README.md, etc.
+```
+
+Alternatively, create a repository from scratch:
 
 ```bash
 # Create plugin directory

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -46,7 +46,7 @@ mise install my-plugin:some-tool@1.0.0
 mise use my-plugin:some-tool@latest
 ```
 
-See [Backend Plugin Development](backend-plugin-development.md) for creating backend plugins.
+See [Backend Plugin Development](backend-plugin-development.md) for creating backend plugins. You can start quickly with the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template).
 
 ## Tool Plugins
 
@@ -68,7 +68,7 @@ mise install my-tool@1.0.0
 mise use my-tool@latest
 ```
 
-See [Tool Plugin Development](tool-plugin-development.md) for creating tool plugins.
+See [Tool Plugin Development](tool-plugin-development.md) for creating tool plugins. The [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) provides a ready-to-use starting point.
 
 ## General Plugin Usage
 

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -261,28 +261,28 @@ Create shared functions in the `lib/` directory:
 local M = {}
 
 function M.get_arch()
-    local arch = os.getenv("PROCESSOR_ARCHITECTURE") or os.capture("uname -m")
-    if arch:match("x86_64") or arch:match("AMD64") then
+    -- Use the RUNTIME object provided by vfox/mise
+    local arch = RUNTIME.archType
+    if arch == "amd64" or arch == "x86_64" then
         return "x64"
-    elseif arch:match("i386") or arch:match("i686") then
+    elseif arch == "386" or arch == "i386" then
         return "x86"
-    elseif arch:match("arm64") or arch:match("aarch64") then
+    elseif arch == "arm64" or arch == "aarch64" then
         return "arm64"
     else
-        return "x64"  -- default
+        return arch  -- return as-is for other architectures
     end
 end
 
 function M.get_os()
-    if package.config:sub(1,1) == '\\' then
+    -- Use the RUNTIME object provided by vfox/mise
+    local os = RUNTIME.osType:lower()
+    if os == "windows" then
         return "win"
+    elseif os == "darwin" then
+        return "darwin"
     else
-        local os_name = os.capture("uname"):lower()
-        if os_name:find("darwin") then
-            return "darwin"
-        else
-            return "linux"
-        end
+        return "linux"
     end
 end
 
@@ -347,11 +347,12 @@ end
 -- hooks/pre_install.lua
 function PLUGIN:PreInstall(ctx)
     local version = ctx.version
-    local helper = require("lib/helper")
-    
-    -- Determine platform
-    local platform = helper.get_platform()
-    local extension = platform:match("win") and "zip" or "tar.gz"
+
+    -- Determine platform using RUNTIME object
+    local os_name = RUNTIME.osType:lower()
+    local arch = RUNTIME.archType == "amd64" and "x64" or RUNTIME.archType
+    local platform = os_name .. "-" .. arch
+    local extension = (os_name == "windows") and "zip" or "tar.gz"
     
     -- Build download URL
     local filename = "node-v" .. version .. "-" .. platform .. "." .. extension
@@ -388,8 +389,7 @@ end
 -- hooks/env_keys.lua
 function PLUGIN:EnvKeys(ctx)
     local mainPath = ctx.path
-    local helper = require("lib/helper")
-    local os_type = helper.get_os()
+    local os_type = RUNTIME.osType:lower()
     
     local env_vars = {
         {
@@ -404,7 +404,7 @@ function PLUGIN:EnvKeys(ctx)
     
     -- Add npm global modules to PATH
     local npm_global_path = mainPath .. "/lib/node_modules/.bin"
-    if os_type == "win" then
+    if os_type == "windows" then
         npm_global_path = mainPath .. "/node_modules/.bin"
     end
     
@@ -424,10 +424,8 @@ end
 function PLUGIN:PostInstall(ctx)
     local sdkInfo = ctx.sdkInfo['nodejs']
     local path = sdkInfo.path
-    local helper = require("lib/helper")
-    
     -- Set executable permissions on Unix systems
-    if helper.get_os() ~= "win" then
+    if RUNTIME.osType ~= "Windows" then
         os.execute("chmod +x " .. path .. "/bin/*")
     end
     
@@ -437,7 +435,7 @@ function PLUGIN:PostInstall(ctx)
     
     -- Configure npm to use local cache
     local npm_cmd = path .. "/bin/npm"
-    if helper.get_os() == "win" then
+    if RUNTIME.osType == "Windows" then
         npm_cmd = path .. "/npm.cmd"
     end
     
@@ -575,14 +573,14 @@ end
 
 ### Platform Detection
 
-Handle different operating systems properly:
+Handle different operating systems properly using the RUNTIME object:
 
 ```lua
 -- lib/platform.lua
 local M = {}
 
 function M.is_windows()
-    return package.config:sub(1,1) == '\\'
+    return RUNTIME.osType == "Windows"
 end
 
 function M.get_exe_extension()
@@ -595,6 +593,10 @@ end
 
 return M
 ```
+
+**Note:** The `RUNTIME` object is automatically available in all plugin hooks and provides:
+- `RUNTIME.osType`: Operating system type ("Windows", "Linux", "Darwin")
+- `RUNTIME.archType`: Architecture ("amd64", "arm64", "386", etc.)
 
 ### Version Normalization
 
@@ -649,14 +651,12 @@ Different installation logic based on platform or version:
 ```lua
 function PLUGIN:PreInstall(ctx)
     local version = ctx.version
-    local helper = require("lib/helper")
-    local platform = helper.get_platform()
-    
-    -- Different logic for different platforms
-    if platform:match("win") then
+
+    -- Different logic for different platforms using RUNTIME object
+    if RUNTIME.osType == "Windows" then
         -- Windows-specific installation
         return install_windows(version)
-    elseif platform:match("darwin") then
+    elseif RUNTIME.osType == "Darwin" then
         -- macOS-specific installation
         return install_macos(version)
     else
@@ -742,8 +742,7 @@ function PLUGIN:EnvKeys(ctx)
     }
     
     -- Platform-specific additions
-    local helper = require("lib/helper")
-    if helper.get_os() == "darwin" then
+    if RUNTIME.osType == "Darwin" then
         table.insert(env_vars, {
             key = "DYLD_LIBRARY_PATH",
             value = mainPath .. "/lib"

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -276,10 +276,10 @@ end
 
 function M.get_os()
     -- Use the RUNTIME object provided by vfox/mise
-    local os = RUNTIME.osType:lower()
-    if os == "windows" then
+    local os = RUNTIME.osType
+    if os == "Windows" then
         return "win"
-    elseif os == "darwin" then
+    elseif os == "Darwin" then
         return "darwin"
     else
         return "linux"
@@ -349,10 +349,17 @@ function PLUGIN:PreInstall(ctx)
     local version = ctx.version
 
     -- Determine platform using RUNTIME object
-    local os_name = RUNTIME.osType:lower()
     local arch = RUNTIME.archType == "amd64" and "x64" or RUNTIME.archType
-    local platform = os_name .. "-" .. arch
-    local extension = (os_name == "windows") and "zip" or "tar.gz"
+    local os_token
+    if RUNTIME.osType == "Windows" then
+        os_token = "win"
+    elseif RUNTIME.osType == "Darwin" then
+        os_token = "darwin"
+    else
+        os_token = "linux"
+    end
+    local platform = os_token .. "-" .. arch
+    local extension = (RUNTIME.osType == "Windows") and "zip" or "tar.gz"
     
     -- Build download URL
     local filename = "node-v" .. version .. "-" .. platform .. "." .. extension
@@ -389,7 +396,7 @@ end
 -- hooks/env_keys.lua
 function PLUGIN:EnvKeys(ctx)
     local mainPath = ctx.path
-    local os_type = RUNTIME.osType:lower()
+    local os_type = RUNTIME.osType
     
     local env_vars = {
         {
@@ -404,7 +411,7 @@ function PLUGIN:EnvKeys(ctx)
     
     -- Add npm global modules to PATH
     local npm_global_path = mainPath .. "/lib/node_modules/.bin"
-    if os_type == "windows" then
+    if os_type == "Windows" then
         npm_global_path = mainPath .. "/node_modules/.bin"
     end
     

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -212,12 +212,36 @@ end
 
 ## Creating a Tool Plugin
 
+### Using the Template Repository
+
+The easiest way to create a new tool plugin is to use the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) repository as a starting point:
+
+```bash
+# Clone the template
+git clone https://github.com/jdx/mise-tool-plugin-template my-tool-plugin
+cd my-tool-plugin
+
+# Remove the template's git history and start fresh
+rm -rf .git
+git init
+
+# Customize the plugin for your tool
+# Edit metadata.lua, hooks/*.lua files, etc.
+```
+
+The template includes:
+- Pre-configured plugin structure with all required hooks
+- Example implementations with comments
+- Linting configuration (`.luacheckrc`, `stylua.toml`)
+- Testing setup with mise tasks
+- GitHub Actions workflow for CI
+
 ### 1. Plugin Structure
 
-Create a directory with this structure:
+Create a directory with this structure (or use the template above):
 
 ```
-nodejs-plugin/
+my-tool-plugin/
 ├── metadata.lua          # Plugin metadata and configuration
 ├── hooks/               # Hook functions directory
 │   ├── available.lua    # List available versions [required]
@@ -263,11 +287,11 @@ local M = {}
 function M.get_arch()
     -- Use the RUNTIME object provided by vfox/mise
     local arch = RUNTIME.archType
-    if arch == "amd64" or arch == "x86_64" then
+    if arch == "amd64" then
         return "x64"
-    elseif arch == "386" or arch == "i386" then
+    elseif arch == "386" then
         return "x86"
-    elseif arch == "arm64" or arch == "aarch64" then
+    elseif arch == "arm64" then
         return "arm64"
     else
         return arch  -- return as-is for other architectures
@@ -350,11 +374,11 @@ function PLUGIN:PreInstall(ctx)
 
     -- Determine platform using RUNTIME object
     local arch_token
-    if RUNTIME.archType == "amd64" or RUNTIME.archType == "x86_64" then
+    if RUNTIME.archType == "amd64" then
         arch_token = "x64"
-    elseif RUNTIME.archType == "386" or RUNTIME.archType == "i386" or RUNTIME.archType == "i686" then
+    elseif RUNTIME.archType == "386" then
         arch_token = "x86"
-    elseif RUNTIME.archType == "arm64" or RUNTIME.archType == "aarch64" then
+    elseif RUNTIME.archType == "arm64" then
         arch_token = "arm64"
     else
         arch_token = RUNTIME.archType
@@ -503,21 +527,31 @@ end
 
 ```bash
 # Link your plugin for development
-mise plugin link nodejs /path/to/nodejs-plugin
+mise plugin link my-tool /path/to/my-tool-plugin
 
 # Test listing versions
-mise ls-remote nodejs
+mise ls-remote my-tool
 
 # Test installation
-mise install nodejs@20.0.0
+mise install my-tool@1.0.0
 
 # Test environment setup
-mise use nodejs@20.0.0
-node --version
+mise use my-tool@1.0.0
+my-tool --version
 
-# Test legacy file parsing
-echo "18.18.0" > .nvmrc
-mise use nodejs
+# Test legacy file parsing (if applicable)
+echo "2.0.0" > .my-tool-version
+mise use my-tool
+```
+
+If you're using the template repository, you can run the included tests:
+
+```bash
+# Run linting
+mise run lint
+
+# Run tests
+mise run test
 ```
 
 ### Debug Mode
@@ -771,6 +805,7 @@ end
 
 ## Next Steps
 
+- [Start with the plugin template](https://github.com/jdx/mise-tool-plugin-template)
 - [Learn about Backend Plugin Development](backend-plugin-development.md)
 - [Explore available Lua modules](plugin-lua-modules.md)
 - [Publishing your plugin](plugin-publishing.md)

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -349,7 +349,16 @@ function PLUGIN:PreInstall(ctx)
     local version = ctx.version
 
     -- Determine platform using RUNTIME object
-    local arch = RUNTIME.archType == "amd64" and "x64" or RUNTIME.archType
+    local arch_token
+    if RUNTIME.archType == "amd64" or RUNTIME.archType == "x86_64" then
+        arch_token = "x64"
+    elseif RUNTIME.archType == "386" or RUNTIME.archType == "i386" or RUNTIME.archType == "i686" then
+        arch_token = "x86"
+    elseif RUNTIME.archType == "arm64" or RUNTIME.archType == "aarch64" then
+        arch_token = "arm64"
+    else
+        arch_token = RUNTIME.archType
+    end
     local os_token
     if RUNTIME.osType == "Windows" then
         os_token = "win"
@@ -358,7 +367,7 @@ function PLUGIN:PreInstall(ctx)
     else
         os_token = "linux"
     end
-    local platform = os_token .. "-" .. arch
+    local platform = os_token .. "-" .. arch_token
     local extension = (RUNTIME.osType == "Windows") and "zip" or "tar.gz"
     
     -- Build download URL


### PR DESCRIPTION
- **docs: simplify OS detection in tool plugin development**
- **docs: standardize RUNTIME.osType comparisons and platform tokens in tool plugin docs**
- **docs(tool-plugins): correct Node.js platform arch/os mapping; standardize RUNTIME.osType checks**
- **docs(tool-plugins): rely on normalized RUNTIME.archType; simplify arch mapping**
- **docs: add references to mise-tool-plugin-template repository**
- **docs(getting-started): add backends step with diagram, github example, env vars and simple tasks**
