### PR TITLE
fix(devcontainer): fix cursor background agent startup

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,6 +3,19 @@
 # Setup script for mise development shim
 # This creates a shim that allows running mise via 'cargo run'
 
+echo "Ensuring Rust is up to date for edition 2024 support..."
+
+# Install rustup if not already installed
+if ! command -v rustup &> /dev/null; then
+    echo "Installing rustup..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+# Update to latest stable (1.83+ supports edition 2024)
+rustup update stable
+rustup default stable
+
 echo "Setting up mise development shim..."
 
 cat > /usr/local/bin/mise << 'EOF'
@@ -11,16 +24,35 @@ cat > /usr/local/bin/mise << 'EOF'
 # Mise development shim
 # This script allows running the development version of mise via 'cargo run'
 
-# Change to the mise project directory
-cd /workspaces/mise
+# Ensure cargo is in PATH
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Find the mise project directory - handle both /workspaces and /workspace
+if [ -d "/workspaces/mise" ]; then
+    MISE_DIR="/workspaces/mise"
+elif [ -d "/workspace" ]; then
+    MISE_DIR="/workspace"
+else
+    echo "Error: Could not find mise project directory"
+    exit 1
+fi
 
 # Run cargo with all arguments passed through
-exec cargo run -- "$@"
+# Using --manifest-path allows the command to work from any directory
+exec cargo run --all-features --manifest-path "$MISE_DIR/Cargo.toml" -- "$@"
 EOF
 
 chmod +x /usr/local/bin/mise
 
 echo "Mise development shim created at /usr/local/bin/mise"
-echo "You can now run 'mise' commands which will use 'cargo run' under the hood" 
+echo "You can now run 'mise' commands which will use 'cargo run' under the hood"
 
-mise --cd /workspaces/mise install
+# Install mise dependencies in the project directory
+echo "Installing mise dependencies..."
+if [ -d "/workspaces/mise" ]; then
+    cd /workspaces/mise && mise install
+elif [ -d "/workspace" ]; then
+    cd /workspace && mise install
+else
+    echo "Warning: Could not find project directory to install dependencies"
+fi


### PR DESCRIPTION
## Summary
- Fixed cursor background agent startup failure by updating devcontainer configuration
- Switched from nightly to stable Rust (1.83+ supports edition 2024)  
- Made mise shim work from any directory using --manifest-path

## Problem
The cursor background agent was failing to start with error:
```
feature `edition2024` is required
The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.82.0)
```

Also, the mise shim had path issues where it would fail with:
```
/usr/local/bin/mise: line 7: cd: /workspaces/mise: No such file or directory
```

## Solution
1. Updated to use stable Rust instead of requiring nightly (stable 1.83+ supports edition 2024)
2. Fixed the mise shim to use `--manifest-path` so it works from any directory
3. Added proper handling for both `/workspaces` and `/workspace` directory paths
4. Added `--all-features` flag to match development builds

## Test plan
- [ ] Build and run in cursor devcontainer
- [ ] Verify mise shim works from any directory
- [ ] Verify cargo build succeeds with edition 2024

🤖 Generated with [Claude Code](https://claude.ai/code)