### PR TITLE
fix: unify project_root and config_root resolution

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1061,7 +1061,7 @@ impl Run {
         if let (Some(task_config_root), Some(current_config_root)) =
             (task_cf.project_root(), config.project_root.as_ref())
         {
-            if task_config_root == current_config_root && config_env_entries.is_empty() {
+            if task_config_root == *current_config_root && config_env_entries.is_empty() {
                 trace!(
                     "task {} config root matches current and no config env, using standard env resolution",
                     task.name
@@ -1081,7 +1081,7 @@ impl Run {
     ) -> Result<tera::Context> {
         let mut tera_ctx = ts.tera_ctx(config).await?.clone();
         if let Some(root) = task_cf.project_root() {
-            tera_ctx.insert("config_root", root);
+            tera_ctx.insert("config_root", &root);
         }
         Ok(tera_ctx)
     }

--- a/src/config/config_file/config_root.rs
+++ b/src/config/config_file/config_root.rs
@@ -30,23 +30,22 @@ pub fn config_root(path: &Path) -> PathBuf {
         .components()
         .map(|c| c.as_os_str().to_string_lossy().to_string())
         .collect::<Vec<_>>();
-    const EMPTY: &str = "";
-    let filename = parts.last().map(|p| p.as_str()).unwrap_or(EMPTY);
+    let filename = parts.last().map(|p| p.as_str()).unwrap_or_default();
     let parent = parts
         .iter()
         .nth_back(1)
         .map(|p| p.as_str())
-        .unwrap_or(EMPTY);
+        .unwrap_or_default();
     let grandparent = parts
         .iter()
         .nth_back(2)
         .map(|p| p.as_str())
-        .unwrap_or(EMPTY);
+        .unwrap_or_default();
     let great_grandparent = parts
         .iter()
         .nth_back(3)
         .map(|p| p.as_str())
-        .unwrap_or(EMPTY);
+        .unwrap_or_default();
     let parent_path = || path.parent().unwrap().to_path_buf();
     let grandparent_path = || parent_path().parent().unwrap().to_path_buf();
     let great_grandparent_path = || grandparent_path().parent().unwrap().to_path_buf();
@@ -84,31 +83,64 @@ mod tests {
     #[test]
     fn test_config_root() {
         for p in &[
-            "/foo/bar/.config/mise/conf.d/config.toml",
-            "/foo/bar/.config/mise/conf.d/foo.toml",
-            "/foo/bar/.config/mise/config.local.toml",
-            "/foo/bar/.config/mise/config.toml",
-            "/foo/bar/.config/mise.local.toml",
-            "/foo/bar/.config/mise.toml",
-            "/foo/bar/.mise.env.toml",
-            "/foo/bar/.mise.local.toml",
-            "/foo/bar/.mise.toml",
-            "/foo/bar/.mise/conf.d/config.toml",
-            "/foo/bar/.mise/config.local.toml",
-            "/foo/bar/.mise/config.toml",
-            "/foo/bar/.tool-versions",
-            "/foo/bar/mise.env.toml",
-            "/foo/bar/mise.local.toml",
-            "/foo/bar/mise.toml",
-            "/foo/bar/mise/config.local.toml",
-            "/foo/bar/mise/config.toml",
-            "/foo/bar/.config/mise/config.env.toml",
-            "/foo/bar/.config/mise.env.toml",
-            "/foo/bar/.mise/config.env.toml",
-            "/foo/bar/.mise.env.toml",
+            "/foo/mise/.config/mise/conf.d/config.toml",
+            "/foo/mise/.config/mise/conf.d/foo.toml",
+            "/foo/mise/.config/mise/config.local.toml",
+            "/foo/mise/.config/mise/config.toml",
+            "/foo/mise/.config/mise.local.toml",
+            "/foo/mise/.config/mise.toml",
+            "/foo/mise/.mise.env.toml",
+            "/foo/mise/.mise.local.toml",
+            "/foo/mise/.mise.toml",
+            "/foo/mise/.mise/conf.d/config.toml",
+            "/foo/mise/.mise/conf.d/foo.toml",
+            "/foo/mise/.mise/config.local.toml",
+            "/foo/mise/.mise/config.toml",
+            "/foo/mise/.tool-versions",
+            "/foo/mise/mise.env.toml",
+            "/foo/mise/mise.local.toml",
+            "/foo/mise/mise.toml",
+            "/foo/mise/mise/config.local.toml",
+            "/foo/mise/mise/config.toml",
+            "/foo/mise/.config/mise/config.env.toml",
+            "/foo/mise/.config/mise.env.toml",
+            "/foo/mise/.mise/config.env.toml",
+            "/foo/mise/.mise.env.toml",
         ] {
             println!("{p}");
-            assert_eq!(config_root(Path::new(p)), PathBuf::from("/foo/bar"));
+            assert_eq!(config_root(Path::new(p)), PathBuf::from("/foo/mise"));
+        }
+    }
+
+    #[test]
+    fn test_config_root_mise_dir() {
+        for p in &[
+            "/foo/mise/.config/mise/conf.d/config.toml",
+            "/foo/mise/.config/mise/conf.d/foo.toml",
+            "/foo/mise/.config/mise/config.local.toml",
+            "/foo/mise/.config/mise/config.toml",
+            "/foo/mise/.config/mise.local.toml",
+            "/foo/mise/.config/mise.toml",
+            "/foo/mise/.mise.env.toml",
+            "/foo/mise/.mise.local.toml",
+            "/foo/mise/.mise.toml",
+            "/foo/mise/.mise/conf.d/config.toml",
+            "/foo/mise/.mise/conf.d/foo.toml",
+            "/foo/mise/.mise/config.local.toml",
+            "/foo/mise/.mise/config.toml",
+            "/foo/mise/.tool-versions",
+            "/foo/mise/mise.env.toml",
+            "/foo/mise/mise.local.toml",
+            "/foo/mise/mise.toml",
+            "/foo/mise/mise/config.local.toml",
+            "/foo/mise/mise/config.toml",
+            "/foo/mise/.config/mise/config.env.toml",
+            "/foo/mise/.config/mise.env.toml",
+            "/foo/mise/.mise/config.env.toml",
+            "/foo/mise/.mise.env.toml",
+        ] {
+            println!("{p}");
+            assert_eq!(config_root(Path::new(p)), PathBuf::from("/foo/mise"));
         }
     }
 }

--- a/src/config/config_file/config_root.rs
+++ b/src/config/config_file/config_root.rs
@@ -83,32 +83,32 @@ mod tests {
     #[test]
     fn test_config_root() {
         for p in &[
-            "/foo/mise/.config/mise/conf.d/config.toml",
-            "/foo/mise/.config/mise/conf.d/foo.toml",
-            "/foo/mise/.config/mise/config.local.toml",
-            "/foo/mise/.config/mise/config.toml",
-            "/foo/mise/.config/mise.local.toml",
-            "/foo/mise/.config/mise.toml",
-            "/foo/mise/.mise.env.toml",
-            "/foo/mise/.mise.local.toml",
-            "/foo/mise/.mise.toml",
-            "/foo/mise/.mise/conf.d/config.toml",
-            "/foo/mise/.mise/conf.d/foo.toml",
-            "/foo/mise/.mise/config.local.toml",
-            "/foo/mise/.mise/config.toml",
-            "/foo/mise/.tool-versions",
-            "/foo/mise/mise.env.toml",
-            "/foo/mise/mise.local.toml",
-            "/foo/mise/mise.toml",
-            "/foo/mise/mise/config.local.toml",
-            "/foo/mise/mise/config.toml",
-            "/foo/mise/.config/mise/config.env.toml",
-            "/foo/mise/.config/mise.env.toml",
-            "/foo/mise/.mise/config.env.toml",
-            "/foo/mise/.mise.env.toml",
+            "/foo/bar/.config/mise/conf.d/config.toml",
+            "/foo/bar/.config/mise/conf.d/foo.toml",
+            "/foo/bar/.config/mise/config.local.toml",
+            "/foo/bar/.config/mise/config.toml",
+            "/foo/bar/.config/mise.local.toml",
+            "/foo/bar/.config/mise.toml",
+            "/foo/bar/.mise.env.toml",
+            "/foo/bar/.mise.local.toml",
+            "/foo/bar/.mise.toml",
+            "/foo/bar/.mise/conf.d/config.toml",
+            "/foo/bar/.mise/conf.d/foo.toml",
+            "/foo/bar/.mise/config.local.toml",
+            "/foo/bar/.mise/config.toml",
+            "/foo/bar/.tool-versions",
+            "/foo/bar/mise.env.toml",
+            "/foo/bar/mise.local.toml",
+            "/foo/bar/mise.toml",
+            "/foo/bar/mise/config.local.toml",
+            "/foo/bar/mise/config.toml",
+            "/foo/bar/.config/mise/config.env.toml",
+            "/foo/bar/.config/mise.env.toml",
+            "/foo/bar/.mise/config.env.toml",
+            "/foo/bar/.mise.env.toml",
         ] {
             println!("{p}");
-            assert_eq!(config_root(Path::new(p)), PathBuf::from("/foo/mise"));
+            assert_eq!(config_root(Path::new(p)), PathBuf::from("/foo/bar"));
         }
     }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -30,7 +30,7 @@ use crate::task::Task;
 use crate::tera::{BASE_CONTEXT, get_tera};
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource, ToolVersionOptions};
 use crate::watch_files::WatchFile;
-use crate::{dirs, file};
+use crate::file;
 
 use super::{ConfigFileType, min_version::MinVersionSpec};
 
@@ -388,28 +388,6 @@ impl ConfigFile for MiseToml {
 
     fn min_version(&self) -> Option<&MinVersionSpec> {
         self.min_version.as_ref()
-    }
-
-    fn project_root(&self) -> Option<&Path> {
-        let filename = self.path.file_name().unwrap_or_default().to_string_lossy();
-        match self.path.parent() {
-            Some(dir) => match dir {
-                dir if dir.starts_with(*dirs::CONFIG) => None,
-                dir if dir.starts_with(*dirs::SYSTEM) => None,
-                dir if dir == *dirs::HOME => None,
-                dir if !filename.starts_with('.')
-                    && (dir.ends_with(".mise") || dir.ends_with(".config")) =>
-                {
-                    dir.parent()
-                }
-                dir if !filename.starts_with('.') && dir.ends_with(".config/mise") => {
-                    dir.parent().unwrap().parent()
-                }
-                dir if !filename.starts_with('.') && dir.ends_with("mise") => dir.parent(),
-                dir => Some(dir),
-            },
-            None => None,
-        }
     }
 
     fn plugins(&self) -> eyre::Result<HashMap<String, String>> {
@@ -1685,6 +1663,7 @@ mod tests {
     use insta::{assert_debug_snapshot, assert_snapshot};
     use test_log::test;
 
+    use crate::dirs;
     use crate::test::replace_path;
     use crate::toolset::ToolRequest;
     use crate::{config::Config, dirs::CWD};

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -22,6 +22,7 @@ use crate::config::config_file::{config_root, toml::deserialize_arr};
 use crate::config::env_directive::{AgeFormat, EnvDirective, EnvDirectiveOptions, RequiredValue};
 use crate::config::settings::SettingsPartial;
 use crate::config::{Alias, AliasMap, Config};
+use crate::file;
 use crate::file::{create_dir_all, display_path};
 use crate::hooks::{Hook, Hooks};
 use crate::redactions::Redactions;
@@ -30,7 +31,6 @@ use crate::task::Task;
 use crate::tera::{BASE_CONTEXT, get_tera};
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource, ToolVersionOptions};
 use crate::watch_files::WatchFile;
-use crate::file;
 
 use super::{ConfigFileType, min_version::MinVersionSpec};
 

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -54,7 +54,7 @@ pub trait ConfigFile: Debug + Send + Sync {
     /// if it's a global/system config, returns None
     /// files like ~/src/foo/.mise/config.toml will return ~/src/foo
     /// and ~/src/foo/.mise.config.toml will return None
-    fn project_root(&self) -> Option<&Path> {
+    fn project_root(&self) -> Option<PathBuf> {
         let p = self.get_path();
         if config::is_global_config(p) {
             return None;
@@ -64,7 +64,7 @@ pub trait ConfigFile: Debug + Send + Sync {
                 dir if dir.starts_with(*dirs::CONFIG) => None,
                 dir if dir.starts_with(*dirs::SYSTEM) => None,
                 dir if dir == *dirs::HOME => None,
-                dir => Some(dir),
+                _ => Some(config_root::config_root(p)),
             },
             None => None,
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1573,9 +1573,9 @@ async fn load_config_and_file_tasks(
     config: &Arc<Config>,
     cf: Arc<dyn ConfigFile>,
 ) -> Result<Vec<Task>> {
-    let project_root = cf.project_root().unwrap_or(&*env::HOME);
-    let tasks = load_config_tasks(config, cf.clone(), project_root).await?;
-    let file_tasks = load_file_tasks(config, cf.clone(), project_root).await?;
+    let project_root = cf.project_root().unwrap_or(env::HOME.clone());
+    let tasks = load_config_tasks(config, cf.clone(), &project_root).await?;
+    let file_tasks = load_file_tasks(config, cf.clone(), &project_root).await?;
     Ok(tasks.into_iter().chain(file_tasks).collect())
 }
 


### PR DESCRIPTION
I sometimes encounter a bug when developing in `~/.ghr/github.com/risu729/mise` directory, so I added tests for it.
It has been caused by this, but `config_root` handles this case correctly as shown by the test.
```
dir if !filename.starts_with('.') && dir.ends_with("mise") => dir.parent(),
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies project_root to use config_root across config files, updates run/env handling accordingly, and adds/expands config_root tests.
> 
> - **Config resolution**:
>   - `ConfigFile::project_root` now returns `Option<PathBuf>` and uses `config_root::config_root` for determination.
>   - Updated call sites to handle owned `PathBuf` (e.g., in `config::load_config_and_file_tasks`).
> - **CLI/task env**:
>   - Adjust env resolution check to compare `PathBuf` roots and minor `tera` context insertion (`config_root`).
> - **Tests**:
>   - Extend `config_root` test cases, including `.mise/conf.d/foo.toml` and directories under `.../mise/...` to validate correct root detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ba992aedb239675fc04db3ad0cf1ec96a8eafb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->