### PR TITLE
chore: release 2025.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2025.10.2](https://github.com/jdx/mise/compare/v2025.10.1..v2025.10.2) - 2025-10-03
+
+### 🐛 Bug Fixes
+
+- **(shell)** prevent infinite loop in zsh command-not-found handler by @yordis in [#6516](https://github.com/jdx/mise/pull/6516)
+- **(snapcraft)** add missing home plug for the home directory access permission by @phanect in [#6525](https://github.com/jdx/mise/pull/6525)
+- **(vfox)** implement headers support on http mod by @BasixKOR in [#6521](https://github.com/jdx/mise/pull/6521)
+- set MIX_HOME and MIX_ARCHIVES when using the elixir plugin by @numso in [#6504](https://github.com/jdx/mise/pull/6504)
+
+### 📦️ Dependency Updates
+
+- update docker/login-action digest to 5e57cd1 by @renovate[bot] in [#6522](https://github.com/jdx/mise/pull/6522)
+- update fedora:43 docker digest to 2c0d72b by @renovate[bot] in [#6523](https://github.com/jdx/mise/pull/6523)
+
+### Security
+
+- verify macOS binary signature during self-update by @jdx in [#6528](https://github.com/jdx/mise/pull/6528)
+
+### New Contributors
+
+- @yordis made their first contribution in [#6516](https://github.com/jdx/mise/pull/6516)
+- @numso made their first contribution in [#6504](https://github.com/jdx/mise/pull/6504)
+- @BasixKOR made their first contribution in [#6521](https://github.com/jdx/mise/pull/6521)
+
 ## [2025.10.1](https://github.com/jdx/mise/compare/v2025.10.0..v2025.10.1) - 2025-10-03
 
 ### 📦 Registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.10.1"
+version = "2025.10.2"
 dependencies = [
  "age",
  "aqua-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox", "crates/aqua-registry"]
 
 [package]
 name = "mise"
-version = "2025.10.1"
+version = "2025.10.2"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.10.1 macos-arm64 (a1b2d3e 2025-10-03)
+2025.10.2 macos-arm64 (a1b2d3e 2025-10-03)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_1.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_2.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage > "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_1.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_2.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage > "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_10_1.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_10_2.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.10.1";
+  version = "2025.10.2";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "19.6k",
+      stars: "19.7k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.10.1
+Version: 2025.10.2
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2025.10.1"
+version: "2025.10.2"
 summary: dev tools, env vars, task runner
 description: |
   dev tools, env vars, task runner


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(shell)** prevent infinite loop in zsh command-not-found handler by @yordis in [#6516](https://github.com/jdx/mise/pull/6516)
- **(snapcraft)** add missing home plug for the home directory access permission by @phanect in [#6525](https://github.com/jdx/mise/pull/6525)
- **(vfox)** implement headers support on http mod by @BasixKOR in [#6521](https://github.com/jdx/mise/pull/6521)
- set MIX_HOME and MIX_ARCHIVES when using the elixir plugin by @numso in [#6504](https://github.com/jdx/mise/pull/6504)

### 📦️ Dependency Updates

- update docker/login-action digest to 5e57cd1 by @renovate[bot] in [#6522](https://github.com/jdx/mise/pull/6522)
- update fedora:43 docker digest to 2c0d72b by @renovate[bot] in [#6523](https://github.com/jdx/mise/pull/6523)

### Security

- verify macOS binary signature during self-update by @jdx in [#6528](https://github.com/jdx/mise/pull/6528)

### New Contributors

- @yordis made their first contribution in [#6516](https://github.com/jdx/mise/pull/6516)
- @numso made their first contribution in [#6504](https://github.com/jdx/mise/pull/6504)
- @BasixKOR made their first contribution in [#6521](https://github.com/jdx/mise/pull/6521)