### PR TITLE
fix(env): skip tools=true module hooks in dependency_env

### DIFF
--- a/e2e/env/test_env_module_tools_no_spurious_warning
+++ b/e2e/env/test_env_module_tools_no_spurious_warning
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# Regression test for https://github.com/jdx/mise/discussions/8962
+#
+# When a vfox backend tool is in the toolset, its _exec_env calls
+# dependency_env() which used to call full_env() → load_post_env().
+# That resolved ALL tools=true modules (including fnox-env) with a PATH
+# that only contained dependency-toolset tools — not fnox — causing a
+# spurious "fnox: command not found" warning.
+#
+# The fix changes dependency_env to use full_env_without_tools so it
+# skips tools=true module resolution entirely.
+
+# 1. Install fnox tool and fnox-env plugin
+mise plugins install fnox-env https://github.com/jdx/mise-env-fnox
+
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[tools]
+fnox = "latest"
+
+[env]
+_.fnox-env = { tools = true }
+
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+EOF
+
+mise i
+
+# Verify fnox is installed
+assert "mise x -- fnox --version"
+
+# 2. Create a fake vfox plugin with env_keys hook (triggers dependency_env)
+PLUGIN_NAME="dummy-vfox-trigger"
+PLUGIN_DIR="$MISE_DATA_DIR/plugins/$PLUGIN_NAME"
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'EOFMETA'
+PLUGIN = {}
+PLUGIN.name = "dummy-vfox-trigger"
+PLUGIN.version = "0.1.0"
+PLUGIN.homepage = ""
+PLUGIN.license = "MIT"
+PLUGIN.description = "Dummy vfox plugin to trigger dependency_env"
+PLUGIN.minRuntimeVersion = "0.3.0"
+EOFMETA
+
+cat >"$PLUGIN_DIR/hooks/available.lua" <<'EOFHOOK'
+function PLUGIN:Available(ctx)
+    return {
+        { version = "1.0.0" }
+    }
+end
+EOFHOOK
+
+cat >"$PLUGIN_DIR/hooks/env_keys.lua" <<'EOFHOOK'
+function PLUGIN:EnvKeys(ctx)
+    return {}
+end
+EOFHOOK
+
+# 3. Fake-install the vfox tool by creating the install directory
+INSTALL_DIR="$MISE_DATA_DIR/installs/$PLUGIN_NAME/1.0.0"
+mkdir -p "$INSTALL_DIR/bin"
+cat >"$INSTALL_DIR/bin/dummy-vfox-trigger" <<'EOFBIN'
+#!/bin/sh
+echo "dummy-vfox-trigger 1.0.0"
+EOFBIN
+chmod +x "$INSTALL_DIR/bin/dummy-vfox-trigger"
+
+# 4. Add the vfox tool to config alongside fnox + fnox-env
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[tools]
+fnox = "latest"
+"vfox:$PLUGIN_NAME" = "1.0.0"
+
+[env]
+_.fnox-env = { tools = true }
+
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+EOF
+
+# 5. Run mise env and capture stderr — should NOT contain "command not found"
+STDERR_OUTPUT=$(mise env -s bash 2>&1 1>/dev/null || true)
+if echo "$STDERR_OUTPUT" | grep -q "command not found"; then
+	echo "FAIL: Spurious 'command not found' warning in mise env stderr:"
+	echo "$STDERR_OUTPUT"
+	exit 1
+fi
+echo "PASS: No spurious warning from tools=true module during dependency_env"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1405,10 +1405,14 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     async fn dependency_env(&self, config: &Arc<Config>) -> eyre::Result<BTreeMap<String, String>> {
+        // Use full_env_without_tools to avoid triggering `tools = true` env module
+        // hooks (e.g., MiseEnv Lua hooks). Those modules may depend on tools that
+        // are not in the dependency toolset, causing "command not found" errors.
+        // The dependency env only needs tool bin paths on PATH, not module outputs.
         let mut env = self
             .dependency_toolset(config)
             .await?
-            .full_env(config)
+            .full_env_without_tools(config)
             .await?;
 
         // Remove mise shims from PATH to prevent infinite shim recursion when a

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -23,7 +23,9 @@ impl Toolset {
     }
 
     /// Like full_env but skips `tools=true` env directives (load_post_env).
-    /// Used for preinstall hooks where tool-dependent env vars aren't available yet.
+    /// Used for preinstall hooks where tool-dependent env vars aren't available yet,
+    /// and for dependency_env where resolving tools=true modules on a partial toolset
+    /// would trigger spurious errors from modules expecting the full PATH.
     pub async fn full_env_without_tools(&self, config: &Arc<Config>) -> Result<EnvMap> {
         let mut env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
         env.extend(self.env_with_path_without_tools(config).await?);
@@ -32,7 +34,8 @@ impl Toolset {
 
     /// Like env_with_path but skips `tools=true` env directives.
     /// Used during tool installation where tool-dependent env vars
-    /// may reference tools that aren't installed yet.
+    /// may reference tools that aren't installed yet, and in
+    /// dependency_env to avoid triggering module hooks on a partial PATH.
     pub async fn env_with_path_without_tools(&self, config: &Arc<Config>) -> Result<EnvMap> {
         let (mut env, add_paths) = self.env(config).await?;
         let mut path_env = PathEnv::from_iter(env::PATH.clone());


### PR DESCRIPTION
## Summary
- `dependency_env()` called `full_env()` which cascaded into `load_post_env()` resolving ALL `tools=true` env modules — including ones like `fnox-env` that call `cmd.exec()` expecting full toolset binaries on PATH
- When a vfox tool's `_exec_env` triggered `dependency_env`, the PATH only had the dependency toolset's tools, not the full toolset — causing spurious "command not found" warnings from module hooks
- Switch to `full_env_without_tools()` which provides dependency tool bin paths on PATH without triggering `tools=true` module resolution

Fixes https://github.com/jdx/mise/discussions/8962

## Test plan
- [x] Added e2e test `test_env_module_tools_no_spurious_warning` that installs fnox + fnox-env plugin with `tools=true`, adds a vfox tool, and verifies no "command not found" warning
- [x] Unit tests pass (612 tests)
- [x] Existing e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dependency execution environments are built, which could affect tools that implicitly relied on `tools=true` module outputs during dependency resolution. Scope is small and covered by a new e2e regression test.
> 
> **Overview**
> Stops `dependency_env()` from calling `full_env()` and instead uses `full_env_without_tools()`, so building a dependency-only environment no longer triggers `tools=true` env-module hooks (avoiding noisy "command not found" warnings when the PATH is incomplete).
> 
> Adds an e2e regression test (`test_env_module_tools_no_spurious_warning`) that installs a `tools=true` env module and a dummy vfox tool, then asserts `mise env` produces no spurious stderr warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf367d016d0bb01e001f31c096ebfb210dbe11d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->