### PR TITLE
feat(env): add support for required environment variables

### DIFF
--- a/e2e/config/test_required_env_vars
+++ b/e2e/config/test_required_env_vars
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Test 1: Required env var defined before mise runs (should succeed)
+export REQUIRED_VAR1="predefined_value"
+
+cat <<EOF >mise.toml
+[env]
+REQUIRED_VAR1 = { value = "from_config", required = true }
+NORMAL_VAR = "normal_value"
+EOF
+
+# This should succeed
+mise env >/dev/null
+
+# Test 2: Required env var defined in a later config file (should succeed)
+unset REQUIRED_VAR1
+
+cat <<EOF >mise.toml
+[env]
+REQUIRED_VAR2 = { value = "defined_in_config", required = true }
+NORMAL_VAR = "normal_value"
+EOF
+
+cat <<EOF >mise.local.toml
+[env]
+REQUIRED_VAR2 = "overridden_in_local"
+EOF
+
+# This should also succeed
+mise env >/dev/null
+
+# Test 3: Required env var not defined anywhere (should fail)
+rm -f mise.local.toml
+
+cat <<EOF >mise.toml
+[env]
+REQUIRED_VAR3 = { value = "config_value", required = true }
+NORMAL_VAR = "normal_value"
+EOF
+
+unset REQUIRED_VAR3
+
+# This should fail with a clear error message
+if mise env 2>error.log; then
+	echo "ERROR: Expected mise env to fail but it succeeded"
+	exit 1
+fi
+
+assert_contains "cat error.log" "Required environment variable 'REQUIRED_VAR3' is not defined"
+
+# Test 4: Multiple required vars, some defined, some not (should fail)
+export REQUIRED_VAR4="defined"
+
+cat <<EOF >mise.toml
+[env]
+REQUIRED_VAR4 = { value = "config_value", required = true }
+REQUIRED_VAR5 = { value = "config_value", required = true }
+NORMAL_VAR = "normal_value"
+EOF
+
+unset REQUIRED_VAR5
+
+if mise env 2>error2.log; then
+	echo "ERROR: Expected mise env to fail but it succeeded"
+	exit 1
+fi
+
+assert_contains "cat error2.log" "Required environment variable 'REQUIRED_VAR5' is not defined"
+
+# Cleanup
+rm -f mise.toml mise.local.toml error.log error2.log
+unset REQUIRED_VAR1 REQUIRED_VAR2 REQUIRED_VAR3 REQUIRED_VAR4 REQUIRED_VAR5

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1094,6 +1094,7 @@ impl<'de> de::Deserialize<'de> for EnvList {
                                     options: EnvDirectiveOptions {
                                         tools: true,
                                         redact: false,
+                                        required: false,
                                     },
                                 });
                             }

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env-4.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env-4.snap
@@ -11,6 +11,7 @@ MiseToml(~/cwd/.test.mise.toml): ToolRequestSet: <empty> {
             EnvDirectiveOptions {
                 tools: false,
                 redact: false,
+                required: false,
             },
         ),
         Val(
@@ -19,6 +20,7 @@ MiseToml(~/cwd/.test.mise.toml): ToolRequestSet: <empty> {
             EnvDirectiveOptions {
                 tools: false,
                 redact: false,
+                required: false,
             },
         ),
         Val(
@@ -27,6 +29,7 @@ MiseToml(~/cwd/.test.mise.toml): ToolRequestSet: <empty> {
             EnvDirectiveOptions {
                 tools: false,
                 redact: false,
+                required: false,
             },
         ),
     ],

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-5.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-5.snap
@@ -1,7 +1,6 @@
 ---
 source: src/config/config_file/mise_toml.rs
 expression: "replace_path(&format!(\"{:#?}\", &cf))"
-snapshot_kind: text
 ---
 MiseToml(~/fixtures/.mise.toml): ToolRequestSet: terraform@1.0.0 node@18 node@prefix:20 node@ref:master node@path:~/.nodes/18 jq@prefix:1.6 shellcheck@0.9.0 python@3.10.0 python@3.9.0 {
     env: [
@@ -11,6 +10,7 @@ MiseToml(~/fixtures/.mise.toml): ToolRequestSet: terraform@1.0.0 node@18 node@pr
             EnvDirectiveOptions {
                 tools: false,
                 redact: false,
+                required: false,
             },
         ),
     ],

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture.snap
@@ -1,7 +1,6 @@
 ---
 source: src/config/config_file/mise_toml.rs
 expression: cf.env_entries().unwrap()
-snapshot_kind: text
 ---
 [
     Val(
@@ -10,6 +9,7 @@ snapshot_kind: text
         EnvDirectiveOptions {
             tools: false,
             redact: false,
+            required: false,
         },
     ),
 ]

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -178,6 +178,7 @@ mod tests {
                         options: EnvDirectiveOptions {
                             tools: true,
                             redact: false,
+                            required: false,
                         },
                     },
                     Default::default(),
@@ -192,6 +193,7 @@ mod tests {
                         options: EnvDirectiveOptions {
                             tools: true,
                             redact: false,
+                            required: false,
                         },
                     },
                     Default::default(),


### PR DESCRIPTION
## Summary
- Implement required environment variable validation with `env.FOO = {required = true}` syntax
- Required variables must be defined either before mise runs (in environment) OR in a later config file (e.g., mise.local.toml)  
- Validation fails if a config file declares a variable as required but doesn't provide it from an external source

## Test plan
- [x] Added comprehensive e2e test with multiple scenarios:
  - Required env var defined before mise runs (should succeed)
  - Required env var defined in a later config file (should succeed)  
  - Required env var not defined anywhere (should fail)
  - Multiple required vars with some missing (should fail)
- [x] All unit tests pass
- [x] All existing e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)