### PR TITLE
fix(task): load toml tasks in `task_config.includes` in system/global config and monorepo subdirs

### DIFF
--- a/e2e/tasks/test_task_monorepo_includes
+++ b/e2e/tasks/test_task_monorepo_includes
@@ -41,7 +41,7 @@ chmod +x projects/frontend/tasks/another.long-name.sh
 # --- Assertions ---
 
 # Verify all tasks are discovered
-assert_contains "mise tasks ls --all" "//:root-task"
+assert_contains "mise tasks ls --debug --all" "//:root-task"
 assert_contains "mise tasks ls --all" "//projects/frontend:toml-task"
 assert_contains "mise tasks ls --all" "//projects/frontend:script-task"
 assert_contains "mise tasks ls --all" "//projects/frontend:another.long-name"

--- a/e2e/tasks/test_task_monorepo_includes
+++ b/e2e/tasks/test_task_monorepo_includes
@@ -54,12 +54,12 @@ assert_contains "mise run '//projects/frontend:another.long-name.sh'" "task with
 
 # Verify running from a subdirectory
 cd projects/frontend
-assert_contains "mise run toml-task" "task from toml"
-assert_contains "mise run script-task" "task from script"
-assert_contains "mise run another.long-name" "task with long name"
+assert_contains "mise run :toml-task" "task from toml"
+assert_contains "mise run :script-task" "task from script"
+assert_contains "mise run :another.long-name" "task with long name"
 
 # Verify wildcard execution from subdirectory
-output=$(mise run '*')
+output=$(mise run ':*')
 assert_contains "echo '$output'" "task from toml"
 assert_contains "echo '$output'" "task from script"
 assert_contains "echo '$output'" "task with long name"

--- a/e2e/tasks/test_task_monorepo_includes
+++ b/e2e/tasks/test_task_monorepo_includes
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Test monorepo task edge cases: multiple dot extensions
+export MISE_EXPERIMENTAL=1
+
+# Create monorepo root config
+cat <<EOF >mise.toml
+experimental_monorepo_root = true
+
+[tasks.root-task]
+run = 'echo "root task"'
+EOF
+
+# Create project structure with task_config.includes
+mkdir -p projects/frontend/tasks
+cat <<EOF >projects/frontend/mise.toml
+[task_config]
+includes = ["tasks.toml", "tasks"]
+EOF
+
+# Create included TOML file with a task
+cat <<EOF >projects/frontend/tasks.toml
+[toml-task]
+run = 'echo "task from toml"'
+EOF
+
+# Create included script task
+cat <<'EOF' >projects/frontend/tasks/script-task.sh
+#!/usr/bin/env bash
+echo "task from script"
+EOF
+chmod +x projects/frontend/tasks/script-task.sh
+
+# Create included script task with multiple extensions
+cat <<'EOF' >projects/frontend/tasks/another.long-name.sh
+#!/usr/bin/env bash
+echo "task with long name"
+EOF
+chmod +x projects/frontend/tasks/another.long-name.sh
+
+# --- Assertions ---
+
+# Verify all tasks are discovered
+assert_contains "mise tasks ls --all" "//:root-task"
+assert_contains "mise tasks ls --all" "//projects/frontend:toml-task"
+assert_contains "mise tasks ls --all" "//projects/frontend:script-task"
+assert_contains "mise tasks ls --all" "//projects/frontend:another.long-name"
+
+# Verify running tasks from root
+assert_contains "mise run '//projects/frontend:toml-task'" "task from toml"
+assert_contains "mise run '//projects/frontend:script-task'" "task from script"
+assert_contains "mise run '//projects/frontend:another.long-name'" "task with long name"
+assert_contains "mise run '//projects/frontend:another.long-name.sh'" "task with long name"
+
+# Verify running from a subdirectory
+cd projects/frontend
+assert_contains "mise run toml-task" "task from toml"
+assert_contains "mise run script-task" "task from script"
+assert_contains "mise run another.long-name" "task with long name"
+
+# Verify wildcard execution from subdirectory
+output=$(mise run '*')
+assert_contains "echo '$output'" "task from toml"
+assert_contains "echo '$output'" "task from script"
+assert_contains "echo '$output'" "task with long name"
+
+cd ../..
+
+# Verify wildcard execution from root
+output=$(mise run '//projects/frontend:*')
+assert_contains "echo '$output'" "task from toml"
+assert_contains "echo '$output'" "task from script"
+assert_contains "echo '$output'" "task with long name"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1611,7 +1611,7 @@ async fn load_tasks_includes(
     root: &Path,
     config_root: &Path,
 ) -> Result<Vec<Task>> {
-    if root.is_file() {
+    if root.is_file() && root.extension().map(|e| e == "toml").unwrap_or(false) {
         load_task_file(config, root, config_root).await
     } else if root.is_dir() {
         let files = WalkDir::new(root)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1714,7 +1714,7 @@ pub async fn load_tasks_in_dir(
     }
     let mut file_tasks = vec![];
     for p in task_includes_for_dir(dir, config_files) {
-        file_tasks.extend(load_tasks_includes(&config, &p, &dir).await?);
+        file_tasks.extend(load_tasks_includes(config, &p, dir).await?);
     }
     let mut tasks = file_tasks
         .into_iter()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1628,36 +1628,39 @@ async fn load_tasks_includes(
     root: &Path,
     config_root: &Path,
 ) -> Result<Vec<Task>> {
-    if !root.is_dir() {
-        return Ok(vec![]);
+    if root.is_file() {
+        load_task_file(config, root, config_root).await
+    } else if root.is_dir() {
+        let files = WalkDir::new(root)
+            .follow_links(true)
+            .into_iter()
+            // skip hidden directories (if the root is hidden that's ok)
+            .filter_entry(|e| e.path() == root || !e.file_name().to_string_lossy().starts_with('.'))
+            .filter_ok(|e| e.file_type().is_file())
+            .map_ok(|e| e.path().to_path_buf())
+            .try_collect::<_, Vec<PathBuf>, _>()?
+            .into_iter()
+            .filter(|p| file::is_executable(p))
+            .filter(|p| {
+                !Settings::get()
+                    .task_disable_paths
+                    .iter()
+                    .any(|d| p.starts_with(d))
+            })
+            .collect::<Vec<_>>();
+        let mut tasks = vec![];
+        let root = Arc::new(root.to_path_buf());
+        let config_root = Arc::new(config_root.to_path_buf());
+        for path in files {
+            let root = root.clone();
+            let config_root = config_root.clone();
+            let config = config.clone();
+            tasks.push(Task::from_path(&config, &path, &root, &config_root).await?);
+        }
+        Ok(tasks)
+    } else {
+        Ok(vec![])
     }
-    let files = WalkDir::new(root)
-        .follow_links(true)
-        .into_iter()
-        // skip hidden directories (if the root is hidden that's ok)
-        .filter_entry(|e| e.path() == root || !e.file_name().to_string_lossy().starts_with('.'))
-        .filter_ok(|e| e.file_type().is_file())
-        .map_ok(|e| e.path().to_path_buf())
-        .try_collect::<_, Vec<PathBuf>, _>()?
-        .into_iter()
-        .filter(|p| file::is_executable(p))
-        .filter(|p| {
-            !Settings::get()
-                .task_disable_paths
-                .iter()
-                .any(|d| p.starts_with(d))
-        })
-        .collect::<Vec<_>>();
-    let mut tasks = vec![];
-    let root = Arc::new(root.to_path_buf());
-    let config_root = Arc::new(config_root.to_path_buf());
-    for path in files {
-        let root = root.clone();
-        let config_root = config_root.clone();
-        let config = config.clone();
-        tasks.push(Task::from_path(&config, &path, &root, &config_root).await?);
-    }
-    Ok(tasks)
 }
 
 async fn load_file_tasks(
@@ -1709,21 +1712,8 @@ pub async fn load_tasks_in_dir(
         let dir = dir.to_path_buf();
         config_tasks.extend(load_config_tasks(config, cf.clone(), &dir).await?);
     }
-    let includes = task_includes_for_dir(dir, config_files);
-    let extra_tasks = includes
-        .iter()
-        .filter(|p| p.is_file() && p.extension().unwrap_or_default().to_string_lossy() == "toml");
-    for p in extra_tasks {
-        let p = p.clone();
-        let dir = dir.to_path_buf();
-        let config = config.clone();
-        config_tasks.extend(load_task_file(&config, &p, &dir).await?);
-    }
     let mut file_tasks = vec![];
-    for p in includes {
-        let dir = dir.to_path_buf();
-        let p = p.clone();
-        let config = config.clone();
+    for p in task_includes_for_dir(dir, config_files) {
         file_tasks.extend(load_tasks_includes(&config, &p, &dir).await?);
     }
     let mut tasks = file_tasks


### PR DESCRIPTION
It works fine for directories, but not for TOML files.

This PR treats tasks in `tasks.toml` as "file tasks", but I think it won't cause any issues.
I'll refactor the code around `includes` later, as currently it seems some parts are duplicated.
Also, I noticed `task_includes` in `mise.local.toml` was not honoured if `mise.toml` had it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable loading tasks from TOML files in `task_config.includes` and unify include processing for files/dirs, with new e2e tests for monorepo task discovery/execution.
> 
> - **Backend**:
>   - `load_tasks_includes` now supports `.toml` files via `load_task_file`; keeps dir scan for executable scripts.
>   - `load_tasks_in_dir`/`load_file_tasks` simplified to use `task_includes_for_dir` and the unified loader; removed duplicate TOML-only path handling.
> - **Tests**:
>   - Add `e2e/tasks/test_task_monorepo_includes` to validate monorepo task discovery and execution (root, subdir, wildcard), including TOML-defined tasks and script tasks with multiple-dot names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afedda9eab23b7e26d56ac7f255f6d81adec5dc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->