### PR TITLE
registry: fix hivemind

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2074,7 +2074,11 @@ backends = ["github:ddworken/hishtory", "asdf:asdf-community/asdf-hishtory"]
 description = "Your shell history: synced, queryable, and in context"
 
 [tools.hivemind]
-backends = ["ubi:DarthSim/hivemind", "github:DarthSim/hivemind", "go:github.com/DarthSim/hivemind"]
+backends = [
+  "ubi:DarthSim/hivemind",
+  "github:DarthSim/hivemind",
+  "go:github.com/DarthSim/hivemind",
+]
 description = "Process manager for Procfile-based applications"
 test = ["hivemind --version", "Hivemind version {{version}}"]
 


### PR DESCRIPTION
Currently `hivemind` is failing to install with the latest mise version:

```
  mise ERROR Failed to install github:DarthSim/hivemind@1.1.0:
     0: failed to extract tar: ~/.local/share/mise/downloads/hivemind/1.1.0/hivemind-v1.1.0-linux-amd64.gz to ~/.local/share/mise/installs/hivemind/1.1.0
     1: numeric field was not a number:  when getting cksum for ELF
```

Not sure why the `github:` backend is failing but defaulting to using ubi for hivemind instead seems to work fine.

Tests:

```
$ cargo run --bin mise -- install hivemind
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/mise install hivemind`
mise Installed executable into /Users/mnm/.local/share/mise/installs/hivemind/1.1.0/hivemind
$ cargo run --bin mise -- tool hivemind
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45s
     Running `target/debug/mise tool hivemind`
Backend:            ubi:DarthSim/hivemind
Installed Versions: 1.1.0
Tool Options:       [none]
$ cargo run --bin mise -- uninstall hivemind
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.48s
     Running `target/debug/mise uninstall hivemind`
```