### PR TITLE
chore: release 2025.9.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2025.9.16](https://github.com/jdx/mise/compare/v2025.9.15..v2025.9.16) - 2025-09-22
+
+### 📦 Registry
+
+- use npm backend for zbctl by @risu729 in [#6379](https://github.com/jdx/mise/pull/6379)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** remove blake3 support from aqua checksum algorithms by @risu729 in [#6370](https://github.com/jdx/mise/pull/6370)
+- **(aqua)** remove cosign and slsa-verifier dependencies by @risu729 in [#6371](https://github.com/jdx/mise/pull/6371)
+- **(aqua)** remove cosign.experimental by @risu729 in [#6376](https://github.com/jdx/mise/pull/6376)
+
+### 📚 Documentation
+
+- minisign doesn't require cli by @risu729 in [#6369](https://github.com/jdx/mise/pull/6369)
+
+### Chore
+
+- ignore renovate new bot name by @risu729 in [#6364](https://github.com/jdx/mise/pull/6364)
+
 ## [2025.9.15](https://github.com/jdx/mise/compare/v2025.9.14..v2025.9.15) - 2025-09-21
 
 ### 📦 Registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.9.15"
+version = "2025.9.16"
 dependencies = [
  "aqua-registry",
  "async-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox", "crates/aqua-registry"]
 
 [package]
 name = "mise"
-version = "2025.9.15"
+version = "2025.9.16"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.9.15 macos-arm64 (a1b2d3e 2025-09-21)
+2025.9.16 macos-arm64 (a1b2d3e 2025-09-22)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_9_15:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_15 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_9_15;
+  if ( [[ -z "${_usage_spec_mise_2025_9_16:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_16 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_9_16;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_9_15 spec
+    _store_cache _usage_spec_mise_2025_9_16 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_9_15:-} ]]; then
-        _usage_spec_mise_2025_9_15="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_9_16:-} ]]; then
+        _usage_spec_mise_2025_9_16="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_15}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_16}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_9_15
-  set -g _usage_spec_mise_2025_9_15 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_9_16
+  set -g _usage_spec_mise_2025_9_16 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_15" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_16" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_15" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_16" -- (commandline -opc) (commandline -t))'
 end

--- a/crates/aqua-registry/aqua-registry/pkgs/k1LoW/concrun/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/k1LoW/concrun/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: concrun
+    description: Run commands concurrently
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: concrun_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux
+          - darwin

--- a/crates/aqua-registry/aqua-registry/pkgs/shinagawa-web/gomarklint/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/shinagawa-web/gomarklint/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: shinagawa-web
+    repo_name: gomarklint
+    description: A fast and configurable Markdown linter written in Go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: gomarklint_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: gomarklint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.9.15";
+  version = "2025.9.16";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.9.15
+Version: 2025.9.16
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 📦 Registry

- use npm backend for zbctl by @risu729 in [#6379](https://github.com/jdx/mise/pull/6379)

### 🐛 Bug Fixes

- **(aqua)** remove blake3 support from aqua checksum algorithms by @risu729 in [#6370](https://github.com/jdx/mise/pull/6370)
- **(aqua)** remove cosign and slsa-verifier dependencies by @risu729 in [#6371](https://github.com/jdx/mise/pull/6371)
- **(aqua)** remove cosign.experimental by @risu729 in [#6376](https://github.com/jdx/mise/pull/6376)

### 📚 Documentation

- minisign doesn't require cli by @risu729 in [#6369](https://github.com/jdx/mise/pull/6369)

### Chore

- ignore renovate new bot name by @risu729 in [#6364](https://github.com/jdx/mise/pull/6364)