### PR TITLE
fix(shell): resolve MISE_*_VERSION env vars for tool names with dashes

### DIFF
--- a/e2e/cli/test_shell_env_var_dashed_tools
+++ b/e2e/cli/test_shell_env_var_dashed_tools
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Verify that MISE_<TOOL>_VERSION env vars normalize underscores back to dashes.
+# Without the fix, MISE_TINY_DASH_VERSION resolves to "tiny_dash" (underscore)
+# instead of "tiny-dash", causing a registry lookup failure.
+export MISE_TINY_DASH_VERSION=1.0.0
+
+# The underscore form "tiny_dash" should never appear — it means normalization failed
+assert_not_contains "mise ls 2>&1" "tiny_dash"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -55,12 +55,14 @@ pub struct BackendArg {
 
 impl<A: AsRef<str>> From<A> for BackendArg {
     fn from(s: A) -> Self {
-        let mut short = unalias_backend(s.as_ref()).to_string();
+        let unaliased = unalias_backend(s.as_ref());
         // Normalize underscores to dashes in tool names (not backend:path syntax).
         // Env vars like MISE_CLAUDE_CODE_VERSION lose dashes via to_shouty_snake_case.
-        if !short.contains(':') {
-            short = short.replace('_', "-");
-        }
+        let short = if !unaliased.contains(':') && unaliased.contains('_') {
+            unaliased.replace('_', "-")
+        } else {
+            unaliased.to_string()
+        };
         // Check if this is a full backend identifier (e.g., "aqua:oven-sh/bun")
         // If so, treat it as explicit since the user specified the backend
         let explicit = if let Some((prefix, _)) = short.split_once(':') {

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -55,7 +55,12 @@ pub struct BackendArg {
 
 impl<A: AsRef<str>> From<A> for BackendArg {
     fn from(s: A) -> Self {
-        let short = unalias_backend(s.as_ref()).to_string();
+        let mut short = unalias_backend(s.as_ref()).to_string();
+        // Normalize underscores to dashes in tool names (not backend:path syntax).
+        // Env vars like MISE_CLAUDE_CODE_VERSION lose dashes via to_shouty_snake_case.
+        if !short.contains(':') {
+            short = short.replace('_', "-");
+        }
         // Check if this is a full backend identifier (e.g., "aqua:oven-sh/bun")
         // If so, treat it as explicit since the user specified the backend
         let explicit = if let Some((prefix, _)) = short.split_once(':') {
@@ -724,5 +729,20 @@ mod tests {
             "gitlab:jdxcode/mise-test-fixtures[asset_pattern=hello-world-1.0.0.tar.gz,bin_path=hello-world-1.0.0/bin]",
             fa.full_with_opts()
         );
+    }
+
+    #[test]
+    fn test_backend_arg_underscore_normalization() {
+        // Underscores in plain tool names should become dashes
+        let ba: BackendArg = "claude_code".into();
+        assert_eq!(ba.short, "claude-code");
+
+        // Backend-prefixed names should not be normalized
+        let ba: BackendArg = "aqua:some_org/some_tool".into();
+        assert!(ba.short.contains('_'));
+
+        // Single-word tools unaffected
+        let ba: BackendArg = "node".into();
+        assert_eq!(ba.short, "node");
     }
 }


### PR DESCRIPTION
## Summary

`mise shell claude-code@2.1.100` sets `MISE_CLAUDE_CODE_VERSION=2.1.100` via `to_shouty_snake_case()` (dashes → underscores). When mise reads it back, `.to_lowercase()` produces `claude_code` instead of `claude-code`, so registry lookup fails:

```
mise WARN  Failed to resolve tool version list for claude_code: claude_code not found in mise tool registry
```

The root cause: `to_shouty_snake_case()` is lossy — both `-` and `_` become `_`. The reverse path in `load_runtime_env` doesn't restore dashes.

## Fix

Normalize underscores to dashes in `BackendArg::from()` for non-backend-prefixed names (no `:`). This is a single change point that fixes all input paths (env vars, CLI args, configs).

Why this is safe:
- Zero registry tools use underscores — all use kebab-case
- Codebase already normalizes to kebab-case for paths (`to_kebab_case()` in `new_raw`, `install_state`, plugins)
- Backend-prefixed names (`aqua:org/tool`) are excluded by the `:` check

## Alternatives considered

1. **Fix at parse site** — Add `.replace('_', '-')` in both `load_runtime_env` functions (`builder.rs` and `tool_request_set.rs`). Targeted but only fixes the env var path; other underscore inputs would still break.

2. **Different encoding on write side** — Use double-underscore (`__`) for literal underscores when creating env vars, single `_` for dashes. Most correct but breaking change for existing users with `MISE_*_VERSION` in shell configs.

3. **Normalize in `BackendArg` (chosen)** — Single change point, fixes all input paths, no breaking change. If a hypothetical underscore-named tool existed, it would already be broken by kebab-case normalization throughout the codebase.

## Test plan

- [x] Added `test_backend_arg_underscore_normalization` unit test covering plain names, backend-prefixed names, and single-word tools
- [x] All 624 unit tests pass
- [x] `mise run build` compiles cleanly

---
*This PR was generated by Claude Code.*