### PR TITLE
chore(hk): bump to v1.18.1

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.15.1/hk@1.15.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.15.1/hk@1.15.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.1/hk@1.18.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.1/hk@1.18.1#/Builtins.pkl"
 
 local bash_glob = List("*.sh", "xtasks/**", "scripts/**", "e2e/**")
 local bash_exclude = List("*.ps1", "**/*.fish", "*.ts", "*.js", "*.json", "*.bat", "**/.*", "src/assets/bash_zsh_support/**", "e2e/shell/xonsh_script", "**/*.py")


### PR DESCRIPTION
## Summary
- Upgrades hk from v1.15.1 to v1.18.1 to fix lint-fix command

🤖 Generated with [Claude Code](https://claude.com/claude-code)