### PR TITLE
fix: parse inline CLI options for ls-remote, overrides mise.toml

### DIFF
--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -632,8 +632,9 @@ impl Backend for CondaBackend {
     async fn list_remote_versions_with_info(
         &self,
         config: &Arc<Config>,
+        opts: Option<crate::toolset::ToolVersionOptions>,
     ) -> Result<Vec<VersionInfo>> {
-        self._list_remote_versions(config).await
+        self._list_remote_versions_with_opts(config, opts).await
     }
 
     async fn install_version_(

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -155,12 +155,24 @@ impl Backend for UnifiedGitBackend {
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
+        self._list_remote_versions_with_opts(config, None).await
+    }
+
+    async fn _list_remote_versions_with_opts(
+        &self,
+        config: &Arc<Config>,
+        opts: Option<ToolVersionOptions>,
+    ) -> Result<Vec<VersionInfo>> {
         let repo = self.ba.tool_name();
         let id = self.ba.to_string();
-        let opts = config
-            .get_tool_opts(&self.ba)
-            .await?
-            .unwrap_or_else(|| self.ba.opts());
+        let opts = if let Some(inline) = opts {
+            inline
+        } else {
+            config
+                .get_tool_opts(&self.ba)
+                .await?
+                .unwrap_or_else(|| self.ba.opts())
+        };
         let api_url = self.get_api_url(&opts);
         let version_prefix = opts.get("version_prefix");
 

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -563,8 +563,14 @@ impl HttpBackend {
     // -------------------------------------------------------------------------
 
     /// Fetch versions from version_list_url if configured
-    async fn fetch_versions(&self, config: &Arc<Config>) -> Result<Vec<String>> {
-        let opts = if !self.ba.opts().contains_key("version_list_url") {
+    async fn fetch_versions(
+        &self,
+        config: &Arc<Config>,
+        opts: Option<ToolVersionOptions>,
+    ) -> Result<Vec<String>> {
+        let opts = if let Some(inline) = opts {
+            inline
+        } else if !self.ba.opts().contains_key("version_list_url") {
             config.get_tool_opts(&self.ba).await?.unwrap_or_default()
         } else {
             self.ba.opts()
@@ -617,7 +623,15 @@ impl Backend for HttpBackend {
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-        let versions = self.fetch_versions(config).await?;
+        self._list_remote_versions_with_opts(config, None).await
+    }
+
+    async fn _list_remote_versions_with_opts(
+        &self,
+        config: &Arc<Config>,
+        opts: Option<ToolVersionOptions>,
+    ) -> Result<Vec<VersionInfo>> {
+        let versions = self.fetch_versions(config, opts).await?;
         Ok(versions
             .into_iter()
             .map(|v| VersionInfo {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -24,7 +24,8 @@ use crate::registry::{REGISTRY, full_to_url, normalize_remote, tool_enabled};
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{
-    ResolveOptions, ToolRequest, ToolVersion, Toolset, install_state, is_outdated_version,
+    ResolveOptions, ToolRequest, ToolVersion, ToolVersionOptions, Toolset, install_state,
+    is_outdated_version,
 };
 use crate::ui::progress_report::SingleReport;
 use crate::{
@@ -465,7 +466,7 @@ pub trait Backend: Debug + Send + Sync {
 
     async fn list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<String>> {
         Ok(self
-            .list_remote_versions_with_info(config)
+            .list_remote_versions_with_info(config, None)
             .await?
             .into_iter()
             .map(|v| v.version)
@@ -473,16 +474,34 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     /// List remote versions with additional metadata like created_at timestamps.
-    /// Results are cached. Backends can override `_list_remote_versions_with_info`
-    /// to provide timestamp information.
+    /// Results are cached when `opts` is `None`. When `opts` is `Some`, the cache is
+    /// bypassed since results depend on the provided options (e.g. inline CLI opts).
     ///
     /// This method first tries the versions host (mise-versions.jdx.dev) which provides
     /// version info with created_at timestamps. If that fails, it falls back to the
-    /// backend's `_list_remote_versions_with_info` implementation.
+    /// backend's `_list_remote_versions` implementation.
     async fn list_remote_versions_with_info(
         &self,
         config: &Arc<Config>,
+        opts: Option<ToolVersionOptions>,
     ) -> eyre::Result<Vec<VersionInfo>> {
+        // When opts are provided (e.g. inline CLI opts like [channels=["bioconda"]]),
+        // skip the cache since results depend on the opts.
+        if opts.is_some() {
+            let versions = self
+                ._list_remote_versions_with_opts(config, opts)
+                .await?
+                .into_iter()
+                .filter(|v| {
+                    matches!(
+                        v.version.parse::<ToolVersionType>(),
+                        Ok(ToolVersionType::Version(_))
+                    )
+                })
+                .collect::<Vec<_>>();
+            return Ok(versions);
+        }
+
         let remote_versions = self.get_remote_version_cache();
         let remote_versions = remote_versions.lock().await;
         let ba = self.ba().clone();
@@ -585,6 +604,18 @@ pub trait Backend: Debug + Send + Sync {
     /// Override this to provide version listing with optional timestamp information.
     /// Return `VersionInfo` with `created_at: None` if timestamps are not available.
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>>;
+
+    /// Like `_list_remote_versions` but accepts caller-supplied opts (e.g. from inline
+    /// CLI syntax like `[channels=["bioconda"]]`). Backends that use opts override this;
+    /// the default delegates to `_list_remote_versions` ignoring opts.
+    async fn _list_remote_versions_with_opts(
+        &self,
+        config: &Arc<Config>,
+        opts: Option<ToolVersionOptions>,
+    ) -> eyre::Result<Vec<VersionInfo>> {
+        let _ = opts;
+        self._list_remote_versions(config).await
+    }
 
     async fn latest_stable_version(&self, config: &Arc<Config>) -> eyre::Result<Option<String>> {
         self.latest_version(config, Some("latest".into())).await
@@ -729,7 +760,7 @@ pub trait Backend: Debug + Send + Sync {
         let versions = match before_date {
             Some(before) => {
                 // Use version info to filter by date
-                let versions_with_info = self.list_remote_versions_with_info(config).await?;
+                let versions_with_info = self.list_remote_versions_with_info(config, None).await?;
                 let filtered = VersionInfo::filter_by_date(versions_with_info, before);
                 // Warn if no versions have timestamps
                 if filtered.iter().all(|v| v.created_at.is_none()) && !filtered.is_empty() {
@@ -780,7 +811,7 @@ pub trait Backend: Debug + Send + Sync {
                     matches = match before_date {
                         Some(before) => {
                             let versions_with_info =
-                                self.list_remote_versions_with_info(config).await?;
+                                self.list_remote_versions_with_info(config, None).await?;
                             VersionInfo::filter_by_date(versions_with_info, before)
                                 .into_iter()
                                 .map(|v| v.version)
@@ -833,7 +864,7 @@ pub trait Backend: Debug + Send + Sync {
     /// Check if a version is a rolling release (like "nightly") that should
     /// always be considered potentially outdated for `mise up` purposes
     async fn is_version_rolling(&self, config: &Arc<Config>, version: &str) -> bool {
-        let versions = match self.list_remote_versions_with_info(config).await {
+        let versions = match self.list_remote_versions_with_info(config, None).await {
             Ok(v) => v,
             Err(_) => return false,
         };
@@ -842,7 +873,7 @@ pub trait Backend: Debug + Send + Sync {
 
     /// Get version info for a specific version (including checksum for rolling releases)
     async fn get_version_info(&self, config: &Arc<Config>, version: &str) -> Option<VersionInfo> {
-        let versions = match self.list_remote_versions_with_info(config).await {
+        let versions = match self.list_remote_versions_with_info(config, None).await {
             Ok(v) => v,
             Err(_) => return None,
         };

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -268,8 +268,16 @@ impl S3Backend {
     }
 
     /// Fetch versions using the configured method (manifest or listing)
-    async fn fetch_versions(&self, config: &Arc<Config>) -> Result<Vec<String>> {
-        let opts = config.get_tool_opts(&self.ba).await?.unwrap_or_default();
+    async fn fetch_versions(
+        &self,
+        config: &Arc<Config>,
+        opts: Option<ToolVersionOptions>,
+    ) -> Result<Vec<String>> {
+        let opts = if let Some(inline) = opts {
+            inline
+        } else {
+            config.get_tool_opts(&self.ba).await?.unwrap_or_default()
+        };
 
         // Try manifest-based version discovery first
         if let Some(manifest_url) = Self::get_opt(&opts, "version_list_url") {
@@ -428,7 +436,15 @@ impl Backend for S3Backend {
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-        let versions = self.fetch_versions(config).await?;
+        self._list_remote_versions_with_opts(config, None).await
+    }
+
+    async fn _list_remote_versions_with_opts(
+        &self,
+        config: &Arc<Config>,
+        opts: Option<ToolVersionOptions>,
+    ) -> Result<Vec<VersionInfo>> {
+        let versions = self.fetch_versions(config, opts).await?;
         Ok(versions
             .into_iter()
             .map(|v| VersionInfo {

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -61,11 +61,18 @@ impl Backend for VfoxBackend {
                     Settings::get().ensure_experimental("custom backends")?;
                     debug!("Using backend method for plugin: {}", this.pathname);
                     let tool_name = this.get_tool_name()?;
-                    let opts = config
-                        .get_tool_opts(&this.ba)
-                        .await?
-                        .map(|o| o.opts)
-                        .unwrap_or_default();
+                    // Inline opts (e.g. [channels=bioconda] CLI syntax) are used exclusively
+                    // when present. Config-file opts (mise.toml) are only used as a fallback
+                    // when no inline opts were provided.
+                    let opts = if let Some(inline) = &this.ba.opts {
+                        inline.opts.clone()
+                    } else {
+                        config
+                            .get_tool_opts(&this.ba)
+                            .await?
+                            .map(|o| o.opts)
+                            .unwrap_or_default()
+                    };
                     let versions = vfox
                         .backend_list_versions(&this.pathname, tool_name, opts)
                         .await

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -22,7 +22,7 @@ use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::plugins::Plugin;
 use crate::plugins::vfox_plugin::VfoxPlugin;
-use crate::toolset::{ToolVersion, Toolset, install_state};
+use crate::toolset::{ToolVersion, ToolVersionOptions, Toolset, install_state};
 use crate::ui::multi_progress_report::MultiProgressReport;
 
 #[derive(Debug)]
@@ -50,6 +50,14 @@ impl Backend for VfoxBackend {
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
+        self._list_remote_versions_with_opts(config, None).await
+    }
+
+    async fn _list_remote_versions_with_opts(
+        &self,
+        config: &Arc<Config>,
+        opts: Option<ToolVersionOptions>,
+    ) -> eyre::Result<Vec<VersionInfo>> {
         let this = self;
         timeout::run_with_timeout_async(
             || async {
@@ -61,11 +69,10 @@ impl Backend for VfoxBackend {
                     Settings::get().ensure_experimental("custom backends")?;
                     debug!("Using backend method for plugin: {}", this.pathname);
                     let tool_name = this.get_tool_name()?;
-                    // Inline opts (e.g. [channels=bioconda] CLI syntax) are used exclusively
-                    // when present. Config-file opts (mise.toml) are only used as a fallback
-                    // when no inline opts were provided.
-                    let opts = if let Some(inline) = &this.ba.opts {
-                        inline.opts.clone()
+                    // Inline opts (passed via opts param) take precedence.
+                    // Fall back to config-file opts (mise.toml) when not provided.
+                    let opts = if let Some(inline) = opts {
+                        inline.opts
                     } else {
                         config
                             .get_tool_opts(&this.ba)

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -103,7 +103,7 @@ impl From<InstallStateTool> for BackendArg {
 /// Split a string like `"http:hello[url=...,bin=bin]"` into `("http:hello", "url=...,bin=bin")`.
 /// Returns `None` if no bracketed opts are present.
 pub fn split_bracketed_opts(s: &str) -> Option<(&str, &str)> {
-    regex!(r"^(.+)\[(.+)\]$")
+    regex!(r"^([^\[]+)\[(.+)\]$")
         .captures(s)
         .map(|c| (c.get(1).unwrap().as_str(), c.get(2).unwrap().as_str()))
 }

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -110,7 +110,18 @@ impl LsRemote {
     async fn get_plugin(&self, config: &Arc<Config>) -> Result<Option<Arc<dyn Backend>>> {
         match &self.plugin {
             Some(tool_arg) => {
-                let backend = tool_arg.ba.backend()?;
+                // When inline opts are present (e.g. [channels=["bioconda"]]), bypass the
+                // TOOLS cache so the backend carries those opts in its BackendArg, allowing
+                // _list_remote_versions to use them exclusively (overriding mise.toml).
+                // Without inline opts, fall back to the TOOLS-cache backend so mise.toml is read.
+                let backend = if tool_arg.ba.opts.is_some() {
+                    match backend::arg_to_backend((*tool_arg.ba).clone()) {
+                        Some(b) => b,
+                        None => tool_arg.ba.backend()?,
+                    }
+                } else {
+                    tool_arg.ba.backend()?
+                };
                 let mpr = MultiProgressReport::get();
                 if let Some(plugin) = backend.plugin() {
                     plugin.ensure_installed(config, &mpr, false, false).await?;

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -66,8 +66,13 @@ impl LsRemote {
         };
         let matches_prefix = |v: &str| prefix.as_ref().is_none_or(|p| v.starts_with(p));
 
+        // Extract inline opts (e.g. [channels=["bioconda"]]) from the tool arg.
+        // When present, they are passed to list_remote_versions_with_info which bypasses
+        // the cache and passes them through to the backend, overriding mise.toml opts.
+        let opts = self.plugin.as_ref().and_then(|ta| ta.ba.opts.clone());
+
         let versions: Vec<_> = plugin
-            .list_remote_versions_with_info(config)
+            .list_remote_versions_with_info(config, opts)
             .await?
             .into_iter()
             .filter(|v| matches_prefix(&v.version))
@@ -87,7 +92,7 @@ impl LsRemote {
         let mut versions = vec![];
         for b in backend::list() {
             let tool = b.id().to_string();
-            for v in b.list_remote_versions_with_info(config).await? {
+            for v in b.list_remote_versions_with_info(config, None).await? {
                 versions.push(VersionOutputAll {
                     tool: tool.clone(),
                     version: v.version,
@@ -110,18 +115,7 @@ impl LsRemote {
     async fn get_plugin(&self, config: &Arc<Config>) -> Result<Option<Arc<dyn Backend>>> {
         match &self.plugin {
             Some(tool_arg) => {
-                // When inline opts are present (e.g. [channels=["bioconda"]]), bypass the
-                // TOOLS cache so the backend carries those opts in its BackendArg, allowing
-                // _list_remote_versions to use them exclusively (overriding mise.toml).
-                // Without inline opts, fall back to the TOOLS-cache backend so mise.toml is read.
-                let backend = if tool_arg.ba.opts.is_some() {
-                    match backend::arg_to_backend((*tool_arg.ba).clone()) {
-                        Some(b) => b,
-                        None => tool_arg.ba.backend()?,
-                    }
-                } else {
-                    tool_arg.ba.backend()?
-                };
+                let backend = tool_arg.ba.backend()?;
                 let mpr = MultiProgressReport::get();
                 if let Some(plugin) = backend.plugin() {
                     plugin.ensure_installed(config, &mpr, false, false).await?;

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -364,8 +364,9 @@ impl Backend for JavaPlugin {
     async fn list_remote_versions_with_info(
         &self,
         config: &Arc<Config>,
+        opts: Option<crate::toolset::ToolVersionOptions>,
     ) -> Result<Vec<VersionInfo>> {
-        self._list_remote_versions(config).await
+        self._list_remote_versions_with_opts(config, opts).await
     }
 
     fn list_installed_versions_matching(&self, query: &str) -> Vec<String> {


### PR DESCRIPTION
This PR enables `ls-remote` to parse options from the CLI (e.g. `mise ls-remote "vfox-pixi:samtools[channels=bioconda]"`), overriding options from `mise.toml` if the latter exists, as introduced in #8875 . Also adds support for parsing TOML arrays (e.g. `mise ls-remote 'vfox-pixi:samtools[channels=["conda-forge", "bioconda"]]'`)