### PR TITLE
fix(release): publish extracted mise.exe alongside Windows zip

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -46,6 +46,8 @@ for platform in "${windows_platforms[@]}"; do
 	zipsign sign zip "$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.zip" ~/.zipsign/mise.priv
 	zipsign verify zip "$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.zip" "$BASE_DIR/zipsign.pub"
 	cp "$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.zip" "$RELEASE_DIR/mise-latest-$platform.zip"
+	unzip -p "$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.zip" mise/bin/mise.exe >"$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.exe"
+	cp "$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.exe" "$RELEASE_DIR/mise-latest-$platform.exe"
 done
 
 echo "::group::Checksums"


### PR DESCRIPTION
## Problem

`SHASUMS256.txt` includes hashes for the Windows `.zip` files but not for the extracted `.exe` binaries. `mise-action` verifies the sha256 of the extracted binary after unpacking, so users currently cannot pin `sha256` for the Windows binary — it's simply not in the checksum file.

## Fix

After signing and verifying each Windows zip, extract `mise.exe` from it and copy it as a release asset (both versioned and `mise-latest-<platform>.exe`). The existing checksum generation loop then picks up the `.exe` files automatically and adds them to `SHASUMS256.txt`.

Two lines added to `scripts/release.sh`, no other changes.

## Testing

- [ ] Verify `SHASUMS256.txt` contains entries for `.exe` files after a release build
- [ ] Verify `mise-action` can verify the Windows binary sha256 with the pinned hash