### PR TITLE
fix: fix an issue where Swift could not be installed on arm64 Ubuntu

### DIFF
--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -208,8 +208,8 @@ fn platform_directory() -> String {
     } else if let Ok(os_release) = &*os_release::OS_RELEASE {
         let settings = Settings::get();
         let arch = settings.arch();
-        if os_release.id == "ubuntu" && arch == "aarch64" {
-            let retval = format!("{}{}-{}", os_release.id, os_release.version_id, arch);
+        if os_release.id == "ubuntu" && arch == "arm64" {
+            let retval = format!("{}{}-aarch64", os_release.id, os_release.version_id);
             retval.replace(".", "")
         } else {
             platform().replace(".", "")
@@ -254,8 +254,12 @@ fn extension() -> &'static str {
 
 fn architecture(settings: &Settings) -> Option<&str> {
     let arch = settings.arch();
-    if cfg!(target_os = "linux") && arch != "x64" {
-        return Some(arch);
+    if cfg!(target_os = "linux") {
+        return match arch {
+            "x64" => None,
+            "arm64" => Some("aarch64"),
+            _ => Some(arch),
+        };
     } else if cfg!(windows) && arch == "arm64" {
         return Some("arm64");
     }


### PR DESCRIPTION
Hi there! First and foremost, thank you for creating and maintaining this fantastic tool. I use it every day and really appreciate it.

I've read the [Contribution Guidelines](https://mise.jdx.dev/contributing.html) and believe this qualifies as a "something obvious" fix, so I've opened this PR. This is my first time contributing to this repository, so I'd appreciate it if you could point out any mistakes or areas for improvement.

## The Issue

I noticed that `mise install swift` fails on arm64 Ubuntu.

From my investigation, this issue seems to be caused by #5629, which changed the return value of `Settings::get().arch()` from `aarch64` to `arm64`.

## The Fix

I've adjusted the code to generate the correct download URL for Swift on arm64 Ubuntu, taking the new architecture name into account.

I couldn't find any corresponding tests for this functionality, so no tests have been modified.

---

Thanks for your time and consideration!