### PR TITLE
fix(installing-mise.md): broken link

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -297,7 +297,7 @@ echo 'mise activate fish | source' >> ~/.config/fish/config.fish
 For homebrew and possibly other installs mise is automatically activated so
 this is not necessary.
 
-See [`MISE_FISH_AUTO_ACTIVATE=1`](/configuration#mise_fish_auto_activate1) for more information.
+See [`MISE_FISH_AUTO_ACTIVATE=1`](/configuration#mise-fish-auto-activate-1) for more information.
 :::
 
 ### Powershell


### PR DESCRIPTION
Found a broken link to the fish automatic activation env variable section. :)