### PR TITLE
fix(vfox-plugin): support Git URL with commit hash for mise.toml

### DIFF
--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -1,3 +1,5 @@
+use crate::config::{Config, Settings};
+use crate::errors::Error::PluginNotInstalled;
 use crate::file::{display_path, remove_all};
 use crate::git::{CloneOptions, Git};
 use crate::http::HTTP;
@@ -6,11 +8,12 @@ use crate::plugins::{Plugin, PluginSource};
 use crate::result::Result;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
-use crate::{config::Config, dirs, file, registry};
+use crate::ui::prompt;
+use crate::{dirs, file, lock_file, registry};
 use async_trait::async_trait;
 use console::style;
 use contracts::requires;
-use eyre::{Context, eyre};
+use eyre::{Context, bail, eyre};
 use indexmap::{IndexMap, indexmap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard, mpsc};
@@ -202,7 +205,7 @@ impl Plugin for VfoxPlugin {
         &self,
         config: &Arc<Config>,
         mpr: &MultiProgressReport,
-        _force: bool,
+        force: bool,
         dry_run: bool,
     ) -> Result<()> {
         // Skip installation for embedded plugins
@@ -210,15 +213,41 @@ impl Plugin for VfoxPlugin {
             return Ok(());
         }
 
-        if !self.plugin_path.exists() {
-            let url = self.get_repo_url(config)?;
-            trace!("Cloning vfox plugin: {url}");
-            let pr = mpr.add_with_options(&format!("clone vfox plugin {url}"), dry_run);
-            if !dry_run {
-                self.repo()
-                    .clone(url.as_str(), CloneOptions::default().pr(pr.as_ref()))?;
-                warn_if_env_plugin_shadows_registry(&self.name, &self.plugin_path);
+        let settings = Settings::try_get()?;
+        if !force {
+            if self.is_installed() {
+                return Ok(());
             }
+            if !settings.yes && self.repo_url.lock().unwrap().is_none() {
+                let url = self.get_repo_url(config)?;
+                let url_string = url.to_string();
+                if !registry::is_trusted_plugin(self.name(), &url_string) {
+                    warn!(
+                        "⚠️ {} is a community-developed plugin – {}",
+                        style(&self.name).blue(),
+                        style(&url_string.trim_end_matches(".git")).yellow()
+                    );
+                    if settings.paranoid {
+                        bail!(
+                            "Paranoid mode is enabled, refusing to install community-developed plugin"
+                        );
+                    }
+                    if !prompt::confirm_with_all(format!(
+                        "Would you like to install {}?",
+                        self.name
+                    ))? {
+                        Err(PluginNotInstalled(self.name.clone()))?
+                    }
+                }
+            }
+        }
+
+        let prefix = format!("plugin:{}", style(&self.name).blue().for_stderr());
+        let pr = mpr.add_with_options(&prefix, dry_run);
+        if !dry_run {
+            let _lock = lock_file::get(&self.plugin_path, force)?;
+            self.install(config, pr.as_ref()).await?;
+            warn_if_env_plugin_shadows_registry(&self.name, &self.plugin_path);
         }
         Ok(())
     }


### PR DESCRIPTION
The `ensure_installed` method of the vfox backend is very different from the asdf backend; it's a simplified version and behaves differently from the `install` method of vfox itself.

This PR fixes this by reusing the plugin install logic to make them consistent.

Before this fix, a Git URL with a commit hash for `mise.toml` would not work when using `mise install` to install the tools (because in that case, the `ensure_installed` method will be invoked to handle the tools with specified plugins).

An example of a failure use case:

```toml
[plugins]
"vfox:something" = "https://github.com/org/repo#commit_hash"

[tools]
"vfox:something" = "1.0.0"
```

P.S.: `mise plugin install` would still work, because it invokes the `install` method instead of the `ensure_installed` method.