### PR TITLE
chore: release 2025.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2025.10.5](https://github.com/jdx/mise/compare/v2025.10.4..v2025.10.5) - 2025-10-07
+
+### 📦 Registry
+
+- add jules by @alefteris in [#6568](https://github.com/jdx/mise/pull/6568)
+
+### 🐛 Bug Fixes
+
+- **(docs)** improve favicon support for Safari by @jdx in [#6567](https://github.com/jdx/mise/pull/6567)
+- **(github)** download assets via API to respect GITHUB_TOKEN by @roele in [#6496](https://github.com/jdx/mise/pull/6496)
+- **(task)** load toml tasks in `task_config.includes` in system/global config and monorepo subdirs by @risu729 in [#6545](https://github.com/jdx/mise/pull/6545)
+- **(task)** handle dots in monorepo directory names correctly by @jdx in [#6571](https://github.com/jdx/mise/pull/6571)
+
+### 📚 Documentation
+
+- **(readme)** add GitHub Issues & Discussions section by @rsyring in [#6573](https://github.com/jdx/mise/pull/6573)
+- **(tasks)** create dedicated monorepo tasks documentation by @jdx in [#6561](https://github.com/jdx/mise/pull/6561)
+- **(tasks)** enhance monorepo documentation with tool comparisons by @jdx in [#6563](https://github.com/jdx/mise/pull/6563)
+
 ## [2025.10.4](https://github.com/jdx/mise/compare/v2025.10.3..v2025.10.4) - 2025-10-06
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.10.4"
+version = "2025.10.5"
 dependencies = [
  "age",
  "aqua-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox", "crates/aqua-registry"]
 
 [package]
 name = "mise"
-version = "2025.10.4"
+version = "2025.10.5"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.10.4 macos-arm64 (a1b2d3e 2025-10-06)
+2025.10.5 macos-arm64 (a1b2d3e 2025-10-07)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_4.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_5.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage > "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_4.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_5.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage > "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_10_4.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_10_5.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/crates/aqua-registry/aqua-registry/pkgs/borgbackup/borg/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/borgbackup/borg/registry.yaml
@@ -6,50 +6,90 @@ packages:
     description: Deduplicating archiver with compression and authenticated encryption
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["0.28.0", "0.28.1", "0.30.1"]
+      - version_constraint: Version in ["0.28.0", "0.28.1", "0.30.1"] || semver(">= 1.2.0-a2, <= 1.2.0-a5")
         no_asset: true
-      - version_constraint: Version == "1.0.1"
+      - version_constraint: Version in ["1.0.1", "1.1.15b1"]
         asset: borg-{{.OS}}64
         format: raw
-        replacements:
-          amd64: x64
         supported_envs:
           - linux/amd64
       - version_constraint: Version == "1.0.3"
         asset: borg-{{.OS}}64
         format: raw
-        rosetta2: true
-        replacements:
-          amd64: x64
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 1.1.18")
+      - version_constraint: Version in ["0.26.1", "0.27.0"] || semver("<= 1.2.0b3")
         asset: borg-{{.OS}}64
         format: raw
-        rosetta2: true
         replacements:
-          amd64: x64
           darwin: macosx
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 1.2.8")
+      - version_constraint: semver("<= 1.2.0") || Version == "1.3.0a1"
         asset: borg-{{.OS}}64
         format: raw
-        rosetta2: true
         replacements:
-          amd64: x64
           darwin: macos
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: "true"
+      - version_constraint: Version in ["1.2.7", "1.2.8", "1.2.9"]
+        asset: borg-{{.OS}}64
+        format: raw
+        replacements:
+          linux: linuxnewer
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.2.6") || semver(">= 2.0.0a2, <= 2.0.0-b1") || Version in ["2.0.0b2", "2.0.0b3", "2.0.0b6", "2.0.0b7"]
+        asset: borg-{{.OS}}64
+        format: raw
+        replacements:
+          linux: linuxnew
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "2.0.0b4"
+        asset: borg-{{.OS}}64
+        format: raw
+        replacements:
+          linux: linuxnew
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "2.0.0b5"
+        asset: borg-{{.OS}}{{.Arch}}
+        format: raw
+        replacements:
+          linux: linuxnew
+          darwin: macos
+          amd64: "64"
+          arm64: -arm
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.4.0-rc1") || Version == "2.0.0b8"
         asset: borg-{{.OS}}
         format: raw
-        rosetta2: true
         replacements:
-          linux: linux-glibc228
+          linux: linux-glibc236
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version in ["2.0.0b12", "2.0.0b13", "2.0.0b14", "2.0.0b19"]
+        asset: borg-{{.OS}}-glibc236
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 1.4.1") || true
+        asset: borg-{{.OS}}
+        format: raw
+        replacements:
+          linux: linux-glibc236
           darwin: macos1012
         supported_envs:
           - linux/amd64

--- a/crates/aqua-registry/aqua-registry/pkgs/flutter/flutter/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/flutter/flutter/registry.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: http
+    repo_owner: flutter
+    repo_name: flutter
+    description: Flutter SDK - Google's UI toolkit for building beautiful, natively compiled applications
+    version_source: github_tag
+    version_filter: Version matches "^\\d+\\.\\d+\\.\\d+$"
+    files:
+      - name: flutter
+        src: flutter/bin/flutter
+      - name: dart
+        src: flutter/bin/dart
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        url: https://storage.googleapis.com/flutter_infra_release/releases/stable/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-stable.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.xz
+          - goos: windows
+            goarch: arm64
+            url: https://storage.googleapis.com/flutter_infra_release/releases/stable/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-stable.{{.Format}}
+          - goarch: arm64
+            url: https://storage.googleapis.com/flutter_infra_release/releases/stable/{{.OS}}/flutter_{{.OS}}_{{.Arch}}_{{trimV .Version}}-stable.{{.Format}}

--- a/crates/aqua-registry/aqua-registry/pkgs/grafana/grafanactl/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/grafana/grafanactl/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: grafana
+    repo_name: grafanactl
+    description: The Grafana CLI. Command-line tool designed to simplify interaction with Grafana resources
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: grafanactl_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: grafanactl_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.10.4";
+  version = "2025.10.5";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "19.7k",
+      stars: "20k",
     };
   },
 };

--- a/mise.lock
+++ b/mise.lock
@@ -56,7 +56,7 @@ version = "1.43.2"
 backend = "cargo:cargo-insta"
 
 [[tools."cargo:cargo-release"]]
-version = "0.25.19"
+version = "0.25.20"
 backend = "cargo:cargo-release"
 
 [[tools."cargo:git-cliff"]]
@@ -95,18 +95,13 @@ size = 12793347
 url = "https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_macOS_arm64.zip"
 
 [[tools.hk]]
-version = "1.18.1"
+version = "1.18.2"
 backend = "aqua:jdx/hk"
 
 [tools.hk.platforms.linux-x64]
-checksum = "blake3:bc8be608f0909940687158ca66ce8a2c35a68a8257b2d051272ca441d13382ba"
-size = 7170910
-url = "https://github.com/jdx/hk/releases/download/v1.18.1/hk-x86_64-unknown-linux-gnu.tar.gz"
-
-[tools.hk.platforms.macos-arm64]
-checksum = "blake3:a48bf25b18f27f9a0f306ca77a0791d4963a999e85aee4251eb8cbc175884353"
-size = 6206992
-url = "https://github.com/jdx/hk/releases/download/v1.18.1/hk-aarch64-apple-darwin.tar.gz"
+checksum = "blake3:e61406636570d5ecdda7d5eee809585cbb7a6a1d1b8ac87fd6f2827c931fef1a"
+size = 7177308
+url = "https://github.com/jdx/hk/releases/download/v1.18.2/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [[tools.jq]]
 version = "1.8.1"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.10.4
+Version: 2025.10.5
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2025.10.4"
+version: "2025.10.5"
 summary: dev tools, env vars, task runner
 description: |
   dev tools, env vars, task runner


### PR DESCRIPTION
### 📦 Registry

- add jules by @alefteris in [#6568](https://github.com/jdx/mise/pull/6568)

### 🐛 Bug Fixes

- **(docs)** improve favicon support for Safari by @jdx in [#6567](https://github.com/jdx/mise/pull/6567)
- **(github)** download assets via API to respect GITHUB_TOKEN by @roele in [#6496](https://github.com/jdx/mise/pull/6496)
- **(task)** load toml tasks in `task_config.includes` in system/global config and monorepo subdirs by @risu729 in [#6545](https://github.com/jdx/mise/pull/6545)
- **(task)** handle dots in monorepo directory names correctly by @jdx in [#6571](https://github.com/jdx/mise/pull/6571)

### 📚 Documentation

- **(readme)** add GitHub Issues & Discussions section by @rsyring in [#6573](https://github.com/jdx/mise/pull/6573)
- **(tasks)** create dedicated monorepo tasks documentation by @jdx in [#6561](https://github.com/jdx/mise/pull/6561)
- **(tasks)** enhance monorepo documentation with tool comparisons by @jdx in [#6563](https://github.com/jdx/mise/pull/6563)