### PR TITLE
registry: add github backend for graphite

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1929,7 +1929,10 @@ backends = ["aqua:common-fate/granted", "asdf:dex4er/asdf-granted"]
 description = "The easiest way to access AWS"
 
 [tools.graphite]
-backends = ["npm:@withgraphite/graphite-cli"]
+backends = [
+  "github:withgraphite/homebrew-tap[exe=gt]",
+  "npm:@withgraphite/graphite-cli",
+]
 description = "Code review for the age of AI"
 test = ["gt --version", "{{version}}"]
 


### PR DESCRIPTION
## Summary
- Add `github:withgraphite/homebrew-tap` as the primary backend for graphite
- Keep npm backend as a fallback option
- The GitHub backend downloads pre-built binaries directly from releases

## Test plan
- [x] Tested installation with `mise test-tool graphite`
- [x] Verified GitHub backend works: `mise install github:withgraphite/homebrew-tap@latest`
- [x] Confirmed gt command executes: `mise exec graphite -- gt --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Homebrew tap backend for `tools.graphite`, retaining the existing npm backend.
> 
> - **Registry**
>   - **`tools.graphite`**:
>     - Add `github:withgraphite/homebrew-tap[exe=gt]` to `backends`.
>     - Keep `npm:@withgraphite/graphite-cli` as a fallback backend.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af1e7b2512fceb06d0729819e8178730a5c5bf71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->