### PR TITLE
registry: fix atlas-community test expected output

### DIFF
--- a/registry/atlas-community.toml
+++ b/registry/atlas-community.toml
@@ -1,3 +1,3 @@
 backends = ["aqua:ariga/atlas/community"]
 description = "A modern tool for managing database schemas (Community Edition)"
-test = { cmd = "atlas version", expected = "atlas community version v{{version}}" }
+test = { cmd = "atlas version", expected = "version v{{version}}" }


### PR DESCRIPTION
## Summary
- Upstream atlas-community changed `atlas version` output from `atlas community version v1.2.0` to `atlas community community version v1.2.0`
- Use looser match on just `version v{{version}}` to avoid breaking on future prefix changes

## Test plan
- [ ] Verify atlas-community passes in test-tool CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to a registry test expectation string; it only affects CI validation and not runtime behavior.
> 
> **Overview**
> Updates `registry/atlas-community.toml` to loosen the `atlas version` test `expected` output from a fixed prefix (`atlas community version v{{version}}`) to a prefix-agnostic match (`version v{{version}}`), reducing breakage when upstream changes the command’s wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48d01ff1c504ca873c31b59ddcac1e08c5bf941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->