### PR TITLE
registry: add rite (follow-up to #9116)

### DIFF
--- a/registry/rite.toml
+++ b/registry/rite.toml
@@ -1,0 +1,3 @@
+backends = ["github:clintmod/rite", "go:github.com/clintmod/rite/cmd/rite"]
+description = "Task runner with Unix-native variable precedence; hard fork of go-task"
+test = { cmd = "rite --version", expected = "v{{version}}" }

--- a/registry/rite.toml
+++ b/registry/rite.toml
@@ -1,4 +1,4 @@
 backends = ["github:clintmod/rite", "go:github.com/clintmod/rite/cmd/rite"]
 description = "Task runner with Unix-native variable precedence; hard fork of go-task"
-test = { cmd = "rite --version", expected = "v{{version}}" }
 idiomatic_files = ["Ritefile.yml", "Ritefile.yaml", "Ritefile"]
+test = { cmd = "rite --version", expected = "v{{version}}" }

--- a/registry/rite.toml
+++ b/registry/rite.toml
@@ -1,3 +1,4 @@
 backends = ["github:clintmod/rite", "go:github.com/clintmod/rite/cmd/rite"]
 description = "Task runner with Unix-native variable precedence; hard fork of go-task"
 test = { cmd = "rite --version", expected = "v{{version}}" }
+idiomatic_files = ["Ritefile.yml", "Ritefile.yaml", "Ritefile"]


### PR DESCRIPTION
Follow-up to #9116, which was closed without comment. Re-opening with the [gemini-code-assist suggestion](https://github.com/jdx/mise/pull/9116#issuecomment-) addressed.

## What changed since #9116

```diff
+idiomatic_files = ["Ritefile.yml", "Ritefile.yaml", "Ritefile"]
```

That was the only bot feedback on the prior PR, so I'm assuming it was the blocker. **If the close reason was actually policy** (mise already registers `task` / go-task and you'd rather not carry a hard fork), say the word and I'll close this — I'd just like to not guess. No hard feelings either way; I want to respect the registry's curation bar.

## Why rite

`rite` is a hard fork of `go-task/task` with one focused change: variable precedence follows Unix conventions (CLI args > shell env > task vars > defaults), where upstream task uses last-in-wins with task-level `vars:` shadowing CLI/env. Upstream confirmed in [go-task/task#2035](https://github.com/go-task/task/issues/2035) they intend to keep their model. rite exists for users who want the Unix model without fighting the framework.

- Repo: https://github.com/clintmod/rite
- License: MIT (same as go-task)
- Releases: goreleaser, signed archives for darwin/linux/windows/freebsd × amd64/arm64/arm/386/riscv64, plus deb/rpm/apk
- Current: v1.0.2 (three tags shipped in the last 24h as I shook out CalVer experiments — cadence will normalize)

## Backends

```toml
backends = ["github:clintmod/rite", "go:github.com/clintmod/rite/cmd/rite"]
```

- `github:` primary — pulls goreleaser-built archives, no toolchain required.
- `go:` fallback for platforms without a prebuilt asset.

No `aqua:` / `ubi:` because the goreleaser asset names match what the `github:` backend expects directly.

## Test plan

```
mise install rite@1.0.2
rite --version   # → v1.0.2
```

Matches the inline `test = { cmd = "rite --version", expected = "v{{version}}" }`.