### PR TITLE
fix(task): prevent deadlock when MISE_JOBS=1 with sub-task references

### DIFF
--- a/e2e/cli/test_run_subtask_jobs1
+++ b/e2e/cli/test_run_subtask_jobs1
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Test that tasks with mixed sub-task references and scripts don't deadlock with MISE_JOBS=1
+# Regression test for https://github.com/jdx/mise/discussions/8967
+
+cat >mise.toml <<'TOML'
+[tasks.foo]
+run = "echo foo"
+
+[tasks.test]
+run = [
+    { task = "foo" },
+    "echo bar",
+]
+TOML
+
+MISE_JOBS=1 assert "mise run test" "foo
+bar"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -707,6 +707,7 @@ impl Run {
             .unwrap_or(false)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn run_task_sched(
         &self,
         task: &Task,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -521,11 +521,19 @@ impl Run {
         // always sees the parent in `executed` — avoiding a race where a
         // concurrent task fails between spawn and first poll.
         deps_for_remove.lock().await.mark_executed(&task);
+        let semaphore = ctx.semaphore.clone();
         ctx.jset.lock().await.spawn(async move {
-            let _permit = permit_opt;
+            let mut permit = permit_opt;
             let completed = deps_for_remove.lock().await.handled_task_keys();
             let result = this
-                .run_task_sched(&task, &ctx.config, ctx.sched_tx.clone(), completed)
+                .run_task_sched(
+                    &task,
+                    &ctx.config,
+                    ctx.sched_tx.clone(),
+                    completed,
+                    semaphore,
+                    &mut permit,
+                )
                 .await;
             if let Err(err) = &result {
                 let status = Error::get_exit_status(err);
@@ -692,11 +700,13 @@ impl Run {
         config: &Arc<Config>,
         sched_tx: Arc<tokio::sync::mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
         completed_tasks: std::collections::HashSet<crate::task::TaskKey>,
+        semaphore: Arc<tokio::sync::Semaphore>,
+        permit: &mut Option<tokio::sync::OwnedSemaphorePermit>,
     ) -> Result<()> {
         self.executor
             .as_ref()
             .expect("executor must be initialized before running tasks")
-            .run_task_sched(task, config, sched_tx, completed_tasks)
+            .run_task_sched(task, config, sched_tx, completed_tasks, semaphore, permit)
             .await
     }
 

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -176,6 +176,7 @@ impl TaskExecutor {
     }
 
     /// Run a task, returning true if the task actually executed (not skipped).
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_task_sched(
         &self,
         task: &Task,

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -29,7 +29,7 @@ use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 use std::time::{Duration, SystemTime};
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot};
 use xx::file;
 
 /// Global lock for interactive task exclusivity.
@@ -181,6 +181,8 @@ impl TaskExecutor {
         config: &Arc<Config>,
         sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
         completed_tasks: HashSet<TaskKey>,
+        semaphore: Arc<Semaphore>,
+        permit: &mut Option<OwnedSemaphorePermit>,
     ) -> Result<()> {
         let prefix = task.estyled_prefix();
         let total_start = std::time::Instant::now();
@@ -329,6 +331,8 @@ impl TaskExecutor {
                 sched_tx,
                 confirm_guard,
                 &completed_tasks,
+                semaphore,
+                permit,
             )
             .await?;
             trace!(
@@ -365,6 +369,8 @@ impl TaskExecutor {
         sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
         existing_guard: Option<RuntimeLockGuard<'static>>,
         completed_tasks: &HashSet<TaskKey>,
+        semaphore: Arc<Semaphore>,
+        permit: &mut Option<OwnedSemaphorePermit>,
     ) -> Result<()> {
         let (env, task_env) = full_env;
         use crate::task::RunEntry;
@@ -407,6 +413,11 @@ impl TaskExecutor {
                         Some(override_env.as_slice())
                     };
                     guard = None; // drop lock before waiting on sub-tasks
+                    // Release the semaphore permit before waiting on sub-tasks to
+                    // avoid deadlock when MISE_JOBS=1 (the sub-task needs a permit
+                    // but we're holding the only one).
+                    let had_permit = permit.is_some();
+                    *permit = None;
                     self.inject_and_wait(
                         config,
                         &[resolved_spec],
@@ -417,6 +428,9 @@ impl TaskExecutor {
                         completed_tasks,
                     )
                     .await?;
+                    if had_permit {
+                        *permit = Some(semaphore.clone().acquire_owned().await?);
+                    }
                 }
                 RunEntry::TaskGroup { tasks } => {
                     let resolved_tasks: Vec<String> = tasks
@@ -424,6 +438,8 @@ impl TaskExecutor {
                         .map(|t| crate::task::resolve_task_pattern(t, Some(task)))
                         .collect();
                     guard = None; // drop lock before waiting on sub-tasks
+                    let had_permit = permit.is_some();
+                    *permit = None;
                     self.inject_and_wait(
                         config,
                         &resolved_tasks,
@@ -434,6 +450,9 @@ impl TaskExecutor {
                         completed_tasks,
                     )
                     .await?;
+                    if had_permit {
+                        *permit = Some(semaphore.clone().acquire_owned().await?);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fixes deadlock when `MISE_JOBS=1` and a task's `run` array contains both sub-task references (`{ task = "foo" }`) and scripts
- The parent task acquires the single semaphore permit, then waits for the sub-task which also needs that permit — classic deadlock
- Fix: temporarily release the parent's permit before `inject_and_wait`, re-acquire afterward

Fixes #8967

## Test plan
- [x] Added e2e test `test_run_subtask_jobs1` that reproduces the exact scenario from the discussion
- [x] Verified the test hangs without the fix and passes with it
- [x] Verified normal (non-MISE_JOBS=1) execution still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task scheduling/semaphore permit handling during nested sub-task execution; mistakes could impact task concurrency limits or cause hangs under certain job configurations.
> 
> **Overview**
> Prevents a deadlock when running tasks with `MISE_JOBS=1` whose `run` array mixes sub-task entries (e.g. `{ task = "foo" }`) and script lines by **releasing the parent task’s semaphore permit before `inject_and_wait` and re-acquiring it afterward**.
> 
> This threads the scheduler `Semaphore` and the current `OwnedSemaphorePermit` through `Run::run_task_sched` into `TaskExecutor::exec_task_run_entries` so nested sub-task execution can yield the permit while waiting. Adds an e2e regression test `test_run_subtask_jobs1` to reproduce the hang and verify correct output ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb780c0a18d936dedd21f9d512d61ec8a70976b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->