### PR TITLE
feat: support latest suffix for Java, Python and Ruby flavoured versions

### DIFF
--- a/docs/lang/java.md
+++ b/docs/lang/java.md
@@ -19,9 +19,11 @@ mise use -g java@openjdk-21
 mise use -g java@21         # alternate shorthands for openjdk-only
 ```
 
-You can also install a jdk from a different vendor:
+You can also install a jdk from a different vendor. To get the latest version from a vendor just use the
+vendor prefix.
 
 ```sh
+mise use -g java@temurin        # latest version from Temurin
 mise use -g java@temurin-21
 mise use -g java@zulu-21
 mise use -g java@corretto-21

--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -28,6 +28,13 @@ $ python3.11 -V
 3.11.0
 ```
 
+You can also install a specific python flavour. To get the latest version from a flavour just use the
+flavour prefix.
+
+```sh
+mise use -g python@anaconda         # latest version of anaconda
+```
+
 See the [Python Cookbook](/mise-cookbook/python.html) for common tasks and examples.
 
 ## `.python-version` support

--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -24,6 +24,13 @@ from source. Ensure that you have the necessary
 You can check its [README](https://github.com/rbenv/ruby-build/blob/master/README.md) for additional settings and some
 troubleshooting.
 
+You can also install a specific ruby flavour. To get the latest version from a flavour, just use the
+flavour prefix.
+
+```sh
+mise use -g ruby@truffleruby            # latest version of truffleruby
+```
+
 ## Default gems
 
 mise can automatically install a default set of gems right after installing a new ruby version.

--- a/e2e/cli/test_latest
+++ b/e2e/cli/test_latest
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Java
+# assert shorthand is a N.N.N version
+assert "mise latest java | grep -E '^[0-9]+(\\.[0-9]+)*$'"
+# assert vendor version ends with -N.N.N(-SUFFIX)?
+assert "mise latest java@temurin | grep -E '\\-[0-9]+(\\.[0-9]+)*(\..*)?$'"
+# assert vendor 21 version ends with -21.N.N(-SUFFIX)?
+assert "mise latest java@temurin-21 | grep -E '\\-21(\\.[0-9]+)*(\..*)?$'"
+
+# Python
+# assert shorthand is a N.N.N version
+assert "mise latest python | grep -E '^[0-9]+(\\.[0-9]+)*$'"
+# assert vendor version ends with -N.N.N
+assert "mise latest python@anaconda | grep -E '\\-[0-9]+(\\.[0-9]+)*$'"
+# assert vendor 2 version ends with -2.N.N
+assert "mise latest python@anaconda-2 | grep -E '\\-2(\\.[0-9]+)*$'"
+
+# Ruby
+# assert shorthand is a N.N.N version
+assert "mise latest ruby | grep -E '^[0-9]+(\\.[0-9]+)*$'"
+# assert vendor version ends with -N.N.N
+assert "mise latest ruby@truffleruby | grep -E '\\-[0-9]+(\\.[0-9]+)*$'"
+# assert vendor 22 version ends with -22.N.N
+assert "mise latest ruby@truffleruby-22 | grep -E '\\-22(\\.[0-9]+)*$'"

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -456,17 +456,11 @@ impl Backend for JavaPlugin {
     }
 
     fn fuzzy_match_filter(&self, versions: Vec<String>, query: &str) -> Vec<String> {
-        let query_trim = regex::escape(query.trim_end_matches('-'));
-        let query_version = format!("{}[0-9.]+", regex::escape(query));
-        let query_trim_version = format!("{query_trim}-[0-9.]+");
+        let query_escaped = regex::escape(query);
         let query = match query {
             "latest" => "[0-9].*",
-            // ends with a dash; use <query><version>
-            q if q.ends_with('-') => &query_version,
-            // not a shorthand version; use <query>-<version>
-            q if regex!("^[a-zA-Z]+$").is_match(q) => &query_trim_version,
-            // else; use trimmed query
-            _ => &query_trim,
+            // else; use escaped query
+            _ => &query_escaped,
         };
         let query_regex = Regex::new(&format!("^{query}([+-.].+)?$")).unwrap();
 


### PR DESCRIPTION
Adds support for `-latest` suffix in Java, Python and Ruby core plugins which have vendor builds. So `mise latest ruby@truffleruby` and `mise latest ruby@truffleruby-latest` are equivalent while the later is a bit more expressive in its intent.