### PR TITLE
fix(snapcraft): use classic confinement

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,7 +82,7 @@ See the [copr page](https://copr.fedorainfracloud.org/coprs/jdxcode/mise/) for m
 == Snap (beta)
 
 ```sh
-sudo snap install mise --beta
+sudo snap install mise --classic --beta
 ```
 
 See the [snapcraft.io page](https://snapcraft.io/mise) for more information.

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -167,7 +167,7 @@ dnf install mise
 ### Snap (Linux, currently in beta)
 
 ```sh
-sudo snap install mise --beta
+sudo snap install mise --classic --beta
 ```
 
 [snapcraft.io page](https://snapcraft.io/mise)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,6 +43,8 @@ parts:
 
     build-packages:
       - libssl-dev
+    build-attributes:
+      - enable-patchelf
 
   update-instructions:
     plugin: dump

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,7 +4,7 @@
 #
 # ```shell
 # snapcraft pack
-# snap install ./mise_20xx.xx.x_amd64.snap --dangerous
+# snap install ./mise_20xx.xx.x_amd64.snap --dangerous --classic
 # ```
 
 name: mise
@@ -24,7 +24,7 @@ donation:
   - https://github.com/sponsors/jdx
 
 grade: devel
-confinement: strict
+confinement: classic
 
 platforms:
   amd64:
@@ -56,17 +56,3 @@ parts:
 apps:
   mise:
     command: bin/mise
-    plugs:
-      - home
-      - network
-      - network-bind
-      - process-control
-      - user-config
-
-plugs:
-  user-config:
-    interface: personal-files
-    write:
-      - $HOME/.cache/mise
-      - $HOME/.config/mise
-      - $HOME/.local/share/mise


### PR DESCRIPTION
This is a follow-up PR for #6472 and #6525.

This PR uses the classic confinement for the snap package of mise.
As mentioned in https://github.com/jdx/mise/pull/6525#issuecomment-3366205021, `mise x -- sudo apt install` may not work in strict confinement, for example.
To allow system commands to work, we will switch to the classic confinement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the snap to classic confinement and updates docs and packaging accordingly.
> 
> - **Snap packaging**:
>   - Set `confinement: classic` in `snapcraft.yaml` and update local install comment to `--dangerous --classic`.
>   - Remove `apps.mise.plugs` and `plugs.user-config` sections; add `build-attributes: [enable-patchelf]`.
> - **Docs**:
>   - Update Snap install command to `sudo snap install mise --classic --beta` in `docs/getting-started.md` and `docs/installing-mise.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02e7b7a10482182f69c5f45760054a2b17a5b679. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->