### PR TITLE
registry: add github backend for typst

### DIFF
--- a/registry/typst.toml
+++ b/registry/typst.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:typst/typst",
+  "github:typst/typst",
   "asdf:stephane-klein/asdf-typst",
   "cargo:typst-cli",
 ]


### PR DESCRIPTION
This pull request adds a [GitHub backend](https://github.com/typst/typst/releases) for Typst to the registry.