### PR TITLE
test(e2e): resolve mise via PATH in backend missing deps test

### DIFF
--- a/e2e/backend/test_backend_missing_deps
+++ b/e2e/backend/test_backend_missing_deps
@@ -4,7 +4,9 @@
 
 # Create a PATH that has mise but not package managers
 # ROOT is set by run_test script
-MISE_DIR="${CARGO_TARGET_DIR:-$ROOT/target}/debug"
+# Resolve the mise binary from PATH (release e2e ensures it's installed)
+MISE_BIN="$(command -v mise)"
+MISE_DIR="$(dirname "$MISE_BIN")"
 export PATH="$MISE_DIR:/usr/bin:/bin:/usr/sbin:/sbin"
 
 # Track overall test status


### PR DESCRIPTION
Fixes CI failure in PR #6352 where the e2e test `backend/test_backend_missing_deps` assumed mise would be in `target/debug`, causing failures in release e2e tests.

**Changes:**
- Updated `e2e/backend/test_backend_missing_deps` to use `command -v mise` to resolve the binary from PATH
- This works for both local development builds and release e2e tests where mise is installed

**Testing:**
- ✅ Verified the specific failing test now passes locally
- ✅ Test still validates all backend dependency error scenarios

**Related:**
- Fixes failure in https://github.com/jdx/mise/pull/6352