### PR TITLE
fix: Use sigstore-rust for attestation verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,17 +106,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -291,45 +280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "asn1-rs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom 7.1.3",
- "num-traits",
- "rusticata-macros",
- "thiserror 2.0.18",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,17 +380,6 @@ name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "async-spooled-tempfile"
@@ -945,18 +884,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,7 +952,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1507,6 +1434,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmpv2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961b955a666e25ee5a1091d219128d6e6401e3dab84efb1a2bf6b4035d797b39"
+dependencies = [
+ "crmf",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
+name = "cms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "coalesced_map"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,7 +1527,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1693,26 +1644,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "const_format"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
 
 [[package]]
 name = "constant_time_eq"
@@ -1843,6 +1774,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crmf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fe21b96d5b87f5de4b5b7202ec41c00110ac817ce6728fe75fb2fe5962ed92"
+dependencies = [
+ "cms",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,18 +1843,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,21 +1860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "crypto_secretbox"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
-dependencies = [
- "aead",
- "cipher",
- "generic-array",
- "poly1305",
- "salsa20",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2001,16 +1917,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -2027,20 +1933,6 @@ checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core 0.23.0",
  "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2067,17 +1959,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
  "syn 2.0.117",
 ]
 
@@ -2131,12 +2012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,12 +2028,6 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-
-[[package]]
-name = "decoded-char"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5440d1dc8ea7cae44cda3c64568db29bfa2434aba51ae66a50c00488841a65a3"
 
 [[package]]
 name = "deflate64"
@@ -2193,20 +2062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der-parser"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom 7.1.3",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
 name = "der_derive"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,37 +2090,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -2354,7 +2178,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2435,20 +2259,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,7 +2276,6 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
  "signature",
@@ -2479,27 +2288,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "elsa"
@@ -2643,7 +2431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2732,16 +2520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,7 +2534,7 @@ dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
  "thiserror 2.0.18",
- "typed-path 0.12.3",
+ "typed-path",
  "url",
 ]
 
@@ -3100,7 +2878,6 @@ dependencies = [
  "serde",
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -3144,18 +2921,6 @@ dependencies = [
  "wasip2",
  "wasip3",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4136,17 +3901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4208,9 +3962,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4326,15 +4077,6 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
-]
-
-[[package]]
-name = "http-auth"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4553,7 +4295,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4639,7 +4381,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5017,7 +4759,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5060,36 +4802,6 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5143,18 +4855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-number"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479dfd2ad8e4b4ae076b031f72ef2f3791f65e2a0f51e5f3408dbf716c4c2f82"
-dependencies = [
- "lexical",
- "ryu-js",
- "serde",
- "smallvec",
-]
-
-[[package]]
 name = "json-patch"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5164,25 +4864,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "json-syntax"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044a68aba3f96d712f492b72be25e10f96201eaaca3207a7d6e68d6d5105fda9"
-dependencies = [
- "decoded-char",
- "hashbrown 0.12.3",
- "indexmap 1.9.3",
- "json-number",
- "locspan",
- "locspan-derive",
- "ryu-js",
- "serde",
- "smallstr",
- "smallvec",
- "utf8-decode",
 ]
 
 [[package]]
@@ -5202,22 +4883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "jwt"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
-dependencies = [
- "base64 0.13.1",
- "crypto-common 0.1.7",
- "digest 0.10.7",
- "hmac",
- "serde",
- "serde_json",
- "sha2 0.10.9",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5237,7 +4903,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5297,72 +4963,6 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "lexical"
-version = "7.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc8a009b2ff1f419ccc62706f04fe0ca6e67b37460513964a3dfdb919bb37d6"
-dependencies = [
- "lexical-core",
-]
-
-[[package]]
-name = "lexical-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
-dependencies = [
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
-
-[[package]]
-name = "lexical-write-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
-dependencies = [
- "lexical-util",
-]
 
 [[package]]
 name = "libbz2-rs-sys"
@@ -5451,24 +5051,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
-]
-
-[[package]]
-name = "locspan"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33890449fcfac88e94352092944bf321f55e5deb4e289a6f51c87c55731200a0"
-
-[[package]]
-name = "locspan-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88991223b049a3d29ca1f60c05639581336a0f3ee4bf8a659dddecc11c4961a"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5687,16 +5269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5794,6 +5366,7 @@ dependencies = [
  "miette",
  "minisign-verify",
  "mise-interactive-config",
+ "mise-sigstore",
  "mockito",
  "netrc-rs",
  "nix 0.31.2",
@@ -5833,7 +5406,6 @@ dependencies = [
  "shell-words",
  "shellexpand",
  "signal-hook 0.3.18",
- "sigstore-verification",
  "siphasher",
  "strum 0.27.2",
  "sys-info",
@@ -5882,6 +5454,23 @@ dependencies = [
 [[package]]
 name = "mise-shim"
 version = "2026.2.5"
+
+[[package]]
+name = "mise-sigstore"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sigstore-trust-root",
+ "sigstore-types",
+ "sigstore-verify",
+ "snap",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "mlua"
@@ -5959,12 +5548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5980,12 +5563,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netrc-rs"
@@ -6079,7 +5656,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6195,120 +5772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "oauth2"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "getrandom 0.2.17",
- "http 1.4.0",
- "rand 0.8.5",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags",
- "objc2",
-]
-
-[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "oci-client"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
-dependencies = [
- "bytes",
- "chrono",
- "futures-util",
- "http 1.4.0",
- "http-auth",
- "jwt",
- "lazy_static",
- "oci-spec",
- "olpc-cjson",
- "regex",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "unicase",
-]
-
-[[package]]
-name = "oci-spec"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
-dependencies = [
- "const_format",
- "derive_builder",
- "getset",
- "regex",
- "serde",
- "serde_json",
- "strum 0.27.2",
- "strum_macros 0.27.2",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
-dependencies = [
- "asn1-rs",
-]
-
-[[package]]
-name = "olpc-cjson"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
-dependencies = [
- "serde",
- "serde_json",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -6328,37 +5797,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openidconnect"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
-dependencies = [
- "base64 0.21.7",
- "chrono",
- "dyn-clone",
- "ed25519-dalek",
- "hmac",
- "http 1.4.0",
- "itertools 0.10.5",
- "log",
- "oauth2",
- "p256",
- "p384",
- "rand 0.8.5",
- "rsa",
- "serde",
- "serde-value",
- "serde_json",
- "serde_path_to_error",
- "serde_plain",
- "serde_with",
- "sha2 0.10.9",
- "subtle",
- "thiserror 1.0.69",
- "url",
-]
 
 [[package]]
 name = "openssl"
@@ -6435,7 +5873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6449,30 +5887,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "papergrid"
@@ -6526,17 +5940,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6566,7 +5969,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59953de32542217edd1cc5fd52ac7ca2de57d7613a3a3e569370e5ea09231df3"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "fs-err",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -6747,29 +6150,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes",
- "cbc",
- "der",
- "pbkdf2",
- "scrypt",
- "sha2 0.10.9",
- "spki",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
- "pkcs5",
- "rand_core 0.6.4",
  "spki",
 ]
 
@@ -6893,39 +6279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6987,92 +6340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
-dependencies = [
- "heck",
- "itertools 0.12.1",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 2.0.117",
- "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "prost-reflect"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
-dependencies = [
- "base64 0.22.1",
- "prost",
- "prost-reflect-derive",
- "prost-types",
- "serde",
- "serde-value",
-]
-
-[[package]]
-name = "prost-reflect-build"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8214ae2c30bbac390db0134d08300e770ef89b6d4e5abf855e8d300eded87e28"
-dependencies = [
- "prost-build",
- "prost-reflect",
-]
-
-[[package]]
-name = "prost-reflect-derive"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6d90e29fa6c0d13c2c19ba5e4b3fb0efbf5975d27bcf4e260b7b15455bcabe"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
-dependencies = [
- "prost",
-]
-
-[[package]]
 name = "purl"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7121,7 +6388,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.38",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7159,9 +6426,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7326,7 +6593,7 @@ version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e41ab6700748842122199ae89c110bf152b0c95d0fcf0bdf9c6fd49255f05533"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "anyhow",
  "dashmap 6.1.0",
  "digest 0.10.7",
@@ -7359,7 +6626,7 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809c0147f00c67143f90a1e01870a8856b68d3072dbe91cdf78c4dbab44a944e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "chrono",
  "core-foundation 0.10.1",
  "dirs",
@@ -7391,7 +6658,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
- "typed-path 0.12.3",
+ "typed-path",
  "url",
 ]
 
@@ -7548,7 +6815,7 @@ version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ec1a9f8de181bb4e5e62060f48d3c0a66d69dd2b93119c7fb77b0e242ffcc"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "anyhow",
  "async-compression",
  "async-fd-lock",
@@ -7808,7 +7075,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -7902,7 +7168,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a085c6cecab01bf88df532b7a03f066d5ab92e461bf4614a9de13f562eb163"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bitvec",
  "elsa",
  "event-listener",
@@ -7920,16 +7186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
  "rand 0.9.4",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -8131,15 +7387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom 7.1.3",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8162,7 +7409,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8184,7 +7431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -8223,7 +7469,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.21.1",
+ "jni",
  "log",
  "once_cell",
  "rustls 0.23.38",
@@ -8233,7 +7479,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8290,9 +7536,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "ryu-js"
-version = "0.2.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "salsa20"
@@ -8386,7 +7632,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
- "password-hash",
  "pbkdf2",
  "salsa20",
  "sha2 0.10.9",
@@ -8407,20 +7652,6 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "seccompiler"
@@ -8617,23 +7848,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
+name = "serde_json_canonicalizer"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
 dependencies = [
- "itoa",
+ "ryu-js",
  "serde",
- "serde_core",
-]
-
-[[package]]
-name = "serde_plain"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
-dependencies = [
- "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -8918,7 +8140,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -8933,114 +8155,163 @@ dependencies = [
 ]
 
 [[package]]
-name = "sigstore"
-version = "0.13.0"
+name = "sigstore-bundle"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bba786054331bdc89e90f74373b68a6c3b63c9754cf20e3a4a629d0165fe38"
+checksum = "5e1c326f5796df635de915cc1b2d29485423df10a4997be6103091772f503451"
 dependencies = [
- "async-trait",
- "aws-lc-rs",
  "base64 0.22.1",
- "cfg-if",
- "chrono",
- "const-oid 0.9.6",
- "crypto_secretbox",
- "digest 0.10.7",
- "ecdsa",
- "ed25519",
- "ed25519-dalek",
- "elliptic-curve",
- "futures",
- "futures-util",
  "hex",
- "json-syntax",
- "oci-client",
- "olpc-cjson",
- "openidconnect",
- "p256",
- "p384",
- "pem",
- "pkcs1",
- "pkcs8",
- "rand 0.8.5",
- "regex",
- "reqwest 0.12.28",
- "ring",
- "rsa",
- "rustls-pki-types",
- "rustls-webpki 0.103.12",
- "scrypt",
  "serde",
  "serde_json",
- "serde_repr",
- "serde_with",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-tsa",
+ "sigstore-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-crypto"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6271208173601a0f058f5fb5354561905a7ead9b4185d85a6c2ed97fbdd31338"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "const-oid 0.9.6",
+ "der",
+ "digest 0.10.7",
+ "pem",
+ "rand_core 0.10.1",
  "sha2 0.10.9",
  "signature",
- "sigstore_protobuf_specs",
+ "sigstore-types",
+ "spki",
  "thiserror 2.0.18",
- "tls_codec",
- "tokio",
- "tokio-util",
- "tough",
  "tracing",
- "url",
- "webbrowser",
  "x509-cert",
- "zeroize",
 ]
 
 [[package]]
-name = "sigstore-protobuf-specs-derive"
-version = "0.0.1"
+name = "sigstore-merkle"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35"
+checksum = "692e1c1037124c0305e6e342c6a5fa180a31d6ce0eafc0e6c8f001d200083f8d"
 dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "sigstore-verification"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b0ce9ca6304f85b3a089d403441695cc5428beb9cf5c08cc04ea0841516fd"
-dependencies = [
- "async-trait",
  "base64 0.22.1",
- "ed25519-dalek",
  "hex",
- "log",
- "p256",
- "p384",
+ "sigstore-crypto",
+ "sigstore-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-rekor"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21abbf2ab10930dd2eb77cbc4c24b1efa6da89f6f0dce9b28b7c1362e7b80da8"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
- "sha2 0.11.0",
- "signature",
- "sigstore",
- "snap",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-types",
  "thiserror 2.0.18",
- "tokio",
- "x509-parser",
+ "url",
 ]
 
 [[package]]
-name = "sigstore_protobuf_specs"
-version = "0.5.1"
+name = "sigstore-trust-root"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd627b4d5240ac660de3357b5d0156d5c63b872be1deae5046c3c8eb65d488e2"
+checksum = "45f9d2f2dc33e04c80cfd5f11c93b64f0a2555b1d7f92b5aa16307266f05ad8c"
 dependencies = [
- "anyhow",
- "glob",
- "prost",
- "prost-build",
- "prost-reflect",
- "prost-reflect-build",
- "prost-types",
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "rustls-pki-types",
  "serde",
  "serde_json",
- "sigstore-protobuf-specs-derive",
- "which 8.0.2",
+ "sigstore-crypto",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "x509-cert",
+]
+
+[[package]]
+name = "sigstore-tsa"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43c677d430038c216b4f6368efc8cea42f35eca4d20fe5fcf51133d71b3b51b"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "chrono",
+ "cmpv2",
+ "cms",
+ "const-oid 0.9.6",
+ "der",
+ "hex",
+ "rand 0.10.1",
+ "reqwest 0.13.2",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.12",
+ "sigstore-crypto",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "x509-cert",
+ "x509-tsp",
+]
+
+[[package]]
+name = "sigstore-types"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47aa6bca8f329e06c7ccb5b9f9be82b165b2be063396be0ee57b13402b994744"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "pem",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-verify"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44caf1ea504259cf70c7c16527d8a3fa07bd9374ba4e59ec247e7d13a7f2cb8"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "cms",
+ "const-oid 0.9.6",
+ "hex",
+ "pem",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.12",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sigstore-bundle",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-trust-root",
+ "sigstore-tsa",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "tls_codec",
+ "tracing",
+ "x509-cert",
 ]
 
 [[package]]
@@ -9061,16 +8332,6 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "value-trait",
-]
-
-[[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
 ]
 
 [[package]]
@@ -9117,45 +8378,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallstr"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
-dependencies = [
- "serde",
- "smallvec",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "snafu"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
-dependencies = [
- "futures-core",
- "pin-project",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -9418,7 +8646,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c221a50eef1a5493074f11ca1ed62bef28c05a4d925002944cc686b2e783a5b3"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arc-swap",
  "either",
  "globset",
@@ -9454,7 +8682,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9495,7 +8723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9831,41 +9059,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
-name = "tough"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88d0ee9525696569cc2af5d46f8a739028c0268895071e0386957195b0c9161"
-dependencies = [
- "async-recursion",
- "async-trait",
- "aws-lc-rs",
- "bytes",
- "chrono",
- "dyn-clone",
- "futures",
- "futures-core",
- "globset",
- "hex",
- "log",
- "olpc-cjson",
- "pem",
- "percent-encoding",
- "reqwest 0.12.28",
- "rustls 0.23.38",
- "serde",
- "serde_json",
- "serde_plain",
- "snafu",
- "tempfile",
- "tokio",
- "tokio-util",
- "typed-path 0.9.3",
- "untrusted 0.7.1",
- "url",
- "walkdir",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9921,7 +9114,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -10001,12 +9193,6 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.2",
 ]
-
-[[package]]
-name = "typed-path"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
 
 [[package]]
 name = "typed-path"
@@ -10099,12 +9285,6 @@ dependencies = [
  "serde",
  "tinystr",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bom"
@@ -10229,12 +9409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8-decode"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10320,12 +9494,12 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "log",
+ "mise-sigstore",
  "mlua",
  "once_cell",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sigstore-verification",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -10540,22 +9714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webbrowser"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
-dependencies = [
- "core-foundation 0.10.1",
- "jni 0.22.4",
- "log",
- "ndk-context",
- "objc2",
- "objc2-foundation",
- "url",
- "web-sys",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10622,7 +9780,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11330,20 +10488,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-parser"
-version = "0.18.1"
+name = "x509-tsp"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+checksum = "f5ceece934a21607055b7ac5c25adb56a2ff559804b10705dc674d1d838c15e1"
 dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom 7.1.3",
- "oid-registry",
- "rusticata-macros",
- "thiserror 2.0.18",
- "time",
+ "cmpv2",
+ "cms",
+ "der",
 ]
 
 [[package]]
@@ -11600,7 +10752,7 @@ dependencies = [
  "ppmd-rust",
  "sha1 0.10.6",
  "time",
- "typed-path 0.12.3",
+ "typed-path",
  "zeroize",
  "zopfli",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/aqua-registry",
   "crates/mise-interactive-config",
   "crates/mise-shim",
+  "crates/mise-sigstore",
 ]
 
 [package]
@@ -99,7 +100,7 @@ expr-lang = "1"
 eyre = "0.6"
 filetime = "0.2"
 flate2 = "1"
-sigstore-verification = { version = "0.2", default-features = false }
+mise-sigstore = { path = "crates/mise-sigstore", default-features = false }
 fslock = "0.2.1"
 fuzzy-matcher = "0.3"
 gix = { version = "<1", features = ["worktree-mutation"] }
@@ -250,7 +251,7 @@ native-tls = [
   "reqwest/native-tls",
   "rattler/native-tls",
   "rattler_repodata_gateway/native-tls",
-  "sigstore-verification/native-tls",
+  "mise-sigstore/native-tls",
   "ubi/native-tls",
   "vfox/native-tls",
   "xx/native-tls",
@@ -260,7 +261,7 @@ rustls = [
   "reqwest/rustls-tls",
   "rattler/rustls-tls",
   "rattler_repodata_gateway/rustls-tls",
-  "sigstore-verification/rustls",
+  "mise-sigstore/rustls",
   "ubi/rustls-tls",
   "vfox/rustls",
   "xx/rustls",
@@ -270,7 +271,7 @@ rustls-native-roots = [
   "reqwest/rustls-tls-native-roots",
   "rattler/rustls-tls",
   "rattler_repodata_gateway/rustls-tls",
-  "sigstore-verification/rustls-native-roots",
+  "mise-sigstore/rustls-native-roots",
   "ubi/rustls-tls-native-roots",
   "vfox/rustls-native-roots",
   "xx/rustls-native-roots",

--- a/crates/mise-sigstore/Cargo.toml
+++ b/crates/mise-sigstore/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "mise-sigstore"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Sigstore verification helpers for mise"
+repository = "https://github.com/jdx/mise"
+
+[dependencies]
+hex = "0.4"
+base64 = "0.22"
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+sigstore-trust-root = { version = "0.6.4", default-features = false }
+sigstore-types = { version = "0.6.4", default-features = false }
+sigstore-verify = { version = "0.6.4", default-features = false }
+snap = "1"
+thiserror = "2"
+
+[features]
+default = ["rustls"]
+native-tls = ["reqwest/native-tls", "sigstore-verify/native-tls"]
+rustls = ["reqwest/rustls-tls", "sigstore-verify/rustls"]
+rustls-native-roots = ["reqwest/rustls-tls-native-roots", "sigstore-verify/rustls"]

--- a/crates/mise-sigstore/Cargo.toml
+++ b/crates/mise-sigstore/Cargo.toml
@@ -23,4 +23,7 @@ thiserror = "2"
 default = ["rustls"]
 native-tls = ["reqwest/native-tls", "sigstore-verify/native-tls"]
 rustls = ["reqwest/rustls-tls", "sigstore-verify/rustls"]
-rustls-native-roots = ["reqwest/rustls-tls-native-roots", "sigstore-verify/rustls"]
+rustls-native-roots = [
+  "reqwest/rustls-tls-native-roots",
+  "sigstore-verify/rustls",
+]

--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -43,7 +43,11 @@ pub async fn has_github_attestations(
     token: Option<&str>,
 ) -> Result<bool, AttestationError> {
     let digest = digest.strip_prefix("sha256:").unwrap_or(digest);
-    let response = fetch_github_attestations(owner, repo, digest, token).await?;
+    let response = match fetch_github_attestations(owner, repo, digest, token).await {
+        Ok(response) => response,
+        Err(AttestationError::NoAttestations) => return Ok(false),
+        Err(e) => return Err(e),
+    };
     Ok(!response.attestations.is_empty())
 }
 
@@ -305,7 +309,12 @@ fn verify_workflow_identity(
             "signing certificate did not include an identity".to_string(),
         ));
     };
-    if actual == expected || actual.contains(expected) || expected.contains(actual) {
+    if expected.is_empty() || actual.is_empty() {
+        return Err(AttestationError::Verification(
+            "signing certificate identity or expected workflow is empty".to_string(),
+        ));
+    }
+    if actual == expected || actual.contains(expected) {
         Ok(())
     } else {
         Err(AttestationError::Verification(format!(

--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -1,0 +1,345 @@
+use std::fs;
+use std::path::Path;
+
+use base64::Engine;
+use reqwest::StatusCode;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use sigstore_trust_root::TrustedRoot;
+use sigstore_types::{Bundle, DerPublicKey, Sha256Hash, SignatureBytes, SignatureContent};
+use sigstore_verify::{VerificationPolicy, verify};
+
+#[derive(Debug, thiserror::Error)]
+pub enum AttestationError {
+    #[error("no attestations found")]
+    NoAttestations,
+    #[error("verification failed: {0}")]
+    Verification(String),
+    #[error("attestation API error: {0}")]
+    Api(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubAttestationsResponse {
+    attestations: Vec<GitHubAttestation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubAttestation {
+    bundle: Option<serde_json::Value>,
+    bundle_url: Option<String>,
+}
+
+pub async fn has_github_attestations(
+    owner: &str,
+    repo: &str,
+    digest: &str,
+    token: Option<&str>,
+) -> Result<bool, AttestationError> {
+    let digest = digest.strip_prefix("sha256:").unwrap_or(digest);
+    let response = fetch_github_attestations(owner, repo, digest, token).await?;
+    Ok(!response.attestations.is_empty())
+}
+
+pub async fn verify_github_attestation(
+    artifact_path: &Path,
+    owner: &str,
+    repo: &str,
+    token: Option<&str>,
+    signer_workflow: Option<&str>,
+) -> Result<bool, AttestationError> {
+    let digest = sha256_file_hex(artifact_path)?;
+    let response = fetch_github_attestations(owner, repo, &digest, token).await?;
+    if response.attestations.is_empty() {
+        return Err(AttestationError::NoAttestations);
+    }
+
+    let artifact_digest =
+        Sha256Hash::from_hex(&digest).map_err(|e| AttestationError::Verification(e.to_string()))?;
+    let mut last_error = None;
+    for attestation in response.attestations {
+        match load_github_bundle(attestation, token).await {
+            Ok(bundle_json) => {
+                match verify_bundle_digest(artifact_digest, &bundle_json, signer_workflow, false) {
+                    Ok(true) => return Ok(true),
+                    Ok(false) => last_error = Some("verification returned false".to_string()),
+                    Err(e) => last_error = Some(e.to_string()),
+                }
+            }
+            Err(e) => last_error = Some(e.to_string()),
+        }
+    }
+
+    Err(AttestationError::Verification(last_error.unwrap_or_else(
+        || "no attestation bundle verified successfully".to_string(),
+    )))
+}
+
+pub async fn verify_slsa_provenance(
+    artifact_path: &Path,
+    provenance_path: &Path,
+    _min_level: u8,
+) -> Result<bool, AttestationError> {
+    let artifact = fs::read(artifact_path)?;
+    let provenance = fs::read_to_string(provenance_path)?;
+
+    for bundle_json in bundle_candidates(&provenance) {
+        match verify_bundle_bytes(&artifact, &bundle_json, None) {
+            Ok(true) => return Ok(true),
+            Ok(false) => {}
+            Err(_) => {}
+        }
+    }
+
+    Err(AttestationError::Verification(
+        "file does not contain valid attestations or SLSA provenance".to_string(),
+    ))
+}
+
+pub async fn verify_cosign_signature(
+    artifact_path: &Path,
+    bundle_path: &Path,
+) -> Result<bool, AttestationError> {
+    let artifact = fs::read(artifact_path)?;
+    let bundle_json = fs::read_to_string(bundle_path)?;
+    verify_bundle_bytes(&artifact, &bundle_json, None)
+}
+
+pub async fn verify_cosign_signature_with_key(
+    artifact_path: &Path,
+    signature_path: &Path,
+    key_path: &Path,
+) -> Result<bool, AttestationError> {
+    let artifact = fs::read(artifact_path)?;
+    let signature = decode_signature(&fs::read(signature_path)?);
+    let key = fs::read_to_string(key_path)?;
+    let public_key =
+        DerPublicKey::from_pem(&key).map_err(|e| AttestationError::Verification(e.to_string()))?;
+    let signature = SignatureBytes::new(signature);
+
+    sigstore_verify::crypto::verify_signature_auto(&public_key, &signature, &artifact)
+        .map_err(|e| AttestationError::Verification(e.to_string()))?;
+    Ok(true)
+}
+
+async fn fetch_github_attestations(
+    owner: &str,
+    repo: &str,
+    digest: &str,
+    token: Option<&str>,
+) -> Result<GitHubAttestationsResponse, AttestationError> {
+    let url = format!("https://api.github.com/repos/{owner}/{repo}/attestations/sha256:{digest}");
+    let client = reqwest::Client::new();
+    let mut request = client
+        .get(url)
+        .header("accept", "application/vnd.github+json")
+        .header("x-github-api-version", "2022-11-28")
+        .header("user-agent", "mise");
+    if let Some(token) = token {
+        request = request.bearer_auth(token);
+    }
+
+    let response = request.send().await?;
+    if response.status() == StatusCode::NOT_FOUND {
+        return Err(AttestationError::NoAttestations);
+    }
+    if !response.status().is_success() {
+        return Err(AttestationError::Api(format!(
+            "GitHub returned {}",
+            response.status()
+        )));
+    }
+    Ok(response.json().await?)
+}
+
+async fn load_github_bundle(
+    attestation: GitHubAttestation,
+    token: Option<&str>,
+) -> Result<String, AttestationError> {
+    if let Some(bundle) = attestation.bundle {
+        return Ok(serde_json::to_string(&bundle)?);
+    }
+
+    let bundle_url = attestation
+        .bundle_url
+        .ok_or_else(|| AttestationError::Verification("attestation has no bundle".to_string()))?;
+    let client = reqwest::Client::new();
+    let mut request = client.get(&bundle_url).header("user-agent", "mise");
+    if let Some(token) = token {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await?;
+    if !response.status().is_success() {
+        return Err(AttestationError::Api(format!(
+            "GitHub bundle download returned {}",
+            response.status()
+        )));
+    }
+    let bytes = response.bytes().await?;
+    if bundle_url.ends_with(".json.sn") {
+        let decompressed = snap::raw::Decoder::new()
+            .decompress_vec(&bytes)
+            .map_err(|e| AttestationError::Verification(e.to_string()))?;
+        return String::from_utf8(decompressed)
+            .map_err(|e| AttestationError::Verification(e.to_string()));
+    }
+    String::from_utf8(bytes.to_vec()).map_err(|e| AttestationError::Verification(e.to_string()))
+}
+
+fn verify_bundle_digest(
+    artifact_digest: Sha256Hash,
+    bundle_json: &str,
+    signer_workflow: Option<&str>,
+    verify_tlog: bool,
+) -> Result<bool, AttestationError> {
+    let bundle = Bundle::from_json(bundle_json)
+        .map_err(|e| AttestationError::Verification(e.to_string()))?;
+    let root =
+        TrustedRoot::production().map_err(|e| AttestationError::Verification(e.to_string()))?;
+    let mut policy = VerificationPolicy::default();
+    if !verify_tlog {
+        policy = policy.skip_tlog();
+    }
+    let result = match verify(artifact_digest, &bundle, &policy, &root) {
+        Ok(result) => result,
+        Err(e) if !verify_tlog && e.to_string().contains("tlog") => {
+            return verify_github_dsse_bundle(artifact_digest, &bundle, signer_workflow);
+        }
+        Err(e) => return Err(AttestationError::Verification(e.to_string())),
+    };
+    verify_workflow_identity(&result.identity, signer_workflow)?;
+    Ok(result.success)
+}
+
+fn verify_github_dsse_bundle(
+    artifact_digest: Sha256Hash,
+    bundle: &Bundle,
+    signer_workflow: Option<&str>,
+) -> Result<bool, AttestationError> {
+    let cert = bundle
+        .signing_certificate()
+        .ok_or_else(|| AttestationError::Verification("bundle has no certificate".to_string()))?;
+    let cert_info = sigstore_verify::crypto::parse_certificate_info(cert.as_bytes())
+        .map_err(|e| AttestationError::Verification(e.to_string()))?;
+
+    let SignatureContent::DsseEnvelope(envelope) = &bundle.content else {
+        return Err(AttestationError::Verification(
+            "GitHub attestation bundle is not a DSSE envelope".to_string(),
+        ));
+    };
+
+    let pae = envelope.pae();
+    if !envelope.signatures.iter().any(|sig| {
+        sigstore_verify::crypto::verify_signature(
+            &cert_info.public_key,
+            &pae,
+            &sig.sig,
+            cert_info.signing_scheme,
+        )
+        .is_ok()
+    }) {
+        return Err(AttestationError::Verification(
+            "DSSE signature verification failed".to_string(),
+        ));
+    }
+
+    let payload = envelope.decode_payload();
+    let payload =
+        std::str::from_utf8(&payload).map_err(|e| AttestationError::Verification(e.to_string()))?;
+    if !statement_matches_sha256(payload, &artifact_digest.to_hex())? {
+        return Err(AttestationError::Verification(
+            "artifact hash does not match any subject in attestation".to_string(),
+        ));
+    }
+
+    verify_workflow_identity(&cert_info.identity, signer_workflow)?;
+    Ok(true)
+}
+
+fn statement_matches_sha256(payload: &str, expected: &str) -> Result<bool, AttestationError> {
+    let statement: serde_json::Value = serde_json::from_str(payload)?;
+    let subjects = statement
+        .get("subject")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| AttestationError::Verification("attestation has no subjects".to_string()))?;
+    Ok(subjects.iter().any(|subject| {
+        subject
+            .get("digest")
+            .and_then(|digest| digest.get("sha256"))
+            .and_then(|sha256| sha256.as_str())
+            .is_some_and(|sha256| sha256.eq_ignore_ascii_case(expected))
+    }))
+}
+
+fn verify_bundle_bytes(
+    artifact: &[u8],
+    bundle_json: &str,
+    signer_workflow: Option<&str>,
+) -> Result<bool, AttestationError> {
+    let bundle = Bundle::from_json(bundle_json)
+        .map_err(|e| AttestationError::Verification(e.to_string()))?;
+    let root =
+        TrustedRoot::production().map_err(|e| AttestationError::Verification(e.to_string()))?;
+    let policy = VerificationPolicy::default();
+    let result = verify(artifact, &bundle, &policy, &root)
+        .map_err(|e| AttestationError::Verification(e.to_string()))?;
+    verify_workflow_identity(&result.identity, signer_workflow)?;
+    Ok(result.success)
+}
+
+fn verify_workflow_identity(
+    identity: &Option<String>,
+    signer_workflow: Option<&str>,
+) -> Result<(), AttestationError> {
+    let Some(expected) = signer_workflow else {
+        return Ok(());
+    };
+    let Some(actual) = identity else {
+        return Err(AttestationError::Verification(
+            "signing certificate did not include an identity".to_string(),
+        ));
+    };
+    if actual == expected || actual.contains(expected) || expected.contains(actual) {
+        Ok(())
+    } else {
+        Err(AttestationError::Verification(format!(
+            "identity mismatch: expected workflow {expected}, got {actual}"
+        )))
+    }
+}
+
+fn bundle_candidates(input: &str) -> Vec<String> {
+    let trimmed = input.trim();
+    if trimmed.starts_with('{') {
+        return vec![trimmed.to_string()];
+    }
+    trimmed
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with('{'))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn sha256_file_hex(path: &Path) -> Result<String, AttestationError> {
+    let data = fs::read(path)?;
+    Ok(hex::encode(Sha256::digest(&data)))
+}
+
+fn decode_signature(bytes: &[u8]) -> Vec<u8> {
+    let trimmed = std::str::from_utf8(bytes)
+        .map(str::trim)
+        .unwrap_or_default();
+    if !trimmed.is_empty()
+        && let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(trimmed)
+    {
+        return decoded;
+    }
+    bytes.to_vec()
+}

--- a/crates/vfox/Cargo.toml
+++ b/crates/vfox/Cargo.toml
@@ -71,12 +71,7 @@ native-tls = [
   "reqwest/native-tls",
   "mise-sigstore/native-tls",
 ]
-rustls = [
-  "xx/rustls",
-  "xx/http",
-  "reqwest/rustls-tls",
-  "mise-sigstore/rustls",
-]
+rustls = ["xx/rustls", "xx/http", "reqwest/rustls-tls", "mise-sigstore/rustls"]
 rustls-native-roots = [
   "reqwest/rustls-tls-native-roots",
   "xx/http",

--- a/crates/vfox/Cargo.toml
+++ b/crates/vfox/Cargo.toml
@@ -55,7 +55,7 @@ xx = { version = "2", default-features = false, features = ["archive", "hash"] }
 env_logger = { version = "0.11", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 tempfile = "3"
-sigstore-verification = { version = "0.2", default-features = false }
+mise-sigstore = { path = "../mise-sigstore", default-features = false }
 
 [dev-dependencies]
 insta = "1"
@@ -69,19 +69,19 @@ native-tls = [
   "xx/native-tls",
   "xx/http",
   "reqwest/native-tls",
-  "sigstore-verification/native-tls",
+  "mise-sigstore/native-tls",
 ]
 rustls = [
   "xx/rustls",
   "xx/http",
   "reqwest/rustls-tls",
-  "sigstore-verification/rustls",
+  "mise-sigstore/rustls",
 ]
 rustls-native-roots = [
   "reqwest/rustls-tls-native-roots",
   "xx/http",
   "xx/rustls-native-roots",
-  "sigstore-verification/rustls-native-roots",
+  "mise-sigstore/rustls-native-roots",
 ]
 vendored-lua = ["mlua/vendored"]
 

--- a/crates/vfox/src/error.rs
+++ b/crates/vfox/src/error.rs
@@ -20,7 +20,7 @@ pub enum VfoxError {
     #[error(transparent)]
     UrlParseError(#[from] url::ParseError),
     #[error(transparent)]
-    AttestationError(#[from] sigstore_verification::AttestationError),
+    AttestationError(#[from] mise_sigstore::AttestationError),
 }
 
 pub type Result<T> = std::result::Result<T, VfoxError>;

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -434,7 +434,7 @@ impl Vfox {
                 let token = std::env::var("MISE_GITHUB_TOKEN")
                     .or_else(|_| std::env::var("GITHUB_TOKEN"))
                     .or(Err("GitHub artifact attestation verification requires either the MISE_GITHUB_TOKEN or GITHUB_TOKEN environment variable set"))?;
-                sigstore_verification::verify_github_attestation(
+                mise_sigstore::verify_github_attestation(
                     file,
                     owner.as_str(),
                     repo.as_str(),
@@ -454,15 +454,14 @@ impl Vfox {
 
             if let Some(sig_or_bundle_path) = &attestation.cosign_sig_or_bundle_path {
                 if let Some(public_key_path) = &attestation.cosign_public_key_path {
-                    sigstore_verification::verify_cosign_signature_with_key(
+                    mise_sigstore::verify_cosign_signature_with_key(
                         file,
                         sig_or_bundle_path,
                         public_key_path,
                     )
                     .await?;
                 } else {
-                    sigstore_verification::verify_cosign_signature(file, sig_or_bundle_path)
-                        .await?;
+                    mise_sigstore::verify_cosign_signature(file, sig_or_bundle_path).await?;
                 }
                 // Cosign has the lowest recording priority: only record it if no
                 // higher-priority verification was already recorded.
@@ -476,8 +475,7 @@ impl Vfox {
 
             if let Some(provenance_path) = &attestation.slsa_provenance_path {
                 let min_level = attestation.slsa_min_level.unwrap_or(1u8);
-                sigstore_verification::verify_slsa_provenance(file, provenance_path, min_level)
-                    .await?;
+                mise_sigstore::verify_slsa_provenance(file, provenance_path, min_level).await?;
                 // SLSA has mid-tier recording priority: record it unless GitHub
                 // attestation (higher priority) was already recorded.
                 // Note: if Cosign also passed, SLSA supersedes it (SLSA > Cosign).

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -851,7 +851,7 @@ impl AquaBackend {
             .as_ref()
             .and_then(|att| att.signer_workflow.clone());
 
-        match sigstore_verification::verify_github_attestation(
+        match mise_sigstore::verify_github_attestation(
             artifact_path,
             &pkg.repo_owner,
             &pkg.repo_name,
@@ -920,9 +920,7 @@ impl AquaBackend {
         HTTP.download_file(&provenance_url, &provenance_path, pr)
             .await?;
 
-        match sigstore_verification::verify_slsa_provenance(artifact_path, &provenance_path, 1u8)
-            .await
-        {
+        match mise_sigstore::verify_slsa_provenance(artifact_path, &provenance_path, 1u8).await {
             Ok(true) => {
                 debug!("SLSA provenance verified");
                 Ok(provenance_url)
@@ -1037,7 +1035,7 @@ impl AquaBackend {
                 checksum_path.with_extension("sig")
             };
 
-            match sigstore_verification::verify_cosign_signature_with_key(
+            match mise_sigstore::verify_cosign_signature_with_key(
                 checksum_path,
                 &sig_path,
                 &key_path,
@@ -1068,8 +1066,7 @@ impl AquaBackend {
             let bundle_path = download_dir.join(get_filename_from_url(&bundle_url));
             HTTP.download_file(&bundle_url, &bundle_path, pr).await?;
 
-            match sigstore_verification::verify_cosign_signature(checksum_path, &bundle_path).await
-            {
+            match mise_sigstore::verify_cosign_signature(checksum_path, &bundle_path).await {
                 Ok(true) => {
                     debug!("cosign (bundle) verified");
                     Ok(())

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -52,10 +52,10 @@ enum VerificationStatus {
 /// Check if an SLSA verification error indicates a format/parsing issue rather than
 /// an actual verification failure. Some provenance files (e.g., BuildKit raw provenance)
 /// exist but aren't in a sigstore-verifiable format.
-fn is_slsa_format_issue(e: &sigstore_verification::AttestationError) -> bool {
+fn is_slsa_format_issue(e: &mise_sigstore::AttestationError) -> bool {
     match e {
-        sigstore_verification::AttestationError::NoAttestations => true,
-        sigstore_verification::AttestationError::Verification(msg) => {
+        mise_sigstore::AttestationError::NoAttestations => true,
+        mise_sigstore::AttestationError::Verification(msg) => {
             msg.contains("does not contain valid attestations")
                 || msg.contains("No certificate found")
                 || msg.contains("neither DSSE envelope nor message signature")
@@ -475,30 +475,21 @@ impl UnifiedGitBackend {
             let parts: Vec<&str> = repo.split('/').collect();
             if parts.len() == 2 {
                 let (owner, repo_name) = (parts[0], parts[1]);
-                match sigstore_verification::sources::github::GitHubSource::new(
+                match mise_sigstore::has_github_attestations(
                     owner,
                     repo_name,
+                    digest,
                     env::GITHUB_TOKEN.as_deref(),
-                ) {
-                    Ok(source) => {
-                        use sigstore_verification::AttestationSource;
-                        let artifact_ref = sigstore_verification::ArtifactRef::from_digest(digest);
-                        match source.fetch_attestations(&artifact_ref).await {
-                            Ok(attestations) if !attestations.is_empty() => {
-                                return Some(ProvenanceType::GithubAttestations);
-                            }
-                            Ok(_) => {}
-                            Err(e) => {
-                                warn!(
-                                    "GitHub attestation API query failed for {owner}/{repo_name}: {e}. \
-                                     Lockfile may not record github-attestations provenance."
-                                );
-                            }
-                        }
+                )
+                .await
+                {
+                    Ok(true) => {
+                        return Some(ProvenanceType::GithubAttestations);
                     }
+                    Ok(false) => {}
                     Err(e) => {
                         warn!(
-                            "Failed to create GitHub attestation source for {owner}/{repo_name}: {e}. \
+                            "GitHub attestation API query failed for {owner}/{repo_name}: {e}. \
                              Lockfile may not record github-attestations provenance."
                         );
                     }
@@ -572,7 +563,7 @@ impl UnifiedGitBackend {
             let parts: Vec<&str> = repo.split('/').collect();
             if parts.len() == 2 {
                 let (owner, repo_name) = (parts[0], parts[1]);
-                match sigstore_verification::verify_github_attestation(
+                match mise_sigstore::verify_github_attestation(
                     &artifact_path,
                     owner,
                     repo_name,
@@ -590,7 +581,7 @@ impl UnifiedGitBackend {
                             "GitHub artifact attestations verification returned false"
                         ));
                     }
-                    Err(sigstore_verification::AttestationError::NoAttestations) => {
+                    Err(mise_sigstore::AttestationError::NoAttestations) => {
                         debug!("no GitHub attestations found at lock time, trying SLSA");
                     }
                     Err(e) => {
@@ -638,12 +629,8 @@ impl UnifiedGitBackend {
                 .await?;
 
                 let provenance_url = provenance_asset.browser_download_url.clone();
-                match sigstore_verification::verify_slsa_provenance(
-                    &artifact_path,
-                    &provenance_path,
-                    1u8,
-                )
-                .await
+                match mise_sigstore::verify_slsa_provenance(&artifact_path, &provenance_path, 1u8)
+                    .await
                 {
                     Ok(true) => {
                         debug!("lock-time SLSA provenance verified for {}", repo);
@@ -1565,7 +1552,7 @@ impl UnifiedGitBackend {
         }
         let (owner, repo_name) = (parts[0], parts[1]);
 
-        match sigstore_verification::verify_github_attestation(
+        match mise_sigstore::verify_github_attestation(
             file_path,
             owner,
             repo_name,
@@ -1582,7 +1569,7 @@ impl UnifiedGitBackend {
                 }
                 Ok(verified)
             }
-            Err(sigstore_verification::AttestationError::NoAttestations) => {
+            Err(mise_sigstore::AttestationError::NoAttestations) => {
                 Err(VerificationStatus::NoAttestations)
             }
             Err(e) => Err(VerificationStatus::Error(e.to_string())),
@@ -1673,7 +1660,7 @@ impl UnifiedGitBackend {
 
         // Verify the provenance
         let provenance_download_url = provenance_asset.browser_download_url.clone();
-        match sigstore_verification::verify_slsa_provenance(
+        match mise_sigstore::verify_slsa_provenance(
             file_path,
             &provenance_path,
             1, // Minimum SLSA level
@@ -1918,14 +1905,14 @@ mod tests {
 
     #[test]
     fn test_is_slsa_format_issue_no_attestations() {
-        let err = sigstore_verification::AttestationError::NoAttestations;
+        let err = mise_sigstore::AttestationError::NoAttestations;
         assert!(is_slsa_format_issue(&err));
     }
 
     #[test]
     fn test_is_slsa_format_issue_invalid_format() {
         // This is the exact error from BuildKit raw provenance files parsed line-by-line
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = mise_sigstore::AttestationError::Verification(
             "File does not contain valid attestations or SLSA provenance".to_string(),
         );
         assert!(is_slsa_format_issue(&err));
@@ -1933,7 +1920,7 @@ mod tests {
 
     #[test]
     fn test_is_slsa_format_issue_no_certificate() {
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = mise_sigstore::AttestationError::Verification(
             "No certificate found in attestation bundle".to_string(),
         );
         assert!(is_slsa_format_issue(&err));
@@ -1941,7 +1928,7 @@ mod tests {
 
     #[test]
     fn test_is_slsa_format_issue_no_dsse_envelope() {
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = mise_sigstore::AttestationError::Verification(
             "Bundle has neither DSSE envelope nor message signature".to_string(),
         );
         assert!(is_slsa_format_issue(&err));
@@ -1950,7 +1937,7 @@ mod tests {
     #[test]
     fn test_is_slsa_format_issue_real_verification_failure() {
         // Digest mismatch = real verification failure, NOT a format issue
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = mise_sigstore::AttestationError::Verification(
             "Artifact digest mismatch: expected abc123".to_string(),
         );
         assert!(!is_slsa_format_issue(&err));
@@ -1959,7 +1946,7 @@ mod tests {
     #[test]
     fn test_is_slsa_format_issue_signature_failure() {
         // Signature verification failure = real failure, NOT a format issue
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = mise_sigstore::AttestationError::Verification(
             "P-256 signature verification failed: invalid signature".to_string(),
         );
         assert!(!is_slsa_format_issue(&err));
@@ -1967,7 +1954,7 @@ mod tests {
 
     #[test]
     fn test_is_slsa_format_issue_api_error() {
-        let err = sigstore_verification::AttestationError::Api("connection refused".to_string());
+        let err = mise_sigstore::AttestationError::Api("connection refused".to_string());
         assert!(!is_slsa_format_issue(&err));
     }
 }

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -625,7 +625,7 @@ impl PythonPlugin {
         ctx.pr
             .set_message("verify GitHub artifact attestations".to_string());
 
-        match sigstore_verification::verify_github_attestation(
+        match mise_sigstore::verify_github_attestation(
             tarball_path,
             "astral-sh",
             "python-build-standalone",
@@ -646,7 +646,7 @@ impl PythonPlugin {
             Ok(false) => Err(eyre!(
                 "GitHub artifact attestations verification failed for python@{version}\n{ATTESTATION_HELP}"
             )),
-            Err(sigstore_verification::AttestationError::NoAttestations) => Err(eyre!(
+            Err(mise_sigstore::AttestationError::NoAttestations) => Err(eyre!(
                 "No GitHub artifact attestations found for python@{version}\n{ATTESTATION_HELP}"
             )),
             Err(e) => Err(eyre!(

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -802,7 +802,7 @@ impl RubyPlugin {
         ctx.pr
             .set_message("verify GitHub artifact attestations".to_string());
 
-        match sigstore_verification::verify_github_attestation(
+        match mise_sigstore::verify_github_attestation(
             tarball_path,
             owner,
             repo,
@@ -823,7 +823,7 @@ impl RubyPlugin {
             Ok(false) => Err(eyre!(
                 "GitHub artifact attestations verification failed for ruby@{version}\n{ATTESTATION_HELP}"
             )),
-            Err(sigstore_verification::AttestationError::NoAttestations) => Err(eyre!(
+            Err(mise_sigstore::AttestationError::NoAttestations) => Err(eyre!(
                 "No GitHub artifact attestations found for ruby@{version}\n{ATTESTATION_HELP}"
             )),
             Err(e) => Err(eyre!(


### PR DESCRIPTION
## Summary

- add a shared `mise-sigstore` workspace crate built on the `sigstore-rust` crates
- remove the `sigstore-verification` dependency from `mise` and `vfox`
- route GitHub artifact attestations, SLSA bundle provenance, and cosign bundle/key checks through the new wrapper
- replace the lock-time GitHub attestation probe with a direct GitHub API query

## Notes

GitHub's artifact attestation API currently returns v0.3 bundles without transparency log entries. The upstream `sigstore-verify` API rejects those before signature verification, so the GitHub attestation path falls back to `sigstore-rust` bundle parsing and crypto verification for the DSSE envelope, then checks that the in-toto subject SHA-256 matches the artifact. Cosign and local bundle verification continue through the public `sigstore-verify` API.

## Verification

- `cargo check`
- `cargo run --quiet -- install github:jdx/communique@0.1.9 -y` with temp `MISE_DATA_DIR`, `MISE_CACHE_DIR`, and `MISE_CONFIG_DIR`

The communique repro now reaches `✓ GitHub artifact attestations verified` and installs successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Replaces the artifact attestation/provenance verification implementation and dependency stack, including custom fallback verification for GitHub DSSE bundles; mistakes could allow invalid artifacts to be treated as verified or cause installs/locks to fail.
> 
> **Overview**
> Adds a new workspace crate, `crates/mise-sigstore`, that wraps `sigstore-rust` libraries to verify **GitHub artifact attestations**, **SLSA provenance bundles**, and **cosign bundle/key signatures**, plus a helper to query whether GitHub attestations exist.
> 
> Migrates `mise`, `vfox`, Aqua backend, and core plugins (e.g. Python/Ruby) to call `mise_sigstore::*` APIs instead of `sigstore-verification`, and updates lock-time provenance detection to use a direct `has_github_attestations` API query.
> 
> Updates workspace wiring/features (`native-tls`/`rustls`) and refreshes `Cargo.lock` accordingly (removing prior sigstore-related deps and pulling in `sigstore-*` v0.6.4 crates and related transitive updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a8f95d94e4b6b971edfbeed10f20d569e7da31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->