### PR TITLE
chore: use deprecated_at! macro for ubi backend deprecation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,18 @@ All commit messages and PR titles MUST follow conventional commit format:
 3. Use `mise run test:e2e [test_filename]...` for running specific e2e tests
 4. Never run e2e tests by executing them directly - always use the mise task
 
+## Deprecation Policy
+
+When deprecating a feature or backend:
+
+1. **Immediately**: Mark as deprecated in docs (add warning banner)
+2. **6 months later** (`warn_at`): Display deprecation warning in CLI using `deprecated_at!` macro from `src/output.rs`
+3. **12 months after warn** (`remove_at`): `debug_assert!` in `deprecated_at!` fires, signaling the code should be removed
+
+Use mise version format for dates (e.g., `deprecated_at!("2026.10.0", "2027.10.0", "id", "message")`).
+
+If the replacement has been available for a long time, the CLI warning can start immediately (set `warn_at` to the current version).
+
 ## Important Implementation Notes
 
 ### Backend System

--- a/docs/dev-tools/backends/ubi.md
+++ b/docs/dev-tools/backends/ubi.md
@@ -1,4 +1,4 @@
-# Ubi Backend
+# Ubi Backend <Badge type="danger" text="deprecated" />
 
 ::: warning
 The ubi backend is **deprecated**. Please use the [github backend](/dev-tools/backends/github) instead.

--- a/docs/dev-tools/backends/ubi.md
+++ b/docs/dev-tools/backends/ubi.md
@@ -3,7 +3,7 @@
 ::: warning
 The ubi backend is **deprecated**. Please use the [github backend](/dev-tools/backends/github) instead.
 
-To migrate, replace `ubi:owner/repo` with `github:owner/repo` in your configuration files.
+The github backend offers several advantages over ubi including provenance verification, download progress reports, and fewer dependencies. To migrate, replace `ubi:owner/repo` with `github:owner/repo` in your configuration files.
 :::
 
 You may install GitHub Releases and URL packages directly using [ubi](https://github.com/houseabsolute/ubi) backend. ubi is directly compiled into

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -42,7 +42,7 @@ impl Backend for UbiBackend {
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         deprecated_at!(
             "2026.4.0",
-            "2027.5.0",
+            "2027.1.0",
             "ubi",
             "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."
         );
@@ -201,7 +201,7 @@ impl Backend for UbiBackend {
     ) -> eyre::Result<ToolVersion> {
         deprecated_at!(
             "2026.4.0",
-            "2027.5.0",
+            "2027.1.0",
             "ubi",
             "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."
         );

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -42,7 +42,7 @@ impl Backend for UbiBackend {
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         deprecated_at!(
             "2026.4.0",
-            "2027.10.0",
+            "2027.5.0",
             "ubi",
             "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."
         );
@@ -201,7 +201,7 @@ impl Backend for UbiBackend {
     ) -> eyre::Result<ToolVersion> {
         deprecated_at!(
             "2026.4.0",
-            "2027.10.0",
+            "2027.5.0",
             "ubi",
             "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."
         );

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -41,8 +41,8 @@ impl Backend for UbiBackend {
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         deprecated_at!(
-            "2026.5.0",
-            "2027.5.0",
+            "2026.10.0",
+            "2027.10.0",
             "ubi",
             "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."
         );
@@ -200,8 +200,8 @@ impl Backend for UbiBackend {
         mut tv: ToolVersion,
     ) -> eyre::Result<ToolVersion> {
         deprecated_at!(
-            "2026.5.0",
-            "2027.5.0",
+            "2026.10.0",
+            "2027.10.0",
             "ubi",
             "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."
         );

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -40,6 +40,12 @@ impl Backend for UbiBackend {
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
+        deprecated_at!(
+            "2026.5.0",
+            "2027.5.0",
+            "ubi",
+            "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."
+        );
         if name_is_url(&self.tool_name()) {
             Ok(vec![VersionInfo {
                 version: "latest".to_string(),
@@ -193,9 +199,11 @@ impl Backend for UbiBackend {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> eyre::Result<ToolVersion> {
-        deprecated!(
+        deprecated_at!(
+            "2026.5.0",
+            "2027.5.0",
             "ubi",
-            "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)"
+            "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."
         );
         // Check if lockfile has URL for this platform
         let platform_key = self.get_platform_key();

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -41,7 +41,7 @@ impl Backend for UbiBackend {
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         deprecated_at!(
-            "2026.10.0",
+            "2026.4.0",
             "2027.10.0",
             "ubi",
             "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."
@@ -200,7 +200,7 @@ impl Backend for UbiBackend {
         mut tv: ToolVersion,
     ) -> eyre::Result<ToolVersion> {
         deprecated_at!(
-            "2026.10.0",
+            "2026.4.0",
             "2027.10.0",
             "ubi",
             "The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)."


### PR DESCRIPTION
## Summary
- Switch the ubi backend deprecation from the always-on `deprecated!` macro to `deprecated_at!` with `warn_at=2026.4.0` (immediate) and `remove_at=2027.1.0` (12 months from original docs deprecation in Dec 2025)
- Add deprecation warning to `_list_remote_versions` so users see it during version resolution, not just on install
- Add `<Badge type="danger" text="deprecated" />` to the ubi docs page
- Mention github backend advantages (provenance, progress reports, fewer dependencies) in the deprecation notice
- Document deprecation policy in CLAUDE.md

## Test plan
- [x] `cargo check` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)