### PR TITLE
fix(completions): update zsh completions for usage v3.1.0

### DIFF
--- a/completions/_mise
+++ b/completions/_mise
@@ -27,7 +27,11 @@ _mise() {
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi
-  _arguments "*: :(($(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}" )))"
+  local -a completions=()
+  while IFS= read -r line; do
+    completions+=("$line")
+  done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}")
+  _describe 'completions' completions -S ''
   return 0
 }
 

--- a/completions/_mise
+++ b/completions/_mise
@@ -27,11 +27,7 @@ _mise() {
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi
-  local -a completions=()
-  while IFS= read -r line; do
-    completions+=("$line")
-  done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}")
-  _describe 'completions' completions -S ''
+  _arguments "*: :(($(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}" )))"
   return 0
 }
 

--- a/e2e/tasks/test_task_completion
+++ b/e2e/tasks/test_task_completion
@@ -9,5 +9,5 @@ run = 'echo build'
 EOF
 
 mise usage >./mise.usage.kdl
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run build -- -c ''" "'mise.toml'
-'mise.usage.kdl'"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run build -- -c ''" "mise.toml
+mise.usage.kdl"

--- a/mise.lock
+++ b/mise.lock
@@ -225,7 +225,7 @@ version = "0.2.3"
 backend = "cargo:toml-cli"
 
 [[tools."cargo:usage-cli"]]
-version = "2.18.2"
+version = "3.1.0"
 backend = "cargo:usage-cli"
 
 [[tools.communique]]


### PR DESCRIPTION
## Summary
- Usage v3.1.0 changed zsh `complete-word` output from quoted (`'val'`) to unquoted (`val`) format and switched the generated completion template from `_arguments` to `_describe -S ''`
- Updates the prerendered `completions/_mise` to use the new `_describe` pattern
- Updates `e2e/tasks/test_task_completion` expected output to match

## Test plan
- [ ] e2e `tasks/test_task_completion` passes with usage v3.1.0
- [ ] Zsh completions work correctly with the new `_describe` approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only shell completion generation/formatting and the associated e2e assertion; impact is limited to zsh completions output/behavior.
> 
> **Overview**
> Updates the generated zsh completion script `completions/_mise` to match `usage complete-word` output in usage-cli v3.1.0 by switching from `_arguments` to `_describe` and reading completion lines into an array.
> 
> Adjusts the `e2e/tasks/test_task_completion` expected output to reflect the new unquoted completion formatting, and bumps `cargo:usage-cli` in `mise.lock` from `2.18.2` to `3.1.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 508afbe01b6db99138d7e4eb4d7e4bc4462ea2f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->