### PR TITLE
registry: use aqua backend for npm

### DIFF
--- a/crates/aqua-registry/aqua-registry/pkgs/npm/cli/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/npm/cli/registry.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: http
+    repo_owner: npm
+    repo_name: cli
+    description: the package manager for JavaScript
+    version_source: github_tag
+    url: https://registry.npmjs.org/npm/-/npm-{{trimV .Version}}.tgz
+    format: tar.gz
+    files:
+      - name: npm
+        src: package/bin/npm
+      - name: npx
+        src: package/bin/npx
+    overrides:
+      - goos: windows
+        files:
+          - name: npm
+            src: package/bin/npm.cmd
+          - name: npx
+            src: package/bin/npx.cmd

--- a/crates/aqua-registry/build.rs
+++ b/crates/aqua-registry/build.rs
@@ -10,6 +10,7 @@ fn generate_baked_registry(out_dir: &str) {
     let dest_path = Path::new(out_dir).join("aqua_standard_registry.rs");
 
     let registry_dir = find_registry_dir();
+    println!("cargo:rerun-if-changed={}", registry_dir.display());
 
     let registries =
         collect_aqua_registries(&registry_dir).expect("Failed to collect aqua registry files");

--- a/registry/npm.toml
+++ b/registry/npm.toml
@@ -3,4 +3,4 @@ depends = ["node"]
 description = "the package manager for JavaScript"
 idiomatic_files = ["package.json"]
 overrides = ["node"]
-test = { cmd = "npm --version", expected = "{{version}}" }
+test = { cmd = "node --version && npm --version", expected = "{{version}}" }

--- a/registry/npm.toml
+++ b/registry/npm.toml
@@ -1,6 +1,6 @@
 backends = ["aqua:npm/cli", "npm:npm"]
-description = "the package manager for JavaScript"
 depends = ["node"]
+description = "the package manager for JavaScript"
 idiomatic_files = ["package.json"]
 overrides = ["node"]
 test = { cmd = "npm --version", expected = "{{version}}" }

--- a/registry/npm.toml
+++ b/registry/npm.toml
@@ -1,5 +1,6 @@
-backends = ["npm:npm"]
+backends = ["aqua:npm/cli", "npm:npm"]
 description = "the package manager for JavaScript"
+depends = ["node"]
 idiomatic_files = ["package.json"]
 overrides = ["node"]
 test = { cmd = "npm --version", expected = "{{version}}" }


### PR DESCRIPTION
This should avoid some bugs caused by `npm:npm`.
I'll open a PR to aqua-registry. https://github.com/aquaproj/aqua-registry/pull/48803

npm bundles all of its dependencies, so it works like a single binary (but a JavaScript file, so node is required).