### PR TITLE
test(e2e): remove deprecated MISE_LEGACY_VERSION_FILE assertions

### DIFF
--- a/e2e/core/test_node_slow
+++ b/e2e/core/test_node_slow
@@ -23,7 +23,3 @@ mise ls
 assert "mise x -- node --version" "v20.1.0"
 assert_contains "mise ls-remote nodejs" "20.1.0"
 mise use --rm node
-
-# MISE_LEGACY_VERSION_FILE env var
-assert_contains "MISE_LEGACY_VERSION_FILE=1 mise current node" "$latest"
-assert_not_contains "MISE_LEGACY_VERSION_FILE=0 mise current node" "$latest"


### PR DESCRIPTION
## Summary
- Removes deprecated `MISE_LEGACY_VERSION_FILE` test assertions from `core/test_node_slow`

## Context
The `legacy_version_file` setting has been deprecated in favor of `idiomatic_version_file_enable_tools`. The test was checking both `MISE_LEGACY_VERSION_FILE=1` and `MISE_LEGACY_VERSION_FILE=0` behavior, but this is no longer relevant.

The test already correctly sets `idiomatic_version_file_enable_tools` for node on line 12, which is the modern way to enable idiomatic version files.

## Changes
- Removed lines 27-29 which tested the deprecated `MISE_LEGACY_VERSION_FILE` environment variable

## Test plan
- [x] Test passes with `MISE_GPG_VERIFY=0 mise run test:e2e core/test_node_slow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove deprecated MISE_LEGACY_VERSION_FILE assertions from e2e/core/test_node_slow.
> 
> - **Tests**:
>   - Remove deprecated `MISE_LEGACY_VERSION_FILE` assertions from `e2e/core/test_node_slow`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c64201b3e546ccb4c42bda5bdd113c2bd030e396. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->