### PR TITLE
fix(env): preserve externally prepended paths when one is already in orig PATH

### DIFF
--- a/e2e/env/test_path_all_orig_duplicated
+++ b/e2e/env/test_path_all_orig_duplicated
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Regression guard for the boundary-detection logic when every orig-PATH entry
+# has a stale tail copy AND a new path is appended after the tail copies.
+# This is a synthetic worst case, not a literal `direnv PATH_add` output
+# (real PATH_add prepends to the front, producing layouts like `b:a:a:b:SYS`).
+# It exercises the tail-anchored boundary detection in `build_path_operations()`
+# to ensure appended paths are not promoted to pre when all orig entries are
+# duplicated.
+
+MISE_BIN="$(which mise)"
+
+mkdir -p "$HOME/orig-bin-a"
+mkdir -p "$HOME/orig-bin-b"
+mkdir -p "$HOME/appended-bin"
+
+cat >"$HOME/orig-bin-a/check-priority" <<'EOF'
+#!/usr/bin/env bash
+echo "orig-a"
+EOF
+cat >"$HOME/appended-bin/check-priority" <<'EOF'
+#!/usr/bin/env bash
+echo "appended"
+EOF
+chmod +x "$HOME/orig-bin-a/check-priority"
+chmod +x "$HOME/appended-bin/check-priority"
+
+cat >mise.toml <<'EOF'
+EOF
+
+# Orig PATH has exactly two custom entries — both will be duplicated.
+export __MISE_ORIG_PATH="$HOME/orig-bin-a:$HOME/orig-bin-b"
+
+# External tool prepended copies of BOTH orig paths (all-duplicated scenario).
+# System paths are included so shell commands remain available after the override.
+# appended-bin was added after the orig block and must remain after it.
+export PATH="$HOME/orig-bin-a:$HOME/orig-bin-b:/usr/local/bin:/usr/bin:/bin:$HOME/orig-bin-a:$HOME/orig-bin-b:$HOME/appended-bin"
+
+eval "$("$MISE_BIN" hook-env -s bash)"
+
+echo "DEBUG: PATH=$PATH"
+
+ORIG_A_FIRST_POS=$(echo "$PATH" | tr ':' '\n' | grep -n "orig-bin-a" | head -1 | cut -d: -f1)
+APPENDED_POS=$(echo "$PATH" | tr ':' '\n' | grep -n "appended-bin" | head -1 | cut -d: -f1)
+
+echo "DEBUG: orig-bin-a first at $ORIG_A_FIRST_POS, appended-bin at $APPENDED_POS"
+
+if [[ -z $APPENDED_POS ]]; then
+	echo "FAIL: appended-bin not found in PATH"
+	exit 1
+fi
+
+if [[ -z $ORIG_A_FIRST_POS ]]; then
+	echo "FAIL: orig-bin-a not found in PATH"
+	exit 1
+fi
+
+# appended-bin must come AFTER the orig block, not be promoted to the front
+if [[ $APPENDED_POS -gt $ORIG_A_FIRST_POS ]]; then
+	echo "SUCCESS: appended-bin stays after orig block (not promoted to pre)"
+else
+	echo "FAIL: appended-bin ($APPENDED_POS) was promoted before orig-bin-a ($ORIG_A_FIRST_POS)"
+	echo "All-duplicated-orig edge case: appended path incorrectly classified as pre"
+	exit 1
+fi
+
+# orig-bin-a wins check-priority (it's in the orig block ahead of appended-bin)
+assert_contains "check-priority" "orig-a"

--- a/e2e/env/test_path_external_prepend_existing
+++ b/e2e/env/test_path_external_prepend_existing
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Test that all externally prepended paths stay at the front of PATH even
+# when one of them already exists in __MISE_ORIG_PATH.
+
+# Save the mise binary path before we override PATH
+MISE_BIN="$(which mise)"
+
+# Original PATH at activation time — note that existing-bin is present
+export __MISE_ORIG_PATH="$HOME/system-bin:/usr/local/bin:/usr/bin:/bin:$HOME/existing-bin"
+
+mkdir -p "$HOME/existing-bin"
+mkdir -p "$HOME/system-bin"
+mkdir -p "$HOME/prepended-bin"
+
+cat >"$HOME/system-bin/check-priority" <<'EOF'
+#!/usr/bin/env bash
+echo "system"
+EOF
+
+cat >"$HOME/prepended-bin/check-priority" <<'EOF'
+#!/usr/bin/env bash
+echo "prepended"
+EOF
+
+chmod +x "$HOME/system-bin/check-priority"
+chmod +x "$HOME/prepended-bin/check-priority"
+
+# Simulate an external tool (e.g., direnv) that prepended two paths.
+# Because prepending is LIFO, existing-bin (added second) ends up first:
+#   PATH_add prepended-bin  -> prepended-bin:<orig>
+#   PATH_add existing-bin   -> existing-bin:prepended-bin:<orig>
+# Critically, existing-bin already appears in __MISE_ORIG_PATH.
+export PATH="$HOME/existing-bin:$HOME/prepended-bin:$HOME/system-bin:/usr/local/bin:/usr/bin:/bin:$HOME/existing-bin"
+
+cat >mise.toml <<'EOF'
+EOF
+
+eval "$("$MISE_BIN" hook-env -s bash)"
+
+echo "DEBUG: PATH=$PATH"
+
+# prepended-bin should be BEFORE system-bin — it was prepended by the external tool
+PREPENDED_POS=$(echo "$PATH" | tr ':' '\n' | grep -n "prepended-bin" | head -1 | cut -d: -f1)
+SYSTEM_POS=$(echo "$PATH" | tr ':' '\n' | grep -n "system-bin" | head -1 | cut -d: -f1)
+
+echo "DEBUG: prepended-bin at position $PREPENDED_POS, system-bin at position $SYSTEM_POS"
+
+if [[ -z $PREPENDED_POS ]]; then
+	echo "FAIL: prepended-bin not found in PATH"
+	exit 1
+fi
+
+if [[ -z $SYSTEM_POS ]]; then
+	echo "FAIL: system-bin not found in PATH"
+	exit 1
+fi
+
+if [[ $PREPENDED_POS -lt $SYSTEM_POS ]]; then
+	echo "SUCCESS: prepended-bin stays before system-bin (prepend preserved)"
+else
+	echo "FAIL: prepended-bin ($PREPENDED_POS) was moved after system-bin ($SYSTEM_POS)"
+	echo "Prepended path was misclassified because an already-in-orig path preceded it"
+	exit 1
+fi
+
+# Confirm the winning binary is actually from prepended-bin, not system-bin.
+# This validates the end-to-end functional outcome beyond position alone.
+assert_contains "check-priority" "prepended"
+
+# existing-bin must appear exactly twice in PATH: once at the front (prepended
+# by the external tool) and once at its original tail position.  Assert that
+# both copies survive.
+EXISTING_BIN_COUNT=$(echo "$PATH" | tr ':' '\n' | grep -c "existing-bin")
+echo "DEBUG: existing-bin count in PATH: $EXISTING_BIN_COUNT"
+if [[ $EXISTING_BIN_COUNT -ne 2 ]]; then
+	echo "FAIL: expected existing-bin to appear 2 times in PATH but got $EXISTING_BIN_COUNT"
+	exit 1
+fi
+echo "SUCCESS: existing-bin appears exactly 2 times in PATH (prepend copy + original tail copy)"

--- a/e2e/env/test_path_interleaved_regression
+++ b/e2e/env/test_path_interleaved_regression
@@ -9,6 +9,9 @@
 # 4. User adds MORE Homebrew paths (which get interleaved with system paths)
 # Result: Paths after the first system path match were being lost
 
+# Save the mise binary path before we override PATH
+MISE_BIN="$(which mise)"
+
 export MISE_EXPERIMENTAL=1
 
 # Simulate the PATH that existed when mise was first activated
@@ -28,8 +31,8 @@ cat >.mise.toml <<EOF
 tiny = "latest"
 EOF
 
-# Run hook-env and source it
-eval "$(mise hook-env -s bash)"
+# Run hook-env using the saved binary path
+eval "$("$MISE_BIN" hook-env -s bash)"
 
 # Verify that all Homebrew paths are still present
 # The bug would cause paths after /usr/local/bin to be lost
@@ -40,3 +43,26 @@ assert_contains "echo $PATH" "/opt/homebrew/opt/grep/libexec/gnubin"
 # Verify system paths are still present
 assert_contains "echo $PATH" "/usr/local/bin"
 assert_contains "echo $PATH" "/usr/bin"
+
+# Verify ordering: curl/bin was prepended before the orig block and must stay
+# before /usr/local/bin. Interleaved paths (findutils, grep) must NOT be promoted
+# ahead of /usr/local/bin — that would give them unintended priority.
+CURL_POS=$(echo "$PATH" | tr ':' '\n' | grep -n "opt/curl" | head -1 | cut -d: -f1)
+USR_LOCAL_POS=$(echo "$PATH" | tr ':' '\n' | grep -n "usr/local/bin" | head -1 | cut -d: -f1)
+FINDUTILS_POS=$(echo "$PATH" | tr ':' '\n' | grep -n "findutils" | head -1 | cut -d: -f1)
+
+echo "DEBUG: curl/bin at $CURL_POS, /usr/local/bin at $USR_LOCAL_POS, findutils at $FINDUTILS_POS"
+
+if [[ $CURL_POS -lt $USR_LOCAL_POS ]]; then
+	echo "SUCCESS: curl/bin stays before /usr/local/bin (prepend preserved)"
+else
+	echo "FAIL: curl/bin ($CURL_POS) moved after /usr/local/bin ($USR_LOCAL_POS)"
+	exit 1
+fi
+
+if [[ $FINDUTILS_POS -gt $USR_LOCAL_POS ]]; then
+	echo "SUCCESS: findutils not promoted before /usr/local/bin (interleaved entry kept out of pre)"
+else
+	echo "FAIL: findutils ($FINDUTILS_POS) was promoted before /usr/local/bin ($USR_LOCAL_POS)"
+	exit 1
+fi

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -12,7 +12,7 @@ use console::truncate_str;
 use eyre::Result;
 use indexmap::IndexSet;
 use itertools::Itertools;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::{borrow::Cow, sync::Arc};
@@ -268,16 +268,38 @@ impl HookEnv {
                 // Also collect orig paths in their current order to preserve any
                 // reordering done after activation (e.g., by ~/.zlogin which runs
                 // after ~/.zshrc where mise activate is typically placed).
+                //
+                // The pre/post boundary fires on the *last* occurrence of each orig
+                // entry in current_paths.  For a duplicated entry (moved-to-front copy +
+                // stale tail copy) the first copy is in the "pre" zone and the last copy
+                // is the genuine original-position tail; anchoring on the last occurrence
+                // correctly places new prepends in pre even when all orig entries are
+                // duplicated.
+                let orig_count_in_current = current_paths
+                    .iter()
+                    .filter(|p| orig_set.contains(p))
+                    .counts();
+
                 let mut pre = Vec::new();
                 let mut post_user = Vec::new();
                 let mut orig_reordered = Vec::new();
-                let mut seen_orig = false;
                 let mut seen_in_current: HashSet<&PathBuf> = HashSet::new();
+                // Running count of how many times each orig path has been seen so far.
+                let mut seen_orig_count: HashMap<&PathBuf, usize> = HashMap::new();
+                // true once iteration has passed the genuine tail position of any orig entry.
+                let mut past_orig_boundary = false;
                 for path in &current_paths {
                     if orig_set.contains(path) {
-                        seen_orig = true;
+                        let seen = seen_orig_count.entry(path).or_insert(0);
+                        *seen += 1;
                         orig_reordered.push(path.clone());
                         seen_in_current.insert(path);
+                        // Anchor the boundary on the last occurrence of this orig path.
+                        // Earlier copies are external prepends; the last copy is the
+                        // original tail position — that is the real pre/post boundary.
+                        if *seen == orig_count_in_current.get(path).copied().unwrap_or(1) {
+                            past_orig_boundary = true;
+                        }
                         continue;
                     }
 
@@ -287,7 +309,7 @@ impl HookEnv {
                     }
 
                     // Place in pre or post_user based on position relative to original PATH
-                    if seen_orig {
+                    if past_orig_boundary {
                         post_user.push(path.clone());
                     } else {
                         pre.push(path.clone());


### PR DESCRIPTION
## Summary

When both `mise activate` and `direnv hook` are active in zsh, paths
added via `PATH_add` in `.envrc` can end up at the **end** of PATH
instead of the beginning -- the opposite of what `PATH_add` is supposed
to do. Tools in a virtualenv or project-local scripts silently lose
priority over system binaries.

**Root cause:** `build_path_operations()` in `hook_env.rs` uses a
`seen_orig` boolean to mark the boundary between "prepended" (pre) and
"appended" (post_user) paths. It fires as soon as the first orig-PATH
entry appears in current PATH. But if an external tool prepended a path
that *already existed* in `__MISE_ORIG_PATH`, that entry appeared first
in the current PATH and triggered the flag immediately. Every genuinely
new prepend after it was misclassified as post_user and landed at the
end.

## Changes

### 1. Bug fix (`hook_env.rs`)

Replace the single `seen_orig` boolean with boundary detection that
identifies the genuine original-position (tail) copy of each orig entry.
A path moved to the front by an external tool is correctly kept in the
pre zone; the boundary fires only when iteration reaches the tail copy.
This also handles the edge case where all orig entries are duplicated —
the boundary still fires correctly when the tail copies are reached.

### 2. Existing test fix (`test_path_interleaved_regression`)

This test was not exercising `hook-env`: it called `mise hook-env` after
overriding PATH, which removed the mise binary from PATH, so `eval` ran
on an empty string and all assertions were trivially checking the
manually-set PATH. Fixed by saving the mise binary path before the PATH
override (`MISE_BIN=$(which mise)`) and adding ordering assertions that
verify prepended paths stay before orig entries and interleaved paths are
not promoted ahead of them.

Proved the test was previously inert: introducing a deliberate ordering
bug in `hook_env.rs` passed the old test but failed the new one.

### 3. New tests

**`test_path_external_prepend_existing`** — directly reproduces the direnv
scenario: `__MISE_ORIG_PATH` contains `existing-bin`, then current PATH has
`existing-bin:prepended-bin:<orig>` simulating two `PATH_add` calls where one
path already exists in orig. Asserts that `prepended-bin` stays before
`system-bin` after `hook-env`, that the `check-priority` binary resolves from
the prepended location, and that `existing-bin` appears exactly twice in PATH
(prepend copy + original tail copy).

**`test_path_all_orig_duplicated`** — covers the edge case where an external
tool duplicates *every* orig path to the front (e.g., consecutive `PATH_add`
calls for all orig entries). Asserts that paths appended after the orig block
stay after it and are not promoted to the front.

## Reproduction

```zsh
# ~/.local/bin is already in PATH when mise activates
export PATH="${HOME}/.local/bin:${PATH}"

$ cat ~/project/.envrc
PATH_add "${PWD}/venv/bin"      # genuinely new
PATH_add "${HOME}/.local/bin"   # already in orig PATH, added last so ends up first

$ cd ~/project
$ echo $PATH | tr ':' '\n'
/home/user/.local/bin
/usr/local/bin
/usr/bin
/bin
/home/user/.local/bin
/home/user/project/venv/bin    # landed at the very end (should be near front)
```

Workarounds (both avoid the bug):
- Swap the `PATH_add` order so the already-in-orig entry is added first
- Remove the redundant `PATH_add` for a path already in orig PATH

## Test plan

- [x] `mise run test:e2e test_path_external_prepend_existing` -- passes (fails on old code)
- [x] `mise run test:e2e test_path_interleaved_regression` -- passes with real hook-env exercise
- [x] All 12 PATH-related e2e tests pass (`test_path*`)
- [x] `cargo test --all-features` passes
- [x] `TEST_ALL=1 mise run test:e2e -- env` passes
- [x] `mise run test:e2e test_path_all_orig_duplicated` -- boundary guard for all-orig-duplicated case

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
