### PR TITLE
fix(install): add missing env vars to tool postinstall hooks

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -12,6 +12,7 @@ use jiff::Timestamp;
 
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::cmd::CmdLineRunner;
+use crate::config::config_file::config_root;
 use crate::config::{Config, Settings};
 use crate::file::{display_path, remove_all, remove_all_with_warning};
 use crate::install_context::InstallContext;
@@ -1145,7 +1146,7 @@ pub trait Backend: Debug + Send + Sync {
             path_env.add(p);
         }
 
-        CmdLineRunner::new(&*env::SHELL)
+        let mut runner = CmdLineRunner::new(&*env::SHELL)
             .env(&*env::PATH_KEY, path_env.join())
             .env("MISE_TOOL_INSTALL_PATH", tv.install_path())
             .env("MISE_TOOL_NAME", tv.ba().short.clone())
@@ -1153,8 +1154,18 @@ pub trait Backend: Debug + Send + Sync {
             .with_pr(ctx.pr.as_ref())
             .arg(env::SHELL_COMMAND_FLAG)
             .arg(script)
-            .envs(env_vars)
-            .execute()?;
+            .envs(env_vars);
+
+        // Set MISE_CONFIG_ROOT and MISE_PROJECT_ROOT from the tool's source config file
+        if let Some(source_path) = tv.request.source().path() {
+            let root = config_root::config_root(source_path);
+            let root = root.to_string_lossy().to_string();
+            runner = runner
+                .env("MISE_CONFIG_ROOT", &root)
+                .env("MISE_PROJECT_ROOT", &root);
+        }
+
+        runner.execute()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Set `MISE_CONFIG_ROOT` and `MISE_PROJECT_ROOT` env vars in tool-level `postinstall` hooks, matching the behavior of project-level `[hooks] postinstall`

Fixes #8366

## Test plan
- [ ] Verify `$MISE_CONFIG_ROOT` and `$MISE_PROJECT_ROOT` are set in tool postinstall hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts environment passed to tool `postinstall` hook execution, with no changes to install logic beyond adding two env vars derived from the source config path.
> 
> **Overview**
> Tool-level `postinstall` hooks now receive `MISE_CONFIG_ROOT` and `MISE_PROJECT_ROOT`, derived from the tool request’s source config path via `config_root::config_root`.
> 
> This aligns tool `postinstall` hook execution with project-level hook behavior by extending the `CmdLineRunner` environment before running the rendered script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb29981830f4a3175ba317738cc2f5bff2f620a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->