### PR TITLE
feat(github): filter remote versions by version_prefix

### DIFF
--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -62,7 +62,7 @@ Specifies a custom version prefix for release tags. By default, mise handles the
 
 When `version_prefix` is configured, mise will:
 
-- Strip the prefix when listing available versions
+- Filter available versions with the prefix and strip it
 - Add the prefix when searching for releases
 - Try both prefixed and non-prefixed versions during installation
 

--- a/docs/dev-tools/backends/gitlab.md
+++ b/docs/dev-tools/backends/gitlab.md
@@ -63,7 +63,7 @@ Specifies a custom version prefix for release tags. By default, mise handles the
 
 When `version_prefix` is configured, mise will:
 
-- Strip the prefix when listing available versions
+- Filter available versions with the prefix and strip it
 - Add the prefix when searching for releases
 - Try both prefixed and non-prefixed versions during installation
 

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -45,6 +45,10 @@ impl Backend for UnifiedGitBackend {
             let releases = gitlab::list_releases_from_url(api_url.as_str(), &repo).await?;
             Ok(releases
                 .into_iter()
+                .filter(|r| {
+                    opts.get("version_prefix")
+                        .map_or(true, |p| r.tag_name.starts_with(p))
+                })
                 .map(|r| self.strip_version_prefix(&r.tag_name))
                 .rev()
                 .collect())
@@ -52,6 +56,10 @@ impl Backend for UnifiedGitBackend {
             let releases = github::list_releases_from_url(api_url.as_str(), &repo).await?;
             Ok(releases
                 .into_iter()
+                .filter(|r| {
+                    opts.get("version_prefix")
+                        .map_or(true, |p| r.tag_name.starts_with(p))
+                })
                 .map(|r| self.strip_version_prefix(&r.tag_name))
                 .rev()
                 .collect())

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -47,7 +47,7 @@ impl Backend for UnifiedGitBackend {
                 .into_iter()
                 .filter(|r| {
                     opts.get("version_prefix")
-                        .map_or(true, |p| r.tag_name.starts_with(p))
+                        .is_none_or(|p| r.tag_name.starts_with(p))
                 })
                 .map(|r| self.strip_version_prefix(&r.tag_name))
                 .rev()
@@ -58,7 +58,7 @@ impl Backend for UnifiedGitBackend {
                 .into_iter()
                 .filter(|r| {
                     opts.get("version_prefix")
-                        .map_or(true, |p| r.tag_name.starts_with(p))
+                        .is_none_or(|p| r.tag_name.starts_with(p))
                 })
                 .map(|r| self.strip_version_prefix(&r.tag_name))
                 .rev()


### PR DESCRIPTION
This is to fix `bitwarden-secrets-manager` in the registry.
https://github.com/jdx/mise-versions/blob/main/docs/bitwarden-secrets-manager

I believe this is okay for most cases, and this matches with `tag_regex` behaviour in the ubi backend.