### PR TITLE
fix(task): render dependency templates even when no args are passed

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -334,8 +334,16 @@ impl Run {
         // Re-render dependency templates with parent task's usage arg/flag values.
         // This enables patterns like: depends = ["child {{usage.app}}"]
         for task in &mut task_list {
-            if !task.args.is_empty() {
-                let usage_values = crate::task::parse_usage_values_from_task(&config, task).await?;
+            let has_usage_deps = |raw: &Option<Vec<_>>| {
+                raw.as_ref()
+                    .is_some_and(|r| r.iter().any(crate::task::dep_has_usage_ref))
+            };
+            if has_usage_deps(&task.depends_raw)
+                || has_usage_deps(&task.depends_post_raw)
+                || has_usage_deps(&task.wait_for_raw)
+            {
+                let usage_values =
+                    crate::task::parse_usage_values_from_task(&config, task).await?;
                 if !usage_values.is_empty() {
                     task.render_depends_with_usage(&config, &usage_values)
                         .await?;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -342,8 +342,7 @@ impl Run {
                 || has_usage_deps(&task.depends_post_raw)
                 || has_usage_deps(&task.wait_for_raw)
             {
-                let usage_values =
-                    crate::task::parse_usage_values_from_task(&config, task).await?;
+                let usage_values = crate::task::parse_usage_values_from_task(&config, task).await?;
                 if !usage_values.is_empty() {
                     task.render_depends_with_usage(&config, &usage_values)
                         .await?;

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -85,16 +85,15 @@ impl Deps {
                 fetcher.fetch_tasks(&mut tasks_to_fetch).await?;
                 a = tasks_to_fetch.into_iter().next().unwrap();
             }
-            // If this task received args (from a parent dependency), re-render
-            // its dependency templates with usage values so {{usage.*}} resolves.
+            // Re-render dependency templates with usage values (including defaults)
+            // so {{usage.*}} resolves.
             let has_usage_deps = |raw: &Option<Vec<_>>| {
                 raw.as_ref()
                     .is_some_and(|r| r.iter().any(dep_has_usage_ref))
             };
-            if !a.args.is_empty()
-                && (has_usage_deps(&a.depends_raw)
-                    || has_usage_deps(&a.depends_post_raw)
-                    || has_usage_deps(&a.wait_for_raw))
+            if has_usage_deps(&a.depends_raw)
+                || has_usage_deps(&a.depends_post_raw)
+                || has_usage_deps(&a.wait_for_raw)
             {
                 let usage_values = parse_usage_values_from_task(config, &a).await?;
                 if !usage_values.is_empty() {


### PR DESCRIPTION
  ## Summary
  - Fix `{{usage.*}}` templates in `depends` not being rendered when the task is invoked without arguments
  - The `!task.args.is_empty()` guard in both `run.rs` and `deps.rs` prevented template rendering when no CLI args were passed, even though the usage spec may define defaults
  - Dependencies with unrendered `{{usage.*}}` templates were silently dropped, causing the task to run with no dependencies at all