### PR TITLE
fix(env): use OS path separator for path-list env vars on Windows

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -535,7 +535,8 @@ of what is set in `mise.toml`/`.tool-versions`.
 ### `MISE_TRUSTED_CONFIG_PATHS`
 
 This is a list of paths that mise will automatically mark as
-trusted. They can be separated with `:`.
+trusted. They are separated according to platform conventions for the PATH
+environment variable: `:` on Unix and `;` on Windows.
 
 ### `MISE_CEILING_PATHS`
 

--- a/docs/mise-cookbook/docker.md
+++ b/docs/mise-cookbook/docker.md
@@ -69,7 +69,7 @@ Users can install additional versions in their own directory — those take prio
 system versions. To customize the system directory, set `MISE_SYSTEM_DATA_DIR`.
 
 You can also configure additional shared directories with `MISE_SHARED_INSTALL_DIRS`
-(colon-separated paths) or the `shared_install_dirs` setting.
+(paths separated by `:` on Unix and `;` on Windows) or the `shared_install_dirs` setting.
 
 ### Devcontainers with home directory mounts
 

--- a/e2e-win/trusted_config_paths.Tests.ps1
+++ b/e2e-win/trusted_config_paths.Tests.ps1
@@ -1,0 +1,52 @@
+Describe 'MISE_TRUSTED_CONFIG_PATHS' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+
+        # Create two separate project directories with mise.toml files
+        $script:DirA = Join-Path $script:TestRoot "project_a"
+        $script:DirB = Join-Path $script:TestRoot "project_b"
+        New-Item -ItemType Directory -Path $script:DirA | Out-Null
+        New-Item -ItemType Directory -Path $script:DirB | Out-Null
+
+        @"
+[env]
+PROJECT = "a"
+"@ | Out-File (Join-Path $script:DirA ".mise.toml")
+
+        @"
+[env]
+PROJECT = "b"
+"@ | Out-File (Join-Path $script:DirB ".mise.toml")
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore
+        Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+    }
+
+    AfterEach {
+        Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+    }
+
+    It 'trusts a single path set via env var' {
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:DirA
+        Set-Location $script:DirA
+        $output = mise env | Out-String
+        $output | Should -Match "export PROJECT=a"
+    }
+
+    It 'trusts multiple Windows paths separated by semicolon' {
+        # On Windows, paths are separated by ; (not :) because absolute paths
+        # contain : in the drive letter (e.g. C:\foo). Using ; avoids ambiguity.
+        $env:MISE_TRUSTED_CONFIG_PATHS = "$($script:DirA);$($script:DirB)"
+        Set-Location $script:DirA
+        $output = mise env | Out-String
+        $output | Should -Match "export PROJECT=a"
+        Set-Location $script:DirB
+        $output = mise env | Out-String
+        $output | Should -Match "export PROJECT=b"
+    }
+}

--- a/e2e/cli/test_trusted_config_paths
+++ b/e2e/cli/test_trusted_config_paths
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+mkdir -p project_a project_b
+
+cat <<EOF >project_a/.mise.toml
+[env]
+PROJECT = "a"
+EOF
+
+cat <<EOF >project_b/.mise.toml
+[env]
+PROJECT = "b"
+EOF
+
+DIR_A="$(cd project_a && pwd)"
+DIR_B="$(cd project_b && pwd)"
+
+# Single trusted path: config in DIR_A is loaded
+cd project_a
+assert_contains "MISE_TRUSTED_CONFIG_PATHS=$DIR_A mise env" "PROJECT=a"
+
+# Multiple colon-separated paths: both configs are loaded
+assert_contains "MISE_TRUSTED_CONFIG_PATHS=$DIR_A:$DIR_B mise env" "PROJECT=a"
+cd ../project_b
+assert_contains "MISE_TRUSTED_CONFIG_PATHS=$DIR_A:$DIR_B mise env" "PROJECT=b"

--- a/e2e/config/test_config_ignored_paths
+++ b/e2e/config/test_config_ignored_paths
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Test MISE_IGNORED_CONFIG_PATHS with multiple colon-separated paths.
+# This exercises the env.rs early-init parsing which was fixed to use
+# std::env::split_paths instead of v.split(':').
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+mkdir -p child
+
+cat <<EOF >.mise.toml
+[env]
+PARENT = "true"
+EOF
+
+cat <<EOF >child/.mise.toml
+[env]
+CHILD = "true"
+EOF
+
+assert "mise trust --all"
+cd child
+
+WORKDIR="$(cd .. && pwd)"
+CHILD_DIR="$(pwd)"
+
+# Baseline: both configs are visible from child dir
+assert_contains "mise env" "PARENT"
+assert_contains "mise env" "CHILD"
+
+# Single ignored path: child config ignored, parent still visible
+assert_not_contains "MISE_IGNORED_CONFIG_PATHS=$CHILD_DIR mise env" "CHILD"
+assert_contains "MISE_IGNORED_CONFIG_PATHS=$CHILD_DIR mise env" "PARENT"
+
+# Multiple colon-separated paths: both configs ignored
+assert_not_contains "MISE_IGNORED_CONFIG_PATHS=$CHILD_DIR:$WORKDIR mise env" "CHILD"
+assert_not_contains "MISE_IGNORED_CONFIG_PATHS=$CHILD_DIR:$WORKDIR mise env" "PARENT"

--- a/schema/mise-settings.json
+++ b/schema/mise-settings.json
@@ -119,6 +119,7 @@
             "bool_string",
             "list_by_comma",
             "list_by_colon",
+            "list_by_os_path_separator",
             "set_by_comma",
             "parse_url_replacements"
           ],

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1656,7 +1656,7 @@
         },
         "trusted_config_paths": {
           "default": [],
-          "description": "This is a list of config paths that mise will automatically mark as trusted. Any config files under these paths will be trusted without prompting. Set to `[\"/\"]` to trust all config files, effectively disabling the trust mechanism.",
+          "description": "This is a list of config paths that mise will automatically mark as trusted. Any config files under these paths will be trusted without prompting. Set to `[\"/\"]` to trust all config files, effectively disabling the trust mechanism. Paths are separated by the OS path separator when using the environment variable (`:` on Unix, `;` on Windows).",
           "type": "array",
           "items": {
             "type": "string"

--- a/settings.toml
+++ b/settings.toml
@@ -249,9 +249,12 @@ This follows the same semantics as Git's `GIT_CEILING_DIRECTORIES`.
 This is an early-init setting: it must be set in `.miserc.toml`, environment
 variables, or CLI flags. Setting it in `mise.toml` will have no effect because
 config file discovery has already occurred by the time `mise.toml` is read.
+
+Paths are separated by the OS path separator when using the environment variable
+(`:` on Unix, `;` on Windows).
 """
 env = "MISE_CEILING_PATHS"
-parse_env = "list_by_colon"
+parse_env = "list_by_os_path_separator"
 rc = true
 rust_type = "BTreeSet<PathBuf>"
 type = "ListPath"
@@ -996,9 +999,12 @@ This is a list of config paths that mise will ignore.
 This is an early-init setting: it must be set in `.miserc.toml`, environment
 variables, or CLI flags. Setting it in `mise.toml` will have no effect because
 config file discovery has already occurred by the time `mise.toml` is read.
+
+Paths are separated by the OS path separator when using the environment variable
+(`:` on Unix, `;` on Windows).
 """
 env = "MISE_IGNORED_CONFIG_PATHS"
-parse_env = "list_by_colon"
+parse_env = "list_by_os_path_separator"
 rc = true
 rust_type = "BTreeSet<PathBuf>"
 type = "ListPath"
@@ -1809,11 +1815,12 @@ This is useful for shared environments like Docker containers or bastion hosts w
 base set of tools is pre-installed in a shared location, and users can install additional
 tools in their own directory.
 
-Paths are colon-separated when using the environment variable.
+Paths are separated by the OS path separator when using the environment variable
+(`:` on Unix, `;` on Windows).
 """
 env = "MISE_SHARED_INSTALL_DIRS"
 optional = true
-parse_env = "list_by_colon"
+parse_env = "list_by_os_path_separator"
 rust_type = "Vec<PathBuf>"
 type = "ListPath"
 
@@ -1948,8 +1955,14 @@ type = "Path"
 [task.disable_paths]
 default = []
 description = "Paths that mise will not look for tasks in."
+docs = """
+Paths that mise will not look for tasks in.
+
+Paths are separated by the OS path separator when using the environment variable
+(`:` on Unix, `;` on Windows).
+"""
 env = "MISE_TASK_DISABLE_PATHS"
-parse_env = "list_by_colon"
+parse_env = "list_by_os_path_separator"
 rust_type = "BTreeSet<PathBuf>"
 type = "ListPath"
 
@@ -2216,9 +2229,11 @@ type = "Bool"
 default = []
 description = """This is a list of config paths that mise will automatically mark as \
 trusted. Any config files under these paths will be trusted without prompting. \
-Set to `["/"]` to trust all config files, effectively disabling the trust mechanism."""
+Set to `["/"]` to trust all config files, effectively disabling the trust mechanism. \
+Paths are separated by the OS path separator when using the environment variable \
+(`:` on Unix, `;` on Windows)."""
 env = "MISE_TRUSTED_CONFIG_PATHS"
-parse_env = "list_by_colon"
+parse_env = "list_by_os_path_separator"
 rust_type = "BTreeSet<PathBuf>"
 type = "ListPath"
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -878,6 +878,18 @@ pub fn parse_url_replacements(input: &str) -> Result<IndexMap<String, String>, s
     serde_json::from_str(input)
 }
 
+/// Parse a path list from an environment variable using the OS-native path
+/// separator (`:` on Unix, `;` on Windows). This correctly handles Windows
+/// absolute paths whose drive letters contain `:` (e.g. `C:\foo`).
+fn list_by_os_path_separator<C>(input: &str) -> Result<C, std::convert::Infallible>
+where
+    C: FromIterator<PathBuf>,
+{
+    Ok(std::env::split_paths(input)
+        .filter(|p| !p.as_os_str().is_empty())
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1069,5 +1081,55 @@ mod tests {
         assert!(node.configure_cmd(path).contains("--verbose"));
         assert!(node.make_cmd().starts_with("gmake -j4 -s"));
         assert_eq!(node.make_install_cmd(), "gmake install --no-strip");
+    }
+
+    #[test]
+    fn test_list_by_os_path_separator_empty() {
+        let result: Result<Vec<PathBuf>, _> = list_by_os_path_separator("");
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_list_by_os_path_separator_single() {
+        #[cfg(not(windows))]
+        let (input, expected) = ("/foo/bar", PathBuf::from("/foo/bar"));
+        #[cfg(windows)]
+        let (input, expected) = (r"C:\foo\bar", PathBuf::from(r"C:\foo\bar"));
+        let result: Vec<PathBuf> = list_by_os_path_separator(input).unwrap();
+        assert_eq!(result, vec![expected]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_list_by_os_path_separator_multiple_unix() {
+        let result: Vec<PathBuf> = list_by_os_path_separator("/foo:/bar").unwrap();
+        assert_eq!(result, vec![PathBuf::from("/foo"), PathBuf::from("/bar")]);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_list_by_os_path_separator_multiple_windows() {
+        let result: Vec<PathBuf> = list_by_os_path_separator(r"C:\foo;D:\bar").unwrap();
+        assert_eq!(
+            result,
+            vec![PathBuf::from(r"C:\foo"), PathBuf::from(r"D:\bar")]
+        );
+    }
+
+    #[test]
+    fn test_list_by_os_path_separator_as_btreeset() {
+        // Verify the function works with BTreeSet as the collection type,
+        // matching the field types used in Settings (e.g. trusted_config_paths).
+        #[cfg(not(windows))]
+        let (input, a, b) = ("/foo:/bar", PathBuf::from("/foo"), PathBuf::from("/bar"));
+        #[cfg(windows)]
+        let (input, a, b) = (
+            r"C:\foo;D:\bar",
+            PathBuf::from(r"C:\foo"),
+            PathBuf::from(r"D:\bar"),
+        );
+        let result: BTreeSet<PathBuf> = list_by_os_path_separator(input).unwrap();
+        assert_eq!(result, [a, b].into_iter().collect());
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -264,12 +264,10 @@ pub static MISE_GLOBAL_CONFIG_ROOT: Lazy<PathBuf> =
 pub static MISE_SYSTEM_CONFIG_FILE: Lazy<Option<PathBuf>> =
     Lazy::new(|| var_path("MISE_SYSTEM_CONFIG_FILE"));
 pub static MISE_IGNORED_CONFIG_PATHS: Lazy<Vec<PathBuf>> = Lazy::new(|| {
-    var("MISE_IGNORED_CONFIG_PATHS")
-        .ok()
+    var_os("MISE_IGNORED_CONFIG_PATHS")
         .map(|v| {
-            v.split(':')
-                .filter(|p| !p.is_empty())
-                .map(PathBuf::from)
+            split_paths(&v)
+                .filter(|p| !p.as_os_str().is_empty())
                 .map(replace_path)
                 .collect()
         })
@@ -280,8 +278,7 @@ pub static MISE_IGNORED_CONFIG_PATHS: Lazy<Vec<PathBuf>> = Lazy::new(|| {
         .unwrap_or_default()
 });
 pub static MISE_CEILING_PATHS: Lazy<HashSet<PathBuf>> = Lazy::new(|| {
-    var("MISE_CEILING_PATHS")
-        .ok()
+    var_os("MISE_CEILING_PATHS")
         .map(|v| {
             split_paths(&v)
                 .filter(|p| !p.as_os_str().is_empty())


### PR DESCRIPTION
This pull request standardizes how environment variables that represent lists of file system paths are parsed, ensuring they use the OS-native path separator (`:` on Unix, `;` on Windows) instead of always using a colon. This change improves cross-platform compatibility, particularly for Windows users, and updates documentation, configuration schemas, and tests accordingly.

**Core logic and parsing improvements:**

* Introduced a new `list_by_os_path_separator` parser that uses the OS-native path separator for environment variables representing path lists, replacing the previous colon-based parsing logic. This is implemented in `src/config/settings.rs` and thoroughly tested. [[1]](diffhunk://#diff-d572ad1b7153cbdba3cde3e371ecfa12b90d84f7a243edc9cec3bf47fe7ed086R881-R892) [[2]](diffhunk://#diff-d572ad1b7153cbdba3cde3e371ecfa12b90d84f7a243edc9cec3bf47fe7ed086R1085-R1134)
* Updated environment variable parsing in `src/env.rs` for `MISE_IGNORED_CONFIG_PATHS` and `MISE_CEILING_PATHS` to use `var_os` and `split_paths`, ensuring correct handling of Windows paths. [[1]](diffhunk://#diff-4da8e8ee5c65a27bd048a2f2e55de0a9c75e87618fc02e17b235cc5413e625a0L267-R270) [[2]](diffhunk://#diff-4da8e8ee5c65a27bd048a2f2e55de0a9c75e87618fc02e17b235cc5413e625a0L283-R281)

**Configuration and schema updates:**

* Modified `settings.toml` to use `list_by_os_path_separator` for relevant settings (`MISE_TRUSTED_CONFIG_PATHS`, `MISE_IGNORED_CONFIG_PATHS`, `MISE_CEILING_PATHS`, `MISE_SHARED_INSTALL_DIRS`, `MISE_TASK_DISABLE_PATHS`), and clarified documentation to specify the OS-native path separator. [[1]](diffhunk://#diff-1dd754894f1ddb0df5932165d4c0e7583150ae19418b696d6a3fd2ea976f5253R252-R257) [[2]](diffhunk://#diff-1dd754894f1ddb0df5932165d4c0e7583150ae19418b696d6a3fd2ea976f5253R1002-R1007) [[3]](diffhunk://#diff-1dd754894f1ddb0df5932165d4c0e7583150ae19418b696d6a3fd2ea976f5253L1812-R1823) [[4]](diffhunk://#diff-1dd754894f1ddb0df5932165d4c0e7583150ae19418b696d6a3fd2ea976f5253R1958-R1965) [[5]](diffhunk://#diff-1dd754894f1ddb0df5932165d4c0e7583150ae19418b696d6a3fd2ea976f5253L2219-R2236)
* Updated JSON schemas and documentation to reflect the new parsing behavior and clarify the use of the OS path separator in environment variables. [[1]](diffhunk://#diff-eaffd3b47dfb44cf8d7b5d1c432d060ce1774840bc8e6615339a38e535d4e926R122) [[2]](diffhunk://#diff-dff5883d28be941c00a984c7e5cc7add33efae468ad68c121431f5007d7fcf19L1639-R1639) [[3]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180L538-R539) [[4]](diffhunk://#diff-ca8222c37ef6fe90efdfabe06ba2463c8f3495c975f63508ba6cc28859f91137L72-R72)

**Testing improvements:**

* Added new end-to-end tests for trusted and ignored config paths on both Unix (`e2e/cli/test_trusted_config_paths`, `e2e/config/test_config_ignored_paths`) and Windows (`e2e-win/trusted_config_paths.Tests.ps1`) to verify correct parsing and behavior with both single and multiple paths. [[1]](diffhunk://#diff-483169667c2fce350402418107681574625aa98782a793661867b5ac1dc6d261R1-R27) [[2]](diffhunk://#diff-a14cdaad45b560d715698cf2a2ca67172e455b0d66ff12f710c8e7461363db5dR1-R37) [[3]](diffhunk://#diff-741aa76d437b51929b47a2c89a1e1e6737569da515001a453e076b9e4741091bR1-R52)