### PR TITLE
chore: release 2025.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2025.10.1](https://github.com/jdx/mise/compare/v2025.10.0..v2025.10.1) - 2025-10-03
+
+### 📦 Registry
+
+- add tombi by @TyceHerrman in [#6520](https://github.com/jdx/mise/pull/6520)
+
+### 🚀 Features
+
+- **(snapcraft)** add snap package by @phanect in [#6472](https://github.com/jdx/mise/pull/6472)
+
+### 🐛 Bug Fixes
+
+- **(cache)** remove duplicate bytes in prune output by @risu729 in [#6515](https://github.com/jdx/mise/pull/6515)
+
+### Chore
+
+- **(copr)** increase COPR publish timeout by 60 minutes by @Copilot in [#6512](https://github.com/jdx/mise/pull/6512)
+
+### New Contributors
+
+- @phanect made their first contribution in [#6472](https://github.com/jdx/mise/pull/6472)
+
 ## [2025.10.0](https://github.com/jdx/mise/compare/v2025.9.25..v2025.10.0) - 2025-10-01
 
 ### 📦 Registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.10.0"
+version = "2025.10.1"
 dependencies = [
  "age",
  "aqua-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox", "crates/aqua-registry"]
 
 [package]
 name = "mise"
-version = "2025.10.0"
+version = "2025.10.1"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.10.0 macos-arm64 (a1b2d3e 2025-10-01)
+2025.10.1 macos-arm64 (a1b2d3e 2025-10-03)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_0.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_1.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage > "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_0.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_1.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage > "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_10_0.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_10_1.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.10.0";
+  version = "2025.10.1";
 
   src = lib.cleanSource ./.;
 

--- a/mise.lock
+++ b/mise.lock
@@ -72,18 +72,13 @@ version = "2.3.2"
 backend = "cargo:usage-cli"
 
 [[tools.cosign]]
-version = "2.6.0"
+version = "2.6.1"
 backend = "aqua:sigstore/cosign"
 
 [tools.cosign.platforms.linux-x64]
-checksum = "sha256:ea5c65f99425d6cfbb5c4b5de5dac035f14d09131c1a0ea7c7fc32eab39364f9"
-size = 155329864
-url = "https://github.com/sigstore/cosign/releases/download/v2.6.0/cosign-linux-amd64"
-
-[tools.cosign.platforms.macos-arm64]
-checksum = "sha256:dea5b83b8b375b99ac803c7bdb1f798963dbeb47789ceb72153202e7f20e8d07"
-size = 154611890
-url = "https://github.com/sigstore/cosign/releases/download/v2.6.0/cosign-darwin-arm64"
+checksum = "sha256:064954c5d8c7e3b28188eee5b1727b31c411550bc5fefd41aa672d3c761d103a"
+size = 155339383
+url = "https://github.com/sigstore/cosign/releases/download/v2.6.1/cosign-linux-amd64"
 
 [[tools.gh]]
 version = "2.62.0"
@@ -100,13 +95,13 @@ size = 12793347
 url = "https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_macOS_arm64.zip"
 
 [[tools.hk]]
-version = "1.15.7"
+version = "1.16.0"
 backend = "aqua:jdx/hk"
 
 [tools.hk.platforms.linux-x64]
-checksum = "blake3:f4d35bcfb24c82d065ef7f65331386ec8f4721b2a9ae501bce977de91a1c8658"
-size = 6986299
-url = "https://github.com/jdx/hk/releases/download/v1.15.7/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "blake3:c3668b4b8f7942d432a7137d34fb50fee92c62b6307d5cf7f0665738299523d1"
+size = 6958777
+url = "https://github.com/jdx/hk/releases/download/v1.16.0/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [[tools.jq]]
 version = "1.8.1"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.10.0
+Version: 2025.10.1
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: mise
 title: mise-en-place
-version: "2025.10.0"
+version: "2025.10.1"
 summary: dev tools, env vars, task runner
 description: |
   dev tools, env vars, task runner


### PR DESCRIPTION
### 📦 Registry

- add tombi by @TyceHerrman in [#6520](https://github.com/jdx/mise/pull/6520)

### 🚀 Features

- **(snapcraft)** add snap package by @phanect in [#6472](https://github.com/jdx/mise/pull/6472)

### 🐛 Bug Fixes

- **(cache)** remove duplicate bytes in prune output by @risu729 in [#6515](https://github.com/jdx/mise/pull/6515)

### Chore

- **(copr)** increase COPR publish timeout by 60 minutes by @Copilot in [#6512](https://github.com/jdx/mise/pull/6512)

### New Contributors

- @phanect made their first contribution in [#6472](https://github.com/jdx/mise/pull/6472)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepare 2025.10.1 release: bump versions across build/packaging, update completions, refresh tool locks, and add changelog entries.
> 
> - **Release 2025.10.1**
>   - Version bump across `Cargo.toml`, `Cargo.lock`, `default.nix`, `packaging/rpm/mise.spec`, `snapcraft.yaml`, and `README.md`.
>   - Update shell completion cache filenames to `..._2025_10_1.spec` in `completions/_mise`, `completions/mise.bash`, and `completions/mise.fish`.
>   - Refresh `mise.lock` tool pins:
>     - `cosign` → `v2.6.1` (checksums/URL updated)
>     - `hk` → `v1.16.0` (checksums/URL updated)
>   - Update `CHANGELOG.md` with: registry add `tombi`, feature (snap package), bug fix (cache prune output), chore (COPR timeout), and new contributor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7421c7b65bc8a38f62cbaf32445cbeedac49034e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->