### PR TITLE
fix(task): propagate MISE_ENV to child tasks when using -E flag

### DIFF
--- a/e2e/tasks/test_task_env_flag_propagation
+++ b/e2e/tasks/test_task_env_flag_propagation
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Test that -E/--env flag is propagated to child tasks
+# See: https://github.com/jdx/mise/discussions/7865
+
+# Create env-specific config with env vars
+cat <<EOF >mise.dev.toml
+[env]
+MY_DEV_VAR = "dev-value"
+EOF
+
+# Create main config with tasks that depend on each other
+cat <<EOF >mise.toml
+[tasks.child]
+run = 'echo "MY_DEV_VAR=\$MY_DEV_VAR"'
+
+[tasks.parent]
+depends = ["child"]
+run = 'echo "parent done"'
+
+# A task that invokes mise run internally (simulates nested mise invocation)
+[tasks.nested-mise]
+run = 'mise run child'
+EOF
+
+# Test 1: Child task should see env vars when called with -E
+assert_contains "mise -E dev run child" "MY_DEV_VAR=dev-value"
+
+# Test 2: Parent task should see env vars in its child when called with -E
+assert_contains "mise -E dev run parent" "MY_DEV_VAR=dev-value"
+
+# Test 3: Nested mise invocation should inherit MISE_ENV
+assert_contains "mise -E dev run nested-mise" "MY_DEV_VAR=dev-value"
+
+# Test 4: Same tests with --env instead of -E
+assert_contains "mise --env dev run child" "MY_DEV_VAR=dev-value"
+assert_contains "mise --env dev run parent" "MY_DEV_VAR=dev-value"
+assert_contains "mise --env dev run nested-mise" "MY_DEV_VAR=dev-value"

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -184,6 +184,10 @@ impl TaskExecutor {
         if !self.timings {
             env.insert("MISE_TASK_TIMINGS".to_string(), "0".to_string());
         }
+        // Propagate MISE_ENV to child tasks so -E flag works for nested mise invocations
+        if !crate::env::MISE_ENV.is_empty() {
+            env.insert("MISE_ENV".to_string(), crate::env::MISE_ENV.join(","));
+        }
         if let Some(cwd) = &*crate::dirs::CWD {
             env.insert("MISE_ORIGINAL_CWD".into(), cwd.display().to_string());
         }


### PR DESCRIPTION
## Summary

- When running tasks with `-E <env>` (or `--env <env>`), the `MISE_ENV` value was not being propagated to child task processes
- This caused env-specific config files (`mise.<env>.toml`) to not be loaded for child tasks or nested mise invocations
- This fix adds `MISE_ENV` to the environment passed to child tasks, ensuring that `-E dev` behaves the same as `export MISE_ENV=dev`

Fixes: https://github.com/jdx/mise/discussions/7865

## Test plan

- [x] Added e2e test `test_task_env_flag_propagation` that verifies:
  - Child tasks receive env vars from env-specific config when using `-E`
  - Parent tasks pass env vars to dependent child tasks
  - Nested mise invocations (`mise run` calling `mise run`) inherit `MISE_ENV`
  - Both `-E` and `--env` flags work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures env-specific configs are honored in child and nested tasks when using `-E/--env`.
> 
> - In `src/task/task_executor.rs`, injects `MISE_ENV` into child task env (`env.insert("MISE_ENV", crate::env::MISE_ENV.join(","))`) so nested `mise run` picks up the selected environment
> - Adds e2e `e2e/tasks/test_task_env_flag_propagation` validating env var visibility for `child`, `parent` (with `depends = ["child"]`), and a nested `mise run`, for both `-E` and `--env` flags
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e871b264c105b0718b83535f25c1416f353e89be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->