### PR TITLE
fix(docs): improve favicon support for Safari

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -256,8 +256,34 @@ export default withMermaid(
     },
     head: [
       // Favicon
+      ["link", { rel: "icon", href: "/favicon.ico", sizes: "any" }],
+      [
+        "link",
+        {
+          rel: "icon",
+          href: "/favicon-16x16.png",
+          type: "image/png",
+          sizes: "16x16",
+        },
+      ],
+      [
+        "link",
+        {
+          rel: "icon",
+          href: "/favicon-32x32.png",
+          type: "image/png",
+          sizes: "32x32",
+        },
+      ],
       ["link", { rel: "icon", href: "/logo.svg", type: "image/svg+xml" }],
-      ["link", { rel: "apple-touch-icon", href: "/logo.svg" }],
+      [
+        "link",
+        {
+          rel: "apple-touch-icon",
+          href: "/apple-touch-icon.png",
+          sizes: "180x180",
+        },
+      ],
       // Google Fonts
       [
         "link",


### PR DESCRIPTION
## Summary
Fixes favicon display issues in Safari by adding proper fallback formats.

## Changes
- Added `.ico` file as primary favicon for better Safari compatibility
- Included PNG favicon variants (16x16, 32x32) with proper sizes
- Kept SVG favicon for modern browsers
- Fixed `apple-touch-icon` to use proper PNG file instead of SVG
- Proper fallback chain ensures all browsers get appropriate icon format

## Why
Safari has historically had issues with SVG favicons. By providing `.ico` and PNG fallbacks in the proper order, the favicon will now display correctly across all browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds .ico and PNG favicon variants and updates apple-touch-icon to PNG for broader browser compatibility.
> 
> - **Docs site head config (`docs/.vitepress/config.ts`)**:
>   - Add favicon fallbacks: `favicon.ico` (any), `favicon-16x16.png`, `favicon-32x32.png`.
>   - Keep SVG favicon for modern browsers.
>   - Replace `apple-touch-icon` SVG with `apple-touch-icon.png` (180x180).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 581e4651041fbdedb23ce7dc83ba48eb04c07b69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->