### PR TITLE
fix(tasks): respect env precedence for task config

### DIFF
--- a/e2e/tasks/test_task_includes_env_precedence
+++ b/e2e/tasks/test_task_includes_env_precedence
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+cat <<'TOML' >mise.prod.toml
+[task_config]
+includes = ["prod-tasks"]
+TOML
+
+mkdir -p prod-tasks
+cat <<'SCRIPT' >prod-tasks/prod-task
+#!/usr/bin/env bash
+echo "prod task"
+SCRIPT
+chmod +x prod-tasks/prod-task
+
+cat <<'TOML' >mise.ci.toml
+[task_config]
+includes = ["ci-tasks"]
+TOML
+
+mkdir -p ci-tasks
+cat <<'SCRIPT' >ci-tasks/ci-task
+#!/usr/bin/env bash
+echo "ci task"
+SCRIPT
+chmod +x ci-tasks/ci-task
+
+assert_contains "MISE_ENV=prod,ci mise tasks ls" "ci-task"
+assert_not_contains "MISE_ENV=prod,ci mise tasks ls" "prod-task"

--- a/e2e/tasks/test_task_includes_env_precedence
+++ b/e2e/tasks/test_task_includes_env_precedence
@@ -1,28 +1,31 @@
 #!/usr/bin/env bash
 
+mkdir -p prod-tasks ci-tasks prod-work ci-work
+
 cat <<'TOML' >mise.prod.toml
 [task_config]
 includes = ["prod-tasks"]
+dir = "{{config_root}}/prod-work"
 TOML
 
-mkdir -p prod-tasks
 cat <<'SCRIPT' >prod-tasks/prod-task
 #!/usr/bin/env bash
-echo "prod task"
+pwd
 SCRIPT
 chmod +x prod-tasks/prod-task
 
 cat <<'TOML' >mise.ci.toml
 [task_config]
 includes = ["ci-tasks"]
+dir = "{{config_root}}/ci-work"
 TOML
 
-mkdir -p ci-tasks
 cat <<'SCRIPT' >ci-tasks/ci-task
 #!/usr/bin/env bash
-echo "ci task"
+pwd
 SCRIPT
 chmod +x ci-tasks/ci-task
 
 assert_contains "MISE_ENV=prod,ci mise tasks ls" "ci-task"
 assert_not_contains "MISE_ENV=prod,ci mise tasks ls" "prod-task"
+assert "MISE_ENV=prod,ci mise run ci-task" "$(pwd)/ci-work"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -878,6 +878,7 @@ impl Config {
 }
 
 fn configs_at_root<'a>(dir: &Path, config_files: &'a ConfigMap) -> Vec<&'a Arc<dyn ConfigFile>> {
+    // Highest precedence config files are returned first.
     let mut configs: Vec<&'a Arc<dyn ConfigFile>> = DEFAULT_CONFIG_FILENAMES
         .iter()
         .rev()
@@ -2365,11 +2366,10 @@ async fn load_file_tasks(
 pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Vec<PathBuf> {
     let configs = configs_at_root(dir, config_files);
 
-    // Find the first config that has explicit task_config.includes
+    // Find the highest-precedence config that has explicit task_config.includes
     // and resolve paths relative to that config file's directory
     let (includes, resolve_dir) = configs
         .iter()
-        .rev()
         .find_map(|cf| {
             cf.task_config().includes.clone().map(|includes| {
                 // Resolve relative paths from the config root, not the config file's directory
@@ -2404,7 +2404,6 @@ pub async fn load_tasks_in_dir(
 
     let git_includes: Vec<String> = configs
         .iter()
-        .rev()
         .find_map(|cf| cf.task_config().includes.clone())
         .unwrap_or_default()
         .into_iter()
@@ -2417,11 +2416,8 @@ pub async fn load_tasks_in_dir(
         config_tasks.extend(load_config_tasks(config, (*cf).clone(), &dir, templates).await?);
     }
 
-    // Find task_config.dir from the nearest config that defines it
-    let task_config_dir = configs
-        .iter()
-        .rev()
-        .find_map(|cf| cf.task_config().dir.clone());
+    // Find task_config.dir from the highest-precedence config that defines it
+    let task_config_dir = configs.iter().find_map(|cf| cf.task_config().dir.clone());
 
     let mut file_tasks = vec![];
     for p in task_includes_for_dir(dir, config_files) {


### PR DESCRIPTION
## Summary

Fixes `task_config` precedence when multiple `MISE_ENV` values are active.

`configs_at_root` returns config files highest-precedence first, but the task include resolver reversed that list before selecting the first explicit `task_config.includes`. With `MISE_ENV=prod,ci`, that made `mise.prod.toml` win over `mise.ci.toml`, contrary to the documented last-env-wins behavior.

The fix applies the same precedence order to local includes, remote `git::` includes, and `task_config.dir` selection. The e2e test now covers both include replacement and `dir` precedence.

## Verification

- `cargo build`
- `cargo fmt --check`
- `git diff --check`
- `e2e/run_test tasks/test_task_includes_env_precedence`
- `e2e/run_test config/test_config_env`
- `e2e/run_test env/test_env_profiles`
- `e2e/run_test tasks/test_task_mise_env_profiles`