### PR TITLE
fix(tasks): validate monorepo setup before running monorepo tasks

### DIFF
--- a/e2e/tasks/test_task_monorepo_validation
+++ b/e2e/tasks/test_task_monorepo_validation
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Test validation for monorepo task paths
+
+# Test 1: Running monorepo task without MISE_EXPERIMENTAL should error
+unset MISE_EXPERIMENTAL
+cat <<EOF >mise.toml
+experimental_monorepo_root = true
+
+[tasks.local]
+run = 'echo "local task"'
+EOF
+
+# Should fail with helpful error about MISE_EXPERIMENTAL
+assert_fail "mise run '//some:task'" "require experimental mode"
+
+# Test 2: Running monorepo task with MISE_EXPERIMENTAL but without monorepo root should error
+export MISE_EXPERIMENTAL=1
+cat <<EOF >mise.toml
+[tasks.local]
+run = 'echo "local task"'
+EOF
+
+# Should fail with helpful error about experimental_monorepo_root
+assert_fail "mise run '//some:task'" "require a monorepo root configuration"
+
+# Test 3: Wildcard patterns should also trigger validation
+unset MISE_EXPERIMENTAL
+cat <<EOF >mise.toml
+[tasks.local]
+run = 'echo "local task"'
+EOF
+
+# Wildcard pattern without experimental mode should fail
+assert_fail "mise run '//...:build'" "require experimental mode"
+
+# Test 4: Three-dot syntax should also trigger validation
+assert_fail "mise run '...:build'" "require experimental mode"

--- a/mise.lock
+++ b/mise.lock
@@ -98,6 +98,11 @@ url = "https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_macOS_arm6
 version = "1.18.1"
 backend = "aqua:jdx/hk"
 
+[tools.hk.platforms.linux-x64]
+checksum = "blake3:bc8be608f0909940687158ca66ce8a2c35a68a8257b2d051272ca441d13382ba"
+size = 7170910
+url = "https://github.com/jdx/hk/releases/download/v1.18.1/hk-x86_64-unknown-linux-gnu.tar.gz"
+
 [tools.hk.platforms.macos-arm64]
 checksum = "blake3:a48bf25b18f27f9a0f306ca77a0791d4963a999e85aee4251eb8cbc175884353"
 size = 6206992

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1554,6 +1554,41 @@ fn last_modified_file(files: impl IntoIterator<Item = PathBuf>) -> Result<Option
         .max())
 }
 
+fn validate_monorepo_setup(config: &Arc<Config>) -> Result<()> {
+    // Check if experimental mode is enabled
+    if !Settings::get().experimental {
+        bail!(
+            "Monorepo task paths (like `//path:task`) require experimental mode.\n\
+            \n\
+            To enable experimental features, set:\n\
+            {}\n\
+            \n\
+            Or run with: {}",
+            style::eyellow("  export MISE_EXPERIMENTAL=true"),
+            style::eyellow("MISE_EXPERIMENTAL=1 mise run ...")
+        );
+    }
+
+    // Check if a monorepo root is configured
+    if !config.is_monorepo() {
+        bail!(
+            "Monorepo task paths (like `//path:task`) require a monorepo root configuration.\n\
+            \n\
+            To set up monorepo support, add this to your root mise.toml:\n\
+            {}\n\
+            \n\
+            Then create task files in subdirectories that will be automatically discovered.\n\
+            See {} for more information.",
+            style::eyellow("  experimental_monorepo_root = true"),
+            style::eunderline(
+                "https://mise.jdx.dev/tasks/task-configuration.html#monorepo-support"
+            )
+        );
+    }
+
+    Ok(())
+}
+
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
@@ -1753,6 +1788,9 @@ pub async fn get_task_lists(
         if monorepo_patterns.is_empty() {
             None
         } else {
+            // Validate monorepo setup before attempting to load tasks
+            validate_monorepo_setup(config)?;
+
             // Merge all path hints from the patterns into a single context
             Some(TaskLoadContext::from_patterns(
                 monorepo_patterns.into_iter(),


### PR DESCRIPTION
## Summary

When users attempt to run tasks with monorepo syntax (like `//path:task` or `...:task`), validate that they have the proper setup:

1. `MISE_EXPERIMENTAL=1` enabled
2. `experimental_monorepo_root = true` configured in root mise.toml

Provides clear, actionable error messages with setup instructions when validation fails, preventing confusing "task not found" errors.

## Changes

- Added `validate_monorepo_setup()` function in `src/cli/run.rs:1557`
- Validation is triggered when monorepo patterns (`//` or `...`) are detected
- Clear error messages guide users on:
  - How to enable experimental mode (`MISE_EXPERIMENTAL=true`)
  - How to configure monorepo root (`experimental_monorepo_root = true`)
  - Link to documentation for more information
- Added comprehensive e2e test: `e2e/tasks/test_task_monorepo_validation`

## Test plan

- [x] Added e2e test covering:
  - Running `//` tasks without `MISE_EXPERIMENTAL` → error with instructions
  - Running `//` tasks without `experimental_monorepo_root` → error with instructions  
  - Running wildcard patterns (`//...:task`) without setup → error
  - Running ellipsis patterns (`...:task`) without setup → error
- [x] All tests pass: `mise run test:e2e test_task_monorepo_validation`
- [x] Code formatted with `mise run lint-fix`

## Example error messages

**Without experimental mode:**
```
Error: Monorepo task paths (like `//path:task`) require experimental mode.

To enable experimental features, set:
  export MISE_EXPERIMENTAL=true

Or run with: MISE_EXPERIMENTAL=1 mise run ...
```

**Without monorepo root:**
```
Error: Monorepo task paths (like `//path:task`) require a monorepo root configuration.

To set up monorepo support, add this to your root mise.toml:
  experimental_monorepo_root = true

Then create task files in subdirectories that will be automatically discovered.
See https://mise.jdx.dev/tasks/task-configuration.html#monorepo-support for more information.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validate experimental mode and monorepo root before executing monorepo task paths (`//`, `...`), with clear errors and new e2e coverage.
> 
> - **Tasks/CLI**:
>   - Add `validate_monorepo_setup` in `src/cli/run.rs` to require `MISE_EXPERIMENTAL=1` and `experimental_monorepo_root = true` for monorepo task paths like `//path:task`, `//...:task`, and `...:task`.
>   - Invoke validation when monorepo patterns are detected, before building `TaskLoadContext::from_patterns`.
>   - Error messages include setup instructions and a docs link.
> - **Tests**:
>   - Add e2e `e2e/tasks/test_task_monorepo_validation` covering missing experimental mode, missing monorepo root, and wildcard/ellipsis patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7e31439ac188b45f7a5c761403e6d3ed93d8c63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->