### PR TITLE
registry: revert opam/k3kcli backends to ubi

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2354,8 +2354,9 @@ description = "Little helper to run CNCF's k3s in Docker"
 test = ["k3d --version", "k3d version v{{version}}"]
 
 [tools.k3kcli]
-backends = ['github:rancher/k3k[tag_regex=v\d]', "asdf:xanmanning/asdf-k3kcli"]
+backends = ['ubi:rancher/k3k[tag_regex=v\d]', "asdf:xanmanning/asdf-k3kcli"]
 description = "K3k, Kubernetes in Kubernetes, is a tool that empowers you to create and manage isolated K3s clusters within your existing Kubernetes environment"
+test = ["k3k version", "k3k version {{version}}"]
 
 [tools.k3s]
 backends = ["asdf:mise-plugins/mise-k3s"]

--- a/registry.toml
+++ b/registry.toml
@@ -3217,8 +3217,9 @@ backends = ["aqua:open-policy-agent/opa", "asdf:tochukwuvictor/asdf-opa"]
 description = "Open Policy Agent (OPA) is an open source, general-purpose policy engine"
 
 [tools.opam]
-backends = ["github:ocaml/opam", "asdf:asdf-community/asdf-opam"]
+backends = ["ubi:ocaml/opam", "asdf:asdf-community/asdf-opam"]
 description = "(ocaml) opam is a source-based package manager. It supports multiple simultaneous compiler installations, flexible package constraints, and a Git-friendly development workflow"
+test = ["opam --version", "{{version}}"]
 
 [tools.openbao]
 backends = ["github:openbao/openbao[exe=bao]"]

--- a/registry.toml
+++ b/registry.toml
@@ -2362,7 +2362,8 @@ test = ["k3d --version", "k3d version v{{version}}"]
 [tools.k3kcli]
 backends = ['ubi:rancher/k3k[tag_regex=v\d]', "asdf:xanmanning/asdf-k3kcli"]
 description = "K3k, Kubernetes in Kubernetes, is a tool that empowers you to create and manage isolated K3s clusters within your existing Kubernetes environment"
-test = ["k3k version", "k3k version {{version}}"]
+# TODO: enable tests after versions host update
+# test = ["k3k version", "k3k version {{version}}"]
 
 [tools.k3s]
 backends = ["asdf:mise-plugins/mise-k3s"]


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/6402.

Neither works with the GitHub backend because the releases have archives, but we need to download non-archive files.
https://github.com/ocaml/opam/releases/tag/2.4.1
https://github.com/rancher/k3k/releases/tag/v0.3.4

We should fix it, but I don't have a good idea how to fix it.
Maybe we can only exclude small non-archive files (text files) when archive files exist, but I think this also causes some bugs.