### PR TITLE
feat(cli): add mise cache path command

### DIFF
--- a/docs/cli/cache.md
+++ b/docs/cli/cache.md
@@ -10,4 +10,5 @@ Run `mise cache` with no args to view the current cache directory.
 ## Subcommands
 
 - [`mise cache clear [PLUGIN]…`](/cli/cache/clear.md)
+- [`mise cache path`](/cli/cache/path.md)
 - [`mise cache prune [--dry-run] [-v --verbose…] [PLUGIN]…`](/cli/cache/prune.md)

--- a/docs/cli/cache/path.md
+++ b/docs/cli/cache/path.md
@@ -1,0 +1,7 @@
+# `mise cache path`
+
+- **Usage**: `mise cache path`
+- **Aliases**: `dir`
+- **Source code**: [`src/cli/cache/path.rs`](https://github.com/jdx/mise/blob/main/src/cli/cache/path.rs)
+
+Show the cache directory path

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -69,6 +69,7 @@ Can also use `MISE_NO_CONFIG=1`
 - [`mise bin-paths [TOOL@VERSION]…`](/cli/bin-paths.md)
 - [`mise cache <SUBCOMMAND>`](/cli/cache.md)
 - [`mise cache clear [PLUGIN]…`](/cli/cache/clear.md)
+- [`mise cache path`](/cli/cache/path.md)
 - [`mise cache prune [--dry-run] [-v --verbose…] [PLUGIN]…`](/cli/cache/prune.md)
 - [`mise completion [--include-bash-completion-lib] [SHELL]`](/cli/completion.md)
 - [`mise config [FLAGS] <SUBCOMMAND>`](/cli/config.md)

--- a/e2e/cli/test_cache_path
+++ b/e2e/cli/test_cache_path
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Test cache path command and its alias
+
+# Test `mise cache` shows cache directory
+assert_contains "mise cache" "$MISE_CACHE_DIR"
+
+# Test `mise cache path` shows cache directory
+assert_contains "mise cache path" "$MISE_CACHE_DIR"
+
+# Test `mise cache dir` alias shows cache directory
+assert_contains "mise cache dir" "$MISE_CACHE_DIR"
+
+# Test with custom cache directory
+export MISE_CACHE_DIR=/tmp/test-mise-cache
+assert_contains "mise cache path" "/tmp/test-mise-cache"
+assert_contains "mise cache dir" "/tmp/test-mise-cache"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -133,6 +133,9 @@ cmd cache help="Manage the mise cache" {
         flag --outdate help="Mark all cache files as old" hide=#true
         arg "[PLUGIN]…" help="Plugin(s) to clear cache for e.g.: node, python" required=#false var=#true
     }
+    cmd path help="Show the cache directory path" {
+        alias dir
+    }
     cmd prune help="Removes stale mise cache files" {
         alias p
         long_help "Removes stale mise cache files\n\nBy default, this command will remove files that have not been accessed in 30 days.\nChange this with the MISE_CACHE_PRUNE_AGE environment variable."

--- a/src/cli/cache/mod.rs
+++ b/src/cli/cache/mod.rs
@@ -4,6 +4,7 @@ use eyre::Result;
 use crate::env;
 
 mod clear;
+mod path;
 mod prune;
 
 /// Manage the mise cache
@@ -19,6 +20,7 @@ pub struct Cache {
 #[derive(Debug, Subcommand)]
 enum Commands {
     Clear(clear::CacheClear),
+    Path(path::CachePath),
     Prune(prune::CachePrune),
 }
 
@@ -26,6 +28,7 @@ impl Commands {
     pub fn run(self) -> Result<()> {
         match self {
             Self::Clear(cmd) => cmd.run(),
+            Self::Path(cmd) => cmd.run(),
             Self::Prune(cmd) => cmd.run(),
         }
     }

--- a/src/cli/cache/path.rs
+++ b/src/cli/cache/path.rs
@@ -1,0 +1,15 @@
+use eyre::Result;
+
+use crate::env;
+
+/// Show the cache directory path
+#[derive(Debug, clap::Args)]
+#[clap(verbatim_doc_comment, visible_alias = "dir")]
+pub struct CachePath {}
+
+impl CachePath {
+    pub fn run(self) -> Result<()> {
+        miseprintln!("{}", env::MISE_CACHE_DIR.display());
+        Ok(())
+    }
+}

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -279,6 +279,10 @@ esac`),
           },
         },
         {
+          name: ["path", "dir"],
+          description: "Show the cache directory path",
+        },
+        {
           name: ["prune", "p"],
           description: "Removes stale mise cache files",
           options: [


### PR DESCRIPTION
## Summary
- Add new `mise cache path` command to explicitly show the cache directory path
- Includes `mise cache dir` as a convenient alias for better UX
- Comprehensive e2e testing for both command forms

## Changes
- **New command**: `mise cache path` and `mise cache dir` (alias)
- **Implementation**: `/home/jdx/src/mise/src/cli/cache/path.rs:1`
- **Testing**: `/home/jdx/src/mise/e2e/cli/test_cache_path:1` covers both commands and custom cache directory
- **Documentation**: Auto-generated with alias clearly shown

## Test plan
- [x] Build passes
- [x] E2E tests pass for both `mise cache path` and `mise cache dir`
- [x] Help text shows alias correctly
- [x] Works with custom `MISE_CACHE_DIR` environment variable
- [x] Documentation generated correctly

This addresses the user request for explicit cache path access, complementing the existing `mise cache` behavior while providing the clearer `mise cache path` command.

🤖 Generated with [Claude Code](https://claude.ai/code)