### PR TITLE
fix(github): correctly paginate releases/tags for private repos

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -114,6 +114,7 @@ async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GithubRelease>>
 
     if *env::MISE_LIST_ALL_VERSIONS {
         while let Some(next) = next_page(&headers) {
+            headers = get_headers(&next);
             let (more, h) = crate::http::HTTP_FETCH
                 .json_headers_with_headers::<Vec<GithubRelease>, _>(next, &headers)
                 .await?;
@@ -155,6 +156,7 @@ async fn list_tags_(api_url: &str, repo: &str) -> Result<Vec<String>> {
 
     if *env::MISE_LIST_ALL_VERSIONS {
         while let Some(next) = next_page(&headers) {
+            headers = get_headers(&next);
             let (more, h) = crate::http::HTTP_FETCH
                 .json_headers_with_headers::<Vec<GithubTag>, _>(next, &headers)
                 .await?;


### PR DESCRIPTION
Currently, authentication headers are not preserved when paginating GitHub releases or tags when `MISE_LIST_ALL_VERSIONS` is set. This results in `mise` failing with an HTTP error.

<details>
<summary>mise output before PR</summary>

```
❯ MISE_VERBOSE=1 MISE_LIST_ALL_VERSIONS=1 MISE_GITHUB_TOKEN=$(gh auth token) /usr/bin/mise ls-remote ubi:private/repo
DEBUG Version: 2025.9.12 linux-x64 (2025-09-16)
DEBUG ARGS: /usr/bin/mise ls-remote ubi:private/repo
DEBUG config: ~/.config/mise/config.toml
DEBUG GET https://api.github.com/repos/private/repo/releases
DEBUG starting new connection: https://api.github.com/
DEBUG GET https://api.github.com/repos/private/repo/releases 200 OK
DEBUG GET https://api.github.com/repositories/123456789/releases?page=2
DEBUG GET https://api.github.com/repositories/123456789/releases?page=2 404 Not Found
Error:
   0: HTTP status client error (404 Not Found) for url (https://api.github.com/repositories/123456789/releases?page=2)

Location:
   src/http.rs:92

Version:
   2025.9.12 linux-x64 (2025-09-16)

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

</details>

<details>
<summary>mise output after PR</summary>

```
❯ MISE_VERBOSE=1 MISE_LIST_ALL_VERSIONS=1 MISE_GITHUB_TOKEN=$(gh auth token) mise ls-remote ubi:private/repo
DEBUG Version: 2025.9.12-DEBUG linux-x64 (2025-09-18)
DEBUG ARGS: mise ls-remote ubi:private/repo
DEBUG config: ~/.config/mise/config.toml
DEBUG GET https://api.github.com/repos/private/repo/releases
DEBUG starting new connection: https://api.github.com/
DEBUG GET https://api.github.com/repos/private/repo/releases 200 OK
DEBUG GET https://api.github.com/repositories/123456789/releases?page=2
DEBUG GET https://api.github.com/repositories/123456789/releases?page=2 200 OK
DEBUG GET https://api.github.com/repositories/123456789/releases?page=3
DEBUG GET https://api.github.com/repositories/123456789/releases?page=3 200 OK
DEBUG GET https://api.github.com/repositories/123456789/releases?page=4
DEBUG GET https://api.github.com/repositories/123456789/releases?page=4 200 OK
DEBUG GET https://api.github.com/repositories/123456789/releases?page=5
DEBUG GET https://api.github.com/repositories/123456789/releases?page=5 200 OK
DEBUG GET https://api.github.com/repositories/123456789/releases?page=6
DEBUG GET https://api.github.com/repositories/123456789/releases?page=6 200 OK
DEBUG GET https://api.github.com/repositories/123456789/releases?page=7
DEBUG GET https://api.github.com/repositories/123456789/releases?page=7 200 OK
DEBUG GET https://api.github.com/repositories/123456789/releases?page=8
DEBUG GET https://api.github.com/repositories/123456789/releases?page=8 200 OK
DEBUG GET https://api.github.com/repositories/123456789/releases?page=9
DEBUG GET https://api.github.com/repositories/123456789/releases?page=9 200 OK
1.0.0
1.0.1
1.1.0
1.1.1
1.1.2
1.1.3
[...the rest of the versions...]
```

</details>