### PR TITLE
chore: bump sigstore-verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9001,9 +9001,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verification"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b0ce9ca6304f85b3a089d403441695cc5428beb9cf5c08cc04ea0841516fd"
+checksum = "234e57d0dbeea51543961991b61785d44ec7a6eb37d344a7f9ac47f1d7c9f8f0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",


### PR DESCRIPTION
## Summary
- bump `sigstore-verification` from `0.2.3` to `0.2.5` in `Cargo.lock`
- includes the upstream fix for GitHub release attestation certs whose SAN is `https://dotcom.releases.github.com` without a trailing slash
- upstream fix PR: https://github.com/jdx/sigstore-verification/pull/43
- upstream release PR: https://github.com/jdx/sigstore-verification/pull/44

## Verification
- reproduced the CI failure locally with `sigstore-verification 0.2.4`:
  - `mise install github:jdx/communique@0.1.9`
  - `mise install github:jdx/fnox@1.20.0`
- confirmed a local path patch to `sigstore-verification` fixed both installs
- confirmed published `sigstore-verification 0.2.5` fixes both installs:
  - `github:jdx/communique@0.1.9` verifies GitHub artifact attestations and installs
  - `github:jdx/fnox@1.20.0` verifies GitHub artifact attestations and installs
- `cargo check -p mise -p vfox`
- `cargo build --all-features`

Note: the attestation installs still print the existing non-fatal Rekor public-key warning, but the `GitHub artifact attestations verified` step succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency lockfile-only bump; behavior changes are limited to whatever upstream includes in the `sigstore-verification` patch update.
> 
> **Overview**
> Bumps the `sigstore-verification` dependency in `Cargo.lock` from `0.2.3` to `0.2.5` (checksum updated accordingly), without changing any source code or declared dependency constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411d72630750b92fdd885ac7cf29bf8baa058709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
