### PR TITLE
security: verify macOS binary signature during self-update

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -9,7 +9,7 @@ use crate::config::Settings;
 use crate::{cmd, env};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default, serde::Deserialize)]
 struct InstructionsToml {
@@ -200,6 +200,14 @@ impl SelfUpdate {
             .args(["--display", "--verbose=2"])
             .arg(binary_path)
             .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!(
+                "Failed to display binary signature information: {}",
+                stderr.trim()
+            );
+        }
 
         let stderr = String::from_utf8_lossy(&output.stderr);
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -9,9 +9,9 @@ use crate::config::Settings;
 use crate::{cmd, env};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::PathBuf;
 #[cfg(target_os = "macos")]
 use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(Debug, Default, serde::Deserialize)]
 struct InstructionsToml {
@@ -173,9 +173,7 @@ impl SelfUpdate {
         );
 
         // Check if codesign is available
-        let codesign_check = Command::new("which")
-            .arg("codesign")
-            .output();
+        let codesign_check = Command::new("which").arg("codesign").output();
 
         if codesign_check.is_err() || !codesign_check.unwrap().status.success() {
             warn!("codesign command not found in PATH, skipping binary signature verification");

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -9,7 +9,7 @@ use crate::config::Settings;
 use crate::{cmd, env};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Default, serde::Deserialize)]
 struct InstructionsToml {
@@ -165,7 +165,10 @@ impl SelfUpdate {
     fn verify_macos_signature(binary_path: &Path) -> Result<()> {
         use std::process::Command;
 
-        debug!("Verifying macOS code signature for: {}", binary_path.display());
+        debug!(
+            "Verifying macOS code signature for: {}",
+            binary_path.display()
+        );
 
         // Run codesign --verify --deep --strict on the binary
         let output = Command::new("codesign")


### PR DESCRIPTION
## Summary
- Add `codesign` verification to `self-update` command for macOS binaries
- Verify both signature validity and signing authority after successful update
- Prevent installation of unsigned or maliciously signed binaries

## Implementation Details
The verification uses `codesign` CLI tool with two checks:
1. `codesign --verify --deep --strict` - Validates the signature integrity
2. `codesign --display --verbose=2` - Verifies the signing authority matches "Developer ID Application: Jeffrey Dickey"

The verification only runs on macOS (`#[cfg(target_os = "macos")]`) and only when an update was actually performed.

## Test plan
- [x] Code compiles successfully with `cargo check`
- [x] Verified current mise binary has valid signature using codesign
- [x] Confirmed signing authority matches expected Developer ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add macOS-only codesign verification post-update, enforcing the `dev.jdx.mise` identifier and failing on invalid signatures.
> 
> - **Security**: macOS code signature verification in `self_update`
>   - After a successful update, verify the updated binary (`env::MISE_BIN`) via `codesign` with `--verify --deep --strict` and requirement `identifier "dev.jdx.mise"`.
>   - On verification failure, abort with an error; if `codesign` is not found, log warnings and skip verification.
>   - macOS-only (`#[cfg(target_os = "macos")]`); adds `verify_macos_signature` helper and required `Path` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 057a1e68ba08c7771cbcb095d0a206662913db33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->