### PR TITLE
fix(shell): prevent infinite loop in zsh command-not-found handler

### DIFF
--- a/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
@@ -1,7 +1,7 @@
 ---
 source: src/shell/zsh.rs
-expression: "zsh.activate(exe, \" --status\".into())"
-snapshot_kind: text
+assertion_line: 173
+expression: zsh.activate(opts)
 ---
 export MISE_SHELL=zsh
 export __MISE_ORIG_PATH="$PATH"
@@ -42,17 +42,47 @@ fi
 _mise_hook
 if [ -z "${_mise_cmd_not_found:-}" ]; then
     _mise_cmd_not_found=1
-    [ -n "$(declare -f command_not_found_handler)" ] && eval "${$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}"
+    # preserve existing handler if present
+    if typeset -f command_not_found_handler >/dev/null; then
+        functions -c command_not_found_handler _command_not_found_handler
+    fi
 
-    function command_not_found_handler() {
-        if [[ "$1" != "mise" && "$1" != "mise-"* ]] && /some/dir/mise hook-not-found -s zsh -- "$1"; then
-          _mise_hook
-          "$@"
-        elif [ -n "$(declare -f _command_not_found_handler)" ]; then
-            _command_not_found_handler "$@"
+    typeset -gA _mise_cnf_tried
+
+    # helper for fallback behavior
+    _mise_fallback() {
+        local _cmd="$1"; shift
+        if typeset -f _command_not_found_handler >/dev/null; then
+            _command_not_found_handler "$_cmd" "$@"
+            return $?
         else
-            echo "zsh: command not found: $1" >&2
+            print -u2 -- "zsh: command not found: $_cmd"
             return 127
         fi
+    }
+
+    command_not_found_handler() {
+        local cmd="$1"; shift
+
+        # never intercept mise itself or retry already-attempted commands
+        if [[ "$cmd" == "mise" || "$cmd" == mise-* || -n "${_mise_cnf_tried["$cmd"]}" ]]; then
+            _mise_fallback "$cmd" "$@"
+            return $?
+        fi
+
+        # run the hook; only retry if the command is actually found afterward
+        if /some/dir/mise hook-not-found -s zsh -- "$cmd"; then
+            _mise_hook
+            if command -v -- "$cmd" >/dev/null 2>&1; then
+                "$cmd" "$@"
+                return $?
+            fi
+        else
+            # only mark as tried if mise explicitly can't handle it
+            _mise_cnf_tried["$cmd"]=1
+        fi
+
+        # fall back
+        _mise_fallback "$cmd" "$@"
     }
 fi


### PR DESCRIPTION
Related to https://github.com/jdx/mise/discussions/6374#discussioncomment-14576061 I recently installed `mise` and my computer kept getting the error around "forking" exhausting the entire computer. Causing me to restart it since all programs started to halt.

The original zsh command-not-found handler could cause infinite loops when mise hook-not-found exits with status 0 but the command is still not found on PATH. The handler would blindly re-execute the command without checking if it became available, causing zsh to call the handler again infinitely.

This fix implements several safety measures:

1. Command resolution check: Only re-execute if 'command -v -- cmd' confirms the command is actually available on PATH after running _mise_hook

2. Retry tracking: Use _mise_cnf_tried associative array to track which commands have been attempted in the current shell session, preventing retry loops

3. Mise exclusion: Never intercept 'mise' or 'mise-*' commands to prevent conflicts with mise's own operations

4. Graceful fallback: Fall back to the original command_not_found_handler or return 127 if the command remains unavailable

The fix eliminates the fork/loop issue while maintaining all existing functionality for auto-installing missing tools when they are actually available after the hook runs.

Fixes infinite loop scenario where:
- Tool is configured in mise.toml but not installed
- mise hook-not-found returns 0 (success)
- _mise_hook runs but command remains unavailable
- Handler re-executes command anyway, triggering infinite recursion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the zsh command-not-found handler to avoid infinite retry loops with safe re-exec checks, fallback handling, and retry tracking.
> 
> - **Shell (zsh)**:
>   - **command_not_found_handler overhaul** in `src/shell/zsh.rs`:
>     - Preserve existing handler via `functions -c command_not_found_handler _command_not_found_handler`.
>     - Add `_mise_cnf_tried` associative array to track attempted commands.
>     - Introduce `_mise_fallback` helper to delegate to original handler or print error and return 127.
>     - Re-run command only if `{exe} hook-not-found` succeeds and `command -v` confirms availability; call `_mise_hook` before retry.
>     - Exclude `mise`/`mise-*` and already-attempted commands from interception.
>     - Adjust error output to `print -u2` when no handler is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fa2f23456a6e470dc10318338937af3e9d0fcaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->