### PR TITLE
fix(toolset): round-trip serialized tool options

### DIFF
--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -399,15 +399,14 @@ impl BackendArg {
         if split_bracketed_opts(&full).is_some() {
             return full;
         }
-        if let Some(opts) = &self.opts {
-            if let Some(opts_str) = serialize_tool_options(
+        if let Some(opts) = &self.opts
+            && let Some(opts_str) = serialize_tool_options(
                 opts.opts
                     .iter()
                     .filter(|(k, _)| !EPHEMERAL_OPT_KEYS.contains(&k.as_str())),
             ) {
                 return format!("{full}[{opts_str}]");
             }
-        }
         full
     }
 

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -404,9 +404,10 @@ impl BackendArg {
                 opts.opts
                     .iter()
                     .filter(|(k, _)| !EPHEMERAL_OPT_KEYS.contains(&k.as_str())),
-            ) {
-                return format!("{full}[{opts_str}]");
-            }
+            )
+        {
+            return format!("{full}[{opts_str}]");
+        }
         full
     }
 

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -17,7 +17,6 @@ use std::env;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::path::PathBuf;
-use xx::regex;
 
 /// Metadata about how a backend was resolved.
 /// This struct is designed for extensibility - additional fields can be added
@@ -106,14 +105,42 @@ impl From<InstallStateTool> for BackendArg {
 /// Split a string like `"http:hello[url=...,bin=bin]"` into `("http:hello", "url=...,bin=bin")`.
 /// Returns `None` if no bracketed opts are present.
 pub fn split_bracketed_opts(s: &str) -> Option<(&str, &str)> {
-    regex!(r"^(.+)\[(.+)\]$")
-        .captures(s)
-        .map(|c| (c.get(1).unwrap().as_str(), c.get(2).unwrap().as_str()))
+    if !s.ends_with(']') {
+        return None;
+    }
+
+    let mut bracket_start = None;
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut escaped = false;
+
+    for (index, ch) in s.char_indices() {
+        match ch {
+            '\'' if !in_double_quotes => in_single_quotes = !in_single_quotes,
+            '"' if !in_single_quotes && !escaped => in_double_quotes = !in_double_quotes,
+            '[' if !in_single_quotes && !in_double_quotes && bracket_start.is_none() => {
+                bracket_start = Some(index);
+            }
+            ']' if !in_single_quotes && !in_double_quotes && index == s.len() - 1 => {
+                if let Some(start) = bracket_start {
+                    return Some((&s[..start], &s[start + 1..index]));
+                }
+                return None;
+            }
+            _ => {}
+        }
+
+        escaped = in_double_quotes && ch == '\\' && !escaped;
+    }
+
+    None
 }
 
 /// Strip trailing `[...]` opts from a string, e.g. `"foo[a=1]"` → `"foo"`.
 pub(crate) fn strip_opts(s: &str) -> String {
-    regex!(r#"\[.+\]$"#).replace_all(s, "").to_string()
+    split_bracketed_opts(s)
+        .map(|(name, _)| name.to_string())
+        .unwrap_or_else(|| s.to_string())
 }
 
 fn parse_backend_components(
@@ -715,6 +742,49 @@ mod tests {
         let reparsed_opts = reparsed.opts();
         assert_eq!(reparsed_opts.get("query"), Some("first,second=value"));
         assert!(!reparsed_opts.contains_key("second"));
+    }
+
+    #[tokio::test]
+    async fn test_full_with_opts_round_trips_strings_with_quotes_and_brackets() {
+        let _config = Config::get().await.unwrap();
+
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "pattern".to_string(),
+            toml::Value::String(r#"a"b"#.to_string()),
+        );
+        opts.opts.insert(
+            "bin_path".to_string(),
+            toml::Value::String("bin[debug]".to_string()),
+        );
+
+        let mut fa: BackendArg = "http:hello-lock".into();
+        fa.set_opts(Some(opts));
+
+        let serialized = fa.full_with_opts();
+        assert_str_eq!(
+            r#"http:hello-lock[pattern='a"b',bin_path="bin[debug]"]"#,
+            serialized
+        );
+
+        let reparsed: BackendArg = serialized.as_str().into();
+        let reparsed_opts = reparsed.opts();
+        assert_eq!(reparsed_opts.get("pattern"), Some(r#"a"b"#));
+        assert_eq!(reparsed_opts.get("bin_path"), Some("bin[debug]"));
+    }
+
+    #[tokio::test]
+    async fn test_split_bracketed_opts_ignores_quoted_brackets() {
+        let _config = Config::get().await.unwrap();
+
+        assert_eq!(
+            split_bracketed_opts(r#"http:hello-lock[pattern='a"b',bin_path="bin[debug]"]"#),
+            Some(("http:hello-lock", r#"pattern='a"b',bin_path="bin[debug]""#))
+        );
+        assert_str_eq!(
+            "http:hello-lock",
+            strip_opts(r#"http:hello-lock[pattern='a"b',bin_path="bin[debug]"]"#)
+        );
     }
 
     #[tokio::test]

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -4,7 +4,10 @@ use crate::config::Config;
 use crate::plugins::PluginType;
 use crate::registry::REGISTRY;
 use crate::toolset::install_state::InstallStateTool;
-use crate::toolset::{EPHEMERAL_OPT_KEYS, ToolVersionOptions, install_state, parse_tool_options};
+use crate::toolset::{
+    EPHEMERAL_OPT_KEYS, ToolVersionOptions, install_state, parse_tool_options,
+    serialize_tool_options,
+};
 use crate::{backend, config, dirs, lockfile, registry};
 use contracts::requires;
 use eyre::{Result, bail};
@@ -397,18 +400,11 @@ impl BackendArg {
             return full;
         }
         if let Some(opts) = &self.opts {
-            let opts_str = opts
-                .opts
-                .iter()
-                .filter(|(k, _)| !EPHEMERAL_OPT_KEYS.contains(&k.as_str()))
-                .filter_map(|(k, v)| match v {
-                    toml::Value::String(s) => Some(format!("{k}={s}")),
-                    toml::Value::Table(_) | toml::Value::Array(_) => None,
-                    _ => Some(format!("{k}={v}")),
-                })
-                .collect::<Vec<_>>()
-                .join(",");
-            if !full.contains(['[', ']']) && !opts_str.is_empty() {
+            if let Some(opts_str) = serialize_tool_options(
+                opts.opts
+                    .iter()
+                    .filter(|(k, _)| !EPHEMERAL_OPT_KEYS.contains(&k.as_str())),
+            ) {
                 return format!("{full}[{opts_str}]");
             }
         }
@@ -697,6 +693,44 @@ mod tests {
             "http:hello-lock[url=https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz,bin_path=hello-world-1.0.0/bin]",
             fa.full_with_opts()
         );
+    }
+
+    #[tokio::test]
+    async fn test_full_with_opts_round_trips_comma_strings() {
+        let _config = Config::get().await.unwrap();
+
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "query".to_string(),
+            toml::Value::String("first,second=value".to_string()),
+        );
+
+        let mut fa: BackendArg = "http:hello-lock".into();
+        fa.set_opts(Some(opts));
+
+        let serialized = fa.full_with_opts();
+        assert_str_eq!(r#"http:hello-lock[query="first,second=value"]"#, serialized);
+
+        let reparsed: BackendArg = serialized.as_str().into();
+        let reparsed_opts = reparsed.opts();
+        assert_eq!(reparsed_opts.get("query"), Some("first,second=value"));
+        assert!(!reparsed_opts.contains_key("second"));
+    }
+
+    #[tokio::test]
+    async fn test_full_with_opts_omits_empty_brackets_for_complex_opts() {
+        let _config = Config::get().await.unwrap();
+
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "targets".to_string(),
+            toml::Value::Array(vec![toml::Value::String("x86_64".to_string())]),
+        );
+
+        let mut fa: BackendArg = "npm:prettier".into();
+        fa.set_opts(Some(opts));
+
+        assert_str_eq!("npm:prettier", fa.full_with_opts());
     }
 
     #[tokio::test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -70,7 +70,7 @@ pub use task_template::TaskTemplate;
 use crate::config::config_file::ConfigFile;
 use crate::env_diff::EnvMap;
 use crate::file::display_path;
-use crate::toolset::Toolset;
+use crate::toolset::{Toolset, serialize_tool_options};
 use crate::ui::style;
 pub use deps::{Deps, TaskKey};
 use task_dep::TaskDep;
@@ -101,19 +101,10 @@ impl TaskToolValue {
         match self {
             TaskToolValue::String(version) => format!("{tool}@{version}"),
             TaskToolValue::Map(map) => {
-                if map.opts.is_empty() {
-                    format!("{tool}@{}", map.version)
+                if let Some(opts_str) = serialize_tool_options(map.opts.iter()) {
+                    format!("{tool}[{opts_str}]@{}", map.version)
                 } else {
-                    let opts_str = map
-                        .opts
-                        .iter()
-                        .map(|(k, v)| match v {
-                            toml::Value::String(s) => format!("{k}={s}"),
-                            _ => format!("{k}={v}"),
-                        })
-                        .collect::<Vec<_>>()
-                        .join(",");
-                    format!("{tool}[{}]@{}", opts_str, map.version)
+                    format!("{tool}@{}", map.version)
                 }
             }
         }
@@ -2812,6 +2803,62 @@ echo "test"
             task.tools.get("1password-cli").unwrap(),
             &TaskToolValue::String("2.0".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn test_to_tool_spec_round_trips_string_opts() {
+        use indexmap::IndexMap;
+
+        use crate::cli::args::ToolArg;
+        use crate::config::Config;
+
+        use super::{TaskToolValue, TaskToolValueMap};
+
+        let _config = Config::get().await.unwrap();
+
+        let mut opts = IndexMap::new();
+        opts.insert(
+            "query".to_string(),
+            toml::Value::String("first,second=value".to_string()),
+        );
+        opts.insert(
+            "targets".to_string(),
+            toml::Value::Array(vec![toml::Value::String("x86_64".to_string())]),
+        );
+
+        let tool = TaskToolValue::Map(TaskToolValueMap {
+            version: "1.0.0".to_string(),
+            opts,
+        });
+
+        let spec = tool.to_tool_spec("http:hello");
+        assert_eq!(spec, r#"http:hello[query="first,second=value"]@1.0.0"#);
+
+        let parsed: ToolArg = spec.parse().unwrap();
+        let parsed_opts = parsed.ba.opts();
+        assert_eq!(parsed_opts.get("query"), Some("first,second=value"));
+        assert!(!parsed_opts.contains_key("targets"));
+        assert!(!parsed_opts.contains_key("second"));
+    }
+
+    #[test]
+    fn test_to_tool_spec_omits_empty_brackets_for_complex_opts() {
+        use indexmap::IndexMap;
+
+        use super::{TaskToolValue, TaskToolValueMap};
+
+        let mut opts = IndexMap::new();
+        opts.insert(
+            "targets".to_string(),
+            toml::Value::Array(vec![toml::Value::String("x86_64".to_string())]),
+        );
+
+        let tool = TaskToolValue::Map(TaskToolValueMap {
+            version: "1.0.0".to_string(),
+            opts,
+        });
+
+        assert_eq!(tool.to_tool_spec("cross"), "cross@1.0.0");
     }
 
     #[test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2841,6 +2841,44 @@ echo "test"
         assert!(!parsed_opts.contains_key("second"));
     }
 
+    #[tokio::test]
+    async fn test_to_tool_spec_round_trips_quoted_string_opts() {
+        use indexmap::IndexMap;
+
+        use crate::cli::args::ToolArg;
+        use crate::config::Config;
+
+        use super::{TaskToolValue, TaskToolValueMap};
+
+        let _config = Config::get().await.unwrap();
+
+        let mut opts = IndexMap::new();
+        opts.insert(
+            "pattern".to_string(),
+            toml::Value::String(r#"a"b"#.to_string()),
+        );
+        opts.insert(
+            "bin_path".to_string(),
+            toml::Value::String("bin[debug]".to_string()),
+        );
+
+        let tool = TaskToolValue::Map(TaskToolValueMap {
+            version: "1.0.0".to_string(),
+            opts,
+        });
+
+        let spec = tool.to_tool_spec("http:hello");
+        assert_eq!(
+            spec,
+            r#"http:hello[pattern='a"b',bin_path="bin[debug]"]@1.0.0"#
+        );
+
+        let parsed: ToolArg = spec.parse().unwrap();
+        let parsed_opts = parsed.ba.opts();
+        assert_eq!(parsed_opts.get("pattern"), Some(r#"a"b"#));
+        assert_eq!(parsed_opts.get("bin_path"), Some("bin[debug]"));
+    }
+
     #[test]
     fn test_to_tool_spec_omits_empty_brackets_for_complex_opts() {
         use indexmap::IndexMap;

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -33,7 +33,9 @@ pub use tool_request_set::{ToolRequestSet, ToolRequestSetBuilder};
 pub use tool_source::ToolSource;
 pub use tool_version::{ResolveOptions, ToolVersion};
 pub use tool_version_list::ToolVersionList;
-pub use tool_version_options::{EPHEMERAL_OPT_KEYS, ToolVersionOptions, parse_tool_options};
+pub use tool_version_options::{
+    EPHEMERAL_OPT_KEYS, ToolVersionOptions, parse_tool_options, serialize_tool_options,
+};
 
 mod builder;
 pub mod env_cache;

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -287,13 +287,15 @@ fn parse_tool_options_manual(s: &str) -> ToolVersionOptions {
 fn split_tool_option_segments(s: &str) -> Vec<String> {
     let mut segments = Vec::new();
     let mut current = String::new();
-    let mut in_quotes = false;
+    let mut in_double_quotes = false;
+    let mut in_single_quotes = false;
     let mut escaped = false;
 
     for ch in s.chars() {
         match ch {
-            '"' if !escaped => in_quotes = !in_quotes,
-            ',' if !in_quotes => {
+            '"' if !escaped && !in_single_quotes => in_double_quotes = !in_double_quotes,
+            '\'' if !in_double_quotes => in_single_quotes = !in_single_quotes,
+            ',' if !in_double_quotes && !in_single_quotes => {
                 segments.push(current);
                 current = String::new();
                 escaped = false;
@@ -303,7 +305,7 @@ fn split_tool_option_segments(s: &str) -> Vec<String> {
         }
 
         current.push(ch);
-        escaped = in_quotes && ch == '\\' && !escaped;
+        escaped = in_double_quotes && ch == '\\' && !escaped;
     }
 
     segments.push(current);
@@ -313,7 +315,10 @@ fn split_tool_option_segments(s: &str) -> Vec<String> {
 fn parse_tool_option_value(raw: &str) -> toml::Value {
     let trimmed = raw.trim();
 
-    if trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2 {
+    if ((trimmed.starts_with('"') && trimmed.ends_with('"'))
+        || (trimmed.starts_with('\'') && trimmed.ends_with('\'')))
+        && trimmed.len() >= 2
+    {
         let toml_str = format!("_x_ = {trimmed}");
         if let Ok(value) = toml::from_str::<toml::Value>(&toml_str)
             && let Some(parsed) = value.get("_x_")
@@ -502,6 +507,14 @@ mod tests {
         let reparsed = parse_tool_options(&serialized);
         assert_eq!(reparsed.get("pattern"), Some(r#"a"b"#));
         assert_eq!(reparsed.get("bin_path"), Some("bin[debug]"));
+    }
+
+    #[test]
+    fn test_parse_tool_options_manual_supports_single_quoted_literals() {
+        let reparsed = parse_tool_options(r#"pattern='a"b',bin_path=bin"#);
+
+        assert_eq!(reparsed.get("pattern"), Some(r#"a"b"#));
+        assert_eq!(reparsed.get("bin_path"), Some("bin"));
     }
 
     #[test]

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -195,6 +195,36 @@ pub fn parse_tool_options(s: &str) -> ToolVersionOptions {
     parse_tool_options_manual(s)
 }
 
+/// Serialize tool options to the bracketed `key=value,key2=value2` form used by
+/// task tool specs and backend args.
+///
+/// Complex values that cannot be round-tripped through that syntax (arrays and
+/// tables) are omitted entirely, matching `BackendArg::full_with_opts()`.
+pub fn serialize_tool_options<'a, I>(opts: I) -> Option<String>
+where
+    I: IntoIterator<Item = (&'a String, &'a toml::Value)>,
+{
+    let serialized = opts
+        .into_iter()
+        .filter_map(|(key, value)| serialize_tool_option(key, value))
+        .collect::<Vec<_>>();
+
+    (!serialized.is_empty()).then(|| serialized.join(","))
+}
+
+fn serialize_tool_option(key: &str, value: &toml::Value) -> Option<String> {
+    match value {
+        toml::Value::Table(_) | toml::Value::Array(_) => None,
+        // Comma-containing strings must be TOML-quoted so they round-trip
+        // through `parse_tool_options()` without being split into fake keys.
+        toml::Value::String(s) if s.contains(',') => {
+            Some(format!("{key}={}", toml::Value::String(s.clone())))
+        }
+        toml::Value::String(s) => Some(format!("{key}={s}")),
+        _ => Some(format!("{key}={value}")),
+    }
+}
+
 /// Try parsing an options string as a TOML inline table.
 /// Returns `Some(opts)` if the string is valid TOML, `None` otherwise.
 fn try_parse_as_toml(s: &str) -> Option<ToolVersionOptions> {
@@ -227,11 +257,11 @@ fn try_parse_as_toml(s: &str) -> Option<ToolVersionOptions> {
 fn parse_tool_options_manual(s: &str) -> ToolVersionOptions {
     let mut tvo = ToolVersionOptions::default();
     let mut current_key: Option<String> = None;
-    for opt in s.split(',') {
+    for opt in split_tool_option_segments(s) {
         if let Some((k, v)) = opt.split_once('=') {
             if !k.trim().is_empty() {
                 tvo.opts
-                    .insert(k.trim().to_string(), toml::Value::String(v.to_string()));
+                    .insert(k.trim().to_string(), parse_tool_option_value(v));
                 current_key = Some(k.trim().to_string());
             }
         } else if !opt.is_empty() {
@@ -241,11 +271,55 @@ fn parse_tool_options_manual(s: &str) -> ToolVersionOptions {
                 && let toml::Value::String(s) = existing_value
             {
                 s.push(',');
-                s.push_str(opt);
+                s.push_str(&opt);
             }
         }
     }
     tvo
+}
+
+fn split_tool_option_segments(s: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut escaped = false;
+
+    for ch in s.chars() {
+        match ch {
+            '"' if !escaped => in_quotes = !in_quotes,
+            ',' if !in_quotes => {
+                segments.push(current);
+                current = String::new();
+                escaped = false;
+                continue;
+            }
+            _ => {}
+        }
+
+        current.push(ch);
+        escaped = in_quotes && ch == '\\' && !escaped;
+        if ch != '\\' {
+            escaped = false;
+        }
+    }
+
+    segments.push(current);
+    segments
+}
+
+fn parse_tool_option_value(raw: &str) -> toml::Value {
+    let trimmed = raw.trim();
+
+    if trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2 {
+        let toml_str = format!("_x_ = {trimmed}");
+        if let Ok(value) = toml::from_str::<toml::Value>(&toml_str)
+            && let Some(parsed) = value.get("_x_")
+        {
+            return parsed.clone();
+        }
+    }
+
+    toml::Value::String(raw.to_string())
 }
 
 #[cfg(test)]
@@ -332,6 +406,19 @@ mod tests {
                 ..Default::default()
             },
         );
+        t(
+            r#"query="first,second=value",bin_path=bin"#,
+            ToolVersionOptions {
+                opts: [
+                    ("query".to_string(), s("first,second=value")),
+                    ("bin_path".to_string(), s("bin")),
+                ]
+                .iter()
+                .cloned()
+                .collect(),
+                ..Default::default()
+            },
+        );
     }
 
     #[test]
@@ -367,6 +454,43 @@ mod tests {
         let opts = parse_tool_options(input);
         assert_eq!(opts.get("bin_path"), Some("bin"));
         assert_eq!(opts.get("strip_components"), Some("1"));
+    }
+
+    #[test]
+    fn test_serialize_tool_options_quotes_comma_strings() {
+        let mut opts = IndexMap::new();
+        opts.insert(
+            "query".to_string(),
+            toml::Value::String("first,second=value".to_string()),
+        );
+        opts.insert(
+            "bin_path".to_string(),
+            toml::Value::String("bin".to_string()),
+        );
+
+        assert_eq!(
+            serialize_tool_options(opts.iter()),
+            Some(r#"query="first,second=value",bin_path=bin"#.to_string())
+        );
+        assert_eq!(
+            parse_tool_options(serialize_tool_options(opts.iter()).unwrap().as_str()).get("query"),
+            Some("first,second=value")
+        );
+    }
+
+    #[test]
+    fn test_serialize_tool_options_skips_complex_values_and_empty_output() {
+        let mut opts = IndexMap::new();
+        opts.insert(
+            "targets".to_string(),
+            toml::Value::Array(vec![toml::Value::String("x86_64".to_string())]),
+        );
+        opts.insert(
+            "platforms".to_string(),
+            toml::Value::Table(toml::map::Map::new()),
+        );
+
+        assert_eq!(serialize_tool_options(opts.iter()), None);
     }
 
     #[test]

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -228,11 +228,7 @@ fn serialize_tool_option(key: &str, value: &toml::Value) -> Option<String> {
 }
 
 fn string_requires_tool_option_quotes(s: &str) -> bool {
-    s.contains(',')
-        || s.contains('"')
-        || s.contains('\'')
-        || s.contains('[')
-        || s.contains(']')
+    s.contains(',') || s.contains('"') || s.contains('\'') || s.contains('[') || s.contains(']')
 }
 
 /// Try parsing an options string as a TOML inline table.
@@ -516,7 +512,10 @@ mod tests {
     #[test]
     fn test_serialize_tool_options_preserves_single_quote_wrapped_strings() {
         let mut opts = IndexMap::new();
-        opts.insert("pattern".to_string(), toml::Value::String("'hi'".to_string()));
+        opts.insert(
+            "pattern".to_string(),
+            toml::Value::String("'hi'".to_string()),
+        );
         opts.insert(
             "bin_path".to_string(),
             toml::Value::String("bin".to_string()),

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -215,14 +215,20 @@ where
 fn serialize_tool_option(key: &str, value: &toml::Value) -> Option<String> {
     match value {
         toml::Value::Table(_) | toml::Value::Array(_) => None,
-        // Comma-containing strings must be TOML-quoted so they round-trip
-        // through `parse_tool_options()` without being split into fake keys.
-        toml::Value::String(s) if s.contains(',') => {
+        // Strings that contain delimiters or quotes must be TOML-quoted so they
+        // round-trip through both the TOML parser and the legacy manual parser.
+        // Brackets also need quoting because `split_bracketed_opts()` uses a
+        // regex to peel off the outer `[...]` payload from backend args.
+        toml::Value::String(s) if string_requires_tool_option_quotes(s) => {
             Some(format!("{key}={}", toml::Value::String(s.clone())))
         }
         toml::Value::String(s) => Some(format!("{key}={s}")),
         _ => Some(format!("{key}={value}")),
     }
+}
+
+fn string_requires_tool_option_quotes(s: &str) -> bool {
+    s.contains(',') || s.contains('"') || s.contains('[') || s.contains(']')
 }
 
 /// Try parsing an options string as a TOML inline table.
@@ -298,9 +304,6 @@ fn split_tool_option_segments(s: &str) -> Vec<String> {
 
         current.push(ch);
         escaped = in_quotes && ch == '\\' && !escaped;
-        if ch != '\\' {
-            escaped = false;
-        }
     }
 
     segments.push(current);
@@ -476,6 +479,29 @@ mod tests {
             parse_tool_options(serialize_tool_options(opts.iter()).unwrap().as_str()).get("query"),
             Some("first,second=value")
         );
+    }
+
+    #[test]
+    fn test_serialize_tool_options_quotes_strings_with_quotes_or_brackets() {
+        let mut opts = IndexMap::new();
+        opts.insert(
+            "pattern".to_string(),
+            toml::Value::String(r#"a"b"#.to_string()),
+        );
+        opts.insert(
+            "bin_path".to_string(),
+            toml::Value::String("bin[debug]".to_string()),
+        );
+
+        let serialized = serialize_tool_options(opts.iter()).unwrap();
+        assert_eq!(
+            serialized,
+            r#"pattern='a"b',bin_path="bin[debug]""#.to_string()
+        );
+
+        let reparsed = parse_tool_options(&serialized);
+        assert_eq!(reparsed.get("pattern"), Some(r#"a"b"#));
+        assert_eq!(reparsed.get("bin_path"), Some("bin[debug]"));
     }
 
     #[test]

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -228,7 +228,11 @@ fn serialize_tool_option(key: &str, value: &toml::Value) -> Option<String> {
 }
 
 fn string_requires_tool_option_quotes(s: &str) -> bool {
-    s.contains(',') || s.contains('"') || s.contains('[') || s.contains(']')
+    s.contains(',')
+        || s.contains('"')
+        || s.contains('\'')
+        || s.contains('[')
+        || s.contains(']')
 }
 
 /// Try parsing an options string as a TOML inline table.
@@ -507,6 +511,22 @@ mod tests {
         let reparsed = parse_tool_options(&serialized);
         assert_eq!(reparsed.get("pattern"), Some(r#"a"b"#));
         assert_eq!(reparsed.get("bin_path"), Some("bin[debug]"));
+    }
+
+    #[test]
+    fn test_serialize_tool_options_preserves_single_quote_wrapped_strings() {
+        let mut opts = IndexMap::new();
+        opts.insert("pattern".to_string(), toml::Value::String("'hi'".to_string()));
+        opts.insert(
+            "bin_path".to_string(),
+            toml::Value::String("bin".to_string()),
+        );
+
+        let serialized = serialize_tool_options(opts.iter()).unwrap();
+        let reparsed = parse_tool_options(&serialized);
+
+        assert_eq!(reparsed.get("pattern"), Some("'hi'"));
+        assert_eq!(reparsed.get("bin_path"), Some("bin"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a shared `serialize_tool_options()` helper for backend and task tool specs
- quote comma-containing string values so bracketed opts can round-trip safely
- omit empty brackets when all remaining opts are filtered out
- teach the legacy manual parser to respect quoted commas so mixed quoted/unquoted payloads still parse correctly

## Root cause
`BackendArg::full_with_opts()` and `TaskToolValue::to_tool_spec()` both hand-rolled the same `key=value` formatting.

That formatting had two round-trip problems:
1. comma-containing string values could be split into fake extra keys on the way back in
2. when every remaining opt was an Array/Table, the task path could emit malformed empty brackets

While validating the serializer fix locally, there was one more shared-boundary issue: selectively quoting only the comma-containing value still hit the legacy manual parser whenever sibling string values stayed unquoted, so the manual parser also needed to stop splitting on commas inside quotes.

## Testing
- `cargo test serialize_tool_options`
- `cargo test full_with_opts`
- `cargo test to_tool_spec`
- `cargo test parse_tool_options`

All runs were executed locally with `RUSTFLAGS=-C debuginfo=0` and `CARGO_INCREMENTAL=0` because this Windows machine was short on disk space during the initial build.
