### PR TITLE
fix(docs): typo in Go Backend

### DIFF
--- a/docs/dev-tools/backends/go.md
+++ b/docs/dev-tools/backends/go.md
@@ -36,7 +36,7 @@ go in `[tools]` in `mise.toml`.
 
 ### `tags`
 
-Specify go build tags (passed as `go install --tags`):
+Specify go build tags (passed as `go install -tags`):
 
 ```toml
 [tools]


### PR DESCRIPTION
Fix "go install" flag for building a Go program with given build tags: --tags => -tags