### PR TITLE
fix(npm): respect install_before when resolving dist-tag versions

### DIFF
--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -21,8 +21,8 @@ install_before = "2023-06-01"
 "npm:prettier" = "latest"
 EOF
 mise install
-installed=$(mise ls --installed npm:prettier --json 2>/dev/null | grep -o '"version":"[^"]*"' | head -1)
-assert_contains "echo '$installed'" "2.8.8"
+installed_ver=$(mise ls --installed npm:prettier 2>/dev/null | awk '{print $2}' | head -1)
+assert_contains "echo '$installed_ver'" "2.8.8"
 
 # Test: without install_before, latest is the absolute latest (newer than 2.8.8)
 mise uninstall npm:prettier --all 2>/dev/null || true
@@ -32,6 +32,6 @@ cat <<EOF >mise.toml
 "npm:prettier" = "latest"
 EOF
 mise install
-installed_ver=$(mise ls --installed npm:prettier 2>&1 | awk '{print $2}')
+installed_ver=$(mise ls --installed npm:prettier 2>/dev/null | awk '{print $2}' | head -1)
 # The latest version should be 3.x or higher (definitely not 2.8.8)
 assert_not_contains "echo '$installed_ver'" "2.8.8"

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -8,31 +8,13 @@ export NPM_CONFIG_FUND=false
 
 mise use node
 
-# Test: npm with install_before should resolve to an older version
+# Test: mise latest with install_before should resolve to an older version
 # prettier 3.0.0 was released 2023-07-05, 2.8.8 was released 2023-05-23
 # Setting install_before to 2023-06-01 should give us 2.8.8 (not 3.x)
-mise uninstall npm:prettier --all 2>/dev/null || true
-rm -f mise.toml
-cat <<EOF >mise.toml
-[settings]
-install_before = "2023-06-01"
-
-[tools]
-"npm:prettier" = "latest"
-EOF
-mise install
-installed_ver=$(mise ls --installed npm:prettier 2>/dev/null | awk '{print $2}' | head -1)
-assert_contains "echo '$installed_ver'" "2.8.8"
+# This exercises NPMBackend::latest_stable_version directly.
+export MISE_INSTALL_BEFORE="2023-06-01"
+assert_contains "mise latest npm:prettier" "2.8.8"
+unset MISE_INSTALL_BEFORE
 
 # Test: without install_before, latest is the absolute latest (newer than 2.8.8)
-mise uninstall npm:prettier --all 2>/dev/null || true
-rm -f mise.toml
-cat <<EOF >mise.toml
-[tools]
-"npm:prettier" = "latest"
-EOF
-mise install
-assert_not_empty "mise ls --installed npm:prettier 2>/dev/null | awk '{print \$2}' | head -1"
-installed_ver=$(mise ls --installed npm:prettier 2>/dev/null | awk '{print $2}' | head -1)
-# The latest version should be 3.x or higher (definitely not 2.8.8)
-assert_not_contains "echo '$installed_ver'" "2.8.8"
+assert_not_contains "mise latest npm:prettier" "2.8.8"

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -32,6 +32,7 @@ cat <<EOF >mise.toml
 "npm:prettier" = "latest"
 EOF
 mise install
+assert_not_empty "mise ls --installed npm:prettier 2>/dev/null | awk '{print \$2}' | head -1"
 installed_ver=$(mise ls --installed npm:prettier 2>/dev/null | awk '{print $2}' | head -1)
 # The latest version should be 3.x or higher (definitely not 2.8.8)
 assert_not_contains "echo '$installed_ver'" "2.8.8"

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Test install_before with npm backend (dist-tag fallback)
+# Regression test for https://github.com/jdx/mise/discussions/9136
+
+require_cmd npm
+
+export NPM_CONFIG_FUND=false
+
+mise use node
+
+# Test: npm with install_before should resolve to an older version
+# prettier 3.0.0 was released 2023-07-05, 2.8.8 was released 2023-05-23
+# Setting install_before to 2023-06-01 should give us 2.8.8 (not 3.x)
+mise uninstall npm:prettier --all 2>/dev/null || true
+rm -f mise.toml
+cat <<EOF >mise.toml
+[settings]
+install_before = "2023-06-01"
+
+[tools]
+"npm:prettier" = "latest"
+EOF
+mise install
+installed=$(mise ls --installed npm:prettier --json 2>/dev/null | grep -o '"version":"[^"]*"' | head -1)
+assert_contains "echo '$installed'" "2.8.8"
+
+# Test: without install_before, latest is the absolute latest (newer than 2.8.8)
+mise uninstall npm:prettier --all 2>/dev/null || true
+rm -f mise.toml
+cat <<EOF >mise.toml
+[tools]
+"npm:prettier" = "latest"
+EOF
+mise install
+installed_ver=$(mise ls --installed npm:prettier 2>&1 | awk '{print $2}')
+# The latest version should be 3.x or higher (definitely not 2.8.8)
+assert_not_contains "echo '$installed_ver'" "2.8.8"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1767,7 +1767,7 @@ pub fn ensure_provenance_setting_enabled(
     Ok(())
 }
 
-fn find_match_in_list(list: &[String], query: &str) -> Option<String> {
+pub(crate) fn find_match_in_list(list: &[String], query: &str) -> Option<String> {
     match list.contains(&query.to_string()) {
         true => Some(query.to_string()),
         false => list.last().map(|s| s.to_string()),

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1767,7 +1767,7 @@ pub fn ensure_provenance_setting_enabled(
     Ok(())
 }
 
-pub(crate) fn find_match_in_list(list: &[String], query: &str) -> Option<String> {
+fn find_match_in_list(list: &[String], query: &str) -> Option<String> {
     match list.contains(&query.to_string()) {
         true => Some(query.to_string()),
         false => list.last().map(|s| s.to_string()),

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -129,6 +129,23 @@ impl Backend for NPMBackend {
         // TODO: Add bun support for getting latest version without npm
         // See TODO in _list_remote_versions for details
         self.ensure_npm_for_version_check(config).await;
+
+        // When install_before is active, the dist-tags shortcut must not be used
+        // because it returns the absolute latest version without date filtering.
+        // Fall back to the full version list which has created_at timestamps for
+        // proper date-based filtering. (See jdx/mise#9136)
+        let before_date = Settings::get()
+            .install_before
+            .as_ref()
+            .and_then(|s| crate::duration::parse_into_timestamp(s).ok());
+        if let Some(before) = before_date {
+            let versions_with_info = self.list_remote_versions_with_info(config).await?;
+            let filtered = crate::backend::VersionInfo::filter_by_date(versions_with_info, before);
+            let versions: Vec<String> = filtered.into_iter().map(|v| v.version).collect();
+            let matches = self.fuzzy_match_filter(versions, "latest");
+            return Ok(crate::backend::find_match_in_list(&matches, "latest"));
+        }
+
         let cache = self.latest_version_cache.lock().await;
         let this = self;
         timeout::run_with_timeout_async(
@@ -596,5 +613,50 @@ mod tests {
         assert!(!NPMBackend::npm_version_supports_min_release_age("10.99.0"));
         assert!(!NPMBackend::npm_version_supports_min_release_age(""));
         assert!(!NPMBackend::npm_version_supports_min_release_age("garbage"));
+    }
+
+    #[test]
+    fn test_version_info_filter_by_date_for_npm_timestamps() {
+        // Simulate npm _list_remote_versions output with created_at timestamps
+        use crate::backend::VersionInfo;
+        let versions = vec![
+            VersionInfo {
+                version: "2.8.7".to_string(),
+                created_at: Some("2023-05-01T12:00:00.000Z".to_string()),
+                ..Default::default()
+            },
+            VersionInfo {
+                version: "2.8.8".to_string(),
+                created_at: Some("2023-05-23T10:00:00.000Z".to_string()),
+                ..Default::default()
+            },
+            VersionInfo {
+                version: "3.0.0".to_string(),
+                created_at: Some("2023-07-05T14:00:00.000Z".to_string()),
+                ..Default::default()
+            },
+            VersionInfo {
+                version: "3.1.0".to_string(),
+                created_at: Some("2023-11-13T12:00:00.000Z".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        // Cutoff 2023-06-01: should include 2.8.7 and 2.8.8, exclude 3.0.0+
+        let cutoff: Timestamp = "2023-06-01T00:00:00Z".parse().unwrap();
+        let filtered = VersionInfo::filter_by_date(versions.clone(), cutoff);
+        let version_strings: Vec<&str> = filtered.iter().map(|v| v.version.as_str()).collect();
+        assert_eq!(version_strings, vec!["2.8.7", "2.8.8"]);
+
+        // Cutoff 2023-08-01: should include up to 3.0.0
+        let cutoff: Timestamp = "2023-08-01T00:00:00Z".parse().unwrap();
+        let filtered = VersionInfo::filter_by_date(versions.clone(), cutoff);
+        let version_strings: Vec<&str> = filtered.iter().map(|v| v.version.as_str()).collect();
+        assert_eq!(version_strings, vec!["2.8.7", "2.8.8", "3.0.0"]);
+
+        // No cutoff (far future): should include all
+        let cutoff: Timestamp = "2099-01-01T00:00:00Z".parse().unwrap();
+        let filtered = VersionInfo::filter_by_date(versions, cutoff);
+        assert_eq!(filtered.len(), 4);
     }
 }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -131,10 +131,17 @@ impl Backend for NPMBackend {
         self.ensure_npm_for_version_check(config).await;
 
         // dist-tags returns the absolute latest; bypass it when install_before
-        // is set so that `mise latest` / `mise edit` respect the date cutoff.
+        // is set (per-tool or global) so that callers like `mise latest` / `mise edit`
+        // that reach this method without a before_date context respect the cutoff.
         // (See jdx/mise#9136)
-        if let Some(before) = Settings::get()
-            .install_before
+        let before_str = config
+            .get_tool_opts(self.ba())
+            .await
+            .ok()
+            .flatten()
+            .and_then(|opts| opts.get("install_before").map(|s| s.to_string()))
+            .or_else(|| Settings::get().install_before.clone());
+        if let Some(before) = before_str
             .as_deref()
             .map(crate::duration::parse_into_timestamp)
             .transpose()?

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -130,36 +130,18 @@ impl Backend for NPMBackend {
         // See TODO in _list_remote_versions for details
         self.ensure_npm_for_version_check(config).await;
 
-        // When install_before is active and this method is called without a
-        // before_date context (e.g. via `mise latest` or `mise edit`), the
-        // dist-tags shortcut must not be used because it returns the absolute
-        // latest version without date filtering.
-        // Note: the primary install path (mise install) already handles this via
-        // latest_version_with_opts which bypasses this method when before_date is
-        // set through effective_before_date / ResolveOptions.
+        // dist-tags returns the absolute latest; bypass it when install_before
+        // is set so that `mise latest` / `mise edit` respect the date cutoff.
         // (See jdx/mise#9136)
-        let before_date = match &Settings::get().install_before {
-            Some(s) => match crate::duration::parse_into_timestamp(s) {
-                Ok(ts) => Some(ts),
-                Err(e) => {
-                    warn!("install_before: failed to parse {:?}: {:#}", s, e);
-                    None
-                }
-            },
-            None => None,
-        };
-        if let Some(before) = before_date {
-            let versions_with_info = self.list_remote_versions_with_info(config).await?;
-            let filtered = crate::backend::VersionInfo::filter_by_date(versions_with_info, before);
-            let versions: Vec<String> = filtered.into_iter().map(|v| v.version).collect();
-            if versions.is_empty() {
-                debug!(
-                    "npm: all versions of {} filtered out by install_before cutoff",
-                    self.tool_name()
-                );
-            }
-            let matches = self.fuzzy_match_filter(versions, "latest");
-            return Ok(crate::backend::find_match_in_list(&matches, "latest"));
+        if let Some(before) = Settings::get()
+            .install_before
+            .as_deref()
+            .map(crate::duration::parse_into_timestamp)
+            .transpose()?
+        {
+            return self
+                .latest_version_with_opts(config, None, Some(before))
+                .await;
         }
 
         let cache = self.latest_version_cache.lock().await;
@@ -629,50 +611,5 @@ mod tests {
         assert!(!NPMBackend::npm_version_supports_min_release_age("10.99.0"));
         assert!(!NPMBackend::npm_version_supports_min_release_age(""));
         assert!(!NPMBackend::npm_version_supports_min_release_age("garbage"));
-    }
-
-    #[test]
-    fn test_version_info_filter_by_date_for_npm_timestamps() {
-        // Simulate npm _list_remote_versions output with created_at timestamps
-        use crate::backend::VersionInfo;
-        let versions = vec![
-            VersionInfo {
-                version: "2.8.7".to_string(),
-                created_at: Some("2023-05-01T12:00:00.000Z".to_string()),
-                ..Default::default()
-            },
-            VersionInfo {
-                version: "2.8.8".to_string(),
-                created_at: Some("2023-05-23T10:00:00.000Z".to_string()),
-                ..Default::default()
-            },
-            VersionInfo {
-                version: "3.0.0".to_string(),
-                created_at: Some("2023-07-05T14:00:00.000Z".to_string()),
-                ..Default::default()
-            },
-            VersionInfo {
-                version: "3.1.0".to_string(),
-                created_at: Some("2023-11-13T12:00:00.000Z".to_string()),
-                ..Default::default()
-            },
-        ];
-
-        // Cutoff 2023-06-01: should include 2.8.7 and 2.8.8, exclude 3.0.0+
-        let cutoff: Timestamp = "2023-06-01T00:00:00Z".parse().unwrap();
-        let filtered = VersionInfo::filter_by_date(versions.clone(), cutoff);
-        let version_strings: Vec<&str> = filtered.iter().map(|v| v.version.as_str()).collect();
-        assert_eq!(version_strings, vec!["2.8.7", "2.8.8"]);
-
-        // Cutoff 2023-08-01: should include up to 3.0.0
-        let cutoff: Timestamp = "2023-08-01T00:00:00Z".parse().unwrap();
-        let filtered = VersionInfo::filter_by_date(versions.clone(), cutoff);
-        let version_strings: Vec<&str> = filtered.iter().map(|v| v.version.as_str()).collect();
-        assert_eq!(version_strings, vec!["2.8.7", "2.8.8", "3.0.0"]);
-
-        // No cutoff (far future): should include all
-        let cutoff: Timestamp = "2099-01-01T00:00:00Z".parse().unwrap();
-        let filtered = VersionInfo::filter_by_date(versions, cutoff);
-        assert_eq!(filtered.len(), 4);
     }
 }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -130,18 +130,34 @@ impl Backend for NPMBackend {
         // See TODO in _list_remote_versions for details
         self.ensure_npm_for_version_check(config).await;
 
-        // When install_before is active, the dist-tags shortcut must not be used
-        // because it returns the absolute latest version without date filtering.
-        // Fall back to the full version list which has created_at timestamps for
-        // proper date-based filtering. (See jdx/mise#9136)
-        let before_date = Settings::get()
-            .install_before
-            .as_ref()
-            .and_then(|s| crate::duration::parse_into_timestamp(s).ok());
+        // When install_before is active and this method is called without a
+        // before_date context (e.g. via `mise latest` or `mise edit`), the
+        // dist-tags shortcut must not be used because it returns the absolute
+        // latest version without date filtering.
+        // Note: the primary install path (mise install) already handles this via
+        // latest_version_with_opts which bypasses this method when before_date is
+        // set through effective_before_date / ResolveOptions.
+        // (See jdx/mise#9136)
+        let before_date = match &Settings::get().install_before {
+            Some(s) => match crate::duration::parse_into_timestamp(s) {
+                Ok(ts) => Some(ts),
+                Err(e) => {
+                    warn!("install_before: failed to parse {:?}: {:#}", s, e);
+                    None
+                }
+            },
+            None => None,
+        };
         if let Some(before) = before_date {
             let versions_with_info = self.list_remote_versions_with_info(config).await?;
             let filtered = crate::backend::VersionInfo::filter_by_date(versions_with_info, before);
             let versions: Vec<String> = filtered.into_iter().map(|v| v.version).collect();
+            if versions.is_empty() {
+                debug!(
+                    "npm: all versions of {} filtered out by install_before cutoff",
+                    self.tool_name()
+                );
+            }
             let matches = self.fuzzy_match_filter(versions, "latest");
             return Ok(crate::backend::find_match_in_list(&matches, "latest"));
         }


### PR DESCRIPTION
## Summary

- When `install_before` is set (per-tool or global), `NPMBackend::latest_stable_version` now delegates to `latest_version_with_opts` (which filters by `created_at` timestamps) instead of using the `dist-tags` shortcut that returns the absolute latest version
- Pre-release versions are already excluded by `VERSION_REGEX` in `fuzzy_match_filter`, so the resolved version is always a stable release — same as `dist-tags.latest`

Fixes https://github.com/jdx/mise/discussions/9136

## Details

`NPMBackend::latest_stable_version` overrides the default trait implementation to use `npm view <pkg> dist-tags --json`. This shortcut ignores `install_before` date filtering.

The primary install path (`mise install`) is unaffected because `effective_before_date` sets `ResolveOptions.before_date`, and `latest_version_with_opts` routes through `list_versions_matching_with_opts` — bypassing `latest_stable_version` entirely.

However, callers that don't go through `effective_before_date` — such as `mise latest` and `mise edit` — reach `latest_stable_version` directly. The fix adds a guard that checks per-tool `install_before` (via `config.get_tool_opts`) and the global setting, then delegates to the existing date-filtered resolution path.

### Note on pre-release versions

The fallback path uses `fuzzy_match_filter` which excludes pre-release versions (`-alpha`, `-beta`, `-rc`, etc.) via `VERSION_REGEX`. In the rare case where a package tags a pre-release as `latest` in dist-tags, the fallback would resolve to the newest stable version instead. This only affects the `install_before` code path and matches how all other backends handle `latest`.

## Test plan

- [x] New E2E test `e2e/backend/test_npm_install_before`: uses `mise latest` with `MISE_INSTALL_BEFORE` to verify `latest_stable_version` respects the date cutoff
- [x] Existing unit tests pass (`cargo test --bin mise backend::npm::tests` — 8/8)
- [x] `cargo check` passes
- [x] CI: macOS unit, Windows unit, Windows E2E all pass

Generated with [Claude Code](https://claude.ai/claude-code)