### PR TITLE
fix(lock): don't set env tag when tool exists in base config

### DIFF
--- a/e2e/lockfile/test_lockfile_env_base_override
+++ b/e2e/lockfile/test_lockfile_env_base_override
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Test that env tag is NOT set when a tool exists in both base and env-specific configs
+# Bug: MISE_ENV=dev mise install incorrectly sets env=["dev"] on a tool that is also
+# defined in the base mise.toml
+
+export MISE_LOCKFILE=1
+
+echo "=== Setup: jq in both base and dev config ==="
+
+cat >mise.toml <<'EOF'
+[settings]
+lockfile = true
+
+[tools]
+tiny = "1"
+EOF
+
+cat >mise.dev.toml <<'EOF'
+[tools]
+tiny = "1"
+EOF
+
+touch mise.lock
+
+# Install with base config first
+assert "mise install tiny@1.0.1"
+
+echo "=== Test: MISE_ENV=dev should NOT add env tag when tool is also in base ==="
+
+assert "MISE_ENV=dev mise install"
+
+# The tool should NOT have env=["dev"] because it exists in both configs
+assert_not_contains "cat mise.lock" 'env = '
+
+echo "=== Test: tool only in env config SHOULD get env tag ==="
+
+# Remove tiny from base config
+cat >mise.toml <<'EOF'
+[settings]
+lockfile = true
+EOF
+
+rm -f mise.lock
+touch mise.lock
+
+assert "MISE_ENV=dev mise install"
+
+# Now env tag should be present since tiny is only in mise.dev.toml
+assert_contains "cat mise.lock" 'env = ["dev"]'
+
+echo "=== Cleanup ==="
+rm -f mise.lock mise.toml mise.dev.toml
+
+echo "lockfile env base override tests passed!"

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -905,6 +905,33 @@ pub fn update_lockfiles(config: &Config, ts: &Toolset, new_versions: &[ToolVersi
             }
         }
 
+        // Check if any env-specific tool is also defined in a base config file.
+        // When MISE_ENV is set, env configs override base configs in the resolved toolset,
+        // so tools_by_source only has the env-specific entry. But the tool is still defined
+        // in the base config, so it shouldn't get an env tag.
+        for (config_path, env) in &configs {
+            if env.is_some() {
+                continue; // only look at base configs
+            }
+            if let Some(cf) = config.config_files.get(config_path) {
+                if let Ok(trs) = cf.to_tool_request_set() {
+                    for (ba, _requests, _source) in trs.iter() {
+                        if let Some(entries) = tools_with_env.get_mut(&ba.short) {
+                            // This tool is defined in a base config — add a base marker
+                            // so merge_tool_entries_with_env sees has_base=true
+                            let already_has_base = entries.iter().any(|(_, e)| e.is_none());
+                            if !already_has_base {
+                                // Find the matching env entry and clone it as a base entry
+                                if let Some((tool, _)) = entries.first().cloned() {
+                                    entries.push((tool, None));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // Preserve base entries from existing lockfile that were overridden by env configs
         // Without this, base entries (env=None) get dropped when env configs override them
         // Only preserve if ALL new entries are env-specific - if any new entry has env=None,

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -913,8 +913,8 @@ pub fn update_lockfiles(config: &Config, ts: &Toolset, new_versions: &[ToolVersi
             if env.is_some() {
                 continue; // only look at base configs
             }
-            if let Some(cf) = config.config_files.get(config_path) {
-                if let Ok(trs) = cf.to_tool_request_set() {
+            if let Some(cf) = config.config_files.get(config_path)
+                && let Ok(trs) = cf.to_tool_request_set() {
                     for (ba, _requests, _source) in trs.iter() {
                         if let Some(entries) = tools_with_env.get_mut(&ba.short) {
                             // This tool is defined in a base config — add a base marker
@@ -929,7 +929,6 @@ pub fn update_lockfiles(config: &Config, ts: &Toolset, new_versions: &[ToolVersi
                         }
                     }
                 }
-            }
         }
 
         // Preserve base entries from existing lockfile that were overridden by env configs


### PR DESCRIPTION
## Summary
- Fix bug where `MISE_ENV=dev mise install` incorrectly sets `env=["dev"]` on lockfile entries for tools that also exist in the base `mise.toml`
- When a tool appears in both `mise.toml` and `mise.dev.toml`, the lockfile entry should NOT have an env tag since the tool is available in all environments
- Add e2e test covering both cases: tool in both configs (no env tag) and tool only in env config (env tag set)

## Context
Reported in https://github.com/jdx/mise/discussions/8000#discussioncomment-16046070 — user saw duplicate lockfile entries with env flip-flopping between base and env-specific installs.

The root cause: `update_lockfiles()` collects tools from env-specific configs and tags them with the env name, but doesn't check whether those same tools also exist in the base config. This fix adds a pass that checks base configs and marks tools as base-available so `merge_tool_entries_with_env` correctly sets `has_base=true` and omits the env tag.

## Test plan
- [x] New e2e test `e2e/lockfile/test_lockfile_env_base_override` validates:
  - `MISE_ENV=dev mise install` does NOT add env tag when tool is in both configs
  - `MISE_ENV=dev mise install` DOES add env tag when tool is only in env config
- [x] Existing lockfile e2e tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lockfile update/merge logic, which can affect how tool versions are persisted across environments; the change is targeted and covered by a new e2e regression test.
> 
> **Overview**
> Fixes a lockfile bug where running `MISE_ENV=... mise install` could incorrectly write `env = ["..."]` for tools that are also defined in the base `mise.toml`, causing flip-flopping/duplicate entries.
> 
> `update_lockfiles()` now cross-checks base config files and marks affected tools as base-available before merging, so `merge_tool_entries_with_env` omits the env tag when appropriate. Adds an e2e test (`e2e/lockfile/test_lockfile_env_base_override`) covering both the “tool in base+env config => no env tag” and “tool only in env config => env tag present” cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aac336e0b245b098394de2a8fb2d1388b33aee5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->