### PR TITLE
registry: prefer k3s from Aqua over ASDF plugin

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2423,7 +2423,7 @@ description = "K3k, Kubernetes in Kubernetes, is a tool that empowers you to cre
 test = ["k3k --version", "k3kcli version v{{version}}"]
 
 [tools.k3s]
-backends = ["asdf:mise-plugins/mise-k3s"]
+backends = ["aqua:k3s-io/k3s", "asdf:mise-plugins/mise-k3s"]
 description = "The certified Kubernetes distribution built for IoT & Edge computing"
 
 [tools.k3sup]

--- a/registry.toml
+++ b/registry.toml
@@ -2425,6 +2425,7 @@ test = ["k3k --version", "k3kcli version v{{version}}"]
 [tools.k3s]
 backends = ["aqua:k3s-io/k3s", "asdf:mise-plugins/mise-k3s"]
 description = "The certified Kubernetes distribution built for IoT & Edge computing"
+test = ["k3s --version", "k3s version v{{version}}"]
 
 [tools.k3sup]
 backends = ["aqua:alexellis/k3sup", "asdf:cgroschupp/asdf-k3sup"]


### PR DESCRIPTION
I tried using the new `github` backend, but k3s has strange release artifacts :D
