### PR TITLE
chore: release 2025.9.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2025.9.25](https://github.com/jdx/mise/compare/v2025.9.24..v2025.9.25) - 2025-09-30
+
+### 📦 Registry
+
+- prefer k3s from Aqua over ASDF plugin by @TobiX in [#6486](https://github.com/jdx/mise/pull/6486)
+
+### 🐛 Bug Fixes
+
+- **(auto-install)** support installing non-active backend versions by @jdx in [#6484](https://github.com/jdx/mise/pull/6484)
+- **(install)** remove duplicate 'mise' text in install header by @jdx in [#6489](https://github.com/jdx/mise/pull/6489)
+- **(task)** prevent hang when tasks with multiple dependencies fail by @stempler in [#6481](https://github.com/jdx/mise/pull/6481)
+
+### 🧪 Testing
+
+- **(e2e)** use local HTTP server instead of httpbin.org for tool-stub tests by @jdx in [#6488](https://github.com/jdx/mise/pull/6488)
+
+### Chore
+
+- **(ci)** prevent release workflow from running on release branch pushes by @jdx in [#6490](https://github.com/jdx/mise/pull/6490)
+- **(ci)** parallelize release workflow to start e2e tests earlier by @jdx in [#6491](https://github.com/jdx/mise/pull/6491)
+
+### New Contributors
+
+- @stempler made their first contribution in [#6481](https://github.com/jdx/mise/pull/6481)
+
 ## [2025.9.24](https://github.com/jdx/mise/compare/v2025.9.23..v2025.9.24) - 2025-09-29
 
 ### 📦 Registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.9.24"
+version = "2025.9.25"
 dependencies = [
  "age",
  "aqua-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox", "crates/aqua-registry"]
 
 [package]
 name = "mise"
-version = "2025.9.24"
+version = "2025.9.25"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.9.24 macos-arm64 (a1b2d3e 2025-09-29)
+2025.9.25 macos-arm64 (a1b2d3e 2025-09-30)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_9_24.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_9_25.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage > "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_9_24.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_9_25.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage > "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_9_24.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_9_25.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/crates/aqua-registry/aqua-registry/pkgs/hougesen/mdsf/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/hougesen/mdsf/registry.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: hougesen
+    repo_name: mdsf
+    description: Format markdown code blocks using your favorite tools
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.2")
+        no_asset: true
+      - version_constraint: semver("<= 0.2.2")
+        asset: mdsf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            asset: mdsf-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.2.3"
+        asset: mdsf-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: mdsf
+            src: "{{.AssetWithoutExt}}/mdsf"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: mdsf-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: mdsf
+            src: "{{.AssetWithoutExt}}/mdsf"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.9.24";
+  version = "2025.9.25";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.9.24
+Version: 2025.9.25
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System


### PR DESCRIPTION
### 📦 Registry

- prefer k3s from Aqua over ASDF plugin by @TobiX in [#6486](https://github.com/jdx/mise/pull/6486)

### 🐛 Bug Fixes

- **(auto-install)** support installing non-active backend versions by @jdx in [#6484](https://github.com/jdx/mise/pull/6484)
- **(install)** remove duplicate 'mise' text in install header by @jdx in [#6489](https://github.com/jdx/mise/pull/6489)
- **(task)** prevent hang when tasks with multiple dependencies fail by @stempler in [#6481](https://github.com/jdx/mise/pull/6481)

### 🧪 Testing

- **(e2e)** use local HTTP server instead of httpbin.org for tool-stub tests by @jdx in [#6488](https://github.com/jdx/mise/pull/6488)

### Chore

- **(ci)** prevent release workflow from running on release branch pushes by @jdx in [#6490](https://github.com/jdx/mise/pull/6490)
- **(ci)** parallelize release workflow to start e2e tests earlier by @jdx in [#6491](https://github.com/jdx/mise/pull/6491)

### New Contributors

- @stempler made their first contribution in [#6481](https://github.com/jdx/mise/pull/6481)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps to 2025.9.25 with CHANGELOG update, packaging/completions version sync, and adds `mdsf` to the embedded Aqua registry.
> 
> - **Release/Versioning**:
>   - Bump `mise` to `2025.9.25` in `Cargo.toml`, `Cargo.lock`, `default.nix`, `packaging/rpm/mise.spec`, and `README.md`.
>   - Update shell completion cache spec filenames to `usage__usage_spec_mise_2025_9_25.spec` in `completions/_mise`, `completions/mise.bash`, and `completions/mise.fish`.
>   - Add `CHANGELOG.md` entry for `2025.9.25`.
> - **Registry**:
>   - Add Aqua registry package `hougesen/mdsf` at `crates/aqua-registry/aqua-registry/pkgs/hougesen/mdsf/registry.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be0e5c1613387ba1206af24584924c176e610589. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->