### PR TITLE
fix(aqua): support github_artifact_attestations.enabled

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -565,31 +565,47 @@ fn apply_override(mut orig: AquaPackage, avo: &AquaPackage) -> AquaPackage {
     }
 
     if let Some(avo_checksum) = avo.checksum.clone() {
-        let mut checksum = orig.checksum.unwrap_or_else(|| avo_checksum.clone());
-        checksum.merge(avo_checksum);
-        orig.checksum = Some(checksum);
+        match &mut orig.checksum {
+            Some(checksum) => {
+                checksum.merge(avo_checksum.clone());
+            }
+            None => {
+                orig.checksum = Some(avo_checksum.clone());
+            }
+        }
     }
 
     if let Some(avo_slsa_provenance) = avo.slsa_provenance.clone() {
-        let mut slsa_provenance = orig
-            .slsa_provenance
-            .unwrap_or_else(|| avo_slsa_provenance.clone());
-        slsa_provenance.merge(avo_slsa_provenance);
-        orig.slsa_provenance = Some(slsa_provenance);
+        match &mut orig.slsa_provenance {
+            Some(slsa_provenance) => {
+                slsa_provenance.merge(avo_slsa_provenance.clone());
+            }
+            None => {
+                orig.slsa_provenance = Some(avo_slsa_provenance.clone());
+            }
+        }
     }
 
     if let Some(avo_minisign) = avo.minisign.clone() {
-        let mut minisign = orig.minisign.unwrap_or_else(|| avo_minisign.clone());
-        minisign.merge(avo_minisign);
-        orig.minisign = Some(minisign);
+        match &mut orig.minisign {
+            Some(minisign) => {
+                minisign.merge(avo_minisign.clone());
+            }
+            None => {
+                orig.minisign = Some(avo_minisign.clone());
+            }
+        }
     }
 
-    if let Some(avo_github_artifact_attestations) = avo.github_artifact_attestations.clone() {
-        let mut github_artifact_attestations = orig
-            .github_artifact_attestations
-            .unwrap_or_else(|| avo_github_artifact_attestations.clone());
-        github_artifact_attestations.merge(avo_github_artifact_attestations);
-        orig.github_artifact_attestations = Some(github_artifact_attestations);
+    if let Some(avo_attestations) = avo.github_artifact_attestations.clone() {
+        match &mut orig.github_artifact_attestations {
+            Some(orig_attestations) => {
+                orig_attestations.merge(avo_attestations.clone());
+            }
+            None => {
+                orig.github_artifact_attestations = Some(avo_attestations.clone());
+            }
+        }
     }
 
     if avo.no_asset {

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -151,6 +151,7 @@ pub struct AquaMinisign {
 /// GitHub artifact attestations configuration
 #[derive(Debug, Deserialize, Clone)]
 pub struct AquaGithubArtifactAttestations {
+    pub enabled: Option<bool>,
     pub signer_workflow: Option<String>,
 }
 
@@ -583,8 +584,12 @@ fn apply_override(mut orig: AquaPackage, avo: &AquaPackage) -> AquaPackage {
         orig.minisign = Some(minisign);
     }
 
-    if let Some(avo_attestations) = avo.github_artifact_attestations.clone() {
-        orig.github_artifact_attestations = Some(avo_attestations);
+    if let Some(avo_github_artifact_attestations) = avo.github_artifact_attestations.clone() {
+        let mut github_artifact_attestations = orig
+            .github_artifact_attestations
+            .unwrap_or_else(|| avo_github_artifact_attestations.clone());
+        github_artifact_attestations.merge(avo_github_artifact_attestations);
+        orig.github_artifact_attestations = Some(github_artifact_attestations);
     }
 
     if avo.no_asset {
@@ -874,6 +879,17 @@ impl AquaMinisign {
         }
         if let Some(public_key) = other.public_key {
             self.public_key = Some(public_key);
+        }
+    }
+}
+
+impl AquaGithubArtifactAttestations {
+    fn merge(&mut self, other: Self) {
+        if let Some(enabled) = other.enabled {
+            self.enabled = Some(enabled);
+        }
+        if let Some(signer_workflow) = other.signer_workflow {
+            self.signer_workflow = Some(signer_workflow);
         }
     }
 }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -644,57 +644,51 @@ impl AquaBackend {
             return Ok(());
         }
 
-        // Check if this package expects attestations
-        let expects_attestations = pkg.github_artifact_attestations.is_some();
+        if let Some(github_attestations) = &pkg.github_artifact_attestations {
+            if github_attestations.enabled == Some(false) {
+                debug!("GitHub attestations verification is disabled for {tv}");
+                return Ok(());
+            }
 
-        if expects_attestations {
             ctx.pr.set_message("verify GitHub attestations".to_string());
-        }
 
-        let artifact_path = tv.download_path().join(filename);
+            let artifact_path = tv.download_path().join(filename);
 
-        // Use our new attestation verification library
-        let token = env::GITHUB_TOKEN.as_ref().cloned();
+            // Get expected workflow from registry
+            let signer_workflow = pkg
+                .github_artifact_attestations
+                .as_ref()
+                .and_then(|att| att.signer_workflow.clone());
 
-        // Get expected workflow from registry
-        let signer_workflow = pkg
-            .github_artifact_attestations
-            .as_ref()
-            .and_then(|att| att.signer_workflow.clone());
-
-        match sigstore_verification::verify_github_attestation(
-            &artifact_path,
-            &pkg.repo_owner,
-            &pkg.repo_name,
-            token.as_deref(),
-            signer_workflow.as_deref(),
-        )
-        .await
-        {
-            Ok(true) => {
-                ctx.pr
-                    .set_message("✓ GitHub attestations verified".to_string());
-                debug!("GitHub attestations verified successfully for {tv}");
-            }
-            Ok(false) => {
-                return Err(eyre!(
-                    "GitHub attestations verification returned false for {tv}"
-                ));
-            }
-            Err(sigstore_verification::AttestationError::NoAttestations) => {
-                if expects_attestations {
-                    // Package is configured to have attestations but none were found
+            match sigstore_verification::verify_github_attestation(
+                &artifact_path,
+                &pkg.repo_owner,
+                &pkg.repo_name,
+                env::GITHUB_TOKEN.as_deref(),
+                signer_workflow.as_deref(),
+            )
+            .await
+            {
+                Ok(true) => {
+                    ctx.pr
+                        .set_message("✓ GitHub attestations verified".to_string());
+                    debug!("GitHub attestations verified successfully for {tv}");
+                }
+                Ok(false) => {
+                    return Err(eyre!(
+                        "GitHub attestations verification returned false for {tv}"
+                    ));
+                }
+                Err(sigstore_verification::AttestationError::NoAttestations) => {
                     return Err(eyre!(
                         "No GitHub attestations found for {tv}, but attestations are expected per aqua registry configuration"
                     ));
-                } else {
-                    debug!("No GitHub attestations found for {tv}");
                 }
-            }
-            Err(e) => {
-                return Err(eyre!(
-                    "GitHub attestations verification failed for {tv}: {e}"
-                ));
+                Err(e) => {
+                    return Err(eyre!(
+                        "GitHub attestations verification failed for {tv}: {e}"
+                    ));
+                }
             }
         }
 


### PR DESCRIPTION
It's currently now used, but might be used in the future to ignore it.