### PR TITLE
test(test-tool): uninstall all versions and clear cache before installation

### DIFF
--- a/e2e/cli/test_test_tool_clean
+++ b/e2e/cli/test_test_tool_clean
@@ -6,48 +6,45 @@ set -euxo pipefail
 echo "=== Test 1: Clean existing installations ==="
 
 # Install multiple versions first
-mise install tiny@2.0.0
-mise install tiny@3.1.0
+mise install shellcheck@0.9.0
+mise install shellcheck@0.10.0
 
 # Verify both versions are installed
-mise ls tiny | grep "2.0.0"
-mise ls tiny | grep "3.1.0"
-[ -d "$MISE_DATA_DIR/installs/tiny/2.0.0" ]
-[ -d "$MISE_DATA_DIR/installs/tiny/3.1.0" ]
+mise ls shellcheck | grep "0.9.0"
+mise ls shellcheck | grep "0.10.0"
+[ -d "$MISE_DATA_DIR/installs/shellcheck/0.9.0" ]
+[ -d "$MISE_DATA_DIR/installs/shellcheck/0.10.0" ]
 
 # Create a marker file to verify directories are cleaned
-touch "$MISE_DATA_DIR/installs/tiny/marker.txt"
-touch "$MISE_CACHE_DIR/tiny/marker.txt" 2>/dev/null || true
+touch "$MISE_DATA_DIR/installs/shellcheck/marker.txt"
+touch "$MISE_CACHE_DIR/shellcheck/marker.txt" 2>/dev/null || true
 
-# Run test-tool which should clean everything first
-# Note: tiny doesn't have a test definition so we need --include-non-defined
-# Also, the tool name is rtx-tiny not tiny, so the test will fail, but that's ok
-# We're only testing the cleaning behavior here
-mise test-tool tiny --include-non-defined 2>&1 | grep -E "(Removing|cleaning)" || true
+# Run test-tool which should clean everything first and succeed
+mise test-tool shellcheck
 
 # Verify the marker files are gone (directories were cleaned)
-if [ -f "$MISE_DATA_DIR/installs/tiny/marker.txt" ]; then
+if [ -f "$MISE_DATA_DIR/installs/shellcheck/marker.txt" ]; then
 	echo "ERROR: installs directory was not cleaned"
 	exit 1
 fi
 
-# Verify test-tool installed the latest version (even though the test itself failed)
-mise ls tiny | grep -E "3\.[0-9]+\.[0-9]+"
-[ -d "$MISE_DATA_DIR/installs/tiny" ]
+# Verify test-tool installed the latest version
+mise ls shellcheck | grep -E "0\.[0-9]+\.[0-9]+"
+[ -d "$MISE_DATA_DIR/installs/shellcheck" ]
 
 # Test 2: Verify cache directory is cleaned
 echo "=== Test 2: Cache directory cleaning ==="
 
 # Create cache content
-mkdir -p "$MISE_CACHE_DIR/tiny"
-echo "cached data" >"$MISE_CACHE_DIR/tiny/test.cache"
+mkdir -p "$MISE_CACHE_DIR/shellcheck"
+echo "cached data" >"$MISE_CACHE_DIR/shellcheck/test.cache"
 
-# Run test-tool again (allow it to fail since we're only testing cleaning)
-mise test-tool tiny --include-non-defined 2>&1 | grep -E "(Removing|cleaning)" || true
+# Run test-tool again
+mise test-tool shellcheck
 
 # Verify cache was cleaned and recreated
-[ -d "$MISE_CACHE_DIR/tiny" ]
-if [ -f "$MISE_CACHE_DIR/tiny/test.cache" ]; then
+[ -d "$MISE_CACHE_DIR/shellcheck" ]
+if [ -f "$MISE_CACHE_DIR/shellcheck/test.cache" ]; then
 	echo "ERROR: cache directory was not cleaned"
 	exit 1
 fi

--- a/e2e/cli/test_test_tool_clean
+++ b/e2e/cli/test_test_tool_clean
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Install a tool first
+mise install tiny@3.1.0
+
+# Verify it's installed
+mise ls tiny | grep "3.1.0"
+[ -d "$MISE_DATA_DIR/installs/tiny" ]
+[ -d "$MISE_CACHE_DIR/tiny" ]
+
+# Run test-tool which should clean everything first
+mise test-tool tiny
+
+# Verify the tool is still installed (test-tool should have reinstalled it)
+mise ls tiny | grep -E "3\.[0-9]+\.[0-9]+"
+
+# Install another version
+mise install tiny@2.0.0
+
+# Verify both versions are installed
+mise ls tiny | grep "2.0.0"
+mise ls tiny | grep "3"
+
+# Run test-tool again - it should uninstall all versions first
+mise test-tool tiny
+
+# Check that only the latest version remains
+versions_count=$(mise ls tiny | wc -l)
+if [ "$versions_count" -ne 1 ]; then
+	echo "ERROR: Expected only 1 version after test-tool, but found $versions_count"
+	mise ls tiny
+	exit 1
+fi
+
+# Verify latest version is installed
+mise ls tiny | grep -E "3\.[0-9]+\.[0-9]+"
+
+echo "Test passed: test-tool correctly uninstalls all versions before installing"

--- a/e2e/cli/test_test_tool_clean
+++ b/e2e/cli/test_test_tool_clean
@@ -2,39 +2,54 @@
 
 set -euxo pipefail
 
-# Install a tool first
-mise install tiny@3.1.0
+# Test 1: Verify test-tool cleans existing installations before running
+echo "=== Test 1: Clean existing installations ==="
 
-# Verify it's installed
-mise ls tiny | grep "3.1.0"
-[ -d "$MISE_DATA_DIR/installs/tiny" ]
-[ -d "$MISE_CACHE_DIR/tiny" ]
-
-# Run test-tool which should clean everything first
-mise test-tool tiny
-
-# Verify the tool is still installed (test-tool should have reinstalled it)
-mise ls tiny | grep -E "3\.[0-9]+\.[0-9]+"
-
-# Install another version
+# Install multiple versions first
 mise install tiny@2.0.0
+mise install tiny@3.1.0
 
 # Verify both versions are installed
 mise ls tiny | grep "2.0.0"
-mise ls tiny | grep "3"
+mise ls tiny | grep "3.1.0"
+[ -d "$MISE_DATA_DIR/installs/tiny/2.0.0" ]
+[ -d "$MISE_DATA_DIR/installs/tiny/3.1.0" ]
 
-# Run test-tool again - it should uninstall all versions first
-mise test-tool tiny
+# Create a marker file to verify directories are cleaned
+touch "$MISE_DATA_DIR/installs/tiny/marker.txt"
+touch "$MISE_CACHE_DIR/tiny/marker.txt" 2>/dev/null || true
 
-# Check that only the latest version remains
-versions_count=$(mise ls tiny | wc -l)
-if [ "$versions_count" -ne 1 ]; then
-	echo "ERROR: Expected only 1 version after test-tool, but found $versions_count"
-	mise ls tiny
+# Run test-tool which should clean everything first
+# Note: tiny doesn't have a test definition so we need --include-non-defined
+# Also, the tool name is rtx-tiny not tiny, so the test will fail, but that's ok
+# We're only testing the cleaning behavior here
+mise test-tool tiny --include-non-defined 2>&1 | grep -E "(Removing|cleaning)" || true
+
+# Verify the marker files are gone (directories were cleaned)
+if [ -f "$MISE_DATA_DIR/installs/tiny/marker.txt" ]; then
+	echo "ERROR: installs directory was not cleaned"
 	exit 1
 fi
 
-# Verify latest version is installed
+# Verify test-tool installed the latest version (even though the test itself failed)
 mise ls tiny | grep -E "3\.[0-9]+\.[0-9]+"
+[ -d "$MISE_DATA_DIR/installs/tiny" ]
 
-echo "Test passed: test-tool correctly uninstalls all versions before installing"
+# Test 2: Verify cache directory is cleaned
+echo "=== Test 2: Cache directory cleaning ==="
+
+# Create cache content
+mkdir -p "$MISE_CACHE_DIR/tiny"
+echo "cached data" >"$MISE_CACHE_DIR/tiny/test.cache"
+
+# Run test-tool again (allow it to fail since we're only testing cleaning)
+mise test-tool tiny --include-non-defined 2>&1 | grep -E "(Removing|cleaning)" || true
+
+# Verify cache was cleaned and recreated
+[ -d "$MISE_CACHE_DIR/tiny" ]
+if [ -f "$MISE_CACHE_DIR/tiny/test.cache" ]; then
+	echo "ERROR: cache directory was not cleaned"
+	exit 1
+fi
+
+echo "Test passed: test-tool correctly cleans all directories before installing"


### PR DESCRIPTION
## Summary
- Modified `mise test-tool` to uninstall all existing versions and clear cache before testing
- Added e2e test to verify the new behavior

## Details
This ensures a clean state when testing tools by:
- Uninstalling all existing versions of the tool
- Clearing the backend cache directory  
- Then performing a fresh installation and test

This helps ensure tests are reproducible and not affected by previous installations or cached data.

## Test plan
- [x] Added e2e test `test_test_tool_clean` to verify the cleanup behavior
- [x] Verified existing test-tool functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)