### PR TITLE
fix(task): support object syntax in task-level tools

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -76,6 +76,50 @@ pub use deps::{Deps, TaskKey};
 use task_dep::TaskDep;
 use task_sources::{RawOutputTemplates, TaskOutputs};
 
+/// Represents a tool value in task-level tools field.
+/// Supports both string syntax (e.g., "1.0.0") and object syntax
+/// (e.g., { version = "1.0.0", targets = ["x86_64"] })
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TaskToolValue {
+    String(String),
+    Map(TaskToolValueMap),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskToolValueMap {
+    pub version: String,
+    #[serde(flatten)]
+    pub opts: IndexMap<String, toml::Value>,
+}
+
+impl TaskToolValue {
+    /// Convert to a tool specification string for ToolArg parsing.
+    /// String values become "{tool}@{version}".
+    /// Map values become "{tool}[{opts}]@{version}" where opts are serialized.
+    pub fn to_tool_spec(&self, tool: &str) -> String {
+        match self {
+            TaskToolValue::String(version) => format!("{tool}@{version}"),
+            TaskToolValue::Map(map) => {
+                if map.opts.is_empty() {
+                    format!("{tool}@{}", map.version)
+                } else {
+                    let opts_str = map
+                        .opts
+                        .iter()
+                        .map(|(k, v)| match v {
+                            toml::Value::String(s) => format!("{k}={s}"),
+                            _ => format!("{k}={v}"),
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    format!("{tool}[{}]@{}", opts_str, map.version)
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RunEntry {
@@ -303,7 +347,7 @@ pub struct Task {
     #[serde(default)]
     pub silent: Silent,
     #[serde(default)]
-    pub tools: IndexMap<String, String>,
+    pub tools: IndexMap<String, TaskToolValue>,
     #[serde(default)]
     pub usage: String,
     #[serde(default)]
@@ -488,7 +532,29 @@ impl Task {
             .parse_table("tools")
             .map(|t| {
                 t.into_iter()
-                    .filter_map(|(k, v)| v.as_str().map(|vs| (k, vs.to_string())))
+                    .filter_map(|(k, v)| {
+                        if let toml::Value::String(s) = &v {
+                            Some((k, TaskToolValue::String(s.clone())))
+                        } else if let toml::Value::Table(table) = &v {
+                            if let Some(toml::Value::String(version)) = table.get("version") {
+                                let mut opts = IndexMap::new();
+                                for (ok, ov) in table.iter().filter(|(ok, _)| *ok != "version") {
+                                    opts.insert(ok.clone(), ov.clone());
+                                }
+                                Some((
+                                    k,
+                                    TaskToolValue::Map(TaskToolValueMap {
+                                        version: version.clone(),
+                                        opts,
+                                    }),
+                                ))
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    })
                     .collect()
             })
             .unwrap_or_default();
@@ -1123,7 +1189,19 @@ impl Task {
             *shell = tera.render_str(shell, &tera_ctx)?;
         }
         for (_, v) in &mut self.tools {
-            *v = tera.render_str(v, &tera_ctx)?;
+            match v {
+                TaskToolValue::String(s) => {
+                    *v = TaskToolValue::String(tera.render_str(s, &tera_ctx)?);
+                }
+                TaskToolValue::Map(map) => {
+                    map.version = tera.render_str(&map.version, &tera_ctx)?;
+                    for (_ok, ov) in &mut map.opts {
+                        if let toml::Value::String(s) = ov {
+                            *ov = toml::Value::String(tera.render_str(s, &tera_ctx)?);
+                        }
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -2621,6 +2699,8 @@ echo "test"
         use std::os::unix::fs::PermissionsExt;
         use tempfile::tempdir;
 
+        use super::TaskToolValue;
+
         let temp_dir = tempdir().unwrap();
         let tasks_dir = temp_dir.path().join("tasks");
         fs::create_dir(&tasks_dir).unwrap();
@@ -2663,9 +2743,18 @@ echo "test"
             "Expected 'ruby' in tools: {:?}",
             task.tools
         );
-        assert_eq!(task.tools.get("node").unwrap(), "20");
-        assert_eq!(task.tools.get("python").unwrap(), "3.11");
-        assert_eq!(task.tools.get("ruby").unwrap(), "3.2");
+        assert_eq!(
+            task.tools.get("node").unwrap(),
+            &TaskToolValue::String("20".to_string())
+        );
+        assert_eq!(
+            task.tools.get("python").unwrap(),
+            &TaskToolValue::String("3.11".to_string())
+        );
+        assert_eq!(
+            task.tools.get("ruby").unwrap(),
+            &TaskToolValue::String("3.2".to_string())
+        );
     }
 
     #[tokio::test]
@@ -2676,6 +2765,8 @@ echo "test"
         use std::fs;
         use std::os::unix::fs::PermissionsExt;
         use tempfile::tempdir;
+
+        use super::TaskToolValue;
 
         let temp_dir = tempdir().unwrap();
         let tasks_dir = temp_dir.path().join("tasks");
@@ -2713,8 +2804,14 @@ echo "test"
             "Expected '1password-cli' in tools: {:?}",
             task.tools
         );
-        assert_eq!(task.tools.get("git-cliff").unwrap(), "1.0");
-        assert_eq!(task.tools.get("1password-cli").unwrap(), "2.0");
+        assert_eq!(
+            task.tools.get("git-cliff").unwrap(),
+            &TaskToolValue::String("1.0".to_string())
+        );
+        assert_eq!(
+            task.tools.get("1password-cli").unwrap(),
+            &TaskToolValue::String("2.0".to_string())
+        );
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -206,7 +206,7 @@ impl TaskExecutor {
 
         let mut tools = self.tool.clone();
         for (k, v) in &task.tools {
-            tools.push(format!("{k}@{v}").parse()?);
+            tools.push(v.to_tool_spec(k).parse()?);
         }
         let ts_build_start = std::time::Instant::now();
 

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -1,7 +1,7 @@
 use crate::config::config_file::mise_toml::EnvList;
 use crate::config::config_file::toml::deserialize_arr;
 use crate::task::task_sources::TaskOutputs;
-use crate::task::{RunEntry, Silent, Task, TaskConfirm, TaskDep};
+use crate::task::{RunEntry, Silent, Task, TaskDep, TaskToolValue};
 use indexmap::IndexMap;
 use serde::Deserialize;
 
@@ -14,7 +14,7 @@ pub struct TaskTemplate {
     #[serde(default, rename = "alias", deserialize_with = "deserialize_arr")]
     pub aliases: Vec<String>,
     #[serde(default)]
-    pub confirm: Option<TaskConfirm>,
+    pub confirm: Option<String>,
     #[serde(default, deserialize_with = "deserialize_arr")]
     pub depends: Vec<TaskDep>,
     #[serde(default, deserialize_with = "deserialize_arr")]
@@ -42,7 +42,7 @@ pub struct TaskTemplate {
     #[serde(default)]
     pub silent: Option<Silent>,
     #[serde(default)]
-    pub tools: IndexMap<String, String>,
+    pub tools: IndexMap<String, TaskToolValue>,
     #[serde(default)]
     pub usage: String,
     #[serde(default)]
@@ -258,13 +258,16 @@ mod tests {
     #[test]
     fn test_merge_template_tools_deep_merge() {
         let mut task = Task {
-            tools: IndexMap::from([("node".to_string(), "20".to_string())]),
+            tools: IndexMap::from([("node".to_string(), TaskToolValue::String("20".to_string()))]),
             ..Default::default()
         };
         let template = TaskTemplate {
             tools: IndexMap::from([
-                ("python".to_string(), "3.12".to_string()),
-                ("node".to_string(), "18".to_string()), // Should be overridden by task
+                (
+                    "python".to_string(),
+                    TaskToolValue::String("3.12".to_string()),
+                ),
+                ("node".to_string(), TaskToolValue::String("18".to_string())), // Should be overridden by task
             ]),
             ..Default::default()
         };
@@ -273,8 +276,14 @@ mod tests {
 
         // Should have both tools, with task's node version
         assert_eq!(task.tools.len(), 2);
-        assert_eq!(task.tools.get("node"), Some(&"20".to_string()));
-        assert_eq!(task.tools.get("python"), Some(&"3.12".to_string()));
+        assert_eq!(
+            task.tools.get("node"),
+            Some(&TaskToolValue::String("20".to_string()))
+        );
+        assert_eq!(
+            task.tools.get("python"),
+            Some(&TaskToolValue::String("3.12".to_string()))
+        );
     }
 
     #[test]

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -1,7 +1,7 @@
 use crate::config::config_file::mise_toml::EnvList;
 use crate::config::config_file::toml::deserialize_arr;
 use crate::task::task_sources::TaskOutputs;
-use crate::task::{RunEntry, Silent, Task, TaskDep, TaskToolValue};
+use crate::task::{RunEntry, Silent, Task, TaskConfirm, TaskDep, TaskToolValue};
 use indexmap::IndexMap;
 use serde::Deserialize;
 
@@ -14,7 +14,7 @@ pub struct TaskTemplate {
     #[serde(default, rename = "alias", deserialize_with = "deserialize_arr")]
     pub aliases: Vec<String>,
     #[serde(default)]
-    pub confirm: Option<String>,
+    pub confirm: Option<TaskConfirm>,
     #[serde(default, deserialize_with = "deserialize_arr")]
     pub depends: Vec<TaskDep>,
     #[serde(default, deserialize_with = "deserialize_arr")]

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -34,7 +34,7 @@ impl<'a> TaskToolInstaller<'a> {
         for t in &all_tasks {
             // Collect tools from task.tools (task-level tool overrides)
             for (k, v) in &t.tools {
-                all_tools.push(format!("{k}@{v}").parse()?);
+                all_tools.push(v.to_tool_spec(k).parse()?);
             }
 
             // Collect tools from monorepo task config files


### PR DESCRIPTION
## Summary

Task-level `tools` field previously only accepted string values like:
```toml
[tasks.example]
tools = { rust = "nightly-2024-12-14" }
```

This change adds support for object/map syntax matching top-level `[tools]`:
```toml
[tasks.example]
tools = { rust = { version = "nightly-2024-12-14", targets = "aarch64-linux-android" } }
```

This allows scoping Rust cross-compilation targets to specific tasks without requiring them at the global `[tools]` level.

## Problem

The issue reported: "invalid type: map, expected a string" when using object syntax at task level, while the same syntax works at top-level `[tools]`.

## Solution

- Created `TaskToolValue` enum with `String(String)` and `Map(TaskToolValueMap)` variants
- `TaskToolValueMap` stores `version` and remaining options as `IndexMap<String, toml::Value>`
- Added `to_tool_spec()` method to convert to ToolArg-compatible format
- Updated task_tool_installer and task_executor to use the new method

## Backwards Compatibility

- String syntax `tools = { rust = "1.0" }` continues to work unchanged
- Object syntax `tools = { rust = { version = "1.0", targets = "..." } }` now supported

## Testing

- Unit tests updated for new `TaskToolValue` type
- All existing task tools tests pass

---

Fixes #10421