### PR TITLE
fix(install): support aliased installs sharing a backend

### DIFF
--- a/e2e/backend/test_github_tool_alias_asset_pattern
+++ b/e2e/backend/test_github_tool_alias_asset_pattern
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 # Test that tool_alias with asset_pattern uses the alias-specific options
 # Regression test for https://github.com/jdx/mise/discussions/8847
+# Regression test for https://github.com/jdx/mise/discussions/9074
 # When both the original tool and an aliased tool are configured with different
-# asset_pattern values, each should use its own pattern.
+# asset_pattern values, each should use its own pattern. Distinct aliases that
+# resolve to the same backend/version must also be scheduled as distinct installs.
 
 cat <<'EOF' >mise.toml
 [tool_alias]
+hw1 = "github:jdx/mise-test-fixtures"
 hw2 = "github:jdx/mise-test-fixtures"
 
-[tools."github:jdx/mise-test-fixtures"]
+[tools.hw1]
 version = "1.0.0"
 asset_pattern = "hello-world-1.0.0.tar.gz"
 bin_path = "hello-world-1.0.0/bin"
@@ -24,5 +27,6 @@ EOF
 mise install
 # Both should install successfully with the correct asset
 assert_contains "mise x -- hello-world" "hello world"
-# The aliased tool should have installed using hello-world-2.0.0.tar.gz
+# Both aliases should have installed using their own asset patterns
+assert "test -d ~/.local/share/mise/installs/hw1/1.0.0/hello-world-1.0.0"
 assert "test -d ~/.local/share/mise/installs/hw2/1.0.0/hello-world-2.0.0"

--- a/src/toolset/tool_deps.rs
+++ b/src/toolset/tool_deps.rs
@@ -7,12 +7,12 @@ use crate::cli::args::BackendArg;
 use crate::deps_graph::DepsGraph;
 use crate::toolset::tool_request::ToolRequest;
 
-/// Unique key for a tool request (backend full name + version)
+/// Unique key for a tool request (tool short name + version)
 pub type ToolKey = String;
 
 /// Creates a unique key for a ToolRequest
-fn tool_key(tr: &ToolRequest) -> ToolKey {
-    format!("{}@{}", tr.ba().full(), tr.version())
+pub(crate) fn tool_key(tr: &ToolRequest) -> ToolKey {
+    format!("{}@{}", tr.ba().short, tr.version())
 }
 
 /// Manages a dependency graph of tools for installation scheduling.
@@ -26,7 +26,9 @@ pub struct ToolDeps {
 impl ToolDeps {
     /// Creates a new ToolDeps from a list of tool requests.
     /// Builds the dependency graph based on each tool's dependencies.
-    /// Duplicate tool requests (same backend and version) are deduplicated.
+    /// Duplicate tool requests (same tool short name and version) are deduplicated.
+    /// Distinct aliases may resolve to the same backend/version but still need separate
+    /// install jobs because they can have different options and install directories.
     pub fn new(requests: Vec<ToolRequest>) -> Result<Self> {
         // Build nodes
         let nodes: Vec<(ToolKey, ToolRequest)> = requests
@@ -119,9 +121,51 @@ impl ToolDeps {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use crate::config::Config;
+    use crate::toolset::{ToolSource, ToolVersionOptions};
 
     #[test]
     fn test_empty_deps() {
         let _deps = ToolDeps::new(vec![]).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_aliases_to_same_backend_are_distinct() {
+        let _config = Config::get().await.unwrap();
+        let source = ToolSource::Argument;
+        let backend1 = Arc::new(BackendArg::new(
+            "foo".to_string(),
+            Some("github:owner/repo".to_string()),
+        ));
+        let backend2 = Arc::new(BackendArg::new(
+            "bar".to_string(),
+            Some("github:owner/repo".to_string()),
+        ));
+        let requests = vec![
+            ToolRequest::Version {
+                backend: backend1,
+                version: "1.0.0".to_string(),
+                options: ToolVersionOptions::default(),
+                source: source.clone(),
+            },
+            ToolRequest::Version {
+                backend: backend2,
+                version: "1.0.0".to_string(),
+                options: ToolVersionOptions::default(),
+                source,
+            },
+        ];
+
+        let mut deps = ToolDeps::new(requests).unwrap();
+        let mut rx = deps.subscribe();
+        let mut emitted = vec![];
+        while let Ok(Some(tr)) = rx.try_recv() {
+            emitted.push(tr.ba().short.clone());
+        }
+
+        emitted.sort();
+        assert_eq!(emitted, vec!["bar".to_string(), "foo".to_string()]);
     }
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -16,7 +16,7 @@ use crate::plugins::PluginType;
 use crate::toolset::Toolset;
 use crate::toolset::helpers::show_python_install_hint;
 use crate::toolset::install_options::InstallOptions;
-use crate::toolset::tool_deps::ToolDeps;
+use crate::toolset::tool_deps::{ToolDeps, tool_key};
 use crate::toolset::tool_request::{ToolRequest, effective_before_date};
 use crate::toolset::tool_source::ToolSource;
 use crate::toolset::tool_version::ToolVersion;
@@ -296,7 +296,7 @@ impl Toolset {
         let request_order: HashMap<String, usize> = versions
             .iter()
             .enumerate()
-            .map(|(i, tr)| (format!("{}@{}", tr.ba().full(), tr.version()), i))
+            .map(|(i, tr)| (tool_key(tr), i))
             .collect();
 
         // Build dependency graph
@@ -437,7 +437,7 @@ impl Toolset {
 
         // Sort installed versions by original request order to preserve user's intended ordering
         installed.sort_by_key(|tv| {
-            let key = format!("{}@{}", tv.ba().full(), tv.request.version());
+            let key = tool_key(&tv.request);
             request_order.get(&key).copied().unwrap_or(usize::MAX)
         });
 


### PR DESCRIPTION
## Summary

- Key install dependency graph nodes by configured tool short name plus version, so aliases that resolve to the same backend/version are scheduled independently.
- Use the same alias-aware key when preserving install result order.
- Extend the GitHub `tool_alias` asset-pattern e2e test to cover two aliases sharing one GitHub backend/version with different assets.

## Root Cause

`ToolDeps` previously keyed scheduler nodes as `<backend full>@<version>`. Distinct aliases like `iii` and `iii-console` can both resolve to `github:iii-hq/iii@latest`, so the dependency graph collapsed the second request as a duplicate and skipped its install job.

## Impact

Aliases that point at the same backend release can now install separately while keeping alias-specific options such as `asset_pattern`, `bin_path`, and `postinstall`. Duplicate requests for the same configured tool/version remain deduplicated.

Fixes https://github.com/jdx/mise/discussions/9074

## Validation

- `cargo fmt`
- `cargo test toolset::tool_deps::tests::test_aliases_to_same_backend_are_distinct`
- `./e2e/run_test e2e/backend/test_github_tool_alias_asset_pattern`
- commit hook suite via `hk`, including `cargo check --all-features`, `cargo fmt --all -- --check`, shellcheck, shfmt, schema validation, and related linters

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install scheduling keys from backend+version to tool short-name+version, which affects dependency graph deduplication and install ordering and could impact parallel install behavior for tools with shared backends.
> 
> **Overview**
> Fixes an install scheduler edge case where multiple configured aliases resolving to the same backend/version were incorrectly deduplicated into a single install job.
> 
> `ToolDeps` now keys dependency-graph nodes by `tool short name@version` (via shared `tool_key`), and `toolset_install` uses the same key to preserve original request ordering. Adds coverage via a new unit test for distinct aliases and extends the GitHub e2e `tool_alias` `asset_pattern` test to assert both aliases install into their own directories with their own assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d8b14f880684c966fb53756a2ebac14f4a7bbef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->