### PR TITLE
fix(env): use runtime symlink paths for fuzzy versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,17 @@ echo '~/.local/bin/mise activate pwsh | Out-String | Invoke-Expression' >> ~/.co
 ### Execute commands with specific tools
 
 ```sh-session
-$ mise exec node@24 -- node -v
-mise node@24.x.x ✓ installed
-v24.x.x
+$ mise exec node@26 -- node -v
+mise node@26.x.x ✓ installed
+v26.x.x
 ```
 
 ### Install tools
 
 ```sh-session
-$ mise use --global node@24 go@1
+$ mise use --global node@26 go@1
 $ node -v
-v24.x.x
+v26.x.x
 $ go version
 go version go1.x.x macos/arm64
 ```

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -13,9 +13,9 @@ The following demo shows:
 `mise exec <tool> -- <command>` allows you to run any tools with mise
 
 ```shell
-mise exec node@24 -- node -v
-# mise node@24.x.x ✓ installed
-# v24.x.x
+mise exec node@26 -- node -v
+# mise node@26.x.x ✓ installed
+# v26.x.x
 ```
 
 node is only available in the mise environment, not globally
@@ -53,7 +53,7 @@ node -v
 
 ```shell
 which node
-# /root/.local/share/mise/installs/node/22.14.0/bin/node
+# /root/.local/share/mise/installs/node/lts/bin/node
 ```
 
 Note that we get back the path to the real node here, not a shim.
@@ -96,28 +96,28 @@ mise ls
 
 ---
 
-Let's enter a project directory where we will set up node@23
+Let's enter a project directory where we will set up node@26
 
 ```shell
 cd myproj
-mise use node@23 pnpm@10
-# mise node@23.10.0 ✓ installed
+mise use node@26 pnpm@10
+# mise node@26.x.x ✓ installed
 # mise pnpm@10.7.0 ✓ installed
 ```
 
 ```shell
 node -v
-# v23.10.0
+# v26.x.x
 pnpm -v
 # 10.7.0
 ```
 
-As expected, `node -v` is now v23.x
+As expected, `node -v` is now v26.x
 
 ```shell
 cat mise.toml
 # [tools]
-# node = "23"
+# node = "26"
 # pnpm = "10"
 ```
 

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -284,28 +284,28 @@ For some users, `mise use` might be the only command you need to learn. It will 
 
 ```shell
 > cd my-project
-> mise use node@24
+> mise use node@26
 # download node, verify signature...
-mise node@24.x.x ✓ installed
-mise ~/my-project/mise.toml tools: node@24.x.x # mise.toml created/updated
+mise node@26.x.x ✓ installed
+mise ~/my-project/mise.toml tools: node@26.x.x # mise.toml created/updated
 
 > which node
-~/.local/share/installs/node/24.x.x/bin/node
+~/.local/share/mise/installs/node/26/bin/node
 ```
 
-`mise use node@24` will install the latest version of node-24 and create/update the
+`mise use node@26` will install the latest version of node-26 and create/update the
 `mise.toml`
 config file in the local directory. The resulting file looks like this:
 
 ```toml [mise.toml]
 [tools]
-node = "24"
+node = "26"
 ```
 
 Anytime you're in that directory, that version of `node` will be used.
 
-`mise use -g node@24` will do the same but update the [global config](/configuration.html#global-config-config-mise-config-toml) (`~/.config/mise/config.toml`) so
-unless there is a config file in the local directory hierarchy, node-24 will be the default version
+`mise use -g node@26` will do the same but update the [global config](/configuration.html#global-config-config-mise-config-toml) (`~/.config/mise/config.toml`) so
+unless there is a config file in the local directory hierarchy, node-26 will be the default version
 for
 the user.
 

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -188,7 +188,7 @@ When you want to update tool versions:
 
 ```sh
 # Update tool version in mise.toml
-mise use node@24
+mise use node@26
 
 # This will update both the installation and mise.lock
 ```

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -28,10 +28,11 @@ echo $PATH
 If using [`mise activate`](/cli/activate.html), `mise` will automatically add the required tools to `PATH`.
 
 ```sh
-PATH="$HOME/.local/share/mise/installs/python/3.13.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+PATH="$HOME/.local/share/mise/installs/python/3.15.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 ```
 
 In this example, the python `bin` directory was added at the beginning of the `PATH`, making it available in the current shell session.
+When a fuzzy version like `python = "3.15"` or `node = "26"` is active, this path may use the requested-version symlink, such as `~/.local/share/mise/installs/python/3.15/bin`, instead of the fully resolved patch version.
 
 While the `PATH` design of `mise` works great in most cases, there are some situations where `shims` are preferable. This is the case when you are not using an interactive shell (for example, when using `mise` in an IDE or a script).
 

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -53,7 +53,7 @@ mise exec -- echo $MY_VAR
 You can of course combine them with [tools](/dev-tools/):
 
 ```sh
-mise use node@24
+mise use node@26
 mise set MY_VAR=123
 cat mise.toml
 # [tools]
@@ -81,7 +81,7 @@ If you are using [`shims`](/dev-tools/shims.html), the environment variables wil
 
 ```shell
 mise set NODE_ENV=production
-mise use node@24
+mise use node@26
 # using the absolute path for the example
 ~/.local/share/mise/shims/node --eval 'console.log(process.env.NODE_ENV)'
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,23 +95,23 @@ If `mise` isn't on `PATH` yet, use `~/.local/bin/mise` instead.
 ```sh
 mise exec python@3 -- python
 # this will download and install Python if it is not already installed
-# Python 3.13.2
+# Python 3.15.0
 # >>> ...
 ```
 
-or run node 24:
+or run node 26:
 
 ```sh
-mise exec node@24 -- node -v
-# v24.x.x
+mise exec node@26 -- node -v
+# v26.x.x
 ```
 
 To install a tool permanently, use [`mise u|use`](/cli/use.html):
 
 ```shell
-mise use --global node@24 # install node 24 and set it as the global default
+mise use --global node@26 # install node 26 and set it as the global default
 mise exec -- node my-script.js
-# run my-script.js with node 24...
+# run my-script.js with node 26...
 ```
 
 [`mise r|run`](/cli/run.html) lets you run [tasks](/tasks/) or scripts with the full mise context (tools + env vars) loaded.
@@ -211,16 +211,16 @@ Restart your shell session after modifying your rc file. Run [`mise dr|doctor`](
 With mise activated, tools are available directly on `PATH`:
 
 ```sh
-mise use --global node@24
+mise use --global node@26
 node -v
-# v24.x.x
+# v26.x.x
 ```
 
-When you ran `mise use --global node@24`, mise updated your global config:
+When you ran `mise use --global node@26`, mise updated your global config:
 
 ```toml [~/.config/mise/config.toml]
 [tools]
-node = "24"
+node = "26"
 ```
 
 ### Shell Feature Compatibility {#shell-feature-compatibility}

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -11,11 +11,11 @@ The code for this is inside the mise repository at [`./src/plugins/core/node.rs`
 
 ## Usage
 
-The following installs the latest version of node-20.x and makes it the global
+The following installs the latest version of node-26.x and makes it the global
 default:
 
 ```sh
-mise use -g node@20
+mise use -g node@26
 ```
 
 See the [Node.JS Cookbook](/mise-cookbook/nodejs.html) for common tasks and examples.
@@ -28,7 +28,7 @@ you can pin it alongside Node in your `mise.toml`:
 
 ```toml [mise.toml]
 [tools]
-node = "24"
+node = "26"
 npm = "11"
 ```
 
@@ -42,7 +42,7 @@ This resolves aliases like `lts` and `latest` to exact version numbers in `mise.
 
 ```toml [mise.toml]
 [tools]
-node = "24.14.1"
+node = "26.1.0"
 npm = "11.12.1"
 ```
 

--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -11,21 +11,21 @@ at [`./src/plugins/core/python.rs`](https://github.com/jdx/mise/blob/main/src/pl
 
 ## Usage
 
-The following installs the latest version of python-3.11.x and makes it the global
+The following installs the latest version of python-3.15.x and makes it the global
 default:
 
 ```sh
-mise use -g python@3.11
+mise use -g python@3.15
 ```
 
 You can also use multiple versions of python at the same time:
 
 ```sh
-$ mise use -g python@3.10 python@3.11
+$ mise use -g python@3.14 python@3.15
 $ python -V
-3.10.0
-$ python3.11 -V
-3.11.0
+3.14.0
+$ python3.15 -V
+3.15.0
 ```
 
 You can also install a specific python flavour. To get the latest version from a flavour just use the
@@ -64,14 +64,14 @@ Use `_.python.venv` in the `[env]` section of `mise.toml`:
 
 ```toml
 [tools]
-python = "3.11" # [optional] will be used for the venv
+python = "3.15" # [optional] will be used for the venv
 
 [env]
 _.python.venv = ".venv" # relative to this file's directory
 _.python.venv = "/root/.venv" # can be absolute
 _.python.venv = "{{env.HOME}}/.cache/venv/myproj" # can use templates
 _.python.venv = { path = ".venv", create = true } # create the venv if it doesn't exist
-_.python.venv = { path = ".venv", create = true, python = "3.10" } # use a specific python version
+_.python.venv = { path = ".venv", create = true, python = "3.15" } # use a specific python version
 _.python.venv = {
   path = ".venv", create = true,
   python_create_args = ["--without-pip"], # pass args to python -m venv
@@ -125,7 +125,7 @@ install path instead:
 
 ```toml
 [tools]
-python = "3.12"
+python = "3.15"
 
 [env]
 UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }

--- a/docs/mise-cookbook/docker.md
+++ b/docs/mise-cookbook/docker.md
@@ -54,15 +54,15 @@ ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
 RUN curl https://mise.run | sh
 
 # Pre-install tools to the system-wide shared directory
-RUN mise install --system node@22 python@3.13
+RUN mise install --system node@26 python@3.15
 ```
 
 Users in the container will see these tools automatically:
 
 ```shell
 $ mise ls
-node    22.0.0 (system)
-python  3.13.0 (system)
+node    26.0.0 (system)
+python  3.15.0 (system)
 ```
 
 Users can install additional versions in their own directory — those take priority over
@@ -83,7 +83,7 @@ this path is outside `~` and survives home directory mounts:
 ```Dockerfile [Dockerfile]
 FROM debian:13-slim
 # ... install mise ...
-RUN mise install --system node@22 python@3.13
+RUN mise install --system node@26 python@3.15
 ```
 
 When the container starts with `~` mounted, users still see the system tools automatically.

--- a/docs/mise-cookbook/nodejs.md
+++ b/docs/mise-cookbook/nodejs.md
@@ -16,10 +16,10 @@ This will install the latest version of Node.js and create a `mise.toml` file wi
 node = "latest"
 ```
 
-If you want to install Node.JS globally instead (for example, node v24), you can use the following command:
+If you want to install Node.JS globally instead (for example, node v26), you can use the following command:
 
 ```shell
-mise use -g node@24
+mise use -g node@26
 ```
 
 ## Add node modules binaries to the PATH

--- a/docs/tapes/demo.tape
+++ b/docs/tapes/demo.tape
@@ -32,7 +32,7 @@ Enter
 Type '# "mise exec <tool> -- <command>" allows you to run any tools with mise'
 Sleep 1s Enter Wait
 
-Type "mise exec node@24 -- node -v"
+Type "mise exec node@26 -- node -v"
 Sleep 500ms Enter Wait Sleep 2s
 
 Type '# node is only available in the mise environment, not globally' Sleep 500ms Enter Wait
@@ -95,20 +95,20 @@ Type 'mise ls' Sleep 500ms Enter Wait
 Sleep 3s
 
 Type 'clear' Sleep 500ms Enter Wait
-Type '# Lets enter a project directory where we will set up node@23 and pnpm@10' Enter
+Type '# Lets enter a project directory where we will set up node@26 and pnpm@10' Enter
 Sleep 1s
 
 Type "cd myproj" Sleep 500ms Enter Wait
 Sleep 1s
 
-Type "mise use node@23 pnpm@10" Sleep 500ms Enter Wait
+Type "mise use node@26 pnpm@10" Sleep 500ms Enter Wait
 Type "node -v" Enter Wait
 Sleep 2s
 
 Type "pnpm -v" Enter Wait
 Sleep 2s
 
-Type '# As expected, `node -v` is now v23.x' Enter Wait
+Type '# As expected, `node -v` is now v26.x' Enter Wait
 Sleep 2s
 
 Type 'bat mise.toml' Sleep 500ms Enter Wait

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -203,7 +203,7 @@ See [`install_before`](/configuration/settings.html#install_before) for more det
 ## [`mise up --bump`](/cli/upgrade.html)
 
 Use `mise up --bump` to upgrade all software to the latest version and update `mise.toml` files. This keeps the same semver range as before,
-so if you had `node = "22"` and node 24 is the latest, `mise up --bump node` will change `mise.toml` to `node = "24"`.
+so if you had `node = "24"` and node 26 is the latest, `mise up --bump node` will change `mise.toml` to `node = "26"`.
 
 ## cargo-binstall
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -74,7 +74,7 @@ detected with your setup. If you submit a bug report, please include the output 
 
 Likely this means that mise isn't first in PATH—using shims or `mise activate`. You can verify if
 this is the case by calling `which -a`, for example, if node@20.0.0 is being used but mise specifies
-node@24.0.0, first make sure that mise has this version installed and active by running `mise ls node`.
+node@26.0.0, first make sure that mise has this version installed and active by running `mise ls node`.
 It should not say missing and have the correct "Requested" version:
 
 ```bash

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -19,16 +19,16 @@ You use it like so (note that `mise` must be [activated](/getting-started.html#a
 
 ```bash
 mkdir example-project && cd example-project
-mise use node@24
+mise use node@26
 node -v
-# v24.x.x
+# v26.x.x
 ```
 
 And you'll also note that you now have a `mise.toml` file with the following content:
 
 ```mise-toml [mise.toml]
 [tools]
-node = "24"
+node = "26"
 ```
 
 - If this file is in the root of a project, `node` will be installed whenever someone runs [`mise install|i`](/cli/install).
@@ -83,7 +83,7 @@ Upgrading tool versions can be done with [`mise up|upgrade`](/cli/upgrade). By d
 the version prefix in `mise.toml`. If a [lockfile](/configuration/settings#lockfile) exists,
 mise will update `mise.lock` to the latest version of the tool with the prefix from `mise.toml`.
 
-So if you have `node = "24"` in `mise.toml`, then `mise upgrade node` will upgrade to the latest version of `node 24`.
+So if you have `node = "26"` in `mise.toml`, then `mise upgrade node` will upgrade to the latest version of `node 26`.
 
 If you'd like to upgrade to the latest version of node, you can use `mise upgrade --bump node`. It will set the version
 at the same specificity as the current version, so if you have `node = "24"`, but use `mise upgrade --bump node` to update to

--- a/e2e/cli/test_bin_paths
+++ b/e2e/cli/test_bin_paths
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 mise use dummy@latest tiny@latest
-assert "mise bin-paths dummy" "$MISE_DATA_DIR/installs/dummy/2.0.0/bin"
-assert "mise bin-paths tiny" "$MISE_DATA_DIR/installs/tiny/3.1.0/bin"
-assert "mise bin-paths" "$MISE_DATA_DIR/installs/dummy/2.0.0/bin
-$MISE_DATA_DIR/installs/tiny/3.1.0/bin"
+assert "mise bin-paths dummy" "$MISE_DATA_DIR/installs/dummy/latest/bin"
+assert "mise bin-paths tiny" "$MISE_DATA_DIR/installs/tiny/latest/bin"
+assert "mise bin-paths" "$MISE_DATA_DIR/installs/dummy/latest/bin
+$MISE_DATA_DIR/installs/tiny/latest/bin"

--- a/e2e/tools/test_runtime_symlinks
+++ b/e2e/tools/test_runtime_symlinks
@@ -8,3 +8,6 @@ assert "ls -l $MISE_DATA_DIR/installs/dummy | grep '\->' | awk '{print \$(NF-2),
 2.0 ./2.0.0
 2.1 ./2.1.0
 latest ./2.1.0"
+
+assert "mise bin-paths dummy@1.0" "$MISE_DATA_DIR/installs/dummy/1.0/bin"
+assert "mise bin-paths dummy@prefix:1" "$MISE_DATA_DIR/installs/dummy/1/bin"

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -391,6 +391,7 @@ impl Backend for AsdfBackend {
     }
 
     async fn list_bin_paths(&self, config: &Arc<Config>, tv: &ToolVersion) -> Result<Vec<PathBuf>> {
+        let runtime_path = tv.runtime_path();
         Ok(self
             .cache
             .list_bin_paths(config, self, tv, async || {
@@ -398,7 +399,7 @@ impl Backend for AsdfBackend {
             })
             .await?
             .into_iter()
-            .map(|path| tv.install_path().join(path))
+            .map(|path| runtime_path.join(path))
             .collect())
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1228,7 +1228,7 @@ pub trait Backend: Debug + Send + Sync {
     ) -> Result<Vec<PathBuf>> {
         match tv.request {
             ToolRequest::System { .. } => Ok(vec![]),
-            _ => Ok(vec![tv.install_path().join("bin")]),
+            _ => Ok(vec![tv.runtime_path().join("bin")]),
         }
     }
 

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -13,6 +13,7 @@ use crate::env;
 use crate::file;
 use crate::hash::hash_to_str;
 use crate::lockfile::{CondaPackageInfo, LockfileTool, PlatformInfo};
+use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, tool_request};
 use console::style;
 use dashmap::DashMap;
@@ -34,6 +35,7 @@ pub fn reset_install_path_cache() {
 pub struct ToolVersion {
     pub request: ToolRequest,
     pub version: String,
+    locked: bool,
     pub lock_platforms: BTreeMap<String, PlatformInfo>,
     pub install_path: Option<PathBuf>,
     /// Conda packages resolved during installation: (platform, basename) -> CondaPackageInfo
@@ -45,6 +47,7 @@ impl ToolVersion {
         ToolVersion {
             request,
             version,
+            locked: false,
             lock_platforms: Default::default(),
             install_path: None,
             conda_packages: Default::default(),
@@ -91,6 +94,7 @@ impl ToolVersion {
 
     fn from_lockfile(request: ToolRequest, lt: LockfileTool) -> Self {
         let mut tv = Self::new(request, lt.version);
+        tv.locked = true;
         tv.lock_platforms = lt.platforms;
         tv
     }
@@ -144,6 +148,36 @@ impl ToolVersion {
 
         INSTALL_PATH_CACHE.insert(self.clone(), path.clone());
         path
+    }
+    pub fn runtime_path(&self) -> PathBuf {
+        if self.locked {
+            return self.install_path();
+        }
+        let Some(pathname) = self.runtime_pathname() else {
+            return self.install_path();
+        };
+        let path = self.ba().installs_path.join(&pathname);
+        let path = env::find_in_shared_installs(path, &self.ba().tool_dir_name(), &pathname);
+        if path.is_dir() && is_runtime_symlink(&path) {
+            return path;
+        }
+
+        #[cfg(windows)]
+        if path.is_file()
+            && is_runtime_symlink(&path)
+            && let Ok(Some(target)) = file::resolve_symlink(&path)
+            && let Some(parent) = path.parent()
+        {
+            let target = parent.join(target);
+            if target.is_dir() {
+                return target
+                    .absolutize()
+                    .expect("failed to absolutize path")
+                    .to_path_buf();
+            }
+        }
+
+        self.install_path()
     }
     pub fn cache_path(&self) -> PathBuf {
         self.ba().cache_path.join(self.tv_pathname())
@@ -207,6 +241,14 @@ impl ToolVersion {
             }
         }
         .replace([':', '/'], "-")
+    }
+    fn runtime_pathname(&self) -> Option<String> {
+        let pathname = match &self.request {
+            ToolRequest::Version { version, .. } if version != &self.version => version,
+            ToolRequest::Prefix { prefix, .. } => prefix,
+            _ => return None,
+        };
+        Some(pathname.replace([':', '/'], "-"))
     }
     async fn resolve_version(
         config: &Arc<Config>,
@@ -531,5 +573,52 @@ impl Display for ResolveOptions {
             opts.push(format!("before_date={ts}"));
         }
         write!(f, "({})", opts.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::BackendResolution;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn runtime_path_does_not_return_file_based_runtime_symlink() -> Result<()> {
+        reset_install_path_cache();
+
+        let temp_dir = tempfile::tempdir()?;
+        let short = format!(
+            "dummy-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let mut backend = BackendArg::new_raw(
+            short.clone(),
+            None,
+            short,
+            None,
+            BackendResolution::new(false),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join("dummy");
+
+        let install_path = backend.installs_path.join("1.0.1");
+        fs::create_dir_all(install_path.join("bin"))?;
+        fs::write(backend.installs_path.join("1.0"), "./1.0.1")?;
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "1.0".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "1.0.1".into());
+
+        let runtime_path = tv.runtime_path();
+        assert_eq!(runtime_path, install_path);
+        assert!(runtime_path.is_dir());
+
+        Ok(())
     }
 }

--- a/src/toolset/toolset_paths.rs
+++ b/src/toolset/toolset_paths.rs
@@ -12,7 +12,7 @@ use crate::uv;
 use itertools::Itertools;
 
 // Cache Toolset::list_paths results across identical toolsets within a process.
-// Keyed by project_root plus sorted list of backend@version pairs currently installed.
+// Keyed by project_root plus sorted list of backend@requested=version pairs currently installed.
 pub(super) static LIST_PATHS_CACHE: Lazy<DashMap<String, Vec<PathBuf>>> = Lazy::new(DashMap::new);
 
 impl Toolset {
@@ -26,7 +26,7 @@ impl Toolset {
 
         let installed_strs: Vec<String> = installed
             .iter()
-            .map(|(p, tv)| format!("{}@{}", p.id(), tv.version))
+            .map(|(p, tv)| format!("{}@{}={}", p.id(), tv.request.version(), tv.version))
             .sorted()
             .collect();
         key_parts.extend(installed_strs);


### PR DESCRIPTION
## Summary

Use runtime symlink paths when building environment-facing tool paths for fuzzy or rolling requests, while keeping concrete install paths for install state and filesystem operations.

This fixes a case where `python = "3.14"` resolved to `3.14.4` and PATH used `.../installs/python/3.14.4/bin` instead of the stable requested-version symlink `.../installs/python/3.14/bin`. Tools that cache interpreter paths, such as virtualenvs, can then survive patch upgrades where the concrete install directory changes.

## Root Cause

`ToolVersion::install_path()` is intentionally based on the resolved version and is used broadly for install directories, downloads, cache paths, incomplete markers, and uninstall state. PATH generation also used that same concrete install path through backend `list_bin_paths()`, so runtime symlinks created by `runtime_symlinks::rebuild()` were not used for active PATH entries.

## Changes

- Add `ToolVersion::runtime_path()` for PATH-facing paths.
- Use `runtime_path()` in the default backend bin path implementation and asdf bin paths.
- Ensure `runtime_path()` only returns traversable directories, and resolve Windows file-based pseudo-symlinks to their concrete install directory.
- Keep lockfile-resolved tool versions on their concrete install path so fuzzy runtime symlinks cannot drift past the locked version.
- Include the requested version in the tool path cache key so exact and fuzzy requests resolving to the same concrete version do not share stale cached paths.
- Add e2e coverage for `dummy@1.0` and `dummy@prefix:1` returning runtime symlink bin paths.
- Add a unit regression test for file-based runtime symlink paths.
- Update `latest` bin-path expectations to use the existing `latest` runtime symlink.
- Update docs examples for runtime symlink paths and refresh visible Node/Python examples to Node 26 and Python 3.15.

## Validation

- `cargo test runtime_path_does_not_return_file_based_runtime_symlink`
- `mise run format`
- `mise run test:e2e e2e/lockfile/test_lockfile_exec`
- `mise run test:e2e e2e/tools/test_runtime_symlinks e2e/cli/test_bin_paths e2e/tools/test_path_order`
- `markdownlint README.md docs/demo.md docs/dev-tools/index.md docs/dev-tools/mise-lock.md docs/dev-tools/shims.md docs/environments/index.md docs/getting-started.md docs/lang/node.md docs/lang/python.md docs/mise-cookbook/docker.md docs/mise-cookbook/nodejs.md docs/tips-and-tricks.md docs/troubleshooting.md docs/walkthrough.md`
- Commit hook `hk` lint set, including `cargo check --all-features`

This PR was generated by Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how PATH/bin-paths are computed for non-pinned tool requests, which can affect runtime selection and downstream tooling that relies on specific filesystem paths. While scoped and covered by new tests, it touches core environment construction across backends.
> 
> **Overview**
> Ensures environment-facing tool paths (e.g., `PATH`/`mise bin-paths`) use the *requested-version* runtime symlink (like `.../installs/python/3.15/bin` or `.../installs/node/lts/bin`) instead of the resolved patch install directory, by introducing `ToolVersion::runtime_path()` and routing backend `list_bin_paths()` through it (including the asdf backend).
> 
> Updates toolset path caching to key on `requested=resolved` to avoid stale path reuse when different requests resolve to the same concrete version, adds/adjusts unit + e2e coverage for runtime symlink bin paths (including `latest`, prefix, and version requests), and refreshes docs/demo examples to Node 26 / Python 3.15 while documenting the runtime-symlink PATH behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a65c8aa7cd2051cdb75d31301b156c9edb0b16d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->