### PR TITLE
registry: update granted aqua backend repo

### DIFF
--- a/registry/granted.toml
+++ b/registry/granted.toml
@@ -1,2 +1,2 @@
-backends = ["aqua:common-fate/granted", "asdf:dex4er/asdf-granted"]
+backends = ["aqua:fwdcloudsec/granted", "asdf:dex4er/asdf-granted"]
 description = "The easiest way to access AWS"


### PR DESCRIPTION
## Summary
- update the `granted` registry entry to use `aqua:fwdcloudsec/granted`
- keep the existing asdf fallback unchanged
- align the top-level mise registry alias with the bundled aqua registry package metadata

## Why
`granted` moved from `common-fate/granted` to `fwdcloudsec/granted`. The embedded aqua registry already knows about the new package location, but `registry/granted.toml` still pointed the default backend at the old repo. That left `mise up` and default installs resolving through `aqua:common-fate/granted`, which now fails as reported in discussion #9003.

Discussion: https://github.com/jdx/mise/discussions/9003

## Validation
- `./target/debug/mise registry granted`
- `./target/debug/mise test-tool granted`
