### PR TITLE
add winget backend

### DIFF
--- a/docs/dev-tools/backends/index.md
+++ b/docs/dev-tools/backends/index.md
@@ -25,4 +25,5 @@ Below is a list of the available backends in mise:
 - [spm](/dev-tools/backends/spm) <Badge type="warning" text="experimental" />
 - [ubi](/dev-tools/backends/ubi)
 - [vfox](/dev-tools/backends/vfox) (provide tools through [plugins](/plugins.html))
+- [winget](/dev-tools/backends/winget) <Badge type="warning" text="experimental" /> <Badge type="tip" text="Windows only" />
 - [custom backends](/backend-plugin-development) (build your own backend with a plugin which itself provides many tools)

--- a/docs/dev-tools/backends/winget.md
+++ b/docs/dev-tools/backends/winget.md
@@ -1,0 +1,62 @@
+# Winget Backend
+
+The code for this is inside the mise repository at [`./src/backend/winget.rs`](https://github.com/jdx/mise/blob/main/src/backend/winget.rs).
+
+::: tip Important
+The winget backend is **Windows-only** and requires the [Windows Package Manager](https://github.com/microsoft/winget-cli) (`winget`) to be installed.
+
+On Windows 10 (1709+) and Windows 11, winget is typically pre-installed via the App Installer package from the Microsoft Store.
+:::
+
+## Dependencies
+
+This relies on having `winget` installed on your Windows system. winget is the official Windows package manager from Microsoft.
+
+## Usage
+
+The following example installs [AWS CLI](https://aws.amazon.com/cli/) via winget:
+
+**Note:** This example was updated to use a more practical package. See [mise discussion #8311](https://github.com/jdx/mise/discussions/8311) and [aqua-registry issue #14093](https://github.com/aquaproj/aqua-registry/issues/14093) for more context.
+
+The latest version of AWS CLI will be installed and set as the active version on PATH:
+
+```sh
+$ mise use winget:Amazon.AWSCLI
+$ aws --version
+aws-cli/2.15.0 Python/3.11.7 Windows/11.0.22621 exe/AMD64.prod.exe
+```
+
+The version will be set in `~/.config/mise/config.toml` with the following format:
+
+```toml
+[tools]
+"winget:Amazon.AWSCLI" = "latest"
+```
+
+### Specifying a version
+
+```sh
+$ mise use winget:Amazon.AWSCLI@2.15.0
+```
+
+```toml
+[tools]
+"winget:Amazon.AWSCLI" = "2.15.0"
+```
+
+### Supported Winget Syntax
+
+| Description                            | Usage                                   |
+| -------------------------------------- | --------------------------------------- |
+| Winget shorthand latest version        | `winget:Amazon.AWSCLI`                  |
+| Winget shorthand for specific version  | `winget:Amazon.AWSCLI@2.15.0`          |
+
+::: tip Package IDs
+Winget package IDs follow the format used in the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository.
+You can search for package IDs using `winget search <name>`.
+:::
+
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `winget` backend—these
+go in `[tools]` in `mise.toml`.

--- a/docs/dev-tools/backends/winget.md
+++ b/docs/dev-tools/backends/winget.md
@@ -36,7 +36,7 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 ### Specifying a version
 
 ```sh
-$ mise use winget:Amazon.AWSCLI@2.15.0
+mise use winget:Amazon.AWSCLI@2.15.0
 ```
 
 ```toml
@@ -46,10 +46,10 @@ $ mise use winget:Amazon.AWSCLI@2.15.0
 
 ### Supported Winget Syntax
 
-| Description                            | Usage                                   |
-| -------------------------------------- | --------------------------------------- |
-| Winget shorthand latest version        | `winget:Amazon.AWSCLI`                  |
-| Winget shorthand for specific version  | `winget:Amazon.AWSCLI@2.15.0`          |
+| Description                           | Usage                         |
+| ------------------------------------- | ----------------------------- |
+| Winget shorthand latest version       | `winget:Amazon.AWSCLI`        |
+| Winget shorthand for specific version | `winget:Amazon.AWSCLI@2.15.0` |
 
 ::: tip Package IDs
 Winget package IDs follow the format used in the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository.

--- a/src/backend/backend_type.rs
+++ b/src/backend/backend_type.rs
@@ -33,6 +33,7 @@ pub enum BackendType {
     Ubi,
     Vfox,
     VfoxBackend(String),
+    Winget,
     Unknown,
 }
 
@@ -68,6 +69,7 @@ impl BackendType {
             "s3" => BackendType::S3,
             "ubi" => BackendType::Ubi,
             "vfox" => BackendType::Vfox,
+            "winget" => BackendType::Winget,
             _ => BackendType::Unknown,
         }
     }
@@ -80,6 +82,10 @@ impl BackendType {
             BackendType::Dotnet => dotnet::EXPERIMENTAL,
             BackendType::S3 => s3::EXPERIMENTAL,
             BackendType::Spm => spm::EXPERIMENTAL,
+            #[cfg(windows)]
+            BackendType::Winget => super::winget::EXPERIMENTAL,
+            #[cfg(not(windows))]
+            BackendType::Winget => true,
             _ => false,
         }
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -64,6 +64,8 @@ pub mod static_helpers;
 pub mod ubi;
 pub mod version_list;
 pub mod vfox;
+#[cfg(windows)]
+pub mod winget;
 
 pub type ABackend = Arc<dyn Backend>;
 pub type BackendMap = BTreeMap<String, ABackend>;
@@ -271,6 +273,10 @@ pub fn arg_to_backend(ba: BackendArg) -> Option<ABackend> {
             ba,
             Some(plugin_name.to_string()),
         ))),
+        #[cfg(windows)]
+        BackendType::Winget => Some(Arc::new(winget::WingetBackend::from_arg(ba))),
+        #[cfg(not(windows))]
+        BackendType::Winget => None,
         BackendType::Unknown => None,
     }
 }

--- a/src/backend/winget.rs
+++ b/src/backend/winget.rs
@@ -1,0 +1,167 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::backend::Backend;
+use crate::backend::VersionInfo;
+use crate::backend::backend_type::BackendType;
+use crate::cli::args::BackendArg;
+use crate::cmd::CmdLineRunner;
+use crate::config::{Config, Settings};
+use crate::install_context::InstallContext;
+use crate::toolset::ToolVersion;
+
+/// Winget backend requires experimental mode to be enabled
+pub const EXPERIMENTAL: bool = true;
+
+#[derive(Debug)]
+pub struct WingetBackend {
+    ba: Arc<BackendArg>,
+}
+
+#[async_trait]
+impl Backend for WingetBackend {
+    fn get_type(&self) -> BackendType {
+        BackendType::Winget
+    }
+
+    fn ba(&self) -> &Arc<BackendArg> {
+        &self.ba
+    }
+
+    fn supports_lockfile_url(&self) -> bool {
+        false
+    }
+
+    async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
+        self.warn_if_dependency_missing(
+            config,
+            "winget",
+            "winget is required for the winget backend.\n\
+            Install it from https://github.com/microsoft/winget-cli or via the Microsoft Store.",
+        )
+        .await;
+
+        let raw = cmd!(
+            "winget",
+            "show",
+            "--id",
+            self.tool_name(),
+            "--versions",
+            "--disable-interactivity",
+            "--accept-source-agreements"
+        )
+        .read()?;
+
+        let versions = parse_winget_versions(&raw);
+        Ok(versions)
+    }
+
+    async fn install_version_(
+        &self,
+        ctx: &InstallContext,
+        tv: ToolVersion,
+    ) -> eyre::Result<ToolVersion> {
+        Settings::get().ensure_experimental("winget backend")?;
+
+        self.warn_if_dependency_missing(
+            &ctx.config,
+            "winget",
+            "winget is required for the winget backend.\n\
+            Install it from https://github.com/microsoft/winget-cli or via the Microsoft Store.",
+        )
+        .await;
+
+        let mut cmd = CmdLineRunner::new("winget")
+            .arg("install")
+            .arg("--id")
+            .arg(self.tool_name())
+            .arg("--location")
+            .arg(tv.install_path())
+            .arg("--disable-interactivity")
+            .arg("--accept-source-agreements")
+            .arg("--accept-package-agreements");
+
+        if tv.version != "latest" {
+            cmd = cmd.arg("--version").arg(&tv.version);
+        }
+
+        cmd.with_pr(ctx.pr.as_ref())
+            .envs(self.dependency_env(&ctx.config).await?)
+            .execute()?;
+
+        Ok(tv)
+    }
+
+    async fn install_operation_count(&self, _tv: &ToolVersion, _ctx: &InstallContext) -> usize {
+        2
+    }
+}
+
+impl WingetBackend {
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
+    }
+}
+
+/// Parse the output of `winget show --id <id> --versions` into version info.
+fn parse_winget_versions(output: &str) -> Vec<VersionInfo> {
+    let mut versions = Vec::new();
+    let mut past_separator = false;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("---") {
+            past_separator = true;
+            continue;
+        }
+        if past_separator && !trimmed.is_empty() {
+            versions.push(VersionInfo {
+                version: trimmed.to_string(),
+                ..Default::default()
+            });
+        }
+    }
+
+    // winget outputs newest first, mise expects oldest first
+    versions.reverse();
+    versions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_winget_versions() {
+        let output = "\
+Found Python 3 [Python.Python.3.12]
+Version
+---------
+3.12.5
+3.12.4
+3.12.3
+3.12.2
+3.12.1
+3.12.0
+";
+        let versions = parse_winget_versions(output);
+        assert_eq!(versions.len(), 6);
+        assert_eq!(versions[0].version, "3.12.0");
+        assert_eq!(versions[5].version, "3.12.5");
+    }
+
+    #[test]
+    fn test_parse_winget_versions_empty() {
+        let output = "";
+        let versions = parse_winget_versions(output);
+        assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn test_parse_winget_versions_no_separator() {
+        let output = "No package found matching input criteria.";
+        let versions = parse_winget_versions(output);
+        assert!(versions.is_empty());
+    }
+}

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -86,6 +86,13 @@ impl BackendProvider for MiseBackendProvider {
                 BackendType::Http => ("http", Some("Download files from HTTP URLs")),
                 BackendType::S3 => ("s3", Some("Download from S3 buckets")),
                 BackendType::Ubi => ("ubi", Some("Universal Binary Installer")),
+                #[cfg(not(windows))]
+                BackendType::Winget => continue,
+                #[cfg(windows)]
+                BackendType::Winget => (
+                    "winget",
+                    Some("Install packages via Windows Package Manager"),
+                ),
                 // Skip internal/meta types
                 BackendType::Core
                 | BackendType::Vfox


### PR DESCRIPTION
Adds a new experimental backend that allows installing tools via Windows Package Manager (winget). Uses winget show --versions to list available versions and winget install --location for
installation into mise-managed directories.

made with help from Claude Code