### PR TITLE
refactor(backend): add sub-traits and extract task loading

### DIFF
--- a/src/backend/traits/bin_paths.rs
+++ b/src/backend/traits/bin_paths.rs
@@ -1,0 +1,96 @@
+//! Binary path provider trait for backends
+//!
+//! This trait handles binary paths and execution environment.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+
+use crate::config::Config;
+use crate::toolset::ResolveOptions;
+use crate::toolset::outdated_info::OutdatedInfo;
+use crate::toolset::{ToolRequest, ToolVersion, Toolset};
+
+use super::identity::BackendIdentity;
+
+/// Trait for binary path discovery and execution environment.
+///
+/// This trait provides methods for:
+/// - Listing binary paths for a tool version
+/// - Computing execution environment
+/// - Finding specific binaries (which)
+/// - Computing PATH for commands
+#[async_trait]
+pub trait BinPathProvider: BackendIdentity {
+    // ========== Binary Paths ==========
+
+    /// List all binary paths for a tool version.
+    ///
+    /// Default returns `<install_path>/bin`. Backends can override
+    /// for tools with different layouts.
+    async fn list_bin_paths(
+        &self,
+        _config: &Arc<Config>,
+        tv: &ToolVersion,
+    ) -> Result<Vec<PathBuf>> {
+        match tv.request {
+            ToolRequest::System { .. } => Ok(vec![]),
+            _ => Ok(vec![tv.install_path().join("bin")]),
+        }
+    }
+
+    // ========== Execution Environment ==========
+
+    /// Get additional environment variables for this tool version.
+    ///
+    /// These are merged with the toolset environment when running commands.
+    async fn exec_env(
+        &self,
+        _config: &Arc<Config>,
+        _ts: &Toolset,
+        _tv: &ToolVersion,
+    ) -> Result<BTreeMap<String, String>> {
+        Ok(BTreeMap::new())
+    }
+
+    /// Build the PATH environment variable for running commands.
+    ///
+    /// Combines this tool's bin paths with dependency paths and system PATH.
+    async fn path_env_for_cmd(&self, config: &Arc<Config>, tv: &ToolVersion) -> Result<OsString>;
+
+    // ========== Binary Discovery ==========
+
+    /// Find a specific binary in this tool's paths.
+    ///
+    /// Returns the full path to the binary if found.
+    async fn which(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        bin_name: &str,
+    ) -> Result<Option<PathBuf>>;
+
+    // ========== Outdated Info ==========
+
+    /// Get outdated information for a tool version.
+    async fn outdated_info(
+        &self,
+        _config: &Arc<Config>,
+        _tv: &ToolVersion,
+        _bump: bool,
+        _opts: &ResolveOptions,
+    ) -> Result<Option<OutdatedInfo>> {
+        Ok(None)
+    }
+
+    // ========== Metadata ==========
+
+    /// Get a description of this tool.
+    async fn description(&self) -> Option<String> {
+        None
+    }
+}

--- a/src/backend/traits/dependencies.rs
+++ b/src/backend/traits/dependencies.rs
@@ -1,0 +1,73 @@
+//! Dependency management trait for backends
+//!
+//! This trait handles tool dependencies and environment resolution.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+use indexmap::IndexSet;
+
+use crate::cli::args::BackendArg;
+use crate::config::Config;
+use crate::toolset::Toolset;
+
+use super::identity::BackendIdentity;
+
+/// Trait for dependency management.
+///
+/// This trait provides methods for:
+/// - Declaring tool dependencies
+/// - Resolving dependency toolsets
+/// - Finding dependency binaries
+/// - Checking for missing dependencies
+#[async_trait]
+pub trait DependencyManager: BackendIdentity {
+    // ========== Dependency Declaration ==========
+
+    /// Get required dependencies for this tool.
+    ///
+    /// If any of these tools are installing in parallel, we should
+    /// wait for them to finish before installing this tool.
+    fn get_dependencies(&self) -> Result<Vec<&str>> {
+        Ok(vec![])
+    }
+
+    /// Get optional dependencies for this tool.
+    ///
+    /// These wait for install but do not warn (e.g., cargo-binstall).
+    fn get_optional_dependencies(&self) -> Result<Vec<&str>> {
+        Ok(vec![])
+    }
+
+    /// Get all dependencies (required + optional) transitively.
+    fn get_all_dependencies(&self, optional: bool) -> Result<IndexSet<BackendArg>>;
+
+    // ========== Dependency Resolution ==========
+
+    /// Get the toolset containing all dependencies.
+    async fn dependency_toolset(&self, config: &Arc<Config>) -> Result<Toolset>;
+
+    /// Find a binary in the dependency toolset.
+    async fn dependency_which(&self, config: &Arc<Config>, bin: &str) -> Option<PathBuf>;
+
+    /// Get environment variables from dependencies.
+    async fn dependency_env(&self, config: &Arc<Config>) -> Result<BTreeMap<String, String>>;
+
+    // ========== Dependency Warnings ==========
+
+    /// Warn if any required dependencies are missing.
+    async fn warn_if_dependencies_missing(&self, config: &Arc<Config>) -> Result<()>;
+
+    /// Check if a required dependency is available and warn if not.
+    ///
+    /// Provides a consistent warning message format across all backends.
+    async fn warn_if_dependency_missing(
+        &self,
+        config: &Arc<Config>,
+        program: &str,
+        install_instructions: &str,
+    );
+}

--- a/src/backend/traits/identity.rs
+++ b/src/backend/traits/identity.rs
@@ -1,0 +1,50 @@
+//! Core identity trait for backends
+//!
+//! This trait defines the fundamental identity of a backend and is required
+//! by all other backend traits.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use crate::cli::args::BackendArg;
+use crate::plugins::{PluginEnum, PluginType};
+
+use super::super::backend_type::BackendType;
+
+/// Core identity trait for backends.
+///
+/// This is the foundational trait that all backends must implement.
+/// It provides identity, type information, and optional plugin association.
+pub trait BackendIdentity: Debug + Send + Sync {
+    /// Returns the unique identifier for this backend (short name).
+    ///
+    /// This is typically the tool's short name like "node", "python", etc.
+    fn id(&self) -> &str {
+        &self.ba().short
+    }
+
+    /// Returns the human-readable tool name.
+    fn tool_name(&self) -> String {
+        self.ba().tool_name()
+    }
+
+    /// Returns the backend type (Core, Asdf, Vfox, Cargo, etc.)
+    fn get_type(&self) -> BackendType {
+        BackendType::Core
+    }
+
+    /// Returns a reference to the BackendArg for this backend.
+    ///
+    /// This is the only required method - all other methods have default implementations.
+    fn ba(&self) -> &Arc<BackendArg>;
+
+    /// Returns the plugin type if this backend is backed by a plugin.
+    fn get_plugin_type(&self) -> Option<PluginType> {
+        None
+    }
+
+    /// Returns the plugin if this backend is backed by one.
+    fn plugin(&self) -> Option<&PluginEnum> {
+        None
+    }
+}

--- a/src/backend/traits/installer.rs
+++ b/src/backend/traits/installer.rs
@@ -1,0 +1,113 @@
+//! Installer trait for backends
+//!
+//! This trait handles tool installation and uninstallation.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+
+use crate::config::Config;
+use crate::install_context::InstallContext;
+use crate::toolset::ToolVersion;
+use crate::ui::progress_report::SingleReport;
+
+use super::identity::BackendIdentity;
+
+/// Trait for tool installation and uninstallation.
+///
+/// This trait provides methods for:
+/// - Installing tool versions
+/// - Uninstalling tool versions
+/// - Managing installation directories
+/// - Checking installation status
+#[async_trait]
+pub trait Installer: BackendIdentity {
+    // ========== Installation ==========
+
+    /// Install a tool version.
+    ///
+    /// This is the main entry point for installation. It handles:
+    /// - Dry-run mode
+    /// - Force reinstallation
+    /// - Locked mode verification
+    /// - Directory setup and cleanup
+    /// - Post-install hooks
+    ///
+    /// Backends should implement `install_version_` for the actual installation logic.
+    async fn install_version(&self, ctx: InstallContext, tv: ToolVersion) -> Result<ToolVersion>;
+
+    /// Backend implementation for installing a tool version.
+    ///
+    /// This is the method backends must implement with their
+    /// actual installation logic (download, extract, compile, etc.)
+    async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion>;
+
+    // ========== Uninstallation ==========
+
+    /// Uninstall a tool version.
+    ///
+    /// Handles removing the installation directory, cache, and downloads.
+    async fn uninstall_version(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        pr: &dyn SingleReport,
+        dryrun: bool,
+    ) -> Result<()>;
+
+    /// Backend-specific uninstallation logic.
+    ///
+    /// Override this for backends that need custom cleanup.
+    async fn uninstall_version_impl(
+        &self,
+        _config: &Arc<Config>,
+        _pr: &dyn SingleReport,
+        _tv: &ToolVersion,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Purge all versions of this tool.
+    fn purge(&self, pr: &dyn SingleReport) -> Result<()>;
+
+    // ========== Directory Management ==========
+
+    /// Create installation directories for a tool version.
+    fn create_install_dirs(&self, tv: &ToolVersion) -> Result<()>;
+
+    /// Clean up directories on installation error.
+    fn cleanup_install_dirs_on_error(&self, tv: &ToolVersion);
+
+    /// Clean up temporary directories after successful installation.
+    fn cleanup_install_dirs(&self, tv: &ToolVersion);
+
+    /// Get the path to the incomplete marker file.
+    fn incomplete_file_path(&self, tv: &ToolVersion) -> PathBuf;
+
+    // ========== Status Checking ==========
+
+    /// Check if a version is installed.
+    fn is_version_installed(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        check_symlink: bool,
+    ) -> bool;
+
+    /// Check if a version is outdated.
+    async fn is_version_outdated(&self, config: &Arc<Config>, tv: &ToolVersion) -> bool;
+
+    // ========== Symlink Management ==========
+
+    /// Get the symlink path if this version is a symlink.
+    fn symlink_path(&self, tv: &ToolVersion) -> Option<PathBuf>;
+
+    /// Create a symlink for a version.
+    fn create_symlink(
+        &self,
+        version: &str,
+        target: &std::path::Path,
+    ) -> Result<Option<(PathBuf, PathBuf)>>;
+}

--- a/src/backend/traits/lockfile.rs
+++ b/src/backend/traits/lockfile.rs
@@ -1,0 +1,164 @@
+//! Lockfile support trait for backends
+//!
+//! This trait handles platform-specific metadata for lockfile generation.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use async_trait::async_trait;
+use eyre::Result;
+
+use crate::config::Settings;
+use crate::install_context::InstallContext;
+use crate::lockfile::PlatformInfo;
+use crate::platform::Platform;
+use crate::toolset::ToolVersion;
+
+use super::super::platform_target::PlatformTarget;
+use super::super::{GitHubReleaseInfo, SecurityFeature};
+use super::identity::BackendIdentity;
+
+/// Trait for lockfile and platform-specific metadata support.
+///
+/// This trait provides methods for:
+/// - Platform key generation for lockfile storage
+/// - Resolving lockfile options
+/// - Platform variant enumeration
+/// - Checksum verification
+/// - Security feature information
+#[async_trait]
+pub trait LockfileSupport: BackendIdentity {
+    // ========== Platform Keys ==========
+
+    /// Generate a platform key for lockfile storage.
+    ///
+    /// Default implementation uses os-arch format.
+    /// Backends can override for more specific keys.
+    fn get_platform_key(&self) -> String {
+        let settings = Settings::get();
+        let os = settings.os();
+        let arch = settings.arch();
+        format!("{os}-{arch}")
+    }
+
+    /// Resolve lockfile options for a tool request on a target platform.
+    ///
+    /// These options affect artifact identity and must match exactly
+    /// for lockfile lookup.
+    fn resolve_lockfile_options(
+        &self,
+        _request: &crate::toolset::ToolRequest,
+        _target: &PlatformTarget,
+    ) -> BTreeMap<String, String> {
+        BTreeMap::new() // Default: no options affect artifact identity
+    }
+
+    /// Return all platform variants that should be locked for a given platform.
+    ///
+    /// Some tools have compile-time variants (e.g., bun has baseline/musl)
+    /// that result in different download URLs and checksums.
+    fn platform_variants(&self, platform: &Platform) -> Vec<Platform> {
+        vec![platform.clone()] // Default: just the base platform
+    }
+
+    // ========== Lock Info Resolution ==========
+
+    /// Resolve platform-specific lock information without installation.
+    async fn resolve_lock_info(
+        &self,
+        tv: &ToolVersion,
+        target: &PlatformTarget,
+    ) -> Result<PlatformInfo>;
+
+    /// Provide tarball URL for platform-specific tool installation.
+    ///
+    /// Backends can implement this for simple tarball-based tools.
+    async fn get_tarball_url(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<Option<String>> {
+        Ok(None) // Default: no tarball URL available
+    }
+
+    /// Provide GitHub/GitLab release info for platform-specific tool installation.
+    async fn get_github_release_info(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<Option<GitHubReleaseInfo>> {
+        Ok(None) // Default: no GitHub release info available
+    }
+
+    /// Shared logic for processing tarball-based tools.
+    async fn resolve_lock_info_from_tarball(
+        &self,
+        tarball_url: &str,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<PlatformInfo> {
+        Ok(PlatformInfo {
+            checksum: None,
+            size: None,
+            url: Some(tarball_url.to_string()),
+            url_api: None,
+        })
+    }
+
+    /// Shared logic for processing GitHub/GitLab release-based tools.
+    async fn resolve_lock_info_from_github_release(
+        &self,
+        release_info: &GitHubReleaseInfo,
+        _tv: &ToolVersion,
+        target: &PlatformTarget,
+    ) -> Result<PlatformInfo> {
+        let asset_name = release_info.asset_pattern.as_ref().map(|pattern| {
+            pattern
+                .replace("{os}", target.os_name())
+                .replace("{arch}", target.arch_name())
+        });
+
+        let asset_url = match (&release_info.api_url, &asset_name) {
+            (Some(base_url), Some(name)) => Some(format!("{}/{}", base_url, name)),
+            _ => asset_name.clone(),
+        };
+
+        Ok(PlatformInfo {
+            checksum: None,
+            size: None,
+            url: asset_url,
+            url_api: None,
+        })
+    }
+
+    /// Fallback method when no specific metadata resolution is available.
+    async fn resolve_lock_info_fallback(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<PlatformInfo> {
+        Ok(PlatformInfo {
+            checksum: None,
+            size: None,
+            url: None,
+            url_api: None,
+        })
+    }
+
+    // ========== Checksum Verification ==========
+
+    /// Verify checksum of a downloaded file.
+    fn verify_checksum(
+        &self,
+        ctx: &InstallContext,
+        tv: &mut ToolVersion,
+        file: &Path,
+    ) -> Result<()>;
+
+    // ========== Security ==========
+
+    /// Get security features supported by this backend.
+    async fn security_info(&self) -> Vec<SecurityFeature> {
+        vec![]
+    }
+}

--- a/src/backend/traits/mod.rs
+++ b/src/backend/traits/mod.rs
@@ -1,0 +1,30 @@
+//! Backend trait decomposition
+//!
+//! This module splits the monolithic Backend trait into focused sub-traits
+//! for better separation of concerns and easier implementation.
+//!
+//! # Trait Hierarchy
+//!
+//! - `BackendIdentity` - Core identity (required by all)
+//! - `VersionProvider` - Version discovery and listing
+//! - `Installer` - Installation and uninstallation
+//! - `LockfileSupport` - Lockfile and platform-specific metadata
+//! - `DependencyManager` - Dependency resolution
+//! - `BinPathProvider` - Binary paths and execution environment
+//!
+//! The main `Backend` trait combines all these traits with additional
+//! convenience methods and caching.
+
+mod bin_paths;
+mod dependencies;
+mod identity;
+mod installer;
+mod lockfile;
+mod version_provider;
+
+pub use bin_paths::BinPathProvider;
+pub use dependencies::DependencyManager;
+pub use identity::BackendIdentity;
+pub use installer::Installer;
+pub use lockfile::LockfileSupport;
+pub use version_provider::VersionProvider;

--- a/src/backend/traits/version_provider.rs
+++ b/src/backend/traits/version_provider.rs
@@ -1,0 +1,161 @@
+//! Version provider trait for backends
+//!
+//! This trait handles version discovery, listing, and querying.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+use jiff::Timestamp;
+
+use crate::config::Config;
+use crate::toolset::install_state;
+
+use super::super::VersionInfo;
+use super::identity::BackendIdentity;
+
+/// Trait for version discovery and listing.
+///
+/// This trait provides methods for:
+/// - Listing remote versions available for installation
+/// - Listing locally installed versions
+/// - Querying for specific versions (latest, matching patterns)
+/// - Parsing idiomatic version files
+#[async_trait]
+pub trait VersionProvider: BackendIdentity {
+    // ========== Remote Version Listing ==========
+
+    /// List all remote versions available for installation.
+    ///
+    /// This is the simple version that returns just version strings.
+    async fn list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<String>> {
+        Ok(self
+            .list_remote_versions_with_info(config)
+            .await?
+            .into_iter()
+            .map(|v| v.version)
+            .collect())
+    }
+
+    /// List remote versions with additional metadata.
+    ///
+    /// Returns version info including optional created_at timestamps
+    /// for date-based filtering. Backends should implement
+    /// `_list_remote_versions_with_info` or `_list_remote_versions`.
+    async fn list_remote_versions_with_info(
+        &self,
+        config: &Arc<Config>,
+    ) -> Result<Vec<VersionInfo>>;
+
+    /// Backend implementation for fetching remote versions with metadata.
+    ///
+    /// Default wraps `_list_remote_versions` with no timestamps.
+    /// Override this to provide timestamp information.
+    async fn _list_remote_versions_with_info(
+        &self,
+        config: &Arc<Config>,
+    ) -> Result<Vec<VersionInfo>> {
+        Ok(self
+            ._list_remote_versions(config)
+            .await?
+            .into_iter()
+            .map(|v| VersionInfo {
+                version: v,
+                ..Default::default()
+            })
+            .collect())
+    }
+
+    /// Backend implementation for fetching remote versions (without metadata).
+    ///
+    /// Override this OR `_list_remote_versions_with_info` (not both needed).
+    /// WARNING: Implementing neither will cause infinite recursion.
+    async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<String>> {
+        Ok(self
+            ._list_remote_versions_with_info(config)
+            .await?
+            .into_iter()
+            .map(|v| v.version)
+            .collect())
+    }
+
+    // ========== Installed Version Listing ==========
+
+    /// List all locally installed versions.
+    fn list_installed_versions(&self) -> Vec<String> {
+        install_state::list_versions(&self.ba().short)
+    }
+
+    /// List installed versions matching a query pattern.
+    fn list_installed_versions_matching(&self, query: &str) -> Vec<String> {
+        let versions = self.list_installed_versions();
+        self.fuzzy_match_filter(versions, query)
+    }
+
+    // ========== Version Querying ==========
+
+    /// Get the latest stable version.
+    async fn latest_stable_version(&self, config: &Arc<Config>) -> Result<Option<String>> {
+        self.latest_version(config, Some("latest".into())).await
+    }
+
+    /// Get the latest version matching an optional query.
+    async fn latest_version(
+        &self,
+        config: &Arc<Config>,
+        query: Option<String>,
+    ) -> Result<Option<String>>;
+
+    /// Get the latest version with date filtering support.
+    async fn latest_version_with_opts(
+        &self,
+        config: &Arc<Config>,
+        query: Option<String>,
+        before_date: Option<Timestamp>,
+    ) -> Result<Option<String>>;
+
+    /// List remote versions matching a query pattern.
+    async fn list_versions_matching(
+        &self,
+        config: &Arc<Config>,
+        query: &str,
+    ) -> Result<Vec<String>> {
+        let versions = self.list_remote_versions(config).await?;
+        Ok(self.fuzzy_match_filter(versions, query))
+    }
+
+    /// List versions matching a query, optionally filtered by release date.
+    async fn list_versions_matching_with_opts(
+        &self,
+        config: &Arc<Config>,
+        query: &str,
+        before_date: Option<Timestamp>,
+    ) -> Result<Vec<String>>;
+
+    /// Get the latest installed version matching an optional query.
+    fn latest_installed_version(&self, query: Option<String>) -> Result<Option<String>>;
+
+    // ========== Idiomatic Version Files ==========
+
+    /// List idiomatic version filenames for this backend.
+    ///
+    /// These are files like `.node-version`, `.python-version`, etc.
+    async fn idiomatic_filenames(&self) -> Result<Vec<String>>;
+
+    /// Parse an idiomatic version file and return the version string.
+    async fn parse_idiomatic_file(&self, path: &Path) -> Result<String>;
+
+    // ========== Aliases ==========
+
+    /// Get version aliases (e.g., "lts" -> "20.10.0").
+    fn get_aliases(&self) -> Result<BTreeMap<String, String>> {
+        Ok(BTreeMap::new())
+    }
+
+    // ========== Utility ==========
+
+    /// Filter versions using fuzzy matching.
+    fn fuzzy_match_filter(&self, versions: Vec<String>, query: &str) -> Vec<String>;
+}

--- a/src/config/task_loader.rs
+++ b/src/config/task_loader.rs
@@ -40,8 +40,8 @@ pub async fn load_all_tasks_with_context(
     ctx: Option<&crate::task::TaskLoadContext>,
 ) -> Result<BTreeMap<String, Task>> {
     time!("load_all_tasks");
-    let local_tasks = load_local_tasks_with_context(&config, ctx).await?;
-    let global_tasks = load_global_tasks(&config).await?;
+    let local_tasks = load_local_tasks_with_context(config, ctx).await?;
+    let global_tasks = load_global_tasks(config).await?;
     let mut tasks: BTreeMap<String, Task> = local_tasks
         .into_iter()
         .chain(global_tasks)

--- a/src/config/task_loader.rs
+++ b/src/config/task_loader.rs
@@ -1,0 +1,511 @@
+//! Task loading functionality for mise configuration
+//!
+//! This module handles discovering and loading tasks from:
+//! - Config files (mise.toml `[tasks]` sections)
+//! - Task directories (mise-tasks/, .mise-tasks/, etc.)
+//! - Monorepo subdirectories (when experimental_monorepo_root is enabled)
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use eyre::Result;
+use indexmap::IndexMap;
+use itertools::Itertools;
+use walkdir::WalkDir;
+
+use crate::config::config_file::ConfigFile;
+use crate::config::config_file::mise_toml::Tasks;
+use crate::config::settings::Settings;
+use crate::config::{Config, DEFAULT_CONFIG_FILENAMES, config_file, is_global_config};
+use crate::file::{self, display_path};
+use crate::task::Task;
+
+type ConfigMap = IndexMap<PathBuf, Arc<dyn ConfigFile>>;
+
+/// Default directories to search for task files
+pub fn default_task_includes() -> Vec<PathBuf> {
+    vec![
+        PathBuf::from("mise-tasks"),
+        PathBuf::from(".mise-tasks"),
+        PathBuf::from(".mise").join("tasks"),
+        PathBuf::from(".config").join("mise").join("tasks"),
+        PathBuf::from("mise").join("tasks"),
+    ]
+}
+
+/// Load all tasks for a config, optionally with a specific context
+pub async fn load_all_tasks_with_context(
+    config: &Arc<Config>,
+    ctx: Option<&crate::task::TaskLoadContext>,
+) -> Result<BTreeMap<String, Task>> {
+    time!("load_all_tasks");
+    let local_tasks = load_local_tasks_with_context(&config, ctx).await?;
+    let global_tasks = load_global_tasks(&config).await?;
+    let mut tasks: BTreeMap<String, Task> = local_tasks
+        .into_iter()
+        .chain(global_tasks)
+        .rev()
+        .inspect(|t| {
+            trace!(
+                "loaded task {} – {}",
+                &t.name,
+                display_path(&t.config_source)
+            )
+        })
+        .map(|t| (t.name.clone(), t))
+        .collect();
+    let all_tasks = tasks.clone();
+    for task in tasks.values_mut() {
+        task.display_name = task.display_name(&all_tasks);
+    }
+    time!("load_all_tasks {count}", count = tasks.len(),);
+    Ok(tasks)
+}
+
+/// Load tasks from local (non-global) config files
+pub async fn load_local_tasks_with_context(
+    config: &Arc<Config>,
+    ctx: Option<&crate::task::TaskLoadContext>,
+) -> Result<Vec<Task>> {
+    use crate::config::find_monorepo_root;
+    use crate::dirs;
+
+    let mut tasks = vec![];
+    let monorepo_root = find_monorepo_root(&config.config_files);
+
+    // Load tasks from parent directories (current working directory up to root)
+    let local_config_files = config
+        .config_files
+        .iter()
+        .filter(|(_, cf)| !is_global_config(cf.get_path()))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect::<IndexMap<_, _>>();
+
+    for d in crate::config::all_dirs()? {
+        if cfg!(test) && !d.starts_with(*dirs::HOME) {
+            continue;
+        }
+        let mut dir_tasks = load_tasks_in_dir(config, &d, &local_config_files).await?;
+
+        if let Some(ref monorepo_root) = monorepo_root {
+            prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
+        }
+
+        tasks.extend(dir_tasks);
+    }
+
+    // Determine if we should load monorepo tasks from subdirectories
+    let should_load_subdirs = ctx.is_some_and(|c| c.load_all || !c.path_hints.is_empty());
+
+    // If in a monorepo, also discover and load tasks from subdirectories
+    if let Some(monorepo_root) = &monorepo_root {
+        if !should_load_subdirs {
+            return Ok(tasks);
+        }
+
+        let subdirs = discover_monorepo_subdirs(monorepo_root, ctx)?;
+
+        // Load tasks from subdirectories in parallel
+        let subdir_tasks_futures: Vec<_> = subdirs
+            .into_iter()
+            .filter(|subdir| !cfg!(test) || subdir.starts_with(*dirs::HOME))
+            .map(|subdir| {
+                let config = config.clone();
+                let monorepo_root = monorepo_root.clone();
+                async move {
+                    let mut all_tasks = Vec::new();
+                    for config_filename in DEFAULT_CONFIG_FILENAMES.iter() {
+                        let config_path = subdir.join(config_filename);
+                        if config_path.exists() {
+                            match config_file::parse(&config_path).await {
+                                Ok(cf) => {
+                                    let mut subdir_tasks =
+                                        load_config_and_file_tasks(&config, cf.clone()).await?;
+
+                                    prefix_monorepo_task_names(
+                                        &mut subdir_tasks,
+                                        &subdir,
+                                        &monorepo_root,
+                                    );
+                                    for task in subdir_tasks.iter_mut() {
+                                        task.cf = Some(cf.clone());
+                                    }
+
+                                    all_tasks.extend(subdir_tasks);
+                                }
+                                Err(err) => {
+                                    let rel_path = subdir
+                                        .strip_prefix(&monorepo_root)
+                                        .unwrap_or(&subdir);
+                                    warn!(
+                                        "Failed to parse config file {} in monorepo subdirectory {}: {}. Tasks from this directory will not be loaded.",
+                                        config_path.display(),
+                                        rel_path.display(),
+                                        err
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Ok::<Vec<Task>, eyre::Report>(all_tasks)
+                }
+            })
+            .collect();
+
+        use tokio::task::JoinSet;
+        let mut join_set = JoinSet::new();
+        for future in subdir_tasks_futures {
+            join_set.spawn(future);
+        }
+
+        while let Some(result) = join_set.join_next().await {
+            tasks.extend(result??);
+        }
+    }
+
+    Ok(tasks)
+}
+
+/// Load tasks from global config files
+pub async fn load_global_tasks(config: &Arc<Config>) -> Result<Vec<Task>> {
+    let config_files = config
+        .config_files
+        .values()
+        .filter(|cf| is_global_config(cf.get_path()))
+        .collect::<Vec<_>>();
+    let mut tasks = vec![];
+    for cf in config_files {
+        tasks.extend(load_config_and_file_tasks(config, cf.clone()).await?);
+    }
+    Ok(tasks)
+}
+
+/// Load tasks from both config file [tasks] section and task directories
+pub async fn load_config_and_file_tasks(
+    config: &Arc<Config>,
+    cf: Arc<dyn ConfigFile>,
+) -> Result<Vec<Task>> {
+    let config_root = cf.config_root();
+    let tasks = load_config_tasks(config, cf.clone(), &config_root).await?;
+    let file_tasks = load_file_tasks(config, cf.clone(), &config_root).await?;
+    Ok(tasks.into_iter().chain(file_tasks).collect())
+}
+
+/// Load tasks defined in the [tasks] section of a config file
+pub async fn load_config_tasks(
+    config: &Arc<Config>,
+    cf: Arc<dyn ConfigFile>,
+    config_root: &Path,
+) -> Result<Vec<Task>> {
+    let is_global = is_global_config(cf.get_path());
+    let config_root = Arc::new(config_root.to_path_buf());
+    let mut tasks = vec![];
+    for t in cf.tasks().into_iter() {
+        let config_root = config_root.clone();
+        let config = config.clone();
+        let mut t = t.clone();
+        if is_global {
+            t.global = true;
+        }
+        match t.render(&config, &config_root).await {
+            Ok(()) => {
+                tasks.push(t);
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        }
+    }
+    Ok(tasks)
+}
+
+/// Load tasks from task include directories (mise-tasks/, etc.)
+pub async fn load_file_tasks(
+    config: &Arc<Config>,
+    cf: Arc<dyn ConfigFile>,
+    config_root: &Path,
+) -> Result<Vec<Task>> {
+    let includes = cf
+        .task_config()
+        .includes
+        .clone()
+        .unwrap_or_else(default_task_includes)
+        .into_iter()
+        .map(|p| cf.get_path().parent().unwrap().join(p))
+        .collect::<Vec<_>>();
+    let mut tasks = vec![];
+    let config_root = Arc::new(config_root.to_path_buf());
+    for p in includes {
+        let config_root = config_root.clone();
+        let config = config.clone();
+        tasks.extend(load_tasks_includes(&config, &p, &config_root).await?);
+    }
+    Ok(tasks)
+}
+
+/// Load tasks from an include path (file or directory)
+pub async fn load_tasks_includes(
+    config: &Arc<Config>,
+    root: &Path,
+    config_root: &Path,
+) -> Result<Vec<Task>> {
+    if root.is_file() && root.extension().map(|e| e == "toml").unwrap_or(false) {
+        load_task_file(config, root, config_root).await
+    } else if root.is_dir() {
+        let files = WalkDir::new(root)
+            .follow_links(true)
+            .into_iter()
+            .filter_entry(|e| e.path() == root || !e.file_name().to_string_lossy().starts_with('.'))
+            .filter_ok(|e| e.file_type().is_file())
+            .map_ok(|e| e.path().to_path_buf())
+            .try_collect::<_, Vec<PathBuf>, _>()?
+            .into_iter()
+            .filter(|p| file::is_executable(p))
+            .filter(|p| {
+                !Settings::get()
+                    .task_disable_paths
+                    .iter()
+                    .any(|d| p.starts_with(d))
+            })
+            .collect::<Vec<_>>();
+        let mut tasks = vec![];
+        let root = Arc::new(root.to_path_buf());
+        let config_root = Arc::new(config_root.to_path_buf());
+        for path in files {
+            let root = root.clone();
+            let config_root = config_root.clone();
+            let config = config.clone();
+            tasks.push(Task::from_path(&config, &path, &root, &config_root).await?);
+        }
+        Ok(tasks)
+    } else {
+        Ok(vec![])
+    }
+}
+
+/// Load a single TOML task file
+pub async fn load_task_file(
+    config: &Arc<Config>,
+    path: &Path,
+    config_root: &Path,
+) -> Result<Vec<Task>> {
+    let raw = file::read_to_string_async(path).await?;
+    let mut tasks = toml::from_str::<Tasks>(&raw)
+        .wrap_err_with(|| format!("Error parsing task file: {}", display_path(path)))?
+        .0;
+    for (name, task) in &mut tasks {
+        task.name = name.clone();
+        task.config_source = path.to_path_buf();
+        task.config_root = Some(config_root.to_path_buf());
+    }
+    let mut out = vec![];
+    for (_, mut task) in tasks {
+        let config_root = config_root.to_path_buf();
+        if let Err(err) = task.render(config, &config_root).await {
+            warn!("rendering task: {err:?}");
+        }
+        out.push(task);
+    }
+    Ok(out)
+}
+
+/// Load tasks in a specific directory
+pub async fn load_tasks_in_dir(
+    config: &Arc<Config>,
+    dir: &Path,
+    config_files: &ConfigMap,
+) -> Result<Vec<Task>> {
+    let configs = configs_at_root(dir, config_files);
+    let mut config_tasks = vec![];
+    for cf in configs {
+        let dir = dir.to_path_buf();
+        config_tasks.extend(load_config_tasks(config, cf.clone(), &dir).await?);
+    }
+    let mut file_tasks = vec![];
+    for p in task_includes_for_dir(dir, config_files) {
+        file_tasks.extend(load_tasks_includes(config, &p, dir).await?);
+    }
+    let mut tasks = file_tasks
+        .into_iter()
+        .chain(config_tasks)
+        .sorted_by_cached_key(|t| t.name.clone())
+        .collect::<Vec<_>>();
+    let all_tasks = tasks
+        .clone()
+        .into_iter()
+        .map(|t| (t.name.clone(), t))
+        .collect::<BTreeMap<_, _>>();
+    for task in tasks.iter_mut() {
+        task.display_name = task.display_name(&all_tasks);
+    }
+    Ok(tasks)
+}
+
+/// Get task include paths for a directory
+pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Vec<PathBuf> {
+    configs_at_root(dir, config_files)
+        .iter()
+        .rev()
+        .find_map(|cf| cf.task_config().includes.clone())
+        .unwrap_or_else(default_task_includes)
+        .into_iter()
+        .map(|p| if p.is_absolute() { p } else { dir.join(p) })
+        .filter(|p| p.exists())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .unique()
+        .collect::<Vec<_>>()
+}
+
+// ========== Monorepo Support ==========
+
+/// Add path prefix to task names for monorepo tasks
+fn prefix_monorepo_task_names(tasks: &mut [Task], dir: &Path, monorepo_root: &Path) {
+    const MONOREPO_PATH_PREFIX: &str = "//";
+    const MONOREPO_TASK_SEPARATOR: &str = ":";
+
+    if let Ok(rel_path) = dir.strip_prefix(monorepo_root) {
+        let prefix = rel_path
+            .to_string_lossy()
+            .replace(std::path::MAIN_SEPARATOR, "/");
+        for task in tasks.iter_mut() {
+            task.name = format!(
+                "{}{}{}{}",
+                MONOREPO_PATH_PREFIX, prefix, MONOREPO_TASK_SEPARATOR, task.name
+            );
+        }
+    }
+}
+
+/// Discover subdirectories in a monorepo that contain mise config files
+fn discover_monorepo_subdirs(
+    root: &Path,
+    ctx: Option<&crate::task::TaskLoadContext>,
+) -> Result<Vec<PathBuf>> {
+    const DEFAULT_IGNORED_DIRS: &[&str] = &["node_modules", "target", "dist", "build"];
+
+    let mut subdirs = Vec::new();
+    let settings = Settings::get();
+    let respect_gitignore = settings.task.monorepo_respect_gitignore;
+    let max_depth = settings.task.monorepo_depth as usize;
+
+    let excluded_dirs: Vec<&str> = if settings.task.monorepo_exclude_dirs.is_empty() {
+        DEFAULT_IGNORED_DIRS.to_vec()
+    } else {
+        settings
+            .task
+            .monorepo_exclude_dirs
+            .iter()
+            .map(|s| s.as_str())
+            .collect()
+    };
+
+    if respect_gitignore {
+        let walker = ignore::WalkBuilder::new(root)
+            .max_depth(Some(max_depth))
+            .hidden(true)
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true)
+            .require_git(false)
+            .build();
+
+        for entry in walker {
+            let entry = entry?;
+            if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                let dir = entry.path();
+
+                if dir == root {
+                    continue;
+                }
+
+                let name = dir.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if excluded_dirs.contains(&name) {
+                    continue;
+                }
+
+                let has_config = DEFAULT_CONFIG_FILENAMES
+                    .iter()
+                    .any(|f| dir.join(f).exists());
+                if has_config {
+                    if let Some(ctx) = ctx {
+                        let rel_path = dir
+                            .strip_prefix(root)
+                            .ok()
+                            .and_then(|p| p.to_str())
+                            .unwrap_or("");
+                        if ctx.should_load_subdir(rel_path, root.to_str().unwrap_or("")) {
+                            subdirs.push(dir.to_path_buf());
+                        }
+                    } else {
+                        subdirs.push(dir.to_path_buf());
+                    }
+                }
+            }
+        }
+    } else {
+        for entry in WalkDir::new(root)
+            .min_depth(1)
+            .max_depth(max_depth)
+            .into_iter()
+            .filter_entry(|e| {
+                let name = e.file_name().to_string_lossy();
+                !name.starts_with('.') && !excluded_dirs.contains(&name.as_ref())
+            })
+        {
+            let entry = entry?;
+            if entry.file_type().is_dir() {
+                let dir = entry.path();
+                let has_config = DEFAULT_CONFIG_FILENAMES
+                    .iter()
+                    .any(|f| dir.join(f).exists());
+                if has_config {
+                    if let Some(ctx) = ctx {
+                        let rel_path = dir
+                            .strip_prefix(root)
+                            .ok()
+                            .and_then(|p| p.to_str())
+                            .unwrap_or("");
+                        if ctx.should_load_subdir(rel_path, root.to_str().unwrap_or("")) {
+                            subdirs.push(dir.to_path_buf());
+                        }
+                    } else {
+                        subdirs.push(dir.to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(subdirs)
+}
+
+// ========== Helper Functions ==========
+
+/// Get config files at a specific directory root
+fn configs_at_root<'a>(dir: &Path, config_files: &'a ConfigMap) -> Vec<&'a Arc<dyn ConfigFile>> {
+    let mut configs: Vec<&'a Arc<dyn ConfigFile>> = DEFAULT_CONFIG_FILENAMES
+        .iter()
+        .rev()
+        .flat_map(|f| {
+            if f.contains('*') {
+                crate::config::glob(dir, f)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|path| config_files.get(&path))
+                    .collect::<Vec<_>>()
+            } else {
+                config_files
+                    .get(&dir.join(f))
+                    .into_iter()
+                    .collect::<Vec<_>>()
+            }
+        })
+        .collect();
+    let mut seen = std::collections::HashSet::new();
+    configs.retain(|cf| seen.insert(cf.get_path().to_path_buf()));
+    configs
+}
+
+use eyre::WrapErr;


### PR DESCRIPTION
## Summary

Phase 1 of codebase refactoring to improve code organization:

### 1. Backend Trait Sub-traits Architecture
- Created `src/backend/traits/` module with 6 focused sub-traits that logically organize the 70+ methods in the monolithic Backend trait:
  - **BackendIdentity**: Core identity (id, type, plugin association)
  - **VersionProvider**: Version discovery and listing
  - **Installer**: Installation and uninstallation
  - **LockfileSupport**: Lockfile and platform metadata
  - **DependencyManager**: Dependency resolution
  - **BinPathProvider**: Binary paths and execution environment
- Added comprehensive documentation explaining the sub-trait architecture
- Added section comments organizing existing Backend methods by category
- Re-exported sub-traits from the backend module for convenient access

### 2. Task Loading Extraction
- Created `src/config/task_loader.rs` module (~500 lines)
- Extracted all task loading functions from `config/mod.rs`:
  - `load_all_tasks_with_context`
  - `load_local_tasks_with_context`
  - `load_global_tasks`
  - `load_config_and_file_tasks`
  - `load_config_tasks`
  - `load_file_tasks`
  - `load_tasks_includes`
  - `load_task_file`
  - `load_tasks_in_dir`
  - `task_includes_for_dir`
  - Monorepo task discovery (`discover_monorepo_subdirs`, `prefix_monorepo_task_names`)
- Public functions in `config/mod.rs` now delegate to the task_loader module
- Reduced `config/mod.rs` by ~470 lines

### Benefits
- **Better separation of concerns**: Task loading is now isolated from config management
- **Clearer documentation**: Sub-traits document the capabilities each backend needs
- **Easier testing**: Focused modules are easier to test in isolation
- **Future extensibility**: Sub-traits enable incremental backend implementation

### Stats
- +1,254 lines (new traits and task_loader module)
- -472 lines (extracted from config/mod.rs)
- Net: +782 lines (mostly documentation and trait definitions)

## Test plan
- [x] All 382 unit tests pass
- [x] Lint passes
- [x] Code compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Decomposes the monolithic Backend into focused sub-traits and moves all task-loading logic from config/mod.rs into a new config/task_loader module with delegated public APIs.
> 
> - **Backend**:
>   - **Trait decomposition**: Introduces `src/backend/traits/*` with `BackendIdentity`, `VersionProvider`, `Installer`, `LockfileSupport`, `DependencyManager`, `BinPathProvider`; re-exported in `backend::mod`.
>   - Adds comprehensive docs and sectioned method groupings in `Backend` for clarity; no functional changes.
> - **Config**:
>   - **Task loading extraction**: Adds `src/config/task_loader.rs` and migrates task discovery/loading (includes, monorepo handling, file parsing) from `config/mod.rs`.
>   - `config/mod.rs` now delegates to `task_loader` (`load_all_tasks_with_context`, `load_tasks_in_dir`, `task_includes_for_dir`), significantly reducing file size.
>   - Adjusts visibility/utilities (`find_monorepo_root`, `all_dirs`) for reuse in the new module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7857618e2aafef967c59f3e6e2cd42f132b490c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->