### PR TITLE
chore: release 2025.9.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [2025.9.18](https://github.com/jdx/mise/compare/v2025.9.17..v2025.9.18) - 2025-09-24
+
+### 📦 Registry
+
+- replace amplify-cli github backend with ubi by @eggplants in [#6396](https://github.com/jdx/mise/pull/6396)
+
+### 🚀 Features
+
+- **(template)** add read_file() function by @jdx in [#6400](https://github.com/jdx/mise/pull/6400)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** support github_artifact_attestations.enabled by @risu729 in [#6372](https://github.com/jdx/mise/pull/6372)
+- use /c instead of -c on windows in postinstall hook by @risu729 in [#6397](https://github.com/jdx/mise/pull/6397)
+
+### 🧪 Testing
+
+- **(test-tool)** uninstall all versions and clear cache before installation by @jdx in [#6393](https://github.com/jdx/mise/pull/6393)
+
+### New Contributors
+
+- @eggplants made their first contribution in [#6396](https://github.com/jdx/mise/pull/6396)
+
 ## [2025.9.17](https://github.com/jdx/mise/compare/v2025.9.16..v2025.9.17) - 2025-09-24
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.9.17"
+version = "2025.9.18"
 dependencies = [
  "aqua-registry",
  "async-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox", "crates/aqua-registry"]
 
 [package]
 name = "mise"
-version = "2025.9.17"
+version = "2025.9.18"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.9.17 macos-arm64 (a1b2d3e 2025-09-24)
+2025.9.18 macos-arm64 (a1b2d3e 2025-09-24)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,11 @@ _mise() {
     zstyle ":completion:${curcontext}:" cache-policy _usage_mise_cache_policy
   fi
 
-  if ( [[ -z "${_usage_spec_mise_2025_9_17:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_17 ) \
-      && ! _retrieve_cache _usage_spec_mise_2025_9_17;
+  if ( [[ -z "${_usage_spec_mise_2025_9_18:-}" ]] || _cache_invalid _usage_spec_mise_2025_9_18 ) \
+      && ! _retrieve_cache _usage_spec_mise_2025_9_18;
   then
     spec="$(mise usage)"
-    _store_cache _usage_spec_mise_2025_9_17 spec
+    _store_cache _usage_spec_mise_2025_9_18 spec
   fi
 
   _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -6,14 +6,14 @@ _mise() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mise_2025_9_17:-} ]]; then
-        _usage_spec_mise_2025_9_17="$(mise usage)"
+    if [[ -z ${_usage_spec_mise_2025_9_18:-} ]]; then
+        _usage_spec_mise_2025_9_18="$(mise usage)"
     fi
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_17}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mise_2025_9_18}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -6,12 +6,12 @@ if ! command -v usage &> /dev/null
     return 1
 end
 
-if ! set -q _usage_spec_mise_2025_9_17
-  set -g _usage_spec_mise_2025_9_17 (mise usage | string collect)
+if ! set -q _usage_spec_mise_2025_9_18
+  set -g _usage_spec_mise_2025_9_18 (mise usage | string collect)
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_17" -- (commandline -xpc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_18" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_17" -- (commandline -opc) (commandline -t))'
+    complete -xc mise -a '(usage complete-word --shell fish -s "$_usage_spec_mise_2025_9_18" -- (commandline -opc) (commandline -t))'
 end

--- a/crates/aqua-registry/aqua-registry/pkgs/Adembc/lazyssh/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/Adembc/lazyssh/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Adembc
+    repo_name: lazyssh
+    description: "A terminal-based SSH manager inspired by lazydocker and k9s - Written in go"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: lazyssh_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/crates/aqua-registry/aqua-registry/pkgs/CyberAgent/reminder-lint/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/CyberAgent/reminder-lint/registry.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: CyberAgent
+    repo_name: reminder-lint
+    description: Code remind tool for any languages and any config files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: reminder-lint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        files:
+          - name: reminder-lint
+            src: "{{.AssetWithoutExt}}/reminder-lint"
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: reminder-lint
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/crates/aqua-registry/aqua-registry/pkgs/bmf-san/ggc/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/bmf-san/ggc/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: bmf-san
+    repo_name: ggc
+    description: A modern Git CLI tool with both traditional command-line and interactive incremental-search UI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 3.2.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: ggc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ggc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/crates/aqua-registry/aqua-registry/pkgs/docker/cagent/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/docker/cagent/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: docker
+    repo_name: cagent
+    description: Agent Builder and Runtime by Docker Engineering
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.3.4")
+        asset: cagent-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+      - version_constraint: "true"
+        asset: cagent-{{.OS}}-{{.Arch}}
+        format: raw

--- a/crates/aqua-registry/aqua-registry/pkgs/sibprogrammer/xq/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/sibprogrammer/xq/registry.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sibprogrammer
+    repo_name: xq
+    description: Command-line XML and HTML beautifier and content extractor
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.2.0"
+        asset: xq_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 1.1.4")
+        asset: xq_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: xq_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/crates/aqua-registry/aqua-registry/pkgs/wakatara/harsh/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/wakatara/harsh/registry.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: wakatara
+    repo_name: harsh
+    description: Habit tracking for geeks. A minimalist, command line tool for tracking and understanding your habits
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.7")
+        asset: harsh_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.8.10")
+        asset: harsh_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: harsh_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.9.17";
+  version = "2025.9.18";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "19.4k",
+      stars: "19.5k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.9.17
+Version: 2025.9.18
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 📦 Registry

- replace amplify-cli github backend with ubi by @eggplants in [#6396](https://github.com/jdx/mise/pull/6396)

### 🚀 Features

- **(template)** add read_file() function by @jdx in [#6400](https://github.com/jdx/mise/pull/6400)

### 🐛 Bug Fixes

- **(aqua)** support github_artifact_attestations.enabled by @risu729 in [#6372](https://github.com/jdx/mise/pull/6372)
- use /c instead of -c on windows in postinstall hook by @risu729 in [#6397](https://github.com/jdx/mise/pull/6397)

### 🧪 Testing

- **(test-tool)** uninstall all versions and clear cache before installation by @jdx in [#6393](https://github.com/jdx/mise/pull/6393)

### New Contributors

- @eggplants made their first contribution in [#6396](https://github.com/jdx/mise/pull/6396)