### PR TITLE
feat(vfox): add file.read lua function

### DIFF
--- a/docs/plugin-lua-modules.md
+++ b/docs/plugin-lua-modules.md
@@ -356,6 +356,13 @@ print(full_path)  -- On Unix: /foo/bar/baz.txt, on Windows: \foo\bar\baz.txt
 
 The `file.join_path(...)` function joins any number of path segments using the correct separator for the current operating system. This is the recommended way to construct file paths in cross-platform plugins.
 
+### Read File Contents
+
+```lua
+local file = require("file")
+print(file.read("/path/to/file"))
+```
+
 ### Create Symbolic Links
 
 ```lua


### PR DESCRIPTION
The [tool plugin docs](https://mise.jdx.dev/tool-plugin-development.html) reference a `file.read` function in multiple examples, but none currently exist in the `file` module that comes with the `vfox` crate. This PR implements it so that the docs are more accurate, in addition to its general utility.