### PR TITLE
fix(backends): deprecate b shorthand

### DIFF
--- a/docs/cli/backends.md
+++ b/docs/cli/backends.md
@@ -2,7 +2,6 @@
 # `mise backends`
 
 - **Usage**: `mise backends <SUBCOMMAND>`
-- **Aliases**: `b`
 - **Source code**: [`src/cli/backends/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/backends/mod.rs)
 
 Manage backends
@@ -10,3 +9,8 @@ Manage backends
 ## Subcommands
 
 - [`mise backends ls`](/cli/backends/ls.md)
+
+Deprecation:
+
+The `mise b` alias is deprecated and will be removed in mise 2027.4.16.
+Use `mise backends` instead.

--- a/docs/cli/backends.md
+++ b/docs/cli/backends.md
@@ -12,5 +12,5 @@ Manage backends
 
 Deprecation:
 
-The `mise b` alias is deprecated and will be removed in mise 2027.4.16.
+The `mise b` alias is deprecated and will be removed in mise 2027.4.0.
 Use `mise backends` instead.

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -123,8 +123,12 @@ cmd "asdf" hide=true help="[internal] simulates asdf for plugins that call \"asd
     arg "[ARGS]..." help="all arguments" var=true
 }
 cmd "backends" help="Manage backends" {
-    alias "b"
-    alias "backend" "backend-list" hide=true
+    alias "b" "backend" "backend-list" hide=true
+    after_long_help r"Deprecation:
+
+The `mise b` alias is deprecated and will be removed in mise 2027.4.16.
+Use `mise backends` instead.
+"
     cmd "ls" help="List built-in backends" {
         alias "list"
         after_long_help r"Examples:

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -126,7 +126,7 @@ cmd "backends" help="Manage backends" {
     alias "b" "backend" "backend-list" hide=true
     after_long_help r"Deprecation:
 
-The `mise b` alias is deprecated and will be removed in mise 2027.4.16.
+The `mise b` alias is deprecated and will be removed in mise 2027.4.0.
 Use `mise backends` instead.
 "
     cmd "ls" help="List built-in backends" {

--- a/e2e/cli/test_backends
+++ b/e2e/cli/test_backends
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
 assert_contains "mise backends" "cargo"
+assert_contains "mise b 2>&1" "deprecated [cli.backends.b]"
+assert_contains "mise b 2>&1" "cargo"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -132,9 +132,6 @@ Clears an alias for a backend/plugin
 .TP
 \fBbackends\fR
 Manage backends
-.RS
-\fIAliases: \fRb
-.RE
 .TP
 \fBbackends ls\fR
 List built\-in backends

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -122,8 +122,8 @@ cmd asdf hide=#true help="[internal] simulates asdf for plugins that call \"asdf
     arg "[ARGS]…" help="all arguments" required=#false double_dash=automatic var=#true
 }
 cmd backends help="Manage backends" {
-    alias b
-    alias backend backend-list hide=#true
+    alias b backend backend-list hide=#true
+    after_long_help "Deprecation:\n\nThe `mise b` alias is deprecated and will be removed in mise 2027.4.16.\nUse `mise backends` instead.\n"
     cmd ls help="List built-in backends" {
         alias list
         after_long_help "Examples:\n\n    $ mise backends ls\n    aqua\n    asdf\n    cargo\n    core\n    dotnet\n    gem\n    go\n    npm\n    pipx\n    spm\n    ubi\n    vfox\n"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -123,7 +123,7 @@ cmd asdf hide=#true help="[internal] simulates asdf for plugins that call \"asdf
 }
 cmd backends help="Manage backends" {
     alias b backend backend-list hide=#true
-    after_long_help "Deprecation:\n\nThe `mise b` alias is deprecated and will be removed in mise 2027.4.16.\nUse `mise backends` instead.\n"
+    after_long_help "Deprecation:\n\nThe `mise b` alias is deprecated and will be removed in mise 2027.4.0.\nUse `mise backends` instead.\n"
     cmd ls help="List built-in backends" {
         alias list
         after_long_help "Examples:\n\n    $ mise backends ls\n    aqua\n    asdf\n    cargo\n    core\n    dotnet\n    gem\n    go\n    npm\n    pipx\n    spm\n    ubi\n    vfox\n"

--- a/src/cli/backends/mod.rs
+++ b/src/cli/backends/mod.rs
@@ -4,11 +4,23 @@ use eyre::Result;
 mod ls;
 
 #[derive(Debug, clap::Args)]
-#[clap(about = "Manage backends", visible_alias = "b", aliases = ["backend", "backend-list"])]
+#[clap(
+    about = "Manage backends",
+    aliases = ["b", "backend", "backend-list"],
+    after_long_help = AFTER_LONG_HELP
+)]
 pub struct Backends {
     #[clap(subcommand)]
     command: Option<Commands>,
 }
+
+static AFTER_LONG_HELP: &str = color_print::cstr!(
+    r#"<bold><underline>Deprecation:</underline></bold>
+
+The `mise b` alias is deprecated and will be removed in mise 2027.4.16.
+Use `mise backends` instead.
+"#
+);
 
 #[derive(Debug, Subcommand)]
 enum Commands {

--- a/src/cli/backends/mod.rs
+++ b/src/cli/backends/mod.rs
@@ -17,7 +17,7 @@ pub struct Backends {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Deprecation:</underline></bold>
 
-The `mise b` alias is deprecated and will be removed in mise 2027.4.16.
+The `mise b` alias is deprecated and will be removed in mise 2027.4.0.
 Use `mise backends` instead.
 "#
 );

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -443,6 +443,24 @@ fn is_known_subcommand(cmd: &clap::Command, arg: &str) -> bool {
         .any(|name| name == arg)
 }
 
+fn uses_deprecated_backends_alias(cmd: &clap::Command, args: &[String]) -> bool {
+    matches!(
+        first_non_global_arg_idx(cmd, args).and_then(|idx| args.get(idx)),
+        Some(arg) if arg == "b"
+    )
+}
+
+fn warn_deprecated_backends_alias(cmd: &clap::Command, args: &[String]) {
+    if uses_deprecated_backends_alias(cmd, args) {
+        deprecated_at!(
+            "2026.4.16",
+            "2027.4.16",
+            "cli.backends.b",
+            "`mise b` is deprecated. Use `mise backends` instead."
+        );
+    }
+}
+
 /// Escape flags after task names so clap doesn't parse them as mise flags.
 /// This preserves ::: separators for multi-task handling while preventing
 /// clap from consuming flags like --jobs that appear after task names.
@@ -622,6 +640,7 @@ impl Cli {
         measure!("add_cli_matches", { Settings::add_cli_matches(&cli) });
         let _ = measure!("settings", { Settings::try_get() });
         measure!("logger", { logger::init() });
+        warn_deprecated_backends_alias(&cmd, args);
         measure!("migrate", { migrate::run().await });
         if let Err(err) = crate::cache::auto_prune() {
             warn!("auto_prune failed: {err:?}");
@@ -864,6 +883,48 @@ mod tests {
         ];
 
         assert_eq!(escape_task_args(&cmd, &args), args);
+    }
+
+    #[test]
+    fn test_uses_deprecated_backends_alias() {
+        let cmd = Cli::command();
+        let args = vec!["mise".to_string(), "b".to_string()];
+
+        assert!(uses_deprecated_backends_alias(&cmd, &args));
+    }
+
+    #[test]
+    fn test_uses_deprecated_backends_alias_after_global_flag() {
+        let cmd = Cli::command();
+        let args = vec![
+            "mise".to_string(),
+            "--cd".to_string(),
+            "project".to_string(),
+            "b".to_string(),
+        ];
+
+        assert!(uses_deprecated_backends_alias(&cmd, &args));
+    }
+
+    #[test]
+    fn test_uses_deprecated_backends_alias_ignores_global_flag_value() {
+        let cmd = Cli::command();
+        let args = vec![
+            "mise".to_string(),
+            "--cd".to_string(),
+            "b".to_string(),
+            "backends".to_string(),
+        ];
+
+        assert!(!uses_deprecated_backends_alias(&cmd, &args));
+    }
+
+    #[test]
+    fn test_uses_deprecated_backends_alias_ignores_task_arg() {
+        let cmd = Cli::command();
+        let args = vec!["mise".to_string(), "run".to_string(), "b".to_string()];
+
+        assert!(!uses_deprecated_backends_alias(&cmd, &args));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -453,8 +453,8 @@ fn uses_deprecated_backends_alias(cmd: &clap::Command, args: &[String]) -> bool 
 fn warn_deprecated_backends_alias(cmd: &clap::Command, args: &[String]) {
     if uses_deprecated_backends_alias(cmd, args) {
         deprecated_at!(
-            "2026.4.16",
-            "2027.4.16",
+            "2026.4.0",
+            "2027.4.0",
             "cli.backends.b",
             "`mise b` is deprecated. Use `mise backends` instead."
         );

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -654,7 +654,7 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["backends", "b"],
+      name: "backends",
       description: "Manage backends",
       subcommands: [
         {


### PR DESCRIPTION
## Summary
- hide the `mise b` alias from generated help/docs while preserving it as a hidden clap alias during the deprecation window
- warn via `deprecated_at!` when `mise b` is invoked, with removal scheduled for mise 2027.4.0
- add focused unit/e2e coverage and regenerate usage docs

## Tests
- `mise run format`
- `mise run render:usage`
- `cargo test --all-features cli::tests::test_uses_deprecated_backends_alias`
- `mise run test:e2e e2e/cli/test_backends`
- `cargo fmt --all -- --check`
- `git diff --check`

*This PR description was generated by an AI coding assistant.*