### PR TITLE
fix(github): use full token resolution chain for attestation verification

### DIFF
--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -9,7 +9,6 @@ use crate::backend::static_helpers::{
 };
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::config::{Config, Settings};
-use crate::env;
 use crate::file;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
@@ -478,7 +477,7 @@ impl UnifiedGitBackend {
                 match sigstore_verification::sources::github::GitHubSource::new(
                     owner,
                     repo_name,
-                    env::GITHUB_TOKEN.as_deref(),
+                    github::resolve_token_for_api_url(api_url).as_deref(),
                 ) {
                     Ok(source) => {
                         use sigstore_verification::AttestationSource;
@@ -576,7 +575,7 @@ impl UnifiedGitBackend {
                     &artifact_path,
                     owner,
                     repo_name,
-                    env::GITHUB_TOKEN.as_deref(),
+                    github::resolve_token_for_api_url(api_url).as_deref(),
                     None,
                 )
                 .await
@@ -1564,12 +1563,13 @@ impl UnifiedGitBackend {
             )));
         }
         let (owner, repo_name) = (parts[0], parts[1]);
+        let api_url = self.get_api_url(&tv.request.options());
 
         match sigstore_verification::verify_github_attestation(
             file_path,
             owner,
             repo_name,
-            env::GITHUB_TOKEN.as_deref(),
+            github::resolve_token_for_api_url(&api_url).as_deref(),
             None, // We don't know the expected workflow
         )
         .await

--- a/src/github.rs
+++ b/src/github.rs
@@ -452,12 +452,12 @@ pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
 /// Resolve the GitHub token from a full API base URL (e.g., "https://api.github.com").
 /// Extracts the hostname and delegates to [`resolve_token`].
 pub fn resolve_token_for_api_url(api_url: &str) -> Option<String> {
-    let host = url::Url::parse(api_url)
-        .ok()
-        .and_then(|u| u.host_str().map(|h| h.to_string()));
-    let host = host.as_deref().unwrap_or("api.github.com");
-    let lookup_host = canonical_host(host.as_deref()).unwrap_or("github.com");
-    resolve_token(lookup_host).map(|(t, _)| t)
+    let parsed = url::Url::parse(api_url).ok();
+    let host = parsed
+        .as_ref()
+        .and_then(|u| u.host_str())
+        .unwrap_or("api.github.com");
+    resolve_token(host).map(|(t, _)| t)
 }
 
 pub fn get_headers<U: IntoUrl>(url: U) -> HeaderMap {

--- a/src/github.rs
+++ b/src/github.rs
@@ -449,6 +449,17 @@ pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
     None
 }
 
+/// Resolve the GitHub token from a full API base URL (e.g., "https://api.github.com").
+/// Extracts the hostname and delegates to [`resolve_token`].
+pub fn resolve_token_for_api_url(api_url: &str) -> Option<String> {
+    let host = url::Url::parse(api_url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_string()));
+    let host = host.as_deref().unwrap_or("api.github.com");
+    let lookup_host = canonical_host(Some(host)).unwrap_or(host);
+    resolve_token(lookup_host).map(|(t, _)| t)
+}
+
 pub fn get_headers<U: IntoUrl>(url: U) -> HeaderMap {
     let mut headers = HeaderMap::new();
     let url = url.into_url().unwrap();

--- a/src/github.rs
+++ b/src/github.rs
@@ -456,7 +456,7 @@ pub fn resolve_token_for_api_url(api_url: &str) -> Option<String> {
         .ok()
         .and_then(|u| u.host_str().map(|h| h.to_string()));
     let host = host.as_deref().unwrap_or("api.github.com");
-    let lookup_host = canonical_host(Some(host)).unwrap_or(host);
+    let lookup_host = canonical_host(host.as_deref()).unwrap_or("github.com");
     resolve_token(lookup_host).map(|(t, _)| t)
 }
 


### PR DESCRIPTION
## Summary

- Attestation verification was passing only the env-var token (`MISE_GITHUB_TOKEN` / `GITHUB_TOKEN`) to the GitHub API, bypassing the full token resolution chain
- This meant tokens from `credential_command`, `github_tokens.toml`, the `gh` CLI, and `git credential fill` were silently ignored during attestation calls
- Result: unauthenticated requests hit GitHub's IP-based rate limit even when a valid token was configured via the credential helper

## Fix

- Added `github::resolve_token_for_api_url(api_url)` to `src/github.rs` — parses the hostname from the API URL and delegates to the existing `resolve_token` priority chain
- Replaced all three `env::GITHUB_TOKEN.as_deref()` call sites in attestation verification (`detect_provenance_type`, `verify_provenance_at_lock_time`, `try_verify_github_attestations`) with the new helper
- The third site didn't have `api_url` in scope; it now derives it from `self.get_api_url(&tv.request.options())`

## Test plan

- [ ] Install a tool with GitHub artifact attestations enabled while token is set only via `credential_command` (not env var) — should verify without 403
- [ ] Confirm existing unit/e2e tests pass: `mise run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provenance/attestation verification and how auth tokens are selected, which can affect security verification outcomes and GitHub rate-limiting behavior, but the change is small and reuses existing token-resolution logic.
> 
> **Overview**
> GitHub attestation detection and verification now authenticate using the same per-host token resolution chain as normal GitHub API requests, rather than only `GITHUB_TOKEN`/`MISE_GITHUB_TOKEN`.
> 
> This adds `github::resolve_token_for_api_url()` and updates all GitHub attestation call sites in `backend/github.rs` (including the install-time path that now derives `api_url` from options) to pass the resolved token for the configured API base URL, improving behavior for enterprise/custom hosts and non-env token sources (credential command, tokens file, gh CLI, git credentials).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa5005ec7ce8f515b61acd11aabb5d701f7b480b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->