### PR TITLE
docs(github): document multiple release assets workaround

### DIFF
--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -93,6 +93,27 @@ linux-x64 = { asset_pattern = "gh_*_linux_x64.tar.gz" }
 macos-arm64 = { asset_pattern = "gh_*_macOS_arm64.tar.gz" }
 ```
 
+### Multiple Assets from the Same Release
+
+The GitHub backend installs one release asset for each tool. If a repository publishes
+multiple binaries as separate assets in the same release, define one tool alias per
+binary and point each alias at the same `github:owner/repo` backend. Then configure
+each aliased tool with its own `asset_pattern`.
+
+```toml
+[tool_alias]
+tool-a = "github:owner/repo"
+tool-b = "github:owner/repo"
+
+[tools.tool-a]
+version = "latest"
+asset_pattern = "tool-a-*"
+
+[tools.tool-b]
+version = "latest"
+asset_pattern = "tool-b-*"
+```
+
 ### `checksum`
 
 Verify the downloaded file with a checksum:


### PR DESCRIPTION
## Summary
- document the #9093 workaround syntax for installing multiple separate assets from one GitHub release
- use generic `owner/repo` placeholders instead of discussion-specific binaries

## Testing
- `./xtasks/lint-fix.sh`
- locally verified with `target/debug/mise` `2026.4.16-DEBUG` that two aliases pointing at the same GitHub backend with different `[tools.<alias>]` `asset_pattern` values install distinct assets
- confirmed jdx/mise#9093 uses the same `[tool_alias]` plus `[tools.<alias>]` syntax

Context: https://github.com/jdx/mise/discussions/8266
Related fix: https://github.com/jdx/mise/pull/9093

*This pull request was generated by an AI coding assistant.*
