### PR TITLE
chore: release 2025.9.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [2025.9.15](https://github.com/jdx/mise/compare/v2025.9.14..v2025.9.15) - 2025-09-21
+
+### 📦 Registry
+
+- add missing cargo backends by @jayvdb in [#6307](https://github.com/jdx/mise/pull/6307)
+
+### 🚀 Features
+
+- add env propagation by @Its-Just-Nans in [#6342](https://github.com/jdx/mise/pull/6342)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** improve GitHub token handling for sigstore verification by @jdx in [#6351](https://github.com/jdx/mise/pull/6351)
+- **(backend)** change dependency checks to warnings instead of errors by @jdx in [#6363](https://github.com/jdx/mise/pull/6363)
+- **(npm)** improve error message when npm/bun is not installed by @jdx in [#6359](https://github.com/jdx/mise/pull/6359)
+- **(vfox)** enable TLS support for reqwest to fix CI tests by @jdx in [#6356](https://github.com/jdx/mise/pull/6356)
+
+### 🚜 Refactor
+
+- **(registry)** convert to nested TOML sections format by @jdx in [#6361](https://github.com/jdx/mise/pull/6361)
+
+### 🧪 Testing
+
+- **(e2e)** resolve mise via PATH in backend missing deps test by @jdx in [#6362](https://github.com/jdx/mise/pull/6362)
+- **(vfox)** replace flaky external HTTP tests with local mock server by @jdx in [#6354](https://github.com/jdx/mise/pull/6354)
+
+### 📦️ Dependency Updates
+
+- pin dependencies by @renovate[bot] in [#6243](https://github.com/jdx/mise/pull/6243)
+
+### Chore
+
+- **(install.sh)** add `MISE_INSTALL_MUSL` to force installing musl variants on Linux by @malept in [#6355](https://github.com/jdx/mise/pull/6355)
+
 ## [2025.9.14](https://github.com/jdx/mise/compare/v2025.9.13..v2025.9.14) - 2025-09-20
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.9.14"
+version = "2025.9.15"
 dependencies = [
  "aqua-registry",
  "async-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox", "crates/aqua-registry"]
 
 [package]
 name = "mise"
-version = "2025.9.14"
+version = "2025.9.15"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.9.14 macos-arm64 (a1b2d3e 2025-09-20)
+2025.9.15 macos-arm64 (a1b2d3e 2025-09-21)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_9_14:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_14 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_9_14;
+  if ( [[ -z "${_usage_spec_mise_2025_9_15:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_15 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_9_15;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_9_14 spec
+    _store_cache _usage_spec_mise_2025_9_15 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_9_14:-} ]]; then
-        _usage_spec_mise_2025_9_14="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_9_15:-} ]]; then
+        _usage_spec_mise_2025_9_15="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_14}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_15}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_9_14
-  set -g _usage_spec_mise_2025_9_14 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_9_15
+  set -g _usage_spec_mise_2025_9_15 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_14" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_15" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_14" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_15" -- (commandline -opc) (commandline -t))'
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.9.14";
+  version = "2025.9.15";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "19.3k",
+      stars: "19.4k",
     };
   },
 };

--- a/mise.lock
+++ b/mise.lock
@@ -65,7 +65,7 @@ version = "0.25.18"
 backend = "cargo:cargo-release"
 
 [[tools."cargo:git-cliff"]]
-version = "2.10.0"
+version = "2.10.1"
 backend = "cargo:git-cliff"
 
 [[tools."cargo:toml-cli"]]
@@ -105,13 +105,13 @@ size = 12793347
 url = "https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_macOS_arm64.zip"
 
 [[tools.hk]]
-version = "1.15.2"
+version = "1.15.3"
 backend = "aqua:jdx/hk"
 
 [tools.hk.platforms.linux-x64]
-checksum = "blake3:1483cd4e370928d780557b636cf5dfde3a994be178ee45d53c12fa20c37916b1"
-size = 6966719
-url = "https://github.com/jdx/hk/releases/download/v1.15.2/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "blake3:ddfbc94d8c9f6fb12682ec4b02ce12a2e05961afc6139a2989a5e6bc4d94a259"
+size = 6982412
+url = "https://github.com/jdx/hk/releases/download/v1.15.3/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [[tools.jq]]
 version = "1.8.1"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.9.14
+Version: 2025.9.15
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 📦 Registry

- add missing cargo backends by @jayvdb in [#6307](https://github.com/jdx/mise/pull/6307)

### 🚀 Features

- add env propagation by @Its-Just-Nans in [#6342](https://github.com/jdx/mise/pull/6342)

### 🐛 Bug Fixes

- **(aqua)** improve GitHub token handling for sigstore verification by @jdx in [#6351](https://github.com/jdx/mise/pull/6351)
- **(backend)** change dependency checks to warnings instead of errors by @jdx in [#6363](https://github.com/jdx/mise/pull/6363)
- **(npm)** improve error message when npm/bun is not installed by @jdx in [#6359](https://github.com/jdx/mise/pull/6359)
- **(vfox)** enable TLS support for reqwest to fix CI tests by @jdx in [#6356](https://github.com/jdx/mise/pull/6356)

### 🚜 Refactor

- **(registry)** convert to nested TOML sections format by @jdx in [#6361](https://github.com/jdx/mise/pull/6361)

### 🧪 Testing

- **(e2e)** resolve mise via PATH in backend missing deps test by @jdx in [#6362](https://github.com/jdx/mise/pull/6362)
- **(vfox)** replace flaky external HTTP tests with local mock server by @jdx in [#6354](https://github.com/jdx/mise/pull/6354)

### 📦️ Dependency Updates

- pin dependencies by @renovate[bot] in [#6243](https://github.com/jdx/mise/pull/6243)

### Chore

- **(install.sh)** add `MISE_INSTALL_MUSL` to force installing musl variants on Linux by @malept in [#6355](https://github.com/jdx/mise/pull/6355)