### PR TITLE
fix(aqua): skip registry lookup for linked versions in list_bin_paths

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -914,4 +914,57 @@ mod tests {
         let result = file.src(&pkg, "8.14.3", "darwin", "arm64").unwrap();
         assert_eq!(result, Some("gradle-8.14.3/bin/gradle".to_string()));
     }
+
+    #[test]
+    fn test_aqua_file_src_empty_asset_produces_absolute_path() {
+        // When a linked version name like "brew" matches a wrong version_override
+        // that has no asset field, the package ends up with an empty asset.
+        // The src template "{{.AssetWithoutExt}}/name" then renders to "/name"
+        // which is an absolute path — this caused a StripPrefixError panic
+        // in the aqua backend's list_bin_paths.
+        let pkg = AquaPackage {
+            repo_owner: "mozilla".to_string(),
+            repo_name: "sccache".to_string(),
+            asset: String::new(),
+            ..Default::default()
+        };
+        let file = AquaFile {
+            name: "sccache".to_string(),
+            src: Some("{{.AssetWithoutExt}}/sccache".to_string()),
+        };
+
+        let result = file.src(&pkg, "brew", "darwin", "arm64").unwrap();
+        assert_eq!(result, Some("/sccache".to_string()));
+    }
+
+    #[test]
+    fn test_version_override_non_version_string_matches_semver() {
+        // Non-version strings like "brew" are parsed as valid General versions
+        // by the versions crate, and can match semver constraints unexpectedly.
+        // This documents the root cause of the linked-version panic.
+        let pkg = AquaPackage {
+            version_constraint: "false".to_string(),
+            version_overrides: vec![
+                AquaPackage {
+                    version_constraint: "semver(\"<= 0.2.13\")".to_string(),
+                    error_message: Some("too old".to_string()),
+                    ..Default::default()
+                },
+                AquaPackage {
+                    version_constraint: "true".to_string(),
+                    asset: "tool-{{.Version}}.tar.gz".to_string(),
+                    format: "tar.gz".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let result = pkg.version_override(&["brew"]);
+        // "brew" matches semver("<= 0.2.13") instead of "true",
+        // because Versioning::new("brew") parses as General(Alphanum("brew"))
+        // which sorts before numeric versions.
+        assert!(result.error_message.is_some());
+        assert!(result.asset.is_empty());
+    }
 }

--- a/e2e/backend/test_aqua_linked_version
+++ b/e2e/backend/test_aqua_linked_version
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Test that aqua-backed tools with linked versions don't crash
+# Regression test for StripPrefixError panic when list_bin_paths processes linked versions
+# through the aqua registry with non-version strings
+
+# Install sccache (aqua-backed tool whose registry has {{.AssetWithoutExt}} src template
+# and semver constraints that incorrectly match non-version strings)
+mise install aqua:mozilla/sccache@0.10.0
+
+# Create a fake external install directory with a bin/ subdirectory and a dummy binary
+mkdir -p "$PWD/tmp/sccache-linked/bin"
+touch "$PWD/tmp/sccache-linked/bin/sccache"
+chmod +x "$PWD/tmp/sccache-linked/bin/sccache"
+
+# Link it as a linked version
+mise link sccache@mylink "$PWD/tmp/sccache-linked"
+assert_contains "mise ls sccache" "mylink (symlink)"
+
+# Activate sccache so it's in the toolset — this ensures list_bin_paths is called
+# for the linked version during reshim/doctor
+cat >mise.toml <<EOF
+[tools]
+sccache = "mylink"
+EOF
+
+# mise reshim exercises list_bin_paths for all configured versions.
+# Previously this panicked with StripPrefixError because the aqua backend tried to
+# look up "mylink" in the registry, which matched wrong version constraints and
+# produced an absolute path that couldn't be strip_prefix'd.
+assert_succeed "mise reshim"

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -479,6 +479,16 @@ impl Backend for AquaBackend {
         }
 
         let install_path = tv.install_path();
+
+        // For linked versions (external symlinks created via `mise link`),
+        // skip aqua registry lookup — the linked install has its own layout.
+        if let Ok(Some(target)) = file::resolve_symlink(&install_path) {
+            if target.is_absolute() {
+                let bin = install_path.join("bin");
+                return Ok(if bin.is_dir() { vec![bin] } else { vec![install_path] });
+            }
+        }
+
         let cache: CacheManager<Vec<PathBuf>> =
             CacheManagerBuilder::new(tv.cache_path().join("bin_paths.msgpack.z"))
                 .with_fresh_file(install_path.clone())
@@ -503,7 +513,7 @@ impl Backend for AquaBackend {
                     .into_iter()
                     .unique()
                     .filter(|p| p.exists())
-                    .map(|p| p.strip_prefix(&install_path).unwrap().to_path_buf())
+                    .filter_map(|p| p.strip_prefix(&install_path).ok().map(|p| p.to_path_buf()))
                     .collect())
             })
             .await?

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -482,12 +482,15 @@ impl Backend for AquaBackend {
 
         // For linked versions (external symlinks created via `mise link`),
         // skip aqua registry lookup — the linked install has its own layout.
-        if let Ok(Some(target)) = file::resolve_symlink(&install_path) {
-            if target.is_absolute() {
+        if let Ok(Some(target)) = file::resolve_symlink(&install_path)
+            && target.is_absolute() {
                 let bin = install_path.join("bin");
-                return Ok(if bin.is_dir() { vec![bin] } else { vec![install_path] });
+                return Ok(if bin.is_dir() {
+                    vec![bin]
+                } else {
+                    vec![install_path]
+                });
             }
-        }
 
         let cache: CacheManager<Vec<PathBuf>> =
             CacheManagerBuilder::new(tv.cache_path().join("bin_paths.msgpack.z"))

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -483,14 +483,15 @@ impl Backend for AquaBackend {
         // For linked versions (external symlinks created via `mise link`),
         // skip aqua registry lookup — the linked install has its own layout.
         if let Ok(Some(target)) = file::resolve_symlink(&install_path)
-            && target.is_absolute() {
-                let bin = install_path.join("bin");
-                return Ok(if bin.is_dir() {
-                    vec![bin]
-                } else {
-                    vec![install_path]
-                });
-            }
+            && target.is_absolute()
+        {
+            let bin = install_path.join("bin");
+            return Ok(if bin.is_dir() {
+                vec![bin]
+            } else {
+                vec![install_path]
+            });
+        }
 
         let cache: CacheManager<Vec<PathBuf>> =
             CacheManagerBuilder::new(tv.cache_path().join("bin_paths.msgpack.z"))


### PR DESCRIPTION
Ref: #8772                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                         
  ## Summary

  - Fix `StripPrefixError` panic when running `mise doctor`, `mise reshim`, or any command that calls `list_bin_paths` on an aqua-backed tool with a linked version (created via `mise link`)                                                              
  - Detect linked versions (absolute-path symlinks) early in `list_bin_paths` and return `install_path/bin` directly, skipping the aqua registry lookup entirely
  - Harden `strip_prefix` from `.unwrap()` to `.filter_map(...ok()...)` as a safety net                                                                                                                                                                    
                                                                                                                                                                                                                                                           
  ## Root cause
                                                                                                                                                                                                                                                           
  1. Linked version names (e.g. `"brew"`, `"mylink"`) are passed to the aqua registry as version strings                                                                                                                                                 
  2. `Versioning::new("brew")` from the `versions` crate parses them as valid `General` versions
  3. Semver constraints like `<= 0.2.13` incorrectly match because alphabetic versions sort before numeric ones                                                                                                                                            
  4. This selects a wrong `version_override` with no `asset`/`format` fields
  5. An empty asset renders `{{.AssetWithoutExt}}/sccache` as `"/sccache"` (absolute path)                                                                                                                                                                 
  6. `PathBuf::join("/sccache")` replaces the entire install path, so `strip_prefix` panics                                                                                                                                                              
                                                                                                                                                                                                                                                           
  🤖 Generated with [Claude Code](https://claude.com/claude-code)              