### PR TITLE
fix(task): exclude inherited tasks from wildcard pattern matching

### DIFF
--- a/e2e/tasks/test_task_monorepo_wildcard_inherited
+++ b/e2e/tasks/test_task_monorepo_wildcard_inherited
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Test that wildcard patterns (//...:task) do NOT match inherited tasks
+# Only tasks explicitly defined in a subdirectory should match wildcards
+# See: https://github.com/jdx/mise/discussions/6564#discussioncomment-15607613
+
+export MISE_EXPERIMENTAL=1
+
+# Create monorepo root with a "test" task
+cat <<'TOML' >mise.toml
+experimental_monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+
+[tasks.test]
+run = 'echo "root test"'
+
+[tasks.root-only]
+run = 'echo "root only task"'
+TOML
+
+# Create package-a WITH its own test task (should match //...:test)
+mkdir -p packages/package-a
+cat <<'TOML' >packages/package-a/mise.toml
+[tasks.test]
+run = 'echo "package-a test"'
+TOML
+
+# Create package-b WITHOUT its own test task (should NOT match //...:test due to inheritance)
+mkdir -p packages/package-b
+cat <<'TOML' >packages/package-b/mise.toml
+[tasks.build]
+run = 'echo "package-b build"'
+TOML
+
+# Create package-c WITH its own test task (should match //...:test)
+mkdir -p packages/package-c
+cat <<'TOML' >packages/package-c/mise.toml
+[tasks.test]
+run = 'echo "package-c test"'
+TOML
+
+mise trust --all
+
+# --- Test 1: Wildcard should only match explicitly defined tasks ---
+echo "=== Test 1: Wildcard should only match package-a and package-c (not package-b) ==="
+
+# Should include package-a and package-c (they define test explicitly)
+assert_contains "mise run '//packages/...:test'" "package-a test"
+assert_contains "mise run '//packages/...:test'" "package-c test"
+
+# Should NOT include package-b (its test is inherited from root)
+assert_not_contains "mise run '//packages/...:test'" "root test"
+
+# --- Test 2: Explicit paths still work for inherited tasks ---
+echo "=== Test 2: Explicit path should work for inherited task ==="
+assert_contains "mise run //packages/package-b:test" "root test"
+
+# --- Test 3: Root wildcard with root task should still work ---
+echo "=== Test 3: Root task still visible ==="
+assert_contains "mise run //:test" "root test"
+
+# --- Test 4: Task that only exists at root should NOT match //packages/...: wildcard ---
+echo "=== Test 4: Root-only task should not match subdirectory wildcard ==="
+# This should fail with "task not found" since no package explicitly defines root-only
+assert_fail "mise run '//packages/...:root-only'"
+
+# --- Test 5: Inherited tasks still visible in task list (with --all) ---
+echo "=== Test 5: Inherited tasks visible in task list ==="
+# Inherited tasks should still be listed
+assert_contains "mise tasks --all" "//packages/package-b:test"
+assert_contains "mise tasks --all" "//packages/package-b:root-only"
+
+# --- Test 6: Circular dependency should NOT occur ---
+# This was the original bug: root defines test = { depends = ['//...:test'] }
+# which would create a cycle through inherited tasks
+echo "=== Test 6: No circular dependency with wildcard depends ==="
+cat <<'TOML' >mise.toml
+experimental_monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+
+[tasks.test]
+depends = ['//packages/...:test']
+run = 'echo "root test complete"'
+description = 'run all tests'
+TOML
+
+# This should work without circular dependency error
+assert_contains "mise run //:test" "package-a test"
+assert_contains "mise run //:test" "package-c test"
+assert_contains "mise run //:test" "root test complete"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1726,6 +1726,14 @@ async fn load_local_tasks_with_context(
                     // dir = "{{cwd}}" if they want the task to run from wherever it's invoked.
                     let mut all_tasks: Vec<Task> = task_map.into_values().collect();
 
+                    // Mark tasks as inherited if they come from a parent config
+                    // (their config_root differs from the subdir we're loading for)
+                    for task in all_tasks.iter_mut() {
+                        if let Some(ref config_root) = task.config_root {
+                            task.inherited = config_root != &subdir;
+                        }
+                    }
+
                     prefix_monorepo_task_names(&mut all_tasks, &subdir, &monorepo_root);
 
                     Ok::<Vec<Task>, eyre::Report>(all_tasks)

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -288,6 +288,11 @@ pub async fn get_task_lists(
         let cur_tasks = tasks_with_aliases
             .get_matching(&t)?
             .into_iter()
+            // When using wildcard patterns (containing "..."), filter out inherited tasks
+            // to avoid matching tasks that exist only due to inheritance from parent configs.
+            // This prevents issues like circular dependencies when root defines
+            // `test = { depends = ['//...:test'] }` and subdirs inherit that task.
+            .filter(|task| !t.contains("...") || !task.inherited)
             .cloned()
             .collect_vec();
         if cur_tasks.is_empty() {


### PR DESCRIPTION
## Summary

- Wildcard patterns like `//...:task` now only match tasks explicitly defined at that path, not tasks inherited from parent configs
- Adds `inherited` field to Task struct to track task origin
- Fixes circular dependency when root defines `depends = ['//...:test']` and subdirs inherit that task
- Fixes unexpected execution when running `//packages/...:build` on packages that don't define their own build task
- Explicit paths like `//packages/app:build` still work for inherited tasks (explicit intent)

## Test plan

- [x] Added e2e test `test_task_monorepo_wildcard_inherited` covering:
  - Wildcards only match explicitly defined tasks
  - Explicit paths still work for inherited tasks
  - Inherited tasks still visible in task list
  - No circular dependency with wildcard depends
- [x] Existing monorepo tests pass (`test_task_monorepo_task_inheritance`, `test_task_monorepo_syntax`, `test_task_monorepo_optional_colon`, `test_task_monorepo_name_conflicts`)

Fixes: https://github.com/jdx/mise/discussions/6564#discussioncomment-15607613

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents wildcard patterns from matching inherited monorepo tasks and adds safeguards against cycles.
> 
> - Add `Task.inherited` (non-serialized) and set it during subdir task load to track task origin
> - Filter wildcard matches (`...`) to exclude inherited tasks in both dependency resolution and task lookup
> - Keep explicit paths (e.g., `//pkg:task`) working for inherited tasks; root tasks still match `//:task`
> - New e2e `test_task_monorepo_wildcard_inherited` covering wildcard behavior, explicit paths, task listing, and circular dependency regression
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cda978fb508309e357fb68590b470d16f3272abb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->