### PR TITLE
registry: disable oxlint test temporarily

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -3328,7 +3328,9 @@ test = ["oxker --version", "oxker {{version}}"]
 [tools.oxlint]
 backends = ["aqua:oxc-project/oxc/oxlint", "ubi:oxc-project/oxc", "npm:oxlint"]
 description = "This is the linter for oxc."
-test = ["oxlint --version", "Version: {{version}}"]
+# TODO: Re-enable test once the aqua registry is fixed
+# The latest release has incorrect binary naming (oxlint.linux-x64-gnu.node instead of oxlint)
+# test = ["oxlint --version", "Version: {{version}}"]
 
 [tools.pachctl]
 backends = ["aqua:pachyderm/pachyderm", "asdf:abatilo/asdf-pachctl"]


### PR DESCRIPTION
## Summary
Temporarily disabling the oxlint test due to broken aqua registry release

## Details
The latest oxlint release has a broken aqua registry configuration where the binary is incorrectly named (`oxlint.linux-x64-gnu.node` instead of `oxlint`). This causes the test to fail.

Disabling the test by commenting it out in `registry.toml` until the upstream aqua registry is fixed.

## TODO
Re-enable test once the aqua registry is fixed

## Related
- #6445 - Documents the issue and fixes balena-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Comment out `oxlint` test in `registry.toml` due to incorrect binary naming in the aqua registry release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c418fc55dd1301cfcbca986762a2e9e8b557b938. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->