### PR TITLE
fix(pipx): honor install_before for uv and pipx installs

### DIFF
--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -28,9 +28,9 @@ This relies on having `uv` (recommended) or `pipx` installed.
 If you have `uv` installed, mise will use `uv tool install` under the hood and you don't need to install `pipx` to run the commands containing "pipx:".
 
 When [`install_before`](/configuration/settings.html#install_before) is set and mise installs a
-`pipx:` tool through uv, mise forwards the cutoff to uv as `UV_EXCLUDE_NEWER` so transitive Python
-dependencies are resolved only from releases uploaded before that timestamp. This only applies to
-the uv install path; the `pipx` fallback does not receive a transitive release-age cutoff.
+`pipx:` tool through uv, mise passes uv's `--exclude-newer` flag so transitive Python dependencies
+are resolved only from releases uploaded before that timestamp. This only applies to the uv install
+path; the `pipx` fallback does not receive a transitive release-age cutoff.
 
 In case you need `pipx` for other reasons, you can install it with or without mise.
 Here is how to install `pipx` with mise:

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -27,6 +27,11 @@ This relies on having `uv` (recommended) or `pipx` installed.
 
 If you have `uv` installed, mise will use `uv tool install` under the hood and you don't need to install `pipx` to run the commands containing "pipx:".
 
+When [`install_before`](/configuration/settings.html#install_before) is set and mise installs a
+`pipx:` tool through uv, mise forwards the cutoff to uv as `UV_EXCLUDE_NEWER` so transitive Python
+dependencies are resolved only from releases uploaded before that timestamp. This only applies to
+the uv install path; the `pipx` fallback does not receive a transitive release-age cutoff.
+
 In case you need `pipx` for other reasons, you can install it with or without mise.
 Here is how to install `pipx` with mise:
 

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -27,10 +27,9 @@ This relies on having `uv` (recommended) or `pipx` installed.
 
 If you have `uv` installed, mise will use `uv tool install` under the hood and you don't need to install `pipx` to run the commands containing "pipx:".
 
-When [`install_before`](/configuration/settings.html#install_before) is set and mise installs a
-`pipx:` tool through uv, mise passes uv's `--exclude-newer` flag so transitive Python dependencies
-are resolved only from releases uploaded before that timestamp. This only applies to the uv install
-path; the `pipx` fallback does not receive a transitive release-age cutoff.
+When [`install_before`](/configuration/settings.html#install_before) is set, mise forwards the cutoff
+to transitive Python dependency resolution during install. The uv install path uses uv's
+`--exclude-newer` flag, and the `pipx` fallback passes pip's `--uploaded-prior-to` flag.
 
 In case you need `pipx` for other reasons, you can install it with or without mise.
 Here is how to install `pipx` with mise:

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -360,6 +360,10 @@ install_before = "7d"  # only resolve to versions released more than 7 days ago
 
 This pairs well with lockfiles — use `install_before` to avoid picking up brand-new releases, and lockfiles to pin the exact versions you've vetted.
 
+Some package-manager backends also forward this cutoff into transitive dependency resolution during
+install. This includes `npm:` tools and `pipx:` tools installed through uv. The `pipx` fallback path
+does not receive a transitive release-age cutoff.
+
 ## See Also
 
 - [Configuration Settings](/configuration/settings) - All available settings

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -361,8 +361,7 @@ install_before = "7d"  # only resolve to versions released more than 7 days ago
 This pairs well with lockfiles — use `install_before` to avoid picking up brand-new releases, and lockfiles to pin the exact versions you've vetted.
 
 Some package-manager backends also forward this cutoff into transitive dependency resolution during
-install. This includes `npm:` tools and `pipx:` tools installed through uv. The `pipx` fallback path
-does not receive a transitive release-age cutoff.
+install. This includes `npm:` and `pipx:` tools.
 
 ## See Also
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -180,8 +180,8 @@ install_before = "7d"  # only install versions released more than 7 days ago
 
 Supports relative durations (`7d`, `6m`, `1y`) and absolute dates (`2024-06-01`). For most backends, this only affects fuzzy version resolution (e.g., `node@20` or `latest`) — explicitly pinned versions like `node@22.5.0` bypass the filter.
 
-For `npm:` tools and `pipx:` tools installed through uv, the same cutoff is also forwarded to
-transitive dependency resolution during install. Refer to the
+For `npm:` and `pipx:` tools, the same cutoff is also forwarded to transitive dependency resolution
+during install. Refer to the
 [npm backend docs](/dev-tools/backends/npm.html) and [pipx backend docs](/dev-tools/backends/pipx.html)
 for package-manager support details.
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -180,11 +180,10 @@ install_before = "7d"  # only install versions released more than 7 days ago
 
 Supports relative durations (`7d`, `6m`, `1y`) and absolute dates (`2024-06-01`). For most backends, this only affects fuzzy version resolution (e.g., `node@20` or `latest`) — explicitly pinned versions like `node@22.5.0` bypass the filter.
 
-For `npm:` tools, the same cutoff is also forwarded to transitive dependency resolution during
-install. For `pipx:` tools, this transitive cutoff is forwarded only when mise installs through uv
-using `UV_EXCLUDE_NEWER`; the `pipx` fallback does not receive it. Refer to the
-[npm backend docs](/dev-tools/backends/npm.html) and
-[pipx backend docs](/dev-tools/backends/pipx.html) for package-manager support details.
+For `npm:` tools and `pipx:` tools installed through uv, the same cutoff is also forwarded to
+transitive dependency resolution during install. Refer to the
+[npm backend docs](/dev-tools/backends/npm.html) and [pipx backend docs](/dev-tools/backends/pipx.html)
+for package-manager support details.
 
 You can also set `install_before` per-tool to override the global setting:
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -181,8 +181,10 @@ install_before = "7d"  # only install versions released more than 7 days ago
 Supports relative durations (`7d`, `6m`, `1y`) and absolute dates (`2024-06-01`). For most backends, this only affects fuzzy version resolution (e.g., `node@20` or `latest`) — explicitly pinned versions like `node@22.5.0` bypass the filter.
 
 For `npm:` tools, the same cutoff is also forwarded to transitive dependency resolution during
-install. Refer to the [npm backend docs](/dev-tools/backends/npm.html) for package-manager support
-details.
+install. For `pipx:` tools, this transitive cutoff is forwarded only when mise installs through uv
+using `UV_EXCLUDE_NEWER`; the `pipx` fallback does not receive it. Refer to the
+[npm backend docs](/dev-tools/backends/npm.html) and
+[pipx backend docs](/dev-tools/backends/pipx.html) for package-manager support details.
 
 You can also set `install_before` per-tool to override the global setting:
 

--- a/settings.toml
+++ b/settings.toml
@@ -1037,6 +1037,10 @@ like `node@20` or `latest`. Explicitly pinned versions like `node@22.5.0` are no
 allowing you to selectively use newer versions for specific tools while keeping others behind the
 cutoff date.
 
+Some package-manager backends also forward the cutoff to transitive dependency resolution during
+install. This includes `npm:` tools and `pipx:` tools installed through uv. The `pipx` fallback path
+does not receive a transitive release-age cutoff.
+
 Can be overridden with the `--before` CLI flag or per-tool with the `install_before` tool option.
 
 ```toml

--- a/settings.toml
+++ b/settings.toml
@@ -1038,8 +1038,7 @@ allowing you to selectively use newer versions for specific tools while keeping 
 cutoff date.
 
 Some package-manager backends also forward the cutoff to transitive dependency resolution during
-install. This includes `npm:` tools and `pipx:` tools installed through uv. The `pipx` fallback path
-does not receive a transitive release-age cutoff.
+install. This includes `npm:` and `pipx:` tools.
 
 Can be overridden with the `--before` CLI flag or per-tool with the `install_before` tool option.
 

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use jiff::Timestamp;
 use regex::Regex;
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fmt::Debug, sync::Arc};
@@ -230,7 +231,7 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
-            cmd = Self::apply_uv_exclude_newer(cmd, ctx.before_date);
+            cmd = cmd.args(Self::uv_exclude_newer_args(ctx.before_date));
             if let Some(args) = tv.request.options().get("uvx_args") {
                 cmd = cmd.args(shell_words::split(args)?);
             }
@@ -290,18 +291,10 @@ pub fn install_time_option_keys() -> Vec<String> {
 }
 
 impl PIPXBackend {
-    fn uv_exclude_newer_env(before_date: Option<Timestamp>) -> Option<(&'static str, String)> {
-        before_date.map(|before_date| ("UV_EXCLUDE_NEWER", before_date.to_string()))
-    }
-
-    fn apply_uv_exclude_newer<'a>(
-        cmd: CmdLineRunner<'a>,
-        before_date: Option<Timestamp>,
-    ) -> CmdLineRunner<'a> {
-        if let Some((key, value)) = Self::uv_exclude_newer_env(before_date) {
-            cmd.env(key, value)
-        } else {
-            cmd
+    fn uv_exclude_newer_args(before_date: Option<Timestamp>) -> Vec<OsString> {
+        match before_date {
+            Some(before_date) => vec!["--exclude-newer".into(), before_date.to_string().into()],
+            None => vec![],
         }
     }
 
@@ -662,20 +655,27 @@ fn fix_venv_python_symlink(_install_path: &Path, _pkg_name: &str) -> Result<()> 
 mod tests {
     use super::PIPXBackend;
     use pretty_assertions::assert_eq;
+    use std::ffi::OsString;
 
     #[test]
-    fn test_uv_exclude_newer_env_with_cutoff() {
+    fn test_uv_exclude_newer_args_with_cutoff() {
         let before_date = "2024-01-02T03:04:05Z".parse().unwrap();
-        let env = PIPXBackend::uv_exclude_newer_env(Some(before_date));
+        let args = PIPXBackend::uv_exclude_newer_args(Some(before_date));
 
         assert_eq!(
-            env,
-            Some(("UV_EXCLUDE_NEWER", "2024-01-02T03:04:05Z".to_string()))
+            args,
+            vec![
+                OsString::from("--exclude-newer"),
+                OsString::from("2024-01-02T03:04:05Z"),
+            ]
         );
     }
 
     #[test]
-    fn test_uv_exclude_newer_env_without_cutoff() {
-        assert_eq!(PIPXBackend::uv_exclude_newer_env(None), None);
+    fn test_uv_exclude_newer_args_without_cutoff() {
+        assert_eq!(
+            PIPXBackend::uv_exclude_newer_args(None),
+            Vec::<OsString>::new()
+        );
     }
 }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -442,9 +442,9 @@ impl PIPXBackend {
         cmd.with_pr(pr)
             .env("PIP_INDEX_URL", Self::get_index_url()?)
             .envs(ts.env_with_path_without_tools(config).await?)
+            .env_remove("PIPX_SHARED_LIBS")
             .env("PIPX_HOME", tv.install_path())
             .env("PIPX_BIN_DIR", tv.install_path().join("bin"))
-            .env("PIPX_SHARED_LIBS", tv.install_path().join("shared"))
             .prepend_path(ts.list_paths(config).await)?
             .prepend_path(vec![tv.install_path().join("bin")])?
             .prepend_path(b.dependency_toolset(config).await?.list_paths(config).await)

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -303,7 +303,7 @@ impl PIPXBackend {
         match before_date {
             Some(before_date) => vec![
                 "--pip-args".into(),
-                format!("--uploaded-prior-to {before_date}").into(),
+                format!("--uploaded-prior-to={before_date}").into(),
             ],
             None => vec![],
         }
@@ -700,7 +700,7 @@ mod tests {
             args,
             vec![
                 OsString::from("--pip-args"),
-                OsString::from("--uploaded-prior-to 2024-01-02T03:04:05Z"),
+                OsString::from("--uploaded-prior-to=2024-01-02T03:04:05Z"),
             ]
         );
     }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -247,6 +247,7 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
+            cmd = cmd.args(Self::pip_uploaded_prior_to_args(ctx.before_date));
             if let Some(args) = tv.request.options().get("pipx_args") {
                 cmd = cmd.args(shell_words::split(args)?);
             }
@@ -294,6 +295,16 @@ impl PIPXBackend {
     fn uv_exclude_newer_args(before_date: Option<Timestamp>) -> Vec<OsString> {
         match before_date {
             Some(before_date) => vec!["--exclude-newer".into(), before_date.to_string().into()],
+            None => vec![],
+        }
+    }
+
+    fn pip_uploaded_prior_to_args(before_date: Option<Timestamp>) -> Vec<OsString> {
+        match before_date {
+            Some(before_date) => vec![
+                "--pip-args".into(),
+                format!("--uploaded-prior-to {before_date}").into(),
+            ],
             None => vec![],
         }
     }
@@ -429,10 +440,11 @@ impl PIPXBackend {
             cmd = cmd.arg(arg);
         }
         cmd.with_pr(pr)
-            .env("PIPX_HOME", tv.install_path())
-            .env("PIPX_BIN_DIR", tv.install_path().join("bin"))
             .env("PIP_INDEX_URL", Self::get_index_url()?)
             .envs(ts.env_with_path_without_tools(config).await?)
+            .env("PIPX_HOME", tv.install_path())
+            .env("PIPX_BIN_DIR", tv.install_path().join("bin"))
+            .env("PIPX_SHARED_LIBS", tv.install_path().join("shared"))
             .prepend_path(ts.list_paths(config).await)?
             .prepend_path(vec![tv.install_path().join("bin")])?
             .prepend_path(b.dependency_toolset(config).await?.list_paths(config).await)
@@ -675,6 +687,28 @@ mod tests {
     fn test_uv_exclude_newer_args_without_cutoff() {
         assert_eq!(
             PIPXBackend::uv_exclude_newer_args(None),
+            Vec::<OsString>::new()
+        );
+    }
+
+    #[test]
+    fn test_pip_uploaded_prior_to_args_with_cutoff() {
+        let before_date = "2024-01-02T03:04:05Z".parse().unwrap();
+        let args = PIPXBackend::pip_uploaded_prior_to_args(Some(before_date));
+
+        assert_eq!(
+            args,
+            vec![
+                OsString::from("--pip-args"),
+                OsString::from("--uploaded-prior-to 2024-01-02T03:04:05Z"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_pip_uploaded_prior_to_args_without_cutoff() {
+        assert_eq!(
+            PIPXBackend::pip_uploaded_prior_to_args(None),
             Vec::<OsString>::new()
         );
     }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use eyre::{Result, eyre};
 use indexmap::IndexMap;
 use itertools::Itertools;
+use jiff::Timestamp;
 use regex::Regex;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -229,6 +230,7 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
+            cmd = Self::apply_transitive_install_before(cmd, PipxInstaller::Uvx, ctx.before_date);
             if let Some(args) = tv.request.options().get("uvx_args") {
                 cmd = cmd.args(shell_words::split(args)?);
             }
@@ -244,6 +246,7 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
+            cmd = Self::apply_transitive_install_before(cmd, PipxInstaller::Pipx, ctx.before_date);
             if let Some(args) = tv.request.options().get("pipx_args") {
                 cmd = cmd.args(shell_words::split(args)?);
             }
@@ -288,6 +291,32 @@ pub fn install_time_option_keys() -> Vec<String> {
 }
 
 impl PIPXBackend {
+    fn transitive_install_before_env(
+        installer: PipxInstaller,
+        before_date: Option<Timestamp>,
+    ) -> Option<(&'static str, String)> {
+        before_date.map(|before_date| {
+            let env_key = match installer {
+                PipxInstaller::Uvx => "UV_EXCLUDE_NEWER",
+                PipxInstaller::Pipx => "PIP_EXCLUDE_NEWER",
+            };
+            (env_key, before_date.to_string())
+        })
+    }
+
+    fn apply_transitive_install_before<'a>(
+        mut cmd: CmdLineRunner<'a>,
+        installer: PipxInstaller,
+        before_date: Option<Timestamp>,
+    ) -> CmdLineRunner<'a> {
+        if let Some((env_key, env_value)) =
+            Self::transitive_install_before_env(installer, before_date)
+        {
+            cmd = cmd.env(env_key, env_value);
+        }
+        cmd
+    }
+
     pub fn from_arg(ba: BackendArg) -> Self {
         Self {
             latest_version_cache: CacheManagerBuilder::new(
@@ -639,4 +668,43 @@ fn fix_venv_python_symlink(install_path: &Path, pkg_name: &str) -> Result<()> {
 #[cfg(not(unix))]
 fn fix_venv_python_symlink(_install_path: &Path, _pkg_name: &str) -> Result<()> {
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PipxInstaller {
+    Uvx,
+    Pipx,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PIPXBackend, PipxInstaller};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_transitive_install_before_env_for_uvx() {
+        let before_date = "2024-01-02T03:04:05Z".parse().unwrap();
+        let env = PIPXBackend::transitive_install_before_env(PipxInstaller::Uvx, Some(before_date));
+        assert_eq!(
+            env,
+            Some(("UV_EXCLUDE_NEWER", "2024-01-02T03:04:05Z".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_transitive_install_before_env_for_pipx() {
+        let before_date = "2024-01-02T03:04:05Z".parse().unwrap();
+        let env =
+            PIPXBackend::transitive_install_before_env(PipxInstaller::Pipx, Some(before_date));
+        assert_eq!(
+            env,
+            Some(("PIP_EXCLUDE_NEWER", "2024-01-02T03:04:05Z".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_transitive_install_before_env_without_cutoff() {
+        let env = PIPXBackend::transitive_install_before_env(PipxInstaller::Pipx, None);
+        assert_eq!(env, None);
+    }
 }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -230,7 +230,7 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
-            cmd = Self::apply_transitive_install_before(cmd, PipxInstaller::Uvx, ctx.before_date);
+            cmd = Self::apply_uv_exclude_newer(cmd, ctx.before_date);
             if let Some(args) = tv.request.options().get("uvx_args") {
                 cmd = cmd.args(shell_words::split(args)?);
             }
@@ -246,7 +246,6 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
-            cmd = Self::apply_transitive_install_before(cmd, PipxInstaller::Pipx, ctx.before_date);
             if let Some(args) = tv.request.options().get("pipx_args") {
                 cmd = cmd.args(shell_words::split(args)?);
             }
@@ -291,30 +290,19 @@ pub fn install_time_option_keys() -> Vec<String> {
 }
 
 impl PIPXBackend {
-    fn transitive_install_before_env(
-        installer: PipxInstaller,
-        before_date: Option<Timestamp>,
-    ) -> Option<(&'static str, String)> {
-        before_date.map(|before_date| {
-            let env_key = match installer {
-                PipxInstaller::Uvx => "UV_EXCLUDE_NEWER",
-                PipxInstaller::Pipx => "PIP_EXCLUDE_NEWER",
-            };
-            (env_key, before_date.to_string())
-        })
+    fn uv_exclude_newer_env(before_date: Option<Timestamp>) -> Option<(&'static str, String)> {
+        before_date.map(|before_date| ("UV_EXCLUDE_NEWER", before_date.to_string()))
     }
 
-    fn apply_transitive_install_before<'a>(
-        mut cmd: CmdLineRunner<'a>,
-        installer: PipxInstaller,
+    fn apply_uv_exclude_newer<'a>(
+        cmd: CmdLineRunner<'a>,
         before_date: Option<Timestamp>,
     ) -> CmdLineRunner<'a> {
-        if let Some((env_key, env_value)) =
-            Self::transitive_install_before_env(installer, before_date)
-        {
-            cmd = cmd.env(env_key, env_value);
+        if let Some((key, value)) = Self::uv_exclude_newer_env(before_date) {
+            cmd.env(key, value)
+        } else {
+            cmd
         }
-        cmd
     }
 
     pub fn from_arg(ba: BackendArg) -> Self {
@@ -670,21 +658,16 @@ fn fix_venv_python_symlink(_install_path: &Path, _pkg_name: &str) -> Result<()> 
     Ok(())
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum PipxInstaller {
-    Uvx,
-    Pipx,
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{PIPXBackend, PipxInstaller};
+    use super::PIPXBackend;
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn test_transitive_install_before_env_for_uvx() {
+    fn test_uv_exclude_newer_env_with_cutoff() {
         let before_date = "2024-01-02T03:04:05Z".parse().unwrap();
-        let env = PIPXBackend::transitive_install_before_env(PipxInstaller::Uvx, Some(before_date));
+        let env = PIPXBackend::uv_exclude_newer_env(Some(before_date));
+
         assert_eq!(
             env,
             Some(("UV_EXCLUDE_NEWER", "2024-01-02T03:04:05Z".to_string()))
@@ -692,19 +675,7 @@ mod tests {
     }
 
     #[test]
-    fn test_transitive_install_before_env_for_pipx() {
-        let before_date = "2024-01-02T03:04:05Z".parse().unwrap();
-        let env =
-            PIPXBackend::transitive_install_before_env(PipxInstaller::Pipx, Some(before_date));
-        assert_eq!(
-            env,
-            Some(("PIP_EXCLUDE_NEWER", "2024-01-02T03:04:05Z".to_string()))
-        );
-    }
-
-    #[test]
-    fn test_transitive_install_before_env_without_cutoff() {
-        let env = PIPXBackend::transitive_install_before_env(PipxInstaller::Pipx, None);
-        assert_eq!(env, None);
+    fn test_uv_exclude_newer_env_without_cutoff() {
+        assert_eq!(PIPXBackend::uv_exclude_newer_env(None), None);
     }
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -335,6 +335,15 @@ impl<'a> CmdLineRunner<'a> {
         self.cmd.env(key, val);
         self
     }
+
+    pub fn env_remove<K>(mut self, key: K) -> Self
+    where
+        K: AsRef<OsStr>,
+    {
+        self.cmd.env_remove(key);
+        self
+    }
+
     pub fn envs<I, K, V>(mut self, vars: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,


### PR DESCRIPTION
Supersedes and includes https://github.com/jdx/mise/pull/9105.

## Summary
- forward `install_before` to transitive Python package resolution when `pipx:` tools are installed through uv
- pass uv's `--exclude-newer <timestamp>` flag on the uv install path
- pass pip's `--uploaded-prior-to <timestamp>` flag through `pipx install --pip-args` on the pipx fallback path
- remove any inherited `PIPX_SHARED_LIBS` before invoking pipx so pipx falls back to `PIPX_HOME/shared`
- update docs now that both uv and pipx install paths forward the cutoff
- add focused unit coverage for uv and pipx argument generation

## uv compatibility
`--exclude-newer` was added in https://github.com/astral-sh/uv/pull/2166 and is included in https://github.com/astral-sh/uv/releases/tag/0.1.15, so we do not need to check the uv version before using this flag.

## Why we can always use `--uploaded-prior-to`
`--uploaded-prior-to` was added in https://github.com/pypa/pip/pull/13625 and released in pip 26.0, announced on January 31, 2026: https://discuss.python.org/t/announcement-pip-26-0-release/105947. PyPI currently lists pip 26.0.1 as the latest release as of April 17, 2026: https://pypi.org/project/pip/.

pipx does not use a fixed bundled pip. It creates or reuses a shared virtual environment containing pip and ensures that shared pip is updated to the latest version: https://pipx.pypa.io/stable/how-pipx-works/. In the current pipx source, shared pip is installed/upgraded with `pip >= 23.1` and no upper bound, so normal PyPI access gets the latest pip: https://github.com/pypa/pipx/blob/main/src/pipx/shared_libs.py.

mise sets `PIPX_HOME` to the tool version's install path when invoking the pipx fallback. That install path is prepared before the backend runs: fresh installs create a new install directory, and `mise install --force` uninstalls the existing version, removes the install path, and recreates it before calling `pipx install`. With pipx's default behavior, `PIPX_SHARED_LIBS` resolves to `<install_path>/shared`, which is new for that install and can be initialized/upgraded by pipx to the latest pip.

## Why unsetting `PIPX_SHARED_LIBS` is acceptable
`PIPX_SHARED_LIBS` is a real pipx override: it can point pipx's shared pip virtualenv outside `PIPX_HOME`. pipx documents that it defaults to `PIPX_HOME/shared`, but can be overridden: https://pipx.pypa.io/stable/reference/environment-variables/. It can be useful for deliberate CI caching or ephemeral `PIPX_HOME` setups, but it only shares the packaging toolchain, especially pip. It does not make installed pipx apps share their application dependencies.

For mise-managed `pipx:` installs, inheriting an external `PIPX_SHARED_LIBS` is unsafe for this feature because it can point at an older shared pip that does not support `--uploaded-prior-to`. It also makes the mise install path no longer self-contained, because pipx app venvs can contain absolute `.pth` pointers into that external shared libs path. Moving, deleting, or changing that external path can break later `pipx upgrade`, `pipx inject`, or `pipx runpip` operations.

I could not find public discussions indicating that users commonly rely on `PIPX_SHARED_LIBS` for mise-managed pipx installs, and the default pipx guidance is to leave it unset unless there is a specific reason. So excluding this inherited variable for mise's pipx subprocesses should not be breaking for most users, and it avoids a footgun where a global shell/profile setting silently changes mise's install behavior.

Related pipx docs for shared pip maintenance:
- https://pipx.pypa.io/stable/reference/examples/#pipx-upgrade-shared-examples
- https://pipx.pypa.io/stable/reference/cli/#pipx-upgrade-shared

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test -q uv_exclude_newer_args`
- `cargo test -q pip_uploaded_prior_to_args`