### PR TITLE
registry: add rite

### DIFF
--- a/registry/rite.toml
+++ b/registry/rite.toml
@@ -1,0 +1,3 @@
+backends = ["github:clintmod/rite", "go:github.com/clintmod/rite/cmd/rite"]
+description = "Task runner with Unix-native variable precedence; hard fork of go-task"
+test = { cmd = "rite --version", expected = "v{{version}}" }


### PR DESCRIPTION
Adds [`rite`](https://github.com/clintmod/rite) to the registry.

`rite` is a task runner with Unix-native variable precedence — a hard fork of [`go-task/task`](https://github.com/go-task/task). The fork exists because go-task's variable model inverts Unix semantics (task-level `vars:` override CLI args and shell env), and the upstream project has publicly committed to keeping that inversion in their planned redesign ([go-task/task#2035](https://github.com/go-task/task/issues/2035)). `rite` reorders precedence so shell env > CLI args > entrypoint vars > task-scope defaults, matching what every other Unix tool does.

- **Homepage:** https://clintmod.github.io/rite
- **Repository:** https://github.com/clintmod/rite
- **License:** MIT

## Backends

```toml
backends = ["github:clintmod/rite", "go:github.com/clintmod/rite/cmd/rite"]
```

`github:` is primary — `rite` ships goreleaser-built assets (`rite_<os>_<arch>.tar.gz` / `.zip`) for darwin/linux/windows/freebsd × amd64/arm64/arm/386/riscv64 on every tag. `go:` is the compile-from-source fallback.

## Release cadence

Actively maintained — three tags shipped in the last 24 hours (v1.0.0 → v1.0.1 → v1.0.2). Releases are automated through goreleaser on every `v*` tag.

## Test plan

```sh
mise install rite@1.0.2
rite --version    # → v1.0.2
```

The included test entry uses `expected = "v{{version}}"`, matching tools like `caddy` and `age` that print a leading `v`.