### PR TITLE
registry: add openpass (github:danieljustus/OpenPass)

### DIFF
--- a/registry/openpass.toml
+++ b/registry/openpass.toml
@@ -1,0 +1,3 @@
+backends = ["github:ProfDrJu/OpenPass"]
+description = "CLI password manager with age encryption"
+test = { cmd = "openpass --version", expected = "{{version}}" }


### PR DESCRIPTION
Add OpenPass to the mise registry for installation via `mise use openpass`.

Uses the canonical repository owner `danieljustus/OpenPass` and matches the smoke test expectation to the actual `openpass --version` output.