### PR TITLE
fix(task): prevent panic when running parallel sub-tasks with replacing output

### DIFF
--- a/e2e/tasks/test_task_parallel_replacing
+++ b/e2e/tasks/test_task_parallel_replacing
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Regression test: parallel sub-tasks with "replacing" output mode should not
+# panic due to missing progress reporter entries (GitHub discussion #8985).
+
+cat <<EOF >mise.toml
+[settings.task]
+output = "replacing"
+
+[tasks.parallel]
+description = "Run tasks in parallel via direct tasks array"
+run = [{ tasks = ["t:1", "t:2", "t:3"] }]
+
+[tasks."t:1"]
+run = "echo 'task 1 done'"
+
+[tasks."t:2"]
+run = "echo 'task 2 done'"
+
+[tasks."t:3"]
+run = "echo 'task 3 done'"
+EOF
+
+# Should complete without panicking
+assert "mise run parallel"

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -922,7 +922,7 @@ impl TaskExecutor {
                 }
                 // Show progress indicator except when both streams are fully suppressed
                 if !task.silent.suppresses_both() {
-                    let pr = self.output_handler.task_prs.get(task).unwrap().clone();
+                    let pr = self.output_handler.get_or_init_task_pr(task);
                     cmd = cmd.with_pr_arc(pr);
                 }
             }

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -183,7 +183,7 @@ pub struct OutputHandlerConfig {
 /// Handles task output routing, formatting, and display
 pub struct OutputHandler {
     pub keep_order_state: Arc<Mutex<KeepOrderState>>,
-    pub task_prs: IndexMap<Task, Arc<Box<dyn SingleReport>>>,
+    pub task_prs: Arc<Mutex<IndexMap<Task, Arc<Box<dyn SingleReport>>>>>,
     pub timed_outputs: Arc<Mutex<IndexMap<String, (SystemTime, String)>>>,
 
     // Configuration from CLI args
@@ -212,10 +212,25 @@ impl Clone for OutputHandler {
 }
 
 impl OutputHandler {
+    /// Get or lazily create a progress reporter for a task in Replacing mode.
+    pub fn get_or_init_task_pr(&self, task: &Task) -> Arc<Box<dyn SingleReport>> {
+        let mut prs = self.task_prs.lock().unwrap();
+        if let Some(pr) = prs.get(task) {
+            pr.clone()
+        } else {
+            let pr = MultiProgressReport::get().add(&task.estyled_prefix());
+            let pr = Arc::new(pr);
+            prs.insert(task.clone(), pr.clone());
+            pr
+        }
+    }
+}
+
+impl OutputHandler {
     pub fn new(config: OutputHandlerConfig) -> Self {
         Self {
             keep_order_state: Arc::new(Mutex::new(KeepOrderState::new())),
-            task_prs: IndexMap::new(),
+            task_prs: Arc::new(Mutex::new(IndexMap::new())),
             timed_outputs: Arc::new(Mutex::new(IndexMap::new())),
             output: config.output,
             silent: config.silent,
@@ -236,8 +251,7 @@ impl OutputHandler {
                 }
             }
             TaskOutput::Replacing => {
-                let pr = MultiProgressReport::get().add(&task.estyled_prefix());
-                self.task_prs.insert(task.clone(), Arc::new(pr));
+                self.get_or_init_task_pr(task);
             }
             _ => {}
         }
@@ -300,7 +314,7 @@ impl OutputHandler {
                 );
             }
             TaskOutput::Replacing => {
-                let pr = self.task_prs.get(task).unwrap().clone();
+                let pr = self.get_or_init_task_pr(task);
                 pr.set_message(format!("{prefix} {line}"));
             }
             _ => {

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -8,6 +8,8 @@ use indexmap::IndexMap;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
+type TaskPrMap = Arc<Mutex<IndexMap<Task, Arc<Box<dyn SingleReport>>>>>;
+
 /// A single line of output, tagged by stream.
 pub enum KeepOrderLine {
     Stdout(String, String), // (prefix, line)
@@ -183,7 +185,7 @@ pub struct OutputHandlerConfig {
 /// Handles task output routing, formatting, and display
 pub struct OutputHandler {
     pub keep_order_state: Arc<Mutex<KeepOrderState>>,
-    pub task_prs: Arc<Mutex<IndexMap<Task, Arc<Box<dyn SingleReport>>>>>,
+    pub task_prs: TaskPrMap,
     pub timed_outputs: Arc<Mutex<IndexMap<String, (SystemTime, String)>>>,
 
     // Configuration from CLI args


### PR DESCRIPTION
## Summary
- Fixes panic (`unwrap()` on `None`) when running parallel sub-tasks (via `tasks = [...]` in run steps) with `output = "replacing"` mode
- Dynamically injected sub-tasks were never initialized in the `task_prs` map, so accessing their progress reporter panicked
- Changed `task_prs` to `Arc<Mutex<IndexMap>>` with lazy initialization via `get_or_init_task_pr()`

Closes discussion #8985

## Test plan
- [x] Added `e2e/tasks/test_task_parallel_replacing` that reproduces the panic
- [x] Verified test panics without the fix and passes with it
- [x] `cargo check` passes
- [x] Lints pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task output/progress reporter bookkeeping in `Replacing` mode by introducing shared locking and lazy initialization, which could affect concurrency behavior and performance under parallel task execution.
> 
> **Overview**
> Prevents a panic in `output = "replacing"` when parallel/injected sub-tasks emit output before being registered by lazily creating per-task progress reporters via `OutputHandler::get_or_init_task_pr()`.
> 
> `task_prs` is now a shared `Arc<Mutex<...>>` and all call sites that previously `unwrap()`ed a missing reporter now fetch-or-create it; adds an e2e regression test covering `mise run` of parallel sub-tasks in replacing mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772b03d86935abf3c551d94c90740881f024fda5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->