### PR TITLE
chore(clippy): replace &Box<dyn SingleReport> with &dyn SingleReport

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -365,7 +365,7 @@ impl AquaBackend {
             return Ok(());
         }
         ctx.pr.set_message(format!("download {filename}"));
-        HTTP.download_file(url, &tarball_path, Some(&ctx.pr))
+        HTTP.download_file(url, &tarball_path, Some(ctx.pr.as_ref()))
             .await?;
         Ok(())
     }
@@ -397,7 +397,7 @@ impl AquaBackend {
                         AquaChecksumType::Http => checksum.url(pkg, v, os(), arch())?,
                     };
                     let checksum_path = download_path.join(format!("{filename}.checksum"));
-                    HTTP.download_file(&url, &checksum_path, Some(&ctx.pr))
+                    HTTP.download_file(&url, &checksum_path, Some(ctx.pr.as_ref()))
                         .await?;
                     self.cosign_checksums(ctx, pkg, v, tv, &checksum_path, &download_path)
                         .await?;
@@ -499,7 +499,8 @@ impl AquaBackend {
                         .map(|a| a.browser_download_url);
                     if let Some(url) = url {
                         let path = tv.download_path().join(asset);
-                        HTTP.download_file(&url, &path, Some(&ctx.pr)).await?;
+                        HTTP.download_file(&url, &path, Some(ctx.pr.as_ref()))
+                            .await?;
                         path
                     } else {
                         warn!("no asset found for minisign of {tv}: {asset}");
@@ -509,7 +510,8 @@ impl AquaBackend {
                 AquaMinisignType::Http => {
                     let url = minisign.url(pkg, v, os(), arch())?;
                     let path = tv.download_path().join(filename).with_extension(".minisig");
-                    HTTP.download_file(&url, &path, Some(&ctx.pr)).await?;
+                    HTTP.download_file(&url, &path, Some(ctx.pr.as_ref()))
+                        .await?;
                     path
                 }
             };
@@ -561,7 +563,8 @@ impl AquaBackend {
                         .map(|a| a.browser_download_url);
                     if let Some(url) = url {
                         let path = tv.download_path().join(asset);
-                        HTTP.download_file(&url, &path, Some(&ctx.pr)).await?;
+                        HTTP.download_file(&url, &path, Some(ctx.pr.as_ref()))
+                            .await?;
                         path
                     } else {
                         warn!("no asset found for slsa verification of {tv}: {asset}");
@@ -573,7 +576,8 @@ impl AquaBackend {
                     let provenance_filename =
                         url.split('/').next_back().unwrap_or("provenance.json");
                     let path = tv.download_path().join(provenance_filename);
-                    HTTP.download_file(&url, &path, Some(&ctx.pr)).await?;
+                    HTTP.download_file(&url, &path, Some(ctx.pr.as_ref()))
+                        .await?;
                     path
                 }
                 t => {
@@ -721,7 +725,7 @@ impl AquaBackend {
                     let key_path = if key_arg.starts_with("http") {
                         let key_filename = key_arg.split('/').next_back().unwrap_or("cosign.pub");
                         let key_path = download_path.join(key_filename);
-                        HTTP.download_file(&key_arg, &key_path, Some(&ctx.pr))
+                        HTTP.download_file(&key_arg, &key_path, Some(ctx.pr.as_ref()))
                             .await?;
                         key_path
                     } else {
@@ -736,7 +740,7 @@ impl AquaBackend {
                                 let sig_filename =
                                     sig_arg.split('/').next_back().unwrap_or("checksum.sig");
                                 let sig_path = download_path.join(sig_filename);
-                                HTTP.download_file(&sig_arg, &sig_path, Some(&ctx.pr))
+                                HTTP.download_file(&sig_arg, &sig_path, Some(ctx.pr.as_ref()))
                                     .await?;
                                 sig_path
                             } else {
@@ -779,7 +783,7 @@ impl AquaBackend {
                     let bundle_path = if bundle_arg.starts_with("http") {
                         let filename = bundle_arg.split('/').next_back().unwrap_or("bundle.json");
                         let bundle_path = download_path.join(filename);
-                        HTTP.download_file(&bundle_arg, &bundle_path, Some(&ctx.pr))
+                        HTTP.download_file(&bundle_arg, &bundle_path, Some(ctx.pr.as_ref()))
                             .await?;
                         bundle_path
                     } else {
@@ -860,7 +864,7 @@ impl AquaBackend {
             .expect("at least one bin path should exist");
         let mut tar_opts = TarOptions {
             format: format.parse().unwrap_or_default(),
-            pr: Some(&ctx.pr),
+            pr: Some(ctx.pr.as_ref()),
             strip_components: 0,
             ..Default::default()
         };

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -342,7 +342,7 @@ impl Backend for AsdfBackend {
             sm.prepend_path(p);
         }
 
-        let run_script = |script| sm.run_by_line(script, &ctx.pr);
+        let run_script = |script| sm.run_by_line(script, ctx.pr.as_ref());
 
         if sm.script_exists(&Download) {
             ctx.pr.set_message("bin/download".into());
@@ -358,7 +358,7 @@ impl Backend for AsdfBackend {
     async fn uninstall_version_impl(
         &self,
         config: &Arc<Config>,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
         tv: &ToolVersion,
     ) -> Result<()> {
         if self.plugin_path.join("bin/uninstall").exists() {

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -131,7 +131,7 @@ impl Backend for CargoBackend {
 
         cmd.arg("--root")
             .arg(tv.install_path())
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path(&ctx.config).await?)
             .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
             .prepend_path(

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -85,7 +85,7 @@ impl Backend for DotnetBackend {
             cli = cli.arg("--version").arg(&tv.version);
         }
 
-        cli.with_pr(&ctx.pr)
+        cli.with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
             .execute()?;
 

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -69,7 +69,7 @@ impl Backend for GemBackend {
             //       uninstalling the ruby version used to install the gem will break the
             //       gem. We should find a way to fix this.
             // .arg("--env-shebang")
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
             .execute()?;
 

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -171,12 +171,12 @@ impl UnifiedGitBackend {
         platform_info.url = Some(asset_url.to_string());
 
         ctx.pr.set_message(format!("download {filename}"));
-        HTTP.download_file_with_headers(asset_url, &file_path, &headers, Some(&ctx.pr))
+        HTTP.download_file_with_headers(asset_url, &file_path, &headers, Some(ctx.pr.as_ref()))
             .await?;
 
         // Verify and install
-        verify_artifact(tv, &file_path, opts, Some(&ctx.pr))?;
-        install_artifact(tv, &file_path, opts, Some(&ctx.pr))?;
+        verify_artifact(tv, &file_path, opts, Some(ctx.pr.as_ref()))?;
+        install_artifact(tv, &file_path, opts, Some(ctx.pr.as_ref()))?;
         self.verify_checksum(ctx, tv, &file_path)?;
 
         Ok(())

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -119,7 +119,7 @@ impl Backend for GoBackend {
             }
 
             cmd.arg(format!("{}@{v}", self.tool_name()))
-                .with_pr(&ctx.pr)
+                .with_pr(ctx.pr.as_ref())
                 .envs(self.dependency_env(&ctx.config).await?)
                 .env("GOBIN", tv.install_path().join("bin"))
                 .execute()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -445,7 +445,7 @@ pub trait Backend: Debug + Send + Sync {
         }
         Ok(())
     }
-    fn purge(&self, pr: &Box<dyn SingleReport>) -> eyre::Result<()> {
+    fn purge(&self, pr: &dyn SingleReport) -> eyre::Result<()> {
         rmdir(&self.ba().installs_path, pr)?;
         rmdir(&self.ba().cache_path, pr)?;
         rmdir(&self.ba().downloads_path, pr)?;
@@ -492,7 +492,7 @@ pub trait Backend: Debug + Send + Sync {
 
         if self.is_version_installed(&ctx.config, &tv, true) {
             if ctx.force {
-                self.uninstall_version(&ctx.config, &tv, &ctx.pr, false)
+                self.uninstall_version(&ctx.config, &tv, ctx.pr.as_ref(), false)
                     .await?;
             } else {
                 return Ok(tv);
@@ -559,7 +559,7 @@ pub trait Backend: Debug + Send + Sync {
         CmdLineRunner::new(&*env::SHELL)
             .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .env("MISE_TOOL_INSTALL_PATH", tv.install_path())
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .arg(env::SHELL_COMMAND_FLAG)
             .arg(script)
             .envs(env_vars)
@@ -571,7 +571,7 @@ pub trait Backend: Debug + Send + Sync {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
         dryrun: bool,
     ) -> eyre::Result<()> {
         pr.set_message("uninstall".into());
@@ -599,7 +599,7 @@ pub trait Backend: Debug + Send + Sync {
     async fn uninstall_version_impl(
         &self,
         _config: &Arc<Config>,
-        _pr: &Box<dyn SingleReport>,
+        _pr: &dyn SingleReport,
         _tv: &ToolVersion,
     ) -> Result<()> {
         Ok(())
@@ -837,13 +837,13 @@ pub trait Backend: Debug + Send + Sync {
         if let Some(checksum) = &platform_info.checksum {
             ctx.pr.set_message(format!("checksum {filename}"));
             if let Some((algo, check)) = checksum.split_once(':') {
-                hash::ensure_checksum(file, check, Some(&ctx.pr), algo)?;
+                hash::ensure_checksum(file, check, Some(ctx.pr.as_ref()), algo)?;
             } else {
                 bail!("Invalid checksum: {checksum}");
             }
         } else if lockfile_enabled {
             ctx.pr.set_message(format!("generate checksum {filename}"));
-            let hash = hash::file_hash_blake3(file, Some(&ctx.pr))?;
+            let hash = hash::file_hash_blake3(file, Some(ctx.pr.as_ref()))?;
             platform_info.checksum = Some(format!("blake3:{hash}"));
         }
 
@@ -992,7 +992,7 @@ fn find_match_in_list(list: &[String], query: &str) -> Option<String> {
     }
 }
 
-fn rmdir(dir: &Path, pr: &Box<dyn SingleReport>) -> eyre::Result<()> {
+fn rmdir(dir: &Path, pr: &dyn SingleReport) -> eyre::Result<()> {
     if !dir.exists() {
         return Ok(());
     }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -95,7 +95,7 @@ impl Backend for NPMBackend {
                 .arg(format!("{}@{}", self.tool_name(), tv.version))
                 .arg("--global")
                 .arg("--trust")
-                .with_pr(&ctx.pr)
+                .with_pr(ctx.pr.as_ref())
                 .envs(ctx.ts.env_with_path(&ctx.config).await?)
                 .env("BUN_INSTALL_GLOBAL_DIR", tv.install_path())
                 .env("BUN_INSTALL_BIN", tv.install_path().join("bin"))
@@ -115,7 +115,7 @@ impl Backend for NPMBackend {
                 .arg(format!("{}@{}", self.tool_name(), tv.version))
                 .arg("--prefix")
                 .arg(tv.install_path())
-                .with_pr(&ctx.pr)
+                .with_pr(ctx.pr.as_ref())
                 .envs(ctx.ts.env_with_path(&ctx.config).await?)
                 .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                 .prepend_path(

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -189,7 +189,7 @@ impl Backend for PIPXBackend {
                 self,
                 &tv,
                 &ctx.ts,
-                &ctx.pr,
+                ctx.pr.as_ref(),
             )
             .await?;
             if let Some(args) = tv.request.options().get("uvx_args") {
@@ -204,7 +204,7 @@ impl Backend for PIPXBackend {
                 self,
                 &tv,
                 &ctx.ts,
-                &ctx.pr,
+                ctx.pr.as_ref(),
             )
             .await?;
             if let Some(args) = tv.request.options().get("pipx_args") {
@@ -296,7 +296,7 @@ impl PIPXBackend {
                     ("install", format!("{}=={}", tv.ba().tool_name, tv.version)),
                 ] {
                     let args = &["tool", cmd, tool];
-                    Self::uvx_cmd(config, args, &*b, &tv, &ts, &pr)
+                    Self::uvx_cmd(config, args, &*b, &tv, &ts, pr.as_ref())
                         .await?
                         .execute()?;
                 }
@@ -305,7 +305,7 @@ impl PIPXBackend {
             let pr = MultiProgressReport::get().add("reinstalling pipx tools");
             for (b, tv) in pipx_tools {
                 let args = &["reinstall", &tv.ba().tool_name];
-                Self::pipx_cmd(config, args, &*b, &tv, &ts, &pr)
+                Self::pipx_cmd(config, args, &*b, &tv, &ts, pr.as_ref())
                     .await?
                     .execute()?;
             }
@@ -319,7 +319,7 @@ impl PIPXBackend {
         b: &dyn Backend,
         tv: &ToolVersion,
         ts: &Toolset,
-        pr: &'a Box<dyn SingleReport>,
+        pr: &'a dyn SingleReport,
     ) -> Result<CmdLineRunner<'a>> {
         let mut cmd = CmdLineRunner::new("uv");
         for arg in args {
@@ -341,7 +341,7 @@ impl PIPXBackend {
         b: &dyn Backend,
         tv: &ToolVersion,
         ts: &Toolset,
-        pr: &'a Box<dyn SingleReport>,
+        pr: &'a dyn SingleReport,
     ) -> Result<CmdLineRunner<'a>> {
         let mut cmd = CmdLineRunner::new("pipx");
         for arg in args {

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -133,7 +133,7 @@ impl SPMBackend {
             );
             repo.clone(
                 package_repo.url.as_str(),
-                CloneOptions::default().pr(&ctx.pr),
+                CloneOptions::default().pr(ctx.pr.as_ref()),
             )?;
         }
         debug!("Checking out revision: {revision}");
@@ -192,7 +192,7 @@ impl SPMBackend {
             .arg(repo_dir)
             .arg("--cache-path")
             .arg(dirs::CACHE.join("spm"))
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .prepend_path(
                 self.dependency_toolset(&ctx.config)
                     .await?

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -175,7 +175,7 @@ pub fn install_artifact(
     tv: &crate::toolset::ToolVersion,
     file_path: &Path,
     opts: &ToolVersionOptions,
-    pr: Option<&Box<dyn SingleReport>>,
+    pr: Option<&dyn SingleReport>,
 ) -> eyre::Result<()> {
     let install_path = tv.install_path();
     let mut strip_components = opts.get("strip_components").and_then(|s| s.parse().ok());
@@ -273,7 +273,7 @@ pub fn verify_artifact(
     _tv: &crate::toolset::ToolVersion,
     file_path: &Path,
     opts: &crate::toolset::ToolVersionOptions,
-    pr: Option<&Box<dyn SingleReport>>,
+    pr: Option<&dyn SingleReport>,
 ) -> Result<()> {
     // Check platform-specific checksum first, then fall back to generic
     let checksum = lookup_platform_key(opts, "checksum").or_else(|| opts.get("checksum").cloned());
@@ -303,7 +303,7 @@ pub fn verify_artifact(
 pub fn verify_checksum_str(
     file_path: &Path,
     checksum: &str,
-    pr: Option<&Box<dyn SingleReport>>,
+    pr: Option<&dyn SingleReport>,
 ) -> Result<()> {
     if let Some((algo, hash_str)) = checksum.split_once(':') {
         hash::ensure_checksum(file_path, hash_str, pr, algo)?;

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -221,14 +221,14 @@ impl Backend for UbiBackend {
             ctx.pr
                 .set_message(format!("checksum verify {platform_key}"));
             if let Some((algo, check)) = checksum.split_once(':') {
-                hash::ensure_checksum(file, check, Some(&ctx.pr), algo)?;
+                hash::ensure_checksum(file, check, Some(ctx.pr.as_ref()), algo)?;
             } else {
                 bail!("Invalid checksum: {platform_key}");
             }
         } else if Settings::get().lockfile && Settings::get().experimental {
             ctx.pr
                 .set_message(format!("checksum generate {platform_key}"));
-            let hash = hash::file_hash_blake3(file, Some(&ctx.pr))?;
+            let hash = hash::file_hash_blake3(file, Some(ctx.pr.as_ref()))?;
             platform_info.checksum = Some(format!("blake3:{hash}"));
         }
         Ok(())

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -369,7 +369,8 @@ impl ToolStub {
         let pr = mpr.add(&format!("download {filename}"));
 
         // Download using mise's HTTP client
-        HTTP.download_file(url, &archive_path, Some(&pr)).await?;
+        HTTP.download_file(url, &archive_path, Some(pr.as_ref()))
+            .await?;
 
         // Read the file to calculate checksum and size
         let bytes = file::read(&archive_path)?;
@@ -381,7 +382,7 @@ impl ToolStub {
             // Update progress message for extraction and reuse the same progress reporter
             pr.set_message(format!("extract {filename}"));
             match self
-                .extract_and_find_binary(&archive_path, &temp_dir, &filename, &pr)
+                .extract_and_find_binary(&archive_path, &temp_dir, &filename, pr.as_ref())
                 .await
             {
                 Ok(path) => {
@@ -407,7 +408,7 @@ impl ToolStub {
         archive_path: &std::path::Path,
         temp_dir: &tempfile::TempDir,
         _filename: &str,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> Result<String> {
         // Try to extract and find executables
         let extracted_dir = temp_dir.path().join("extracted");

--- a/src/cli/plugins/uninstall.rs
+++ b/src/cli/plugins/uninstall.rs
@@ -44,10 +44,10 @@ impl PluginsUninstall {
             if plugin.is_installed() {
                 let prefix = format!("plugin:{}", style::eblue(&plugin.name()));
                 let pr = mpr.add(&prefix);
-                plugin.uninstall(&pr).await?;
+                plugin.uninstall(pr.as_ref()).await?;
                 if self.purge {
                     let backend = backend::get(&plugin_name.into()).unwrap();
-                    backend.purge(&pr)?;
+                    backend.purge(pr.as_ref())?;
                 }
                 pr.finish_with_message("uninstalled".into());
             } else {

--- a/src/cli/plugins/update.rs
+++ b/src/cli/plugins/update.rs
@@ -53,7 +53,7 @@ impl Update {
                 let mpr = MultiProgressReport::get();
                 let pr = mpr.add(&prefix);
                 plugin
-                    .update(&pr, ref_)
+                    .update(pr.as_ref(), ref_)
                     .await
                     .wrap_err_with(|| format!("[{plugin}] plugin update"))?;
                 Ok(())

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -119,7 +119,8 @@ async fn delete(
         let pr = mpr.add(&prefix);
         if dry_run || Settings::get().yes || prompt::confirm_with_all(format!("remove {} ?", &tv))?
         {
-            p.uninstall_version(config, &tv, &pr, dry_run).await?;
+            p.uninstall_version(config, &tv, pr.as_ref(), dry_run)
+                .await?;
             runtime_symlinks::remove_missing_symlinks(p)?;
             pr.finish();
         }

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -55,7 +55,7 @@ impl Uninstall {
 
             let pr = mpr.add(&tv.style());
             if let Err(err) = plugin
-                .uninstall_version(&config, &tv, &pr, self.dry_run)
+                .uninstall_version(&config, &tv, pr.as_ref(), self.dry_run)
                 .await
             {
                 error!("{err}");

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -204,7 +204,7 @@ impl Upgrade {
             {
                 let pr = mpr.add(&format!("uninstall {}@{}", o.name, tv));
                 if let Err(e) = self
-                    .uninstall_old_version(config, &o.tool_version, &pr)
+                    .uninstall_old_version(config, &o.tool_version, pr.as_ref())
                     .await
                 {
                     warn!("Failed to uninstall old version of {}: {}", o.name, e);
@@ -231,7 +231,7 @@ impl Upgrade {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> Result<()> {
         tv.backend()?
             .uninstall_version(config, tv, pr, self.dry_run)

--- a/src/file.rs
+++ b/src/file.rs
@@ -668,7 +668,7 @@ impl TarFormat {
 pub struct TarOptions<'a> {
     pub format: TarFormat,
     pub strip_components: usize,
-    pub pr: Option<&'a Box<dyn SingleReport>>,
+    pub pr: Option<&'a dyn SingleReport>,
     /// When false, files will be extracted with current timestamp instead of archive's mtime
     pub preserve_mtime: bool,
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -285,12 +285,12 @@ impl Debug for Git {
 
 #[derive(Default)]
 pub struct CloneOptions<'a> {
-    pr: Option<&'a Box<dyn SingleReport>>,
+    pr: Option<&'a dyn SingleReport>,
     branch: Option<String>,
 }
 
 impl<'a> CloneOptions<'a> {
-    pub fn pr(mut self, pr: &'a Box<dyn SingleReport>) -> Self {
+    pub fn pr(mut self, pr: &'a dyn SingleReport) -> Self {
         self.pr = Some(pr);
         self
     }

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -15,6 +15,6 @@ fn add_keys(ctx: &InstallContext, keys: &str) -> Result<()> {
         .arg("--quiet")
         .arg("--import")
         .stdin_string(keys)
-        .with_pr(&ctx.pr)
+        .with_pr(ctx.pr.as_ref())
         .execute()
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -26,7 +26,7 @@ pub fn hash_sha256_to_str(s: &str) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-pub fn file_hash_sha256(path: &Path, pr: Option<&Box<dyn SingleReport>>) -> Result<String> {
+pub fn file_hash_sha256(path: &Path, pr: Option<&dyn SingleReport>) -> Result<String> {
     let use_external_hasher = file::size(path).unwrap_or_default() > 50 * 1024 * 1024;
     if use_external_hasher && file::which("sha256sum").is_some() {
         let out = cmd!("sha256sum", path).read()?;
@@ -36,7 +36,7 @@ pub fn file_hash_sha256(path: &Path, pr: Option<&Box<dyn SingleReport>>) -> Resu
     }
 }
 
-fn file_hash_prog<D>(path: &Path, pr: Option<&Box<dyn SingleReport>>) -> Result<String>
+fn file_hash_prog<D>(path: &Path, pr: Option<&dyn SingleReport>) -> Result<String>
 where
     D: Digest + Write,
     D::OutputSize: std::ops::Add,
@@ -69,7 +69,7 @@ pub fn hash_blake3_to_str(s: &str) -> String {
     hasher.finalize().to_hex().to_string()
 }
 
-pub fn file_hash_blake3(path: &Path, pr: Option<&Box<dyn SingleReport>>) -> Result<String> {
+pub fn file_hash_blake3(path: &Path, pr: Option<&dyn SingleReport>) -> Result<String> {
     let mut file = file::open(path)?;
     if let Some(pr) = pr {
         pr.set_length(file.metadata()?.len());
@@ -93,7 +93,7 @@ pub fn file_hash_blake3(path: &Path, pr: Option<&Box<dyn SingleReport>>) -> Resu
 pub fn ensure_checksum(
     path: &Path,
     checksum: &str,
-    pr: Option<&Box<dyn SingleReport>>,
+    pr: Option<&dyn SingleReport>,
     algo: &str,
 ) -> Result<()> {
     let use_external_hasher = file::size(path).unwrap_or(u64::MAX) > 10 * 1024 * 1024;

--- a/src/http.rs
+++ b/src/http.rs
@@ -186,7 +186,7 @@ impl Client {
         &self,
         url: U,
         path: &Path,
-        pr: Option<&Box<dyn SingleReport>>,
+        pr: Option<&dyn SingleReport>,
     ) -> Result<()> {
         let url = url.into_url()?;
         let headers = github_headers(&url);
@@ -199,7 +199,7 @@ impl Client {
         url: U,
         path: &Path,
         headers: &HeaderMap,
-        pr: Option<&Box<dyn SingleReport>>,
+        pr: Option<&dyn SingleReport>,
     ) -> Result<()> {
         let url = url.into_url()?;
         debug!("GET Downloading {} to {}", &url, display_path(path));

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -59,7 +59,7 @@ impl AsdfPlugin {
 
     fn exec_hook_post_plugin_update(
         &self,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
         pre: String,
         post: String,
     ) -> eyre::Result<()> {
@@ -78,12 +78,12 @@ impl AsdfPlugin {
         Ok(())
     }
 
-    fn exec_hook(&self, pr: &Box<dyn SingleReport>, hook: &str) -> eyre::Result<()> {
+    fn exec_hook(&self, pr: &dyn SingleReport, hook: &str) -> eyre::Result<()> {
         self.exec_hook_env(pr, hook, Default::default())
     }
     fn exec_hook_env(
         &self,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
         hook: &str,
         env: HashMap<OsString, OsString>,
     ) -> eyre::Result<()> {
@@ -265,13 +265,13 @@ impl Plugin for AsdfPlugin {
         let pr = mpr.add_with_options(&prefix, dry_run);
         if !dry_run {
             let _lock = lock_file::get(&self.plugin_path, force)?;
-            self.install(config, &pr).await
+            self.install(config, pr.as_ref()).await
         } else {
             Ok(())
         }
     }
 
-    async fn update(&self, pr: &Box<dyn SingleReport>, gitref: Option<String>) -> Result<()> {
+    async fn update(&self, pr: &dyn SingleReport, gitref: Option<String>) -> Result<()> {
         let plugin_path = self.plugin_path.to_path_buf();
         if plugin_path.is_symlink() {
             warn!(
@@ -300,7 +300,7 @@ impl Plugin for AsdfPlugin {
         Ok(())
     }
 
-    async fn uninstall(&self, pr: &Box<dyn SingleReport>) -> Result<()> {
+    async fn uninstall(&self, pr: &dyn SingleReport) -> Result<()> {
         if !self.is_installed() {
             return Ok(());
         }
@@ -325,7 +325,7 @@ impl Plugin for AsdfPlugin {
         Ok(())
     }
 
-    async fn install(&self, config: &Arc<Config>, pr: &Box<dyn SingleReport>) -> eyre::Result<()> {
+    async fn install(&self, config: &Arc<Config>, pr: &dyn SingleReport) -> eyre::Result<()> {
         let repository = self.get_repo_url(config)?;
         let (repo_url, repo_ref) = Git::split_url_and_ref(&repository);
         debug!("asdf_plugin[{}]:install {:?}", self.name, repository);

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -40,12 +40,12 @@ impl BunPlugin {
     fn test_bun(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
         ctx.pr.set_message("bun -v".into());
         CmdLineRunner::new(self.bun_bin(tv))
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .arg("-v")
             .execute()
     }
 
-    async fn download(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<PathBuf> {
+    async fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
         let url = format!(
             "https://github.com/oven-sh/bun/releases/download/bun-v{}/bun-{}-{}.zip",
             tv.version,
@@ -112,7 +112,7 @@ impl Backend for BunPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        let tarball_path = self.download(&tv, &ctx.pr).await?;
+        let tarball_path = self.download(&tv, ctx.pr.as_ref()).await?;
         self.verify_checksum(ctx, &mut tv, &tarball_path)?;
         self.install(ctx, &tv, &tarball_path)?;
         self.verify(ctx, &tv)?;

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -41,7 +41,7 @@ impl DenoPlugin {
         })
     }
 
-    fn test_deno(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<()> {
+    fn test_deno(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<()> {
         pr.set_message("deno -V".into());
         CmdLineRunner::new(self.deno_bin(tv))
             .with_pr(pr)
@@ -49,7 +49,7 @@ impl DenoPlugin {
             .execute()
     }
 
-    async fn download(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<PathBuf> {
+    async fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
         let settings = Settings::get();
         let url = format!(
             "https://dl.deno.land/release/v{}/deno-{}-{}.zip",
@@ -68,12 +68,7 @@ impl DenoPlugin {
         Ok(tarball_path)
     }
 
-    fn install(
-        &self,
-        tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
-        tarball_path: &Path,
-    ) -> Result<()> {
+    fn install(&self, tv: &ToolVersion, pr: &dyn SingleReport, tarball_path: &Path) -> Result<()> {
         let filename = tarball_path.file_name().unwrap().to_string_lossy();
         pr.set_message(format!("extract {filename}"));
         file::remove_all(tv.install_path())?;
@@ -91,7 +86,7 @@ impl DenoPlugin {
         Ok(())
     }
 
-    fn verify(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<()> {
+    fn verify(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<()> {
         self.test_deno(tv, pr)
     }
 }
@@ -124,10 +119,10 @@ impl Backend for DenoPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        let tarball_path = self.download(&tv, &ctx.pr).await?;
+        let tarball_path = self.download(&tv, ctx.pr.as_ref()).await?;
         self.verify_checksum(ctx, &mut tv, &tarball_path)?;
-        self.install(&tv, &ctx.pr, &tarball_path)?;
-        self.verify(&tv, &ctx.pr)?;
+        self.install(&tv, ctx.pr.as_ref(), &tarball_path)?;
+        self.verify(&tv, ctx.pr.as_ref())?;
 
         Ok(tv)
     }

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -37,13 +37,13 @@ impl ElixirPlugin {
     async fn test_elixir(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
         ctx.pr.set_message("elixir --version".into());
         CmdLineRunner::new(self.elixir_bin(tv))
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
             .arg("--version")
             .execute()
     }
 
-    async fn download(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<PathBuf> {
+    async fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
         let version = &tv.version;
         let version = if regex!(r"^[0-9]").is_match(version) {
             &format!("v{version}")
@@ -123,7 +123,7 @@ impl Backend for ElixirPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        let tarball_path = self.download(&tv, &ctx.pr).await?;
+        let tarball_path = self.download(&tv, ctx.pr.as_ref()).await?;
         self.verify_checksum(ctx, &mut tv, &tarball_path)?;
         self.install(ctx, &tv, &tarball_path).await?;
         self.verify(ctx, &tv).await?;

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -125,7 +125,7 @@ impl ErlangPlugin {
 
         ctx.pr.set_message(format!("Downloading {filename}"));
         if !tarball_path.exists() {
-            HTTP.download_file(&url, &tarball_path, Some(&ctx.pr))
+            HTTP.download_file(&url, &tarball_path, Some(ctx.pr.as_ref()))
                 .await?;
         }
         ctx.pr.set_message(format!("Extracting {filename}"));
@@ -134,7 +134,7 @@ impl ErlangPlugin {
             &tv.download_path(),
             &TarOptions {
                 strip_components: 0,
-                pr: Some(&ctx.pr),
+                pr: Some(ctx.pr.as_ref()),
                 format: file::TarFormat::TarGz,
                 ..Default::default()
             },
@@ -143,7 +143,7 @@ impl ErlangPlugin {
         self.move_to_install_path(&tv)?;
 
         CmdLineRunner::new(tv.install_path().join("Install"))
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .arg("-minimal")
             .arg(tv.install_path())
             .execute()?;
@@ -198,8 +198,12 @@ impl ErlangPlugin {
         };
         ctx.pr.set_message(format!("Downloading {tarball_name}"));
         let tarball_path = tv.download_path().join(&tarball_name);
-        HTTP.download_file(&asset.browser_download_url, &tarball_path, Some(&ctx.pr))
-            .await?;
+        HTTP.download_file(
+            &asset.browser_download_url,
+            &tarball_path,
+            Some(ctx.pr.as_ref()),
+        )
+        .await?;
         self.verify_checksum(ctx, &mut tv, &tarball_path)?;
         ctx.pr.set_message(format!("Extracting {tarball_name}"));
         file::untar(
@@ -207,7 +211,7 @@ impl ErlangPlugin {
             &tv.install_path(),
             &TarOptions {
                 strip_components: 0,
-                pr: Some(&ctx.pr),
+                pr: Some(ctx.pr.as_ref()),
                 format: file::TarFormat::TarGz,
                 ..Default::default()
             },
@@ -242,8 +246,12 @@ impl ErlangPlugin {
         };
         ctx.pr.set_message(format!("Downloading {}", zip_name));
         let zip_path = tv.download_path().join(&zip_name);
-        HTTP.download_file(&asset.browser_download_url, &zip_path, Some(&ctx.pr))
-            .await?;
+        HTTP.download_file(
+            &asset.browser_download_url,
+            &zip_path,
+            Some(ctx.pr.as_ref()),
+        )
+        .await?;
         self.verify_checksum(ctx, &mut tv, &zip_path)?;
         ctx.pr.set_message(format!("Extracting {}", zip_name));
         file::unzip(&zip_path, &tv.install_path(), &Default::default())?;

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -58,7 +58,7 @@ impl GoPlugin {
     fn install_default_packages(
         &self,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> eyre::Result<()> {
         let settings = Settings::get();
         let default_packages_file = file::replace_path(&settings.go_default_packages_file);
@@ -84,7 +84,7 @@ impl GoPlugin {
         Ok(())
     }
 
-    fn test_go(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> eyre::Result<()> {
+    fn test_go(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> eyre::Result<()> {
         pr.set_message("go version".into());
         CmdLineRunner::new(self.go_bin(tv))
             // run the command in the install path to prevent issues with go.mod version mismatch
@@ -94,11 +94,7 @@ impl GoPlugin {
             .execute()
     }
 
-    async fn download(
-        &self,
-        tv: &mut ToolVersion,
-        pr: &Box<dyn SingleReport>,
-    ) -> eyre::Result<PathBuf> {
+    async fn download(&self, tv: &mut ToolVersion, pr: &dyn SingleReport) -> eyre::Result<PathBuf> {
         let settings = Settings::get();
         let filename = format!(
             "go{}.{}-{}.{}",
@@ -134,7 +130,7 @@ impl GoPlugin {
     fn install(
         &self,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
         tarball_path: &Path,
     ) -> eyre::Result<()> {
         let tarball = tarball_path
@@ -161,7 +157,7 @@ impl GoPlugin {
         Ok(())
     }
 
-    fn verify(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> eyre::Result<()> {
+    fn verify(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> eyre::Result<()> {
         self.test_go(tv, pr)?;
         if let Err(err) = self.install_default_packages(tv, pr) {
             warn!("failed to install default go packages: {err:#}");
@@ -228,10 +224,10 @@ impl Backend for GoPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        let tarball_path = self.download(&mut tv, &ctx.pr).await?;
+        let tarball_path = self.download(&mut tv, ctx.pr.as_ref()).await?;
         self.verify_checksum(ctx, &mut tv, &tarball_path)?;
-        self.install(&tv, &ctx.pr, &tarball_path)?;
-        self.verify(&tv, &ctx.pr)?;
+        self.install(&tv, ctx.pr.as_ref(), &tarball_path)?;
+        self.verify(&tv, ctx.pr.as_ref())?;
 
         Ok(tv)
     }
@@ -239,7 +235,7 @@ impl Backend for GoPlugin {
     async fn uninstall_version_impl(
         &self,
         _config: &Arc<Config>,
-        _pr: &Box<dyn SingleReport>,
+        _pr: &dyn SingleReport,
         tv: &ToolVersion,
     ) -> eyre::Result<()> {
         let gopath = self.gopath(tv);

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -52,7 +52,7 @@ impl NodePlugin {
             .fetch_tarball(
                 ctx,
                 tv,
-                &ctx.pr,
+                ctx.pr.as_ref(),
                 &opts.binary_tarball_url,
                 &opts.binary_tarball_path,
                 &opts.version,
@@ -111,7 +111,7 @@ impl NodePlugin {
                     &TarOptions {
                         format: TarFormat::TarGz,
                         strip_components: 1,
-                        pr: Some(&ctx.pr),
+                        pr: Some(ctx.pr.as_ref()),
                         ..Default::default()
                     },
                 )?;
@@ -156,7 +156,7 @@ impl NodePlugin {
         self.fetch_tarball(
             ctx,
             tv,
-            &ctx.pr,
+            ctx.pr.as_ref(),
             &opts.source_tarball_url,
             &opts.source_tarball_path,
             &opts.version,
@@ -169,7 +169,7 @@ impl NodePlugin {
             opts.build_dir.parent().unwrap(),
             &TarOptions {
                 format: TarFormat::TarGz,
-                pr: Some(&ctx.pr),
+                pr: Some(ctx.pr.as_ref()),
                 ..Default::default()
             },
         )?;
@@ -183,7 +183,7 @@ impl NodePlugin {
         &self,
         ctx: &InstallContext,
         tv: &mut ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
         url: &Url,
         local: &Path,
         version: &str,
@@ -210,7 +210,7 @@ impl NodePlugin {
     fn sh<'a>(&self, ctx: &'a InstallContext, opts: &BuildOpts) -> eyre::Result<CmdLineRunner<'a>> {
         let mut cmd = CmdLineRunner::new("sh")
             .prepend_path(opts.path.clone())?
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .current_dir(&opts.build_dir)
             .arg("-c");
         if let Some(cflags) = &*env::MISE_NODE_CFLAGS {
@@ -237,8 +237,12 @@ impl NodePlugin {
     ) -> Result<String> {
         let tarball_name = tarball.file_name().unwrap().to_string_lossy().to_string();
         let shasums_file = tarball.parent().unwrap().join("SHASUMS256.txt");
-        HTTP.download_file(self.shasums_url(version)?, &shasums_file, Some(&ctx.pr))
-            .await?;
+        HTTP.download_file(
+            self.shasums_url(version)?,
+            &shasums_file,
+            Some(ctx.pr.as_ref()),
+        )
+        .await?;
         if Settings::get().node.gpg_verify != Some(false) && version.starts_with("2") {
             self.verify_with_gpg(ctx, &shasums_file, version).await?;
         }
@@ -260,7 +264,10 @@ impl NodePlugin {
         }
         let sig_file = shasums_file.with_extension("asc");
         let sig_url = format!("{}.sig", self.shasums_url(v)?);
-        if let Err(e) = HTTP.download_file(sig_url, &sig_file, Some(&ctx.pr)).await {
+        if let Err(e) = HTTP
+            .download_file(sig_url, &sig_file, Some(ctx.pr.as_ref()))
+            .await
+        {
             if matches!(http::error_code(&e), Some(404)) {
                 warn!("gpg signature not found, skipping verification");
                 return Ok(());
@@ -275,7 +282,7 @@ impl NodePlugin {
             .arg("--verify")
             .arg(sig_file)
             .arg(shasums_file)
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .execute()?;
         Ok(())
     }
@@ -308,7 +315,7 @@ impl NodePlugin {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> Result<()> {
         let body = file::read_to_string(&*env::MISE_NODE_DEFAULT_PACKAGES_FILE).unwrap_or_default();
         for package in body.lines() {
@@ -337,11 +344,7 @@ impl NodePlugin {
         Ok(())
     }
 
-    fn enable_default_corepack_shims(
-        &self,
-        tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
-    ) -> Result<()> {
+    fn enable_default_corepack_shims(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<()> {
         pr.set_message("enable corepack shims".into());
         let corepack = self.corepack_path(tv);
         CmdLineRunner::new(corepack)
@@ -356,7 +359,7 @@ impl NodePlugin {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> Result<()> {
         pr.set_message("node -v".into());
         CmdLineRunner::new(self.node_path(tv))
@@ -370,7 +373,7 @@ impl NodePlugin {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> Result<()> {
         pr.set_message("npm -v".into());
         CmdLineRunner::new(self.npm_path(tv))
@@ -491,19 +494,19 @@ impl Backend for NodePlugin {
             self.install_precompiled(ctx, &mut tv, &opts).await?;
         }
         debug!("{:?}: checking installation is working as expected", self);
-        self.test_node(&ctx.config, &tv, &ctx.pr).await?;
+        self.test_node(&ctx.config, &tv, ctx.pr.as_ref()).await?;
         if !cfg!(windows) {
             self.install_npm_shim(&tv)?;
         }
-        self.test_npm(&ctx.config, &tv, &ctx.pr).await?;
+        self.test_npm(&ctx.config, &tv, ctx.pr.as_ref()).await?;
         if let Err(err) = self
-            .install_default_packages(&ctx.config, &tv, &ctx.pr)
+            .install_default_packages(&ctx.config, &tv, ctx.pr.as_ref())
             .await
         {
             warn!("failed to install default npm packages: {err:#}");
         }
         if *env::MISE_NODE_COREPACK && self.corepack_path(&tv).exists() {
-            self.enable_default_corepack_shims(&tv, &ctx.pr)?;
+            self.enable_default_corepack_shims(&tv, ctx.pr.as_ref())?;
         }
 
         Ok(tv)

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -63,7 +63,7 @@ impl RubyPlugin {
     }
 
     async fn update_build_tool(&self, ctx: Option<&InstallContext>) -> Result<()> {
-        let pr = ctx.map(|ctx| &ctx.pr);
+        let pr = ctx.map(|ctx| ctx.pr.as_ref());
         if Settings::get().ruby.ruby_install {
             self.update_ruby_install(pr)
                 .await
@@ -75,7 +75,7 @@ impl RubyPlugin {
         }
     }
 
-    fn install_ruby_build(&self, pr: Option<&Box<dyn SingleReport>>) -> Result<()> {
+    fn install_ruby_build(&self, pr: Option<&dyn SingleReport>) -> Result<()> {
         debug!(
             "Installing ruby-build to {}",
             self.ruby_build_path().display()
@@ -97,7 +97,7 @@ impl RubyPlugin {
         file::remove_all(&tmp)?;
         Ok(())
     }
-    async fn update_ruby_build(&self, pr: Option<&Box<dyn SingleReport>>) -> Result<()> {
+    async fn update_ruby_build(&self, pr: Option<&dyn SingleReport>) -> Result<()> {
         let _lock = self.lock_build_tool();
         if self.ruby_build_bin().exists() {
             let cur = self.ruby_build_version()?;
@@ -120,7 +120,7 @@ impl RubyPlugin {
         Ok(())
     }
 
-    fn install_ruby_install(&self, pr: Option<&Box<dyn SingleReport>>) -> Result<()> {
+    fn install_ruby_install(&self, pr: Option<&dyn SingleReport>) -> Result<()> {
         let settings = Settings::get();
         debug!(
             "Installing ruby-install to {}",
@@ -144,7 +144,7 @@ impl RubyPlugin {
         file::remove_all(&tmp)?;
         Ok(())
     }
-    async fn update_ruby_install(&self, pr: Option<&Box<dyn SingleReport>>) -> Result<()> {
+    async fn update_ruby_install(&self, pr: Option<&dyn SingleReport>) -> Result<()> {
         let _lock = self.lock_build_tool();
         let ruby_install_path = self.ruby_install_path();
         if !ruby_install_path.exists() {
@@ -177,7 +177,7 @@ impl RubyPlugin {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> Result<()> {
         let settings = Settings::get();
         let default_gems_file = file::replace_path(&settings.ruby.default_packages_file);
@@ -230,7 +230,7 @@ impl RubyPlugin {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &'a Box<dyn SingleReport>,
+        pr: &'a dyn SingleReport,
     ) -> Result<CmdLineRunner<'a>> {
         let settings = Settings::get();
         let cmd = if settings.ruby.ruby_install {
@@ -363,12 +363,15 @@ impl Backend for RubyPlugin {
             warn!("ruby build tool update error: {err:#}");
         }
         ctx.pr.set_message("ruby-build".into());
-        self.install_cmd(&ctx.config, &tv, &ctx.pr)
+        self.install_cmd(&ctx.config, &tv, ctx.pr.as_ref())
             .await?
             .execute()?;
 
         self.install_rubygems_hook(&tv)?;
-        if let Err(err) = self.install_default_gems(&ctx.config, &tv, &ctx.pr).await {
+        if let Err(err) = self
+            .install_default_gems(&ctx.config, &tv, ctx.pr.as_ref())
+            .await
+        {
             warn!("failed to install default ruby gems {err:#}");
         }
         Ok(tv)

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -45,7 +45,7 @@ impl RubyPlugin {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> Result<()> {
         let settings = Settings::get();
         let default_gems_file = file::replace_path(&settings.ruby.default_packages_file);
@@ -76,7 +76,7 @@ impl RubyPlugin {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> Result<()> {
         pr.set_message("ruby -v".into());
         CmdLineRunner::new(self.ruby_path(tv))
@@ -90,7 +90,7 @@ impl RubyPlugin {
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
     ) -> Result<()> {
         pr.set_message("gem -v".into());
         CmdLineRunner::new(self.gem_path(tv))
@@ -109,7 +109,7 @@ impl RubyPlugin {
         Ok(())
     }
 
-    async fn download(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<PathBuf> {
+    async fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
         let arch = arch();
         let url = format!(
             "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-{version}-1/rubyinstaller-{version}-1-{arch}.7z",
@@ -144,7 +144,7 @@ impl RubyPlugin {
     }
 
     async fn verify(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
-        self.test_ruby(&ctx.config, tv, &ctx.pr).await
+        self.test_ruby(&ctx.config, tv, ctx.pr.as_ref()).await
     }
 }
 
@@ -200,13 +200,16 @@ impl Backend for RubyPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> eyre::Result<ToolVersion> {
-        let tarball = self.download(&tv, &ctx.pr).await?;
+        let tarball = self.download(&tv, ctx.pr.as_ref()).await?;
         self.verify_checksum(ctx, &mut tv, &tarball)?;
         self.install(ctx, &tv, &tarball).await?;
         self.verify(ctx, &tv).await?;
         self.install_rubygems_hook(&tv)?;
-        self.test_gem(&ctx.config, &tv, &ctx.pr).await?;
-        if let Err(err) = self.install_default_gems(&ctx.config, &tv, &ctx.pr).await {
+        self.test_gem(&ctx.config, &tv, ctx.pr.as_ref()).await?;
+        if let Err(err) = self
+            .install_default_gems(&ctx.config, &tv, ctx.pr.as_ref())
+            .await
+        {
             warn!("failed to install default ruby gems {err:#}");
         }
         Ok(tv)

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -35,13 +35,13 @@ impl RustPlugin {
             return Ok(());
         }
         ctx.pr.set_message("Downloading rustup-init".into());
-        HTTP.download_file(rustup_url(&settings), &rustup_path(), Some(&ctx.pr))
+        HTTP.download_file(rustup_url(&settings), &rustup_path(), Some(ctx.pr.as_ref()))
             .await?;
         file::make_executable(rustup_path())?;
         file::create_dir_all(rustup_home())?;
         let ts = ctx.config.get_toolset().await?;
         let cmd = CmdLineRunner::new(rustup_path())
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .arg("--no-modify-path")
             .arg("--default-toolchain")
             .arg("none")
@@ -55,7 +55,7 @@ impl RustPlugin {
         ctx.pr.set_message(format!("{RUSTC_BIN} -V"));
         let ts = ctx.config.get_toolset().await?;
         CmdLineRunner::new(RUSTC_BIN)
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .arg("-V")
             .envs(self.exec_env(&ctx.config, ts, tv).await?)
             .prepend_path(self.list_bin_paths(&ctx.config, tv).await?)?
@@ -104,7 +104,7 @@ impl Backend for RustPlugin {
         let (profile, components, targets) = get_args(&tv);
 
         CmdLineRunner::new(RUSTUP_BIN)
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .arg("toolchain")
             .arg("install")
             .arg(&tv.version)
@@ -127,7 +127,7 @@ impl Backend for RustPlugin {
     async fn uninstall_version_impl(
         &self,
         config: &Arc<Config>,
-        pr: &Box<dyn SingleReport>,
+        pr: &dyn SingleReport,
         tv: &ToolVersion,
     ) -> Result<()> {
         let ts = config.get_toolset().await?;

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -34,12 +34,12 @@ impl SwiftPlugin {
     fn test_swift(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
         ctx.pr.set_message("swift --version".into());
         CmdLineRunner::new(self.swift_bin(tv))
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .arg("--version")
             .execute()
     }
 
-    async fn download(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<PathBuf> {
+    async fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
         let settings = Settings::get();
         let url = format!(
             "https://download.swift.org/swift-{version}-release/{platform_directory}/swift-{version}-RELEASE/swift-{version}-RELEASE-{platform}{architecture}.{extension}",
@@ -77,7 +77,7 @@ impl SwiftPlugin {
                 .arg("--expand-full")
                 .arg(tarball_path)
                 .arg(&tmp)
-                .with_pr(&ctx.pr)
+                .with_pr(ctx.pr.as_ref())
                 .execute()?;
             file::remove_all(tv.install_path())?;
             file::rename(
@@ -93,7 +93,7 @@ impl SwiftPlugin {
                 &tv.install_path(),
                 &file::TarOptions {
                     format: file::TarFormat::TarGz,
-                    pr: Some(&ctx.pr),
+                    pr: Some(ctx.pr.as_ref()),
                     strip_components: 1,
                     ..Default::default()
                 },
@@ -131,7 +131,7 @@ impl SwiftPlugin {
         }
         gpg::add_keys_swift(ctx)?;
         let sig_path = PathBuf::from(format!("{}.sig", tarball_path.to_string_lossy()));
-        HTTP.download_file(format!("{}.sig", url(tv)), &sig_path, Some(&ctx.pr))
+        HTTP.download_file(format!("{}.sig", url(tv)), &sig_path, Some(ctx.pr.as_ref()))
             .await?;
         self.gpg(ctx)
             .arg("--quiet")
@@ -149,7 +149,7 @@ impl SwiftPlugin {
     }
 
     fn gpg<'a>(&self, ctx: &'a InstallContext) -> CmdLineRunner<'a> {
-        CmdLineRunner::new("gpg").with_pr(&ctx.pr)
+        CmdLineRunner::new("gpg").with_pr(ctx.pr.as_ref())
     }
 }
 
@@ -184,7 +184,7 @@ impl Backend for SwiftPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        let tarball_path = self.download(&tv, &ctx.pr).await?;
+        let tarball_path = self.download(&tv, ctx.pr.as_ref()).await?;
         if cfg!(target_os = "linux") && Settings::get().swift.gpg_verify != Some(false) {
             self.verify_gpg(ctx, &tv, &tarball_path).await?;
         }

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -46,12 +46,12 @@ impl ZigPlugin {
     fn test_zig(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
         ctx.pr.set_message("zig version".into());
         CmdLineRunner::new(self.zig_bin(tv))
-            .with_pr(&ctx.pr)
+            .with_pr(ctx.pr.as_ref())
             .arg("version")
             .execute()
     }
 
-    async fn download(&self, tv: &ToolVersion, pr: &Box<dyn SingleReport>) -> Result<PathBuf> {
+    async fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
         let settings = Settings::get();
         let indexes = HashMap::from([
             ("zig", "https://ziglang.org/download/index.json"),
@@ -99,7 +99,7 @@ impl ZigPlugin {
             &tv.install_path(),
             &TarOptions {
                 strip_components: 1,
-                pr: Some(&ctx.pr),
+                pr: Some(ctx.pr.as_ref()),
                 ..Default::default()
             },
         )?;
@@ -187,7 +187,7 @@ impl Backend for ZigPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        let tarball_path = self.download(&tv, &ctx.pr).await?;
+        let tarball_path = self.download(&tv, ctx.pr.as_ref()).await?;
         self.verify_checksum(ctx, &mut tv, &tarball_path)?;
         self.install(ctx, &tv, &tarball_path)?;
         self.verify(ctx, &tv)?;

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -112,11 +112,7 @@ impl PluginEnum {
         }
     }
 
-    pub async fn update(
-        &self,
-        pr: &Box<dyn SingleReport>,
-        gitref: Option<String>,
-    ) -> eyre::Result<()> {
+    pub async fn update(&self, pr: &dyn SingleReport, gitref: Option<String>) -> eyre::Result<()> {
         match self {
             PluginEnum::Asdf(plugin) => plugin.update(pr, gitref).await,
             PluginEnum::Vfox(plugin) => plugin.update(pr, gitref).await,
@@ -124,7 +120,7 @@ impl PluginEnum {
         }
     }
 
-    pub async fn uninstall(&self, pr: &Box<dyn SingleReport>) -> eyre::Result<()> {
+    pub async fn uninstall(&self, pr: &dyn SingleReport) -> eyre::Result<()> {
         match self {
             PluginEnum::Asdf(plugin) => plugin.uninstall(pr).await,
             PluginEnum::Vfox(plugin) => plugin.uninstall(pr).await,
@@ -132,11 +128,7 @@ impl PluginEnum {
         }
     }
 
-    pub async fn install(
-        &self,
-        config: &Arc<Config>,
-        pr: &Box<dyn SingleReport>,
-    ) -> eyre::Result<()> {
+    pub async fn install(&self, config: &Arc<Config>, pr: &dyn SingleReport) -> eyre::Result<()> {
         match self {
             PluginEnum::Asdf(plugin) => plugin.install(config, pr).await,
             PluginEnum::Vfox(plugin) => plugin.install(config, pr).await,
@@ -258,21 +250,13 @@ pub trait Plugin: Debug + Send {
     ) -> eyre::Result<()> {
         Ok(())
     }
-    async fn update(
-        &self,
-        _pr: &Box<dyn SingleReport>,
-        _gitref: Option<String>,
-    ) -> eyre::Result<()> {
+    async fn update(&self, _pr: &dyn SingleReport, _gitref: Option<String>) -> eyre::Result<()> {
         Ok(())
     }
-    async fn uninstall(&self, _pr: &Box<dyn SingleReport>) -> eyre::Result<()> {
+    async fn uninstall(&self, _pr: &dyn SingleReport) -> eyre::Result<()> {
         Ok(())
     }
-    async fn install(
-        &self,
-        _config: &Arc<Config>,
-        _pr: &Box<dyn SingleReport>,
-    ) -> eyre::Result<()> {
+    async fn install(&self, _config: &Arc<Config>, _pr: &dyn SingleReport) -> eyre::Result<()> {
         Ok(())
     }
     fn external_commands(&self) -> eyre::Result<Vec<Command>> {

--- a/src/plugins/script_manager.rs
+++ b/src/plugins/script_manager.rs
@@ -164,7 +164,7 @@ impl ScriptManager {
             .wrap_err_with(|| ScriptFailed(display_path(self.get_script_path(script)), None))
     }
 
-    pub fn run_by_line(&self, script: &Script, pr: &Box<dyn SingleReport>) -> Result<()> {
+    pub fn run_by_line(&self, script: &Script, pr: &dyn SingleReport) -> Result<()> {
         let path = self.get_script_path(script);
         pr.set_message(display_path(&path));
         let mut cmd = CmdLineRunner::new(path.clone());

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -138,13 +138,13 @@ impl Plugin for VfoxPlugin {
             let pr = mpr.add_with_options(&format!("clone vfox plugin {url}"), dry_run);
             if !dry_run {
                 self.repo()
-                    .clone(url.as_str(), CloneOptions::default().pr(&pr))?;
+                    .clone(url.as_str(), CloneOptions::default().pr(pr.as_ref()))?;
             }
         }
         Ok(())
     }
 
-    async fn update(&self, pr: &Box<dyn SingleReport>, gitref: Option<String>) -> Result<()> {
+    async fn update(&self, pr: &dyn SingleReport, gitref: Option<String>) -> Result<()> {
         let plugin_path = self.plugin_path.to_path_buf();
         if plugin_path.is_symlink() {
             warn!(
@@ -172,7 +172,7 @@ impl Plugin for VfoxPlugin {
         Ok(())
     }
 
-    async fn uninstall(&self, pr: &Box<dyn SingleReport>) -> Result<()> {
+    async fn uninstall(&self, pr: &dyn SingleReport) -> Result<()> {
         if !self.is_installed() {
             return Ok(());
         }
@@ -196,7 +196,7 @@ impl Plugin for VfoxPlugin {
         Ok(())
     }
 
-    async fn install(&self, _config: &Arc<Config>, pr: &Box<dyn SingleReport>) -> eyre::Result<()> {
+    async fn install(&self, _config: &Arc<Config>, pr: &dyn SingleReport) -> eyre::Result<()> {
         let repository = self.get_repo_url()?;
         let (repo_url, repo_ref) = Git::split_url_and_ref(repository.as_str());
         debug!("vfox_plugin[{}]:install {:?}", self.name, repository);

--- a/src/uv.rs
+++ b/src/uv.rs
@@ -63,7 +63,7 @@ async fn get_or_create_venv(ts: &Toolset, venv_path: PathBuf, uv_path: PathBuf) 
         let pr = mpr.add("Creating uv venv");
         let mut cmd = CmdLineRunner::new(uv_path)
             .current_dir(uv_root().unwrap())
-            .with_pr(&pr)
+            .with_pr(pr.as_ref())
             .envs(&venv.env)
             .arg("venv");
         if !log::log_enabled!(log::Level::Debug) {


### PR DESCRIPTION
## Summary
Replaces all instances of `&Box<dyn SingleReport>` parameters with `&dyn SingleReport` as recommended by clippy warning. This is more idiomatic Rust as it avoids the unnecessary indirection through a Box when we only need a trait object reference.

## Changes
- **Function Signatures**: Updated parameter types across 44 files including all backend implementations and core plugins
- **Call Sites**: Fixed call sites to use `.as_ref()` where needed to dereference Box types  
- **Complex Dereferencing**: Updated `cmd.rs` to properly handle `Arc<Box<dyn SingleReport>>` dereferencing
- **Formatting**: Applied `cargo fmt` for consistent code style

## Files Modified
### Backends
- `src/backend/asdf.rs`, `src/backend/aqua.rs`, `src/backend/cargo.rs`
- `src/backend/dotnet.rs`, `src/backend/gem.rs`, `src/backend/go.rs`
- `src/backend/http.rs`, `src/backend/npm.rs`, `src/backend/pipx.rs`
- `src/backend/spm.rs`, `src/backend/ubi.rs`, `src/backend/mod.rs`

### Core Plugins  
- `src/plugins/core/bun.rs`, `src/plugins/core/deno.rs`, `src/plugins/core/elixir.rs`
- `src/plugins/core/erlang.rs`, `src/plugins/core/go.rs`, `src/plugins/core/java.rs`
- `src/plugins/core/node.rs`, `src/plugins/core/python.rs`, `src/plugins/core/ruby.rs`
- `src/plugins/core/rust.rs`, `src/plugins/core/swift.rs`, `src/plugins/core/zig.rs`

### CLI & Utilities
- `src/cmd.rs`, `src/cli/generate/tool_stub.rs`, `src/cli/prune.rs`
- `src/cli/plugins/uninstall.rs`, `src/cli/plugins/update.rs`, `src/cli/uninstall.rs`
- `src/cli/upgrade.rs`, `src/gpg.rs`, `src/uv.rs`

### Plugin Systems
- `src/plugins/asdf_plugin.rs`, `src/plugins/vfox_plugin.rs`, `src/plugins/mod.rs`

## Testing
- ✅ All 65 clippy warnings resolved
- ✅ Code builds successfully with `cargo build --all-features`
- ✅ No remaining clippy warnings with `cargo clippy --all-features`
- ✅ All pre-commit hooks passed

## Before/After
```rust
// Before
fn some_function(pr: &Box<dyn SingleReport>) { ... }

// After  
fn some_function(pr: &dyn SingleReport) { ... }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors APIs to take `&dyn SingleReport` instead of `&Box<dyn SingleReport>` and updates all call sites and helpers to use `.as_ref()` accordingly.
> 
> - **Core API change**:
>   - Replace `&Box<dyn SingleReport>` with `&dyn SingleReport` across public/internal functions (`HTTP::*download*`, `hash::*`, `file::TarOptions`, `cmd::CmdLineRunner::with_pr`, `git::CloneOptions::pr`, backend trait methods, plugin hooks).
>   - Update `CmdLineRunner` to correctly handle `pr` and `pr_arc` trait-object references.
> - **Propagation**:
>   - Backend implementations (`aqua`, `asdf`, `cargo`, `dotnet`, `gem`, `github`, `go`, `http`, `npm`, `pipx`, `spm`, `ubi`, `mod`) migrated to pass `ctx.pr.as_ref()`.
>   - Core plugins (`bun`, `deno`, `elixir`, `erlang`, `go`, `java`, `node`, `python`, `ruby*`, `rust`, `swift`, `zig`) updated accordingly.
>   - CLI and utilities (`cmd`, `gpg`, `uv`, generator, prune/uninstall/upgrade flows) updated to new signatures and passing style.
> - **Misc**:
>   - Adjust progress/tar extraction options and verification helpers to new trait-object reference type; minor formatting changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b330fbecfef947756692065723b872774f6aa99b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->