### PR TITLE
fix: Add bash option in example

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -30,7 +30,7 @@ you may source it separately or enable this flag to include it in the script.
 Examples:
 
 ```
-mise completion bash > ~/.local/share/bash-completion/completions/mise
+mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise
 mise completion zsh  > /usr/local/share/zsh/site-functions/_mise
 mise completion fish > ~/.config/fish/completions/mise.fish
 ```

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -146,7 +146,7 @@ cmd cache help="Manage the mise cache" {
 }
 cmd completion help="Generate shell completions" {
     alias complete completions hide=#true
-    after_long_help "Examples:\n\n    $ mise completion bash > ~/.local/share/bash-completion/completions/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n"
+    after_long_help "Examples:\n\n    $ mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n"
     flag "-s --shell" help="Shell type to generate completions for" hide=#true {
         arg <SHELL_TYPE> {
             choices bash fish zsh

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -87,7 +87,7 @@ impl Completion {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    $ <bold>mise completion bash > ~/.local/share/bash-completion/completions/mise</bold>
+    $ <bold>mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise</bold>
     $ <bold>mise completion zsh  > /usr/local/share/zsh/site-functions/_mise</bold>
     $ <bold>mise completion fish > ~/.config/fish/completions/mise.fish</bold>
 "#


### PR DESCRIPTION
Add bash option in example

in  completion.rs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates bash completion examples to use `--include-bash-completion-lib` across docs, usage spec, and CLI help text.
> 
> - **CLI completion examples**:
>   - Update bash example to include `--include-bash-completion-lib` in:
>     - `docs/cli/completion.md`
>     - `mise.usage.kdl` (`cmd completion` after_long_help)
>     - `src/cli/completion.rs` (`AFTER_LONG_HELP`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb5cfcd542cd157af26200c7d6afa49fa6c15eda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->