### PR TITLE
feat(java): add support for Liberica NIK releases

### DIFF
--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -510,7 +510,7 @@ struct JavaMetadata {
     file_type: Option<String>,
     // filename: String,
     image_type: Option<String>,
-    // java_version: String,
+    java_version: String,
     jvm_impl: String,
     // os: String,
     // release_type: String,
@@ -541,6 +541,14 @@ impl Display for JavaMetadata {
         }
         if self.jvm_impl == "openj9" {
             v.push(self.jvm_impl.clone());
+        }
+        if self.vendor == "liberica-nik" {
+            let major = self
+                .java_version
+                .split('.')
+                .next()
+                .unwrap_or(&self.java_version);
+            v.push(format!("openjdk{}", major));
         }
         v.push(self.version.clone());
         write!(f, "{}", v.join("-"))


### PR DESCRIPTION
In preparation to add support for Java Liberica NIK (#6262) we need to add the `java_version` the build is based on.