### PR TITLE
feat: add a http_retries setting to define number of retry attempts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4625,6 +4625,7 @@ dependencies = [
  "test-log",
  "thiserror 2.0.16",
  "tokio",
+ "tokio-retry",
  "toml 0.8.23",
  "toml_edit",
  "ubi",
@@ -7537,6 +7538,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ tera = "1"
 terminal_size = "0.4"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+tokio-retry = "0.3"
 toml = { version = "0.8", features = ["parse"] }
 toml_edit = { version = "0.22", features = ["parse"] }
 ubi = { version = "0.7.3", default-features = false }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -608,6 +608,11 @@
           "description": "Timeout in seconds for all HTTP requests in mise.",
           "type": "string"
         },
+        "http_retries": {
+          "default": 0,
+          "description": "Number of retries for HTTP requests in mise.",
+          "type": "number"
+        },
         "idiomatic_version_file": {
           "default": true,
           "description": "Set to false to disable the idiomatic version files such as .node-version, .ruby-version, etc.",

--- a/settings.toml
+++ b/settings.toml
@@ -486,6 +486,15 @@ description = "Timeout in seconds for all HTTP requests in mise."
 env = "MISE_HTTP_TIMEOUT"
 type = "Duration"
 
+[http_retries]
+default = 0
+description = "Number of retries for HTTP requests in mise."
+docs = """
+Uses an exponential backoff strategy. The duration is calculated by taking the base (10ms) to the n-th power.
+"""
+env = "MISE_HTTP_RETRIES"
+type = "Integer"
+
 [idiomatic_version_file]
 default = true
 deprecated = "This has been replaced with the idiomatic_version_file_enable_tools setting."

--- a/src/http.rs
+++ b/src/http.rs
@@ -7,6 +7,8 @@ use regex::Regex;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{ClientBuilder, IntoUrl, Method, Response};
 use std::sync::LazyLock as Lazy;
+use tokio_retry::Retry;
+use tokio_retry::strategy::{ExponentialBackoff, jitter};
 use url::Url;
 
 use crate::cli::version;
@@ -201,11 +203,12 @@ impl Client {
     ) -> Result<()> {
         let url = url.into_url()?;
         debug!("GET Downloading {} to {}", &url, display_path(path));
-
-        let mut resp = self.get_async_with_headers(url, headers).await?;
+        let mut resp = self.get_async_with_headers(url.clone(), headers).await?;
         if let Some(length) = resp.content_length() {
             if let Some(pr) = pr {
+                // Reset progress on each attempt
                 pr.set_length(length);
+                pr.set_position(0);
             }
         }
 
@@ -229,18 +232,29 @@ impl Client {
         headers: &HeaderMap,
         verb_label: &str,
     ) -> Result<Response> {
-        match self
-            .send_once(method.clone(), url.clone(), headers, verb_label)
-            .await
-        {
-            Ok(resp) => Ok(resp),
-            Err(_) if url.scheme() == "http" => {
-                let mut url = url;
-                url.set_scheme("https").unwrap();
-                self.send_once(method, url, headers, verb_label).await
-            }
-            Err(err) => Err(err),
-        }
+        Retry::spawn(
+            default_backoff_strategy(Settings::get().http_retries),
+            || {
+                let method = method.clone();
+                let url = url.clone();
+                let headers = headers.clone();
+                async move {
+                    match self
+                        .send_once(method.clone(), url.clone(), &headers, verb_label)
+                        .await
+                    {
+                        Ok(resp) => Ok(resp),
+                        Err(_err) if url.scheme() == "http" => {
+                            let mut url = url;
+                            url.set_scheme("https").unwrap();
+                            self.send_once(method, url, &headers, verb_label).await
+                        }
+                        Err(err) => Err(err),
+                    }
+                }
+            },
+        )
+        .await
     }
 
     async fn send_once(
@@ -414,6 +428,12 @@ fn display_github_rate_limit(resp: &Response) {
             );
         }
     }
+}
+
+fn default_backoff_strategy(retries: i64) -> impl Iterator<Item = std::time::Duration> {
+    ExponentialBackoff::from_millis(10)
+        .map(jitter)
+        .take(retries.max(0) as usize)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I gave `Add --retry option for mise install` (#6429)  a try (hence draft). 

Not quite sure about making this global even though it affects various commands (e.g. ls, install, outdated, ...). Also not sure about the wording. Should we use `MISE_HTTP_RETRIES` to make it more clear or leave it open for possible use for other types of retries?

WDYT @jdx?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `http_retries` setting and implements exponential-backoff retries for HTTP requests and downloads.
> 
> - **HTTP Retries**
>   - Implement retries using `tokio-retry` with exponential backoff + jitter in `src/http.rs` (`download_file_with_headers`, `send_with_https_fallback`).
>   - Add `default_backoff_strategy(retries)` helper to control retry count.
> - **Configuration**
>   - New setting: `settings.http_retries` (env: `MISE_HTTP_RETRIES`) with docs; exposed in `settings.toml` and `schema/mise.json`.
> - **Dependencies**
>   - Add `tokio-retry` crate; update `Cargo.toml` and `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac6c653d2ccbd4e7cc7ce0ad549b387a5dd5880e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->