### PR TITLE
fix: respect disable_backends for explicitly declared backend-prefixed tools

### DIFF
--- a/e2e/backend/test_disable_backends
+++ b/e2e/backend/test_disable_backends
@@ -9,3 +9,18 @@ mise uninstall age
 
 MISE_DISABLE_BACKENDS=aqua mise install age
 ls "$MISE_DATA_DIR/plugins/age"
+
+# Test that disable_backends also works for tools with explicit backend
+# prefixes in config files (not just short-name registry tools).
+# Previously, get() in mod.rs would bypass the disable_backends filter
+# and re-create the backend on demand for explicitly declared tools.
+cat >.mise.toml <<'EOF'
+[tools]
+"aqua:FiloSottile/age" = "latest"
+EOF
+
+# With aqua backend disabled, the explicit aqua: tool should be skipped
+# entirely — mise should not attempt to resolve or install it.
+MISE_DISABLE_BACKENDS=aqua mise install
+assert_fail "mise ls --installed aqua:FiloSottile/age 2>/dev/null | grep age"
+rm .mise.toml

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -220,6 +220,17 @@ pub fn get(ba: &BackendArg) -> Option<ABackend> {
     let tools_ = tools.as_ref().unwrap();
     if let Some(backend) = tools_.get(&ba.short) {
         Some(backend.clone())
+    } else if Settings::get()
+        .disable_backends
+        .contains(&ba.backend_type().to_string())
+    {
+        None
+    } else if !tool_enabled(
+        &Settings::get().enable_tools(),
+        &Settings::get().disable_tools(),
+        &ba.short,
+    ) {
+        None
     } else if let Some(backend) = arg_to_backend(ba.clone()) {
         let mut tools_ = tools_.deref().clone();
         tools_.insert(ba.short.clone(), backend.clone());


### PR DESCRIPTION
## Summary

`disable_backends` is bypassed when tools are declared with explicit backend prefixes (e.g. `go:golang.org/x/tools/cmd/goimports` or `aqua:FiloSottile/age`) in config files. This PR fixes `get()` in `src/backend/mod.rs` to check both `disable_backends` and `disable_tools`/`enable_tools` before creating new backends on demand.

## The Problem

`load_tools()` correctly filters out disabled backends from the `TOOLS` map:

```rust
tools.retain(|backend| {
    !Settings::get()
        .disable_backends
        .contains(&backend.get_type().to_string())
});
```

But `get()` — called during config resolution for explicitly declared tools — finds no entry in the map and silently re-creates the backend without any checks:

```rust
pub fn get(ba: &BackendArg) -> Option<ABackend> {
    // ...
    } else if let Some(backend) = arg_to_backend(ba.clone()) {
        // ← creates backend regardless of disable_backends
    }
}
```

### Reproduction

```toml
# mise.toml
[tools]
"go:golang.org/x/tools/cmd/goimports" = "latest"
```

```bash
MISE_DISABLE_BACKENDS=go mise install  # Still tries to install go: tools
```

### Why existing tests don't catch this

`e2e/backend/test_disable_backends` only tests `aqua` with the short-name tool `age` (resolved through the registry). Short-name tools go through the `load_tools()` path and ARE correctly filtered. The bug only manifests with explicit backend-prefixed declarations.

## The Fix

Added `disable_backends` and `tool_enabled` checks to `get()` before creating new backends:

```rust
pub fn get(ba: &BackendArg) -> Option<ABackend> {
    let mut tools = TOOLS.lock().unwrap();
    let tools_ = tools.as_ref().unwrap();
    if let Some(backend) = tools_.get(&ba.short) {
        Some(backend.clone())
    } else if Settings::get()
        .disable_backends
        .contains(&ba.backend_type().to_string())
    {
        None
    } else if !tool_enabled(
        &Settings::get().enable_tools(),
        &Settings::get().disable_tools(),
        &ba.short,
    ) {
        None
    } else if let Some(backend) = arg_to_backend(ba.clone()) {
        // ... insert and return
    }
}
```

Also extended the e2e test to cover explicit backend-prefixed tools.

## Related

- Discussion with full root cause analysis: https://github.com/jdx/mise/discussions/8789
- Go backend `supports_lockfile_url` fix (related bug found together): https://github.com/jdx/mise/pull/8790