### PR TITLE
fix: allow installing bun and others when downloads folder is on a different mount

### DIFF
--- a/e2e/backend/test_bun_cross_device_install
+++ b/e2e/backend/test_bun_cross_device_install
@@ -48,7 +48,7 @@ with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
     info.external_attr = 0o755 << 16
     zf.writestr(info, script)
 PY
-sha256sum "$FIXTURE_DIR/bun-linux-aarch64.zip" | awk '{print $1 "  bun-linux-aarch64.zip"}' > "$FIXTURE_DIR/SHASUMS256.txt"
+sha256sum "$FIXTURE_DIR/bun-linux-aarch64.zip" | awk '{print $1 "  bun-linux-aarch64.zip"}' >"$FIXTURE_DIR/SHASUMS256.txt"
 
 # Serve the fixture with Python's stdlib HTTP server so the test can exercise
 # the real Bun download + checksum + unzip path without relying on GitHub.
@@ -61,7 +61,8 @@ sleep 1
 downloads_dir="/dev/shm/mise-bun-cross-device-install-downloads"
 mkdir -p "$downloads_dir"
 rm -rf "$MISE_DATA_DIR/installs/bun/1.3.10"
-export MISE_URL_REPLACEMENTS="$(printf '{\"https://github.com/oven-sh/bun/releases/download\":\"http://127.0.0.1:%s\"}' "$HTTP_PORT")"
+MISE_URL_REPLACEMENTS="$(printf '{\"https://github.com/oven-sh/bun/releases/download\":\"http://127.0.0.1:%s\"}' "$HTTP_PORT")"
+export MISE_URL_REPLACEMENTS
 
 assert_contains "MISE_DOWNLOADS_DIR='$downloads_dir' mise install bun@1.3.10 2>&1" "bun@1.3.10    ✓ installed"
 assert_contains "$MISE_DATA_DIR/installs/bun/1.3.10/bin/bun -v 2>&1" "1.3.10"

--- a/e2e/backend/test_bun_cross_device_install
+++ b/e2e/backend/test_bun_cross_device_install
@@ -12,10 +12,10 @@ if [[ ! -d /dev/shm ]]; then
 	exit 0
 fi
 
-# Put downloads on /dev/shm and installs under the repo root so bun has to
-# move files across filesystems and hits the rename() cross-device case.
+# Put downloads on /dev/shm and installs under /tmp so bun has to move files
+# across filesystems and hits the rename() cross-device case.
 downloads_dir="$(mktemp -d -p /dev/shm mise-bun-cross-device.XXXXXX)"
-installs_dir="$(mktemp -d -p "$ROOT" mise-bun-cross-device.XXXXXX)"
+installs_dir="$(mktemp -d -p /tmp mise-bun-cross-device.XXXXXX)"
 
 cleanup() {
 	if [[ -n $SERVER_PID ]]; then

--- a/e2e/backend/test_bun_cross_device_install
+++ b/e2e/backend/test_bun_cross_device_install
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Regression test: bun install should work when downloads and installs are on different filesystems.
+
+set -euo pipefail
+
+if [[ $(uname) != Linux ]]; then
+	exit 0
+fi
+
+TEST_DIR="$(mktemp -d)"
+HTTP_PORT=8765
+SERVER_PID=""
+
+cleanup() {
+	if [[ -n $SERVER_PID ]]; then
+		kill "$SERVER_PID" 2>/dev/null || true
+	fi
+	rm -rf "$TEST_DIR" /dev/shm/mise-bun-cross-device-install-downloads
+}
+trap cleanup EXIT
+
+# Build a tiny Bun release fixture that exercises the exact same install code path
+# without the network and without large downloads.
+#
+# The script only needs to answer `-v/--version` for the installer verification;
+# the `bun fixture` fallback just makes any other invocation obviously fake while
+# keeping the binary harmless.
+FIXTURE_DIR="$TEST_DIR/releases/bun-v1.3.10"
+mkdir -p "$FIXTURE_DIR"
+python3 - "$FIXTURE_DIR/bun-linux-aarch64.zip" <<'PY'
+import os
+import sys
+import zipfile
+from zipfile import ZipInfo
+
+out_path = sys.argv[1]
+script = b"""#!/usr/bin/env bash
+if [[ ${1:-} == -v || ${1:-} == --version ]]; then
+  echo 1.3.10
+else
+  echo 'bun fixture' "$@"
+fi
+"""
+
+with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+    info = ZipInfo("bun-linux-aarch64/bun")
+    info.create_system = 3
+    info.external_attr = 0o755 << 16
+    zf.writestr(info, script)
+PY
+sha256sum "$FIXTURE_DIR/bun-linux-aarch64.zip" | awk '{print $1 "  bun-linux-aarch64.zip"}' > "$FIXTURE_DIR/SHASUMS256.txt"
+
+# Serve the fixture with Python's stdlib HTTP server so the test can exercise
+# the real Bun download + checksum + unzip path without relying on GitHub.
+pushd "$TEST_DIR/releases" >/dev/null
+python3 -m http.server "$HTTP_PORT" --bind 127.0.0.1 >/dev/null 2>&1 &
+SERVER_PID=$!
+popd >/dev/null
+sleep 1
+
+downloads_dir="/dev/shm/mise-bun-cross-device-install-downloads"
+mkdir -p "$downloads_dir"
+rm -rf "$MISE_DATA_DIR/installs/bun/1.3.10"
+export MISE_URL_REPLACEMENTS="$(printf '{\"https://github.com/oven-sh/bun/releases/download\":\"http://127.0.0.1:%s\"}' "$HTTP_PORT")"
+
+assert_contains "MISE_DOWNLOADS_DIR='$downloads_dir' mise install bun@1.3.10 2>&1" "bun@1.3.10    ✓ installed"
+assert_contains "$MISE_DATA_DIR/installs/bun/1.3.10/bin/bun -v 2>&1" "1.3.10"

--- a/e2e/backend/test_bun_cross_device_install
+++ b/e2e/backend/test_bun_cross_device_install
@@ -3,37 +3,43 @@
 
 set -euo pipefail
 
-if [[ $(uname) != Linux ]]; then
-	exit 0
-fi
-
 TEST_DIR="$(mktemp -d)"
 HTTP_PORT=8765
 SERVER_PID=""
+
+if [[ ! -d /dev/shm ]]; then
+	echo "skipping: /dev/shm is unavailable on this host" >&2
+	exit 0
+fi
+
+# Put downloads on /dev/shm and installs under the repo root so bun has to
+# move files across filesystems and hits the rename() cross-device case.
+downloads_dir="$(mktemp -d -p /dev/shm mise-bun-cross-device.XXXXXX)"
+installs_dir="$(mktemp -d -p "$ROOT" mise-bun-cross-device.XXXXXX)"
 
 cleanup() {
 	if [[ -n $SERVER_PID ]]; then
 		kill "$SERVER_PID" 2>/dev/null || true
 	fi
-	rm -rf "$TEST_DIR" /dev/shm/mise-bun-cross-device-install-downloads
+	# Remove the temporary test harness state and both temp dirs.
+	rm -rf "$TEST_DIR" "$downloads_dir" "$installs_dir"
 }
 trap cleanup EXIT
 
-# Build a tiny Bun release fixture that exercises the exact same install code path
-# without the network and without large downloads.
-#
-# The script only needs to answer `-v/--version` for the installer verification;
-# the `bun fixture` fallback just makes any other invocation obviously fake while
-# keeping the binary harmless.
-FIXTURE_DIR="$TEST_DIR/releases/bun-v1.3.10"
-mkdir -p "$FIXTURE_DIR"
-python3 - "$FIXTURE_DIR/bun-linux-aarch64.zip" <<'PY'
-import os
+# Serve a tiny Bun release fixture with a Python HTTP server so the test can
+# exercise the real Bun download + checksum + unzip path without relying on GitHub.
+python3 -u - "$TEST_DIR" "$HTTP_PORT" <<'PY' >/dev/null 2>&1 &
+import hashlib
+import io
 import sys
 import zipfile
-from zipfile import ZipInfo
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 
-out_path = sys.argv[1]
+root = Path(sys.argv[1])
+port = int(sys.argv[2])
+# Remember the most recent archive request so SHASUMS256.txt can match it.
+state_file = root / "last-requested-zip.txt"
 script = b"""#!/usr/bin/env bash
 if [[ ${1:-} == -v || ${1:-} == --version ]]; then
   echo 1.3.10
@@ -42,27 +48,56 @@ else
 fi
 """
 
-with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-    info = ZipInfo("bun-linux-aarch64/bun")
-    info.create_system = 3
-    info.external_attr = 0o755 << 16
-    zf.writestr(info, script)
-PY
-sha256sum "$FIXTURE_DIR/bun-linux-aarch64.zip" | awk '{print $1 "  bun-linux-aarch64.zip"}' >"$FIXTURE_DIR/SHASUMS256.txt"
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        return
 
-# Serve the fixture with Python's stdlib HTTP server so the test can exercise
-# the real Bun download + checksum + unzip path without relying on GitHub.
-pushd "$TEST_DIR/releases" >/dev/null
-python3 -m http.server "$HTTP_PORT" --bind 127.0.0.1 >/dev/null 2>&1 &
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path.endswith(".zip"):
+            zip_name = Path(path).name
+            archive_name = zip_name.removesuffix(".zip")
+            body = io.BytesIO()
+            with zipfile.ZipFile(body, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                info = zipfile.ZipInfo(f"{archive_name}/bun")
+                info.create_system = 3
+                info.external_attr = 0o755 << 16
+                zf.writestr(info, script)
+            data = body.getvalue()
+            sha = hashlib.sha256(data).hexdigest()
+            state_file.write_text(f"{zip_name}\n{sha}\n")
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/zip")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+
+        if path.endswith("SHASUMS256.txt"):
+            # Bun asks for the checksum file separately, so answer with the hash
+            # of whichever archive the previous request selected.
+            if not state_file.exists():
+                raise RuntimeError("requested SHASUMS256.txt before any zip request")
+            zip_name, sha = state_file.read_text().splitlines()[:2]
+            data = f"{sha}  {zip_name}\n".encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+
+        self.send_error(404)
+
+HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+PY
 SERVER_PID=$!
-popd >/dev/null
 sleep 1
 
-downloads_dir="/dev/shm/mise-bun-cross-device-install-downloads"
-mkdir -p "$downloads_dir"
 rm -rf "$MISE_DATA_DIR/installs/bun/1.3.10"
 MISE_URL_REPLACEMENTS="$(printf '{\"https://github.com/oven-sh/bun/releases/download\":\"http://127.0.0.1:%s\"}' "$HTTP_PORT")"
 export MISE_URL_REPLACEMENTS
 
-assert_contains "MISE_DOWNLOADS_DIR='$downloads_dir' mise install bun@1.3.10 2>&1" "bun@1.3.10    ✓ installed"
-assert_contains "$MISE_DATA_DIR/installs/bun/1.3.10/bin/bun -v 2>&1" "1.3.10"
+assert_succeed "MISE_DOWNLOADS_DIR='$downloads_dir' MISE_INSTALLS_DIR='$installs_dir' mise install bun@1.3.10"
+assert_contains "$installs_dir/bun/1.3.10/bin/bun -v" "1.3.10"

--- a/e2e/run_test
+++ b/e2e/run_test
@@ -87,6 +87,7 @@ within_isolated_env() {
 		LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-}" \
 		${proxy_vars[@]+"${proxy_vars[@]}"} \
 		MISE_CACHE_DIR="$MISE_CACHE_DIR" \
+		MISE_URL_REPLACEMENTS="${MISE_URL_REPLACEMENTS:-}" \
 		MISE_CACHE_PRUNE_AGE="0" \
 		MISE_CONFIG_DIR="$MISE_CONFIG_DIR" \
 		MISE_DATA_DIR="$MISE_DATA_DIR" \

--- a/src/file.rs
+++ b/src/file.rs
@@ -1665,12 +1665,11 @@ mod tests {
         let source_dir = tempdir_in(&source_root).unwrap();
         let source_dev = source_dir.path().metadata().unwrap().dev();
 
-        let target_dir = tempdir_in("/tmp").ok();
-        let Some(target_dir) = target_dir
-            .filter(|dir| dir.path().metadata().ok().map(|m| m.dev()) != Some(source_dev))
-        else {
+        let target_dir = tempdir_in("/tmp").unwrap();
+        if target_dir.path().metadata().unwrap().dev() == source_dev {
+            // This host only has one filesystem for tempdirs, so skip if we can't reproduce EXDEV.
             return;
-        };
+        }
 
         let src = source_dir.path().join("bun");
         let dst = target_dir.path().join("bun");
@@ -1692,12 +1691,11 @@ mod tests {
         let source_dir = tempdir_in(&source_root).unwrap();
         let source_dev = source_dir.path().metadata().unwrap().dev();
 
-        let target_dir = tempdir_in("/tmp").ok();
-        let Some(target_dir) = target_dir
-            .filter(|dir| dir.path().metadata().ok().map(|m| m.dev()) != Some(source_dev))
-        else {
+        let target_dir = tempdir_in("/tmp").unwrap();
+        if target_dir.path().metadata().unwrap().dev() == source_dev {
+            // This host only has one filesystem for tempdirs, so skip if we can't reproduce EXDEV.
             return;
-        };
+        }
 
         let src = source_dir.path().join("bun-tree");
         let dst = target_dir.path().join("bun-tree");

--- a/src/file.rs
+++ b/src/file.rs
@@ -134,6 +134,11 @@ pub fn remove_all_with_warning<P: AsRef<Path>>(path: P) -> Result<()> {
     })
 }
 
+/// Renames `from` to `to`.
+///
+/// Warning: this is the raw `rename(2)`/`fs::rename` behavior. It is atomic on a
+/// single filesystem, but it will fail if `from` and `to` are on different
+/// mounts. If you need a cross-device-safe move, use [`move_file`] instead.
 pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
     let from = from.as_ref();
     let to = to.as_ref();
@@ -145,6 +150,52 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
             display_path(to)
         )
     })
+}
+
+/// Moves a file, falling back to copy+remove when source and destination are on different filesystems.
+///
+/// This preserves the normal `rename` behavior when possible, but avoids cross-device failures
+/// (`EXDEV` on Unix, `ERROR_NOT_SAME_DEVICE` on Windows) when `from` and `to` live on separate
+/// mounts (for example, when downloads are cached on one volume and installs are written to
+/// another).
+pub fn move_file<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+
+    match fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let is_cross_device = {
+                #[cfg(unix)]
+                {
+                    err.raw_os_error() == Some(nix::errno::Errno::EXDEV as i32)
+                }
+                #[cfg(windows)]
+                {
+                    // ERROR_NOT_SAME_DEVICE
+                    err.raw_os_error() == Some(17)
+                }
+                #[cfg(not(any(unix, windows)))]
+                {
+                    false
+                }
+            };
+
+            if is_cross_device {
+                copy(from, to)?;
+                remove_file(from)?;
+                Ok(())
+            } else {
+                Err(err).wrap_err_with(|| {
+                    format!(
+                        "failed rename: {} -> {}",
+                        display_path(from),
+                        display_path(to)
+                    )
+                })
+            }
+        }
+    }
 }
 
 pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
@@ -1616,5 +1667,32 @@ mod tests {
         let path = dir.path().join("nonexistent");
         // Should not error when file does not exist.
         remove_file_async_if_exists(&path).await.unwrap();
+    }
+
+    #[cfg(all(unix, target_os = "linux"))]
+    #[test]
+    fn test_move_file_falls_back_to_copy_across_filesystems() {
+        use std::{fs, os::unix::fs::MetadataExt};
+        use tempfile::tempdir_in;
+
+        let source_root = std::env::current_dir().unwrap();
+        let source_dir = tempdir_in(&source_root).unwrap();
+        let source_dev = source_dir.path().metadata().unwrap().dev();
+
+        let target_dir = tempdir_in("/tmp").ok();
+        let Some(target_dir) = target_dir
+            .filter(|dir| dir.path().metadata().ok().map(|m| m.dev()) != Some(source_dev))
+        else {
+            return;
+        };
+
+        let src = source_dir.path().join("bun");
+        let dst = target_dir.path().join("bun");
+        fs::write(&src, b"hello").unwrap();
+
+        move_file(&src, &dst).unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(fs::read(&dst).unwrap(), b"hello");
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -152,49 +152,35 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
     })
 }
 
-/// Moves a file, falling back to copy+remove when source and destination are on different filesystems.
+/// Moves a path, falling back to copy+remove when source and destination are on different filesystems.
 ///
 /// This preserves the normal `rename` behavior when possible, but avoids cross-device failures
-/// (`EXDEV` on Unix, `ERROR_NOT_SAME_DEVICE` on Windows) when `from` and `to` live on separate
-/// mounts (for example, when downloads are cached on one volume and installs are written to
-/// another).
+/// (`ErrorKind::CrossesDevices`) when `from` and `to` live on separate mounts (for example, when
+/// downloads are cached on one volume and installs are written to another).
 pub fn move_file<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
     let from = from.as_ref();
     let to = to.as_ref();
 
     match fs::rename(from, to) {
         Ok(()) => Ok(()),
-        Err(err) => {
-            let is_cross_device = {
-                #[cfg(unix)]
-                {
-                    err.raw_os_error() == Some(nix::errno::Errno::EXDEV as i32)
-                }
-                #[cfg(windows)]
-                {
-                    // ERROR_NOT_SAME_DEVICE
-                    err.raw_os_error() == Some(17)
-                }
-                #[cfg(not(any(unix, windows)))]
-                {
-                    false
-                }
-            };
-
-            if is_cross_device {
+        Err(err) if err.kind() == std::io::ErrorKind::CrossesDevices => {
+            if from.is_dir() {
+                create_dir_all(to)?;
+                copy_dir_all(from, to)?;
+                remove_all(from)?;
+            } else {
                 copy(from, to)?;
                 remove_file(from)?;
-                Ok(())
-            } else {
-                Err(err).wrap_err_with(|| {
-                    format!(
-                        "failed rename: {} -> {}",
-                        display_path(from),
-                        display_path(to)
-                    )
-                })
             }
+            Ok(())
         }
+        Err(err) => Err(err).wrap_err_with(|| {
+            format!(
+                "failed move: {} -> {}",
+                display_path(from),
+                display_path(to)
+            )
+        }),
     }
 }
 
@@ -1694,5 +1680,33 @@ mod tests {
 
         assert!(!src.exists());
         assert_eq!(fs::read(&dst).unwrap(), b"hello");
+    }
+
+    #[cfg(all(unix, target_os = "linux"))]
+    #[test]
+    fn test_move_dir_falls_back_to_copy_across_filesystems() {
+        use std::{fs, os::unix::fs::MetadataExt};
+        use tempfile::tempdir_in;
+
+        let source_root = std::env::current_dir().unwrap();
+        let source_dir = tempdir_in(&source_root).unwrap();
+        let source_dev = source_dir.path().metadata().unwrap().dev();
+
+        let target_dir = tempdir_in("/tmp").ok();
+        let Some(target_dir) = target_dir
+            .filter(|dir| dir.path().metadata().ok().map(|m| m.dev()) != Some(source_dev))
+        else {
+            return;
+        };
+
+        let src = source_dir.path().join("bun-tree");
+        let dst = target_dir.path().join("bun-tree");
+        fs::create_dir_all(src.join("nested")).unwrap();
+        fs::write(src.join("nested/bun"), b"hello").unwrap();
+
+        move_file(&src, &dst).unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(fs::read(dst.join("nested/bun")).unwrap(), b"hello");
     }
 }

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -41,7 +41,6 @@ impl BunPlugin {
         tv.install_path().join("bin").join(bun_bin_name())
     }
 
-
     fn test_bun(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
         ctx.pr.set_message("bun -v".into());
         CmdLineRunner::new(self.bun_bin(tv))

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -41,6 +41,7 @@ impl BunPlugin {
         tv.install_path().join("bin").join(bun_bin_name())
     }
 
+
     fn test_bun(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
         ctx.pr.set_message("bun -v".into());
         CmdLineRunner::new(self.bun_bin(tv))
@@ -71,7 +72,7 @@ impl BunPlugin {
         file::remove_all(tv.install_path())?;
         file::create_dir_all(tv.install_path().join("bin"))?;
         file::unzip(tarball_path, &tv.download_path(), &Default::default())?;
-        file::rename(
+        file::move_file(
             tv.download_path()
                 .join(format!("bun-{}-{}", os(), arch()))
                 .join(bun_bin_name()),

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -72,7 +72,7 @@ impl DenoPlugin {
         file::remove_all(tv.install_path())?;
         file::create_dir_all(tv.install_path().join("bin"))?;
         file::unzip(tarball_path, &tv.download_path(), &Default::default())?;
-        file::rename(
+        file::move_file(
             tv.download_path().join(if cfg!(target_os = "windows") {
                 "deno.exe"
             } else {

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -171,7 +171,7 @@ impl ErlangPlugin {
             let entry = entry?;
             let dest = tv.install_path().join(entry.file_name());
             trace!("moving {:?} to {:?}", entry.path(), &dest);
-            file::rename(entry.path(), dest)?;
+            file::move_file(entry.path(), dest)?;
         }
 
         Ok(())

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -169,7 +169,7 @@ impl JavaPlugin {
             let entry = entry?;
             let dest = tv.install_path().join(entry.file_name());
             trace!("moving {:?} to {:?}", entry.path(), &dest);
-            file::rename(entry.path(), dest)?;
+            file::move_file(entry.path(), dest)?;
         }
 
         if cfg!(target_os = "macos") {
@@ -196,7 +196,7 @@ impl JavaPlugin {
                 }
                 let dest = tv.install_path().join("Contents").join(entry.file_name());
                 trace!("moving {:?} to {:?}", entry.path(), &dest);
-                file::rename(entry.path(), dest)?;
+                file::move_file(entry.path(), dest)?;
             }
             file::make_symlink(
                 tv.install_path().as_path(),

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -133,7 +133,7 @@ impl RubyPlugin {
         ctx.pr.set_message(format!("extract {filename}"));
         file::remove_all(tv.install_path())?;
         file::un7z(tarball_path, &tv.download_path(), &Default::default())?;
-        file::rename(
+        file::move_file(
             tv.download_path()
                 .join(format!("rubyinstaller-{}-1-{arch}", tv.version)),
             tv.install_path(),


### PR DESCRIPTION
I encountered this as I develop in a devcontainer, and I wanted to cache downloads in a Docker cache mount. This worked for all dev tools I'm using, except bun.

Includes regression test which I checked. Regression test is only for bun, not for the other fixed core dev tools. 

AI-assisted but hand-curated PR. I asked it to review which uses of `rename` should be replaced by `move_file`, inspected the result, and agree. 