### PR TITLE
fix(shim): use which_no_shims when resolving mise binary in reshim and doctor

### DIFF
--- a/e2e/cli/test_reshim_with_shims_on_path
+++ b/e2e/cli/test_reshim_with_shims_on_path
@@ -37,7 +37,7 @@ assert_not_contains "readlink $shimdir/dummy" "$shimdir"
 
 # The mise shim itself must not be circular
 if [ -L "$shimdir/mise" ]; then
-  assert_not_contains "readlink $shimdir/mise" "$shimdir"
+	assert_not_contains "readlink $shimdir/mise" "$shimdir"
 fi
 
 # Doctor should not report missing shims

--- a/e2e/cli/test_reshim_with_shims_on_path
+++ b/e2e/cli/test_reshim_with_shims_on_path
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Regression test: when shims are on PATH and a "mise" shim exists (e.g. because
+# core:rust is managed and ~/.cargo/bin contains the mise binary),
+# `mise reshim` should still create shims pointing to the real mise binary,
+# not to the mise shim itself (which would create a circular symlink).
+# Similarly, `mise doctor` should not report shims as missing.
+
+shimdir="$MISE_DATA_DIR/shims"
+mise_bin="$(which mise)"
+
+# Install a tool so there are shims to create
+mise i dummy@latest
+
+# Reshim without shims on PATH — baseline
+mise reshim
+
+# Verify shim was created and points to the real binary
+assert "readlink $shimdir/dummy" "$mise_bin"
+
+# Simulate what happens when core:rust is in the toolset: the mise binary
+# itself ends up with a shim because ~/.cargo/bin (containing mise) is scanned
+# as a tool bin directory. Create a mise shim pointing to the real binary.
+ln -sf "$mise_bin" "$shimdir/mise"
+
+# Now put shims on PATH (as mise activate --shims does in non-interactive shells)
+export PATH="$shimdir:$PATH"
+
+# Reshim WITH shims on PATH and a mise shim present.
+# Previously this caused file::which("mise") to find the shim, leading to
+# circular symlinks (shim pointing to itself) and broken doctor output.
+mise reshim
+
+# Shim should still point to the real mise binary, not to the shim directory
+assert "readlink $shimdir/dummy" "$mise_bin"
+assert_not_contains "readlink $shimdir/dummy" "$shimdir"
+
+# The mise shim itself must not be circular
+if [ -L "$shimdir/mise" ]; then
+  assert_not_contains "readlink $shimdir/mise" "$shimdir"
+fi
+
+# Doctor should not report missing shims
+assert_not_contains "mise doctor" "shims are missing"

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -385,7 +385,7 @@ impl Doctor {
     }
 
     async fn analyze_shims(&mut self, config: &Arc<Config>, toolset: &Toolset) {
-        let mise_bin = file::which("mise").unwrap_or(env::MISE_BIN.clone());
+        let mise_bin = file::which_no_shims("mise").unwrap_or(env::MISE_BIN.clone());
 
         if let Ok((missing, extra)) = shims::get_shim_diffs(config, mise_bin, toolset).await {
             let cmd = style::nyellow("mise reshim");

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -124,7 +124,7 @@ pub async fn reshim(config: &Arc<Config>, ts: &Toolset, force: bool) -> Result<(
         })
         .lock();
 
-    let mise_bin = file::which("mise").unwrap_or(env::MISE_BIN.clone());
+    let mise_bin = file::which_no_shims("mise").unwrap_or(env::MISE_BIN.clone());
     let mise_bin = mise_bin.absolutize()?; // relative paths don't work as shims
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

When shims are on PATH (standard for non-interactive shells using `mise activate --shims`), `file::which("mise")` in both `reshim()` and `analyze_shims()` resolves to the mise *shim* (`~/.local/share/mise/shims/mise`) instead of the real binary. This causes:

- **`reshim`**: creates shims pointing to the mise shim, including a circular `mise → mise` symlink, breaking all shims
- **`doctor`**: compares shim symlink targets against the shim path rather than the real binary, falsely reporting all shims as "missing" even immediately after `mise reshim`

This is triggered when a `mise` shim exists in the shims directory, which happens when `core:rust` is in the toolset and mise was installed via `cargo install`/`cargo binstall` (the `~/.cargo/bin` directory containing the `mise` binary is scanned as a tool bin directory).

## Fix

Use `file::which_no_shims("mise")` instead of `file::which("mise")` in both `src/shims.rs` (reshim) and `src/cli/doctor/mod.rs` (analyze_shims). The `which_no_shims` function already exists in the codebase for preventing this exact kind of shim self-reference.

## Steps to reproduce

1. Install mise via cargo (`cargo binstall mise` or `cargo install mise`)
2. Have `core:rust` (or any tool whose bin dir contains `mise`) in the toolset
3. Configure shell for non-interactive shim activation:
   ```fish
   # conf.d/mise.fish
   if status is-interactive
     mise activate fish | source
   else
     mise activate fish --shims | source
   end
   ```
4. Run: `fish -c "mise reshim && mise doctor"`
5. Observe: doctor reports all shims as missing, and shims are circular symlinks

## Test plan

- [x] New e2e test `test_reshim_with_shims_on_path` that simulates a `mise` shim on PATH, runs `reshim`, and verifies shims still point to the real binary and `doctor` reports no issues
- [x] Test verified to **fail** on unfixed code and **pass** on fixed code
- [x] All existing shim and doctor e2e tests continue to pass (`test_shims`, `test_shims_fallback`, `test_doctor`, `test_exec_shim_recursion`)