### PR TITLE
fix: `MISE_FETCH_REMOTE_VERSIONS_CACHE` not respected

### DIFF
--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -1,7 +1,7 @@
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::config::Settings;
 use crate::tokens;
-use crate::{dirs, duration, env};
+use crate::{dirs, env};
 use eyre::Result;
 use heck::ToKebabCase;
 use reqwest::IntoUrl;
@@ -47,7 +47,7 @@ async fn get_releases_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<Vec<For
         .entry(key.to_string())
         .or_insert_with(|| {
             CacheManagerBuilder::new(cache_dir().join(format!("{key}-releases.msgpack.z")))
-                .with_fresh_duration(Some(duration::DAILY))
+                .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });
     RELEASES_CACHE.read().await
@@ -60,7 +60,7 @@ async fn get_release_cache<'a>(key: &str) -> RwLockReadGuard<'a, CacheGroup<Forg
         .entry(key.to_string())
         .or_insert_with(|| {
             CacheManagerBuilder::new(cache_dir().join(format!("{key}.msgpack.z")))
-                .with_fresh_duration(Some(duration::DAILY))
+                .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });
     RELEASE_CACHE.read().await

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,7 +1,7 @@
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::config::Settings;
 use crate::tokens;
-use crate::{dirs, duration, env};
+use crate::{dirs, env};
 use eyre::Result;
 use heck::ToKebabCase;
 use reqwest::IntoUrl;
@@ -92,7 +92,7 @@ async fn get_tags_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<Vec<String>
         .entry(key.to_string())
         .or_insert_with(|| {
             CacheManagerBuilder::new(cache_dir().join(format!("{key}-tags.msgpack.z")))
-                .with_fresh_duration(Some(duration::DAILY))
+                .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });
     TAGS_CACHE.read().await
@@ -105,7 +105,7 @@ async fn get_releases_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<Vec<Git
         .entry(key.to_string())
         .or_insert_with(|| {
             CacheManagerBuilder::new(cache_dir().join(format!("{key}-releases.msgpack.z")))
-                .with_fresh_duration(Some(duration::DAILY))
+                .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });
     RELEASES_CACHE.read().await
@@ -118,7 +118,7 @@ async fn get_release_cache<'a>(key: &str) -> RwLockReadGuard<'a, CacheGroup<Gith
         .entry(key.to_string())
         .or_insert_with(|| {
             CacheManagerBuilder::new(cache_dir().join(format!("{key}.msgpack.z")))
-                .with_fresh_duration(Some(duration::DAILY))
+                .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });
     RELEASE_CACHE.read().await

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -13,7 +13,7 @@ use tokio::sync::{RwLock, RwLockReadGuard};
 use xx::regex;
 
 use crate::cache::{CacheManager, CacheManagerBuilder};
-use crate::{dirs, duration, env};
+use crate::{dirs, env};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitlabRelease {
@@ -69,7 +69,7 @@ async fn get_tags_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<Vec<String>
         .entry(key.to_string())
         .or_insert_with(|| {
             CacheManagerBuilder::new(cache_dir().join(format!("{key}-tags.msgpack.z")))
-                .with_fresh_duration(Some(duration::DAILY))
+                .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });
     TAGS_CACHE.read().await
@@ -82,7 +82,7 @@ async fn get_releases_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<Vec<Git
         .entry(key.to_string())
         .or_insert_with(|| {
             CacheManagerBuilder::new(cache_dir().join(format!("{key}-releases.msgpack.z")))
-                .with_fresh_duration(Some(duration::DAILY))
+                .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });
     RELEASES_CACHE.read().await
@@ -95,7 +95,7 @@ async fn get_release_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<GitlabRe
         .entry(key.to_string())
         .or_insert_with(|| {
             CacheManagerBuilder::new(cache_dir().join(format!("{key}.msgpack.z")))
-                .with_fresh_duration(Some(duration::DAILY))
+                .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });
     RELEASE_CACHE.read().await


### PR DESCRIPTION
## Description

The GitHub, GitLab, and Forgejo backends hardcode API response cache durations to `DAILY` (24h), ignoring the `fetch_remote_versions_cache` setting that all other backends respect.

This means `MISE_FETCH_REMOTE_VERSIONS_CACHE=0` has no effect when resolving versions from these backends, and `prefer_offline` mode is not honoured either.

## Changes

Changed the behaviour of these 3 backends to pass `Settings::get().fetch_remote_versions_cache()` through directly, matching the pattern used by the aqua, asdf, go, npm, and pipx backends.

Allows users to bypass stale caches when a new release isn't picked up:

```sh
MISE_FETCH_REMOTE_VERSIONS_CACHE=0 mise use -g github:owner/repo@latest
```

## Testing

Build the binary and ran the below which successfully bypassed the cache to fetch the newer release:

```sh
MISE_FETCH_REMOTE_VERSIONS_CACHE=0 target/debug/mise use -g github:buildkite/cli@latest
```

```sh
❯ mise use -g github:buildkite/cli@latest
  github:buildkite/cli@3.35.1
  mise ~/.config/mise/config.toml tools: github:buildkite/cli@3.35.1

❯ MISE_FETCH_REMOTE_VERSIONS_CACHE=0 target/debug/mise use -g github:buildkite/cli@latest
  github:buildkite/cli@3.35.2  verify SLSA provenance
  mise ~/.config/mise/config.toml tools: github:buildkite/cli@3.35.2
```

## Caveat

I aimed to just open an issue here but that doesn't seem to be an option so hope no offence caused with the PR.