### PR TITLE
refactor(backend): remove unused rolling release helper

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -832,16 +832,6 @@ pub trait Backend: Debug + Send + Sync {
         }
     }
 
-    /// Check if a version is a rolling release (like "nightly") that should
-    /// always be considered potentially outdated for `mise up` purposes
-    async fn is_version_rolling(&self, config: &Arc<Config>, version: &str) -> bool {
-        let versions = match self.list_remote_versions_with_info(config).await {
-            Ok(v) => v,
-            Err(_) => return false,
-        };
-        versions.iter().any(|v| v.version == version && v.rolling)
-    }
-
     /// Get version info for a specific version (including checksum for rolling releases)
     async fn get_version_info(&self, config: &Arc<Config>, version: &str) -> Option<VersionInfo> {
         let versions = match self.list_remote_versions_with_info(config).await {


### PR DESCRIPTION
## Summary

- Remove the unused `Backend::is_version_rolling` helper from `src/backend/mod.rs`.
- Keep the active checksum-based rolling update path (`is_rolling_version_outdated`) unchanged.

## History

Rolling-release support was added in `4a2257afd` / #7757 (`feat(vfox): add rolling release support with checksum tracking`). That change introduced the `rolling` and `checksum` fields on `VersionInfo`, added checksum persistence in `install_state`, and wired `OutdatedInfo::resolve` to call `is_rolling_version_outdated()` when a version string is otherwise up to date.

The direct helper for checking whether a version is rolling (`is_version_rolling`; referred to in cleanup notes as `is_rolling_release`) was added in the same commit, but history does not show a caller for it. Current update behavior already checks `VersionInfo::rolling` inside `is_rolling_version_outdated()`, so removing this helper is a dead-code cleanup rather than restoring a removed call site.

## Verification

- `mise run build`

*This PR was generated by an AI coding assistant.*