### PR TITLE
chore(install.sh): add `MISE_INSTALL_MUSL` to force installing musl variants on Linux

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -42,12 +42,14 @@ get_os() {
 
 get_arch() {
   musl=""
-  if [ "${MISE_INSTALL_MUSL-}" = "1" ] || [ "${MISE_INSTALL_MUSL-}" = "true" ]; then
-    musl="-musl"
-  elif type ldd >/dev/null 2>/dev/null; then
-    libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
-    if [ -n "$libc" ]; then
+  if type ldd >/dev/null 2>/dev/null; then
+    if [ "${MISE_INSTALL_MUSL-}" = "1" ] || [ "${MISE_INSTALL_MUSL-}" = "true" ]; then
       musl="-musl"
+    else
+      libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
+      if [ -n "$libc" ]; then
+        musl="-musl"
+      fi
     fi
   fi
   arch="$(uname -m)"

--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -42,7 +42,9 @@ get_os() {
 
 get_arch() {
   musl=""
-  if type ldd >/dev/null 2>/dev/null; then
+  if [ "${MISE_INSTALL_MUSL-}" = "1" ] || [ "${MISE_INSTALL_MUSL-}" = "true" ]; then
+    musl="-musl"
+  elif type ldd >/dev/null 2>/dev/null; then
     libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
     if [ -n "$libc" ]; then
       musl="-musl"


### PR DESCRIPTION
This allows for the use case of setting an environment variable in CI to always install `-musl` binaries in Linux CI workers, regardless of the presence of a musl-based `libc`, when multiple arches are used in workflows.

Tested by downloading the `install.sh` asset from the `2025.9.14` release and patching it with this change:

```shell
mkdir /tmp/foo
MISE_INSTALL_PATH=/tmp/foo/mise MISE_INSTALL_MUSL=1 ./install.sh
file /tmp/foo/mise
ldd /tmp/foo/mise
```

Expected output of `file` and `ldd`:

```
❯ file /tmp/foo/mise
/tmp/foo/mise: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, not stripped
❯ ldd /tmp/foo/mise
        statically linked
```