### PR TITLE
feat(task): add Tera template support for inline table run tasks

### DIFF
--- a/e2e/tasks/test_task_run_entry_args_env
+++ b/e2e/tasks/test_task_run_entry_args_env
@@ -50,3 +50,27 @@ EOF
 
 assert_contains "mise run all" "step1"
 assert_contains "mise run all" "FOO=bar"
+
+# Test run entry with usage tera template in args
+cat <<'EOF' >mise.toml
+[tasks.greet]
+run = 'echo hello'
+
+[tasks.all]
+usage = 'arg <name>'
+run = [{ task = "greet", args = ["{{usage.name}}"] }]
+EOF
+
+assert_contains "mise run all -- world" "hello world"
+
+# Test run entry with usage tera template in env
+cat <<'EOF' >mise.toml
+[tasks.show-env]
+run = 'echo "APP=$APP"'
+
+[tasks.all]
+usage = 'arg "app_name"'
+run = [{ task = "show-env", env = { APP = "{{usage.app_name}}" } }]
+EOF
+
+assert_contains "mise run all -- myapp" "APP=myapp"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -118,11 +118,7 @@ impl std::hash::Hash for RunEntry {
 }
 
 impl RunEntry {
-    pub fn render(
-        &self,
-        tera: &mut tera::Tera,
-        tera_ctx: &tera::Context,
-    ) -> crate::Result<Self> {
+    pub fn render(&self, tera: &mut tera::Tera, tera_ctx: &tera::Context) -> crate::Result<Self> {
         match self {
             RunEntry::Script(s) => Ok(RunEntry::Script(s.clone())),
             RunEntry::SingleTask { task, args, env } => {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -144,7 +144,7 @@ impl RunEntry {
     }
 
     pub fn has_tera_template(&self) -> bool {
-        let has_ref = |s: &str| s.contains("{{");
+        let has_ref = |s: &str| s.contains("{{") || s.contains("{%") || s.contains("{#");
         match self {
             RunEntry::Script(_) => false,
             RunEntry::SingleTask { task, args, env } => {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -117,6 +117,48 @@ impl std::hash::Hash for RunEntry {
     }
 }
 
+impl RunEntry {
+    pub fn render(
+        &self,
+        tera: &mut tera::Tera,
+        tera_ctx: &tera::Context,
+    ) -> crate::Result<Self> {
+        match self {
+            RunEntry::Script(s) => Ok(RunEntry::Script(s.clone())),
+            RunEntry::SingleTask { task, args, env } => {
+                let task = tera.render_str(task, tera_ctx)?;
+                let args = args
+                    .iter()
+                    .map(|a| tera.render_str(a, tera_ctx))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let env = env
+                    .iter()
+                    .map(|(k, v)| Ok((k.clone(), tera.render_str(v, tera_ctx)?)))
+                    .collect::<Result<IndexMap<_, _>, tera::Error>>()?;
+                Ok(RunEntry::SingleTask { task, args, env })
+            }
+            RunEntry::TaskGroup { tasks } => {
+                let tasks = tasks
+                    .iter()
+                    .map(|t| tera.render_str(t, tera_ctx))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(RunEntry::TaskGroup { tasks })
+            }
+        }
+    }
+
+    pub fn has_tera_template(&self) -> bool {
+        let has_ref = |s: &str| s.contains("{{");
+        match self {
+            RunEntry::Script(_) => false,
+            RunEntry::SingleTask { task, args, env } => {
+                has_ref(task) || args.iter().any(|a| has_ref(a)) || env.values().any(|v| has_ref(v))
+            }
+            RunEntry::TaskGroup { tasks } => tasks.iter().any(|t| has_ref(t)),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum Silent {
     #[default]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -380,6 +380,23 @@ impl TaskExecutor {
         let (env, task_env) = full_env;
         use crate::task::RunEntry;
         let mut script_iter = rendered_scripts.into_iter();
+
+        let needs_tera = task.run().iter().any(RunEntry::has_tera_template);
+        let mut tera_state = if needs_tera {
+            let usage_values =
+                crate::task::parse_usage_values_from_task(config, task).await?;
+            let config_root = task.config_root.clone().unwrap_or_default();
+            let tera = crate::tera::get_tera(Some(&config_root));
+            let mut tera_ctx = task.tera_ctx(config).await?;
+            if !usage_values.is_empty() {
+                tera_ctx.insert("usage", &usage_values);
+            }
+            tera_ctx.insert("env", env);
+            Some((tera, tera_ctx))
+        } else {
+            None
+        };
+
         // Use an existing guard (e.g. from confirmation) or acquire a new one.
         // The lock is held across consecutive script entries for exclusivity
         // and temporarily dropped around inject_and_wait to avoid deadlocking.
@@ -387,7 +404,14 @@ impl TaskExecutor {
             Some(g) => Some(g),
             None => Some(acquire_runtime_lock(task.interactive).await),
         };
-        for entry in task.run() {
+        for raw_entry in task.run() {
+            let rendered;
+            let entry = if let Some((ref mut tera, ref tera_ctx)) = tera_state {
+                rendered = raw_entry.render(tera, tera_ctx)?;
+                &rendered
+            } else {
+                raw_entry
+            };
             match entry {
                 RunEntry::Script(_) => {
                     if let Some((script, args)) = script_iter.next() {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -383,8 +383,7 @@ impl TaskExecutor {
 
         let needs_tera = task.run().iter().any(RunEntry::has_tera_template);
         let mut tera_state = if needs_tera {
-            let usage_values =
-                crate::task::parse_usage_values_from_task(config, task).await?;
+            let usage_values = crate::task::parse_usage_values_from_task(config, task).await?;
             let config_root = task.config_root.clone().unwrap_or_default();
             let tera = crate::tera::get_tera(Some(&config_root));
             let mut tera_ctx = task.tera_ctx(config).await?;

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -383,8 +383,7 @@ impl TaskExecutor {
 
         let needs_tera = task.run().iter().any(RunEntry::has_tera_template);
         let mut tera_state = if needs_tera {
-            let usage_values =
-                crate::task::parse_usage_values_from_task(config, task).await?;
+            let usage_values = crate::task::parse_usage_values_from_task(config, task).await?;
             let config_root = task.config_root.clone().unwrap_or_default();
             let tera = crate::tera::get_tera(Some(&config_root));
             let mut tera_ctx = task.tera_ctx(config).await?;
@@ -406,7 +405,9 @@ impl TaskExecutor {
         };
         for raw_entry in task.run() {
             let rendered;
-            let entry = if let Some((ref mut tera, ref tera_ctx)) = tera_state && raw_entry.has_tera_template() {
+            let entry = if let Some((ref mut tera, ref tera_ctx)) = tera_state
+                && raw_entry.has_tera_template()
+            {
                 rendered = raw_entry.render(tera, tera_ctx)?;
                 &rendered
             } else {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -383,8 +383,10 @@ impl TaskExecutor {
 
         let needs_tera = task.run().iter().any(RunEntry::has_tera_template);
         let mut tera_state = if needs_tera {
-            let usage_values = crate::task::parse_usage_values_from_task(config, task).await?;
-            let tera = crate::tera::get_tera(task.config_root.as_deref());
+            let usage_values =
+                crate::task::parse_usage_values_from_task(config, task).await?;
+            let config_root = task.config_root.clone().unwrap_or_default();
+            let tera = crate::tera::get_tera(Some(&config_root));
             let mut tera_ctx = task.tera_ctx(config).await?;
             if !usage_values.is_empty() {
                 tera_ctx.insert("usage", &usage_values);
@@ -404,7 +406,7 @@ impl TaskExecutor {
         };
         for raw_entry in task.run() {
             let rendered;
-            let entry = if let Some((ref mut tera, ref tera_ctx)) = tera_state {
+            let entry = if let Some((ref mut tera, ref tera_ctx)) = tera_state && raw_entry.has_tera_template() {
                 rendered = raw_entry.render(tera, tera_ctx)?;
                 &rendered
             } else {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -384,8 +384,7 @@ impl TaskExecutor {
         let needs_tera = task.run().iter().any(RunEntry::has_tera_template);
         let mut tera_state = if needs_tera {
             let usage_values = crate::task::parse_usage_values_from_task(config, task).await?;
-            let config_root = task.config_root.clone().unwrap_or_default();
-            let tera = crate::tera::get_tera(Some(&config_root));
+            let tera = crate::tera::get_tera(task.config_root.as_deref());
             let mut tera_ctx = task.tera_ctx(config).await?;
             if !usage_values.is_empty() {
                 tera_ctx.insert("usage", &usage_values);


### PR DESCRIPTION
- Implemented rendering of Tera templates in task arguments and environment variables within the RunEntry structure.
- Enhanced the TaskExecutor to check for Tera templates and render them accordingly during task execution.
- Added e2e tests to verify the correct rendering of templates in task arguments and environment variables.

Fixes #8761 