### PR TITLE
registry: add trzsz-go (aqua:trzsz/trzsz-go)

### DIFF
--- a/registry/trzsz-go.toml
+++ b/registry/trzsz-go.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:trzsz/trzsz-go", "github:trzsz/trzsz-go"]
+description = "trzsz-go is the go version of trzsz, makes all terminals that support local shell to support trzsz ( trz / tsz )"
+test = { cmd = "trzsz --version", expected = "trzsz go {{version}}" }


### PR DESCRIPTION
Available in aqua as of [v4.493.0](https://github.com/aquaproj/aqua-registry/releases/tag/v4.493.0).

Verified with `export MISE_AQUA_BAKED_REGISTRY=false`. Should be merged after baked aqua updated.