### PR TITLE
fix(task): skip Array/Table opts in to_tool_spec

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -107,9 +107,10 @@ impl TaskToolValue {
                     let opts_str = map
                         .opts
                         .iter()
-                        .map(|(k, v)| match v {
-                            toml::Value::String(s) => format!("{k}={s}"),
-                            _ => format!("{k}={v}"),
+                        .filter_map(|(k, v)| match v {
+                            toml::Value::String(s) => Some(format!("{k}={s}")),
+                            toml::Value::Table(_) | toml::Value::Array(_) => None,
+                            _ => Some(format!("{k}={v}")),
                         })
                         .collect::<Vec<_>>()
                         .join(",");


### PR DESCRIPTION
## Summary
Fixes a regression in PR #9087 where Array/Table typed opts values (e.g. `targets = ["x86_64", "aarch64"]`) are serialized as TOML notation containing nested square brackets, breaking `split_bracketed_opts` regex parsing.

## Root Cause
The `to_tool_spec` method used `_ => format!("{k}={v}")` as a fallback for non-String values, which serializes `toml::Value::Array` as `["x86_64", "aarch64"]` — the inner `[]` breaks the bracketed opts parser.

## Fix
Follow the same pattern as `BackendArg::full_with_opts` — use `filter_map` to skip `Table` and `Array` variants:

```rust
.filter_map(|(k, v)| match v {
    toml::Value::String(s) => Some(format!("{k}={s}")),
    toml::Value::Table(_) | toml::Value::Array(_) => None,
    _ => Some(format!("{k}={v}")),
})
```

## Referenced Comment
greptile-apps P1 review (2026-04-14 23:16): https://github.com/jdx/mise/pull/9087#discussion-**