### PR TITLE
fix(registry): allow shfmt on Windows

### DIFF
--- a/registry/shfmt.toml
+++ b/registry/shfmt.toml
@@ -4,5 +4,4 @@ backends = [
   "go:mvdan.cc/sh/v3/cmd/shfmt",
 ]
 description = "A shell parser, formatter, and interpreter with bash support; includes shfmt"
-os = ["linux", "macos"]
 test = { cmd = "shfmt --version", expected = "v{{version}}" }


### PR DESCRIPTION
## Summary

- Remove `os = ["linux", "macos"]` from `registry/shfmt.toml`
- Bundled aqua-registry snapshot already supports shfmt on Windows (aquaproj/aqua-registry#51964)
- aqua auto-completes `.exe` suffix for `format: raw` assets, so `aqua:mvdan/sh` works on Windows
- `go:mvdan.cc/sh/v3/cmd/shfmt` cross-compiles fine

Currently the bare `shfmt` short name is filtered out on Windows at the short-name dispatcher layer before it can reach the aqua backend, forcing Windows users to specify `aqua:mvdan/sh` explicitly.

## Test plan

- [ ] CI