### PR TITLE
registry: remove incorrect bin_path from balena-cli

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -339,10 +339,7 @@ test = ["bb --version", "babashka v{{version}}"]
 
 [tools.balena]
 aliases = ["balena-cli"]
-backends = [
-  "github:balena-io/balena-cli[bin_path=bin]",
-  "asdf:jaredallard/asdf-balena-cli",
-]
+backends = ["github:balena-io/balena-cli", "asdf:jaredallard/asdf-balena-cli"]
 description = "The balena CLI is a Command Line Interface for balenaCloud or openBalena"
 test = ["balena --version", "{{version}}"]
 


### PR DESCRIPTION
## Summary
- Fixed balena-cli by removing incorrect `bin_path=bin` parameter

## Details

### balena-cli fix
The balena-cli GitHub releases extract with the binary at `balena/bin/balena`, which is automatically detected by the github backend. The `bin_path=bin` was incorrect and caused the binary to not be found.

### oxlint issue (not fixed, documented)
oxlint currently has an upstream issue with the aqua backend where the binary is named incorrectly (`oxlint.linux-x64-gnu.node` instead of `oxlint`). This is an aqua registry issue that should be fixed upstream. 

**Workaround:** Users can use the npm backend instead:
```bash
mise install npm:oxlint
```

### Coder CLI
Coder CLI is already available in the registry via `aqua:coder/coder`, no changes needed.

## Test plan
```bash
mise test-tool balena  # Now passes
mise test-tool coder   # Already working
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `bin_path=bin` from `tools.balena` GitHub backend to rely on default binary detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b3f3ca63a0477b4afd09584787e5bfe8fd6a710. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->