### PR TITLE
fix(task): fetch remote task files before parsing usage specs

### DIFF
--- a/e2e/tasks/test_task_remote_dep_no_warning
+++ b/e2e/tasks/test_task_remote_dep_no_warning
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Test that remote git tasks don't produce spurious "failed to parse task file"
+# warnings when invoked with arguments (which triggers usage spec parsing
+# before remote files are fetched).
+# Reproduces: https://github.com/jdx/mise/discussions/8973
+
+#################################################################################
+# Setup - start local git HTTP server
+#################################################################################
+
+rm -f /tmp/mise_git_http_port /tmp/mise_git_http_ready /tmp/mise_git_http_info
+
+python3 "${TEST_ROOT}/helpers/scripts/git_http_backend_server.py" 0 &
+SERVER_PID=$!
+
+wait_for_server() {
+	local max_attempts=30
+	local attempt=1
+	while [ $attempt -le $max_attempts ]; do
+		if [ -f /tmp/mise_git_http_ready ] && [ -f /tmp/mise_git_http_port ]; then
+			return 0
+		fi
+		sleep 1
+		attempt=$((attempt + 1))
+	done
+	echo "ERROR: Git HTTP server failed to start within 30 seconds"
+	kill "$SERVER_PID" 2>/dev/null || true
+	exit 1
+}
+
+wait_for_server
+SERVER_PORT=$(cat /tmp/mise_git_http_port)
+LOCAL_GIT_URL="http://localhost:${SERVER_PORT}/repo.git"
+
+git init
+
+cleanup() {
+	kill "$SERVER_PID" 2>/dev/null || true
+	rm -f /tmp/mise_git_http_port /tmp/mise_git_http_ready /tmp/mise_git_http_info
+}
+trap cleanup EXIT
+
+#################################################################################
+# Test: remote task with args should not emit usage parse warnings
+#################################################################################
+
+cat <<EOF >mise.toml
+[tasks.remote_lint]
+file = "git::${LOCAL_GIT_URL}//xtasks/lint/ripgrep?ref=v2025.1.17"
+EOF
+
+# Run the remote task with extra arguments (-- triggers parse_usage_values_from_task
+# before remote files are fetched) and capture both stdout and stderr
+output=$(mise run remote_lint -- extraarg 2>&1)
+exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+	fail "mise run remote_lint failed with exit code $exit_code: $output"
+fi
+ok "remote task with args ran successfully"
+
+# There should be no "failed to parse task file" warning
+if echo "$output" | grep -q "failed to parse task file"; then
+	fail "Unexpected warning about failed to parse task file in output: $output"
+fi
+ok "No spurious 'failed to parse task file' warning for remote task with args"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -326,6 +326,11 @@ impl Run {
             }
         }
 
+        // Fetch remote task files before parsing usage specs, so that
+        // file-based remote tasks have their files resolved to local cache.
+        let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
+        fetcher.fetch_tasks(&mut task_list).await?;
+
         // Re-render dependency templates with parent task's usage arg/flag values.
         // This enables patterns like: depends = ["child {{usage.app}}"]
         for task in &mut task_list {

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -77,10 +77,10 @@ impl Deps {
             }
             // Fetch remote task files so file-based tasks have local paths
             // before we try to parse their usage specs or execute them.
-            if a.file.as_ref().is_some_and(|f| {
-                let s = f.to_string_lossy();
-                s.starts_with("git::") || s.starts_with("http://") || s.starts_with("https://")
-            }) {
+            if a.file
+                .as_ref()
+                .is_some_and(|f| TaskFetcher::is_remote_source(&f.to_string_lossy()))
+            {
                 let mut tasks_to_fetch = vec![a];
                 fetcher.fetch_tasks(&mut tasks_to_fetch).await?;
                 a = tasks_to_fetch.into_iter().next().unwrap();

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -1,3 +1,4 @@
+use crate::config::Settings;
 use crate::config::env_directive::EnvDirective;
 use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Task, dep_has_usage_ref, parse_usage_values_from_task};
@@ -67,7 +68,8 @@ impl Deps {
             add_idx(t, &mut graph);
         }
         let all_tasks_to_run = resolve_depends(config, tasks).await?;
-        let fetcher = TaskFetcher::new(false);
+        let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
+        let fetcher = TaskFetcher::new(no_cache);
         while let Some(mut a) = stack.pop() {
             if seen.contains(&a) {
                 // prevent infinite loop
@@ -75,7 +77,10 @@ impl Deps {
             }
             // Fetch remote task files so file-based tasks have local paths
             // before we try to parse their usage specs or execute them.
-            {
+            if a.file.as_ref().is_some_and(|f| {
+                let s = f.to_string_lossy();
+                s.starts_with("git::") || s.starts_with("http://") || s.starts_with("https://")
+            }) {
                 let mut tasks_to_fetch = vec![a];
                 fetcher.fetch_tasks(&mut tasks_to_fetch).await?;
                 a = tasks_to_fetch.into_iter().next().unwrap();

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -1,4 +1,5 @@
 use crate::config::env_directive::EnvDirective;
+use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Task, dep_has_usage_ref, parse_usage_values_from_task};
 use crate::{config::Config, task::task_list::resolve_depends};
 use itertools::Itertools;
@@ -66,10 +67,18 @@ impl Deps {
             add_idx(t, &mut graph);
         }
         let all_tasks_to_run = resolve_depends(config, tasks).await?;
+        let fetcher = TaskFetcher::new(false);
         while let Some(mut a) = stack.pop() {
             if seen.contains(&a) {
                 // prevent infinite loop
                 continue;
+            }
+            // Fetch remote task files so file-based tasks have local paths
+            // before we try to parse their usage specs or execute them.
+            {
+                let mut tasks_to_fetch = vec![a];
+                fetcher.fetch_tasks(&mut tasks_to_fetch).await?;
+                a = tasks_to_fetch.into_iter().next().unwrap();
             }
             // If this task received args (from a parent dependency), re-render
             // its dependency templates with usage values so {{usage.*}} resolves.
@@ -88,6 +97,9 @@ impl Deps {
                 }
             }
             let a_idx = add_idx(&a, &mut graph);
+            // Update the graph node with the fetched version of the task
+            // (add_idx may have returned an existing index with an unfetched task)
+            graph[a_idx] = a.clone();
             let (pre, post) = a.resolve_depends(config, &all_tasks_to_run).await?;
             for b in pre {
                 let b_idx = add_idx(&b, &mut graph);

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -48,7 +48,7 @@ impl TaskFetcher {
     }
 
     /// Check if a source path is a remote task file (git or http/https)
-    fn is_remote_source(source: &str) -> bool {
+    pub fn is_remote_source(source: &str) -> bool {
         source.starts_with("git::")
             || source.starts_with("http://")
             || source.starts_with("https://")


### PR DESCRIPTION
## Summary
- Fixes spurious `failed to parse task file` warning when running remote git tasks with arguments
- Remote task files were not fetched before `parse_usage_values_from_task` attempted to read them (introduced when the `{{usage.*}}` dependency template feature was added)
- Fetches remote files early in `run.rs` (before usage spec parsing) and in `deps.rs` (for dependency tasks resolved from config)

Closes https://github.com/jdx/mise/discussions/8973

## Test plan
- [x] New e2e test `test_task_remote_dep_no_warning` verifies no warning when running remote tasks with args
- [x] Test fails on `main` and passes with fix
- [x] Existing tests pass: `test_task_remote_git_https`, `test_task_dep_args`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the task-run and dependency-graph build flow to fetch remote task files earlier, which could affect task resolution/caching behavior and ordering for remote tasks and their dependencies.
> 
> **Overview**
> Prevents spurious `failed to parse task file ... with usage` warnings when running *remote file-based tasks* with extra args by ensuring remote task files are fetched to a local cache **before** `parse_usage_values_from_task` attempts to read usage specs.
> 
> `mise run` now pre-fetches remote task files right after task list resolution, and dependency graph construction (`Deps::new`) also fetches remote task files for dependency tasks and updates the graph node with the fetched version. Adds an e2e regression test (`test_task_remote_dep_no_warning`) that runs a remote git task with `--` args against a local git HTTP server and asserts no warning is emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682ea9416b462aa1e2eba59fbd0b399fa6097e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->