### PR TITLE
feat(registry): add openfga

### DIFF
--- a/registry/openfga.toml
+++ b/registry/openfga.toml
@@ -1,3 +1,3 @@
 backends = ["github:openfga/openfga"]
 description = "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar"
-test = { cmd = "openfga version 2>&1 | grep -o 'v[0-9.]*'", expected = "v{{version}}" }
+test = { cmd = "openfga version 2>&1", expected = "v{{version}}" }

--- a/registry/openfga.toml
+++ b/registry/openfga.toml
@@ -1,0 +1,3 @@
+backends = ["github:openfga/openfga"]
+description = "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar"
+test = { cmd = "openfga version 2>&1 | grep -o 'v[0-9.]*'", expected = "v{{version}}" }


### PR DESCRIPTION
Adds [OpenFGA](https://github.com/openfga/openfga) to the mise registry via the github backend.

OpenFGA is a high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar.

Tested with version 1.14.0:

```
$ mise install openfga@1.14.0
$ openfga version
2026/04/14 15:56:25 OpenFGA version `v1.14.0` build from `40e6b410825813d1d394d7371c5ca31cad17f517` on `2026-04-03T17:26:40Z`
$ mise uninstall openfga@1.14.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)