### PR TITLE
refactor(task): remove duplicated codes

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1334,17 +1334,10 @@ fn prefix_monorepo_task_names(tasks: &mut [Task], dir: &Path, monorepo_root: &Pa
             .to_string_lossy()
             .replace(std::path::MAIN_SEPARATOR, "/");
         for task in tasks.iter_mut() {
-            if prefix.is_empty() {
-                task.name = format!(
-                    "{}{}{}",
-                    MONOREPO_PATH_PREFIX, MONOREPO_TASK_SEPARATOR, task.name
-                );
-            } else {
-                task.name = format!(
-                    "{}{}{}{}",
-                    MONOREPO_PATH_PREFIX, prefix, MONOREPO_TASK_SEPARATOR, task.name
-                );
-            }
+            task.name = format!(
+                "{}{}{}{}",
+                MONOREPO_PATH_PREFIX, prefix, MONOREPO_TASK_SEPARATOR, task.name
+            );
         }
     }
 }
@@ -1405,9 +1398,7 @@ async fn load_local_tasks_with_context(
                                     let mut subdir_tasks =
                                         load_config_and_file_tasks(&config, cf.clone()).await?;
 
-                                    if let Ok(rel_path) = subdir.strip_prefix(&monorepo_root) {
-                                        prefix_monorepo_task_names(&mut subdir_tasks, rel_path, &monorepo_root);
-                                    }
+                                    prefix_monorepo_task_names(&mut subdir_tasks, &subdir, &monorepo_root);
                                     for task in subdir_tasks.iter_mut() {
                                         // Store reference to config file for later use
                                         task.cf = Some(cf.clone());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Deduplicates task loading and monorepo task-name prefixing via a generic loader and shared helper.
> 
> - **Tasks Loading**:
>   - Introduce `load_tasks_by_filter` to load tasks by predicate; replace `load_global_tasks` and `load_system_tasks` calls with filtered loader using `is_global_config`/`is_system_config`.
> - **Monorepo Task Naming**:
>   - Extract `prefix_monorepo_task_names` and use it in `load_local_tasks_with_context` and subdir task loading to replace duplicated inlined prefix logic.
> - **Minor**:
>   - Remove duplicated constants/logic and simplify loops when aggregating tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 882b84b0c88382c3b6c0c9ed8d7234823fc179e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->