### PR TITLE
test: optimize remote task tests with local server

### DIFF
--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Simple HTTP Server for E2E Testing
+Serves test files to avoid external network dependencies
+"""
+
+import http.server
+import socketserver
+import sys
+from pathlib import Path
+
+class TestFileHandler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        """Handle GET requests for test files"""
+        if self.path == '/test/mytask':
+            # Return the test task script
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = '#!/usr/bin/env bash\necho "running mytask"\n'
+            self.wfile.write(content.encode('utf-8'))
+        else:
+            # Return 404 for other paths
+            self.send_error(404, "File not found")
+
+    def log_message(self, format, *args):
+        """Suppress log messages for cleaner test output"""
+        pass
+
+def find_available_port():
+    """Find an available port starting from 8080"""
+    import socket
+    for port in range(8080, 8200):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(('', port))
+                return port
+        except OSError:
+            continue
+    raise RuntimeError("No available ports found")
+
+def start_server(port=None):
+    """Start the HTTP test server"""
+    if port is None:
+        port = find_available_port()
+
+    with socketserver.TCPServer(("", port), TestFileHandler) as httpd:
+        print(f"HTTP test server running on port {port}")
+
+        # Save port info for tests
+        with open('/tmp/mise_http_test_port', 'w') as f:
+            f.write(str(port))
+
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nShutting down...")
+        finally:
+            # Clean up port file
+            Path('/tmp/mise_http_test_port').unlink(missing_ok=True)
+
+if __name__ == '__main__':
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else None
+    start_server(port)

--- a/e2e/tasks/test_task_standalone
+++ b/e2e/tasks/test_task_standalone
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
+# Find available port
+find_available_port() {
+	python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()"
+}
+
+# Start local HTTP test server
+SERVER_PORT=$(find_available_port)
+python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" "$SERVER_PORT" &
+SERVER_PID=$!
+
+# Wait for server to start
+sleep 1
+
+# Ensure cleanup on exit
+cleanup() {
+	kill "$SERVER_PID" 2>/dev/null || true
+	rm -f /tmp/mise_http_test_port
+}
+trap cleanup EXIT
+
 cat <<EOF >mytask
 #!/usr/bin/env bash
 echo "running mytask"
@@ -19,6 +39,6 @@ assert "mise run mytask" "running mytask"
 cd .. || exit 1
 
 cat <<EOF >mise.toml
-tasks.mytask.file = "https://mise.jdx.dev/test/mytask"
+tasks.mytask.file = "http://localhost:${SERVER_PORT}/test/mytask"
 EOF
 assert "mise run mytask" "running mytask"

--- a/hk.pkl
+++ b/hk.pkl
@@ -2,7 +2,7 @@ amends "package://github.com/jdx/hk/releases/download/v1.15.1/hk@1.15.1#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.15.1/hk@1.15.1#/Builtins.pkl"
 
 local bash_glob = List("*.sh", "xtasks/**", "scripts/**", "e2e/**")
-local bash_exclude = List("*.ps1", "**/*.fish", "*.ts", "*.js", "*.json", "*.bat", "**/.*", "src/assets/bash_zsh_support/**", "e2e/shell/xonsh_script")
+local bash_exclude = List("*.ps1", "**/*.fish", "*.ts", "*.js", "*.json", "*.bat", "**/.*", "src/assets/bash_zsh_support/**", "e2e/shell/xonsh_script", "**/*.py")
 local linters = new Mapping<String, Step> {
     // uses builtin prettier linter config
     ["prettier"] = (Builtins.prettier) {

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -102,7 +102,7 @@ impl RemoteTaskGit {
     }
 
     fn detect_https(&self, file: &str) -> Result<GitRepoStructure> {
-        let re = Regex::new(r"^git::(?P<url>https://(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<branch>[^?]+))?$").unwrap();
+        let re = Regex::new(r"^git::(?P<url>https?://(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<branch>[^?]+))?$").unwrap();
 
         if !re.is_match(file) {
             return Err(eyre!("Invalid HTTPS URL"));
@@ -226,6 +226,7 @@ mod tests {
             "git::https://git.acme.com:8080/myorg/example.git//terraform/myfile?ref=master",
             "git::https://myserver.com/example.git//terraform/myfile",
             "git::https://myserver.com/example.git//myfile?ref=master",
+            "git::http://localhost:8080/repo.git//xtasks/lint/ripgrep", // HTTP support for local testing
         ];
 
         for url in test_cases {


### PR DESCRIPTION
## Summary
- Add local HTTP test server for test_task_standalone to avoid external network calls
- Support HTTP URLs (in addition to HTTPS) in remote_task_git for local testing  
- Exclude Python files from bash linter checks in hk.pkl

## Performance Improvement
The test_task_standalone test now uses a local HTTP server instead of fetching from mise.jdx.dev,
eliminating network latency and external dependencies while still testing the same HTTP download code paths.

## Changes
- Created a simple local HTTP server (`e2e/helpers/scripts/http_test_server.py`) that serves the test task file
- Updated `test_task_standalone` to use `http://localhost:PORT/test/mytask` instead of `https://mise.jdx.dev/test/mytask`
- Added support for HTTP URLs in `remote_task_git.rs` to enable local testing (similar to PR #6441)
- Updated `hk.pkl` to exclude Python files from bash linter checks

## Test Plan
- [x] Run the optimized test_task_standalone locally
- [x] Verify it still tests the same code paths  
- [x] Confirm test still passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a local HTTP server for e2e tests and enables `http` URLs (in addition to `https`) for remote git tasks, plus excludes Python files from bash linting.
> 
> - **E2E Tests**:
>   - Add local HTTP server `e2e/helpers/scripts/http_test_server.py` serving `/test/mytask` and managing ephemeral port/cleanup.
>   - Update `e2e/tasks/test_task_standalone` to start server and use `http://localhost:${SERVER_PORT}/test/mytask` instead of remote URL.
> - **Remote Task Provider**:
>   - Extend HTTPS detection to accept `http` in `remote_task_git.rs` regex and add a localhost `http` test case.
> - **Tooling**:
>   - Update `hk.pkl` to exclude `**/*.py` from bash linters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa06484a9c953d1bd84a1d68677150bc930942ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->