### PR TITLE
fix(tasks): restore tool loading from idiomatic version files

### DIFF
--- a/e2e/tasks/test_task_idiomatic_version_file
+++ b/e2e/tasks/test_task_idiomatic_version_file
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Test that tasks can use tools from idiomatic version files
+# Issue: Since v2025.10.3, idiomatic_version_file_enable_tools stopped working in task execution
+
+# First disable the parent /tmp/mise.toml experimental monorepo setting
+# to avoid interference with this test
+if [ -f /tmp/mise.toml ]; then
+	mv /tmp/mise.toml /tmp/mise.toml.bak
+	trap "mv /tmp/mise.toml.bak /tmp/mise.toml" EXIT
+fi
+
+# Create a .node-version file
+echo "24.1.0" >.node-version
+
+# Create mise.toml with idiomatic_version_file_enable_tools setting
+cat >mise.toml <<'EOF'
+[settings]
+idiomatic_version_file_enable_tools = ["node"]
+
+[tasks.call-node]
+run = "which node"
+EOF
+
+# Trust the config
+mise trust
+
+# Install node from .node-version
+mise install
+
+# Run the task and verify it uses the mise-installed node
+assert_contains "mise run call-node" ".local/share/mise/installs/node/24"

--- a/e2e/tasks/test_task_monorepo_tool_inheritance
+++ b/e2e/tasks/test_task_monorepo_tool_inheritance
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Test that monorepo tasks inherit tools from parent mise.toml files
+export MISE_EXPERIMENTAL=1
+export MISE_NODE_VERIFY=0 # Skip GPG verification to avoid keyboxd issues
+
+# Create monorepo root config with shared tools
+cat <<EOF >mise.toml
+experimental_monorepo_root = true
+
+[tools]
+# Root defines node that should be inherited by all subdirectories
+node = "20"
+
+[tasks.root-task]
+run = 'node --version'
+EOF
+
+# Create frontend project that overrides node version
+mkdir -p projects/frontend
+cat <<EOF >projects/frontend/mise.toml
+[tools]
+# Frontend overrides with node 18
+node = "18"
+
+[tasks.build]
+run = 'echo "NODE_VERSION=\$(node --version | sed "s/v//" | cut -d. -f1)"'
+EOF
+
+# Create backend project with NO tools defined - should inherit from root
+mkdir -p projects/backend
+cat <<EOF >projects/backend/mise.toml
+# No tools section - should inherit node 20 from root
+
+[tasks.build]
+run = 'echo "NODE_VERSION=\$(node --version | sed "s/v//" | cut -d. -f1)"'
+EOF
+
+# Create nested project to test multi-level inheritance
+mkdir -p projects/backend/api
+cat <<EOF >projects/backend/api/mise.toml
+# No tools section - should inherit from parent hierarchy
+
+[tasks.build]
+run = 'echo "NODE_VERSION=\$(node --version | sed "s/v//" | cut -d. -f1)"'
+EOF
+
+# Install tools
+mise install
+
+# Test 1: Root task should use node 20 from root config
+echo "=== Test 1: Root task uses node 20 from root config ==="
+assert_contains "mise run //:root-task" "v20"
+
+# Test 2: Frontend task should use node 18 (overridden)
+echo "=== Test 2: Frontend task uses node 18 (overridden) ==="
+assert_contains "mise run //projects/frontend:build" "NODE_VERSION=18"
+
+# Test 3: Backend task should inherit node 20 from root
+echo "=== Test 3: Backend task inherits node 20 from root ==="
+assert_contains "mise run //projects/backend:build" "NODE_VERSION=20"
+
+# Test 4: Nested api task should inherit node 20 from root through parent
+echo "=== Test 4: Nested api task inherits node 20 from root ==="
+assert_contains "mise run //projects/backend/api:build" "NODE_VERSION=20"
+
+echo "=== All tool inheritance tests passed! ==="

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -890,8 +890,7 @@ impl Run {
     ) -> Result<Toolset> {
         // Only use task-specific config file context for monorepo tasks
         // (tasks with self.cf set, not just those with a config_source)
-        if task_cf.is_some() && task.cf.is_some() {
-            let task_cf = task_cf.unwrap();
+        if let (Some(task_cf), Some(_)) = (task_cf, &task.cf) {
             let config_path = Self::canonicalize_path(task_cf.get_path());
 
             trace!(


### PR DESCRIPTION
## Summary

Fixes regression where tasks were unable to access tools from idiomatic version files (e.g., `.node-version`) when `idiomatic_version_file_enable_tools` was configured.

## Issue

Since v2025.10.3, the monorepo task support changes caused tasks to only use tools from their defining config file instead of all config files in the hierarchy. This meant that tools from idiomatic version files like `.node-version` were no longer available in task PATH.

## Root Cause

The issue was in `build_toolset_for_task()` in `src/cli/run.rs`. When a task had a config file reference (`task_cf`), the code would build a toolset from ONLY that config file using `task_cf.to_toolset()`. This excluded tools from other config files in the same directory, such as `.node-version` files.

The monorepo logic was intended to use subdirectory config files for monorepo tasks, but it incorrectly applied this logic to ALL tasks that had a `config_source`, not just monorepo tasks.

## Solution

The fix distinguishes between:
1. **Monorepo tasks** (those with `task.cf` set) - use the monorepo-specific toolset building logic
2. **Regular tasks** - use the standard toolset build that includes ALL config files in the hierarchy

This is done by checking `task.cf.is_some()` before applying the monorepo logic.

## Test Plan

- Added new e2e test `test_task_idiomatic_version_file` that verifies tasks can use tools from `.node-version` files
- Verified existing monorepo tests still pass
- Manually tested that tasks now correctly use tools from idiomatic version files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores task tool resolution from idiomatic version files and corrects monorepo inheritance by merging global and subdirectory toolsets; adds e2e tests covering both cases.
> 
> - **Tasks/Tool Resolution**:
>   - Only use task-specific config context for monorepo tasks (`task.cf` present).
>   - Build toolset from all global configs, then merge the subdirectory config (`task_cf`) so parent tools are inherited and idiomatic version files (e.g., `.node-version`) are honored.
>   - Keep caching behavior; standard toolset path continues to include all configs.
> - **E2E Tests**:
>   - `e2e/tasks/test_task_idiomatic_version_file`: verifies tasks use tools from `.node-version` when `idiomatic_version_file_enable_tools` is set.
>   - `e2e/tasks/test_task_monorepo_tool_inheritance`: validates root inheritance, overrides, and multi-level inheritance for Node versions in monorepo tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43f9fd663b59f21d977f27302c73cb893926bed8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->