### PR TITLE
feat: move summary bar to header position and add MISE_DIAGNOSTIC_LOG

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -601,6 +601,7 @@ impl Cli {
         measure!("add_cli_matches", { Settings::add_cli_matches(&cli) });
         let _ = measure!("settings", { Settings::try_get() });
         measure!("logger", { logger::init() });
+        ui::diagnostic_log::init();
         measure!("migrate", { migrate::run().await });
         if let Err(err) = crate::cache::auto_prune() {
             warn!("auto_prune failed: {err:?}");

--- a/src/env.rs
+++ b/src/env.rs
@@ -198,6 +198,8 @@ pub static MISE_LIST_ALL_VERSIONS: Lazy<bool> = Lazy::new(|| var_is_true("MISE_L
 pub static ARGV0: Lazy<String> = Lazy::new(|| ARGS.read().unwrap()[0].to_string());
 pub static MISE_BIN_NAME: Lazy<&str> = Lazy::new(|| filename(&ARGV0));
 pub static MISE_LOG_FILE: Lazy<Option<PathBuf>> = Lazy::new(|| var_path("MISE_LOG_FILE"));
+pub static MISE_DIAGNOSTIC_LOG: Lazy<Option<PathBuf>> =
+    Lazy::new(|| var_path("MISE_DIAGNOSTIC_LOG"));
 pub static MISE_LOG_FILE_LEVEL: Lazy<Option<LevelFilter>> = Lazy::new(log_file_level);
 fn find_in_tree(base: &Path, rels: &[&[&str]]) -> Option<PathBuf> {
     for rel in rels {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -23,6 +23,16 @@ impl log::Log for Logger {
     }
 
     fn log(&self, record: &Record) {
+        if record.level() <= Level::Warn {
+            ui::diagnostic_log::log_message(
+                match record.level() {
+                    Level::Error => "error",
+                    Level::Warn => "warn",
+                    _ => "info",
+                },
+                &record.args().to_string(),
+            );
+        }
         if record.level() <= self.file_level
             && let Some(log_file) = &self.log_file
         {

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -103,14 +103,14 @@ impl Toolset {
             return Ok(vec![]);
         }
 
-        // Initialize a footer for the entire install session once (before batching)
+        // Initialize a header for the entire install session once (before batching)
         let mpr = MultiProgressReport::get();
-        let footer_reason = if opts.dry_run {
+        let header_reason = if opts.dry_run {
             format!("{} (dry-run)", opts.reason)
         } else {
             opts.reason.clone()
         };
-        mpr.init_footer(opts.dry_run, &footer_reason, versions.len());
+        mpr.init_header(opts.dry_run, &header_reason, versions.len());
 
         // Skip hooks in dry-run mode
         if !opts.dry_run {
@@ -136,8 +136,8 @@ impl Toolset {
                     successful_installations,
                     failed_installations,
                 }) => {
-                    // Count both successes and failures toward footer progress
-                    mpr.footer_inc(successful_installations.len() + failed_installations.len());
+                    // Count both successes and failures toward header progress
+                    mpr.header_inc(successful_installations.len() + failed_installations.len());
                     installed.extend(successful_installations);
 
                     return Err(Error::InstallFailed {
@@ -203,9 +203,9 @@ impl Toolset {
             .await;
         }
 
-        // Finish the global footer
+        // Finish the global header
         if !opts.dry_run {
-            mpr.footer_finish();
+            mpr.header_finish();
         }
         Ok(installed)
     }
@@ -356,8 +356,8 @@ impl Toolset {
                     .await;
 
                     results.push((tr, result));
-                    // Bump footer for each completed tool
-                    MultiProgressReport::get().footer_inc(1);
+                    // Bump header for each completed tool
+                    MultiProgressReport::get().header_inc(1);
                 }
                 results
             });

--- a/src/ui/diagnostic_log.rs
+++ b/src/ui/diagnostic_log.rs
@@ -1,0 +1,133 @@
+use std::fs::{File, OpenOptions, create_dir_all};
+use std::io::Write;
+use std::sync::{Mutex, OnceLock};
+
+use crate::env;
+
+static WRITER: OnceLock<Mutex<File>> = OnceLock::new();
+
+pub fn init() {
+    if let Some(path) = &*env::MISE_DIAGNOSTIC_LOG {
+        if let Some(parent) = path.parent() {
+            let _ = create_dir_all(parent);
+        }
+        match OpenOptions::new().create(true).append(true).open(path) {
+            Ok(file) => {
+                let _ = WRITER.set(Mutex::new(file));
+            }
+            Err(e) => {
+                eprintln!("mise: could not open diagnostic log file {path:?}: {e}");
+            }
+        }
+    }
+}
+
+pub fn is_enabled() -> bool {
+    WRITER.get().is_some()
+}
+
+fn write_line(json: &str) {
+    if let Some(writer) = WRITER.get()
+        && let Ok(mut f) = writer.lock()
+    {
+        let _ = writeln!(f, "{}", json);
+        let _ = f.flush();
+    }
+}
+
+fn timestamp() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+pub fn session_start(total_tools: usize, reason: &str) {
+    if !is_enabled() {
+        return;
+    }
+    let ts = timestamp();
+    let reason = serde_json::to_string(reason).unwrap_or_default();
+    write_line(&format!(
+        r#"{{"ts":"{ts}","event":"session_start","total_tools":{total_tools},"reason":{reason}}}"#
+    ));
+}
+
+pub fn session_end() {
+    if !is_enabled() {
+        return;
+    }
+    let ts = timestamp();
+    write_line(&format!(r#"{{"ts":"{ts}","event":"session_end"}}"#));
+}
+
+pub fn tool_start(tool: &str) {
+    if !is_enabled() {
+        return;
+    }
+    let ts = timestamp();
+    let tool = serde_json::to_string(tool).unwrap_or_default();
+    write_line(&format!(
+        r#"{{"ts":"{ts}","event":"tool_start","tool":{tool}}}"#
+    ));
+}
+
+pub fn message(tool: &str, message: &str) {
+    if !is_enabled() {
+        return;
+    }
+    let ts = timestamp();
+    let tool = serde_json::to_string(tool).unwrap_or_default();
+    let message = serde_json::to_string(message).unwrap_or_default();
+    write_line(&format!(
+        r#"{{"ts":"{ts}","event":"message","tool":{tool},"message":{message}}}"#
+    ));
+}
+
+pub fn progress(tool: &str, bytes_current: u64, bytes_total: u64) {
+    if !is_enabled() {
+        return;
+    }
+    let ts = timestamp();
+    let tool = serde_json::to_string(tool).unwrap_or_default();
+    let progress_pct = if bytes_total > 0 {
+        (bytes_current as f64 / bytes_total as f64 * 100.0).clamp(0.0, 100.0)
+    } else {
+        0.0
+    };
+    write_line(&format!(
+        r#"{{"ts":"{ts}","event":"progress","tool":{tool},"bytes_current":{bytes_current},"bytes_total":{bytes_total},"progress_pct":{progress_pct:.1}}}"#
+    ));
+}
+
+pub fn operation(tool: &str, operation_num: u32, length: u64) {
+    if !is_enabled() {
+        return;
+    }
+    let ts = timestamp();
+    let tool = serde_json::to_string(tool).unwrap_or_default();
+    write_line(&format!(
+        r#"{{"ts":"{ts}","event":"operation","tool":{tool},"operation_num":{operation_num},"length":{length}}}"#
+    ));
+}
+
+pub fn tool_complete(tool: &str, status: &str) {
+    if !is_enabled() {
+        return;
+    }
+    let ts = timestamp();
+    let tool = serde_json::to_string(tool).unwrap_or_default();
+    let status = serde_json::to_string(status).unwrap_or_default();
+    write_line(&format!(
+        r#"{{"ts":"{ts}","event":"tool_complete","tool":{tool},"status":{status}}}"#
+    ));
+}
+
+pub fn log_message(level: &str, message: &str) {
+    if !is_enabled() {
+        return;
+    }
+    let ts = timestamp();
+    let level = serde_json::to_string(level).unwrap_or_default();
+    let message = serde_json::to_string(message).unwrap_or_default();
+    write_line(&format!(
+        r#"{{"ts":"{ts}","event":"log_message","level":{level},"message":{message}}}"#
+    ));
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub use prompt::confirm;
 
 #[cfg_attr(any(test, windows), path = "ctrlc_stub.rs")]
 pub mod ctrlc;
+pub mod diagnostic_log;
 pub(crate) mod info;
 pub mod multi_progress_report;
 pub mod osc;


### PR DESCRIPTION
## Summary
- Moves the progress summary bar from footer to header position, pinning it at the top with tool progress bars appearing below it
- Adds `MISE_DIAGNOSTIC_LOG` env var that writes JSON Lines diagnostic events during installs for debugging and LLM-assisted troubleshooting
- Renames all internal footer references to header for clarity

## Diagnostic Log Events
When `MISE_DIAGNOSTIC_LOG=/path/to/file.jsonl` is set, the following events are written:
- `session_start` / `session_end` — install session lifecycle
- `tool_start` / `tool_complete` — per-tool lifecycle with status
- `message` — progress messages (e.g., "downloading", "extracting")
- `progress` — byte-level progress (throttled to 500ms)
- `operation` — new operation started (download, checksum, extract)
- `log_message` — warn/error log messages

Each line is a JSON object with a `ts` timestamp and `event` field.

## Test plan
- [x] `cargo build` compiles successfully
- [x] `cargo clippy --all-targets` passes with no warnings
- [x] `cargo test` — all 435 unit tests pass
- [ ] Manual: `MISE_DIAGNOSTIC_LOG=/tmp/diag.jsonl mise install` writes valid JSONL
- [ ] Manual: summary bar appears at top, tool bars below
- [ ] Manual: without env var set, no diagnostic file created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it modifies installation progress reporting and hooks into the global logger; issues could affect terminal output/progress behavior or add overhead when enabled.
> 
> **Overview**
> Moves the install session summary progress bar from a *footer* to a pinned *header* (`MultiProgressReport::init_header`, `header_inc`, `header_finish`), updating install flows to drive the new header progress.
> 
> Adds optional JSONL diagnostic logging controlled by `MISE_DIAGNOSTIC_LOG`, initializing it at CLI startup and emitting structured events for session/tool lifecycle, progress/operations, and warning/error log messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c27c0b327116c985a4c9f9cb513a30e2c02b5db4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->