### PR TITLE
fix(task): make --timeout override task.timeout setting

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use super::args::ToolArg;
 use crate::cli::{Cli, unescape_task_args};
 use crate::config::{Config, Settings};
-use crate::duration;
 use crate::env;
 use crate::file::display_path;
 use crate::prepare::{PrepareEngine, PrepareOptions};
@@ -366,12 +365,13 @@ impl Run {
                 .await?;
         }
 
+        // --timeout overrides the task.timeout setting
+        if let Some(timeout_str) = &self.timeout {
+            Settings::task_timeout_override(timeout_str.clone());
+        }
+
         // Apply global timeout for entire run if configured
-        let timeout = if let Some(timeout_str) = &self.timeout {
-            Some(duration::parse_duration(timeout_str)?)
-        } else {
-            Settings::get().task_timeout_duration()
-        };
+        let timeout = Settings::get().task_timeout_duration();
 
         if let Some(timeout) = timeout {
             tokio::time::timeout(timeout, self.parallelize_tasks(config, resolved_tasks))

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -518,6 +518,17 @@ impl Settings {
         crate::config::config_file::config_root::reset();
     }
 
+    /// Override the task.timeout setting with a CLI --timeout value.
+    /// This resets the settings so the new timeout is picked up everywhere.
+    pub fn task_timeout_override(timeout: String) {
+        let mut cli = CLI_SETTINGS.lock().unwrap();
+        let mut partial = cli.take().unwrap_or_default();
+        partial.task.timeout = Some(timeout);
+        *cli = Some(partial);
+        *BASE_SETTINGS.write().unwrap() = None;
+        crate::config::config_file::config_root::reset();
+    }
+
     pub fn lockfile_enabled(&self) -> bool {
         self.lockfile.unwrap_or(true)
     }


### PR DESCRIPTION
## Summary

- `--timeout` now overrides the `task.timeout` setting via `Settings::task_timeout_override()`, so it flows through the same codepath as the setting — including per-task timeout resolution
- Previously `--timeout` bypassed the setting and only wrapped the entire `parallelize_tasks` call directly

Fixes #8858

## Test plan

- [ ] `mise run --timeout 2s slow-task` should behave the same as `MISE_TASK_TIMEOUT=2s mise run slow-task`
- [ ] Without `--timeout`, behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)