### PR TITLE
docs: fix rust profile default

### DIFF
--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -54,9 +54,11 @@ toolchains. Please consult the Rust documentation for the most up-to-date list o
 The `profile` option allows you to specify the type of release to install. The following values
 are supported:
 
-- `minimal`: Includes as few components as possible to get a working compiler (rustc, rust-std, and cargo)
-- `default` (default): Includes all of components in the minimal profile, and adds rust-docs, rustfmt, and clippy
-- `complete`: Includes all the components available through rustup. This should never be used, as it includes every component ever included in the metadata and thus will almost always fail.
+- `minimal`: Includes as few components as possible to get a working compiler (`rustc`, `rust-std`, and `cargo`)
+- `default`: Includes all of components in the minimal profile, and adds `rust-docs`, `rustfmt`, and `clippy`
+- `complete`: Includes all the components available through `rustup`. This should never be used, as it includes every component ever included in the metadata and thus will almost always fail.
+
+If not set, it defaults to the profile configured in `rustup`. You can check your current default by running `rustup show profile`.
 
 ```toml
 [tools]

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -55,7 +55,7 @@ The `profile` option allows you to specify the type of release to install. The f
 are supported:
 
 - `minimal`: Includes as few components as possible to get a working compiler (`rustc`, `rust-std`, and `cargo`)
-- `default`: Includes all of components in the minimal profile, and adds `rust-docs`, `rustfmt`, and `clippy`
+- `default`: Includes all of the components in the minimal profile, and adds `rust-docs`, `rustfmt`, and `clippy`
 - `complete`: Includes all the components available through `rustup`. This should never be used, as it includes every component ever included in the metadata and thus will almost always fail.
 
 If not set, it defaults to the profile configured in `rustup`. You can check your current default by running `rustup show profile`.


### PR DESCRIPTION
https://github.com/jdx/mise/blob/669c83c723e26199aa3970fbe132152d9d1aef54/src/plugins/core/rust.rs#L111-L112

It doesn't default to `default`, but respects the default of `rustup` if not set.