### PR TITLE
feat(template): add read_file() function

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -175,12 +175,19 @@ Mise offers additional functions:
 - `choice(n, alphabet)` - Generate a string of `n` with random sample with replacement
   of `alphabet`. For example, `choice(64, HEX)` will generate a random
   64-character lowercase hex string.
+- `read_file(path) -> String` – Reads the contents of a file at the given path and returns
+  it as a string.
 
-An example of function using `exec`:
+Examples of functions:
 
 ```toml
+# Using exec to get command output
 [alias.node.versions]
 current = "{{ exec(command='node --version') }}"
+
+# Using read_file to include content from a file
+[env]
+VERSION = "{{ read_file(path='VERSION') | trim }}"
 ```
 
 ### Exec Options

--- a/e2e/env/test_env_template_read_file
+++ b/e2e/env/test_env_template_read_file
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+# Test basic read_file functionality
+cat <<EOF >test_version.txt
+1.2.3
+EOF
+
+cat <<EOF >mise.toml
+[env]
+VERSION = "{{ read_file(path='test_version.txt') | trim }}"
+EOF
+
+assert_contains "mise env -s bash | grep VERSION" "export VERSION=1.2.3"
+
+# Test read_file with relative path
+mkdir -p subdir
+cat <<EOF >subdir/info.txt
+test-content
+EOF
+
+cat <<EOF >mise.toml
+[env]
+CONTENT = "{{ read_file(path='subdir/info.txt') | trim }}"
+EOF
+
+assert_contains "mise env -s bash | grep CONTENT" "export CONTENT=test-content"
+
+# Test read_file with multiple lines
+cat <<EOF >multiline.txt
+line1
+line2
+line3
+EOF
+
+cat <<EOF >mise.toml
+[env]
+MULTILINE = "{{ read_file(path='multiline.txt') | replace(from='\n', to=' ') | trim }}"
+EOF
+
+assert_contains "mise env -s bash | grep MULTILINE" "export MULTILINE='line1 line2 line3'"
+
+# Test read_file with vars
+cat <<EOF >config.txt
+production
+EOF
+
+cat <<EOF >mise.toml
+[vars]
+CONFIG_FILE = "config.txt"
+
+[env]
+ENVIRONMENT = "{{ read_file(path=vars.CONFIG_FILE) | trim }}"
+EOF
+
+assert_contains "mise env -s bash | grep ENVIRONMENT" "export ENVIRONMENT=production"
+
+# Test read_file with templated content (should read raw content)
+cat <<EOF >template_test.txt
+{{ env.USER }}
+EOF
+
+cat <<EOF >mise.toml
+[env]
+RAW_CONTENT = "{{ read_file(path='template_test.txt') | trim }}"
+EOF
+
+assert_contains "mise env -s bash | grep RAW_CONTENT" "export RAW_CONTENT='{{ env.USER }}'"
+
+# Test read_file is relative to config_root (not CWD)
+mkdir -p project/config
+cat <<EOF >project/config/version.txt
+2.0.0
+EOF
+
+cat <<EOF >project/config/mise.toml
+[env]
+PROJECT_VERSION = "{{ read_file(path='version.txt') | trim }}"
+EOF
+
+# Save current directory
+ORIG_DIR=$PWD
+
+# Run mise from a different directory to verify read_file is relative to config_root
+cd /tmp
+assert_contains "mise env -s bash -C $ORIG_DIR/project/config | grep PROJECT_VERSION" "export PROJECT_VERSION=2.0.0"
+cd "$ORIG_DIR"
+
+# Test nested config with read_file relative to its own directory
+mkdir -p project/sub
+cat <<EOF >project/data.txt
+parent-data
+EOF
+cat <<EOF >project/sub/data.txt
+sub-data
+EOF
+
+cat <<EOF >project/mise.toml
+[env]
+PARENT_DATA = "{{ read_file(path='data.txt') | trim }}"
+EOF
+
+cat <<EOF >project/sub/mise.toml
+[env]
+SUB_DATA = "{{ read_file(path='data.txt') | trim }}"
+EOF
+
+# Check from parent directory
+assert_contains "mise env -s bash -C project | grep PARENT_DATA" "export PARENT_DATA=parent-data"
+
+# Check from sub directory (should use sub's data.txt)
+assert_contains "mise env -s bash -C project/sub | grep SUB_DATA" "export SUB_DATA=sub-data"
+
+# Cleanup
+rm -f test_version.txt multiline.txt config.txt template_test.txt
+rm -rf subdir project

--- a/e2e/env/test_env_template_read_file
+++ b/e2e/env/test_env_template_read_file
@@ -68,48 +68,51 @@ EOF
 assert_contains "mise env -s bash | grep RAW_CONTENT" "export RAW_CONTENT='{{ env.USER }}'"
 
 # Test read_file is relative to config_root (not CWD)
-mkdir -p project/config
-cat <<EOF >project/config/version.txt
-2.0.0
-EOF
+# Create a nested project structure with config files at different levels
+TEST_ROOT=$PWD
+mkdir -p project/subdir
+cd project
 
-cat <<EOF >project/config/mise.toml
+# Create version files at each level
+echo "1.0.0" >version.txt
+echo "2.0.0" >subdir/version.txt
+
+# Create a data file only in parent
+echo "parent-only-data" >parent-data.txt
+
+# Create mise.toml in parent directory
+cat <<EOF >mise.toml
 [env]
-PROJECT_VERSION = "{{ read_file(path='version.txt') | trim }}"
+PARENT_VERSION = "{{ read_file(path='version.txt') | trim }}"
+PARENT_DATA = "{{ read_file(path='parent-data.txt') | trim }}"
 EOF
 
-# Save current directory
-ORIG_DIR=$PWD
+# Create mise.toml in subdirectory that reads its own version.txt
+cat <<EOF >subdir/mise.toml
+[env]
+SUB_VERSION = "{{ read_file(path='version.txt') | trim }}"
+# This should fail if uncommented - file doesn't exist relative to subdir:
+# SUB_PARENT_DATA = "{{ read_file(path='parent-data.txt') | trim }}"
+EOF
 
-# Run mise from a different directory to verify read_file is relative to config_root
+# Test from parent directory - should read parent's version.txt (1.0.0)
+assert_contains "mise env -s bash | grep PARENT_VERSION" "export PARENT_VERSION=1.0.0"
+assert_contains "mise env -s bash | grep PARENT_DATA" "export PARENT_DATA=parent-only-data"
+
+# Test from subdirectory - should read both configs, each with their own files
+cd subdir
+assert_contains "mise env -s bash | grep PARENT_VERSION" "export PARENT_VERSION=1.0.0"
+assert_contains "mise env -s bash | grep SUB_VERSION" "export SUB_VERSION=2.0.0"
+assert_contains "mise env -s bash | grep PARENT_DATA" "export PARENT_DATA=parent-only-data"
+
+# Now test that running mise from a completely different directory still works
+PROJECT_DIR=$TEST_ROOT/project
 cd /tmp
-assert_contains "mise env -s bash -C $ORIG_DIR/project/config | grep PROJECT_VERSION" "export PROJECT_VERSION=2.0.0"
-cd "$ORIG_DIR"
+assert_contains "mise env -s bash -C $PROJECT_DIR | grep PARENT_VERSION" "export PARENT_VERSION=1.0.0"
+assert_contains "mise env -s bash -C $PROJECT_DIR/subdir | grep SUB_VERSION" "export SUB_VERSION=2.0.0"
 
-# Test nested config with read_file relative to its own directory
-mkdir -p project/sub
-cat <<EOF >project/data.txt
-parent-data
-EOF
-cat <<EOF >project/sub/data.txt
-sub-data
-EOF
-
-cat <<EOF >project/mise.toml
-[env]
-PARENT_DATA = "{{ read_file(path='data.txt') | trim }}"
-EOF
-
-cat <<EOF >project/sub/mise.toml
-[env]
-SUB_DATA = "{{ read_file(path='data.txt') | trim }}"
-EOF
-
-# Check from parent directory
-assert_contains "mise env -s bash -C project | grep PARENT_DATA" "export PARENT_DATA=parent-data"
-
-# Check from sub directory (should use sub's data.txt)
-assert_contains "mise env -s bash -C project/sub | grep SUB_DATA" "export SUB_DATA=sub-data"
+# Go back to original test directory
+cd "$TEST_ROOT"
 
 # Cleanup
 rm -f test_version.txt multiline.txt config.txt template_test.txt

--- a/mise.lock
+++ b/mise.lock
@@ -113,6 +113,11 @@ checksum = "blake3:dbfd6f2b7d0f399f6ec8cd251a76656c27af25aa327c015ef1acf4307c6a4
 size = 6984984
 url = "https://github.com/jdx/hk/releases/download/v1.15.5/hk-x86_64-unknown-linux-gnu.tar.gz"
 
+[tools.hk.platforms.macos-arm64]
+checksum = "blake3:98c9e44790bcff4b4988e6a13f9524272164e98fd475dc43f364cfb41bb4e897"
+size = 6016496
+url = "https://github.com/jdx/hk/releases/download/v1.15.5/hk-aarch64-apple-darwin.tar.gz"
+
 [[tools.jq]]
 version = "1.8.1"
 backend = "aqua:jqlang/jq"


### PR DESCRIPTION
## Summary
- Add a new template function `read_file(path)` that reads file contents relative to config_root
- Files are read relative to the directory containing the mise.toml file, not the current working directory
- Returns raw file contents as a string that can be processed with filters

## Use Case
This allows configuration files to dynamically include content from external files during template rendering. For example:
- Reading version numbers from a VERSION file
- Including configuration from separate files
- Loading environment-specific settings

## Example Usage
```toml
[env]
VERSION = "{{ read_file(path='VERSION') | trim }}"
CONFIG = "{{ read_file(path='config/production.txt') | trim }}"
```

## Test Plan
- [x] Added unit test for the new function
- [x] Added comprehensive e2e tests covering:
  - Basic file reading
  - Relative paths
  - Multi-line content
  - Path resolution relative to config_root (not CWD)
  - Nested configurations with their own relative paths

🤖 Generated with [Claude Code](https://claude.ai/code)