### PR TITLE
chore(deps): disable renovate for aws-config/aws-sdk-* crates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,8 @@
   },
   "packageRules": [
     {
-      "matchPackageNames": ["aws-*"],
+      "description": "AWS SDK requires MSRV 1.91.1, project is 1.88.0. Re-enable when MSRV is bumped.",
+      "matchPackageNames": ["aws-config", "aws-sdk-*"],
       "matchManagers": ["cargo"],
       "enabled": false
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,12 @@
   },
   "nodenv": {
     "enabled": false
-  }
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["aws-*"],
+      "matchManagers": ["cargo"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Disable Renovate updates for `aws-config` and `aws-sdk-*` crates to prevent MSRV-breaking PRs
- AWS SDK bumped their MSRV to 1.91.1, which exceeds our 1.88.0
- Narrowly scoped to avoid blocking updates to `aws-lc-rs` (crypto library)

## Test plan
- [x] Verify renovate.json is valid
- [x] Confirm lint passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)