### PR TITLE
chore: release 2025.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2025.10.6](https://github.com/jdx/mise/compare/v2025.10.5..v2025.10.6) - 2025-10-08
+
+### 📦 Registry
+
+- add vfox-mongod by @blaubaer in [#6586](https://github.com/jdx/mise/pull/6586)
+
+### 🚀 Features
+
+- add OSC 9;4 terminal progress indicators by @jdx in [#6584](https://github.com/jdx/mise/pull/6584)
+- make progress bar a footer by @jdx in [#6590](https://github.com/jdx/mise/pull/6590)
+
+### 🐛 Bug Fixes
+
+- **(task)** preserve ubi tool options during auto-install by @jdx in [#6600](https://github.com/jdx/mise/pull/6600)
+- unify project_root and config_root resolution by @risu729 in [#6588](https://github.com/jdx/mise/pull/6588)
+
+### 🚜 Refactor
+
+- **(exec)** remove redundant tty check for auto-install by @jdx in [#6589](https://github.com/jdx/mise/pull/6589)
+- remove duplicated task loads by @risu729 in [#6594](https://github.com/jdx/mise/pull/6594)
+
+### New Contributors
+
+- @blaubaer made their first contribution in [#6586](https://github.com/jdx/mise/pull/6586)
+
 ## [2025.10.5](https://github.com/jdx/mise/compare/v2025.10.4..v2025.10.5) - 2025-10-07
 
 ### 📦 Registry
@@ -870,7 +895,7 @@
 ### 📦 Registry
 
 - add container-use ([aqua:dagger/container-use](https://github.com/dagger/container-use)) by @TyceHerrman in [#6029](https://github.com/jdx/mise/pull/6029)
-- add prek ([aqua:j178/prek](https://github.com/j178/prek)) by @HenryZhang-ZHY in [#6023](https://github.com/jdx/mise/pull/6023)
+- add prek ([aqua:j178/prek](https://github.com/j178/prek)) by Henry Zhang in [#6023](https://github.com/jdx/mise/pull/6023)
 
 ### 🚀 Features
 
@@ -897,7 +922,6 @@
 ### New Contributors
 
 - @br3ndonland made their first contribution in [#6047](https://github.com/jdx/mise/pull/6047)
-- @HenryZhang-ZHY made their first contribution in [#6023](https://github.com/jdx/mise/pull/6023)
 - @lfromanini made their first contribution in [#6037](https://github.com/jdx/mise/pull/6037)
 
 ## [2025.8.10](https://github.com/jdx/mise/compare/v2025.8.9..v2025.8.10) - 2025-08-14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2025.10.5"
+version = "2025.10.6"
 dependencies = [
  "age",
  "aqua-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/vfox", "crates/aqua-registry"]
 
 [package]
 name = "mise"
-version = "2025.10.5"
+version = "2025.10.6"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Getting started](https://mise.jdx.dev/getting-started.html) for more option
 ```sh-session
 $ curl https://mise.run | sh
 $ ~/.local/bin/mise --version
-2025.10.5 macos-arm64 (a1b2d3e 2025-10-07)
+2025.10.6 macos-arm64 (a1b2d3e 2025-10-08)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_5.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_6.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage > "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_5.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2025_10_6.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage > "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_10_5.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2025_10_6.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/crates/aqua-registry/aqua-registry/pkgs/linkerd/linkerd2/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/linkerd/linkerd2/registry.yaml
@@ -3,30 +3,92 @@ packages:
   - type: github_release
     repo_owner: linkerd
     repo_name: linkerd2
-    asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
-    format: raw
     description: Ultralight, security-first service mesh for Kubernetes. Main repo for Linkerd 2.x
-    overrides:
-      - goos: darwin
-        goarch: amd64
-        asset: linkerd2-cli-{{.Version}}-{{.OS}}
-        checksum:
-          type: github_release
-          asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
-          algorithm: sha256
-      - goos: windows
-        asset: linkerd2-cli-{{.Version}}-{{.OS}}
-        checksum:
-          type: github_release
-          asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
-          algorithm: sha256
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     files:
       - name: linkerd
-    checksum:
-      type: github_release
-      asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "stable-2.9.0"
+        no_asset: true
+      - version_constraint: semver("<= 2.8.1")
+        version_prefix: stable-
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 2.10.0")
+        version_prefix: stable-
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
+      - version_constraint: Version startsWith "stable-"
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: linkerd2-cli-{{.Version}}-{{.OS}}
+          - goos: windows
+            asset: linkerd2-cli-{{.Version}}-{{.OS}}
+      - version_constraint: semver("<= 20.7.5")
+        version_prefix: edge-
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 21.3.2")
+        version_prefix: edge-
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
+      - version_constraint: semver("<= 25.9.3")
+        version_prefix: edge-
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: linkerd2-cli-{{.Version}}-{{.OS}}
+          - goos: windows
+            asset: linkerd2-cli-{{.Version}}-{{.OS}}
+      - version_constraint: Version startsWith "edge-"
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: linkerd2-cli-{{.Version}}-{{.OS}}
+          - goos: windows
+            asset: linkerd2-cli-{{.Version}}-{{.OS}}

--- a/crates/aqua-registry/aqua-registry/pkgs/minio/mc/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/minio/mc/registry.yaml
@@ -8,6 +8,11 @@ packages:
     complete_windows_ext: false
     windows_arm_emulation: true
     format: raw
+    overrides:
+      - goos: windows
+        files:
+          - name: mc
+            link: mc.exe
     checksum:
       type: http
       algorithm: sha256

--- a/crates/aqua-registry/aqua-registry/pkgs/walles/moor/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/walles/moor/registry.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: walles
+    repo_name: moor
+    description: Moor is a pager. It's designed to just do the right thing without any configuration
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.23.3"
+        asset: moar-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        files:
+          - name: moar
+        supported_envs:
+          - windows
+      - version_constraint: semver("<= 0.9.7")
+        no_asset: true
+      - version_constraint: semver("<= 1.8.1")
+        asset: moar-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        files:
+          - name: moar
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 1.11.4")
+        asset: moar-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: moar
+        supported_envs:
+          - darwin
+          - windows
+      - version_constraint: semver("<= 1.23.7")
+        asset: moar-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: moar
+            link: moar
+        supported_envs:
+          - darwin
+          - windows
+      - version_constraint: semver("<= 1.31.4")
+        asset: moar-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: moar
+            link: moar
+        supported_envs:
+          - darwin
+          - windows
+          - linux/amd64
+      - version_constraint: semver("<= 1.33.0")
+        asset: moar-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        files:
+          - name: moar
+            link: moar
+        supported_envs:
+          - darwin
+          - windows
+          - linux/amd64
+      - version_constraint: "true"
+        asset: moor-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        files:
+          - name: moor
+            link: moor
+        supported_envs:
+          - darwin
+          - windows
+          - linux/amd64

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2025.10.5";
+  version = "2025.10.6";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "20k",
+      stars: "20.1k",
     };
   },
 };

--- a/mise.lock
+++ b/mise.lock
@@ -72,13 +72,13 @@ version = "2.3.2"
 backend = "cargo:usage-cli"
 
 [[tools.cosign]]
-version = "2.6.1"
+version = "3.0.1"
 backend = "aqua:sigstore/cosign"
 
 [tools.cosign.platforms.linux-x64]
-checksum = "sha256:064954c5d8c7e3b28188eee5b1727b31c411550bc5fefd41aa672d3c761d103a"
-size = 155339383
-url = "https://github.com/sigstore/cosign/releases/download/v2.6.1/cosign-linux-amd64"
+checksum = "sha256:23c9ff889672f03676b673539de07d5ad4e8efc8247a3ad55c9bc00169aa2305"
+size = 155395688
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.1/cosign-linux-amd64"
 
 [[tools.gh]]
 version = "2.62.0"
@@ -95,13 +95,13 @@ size = 12793347
 url = "https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_macOS_arm64.zip"
 
 [[tools.hk]]
-version = "1.18.2"
+version = "1.18.3"
 backend = "aqua:jdx/hk"
 
 [tools.hk.platforms.linux-x64]
-checksum = "blake3:e61406636570d5ecdda7d5eee809585cbb7a6a1d1b8ac87fd6f2827c931fef1a"
-size = 7177308
-url = "https://github.com/jdx/hk/releases/download/v1.18.2/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "blake3:dcb3b961bcaf97961bd6fea889954b7e38ff7ee3a3c37001632d5e4e65402d36"
+size = 7169077
+url = "https://github.com/jdx/hk/releases/download/v1.18.3/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [[tools.jq]]
 version = "1.8.1"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2025.10.5
+Version: 2025.10.6
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2025.10.5"
+version: "2025.10.6"
 summary: dev tools, env vars, task runner
 description: |
   dev tools, env vars, task runner


### PR DESCRIPTION
### 📦 Registry

- add vfox-mongod by @blaubaer in [#6586](https://github.com/jdx/mise/pull/6586)

### 🚀 Features

- add OSC 9;4 terminal progress indicators by @jdx in [#6584](https://github.com/jdx/mise/pull/6584)
- make progress bar a footer by @jdx in [#6590](https://github.com/jdx/mise/pull/6590)

### 🐛 Bug Fixes

- **(task)** preserve ubi tool options during auto-install by @jdx in [#6600](https://github.com/jdx/mise/pull/6600)
- unify project_root and config_root resolution by @risu729 in [#6588](https://github.com/jdx/mise/pull/6588)

### 🚜 Refactor

- **(exec)** remove redundant tty check for auto-install by @jdx in [#6589](https://github.com/jdx/mise/pull/6589)
- remove duplicated task loads by @risu729 in [#6594](https://github.com/jdx/mise/pull/6594)

### New Contributors

- @blaubaer made their first contribution in [#6586](https://github.com/jdx/mise/pull/6586)