### PR TITLE
fix(go): Remove install-time version override for subpath packages

### DIFF
--- a/e2e/backend/test_go_install_slow
+++ b/e2e/backend/test_go_install_slow
@@ -31,7 +31,7 @@ assert "mise x go:github.com/go-task/task/v3/cmd/task@3.34.1 -- task --version" 
 # See https://github.com/jdx/mise/discussions/6737
 assert "mise x go:github.com/jdx/go-example@e16a340 -- go-example" "hello world"
 
-# Deep sub-module returns no versions from `go list -versions`, so we must keep @latest.
+# Deep sub-module with no tagged versions; proxy resolves a pseudo-version via @latest.
 assert_contains "mise x go:github.com/go-kratos/kratos/cmd/kratos/v2@latest -- bash -c 'kratos --help 2>&1'" "Kratos: An elegant toolkit for Go microservices."
 
 assert_contains "mise x go:github.com/golang-migrate/migrate/v4/cmd/migrate[tags=postgres]@4.18.2 -- bash -c 'migrate --help 2>&1'" "postgres"

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -83,7 +83,7 @@ impl Backend for GoBackend {
     async fn install_version_(
         &self,
         ctx: &InstallContext,
-        mut tv: ToolVersion,
+        tv: ToolVersion,
     ) -> eyre::Result<ToolVersion> {
         // Check if go is available
         self.warn_if_dependency_missing(
@@ -96,18 +96,7 @@ impl Backend for GoBackend {
         )
         .await;
 
-        // Some modules have no tagged versions but resolve via @latest pseudo-version.
-        let mut install_version = tv.version.clone();
-        if tv.request.version() == "latest"
-            && tv.version != "latest"
-            && self
-                .fetch_go_module_versions(&ctx.config, &self.tool_name())
-                .await?
-                .is_some_and(|v| v.is_empty())
-        {
-            install_version = "latest".to_string();
-            tv.version = "latest".to_string();
-        }
+        let install_version = tv.version.clone();
 
         let opts = self.ba.opts();
 


### PR DESCRIPTION
The install method had a workaround that queried `go list -m -versions` on the full tool path (including subpath) and, if no versions were found, overrode tv.version to "latest". This was needed before #8968 because version resolution couldn't distinguish subpath packages from tagless modules.

After #8968, proxy-based resolution handles both cases correctly: subpaths get 404 (truncating to the root module), and tagless modules get their pseudo-version from @latest.

The old workaround now fights with the correct resolution, it queries the subpath (which always returns empty), overrides the version to "latest", and installs into a `.../latest/` directory.

On the next `mise up`, version resolution finds e.g. `1.7.0` but `.../1.7.0/` doesn't exist and causes a reinstall every time.

Apologies for missing this on the original PR!