### PR TITLE
fix(upgrade): update lockfile and config when upgrading to specific version

### DIFF
--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -209,21 +209,23 @@ If the version doesn't match the current config prefix, the config is updated au
 
 The table below shows how each command interacts with `mise.toml` and `mise.lock`:
 
-| Command                     | Installs | Updates `mise.toml`                  | Updates `mise.lock`                        |
-| --------------------------- | -------- | ------------------------------------ | ------------------------------------------ |
-| `mise use node@22`          | Yes      | Yes (sets `node = "22"`)             | Yes                                        |
-| `mise install`              | Yes      | No                                   | Yes (adds newly installed versions)        |
-| `mise install node@22.15.0` | Yes      | No                                   | No (one-off install, not config-driven)    |
-| `mise upgrade`              | Yes      | No                                   | Yes                                        |
-| `mise upgrade node@22.15.0` | Yes      | Only if version doesn't match prefix | Yes                                        |
-| `mise upgrade --bump`       | Yes      | Yes (bumps prefix to match)          | Yes                                        |
-| `mise lock`                 | No       | No                                   | Yes (regenerates for all configured tools) |
-| `mise lock node@22.15.0`    | No       | Only if version doesn't match prefix | Yes                                        |
+| Command                     | Installs | Updates `mise.toml`                  | Updates `mise.lock`                     |
+| --------------------------- | -------- | ------------------------------------ | --------------------------------------- |
+| `mise use node@22`          | Yes      | Yes (sets `node = "22"`)             | Yes                                     |
+| `mise install`              | Yes      | No                                   | Yes                                     |
+| `mise install node`         | Yes      | No                                   | Yes (installs config version for node)  |
+| `mise install node@22.15.0` | Yes      | No                                   | No (one-off install, not config-driven) |
+| `mise upgrade`              | Yes      | No                                   | Yes                                     |
+| `mise upgrade node`         | Yes      | No                                   | Yes (upgrades node within its range)    |
+| `mise upgrade node@22.15.0` | Yes      | Only if version doesn't match prefix | Yes                                     |
+| `mise upgrade --bump`       | Yes      | Yes (bumps prefix to match)          | Yes                                     |
+| `mise lock`                 | No       | No                                   | Yes (regenerates for all tools)         |
+| `mise lock node@22.15.0`    | No       | Only if version doesn't match prefix | Yes                                     |
 
 **Key points:**
 
 - **`mise use`** is for changing which version you want in your config — it always writes to `mise.toml`
-- **`mise install`** installs what's in your config without changing it — ad-hoc `mise install tool@version` is a one-off that doesn't update the lockfile
+- **`mise install`** installs what's in your config without changing it — `mise install node` installs the config's version of node and updates the lockfile, while `mise install node@22.15.0` is a one-off that doesn't
 - **`mise upgrade`** upgrades tools within their configured ranges and updates the lockfile — passing `tool@version` lets you target a specific version
 - **`mise lock`** regenerates lockfile entries without installing — passing `tool@version` lets you pin a specific version
 

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -193,6 +193,40 @@ mise use node@24
 # This will update both the installation and mise.lock
 ```
 
+### Pinning a Locked Version
+
+You can pin a specific version in the lockfile while keeping a fuzzy specifier in `mise.toml`:
+
+```sh
+# mise.toml has node = "latest" or node = "22"
+mise upgrade node@22.15.0   # installs 22.15.0 and updates mise.lock
+mise lock node@22.15.0      # updates mise.lock without reinstalling
+```
+
+If the version doesn't match the current config prefix, the config is updated automatically. For example, if `mise.toml` has `node = "20"` and you run `mise upgrade node@22.15.0`, the config is bumped to `node = "22"` (preserving the same precision level) and the lockfile is set to `22.15.0`.
+
+## Command Behavior with Lockfiles
+
+The table below shows how each command interacts with `mise.toml` and `mise.lock`:
+
+| Command                     | Installs | Updates `mise.toml`                  | Updates `mise.lock`                        |
+| --------------------------- | -------- | ------------------------------------ | ------------------------------------------ |
+| `mise use node@22`          | Yes      | Yes (sets `node = "22"`)             | Yes                                        |
+| `mise install`              | Yes      | No                                   | Yes (adds newly installed versions)        |
+| `mise install node@22.15.0` | Yes      | No                                   | No (one-off install, not config-driven)    |
+| `mise upgrade`              | Yes      | No                                   | Yes                                        |
+| `mise upgrade node@22.15.0` | Yes      | Only if version doesn't match prefix | Yes                                        |
+| `mise upgrade --bump`       | Yes      | Yes (bumps prefix to match)          | Yes                                        |
+| `mise lock`                 | No       | No                                   | Yes (regenerates for all configured tools) |
+| `mise lock node@22.15.0`    | No       | Only if version doesn't match prefix | Yes                                        |
+
+**Key points:**
+
+- **`mise use`** is for changing which version you want in your config — it always writes to `mise.toml`
+- **`mise install`** installs what's in your config without changing it — ad-hoc `mise install tool@version` is a one-off that doesn't update the lockfile
+- **`mise upgrade`** upgrades tools within their configured ranges and updates the lockfile — passing `tool@version` lets you target a specific version
+- **`mise lock`** regenerates lockfile entries without installing — passing `tool@version` lets you pin a specific version
+
 ## Backend Support
 
 Backend support for lockfile features varies:

--- a/e2e/cli/test_lock_version
+++ b/e2e/cli/test_lock_version
@@ -37,3 +37,4 @@ assert_contains "cat mise.toml" '"3"'
 assert_contains "cat mise.lock" "3.0.1"
 assert_not_contains "cat mise.lock" "2.0.0"
 rm -f mise.toml mise.lock
+unset MISE_LOCKFILE

--- a/e2e/cli/test_lock_version
+++ b/e2e/cli/test_lock_version
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Test: mise lock with @version should lock specific version
+export MISE_LOCKFILE=1
+
+cat <<'EOF' >mise.toml
+[tools]
+tiny = "latest"
+EOF
+mise uninstall tiny --all 2>/dev/null || true
+mise install tiny@3.0.0
+touch mise.lock
+mise lock tiny --platform linux-x64
+assert_contains "cat mise.lock" "3.0.0"
+# Now lock a different specific version
+mise lock tiny@3.0.1 --platform linux-x64
+assert_contains "cat mise.lock" "3.0.1"
+assert_not_contains "cat mise.lock" "3.0.0"
+# mise.toml should still say "latest"
+assert_contains "cat mise.toml" '"latest"'
+rm -f mise.toml mise.lock
+
+# Test: lock with version that doesn't match prefix should update config
+cat <<'EOF' >mise.toml
+[tools]
+tiny = "2"
+EOF
+mise uninstall tiny --all 2>/dev/null || true
+mise install tiny@2.0.0
+touch mise.lock
+mise lock tiny --platform linux-x64
+assert_contains "cat mise.lock" "2.0.0"
+mise lock tiny@3.0.1 --platform linux-x64
+# Config should be updated to match new prefix
+assert_contains "cat mise.toml" '"3"'
+# Lockfile should have 3.0.1
+assert_contains "cat mise.lock" "3.0.1"
+assert_not_contains "cat mise.lock" "2.0.0"
+rm -f mise.toml mise.lock

--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -154,3 +154,41 @@ assert_not_contains "mise ls --installed dummy" "1.0.0"
 # tiny should still be at 1.0.0 since we didn't upgrade it
 assert_contains "mise ls --installed tiny" "1.0.0"
 assert_not_contains "mise ls --installed tiny" "1.1.0"
+
+# Test: upgrade with specific version should update lockfile
+export MISE_LOCKFILE=1
+cat <<'EOF' >mise.toml
+[tools]
+tiny = "latest"
+EOF
+mise uninstall tiny --all
+mise install tiny@3.0.0
+touch mise.lock
+mise lock --platform linux-x64
+assert_contains "cat mise.lock" "3.0.0"
+# Upgrade to specific version - lockfile should be updated
+mise upgrade tiny@3.0.1
+assert_contains "cat mise.lock" "3.0.1"
+assert_not_contains "cat mise.lock" "3.0.0"
+# mise.toml should still say "latest"
+assert_contains "cat mise.toml" '"latest"'
+rm -f mise.toml mise.lock
+
+# Test: upgrade with version that doesn't match prefix should update config
+cat <<'EOF' >mise.toml
+[tools]
+tiny = "2"
+EOF
+mise uninstall tiny --all
+mise install tiny@2.0.0
+touch mise.lock
+mise lock --platform linux-x64
+assert_contains "cat mise.lock" "2.0.0"
+mise upgrade tiny@3.0.1
+# Config should be updated to match new prefix
+assert_contains "cat mise.toml" '"3"'
+# Lockfile should have 3.0.1
+assert_contains "cat mise.lock" "3.0.1"
+assert_not_contains "cat mise.lock" "2.0.0"
+rm -f mise.toml mise.lock
+unset MISE_LOCKFILE

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -206,7 +206,10 @@ impl Lock {
             let cli_version = tvr.version();
 
             // Find which config file defines this tool
-            for (_path, cf) in config.config_files.iter() {
+            for (path, cf) in config.config_files.iter() {
+                if crate::config::is_global_config(path) {
+                    continue;
+                }
                 let Ok(trs) = cf.to_tool_request_set() else {
                     continue;
                 };

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -179,8 +179,84 @@ impl Lock {
             miseprintln!("{} No tools configured to lock", style("!").yellow());
         }
 
+        // Update config files when a specific version is requested that doesn't match
+        // the current prefix (e.g., `mise lock tiny@3.0.1` when config has `tiny = "2"`)
+        if !self.dry_run {
+            self.update_config_for_version_args(&config).await?;
+        }
+
         if !all_provenance_errors.is_empty() {
             return Err(eyre::eyre!("{}", all_provenance_errors.join("\n")));
+        }
+
+        Ok(())
+    }
+
+    /// Update config files when a specific version is requested via `mise lock tool@version`
+    /// and the version doesn't match the current config prefix.
+    async fn update_config_for_version_args(&self, config: &Config) -> Result<()> {
+        use crate::semver::split_version_prefix;
+        use crate::toolset::ToolRequest;
+        use crate::toolset::outdated_info::check_semver_bump;
+
+        for tool_arg in &self.tool {
+            let Some(tvr) = &tool_arg.tvr else {
+                continue;
+            };
+            let cli_version = tvr.version();
+
+            // Find which config file defines this tool
+            for (_path, cf) in config.config_files.iter() {
+                let Ok(trs) = cf.to_tool_request_set() else {
+                    continue;
+                };
+                let Some(requests) = trs.tools.get(&tool_arg.ba) else {
+                    continue;
+                };
+                if requests.len() != 1 {
+                    continue;
+                }
+
+                let current_version = requests[0].version();
+                let (prefix, _) = split_version_prefix(&current_version);
+                let old = current_version
+                    .strip_prefix(&prefix)
+                    .unwrap_or(&current_version);
+
+                if let Some(bumped) = check_semver_bump(old, &cli_version) {
+                    if bumped != old {
+                        let new_version = format!("{prefix}{bumped}");
+                        let new_request = match requests[0].clone() {
+                            ToolRequest::Version {
+                                version: _,
+                                backend,
+                                options,
+                                source,
+                            } => ToolRequest::Version {
+                                version: new_version,
+                                backend,
+                                options,
+                                source,
+                            },
+                            ToolRequest::Prefix {
+                                prefix: _,
+                                backend,
+                                options,
+                                source,
+                            } => ToolRequest::Prefix {
+                                prefix: format!("{prefix}{bumped}"),
+                                backend,
+                                options,
+                                source,
+                            },
+                            other => other,
+                        };
+                        cf.replace_versions(&tool_arg.ba, vec![new_request])?;
+                        cf.save()?;
+                    }
+                }
+                break;
+            }
         }
 
         Ok(())
@@ -465,11 +541,25 @@ impl Lock {
         if self.tool.is_empty() {
             all_tools
         } else {
-            let specified: BTreeSet<String> =
-                self.tool.iter().map(|t| t.ba.short.clone()).collect();
+            // Build map of tool args with explicit versions
+            let specified_versions: std::collections::HashMap<String, Option<String>> = self
+                .tool
+                .iter()
+                .map(|t| {
+                    let version = t.tvr.as_ref().map(|tvr| tvr.version());
+                    (t.ba.short.clone(), version)
+                })
+                .collect();
             all_tools
                 .into_iter()
-                .filter(|(ba, _)| specified.contains(&ba.short))
+                .filter(|(ba, _)| specified_versions.contains_key(&ba.short))
+                .map(|(ba, mut tv)| {
+                    // If a specific version was requested, override the resolved version
+                    if let Some(Some(version)) = specified_versions.get(&ba.short) {
+                        tv.version.clone_from(version);
+                    }
+                    (ba, tv)
+                })
                 .collect()
         }
     }

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -181,85 +181,39 @@ impl Lock {
 
         // Update config files when a specific version is requested that doesn't match
         // the current prefix (e.g., `mise lock tiny@3.0.1` when config has `tiny = "2"`)
-        if !self.dry_run {
-            self.update_config_for_version_args(&config).await?;
+        {
+            use crate::toolset::outdated_info::{apply_config_bumps, compute_config_bumps};
+            let tool_versions: Vec<(String, String)> = self
+                .tool
+                .iter()
+                .filter_map(|t| {
+                    t.tvr
+                        .as_ref()
+                        .map(|tvr| (t.ba.short.clone(), tvr.version()))
+                })
+                .collect();
+            let refs: Vec<(&str, &str)> = tool_versions
+                .iter()
+                .map(|(n, v)| (n.as_str(), v.as_str()))
+                .collect();
+            let bumps = compute_config_bumps(&config, &refs);
+            if self.dry_run {
+                for bump in &bumps {
+                    miseprintln!(
+                        "Would update {} from {} to {} in {}",
+                        bump.tool_name,
+                        bump.old_version,
+                        bump.new_version,
+                        display_path(&bump.config_path)
+                    );
+                }
+            } else {
+                apply_config_bumps(&config, &bumps)?;
+            }
         }
 
         if !all_provenance_errors.is_empty() {
             return Err(eyre::eyre!("{}", all_provenance_errors.join("\n")));
-        }
-
-        Ok(())
-    }
-
-    /// Update config files when a specific version is requested via `mise lock tool@version`
-    /// and the version doesn't match the current config prefix.
-    async fn update_config_for_version_args(&self, config: &Config) -> Result<()> {
-        use crate::semver::split_version_prefix;
-        use crate::toolset::ToolRequest;
-        use crate::toolset::outdated_info::check_semver_bump;
-
-        for tool_arg in &self.tool {
-            let Some(tvr) = &tool_arg.tvr else {
-                continue;
-            };
-            let cli_version = tvr.version();
-
-            // Find which config file defines this tool
-            for (path, cf) in config.config_files.iter() {
-                if crate::config::is_global_config(path) {
-                    continue;
-                }
-                let Ok(trs) = cf.to_tool_request_set() else {
-                    continue;
-                };
-                let Some(requests) = trs.tools.get(&tool_arg.ba) else {
-                    continue;
-                };
-                if requests.len() != 1 {
-                    continue;
-                }
-
-                let current_version = requests[0].version();
-                let (prefix, _) = split_version_prefix(&current_version);
-                let old = current_version
-                    .strip_prefix(&prefix)
-                    .unwrap_or(&current_version);
-
-                if let Some(bumped) = check_semver_bump(old, &cli_version)
-                    && bumped != old
-                {
-                    let new_version = format!("{prefix}{bumped}");
-                    let new_request = match requests[0].clone() {
-                        ToolRequest::Version {
-                            version: _,
-                            backend,
-                            options,
-                            source,
-                        } => ToolRequest::Version {
-                            version: new_version,
-                            backend,
-                            options,
-                            source,
-                        },
-                        ToolRequest::Prefix {
-                            prefix: _,
-                            backend,
-                            options,
-                            source,
-                        } => ToolRequest::Prefix {
-                            prefix: format!("{prefix}{bumped}"),
-                            backend,
-                            options,
-                            source,
-                        },
-                        other => other,
-                    };
-                    cf.replace_versions(&tool_arg.ba, vec![new_request])?;
-                    cf.save()?;
-                }
-                break;
-            }
         }
 
         Ok(())

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -223,8 +223,8 @@ impl Lock {
                     .strip_prefix(&prefix)
                     .unwrap_or(&current_version);
 
-                if let Some(bumped) = check_semver_bump(old, &cli_version) {
-                    if bumped != old {
+                if let Some(bumped) = check_semver_bump(old, &cli_version)
+                    && bumped != old {
                         let new_version = format!("{prefix}{bumped}");
                         let new_request = match requests[0].clone() {
                             ToolRequest::Version {
@@ -254,7 +254,6 @@ impl Lock {
                         cf.replace_versions(&tool_arg.ba, vec![new_request])?;
                         cf.save()?;
                     }
-                }
                 break;
             }
         }

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -224,36 +224,37 @@ impl Lock {
                     .unwrap_or(&current_version);
 
                 if let Some(bumped) = check_semver_bump(old, &cli_version)
-                    && bumped != old {
-                        let new_version = format!("{prefix}{bumped}");
-                        let new_request = match requests[0].clone() {
-                            ToolRequest::Version {
-                                version: _,
-                                backend,
-                                options,
-                                source,
-                            } => ToolRequest::Version {
-                                version: new_version,
-                                backend,
-                                options,
-                                source,
-                            },
-                            ToolRequest::Prefix {
-                                prefix: _,
-                                backend,
-                                options,
-                                source,
-                            } => ToolRequest::Prefix {
-                                prefix: format!("{prefix}{bumped}"),
-                                backend,
-                                options,
-                                source,
-                            },
-                            other => other,
-                        };
-                        cf.replace_versions(&tool_arg.ba, vec![new_request])?;
-                        cf.save()?;
-                    }
+                    && bumped != old
+                {
+                    let new_version = format!("{prefix}{bumped}");
+                    let new_request = match requests[0].clone() {
+                        ToolRequest::Version {
+                            version: _,
+                            backend,
+                            options,
+                            source,
+                        } => ToolRequest::Version {
+                            version: new_version,
+                            backend,
+                            options,
+                            source,
+                        },
+                        ToolRequest::Prefix {
+                            prefix: _,
+                            backend,
+                            options,
+                            source,
+                        } => ToolRequest::Prefix {
+                            prefix: format!("{prefix}{bumped}"),
+                            backend,
+                            options,
+                            source,
+                        },
+                        other => other,
+                    };
+                    cf.replace_versions(&tool_arg.ba, vec![new_request])?;
+                    cf.save()?;
+                }
                 break;
             }
         }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -330,15 +330,16 @@ impl Upgrade {
         for tv in &mut successful_versions {
             if matches!(tv.request.source(), ToolSource::Argument)
                 && let Some(tvl) = ts.versions.get(tv.ba())
-                    && matches!(&tvl.source, ToolSource::MiseToml(_)) {
-                        // Use the config's request (preserves version specifier like "latest")
-                        // but keep the resolved version from the upgrade
-                        if let Some(config_tv) = tvl.versions.first() {
-                            tv.request = config_tv.request.clone();
-                        } else {
-                            tv.request.set_source(tvl.source.clone());
-                        }
-                    }
+                && matches!(&tvl.source, ToolSource::MiseToml(_))
+            {
+                // Use the config's request (preserves version specifier like "latest")
+                // but keep the resolved version from the upgrade
+                if let Some(config_tv) = tvl.versions.first() {
+                    tv.request = config_tv.request.clone();
+                } else {
+                    tv.request.set_source(tvl.source.clone());
+                }
+            }
         }
 
         config::rebuild_shims_and_runtime_symlinks(config, ts, &successful_versions).await?;
@@ -417,36 +418,37 @@ impl Upgrade {
 
                 // Check if the new version requires a config update
                 if let Some(bumped) = check_semver_bump(old, cli_version)
-                    && bumped != old {
-                        let new_version = format!("{prefix}{bumped}");
-                        let new_request = match requests[0].clone() {
-                            ToolRequest::Version {
-                                version: _,
-                                backend,
-                                options,
-                                source,
-                            } => ToolRequest::Version {
-                                version: new_version,
-                                backend,
-                                options,
-                                source,
-                            },
-                            ToolRequest::Prefix {
-                                prefix: _,
-                                backend,
-                                options,
-                                source,
-                            } => ToolRequest::Prefix {
-                                prefix: format!("{prefix}{bumped}"),
-                                backend,
-                                options,
-                                source,
-                            },
-                            other => other,
-                        };
-                        cf.replace_versions(o.tool_version.ba(), vec![new_request])?;
-                        cf.save()?;
-                    }
+                    && bumped != old
+                {
+                    let new_version = format!("{prefix}{bumped}");
+                    let new_request = match requests[0].clone() {
+                        ToolRequest::Version {
+                            version: _,
+                            backend,
+                            options,
+                            source,
+                        } => ToolRequest::Version {
+                            version: new_version,
+                            backend,
+                            options,
+                            source,
+                        },
+                        ToolRequest::Prefix {
+                            prefix: _,
+                            backend,
+                            options,
+                            source,
+                        } => ToolRequest::Prefix {
+                            prefix: format!("{prefix}{bumped}"),
+                            backend,
+                            options,
+                            source,
+                        },
+                        other => other,
+                    };
+                    cf.replace_versions(o.tool_version.ba(), vec![new_request])?;
+                    cf.save()?;
+                }
                 break;
             }
         }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -328,9 +328,9 @@ impl Upgrade {
         // Also copy the config's request version (e.g., "latest") so the lockfile update
         // correctly replaces the old entry instead of adding a duplicate.
         for tv in &mut successful_versions {
-            if matches!(tv.request.source(), ToolSource::Argument) {
-                if let Some(tvl) = ts.versions.get(tv.ba()) {
-                    if matches!(&tvl.source, ToolSource::MiseToml(_)) {
+            if matches!(tv.request.source(), ToolSource::Argument)
+                && let Some(tvl) = ts.versions.get(tv.ba())
+                    && matches!(&tvl.source, ToolSource::MiseToml(_)) {
                         // Use the config's request (preserves version specifier like "latest")
                         // but keep the resolved version from the upgrade
                         if let Some(config_tv) = tvl.versions.first() {
@@ -339,8 +339,6 @@ impl Upgrade {
                             tv.request.set_source(tvl.source.clone());
                         }
                     }
-                }
-            }
         }
 
         config::rebuild_shims_and_runtime_symlinks(config, ts, &successful_versions).await?;
@@ -418,8 +416,8 @@ impl Upgrade {
                     .unwrap_or(&current_version);
 
                 // Check if the new version requires a config update
-                if let Some(bumped) = check_semver_bump(old, cli_version) {
-                    if bumped != old {
+                if let Some(bumped) = check_semver_bump(old, cli_version)
+                    && bumped != old {
                         let new_version = format!("{prefix}{bumped}");
                         let new_request = match requests[0].clone() {
                             ToolRequest::Version {
@@ -449,7 +447,6 @@ impl Upgrade {
                         cf.replace_versions(o.tool_version.ba(), vec![new_request])?;
                         cf.save()?;
                     }
-                }
                 break;
             }
         }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -7,7 +7,7 @@ use crate::duration::parse_into_timestamp;
 use crate::file::display_path;
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{
-    ConfigScope, InstallOptions, ResolveOptions, ToolVersion, ToolsetBuilder,
+    ConfigScope, InstallOptions, ResolveOptions, ToolSource, ToolVersion, ToolsetBuilder,
     get_versions_needed_by_tracked_configs,
 };
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -242,7 +242,7 @@ impl Upgrade {
         let tool_requests: Vec<_> = outdated.iter().map(|o| o.tool_request.clone()).collect();
 
         // Install all tools in parallel
-        let (successful_versions, install_error) =
+        let (mut successful_versions, install_error) =
             match ts.install_all_versions(config, tool_requests, &opts).await {
                 Ok(versions) => (versions, eyre::Result::Ok(())),
                 Err(e) => match e.downcast_ref::<crate::errors::Error>() {
@@ -271,6 +271,12 @@ impl Upgrade {
                 }
             }
         }
+
+        // When a specific version is provided via CLI (e.g., `mise upgrade tiny@3.0.1`),
+        // update the config file prefix if the new version doesn't match the current specifier.
+        // This is similar to --bump but uses the CLI-specified version as the target.
+        self.update_config_for_cli_versions(config, &outdated, &successful_versions)
+            .await?;
 
         // Reset config after upgrades so tracked configs resolve with new versions
         *config = Config::reset().await?;
@@ -316,6 +322,27 @@ impl Upgrade {
         }
 
         let ts = config.get_toolset().await?;
+
+        // Fix up sources and requests for lockfile update - CLI args produce
+        // ToolSource::Argument but lockfile update only processes ToolSource::MiseToml.
+        // Also copy the config's request version (e.g., "latest") so the lockfile update
+        // correctly replaces the old entry instead of adding a duplicate.
+        for tv in &mut successful_versions {
+            if matches!(tv.request.source(), ToolSource::Argument) {
+                if let Some(tvl) = ts.versions.get(tv.ba()) {
+                    if matches!(&tvl.source, ToolSource::MiseToml(_)) {
+                        // Use the config's request (preserves version specifier like "latest")
+                        // but keep the resolved version from the upgrade
+                        if let Some(config_tv) = tvl.versions.first() {
+                            tv.request = config_tv.request.clone();
+                        } else {
+                            tv.request.set_source(tvl.source.clone());
+                        }
+                    }
+                }
+            }
+        }
+
         config::rebuild_shims_and_runtime_symlinks(config, ts, &successful_versions).await?;
 
         if successful_versions.iter().any(|v| v.short() == "python") {
@@ -329,6 +356,105 @@ impl Upgrade {
         Self::print_summary(&outdated, &successful_versions)?;
 
         install_error
+    }
+
+    /// When CLI args specify an explicit version (e.g., `mise upgrade tiny@3.0.1`),
+    /// update the config file if the new version doesn't match the current specifier.
+    /// This preserves the same version precision as the original config entry.
+    async fn update_config_for_cli_versions(
+        &self,
+        config: &Arc<Config>,
+        outdated: &[OutdatedInfo],
+        successful_versions: &[ToolVersion],
+    ) -> Result<()> {
+        use crate::semver::split_version_prefix;
+        use crate::toolset::ToolRequest;
+        use crate::toolset::outdated_info::check_semver_bump;
+
+        // Build map of CLI args that have explicit versions
+        let cli_versions: std::collections::HashMap<String, String> = self
+            .tool
+            .iter()
+            .filter_map(|t| {
+                t.tvr
+                    .as_ref()
+                    .map(|tvr| (t.ba.short.clone(), tvr.version()))
+            })
+            .collect();
+
+        if cli_versions.is_empty() {
+            return Ok(());
+        }
+
+        for o in outdated {
+            let Some(cli_version) = cli_versions.get(&o.name) else {
+                continue;
+            };
+
+            // Only process tools that were successfully installed
+            if !successful_versions
+                .iter()
+                .any(|v| v.ba() == o.tool_version.ba())
+            {
+                continue;
+            }
+
+            // Find which config file defines this tool
+            for (_path, cf) in config.config_files.iter() {
+                let Ok(trs) = cf.to_tool_request_set() else {
+                    continue;
+                };
+                let Some(requests) = trs.tools.get(o.tool_version.ba()) else {
+                    continue;
+                };
+                if requests.len() != 1 {
+                    continue;
+                }
+
+                let current_version = requests[0].version();
+                let (prefix, _) = split_version_prefix(&current_version);
+                let old = current_version
+                    .strip_prefix(&prefix)
+                    .unwrap_or(&current_version);
+
+                // Check if the new version requires a config update
+                if let Some(bumped) = check_semver_bump(old, cli_version) {
+                    if bumped != old {
+                        let new_version = format!("{prefix}{bumped}");
+                        let new_request = match requests[0].clone() {
+                            ToolRequest::Version {
+                                version: _,
+                                backend,
+                                options,
+                                source,
+                            } => ToolRequest::Version {
+                                version: new_version,
+                                backend,
+                                options,
+                                source,
+                            },
+                            ToolRequest::Prefix {
+                                prefix: _,
+                                backend,
+                                options,
+                                source,
+                            } => ToolRequest::Prefix {
+                                prefix: format!("{prefix}{bumped}"),
+                                backend,
+                                options,
+                                source,
+                            },
+                            other => other,
+                        };
+                        cf.replace_versions(o.tool_version.ba(), vec![new_request])?;
+                        cf.save()?;
+                    }
+                }
+                break;
+            }
+        }
+
+        Ok(())
     }
 
     async fn uninstall_old_version(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -219,6 +219,32 @@ impl Upgrade {
                     display_path(cf.get_path())
                 );
             }
+            if !self.bump {
+                use crate::toolset::outdated_info::compute_config_bumps;
+                let tool_versions: Vec<(String, String)> = self
+                    .tool
+                    .iter()
+                    .filter_map(|t| {
+                        t.tvr
+                            .as_ref()
+                            .map(|tvr| (t.ba.short.clone(), tvr.version()))
+                    })
+                    .collect();
+                let refs: Vec<(&str, &str)> = tool_versions
+                    .iter()
+                    .map(|(n, v)| (n.as_str(), v.as_str()))
+                    .collect();
+                let bumps = compute_config_bumps(config, &refs);
+                for bump in &bumps {
+                    miseprintln!(
+                        "Would update {} from {} to {} in {}",
+                        bump.tool_name,
+                        bump.old_version,
+                        bump.new_version,
+                        display_path(&bump.config_path)
+                    );
+                }
+            }
             if self.dry_run_code {
                 exit::exit(1);
             }
@@ -274,9 +300,31 @@ impl Upgrade {
 
         // When a specific version is provided via CLI (e.g., `mise upgrade tiny@3.0.1`),
         // update the config file prefix if the new version doesn't match the current specifier.
-        // This is similar to --bump but uses the CLI-specified version as the target.
-        self.update_config_for_cli_versions(config, &outdated, &successful_versions)
-            .await?;
+        // Skip if --bump was used since it already handles config updates.
+        if !self.bump {
+            use crate::toolset::outdated_info::{apply_config_bumps, compute_config_bumps};
+            let tool_versions: Vec<(String, String)> = self
+                .tool
+                .iter()
+                .filter_map(|t| {
+                    t.tvr.as_ref().and_then(|tvr| {
+                        let name = t.ba.short.clone();
+                        // Only process tools that were successfully installed
+                        if successful_versions.iter().any(|v| v.ba().short == name) {
+                            Some((name, tvr.version()))
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .collect();
+            let refs: Vec<(&str, &str)> = tool_versions
+                .iter()
+                .map(|(n, v)| (n.as_str(), v.as_str()))
+                .collect();
+            let bumps = compute_config_bumps(config, &refs);
+            apply_config_bumps(config, &bumps)?;
+        }
 
         // Reset config after upgrades so tracked configs resolve with new versions
         *config = Config::reset().await?;
@@ -355,108 +403,6 @@ impl Upgrade {
         Self::print_summary(&outdated, &successful_versions)?;
 
         install_error
-    }
-
-    /// When CLI args specify an explicit version (e.g., `mise upgrade tiny@3.0.1`),
-    /// update the config file if the new version doesn't match the current specifier.
-    /// This preserves the same version precision as the original config entry.
-    async fn update_config_for_cli_versions(
-        &self,
-        config: &Arc<Config>,
-        outdated: &[OutdatedInfo],
-        successful_versions: &[ToolVersion],
-    ) -> Result<()> {
-        use crate::semver::split_version_prefix;
-        use crate::toolset::ToolRequest;
-        use crate::toolset::outdated_info::check_semver_bump;
-
-        // Build map of CLI args that have explicit versions
-        let cli_versions: std::collections::HashMap<String, String> = self
-            .tool
-            .iter()
-            .filter_map(|t| {
-                t.tvr
-                    .as_ref()
-                    .map(|tvr| (t.ba.short.clone(), tvr.version()))
-            })
-            .collect();
-
-        if cli_versions.is_empty() {
-            return Ok(());
-        }
-
-        for o in outdated {
-            let Some(cli_version) = cli_versions.get(&o.name) else {
-                continue;
-            };
-
-            // Only process tools that were successfully installed
-            if !successful_versions
-                .iter()
-                .any(|v| v.ba() == o.tool_version.ba())
-            {
-                continue;
-            }
-
-            // Find which config file defines this tool
-            for (path, cf) in config.config_files.iter() {
-                if crate::config::is_global_config(path) {
-                    continue;
-                }
-                let Ok(trs) = cf.to_tool_request_set() else {
-                    continue;
-                };
-                let Some(requests) = trs.tools.get(o.tool_version.ba()) else {
-                    continue;
-                };
-                if requests.len() != 1 {
-                    continue;
-                }
-
-                let current_version = requests[0].version();
-                let (prefix, _) = split_version_prefix(&current_version);
-                let old = current_version
-                    .strip_prefix(&prefix)
-                    .unwrap_or(&current_version);
-
-                // Check if the new version requires a config update
-                if let Some(bumped) = check_semver_bump(old, cli_version)
-                    && bumped != old
-                {
-                    let new_version = format!("{prefix}{bumped}");
-                    let new_request = match requests[0].clone() {
-                        ToolRequest::Version {
-                            version: _,
-                            backend,
-                            options,
-                            source,
-                        } => ToolRequest::Version {
-                            version: new_version,
-                            backend,
-                            options,
-                            source,
-                        },
-                        ToolRequest::Prefix {
-                            prefix: _,
-                            backend,
-                            options,
-                            source,
-                        } => ToolRequest::Prefix {
-                            prefix: format!("{prefix}{bumped}"),
-                            backend,
-                            options,
-                            source,
-                        },
-                        other => other,
-                    };
-                    cf.replace_versions(o.tool_version.ba(), vec![new_request])?;
-                    cf.save()?;
-                }
-                break;
-            }
-        }
-
-        Ok(())
     }
 
     async fn uninstall_old_version(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -399,7 +399,10 @@ impl Upgrade {
             }
 
             // Find which config file defines this tool
-            for (_path, cf) in config.config_files.iter() {
+            for (path, cf) in config.config_files.iter() {
+                if crate::config::is_global_config(path) {
+                    continue;
+                }
                 let Ok(trs) = cf.to_tool_request_set() else {
                     continue;
                 };

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -268,41 +268,42 @@ pub fn compute_config_bumps(
                 .unwrap_or(&current_version);
 
             if let Some(bumped) = check_semver_bump(old, cli_version)
-                && bumped != old {
-                    let new_version = format!("{prefix}{bumped}");
-                    let new_request = match requests[0].clone() {
-                        ToolRequest::Version {
-                            version: _,
-                            backend,
-                            options,
-                            source,
-                        } => ToolRequest::Version {
-                            version: new_version.clone(),
-                            backend,
-                            options,
-                            source,
-                        },
-                        ToolRequest::Prefix {
-                            prefix: _,
-                            backend,
-                            options,
-                            source,
-                        } => ToolRequest::Prefix {
-                            prefix: format!("{prefix}{bumped}"),
-                            backend,
-                            options,
-                            source,
-                        },
-                        other => other,
-                    };
-                    bumps.push(ConfigBump {
-                        tool_name: tool_name.to_string(),
-                        config_path: path.clone(),
-                        old_version: current_version.to_string(),
-                        new_version,
-                        new_request,
-                    });
-                }
+                && bumped != old
+            {
+                let new_version = format!("{prefix}{bumped}");
+                let new_request = match requests[0].clone() {
+                    ToolRequest::Version {
+                        version: _,
+                        backend,
+                        options,
+                        source,
+                    } => ToolRequest::Version {
+                        version: new_version.clone(),
+                        backend,
+                        options,
+                        source,
+                    },
+                    ToolRequest::Prefix {
+                        prefix: _,
+                        backend,
+                        options,
+                        source,
+                    } => ToolRequest::Prefix {
+                        prefix: format!("{prefix}{bumped}"),
+                        backend,
+                        options,
+                        source,
+                    },
+                    other => other,
+                };
+                bumps.push(ConfigBump {
+                    tool_name: tool_name.to_string(),
+                    config_path: path.clone(),
+                    old_version: current_version.to_string(),
+                    new_version,
+                    new_request,
+                });
+            }
             break;
         }
     }

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -267,8 +267,8 @@ pub fn compute_config_bumps(
                 .strip_prefix(&prefix)
                 .unwrap_or(&current_version);
 
-            if let Some(bumped) = check_semver_bump(old, cli_version) {
-                if bumped != old {
+            if let Some(bumped) = check_semver_bump(old, cli_version)
+                && bumped != old {
                     let new_version = format!("{prefix}{bumped}");
                     let new_request = match requests[0].clone() {
                         ToolRequest::Version {
@@ -303,7 +303,6 @@ pub fn compute_config_bumps(
                         new_request,
                     });
                 }
-            }
             break;
         }
     }

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -185,7 +185,7 @@ impl Display for OutdatedInfo {
 /// at the same specificity level as the old version
 /// used with `mise outdated --bump` to determine what new semver range to use
 /// given old: "20" and new: "21.2.3", return Some("21")
-fn check_semver_bump(old: &str, new: &str) -> Option<String> {
+pub fn check_semver_bump(old: &str, new: &str) -> Option<String> {
     // Preserve known channel names as-is
     const CHANNEL_NAMES: &[&str] = &[
         "latest", "nightly", "stable", "beta", "dev", "canary", "edge", "lts",

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -225,6 +225,110 @@ pub fn check_semver_bump(old: &str, new: &str) -> Option<String> {
     }
 }
 
+/// Represents a config file update needed when a CLI-specified version doesn't match
+/// the current config prefix.
+pub struct ConfigBump {
+    pub tool_name: String,
+    pub config_path: std::path::PathBuf,
+    pub old_version: String,
+    pub new_version: String,
+    pub new_request: ToolRequest,
+}
+
+/// Compute config bumps needed when CLI-specified versions don't match current config prefixes.
+/// Returns a list of bumps to apply (or preview in dry-run mode).
+pub fn compute_config_bumps(
+    config: &Config,
+    tool_versions: &[(&str, &str)], // (tool_short_name, cli_version)
+) -> Vec<ConfigBump> {
+    let mut bumps = Vec::new();
+
+    for &(tool_name, cli_version) in tool_versions {
+        for (path, cf) in config.config_files.iter() {
+            if crate::config::is_global_config(path) {
+                continue;
+            }
+            let Ok(trs) = cf.to_tool_request_set() else {
+                continue;
+            };
+
+            // Find the tool by short name in this config file
+            let matching = trs.tools.iter().find(|(ba, _)| ba.short == tool_name);
+            let Some((_ba, requests)) = matching else {
+                continue;
+            };
+            if requests.len() != 1 {
+                continue;
+            }
+
+            let current_version = requests[0].version();
+            let (prefix, _) = split_version_prefix(&current_version);
+            let old = current_version
+                .strip_prefix(&prefix)
+                .unwrap_or(&current_version);
+
+            if let Some(bumped) = check_semver_bump(old, cli_version) {
+                if bumped != old {
+                    let new_version = format!("{prefix}{bumped}");
+                    let new_request = match requests[0].clone() {
+                        ToolRequest::Version {
+                            version: _,
+                            backend,
+                            options,
+                            source,
+                        } => ToolRequest::Version {
+                            version: new_version.clone(),
+                            backend,
+                            options,
+                            source,
+                        },
+                        ToolRequest::Prefix {
+                            prefix: _,
+                            backend,
+                            options,
+                            source,
+                        } => ToolRequest::Prefix {
+                            prefix: format!("{prefix}{bumped}"),
+                            backend,
+                            options,
+                            source,
+                        },
+                        other => other,
+                    };
+                    bumps.push(ConfigBump {
+                        tool_name: tool_name.to_string(),
+                        config_path: path.clone(),
+                        old_version: current_version.to_string(),
+                        new_version,
+                        new_request,
+                    });
+                }
+            }
+            break;
+        }
+    }
+
+    bumps
+}
+
+/// Apply config bumps by writing the new versions to their config files.
+pub fn apply_config_bumps(config: &Config, bumps: &[ConfigBump]) -> Result<()> {
+    for bump in bumps {
+        let Some(cf) = config.config_files.get(&bump.config_path) else {
+            continue;
+        };
+        let Ok(trs) = cf.to_tool_request_set() else {
+            continue;
+        };
+        let Some((ba, _)) = trs.tools.iter().find(|(ba, _)| ba.short == bump.tool_name) else {
+            continue;
+        };
+        cf.replace_versions(ba, vec![bump.new_request.clone()])?;
+        cf.save()?;
+    }
+    Ok(())
+}
+
 pub fn is_outdated_version(current: &str, latest: &str) -> bool {
     if let (Some(c), Some(l)) = (Version::new(current), Version::new(latest)) {
         c.lt(&l)


### PR DESCRIPTION
## Summary
- `mise upgrade tool@version` now properly updates the lockfile with the specified version instead of silently ignoring it
- `mise lock tool@version` now respects the `@version` argument instead of ignoring it
- When the specified version doesn't match the current config prefix (e.g., upgrading from `tiny = "2"` to `3.0.1`), the config is updated to match (e.g., `"2"` → `"3"`), preserving the original version precision
- When the version matches (e.g., `tiny = "latest"` upgrading to `3.0.1`), the config is left unchanged

Fixes #8980

## Test plan
- [x] E2E: `mise upgrade tiny@3.0.1` with `tiny = "latest"` → lockfile updated, config unchanged
- [x] E2E: `mise upgrade tiny@3.0.1` with `tiny = "2"` → config bumped to `"3"`, lockfile updated
- [x] E2E: `mise lock tiny@3.0.1` with `tiny = "latest"` → lockfile updated, config unchanged
- [x] E2E: `mise lock tiny@3.0.1` with `tiny = "2"` → config bumped to `"3"`, lockfile updated
- [x] All existing `test_upgrade`, `test_lock`, `test_lock_creation`, `test_lock_global`, `test_lock_local_config` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `mise lock`/`mise upgrade` behavior around explicit `tool@version` arguments, including automatically rewriting project config files and lockfile entries; mistakes could cause unexpected version pinning or config churn.
> 
> **Overview**
> **`mise lock tool@version` and `mise upgrade tool@version` now respect the explicit version** when writing `mise.lock`, instead of resolving and locking the config-selected version.
> 
> When the requested version’s major/prefix doesn’t match the current `mise.toml` spec (e.g., `tiny = "2"` and `tiny@3.0.1`), the CLI now **auto-bumps the config specifier** to the matching prefix (preserving precision), with dry-run output showing the intended edits. `upgrade` also normalizes upgraded `ToolVersion` requests/sources so lockfile updates replace the existing entry (e.g., keep `"latest"` request) rather than creating duplicates.
> 
> Adds E2E coverage for `lock` and `upgrade` explicit-version flows, and updates lockfile docs with guidance/table for version pinning and command behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32935d3b18d9cfb5ed5c588e9f4a9591c883cd77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->