### PR TITLE
feat(registry): add aqua backend for claude with per-backend os support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -107,6 +107,7 @@ fn codegen_registry() {
                         r##"RegistryBackend{{
                             full: r#"{backend}"#,
                             platforms: &[],
+                            os: &[],
                             options: &[],
                         }}"##
                     ));
@@ -123,16 +124,32 @@ fn codegen_registry() {
                                 .collect::<Vec<_>>()
                         })
                         .unwrap_or_default();
+                    let backend_os = backend
+                        .get("os")
+                        .map(|o| {
+                            o.as_array()
+                                .unwrap()
+                                .iter()
+                                .map(|o| o.as_str().unwrap().to_string())
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default();
                     let backend_options = parse_options(backend.get("options"));
                     backends.push(format!(
                         r##"RegistryBackend{{
                             full: r#"{full}"#,
                             platforms: &[{platforms}],
+                            os: &[{os}],
                             options: &[{options}],
                         }}"##,
                         platforms = platforms
                             .into_iter()
                             .map(|p| format!("\"{p}\""))
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        os = backend_os
+                            .into_iter()
+                            .map(|o| format!("\"{o}\""))
                             .collect::<Vec<_>>()
                             .join(", "),
                         options = backend_options

--- a/crates/aqua-registry/aqua-registry/pkgs/anthropics/claude-code/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/anthropics/claude-code/registry.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: http
+    repo_owner: anthropics
+    repo_name: claude-code
+    description: Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands
+    files:
+      - name: claude
+    version_source: github_tag
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        format: raw
+        url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/claude
+        files:
+          - name: claude
+        replacements:
+          amd64: x64
+        supported_envs:
+          - darwin
+          - linux
+        overrides:
+          - goos: linux
+            url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}-musl/claude

--- a/registry.toml
+++ b/registry.toml
@@ -778,6 +778,10 @@ os = ["linux", "macos", "windows"]
 test = ["claude --version", "{{version}} (Claude Code)"]
 
 [[tools.claude.backends]]
+full = "aqua:anthropics/claude-code"
+os = ["linux", "macos"]
+
+[[tools.claude.backends]]
 full = "http:claude"
 
 [tools.claude.backends.options]

--- a/schema/mise-registry.json
+++ b/schema/mise-registry.json
@@ -48,6 +48,25 @@
                     "type": "string",
                     "description": "Full backend specification"
                   },
+                  "os": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "linux",
+                        "macos",
+                        "windows",
+                        "freebsd",
+                        "openbsd",
+                        "netbsd",
+                        "dragonfly",
+                        "solaris",
+                        "android",
+                        "ios"
+                      ]
+                    },
+                    "description": "Operating systems this backend supports"
+                  },
                   "platforms": {
                     "type": "array",
                     "items": {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -35,6 +35,7 @@ pub struct RegistryTool {
 pub struct RegistryBackend {
     pub full: &'static str,
     pub platforms: &'static [&'static str],
+    pub os: &'static [&'static str],
     pub options: &'static [(&'static str, &'static str)],
 }
 
@@ -87,10 +88,13 @@ impl RegistryTool {
         self.backends
             .iter()
             .filter(|rb| {
-                rb.platforms.is_empty()
-                    || rb.platforms.contains(&&*os)
-                    || rb.platforms.contains(&&*arch)
-                    || rb.platforms.contains(&&*platform)
+                // Check OS restriction on backend
+                (rb.os.is_empty() || rb.os.contains(&&*os))
+                    // Check platform restriction on backend
+                    && (rb.platforms.is_empty()
+                        || rb.platforms.contains(&&*os)
+                        || rb.platforms.contains(&&*arch)
+                        || rb.platforms.contains(&&*platform))
             })
             .map(|rb| rb.full)
             .filter(|full| {


### PR DESCRIPTION
## Summary
- Add `aqua:anthropics/claude-code` as primary backend for Linux/macOS
- Uses GitHub tags for version listing (more reliable than version_list_url)
- HTTP backend remains as fallback and for Windows support
- Add `os` field support to backend entries in registry schema

## Test plan
- [x] `mise ls-remote claude` returns versions from GitHub tags
- [x] `mise install claude@latest` works on macOS
- [x] `mise x claude -- claude --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Backend-level OS support**: Add `os` field to backend schema (`schema/mise-registry.json`), emit it in codegen (`build.rs`), extend `RegistryBackend` and apply OS filtering in backend selection (`src/registry.rs`).
> - **Claude backend update**: Add aqua package (`aqua-registry/pkgs/anthropics/claude-code/registry.yaml`) and register `aqua:anthropics/claude-code` as primary backend for `claude` on Linux/macOS in `registry.toml`, keeping HTTP as fallback (incl. Windows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c05d726a13d318e49fb79f7d301c20813364fdd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->