### PR TITLE
fix(vfox): enable TLS support for reqwest to fix CI tests

### DIFF
--- a/crates/vfox/Cargo.toml
+++ b/crates/vfox/Cargo.toml
@@ -32,6 +32,7 @@ mlua = { version = "0.11.0-beta.3", features = [
 once_cell = "1"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
+  "rustls-tls-native-roots",
 ] } # TODO: replace with xx
 serde = "1"
 serde_json = "1"


### PR DESCRIPTION
## Summary

Fixes CI test failures in the vfox crate by enabling TLS support for reqwest.

## Problem

The vfox tests were failing in CI because reqwest was configured without TLS support, causing HTTPS requests to nodejs.org to fail with:
```
ConnectError("invalid URL, scheme is not http")
```

## Solution

Added the `rustls-tls-native-roots` feature to reqwest dependencies in the vfox crate, enabling TLS support for HTTPS requests.

## Testing
- All vfox tests now pass locally
- CI should pass with this change

Follow-up to #6354

🤖 Generated with [Claude Code](https://claude.ai/code)