### PR TITLE
security(ci): avoid exposing MISE_GH_TOKEN to test-tool scripts

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -154,12 +154,8 @@ jobs:
         with:
           api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
       - name: Set GITHUB_TOKEN from pool
-        run: |
-          if [ -n "${{ steps.token.outputs.token }}" ]; then
-            echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
-          else
-            echo "GITHUB_TOKEN=" >> "$GITHUB_ENV"
-          fi
+        if: steps.token.outputs.token
+        run: echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mise

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -18,7 +18,6 @@ env:
   MISE_LOCKFILE: 1
   MISE_USE_VERSIONS_HOST_TRACK: 0
   RUST_BACKTRACE: 1
-  GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
 
 jobs:
   check-changes:
@@ -48,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-changes
     if: needs.check-changes.outputs.registry-changed == 'true'
+    env:
+      GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
@@ -153,8 +154,12 @@ jobs:
         with:
           api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
       - name: Set GITHUB_TOKEN from pool
-        if: steps.token.outputs.token
-        run: echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
+        run: |
+          if [ -n "${{ steps.token.outputs.token }}" ]; then
+            echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
+          else
+            echo "GITHUB_TOKEN=" >> "$GITHUB_ENV"
+          fi
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mise


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` was set at workflow level to `MISE_GH_TOKEN`, making it available to all tool install scripts run by `mise test-tool`
- Moved `MISE_GH_TOKEN` to only the `build` job that needs it
- `test-tool` job now only gets the pooled token from the token pool API

## Test plan
- [ ] Verify registry CI jobs still pass (checkout works without token for public repos)
- [ ] Verify test-tool still gets pooled token for rate limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow scoping change, but could affect CI if any non-`build` steps implicitly relied on `GITHUB_TOKEN` being pre-set to `MISE_GH_TOKEN`.
> 
> **Overview**
> Removes the workflow-level override of `GITHUB_TOKEN` (previously set to `secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN`) in `registry.yml` and scopes it to the `build` job only.
> 
> This reduces secret exposure to `mise test-tool`/tool install scripts while keeping the elevated token available where the build needs it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1e6e1ba6e30cada9e62d39a847ec181dc3fe19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->