### PR TITLE
fix(backend): make pre-tools env vars available in postinstall hooks

### DIFF
--- a/e2e/config/test_hooks_postinstall_env
+++ b/e2e/config/test_hooks_postinstall_env
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Test that postinstall hooks have access to pre_tools environment variables
+
+# Create a mise.toml with env vars that should be available before tools
+cat <<EOF >mise.toml
+[env]
+# Environment variable without tools=true (should be available in postinstall)
+PRE_TOOLS_VAR = "available_before_tools"
+
+# Environment variable explicitly with tools=false
+EXPLICIT_PRE_TOOLS = {value = "explicitly_pre_tools", tools = false}
+
+# Environment variable with tools=true (should NOT be available in postinstall)
+POST_TOOLS_VAR = {value = "available_after_tools", tools = true}
+
+[tools]
+dummy = { version = "latest", postinstall = "echo PRE_TOOLS_VAR=\$PRE_TOOLS_VAR; echo EXPLICIT_PRE_TOOLS=\$EXPLICIT_PRE_TOOLS; echo POST_TOOLS_VAR=\$POST_TOOLS_VAR" }
+EOF
+
+# Remove any existing dummy installation to force reinstall
+rm -rf ~/.mise/installs/dummy
+
+# Run install and capture output
+output=$(mise install dummy 2>&1)
+
+# Check that pre_tools environment variables are available in postinstall
+if [[ $output == *"PRE_TOOLS_VAR=available_before_tools"* ]]; then
+	echo "✓ PRE_TOOLS_VAR is available in postinstall"
+else
+	echo "✗ PRE_TOOLS_VAR is NOT available in postinstall"
+	echo "Output: $output"
+	exit 1
+fi
+
+if [[ $output == *"EXPLICIT_PRE_TOOLS=explicitly_pre_tools"* ]]; then
+	echo "✓ EXPLICIT_PRE_TOOLS is available in postinstall"
+else
+	echo "✗ EXPLICIT_PRE_TOOLS is NOT available in postinstall"
+	echo "Output: $output"
+	exit 1
+fi
+
+# The post_tools var should be empty since it's marked as tools=true
+if [[ $output == *"POST_TOOLS_VAR="* ]]; then
+	echo "✓ POST_TOOLS_VAR is empty as expected"
+else
+	echo "✗ POST_TOOLS_VAR is not empty"
+	echo "Output: $output"
+	exit 1
+fi
+
+# Verify that POST_TOOLS_VAR with tools=true is NOT available in postinstall hook
+if [[ $output != *"POST_TOOLS_VAR=available_after_tools"* ]]; then
+	echo "✓ POST_TOOLS_VAR with tools=true is not available as expected"
+else
+	echo "✗ POST_TOOLS_VAR with tools=true should not be available"
+	echo "Output: $output"
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- Fixed an issue where postinstall hooks could not access pre-tools environment variables
- Environment variables defined with `tools=false` (or without the `tools` parameter) are now available in postinstall hooks
- Added e2e test to verify the behavior

## Problem
Tool postinstall hooks were only receiving `exec_env` from the backend, which was typically empty. This meant that environment variables defined in `mise.toml` were not available during the postinstall phase, even if they were marked as pre-tools variables (not dependent on tools being loaded).

## Solution
Modified `run_postinstall_hook` in `src/backend/mod.rs` to include pre-tools environment variables from the config. The function now:
1. Gets the exec_env as before
2. Adds pre-tools environment variables from `ctx.config.env_maybe()`
3. Passes the combined environment to the postinstall script

## Test plan
- [x] Added e2e test `test_hooks_postinstall_env` that verifies:
  - Pre-tools environment variables are available in postinstall hooks
  - Environment variables with `tools=true` are NOT available (as expected)
- [x] All existing tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)