### PR TITLE
fix(github): download assets via API to respect GITHUB_TOKEN

### DIFF
--- a/e2e/backend/test_github
+++ b/e2e/backend/test_github
@@ -54,4 +54,5 @@ PLATFORM_KEY=$(mise x --cd . -- bash -c "echo \"\$(uname -s | tr '[:upper:]' '[:
 assert_contains "cat mise.lock" "[tools.\"github:jdx/mise-test-fixtures\".platforms.$PLATFORM_KEY]"
 assert_contains "cat mise.lock" 'checksum = "blake3:71f774faa03daf1a58cc3339f8c73e6557348c8e0a2f3fb8148cc26e26bad83f"'
 assert_contains "cat mise.lock" 'url = "https://github.com/jdx/mise-test-fixtures/releases/download/v1.0.0/hello-world-1.0.0.tar.gz"'
+assert_contains "cat mise.lock" 'url_api = "https://api.github.com/repos/jdx/mise-test-fixtures/releases/assets/272317030"'
 assert_contains "cat mise.lock" 'size = '

--- a/e2e/backend/test_github_url_tracking
+++ b/e2e/backend/test_github_url_tracking
@@ -29,7 +29,9 @@ assert_contains "cat mise.lock" 'backend = "github:jdx/mise-test-fixtures"'
 # Get the current platform key
 PLATFORM_KEY=$(mise x --cd . -- bash -c "echo \"\$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-\$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/')\"")
 assert_contains "cat mise.lock" "[tools.\"github:jdx/mise-test-fixtures\".platforms.$PLATFORM_KEY]"
+assert_contains "cat mise.lock" 'name = "hello-world-1.0.0.tar.gz"'
 assert_contains "cat mise.lock" 'url = "https://github.com/jdx/mise-test-fixtures/releases/download/v1.0.0/hello-world-1.0.0.tar.gz"'
+assert_contains "cat mise.lock" 'url_api = "https://api.github.com/repos/jdx/mise-test-fixtures/releases/assets/272317030"'
 
 echo "Lockfile after installation:"
 cat mise.lock

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -23,6 +23,12 @@ pub struct UnifiedGitBackend {
     ba: Arc<BackendArg>,
 }
 
+struct ReleaseAsset {
+    name: String,
+    url: String,
+    url_api: String,
+}
+
 #[async_trait]
 impl Backend for UnifiedGitBackend {
     fn get_type(&self) -> BackendType {
@@ -77,23 +83,26 @@ impl Backend for UnifiedGitBackend {
 
         // Check if URL already exists in lockfile platforms first
         let platform_key = self.get_platform_key();
-        let asset_url = if let Some(existing_platform) = tv
-            .lock_platforms
-            .get(&platform_key)
-            .and_then(|asset| asset.url.clone())
-        {
+        let asset = if let Some(existing_platform) = tv.lock_platforms.get(&platform_key) {
             debug!(
                 "Using existing URL from lockfile for platform {}: {}",
-                platform_key, existing_platform
+                platform_key,
+                existing_platform.url.clone().unwrap_or_default()
             );
-            existing_platform
+            ReleaseAsset {
+                name: existing_platform.name.clone().unwrap_or_else(|| {
+                    get_filename_from_url(existing_platform.url.as_deref().unwrap_or(""))
+                }),
+                url: existing_platform.url.clone().unwrap_or_default(),
+                url_api: existing_platform.url_api.clone().unwrap_or_default(),
+            }
         } else {
             // Find the asset URL for this specific version
             self.resolve_asset_url(&tv, &opts, &repo, &api_url).await?
         };
 
         // Download and install
-        self.download_and_install(ctx, &mut tv, &asset_url, &opts)
+        self.download_and_install(ctx, &mut tv, &asset, &opts)
             .await?;
 
         Ok(tv)
@@ -154,24 +163,33 @@ impl UnifiedGitBackend {
         &self,
         ctx: &InstallContext,
         tv: &mut ToolVersion,
-        asset_url: &str,
+        asset: &ReleaseAsset,
         opts: &ToolVersionOptions,
     ) -> Result<()> {
-        let filename = get_filename_from_url(asset_url);
+        let filename = asset.name.clone();
         let file_path = tv.download_path().join(&filename);
-        let headers = if self.is_gitlab() {
-            gitlab::get_headers(asset_url)
-        } else {
-            github::get_headers(asset_url)
-        };
 
         // Store the asset URL in the tool version
         let platform_key = self.get_platform_key();
         let platform_info = tv.lock_platforms.entry(platform_key).or_default();
-        platform_info.url = Some(asset_url.to_string());
+        platform_info.name = Some(asset.name.clone());
+        platform_info.url = Some(asset.url.clone());
+        platform_info.url_api = Some(asset.url_api.clone());
+
+        // check if url is reachable, 404 might indicate a private repo or asset
+        let url = match HTTP.head(asset.url.clone()).await {
+            Ok(_) => asset.url.clone(),
+            Err(_) => asset.url_api.clone(),
+        };
+
+        let headers = if self.is_gitlab() {
+            gitlab::get_headers(&url)
+        } else {
+            github::get_headers(&url)
+        };
 
         ctx.pr.set_message(format!("download {filename}"));
-        HTTP.download_file_with_headers(asset_url, &file_path, &headers, Some(ctx.pr.as_ref()))
+        HTTP.download_file_with_headers(url, &file_path, &headers, Some(ctx.pr.as_ref()))
             .await?;
 
         // Verify and install
@@ -214,10 +232,14 @@ impl UnifiedGitBackend {
         opts: &ToolVersionOptions,
         repo: &str,
         api_url: &str,
-    ) -> Result<String> {
+    ) -> Result<ReleaseAsset> {
         // Check for direct platform-specific URLs first
         if let Some(direct_url) = lookup_platform_key(opts, "url") {
-            return Ok(direct_url);
+            return Ok(ReleaseAsset {
+                name: get_filename_from_url(&direct_url),
+                url: direct_url.clone(),
+                url_api: direct_url.clone(),
+            });
         }
 
         let version = &tv.version;
@@ -244,7 +266,7 @@ impl UnifiedGitBackend {
         repo: &str,
         api_url: &str,
         version: &str,
-    ) -> Result<String> {
+    ) -> Result<ReleaseAsset> {
         let release = github::get_release_for_url(api_url, repo, version).await?;
 
         let available_assets: Vec<String> = release.assets.iter().map(|a| a.name.clone()).collect();
@@ -269,7 +291,11 @@ impl UnifiedGitBackend {
                     )
                 })?;
 
-            return Ok(asset.browser_download_url);
+            return Ok(ReleaseAsset {
+                name: asset.name,
+                url: asset.browser_download_url,
+                url_api: asset.url,
+            });
         }
 
         // Fall back to auto-detection
@@ -284,7 +310,11 @@ impl UnifiedGitBackend {
                 )
             })?;
 
-        Ok(asset.browser_download_url.clone())
+        Ok(ReleaseAsset {
+            name: asset.name.clone(),
+            url: asset.browser_download_url.clone(),
+            url_api: asset.url.clone(),
+        })
     }
 
     async fn resolve_gitlab_asset_url(
@@ -294,7 +324,7 @@ impl UnifiedGitBackend {
         repo: &str,
         api_url: &str,
         version: &str,
-    ) -> Result<String> {
+    ) -> Result<ReleaseAsset> {
         let release = gitlab::get_release_for_url(api_url, repo, version).await?;
 
         let available_assets: Vec<String> = release
@@ -325,7 +355,11 @@ impl UnifiedGitBackend {
                     )
                 })?;
 
-            return Ok(asset.direct_asset_url);
+            return Ok(ReleaseAsset {
+                name: asset.name,
+                url: asset.url,
+                url_api: asset.direct_asset_url,
+            });
         }
 
         // Fall back to auto-detection
@@ -340,7 +374,11 @@ impl UnifiedGitBackend {
                 )
             })?;
 
-        Ok(asset.direct_asset_url.clone())
+        Ok(ReleaseAsset {
+            name: asset.name.clone(),
+            url: asset.direct_asset_url.clone(),
+            url_api: asset.url.clone(),
+        })
     }
 
     fn auto_detect_asset(&self, available_assets: &[String]) -> Result<String> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -936,9 +936,11 @@ pub trait Backend: Debug + Send + Sync {
         // 2. Potentially download to get checksum
         // 3. Handle any URL-specific logic
         Ok(PlatformInfo {
-            url: Some(tarball_url.to_string()),
             checksum: None, // TODO: Implement checksum fetching
+            name: None,     // TODO: Implement name extraction from URL if needed
             size: None,     // TODO: Implement size fetching via HEAD request
+            url: Some(tarball_url.to_string()),
+            url_api: None,
         })
     }
 
@@ -962,9 +964,11 @@ pub trait Backend: Debug + Send + Sync {
         });
 
         Ok(PlatformInfo {
-            url: asset_url,
             checksum: None, // TODO: Implement checksum fetching from releases
+            name: None,     // TODO: Implement asset name fetching from releases
             size: None,     // TODO: Implement size fetching from GitHub API
+            url: asset_url,
+            url_api: None,
         })
     }
 
@@ -978,9 +982,11 @@ pub trait Backend: Debug + Send + Sync {
         // This is the fallback - no external metadata available
         // The tool would need to be installed to generate platform info
         Ok(PlatformInfo {
-            url: None,
             checksum: None,
             size: None,
+            name: None,
+            url: None,
+            url_api: None,
         })
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -34,6 +34,7 @@ pub struct GithubAsset {
     pub name: String,
     // pub size: u64,
     pub browser_download_url: String,
+    pub url: String,
 }
 
 type CacheGroup<T> = HashMap<String, CacheManager<T>>;
@@ -230,6 +231,13 @@ pub fn get_headers<U: IntoUrl>(url: U) -> HeaderMap {
         }
     } else if let Some(token) = env::MISE_GITHUB_ENTERPRISE_TOKEN.as_ref() {
         set_headers(token);
+    }
+
+    if url.path().contains("/releases/assets/") {
+        headers.insert(
+            "accept",
+            HeaderValue::from_static("application/octet-stream"),
+        );
     }
 
     headers


### PR DESCRIPTION
Currently GitHub backend is not able to download assets from private repositories since the `asset.browser_download_url` does not respect the `GITHUB_TOKEN` (Bearer token header respectively). We should use `asset.url` instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch downloads to API-backed asset URLs (token-aware), add asset name/url/url_api to lockfiles, and set correct headers for GitHub release assets.
> 
> - **Backend (GitHub/GitLab)**:
>   - Introduce `ReleaseAsset { name, url, url_api }` and propagate through resolution and install flows.
>   - Prefer existing lockfile asset info; otherwise resolve via API; store `name`, `url`, and `url_api` in `tv.lock_platforms`.
>   - Download logic: HEAD-check `url`; on failure, fall back to `url_api`; pass appropriate headers; set GitHub `accept: application/octet-stream` for `/releases/assets/`.
>   - Extend GitHub asset model with `GithubAsset.url`.
> - **Lockfile**:
>   - Extend `PlatformInfo` with `name` and `url_api` (serde read/write, conversions, tests updated).
>   - Populate new fields in various lockfile resolution helpers.
> - **Tests (e2e)**:
>   - Verify lockfile includes `name` and `url_api` alongside `url` and `checksum` for GitHub assets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d6e3477e598972d3855092337440b847dc10543. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->