### PR TITLE
fix(install): remove duplicate 'mise' text in install header

### DIFF
--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -116,7 +116,7 @@ impl ProgressReport {
         let pad = *LONGEST_PLUGIN_NAME;
         let pb = ProgressBar::new(length)
             .with_style(HEADER_TEMPLATE.clone())
-            .with_prefix(normal_prefix(pad, &prefix))
+            .with_prefix(pad_prefix(pad, &prefix))
             .with_message(message);
         pb.enable_steady_tick(TICK_INTERVAL);
         ProgressReport { pb }


### PR DESCRIPTION
## Summary
- Fixed UI glitch where install header displayed "mise mise" instead of just "mise"
- The header prefix already contained "mise" in purple color, but `normal_prefix()` was adding another dimmed "mise"
- Changed `new_header()` to use `pad_prefix()` directly to show "mise" only once

## Test plan
- Run `mise install` and verify the header shows "mise" only once in purple color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch `new_header` to use `pad_prefix` instead of `normal_prefix` to avoid duplicating "mise" in the header.
> 
> - **UI Progress Header**:
>   - Update `src/ui/progress_report.rs` `new_header` to use `pad_prefix(pad, &prefix)` instead of `normal_prefix(pad, &prefix)`, preventing duplicate "mise" in header prefixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 716912bd1f7397b6f7ab51612752f1d3a64bff95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->