### PR TITLE
fix(task): show available tasks when run target missing

### DIFF
--- a/e2e/tasks/test_task_missing_suggestions
+++ b/e2e/tasks/test_task_missing_suggestions
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+cat <<EOF >mise.toml
+[tasks.compile]
+description = "compile project"
+run = 'echo "compile"'
+
+[tasks.clean]
+description = "clean compile dir"
+run = 'echo "clean"'
+EOF
+
+assert_fail_contains "mise run complie" "no task complie found"
+assert_fail_contains "mise run complie" "Did you mean one of these?"
+assert_fail_contains "mise run complie" "compile"
+assert_fail_contains "mise run build" "Available tasks:"
+assert_fail_contains "mise run build" "clean    clean compile dir"
+
+rm mise.toml
+export MISE_EXPERIMENTAL=1
+
+cat <<EOF >mise.toml
+experimental_monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+EOF
+
+mkdir -p projects/app
+cat <<EOF >projects/app/mise.toml
+[tasks.compile]
+description = "compile app"
+run = 'echo "compile app"'
+EOF
+
+assert_fail_contains "mise run build" "no task //:build found"
+assert_fail_contains "mise run build" "mise tasks ls --all"
+assert_fail_contains "mise run build" "//projects/app:compile"

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -11,10 +11,12 @@ use demand::{DemandOption, Select};
 use eyre::{Result, bail, ensure, eyre};
 use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
 use itertools::Itertools;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::iter::once;
 use std::path::PathBuf;
 use std::sync::Arc;
+
+const MAX_AVAILABLE_TASKS_IN_ERROR: usize = 20;
 
 /// Find non-executable files in task include directories.
 /// These are files that likely should be tasks but are missing the executable bit.
@@ -102,12 +104,100 @@ fn suggest_similar_commands(name: &str) -> Vec<String> {
         .collect()
 }
 
+async fn tasks_for_missing_task_error(
+    config: &Config,
+    name: &str,
+) -> Result<(Arc<BTreeMap<String, Task>>, bool)> {
+    let tasks = config.tasks().await?;
+
+    // In monorepos, users usually need `tasks ls --all` after a miss. Load that
+    // same view for the error so sibling package tasks can be suggested.
+    if (name.starts_with("//") || config.is_monorepo())
+        && let Ok(all_tasks) = config
+            .tasks_with_context(Some(&TaskLoadContext::all()))
+            .await
+        && !all_tasks.is_empty()
+    {
+        return Ok((all_tasks, true));
+    }
+
+    Ok((tasks, false))
+}
+
+fn similar_tasks(name: &str, tasks: &BTreeMap<String, Task>) -> Vec<String> {
+    let candidates = tasks
+        .values()
+        .filter(|t| !t.hide)
+        .map(|t| t.display_name.clone())
+        .unique()
+        .collect_vec();
+    xx::suggest::similar_n_with_threshold(name, &candidates, 5, 0.75)
+}
+
+fn append_available_tasks(
+    err_msg: &mut String,
+    tasks: &BTreeMap<String, Task>,
+    showing_all_tasks: bool,
+) {
+    let visible_tasks = tasks
+        .values()
+        .filter(|t| !t.hide)
+        .sorted_by(|a, b| a.display_name.cmp(&b.display_name))
+        .unique_by(|t| t.display_name.clone())
+        .collect_vec();
+    if visible_tasks.is_empty() {
+        return;
+    }
+
+    let listed_tasks = visible_tasks
+        .iter()
+        .take(MAX_AVAILABLE_TASKS_IN_ERROR)
+        .collect_vec();
+    let name_width = listed_tasks
+        .iter()
+        .map(|t| t.display_name.len())
+        .chain(once("Name".len()))
+        .max()
+        .unwrap_or("Name".len());
+
+    if showing_all_tasks {
+        err_msg.push_str("\n\nAvailable tasks (`mise tasks ls --all`):");
+    } else {
+        err_msg.push_str("\n\nAvailable tasks:");
+    }
+    err_msg.push_str(&format!(
+        "\n  {:name_width$}  Description",
+        "Name",
+        name_width = name_width
+    ));
+    for task in listed_tasks {
+        let desc = task.description.lines().next().unwrap_or_default();
+        err_msg.push_str(&format!(
+            "\n  {:name_width$}  {}",
+            task.display_name,
+            desc,
+            name_width = name_width
+        ));
+    }
+
+    let remaining = visible_tasks
+        .len()
+        .saturating_sub(MAX_AVAILABLE_TASKS_IN_ERROR);
+    if remaining > 0 {
+        let noun = if remaining == 1 { "task" } else { "tasks" };
+        err_msg.push_str(&format!(
+            "\n  ... and {remaining} more {noun}. Run `mise tasks ls --all` to list all tasks."
+        ));
+    }
+}
+
 /// Show an error when a task is not found, with helpful suggestions
 async fn err_no_task(config: &Config, name: &str) -> Result<()> {
     // Check early if the name looks like a mistyped CLI subcommand
     let similar_cmds = suggest_similar_commands(name);
+    let (tasks_for_error, showing_all_tasks) = tasks_for_missing_task_error(config, name).await?;
 
-    if config.tasks().await.is_ok_and(|t| t.is_empty()) {
+    if tasks_for_error.is_empty() {
         // If the name matches a CLI subcommand closely, suggest that instead of
         // the confusing "no tasks defined" message
         if !similar_cmds.is_empty() {
@@ -208,32 +298,12 @@ async fn err_no_task(config: &Config, name: &str) -> Result<()> {
 
     // Suggest similar tasks using fuzzy matching for monorepo tasks
     let mut err_msg = format!("no task {} found", style::ered(name));
-    if name.starts_with("//") {
-        // Load ALL monorepo tasks for suggestions
-        if let Ok(tasks) = config
-            .tasks_with_context(Some(&TaskLoadContext::all()))
-            .await
-        {
-            let matcher = SkimMatcherV2::default().use_cache(true).smart_case();
-            let similar: Vec<String> = tasks
-                .keys()
-                .filter(|k| k.starts_with("//"))
-                .filter_map(|k| {
-                    matcher
-                        .fuzzy_match(&k.to_lowercase(), &name.to_lowercase())
-                        .map(|score| (score, k.clone()))
-                })
-                .sorted_by_key(|(score, _)| -1 * *score)
-                .take(5)
-                .map(|(_, k)| k)
-                .collect();
 
-            if !similar.is_empty() {
-                err_msg.push_str("\n\nDid you mean one of these?");
-                for task_name in similar {
-                    err_msg.push_str(&format!("\n  - {}", task_name));
-                }
-            }
+    let similar = similar_tasks(name, &tasks_for_error);
+    if !similar.is_empty() {
+        err_msg.push_str("\n\nDid you mean one of these?");
+        for task_name in similar {
+            err_msg.push_str(&format!("\n  - {}", task_name));
         }
     }
 
@@ -243,6 +313,8 @@ async fn err_no_task(config: &Config, name: &str) -> Result<()> {
             err_msg.push_str(&format!("\n  mise {cmd_name}"));
         }
     }
+
+    append_available_tasks(&mut err_msg, &tasks_for_error, showing_all_tasks);
 
     bail!(err_msg);
 }

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -108,8 +108,6 @@ async fn tasks_for_missing_task_error(
     config: &Config,
     name: &str,
 ) -> Result<(Arc<BTreeMap<String, Task>>, bool)> {
-    let tasks = config.tasks().await?;
-
     // In monorepos, users usually need `tasks ls --all` after a miss. Load that
     // same view for the error so sibling package tasks can be suggested.
     if (name.starts_with("//") || config.is_monorepo())
@@ -121,6 +119,7 @@ async fn tasks_for_missing_task_error(
         return Ok((all_tasks, true));
     }
 
+    let tasks = config.tasks().await?;
     Ok((tasks, false))
 }
 


### PR DESCRIPTION
## Summary

- show similar task suggestions for missing `mise run <task>` targets using the resolved task set
- append a compact available-task table to missing-task errors
- load the `tasks ls --all` task view for monorepo missing-task errors so sibling package tasks are visible

## Validation

- `mise run format`
- `mise run test:e2e e2e/tasks/test_task_missing_suggestions`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the missing-task error path and an added e2e test; primary risk is minor UX/performance impact from loading monorepo-wide tasks when a task is missing.
> 
> **Overview**
> Improves the `mise run <task>` missing-target error to suggest **similar task names** and append a compact **Available tasks** table (name + first-line description, capped at 20 with a hint to list all).
> 
> For monorepo contexts (or `//` task paths), the error now loads the `tasks ls --all` view so suggestions and the available-task list include sibling package tasks, and adds an e2e test covering both single-project and monorepo missing-task output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebd880f3aa6bcaa12ca8cce273e5ba9490bf7ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->