### PR TITLE
registry: add rush

### DIFF
--- a/registry/rush.toml
+++ b/registry/rush.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:shenwei356/rush"]
+description = "A cross-platform command-line tool for executing jobs in parallel"
+test = { cmd = "rush --help", expected = "rush -- a cross-platform command-line tool for executing jobs in parallel" }


### PR DESCRIPTION
## Summary
- Add [shenwei356/rush](https://github.com/shenwei356/rush) to the registry using the aqua backend
- Rush is a cross-platform command-line tool for executing jobs in parallel (similar to GNU parallel)

## Test plan
- [x] Verified `mise x rush@0.5.4 -- rush --help` installs and runs successfully via the aqua backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a new registry entry and a non-destructive CLI help-based test; no changes to core logic or security-sensitive code.
> 
> **Overview**
> Adds a new registry definition `registry/rush.toml` for `shenwei356/rush` using the `aqua` backend.
> 
> Includes metadata (`description`) and a simple `test` command (`rush --help`) to validate the installed binary output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e6b54eab2c497d18e4b39a454add8b74788b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->