### PR TITLE
registry: use aqua backend for mc (minio client)

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -2938,8 +2938,10 @@ description = "Apache Maven core"
 test = ["mvn --version", "Apache Maven {{version}}"]
 
 [tools.mc]
-backends = ["asdf:mise-plugins/mise-mc"]
+aliases = ["minio-client"]
+backends = ["aqua:minio/mc"]
 description = "Unix like utilities for object store (minio)"
+test = ["mc --version", "mc version RELEASE"]
 
 [tools.mdbook]
 backends = [


### PR DESCRIPTION
## Summary
- Convert mc (MinIO Client) from asdf plugin to aqua backend
- MinIO Client is available in aqua registry
- Added `minio-client` as alias
- Added test command `mc --version`

## Test plan
- [x] Tested with `mise test-tool mc`
- [x] Successfully installed mc@RELEASE.2025-08-13T08-35-41Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `tools.mc` to the `aqua:minio/mc` backend, adding `minio-client` alias and a version test.
> 
> - **Registry**:
>   - **`tools.mc`**:
>     - Switch backend to `aqua:minio/mc`.
>     - Add alias `minio-client`.
>     - Add test `mc --version` expecting `mc version RELEASE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb0fd214ceae3113bb7cf7b45bbfce08162efeaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->