### PR TITLE
fix: surface GitHub 403 response body in error and show specific warnings by cause

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -415,6 +415,14 @@ impl Client {
             eprintln!("{} {url} {}", verb_label, resp.status());
         }
         debug!("{} {url} {}", verb_label, resp.status());
+        // For 403 responses, read the body to include in the error so callers
+        // can distinguish rate limiting from IP allow list blocks and other causes.
+        if resp.status().as_u16() == 403 {
+            let headers = resp.headers().clone();
+            display_github_rate_limit_headers(403, &headers);
+            let body = resp.text().await.unwrap_or_default();
+            bail!("HTTP status client error (403 Forbidden) for url ({url}): {body}");
+        }
         display_github_rate_limit(&resp);
         resp.error_for_status_ref()?;
         Ok(resp)
@@ -528,15 +536,19 @@ pub fn apply_url_replacements(url: &mut Url) {
 }
 
 fn display_github_rate_limit(resp: &Response) {
-    let status = resp.status().as_u16();
+    display_github_rate_limit_headers(resp.status().as_u16(), resp.headers());
+}
+
+/// Check response headers for GitHub rate limit signals and emit appropriate warnings.
+/// Used for both 429 responses (via `display_github_rate_limit`) and 403 responses
+/// where we've already consumed the body to include in the error message.
+fn display_github_rate_limit_headers(status: u16, headers: &HeaderMap) {
     if status == 403 || status == 429 {
-        let remaining = resp
-            .headers()
+        let remaining = headers
             .get("x-ratelimit-remaining")
             .and_then(|r| r.to_str().ok());
         if remaining.is_some_and(|r| r == "0") {
-            if let Some(reset_time) = resp
-                .headers()
+            if let Some(reset_time) = headers
                 .get("x-ratelimit-reset")
                 .and_then(|h| h.to_str().ok())
                 .and_then(|s| s.parse::<i64>().ok())
@@ -550,8 +562,7 @@ fn display_github_rate_limit(resp: &Response) {
             return;
         }
         // retry-after header is processed only if x-ratelimit-remaining is not 0 or is missing
-        if let Some(retry_after) = resp
-            .headers()
+        if let Some(retry_after) = headers
             .get("retry-after")
             .and_then(|h| h.to_str().ok())
             .and_then(|s| s.parse::<u64>().ok())

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,25 +169,35 @@ fn handle_err(err: Report) -> eyre::Result<()> {
 fn show_github_rate_limit_err(err: &Report) {
     let msg = format!("{err:?}");
     if msg.contains("HTTP status client error (403 Forbidden) for url (https://api.github.com") {
-        if env::GITHUB_TOKEN.is_none() {
-            warn!(
-                "GitHub API returned a 403 Forbidden error with no GITHUB_TOKEN set."
-            );
+        if msg.contains("IP allow list") {
+            // GitHub organizations can enable IP allow lists that block authenticated
+            // requests from non-listed IPs — even to public repos. Unauthenticated
+            // requests are explicitly exempted from IP allow list enforcement.
             warn!(indoc!(
-                r#"GITHUB_TOKEN is not set. This means mise is making unauthenticated requests to GitHub which have a lower rate limit.
+                r#"GitHub API returned 403: the target organization has an IP allow list and your IP is not permitted.
+                   Authenticated requests trigger IP allow list checks even for public repos.
+                   Workaround: unset GITHUB_TOKEN for this operation — anonymous requests bypass IP allow lists for public repos."#
+            ));
+        } else if msg.contains("rate limit exceeded") || msg.contains("rate_limit") {
+            // Rate limit already reported by display_github_rate_limit_headers.
+            // If no token is set, also suggest setting one.
+            if env::GITHUB_TOKEN.is_none() {
+                warn!(indoc!(
+                    r#"GITHUB_TOKEN is not set. This means mise is making unauthenticated requests to GitHub which have a lower rate limit.
+                       To increase the rate limit, set the GITHUB_TOKEN environment variable to a GitHub personal access token.
+                       Create a token at https://github.com/settings/tokens and set it as GITHUB_TOKEN in your environment.
+                       You do not need to give this token any scopes."#
+                ));
+            }
+        } else if env::GITHUB_TOKEN.is_none() {
+            warn!(indoc!(
+                r#"GitHub API returned 403 with no GITHUB_TOKEN set. This means mise is making unauthenticated requests to GitHub which have a lower rate limit.
                    To increase the rate limit, set the GITHUB_TOKEN environment variable to a GitHub personal access token.
                    Create a token at https://github.com/settings/tokens and set it as GITHUB_TOKEN in your environment.
                    You do not need to give this token any scopes."#
             ));
-        } else {
-            warn!(indoc!(
-                r#"GitHub API returned a 403 Forbidden error. This can have several causes:
-                   - Rate limit exceeded: check x-ratelimit-remaining in the response headers
-                   - IP allow list: the target GitHub organization has an IP allow list enabled and your IP is not permitted
-                   - Token permissions: the token may not have access to the required resources
-                   Run with MISE_LOG_LEVEL=debug for the full response body which will identify the exact cause."#
-            ));
         }
+        // For all other authenticated 403s the body is already in the error above.
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,15 +169,23 @@ fn handle_err(err: Report) -> eyre::Result<()> {
 fn show_github_rate_limit_err(err: &Report) {
     let msg = format!("{err:?}");
     if msg.contains("HTTP status client error (403 Forbidden) for url (https://api.github.com") {
-        warn!(
-            "GitHub API returned a 403 Forbidden error. This likely means you have exceeded the rate limit."
-        );
         if env::GITHUB_TOKEN.is_none() {
+            warn!(
+                "GitHub API returned a 403 Forbidden error with no GITHUB_TOKEN set."
+            );
             warn!(indoc!(
                 r#"GITHUB_TOKEN is not set. This means mise is making unauthenticated requests to GitHub which have a lower rate limit.
                    To increase the rate limit, set the GITHUB_TOKEN environment variable to a GitHub personal access token.
                    Create a token at https://github.com/settings/tokens and set it as GITHUB_TOKEN in your environment.
                    You do not need to give this token any scopes."#
+            ));
+        } else {
+            warn!(indoc!(
+                r#"GitHub API returned a 403 Forbidden error. This can have several causes:
+                   - Rate limit exceeded: check x-ratelimit-remaining in the response headers
+                   - IP allow list: the target GitHub organization has an IP allow list enabled and your IP is not permitted
+                   - Token permissions: the token may not have access to the required resources
+                   Run with MISE_LOG_LEVEL=debug for the full response body which will identify the exact cause."#
             ));
         }
     }


### PR DESCRIPTION
## Problem

The response body from GitHub 403 errors is currently dropped — `error_for_status_ref()` only carries the URL and status code. So when GitHub sends a descriptive message (like "IP allow list enabled"), the user never sees it. Instead they always see the same generic warning:

> GitHub API returned a 403 Forbidden error. This likely means you have exceeded the rate limit.

This was discussed in https://github.com/jdx/mise/discussions/9119

## Fix

**`src/http.rs` — surface the body**

For 403 responses, read the body before bailing and include it in the error message. The GitHub-provided reason is now visible in the error.

Also extracts `display_github_rate_limit_headers(status, &HeaderMap)` from `display_github_rate_limit` so the header-based rate limit check still works for the 403 path where the response has been consumed.

**`src/main.rs` — show specific warnings from the body**

`show_github_rate_limit_err` now checks what's actually in the 403 body:

| Body contains | Warning shown |
|---|---|
| `"IP allow list"` | Organization has an IP allow list; unset GITHUB_TOKEN as workaround |
| rate limit signals | Rate limit already shown by `display_github_rate_limit_headers`; add token suggestion if no token set |
| anything else, no token | Existing "set GITHUB_TOKEN" suggestion |
| anything else, token set | Body is already in the error — no extra noise |

## Before / after

**Before** (IP allow list, x-ratelimit-remaining: 14987):
```
WARN  GitHub API returned a 403 Forbidden error. This likely means you have exceeded the rate limit.
```

**After**:
```
Error: HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/aquasecurity/trivy/releases): {"message": "Although you appear to have the correct authorization credentials, the `aquasecurity` organization has an IP allow list enabled, and your IP address is not permitted..."}

WARN  GitHub API returned 403: the target organization has an IP allow list and your IP is not permitted.
      Workaround: unset GITHUB_TOKEN — anonymous requests bypass IP allow lists for public repos.
```

**Before** (actual rate limit):
```
WARN  GitHub rate limit exceeded. Resets at <time>
WARN  GitHub API returned a 403 Forbidden error. This likely means you have exceeded the rate limit.
```

**After** (actual rate limit):
```
WARN  GitHub rate limit exceeded. Resets at <time>
```
(body confirms it; redundant second warning removed)