### PR TITLE
fix(task): support sandbox fields in task templates

### DIFF
--- a/docs/tasks/templates.md
+++ b/docs/tasks/templates.md
@@ -61,6 +61,8 @@ When a task extends a template, fields are merged according to these rules:
 | `depends`, `depends_post`, `wait_for`   | Local overrides completely (not merged)                     |
 | `dir`                                   | Local overrides; defaults to config_root if not in template |
 | `sources`, `outputs`                    | Local overrides completely                                  |
+| Sandbox deny fields                     | Compose with task-local settings                            |
+| Sandbox allow fields                    | Template and task-local values are combined                 |
 | `description`, `shell`, `timeout`, etc. | Local overrides template (if set)                           |
 | `quiet`, `hide`, `raw`                  | Not carried over (must be set explicitly in task)           |
 

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -31,6 +31,8 @@ env_path = "./bin"
 [task_templates.base]
 quiet = true
 dir = "{{config_root}}"
+deny_net = true
+allow_env = ["CI"]
 
 [tasks.build]
 description = "Build the project"

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -1070,6 +1070,59 @@
         "timeout": {
           "description": "timeout for this task",
           "type": "string"
+        },
+        "deny_all": {
+          "default": false,
+          "description": "block reads, writes, network, and env vars",
+          "type": "boolean"
+        },
+        "deny_read": {
+          "default": false,
+          "description": "block filesystem reads",
+          "type": "boolean"
+        },
+        "deny_write": {
+          "default": false,
+          "description": "block all filesystem writes",
+          "type": "boolean"
+        },
+        "deny_net": {
+          "default": false,
+          "description": "block all network access",
+          "type": "boolean"
+        },
+        "deny_env": {
+          "default": false,
+          "description": "block env var inheritance",
+          "type": "boolean"
+        },
+        "allow_read": {
+          "description": "allow reads from specific paths",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_write": {
+          "description": "allow writes to specific paths",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_net": {
+          "description": "allow network to specific hosts",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_env": {
+          "description": "allow specific env vars through",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2686,6 +2686,59 @@
         "timeout": {
           "description": "timeout for this task",
           "type": "string"
+        },
+        "deny_all": {
+          "default": false,
+          "description": "block reads, writes, network, and env vars",
+          "type": "boolean"
+        },
+        "deny_read": {
+          "default": false,
+          "description": "block filesystem reads",
+          "type": "boolean"
+        },
+        "deny_write": {
+          "default": false,
+          "description": "block all filesystem writes",
+          "type": "boolean"
+        },
+        "deny_net": {
+          "default": false,
+          "description": "block all network access",
+          "type": "boolean"
+        },
+        "deny_env": {
+          "default": false,
+          "description": "block env var inheritance",
+          "type": "boolean"
+        },
+        "allow_read": {
+          "description": "allow reads from specific paths",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_write": {
+          "description": "allow writes to specific paths",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_net": {
+          "description": "allow network to specific hosts",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_env": {
+          "description": "allow specific env vars through",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -2936,6 +2989,59 @@
         "timeout": {
           "description": "timeout for this task",
           "type": "string"
+        },
+        "deny_all": {
+          "default": false,
+          "description": "block reads, writes, network, and env vars",
+          "type": "boolean"
+        },
+        "deny_read": {
+          "default": false,
+          "description": "block filesystem reads",
+          "type": "boolean"
+        },
+        "deny_write": {
+          "default": false,
+          "description": "block all filesystem writes",
+          "type": "boolean"
+        },
+        "deny_net": {
+          "default": false,
+          "description": "block all network access",
+          "type": "boolean"
+        },
+        "deny_env": {
+          "default": false,
+          "description": "block env var inheritance",
+          "type": "boolean"
+        },
+        "allow_read": {
+          "description": "allow reads from specific paths",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_write": {
+          "description": "allow writes to specific paths",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_net": {
+          "description": "allow network to specific hosts",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_env": {
+          "description": "allow specific env vars through",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -53,6 +53,33 @@ pub struct TaskTemplate {
     pub run_windows: Vec<RunEntry>,
     #[serde(default)]
     pub file: Option<String>,
+    /// Block reads, writes, network, and env vars
+    #[serde(default)]
+    pub deny_all: bool,
+    /// Block filesystem reads
+    #[serde(default)]
+    pub deny_read: bool,
+    /// Block all filesystem writes
+    #[serde(default)]
+    pub deny_write: bool,
+    /// Block all network access
+    #[serde(default)]
+    pub deny_net: bool,
+    /// Block env var inheritance
+    #[serde(default)]
+    pub deny_env: bool,
+    /// Allow reads from specific paths
+    #[serde(default)]
+    pub allow_read: Vec<std::path::PathBuf>,
+    /// Allow writes to specific paths
+    #[serde(default)]
+    pub allow_write: Vec<std::path::PathBuf>,
+    /// Allow network to specific hosts
+    #[serde(default)]
+    pub allow_net: Vec<String>,
+    /// Allow specific env vars through
+    #[serde(default)]
+    pub allow_env: Vec<String>,
 }
 
 impl Task {
@@ -175,6 +202,19 @@ impl Task {
         {
             self.file = Some(file.into());
         }
+
+        // sandbox: restrictions compose with task-local settings, matching how
+        // task and global sandbox config are combined in the executor.
+        self.deny_all |= template.deny_all;
+        self.deny_read |= template.deny_read;
+        self.deny_write |= template.deny_write;
+        self.deny_net |= template.deny_net;
+        self.deny_env |= template.deny_env;
+
+        self.allow_read.splice(0..0, template.allow_read.clone());
+        self.allow_write.splice(0..0, template.allow_write.clone());
+        self.allow_net.splice(0..0, template.allow_net.clone());
+        self.allow_env.splice(0..0, template.allow_env.clone());
     }
 }
 
@@ -352,5 +392,50 @@ mod tests {
             _ => None,
         });
         assert_eq!(shared_val, Some("task_value"));
+    }
+
+    #[test]
+    fn test_merge_template_sandbox_config() {
+        let mut task = Task {
+            deny_net: true,
+            allow_read: vec!["task-read".into()],
+            allow_env: vec!["TASK_*".to_string()],
+            ..Default::default()
+        };
+        let template = TaskTemplate {
+            deny_all: true,
+            deny_read: true,
+            deny_write: true,
+            deny_env: true,
+            allow_read: vec!["template-read".into()],
+            allow_write: vec!["template-write".into()],
+            allow_net: vec!["example.com".to_string()],
+            allow_env: vec!["TEMPLATE_*".to_string()],
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert!(task.deny_all);
+        assert!(task.deny_read);
+        assert!(task.deny_write);
+        assert!(task.deny_net);
+        assert!(task.deny_env);
+        assert_eq!(
+            task.allow_read,
+            vec![
+                std::path::PathBuf::from("template-read"),
+                std::path::PathBuf::from("task-read")
+            ]
+        );
+        assert_eq!(
+            task.allow_write,
+            vec![std::path::PathBuf::from("template-write")]
+        );
+        assert_eq!(task.allow_net, vec!["example.com".to_string()]);
+        assert_eq!(
+            task.allow_env,
+            vec!["TEMPLATE_*".to_string(), "TASK_*".to_string()]
+        );
     }
 }

--- a/xtasks/render/schema.ts
+++ b/xtasks/render/schema.ts
@@ -133,61 +133,6 @@ schema["$defs"].settings.properties = settings;
 // Generate task and task_template from task_props to avoid unevaluatedProperties
 // (which Tombi doesn't support) while keeping extends only on tasks, not templates.
 const taskProps = schema["$defs"].task_props;
-const taskOnlyProps = {
-  deny_all: {
-    default: false,
-    description: "block reads, writes, network, and env vars",
-    type: "boolean",
-  },
-  deny_read: {
-    default: false,
-    description: "block filesystem reads",
-    type: "boolean",
-  },
-  deny_write: {
-    default: false,
-    description: "block all filesystem writes",
-    type: "boolean",
-  },
-  deny_net: {
-    default: false,
-    description: "block all network access",
-    type: "boolean",
-  },
-  deny_env: {
-    default: false,
-    description: "block env var inheritance",
-    type: "boolean",
-  },
-  allow_read: {
-    description: "allow reads from specific paths",
-    items: {
-      type: "string",
-    },
-    type: "array",
-  },
-  allow_write: {
-    description: "allow writes to specific paths",
-    items: {
-      type: "string",
-    },
-    type: "array",
-  },
-  allow_net: {
-    description: "allow network to specific hosts",
-    items: {
-      type: "string",
-    },
-    type: "array",
-  },
-  allow_env: {
-    description: "allow specific env vars through",
-    items: {
-      type: "string",
-    },
-    type: "array",
-  },
-};
 
 // task_template: task_props + additionalProperties: false
 schema["$defs"].task_template = {
@@ -201,7 +146,6 @@ schema["$defs"].task_template = {
 const taskObjectVariant = {
   properties: {
     ...taskProps.properties,
-    ...taskOnlyProps,
     extends: {
       description: "name of the task template to extend",
       type: "string",


### PR DESCRIPTION
## Summary
- add sandbox fields to `TaskTemplate` deserialization and merge them into extended tasks
- expose sandbox fields in the task template JSON schema output
- cover runtime merge behavior, schema validation, and task template docs

## Notes
- Deny fields compose restrictively with task-local settings.
- Allow lists are combined with template values first, then task-local values.

## Verification
- `bun xtasks/render/schema.ts`
- `cargo fmt --check`
- `jq empty schema/mise.json schema/mise-task.json schema/miserc.json`
- `git diff --check`
- `cargo test task_template`
- `mise run test:e2e e2e/config/test_schema_tombi`
