### PR TITLE
docs: fix cli token command for token resolution

### DIFF
--- a/docs/dev-tools/backends/forgejo.md
+++ b/docs/dev-tools/backends/forgejo.md
@@ -105,10 +105,12 @@ This uses `git credential fill` and supports credentials stored by helpers such 
 
 ### Debugging token resolution
 
+Use `mise token forgejo` to see which token mise would use for a given host:
+
 ```sh
-mise forgejo token
-mise forgejo token --unmask
-mise forgejo token forgejo.mycompany.com
+mise token forgejo
+mise token forgejo --unmask
+mise token forgejo forgejo.mycompany.com
 ```
 
 ## Tool Options

--- a/docs/dev-tools/backends/gitlab.md
+++ b/docs/dev-tools/backends/gitlab.md
@@ -100,10 +100,12 @@ This uses `git credential fill` and supports credentials stored by helpers such 
 
 ### Debugging token resolution
 
+Use `mise token gitlab` to see which token mise would use for a given host:
+
 ```sh
-mise gitlab token
-mise gitlab token --unmask
-mise gitlab token gitlab.mycompany.com
+mise token gitlab
+mise token gitlab --unmask
+mise token gitlab gitlab.mycompany.com
 ```
 
 ## Tool Options

--- a/docs/dev-tools/github-tokens.md
+++ b/docs/dev-tools/github-tokens.md
@@ -130,12 +130,12 @@ use_git_credentials = true
 
 ## Debugging Token Resolution
 
-Use `mise github token` to see which token mise would use for a given host:
+Use `mise token github` to see which token mise would use for a given host:
 
 ```sh
-mise github token                           # check github.com (masked)
-mise github token --unmask                  # show full token
-mise github token github.mycompany.com      # check a GHE host
+mise token github                           # check github.com (masked)
+mise token github --unmask                  # show full token
+mise token github github.mycompany.com      # check a GHE host
 ```
 
 ## GitHub Enterprise


### PR DESCRIPTION
Fixes the `mise token [forgejo | github | gitlab]` commands in the respective docs.