### PR TITLE
fix: allow strip_archive_path_components to strip a dir containing the same filename

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -820,7 +820,10 @@ fn strip_archive_path_components(dir: &Path, strip_depth: usize) -> Result<()> {
         }
 
         // rename the directory to a temp name to avoid conflicts when moving files
-        let temp_path = path.with_extension("tmp_strip");
+        let temp_path = path.with_file_name(format!(
+            "{}_tmp_strip",
+            path.file_name().unwrap().to_string_lossy()
+        ));
         fs::rename(&path, &temp_path)?;
 
         for entry in ls(&temp_path)? {

--- a/src/file.rs
+++ b/src/file.rs
@@ -827,9 +827,13 @@ fn strip_archive_path_components(dir: &Path, strip_depth: usize) -> Result<()> {
         fs::rename(&path, &temp_path)?;
 
         for entry in ls(&temp_path)? {
-            let dest_path = dir.join(entry.file_name().unwrap());
-            fs::rename(entry, dest_path)?;
-        }
+            if let Some(file_name) = entry.file_name() {
+                let dest_path = dir.join(file_name);
+                fs::rename(entry, dest_path)?;
+            } else {
+                // Skip entries with no file name (e.g., paths ending in `..`)
+                continue;
+            }
 
         remove_dir(temp_path)?;
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -833,6 +833,7 @@ fn strip_archive_path_components(dir: &Path, strip_depth: usize) -> Result<()> {
             } else {
                 continue;
             }
+        }
 
         remove_dir(temp_path)?;
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -831,7 +831,6 @@ fn strip_archive_path_components(dir: &Path, strip_depth: usize) -> Result<()> {
                 let dest_path = dir.join(file_name);
                 fs::rename(entry, dest_path)?;
             } else {
-                // Skip entries with no file name (e.g., paths ending in `..`)
                 continue;
             }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -813,22 +813,22 @@ fn strip_archive_path_components(dir: &Path, strip_depth: usize) -> Result<()> {
     }
 
     let top_level_paths = ls(dir)?;
-    let entries: Vec<PathBuf> = top_level_paths
-        .iter()
-        .map(|p| ls(p))
-        .collect::<Result<Vec<_>>>()?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
-    for entry in entries {
-        let mut new_dir = dir.to_path_buf();
-        new_dir.push(entry.file_name().unwrap());
-        fs::rename(entry, new_dir)?;
-    }
+
     for path in top_level_paths {
-        if path.symlink_metadata()?.is_dir() {
-            remove_dir(path)?;
+        if !path.symlink_metadata()?.is_dir() {
+            continue;
         }
+
+        // rename the directory to a temp name to avoid conflicts when moving files
+        let temp_path = path.with_extension("tmp_strip");
+        fs::rename(&path, &temp_path)?;
+
+        for entry in ls(&temp_path)? {
+            let dest_path = dir.join(entry.file_name().unwrap());
+            fs::rename(entry, dest_path)?;
+        }
+
+        remove_dir(temp_path)?;
     }
     Ok(())
 }


### PR DESCRIPTION
`mv .../age-plugin-yubikey/age-plugin-yubikey .../age-plugin-yubikey` fails, so we need to rename the dir before moving the file.