### PR TITLE
fix(self-update): ensure subcommand exists

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -241,7 +241,6 @@ pub enum Commands {
     Reshim(reshim::Reshim),
     Run(Box<run::Run>),
     Search(search::Search),
-    #[cfg(feature = "self_update")]
     SelfUpdate(self_update::SelfUpdate),
     Set(set::Set),
     Settings(settings::Settings),
@@ -311,7 +310,6 @@ impl Commands {
             Self::Reshim(cmd) => cmd.run().await,
             Self::Run(cmd) => (*cmd).run().await,
             Self::Search(cmd) => cmd.run().await,
-            #[cfg(feature = "self_update")]
             Self::SelfUpdate(cmd) => cmd.run().await,
             Self::Set(cmd) => cmd.run().await,
             Self::Settings(cmd) => cmd.run().await,

--- a/src/cli/self_update_stub.rs
+++ b/src/cli/self_update_stub.rs
@@ -8,7 +8,7 @@ use crate::env;
 pub struct SelfUpdate {}
 
 impl SelfUpdate {
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> crate::Result<()> {
         if let Some(instructions) = upgrade_instructions_text() {
             warn!("{}", instructions);
         }

--- a/src/cli/self_update_stub.rs
+++ b/src/cli/self_update_stub.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use crate::env;
 
-#[derive(Debug, clap::Parser)]
+#[derive(Debug, Default, clap::Args)]
 pub struct SelfUpdate {}
 
 impl SelfUpdate {

--- a/src/cli/self_update_stub.rs
+++ b/src/cli/self_update_stub.rs
@@ -4,9 +4,16 @@ use std::path::PathBuf;
 
 use crate::env;
 
+#[derive(Debug, clap::Parser)]
 pub struct SelfUpdate {}
 
 impl SelfUpdate {
+    pub async fn run(self) -> eyre::Result<()> {
+        if let Some(instructions) = upgrade_instructions_text() {
+            warn!("{}", instructions);
+        }
+        eyre::bail!("mise's self-update feature has been disabled at build time, cannot update");
+    }
     pub fn is_available() -> bool {
         false
     }

--- a/src/cli/self_update_stub.rs
+++ b/src/cli/self_update_stub.rs
@@ -5,7 +5,22 @@ use std::path::PathBuf;
 use crate::env;
 
 #[derive(Debug, Default, clap::Args)]
-pub struct SelfUpdate {}
+pub struct SelfUpdate {
+    /// Update to a specific version
+    version: Option<String>,
+
+    /// Update even if already up to date
+    #[clap(long, short)]
+    force: bool,
+
+    /// Skip confirmation prompt
+    #[clap(long, short)]
+    yes: bool,
+
+    /// Disable auto-updating plugins
+    #[clap(long)]
+    no_plugins: bool,
+}
 
 impl SelfUpdate {
     pub async fn run(self) -> crate::Result<()> {


### PR DESCRIPTION
even when the `self_update` Cargo feature is disabled.

Before, the `SelfUpdate` enum variant in `src/cli/mod.rs` inside the `Commands` enum was gated with `#[cfg(feature = "self_update")]`. This meant that when compiling without the `self_update` feature, the subcommand would be completely omitted from the CLI parser, instead of using the stub.

Furthermore, the `SelfUpdate` struct in `src/cli/self_update_stub.rs` did not derive the `clap::Parser` trait, nor did it have an asynchronous `run` method, which is required by the subcommand runner in `src/cli/mod.rs`.