### PR TITLE
feat(task): allow passing arguments to task dependencies via {{usage.*}} templates

### DIFF
--- a/docs/tasks/task-arguments.md
+++ b/docs/tasks/task-arguments.md
@@ -70,6 +70,11 @@ used with Tera's `for` loops and filters like `length`. The `usage` map is
 `flag()`) described later on this page—you should not mix the two approaches in
 the same task.
 
+`{{usage.*}}` templates can also be used in `depends`, `depends_post`, and
+`wait_for` to forward arguments to dependency tasks. See
+[Passing parent task arguments to dependencies](/tasks/task-configuration#passing-parent-task-arguments-to-dependencies)
+for details.
+
 **Help output example:**
 
 ```shellsession

--- a/docs/tasks/task-arguments.md
+++ b/docs/tasks/task-arguments.md
@@ -70,7 +70,7 @@ used with Tera's `for` loops and filters like `length`. The `usage` map is
 `flag()`) described later on this page—you should not mix the two approaches in
 the same task.
 
-`{{usage.*}}` templates can also be used in `depends`, `depends_post`, and
+<span v-pre>`{{usage.*}}`</span> templates can also be used in `depends`, `depends_post`, and
 `wait_for` to forward arguments to dependency tasks. See
 [Passing parent task arguments to dependencies](/tasks/task-configuration#passing-parent-task-arguments-to-dependencies)
 for details.

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -129,6 +129,49 @@ run = "./deploy.sh"
 
 Note: These environment variables are passed only to the specified dependency, not to the current task or other dependencies.
 
+#### Passing parent task arguments to dependencies
+
+You can forward a parent task's arguments to its dependencies using `{{usage.*}}` templates.
+Both the parent and child tasks must define a `usage` spec for the arguments they accept:
+
+```mise-toml
+[tasks.build]
+usage = 'arg "<app>"'
+run = 'echo "building {{usage.app}}"'
+
+[tasks.deploy]
+usage = 'arg "<app>"'
+depends = [{ task = "build", args = ["{{usage.app}}"] }]
+run = 'echo "deploying {{usage.app}}"'
+```
+
+Running `mise run deploy myapp` passes `"myapp"` to both `deploy` and its `build` dependency.
+
+This also works with the string syntax:
+
+```mise-toml
+[tasks.deploy]
+usage = 'arg "<app>"'
+depends = ["build {{usage.app}}"]
+run = 'echo "deploying {{usage.app}}"'
+```
+
+And with flags:
+
+```mise-toml
+[tasks.compile]
+usage = 'flag "--target <target>"'
+run = 'echo "compiling for $usage_target"'
+
+[tasks.package]
+usage = 'flag "--target <target>"'
+depends = [{ task = "compile", args = ["--target", "{{usage.target}}"] }]
+run = 'echo "packaging for $usage_target"'
+```
+
+Arguments flow through dependency chains — if A depends on B which depends on C, each task can
+forward its resolved arguments to its own dependencies.
+
 ### `depends_post`
 
 - **Type**: `string | string[] | { task: string, args?: string[], env?: { [key]: string } }[]`

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -131,7 +131,7 @@ Note: These environment variables are passed only to the specified dependency, n
 
 #### Passing parent task arguments to dependencies
 
-You can forward a parent task's arguments to its dependencies using `{{usage.*}}` templates.
+You can forward a parent task's arguments to its dependencies using <span v-pre>`{{usage.*}}`</span> templates.
 Both the parent and child tasks must define a `usage` spec for the arguments they accept:
 
 ```mise-toml

--- a/e2e/tasks/test_task_dep_args
+++ b/e2e/tasks/test_task_dep_args
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Test passing arguments to task dependencies via {{usage.*}} templates
+
+# Basic test: parent task passes its arg to a dependency
+cat <<'EOF' >mise.toml
+[tasks.build]
+usage = 'arg "<app>"'
+run = 'echo "building {{usage.app}}"'
+
+[tasks.deploy]
+usage = 'arg "<app>"'
+depends = [{ task = "build", args = ["{{usage.app}}"] }]
+run = 'echo "deploying {{usage.app}}"'
+EOF
+
+assert_contains "mise run deploy myapp" "building myapp"
+assert_contains "mise run deploy myapp" "deploying myapp"
+
+# Test with flag syntax
+cat <<'EOF' >mise.toml
+[tasks.compile]
+usage = 'flag "--target <target>"'
+run = 'echo "compiling for $usage_target"'
+
+[tasks.package]
+usage = 'flag "--target <target>"'
+depends = [{ task = "compile", args = ["--target", "{{usage.target}}"] }]
+run = 'echo "packaging for $usage_target"'
+EOF
+
+assert_contains "mise run package --target linux" "compiling for linux"
+assert_contains "mise run package --target linux" "packaging for linux"
+
+# Test with multiple args
+cat <<'EOF' >mise.toml
+[tasks.start-backend]
+usage = 'arg "<app>"'
+run = 'echo "backend {{usage.app}}"'
+
+[tasks.start-frontend]
+usage = 'arg "<app>"'
+run = 'echo "frontend {{usage.app}}"'
+
+[tasks.start]
+usage = 'arg "<app>"'
+depends = [
+    { task = "start-backend", args = ["{{usage.app}}"] },
+    { task = "start-frontend", args = ["{{usage.app}}"] },
+]
+run = 'echo "started {{usage.app}}"'
+EOF
+
+output=$(mise run start myapp 2>&1)
+assert_contains "echo \"$output\"" "backend myapp"
+assert_contains "echo \"$output\"" "frontend myapp"
+assert_contains "echo \"$output\"" "started myapp"
+
+# Test with string syntax for depends args
+cat <<'EOF' >mise.toml
+[tasks.greet]
+usage = 'arg "<name>"'
+run = 'echo "hello {{usage.name}}"'
+
+[tasks.welcome]
+usage = 'arg "<name>"'
+depends = ["greet {{usage.name}}"]
+run = 'echo "welcome {{usage.name}}"'
+EOF
+
+assert_contains "mise run welcome world" "hello world"
+assert_contains "mise run welcome world" "welcome world"
+
+# Test dependency chaining: A -> B -> C, args flow through
+cat <<'EOF' >mise.toml
+[tasks.step1]
+usage = 'arg "<val>"'
+run = 'echo "step1 {{usage.val}}"'
+
+[tasks.step2]
+usage = 'arg "<val>"'
+depends = [{ task = "step1", args = ["{{usage.val}}"] }]
+run = 'echo "step2 {{usage.val}}"'
+
+[tasks.step3]
+usage = 'arg "<val>"'
+depends = [{ task = "step2", args = ["{{usage.val}}"] }]
+run = 'echo "step3 {{usage.val}}"'
+EOF
+
+output=$(mise run step3 hello 2>&1)
+assert_contains "echo \"$output\"" "step1 hello"
+assert_contains "echo \"$output\"" "step2 hello"
+assert_contains "echo \"$output\"" "step3 hello"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -324,6 +324,18 @@ impl Run {
                 task.args.extend(self.args_last.clone());
             }
         }
+
+        // Re-render dependency templates with parent task's usage arg/flag values.
+        // This enables patterns like: depends = ["child {{usage.app}}"]
+        for task in &mut task_list {
+            if !task.args.is_empty() {
+                let usage_values = crate::task::parse_usage_values_from_task(&config, task).await?;
+                if !usage_values.is_empty() {
+                    task.render_depends_with_usage(&config, &usage_values)
+                        .await?;
+                }
+            }
+        }
         time!("run get_task_lists");
 
         // Resolve transitive dependencies once upfront so we can:

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -70,10 +70,14 @@ impl Deps {
             }
             // If this task received args (from a parent dependency), re-render
             // its dependency templates with usage values so {{usage.*}} resolves.
+            let has_usage_deps = |raw: &Option<Vec<_>>| {
+                raw.as_ref()
+                    .is_some_and(|r| r.iter().any(dep_has_usage_ref))
+            };
             if !a.args.is_empty()
-                && a.depends_raw
-                    .as_ref()
-                    .is_some_and(|raw| raw.iter().any(dep_has_usage_ref))
+                && (has_usage_deps(&a.depends_raw)
+                    || has_usage_deps(&a.depends_post_raw)
+                    || has_usage_deps(&a.wait_for_raw))
             {
                 let usage_values = parse_usage_values_from_task(config, &a).await?;
                 if !usage_values.is_empty() {

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -1,5 +1,5 @@
 use crate::config::env_directive::EnvDirective;
-use crate::task::{Task, parse_usage_values_from_task};
+use crate::task::{Task, dep_has_usage_ref, parse_usage_values_from_task};
 use crate::{config::Config, task::task_list::resolve_depends};
 use itertools::Itertools;
 use petgraph::Direction;
@@ -70,7 +70,11 @@ impl Deps {
             }
             // If this task received args (from a parent dependency), re-render
             // its dependency templates with usage values so {{usage.*}} resolves.
-            if !a.args.is_empty() && a.depends_raw.is_some() {
+            if !a.args.is_empty()
+                && a.depends_raw
+                    .as_ref()
+                    .map_or(false, |raw| raw.iter().any(dep_has_usage_ref))
+            {
                 let usage_values = parse_usage_values_from_task(config, &a).await?;
                 if !usage_values.is_empty() {
                     a.render_depends_with_usage(config, &usage_values).await?;

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -1,5 +1,5 @@
 use crate::config::env_directive::EnvDirective;
-use crate::task::Task;
+use crate::task::{Task, parse_usage_values_from_task};
 use crate::{config::Config, task::task_list::resolve_depends};
 use itertools::Itertools;
 use petgraph::Direction;
@@ -63,10 +63,18 @@ impl Deps {
             add_idx(t, &mut graph);
         }
         let all_tasks_to_run = resolve_depends(config, tasks).await?;
-        while let Some(a) = stack.pop() {
+        while let Some(mut a) = stack.pop() {
             if seen.contains(&a) {
                 // prevent infinite loop
                 continue;
+            }
+            // If this task received args (from a parent dependency), re-render
+            // its dependency templates with usage values so {{usage.*}} resolves.
+            if !a.args.is_empty() && a.depends_raw.is_some() {
+                let usage_values = parse_usage_values_from_task(config, &a).await?;
+                if !usage_values.is_empty() {
+                    a.render_depends_with_usage(config, &usage_values).await?;
+                }
             }
             let a_idx = add_idx(&a, &mut graph);
             let (pre, post) = a.resolve_depends(config, &all_tasks_to_run).await?;

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -73,7 +73,7 @@ impl Deps {
             if !a.args.is_empty()
                 && a.depends_raw
                     .as_ref()
-                    .map_or(false, |raw| raw.iter().any(dep_has_usage_ref))
+                    .is_some_and(|raw| raw.iter().any(dep_has_usage_ref))
             {
                 let usage_values = parse_usage_values_from_task(config, &a).await?;
                 if !usage_values.is_empty() {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
@@ -367,6 +368,15 @@ pub struct Task {
     /// with the same display_name but different arguments.
     #[serde(skip)]
     pub show_args_in_prefix: bool,
+
+    /// Original unrendered dependency templates, preserved so they can be
+    /// re-rendered later with parent task args/flags (usage context) available.
+    #[serde(skip)]
+    pub depends_raw: Option<Vec<TaskDep>>,
+    #[serde(skip)]
+    pub depends_post_raw: Option<Vec<TaskDep>>,
+    #[serde(skip)]
+    pub wait_for_raw: Option<Vec<TaskDep>>,
 }
 
 impl Task {
@@ -635,6 +645,7 @@ impl Task {
             .depends
             .iter()
             .chain(self.depends_post.iter())
+            .filter(|td| !dep_has_usage_ref(td))
             .map(|td| match_tasks_with_context(tasks, td, Some(self)))
             .flatten_ok()
             .filter_ok(|t| t.name != self.name)
@@ -697,15 +708,19 @@ impl Task {
 
         let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
         let tasks = build_task_ref_map(all_tasks.iter());
+        // Skip deps with unresolved {{usage.*}} references — they'll be resolved
+        // later when render_depends_with_usage() is called with actual arg values.
         let depends = self
             .depends
             .iter()
+            .filter(|td| !dep_has_usage_ref(td))
             .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
             .flatten_ok()
             .collect_vec();
         let wait_for = self
             .wait_for
             .iter()
+            .filter(|td| !dep_has_usage_ref(td))
             .map(|td| {
                 match_tasks_with_context(&tasks, td, Some(self))
                     .map(|tasks| tasks.into_iter().map(|t| (t, td)).collect_vec())
@@ -730,6 +745,7 @@ impl Task {
         let depends_post = self
             .depends_post
             .iter()
+            .filter(|td| !dep_has_usage_ref(td))
             .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
             .flatten_ok()
             .filter_ok(|t| t.name != self.name)
@@ -1070,14 +1086,28 @@ impl Task {
             self.outputs = TaskOutputs::Auto;
         }
         self.raw_outputs = self.outputs.render(&mut tera, &tera_ctx)?;
+        // Save unrendered dependency templates so they can be re-rendered later
+        // with parent task args available (for passing args to dependencies).
+        self.depends_raw = Some(self.depends.clone());
+        self.depends_post_raw = Some(self.depends_post.clone());
+        self.wait_for_raw = Some(self.wait_for.clone());
+        // Render deps that don't contain {{usage.*}} references. Deps with usage
+        // references are deferred until render_depends_with_usage() is called with
+        // the actual arg values from CLI or parent dependency.
         for d in &mut self.depends {
-            d.render(&mut tera, &tera_ctx)?;
+            if !dep_has_usage_ref(d) {
+                d.render(&mut tera, &tera_ctx)?;
+            }
         }
         for d in &mut self.depends_post {
-            d.render(&mut tera, &tera_ctx)?;
+            if !dep_has_usage_ref(d) {
+                d.render(&mut tera, &tera_ctx)?;
+            }
         }
         for d in &mut self.wait_for {
-            d.render(&mut tera, &tera_ctx)?;
+            if !dep_has_usage_ref(d) {
+                d.render(&mut tera, &tera_ctx)?;
+            }
         }
         if let Some(dir) = &mut self.dir {
             *dir = tera.render_str(dir, &tera_ctx)?;
@@ -1087,6 +1117,50 @@ impl Task {
         }
         for (_, v) in &mut self.tools {
             *v = tera.render_str(v, &tera_ctx)?;
+        }
+        Ok(())
+    }
+
+    /// Re-render dependency templates with usage args/flags from the parent task.
+    /// This allows `depends = ["child {{usage.app}}"]` to resolve when the parent
+    /// task receives `--app=foo` from the CLI.
+    pub async fn render_depends_with_usage(
+        &mut self,
+        config: &Arc<Config>,
+        usage_values: &IndexMap<String, String>,
+    ) -> Result<()> {
+        if usage_values.is_empty() {
+            return Ok(());
+        }
+        let config_root = self.config_root.clone().unwrap_or_default();
+        let mut tera = get_tera(Some(&config_root));
+        let mut tera_ctx = self.tera_ctx(config).await?;
+        // Insert usage values into the tera context so templates like
+        // {{usage.app}} resolve to the actual CLI arg value.
+        let usage_ctx: HashMap<String, tera::Value> = usage_values
+            .iter()
+            .map(|(k, v)| (k.clone(), tera::Value::String(v.clone())))
+            .collect();
+        tera_ctx.insert("usage", &usage_ctx);
+
+        // Re-render from raw templates (not from already-rendered values)
+        if let Some(raw) = &self.depends_raw {
+            self.depends = raw.clone();
+            for d in &mut self.depends {
+                d.render(&mut tera, &tera_ctx)?;
+            }
+        }
+        if let Some(raw) = &self.depends_post_raw {
+            self.depends_post = raw.clone();
+            for d in &mut self.depends_post {
+                d.render(&mut tera, &tera_ctx)?;
+            }
+        }
+        if let Some(raw) = &self.wait_for_raw {
+            self.wait_for = raw.clone();
+            for d in &mut self.wait_for {
+                d.render(&mut tera, &tera_ctx)?;
+            }
         }
         Ok(())
     }
@@ -1373,6 +1447,9 @@ impl Default for Task {
             allow_env: vec![],
             extends: None,
             show_args_in_prefix: false,
+            depends_raw: None,
+            depends_post_raw: None,
+            wait_for_raw: None,
         }
     }
 }
@@ -1659,6 +1736,46 @@ where
             .unique()
             .collect())
     }
+}
+
+/// Check if a TaskDep contains {{usage.*}} references that need deferred rendering.
+fn dep_has_usage_ref(dep: &TaskDep) -> bool {
+    let has_ref = |s: &str| s.contains("{{") && s.contains("usage.");
+    has_ref(&dep.task)
+        || dep.args.iter().any(|a| has_ref(a))
+        || dep.env.values().any(|v| has_ref(v))
+}
+
+/// Parse a task's usage spec against its current args and return a map
+/// of named arg/flag values (e.g., {"app": "myapp", "verbose": "true"}).
+/// Used to provide `{{usage.*}}` context when rendering dependency templates.
+pub async fn parse_usage_values_from_task(
+    config: &Arc<Config>,
+    task: &Task,
+) -> Result<IndexMap<String, String>> {
+    let env: EnvMap = Default::default();
+    let (spec, _) = task
+        .parse_usage_spec_with_vars(config, None, &env, None)
+        .await?;
+    if spec.cmd.args.is_empty() && spec.cmd.flags.is_empty() {
+        return Ok(IndexMap::new());
+    }
+    // Build args list with empty first element (usage parser expects argv[0] to be the command)
+    let args: Vec<String> = once(String::new())
+        .chain(task.args.iter().cloned())
+        .collect();
+    let po = match usage::Parser::new(&spec).parse(&args) {
+        Ok(po) => po,
+        Err(_) => return Ok(IndexMap::new()),
+    };
+    let mut values = IndexMap::new();
+    for (k, v) in po.as_env() {
+        // Strip "usage_" prefix to get the bare arg/flag name
+        if let Some(name) = k.strip_prefix("usage_") {
+            values.insert(name.to_string(), v);
+        }
+    }
+    Ok(values)
 }
 
 #[cfg(test)]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1141,30 +1141,27 @@ impl Task {
         // Re-render from raw templates (not from already-rendered values).
         // Only restore from raw if the field is non-empty — skip_deps clears
         // depends/depends_post/wait_for and we must not undo that.
-        if !self.depends.is_empty() {
-            if let Some(raw) = &self.depends_raw {
+        if !self.depends.is_empty()
+            && let Some(raw) = &self.depends_raw {
                 self.depends = raw.clone();
                 for d in &mut self.depends {
                     d.render(&mut tera, &tera_ctx)?;
                 }
             }
-        }
-        if !self.depends_post.is_empty() {
-            if let Some(raw) = &self.depends_post_raw {
+        if !self.depends_post.is_empty()
+            && let Some(raw) = &self.depends_post_raw {
                 self.depends_post = raw.clone();
                 for d in &mut self.depends_post {
                     d.render(&mut tera, &tera_ctx)?;
                 }
             }
-        }
-        if !self.wait_for.is_empty() {
-            if let Some(raw) = &self.wait_for_raw {
+        if !self.wait_for.is_empty()
+            && let Some(raw) = &self.wait_for_raw {
                 self.wait_for = raw.clone();
                 for d in &mut self.wait_for {
                     d.render(&mut tera, &tera_ctx)?;
                 }
             }
-        }
         Ok(())
     }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1138,23 +1138,31 @@ impl Task {
         // {{usage.app}} resolve to the actual CLI arg value.
         tera_ctx.insert("usage", usage_values);
 
-        // Re-render from raw templates (not from already-rendered values)
-        if let Some(raw) = &self.depends_raw {
-            self.depends = raw.clone();
-            for d in &mut self.depends {
-                d.render(&mut tera, &tera_ctx)?;
+        // Re-render from raw templates (not from already-rendered values).
+        // Only restore from raw if the field is non-empty — skip_deps clears
+        // depends/depends_post/wait_for and we must not undo that.
+        if !self.depends.is_empty() {
+            if let Some(raw) = &self.depends_raw {
+                self.depends = raw.clone();
+                for d in &mut self.depends {
+                    d.render(&mut tera, &tera_ctx)?;
+                }
             }
         }
-        if let Some(raw) = &self.depends_post_raw {
-            self.depends_post = raw.clone();
-            for d in &mut self.depends_post {
-                d.render(&mut tera, &tera_ctx)?;
+        if !self.depends_post.is_empty() {
+            if let Some(raw) = &self.depends_post_raw {
+                self.depends_post = raw.clone();
+                for d in &mut self.depends_post {
+                    d.render(&mut tera, &tera_ctx)?;
+                }
             }
         }
-        if let Some(raw) = &self.wait_for_raw {
-            self.wait_for = raw.clone();
-            for d in &mut self.wait_for {
-                d.render(&mut tera, &tera_ctx)?;
+        if !self.wait_for.is_empty() {
+            if let Some(raw) = &self.wait_for_raw {
+                self.wait_for = raw.clone();
+                for d in &mut self.wait_for {
+                    d.render(&mut tera, &tera_ctx)?;
+                }
             }
         }
         Ok(())

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1142,26 +1142,29 @@ impl Task {
         // Only restore from raw if the field is non-empty — skip_deps clears
         // depends/depends_post/wait_for and we must not undo that.
         if !self.depends.is_empty()
-            && let Some(raw) = &self.depends_raw {
-                self.depends = raw.clone();
-                for d in &mut self.depends {
-                    d.render(&mut tera, &tera_ctx)?;
-                }
+            && let Some(raw) = &self.depends_raw
+        {
+            self.depends = raw.clone();
+            for d in &mut self.depends {
+                d.render(&mut tera, &tera_ctx)?;
             }
+        }
         if !self.depends_post.is_empty()
-            && let Some(raw) = &self.depends_post_raw {
-                self.depends_post = raw.clone();
-                for d in &mut self.depends_post {
-                    d.render(&mut tera, &tera_ctx)?;
-                }
+            && let Some(raw) = &self.depends_post_raw
+        {
+            self.depends_post = raw.clone();
+            for d in &mut self.depends_post {
+                d.render(&mut tera, &tera_ctx)?;
             }
+        }
         if !self.wait_for.is_empty()
-            && let Some(raw) = &self.wait_for_raw {
-                self.wait_for = raw.clone();
-                for d in &mut self.wait_for {
-                    d.render(&mut tera, &tera_ctx)?;
-                }
+            && let Some(raw) = &self.wait_for_raw
+        {
+            self.wait_for = raw.clone();
+            for d in &mut self.wait_for {
+                d.render(&mut tera, &tera_ctx)?;
             }
+        }
         Ok(())
     }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -19,7 +19,6 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
@@ -1137,11 +1136,7 @@ impl Task {
         let mut tera_ctx = self.tera_ctx(config).await?;
         // Insert usage values into the tera context so templates like
         // {{usage.app}} resolve to the actual CLI arg value.
-        let usage_ctx: HashMap<String, tera::Value> = usage_values
-            .iter()
-            .map(|(k, v)| (k.clone(), tera::Value::String(v.clone())))
-            .collect();
-        tera_ctx.insert("usage", &usage_ctx);
+        tera_ctx.insert("usage", usage_values);
 
         // Re-render from raw templates (not from already-rendered values)
         if let Some(raw) = &self.depends_raw {
@@ -1739,8 +1734,12 @@ where
 }
 
 /// Check if a TaskDep contains {{usage.*}} references that need deferred rendering.
-fn dep_has_usage_ref(dep: &TaskDep) -> bool {
-    let has_ref = |s: &str| s.contains("{{") && s.contains("usage.");
+/// Strips whitespace before matching to handle Tera's `{{ usage.foo }}` syntax.
+pub(crate) fn dep_has_usage_ref(dep: &TaskDep) -> bool {
+    let has_ref = |s: &str| {
+        let s = s.replace(' ', "");
+        s.contains("{{usage.")
+    };
     has_ref(&dep.task)
         || dep.args.iter().any(|a| has_ref(a))
         || dep.env.values().any(|v| has_ref(v))
@@ -1766,7 +1765,10 @@ pub async fn parse_usage_values_from_task(
         .collect();
     let po = match usage::Parser::new(&spec).parse(&args) {
         Ok(po) => po,
-        Err(_) => return Ok(IndexMap::new()),
+        Err(e) => {
+            debug!("usage parse failed for task '{}': {e}", task.name);
+            return Ok(IndexMap::new());
+        }
     };
     let mut values = IndexMap::new();
     for (k, v) in po.as_env() {


### PR DESCRIPTION
## Summary
- Task dependencies can now reference parent task arguments using `{{usage.*}}` templates in `depends`, `depends_post`, and `wait_for`
- Arguments flow through dependency chains (A -> B -> C) — each task parses its own usage spec and re-renders child dependency templates with resolved values
- Works with both positional args (`arg`) and flags (`flag`), and with both string and structured dependency syntax

### Example

```toml
[tasks.build]
usage = 'arg "<app>"'
run = 'echo "building {{usage.app}}"'

[tasks.deploy]
usage = 'arg "<app>"'
depends = [{ task = "build", args = ["{{usage.app}}"] }]
run = 'echo "deploying {{usage.app}}"'
```

```
$ mise run deploy myapp
[build] building myapp
[deploy] deploying myapp
```

Closes discussion #4331

## Implementation

Dependency templates containing `{{usage.*}}` are deferred during initial config loading (since CLI args aren't available yet). They are re-rendered later with actual usage values at two points:

1. **Top-level tasks** — after CLI args are resolved in `run.rs`, before dependency graph construction
2. **Dependency chain tasks** — during `Deps::new()` graph building, when a task receives args from its parent

Key changes:
- `Task` stores raw (unrendered) dependency templates in `depends_raw`/`depends_post_raw`/`wait_for_raw`
- New `render_depends_with_usage()` method re-renders deps with a `usage` context
- New `parse_usage_values_from_task()` parses a task's usage spec against its args to extract named values
- Dependency resolution (`resolve_depends`, `all_depends`) skips deps with unresolved `{{usage.*}}` refs

## Test plan
- [x] E2E test `test_task_dep_args` covering:
  - Basic arg passing to dependency
  - Flag passing to dependency
  - Multiple parallel dependencies receiving the same arg
  - String syntax (`depends = ["child {{usage.name}}"]`)
  - Dependency chaining (A -> B -> C, args flow through all levels)
- [x] All existing dep-related e2e tests pass (dep_env, deps, run_depends, depends_post, depends_post_multiple, deps_circular, skip_deps, failure_hang_depends, delegation_dedup, double_dash_behavior, args_position)
- [x] All 563 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task dependency resolution and graph building to defer and later re-render dependency specs, which can affect what tasks run and with what args across chains. Added e2e coverage reduces risk but dependency parsing/rendering changes can have edge cases (e.g., `skip_deps`, mixed template/env syntax).
> 
> **Overview**
> Enables `{{usage.*}}` templates inside `depends`, `depends_post`, and `wait_for` so a task can forward its resolved usage args/flags to dependency tasks (including through multi-level dependency chains).
> 
> Implements deferred rendering for dependency entries that reference `{{usage.*}}` by preserving raw dependency templates on `Task`, skipping unresolved deps during initial resolution, then re-rendering them later once CLI/parent-provided args are known (during `mise run` task list creation and again while building the dependency graph).
> 
> Adds an end-to-end test covering positional args, flags, string vs structured dependency syntax, fan-out dependencies, and chained forwarding, and updates docs to describe the new argument-forwarding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 076b9c5893b73aefe4fde511485f9042c66c4354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->