### PR TITLE
fix(npm): honor install_before without day drift (#9156)

### DIFF
--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -7,7 +7,7 @@ use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::settings::NpmPackageManager;
 use crate::config::{Config, Settings};
-use crate::duration::process_now;
+use crate::duration::{elapsed_seconds_ceil, process_now};
 use crate::install_context::InstallContext;
 use crate::timeout;
 use crate::toolset::ToolVersion;
@@ -304,7 +304,7 @@ impl NPMBackend {
         package_manager: NpmPackageManager,
         before_date: Timestamp,
     ) -> Vec<OsString> {
-        let seconds = Self::elapsed_seconds_ceil(before_date, process_now());
+        let seconds = elapsed_seconds_ceil(before_date, process_now());
         match package_manager {
             NpmPackageManager::Npm => {
                 // Sub-day windows always emit --before because --min-release-age
@@ -350,15 +350,6 @@ impl NPMBackend {
     fn build_pnpm_release_age_args(seconds: u64) -> Vec<OsString> {
         let minutes = seconds.div_ceil(60);
         vec![format!("--config.minimumReleaseAge={minutes}").into()]
-    }
-
-    fn elapsed_seconds_ceil(before_date: Timestamp, now: Timestamp) -> u64 {
-        if before_date >= now {
-            return 0;
-        }
-        let nanos = now.as_nanosecond() - before_date.as_nanosecond();
-        u64::try_from((nanos + 999_999_999) / 1_000_000_000)
-            .expect("elapsed timestamp delta must fit into u64")
     }
 
     /// Returns true if the npm major.minor.patch version is >= 11.10.0,

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -325,17 +325,13 @@ impl NPMBackend {
         seconds: u64,
         supports_min_release_age: bool,
     ) -> Vec<OsString> {
-        // Either branch emits the same `--before` fallback, so merge them:
-        //   * older npm without --min-release-age
-        //   * sub-day windows (--min-release-age is day-granular)
+        // Both older npm (no --min-release-age) and sub-day windows
+        // (--min-release-age is day-granular) fall back to --before.
         if !supports_min_release_age || seconds < 86400 {
             return vec!["--before".into(), before_date.to_string().into()];
         }
-        // Tolerate a small amount of elapsed time between resolving
-        // `install_before` and converting it back to a day count so that e.g.
-        // "3d" doesn't get rounded up to "4d" just because a few seconds have
-        // passed (see #9156). The tolerance only applies here because bun/pnpm
-        // emit the cutoff in units (seconds / minutes) finer than typical drift.
+        // Apply the drift tolerance only for the day-based conversion;
+        // bun/pnpm emit the cutoff in finer units so drift is harmless there.
         let days = seconds
             .saturating_sub(BEFORE_DATE_TOLERANCE_SECS)
             .div_ceil(86400)
@@ -516,8 +512,6 @@ mod tests {
 
     #[test]
     fn test_build_npm_release_age_args_legacy() {
-        // Older npm without --min-release-age always falls back to --before,
-        // regardless of the cutoff window.
         let before_date: Timestamp = "2024-01-02T03:04:05Z".parse().unwrap();
         let args = NPMBackend::build_npm_release_age_args(before_date, 86400, false);
         assert_eq!(
@@ -531,8 +525,6 @@ mod tests {
 
     #[test]
     fn test_build_npm_release_age_args_sub_day_uses_before() {
-        // Sub-day windows fall back to --before even when npm supports
-        // --min-release-age, because that flag is day-granular.
         let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
         let args = NPMBackend::build_npm_release_age_args(before_date, 1, true);
         assert_eq!(
@@ -546,7 +538,6 @@ mod tests {
 
     #[test]
     fn test_build_npm_release_age_args_full_days() {
-        // Exactly 3 full days → --min-release-age=3
         let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
         let args = NPMBackend::build_npm_release_age_args(before_date, 86400 * 3, true);
         assert_eq!(args, vec![OsString::from("--min-release-age=3")]);
@@ -554,8 +545,8 @@ mod tests {
 
     #[test]
     fn test_build_npm_release_age_args_tolerates_drift() {
-        // Regression test for #9156: `install_before = "3d"` re-converted after
-        // ~30s of drift must not round up to 4 days.
+        // Regression test for #9156: "3d" re-converted after ~30s of drift
+        // must not round up to 4 days.
         let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
         let args = NPMBackend::build_npm_release_age_args(before_date, 86400 * 3 + 30, true);
         assert_eq!(args, vec![OsString::from("--min-release-age=3")]);
@@ -563,8 +554,8 @@ mod tests {
 
     #[test]
     fn test_build_npm_release_age_args_past_tolerance_rounds_up() {
-        // Drift larger than the tolerance (60s) should still round up to the
-        // next day so cutoffs remain at least as strict as requested.
+        // Drift larger than BEFORE_DATE_TOLERANCE_SECS still rounds up so
+        // cutoffs remain at least as strict as requested.
         let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
         let args = NPMBackend::build_npm_release_age_args(before_date, 86400 * 3 + 120, true);
         assert_eq!(args, vec![OsString::from("--min-release-age=4")]);
@@ -572,8 +563,8 @@ mod tests {
 
     #[test]
     fn test_build_npm_release_age_args_one_day_boundary() {
-        // `install_before = "1d"` with a few seconds of drift should still
-        // emit --min-release-age=1 rather than falling back to --before.
+        // Small drift at the 1-day boundary must stay at --min-release-age=1
+        // instead of falling through to --before.
         let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
         let args = NPMBackend::build_npm_release_age_args(before_date, 86400 + 5, true);
         assert_eq!(args, vec![OsString::from("--min-release-age=1")]);
@@ -590,8 +581,6 @@ mod tests {
 
     #[test]
     fn test_build_pnpm_release_age_args_rounds_up_to_minutes() {
-        // pnpm's --config.minimumReleaseAge is minute-granular; a 1s delta
-        // should be rounded up to 1 minute.
         let args = NPMBackend::build_pnpm_release_age_args(1);
         assert_eq!(args, vec![OsString::from("--config.minimumReleaseAge=1")]);
     }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -188,16 +188,21 @@ impl Backend for NPMBackend {
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         self.check_install_deps(&ctx.config).await;
-        match Settings::get().npm.package_manager {
+        let package_manager = Settings::get().npm.package_manager;
+        let install_before_args = match ctx.before_date {
+            Some(before_date) => {
+                self.build_transitive_release_age_args(
+                    &ctx.config,
+                    package_manager,
+                    before_date,
+                    process_now(),
+                )
+                .await
+            }
+            None => Vec::new(),
+        };
+        match package_manager {
             NpmPackageManager::Bun => {
-                let install_before_args = ctx.before_date.map_or_else(Vec::new, |before_date| {
-                    Self::build_transitive_release_age_args(
-                        NpmPackageManager::Bun,
-                        before_date,
-                        process_now(),
-                        false,
-                    )
-                });
                 CmdLineRunner::new("bun")
                     .arg("install")
                     .arg(format!("{}@{}", self.tool_name(), tv.version))
@@ -225,14 +230,6 @@ impl Backend for NPMBackend {
             NpmPackageManager::Pnpm => {
                 let bin_dir = tv.install_path().join("bin");
                 crate::file::create_dir_all(&bin_dir)?;
-                let install_before_args = ctx.before_date.map_or_else(Vec::new, |before_date| {
-                    Self::build_transitive_release_age_args(
-                        NpmPackageManager::Pnpm,
-                        before_date,
-                        process_now(),
-                        false,
-                    )
-                });
                 CmdLineRunner::new("pnpm")
                     .arg("add")
                     .arg("--global")
@@ -257,17 +254,6 @@ impl Backend for NPMBackend {
                     .execute()?;
             }
             _ => {
-                let install_before_args = if let Some(before_date) = ctx.before_date {
-                    let supports = self.npm_supports_min_release_age_flag(&ctx.config).await;
-                    Self::build_transitive_release_age_args(
-                        NpmPackageManager::Npm,
-                        before_date,
-                        process_now(),
-                        supports,
-                    )
-                } else {
-                    Vec::new()
-                };
                 CmdLineRunner::new(NPM_PROGRAM)
                     .arg("install")
                     .arg("-g")
@@ -317,45 +303,59 @@ impl NPMBackend {
         }
     }
 
-    fn build_transitive_release_age_args(
+    async fn build_transitive_release_age_args(
+        &self,
+        config: &Arc<Config>,
         package_manager: NpmPackageManager,
         before_date: Timestamp,
         now: Timestamp,
-        npm_supports_min_release_age: bool,
     ) -> Vec<OsString> {
         let seconds = Self::elapsed_seconds_ceil(before_date, now);
         match package_manager {
             NpmPackageManager::Npm => {
-                if npm_supports_min_release_age {
-                    // --min-release-age (npm/cli#8965) is day-granular; for sub-day
-                    // windows (e.g. install_before = "1h") fall back to --before to
-                    // preserve the exact cutoff.
-                    if seconds < 86400 {
-                        return vec!["--before".into(), before_date.to_string().into()];
-                    }
-                    // Tolerate a small amount of elapsed time between resolving
-                    // `install_before` and converting it back to a day count so
-                    // that e.g. "3d" doesn't get rounded up to "4d" just because
-                    // a few seconds have passed (see #9156). The tolerance is
-                    // only applied here because bun/pnpm emit the cutoff in
-                    // units (seconds / minutes) finer than the typical drift.
-                    let days = seconds
-                        .saturating_sub(BEFORE_DATE_TOLERANCE_SECS)
-                        .div_ceil(86400)
-                        .max(1);
-                    vec![format!("--min-release-age={days}").into()]
-                } else {
-                    vec!["--before".into(), before_date.to_string().into()]
-                }
+                // Sub-day windows always emit --before because --min-release-age
+                // is day-granular — which is also the fallback for older npm.
+                // Short-circuiting here lets us skip the `npm --version` probe
+                // entirely when the cutoff is <24h.
+                let supports_min_release_age =
+                    seconds >= 86400 && self.npm_supports_min_release_age_flag(config).await;
+                Self::build_npm_release_age_args(before_date, seconds, supports_min_release_age)
             }
-            NpmPackageManager::Bun => {
-                vec!["--minimum-release-age".into(), seconds.to_string().into()]
-            }
-            NpmPackageManager::Pnpm => {
-                let minutes = seconds.div_ceil(60);
-                vec![format!("--config.minimumReleaseAge={minutes}").into()]
-            }
+            NpmPackageManager::Bun => Self::build_bun_release_age_args(seconds),
+            NpmPackageManager::Pnpm => Self::build_pnpm_release_age_args(seconds),
         }
+    }
+
+    fn build_npm_release_age_args(
+        before_date: Timestamp,
+        seconds: u64,
+        supports_min_release_age: bool,
+    ) -> Vec<OsString> {
+        // Either branch emits the same `--before` fallback, so merge them:
+        //   * older npm without --min-release-age
+        //   * sub-day windows (--min-release-age is day-granular)
+        if !supports_min_release_age || seconds < 86400 {
+            return vec!["--before".into(), before_date.to_string().into()];
+        }
+        // Tolerate a small amount of elapsed time between resolving
+        // `install_before` and converting it back to a day count so that e.g.
+        // "3d" doesn't get rounded up to "4d" just because a few seconds have
+        // passed (see #9156). The tolerance only applies here because bun/pnpm
+        // emit the cutoff in units (seconds / minutes) finer than typical drift.
+        let days = seconds
+            .saturating_sub(BEFORE_DATE_TOLERANCE_SECS)
+            .div_ceil(86400)
+            .max(1);
+        vec![format!("--min-release-age={days}").into()]
+    }
+
+    fn build_bun_release_age_args(seconds: u64) -> Vec<OsString> {
+        vec!["--minimum-release-age".into(), seconds.to_string().into()]
+    }
+
+    fn build_pnpm_release_age_args(seconds: u64) -> Vec<OsString> {
+        let minutes = seconds.div_ceil(60);
+        vec![format!("--config.minimumReleaseAge={minutes}").into()]
     }
 
     fn elapsed_seconds_ceil(before_date: Timestamp, now: Timestamp) -> u64 {
@@ -530,15 +530,11 @@ mod tests {
     }
 
     #[test]
-    fn test_build_transitive_release_age_args_for_npm_legacy() {
+    fn test_build_npm_release_age_args_legacy() {
+        // Older npm without --min-release-age always falls back to --before,
+        // regardless of the cutoff window.
         let before_date: Timestamp = "2024-01-02T03:04:05Z".parse().unwrap();
-        let now: Timestamp = "2024-01-03T03:04:05Z".parse().unwrap();
-        let args = NPMBackend::build_transitive_release_age_args(
-            NpmPackageManager::Npm,
-            before_date,
-            now,
-            false,
-        );
+        let args = NPMBackend::build_npm_release_age_args(before_date, 86400, false);
         assert_eq!(
             args,
             vec![
@@ -549,30 +545,11 @@ mod tests {
     }
 
     #[test]
-    fn test_build_transitive_release_age_args_for_npm_min_release_age() {
-        // 3 full days → --min-release-age=3
+    fn test_build_npm_release_age_args_sub_day_uses_before() {
+        // Sub-day windows fall back to --before even when npm supports
+        // --min-release-age, because that flag is day-granular.
         let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
-        let now: Timestamp = "2024-01-04T00:00:00Z".parse().unwrap();
-        let args = NPMBackend::build_transitive_release_age_args(
-            NpmPackageManager::Npm,
-            before_date,
-            now,
-            true,
-        );
-        assert_eq!(args, vec![OsString::from("--min-release-age=3")]);
-    }
-
-    #[test]
-    fn test_build_transitive_release_age_args_for_npm_sub_day_fallback() {
-        // Sub-day window falls back to --before since --min-release-age is day-granular
-        let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
-        let now: Timestamp = "2024-01-01T00:00:01Z".parse().unwrap();
-        let args = NPMBackend::build_transitive_release_age_args(
-            NpmPackageManager::Npm,
-            before_date,
-            now,
-            true,
-        );
+        let args = NPMBackend::build_npm_release_age_args(before_date, 1, true);
         assert_eq!(
             args,
             vec![
@@ -583,61 +560,43 @@ mod tests {
     }
 
     #[test]
-    fn test_build_transitive_release_age_args_tolerates_drift() {
-        // Regression test for #9156: `install_before = "3d"` resolved to an
-        // absolute date and then re-converted after ~30s of drift must not
-        // round up to 4 days.
+    fn test_build_npm_release_age_args_full_days() {
+        // Exactly 3 full days → --min-release-age=3
         let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
-        let now: Timestamp = "2024-01-04T00:00:30Z".parse().unwrap();
-        let args = NPMBackend::build_transitive_release_age_args(
-            NpmPackageManager::Npm,
-            before_date,
-            now,
-            true,
-        );
+        let args = NPMBackend::build_npm_release_age_args(before_date, 86400 * 3, true);
         assert_eq!(args, vec![OsString::from("--min-release-age=3")]);
     }
 
     #[test]
-    fn test_build_transitive_release_age_args_past_tolerance_rounds_up() {
+    fn test_build_npm_release_age_args_tolerates_drift() {
+        // Regression test for #9156: `install_before = "3d"` re-converted after
+        // ~30s of drift must not round up to 4 days.
+        let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
+        let args = NPMBackend::build_npm_release_age_args(before_date, 86400 * 3 + 30, true);
+        assert_eq!(args, vec![OsString::from("--min-release-age=3")]);
+    }
+
+    #[test]
+    fn test_build_npm_release_age_args_past_tolerance_rounds_up() {
         // Drift larger than the tolerance (60s) should still round up to the
         // next day so cutoffs remain at least as strict as requested.
         let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
-        let now: Timestamp = "2024-01-04T00:02:00Z".parse().unwrap();
-        let args = NPMBackend::build_transitive_release_age_args(
-            NpmPackageManager::Npm,
-            before_date,
-            now,
-            true,
-        );
+        let args = NPMBackend::build_npm_release_age_args(before_date, 86400 * 3 + 120, true);
         assert_eq!(args, vec![OsString::from("--min-release-age=4")]);
     }
 
     #[test]
-    fn test_build_transitive_release_age_args_one_day_boundary() {
+    fn test_build_npm_release_age_args_one_day_boundary() {
         // `install_before = "1d"` with a few seconds of drift should still
         // emit --min-release-age=1 rather than falling back to --before.
         let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
-        let now: Timestamp = "2024-01-02T00:00:05Z".parse().unwrap();
-        let args = NPMBackend::build_transitive_release_age_args(
-            NpmPackageManager::Npm,
-            before_date,
-            now,
-            true,
-        );
+        let args = NPMBackend::build_npm_release_age_args(before_date, 86400 + 5, true);
         assert_eq!(args, vec![OsString::from("--min-release-age=1")]);
     }
 
     #[test]
-    fn test_build_transitive_release_age_args_for_bun() {
-        let before_date: Timestamp = "2024-01-02T03:04:04.100Z".parse().unwrap();
-        let now: Timestamp = "2024-01-02T03:04:05Z".parse().unwrap();
-        let args = NPMBackend::build_transitive_release_age_args(
-            NpmPackageManager::Bun,
-            before_date,
-            now,
-            false,
-        );
+    fn test_build_bun_release_age_args() {
+        let args = NPMBackend::build_bun_release_age_args(1);
         assert_eq!(
             args,
             vec![OsString::from("--minimum-release-age"), OsString::from("1")]
@@ -645,15 +604,10 @@ mod tests {
     }
 
     #[test]
-    fn test_build_transitive_release_age_args_for_pnpm() {
-        let before_date: Timestamp = "2024-01-02T03:03:05.100Z".parse().unwrap();
-        let now: Timestamp = "2024-01-02T03:04:05Z".parse().unwrap();
-        let args = NPMBackend::build_transitive_release_age_args(
-            NpmPackageManager::Pnpm,
-            before_date,
-            now,
-            false,
-        );
+    fn test_build_pnpm_release_age_args_rounds_up_to_minutes() {
+        // pnpm's --config.minimumReleaseAge is minute-granular; a 1s delta
+        // should be rounded up to 1 minute.
+        let args = NPMBackend::build_pnpm_release_age_args(1);
         assert_eq!(args, vec![OsString::from("--config.minimumReleaseAge=1")]);
     }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -191,13 +191,8 @@ impl Backend for NPMBackend {
         let package_manager = Settings::get().npm.package_manager;
         let install_before_args = match ctx.before_date {
             Some(before_date) => {
-                self.build_transitive_release_age_args(
-                    &ctx.config,
-                    package_manager,
-                    before_date,
-                    process_now(),
-                )
-                .await
+                self.build_transitive_release_age_args(&ctx.config, package_manager, before_date)
+                    .await
             }
             None => Vec::new(),
         };
@@ -308,9 +303,8 @@ impl NPMBackend {
         config: &Arc<Config>,
         package_manager: NpmPackageManager,
         before_date: Timestamp,
-        now: Timestamp,
     ) -> Vec<OsString> {
-        let seconds = Self::elapsed_seconds_ceil(before_date, now);
+        let seconds = Self::elapsed_seconds_ceil(before_date, process_now());
         match package_manager {
             NpmPackageManager::Npm => {
                 // Sub-day windows always emit --before because --min-release-age

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -7,6 +7,7 @@ use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::settings::NpmPackageManager;
 use crate::config::{Config, Settings};
+use crate::duration::process_now;
 use crate::install_context::InstallContext;
 use crate::timeout;
 use crate::toolset::ToolVersion;
@@ -16,6 +17,13 @@ use serde_json::Value;
 use std::ffi::OsString;
 use std::{fmt::Debug, sync::Arc};
 use tokio::sync::Mutex as TokioMutex;
+
+/// Tolerance applied when converting an absolute `before_date` back to a
+/// relative duration for CLI flags. This ensures that a user-supplied
+/// `install_before = "3d"` never gets rounded up to `4d` due to small amounts
+/// of elapsed time between when mise resolved the cutoff and when it invoked
+/// the package manager.
+const BEFORE_DATE_TOLERANCE_SECS: u64 = 60;
 
 #[derive(Debug)]
 pub struct NPMBackend {
@@ -186,7 +194,7 @@ impl Backend for NPMBackend {
                     Self::build_transitive_release_age_args(
                         NpmPackageManager::Bun,
                         before_date,
-                        Timestamp::now(),
+                        process_now(),
                         false,
                     )
                 });
@@ -221,7 +229,7 @@ impl Backend for NPMBackend {
                     Self::build_transitive_release_age_args(
                         NpmPackageManager::Pnpm,
                         before_date,
-                        Timestamp::now(),
+                        process_now(),
                         false,
                     )
                 });
@@ -254,7 +262,7 @@ impl Backend for NPMBackend {
                     Self::build_transitive_release_age_args(
                         NpmPackageManager::Npm,
                         before_date,
-                        Timestamp::now(),
+                        process_now(),
                         supports,
                     )
                 } else {
@@ -315,28 +323,35 @@ impl NPMBackend {
         now: Timestamp,
         npm_supports_min_release_age: bool,
     ) -> Vec<OsString> {
+        let seconds = Self::elapsed_seconds_ceil(before_date, now);
         match package_manager {
             NpmPackageManager::Npm => {
                 if npm_supports_min_release_age {
-                    let seconds = Self::elapsed_seconds_ceil(before_date, now);
                     // --min-release-age (npm/cli#8965) is day-granular; for sub-day
                     // windows (e.g. install_before = "1h") fall back to --before to
                     // preserve the exact cutoff.
                     if seconds < 86400 {
                         return vec!["--before".into(), before_date.to_string().into()];
                     }
-                    let days = seconds.div_ceil(86400);
+                    // Tolerate a small amount of elapsed time between resolving
+                    // `install_before` and converting it back to a day count so
+                    // that e.g. "3d" doesn't get rounded up to "4d" just because
+                    // a few seconds have passed (see #9156). The tolerance is
+                    // only applied here because bun/pnpm emit the cutoff in
+                    // units (seconds / minutes) finer than the typical drift.
+                    let days = seconds
+                        .saturating_sub(BEFORE_DATE_TOLERANCE_SECS)
+                        .div_ceil(86400)
+                        .max(1);
                     vec![format!("--min-release-age={days}").into()]
                 } else {
                     vec!["--before".into(), before_date.to_string().into()]
                 }
             }
             NpmPackageManager::Bun => {
-                let seconds = Self::elapsed_seconds_ceil(before_date, now);
                 vec!["--minimum-release-age".into(), seconds.to_string().into()]
             }
             NpmPackageManager::Pnpm => {
-                let seconds = Self::elapsed_seconds_ceil(before_date, now);
                 let minutes = seconds.div_ceil(60);
                 vec![format!("--config.minimumReleaseAge={minutes}").into()]
             }
@@ -565,6 +580,52 @@ mod tests {
                 OsString::from("2024-01-01T00:00:00Z")
             ]
         );
+    }
+
+    #[test]
+    fn test_build_transitive_release_age_args_tolerates_drift() {
+        // Regression test for #9156: `install_before = "3d"` resolved to an
+        // absolute date and then re-converted after ~30s of drift must not
+        // round up to 4 days.
+        let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
+        let now: Timestamp = "2024-01-04T00:00:30Z".parse().unwrap();
+        let args = NPMBackend::build_transitive_release_age_args(
+            NpmPackageManager::Npm,
+            before_date,
+            now,
+            true,
+        );
+        assert_eq!(args, vec![OsString::from("--min-release-age=3")]);
+    }
+
+    #[test]
+    fn test_build_transitive_release_age_args_past_tolerance_rounds_up() {
+        // Drift larger than the tolerance (60s) should still round up to the
+        // next day so cutoffs remain at least as strict as requested.
+        let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
+        let now: Timestamp = "2024-01-04T00:02:00Z".parse().unwrap();
+        let args = NPMBackend::build_transitive_release_age_args(
+            NpmPackageManager::Npm,
+            before_date,
+            now,
+            true,
+        );
+        assert_eq!(args, vec![OsString::from("--min-release-age=4")]);
+    }
+
+    #[test]
+    fn test_build_transitive_release_age_args_one_day_boundary() {
+        // `install_before = "1d"` with a few seconds of drift should still
+        // emit --min-release-age=1 rather than falling back to --before.
+        let before_date: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
+        let now: Timestamp = "2024-01-02T00:00:05Z".parse().unwrap();
+        let args = NPMBackend::build_transitive_release_age_args(
+            NpmPackageManager::Npm,
+            before_date,
+            now,
+            true,
+        );
+        assert_eq!(args, vec![OsString::from("--min-release-age=1")]);
     }
 
     #[test]

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -1,7 +1,5 @@
 use crate::cli::args::ToolArg;
 use crate::config::Config;
-use crate::config::settings::Settings;
-use crate::duration::parse_into_timestamp;
 use crate::install_context::InstallContext;
 use crate::toolset::tool_request::effective_before_date;
 use crate::toolset::{ResolveOptions, ToolsetBuilder};
@@ -29,14 +27,7 @@ pub struct InstallInto {
 impl InstallInto {
     pub async fn run(self) -> Result<()> {
         let config = Config::get().await?;
-        let before_date = match self.tool.tvr.as_ref() {
-            Some(tvr) => effective_before_date(tvr, &Default::default())?,
-            None => Settings::get()
-                .install_before
-                .as_deref()
-                .map(parse_into_timestamp)
-                .transpose()?,
-        };
+        let before_date = effective_before_date(self.tool.tvr.as_ref(), &Default::default())?;
         let ts = Arc::new(
             ToolsetBuilder::new()
                 .with_args(std::slice::from_ref(&self.tool))

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,3 +1,4 @@
+use std::sync::OnceLock;
 pub use std::time::Duration;
 
 use eyre::{Result, bail};
@@ -6,6 +7,19 @@ use jiff::{Span, Timestamp, Zoned, civil::date};
 pub const HOURLY: Duration = Duration::from_secs(60 * 60);
 pub const DAILY: Duration = Duration::from_secs(60 * 60 * 24);
 pub const WEEKLY: Duration = Duration::from_secs(60 * 60 * 24 * 7);
+
+/// Returns a stable "now" timestamp for the lifetime of the process.
+///
+/// This is used for resolving relative durations (e.g. `install_before = "3d"`)
+/// consistently: every resolution of the same relative duration within a single
+/// mise invocation produces the same absolute timestamp, and downstream code
+/// that converts the absolute timestamp back to a duration (e.g. for npm's
+/// `--min-release-age`) gets the exact duration the user specified rather than
+/// a slightly-larger value due to wall clock drift between phases.
+pub fn process_now() -> Timestamp {
+    static PROCESS_NOW: OnceLock<Timestamp> = OnceLock::new();
+    *PROCESS_NOW.get_or_init(Timestamp::now)
+}
 
 pub fn parse_duration(s: &str) -> Result<Duration> {
     match s.parse::<Span>() {
@@ -26,6 +40,9 @@ pub fn parse_duration(s: &str) -> Result<Duration> {
 /// - RFC3339 timestamps: "2024-06-01T12:00:00Z"
 /// - ISO dates: "2024-06-01" (treated as end of day in UTC)
 /// - Relative durations: "90d", "1y", "6m" (subtracted from now)
+///
+/// Relative durations are anchored to [`process_now`] so all resolutions
+/// within a single mise invocation agree on "now".
 pub fn parse_into_timestamp(s: &str) -> Result<Timestamp> {
     // Try RFC3339 timestamp first
     if let Ok(ts) = s.parse::<Timestamp>() {
@@ -44,16 +61,16 @@ pub fn parse_into_timestamp(s: &str) -> Result<Timestamp> {
         return Ok(ts);
     }
 
-    // Try parsing as duration and subtract from now
+    // Try parsing as duration and subtract from the process-local "now".
+    // Using a stable "now" ensures a relative duration like "3d" resolves to
+    // the exact same absolute Timestamp every time within this command.
     if let Ok(span) = s.parse::<Span>() {
         // Validate that duration is positive (negative would result in future date)
         let duration = span.to_duration(date(2025, 1, 1))?;
         if duration.is_negative() {
             bail!("duration must not be negative: {}", s);
         }
-        let now = Timestamp::now();
-        // Convert to Zoned to support calendar units (days, months, years)
-        let now_zoned = now.to_zoned(jiff::tz::TimeZone::UTC);
+        let now_zoned = process_now().to_zoned(jiff::tz::TimeZone::UTC);
         let past = now_zoned.checked_sub(span)?;
         return Ok(past.timestamp());
     }
@@ -61,4 +78,48 @@ pub fn parse_into_timestamp(s: &str) -> Result<Timestamp> {
     bail!(
         "Invalid date or duration: {s}. Expected formats: '2024-06-01', '2024-06-01T12:00:00Z', '90d', '1y'"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_now_is_stable() {
+        // process_now must return the same value across calls so that relative
+        // durations resolve identically every time they are evaluated.
+        let a = process_now();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let b = process_now();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_parse_into_timestamp_relative_is_stable() {
+        // Two resolutions of the same relative duration must produce identical
+        // timestamps within a single process invocation. This is the invariant
+        // that keeps version resolution consistent with the CLI flags passed
+        // to the underlying package manager (see #9156).
+        let a = parse_into_timestamp("3d").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let b = parse_into_timestamp("3d").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_parse_into_timestamp_absolute_date() {
+        let ts = parse_into_timestamp("2024-01-02").unwrap();
+        assert_eq!(ts.to_string(), "2024-01-02T23:59:59Z");
+    }
+
+    #[test]
+    fn test_parse_into_timestamp_rfc3339() {
+        let ts = parse_into_timestamp("2024-01-02T03:04:05Z").unwrap();
+        assert_eq!(ts.to_string(), "2024-01-02T03:04:05Z");
+    }
+
+    #[test]
+    fn test_parse_into_timestamp_rejects_garbage() {
+        assert!(parse_into_timestamp("not a date").is_err());
+    }
 }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -74,9 +74,8 @@ pub fn parse_into_timestamp(s: &str) -> Result<Timestamp> {
         return Ok(ts);
     }
 
-    // Try parsing as duration and subtract from the process-local "now".
-    // Using a stable "now" ensures a relative duration like "3d" resolves to
-    // the exact same absolute Timestamp every time within this command.
+    // Subtract the duration from `process_now` so the same relative
+    // duration resolves to the same absolute Timestamp every time.
     if let Ok(span) = s.parse::<Span>() {
         // Validate that duration is positive (negative would result in future date)
         let duration = span.to_duration(date(2025, 1, 1))?;
@@ -99,8 +98,6 @@ mod tests {
 
     #[test]
     fn test_process_now_is_stable() {
-        // process_now must return the same value across calls so that relative
-        // durations resolve identically every time they are evaluated.
         let a = process_now();
         std::thread::sleep(std::time::Duration::from_millis(5));
         let b = process_now();
@@ -109,10 +106,8 @@ mod tests {
 
     #[test]
     fn test_parse_into_timestamp_relative_is_stable() {
-        // Two resolutions of the same relative duration must produce identical
-        // timestamps within a single process invocation. This is the invariant
-        // that keeps version resolution consistent with the CLI flags passed
-        // to the underlying package manager (see #9156).
+        // Anchored to process_now so version resolution and CLI-flag emission
+        // can't disagree (see #9156).
         let a = parse_into_timestamp("3d").unwrap();
         std::thread::sleep(std::time::Duration::from_millis(5));
         let b = parse_into_timestamp("3d").unwrap();
@@ -152,7 +147,6 @@ mod tests {
 
     #[test]
     fn test_elapsed_seconds_ceil_rounds_up_fractional_second() {
-        // 1.1 s -> 2 s
         let a: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
         let b: Timestamp = "2024-01-01T00:00:01.100Z".parse().unwrap();
         assert_eq!(elapsed_seconds_ceil(a, b), 2);
@@ -160,7 +154,6 @@ mod tests {
 
     #[test]
     fn test_elapsed_seconds_ceil_zero_when_not_elapsed() {
-        // from == to and from > to both clamp to 0
         let t: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
         assert_eq!(elapsed_seconds_ceil(t, t), 0);
         let later: Timestamp = "2024-01-02T00:00:00Z".parse().unwrap();

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -8,6 +8,19 @@ pub const HOURLY: Duration = Duration::from_secs(60 * 60);
 pub const DAILY: Duration = Duration::from_secs(60 * 60 * 24);
 pub const WEEKLY: Duration = Duration::from_secs(60 * 60 * 24 * 7);
 
+/// Returns the number of whole seconds from `from` to `to`, rounded up.
+///
+/// Returns 0 when `from >= to` so callers don't have to guard against the
+/// degenerate "cutoff is already in the future" case.
+pub fn elapsed_seconds_ceil(from: Timestamp, to: Timestamp) -> u64 {
+    if from >= to {
+        return 0;
+    }
+    let nanos = to.as_nanosecond() - from.as_nanosecond();
+    u64::try_from((nanos + 999_999_999) / 1_000_000_000)
+        .expect("elapsed timestamp delta must fit into u64")
+}
+
 /// Returns a stable "now" timestamp for the lifetime of the process.
 ///
 /// This is used for resolving relative durations (e.g. `install_before = "3d"`)
@@ -121,5 +134,36 @@ mod tests {
     #[test]
     fn test_parse_into_timestamp_rejects_garbage() {
         assert!(parse_into_timestamp("not a date").is_err());
+    }
+
+    #[test]
+    fn test_elapsed_seconds_ceil_exact_boundary() {
+        let a: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
+        let b: Timestamp = "2024-01-01T00:00:01Z".parse().unwrap();
+        assert_eq!(elapsed_seconds_ceil(a, b), 1);
+    }
+
+    #[test]
+    fn test_elapsed_seconds_ceil_rounds_up_subsecond() {
+        let a: Timestamp = "2024-01-01T00:00:00.000000001Z".parse().unwrap();
+        let b: Timestamp = "2024-01-01T00:00:01Z".parse().unwrap();
+        assert_eq!(elapsed_seconds_ceil(a, b), 1);
+    }
+
+    #[test]
+    fn test_elapsed_seconds_ceil_rounds_up_fractional_second() {
+        // 1.1 s -> 2 s
+        let a: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
+        let b: Timestamp = "2024-01-01T00:00:01.100Z".parse().unwrap();
+        assert_eq!(elapsed_seconds_ceil(a, b), 2);
+    }
+
+    #[test]
+    fn test_elapsed_seconds_ceil_zero_when_not_elapsed() {
+        // from == to and from > to both clamp to 0
+        let t: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
+        assert_eq!(elapsed_seconds_ceil(t, t), 0);
+        let later: Timestamp = "2024-01-02T00:00:00Z".parse().unwrap();
+        assert_eq!(elapsed_seconds_ceil(later, t), 0);
     }
 }

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -353,7 +353,7 @@ impl ToolRequest {
         opts: &ResolveOptions,
     ) -> Result<ToolVersion> {
         let mut opts = opts.clone();
-        opts.before_date = effective_before_date(self, &opts)?;
+        opts.before_date = effective_before_date(Some(self), &opts)?;
         ToolVersion::resolve(config, self.clone(), &opts).await
     }
 
@@ -395,14 +395,30 @@ fn normalize_arch(arch: &str) -> &str {
     }
 }
 
+/// Resolve the effective `install_before` cutoff to an absolute [`Timestamp`]
+/// in one canonical place.
+///
+/// Precedence (highest to lowest):
+/// 1. `opts.before_date` — typically the pre-resolved `--before` CLI flag.
+/// 2. The per-tool `install_before` option on `request`.
+/// 3. The global `install_before` setting.
+///
+/// All string-based durations (e.g. `"3d"`) are resolved against
+/// [`crate::duration::process_now`] so that every call within a single mise
+/// invocation produces the same absolute timestamp. Downstream code can then
+/// use this timestamp both to resolve which version to install *and* to build
+/// the corresponding package-manager CLI flag (e.g. `--min-release-age`)
+/// without the two drifting apart.
 pub fn effective_before_date(
-    request: &ToolRequest,
+    request: Option<&ToolRequest>,
     opts: &ResolveOptions,
 ) -> Result<Option<Timestamp>> {
     if let Some(before_date) = opts.before_date {
         return Ok(Some(before_date));
     }
-    if let Some(before) = request.options().get("install_before") {
+    if let Some(request) = request
+        && let Some(before) = request.options().get("install_before")
+    {
         return Ok(Some(crate::duration::parse_into_timestamp(before)?));
     }
     if let Some(before) = &Settings::get().install_before {
@@ -486,7 +502,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            effective_before_date(&request, &opts).unwrap(),
+            effective_before_date(Some(&request), &opts).unwrap(),
             Some(cli_before)
         );
         Settings::reset(None);
@@ -498,7 +514,7 @@ mod tests {
         let request = make_request(Some("install_before='2024-01-02'"));
         let opts = ResolveOptions::default();
         assert_eq!(
-            effective_before_date(&request, &opts).unwrap(),
+            effective_before_date(Some(&request), &opts).unwrap(),
             Some(crate::duration::parse_into_timestamp("2024-01-02").unwrap())
         );
         Settings::reset(None);
@@ -512,7 +528,7 @@ mod tests {
         let request = make_request(None);
         let opts = ResolveOptions::default();
         assert_eq!(
-            effective_before_date(&request, &opts).unwrap(),
+            effective_before_date(Some(&request), &opts).unwrap(),
             Some(crate::duration::parse_into_timestamp("2024-01-03").unwrap())
         );
         Settings::reset(None);
@@ -523,7 +539,37 @@ mod tests {
         Settings::reset(None);
         let request = make_request(None);
         let opts = ResolveOptions::default();
-        assert_eq!(effective_before_date(&request, &opts).unwrap(), None);
+        assert_eq!(effective_before_date(Some(&request), &opts).unwrap(), None);
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_before_date_handles_missing_request() {
+        let mut partial = SettingsPartial::empty();
+        partial.install_before = Some("2024-01-03".to_string());
+        Settings::reset(Some(partial));
+        let opts = ResolveOptions::default();
+        assert_eq!(
+            effective_before_date(None, &opts).unwrap(),
+            Some(crate::duration::parse_into_timestamp("2024-01-03").unwrap())
+        );
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_before_date_stable_within_process() {
+        // Resolving the same relative duration twice within the same process
+        // must produce the exact same absolute Timestamp so that version
+        // resolution and CLI-flag emission agree.
+        Settings::reset(None);
+        let mut partial = SettingsPartial::empty();
+        partial.install_before = Some("3d".to_string());
+        Settings::reset(Some(partial));
+        let request = make_request(None);
+        let opts = ResolveOptions::default();
+        let a = effective_before_date(Some(&request), &opts).unwrap();
+        let b = effective_before_date(Some(&request), &opts).unwrap();
+        assert_eq!(a, b);
         Settings::reset(None);
     }
 

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -558,9 +558,8 @@ mod tests {
 
     #[test]
     fn test_effective_before_date_stable_within_process() {
-        // Resolving the same relative duration twice within the same process
-        // must produce the exact same absolute Timestamp so that version
-        // resolution and CLI-flag emission agree.
+        // Covers the invariant behind #9156: relative durations resolve
+        // identically across calls within one invocation.
         Settings::reset(None);
         let mut partial = SettingsPartial::empty();
         partial.install_before = Some("3d".to_string());

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -452,7 +452,7 @@ impl Toolset {
         opts: &Arc<InstallOptions>,
     ) -> Result<ToolVersion> {
         let mpr = MultiProgressReport::get();
-        let before_date = effective_before_date(tr, &opts.resolve_options)?;
+        let before_date = effective_before_date(Some(tr), &opts.resolve_options)?;
         let mut resolve_options = opts.resolve_options.clone();
         resolve_options.before_date = before_date;
 


### PR DESCRIPTION
## Summary

Fixes the off-by-one-day issue described in [discussion #9156](https://github.com/jdx/mise/discussions/9156), where `install_before = "3d"` (or an equivalent CLI flag / per-tool option) caused npm to reject versions mise had just resolved.

### Root cause

`install_before` was resolved to an absolute cutoff once during version resolution, but the npm backend then called `Timestamp::now()` a second time when constructing `--min-release-age`. The small drift between the two `now()`s meant `3d` became `3d + 30s`, which ceil-divided to `--min-release-age=4`, so npm refused the version mise chose with `3d`.

### Fix

- **Stable per-process "now".** Introduce `duration::process_now()` so relative durations like `"3d"` resolve to the same `Timestamp` for the entire lifetime of a mise invocation. `parse_into_timestamp` and all npm backend call sites now use it instead of `Timestamp::now()`.
- **Single precedence path.** `effective_before_date` now takes `Option<&ToolRequest>` so `cli::install_into` and the toolset installer share one code path (CLI flag > per-tool option > global `install_before`).
- **Drift tolerance in the `--min-release-age` branch only.** Subtract 60s from the elapsed seconds before ceil-dividing to days, clamped at a minimum of 1 day. Bun and pnpm already emit the cutoff in finer units (seconds / minutes), so they keep using the unadjusted elapsed seconds. Sub-day windows (e.g. `install_before = "1h"`) still fall back to `--before` using the exact timestamp.

### Behavior examples (npm, `--min-release-age` supported)

| `install_before` | elapsed at install time | before fix | after fix |
| --- | --- | --- | --- |
| `3d` | `3d + 30s` (drift) | `--min-release-age=4` (bug) | `--min-release-age=3` |
| `3d` | `3d + 2min` (beyond tolerance) | `--min-release-age=4` | `--min-release-age=4` |
| `1d` | `1d + 5s` | `--min-release-age=1` (falls back to `--before` in old code near the boundary) | `--min-release-age=1` |
| `1h` | anything `< 24h` | `--before <ts>` | `--before <ts>` (unchanged) |

## Test plan

- [x] `cargo test --bin mise build_transitive_release_age` (new regression tests for drift, past-tolerance rounding, 1d boundary, plus existing npm/bun/pnpm cases)
- [x] `cargo test --bin mise duration` (new tests for `process_now()` stability and `parse_into_timestamp` relative/absolute parsing)
- [x] `cargo test --bin mise effective_before_date` (covers CLI > per-tool > global precedence and the new `Option<&ToolRequest>` signature)
- [x] `cargo clippy --bin mise --tests -- -D warnings`
- [x] `cargo fmt --check`

Closes #9156.

Made with [Cursor](https://cursor.com)