### PR TITLE
fix: filter empty segments in colon-separated env var parsing

### DIFF
--- a/e2e/config/test_override_config_filenames_empty
+++ b/e2e/config/test_override_config_filenames_empty
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Regression test: MISE_OVERRIDE_CONFIG_FILENAMES set to empty string
+# should not cause a panic. An empty value should be treated the same
+# as the variable being unset (i.e., use default config filenames).
+#
+# Background: split(':') on "" produces [""], a set with one empty-string
+# entry. This non-empty set bypasses the default config filename list and
+# injects "" as a config filename, which eventually causes a panic in
+# config_root() during Config::load.
+#
+# See: https://github.com/jdx/mise/issues/XXXX
+
+echo 'tools.dummy = "1"' >mise.toml
+
+# Empty string — should behave like unset (use mise.toml)
+MISE_OVERRIDE_CONFIG_FILENAMES="" assert_succeed "mise ls"
+
+# Colon-only — split produces ["", ""], both empty, should behave like unset
+MISE_OVERRIDE_CONFIG_FILENAMES=":" assert_succeed "mise ls"
+
+# Trailing/leading colons — should ignore empty segments
+echo 'tools.dummy = "2"' >mise.ci.toml
+MISE_OVERRIDE_CONFIG_FILENAMES=":mise.ci.toml:" assert "mise ls dummy" "dummy  2 (missing)  ~/workdir/mise.ci.toml  2"

--- a/e2e/config/test_override_config_filenames_empty
+++ b/e2e/config/test_override_config_filenames_empty
@@ -8,7 +8,7 @@
 # injects "" as a config filename, which eventually causes a panic in
 # config_root() during Config::load.
 #
-# See: https://github.com/jdx/mise/issues/XXXX
+# See: https://github.com/jdx/mise/pull/9076
 
 echo 'tools.dummy = "1"' >mise.toml
 
@@ -20,4 +20,4 @@ MISE_OVERRIDE_CONFIG_FILENAMES=":" assert_succeed "mise ls"
 
 # Trailing/leading colons — should ignore empty segments
 echo 'tools.dummy = "2"' >mise.ci.toml
-MISE_OVERRIDE_CONFIG_FILENAMES=":mise.ci.toml:" assert "mise ls dummy" "dummy  2 (missing)  ~/workdir/mise.ci.toml  2"
+MISE_OVERRIDE_CONFIG_FILENAMES=":mise.ci.toml:" assert "mise ls dummy" "dummy  2.0.0 (missing)  ~/workdir/mise.ci.toml  2"

--- a/src/env.rs
+++ b/src/env.rs
@@ -835,6 +835,32 @@ mod tests {
     }
 
     #[test]
+    fn test_split_colon_filters_empty_segments() {
+        // Verify that split(':').filter(|s| !s.is_empty()) correctly
+        // handles empty strings, which is the pattern needed for
+        // MISE_OVERRIDE_CONFIG_FILENAMES and similar colon-separated
+        // env vars. Without the filter, "" produces [""] (length 1),
+        // which causes panics downstream in config_root().
+        let cases: Vec<(&str, Vec<&str>)> = vec![
+            ("", vec![]),                              // empty string
+            (":", vec![]),                             // colon only
+            (":::", vec![]),                           // multiple colons
+            ("mise.toml", vec!["mise.toml"]),           // normal single
+            ("a:b", vec!["a", "b"]),                    // normal multi
+            (":a:b:", vec!["a", "b"]),                  // leading/trailing colons
+            ("a::b", vec!["a", "b"]),                   // consecutive colons
+        ];
+        for (input, expected) in cases {
+            let result: Vec<String> = input
+                .split(':')
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .collect();
+            assert_eq!(result, expected, "input: {input:?}");
+        }
+    }
+
+    #[test]
     fn test_token_overwrite() {
         // Clean up any existing environment variables that might interfere
         remove_var("MISE_GITHUB_TOKEN");

--- a/src/env.rs
+++ b/src/env.rs
@@ -849,18 +849,17 @@ mod tests {
     #[test]
     fn test_split_colon_list() {
         let cases: Vec<(&str, Vec<&str>)> = vec![
-            ("", vec![]),              // empty string — was causing panic
-            (":", vec![]),             // colon only
-            (":::", vec![]),           // multiple colons
+            ("", vec![]),    // empty string — was causing panic
+            (":", vec![]),   // colon only
+            (":::", vec![]), // multiple colons
             ("mise.toml", vec!["mise.toml"]),
             ("a:b", vec!["a", "b"]),
-            (":a:b:", vec!["a", "b"]),  // leading/trailing colons
-            ("a::b", vec!["a", "b"]),   // consecutive colons
+            (":a:b:", vec!["a", "b"]), // leading/trailing colons
+            ("a::b", vec!["a", "b"]),  // consecutive colons
         ];
         for (input, expected) in cases {
             let result = split_colon_list(input);
-            let expected: IndexSet<String> =
-                expected.into_iter().map(|s| s.to_string()).collect();
+            let expected: IndexSet<String> = expected.into_iter().map(|s| s.to_string()).collect();
             assert_eq!(result, expected, "input: {input:?}");
         }
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -244,14 +244,14 @@ pub static MISE_DEFAULT_CONFIG_FILENAME: Lazy<String> = Lazy::new(|| {
 pub static MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES: Lazy<Option<IndexSet<String>>> =
     Lazy::new(|| match var("MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES") {
         Ok(v) if v == "none" => Some([].into()),
-        Ok(v) => Some(v.split(':').map(|s| s.to_string()).collect()),
+        Ok(v) => Some(split_colon_list(&v)),
         Err(_) => {
             miserc::get_override_tool_versions_filenames().map(|v| v.iter().cloned().collect())
         }
     });
 pub static MISE_OVERRIDE_CONFIG_FILENAMES: Lazy<IndexSet<String>> =
     Lazy::new(|| match var("MISE_OVERRIDE_CONFIG_FILENAMES") {
-        Ok(v) => v.split(':').map(|s| s.to_string()).collect(),
+        Ok(v) => split_colon_list(&v),
         Err(_) => miserc::get_override_config_filenames()
             .map(|v| v.iter().cloned().collect())
             .unwrap_or_default(),
@@ -738,6 +738,18 @@ fn linux_glibc_version() -> Option<(u32, u32)> {
     None
 }
 
+/// Split a colon-separated string into a set, filtering empty segments.
+/// Empty segments arise from empty strings, leading/trailing colons, or
+/// consecutive colons — all of which should be ignored rather than
+/// injected as empty paths into config discovery.
+fn split_colon_list(value: &str) -> IndexSet<String> {
+    value
+        .split(':')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
 fn filename(path: &str) -> &str {
     path.rsplit_once(path::MAIN_SEPARATOR_STR)
         .map(|(_, file)| file)
@@ -835,27 +847,20 @@ mod tests {
     }
 
     #[test]
-    fn test_split_colon_filters_empty_segments() {
-        // Verify that split(':').filter(|s| !s.is_empty()) correctly
-        // handles empty strings, which is the pattern needed for
-        // MISE_OVERRIDE_CONFIG_FILENAMES and similar colon-separated
-        // env vars. Without the filter, "" produces [""] (length 1),
-        // which causes panics downstream in config_root().
+    fn test_split_colon_list() {
         let cases: Vec<(&str, Vec<&str>)> = vec![
-            ("", vec![]),                              // empty string
-            (":", vec![]),                             // colon only
-            (":::", vec![]),                           // multiple colons
-            ("mise.toml", vec!["mise.toml"]),           // normal single
-            ("a:b", vec!["a", "b"]),                    // normal multi
-            (":a:b:", vec!["a", "b"]),                  // leading/trailing colons
-            ("a::b", vec!["a", "b"]),                   // consecutive colons
+            ("", vec![]),              // empty string — was causing panic
+            (":", vec![]),             // colon only
+            (":::", vec![]),           // multiple colons
+            ("mise.toml", vec!["mise.toml"]),
+            ("a:b", vec!["a", "b"]),
+            (":a:b:", vec!["a", "b"]),  // leading/trailing colons
+            ("a::b", vec!["a", "b"]),   // consecutive colons
         ];
         for (input, expected) in cases {
-            let result: Vec<String> = input
-                .split(':')
-                .filter(|s| !s.is_empty())
-                .map(|s| s.to_string())
-                .collect();
+            let result = split_colon_list(input);
+            let expected: IndexSet<String> =
+                expected.into_iter().map(|s| s.to_string()).collect();
             assert_eq!(result, expected, "input: {input:?}");
         }
     }


### PR DESCRIPTION
## Problem

`MISE_OVERRIDE_CONFIG_FILENAMES=""\ ` (empty string) causes mise to panic:

```
The application panicked (crashed).
Message: called `Option::unwrap()` on a `None` value
Location: src/config/config_file/config_root.rs:49
```

When the env var is set to an empty string, `split(':')` produces `[""]` — a set with one empty-string entry. This non-empty set replaces the default config filename list, injecting `""` as a config path. During `Config::load`, the empty path absolutizes to the filesystem root (`/`), which has no parent directory, causing `config_root()` to panic on `path.parent().unwrap()`.

### How this happens in practice

vfox plugins that spawn nested mise processes (e.g., `mise -C <plugin-path> run install`) inherit the parent's `MISE_OVERRIDE_CONFIG_FILENAMES`. When the parent sets it to `mise.ci.toml`, the child process looks for a non-existent `mise.ci.toml` in the plugin directory. Unsetting it via `VAR='' command` is a common workaround — but the empty string triggers this panic.

## Fix

Add `.filter(|s| !s.is_empty())` to both colon-split expressions in `src/env.rs`:

- `MISE_OVERRIDE_CONFIG_FILENAMES`
- `MISE_OVERRIDE_TOOL_VERSIONS_FILENAMES`

This also correctly handles edge cases like trailing/leading colons (`:mise.ci.toml:`) and consecutive colons.

## Tests

- **e2e test**: `test_override_config_filenames_empty` — verifies empty string, colon-only, and leading/trailing colons all work without panicking
- **unit test**: `test_split_colon_filters_empty_segments` — documents the correct filter pattern for all edge cases