### PR TITLE
fix(env): use async subprocess with kill_on_drop for backend version fetching

### DIFF
--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -3,7 +3,7 @@ use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
 use crate::cli::args::BackendArg;
-use crate::cmd::CmdLineRunner;
+use crate::cmd::{CmdLineRunner, cmd_read_async};
 use crate::config::Config;
 use crate::config::Settings;
 use crate::install_context::InstallContext;
@@ -69,19 +69,22 @@ impl Backend for GoBackend {
                     .unique()
                     .collect::<Vec<_>>();
 
+                let env = self.dependency_env(config).await?;
                 for i in indices {
                     let mod_path = parts[..=i].join("/");
-                    let res = cmd!(
+                    let res = cmd_read_async(
                         "go",
-                        "list",
-                        "-mod=readonly",
-                        "-m",
-                        "-versions",
-                        "-json",
-                        mod_path
+                        &[
+                            "list",
+                            "-mod=readonly",
+                            "-m",
+                            "-versions",
+                            "-json",
+                            &mod_path,
+                        ],
+                        &env,
                     )
-                    .full_env(self.dependency_env(config).await?)
-                    .read();
+                    .await;
                     if let Ok(raw) = res {
                         let res = serde_json::from_str::<GoModInfo>(&raw);
                         if let Ok(mod_info) = res {

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -4,7 +4,7 @@ use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
-use crate::cmd::CmdLineRunner;
+use crate::cmd::{CmdLineRunner, cmd_read_async};
 use crate::config::settings::NpmPackageManager;
 use crate::config::{Config, Settings};
 use crate::install_context::InstallContext;
@@ -80,19 +80,16 @@ impl Backend for NPMBackend {
         self.ensure_npm_for_version_check(config).await;
         timeout::run_with_timeout_async(
             async || {
-                let env = self.dependency_env(config).await?;
+                let mut env = self.dependency_env(config).await?;
+                env.insert("NPM_CONFIG_UPDATE_NOTIFIER".into(), "false".into());
 
-                let raw = cmd!(
+                let tool_name = self.tool_name();
+                let raw = cmd_read_async(
                     NPM_PROGRAM,
-                    "view",
-                    self.tool_name(),
-                    "versions",
-                    "time",
-                    "--json"
+                    &["view", &tool_name, "versions", "time", "--json"],
+                    &env,
                 )
-                .full_env(&env)
-                .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-                .read()?;
+                .await?;
                 let data: Value = serde_json::from_str(&raw)?;
                 let versions = data["versions"]
                     .as_array()
@@ -135,11 +132,15 @@ impl Backend for NPMBackend {
                     .get_or_try_init_async(async || {
                         // Always use npm for getting version info since bun info requires package.json
                         // bun is only used for actual package installation
-                        let raw =
-                            cmd!(NPM_PROGRAM, "view", this.tool_name(), "dist-tags", "--json")
-                                .full_env(this.dependency_env(config).await?)
-                                .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-                                .read()?;
+                        let mut env = this.dependency_env(config).await?;
+                        env.insert("NPM_CONFIG_UPDATE_NOTIFIER".into(), "false".into());
+                        let tool_name = this.tool_name();
+                        let raw = cmd_read_async(
+                            NPM_PROGRAM,
+                            &["view", &tool_name, "dist-tags", "--json"],
+                            &env,
+                        )
+                        .await?;
                         let dist_tags: Value = serde_json::from_str(&raw)?;
                         match dist_tags["latest"] {
                             Value::String(ref s) => Ok(Some(s.clone())),

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -99,6 +99,48 @@ where
     duct::cmd(program, args)
 }
 
+/// Async version of `cmd!().read()` that uses `tokio::process::Command`.
+///
+/// Unlike `duct::Expression::read()`, this is truly async — it yields at `.await`
+/// points so `tokio::time::timeout` can cancel it, and `kill_on_drop(true)` ensures
+/// the child process is killed when the future is dropped (preventing orphans).
+pub async fn cmd_read_async<I, K, V>(program: &str, args: &[&str], env: I) -> Result<String>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    let display_args = args.join(" ");
+    debug!("$ {program} {display_args}");
+
+    let output = tokio::process::Command::new(program)
+        .args(args)
+        .env_clear()
+        .envs(env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .output()
+        .await
+        .wrap_err_with(|| format!("failed to run {program}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "{program} {display_args} failed: exit {}{}\n",
+            output.status,
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!("\nstderr: {stderr}")
+            }
+        );
+    }
+
+    Ok(String::from_utf8(output.stdout)
+        .wrap_err_with(|| format!("{program} output was not valid UTF-8"))?)
+}
+
 pub struct CmdLineRunner<'a> {
     cmd: Command,
     pr: Option<&'a dyn SingleReport>,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -137,8 +137,8 @@ where
         );
     }
 
-    Ok(String::from_utf8(output.stdout)
-        .wrap_err_with(|| format!("{program} output was not valid UTF-8"))?)
+    String::from_utf8(output.stdout)
+        .wrap_err_with(|| format!("{program} output was not valid UTF-8"))
 }
 
 pub struct CmdLineRunner<'a> {


### PR DESCRIPTION
## Summary

- Adds `cmd_read_async()` helper in `src/cmd.rs` — wraps `tokio::process::Command` with `kill_on_drop(true)` as an async alternative to `cmd!().read()` (duct)
- Migrates npm and go backend version-fetching paths from blocking `cmd!().read()` to `cmd_read_async()`

## Problem

Inside `run_with_timeout_async` blocks, `cmd!().read()` (duct) is a **synchronous blocking call** — it blocks the tokio worker thread with no yield points. This means:

1. **Timeouts can't fire** — `tokio::time::timeout` works by cancelling futures at `.await` points, but there are none during a blocking `read()` call
2. **Orphaned processes** — `std::process::Child::drop()` does not send a signal, so when a future is dropped, the subprocess continues running as an orphan

## Fix

`cmd_read_async()` uses `tokio::process::Command` which:

- `.output().await` is a real async operation — the timeout can cancel it at the yield point
- `.kill_on_drop(true)` sends SIGKILL to the child when the future is dropped — no orphans

## Scope

This PR migrates the 3 call sites inside async timeout wrappers:
- `src/backend/npm.rs` — `_list_remote_versions()` and `latest_stable_version()`
- `src/backend/go.rs` — `_list_remote_versions()`

The sync `run_fetch_task_with_timeout` callers (ruby, erlang, python, core/go) have the same underlying issue but use a different pattern — they can be addressed in a follow-up.

See #8499 for the full root cause analysis.

## Test plan

- [ ] `mise ls-remote npm:prettier` still works (npm version fetching)
- [ ] `mise ls-remote go:github.com/golangci/golangci-lint/cmd/golangci-lint` still works (go version fetching)
- [ ] Version fetches that exceed `fetch_remote_versions_timeout` now actually time out instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subprocess execution and environment handling in remote version fetching; behavior changes around cancellation, error reporting, and env clearing could impact some platforms/registries.
> 
> **Overview**
> Version-fetching for the Go and NPM backends is switched from blocking `duct` reads to a new async `cmd_read_async()` helper, so `run_with_timeout_async` can actually cancel long-running `go list`/`npm view` calls.
> 
> `cmd_read_async()` runs subprocesses via `tokio::process::Command` with `kill_on_drop(true)`, and NPM version queries now set `NPM_CONFIG_UPDATE_NOTIFIER=false` via the provided env map while using this async path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdaf470703b1bba6856f6015aa1ad18e498c213b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->