### PR TITLE
feat(task): allow to set confirmation default

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -267,7 +267,7 @@ run = "echo my internal task"
 
 ### `confirm`
 
-- **Type**: `string`
+- **Type**: `string` | `{ message: string, default?: string }`
 
 A message to show before running the task. This is useful for tasks that are destructive or take a long
 time to run. The user will be prompted to confirm before the task's own `run` command executes.
@@ -278,7 +278,7 @@ time to run. The user will be prompted to confirm before the task's own `run` co
 
 ```mise-toml
 [tasks.release]
-confirm = "Are you sure you want to cut a release?"
+confirm = { message = "Are you sure you want to cut a release?", default = "no" }
 description = 'Cut a new release'
 file = 'scripts/release.sh'
 ```

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -267,7 +267,7 @@ run = "echo my internal task"
 
 ### `confirm`
 
-- **Type**: `string` | `{ message: string, default?: string }`
+- **Type**: `string` | `{ message: string, default: string }`
 
 A message to show before running the task. This is useful for tasks that are destructive or take a long
 time to run. The user will be prompted to confirm before the task's own `run` command executes.

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -73,8 +73,28 @@
               ]
             },
             "confirm": {
-              "description": "confirmation message before running this task",
-              "type": "string"
+                "oneOf": [
+                    {
+                        "description": "confirmation message before running this task",
+                        "type": "string"
+                    },
+                    {
+                        "description": "confirmation message before running this task with default value",
+                        "properties": {
+                            "message": {
+                                "description": "confirmation message before running this task",
+                                "type": "string"
+                            },
+                            "default": {
+                                "description": "default value for confirmation (yes/no/true/false)",
+                                "type": "string"
+                            }
+                        },
+                        "required": ["message"],
+                        "additionalProperties": false,
+                        "type": "object"
+                    }
+                ]
             },
             "depends": {
               "oneOf": [
@@ -844,8 +864,28 @@
           ]
         },
         "confirm": {
-          "description": "confirmation message before running this task",
-          "type": "string"
+            "oneOf": [
+                {
+                    "description": "confirmation message before running this task",
+                    "type": "string"
+                },
+                {
+                    "description": "confirmation message before running this task with default value",
+                    "properties": {
+                        "message": {
+                            "description": "confirmation message before running this task",
+                            "type": "string"
+                        },
+                        "default": {
+                            "description": "default value for confirmation (yes/no/true/false)",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["message"],
+                    "additionalProperties": false,
+                    "type": "object"
+                }
+            ]
         },
         "depends": {
           "oneOf": [

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -73,28 +73,29 @@
               ]
             },
             "confirm": {
-                "oneOf": [
-                    {
-                        "description": "confirmation message before running this task",
-                        "type": "string"
+              "oneOf": [
+                {
+                  "description": "confirmation message before running this task",
+                  "type": "string"
+                },
+                {
+                  "description": "confirmation message before running this task with default value",
+                  "properties": {
+                    "message": {
+                      "description": "confirmation message before running this task",
+                      "type": "string"
                     },
-                    {
-                        "description": "confirmation message before running this task with default value",
-                        "properties": {
-                            "message": {
-                                "description": "confirmation message before running this task",
-                                "type": "string"
-                            },
-                            "default": {
-                                "description": "default value for confirmation (yes/no/true/false)",
-                                "type": "string"
-                            }
-                        },
-                        "required": ["message"],
-                        "additionalProperties": false,
-                        "type": "object"
+                    "default": {
+                      "description": "default value for confirmation (yes/no/true/false)",
+                      "enum": ["yes", "no", "y", "n", "true", "false"],
+                      "type": "string"
                     }
-                ]
+                  },
+                  "required": ["message", "default"],
+                  "additionalProperties": false,
+                  "type": "object"
+                }
+              ]
             },
             "depends": {
               "oneOf": [
@@ -864,28 +865,29 @@
           ]
         },
         "confirm": {
-            "oneOf": [
-                {
-                    "description": "confirmation message before running this task",
-                    "type": "string"
+          "oneOf": [
+            {
+              "description": "confirmation message before running this task",
+              "type": "string"
+            },
+            {
+              "description": "confirmation message before running this task with default value",
+              "properties": {
+                "message": {
+                  "description": "confirmation message before running this task",
+                  "type": "string"
                 },
-                {
-                    "description": "confirmation message before running this task with default value",
-                    "properties": {
-                        "message": {
-                            "description": "confirmation message before running this task",
-                            "type": "string"
-                        },
-                        "default": {
-                            "description": "default value for confirmation (yes/no/true/false)",
-                            "type": "string"
-                        }
-                    },
-                    "required": ["message"],
-                    "additionalProperties": false,
-                    "type": "object"
+                "default": {
+                  "description": "default value for confirmation (yes/no/true/false)",
+                  "enum": ["yes", "no", "y", "n", "true", "false"],
+                  "type": "string"
                 }
-            ]
+              },
+              "required": ["message", "default"],
+              "additionalProperties": false,
+              "type": "object"
+            }
+          ]
         },
         "depends": {
           "oneOf": [

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1799,8 +1799,28 @@
               ]
             },
             "confirm": {
-              "description": "confirmation message before running this task",
-              "type": "string"
+                "oneOf": [
+                    {
+                        "description": "confirmation message before running this task",
+                        "type": "string"
+                    },
+                    {
+                        "description": "confirmation message before running this task with default value",
+                        "properties": {
+                            "message": {
+                                "description": "confirmation message before running this task",
+                                "type": "string"
+                            },
+                            "default": {
+                                "description": "default value for confirmation (yes/no/true/false)",
+                                "type": "string"
+                            }
+                        },
+                        "required": ["message"],
+                        "additionalProperties": false,
+                        "type": "object"
+                    }
+                ]
             },
             "depends": {
               "oneOf": [
@@ -2460,8 +2480,28 @@
           ]
         },
         "confirm": {
-          "description": "confirmation message before running this task",
-          "type": "string"
+            "oneOf": [
+                {
+                    "description": "confirmation message before running this task",
+                    "type": "string"
+                },
+                {
+                    "description": "confirmation message before running this task with default value",
+                    "properties": {
+                        "message": {
+                            "description": "confirmation message before running this task",
+                            "type": "string"
+                        },
+                        "default": {
+                            "description": "default value for confirmation (yes/no/true/false)",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["message"],
+                    "additionalProperties": false,
+                    "type": "object"
+                }
+            ]
         },
         "depends": {
           "oneOf": [
@@ -2763,8 +2803,28 @@
           ]
         },
         "confirm": {
-          "description": "confirmation message before running this task",
-          "type": "string"
+            "oneOf": [
+                {
+                    "description": "confirmation message before running this task",
+                    "type": "string"
+                },
+                {
+                    "description": "confirmation message before running this task with default value",
+                    "properties": {
+                        "message": {
+                            "description": "confirmation message before running this task",
+                            "type": "string"
+                        },
+                        "default": {
+                            "description": "default value for confirmation (yes/no/true/false)",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["message"],
+                    "additionalProperties": false,
+                    "type": "object"
+                }
+            ]
         },
         "depends": {
           "oneOf": [

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2818,7 +2818,7 @@
                   "type": "string"
                 },
                 "default": {
-                  "description": "default value for confirmation (yes/no/y/n/true/false)",
+                  "description": "default value for confirmation (yes/no/true/false)",
                   "enum": ["yes", "no", "y", "n", "true", "false"],
                   "type": "string"
                 }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1799,28 +1799,29 @@
               ]
             },
             "confirm": {
-                "oneOf": [
-                    {
-                        "description": "confirmation message before running this task",
-                        "type": "string"
+              "oneOf": [
+                {
+                  "description": "confirmation message before running this task",
+                  "type": "string"
+                },
+                {
+                  "description": "confirmation message before running this task with default value",
+                  "properties": {
+                    "message": {
+                      "description": "confirmation message before running this task",
+                      "type": "string"
                     },
-                    {
-                        "description": "confirmation message before running this task with default value",
-                        "properties": {
-                            "message": {
-                                "description": "confirmation message before running this task",
-                                "type": "string"
-                            },
-                            "default": {
-                                "description": "default value for confirmation (yes/no/true/false)",
-                                "type": "string"
-                            }
-                        },
-                        "required": ["message"],
-                        "additionalProperties": false,
-                        "type": "object"
+                    "default": {
+                      "description": "default value for confirmation (yes/no/true/false)",
+                      "enum": ["yes", "no", "y", "n", "true", "false"],
+                      "type": "string"
                     }
-                ]
+                  },
+                  "required": ["message", "default"],
+                  "additionalProperties": false,
+                  "type": "object"
+                }
+              ]
             },
             "depends": {
               "oneOf": [
@@ -2480,28 +2481,29 @@
           ]
         },
         "confirm": {
-            "oneOf": [
-                {
-                    "description": "confirmation message before running this task",
-                    "type": "string"
+          "oneOf": [
+            {
+              "description": "confirmation message before running this task",
+              "type": "string"
+            },
+            {
+              "description": "confirmation message before running this task with default value",
+              "properties": {
+                "message": {
+                  "description": "confirmation message before running this task",
+                  "type": "string"
                 },
-                {
-                    "description": "confirmation message before running this task with default value",
-                    "properties": {
-                        "message": {
-                            "description": "confirmation message before running this task",
-                            "type": "string"
-                        },
-                        "default": {
-                            "description": "default value for confirmation (yes/no/true/false)",
-                            "type": "string"
-                        }
-                    },
-                    "required": ["message"],
-                    "additionalProperties": false,
-                    "type": "object"
+                "default": {
+                  "description": "default value for confirmation (yes/no/true/false)",
+                  "enum": ["yes", "no", "y", "n", "true", "false"],
+                  "type": "string"
                 }
-            ]
+              },
+              "required": ["message", "default"],
+              "additionalProperties": false,
+              "type": "object"
+            }
+          ]
         },
         "depends": {
           "oneOf": [
@@ -2803,28 +2805,29 @@
           ]
         },
         "confirm": {
-            "oneOf": [
-                {
-                    "description": "confirmation message before running this task",
-                    "type": "string"
+          "oneOf": [
+            {
+              "description": "confirmation message before running this task",
+              "type": "string"
+            },
+            {
+              "description": "confirmation message before running this task with default value",
+              "properties": {
+                "message": {
+                  "description": "confirmation message before running this task",
+                  "type": "string"
                 },
-                {
-                    "description": "confirmation message before running this task with default value",
-                    "properties": {
-                        "message": {
-                            "description": "confirmation message before running this task",
-                            "type": "string"
-                        },
-                        "default": {
-                            "description": "default value for confirmation (yes/no/true/false)",
-                            "type": "string"
-                        }
-                    },
-                    "required": ["message"],
-                    "additionalProperties": false,
-                    "type": "object"
+                "default": {
+                  "description": "default value for confirmation (yes/no/y/n/true/false)",
+                  "enum": ["yes", "no", "y", "n", "true", "false"],
+                  "type": "string"
                 }
-            ]
+              },
+              "required": ["message", "default"],
+              "additionalProperties": false,
+              "type": "object"
+            }
+          ]
         },
         "depends": {
           "oneOf": [

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2253,6 +2253,46 @@ mod tests {
         file::remove_file(&p).unwrap();
     }
 
+    #[test]
+    fn test_tasks_confirm_parses() {
+        let body = r#"
+[tasks.deploy]
+confirm = { message = "Are you sure you want to deploy to ({{ env.HOME }})?", default = "no" }
+run = 'echo " $usage_environment"'
+"#;
+
+        let path = std::path::Path::new("/tmp/mise.toml");
+        let rf = MiseToml::from_str(body, path).unwrap();
+        let task = rf.tasks.0.get("deploy").expect("deploy task should exist");
+
+        assert!(matches!(
+            task.confirm,
+            Some(crate::task::TaskConfirm::Options { .. })
+        ));
+    }
+
+    #[test]
+    fn test_task_templates_confirm_parses() {
+        let body = r#"
+[task_templates.deploy]
+confirm = { message = "Are you sure?", default = "no" }
+run = 'echo "template"'
+"#;
+
+        let path = std::path::Path::new("/tmp/mise.toml");
+        let rf = MiseToml::from_str(body, path).unwrap();
+        let template = rf
+            .task_templates
+            .0
+            .get("deploy")
+            .expect("deploy template should exist");
+
+        assert!(matches!(
+            template.confirm,
+            Some(crate::task::TaskConfirm::Options { .. })
+        ));
+    }
+
     #[tokio::test]
     async fn test_remove_alias() {
         let _config = Config::get().await.unwrap();

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -42,6 +42,7 @@ pub(crate) fn reset() {
 pub type FailedTasks = Arc<std::sync::Mutex<Vec<(Task, Option<i32>)>>>;
 
 mod deps;
+pub mod task_confirm;
 pub mod task_context_builder;
 mod task_dep;
 pub mod task_executor;
@@ -60,6 +61,7 @@ pub mod task_sources;
 pub mod task_template;
 pub mod task_tool_installer;
 
+pub use task_confirm::TaskConfirm;
 pub use task_load_context::{TaskLoadContext, expand_colon_task_syntax};
 pub use task_output::TaskOutput;
 pub use task_script_parser::{has_any_args_defined, has_any_usage_spec};
@@ -264,7 +266,7 @@ pub struct Task {
     #[serde(skip)]
     pub config_root: Option<PathBuf>,
     #[serde(default)]
-    pub confirm: Option<String>,
+    pub confirm: Option<TaskConfirm>,
     #[serde(default, deserialize_with = "deserialize_arr")]
     pub depends: Vec<TaskDep>,
     #[serde(default, deserialize_with = "deserialize_arr")]
@@ -458,7 +460,13 @@ impl Task {
             .or(p.parse_str("alias").map(|s| vec![s]))
             .or(p.parse_str("aliases").map(|s| vec![s]))
             .unwrap_or_default();
-        task.confirm = p.parse_str("confirm");
+        task.confirm = p
+            .get_raw("confirm")
+            .map(|v| {
+                TaskConfirm::deserialize(v.clone())
+                    .map_err(|e| eyre!("failed to parse confirm field in task header: {e}"))
+            })
+            .transpose()?;
         task.depends = p.parse_array("depends").unwrap_or_default();
         task.depends_post = p.parse_array("depends_post").unwrap_or_default();
         task.wait_for = p.parse_array("wait_for").unwrap_or_default();
@@ -1800,7 +1808,7 @@ mod tests {
     use crate::{config::Config, dirs};
     use pretty_assertions::assert_eq;
 
-    use super::name_from_path;
+    use super::{TaskConfirm, name_from_path};
 
     // Thread-local storage to capture parser state during tests
     thread_local! {
@@ -2577,7 +2585,10 @@ echo "test"
         assert_eq!(task.shell, Some("bash -c".to_string()));
         assert_eq!(task.quiet, true);
         assert!(!task.tools.is_empty());
-        assert_eq!(task.confirm, Some("Are you sure?".to_string()));
+        assert_eq!(
+            task.confirm,
+            Some(TaskConfirm::Message("Are you sure?".to_string()))
+        );
 
         let mut parsed_fields =
             take_captured_fields().expect("Parser fields should have been captured");

--- a/src/task/task_confirm.rs
+++ b/src/task/task_confirm.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TaskConfirm {
+    Message(String),
+    Options { message: String, default: String },
+}
+
+impl TaskConfirm {
+    pub fn message(&self) -> &str {
+        match self {
+            TaskConfirm::Message(message) => message,
+            TaskConfirm::Options { message, .. } => message,
+        }
+    }
+
+    pub fn default_value(&self) -> Option<&str> {
+        match self {
+            TaskConfirm::Message(_) => None,
+            TaskConfirm::Options { default, .. } => Some(default.as_str()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    use crate::config::Config;
+    use crate::task::{Task, TaskConfirm};
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_from_path_confirm_object() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempdir().unwrap();
+        let task_path = temp_dir.path().join("test_task");
+
+        fs::write(
+            &task_path,
+            r#"#!/bin/bash
+#MISE confirm={message="Proceed?", default="yes"}
+echo \"hello world\"
+"#,
+        )
+        .unwrap();
+        fs::set_permissions(&task_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let task = Task::from_path(&config, &task_path, temp_dir.path(), temp_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(
+            task.confirm,
+            Some(TaskConfirm::Options {
+                message: "Proceed?".to_string(),
+                default: "yes".to_string()
+            })
+        );
+    }
+}

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1026,13 +1026,23 @@ impl TaskExecutor {
         false
     }
 
+    fn parse_confirm_default(default: &str) -> Result<bool> {
+        match default.trim().to_ascii_lowercase().as_str() {
+            "yes" | "y" | "true" => Ok(true),
+            "no" | "n" | "false" => Ok(false),
+            _ => Err(eyre!(
+                "invalid task confirm default: {default:?}, expected one of yes/no/true/false"
+            )),
+        }
+    }
+
     async fn check_confirmation(
         &self,
         config: &Arc<Config>,
         task: &Task,
         env: &BTreeMap<String, String>,
     ) -> Result<()> {
-        if let Some(confirm_template) = &task.confirm
+        if let Some(confirm) = &task.confirm
             && !Settings::get().yes
         {
             let config_root = task.config_root.clone().unwrap_or_default();
@@ -1048,8 +1058,12 @@ impl TaskExecutor {
             }
             tera_ctx.insert("usage", &usage_ctx);
 
-            let message = tera.render_str(confirm_template, &tera_ctx)?;
-            if !crate::ui::confirm(&message).unwrap_or(false) {
+            let message = tera.render_str(confirm.message(), &tera_ctx)?;
+            let default_yes = match confirm.default_value() {
+                Some(default) => Self::parse_confirm_default(default)?,
+                None => true, // keep backwards compatible default of yes if not specified
+            };
+            if !crate::ui::prompt::confirm_with_default(&message, default_yes).unwrap_or(false) {
                 return Err(eyre!("aborted by user"));
             }
         }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1031,7 +1031,7 @@ impl TaskExecutor {
             "yes" | "y" | "true" => Ok(true),
             "no" | "n" | "false" => Ok(false),
             _ => Err(eyre!(
-                "invalid task confirm default: {default:?}, expected one of yes/no/true/false"
+                "invalid task confirm default: {default:?}, expected one of yes/no/y/n/true/false"
             )),
         }
     }

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -1,7 +1,7 @@
 use crate::config::config_file::mise_toml::EnvList;
 use crate::config::config_file::toml::deserialize_arr;
 use crate::task::task_sources::TaskOutputs;
-use crate::task::{RunEntry, Silent, Task, TaskDep};
+use crate::task::{RunEntry, Silent, Task, TaskConfirm, TaskDep};
 use indexmap::IndexMap;
 use serde::Deserialize;
 
@@ -14,7 +14,7 @@ pub struct TaskTemplate {
     #[serde(default, rename = "alias", deserialize_with = "deserialize_arr")]
     pub aliases: Vec<String>,
     #[serde(default)]
-    pub confirm: Option<String>,
+    pub confirm: Option<TaskConfirm>,
     #[serde(default, deserialize_with = "deserialize_arr")]
     pub depends: Vec<TaskDep>,
     #[serde(default, deserialize_with = "deserialize_arr")]

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -11,6 +11,10 @@ static MUTEX: Mutex<()> = Mutex::new(());
 static SKIP_PROMPT: Mutex<bool> = Mutex::new(false);
 
 pub fn confirm<S: Into<String>>(message: S) -> eyre::Result<bool> {
+    confirm_with_default(message, false)
+}
+
+pub fn confirm_with_default<S: Into<String>>(message: S, default_yes: bool) -> eyre::Result<bool> {
     let _lock = MUTEX.lock().unwrap(); // Prevent multiple prompts at once
     ctrlc::show_cursor_after_ctrl_c();
 
@@ -19,6 +23,7 @@ pub fn confirm<S: Into<String>>(message: S) -> eyre::Result<bool> {
     }
     let theme = get_theme();
     let result = Confirm::new(message)
+        .selected(default_yes)
         .clear_screen(true)
         .theme(&theme)
         .run()?;

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -11,7 +11,7 @@ static MUTEX: Mutex<()> = Mutex::new(());
 static SKIP_PROMPT: Mutex<bool> = Mutex::new(false);
 
 pub fn confirm<S: Into<String>>(message: S) -> eyre::Result<bool> {
-    confirm_with_default(message, false)
+    confirm_with_default(message, true)
 }
 
 pub fn confirm_with_default<S: Into<String>>(message: S, default_yes: bool) -> eyre::Result<bool> {


### PR DESCRIPTION
Currently the default selected option for `confirm` in tasks is `Yes` which might not be a sensible default for destructive actions. While keeping this behaviour we add an option to define `confirm` as map with `message` and `default=yes|no`.