### PR TITLE
fix(schema): add missing config fields

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -25,6 +25,9 @@ EOF
 
 # Create a mise.toml exercising task properties that were previously broken
 cat >"$HOME/workdir/mise.toml" <<'TOML'
+env_file = ".env"
+env_path = "./bin"
+
 [task_templates.base]
 quiet = true
 dir = "{{config_root}}"
@@ -36,6 +39,8 @@ run = "cargo build"
 dir = "{{config_root}}"
 quiet = true
 usage = "build [args]"
+deny_env = true
+allow_read = ["."]
 
 [tasks.lint]
 extends = "base"

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -20,7 +20,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise.toml"]
+include = ["mise.toml", "mise-age.toml"]
 EOF
 
 # Create a mise.toml exercising task properties that were previously broken
@@ -48,9 +48,18 @@ run = "cargo clippy"
 description = "Lint the project"
 TOML
 
+# Create a separate file for age schema coverage so mise does not try to decrypt
+# placeholder values while running tombi through `mise x`.
+cat >"$HOME/workdir/mise-age.toml" <<'TOML'
+[env]
+SECRET_SIMPLE = { age = "AGE-SECRET", tools = true }
+SECRET_COMPLEX = { age = { value = "AGE-SECRET", format = "raw", tools = true, redact = true } }
+TOML
+
 # tombi lint should succeed with no errors (warnings about table order are ok)
 cd "$HOME/workdir"
 assert_succeed "$TOMBI lint --offline --no-cache --quiet mise.toml"
+assert_succeed "$TOMBI lint --offline --no-cache --quiet mise-age.toml"
 
 # Verify that invalid properties on tasks are rejected
 cat >"$HOME/workdir/mise-bad.toml" <<'TOML'
@@ -69,10 +78,18 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-tmpl.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-tmpl.toml"]
 EOF
 
 assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad.toml"
+
+# Verify that options for complex age values must be nested inside age
+cat >"$HOME/workdir/mise-bad-age.toml" <<'TOML'
+[env]
+SECRET = { age = { value = "AGE-SECRET" }, tools = true }
+TOML
+
+assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad-age.toml"
 
 # Verify that extends is rejected on task_templates (not supported at runtime)
 cat >"$HOME/workdir/mise-bad-tmpl.toml" <<'TOML'

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -410,50 +410,8 @@
             "type": "object",
             "properties": {
               "age": {
-                "oneOf": [
-                  {
-                    "type": "string",
-                    "description": "[experimental] age-encrypted value (simplified format)"
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "value": {
-                        "type": "string",
-                        "description": "[experimental] age-encrypted value"
-                      },
-                      "format": {
-                        "type": "string",
-                        "enum": ["raw", "zstd"],
-                        "description": "[experimental] compression format for the encrypted value"
-                      },
-                      "tools": {
-                        "type": "boolean",
-                        "description": "load tools before resolving"
-                      },
-                      "redact": {
-                        "type": "boolean",
-                        "description": "redact the value from logs"
-                      },
-                      "required": {
-                        "oneOf": [
-                          {
-                            "type": "boolean",
-                            "description": "require this environment variable to be defined before mise runs or in a later config file"
-                          },
-                          {
-                            "type": "string",
-                            "description": "require this environment variable with user help text on how to set it"
-                          }
-                        ],
-                        "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
-                      }
-                    },
-                    "required": ["value"],
-                    "additionalProperties": false,
-                    "description": "[experimental] age-encrypted value (complex format)"
-                  }
-                ]
+                "type": "string",
+                "description": "[experimental] age-encrypted value (simplified format)"
               },
               "tools": {
                 "type": "boolean",
@@ -475,6 +433,52 @@
                   }
                 ],
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+              }
+            },
+            "required": ["age"],
+            "additionalProperties": false,
+            "description": "[experimental] age-encrypted environment variable"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "age": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "[experimental] age-encrypted value"
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": ["raw", "zstd"],
+                    "description": "[experimental] compression format for the encrypted value"
+                  },
+                  "tools": {
+                    "type": "boolean",
+                    "description": "load tools before resolving"
+                  },
+                  "redact": {
+                    "type": "boolean",
+                    "description": "redact the value from logs"
+                  },
+                  "required": {
+                    "oneOf": [
+                      {
+                        "type": "boolean",
+                        "description": "require this environment variable to be defined before mise runs or in a later config file"
+                      },
+                      {
+                        "type": "string",
+                        "description": "require this environment variable with user help text on how to set it"
+                      }
+                    ],
+                    "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+                  }
+                },
+                "required": ["value"],
+                "additionalProperties": false,
+                "description": "[experimental] age-encrypted value (complex format)"
               }
             },
             "required": ["age"],

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -300,6 +300,59 @@
               "description": "timeout for this task",
               "type": "string"
             },
+            "deny_all": {
+              "default": false,
+              "description": "block reads, writes, network, and env vars",
+              "type": "boolean"
+            },
+            "deny_read": {
+              "default": false,
+              "description": "block filesystem reads",
+              "type": "boolean"
+            },
+            "deny_write": {
+              "default": false,
+              "description": "block all filesystem writes",
+              "type": "boolean"
+            },
+            "deny_net": {
+              "default": false,
+              "description": "block all network access",
+              "type": "boolean"
+            },
+            "deny_env": {
+              "default": false,
+              "description": "block env var inheritance",
+              "type": "boolean"
+            },
+            "allow_read": {
+              "description": "allow reads from specific paths",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "allow_write": {
+              "description": "allow writes to specific paths",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "allow_net": {
+              "description": "allow network to specific hosts",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "allow_env": {
+              "description": "allow specific env vars through",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "extends": {
               "description": "name of the task template to extend",
               "type": "string"
@@ -373,6 +426,27 @@
                         "type": "string",
                         "enum": ["raw", "zstd"],
                         "description": "[experimental] compression format for the encrypted value"
+                      },
+                      "tools": {
+                        "type": "boolean",
+                        "description": "load tools before resolving"
+                      },
+                      "redact": {
+                        "type": "boolean",
+                        "description": "redact the value from logs"
+                      },
+                      "required": {
+                        "oneOf": [
+                          {
+                            "type": "boolean",
+                            "description": "require this environment variable to be defined before mise runs or in a later config file"
+                          },
+                          {
+                            "type": "string",
+                            "description": "require this environment variable with user help text on how to set it"
+                          }
+                        ],
+                        "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                       }
                     },
                     "required": ["value"],
@@ -380,6 +454,27 @@
                     "description": "[experimental] age-encrypted value (complex format)"
                   }
                 ]
+              },
+              "tools": {
+                "type": "boolean",
+                "description": "load tools before resolving"
+              },
+              "redact": {
+                "type": "boolean",
+                "description": "redact the value from logs"
+              },
+              "required": {
+                "oneOf": [
+                  {
+                    "type": "boolean",
+                    "description": "require this environment variable to be defined before mise runs or in a later config file"
+                  },
+                  {
+                    "type": "string",
+                    "description": "require this environment variable with user help text on how to set it"
+                  }
+                ],
+                "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
             "required": ["age"],

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3006,6 +3006,7 @@
     },
     "env_file": {
       "description": "dotenv file(s) to load",
+      "deprecated": true,
       "oneOf": [
         {
           "description": "dotenv file to load",
@@ -3022,6 +3023,7 @@
     },
     "dotenv": {
       "description": "dotenv file(s) to load",
+      "deprecated": true,
       "oneOf": [
         {
           "description": "dotenv file to load",
@@ -3038,6 +3040,7 @@
     },
     "env_path": {
       "description": "PATH entries to add",
+      "deprecated": true,
       "oneOf": [
         {
           "description": "PATH entry to add",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -152,50 +152,8 @@
             "type": "object",
             "properties": {
               "age": {
-                "oneOf": [
-                  {
-                    "type": "string",
-                    "description": "[experimental] age-encrypted value (simplified format)"
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "value": {
-                        "type": "string",
-                        "description": "[experimental] age-encrypted value"
-                      },
-                      "format": {
-                        "type": "string",
-                        "enum": ["raw", "zstd"],
-                        "description": "[experimental] compression format for the encrypted value"
-                      },
-                      "tools": {
-                        "type": "boolean",
-                        "description": "load tools before resolving"
-                      },
-                      "redact": {
-                        "type": "boolean",
-                        "description": "redact the value from logs"
-                      },
-                      "required": {
-                        "oneOf": [
-                          {
-                            "type": "boolean",
-                            "description": "require this environment variable to be defined before mise runs or in a later config file"
-                          },
-                          {
-                            "type": "string",
-                            "description": "require this environment variable with user help text on how to set it"
-                          }
-                        ],
-                        "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
-                      }
-                    },
-                    "required": ["value"],
-                    "additionalProperties": false,
-                    "description": "[experimental] age-encrypted value (complex format)"
-                  }
-                ]
+                "type": "string",
+                "description": "[experimental] age-encrypted value (simplified format)"
               },
               "tools": {
                 "type": "boolean",
@@ -217,6 +175,52 @@
                   }
                 ],
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+              }
+            },
+            "required": ["age"],
+            "additionalProperties": false,
+            "description": "[experimental] age-encrypted environment variable"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "age": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "[experimental] age-encrypted value"
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": ["raw", "zstd"],
+                    "description": "[experimental] compression format for the encrypted value"
+                  },
+                  "tools": {
+                    "type": "boolean",
+                    "description": "load tools before resolving"
+                  },
+                  "redact": {
+                    "type": "boolean",
+                    "description": "redact the value from logs"
+                  },
+                  "required": {
+                    "oneOf": [
+                      {
+                        "type": "boolean",
+                        "description": "require this environment variable to be defined before mise runs or in a later config file"
+                      },
+                      {
+                        "type": "string",
+                        "description": "require this environment variable with user help text on how to set it"
+                      }
+                    ],
+                    "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+                  }
+                },
+                "required": ["value"],
+                "additionalProperties": false,
+                "description": "[experimental] age-encrypted value (complex format)"
               }
             },
             "required": ["age"],

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -168,6 +168,27 @@
                         "type": "string",
                         "enum": ["raw", "zstd"],
                         "description": "[experimental] compression format for the encrypted value"
+                      },
+                      "tools": {
+                        "type": "boolean",
+                        "description": "load tools before resolving"
+                      },
+                      "redact": {
+                        "type": "boolean",
+                        "description": "redact the value from logs"
+                      },
+                      "required": {
+                        "oneOf": [
+                          {
+                            "type": "boolean",
+                            "description": "require this environment variable to be defined before mise runs or in a later config file"
+                          },
+                          {
+                            "type": "string",
+                            "description": "require this environment variable with user help text on how to set it"
+                          }
+                        ],
+                        "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                       }
                     },
                     "required": ["value"],
@@ -175,6 +196,27 @@
                     "description": "[experimental] age-encrypted value (complex format)"
                   }
                 ]
+              },
+              "tools": {
+                "type": "boolean",
+                "description": "load tools before resolving"
+              },
+              "redact": {
+                "type": "boolean",
+                "description": "redact the value from logs"
+              },
+              "required": {
+                "oneOf": [
+                  {
+                    "type": "boolean",
+                    "description": "require this environment variable to be defined before mise runs or in a later config file"
+                  },
+                  {
+                    "type": "string",
+                    "description": "require this environment variable with user help text on how to set it"
+                  }
+                ],
+                "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
             "required": ["age"],
@@ -1980,6 +2022,59 @@
               "description": "timeout for this task",
               "type": "string"
             },
+            "deny_all": {
+              "default": false,
+              "description": "block reads, writes, network, and env vars",
+              "type": "boolean"
+            },
+            "deny_read": {
+              "default": false,
+              "description": "block filesystem reads",
+              "type": "boolean"
+            },
+            "deny_write": {
+              "default": false,
+              "description": "block all filesystem writes",
+              "type": "boolean"
+            },
+            "deny_net": {
+              "default": false,
+              "description": "block all network access",
+              "type": "boolean"
+            },
+            "deny_env": {
+              "default": false,
+              "description": "block env var inheritance",
+              "type": "boolean"
+            },
+            "allow_read": {
+              "description": "allow reads from specific paths",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "allow_write": {
+              "description": "allow writes to specific paths",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "allow_net": {
+              "description": "allow network to specific hosts",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "allow_env": {
+              "description": "allow specific env vars through",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "extends": {
               "description": "name of the task template to extend",
               "type": "string"
@@ -2905,6 +3000,54 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/env"
+          }
+        }
+      ]
+    },
+    "env_file": {
+      "description": "dotenv file(s) to load",
+      "oneOf": [
+        {
+          "description": "dotenv file to load",
+          "type": "string"
+        },
+        {
+          "description": "dotenv files to load",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "dotenv": {
+      "description": "dotenv file(s) to load",
+      "oneOf": [
+        {
+          "description": "dotenv file to load",
+          "type": "string"
+        },
+        {
+          "description": "dotenv files to load",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "env_path": {
+      "description": "PATH entries to add",
+      "oneOf": [
+        {
+          "description": "PATH entry to add",
+          "type": "string"
+        },
+        {
+          "description": "PATH entries to add",
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       ]

--- a/xtasks/render/schema.ts
+++ b/xtasks/render/schema.ts
@@ -133,6 +133,61 @@ schema["$defs"].settings.properties = settings;
 // Generate task and task_template from task_props to avoid unevaluatedProperties
 // (which Tombi doesn't support) while keeping extends only on tasks, not templates.
 const taskProps = schema["$defs"].task_props;
+const taskOnlyProps = {
+  deny_all: {
+    default: false,
+    description: "block reads, writes, network, and env vars",
+    type: "boolean",
+  },
+  deny_read: {
+    default: false,
+    description: "block filesystem reads",
+    type: "boolean",
+  },
+  deny_write: {
+    default: false,
+    description: "block all filesystem writes",
+    type: "boolean",
+  },
+  deny_net: {
+    default: false,
+    description: "block all network access",
+    type: "boolean",
+  },
+  deny_env: {
+    default: false,
+    description: "block env var inheritance",
+    type: "boolean",
+  },
+  allow_read: {
+    description: "allow reads from specific paths",
+    items: {
+      type: "string",
+    },
+    type: "array",
+  },
+  allow_write: {
+    description: "allow writes to specific paths",
+    items: {
+      type: "string",
+    },
+    type: "array",
+  },
+  allow_net: {
+    description: "allow network to specific hosts",
+    items: {
+      type: "string",
+    },
+    type: "array",
+  },
+  allow_env: {
+    description: "allow specific env vars through",
+    items: {
+      type: "string",
+    },
+    type: "array",
+  },
+};
 
 // task_template: task_props + additionalProperties: false
 schema["$defs"].task_template = {
@@ -146,6 +201,7 @@ schema["$defs"].task_template = {
 const taskObjectVariant = {
   properties: {
     ...taskProps.properties,
+    ...taskOnlyProps,
     extends: {
       description: "name of the task template to extend",
       type: "string",


### PR DESCRIPTION
## Summary
- add missing task sandbox fields to the mise task schemas
- add top-level `env_file`/`dotenv`/`env_path` schema entries and mark them deprecated as legacy shortcuts
- allow env age directive options, tighten complex age option nesting, and cover the schema fixture
- keep sandbox fields in a task-only schema overlay so they validate for `[tasks.*]` but do not leak into `[task_templates.*]`, whose Rust type does not deserialize/apply them

## Context
- The renderer builds both task and `task_template` schemas from `task_props`. The new `taskOnlyProps` overlay is for fields accepted by `Task` but not `TaskTemplate`; this mirrors the existing task-only treatment for `extends`.
- `env_file`, `dotenv`, and `env_path` are still accepted by current serde parsing, but they are legacy top-level shortcuts. https://github.com/jdx/mise/pull/1361 marked `env_file`/`env_path` deprecated in favor of `env.mise.file`/`env.mise.path`; https://github.com/jdx/mise/pull/1519 later rewrote env parsing and kept accepting `env_file`, alias `dotenv`, and `env_path` without a runtime deprecation warning. The schema keeps them valid but marks them deprecated to point users at `[env] _.file` / `_.path`.
- Task sandbox config fields were introduced with process sandboxing in https://github.com/jdx/mise/pull/8845; `allow_env` wildcard semantics were later expanded in https://github.com/jdx/mise/pull/8974.
- Age env directives, including flattened `EnvDirectiveOptions` on age values, were introduced in https://github.com/jdx/mise/pull/6463. This PR now mirrors the Rust variants more closely: top-level age options are allowed with `age = "..."`, while complex `age = { value = ... }` options must be nested inside the `age` object.

## Verification
- `bun xtasks/render/schema.ts`
- `jq empty schema/mise.json schema/mise-task.json schema/miserc.json`
- `git diff --check`
- `mise run test:e2e e2e/config/test_schema_tombi`
