### PR TITLE
feat(registry): Add imagemagick github backend entry for Windows binary releases

### DIFF
--- a/registry/imagemagick.toml
+++ b/registry/imagemagick.toml
@@ -1,3 +1,22 @@
-backends = ["conda:imagemagick", "asdf:mise-plugins/mise-imagemagick"]
 description = "ImageMagick is a free, open-source software suite for creating, editing, converting, and displaying images. It supports 200+ formats and offers powerful command-line tools and APIs for automation, scripting, and integration across platforms"
 test = { cmd = "magick --version 2>&1", expected = "ImageMagick" }
+
+[[backends]]
+full = "conda:imagemagick"
+
+[[backends]]
+full = "asdf:mise-plugins/mise-imagemagick"
+
+[[backends]]
+full = "github:ImageMagick/ImageMagick"
+os = ["windows"]
+platforms = ["windows-x64", "windows-x86", "windows-arm64"]
+
+[backends.options.platforms.windows-x64]
+asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x64.7z"
+
+[backends.options.platforms.windows-x86]
+asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x86.7z"
+
+[backends.options.platforms.windows-arm64]
+asset_pattern = "ImageMagick-*-portable-Q16-HDRI-arm64.7z"

--- a/registry/imagemagick.toml
+++ b/registry/imagemagick.toml
@@ -12,5 +12,5 @@ full = "github:ImageMagick/ImageMagick"
 platforms = ["windows"]
 
 [backends.options.platforms]
-windows-x64 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x64.7z" }
 windows-arm64 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-arm64.7z" }
+windows-x64 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x64.7z" }

--- a/registry/imagemagick.toml
+++ b/registry/imagemagick.toml
@@ -13,5 +13,4 @@ platforms = ["windows"]
 
 [backends.options.platforms]
 windows-x64 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x64.7z" }
-windows-x86 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x86.7z" }
 windows-arm64 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-arm64.7z" }

--- a/registry/imagemagick.toml
+++ b/registry/imagemagick.toml
@@ -11,11 +11,7 @@ full = "asdf:mise-plugins/mise-imagemagick"
 full = "github:ImageMagick/ImageMagick"
 platforms = ["windows"]
 
-[backends.options.platforms.windows-x64]
-asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x64.7z"
-
-[backends.options.platforms.windows-x86]
-asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x86.7z"
-
-[backends.options.platforms.windows-arm64]
-asset_pattern = "ImageMagick-*-portable-Q16-HDRI-arm64.7z"
+[backends.options.platforms]
+windows-x64 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x64.7z" }
+windows-x86 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x86.7z" }
+windows-arm64 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-arm64.7z" }

--- a/registry/imagemagick.toml
+++ b/registry/imagemagick.toml
@@ -9,8 +9,7 @@ full = "asdf:mise-plugins/mise-imagemagick"
 
 [[backends]]
 full = "github:ImageMagick/ImageMagick"
-os = ["windows"]
-platforms = ["windows-x64", "windows-x86", "windows-arm64"]
+platforms = ["windows"]
 
 [backends.options.platforms.windows-x64]
 asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x64.7z"


### PR DESCRIPTION
Follow-up to #8386 discussion on `imagemagick`, where #8388 fixed the message and this PR aims to add a github binary releases backend to `imagemagick` registry entry to allow installing on Windows.

Currently, I'm able to install `imagemagick` on Windows from its binary releases on https://github.com/ImageMagick/ImageMagick/releases using the following entry in `~/.config/mise/config.toml`:
```toml
"github:ImageMagick/ImageMagick" = { version = "latest", os = ["windows"], platforms = { windows-x64 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x64.7z" }, windows-x86 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x86.7z" }, windows-arm64 = { asset_pattern = "ImageMagick-*-portable-Q16-HDRI-arm64.7z" } } }
```

Here's an attempt to define that backend in `registry/imagemagick.toml`:
```toml
description = "ImageMagick is a free, open-source software suite for creating, editing, converting, and displaying images. It supports 200+ formats and offers powerful command-line tools and APIs for automation, scripting, and integration across platforms"
test = { cmd = "magick --version 2>&1", expected = "ImageMagick" }

[[backends]]
full = "conda:imagemagick"

[[backends]]
full = "asdf:mise-plugins/mise-imagemagick"

[[backends]]
full = "github:ImageMagick/ImageMagick"
os = ["windows"]
platforms = ["windows-x64", "windows-x86", "windows-arm64"]

[backends.options.platforms.windows-x64]
asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x64.7z"

[backends.options.platforms.windows-x86]
asset_pattern = "ImageMagick-*-portable-Q16-HDRI-x86.7z"

[backends.options.platforms.windows-arm64]
asset_pattern = "ImageMagick-*-portable-Q16-HDRI-arm64.7z"
```

Is there any way how to test it locally @jdx?