### PR TITLE
fix(snapcraft): add missing home plug for the home directory access permission

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,3 +1,12 @@
+# To test this snap package on your local Linux machine,
+# Install snapcraft (`snap install snapcraft --classic`) and
+# run the following commands:
+# 
+# ```shell
+# snapcraft pack
+# snap install ./mise_20xx.xx.x_amd64.snap --dangerous
+# ```
+
 name: mise
 title: mise-en-place
 version: "2025.10.1"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -68,4 +68,5 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.cache/mise
+      - $HOME/.config/mise
       - $HOME/.local/share/mise

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,6 +48,7 @@ apps:
   mise:
     command: bin/mise
     plugs:
+      - home
       - network
       - network-bind
       - process-control

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 # To test this snap package on your local Linux machine,
 # Install snapcraft (`snap install snapcraft --classic`) and
 # run the following commands:
-# 
+#
 # ```shell
 # snapcraft pack
 # snap install ./mise_20xx.xx.x_amd64.snap --dangerous


### PR DESCRIPTION
This is a follow-up PR for #6472.
Sorry, there was a bug in the snap package.

As I mentioned in #6472, Snap packages can only access the explicitly allowed resources.
I found that I did not allow access to the home directory, and this PR adds `home` interface (permission) to `plugs`.
This `home` interface allows mise to access files under the home directory except for hidden files (i.e., dot files).

[The permissions to `$HOME/.cache/mise` and `$HOME/.local/share/mise` are already configured, and I added `$HOME/.config/mise` in this PR](https://github.com/jdx/mise/pull/6525/files#diff-e68b9afd67bb77dec8eda77796d3e0b784c7011203114996383eed6533be0cefR67-R72).
Does mise need file access permission to other hidden directories?
If mise needs access to other hidden directories, I want to add permission to those directories.