### PR TITLE
fix(aqua): remove cosign.experimental

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -113,7 +113,6 @@ pub struct AquaCosignSignature {
 #[derive(Debug, Deserialize, Clone)]
 pub struct AquaCosign {
     pub enabled: Option<bool>,
-    pub experimental: Option<bool>,
     pub signature: Option<AquaCosignSignature>,
     pub key: Option<AquaCosignSignature>,
     pub certificate: Option<AquaCosignSignature>,
@@ -683,9 +682,6 @@ impl AquaCosign {
     fn merge(&mut self, other: Self) {
         if let Some(enabled) = other.enabled {
             self.enabled = Some(enabled);
-        }
-        if let Some(experimental) = other.experimental {
-            self.experimental = Some(experimental);
         }
         if let Some(signature) = other.signature.clone() {
             if self.signature.is_none() {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -812,32 +812,6 @@ impl AquaBackend {
                         }
                     }
                 }
-            } else if cosign.experimental == Some(true) {
-                // Keyless verification with experimental mode
-                // This would need to download the signature/bundle from a default location
-                let sig_or_bundle_path = checksum_path.with_extension("bundle");
-                if sig_or_bundle_path.exists() {
-                    match sigstore_verification::verify_cosign_signature(
-                        checksum_path,
-                        &sig_or_bundle_path,
-                    )
-                    .await
-                    {
-                        Ok(true) => {
-                            ctx.pr.set_message(
-                                "✓ Cosign keyless verification successful".to_string(),
-                            );
-                            debug!("Cosign keyless verification successful for {tv}");
-                        }
-                        Ok(false) => {
-                            return Err(eyre!("Cosign keyless verification failed for {tv}"));
-                        }
-                        Err(e) => {
-                            // If keyless fails, it might not have the bundle, which is OK
-                            debug!("Cosign keyless verification not available for {tv}: {e}");
-                        }
-                    }
-                }
             }
         }
         Ok(())


### PR DESCRIPTION
`cosign.experimental` was removed in https://github.com/aquaproj/aqua/pull/2757. No registries are using it.
The implementation for experimental in https://github.com/jdx/mise/pull/6332 is never used, so I believe it's fine to remove it.