### PR TITLE
registry: add monodep

### DIFF
--- a/registry/monodep.toml
+++ b/registry/monodep.toml
@@ -1,0 +1,3 @@
+backends = ["asdf:gracefullight/mise-monodep-plugin"]
+description = "Polyglot monorepo dependency deduplication for mise-managed workspaces (Node.js + Python hardlink dedup)"
+test = { cmd = "monodep --help", expected = "Monorepo dependency deduplication" }

--- a/registry/monodep.toml
+++ b/registry/monodep.toml
@@ -1,3 +1,3 @@
 backends = ["asdf:gracefullight/mise-monodep-plugin"]
 description = "Polyglot monorepo dependency deduplication for mise-managed workspaces (Node.js + Python hardlink dedup)"
-test = { cmd = "monodep --help", expected = "Monorepo dependency deduplication" }
+test = { cmd = "monodep --version", expected = "{{version}}" }


### PR DESCRIPTION
Adds [monodep](https://github.com/gracefullight/mise-monodep-plugin) to the registry.

monodep deduplicates dependencies across polyglot monorepo workspaces managed by mise.
It reads `[monorepo].config_roots` from `mise.toml`, auto-detects the package manager
(bun/pnpm/npm for Node.js, uv for Python), and hardlinks shared packages
to a project-local `.monodep/store` to save disk space.

Commands: `install`, `sync`, `add`, `update`, `remove`, `doctor`, `why`, `plan`

Example usage: [first-fluke/fullstack-starter mise.toml](https://github.com/first-fluke/fullstack-starter/blob/main/mise.toml)

https://github.com/gracefullight/mise-monodep-plugin