### PR TITLE
fix(toolset): handle underflow in version_sub function

### DIFF
--- a/e2e/plugins/test_version_range
+++ b/e2e/plugins/test_version_range
@@ -12,3 +12,6 @@ assert "mise current tiny" "2.1.0"
 
 mise local tiny@sub-0.1:3.1
 assert "mise current tiny" "3.0.1"
+
+mise local tiny@sub-0.0.1:3.0.0
+assert "mise current tiny" "2.1.0"


### PR DESCRIPTION
Fix integer underflow when subtracting version components, ensuring sub-0.0.1:2.79.0 resolves to the previous version 2.78.0 instead of generating invalid version numbers.

Fixes: https://github.com/jdx/mise/discussions/6360