### PR TITLE
registry: replace amplify-cli github backend with ubi

### DIFF
--- a/e2e/backend/test_ubi
+++ b/e2e/backend/test_ubi
@@ -36,13 +36,6 @@ EOF
 mise use ubi:kscripting/kscript@4.2.3
 assert_contains "mise x ubi:kscripting/kscript@4.2.3 -- which kscript" "/4.2.3/bin/kscript"
 
-cat <<EOF >mise.toml
-[tools]
-"ubi:aws-amplify/amplify-cli" = { version = "13.0.1", exe = "amplify-pkg", rename_exe = "amplify" }
-EOF
-mise use ubi:aws-amplify/amplify-cli@13.0.1
-assert_contains "mise x ubi:aws-amplify/amplify-cli@13.0.1 -- which amplify" "/13.0.1/amplify"
-
 MISE_USE_VERSIONS_HOST=0 assert_not_contains "mise ls-remote cargo-binstall" "binstalk"
 
 # the following tests that tool options from ubi are still retained even if the default backend changes to aqua

--- a/e2e/backend/test_ubi
+++ b/e2e/backend/test_ubi
@@ -36,6 +36,13 @@ EOF
 mise use ubi:kscripting/kscript@4.2.3
 assert_contains "mise x ubi:kscripting/kscript@4.2.3 -- which kscript" "/4.2.3/bin/kscript"
 
+cat <<EOF >mise.toml
+[tools]
+"ubi:aws-amplify/amplify-cli" = { version = "13.0.1", exe = "amplify-pkg", rename_exe = "amplify" }
+EOF
+mise use ubi:aws-amplify/amplify-cli@13.0.1
+assert_contains "mise x ubi:aws-amplify/amplify-cli@13.0.1 -- which amplify" "/13.0.1/amplify"
+
 MISE_USE_VERSIONS_HOST=0 assert_not_contains "mise ls-remote cargo-binstall" "binstalk"
 
 # the following tests that tool options from ubi are still retained even if the default backend changes to aqua

--- a/registry.toml
+++ b/registry.toml
@@ -246,7 +246,7 @@ test = ["auto-doc --help", "auto-doc [flags]"]
 [tools.aws-amplify]
 aliases = ["amplify"]
 backends = [
-  "github:aws-amplify/amplify-cli[exe=amplify]",
+  "ubi:aws-amplify/amplify-cli[exe=amplify-pkg,rename_exe=amplify]",
   "asdf:LozanoMatheus/asdf-aws-amplify-cli",
 ]
 description = "The AWS Amplify CLI is a toolchain for simplifying serverless web and mobile development"

--- a/registry.toml
+++ b/registry.toml
@@ -250,6 +250,7 @@ backends = [
   "asdf:LozanoMatheus/asdf-aws-amplify-cli",
 ]
 description = "The AWS Amplify CLI is a toolchain for simplifying serverless web and mobile development"
+test = ["amplify --version", "{{version}}"]
 
 [tools.aws-cli]
 aliases = ["aws", "awscli"]


### PR DESCRIPTION
Currently, `mise use amplify-cli` installs `amplify-pkg-macos` / `amplify-pkg-linux` / `amplify-pkg-linux-arm64` instead of `amplify`.

Therefore, I modified it to be renamed to `amplify`.