### PR TITLE
refactor(backend): use file util for removals

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -14,7 +14,7 @@ use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::cmd::CmdLineRunner;
 use crate::config::config_file::config_root;
 use crate::config::{Config, Settings};
-use crate::file::{display_path, remove_all, remove_all_with_warning};
+use crate::file::{display_path, remove_all_with_progress, remove_all_with_warning};
 use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::path_env::PathEnv;
@@ -36,8 +36,7 @@ use crate::{
 use crate::{dirs, env, file, hash, lock_file, versions_host};
 use async_trait::async_trait;
 use backend_type::BackendType;
-use console::style;
-use eyre::{Result, WrapErr, bail, eyre};
+use eyre::{Result, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use platform_target::PlatformTarget;
@@ -906,9 +905,9 @@ pub trait Backend: Debug + Send + Sync {
         Ok(())
     }
     fn purge(&self, pr: &dyn SingleReport) -> eyre::Result<()> {
-        rmdir(&self.ba().installs_path, pr)?;
-        rmdir(&self.ba().cache_path, pr)?;
-        rmdir(&self.ba().downloads_path, pr)?;
+        remove_all_with_progress(&self.ba().installs_path, pr)?;
+        remove_all_with_progress(&self.ba().cache_path, pr)?;
+        remove_all_with_progress(&self.ba().downloads_path, pr)?;
         Ok(())
     }
     fn get_aliases(&self) -> eyre::Result<BTreeMap<String, String>> {
@@ -1187,14 +1186,13 @@ pub trait Backend: Debug + Send + Sync {
             self.uninstall_version_impl(config, pr, tv).await?;
         }
         let rmdir = |dir: &Path| {
-            if !dir.exists() {
-                return Ok(());
-            }
-            pr.set_message(format!("remove {}", display_path(dir)));
             if dryrun {
+                if dir.exists() {
+                    pr.set_message(format!("remove {}", display_path(dir)));
+                }
                 return Ok(());
             }
-            remove_all_with_warning(dir)
+            remove_all_with_progress(dir, pr)
         };
         rmdir(&tv.install_path())?;
         if !Settings::get().always_keep_download {
@@ -1762,19 +1760,6 @@ fn find_match_in_list(list: &[String], query: &str) -> Option<String> {
         true => Some(query.to_string()),
         false => list.last().map(|s| s.to_string()),
     }
-}
-
-fn rmdir(dir: &Path, pr: &dyn SingleReport) -> eyre::Result<()> {
-    if !dir.exists() {
-        return Ok(());
-    }
-    pr.set_message(format!("remove {}", &dir.to_string_lossy()));
-    remove_all(dir).wrap_err_with(|| {
-        format!(
-            "Failed to remove directory {}",
-            style(&dir.to_string_lossy()).cyan().for_stderr()
-        )
-    })
 }
 
 pub fn unalias_backend(backend: &str) -> &str {

--- a/src/file.rs
+++ b/src/file.rs
@@ -134,6 +134,15 @@ pub fn remove_all_with_warning<P: AsRef<Path>>(path: P) -> Result<()> {
     })
 }
 
+pub fn remove_all_with_progress<P: AsRef<Path>>(path: P, pr: &dyn SingleReport) -> Result<()> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Ok(());
+    }
+    pr.set_message(format!("remove {}", display_path(path)));
+    remove_all_with_warning(path)
+}
+
 /// Renames `from` to `to`.
 ///
 /// Warning: this is the raw `rename(2)`/`fs::rename` behavior. It is atomic on a

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -1,6 +1,6 @@
 use crate::config::{Config, Settings};
 use crate::errors::Error::PluginNotInstalled;
-use crate::file::{display_path, remove_all};
+use crate::file::{display_path, remove_all_with_progress};
 use crate::git::{CloneOptions, Git};
 use crate::http::HTTP;
 use crate::plugins::{Plugin, PluginSource, Script, ScriptManager};
@@ -335,20 +335,7 @@ impl Plugin for AsdfPlugin {
         self.exec_hook(pr, "pre-plugin-remove")?;
         pr.set_message("uninstall".into());
 
-        let rmdir = |dir: &Path| {
-            if !dir.exists() {
-                return Ok(());
-            }
-            pr.set_message(format!("remove {}", display_path(dir)));
-            remove_all(dir).wrap_err_with(|| {
-                format!(
-                    "Failed to remove directory {}",
-                    style(display_path(dir)).cyan().for_stderr()
-                )
-            })
-        };
-
-        rmdir(&self.plugin_path)?;
+        remove_all_with_progress(&self.plugin_path, pr)?;
 
         Ok(())
     }

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -1,6 +1,6 @@
 use crate::config::{Config, Settings};
 use crate::errors::Error::PluginNotInstalled;
-use crate::file::{display_path, remove_all};
+use crate::file::remove_all_with_progress;
 use crate::git::{CloneOptions, Git};
 use crate::http::HTTP;
 use crate::plugins::warn_if_env_plugin_shadows_registry;
@@ -15,7 +15,7 @@ use console::style;
 use contracts::requires;
 use eyre::{Context, bail, eyre};
 use indexmap::{IndexMap, indexmap};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex, MutexGuard, mpsc};
 use url::Url;
 use vfox::Vfox;
@@ -305,20 +305,7 @@ impl Plugin for VfoxPlugin {
         }
         pr.set_message("uninstall".into());
 
-        let rmdir = |dir: &Path| {
-            if !dir.exists() {
-                return Ok(());
-            }
-            pr.set_message(format!("remove {}", display_path(dir)));
-            remove_all(dir).wrap_err_with(|| {
-                format!(
-                    "Failed to remove directory {}",
-                    style(display_path(dir)).cyan().for_stderr()
-                )
-            })
-        };
-
-        rmdir(&self.plugin_path)?;
+        remove_all_with_progress(&self.plugin_path, pr)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add a progress-aware remove helper in `src/file.rs`
- use it for backend purge, version uninstall removal, and plugin uninstall removal paths
- remove duplicate local `rmdir` closures and now-unused imports

## Tests
- `cargo fmt --check`
- `git diff --check`
- `mise run test:e2e e2e/plugins/test_purge`

*This PR was generated by an AI coding assistant.*