### PR TITLE
fix(task): prevent hang when nested tasks fail

### DIFF
--- a/e2e/tasks/test_task_failure_hang
+++ b/e2e/tasks/test_task_failure_hang
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# https://github.com/jdx/mise/discussions/6391
+
+cat <<EOF >mise.toml
+[tasks.fails]
+run = '''
+sleep 1;
+echo "An error occurred!"
+exit 1;
+'''
+
+[tasks.deponfails]
+depends = ["fails"]
+run = 'echo "This will not run because the dependency fails."'
+
+[tasks.grouped]
+run = [
+    { task = "deponfails" }
+]
+EOF
+
+# Test that task failure with dependencies does not hang
+timeout 5s mise run grouped 2>&1 && exit_code=0 || exit_code=$?
+
+# Check if it was a timeout (exit code 124)
+if [ "$exit_code" -eq 124 ]; then
+	echo "FAIL: Task hung after dependency failure (timeout reached)"
+	exit 1
+fi
+
+# The command should fail with exit code 1
+if [ "$exit_code" -ne 1 ]; then
+	echo "Expected exit code 1, got $exit_code"
+	exit 1
+fi
+
+echo "Test passed: task with failing dependency did not hang"


### PR DESCRIPTION
## Summary
Fixes task execution hanging when nested or dependent tasks fail.

## Problem
When a task failed within a sequence of tasks (especially nested or dependent tasks), mise would hang indefinitely instead of properly exiting with an error. This was reported in https://github.com/jdx/mise/discussions/6391.

## Root Cause
The `inject_and_wait` function was waiting for a completion signal from the dependency graph that would never come. When a task failed:
1. The scheduler would stop spawning new dependent tasks
2. The dependency graph would never become empty (dependent tasks remained in the graph)
3. The `done` signal was never sent because the graph wasn't empty
4. The function would hang forever waiting for the signal

## Solution
Modified the `inject_and_wait` function to:
1. Periodically check if task execution should stop due to failure (every 100ms)
2. When a failure is detected and `continue_on_error` is false, clean up the dependency graph by removing all remaining tasks
3. This triggers the completion signal and allows the function to exit properly with an error

## Test plan
- Added e2e test `test_task_failure_hang` that reproduces the issue
- Test verifies that mise exits with error code 1 instead of hanging when a dependency fails
- All existing task tests pass

Fixes: https://github.com/jdx/mise/discussions/6391

🤖 Generated with [Claude Code](https://claude.ai/code)