### PR TITLE
fix: prevent trust prompt hang in process substitution contexts

### DIFF
--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::sync::Mutex;
 
 use demand::{Confirm, Dialog, DialogButton};
@@ -10,11 +11,22 @@ static MUTEX: Mutex<()> = Mutex::new(());
 
 static SKIP_PROMPT: Mutex<bool> = Mutex::new(false);
 
+/// Returns true if the current process can safely show an interactive prompt.
+///
+/// Requires stderr to be a TTY (so the prompt is visible) AND stdout to be a
+/// TTY. When stdout is not a TTY the process is running inside a command
+/// substitution (`$(…)`) or process substitution (`<(…)`), contexts where
+/// stdin may report as a TTY yet be unable to deliver input — leading to an
+/// unrecoverable hang. See https://github.com/jdx/mise/discussions/8940
+fn can_prompt() -> bool {
+    console::user_attended_stderr() && std::io::stdout().is_terminal() && env::__USAGE.is_none()
+}
+
 pub fn confirm<S: Into<String>>(message: S) -> eyre::Result<bool> {
     let _lock = MUTEX.lock().unwrap(); // Prevent multiple prompts at once
     ctrlc::show_cursor_after_ctrl_c();
 
-    if !console::user_attended_stderr() || env::__USAGE.is_some() {
+    if !can_prompt() {
         return Ok(false);
     }
     let theme = get_theme();
@@ -29,7 +41,7 @@ pub fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<bool> {
     let _lock = MUTEX.lock().unwrap(); // Prevent multiple prompts at once
     ctrlc::show_cursor_after_ctrl_c();
 
-    if !console::user_attended_stderr() || env::__USAGE.is_some() {
+    if !can_prompt() {
         return Ok(false);
     }
 


### PR DESCRIPTION
## Summary

Fixes the unrecoverable terminal hang reported in https://github.com/jdx/mise/discussions/8940.

When mise runs inside `source <(mise completion zsh)` (process substitution), stdout is piped while stdin still reports as a TTY via `isatty()`. However, **stdin cannot actually deliver input** in this context — zsh consumes keystrokes before they reach the child process. The `demand` Dialog renders the trust prompt on stderr but blocks forever waiting for input, leaving the terminal completely stuck.

### Root cause

In zsh's `source <(command)`:
- `isatty(0)` → `true` (stdin appears to be a TTY)
- `isatty(1)` → `false` (stdout goes to the process substitution pipe)
- `isatty(2)` → `true` (stderr is the real terminal)

The existing check (`console::user_attended_stderr()`) passes because stderr IS a TTY. But the process cannot read from stdin — any keystrokes go to zsh, not to the child process. This makes the Dialog block forever.

### Fix

Add a `can_prompt()` helper that also requires **stdout to be a TTY**. When stdout is not a TTY, the process is inside a command substitution (`$(…)`) or process substitution (`<(…)`) — contexts where interactive prompts should not be shown.

### Reproduction

```bash
mkdir /tmp/mise-test && cd /tmp/mise-test
echo '[tools]' > mise.toml
mise trust --untrust .
zsh -l -i -c "echo hello"  # hangs if .zshrc has: source <(mise completion zsh)
```

### Testing

- All 629 existing unit tests pass
- Clippy clean
- Verified the fix with a PTY-based reproduction script that confirms:
  - `source <(mise completion zsh)` in untrusted dir: **was HUNG → now OK** (no prompt, no hang)
  - `eval "$(mise completion zsh)"` in untrusted dir: **still OK**
  - Direct `mise completion zsh` in a real TTY: **prompt still shows and is interactive**