### PR TITLE
fix(task): handle dots in monorepo directory names correctly

### DIFF
--- a/e2e/tasks/test_task_monorepo_dots_in_dir
+++ b/e2e/tasks/test_task_monorepo_dots_in_dir
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Test monorepo tasks with dots in directory names
+export MISE_EXPERIMENTAL=1
+
+# Create monorepo root config
+cat <<'TOML' >mise.toml
+experimental_monorepo_root = true
+
+[tasks.root-task]
+run = 'echo "root task executed"'
+TOML
+
+# Create projects with dots in directory names
+mkdir -p "projects/my.app"
+cat <<'TOML' >"projects/my.app/mise.toml"
+[tasks.build]
+run = 'echo "building my.app"'
+
+[tasks.test]
+run = 'echo "testing my.app"'
+TOML
+
+mkdir -p "projects/my.service.api"
+cat <<'TOML' >"projects/my.service.api/mise.toml"
+[tasks.build]
+run = 'echo "building my.service.api"'
+
+[tasks.deploy]
+depends = ["//projects/my.app:build"]
+run = 'echo "deploying my.service.api"'
+TOML
+
+mkdir -p "projects/feature.v2.beta"
+cat <<'TOML' >"projects/feature.v2.beta/mise.toml"
+[tasks.test]
+run = 'echo "testing feature.v2.beta"'
+TOML
+
+# Test 1: List tasks for directory with single dot
+echo "=== Test 1: List tasks for my.app ==="
+assert_contains "mise tasks ls --all" "//projects/my.app:build"
+assert_contains "mise tasks ls --all" "//projects/my.app:test"
+
+# Test 2: List tasks for directory with multiple dots
+echo "=== Test 2: List tasks for my.service.api ==="
+assert_contains "mise tasks ls --all" "//projects/my.service.api:build"
+assert_contains "mise tasks ls --all" "//projects/my.service.api:deploy"
+
+# Test 3: List tasks for directory with version-like dots
+echo "=== Test 3: List tasks for feature.v2.beta ==="
+assert_contains "mise tasks ls --all" "//projects/feature.v2.beta:test"
+
+# Test 4: Run task from directory with single dot
+echo "=== Test 4: Run build task from my.app ==="
+assert_contains "mise run '//projects/my.app:build'" "building my.app"
+
+# Test 5: Run task from directory with multiple dots
+echo "=== Test 5: Run build task from my.service.api ==="
+assert_contains "mise run '//projects/my.service.api:build'" "building my.service.api"
+
+# Test 6: Run task with dependency across directories with dots
+echo "=== Test 6: Run deploy with cross-directory dependency ==="
+output=$(mise run '//projects/my.service.api:deploy')
+echo "$output"
+echo "$output" | grep -q "building my.app" || (echo "FAIL: Dependency task from my.app not run" && exit 1)
+echo "$output" | grep -q "deploying my.service.api" || (echo "FAIL: Deploy task not run" && exit 1)
+
+# Test 7: Wildcard matching with dots in directory names
+echo "=== Test 7: Wildcard matching ==="
+assert_contains "mise run '//projects/...:build'" "building my.app"
+assert_contains "mise run '//projects/...:build'" "building my.service.api"
+
+# Test 8: Run all test tasks
+echo "=== Test 8: Run all test tasks ==="
+output=$(mise run '//...:test')
+echo "$output"
+echo "$output" | grep -q "testing my.app" || (echo "FAIL: my.app test not run" && exit 1)
+echo "$output" | grep -q "testing feature.v2.beta" || (echo "FAIL: feature.v2.beta test not run" && exit 1)
+
+echo "=== All tests with dots in directory names passed! ==="

--- a/e2e/tasks/test_task_monorepo_dots_in_dir
+++ b/e2e/tasks/test_task_monorepo_dots_in_dir
@@ -90,4 +90,24 @@ if echo "$output" | grep -q "building my.service.api"; then
 fi
 echo "SUCCESS: No false positive matches"
 
+# Test 10: Verify simple patterns can match monorepo tasks
+echo "=== Test 10: Simple pattern matching ==="
+# Create a simple task in the current directory for comparison
+cat <<'TOML' >>mise.toml
+
+[tasks.local-build]
+run = 'echo "local build"'
+TOML
+
+# Test that pattern "build" matches monorepo tasks
+output=$(mise tasks ls --all)
+echo "$output"
+# Count how many "build" tasks exist (should be at least 3: my.app, my.service.api, and local-build)
+build_count=$(echo "$output" | grep -c ":build\|local-build" || true)
+if [ "$build_count" -lt 3 ]; then
+	echo "FAIL: Expected at least 3 build tasks, found $build_count"
+	exit 1
+fi
+echo "SUCCESS: Found $build_count build tasks"
+
 echo "=== All tests with dots in directory names passed! ==="

--- a/e2e/tasks/test_task_monorepo_dots_in_dir
+++ b/e2e/tasks/test_task_monorepo_dots_in_dir
@@ -77,4 +77,17 @@ echo "$output"
 echo "$output" | grep -q "testing my.app" || (echo "FAIL: my.app test not run" && exit 1)
 echo "$output" | grep -q "testing feature.v2.beta" || (echo "FAIL: feature.v2.beta test not run" && exit 1)
 
+# Test 9: Verify no false positive matches between different projects
+echo "=== Test 9: Verify no false positive task matching ==="
+# Running //projects/my.app:build should NOT run //projects/my.service.api:build
+output=$(mise run '//projects/my.app:build')
+echo "$output"
+echo "$output" | grep -q "building my.app" || (echo "FAIL: my.app build not run" && exit 1)
+# Verify my.service.api:build was NOT run (would contain "building my.service.api")
+if echo "$output" | grep -q "building my.service.api"; then
+	echo "FAIL: False positive - my.service.api:build should not have run"
+	exit 1
+fi
+echo "SUCCESS: No false positive matches"
+
 echo "=== All tests with dots in directory names passed! ==="


### PR DESCRIPTION
## Summary
Fixes a bug where monorepo task names with dots in directory paths were incorrectly truncated when displayed. For example, `//projects/my.app:build` would appear as `//projects/my` instead of the full path.

## Changes
- Modified `Task::display_name()` to only strip file extensions from the task name portion after the last colon (`:`)
- Updated `Task::is_match()` to handle colon-separated task names consistently
- Added comprehensive e2e test `test_task_monorepo_dots_in_dir` covering various edge cases

## Test Coverage
The new test covers:
- Single dots in directory names (e.g., `my.app`)
- Multiple dots (e.g., `my.service.api`)
- Version-like dots (e.g., `feature.v2.beta`)
- Cross-directory task dependencies
- Wildcard matching with `//...:task` patterns

## Example
Before: `//projects/my.app:build` → displayed as `//projects/my`
After: `//projects/my.app:build` → displayed as `//projects/my.app:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes display and pattern matching for monorepo tasks with dots by stripping extensions only from the task segment and adds comprehensive e2e tests.
> 
> - **Task resolution/display**:
>   - `Task::display_name()`: Strip file extensions only after the last `:` so monorepo paths with dots (e.g., `//projects/my.app:build.sh`) display correctly.
>   - `Task::is_match()`: Align matching logic to handle colon-separated names and extension stripping, supporting simple patterns (e.g., `build`) against monorepo tasks.
> - **Tests**:
>   - Add `e2e/tasks/test_task_monorepo_dots_in_dir` covering directories with dots, cross-project dependencies, wildcard `//...:task` matching, and false-positive checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f765fceda4c3aa1eb1c993a2f861987e8486175. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->