### PR TITLE
feat(template): add mise_shims variable

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -129,6 +129,7 @@ These variables offer key information about the current environment:
 - `mise_bin: String` - Points to the path to the current mise executable
 - `mise_pid: String` - Points to the pid of the current mise process
 - `mise_env: String` - The configuration environment as specified by `MISE_ENV`, `-E`, or `--env`. Will be undefined if the configuration environment is not set.
+- `mise_shims: PathBuf` - Points to the directory of mise shims
 - `xdg_cache_home: PathBuf` - Points to the directory of XDG cache home
 - `xdg_config_home: PathBuf` - Points to the directory of XDG config home
 - `xdg_data_home: PathBuf` - Points to the directory of XDG data home

--- a/mise.lock
+++ b/mise.lock
@@ -47,6 +47,11 @@ checksum = "blake3:779d104f2f8a3b840a2a56659e3da44f96419d7a5378555b9c3dabe756ac4
 size = 6770808
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.15.6/cargo-binstall-x86_64-unknown-linux-musl.tgz"
 
+[tools.cargo-binstall.platforms.macos-arm64]
+checksum = "blake3:a9ec69060311d1073e50f2028b44a36f6d7b544183648adb5854fd235875d910"
+size = 5996733
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.15.6/cargo-binstall-aarch64-apple-darwin.zip"
+
 [[tools."cargo:cargo-edit"]]
 version = "0.13.7"
 backend = "cargo:cargo-edit"
@@ -107,6 +112,11 @@ backend = "aqua:jdx/hk"
 checksum = "blake3:f4d35bcfb24c82d065ef7f65331386ec8f4721b2a9ae501bce977de91a1c8658"
 size = 6986299
 url = "https://github.com/jdx/hk/releases/download/v1.15.7/hk-x86_64-unknown-linux-gnu.tar.gz"
+
+[tools.hk.platforms.macos-arm64]
+checksum = "blake3:4c2ed7089ba2c4bad522c479584baa14fc5d9f9c059a4945ab65926a24a3a47a"
+size = 6029861
+url = "https://github.com/jdx/hk/releases/download/v1.15.7/hk-aarch64-apple-darwin.tar.gz"
 
 [[tools.jq]]
 version = "1.8.1"
@@ -185,6 +195,11 @@ checksum = "blake3:0ad9524f3f16ad030f8350e7b970c62c24aeff3d813f2565665aecc5a8b79
 size = 2559196
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
 
+[tools.shellcheck.platforms.macos-arm64]
+checksum = "blake3:ad4957ed937da4e876d19e3500fc31d104e43b6e4e11d57a7b7c40140bc870d6"
+size = 7245972
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.xz"
+
 [[tools.shfmt]]
 version = "3.12.0"
 backend = "aqua:mvdan/sh"
@@ -193,6 +208,11 @@ backend = "aqua:mvdan/sh"
 checksum = "sha256:d9fbb2a9c33d13f47e7618cf362a914d029d02a6df124064fff04fd688a745ea"
 size = 2916536
 url = "https://github.com/mvdan/sh/releases/download/v3.12.0/shfmt_v3.12.0_linux_amd64"
+
+[tools.shfmt.platforms.macos-arm64]
+checksum = "sha256:d903802e0ce3ecbc82b98512f55ba370b0d37a93f3f78de394f5b657052b33dd"
+size = 2891858
+url = "https://github.com/mvdan/sh/releases/download/v3.12.0/shfmt_v3.12.0_darwin_arm64"
 
 [[tools.slsa-verifier]]
 version = "2.7.1"
@@ -213,6 +233,11 @@ checksum = "sha256:775f1384d55decfad228e7196a3f683791914f92a473f78fc47700531c29d
 size = 46346424
 url = "https://github.com/getsops/sops/releases/download/v3.11.0/sops-v3.11.0.linux.amd64"
 
+[tools.sops.platforms.macos-arm64]
+checksum = "sha256:45e7562b1f5d022c4d7a4e4c3d1b7b1a7ee6c328356629286cfd18a394b00e7c"
+size = 44823170
+url = "https://github.com/getsops/sops/releases/download/v3.11.0/sops-v3.11.0.darwin.arm64"
+
 [[tools.taplo]]
 version = "0.10.0"
 backend = "aqua:tamasfe/taplo"
@@ -221,6 +246,11 @@ backend = "aqua:tamasfe/taplo"
 checksum = "blake3:4871fab0e60275a1eb46e7190726e144f56c9a9527f59b0d1da5a042baead8e2"
 size = 5116068
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz"
+
+[tools.taplo.platforms.macos-arm64]
+checksum = "blake3:353ecb1ed7d279dec5e2fd388d292ef97db08a651405fa664ffec1b2896c05f0"
+size = 4616415
+url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-darwin-aarch64.gz"
 
 [[tools.wait-for-gh-rate-limit]]
 version = "1.0.0"

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -22,6 +22,7 @@ pub static BASE_CONTEXT: Lazy<Context> = Lazy::new(|| {
     context.insert("env", &*env::PRISTINE_ENV);
     context.insert("mise_bin", &*env::MISE_BIN);
     context.insert("mise_pid", &*env::MISE_PID);
+    context.insert("mise_shims", &*env::MISE_SHIMS_DIR);
     if !(*env::MISE_ENV).is_empty() {
         context.insert("mise_env", &*env::MISE_ENV);
     }
@@ -437,6 +438,13 @@ mod tests {
                 .into_string()
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn test_mise_shims() {
+        let _config = Config::get().await.unwrap();
+        let s = render("{{mise_shims}}");
+        assert!(s.ends_with("/shims")); // test dir is not deterministic
     }
 
     #[tokio::test]


### PR DESCRIPTION
Add `mise_shims` to allow using the exact path of shims. Potentially useful for code generation or other IDE integrations.

Note: I noticed the `mise.lock` got changed after install and I wasn't sure whether to include it. Feel free to remove those if you don't see it fit.