### PR TITLE
fix(task): forward task help args and add raw_args

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -308,6 +308,33 @@ this that no other tasks are running at the same time.
 In the future we could have a property like `single = true` or something that prevents multiple tasks
 from running at the same time. If that sounds useful, search/file a ticket.
 
+### `raw_args`
+
+- **Type**: `bool`
+- **Default**: `false`
+
+When `true`, mise does not parse arguments to the task at all — every argument
+is passed through verbatim to the underlying command, including `--help`/`-h`.
+Use this for tasks that act as a thin proxy for a tool which already has its
+own argument parser (e.g. `next build`, Django `manage.py`, Python scripts
+using `argparse`):
+
+```toml
+[tasks.manage]
+raw_args = true
+run = 'python manage.py'
+```
+
+```sh
+mise run manage --help          # forwarded to manage.py, not intercepted by mise
+mise run manage migrate --fake  # all flags reach manage.py unchanged
+```
+
+Without `raw_args`, mise intercepts `--help` and prints its own task help. As
+an ad-hoc alternative for individual invocations, you can also use
+`mise run task -- --help` — the `--` separator now bypasses mise's usage
+parser specifically for `--help`/`-h`.
+
 ### `interactive`
 
 - **Type**: `bool`

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -333,9 +333,8 @@ mise run manage migrate --fake  # all flags reach manage.py unchanged
 Without `raw_args`, mise intercepts `--help` and prints its own task help. As
 an ad-hoc alternative for individual invocations, you can also use
 `mise run task -- --help` — the `--` separator now bypasses mise's usage
-parser specifically for `--help`/`-h`. A second, inner `--` escapes that
-escape: `mise run task -- -- --help` lets the usage parser see `--help` as
-a literal positional argument.
+parser specifically for `--help`/`-h`. Arguments after that separator belong
+to the task, so `mise run task -- -- --help` forwards `-- --help` to the task.
 
 ### `interactive`
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -333,7 +333,9 @@ mise run manage migrate --fake  # all flags reach manage.py unchanged
 Without `raw_args`, mise intercepts `--help` and prints its own task help. As
 an ad-hoc alternative for individual invocations, you can also use
 `mise run task -- --help` — the `--` separator now bypasses mise's usage
-parser specifically for `--help`/`-h`.
+parser specifically for `--help`/`-h`. A second, inner `--` escapes that
+escape: `mise run task -- -- --help` lets the usage parser see `--help` as
+a literal positional argument.
 
 ### `interactive`
 

--- a/e2e/tasks/test_task_help
+++ b/e2e/tasks/test_task_help
@@ -15,15 +15,18 @@ Arguments:
 assert_contains "mise --help 2>&1 || true" "Usage: mise [OPTIONS] [TASK] [COMMAND]"
 assert_contains "mise install --help 2>&1 || true" "Usage: mise install [OPTIONS] [TOOL@VERSION]..."
 assert_contains "mise run --help 2>&1 || true" "Usage: run [OPTIONS] [TASK] [ARGS]..."
-assert_contains "mise atask -- --help 2>&1 || true" "Usage: atask <myarg>"
+# `-- --help` now bypasses the usage parser so --help reaches the script
+# (see https://github.com/jdx/mise/discussions/5460). The task's required
+# arg renders empty in this case because the parser is skipped entirely.
+assert "mise atask -q -- --help 2>&1 || true" "--help"
 # If task has no usage defined, --help shows task info
 assert_contains "mise run npm --help 2>&1 || true" "Task: npm"
 # With --, --help is passed to the task script
 assert "mise -q npm -- --help 2>&1 || true" "npm --help"
-assert "mise atask -q -- -- --help 2>&1 || true" "--help"
-assert_contains "mise run atask -q -- --help 2>&1 || true" "Usage: atask <myarg>"
-assert_contains "mise run atask -q -- foo --help 2>&1 || true" "Usage: atask <myarg>"
+assert "mise atask -q -- -- --help 2>&1 || true" "-- --help"
+assert "mise run atask -q -- --help 2>&1 || true" "--help"
+assert "mise run atask -q -- foo --help 2>&1 || true" "foo --help"
+assert "mise atask -q -- foo --help 2>&1 || true" "foo --help"
+# Without `--`, --help (with or without extra args) still shows mise's task help
 assert_contains "mise run atask -q foo --help 2>&1 || true" "Usage: atask <myarg>"
-assert_contains "mise atask -q -- foo --help 2>&1 || true" "Usage: atask <myarg>"
-# After the fix, --help shows task help even with extra args
 assert_contains "mise atask -q foo --help 2>&1 || true" "Usage: atask <myarg>"

--- a/e2e/tasks/test_task_help_with_cd
+++ b/e2e/tasks/test_task_help_with_cd
@@ -27,5 +27,7 @@ assert_contains "mise run --cd subdir deploy --help 2>&1 || true" "Usage:"
 assert_contains "mise run --cd subdir deploy --help 2>&1 || true" "<env>"
 assert_not_contains "mise run --cd subdir deploy --help 2>&1 || true" "Deploying"
 
-# Note: For tasks WITH usage specs (arg() calls), the usage library itself
-# intercepts --help even after --, so mise run deploy -- --help also shows help
+# `-- --help` bypasses the usage parser even for tasks with usage specs,
+# so --help is forwarded to the underlying script.
+# See https://github.com/jdx/mise/discussions/5460
+assert_contains "mise run --cd subdir deploy -- --help 2>&1 || true" "Deploying  --help"

--- a/e2e/tasks/test_task_raw_args
+++ b/e2e/tasks/test_task_raw_args
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Tests for the raw_args opt-in and the `-- --help` passthrough escape hatch.
+# See https://github.com/jdx/mise/discussions/5460
+
+cat <<'EOF' >mise.toml
+[tasks.proxy]
+raw_args = true
+run = 'echo "got:$@"'
+
+[tasks.spec_proxy]
+raw_args = true
+usage = '''
+arg "[args]" var=#true
+'''
+run = 'echo "got:$@"'
+
+[tasks.normal]
+usage = '''
+arg "[args]" var=#true
+'''
+run = 'echo "got:${usage_args}"'
+EOF
+
+# raw_args: --help is forwarded to the script instead of being intercepted by mise
+assert "mise run proxy --help" "got: --help"
+assert "mise run proxy -h" "got: -h"
+assert "mise proxy --help" "got: --help"
+
+# raw_args: arbitrary flags pass through unchanged
+assert "mise run proxy --foo bar baz" "got: --foo bar baz"
+
+# raw_args also works when a usage spec is defined (parser is still bypassed)
+assert "mise run spec_proxy --help" "got: --help"
+
+# Bug fix: `-- --help` now bypasses the usage parser even without raw_args.
+# Previously the usage crate intercepted --help regardless of `--`.
+assert "mise run normal -- --help" "got: --help"
+assert "mise run normal -- -h" "got: -h"
+
+# Without `--` and without raw_args, mise still owns --help (no regression)
+assert_contains "mise run normal --help 2>&1 || true" "Usage: normal"

--- a/e2e/tasks/test_task_raw_args
+++ b/e2e/tasks/test_task_raw_args
@@ -40,3 +40,22 @@ assert "mise run normal -- -h" "got: -h"
 
 # Without `--` and without raw_args, mise still owns --help (no regression)
 assert_contains "mise run normal --help 2>&1 || true" "Usage: normal"
+
+# Inner `--` after the trailing-args separator escapes the bypass: --help
+# is then treated as a literal arg by the usage parser instead of triggering
+# the help passthrough. (The usage parser itself consumes the inner `--`
+# as its end-of-options marker, leaving `--help` as a positional value.)
+assert "mise run -q normal -- -- --help 2>&1" "got:--help"
+
+# File-based task with raw_args=true: shebang script gets real positional
+# parameters, so $@ actually receives the forwarded args (unlike inline
+# TOML scripts where args are appended to the command string).
+mkdir -p mise-tasks
+cat <<'EOF' >mise-tasks/file_proxy
+#!/usr/bin/env bash
+#MISE raw_args=true
+echo "got:$*"
+EOF
+chmod +x mise-tasks/file_proxy
+assert "mise run file_proxy --help" "got:--help"
+assert "mise run file_proxy migrate --fake" "got:migrate --fake"

--- a/e2e/tasks/test_task_raw_args
+++ b/e2e/tasks/test_task_raw_args
@@ -41,11 +41,9 @@ assert "mise run normal -- -h" "got: -h"
 # Without `--` and without raw_args, mise still owns --help (no regression)
 assert_contains "mise run normal --help 2>&1 || true" "Usage: normal"
 
-# Inner `--` after the trailing-args separator escapes the bypass: --help
-# is then treated as a literal arg by the usage parser instead of triggering
-# the help passthrough. (The usage parser itself consumes the inner `--`
-# as its end-of-options marker, leaving `--help` as a positional value.)
-assert "mise run -q normal -- -- --help 2>&1" "got:--help"
+# A second `--` is task-side data after the mise boundary. It should be
+# forwarded along with --help instead of being consumed by the task usage parser.
+assert "mise run -q normal -- -- --help 2>&1" "got: -- --help"
 
 # File-based task with raw_args=true: shebang script gets real positional
 # parameters, so $@ actually receives the forwarded args (unlike inline

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -250,6 +250,11 @@
               "description": "directly connect task to stdin/stdout/stderr",
               "type": "boolean"
             },
+            "raw_args": {
+              "default": false,
+              "description": "skip mise's argument parsing for this task — all arguments (including --help/-h) are forwarded verbatim to the underlying command. Use for tasks that proxy a tool with its own argument parser.",
+              "type": "boolean"
+            },
             "run": {
               "oneOf": [
                 {
@@ -1027,6 +1032,11 @@
         "raw": {
           "default": false,
           "description": "directly connect task to stdin/stdout/stderr",
+          "type": "boolean"
+        },
+        "raw_args": {
+          "default": false,
+          "description": "skip mise's argument parsing for this task — all arguments (including --help/-h) are forwarded verbatim to the underlying command. Use for tasks that proxy a tool with its own argument parser.",
           "type": "boolean"
         },
         "run": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1996,6 +1996,11 @@
               "description": "directly connect task to stdin/stdout/stderr",
               "type": "boolean"
             },
+            "raw_args": {
+              "default": false,
+              "description": "skip mise's argument parsing for this task — all arguments (including --help/-h) are forwarded verbatim to the underlying command. Use for tasks that proxy a tool with its own argument parser.",
+              "type": "boolean"
+            },
             "run": {
               "oneOf": [
                 {
@@ -2652,6 +2657,11 @@
           "description": "directly connect task to stdin/stdout/stderr",
           "type": "boolean"
         },
+        "raw_args": {
+          "default": false,
+          "description": "skip mise's argument parsing for this task — all arguments (including --help/-h) are forwarded verbatim to the underlying command. Use for tasks that proxy a tool with its own argument parser.",
+          "type": "boolean"
+        },
         "run": {
           "oneOf": [
             {
@@ -2961,6 +2971,11 @@
         "raw": {
           "default": false,
           "description": "directly connect task to stdin/stdout/stderr",
+          "type": "boolean"
+        },
+        "raw_args": {
+          "default": false,
+          "description": "skip mise's argument parsing for this task — all arguments (including --help/-h) are forwarded verbatim to the underlying command. Use for tasks that proxy a tool with its own argument parser.",
           "type": "boolean"
         },
         "run": {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -390,21 +390,87 @@ fn get_all_run_flags(cmd: &clap::Command) -> (Vec<String>, Vec<String>) {
 /// Prefix used to escape flags that should be passed to tasks, not mise
 const TASK_ARG_ESCAPE_PREFIX: &str = "\x00MISE_TASK_ARG\x00";
 
+fn escape_args_after_separator(args: &[String], separator_idx: usize) -> Vec<String> {
+    let mut result = args[..=separator_idx].to_vec();
+    for arg in &args[separator_idx + 1..] {
+        if arg.starts_with('-') && arg != "-" {
+            result.push(format!("{}{}", TASK_ARG_ESCAPE_PREFIX, arg));
+        } else {
+            result.push(arg.clone());
+        }
+    }
+    result
+}
+
+fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> Option<usize> {
+    let (flags_with_values, _) = get_global_flags(cmd);
+    let mut i = 1;
+    while i < args.len() {
+        let arg = &args[i];
+
+        if arg == "--" {
+            return None;
+        }
+
+        if !arg.starts_with('-') {
+            return Some(i);
+        }
+
+        let flag_takes_value = if arg.starts_with("--") {
+            if arg.contains('=') {
+                false
+            } else {
+                let flag_name = arg.split('=').next().unwrap();
+                flags_with_values.iter().any(|f| f == flag_name)
+            }
+        } else if arg.len() >= 2 {
+            let flag_name = &arg[..2];
+            flags_with_values.iter().any(|f| f == flag_name)
+        } else {
+            false
+        };
+
+        if flag_takes_value && i + 1 < args.len() {
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+fn is_known_subcommand(cmd: &clap::Command, arg: &str) -> bool {
+    cmd.get_subcommands()
+        .flat_map(|s| std::iter::once(s.get_name()).chain(s.get_all_aliases()))
+        .any(|name| name == arg)
+}
+
 /// Escape flags after task names so clap doesn't parse them as mise flags.
 /// This preserves ::: separators for multi-task handling while preventing
 /// clap from consuming flags like --jobs that appear after task names.
 fn escape_task_args(cmd: &clap::Command, args: &[String]) -> Vec<String> {
-    // If there's already a '--' separator, let clap handle everything normally
-    if args.contains(&"--".to_string()) {
-        return args.to_vec();
-    }
-
-    // Find "run" position
-    let run_pos = args.iter().position(|a| a == "run");
+    // Find the mise `run` subcommand position. Do not scan past `--`; values
+    // after that boundary belong to another command or a task.
+    let first_idx = first_non_global_arg_idx(cmd, args);
+    let run_pos = first_idx.filter(|&pos| args[pos] == "run");
     let run_pos = match run_pos {
         Some(pos) => pos,
-        None => return args.to_vec(), // Not a run command
+        None => {
+            if let (Some(task_idx), Some(separator_idx)) =
+                (first_idx, args.iter().position(|a| a == "--"))
+            {
+                if is_known_subcommand(cmd, &args[task_idx]) || separator_idx <= task_idx {
+                    return args.to_vec();
+                }
+                return escape_args_after_separator(args, separator_idx);
+            }
+            return args.to_vec();
+        }
     };
+
+    if let Some(separator_idx) = args[run_pos + 1..].iter().position(|a| a == "--") {
+        return escape_args_after_separator(args, run_pos + 1 + separator_idx);
+    }
 
     let (flags_with_values, _) = get_all_run_flags(cmd);
 
@@ -491,66 +557,19 @@ fn preprocess_args_for_naked_run(cmd: &clap::Command, args: &[String]) -> Vec<St
         return args.to_vec();
     }
 
-    // If there's already a '--' separator, let clap handle everything normally
-    // (user explicitly separated task args)
+    // If there's already a '--' separator, let clap handle the naked task path.
+    // escape_task_args will still protect task-side flags after the separator.
     if args.contains(&"--".to_string()) {
         return args.to_vec();
     }
 
-    let (flags_with_values, _) = get_global_flags(cmd);
-
     // Skip global flags to find the first non-flag argument (subcommand or task)
-    let mut i = 1;
-    while i < args.len() {
-        let arg = &args[i];
-
-        if !arg.starts_with('-') {
-            // Found first non-flag argument
-            break;
-        }
-
-        // Check if this flag takes a value
-        let flag_takes_value = if arg.starts_with("--") {
-            if arg.contains('=') {
-                // --flag=value format, doesn't consume next arg
-                i += 1;
-                continue;
-            } else {
-                let flag_name = arg.split('=').next().unwrap();
-                flags_with_values.iter().any(|f| f == flag_name)
-            }
-        } else {
-            // Short form: check if it's in flags_with_values list
-            if arg.len() >= 2 {
-                let flag_name = &arg[..2]; // Get -X part
-                flags_with_values.iter().any(|f| f == flag_name)
-            } else {
-                false
-            }
-        };
-
-        if flag_takes_value && i + 1 < args.len() {
-            // Skip both the flag and its value
-            i += 2;
-        } else {
-            // Skip just the flag
-            i += 1;
-        }
-    }
-
-    // No non-flag argument found
-    if i >= args.len() {
+    let Some(i) = first_non_global_arg_idx(cmd, args) else {
         return args.to_vec();
-    }
-
-    // Extract all known subcommand names and aliases from the clap Command
-    let known_subcommands: Vec<_> = cmd
-        .get_subcommands()
-        .flat_map(|s| std::iter::once(s.get_name()).chain(s.get_all_aliases()))
-        .collect();
+    };
 
     // Check if the first non-flag argument is a known subcommand
-    if known_subcommands.contains(&args[i].as_str()) {
+    if is_known_subcommand(cmd, &args[i]) {
         return args.to_vec();
     }
 
@@ -787,5 +806,81 @@ mod tests {
                 clap_sort::assert_sorted(subcmd);
             }
         }
+    }
+
+    #[test]
+    fn test_escape_task_args_preserves_task_separator_tail() {
+        let cmd = Cli::command();
+        let args = vec![
+            "mise".to_string(),
+            "run".to_string(),
+            "atask".to_string(),
+            "-q".to_string(),
+            "--".to_string(),
+            "--".to_string(),
+            "--help".to_string(),
+        ];
+
+        let escaped = escape_task_args(&cmd, &args);
+        let separator_idx = escaped.iter().position(|arg| arg == "--").unwrap();
+        assert_eq!(escaped[..=separator_idx], args[..=separator_idx]);
+        assert!(escaped[separator_idx + 1].starts_with(TASK_ARG_ESCAPE_PREFIX));
+        assert!(escaped[separator_idx + 2].starts_with(TASK_ARG_ESCAPE_PREFIX));
+        assert_eq!(
+            unescape_task_args(&escaped[separator_idx + 1..]),
+            vec!["--".to_string(), "--help".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_escape_task_args_preserves_naked_task_separator_tail() {
+        let cmd = Cli::command();
+        let args = vec![
+            "mise".to_string(),
+            "atask".to_string(),
+            "-q".to_string(),
+            "--".to_string(),
+            "--help".to_string(),
+        ];
+
+        assert_eq!(preprocess_args_for_naked_run(&cmd, &args), args);
+        let escaped = escape_task_args(&cmd, &args);
+        let separator_idx = escaped.iter().position(|arg| arg == "--").unwrap();
+        assert_eq!(escaped[..=separator_idx], args[..=separator_idx]);
+        assert!(escaped[separator_idx + 1].starts_with(TASK_ARG_ESCAPE_PREFIX));
+        assert_eq!(
+            unescape_task_args(&escaped[separator_idx + 1..]),
+            vec!["--help".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_escape_task_args_leaves_subcommand_separator_tail_alone() {
+        let cmd = Cli::command();
+        let args = vec![
+            "mise".to_string(),
+            "exec".to_string(),
+            "--".to_string(),
+            "sh".to_string(),
+            "--flag".to_string(),
+        ];
+
+        assert_eq!(escape_task_args(&cmd, &args), args);
+    }
+
+    #[test]
+    fn test_escape_task_args_ignores_run_after_subcommand_separator() {
+        let cmd = Cli::command();
+        let args = vec![
+            "mise".to_string(),
+            "exec".to_string(),
+            "--".to_string(),
+            "npm".to_string(),
+            "run".to_string(),
+            "test".to_string(),
+            "--help".to_string(),
+        ];
+
+        assert_eq!(escape_task_args(&cmd, &args), args);
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -238,6 +238,7 @@ impl Run {
 
         // Unescape task args early so we can check for help flags
         self.args = unescape_task_args(&self.args);
+        self.args_last = unescape_task_args(&self.args_last);
 
         // Temporarily unset cache key to force fresh env computation
         if self.fresh_env {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -267,17 +267,22 @@ impl Run {
             let task_list = get_task_lists(&config, &args, false, false).await?;
 
             if let Some(task) = task_list.first() {
-                // Get usage spec to check if task has defined args/flags
-                let spec = task.parse_usage_spec_for_display(&config).await?;
+                // raw_args tasks act as proxies for tools that handle their
+                // own --help — fall through to normal execution so the flag
+                // reaches the underlying command instead of mise.
+                if !task.raw_args {
+                    // Get usage spec to check if task has defined args/flags
+                    let spec = task.parse_usage_spec_for_display(&config).await?;
 
-                if has_any_usage_spec(&spec) {
-                    // Task has usage spec defined, render help using usage library
-                    println!("{}", usage::docs::cli::render_help(&spec, &spec.cmd, true));
-                } else {
-                    // Task has no usage defined, show basic task info
-                    display_task_help(task)?;
+                    if has_any_usage_spec(&spec) {
+                        // Task has usage spec defined, render help using usage library
+                        println!("{}", usage::docs::cli::render_help(&spec, &spec.cmd, true));
+                    } else {
+                        // Task has no usage defined, show basic task info
+                        display_task_help(task)?;
+                    }
+                    return Ok(());
                 }
-                return Ok(());
             } else {
                 // No task found, show run command help
                 self.get_clap_command().print_long_help()?;
@@ -319,10 +324,13 @@ impl Run {
 
         let mut task_list = get_task_lists(&config, &args, true, self.skip_deps).await?;
 
-        // Args after -- go directly to tasks (no prefix)
+        // Args after -- go directly to tasks (no prefix). They are also
+        // recorded on `trailing_args` so the task renderer can detect
+        // `-- --help` / `-- -h` and bypass the usage parser for them.
         if !self.args_last.is_empty() {
             for task in &mut task_list {
                 task.args.extend(self.args_last.clone());
+                task.trailing_args = self.args_last.clone();
             }
         }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -846,6 +846,24 @@ impl Task {
         Ok((depends, depends_post))
     }
 
+    /// True when mise should not run the usage parser against this task's
+    /// args. Either the task opted in via `raw_args = true`, or the user
+    /// passed `--help`/`-h` after `--` for an ad-hoc passthrough.
+    ///
+    /// A second, inner `--` inside `trailing_args` acts as an escape hatch:
+    /// scanning stops there, so `mise run task -- -- --help` lets the user
+    /// pass a literal `--help` through the usage parser without triggering
+    /// the bypass.
+    pub fn should_bypass_usage_parser(&self) -> bool {
+        if self.raw_args {
+            return true;
+        }
+        self.trailing_args
+            .iter()
+            .take_while(|a| a.as_str() != "--")
+            .any(|a| a == "--help" || a == "-h")
+    }
+
     fn populate_spec_metadata(&self, spec: &mut usage::Spec) {
         spec.name = self.display_name.clone();
         spec.bin = self.display_name.clone();
@@ -941,12 +959,7 @@ impl Task {
         // Without this bypass the usage crate intercepts `--help` even after
         // `--`, which breaks proxy tasks that wrap tools with their own
         // argument parsers.
-        let bypass_parser = self.raw_args
-            || self
-                .trailing_args
-                .iter()
-                .any(|a| a == "--help" || a == "-h");
-        if !bypass_parser && has_any_args_defined(&spec) {
+        if !self.should_bypass_usage_parser() && has_any_args_defined(&spec) {
             let scripts_only = self.run_script_strings();
             let scripts = Self::make_script_parser(cwd, extra_vars)
                 .parse_run_scripts_with_args(config, self, &scripts_only, env, args, &spec)

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -850,17 +850,14 @@ impl Task {
     /// args. Either the task opted in via `raw_args = true`, or the user
     /// passed `--help`/`-h` after `--` for an ad-hoc passthrough.
     ///
-    /// A second, inner `--` inside `trailing_args` acts as an escape hatch:
-    /// scanning stops there, so `mise run task -- -- --help` lets the user
-    /// pass a literal `--help` through the usage parser without triggering
-    /// the bypass.
+    /// The `--` separator is the boundary between mise parsing and task
+    /// parsing, so task-side help flags remain literal task arguments.
     pub fn should_bypass_usage_parser(&self) -> bool {
         if self.raw_args {
             return true;
         }
         self.trailing_args
             .iter()
-            .take_while(|a| a.as_str() != "--")
             .any(|a| a == "--help" || a == "-h")
     }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -332,6 +332,13 @@ pub struct Task {
     pub global: bool,
     #[serde(default)]
     pub raw: bool,
+    /// When true, mise does not parse arguments to the task at all:
+    /// the usage spec parser is bypassed and `--help`/`-h` are passed through
+    /// to the underlying command instead of being intercepted by mise.
+    /// Useful when the task is a thin proxy for a tool that already has its
+    /// own argument parser (e.g. `next build`, Django manage.py, argparse).
+    #[serde(default)]
+    pub raw_args: bool,
     #[serde(default)]
     pub interactive: bool,
     #[serde(default)]
@@ -422,6 +429,13 @@ pub struct Task {
     pub depends_post_raw: Option<Vec<TaskDep>>,
     #[serde(skip)]
     pub wait_for_raw: Option<Vec<TaskDep>>,
+
+    /// Args supplied after a literal `--` separator on the command line.
+    /// Tracked separately from `args` so the usage parser can be bypassed
+    /// when these contain `--help`/`-h`, restoring the documented escape
+    /// hatch for passing help through to the underlying command.
+    #[serde(skip)]
+    pub trailing_args: Vec<String>,
 }
 
 impl Task {
@@ -518,6 +532,7 @@ impl Task {
         task.dir = p.parse_str("dir");
         task.hide = !file::is_executable(path) || p.parse_bool("hide").unwrap_or_default();
         task.raw = p.parse_bool("raw").unwrap_or_default();
+        task.raw_args = p.parse_bool("raw_args").unwrap_or_default();
         task.interactive = p.parse_bool("interactive").unwrap_or_default();
         task.sources = p.parse_array("sources").unwrap_or_default();
         task.outputs = p.get_raw("outputs").map(|to| to.into()).unwrap_or_default();
@@ -920,7 +935,18 @@ impl Task {
         let (spec, scripts) = self
             .parse_usage_spec_with_vars(config, cwd.clone(), env, extra_vars.clone())
             .await?;
-        if has_any_args_defined(&spec) {
+        // Skip the usage parser entirely when the task opts into raw arg
+        // passthrough, or when the user explicitly asked for `--help`/`-h`
+        // to reach the underlying command via `mise run task -- --help`.
+        // Without this bypass the usage crate intercepts `--help` even after
+        // `--`, which breaks proxy tasks that wrap tools with their own
+        // argument parsers.
+        let bypass_parser = self.raw_args
+            || self
+                .trailing_args
+                .iter()
+                .any(|a| a == "--help" || a == "-h");
+        if !bypass_parser && has_any_args_defined(&spec) {
             let scripts_only = self.run_script_strings();
             let scripts = Self::make_script_parser(cwd, extra_vars)
                 .parse_run_scripts_with_args(config, self, &scripts_only, env, args, &spec)
@@ -1510,6 +1536,8 @@ impl Default for Task {
             hide: false,
             global: false,
             raw: false,
+            raw_args: false,
+            trailing_args: vec![],
             interactive: false,
             sources: vec![],
             outputs: Default::default(),
@@ -2632,6 +2660,7 @@ echo "hello world"
 #MISE dir="/some/dir"
 #MISE hide=true
 #MISE raw=true
+#MISE raw_args=true
 #MISE interactive=true
 #MISE sources=["src1.txt", "src2.txt"]
 #MISE outputs=["out1.txt"]
@@ -2658,6 +2687,7 @@ echo "test"
         assert_eq!(task.dir, Some("/some/dir".to_string()));
         assert_eq!(task.hide, true);
         assert_eq!(task.raw, true);
+        assert_eq!(task.raw_args, true);
         assert_eq!(task.interactive, true);
         assert_eq!(task.sources, vec!["src1.txt", "src2.txt"]);
         assert_eq!(task.shell, Some("bash -c".to_string()));

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1081,15 +1081,9 @@ impl TaskExecutor {
         let (spec, _) = task
             .parse_usage_spec_with_vars(config, self.cd.clone(), env, extra_vars)
             .await?;
-        // Mirror the bypass logic in `Task::render_run_scripts_with_args`:
         // raw_args tasks (and `-- --help`/`-- -h` ad-hoc invocations) must
         // skip the usage parser so it can't intercept --help.
-        let bypass_parser = task.raw_args
-            || task
-                .trailing_args
-                .iter()
-                .any(|a| a == "--help" || a == "-h");
-        if !bypass_parser
+        if !task.should_bypass_usage_parser()
             && (!spec.cmd.args.is_empty()
                 || !spec.cmd.flags.is_empty()
                 || !spec.cmd.subcommands.is_empty())

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1081,9 +1081,18 @@ impl TaskExecutor {
         let (spec, _) = task
             .parse_usage_spec_with_vars(config, self.cd.clone(), env, extra_vars)
             .await?;
-        if !spec.cmd.args.is_empty()
-            || !spec.cmd.flags.is_empty()
-            || !spec.cmd.subcommands.is_empty()
+        // Mirror the bypass logic in `Task::render_run_scripts_with_args`:
+        // raw_args tasks (and `-- --help`/`-- -h` ad-hoc invocations) must
+        // skip the usage parser so it can't intercept --help.
+        let bypass_parser = task.raw_args
+            || task
+                .trailing_args
+                .iter()
+                .any(|a| a == "--help" || a == "-h");
+        if !bypass_parser
+            && (!spec.cmd.args.is_empty()
+                || !spec.cmd.flags.is_empty()
+                || !spec.cmd.subcommands.is_empty())
         {
             let args: Vec<String> = get_args();
             trace!("Parsing usage spec for {:?}", args);


### PR DESCRIPTION
## Summary

- Forward task-side `--help`/`-h` after `--` to the task instead of letting the usage parser intercept it.
- Add `raw_args = true` for task definitions and file headers so proxy tasks can skip mise/usage argument parsing entirely.
- Treat `--` as the single boundary between mise parsing and task parsing: `mise run task -- -- --help` forwards `-- --help` to the task.
- Keep non-`run` subcommands intact when their command args contain a literal `run` after `--`, such as `mise exec -- npm run test --help`.

Refs https://github.com/jdx/mise/discussions/5460.

## Behavior

```toml
[tasks.manage]
raw_args = true
run = 'python manage.py'
```

```sh
mise run manage --help            # forwarded to manage.py
mise run manage migrate --fake    # all flags reach manage.py unchanged
mise run othertask -- --help      # forwarded ad hoc, no raw_args needed
mise run othertask -- -- --help   # forwarded as -- --help
```

`mise run task --help` without `--` and without `raw_args` still shows mise task help.

## Validation

- `cargo test --all-features cli::tests::test_escape_task_args_ignores_run_after_subcommand_separator`
- `cargo fmt --check`
- `git diff --check`
- `target/debug/mise run test:e2e e2e/tasks/test_task_raw_args`
- `target/debug/mise run test:e2e e2e/tasks/test_task_help`
- `target/debug/mise exec -- bash -c 'printf "%s\n" "$*"' _ npm run test --help`
- pre-commit `hk` checks during amend

*This PR description was updated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CLI argument preprocessing and task usage parsing, which can subtly affect how flags are routed between mise and tasks across multiple invocation forms.
> 
> **Overview**
> Task execution now supports **argument passthrough** via new `raw_args = true`, causing tasks to skip mise/usage argument parsing so all flags (including `--help`/`-h`) reach the underlying command.
> 
> Separately, CLI preprocessing was adjusted so a literal `--` is treated as the boundary between mise and task parsing: `-- --help` bypasses the usage parser (even when a usage spec exists), `-- -- --help` forwards `-- --help`, and non-`run` subcommands with their own `--` tails are left untouched. Docs, JSON schemas, and e2e/unit tests were updated to cover the new behavior and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 846510fd44a8d19e6be8a913b57a91aa1c6530ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->