### PR TITLE
fix: support npm semver ranges in devEngines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5798,6 +5798,7 @@ dependencies = [
  "mockito",
  "netrc-rs",
  "nix 0.31.2",
+ "nodejs-semver",
  "num_cpus",
  "number_prefix",
  "once_cell",
@@ -6015,6 +6016,18 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nodejs-semver"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a29bc3430baa1e00e10d9aa5f4ed19ce4433eecb40e3926ade5ff2954cc2f3a"
+dependencies = [
+ "bytecount",
+ "miette",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ minisign-verify = "0.2"
 md-5 = "0.11"
 miette = { version = "7", features = ["fancy"] }
 netrc-rs = "0.1"
+nodejs-semver = "4.2"
 num_cpus = "1"
 number_prefix = "0.4"
 once_cell = "1"

--- a/e2e/core/test_package_json
+++ b/e2e/core/test_package_json
@@ -11,7 +11,7 @@ cat >package.json <<'EOF'
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">=22.0.0"
+      "version": ">=22.0.0 <23.0.0"
     }
   }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -951,7 +951,7 @@ pub trait Backend: Debug + Send + Sync {
     /// every backend needing to implement `package.json` support. For other files, it
     /// delegates to `_parse_idiomatic_file`.
     async fn parse_idiomatic_file(&self, path: &Path) -> eyre::Result<Vec<String>> {
-        if path.file_name().is_some_and(|f| f == "package.json") {
+        if crate::config::config_file::idiomatic_version::package_json::is_package_json(path) {
             return crate::config::config_file::idiomatic_version::package_json::parse(
                 path,
                 self.id(),
@@ -1458,10 +1458,6 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     fn fuzzy_match_filter(&self, versions: Vec<String>, query: &str) -> Vec<String> {
-        if let Some(matches) = crate::semver::npm_semver_range_filter(&versions, query) {
-            return matches;
-        }
-
         let escaped_query = regex::escape(query);
         let query_pattern = if query == "latest" {
             "v?[0-9].*"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1458,6 +1458,10 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     fn fuzzy_match_filter(&self, versions: Vec<String>, query: &str) -> Vec<String> {
+        if let Some(matches) = crate::semver::npm_semver_range_filter(&versions, query) {
+            return matches;
+        }
+
         let escaped_query = regex::escape(query);
         let query_pattern = if query == "latest" {
             "v?[0-9].*"

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -327,13 +327,9 @@ fn extract_version(tool: &str, path: &Path) -> Option<String> {
     let filename = path.file_name()?.to_str()?;
     let content = file::read_to_string(path).ok()?;
 
-    match tool {
+    match (tool, filename) {
         // Node.js version from package.json engines
-        "node"
-            if crate::config::config_file::idiomatic_version::package_json::is_package_json(
-                path,
-            ) =>
-        {
+        ("node", "package.json") => {
             let json: serde_json::Value = serde_json::from_str(&content).ok()?;
             json.get("engines")
                 .and_then(|e| e.get("node"))
@@ -341,7 +337,7 @@ fn extract_version(tool: &str, path: &Path) -> Option<String> {
                 .map(|s| s.to_string())
         }
         // Python version from pyproject.toml
-        "python" if filename == "pyproject.toml" => {
+        ("python", "pyproject.toml") => {
             let doc: toml::Value = toml::from_str(&content).ok()?;
             doc.get("project")
                 .and_then(|p| p.get("requires-python"))
@@ -353,16 +349,16 @@ fn extract_version(tool: &str, path: &Path) -> Option<String> {
                 .filter(|s| !s.is_empty())
         }
         // Go version from go.mod
-        "go" if filename == "go.mod" => content
+        ("go", "go.mod") => content
             .lines()
             .find(|line| line.starts_with("go "))
             .map(|line| line.trim_start_matches("go ").trim().to_string()),
         // Version files (simple text content)
-        _ if filename.starts_with('.') && filename.ends_with("-version") => {
+        (_, f) if f.starts_with('.') && f.ends_with("-version") => {
             let v = content.trim().to_string();
             if v.is_empty() { None } else { Some(v) }
         }
-        _ if filename == ".nvmrc" => {
+        (_, ".nvmrc") => {
             let v = content.trim().to_string();
             if v.is_empty() { None } else { Some(v) }
         }

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -327,9 +327,13 @@ fn extract_version(tool: &str, path: &Path) -> Option<String> {
     let filename = path.file_name()?.to_str()?;
     let content = file::read_to_string(path).ok()?;
 
-    match (tool, filename) {
+    match tool {
         // Node.js version from package.json engines
-        ("node", "package.json") => {
+        "node"
+            if crate::config::config_file::idiomatic_version::package_json::is_package_json(
+                path,
+            ) =>
+        {
             let json: serde_json::Value = serde_json::from_str(&content).ok()?;
             json.get("engines")
                 .and_then(|e| e.get("node"))
@@ -337,7 +341,7 @@ fn extract_version(tool: &str, path: &Path) -> Option<String> {
                 .map(|s| s.to_string())
         }
         // Python version from pyproject.toml
-        ("python", "pyproject.toml") => {
+        "python" if filename == "pyproject.toml" => {
             let doc: toml::Value = toml::from_str(&content).ok()?;
             doc.get("project")
                 .and_then(|p| p.get("requires-python"))
@@ -349,16 +353,16 @@ fn extract_version(tool: &str, path: &Path) -> Option<String> {
                 .filter(|s| !s.is_empty())
         }
         // Go version from go.mod
-        ("go", "go.mod") => content
+        "go" if filename == "go.mod" => content
             .lines()
             .find(|line| line.starts_with("go "))
             .map(|line| line.trim_start_matches("go ").trim().to_string()),
         // Version files (simple text content)
-        (_, f) if f.starts_with('.') && f.ends_with("-version") => {
+        _ if filename.starts_with('.') && filename.ends_with("-version") => {
             let v = content.trim().to_string();
             if v.is_empty() { None } else { Some(v) }
         }
-        (_, ".nvmrc") => {
+        _ if filename == ".nvmrc" => {
             let v = content.trim().to_string();
             if v.is_empty() { None } else { Some(v) }
         }

--- a/src/config/config_file/idiomatic_version/package_json.rs
+++ b/src/config/config_file/idiomatic_version/package_json.rs
@@ -26,6 +26,11 @@ struct DevEngine {
     version: Option<String>,
 }
 
+pub fn is_package_json(path: &Path) -> bool {
+    path.file_name()
+        .is_some_and(|file_name| file_name == "package.json")
+}
+
 /// Deserialize a field that may be a single object or an array (take the first element).
 /// The npm devEngines spec allows both forms.
 fn deserialize_one_or_first<'de, D>(
@@ -62,8 +67,8 @@ impl PackageJsonData {
             .and_then(|de| de.runtime.as_ref())
             .filter(|r| r.name.as_deref() == Some(tool_name))
             .and_then(|r| r.version.as_deref())
-            .map(normalize_semver_range)
             .filter(|v| !v.is_empty())
+            .map(str::to_string)
     }
 
     /// Extract a package manager version for the given tool name.
@@ -75,8 +80,8 @@ impl PackageJsonData {
             .and_then(|de| de.package_manager.as_ref())
             .filter(|pm| pm.name.as_deref() == Some(tool_name))
             .and_then(|pm| pm.version.as_deref())
-            .map(normalize_semver_range)
             .filter(|v| !v.is_empty())
+            .map(str::to_string)
             .or_else(|| {
                 // Fall back to packageManager field (e.g. "pnpm@9.1.0+sha256.abc")
                 let pm_field = self.package_manager.as_deref()?;
@@ -92,12 +97,6 @@ impl PackageJsonData {
                 Some(version.to_string())
             })
     }
-}
-
-/// Preserve npm semver ranges from package.json for resolution against the
-/// backend's available versions.
-fn normalize_semver_range(input: &str) -> String {
-    input.trim().to_string()
 }
 
 pub fn parse(path: &Path, tool_name: &str) -> Result<Vec<String>> {
@@ -123,21 +122,6 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
-
-    #[test]
-    fn test_normalize_semver_range() {
-        assert_eq!(normalize_semver_range(" >=18.0.0 "), ">=18.0.0");
-        assert_eq!(normalize_semver_range("^20.0.0"), "^20.0.0");
-        assert_eq!(normalize_semver_range("~18.2.0"), "~18.2.0");
-        assert_eq!(normalize_semver_range("9.1.0"), "9.1.0");
-        assert_eq!(normalize_semver_range("18"), "18");
-        assert_eq!(normalize_semver_range("*"), "*");
-        assert_eq!(normalize_semver_range("x"), "x");
-        assert_eq!(
-            normalize_semver_range(">=20 <21 || >=22"),
-            ">=20 <21 || >=22"
-        );
-    }
 
     #[test]
     fn test_parse_package_json() {
@@ -178,20 +162,6 @@ mod tests {
 
         assert_eq!(parse(&path, "bun").unwrap(), vec!["1.0.0".to_string()]);
         assert_eq!(parse(&path, "node").unwrap(), Vec::<String>::new());
-    }
-
-    #[test]
-    fn test_normalize_semver_range_upper_bound() {
-        assert_eq!(normalize_semver_range("<18.0.0"), "<18.0.0");
-        assert_eq!(normalize_semver_range("<=18.0.0"), "<=18.0.0");
-    }
-
-    #[test]
-    fn test_normalize_semver_range_wildcards() {
-        assert_eq!(normalize_semver_range("18.x"), "18.x");
-        assert_eq!(normalize_semver_range("18.*"), "18.*");
-        assert_eq!(normalize_semver_range("18.2.x"), "18.2.x");
-        assert_eq!(normalize_semver_range("18.2.*"), "18.2.*");
     }
 
     #[test]

--- a/src/config/config_file/idiomatic_version/package_json.rs
+++ b/src/config/config_file/idiomatic_version/package_json.rs
@@ -62,7 +62,7 @@ impl PackageJsonData {
             .and_then(|de| de.runtime.as_ref())
             .filter(|r| r.name.as_deref() == Some(tool_name))
             .and_then(|r| r.version.as_deref())
-            .map(simplify_semver)
+            .map(normalize_semver_range)
             .filter(|v| !v.is_empty())
     }
 
@@ -75,7 +75,7 @@ impl PackageJsonData {
             .and_then(|de| de.package_manager.as_ref())
             .filter(|pm| pm.name.as_deref() == Some(tool_name))
             .and_then(|pm| pm.version.as_deref())
-            .map(simplify_semver)
+            .map(normalize_semver_range)
             .filter(|v| !v.is_empty())
             .or_else(|| {
                 // Fall back to packageManager field (e.g. "pnpm@9.1.0+sha256.abc")
@@ -94,69 +94,10 @@ impl PackageJsonData {
     }
 }
 
-/// Simplify a semver range to a mise-compatible version prefix.
-///
-/// Strips range operators (>=, ^, ~) and trailing `.0` components to produce
-/// a prefix that mise can match against. For exact versions, returns as-is.
-/// Upper-bound operators (`<`, `<=`) are ignored since they don't indicate
-/// a version to install.
-///
-/// # TODO
-/// This doesn't handle all edge cases correctly. For example, `^20.0.1` should not
-/// match `20.0.0`, but our simplified approach strips it to `20` which would match.
-/// Full semver range support may be added in the future.
-fn simplify_semver(input: &str) -> String {
-    let input = input.trim();
-    if input == "*" || input == "x" {
-        return "latest".to_string();
-    }
-
-    // Upper-bound operators don't indicate a version to install
-    if input.starts_with('<') || input.starts_with("<=") {
-        return String::new();
-    }
-
-    // Strip leading range operators
-    let version = input
-        .trim_start_matches(">=")
-        .trim_start_matches('>')
-        .trim_start_matches('^')
-        .trim_start_matches('~')
-        .trim_start_matches('=')
-        .trim();
-
-    if version.is_empty() {
-        return "latest".to_string();
-    }
-
-    // Replace wildcard segments (x, *) with truncation
-    // e.g. "18.x" -> "18", "18.2.*" -> "18.2"
-    let parts: Vec<&str> = version
-        .split('.')
-        .take_while(|p| *p != "x" && *p != "*")
-        .collect();
-    if parts.is_empty() {
-        return "latest".to_string();
-    }
-    if parts.len() < version.split('.').count() {
-        // Had wildcard segments, return truncated prefix
-        return parts.join(".");
-    }
-
-    let had_operator = version != input;
-
-    // Only strip trailing .0 components when a range operator was present,
-    // since ranges imply prefix matching. Exact versions are kept as-is.
-    if had_operator {
-        let trimmed: Vec<&str> = match parts.as_slice() {
-            [major, "0", "0"] => vec![major],
-            [major, minor, "0"] => vec![major, minor],
-            _ => parts,
-        };
-        trimmed.join(".")
-    } else {
-        version.to_string()
-    }
+/// Preserve npm semver ranges from package.json for resolution against the
+/// backend's available versions.
+fn normalize_semver_range(input: &str) -> String {
+    input.trim().to_string()
 }
 
 pub fn parse(path: &Path, tool_name: &str) -> Result<Vec<String>> {
@@ -184,19 +125,18 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn test_simplify_semver() {
-        assert_eq!(simplify_semver(">=18.0.0"), "18");
-        assert_eq!(simplify_semver("^20.0.0"), "20");
-        assert_eq!(simplify_semver("~18.2.0"), "18.2");
-        assert_eq!(simplify_semver("9.1.0"), "9.1.0");
-        assert_eq!(simplify_semver("9.1.2"), "9.1.2");
-        assert_eq!(simplify_semver("18"), "18");
-        assert_eq!(simplify_semver("*"), "latest");
-        assert_eq!(simplify_semver("x"), "latest");
-        assert_eq!(simplify_semver(">= 18.0.0"), "18");
-        assert_eq!(simplify_semver("^18.2.0"), "18.2");
-        assert_eq!(simplify_semver("~18.0.0"), "18");
-        assert_eq!(simplify_semver("=18.0.0"), "18");
+    fn test_normalize_semver_range() {
+        assert_eq!(normalize_semver_range(" >=18.0.0 "), ">=18.0.0");
+        assert_eq!(normalize_semver_range("^20.0.0"), "^20.0.0");
+        assert_eq!(normalize_semver_range("~18.2.0"), "~18.2.0");
+        assert_eq!(normalize_semver_range("9.1.0"), "9.1.0");
+        assert_eq!(normalize_semver_range("18"), "18");
+        assert_eq!(normalize_semver_range("*"), "*");
+        assert_eq!(normalize_semver_range("x"), "x");
+        assert_eq!(
+            normalize_semver_range(">=20 <21 || >=22"),
+            ">=20 <21 || >=22"
+        );
     }
 
     #[test]
@@ -241,17 +181,17 @@ mod tests {
     }
 
     #[test]
-    fn test_simplify_semver_upper_bound() {
-        assert_eq!(simplify_semver("<18.0.0"), "");
-        assert_eq!(simplify_semver("<=18.0.0"), "");
+    fn test_normalize_semver_range_upper_bound() {
+        assert_eq!(normalize_semver_range("<18.0.0"), "<18.0.0");
+        assert_eq!(normalize_semver_range("<=18.0.0"), "<=18.0.0");
     }
 
     #[test]
-    fn test_simplify_semver_wildcards() {
-        assert_eq!(simplify_semver("18.x"), "18");
-        assert_eq!(simplify_semver("18.*"), "18");
-        assert_eq!(simplify_semver("18.2.x"), "18.2");
-        assert_eq!(simplify_semver("18.2.*"), "18.2");
+    fn test_normalize_semver_range_wildcards() {
+        assert_eq!(normalize_semver_range("18.x"), "18.x");
+        assert_eq!(normalize_semver_range("18.*"), "18.*");
+        assert_eq!(normalize_semver_range("18.2.x"), "18.2.x");
+        assert_eq!(normalize_semver_range("18.2.*"), "18.2.*");
     }
 
     #[test]
@@ -267,8 +207,43 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert_eq!(pkg.runtime_version("node"), Some("20".to_string()));
+        assert_eq!(pkg.runtime_version("node"), Some(">=20.0.0".to_string()));
         assert_eq!(pkg.runtime_version("bun"), None);
+    }
+
+    #[test]
+    fn test_runtime_version_lower_bound_range() {
+        let pkg: PackageJsonData = serde_json::from_str(
+            r#"{
+                "devEngines": {
+                    "runtime": {
+                        "name": "node",
+                        "version": ">=25.6.1"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(pkg.runtime_version("node"), Some(">=25.6.1".to_string()));
+    }
+
+    #[test]
+    fn test_runtime_version_compound_range() {
+        let pkg: PackageJsonData = serde_json::from_str(
+            r#"{
+                "devEngines": {
+                    "runtime": {
+                        "name": "node",
+                        "version": ">=20 <21 || >=22"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            pkg.runtime_version("node"),
+            Some(">=20 <21 || >=22".to_string())
+        );
     }
 
     #[test]
@@ -284,7 +259,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert_eq!(pkg.runtime_version("bun"), Some("1".to_string()));
+        assert_eq!(pkg.runtime_version("bun"), Some("^1.0.0".to_string()));
         assert_eq!(pkg.runtime_version("node"), None);
     }
 
@@ -301,7 +276,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert_eq!(pkg.runtime_version("node"), Some("22".to_string()));
+        assert_eq!(pkg.runtime_version("node"), Some(">=22.0.0".to_string()));
     }
 
     #[test]
@@ -332,8 +307,30 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert_eq!(pkg.package_manager_version("pnpm"), Some("9".to_string()));
+        assert_eq!(
+            pkg.package_manager_version("pnpm"),
+            Some(">=9.0.0".to_string())
+        );
         assert_eq!(pkg.package_manager_version("yarn"), None);
+    }
+
+    #[test]
+    fn test_package_manager_version_dev_engines_lower_bound_range() {
+        let pkg: PackageJsonData = serde_json::from_str(
+            r#"{
+                "devEngines": {
+                    "packageManager": {
+                        "name": "yarn",
+                        "version": ">=4.12.0"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            pkg.package_manager_version("yarn"),
+            Some(">=4.12.0".to_string())
+        );
     }
 
     #[test]
@@ -379,7 +376,10 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert_eq!(pkg.package_manager_version("pnpm"), Some("10".to_string()));
+        assert_eq!(
+            pkg.package_manager_version("pnpm"),
+            Some("^10.0.0".to_string())
+        );
     }
 
     #[test]

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -61,7 +61,7 @@ pub fn chunkify_version(v: &str) -> Vec<String> {
 /// existing fuzzy matching for aliases and non-semver tools.
 pub fn npm_semver_range_filter(versions: &[String], query: &str) -> Option<Vec<String>> {
     let query = query.trim();
-    if !looks_like_npm_semver_range(query) {
+    if !is_npm_semver_range_query(query) {
         return None;
     }
     let range = Range::parse(query).ok()?;
@@ -80,7 +80,7 @@ pub fn npm_semver_range_filter(versions: &[String], query: &str) -> Option<Vec<S
     )
 }
 
-fn looks_like_npm_semver_range(query: &str) -> bool {
+pub fn is_npm_semver_range_query(query: &str) -> bool {
     if query.is_empty() || query.eq_ignore_ascii_case("latest") {
         return false;
     }

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -72,9 +72,7 @@ pub fn npm_semver_range_filter(versions: &[String], query: &str) -> Option<Vec<S
             .filter(|v| {
                 let version = v.as_str();
                 NodeVersion::parse(version)
-                    .or_else(|_| {
-                        NodeVersion::parse(version.trim_start_matches(['v', 'V']))
-                    })
+                    .or_else(|_| NodeVersion::parse(version.trim_start_matches(['v', 'V'])))
                     .is_ok_and(|version| range.satisfies(&version))
             })
             .cloned()

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -73,7 +73,7 @@ pub fn npm_semver_range_filter(versions: &[String], query: &str) -> Option<Vec<S
                 let version = v.as_str();
                 NodeVersion::parse(version)
                     .or_else(|_| {
-                        NodeVersion::parse(version.trim_start_matches(|c| c == 'v' || c == 'V'))
+                        NodeVersion::parse(version.trim_start_matches(['v', 'V']))
                     })
                     .is_ok_and(|version| range.satisfies(&version))
             })

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -1,3 +1,4 @@
+use nodejs_semver::{Range, Version as NodeVersion};
 use versions::{Mess, Versioning};
 
 /// splits a version number into an optional prefix and the remaining version string
@@ -54,9 +55,60 @@ pub fn chunkify_version(v: &str) -> Vec<String> {
     chunks
 }
 
+/// Filter a list of version strings with an npm-compatible semver range.
+///
+/// Returns `None` for non-range queries so callers can fall back to mise's
+/// existing fuzzy matching for aliases and non-semver tools.
+pub fn npm_semver_range_filter(versions: &[String], query: &str) -> Option<Vec<String>> {
+    let query = query.trim();
+    if !looks_like_npm_semver_range(query) {
+        return None;
+    }
+    let range = Range::parse(query).ok()?;
+
+    Some(
+        versions
+            .iter()
+            .filter(|v| {
+                let version = v.as_str();
+                NodeVersion::parse(version)
+                    .or_else(|_| {
+                        NodeVersion::parse(version.trim_start_matches(|c| c == 'v' || c == 'V'))
+                    })
+                    .is_ok_and(|version| range.satisfies(&version))
+            })
+            .cloned()
+            .collect(),
+    )
+}
+
+fn looks_like_npm_semver_range(query: &str) -> bool {
+    if query.is_empty() || query.eq_ignore_ascii_case("latest") {
+        return false;
+    }
+    if query == "*" || query.eq_ignore_ascii_case("x") {
+        return true;
+    }
+    if query.contains("||") || query.contains(" - ") {
+        return true;
+    }
+    if matches!(
+        query.as_bytes().first().copied(),
+        Some(b'<' | b'>' | b'=' | b'^' | b'~')
+    ) || query.contains('<')
+        || query.contains('>')
+    {
+        return true;
+    }
+    if query.split_whitespace().count() > 1 {
+        return true;
+    }
+    query.split('.').any(|part| matches!(part, "*" | "x" | "X"))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{chunkify_version, split_version_prefix};
+    use super::{chunkify_version, npm_semver_range_filter, split_version_prefix};
 
     #[test]
     fn test_split_version_prefix() {
@@ -93,6 +145,82 @@ mod tests {
         assert_eq!(
             chunkify_version("2.3.4-beta"),
             vec!["2", ".3", ".4", "-beta"]
+        );
+    }
+
+    #[test]
+    fn test_npm_semver_range_filter_lower_bound() {
+        let versions = ["25.5.0", "25.6.1", "25.8.2"].map(String::from).to_vec();
+
+        assert_eq!(
+            npm_semver_range_filter(&versions, ">=25.6.1").unwrap(),
+            vec!["25.6.1".to_string(), "25.8.2".to_string()]
+        );
+        assert_eq!(
+            npm_semver_range_filter(&versions, ">= 25.6.1").unwrap(),
+            vec!["25.6.1".to_string(), "25.8.2".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_npm_semver_range_filter_compound_bounds() {
+        let versions = ["25.5.0", "25.6.1", "25.8.2", "26.0.0"]
+            .map(String::from)
+            .to_vec();
+
+        assert_eq!(
+            npm_semver_range_filter(&versions, ">=25.6.1 <26").unwrap(),
+            vec!["25.6.1".to_string(), "25.8.2".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_npm_semver_range_filter_caret() {
+        let versions = ["20.0.0", "20.0.1", "20.1.0", "21.0.0"]
+            .map(String::from)
+            .to_vec();
+
+        assert_eq!(
+            npm_semver_range_filter(&versions, "^20.0.1").unwrap(),
+            vec!["20.0.1".to_string(), "20.1.0".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_npm_semver_range_filter_alternatives() {
+        let versions = ["18.19.0", "20.0.0", "21.9.0", "22.0.0"]
+            .map(String::from)
+            .to_vec();
+
+        assert_eq!(
+            npm_semver_range_filter(&versions, ">=18 <20 || >=22").unwrap(),
+            vec!["18.19.0".to_string(), "22.0.0".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_npm_semver_range_filter_preserves_v_prefix() {
+        let versions = ["v25.6.1", "v25.8.2"].map(String::from).to_vec();
+
+        assert_eq!(
+            npm_semver_range_filter(&versions, ">=25.8.0").unwrap(),
+            vec!["v25.8.2".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_npm_semver_range_filter_non_range_queries_fall_back() {
+        assert_eq!(
+            npm_semver_range_filter(&["1.0.0".to_string()], "latest"),
+            None
+        );
+        assert_eq!(
+            npm_semver_range_filter(&["1.0.0".to_string()], "temurin-"),
+            None
+        );
+        assert_eq!(
+            npm_semver_range_filter(&["1.0.0".to_string()], "1.0.0"),
+            None
         );
     }
 }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -296,8 +296,11 @@ impl ToolVersion {
                 return build(v.clone());
             }
         }
-        if is_package_json_idiomatic_request(&request)
-            && crate::semver::is_npm_semver_range_query(&v)
+        if matches!(
+            request.source(),
+            ToolSource::IdiomaticVersionFile(path)
+                if crate::config::config_file::idiomatic_version::package_json::is_package_json(path)
+        ) && crate::semver::is_npm_semver_range_query(&v)
         {
             if !opts.latest_versions {
                 let installed_versions = backend.list_installed_versions();
@@ -513,15 +516,6 @@ fn has_linked_version(ba: &BackendArg) -> bool {
         }
     }
     false
-}
-
-fn is_package_json_idiomatic_request(request: &ToolRequest) -> bool {
-    match request.source() {
-        ToolSource::IdiomaticVersionFile(path) => {
-            crate::config::config_file::idiomatic_version::package_json::is_package_json(path)
-        }
-        _ => false,
-    }
 }
 
 impl Display for ResolveOptions {

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::{cmp::Ordering, sync::LazyLock};
 use std::{collections::BTreeMap, sync::Arc};
 
-use crate::backend::ABackend;
+use crate::backend::{ABackend, VersionInfo};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
 use crate::env;
@@ -13,7 +13,7 @@ use crate::env;
 use crate::file;
 use crate::hash::hash_to_str;
 use crate::lockfile::{CondaPackageInfo, LockfileTool, PlatformInfo};
-use crate::toolset::{ToolRequest, ToolVersionOptions, tool_request};
+use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, tool_request};
 use console::style;
 use dashmap::DashMap;
 use eyre::{Result, bail};
@@ -296,6 +296,37 @@ impl ToolVersion {
                 return build(v.clone());
             }
         }
+        if is_package_json_idiomatic_request(&request)
+            && crate::semver::is_npm_semver_range_query(&v)
+        {
+            if !opts.latest_versions {
+                let installed_versions = backend.list_installed_versions();
+                if let Some(matches) =
+                    crate::semver::npm_semver_range_filter(&installed_versions, &v)
+                    && let Some(v) = matches.last()
+                {
+                    return build(v.clone());
+                }
+            }
+            if !is_offline {
+                let versions = match opts.before_date {
+                    Some(before) => {
+                        let versions_with_info =
+                            backend.list_remote_versions_with_info(config).await?;
+                        VersionInfo::filter_by_date(versions_with_info, before)
+                            .into_iter()
+                            .map(|v| v.version)
+                            .collect()
+                    }
+                    None => backend.list_remote_versions(config).await?,
+                };
+                if let Some(matches) = crate::semver::npm_semver_range_filter(&versions, &v)
+                    && let Some(v) = matches.last()
+                {
+                    return build(v.clone());
+                }
+            }
+        }
         // When OFFLINE, skip ALL remote version fetching regardless of version format
         if is_offline {
             return build(v);
@@ -482,6 +513,15 @@ fn has_linked_version(ba: &BackendArg) -> bool {
         }
     }
     false
+}
+
+fn is_package_json_idiomatic_request(request: &ToolRequest) -> bool {
+    match request.source() {
+        ToolSource::IdiomaticVersionFile(path) => {
+            crate::config::config_file::idiomatic_version::package_json::is_package_json(path)
+        }
+        _ => false,
+    }
 }
 
 impl Display for ResolveOptions {


### PR DESCRIPTION
Refs #8935

## Summary
- preserve package.json devEngines semver ranges instead of simplifying them to exact-looking versions
- resolve npm-compatible ranges with nodejs-semver when filtering backend versions
- cover lower-bound, compound, caret, wildcard, and package manager range behavior

## Tests
- cargo test config::config_file::idiomatic_version::package_json
- cargo test semver
- ./e2e/run_test e2e/core/test_package_json