### PR TITLE
fix: check all github token sources in 403 rate limit warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -170,14 +170,13 @@ fn show_github_rate_limit_err(err: &Report) {
     let msg = format!("{err:?}");
     if msg.contains("HTTP status client error (403 Forbidden) for url (https://api.github.com") {
         warn!(
-            "GitHub API returned a 403 Forbidden error. This likely means you have exceeded the rate limit."
+            "GitHub API returned a 403 Forbidden error. This is most commonly caused by exceeding the rate limit, though other causes (e.g. insufficient token permissions) are possible."
         );
-        if env::GITHUB_TOKEN.is_none() {
+        if github::resolve_token("github.com").is_none() {
             warn!(indoc!(
-                r#"GITHUB_TOKEN is not set. This means mise is making unauthenticated requests to GitHub which have a lower rate limit.
-                   To increase the rate limit, set the GITHUB_TOKEN environment variable to a GitHub personal access token.
-                   Create a token at https://github.com/settings/tokens and set it as GITHUB_TOKEN in your environment.
-                   You do not need to give this token any scopes."#
+                r#"No GitHub token was found, so mise is making unauthenticated requests to GitHub which have a much lower rate limit.
+                   Create a token at https://github.com/settings/tokens (no scopes required) and set it as GITHUB_TOKEN in your environment.
+                   See https://mise.jdx.dev/dev-tools/github-tokens.html for all supported token sources (env vars, gh CLI, credential_command, etc.)."#
             ));
         }
     }


### PR DESCRIPTION
## Summary
- The 403 Forbidden warning previously only checked the `GITHUB_TOKEN` env var, so users who configured a token via `gh` CLI, `github_tokens.toml`, `credential_command`, or `git credential` would still see the "GITHUB_TOKEN is not set" hint. Switched to `github::resolve_token()` so all supported sources are considered.
- Linked to https://mise.jdx.dev/dev-tools/github-tokens.html so users can discover alternate token sources.
- Softened the 403 cause wording — rate-limiting is the most common cause but not the only one.

## Test plan
- [x] `cargo check`
- [ ] Manually trigger a 403 with and without a token set via `gh auth` to confirm the warning only fires when no token is resolved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes error/warning messaging and the condition used to detect whether a GitHub token is available; no functional changes to GitHub API calls themselves.
> 
> **Overview**
> Improves the user-facing warning shown when GitHub API requests fail with `403 Forbidden` by clarifying that rate limiting is the most common (but not only) cause.
> 
> The warning now checks for *any* configured GitHub token via `github::resolve_token("github.com")` instead of only `GITHUB_TOKEN`, and updates the guidance text to point users to the docs for all supported token sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a654a2d1df3eccb9d2e5a746d71a90cead2b847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->