### PR TITLE
refactor(exec): remove redundant tty check for auto-install

### DIFF
--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -71,7 +71,6 @@ impl Exec {
             // in that case the user probably just wants that one tool
             missing_args_only: !self.tool.is_empty()
                 || !Settings::get().exec_auto_install
-                || !console::user_attended_stderr()
                 || *env::__MISE_SHIM,
             resolve_options: Default::default(),
             ..Default::default()


### PR DESCRIPTION
## Summary
- Remove the `console::user_attended_stderr()` check from exec's auto-install logic

## Rationale
This check was redundant since:
- The `exec_auto_install` setting already controls this behavior
- The shim case is handled separately by the `__MISE_SHIM` check  
- Creates inconsistency with `mise run` which only checks the setting

Users who want to disable auto-install in non-interactive contexts can set `MISE_EXEC_AUTO_INSTALL=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies `exec` auto-install by removing the `console::user_attended_stderr()` condition from `missing_args_only`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0940e18f22927ea63801caa782c6e3a003f97d01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->