### PR TITLE
fix(activate): handle empty __MISE_FLAGS array with set -u on bash 3.2

### DIFF
--- a/src/assets/bash/activate.sh
+++ b/src/assets/bash/activate.sh
@@ -35,7 +35,7 @@ mise() {
 
 _mise_hook() {
 	local previous_exit_status=$?
-	eval "$(mise hook-env "${__MISE_FLAGS[@]}" -s bash)"
+	eval "$(mise hook-env ${__MISE_FLAGS[@]+"${__MISE_FLAGS[@]}"} -s bash)"
 	return $previous_exit_status
 }
 
@@ -46,14 +46,14 @@ if [ "$__MISE_HOOK_ENABLED" = "1" ]; then
 			__MISE_BASH_CHPWD_RAN=0
 			return $previous_exit_status
 		fi
-		eval "$(mise hook-env "${__MISE_FLAGS[@]}" -s bash --reason precmd)"
+		eval "$(mise hook-env ${__MISE_FLAGS[@]+"${__MISE_FLAGS[@]}"} -s bash --reason precmd)"
 		return $previous_exit_status
 	}
 
 	_mise_hook_chpwd() {
 		local previous_exit_status=$?
 		__MISE_BASH_CHPWD_RAN=1
-		eval "$(mise hook-env "${__MISE_FLAGS[@]}" -s bash --reason chpwd)"
+		eval "$(mise hook-env ${__MISE_FLAGS[@]+"${__MISE_FLAGS[@]}"} -s bash --reason chpwd)"
 		return $previous_exit_status
 	}
 

--- a/src/shell/snapshots/mise__shell__bash__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__activate.snap
@@ -39,7 +39,7 @@ mise() {
 
 _mise_hook() {
 	local previous_exit_status=$?
-	eval "$(mise hook-env "${__MISE_FLAGS[@]}" -s bash)"
+	eval "$(mise hook-env ${__MISE_FLAGS[@]+"${__MISE_FLAGS[@]}"} -s bash)"
 	return $previous_exit_status
 }
 
@@ -50,14 +50,14 @@ if [ "$__MISE_HOOK_ENABLED" = "1" ]; then
 			__MISE_BASH_CHPWD_RAN=0
 			return $previous_exit_status
 		fi
-		eval "$(mise hook-env "${__MISE_FLAGS[@]}" -s bash --reason precmd)"
+		eval "$(mise hook-env ${__MISE_FLAGS[@]+"${__MISE_FLAGS[@]}"} -s bash --reason precmd)"
 		return $previous_exit_status
 	}
 
 	_mise_hook_chpwd() {
 		local previous_exit_status=$?
 		__MISE_BASH_CHPWD_RAN=1
-		eval "$(mise hook-env "${__MISE_FLAGS[@]}" -s bash --reason chpwd)"
+		eval "$(mise hook-env ${__MISE_FLAGS[@]+"${__MISE_FLAGS[@]}"} -s bash --reason chpwd)"
 		return $previous_exit_status
 	}
 


### PR DESCRIPTION
## Summary
- Use `${arr[@]+"${arr[@]}"}` pattern to safely expand the `__MISE_FLAGS` array when empty
- Bash < 4.4 (including macOS's default bash 3.2) treats `"${arr[@]}"` on an empty array as an unbound variable under `set -u` (nounset)
- This causes scripts that source `.bashrc` (which contains `eval "$(mise activate bash)"`) to fail with: `__MISE_FLAGS[@]: unbound variable`

## Test plan
- [x] Verified the bug reproduces on bash 3.2 (via `docker run bash:3.2`) with `set -u` and empty `__MISE_FLAGS=()`
- [x] Verified the fix works on bash 3.2 with `set -u` and empty flags
- [x] Verified non-empty flags still pass through correctly (`--status`)
- [x] Snapshot tests updated and passing

Fixes https://github.com/jdx/mise/discussions/8987

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to Bash activation script argument expansion, mainly affecting older Bash with `set -u`; behavior should be unchanged when flags are present.
> 
> **Overview**
> Fixes Bash activation hooks to safely expand `__MISE_FLAGS` even when the array is empty under `set -u` (notably on Bash 3.2), by switching to the `${arr[@]+"${arr[@]}"}` expansion pattern.
> 
> Updates the corresponding snapshot (`mise__shell__bash__tests__activate.snap`) to match the new generated activation script output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15c7af0927dcd9987ce90f1a3543d99f3eb64033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->