### PR TITLE
chore: release 2026.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## [2026.4.12](https://github.com/jdx/mise/compare/v2026.4.11..v2026.4.12) - 2026-04-15
+
+### 🚀 Features
+
+- **(npm)** use --min-release-age for npm 11.10.0+ supply chain protection by @webkaz in [#9072](https://github.com/jdx/mise/pull/9072)
+- **(registry)** add openfga by @mnm364 in [#9084](https://github.com/jdx/mise/pull/9084)
+- **(task)** allow to set confirmation default by @roele in [#9089](https://github.com/jdx/mise/pull/9089)
+- support os/arch compound syntax in tool os filtering by @RobertDeRose in [#9088](https://github.com/jdx/mise/pull/9088)
+
+### 🐛 Bug Fixes
+
+- **(activate)** export __MISE_EXE and resolve bare ARGV0 to absolute path by @fru1tworld in [#9081](https://github.com/jdx/mise/pull/9081)
+- **(install)** support aliased installs sharing a backend by @jdx in [#9093](https://github.com/jdx/mise/pull/9093)
+- **(shim)** use which_no_shims when resolving mise binary in reshim and doctor by @kevinswiber in [#9071](https://github.com/jdx/mise/pull/9071)
+- filter empty segments in colon-separated env var parsing by @baby-joel in [#9076](https://github.com/jdx/mise/pull/9076)
+
+### 📚 Documentation
+
+- fix wrong file reference to forgejo backend implemenation by @roele in [#9090](https://github.com/jdx/mise/pull/9090)
+- fix cli token command for token resolution by @roele in [#9077](https://github.com/jdx/mise/pull/9077)
+
+### 📦 Registry
+
+- add trzsz-go ([aqua:trzsz/trzsz-go](https://github.com/trzsz/trzsz-go)) by @ZeroAurora in [#9083](https://github.com/jdx/mise/pull/9083)
+- add copilot ([aqua:github/copilot-cli](https://github.com/github/copilot-cli)) by @risu729 in [#9082](https://github.com/jdx/mise/pull/9082)
+
+### Chore
+
+- add AGENTS.md symlink by @jdx in [#9094](https://github.com/jdx/mise/pull/9094)
+
+### New Contributors
+
+- @kevinswiber made their first contribution in [#9071](https://github.com/jdx/mise/pull/9071)
+- @webkaz made their first contribution in [#9072](https://github.com/jdx/mise/pull/9072)
+- @RobertDeRose made their first contribution in [#9088](https://github.com/jdx/mise/pull/9088)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (7)
+
+- [`IBM-Cloud/ibm-cloud-cli-release`](https://github.com/IBM-Cloud/ibm-cloud-cli-release)
+- [`max-sixty/worktrunk`](https://github.com/max-sixty/worktrunk)
+- [`micelio.dev/hif`](https://github.com/micelio.dev/hif)
+- [`pgplex/pgschema`](https://github.com/pgplex/pgschema)
+- [`rose-pine/rose-pine-bloom`](https://github.com/rose-pine/rose-pine-bloom)
+- [`santosr2/TerraTidy`](https://github.com/santosr2/TerraTidy)
+- [`trzsz/trzsz-go`](https://github.com/trzsz/trzsz-go)
+
+#### Updated Packages (3)
+
+- [`mvdan/sh`](https://github.com/mvdan/sh)
+- [`rvben/rumdl`](https://github.com/rvben/rumdl)
+- [`temporalio/temporal`](https://github.com/temporalio/temporal)
+
 ## [2026.4.11](https://github.com/jdx/mise/compare/v2026.4.10..v2026.4.11) - 2026-04-13
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aqua-registry"
-version = "2026.4.3"
+version = "2026.4.4"
 dependencies = [
  "expr-lang",
  "eyre",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.4.11"
+version = "2026.4.12"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.4.11"
+version = "2026.4.12"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.4.11 macos-arm64 (2026-04-13)
+2026.4.12 macos-arm64 (2026-04-15)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_11.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_12.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_11.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_12.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_4_11.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_4_12.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_4_11.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_4_12.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/crates/aqua-registry/Cargo.toml
+++ b/crates/aqua-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aqua-registry"
-version = "2026.4.3"
+version = "2026.4.4"
 edition = "2024"
 description = "Aqua registry backend for mise"
 authors = ["Jeff Dickey (@jdx)"]

--- a/crates/aqua-registry/aqua-registry/pkgs/IBM-Cloud/ibm-cloud-cli-release/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/IBM-Cloud/ibm-cloud-cli-release/registry.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: http
+    repo_owner: IBM-Cloud
+    repo_name: ibm-cloud-cli-release
+    description: Command line interface for IBM Cloud
+    search_words:
+      - ibmcloud
+      - bluemix
+    files:
+      - name: ibmcloud
+        src: IBM_Cloud_CLI/ibmcloud
+    version_constraint: "false"
+    version_overrides:
+      # distribution wasn't properly multi-arch until v2.5.0 and newer
+      - version_constraint: semver("< 2.5.0")
+        error_message: Please use v2.5.0 or later
+      # the download base path changed from ibm-cloud-cli to ibm-cloud-cli-dn at v2.38.0
+      - version_constraint: semver("< 2.38.0")
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tgz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_macos.tgz
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        # binaries are hosted on IBM's CDN, not as GitHub Release assets
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tgz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          # macOS x86_64 has no arch suffix in the filename
+          - goos: darwin
+            goarch: amd64
+            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}.{{.Format}}
+          - goos: windows
+            format: zip

--- a/crates/aqua-registry/aqua-registry/pkgs/max-sixty/worktrunk/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/max-sixty/worktrunk/registry.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: max-sixty
+    repo_name: worktrunk
+    description: Worktrunk is a CLI for Git worktree management, designed for parallel AI agent workflows
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.12")
+        asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        files:
+          - name: wt
+            src: "{{.AssetWithoutExt}}/wt"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: wt
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        files:
+          - name: wt
+            src: "{{.AssetWithoutExt}}/wt"
+          - name: git-wt
+            src: "{{.AssetWithoutExt}}/git-wt"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: wt
+              - name: git-wt

--- a/crates/aqua-registry/aqua-registry/pkgs/micelio.dev/hif/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/micelio.dev/hif/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: micelio.dev/hif
+    type: http
+    description: hif - the Micelio command-line client. A forge-first version-control system for the agent era
+    link: https://micelio.dev
+    url: https://releases.micelio.dev/hif/{{.Version}}/hif-{{.OS}}-{{.Arch}}.{{.Format}}
+    replacements:
+      amd64: x64
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+    checksum:
+      type: http
+      url: https://releases.micelio.dev/hif/{{.Version}}/SHA256SUMS
+      algorithm: sha256

--- a/crates/aqua-registry/aqua-registry/pkgs/mvdan/sh/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/mvdan/sh/registry.yaml
@@ -3,39 +3,48 @@ packages:
   - type: github_release
     repo_owner: mvdan
     repo_name: sh
-    description: A shell parser, formatter, and interpreter with bash support; includes shfmt
+    description: A shell parser, formatter, and interpreter with bash and zsh support; includes shfmt
     files:
       - name: shfmt
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 3.8.0")
-        format: raw
+      - version_constraint: Version == "v3.6.0"
         asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-        files:
-          - name: shfmt
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v3.7.0"
+        asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 3.1.2")
+        asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+      - version_constraint: semver("<= 3.2.2")
+        asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 3.5.1")
+        asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
       - version_constraint: semver("<= 3.12.0")
-        format: raw
         asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-        files:
-          - name: shfmt
+        format: raw
+        windows_arm_emulation: true
         checksum:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
       - version_constraint: "true"
-        format: raw
         asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-        files:
-          - name: shfmt
+        format: raw
+        windows_arm_emulation: true

--- a/crates/aqua-registry/aqua-registry/pkgs/pgplex/pgschema/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/pgplex/pgschema/registry.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: pgplex
+    repo_name: pgschema
+    description: Terraform-style, declarative schema migration CLI for Postgres. Agent friendly
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.2.1")
+        asset: pgschema-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: semver("<= 1.4.1")
+        asset: pgschema-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: semver("<= 1.5.0")
+        asset: pgschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: pgschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin

--- a/crates/aqua-registry/aqua-registry/pkgs/rose-pine/rose-pine-bloom/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/rose-pine/rose-pine-bloom/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: rose-pine
+    repo_name: rose-pine-bloom
+    description: Generate Rosé Pine themes
+    files:
+      - name: bloom
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v3.0.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: rose-pine-bloom-{{.OS}}-{{.Arch}}
+        format: raw

--- a/crates/aqua-registry/aqua-registry/pkgs/rvben/rumdl/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/rvben/rumdl/registry.yaml
@@ -69,6 +69,23 @@ packages:
               type: github_release
               asset: "{{.Asset}}.sha256"
               algorithm: sha256
+      - version_constraint: semver("<= 0.1.68")
+        asset: rumdl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: rumdl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -86,3 +103,5 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: rvben/rumdl/\.github/workflows/release\.yml

--- a/crates/aqua-registry/aqua-registry/pkgs/santosr2/TerraTidy/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/santosr2/TerraTidy/registry.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: santosr2
+    repo_name: TerraTidy
+    description: A comprehensive quality platform for Terraform and Terragrunt
+    files:
+      - name: terratidy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0-alpha.3")
+        asset: terratidy-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: terratidy-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/santosr2/TerraTidy/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.bundle
+        overrides:
+          - goos: windows
+            format: zip

--- a/crates/aqua-registry/aqua-registry/pkgs/temporalio/temporal/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/temporalio/temporal/registry.yaml
@@ -3,15 +3,36 @@ packages:
   - type: github_release
     repo_owner: temporalio
     repo_name: temporal
-    description: Temporal service and CLI
-    asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
+    description: Temporal Server bundle (temporal-server + database tools)
     files:
-      - name: tctl
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+      - name: temporal-server
+      - name: temporal-cassandra-tool
+      - name: temporal-sql-tool
+      - name: temporal-elasticsearch-tool
+      - name: tdbg
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.30.1")
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: temporal-server
+          - name: temporal-cassandra-tool
+          - name: temporal-sql-tool
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/crates/aqua-registry/aqua-registry/pkgs/trzsz/trzsz-go/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/trzsz/trzsz-go/registry.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: trzsz
+    repo_name: trzsz-go
+    description: trzsz-go is the go version of trzsz, makes all terminals that support local shell to support trzsz ( trz / tsz )
+    files:
+      - name: trzsz
+        src: "{{.AssetWithoutExt}}/trzsz"
+      - name: trz
+        src: "{{.AssetWithoutExt}}/trz"
+      - name: tsz
+        src: "{{.AssetWithoutExt}}/tsz"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.8"
+        asset: trzsz_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.1.7")
+        asset: trzsz_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: trzsz
+            src: "bin/trzsz"
+          - name: trz
+            src: "bin/trz"
+          - name: tsz
+            src: "bin/tsz"
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: trzsz_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: trzsz_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.4.11";
+  version = "2026.4.12";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2026.4.11
+Version: 2026.4.12
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.4.11"
+version: "2026.4.12"
 summary: The front-end to your dev env
 description: |
   mise-en-place is a command line tool to manage your development environment.


### PR DESCRIPTION
### 🚀 Features

- **(npm)** use --min-release-age for npm 11.10.0+ supply chain protection by @webkaz in [#9072](https://github.com/jdx/mise/pull/9072)
- **(registry)** add openfga by @mnm364 in [#9084](https://github.com/jdx/mise/pull/9084)
- **(task)** allow to set confirmation default by @roele in [#9089](https://github.com/jdx/mise/pull/9089)
- support os/arch compound syntax in tool os filtering by @RobertDeRose in [#9088](https://github.com/jdx/mise/pull/9088)

### 🐛 Bug Fixes

- **(activate)** export __MISE_EXE and resolve bare ARGV0 to absolute path by @fru1tworld in [#9081](https://github.com/jdx/mise/pull/9081)
- **(install)** support aliased installs sharing a backend by @jdx in [#9093](https://github.com/jdx/mise/pull/9093)
- **(shim)** use which_no_shims when resolving mise binary in reshim and doctor by @kevinswiber in [#9071](https://github.com/jdx/mise/pull/9071)
- filter empty segments in colon-separated env var parsing by @baby-joel in [#9076](https://github.com/jdx/mise/pull/9076)

### 📚 Documentation

- fix wrong file reference to forgejo backend implemenation by @roele in [#9090](https://github.com/jdx/mise/pull/9090)
- fix cli token command for token resolution by @roele in [#9077](https://github.com/jdx/mise/pull/9077)

### 📦 Registry

- add trzsz-go ([aqua:trzsz/trzsz-go](https://github.com/trzsz/trzsz-go)) by @ZeroAurora in [#9083](https://github.com/jdx/mise/pull/9083)
- add copilot ([aqua:github/copilot-cli](https://github.com/github/copilot-cli)) by @risu729 in [#9082](https://github.com/jdx/mise/pull/9082)

### Chore

- add AGENTS.md symlink by @jdx in [#9094](https://github.com/jdx/mise/pull/9094)

### New Contributors

- @kevinswiber made their first contribution in [#9071](https://github.com/jdx/mise/pull/9071)
- @webkaz made their first contribution in [#9072](https://github.com/jdx/mise/pull/9072)
- @RobertDeRose made their first contribution in [#9088](https://github.com/jdx/mise/pull/9088)

## 📦 Aqua Registry Updates

#### New Packages (7)

- [`IBM-Cloud/ibm-cloud-cli-release`](https://github.com/IBM-Cloud/ibm-cloud-cli-release)
- [`max-sixty/worktrunk`](https://github.com/max-sixty/worktrunk)
- [`micelio.dev/hif`](https://github.com/micelio.dev/hif)
- [`pgplex/pgschema`](https://github.com/pgplex/pgschema)
- [`rose-pine/rose-pine-bloom`](https://github.com/rose-pine/rose-pine-bloom)
- [`santosr2/TerraTidy`](https://github.com/santosr2/TerraTidy)
- [`trzsz/trzsz-go`](https://github.com/trzsz/trzsz-go)

#### Updated Packages (3)

- [`mvdan/sh`](https://github.com/mvdan/sh)
- [`rvben/rumdl`](https://github.com/rvben/rumdl)
- [`temporalio/temporal`](https://github.com/temporalio/temporal)