### PR TITLE
registry: dart use http backend

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1154,8 +1154,35 @@ description = "Command-line tools for Dapr"
 test = ["dapr --version", "CLI version: {{version}}"]
 
 [tools.dart]
-backends = ["asdf:mise-plugins/mise-dart", "vfox:mise-plugins/vfox-dart"]
 description = "An approachable, portable, and productive language for high-quality apps on any platform"
+
+[[tools.dart.backends]]
+full = "http:dart"
+
+[tools.dart.backends.options]
+version_list_url = "https://storage.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/stable/release/&delimiter=/"
+version_regex = "channels/stable/release/(\\d+\\.\\d+\\.\\d+)/"
+
+[tools.dart.backends.options.platforms.macos-x64]
+url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{version}/sdk/dartsdk-macos-x64-release.zip"
+
+[tools.dart.backends.options.platforms.macos-arm64]
+url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{version}/sdk/dartsdk-macos-arm64-release.zip"
+
+[tools.dart.backends.options.platforms.linux-x64]
+url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{version}/sdk/dartsdk-linux-x64-release.zip"
+
+[tools.dart.backends.options.platforms.linux-arm64]
+url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{version}/sdk/dartsdk-linux-arm64-release.zip"
+
+[tools.dart.backends.options.platforms.windows-x64]
+url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{version}/sdk/dartsdk-windows-x64-release.zip"
+
+[[tools.dart.backends]]
+full = "asdf:mise-plugins/mise-dart"
+
+[[tools.dart.backends]]
+full = "vfox:mise-plugins/vfox-dart"
 
 [tools.dasel]
 backends = ["aqua:TomWright/dasel", "asdf:asdf-community/asdf-dasel"]


### PR DESCRIPTION
## Summary
- Switch Dart to http backend for downloading pre-built SDK from Google Cloud Storage
- Uses version listing from GCS API with regex extraction
- Platform-specific URLs for macos-x64, macos-arm64, linux-x64, linux-arm64, windows-x64
- Keeps asdf and vfox as fallbacks

## Test plan
- [x] Tested version listing with `mise ls-remote dart` (shows 1.11.0 through 3.10.7)
- [x] Tested installation with `mise install dart@3.10.7`
- [x] Verified backend is `http:dart`
- [x] Verified dart binary exists in bin directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a primary `http:dart` backend pulling prebuilt SDKs from Google Cloud Storage.
> 
> - Uses GCS API version listing with `version_list_url` and `version_regex`
> - Adds platform-specific URLs for `macos-x64`, `macos-arm64`, `linux-x64`, `linux-arm64`, and `windows-x64`
> - Keeps `asdf:mise-dart` and `vfox:mise-dart` as fallback backends
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f388cbea5b4e5c235e05e560aedfba3e812d2517. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->