### PR TITLE
feat(task): support optional `args` and `env` fields in `run` entries

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -9,16 +9,17 @@ All examples are in toml-task format instead of file, however they apply in both
 
 ### `run`
 
-- **Type**: `string | (string | { task: string } | { tasks: string[] })[]`
+- **Type**: `string | (string | { task: string, args?: string[], env?: { [key]: string } } | { tasks: string[] })[]`
 
 The command(s) to run. This is the only required property for a task.
 
-You can now mix scripts with task references:
+You can mix scripts with task references, and pass optional `args` and `env` to referenced tasks:
 
 ```mise-toml
 [tasks.grouped]
 run = [
   { task = "t1" },          # run t1 (with its dependencies)
+  { task = "build", args = ["--release"], env = { RUSTFLAGS = "-C opt-level=3" } },
   { tasks = ["t2", "t3"] }, # run t2 and t3 in parallel (with their dependencies)
   "echo end",               # then run a script
 ]
@@ -38,7 +39,7 @@ run = ["echo hello"]
 
 ### `run_windows`
 
-- **Type**: `string | (string | { task: string } | { tasks: string[] })[]`
+- **Type**: `string | (string | { task: string, args?: string[], env?: { [key]: string } } | { tasks: string[] })[]`
 
 Windows-specific variant of `run` supporting the same structured syntax:
 

--- a/e2e/tasks/test_task_run_entry_args_env
+++ b/e2e/tasks/test_task_run_entry_args_env
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Test passing args and env via run entry objects
+
+# Test run entry with args
+cat <<EOF >mise.toml
+[tasks.greet]
+run = 'echo hello'
+
+[tasks.all]
+run = [{ task = "greet", args = ["world", "foo"] }]
+EOF
+
+assert_contains "mise run all" "hello world foo"
+
+# Test run entry with env
+cat <<EOF >mise.toml
+[tasks.show-env]
+run = 'echo "FOO=\$FOO BAR=\$BAR"'
+
+[tasks.all]
+run = [{ task = "show-env", env = { FOO = "hello", BAR = "world" } }]
+EOF
+
+assert_contains "mise run all" "FOO=hello BAR=world"
+
+# Test run entry with both args and env
+cat <<EOF >mise.toml
+[tasks.greet]
+run = 'echo "FOO=\$FOO"'
+
+[tasks.all]
+run = [{ task = "greet", args = ["a", "b"], env = { FOO = "test" } }]
+EOF
+
+assert_contains "mise run all" "FOO=test"
+
+# Test mixing script and task entries with args/env
+cat <<EOF >mise.toml
+[tasks.greet]
+run = 'echo "FOO=\$FOO"'
+
+[tasks.all]
+run = [
+  "echo step1",
+  { task = "greet", env = { FOO = "bar" } },
+]
+EOF
+
+assert_contains "mise run all" "step1"
+assert_contains "mise run all" "FOO=bar"

--- a/e2e/tasks/test_task_run_entry_args_env
+++ b/e2e/tasks/test_task_run_entry_args_env
@@ -34,6 +34,7 @@ run = [{ task = "greet", args = ["a", "b"], env = { FOO = "test" } }]
 EOF
 
 assert_contains "mise run all" "FOO=test"
+assert_contains "mise run all" "a b"
 
 # Test mixing script and task entries with args/env
 cat <<EOF >mise.toml

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -688,8 +688,22 @@
           "additionalProperties": false,
           "properties": {
             "task": {
-              "description": "single task name (with optional args) to run",
+              "description": "single task name to run",
               "type": "string"
+            },
+            "args": {
+              "description": "arguments to pass to the task",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "env": {
+              "description": "environment variables to set for the task",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           },
           "required": ["task"]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1633,8 +1633,22 @@
           "additionalProperties": false,
           "properties": {
             "task": {
-              "description": "single task name (with optional args) to run",
+              "description": "single task name to run",
               "type": "string"
+            },
+            "args": {
+              "description": "arguments to pass to the task",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "env": {
+              "description": "environment variables to set for the task",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           },
           "required": ["task"]

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -547,7 +547,9 @@ impl TasksValidate {
                         });
                     }
                 }
-                crate::task::RunEntry::SingleTask { task: task_name } => {
+                crate::task::RunEntry::SingleTask {
+                    task: task_name, ..
+                } => {
                     // Check if referenced task exists (by name, display_name, or alias)
                     if !Self::task_exists(all_tasks, task_name) {
                         issues.push(ValidationIssue {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -102,7 +102,9 @@ impl std::hash::Hash for RunEntry {
                 1u8.hash(state);
                 task.hash(state);
                 args.hash(state);
-                for (k, v) in env {
+                let mut pairs: Vec<_> = env.iter().collect();
+                pairs.sort_by_key(|(k, _)| k.as_str());
+                for (k, v) in pairs {
                     k.hash(state);
                     v.hash(state);
                 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -74,15 +74,45 @@ pub use deps::{Deps, TaskKey};
 use task_dep::TaskDep;
 use task_sources::{RawOutputTemplates, TaskOutputs};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RunEntry {
     /// Shell script entry
     Script(String),
-    /// Run a single task with optional args
-    SingleTask { task: String },
+    /// Run a single task with optional args and env
+    SingleTask {
+        task: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+        #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+        env: IndexMap<String, String>,
+    },
     /// Run multiple tasks in parallel
     TaskGroup { tasks: Vec<String> },
+}
+
+impl std::hash::Hash for RunEntry {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            RunEntry::Script(s) => {
+                0u8.hash(state);
+                s.hash(state);
+            }
+            RunEntry::SingleTask { task, args, env } => {
+                1u8.hash(state);
+                task.hash(state);
+                args.hash(state);
+                for (k, v) in env {
+                    k.hash(state);
+                    v.hash(state);
+                }
+            }
+            RunEntry::TaskGroup { tasks } => {
+                2u8.hash(state);
+                tasks.hash(state);
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
@@ -199,7 +229,16 @@ impl Display for RunEntry {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             RunEntry::Script(s) => write!(f, "{}", s),
-            RunEntry::SingleTask { task } => write!(f, "task: {task}"),
+            RunEntry::SingleTask { task, args, env } => {
+                for (k, v) in env {
+                    write!(f, "{}={} ", k, v)?;
+                }
+                write!(f, "task: {task}")?;
+                if !args.is_empty() {
+                    write!(f, " {}", args.join(" "))?;
+                }
+                Ok(())
+            }
             RunEntry::TaskGroup { tasks } => write!(f, "tasks: {}", tasks.join(", ")),
         }
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -398,6 +398,7 @@ impl TaskExecutor {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn inject_and_wait(
         &self,
         config: &Arc<Config>,

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -344,13 +344,26 @@ impl TaskExecutor {
                         self.exec_script(&script, &args, task, env, prefix).await?;
                     }
                 }
-                RunEntry::SingleTask { task: spec } => {
-                    let resolved_spec = crate::task::resolve_task_pattern(spec, Some(task));
+                RunEntry::SingleTask {
+                    task: spec,
+                    args: entry_args,
+                    env: entry_env,
+                } => {
+                    let mut resolved_spec = crate::task::resolve_task_pattern(spec, Some(task));
+                    if !entry_args.is_empty() {
+                        resolved_spec.push(' ');
+                        resolved_spec.push_str(&entry_args.join(" "));
+                    }
+                    let combined_env: Vec<(String, String)> = task_env
+                        .iter()
+                        .cloned()
+                        .chain(entry_env.iter().map(|(k, v)| (k.clone(), v.clone())))
+                        .collect();
                     guard = None; // drop lock before waiting on sub-tasks
                     self.inject_and_wait(
                         config,
                         &[resolved_spec],
-                        task_env,
+                        &combined_env,
                         sched_tx.clone(),
                         completed_tasks,
                     )

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -355,17 +355,22 @@ impl TaskExecutor {
                     } else {
                         Some(entry_args.clone())
                     };
-                    let combined_env: Vec<(String, String)> = task_env
+                    let override_env: Vec<(String, String)> = entry_env
                         .iter()
-                        .cloned()
-                        .chain(entry_env.iter().map(|(k, v)| (k.clone(), v.clone())))
+                        .map(|(k, v)| (k.clone(), v.clone()))
                         .collect();
+                    let override_env_ref = if override_env.is_empty() {
+                        None
+                    } else {
+                        Some(override_env.as_slice())
+                    };
                     guard = None; // drop lock before waiting on sub-tasks
                     self.inject_and_wait(
                         config,
                         &[resolved_spec],
-                        &combined_env,
+                        task_env,
                         override_args.as_deref(),
+                        override_env_ref,
                         sched_tx.clone(),
                         completed_tasks,
                     )
@@ -381,6 +386,7 @@ impl TaskExecutor {
                         config,
                         &resolved_tasks,
                         task_env,
+                        None,
                         None,
                         sched_tx.clone(),
                         completed_tasks,
@@ -398,6 +404,7 @@ impl TaskExecutor {
         specs: &[String],
         task_env: &[(String, String)],
         override_args: Option<&[String]>,
+        override_env: Option<&[(String, String)]>,
         sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
         completed_tasks: &HashSet<TaskKey>,
     ) -> Result<()> {
@@ -430,6 +437,16 @@ impl TaskExecutor {
                 t.args = override_args
                     .map(|a| a.to_vec())
                     .unwrap_or_else(|| args.clone());
+                // Apply entry-level env via with_dependency_env (high priority,
+                // consistent with depends/depends_post) so it overrides the
+                // sub-task's own declared env.
+                if let Some(env) = override_env {
+                    let env_directives: Vec<EnvDirective> = env
+                        .iter()
+                        .map(|(k, v)| EnvDirective::Val(k.clone(), v.clone(), Default::default()))
+                        .collect();
+                    t = t.with_dependency_env(&env_directives);
+                }
                 if self.skip_deps {
                     t.depends.clear();
                     t.depends_post.clear();

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -453,6 +453,11 @@ impl TaskExecutor {
                             &env_map,
                             config_root,
                         )?;
+                    } else {
+                        trace!(
+                            "re_render_with_env skipped: task {} has no config_root",
+                            t.name
+                        );
                     }
                 }
                 if self.skip_deps {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -446,6 +446,14 @@ impl TaskExecutor {
                         .map(|(k, v)| EnvDirective::Val(k.clone(), v.clone(), Default::default()))
                         .collect();
                     t = t.with_dependency_env(&env_directives);
+                    if let Some(config_root) = &t.config_root {
+                        let env_map: IndexMap<String, String> = env.iter().cloned().collect();
+                        t.outputs.re_render_with_env(
+                            &t.raw_outputs.clone(),
+                            &env_map,
+                            config_root,
+                        )?;
+                    }
                 }
                 if self.skip_deps {
                     t.depends.clear();

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -349,11 +349,12 @@ impl TaskExecutor {
                     args: entry_args,
                     env: entry_env,
                 } => {
-                    let mut resolved_spec = crate::task::resolve_task_pattern(spec, Some(task));
-                    if !entry_args.is_empty() {
-                        resolved_spec.push(' ');
-                        resolved_spec.push_str(&entry_args.join(" "));
-                    }
+                    let resolved_spec = crate::task::resolve_task_pattern(spec, Some(task));
+                    let override_args = if entry_args.is_empty() {
+                        None
+                    } else {
+                        Some(entry_args.clone())
+                    };
                     let combined_env: Vec<(String, String)> = task_env
                         .iter()
                         .cloned()
@@ -364,6 +365,7 @@ impl TaskExecutor {
                         config,
                         &[resolved_spec],
                         &combined_env,
+                        override_args.as_deref(),
                         sched_tx.clone(),
                         completed_tasks,
                     )
@@ -379,6 +381,7 @@ impl TaskExecutor {
                         config,
                         &resolved_tasks,
                         task_env,
+                        None,
                         sched_tx.clone(),
                         completed_tasks,
                     )
@@ -394,6 +397,7 @@ impl TaskExecutor {
         config: &Arc<Config>,
         specs: &[String],
         task_env: &[(String, String)],
+        override_args: Option<&[String]>,
         sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
         completed_tasks: &HashSet<TaskKey>,
     ) -> Result<()> {
@@ -423,7 +427,9 @@ impl TaskExecutor {
             ensure!(!matches.is_empty(), "task not found: {}", name);
             for t in matches {
                 let mut t = (*t).clone();
-                t.args = args.clone();
+                t.args = override_args
+                    .map(|a| a.to_vec())
+                    .unwrap_or_else(|| args.clone());
                 if self.skip_deps {
                     t.depends.clear();
                     t.depends_post.clear();


### PR DESCRIPTION
## Summary

- Extends `RunEntry::SingleTask` to accept optional `args` and `env` fields, matching the existing support in `depends`, `depends_post`, and `wait_for`
- When a `run` entry specifies `args`, they are appended to the task spec; when it specifies `env`, the env vars are merged with the parent task's env and passed to the sub-task
- Enables syntax like:
  ```toml
  [tasks.deploy]
  run = [
    { task = "build", args = ["--release"], env = { RUSTFLAGS = "-C opt-level=3" } },
    "./deploy.sh"
  ]
  ```

Closes #8590

## Test plan

- [x] New e2e test `test_task_run_entry_args_env` covering args-only, env-only, combined, and mixed script+task entries
- [x] All existing related e2e tests pass (`test_task_dep_env`, `test_task_run_depends`, `test_task_delegation_dedup`, `test_task_skip_deps`, `test_task_env_propagation`)
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task execution semantics by allowing per-`run` entry argument and environment overrides for nested tasks, which could affect task deduplication/output caching and sub-task behavior. Coverage is improved with a new e2e test, but this still touches core scheduling/execution paths.
> 
> **Overview**
> Adds support for structured `run`/`run_windows` entries that reference another task with optional `args` and `env`, enabling per-invocation overrides when calling sub-tasks from a task’s `run` list.
> 
> Updates the executor to pass these overrides through sub-task injection (args override parsed spec args; env overrides are applied at dependency-env priority and trigger output template re-rendering), adjusts validation to accept the expanded `RunEntry::SingleTask` shape, and refreshes JSON schemas/docs plus a new e2e test covering args/env/mixed entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fe1b28ff96c309a861af107663c5d53a048afcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->