### PR TITLE
security(ci): run test-tool inside Docker container

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -186,6 +186,7 @@ jobs:
         id: retry
         if: steps.test-tools.outputs.failed_tools != ''
         run: |
+          summary_lines=$(wc -l < "$GITHUB_STEP_SUMMARY")
           docker run --rm \
             -v "$PWD:/mise-src:ro" \
             -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
@@ -195,7 +196,7 @@ jobs:
             -e RUST_BACKTRACE=1 \
             ghcr.io/jdx/mise:e2e \
             mise test-tool ${{ steps.test-tools.outputs.failed_tools }} || true
-          failed_tools=$(grep "Failed Tools" "$GITHUB_STEP_SUMMARY" | sed 's/\*\*Failed Tools\*\*: //' | tr ',' ' ')
+          failed_tools=$(tail -n "+$((summary_lines+1))" "$GITHUB_STEP_SUMMARY" | grep "Failed Tools" | sed 's/\*\*Failed Tools\*\*: //' | tr ',' ' ')
           echo "failed_tools=$failed_tools" >> "$GITHUB_OUTPUT"
       - name: Handle retry failures
         if: steps.retry.outputs.failed_tools != '' && github.head_ref != 'release' && github.ref != 'refs/heads/release'

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -212,39 +212,7 @@ jobs:
         if: steps.retry.outputs.failed_tools != '' && (github.head_ref == 'release' || github.ref == 'refs/heads/release')
         env:
           GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          hard_failures=""
-          for tool in ${{ steps.retry.outputs.failed_tools }}; do
-            backend=$(mise tool --json "$tool" 2>/dev/null | jq -r '.backend // empty')
-            repo=""
-            case "$backend" in
-              github:*|aqua:*)
-                repo=$(echo "$backend" | sed 's/^[^:]*://' | sed 's/\[.*//' | cut -d/ -f1-2)
-                ;;
-            esac
-            if [ -z "$repo" ]; then
-              echo "::warning::Ignoring $tool failure — no github/aqua backend found"
-              continue
-            fi
-            published=$(gh api "repos/$repo/releases/latest" --jq '.published_at' 2>/dev/null || true)
-            if [ -z "$published" ]; then
-              echo "::error::$tool: could not fetch latest release for $repo"
-              hard_failures="$hard_failures $tool"
-              continue
-            fi
-            age_days=$(( ($(date +%s) - $(date -d "$published" +%s)) / 86400 ))
-            if [ "$age_days" -lt 7 ]; then
-              echo "::warning::Ignoring $tool failure — latest release of $repo is ${age_days}d old (< 7d grace period)"
-            else
-              echo "::error::$tool: latest release of $repo is ${age_days}d old"
-              hard_failures="$hard_failures $tool"
-            fi
-          done
-          if [ -n "$hard_failures" ]; then
-            echo "Hard failures:$hard_failures"
-            exit 1
-          fi
-          echo "All failures are within the 7-day grace period for new releases."
+        run: mise run test-tool-retry --check-only --grace-period ${{ steps.retry.outputs.failed_tools }}
 
   registry-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -152,9 +152,8 @@ jobs:
         uses: ./.github/actions/fetch-token
         with:
           api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Set GITHUB_TOKEN from pool
-        if: steps.token.outputs.token
-        run: echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
+      - name: Set pooled token for Docker
+        run: echo "POOL_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mise
@@ -173,10 +172,13 @@ jobs:
             -v "$PWD:/mise-src:ro" \
             -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
             -v "$GITHUB_STEP_SUMMARY:/tmp/github_summary" \
-            -e GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
+            -e GITHUB_TOKEN="${POOL_TOKEN:-}" \
             -e GITHUB_STEP_SUMMARY=/tmp/github_summary \
             -e TEST_TRANCHE="$TEST_TRANCHE" \
             -e TEST_TRANCHE_COUNT="$TEST_TRANCHE_COUNT" \
+            -e MISE_EXPERIMENTAL=1 \
+            -e MISE_LOCKFILE=1 \
+            -e MISE_USE_VERSIONS_HOST_TRACK=0 \
             -e RUST_BACKTRACE=1 \
             ghcr.io/jdx/mise:e2e \
             mise test-tool ${{ needs.list-changed-tools.outputs.tools == '' && '--all' || needs.list-changed-tools.outputs.tools }} || true
@@ -191,8 +193,11 @@ jobs:
             -v "$PWD:/mise-src:ro" \
             -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
             -v "$GITHUB_STEP_SUMMARY:/tmp/github_summary" \
-            -e GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
+            -e GITHUB_TOKEN="${POOL_TOKEN:-}" \
             -e GITHUB_STEP_SUMMARY=/tmp/github_summary \
+            -e MISE_EXPERIMENTAL=1 \
+            -e MISE_LOCKFILE=1 \
+            -e MISE_USE_VERSIONS_HOST_TRACK=0 \
             -e RUST_BACKTRACE=1 \
             ghcr.io/jdx/mise:e2e \
             mise test-tool ${{ steps.test-tools.outputs.failed_tools }} || true
@@ -207,7 +212,39 @@ jobs:
         if: steps.retry.outputs.failed_tools != '' && (github.head_ref == 'release' || github.ref == 'refs/heads/release')
         env:
           GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-        run: mise run test-tool-retry --grace-period ${{ steps.retry.outputs.failed_tools }}
+        run: |
+          hard_failures=""
+          for tool in ${{ steps.retry.outputs.failed_tools }}; do
+            backend=$(mise tool --json "$tool" 2>/dev/null | jq -r '.backend // empty')
+            repo=""
+            case "$backend" in
+              github:*|aqua:*)
+                repo=$(echo "$backend" | sed 's/^[^:]*://' | sed 's/\[.*//' | cut -d/ -f1-2)
+                ;;
+            esac
+            if [ -z "$repo" ]; then
+              echo "::warning::Ignoring $tool failure — no github/aqua backend found"
+              continue
+            fi
+            published=$(gh api "repos/$repo/releases/latest" --jq '.published_at' 2>/dev/null || true)
+            if [ -z "$published" ]; then
+              echo "::error::$tool: could not fetch latest release for $repo"
+              hard_failures="$hard_failures $tool"
+              continue
+            fi
+            age_days=$(( ($(date +%s) - $(date -d "$published" +%s)) / 86400 ))
+            if [ "$age_days" -lt 7 ]; then
+              echo "::warning::Ignoring $tool failure — latest release of $repo is ${age_days}d old (< 7d grace period)"
+            else
+              echo "::error::$tool: latest release of $repo is ${age_days}d old"
+              hard_failures="$hard_failures $tool"
+            fi
+          done
+          if [ -n "$hard_failures" ]; then
+            echo "Hard failures:$hard_failures"
+            exit 1
+          fi
+          echo "All failures are within the 7-day grace period for new releases."
 
   registry-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -159,24 +159,54 @@ jobs:
         with:
           name: mise
           path: target/debug
-      - run: echo target/debug >> "$GITHUB_PATH"
       - run: chmod +x target/debug/mise
-      - run: mise -v
+      - run: echo target/debug >> "$GITHUB_PATH"
       - uses: ./.github/actions/mise-tools
+      - name: Pull e2e Docker image
+        run: docker pull ghcr.io/jdx/mise:e2e
       - id: test-tools
         env:
           TEST_TRANCHE: ${{ matrix.tranche }}
           TEST_TRANCHE_COUNT: ${{ needs.list-changed-tools.outputs.tools == '' && 8 || 1 }}
         run: |
-          mise test-tool ${{ needs.list-changed-tools.outputs.tools == '' && '--all' || needs.list-changed-tools.outputs.tools }} || true
+          docker run --rm \
+            -v "$PWD:/mise-src:ro" \
+            -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
+            -v "$GITHUB_STEP_SUMMARY:/tmp/github_summary" \
+            -e GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
+            -e GITHUB_STEP_SUMMARY=/tmp/github_summary \
+            -e TEST_TRANCHE="$TEST_TRANCHE" \
+            -e TEST_TRANCHE_COUNT="$TEST_TRANCHE_COUNT" \
+            -e RUST_BACKTRACE=1 \
+            ghcr.io/jdx/mise:e2e \
+            mise test-tool ${{ needs.list-changed-tools.outputs.tools == '' && '--all' || needs.list-changed-tools.outputs.tools }} || true
           failed_tools=$(grep "Failed Tools" "$GITHUB_STEP_SUMMARY" | sed 's/\*\*Failed Tools\*\*: //' | tr ',' ' ')
           echo "failed_tools=$failed_tools" >> "$GITHUB_OUTPUT"
       - name: Retry failed tools
-        if: steps.test-tools.outputs.failed_tools != '' && github.head_ref != 'release' && github.ref != 'refs/heads/release'
-        run: mise run test-tool-retry ${{ steps.test-tools.outputs.failed_tools }}
-      - name: Retry failed tools (with grace period for new upstream releases)
-        if: steps.test-tools.outputs.failed_tools != '' && (github.head_ref == 'release' || github.ref == 'refs/heads/release')
-        run: mise run test-tool-retry --grace-period ${{ steps.test-tools.outputs.failed_tools }}
+        id: retry
+        if: steps.test-tools.outputs.failed_tools != ''
+        run: |
+          docker run --rm \
+            -v "$PWD:/mise-src:ro" \
+            -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
+            -v "$GITHUB_STEP_SUMMARY:/tmp/github_summary" \
+            -e GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
+            -e GITHUB_STEP_SUMMARY=/tmp/github_summary \
+            -e RUST_BACKTRACE=1 \
+            ghcr.io/jdx/mise:e2e \
+            mise test-tool ${{ steps.test-tools.outputs.failed_tools }} || true
+          failed_tools=$(grep "Failed Tools" "$GITHUB_STEP_SUMMARY" | sed 's/\*\*Failed Tools\*\*: //' | tr ',' ' ')
+          echo "failed_tools=$failed_tools" >> "$GITHUB_OUTPUT"
+      - name: Handle retry failures
+        if: steps.retry.outputs.failed_tools != '' && github.head_ref != 'release' && github.ref != 'refs/heads/release'
+        run: |
+          echo "Tools still failing after retry: ${{ steps.retry.outputs.failed_tools }}"
+          exit 1
+      - name: Check grace period for release branch failures
+        if: steps.retry.outputs.failed_tools != '' && (github.head_ref == 'release' || github.ref == 'refs/heads/release')
+        env:
+          GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: mise run test-tool-retry --grace-period ${{ steps.retry.outputs.failed_tools }}
 
   registry-ci:
     runs-on: ubuntu-latest

--- a/tasks.md
+++ b/tasks.md
@@ -244,7 +244,7 @@ run all tests
 
 ## `test-tool-retry`
 
-- **Usage**: `test-tool-retry [--grace-period] <tools>…`
+- **Usage**: `test-tool-retry [--grace-period] [--check-only] <tools>…`
 
 Retry failed test-tools with grace period for recent upstream releases
 
@@ -259,6 +259,10 @@ Failed tools to retry
 #### `--grace-period`
 
 Ignore failures from tools whose upstream released &lt;7 days ago
+
+#### `--check-only`
+
+Skip retrying tools, only check grace period (use with --grace-period)
 
 ## `test:build-perf-workspace`
 

--- a/xtasks/test-tool-retry.py
+++ b/xtasks/test-tool-retry.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #MISE description="Retry failed test-tools with grace period for recent upstream releases"
 #USAGE flag "--grace-period" help="Ignore failures from tools whose upstream released <7 days ago"
+#USAGE flag "--check-only" help="Skip retrying tools, only check grace period (use with --grace-period)"
 #USAGE arg "<tools>..." help="Failed tools to retry"
 """Retries failed test-tool runs. With --grace-period, tools backed by
 GitHub/aqua whose latest upstream release is less than 7 days old have
@@ -113,16 +114,20 @@ def check_grace_period(tools: list[str]) -> list[str]:
 
 def main():
     grace_period = "--grace-period" in sys.argv
+    check_only = "--check-only" in sys.argv
     tools = [a for a in sys.argv[1:] if not a.startswith("-")]
 
     if not tools:
-        print("Usage: test-tool-retry [--grace-period] <tool1> [tool2] ...")
+        print("Usage: test-tool-retry [--grace-period] [--check-only] <tool1> [tool2] ...")
         sys.exit(1)
 
-    still_failing = retry_tools(tools)
-    if not still_failing:
-        print("All tools passed on retry.")
-        sys.exit(0)
+    if check_only:
+        still_failing = tools
+    else:
+        still_failing = retry_tools(tools)
+        if not still_failing:
+            print("All tools passed on retry.")
+            sys.exit(0)
 
     if not grace_period:
         print(f"Failed tools: {', '.join(still_failing)}")


### PR DESCRIPTION
## Summary
- Run `mise test-tool` inside `ghcr.io/jdx/mise:e2e` Docker container to isolate tool install scripts from the CI runner
- Prevents tool scripts from accessing runner secrets (`ACTIONS_RUNTIME_TOKEN`, etc.) and host environment
- Only `GITHUB_TOKEN` (pooled) is passed into the container
- `GITHUB_STEP_SUMMARY` is bind-mounted so job summaries still work
- Grace period check (release branch only) runs on the host since it needs `gh` CLI and only queries APIs

## Test plan
- [ ] Verify test-tool jobs pass in CI with Docker
- [ ] Verify retry logic still works for failing tools
- [ ] Verify GITHUB_STEP_SUMMARY is populated correctly through the bind mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the `registry.yml` CI execution environment and retry behavior, which could cause unexpected test failures/flakiness or summary parsing issues, but it’s scoped to CI and not production runtime.
> 
> **Overview**
> **Registry CI now runs tool tests inside Docker.** The `test-tool` job pulls `ghcr.io/jdx/mise:e2e` and executes `mise test-tool` (and the retry run) via `docker run`, bind-mounting the workspace, the built `mise` binary, and `GITHUB_STEP_SUMMARY`, and passing only a pooled `GITHUB_TOKEN` into the container.
> 
> **Retry/grace-period handling is reworked.** The workflow now captures retry failures explicitly (failing PRs after a retry), while release branches run `mise run test-tool-retry --check-only --grace-period` on remaining failures; `xtasks/test-tool-retry.py` adds `--check-only` to skip reruns and only apply the grace-period evaluation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f398e8b3efe166c3f8b1d3f1f84e32aac73319a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->