### PR TITLE
registry: add openpass (github:danieljustus/OpenPass)

### DIFF
--- a/registry/openpass.toml
+++ b/registry/openpass.toml
@@ -1,3 +1,3 @@
 backends = ["github:ProfDrJu/OpenPass"]
 description = "CLI password manager with age encryption"
-test = { cmd = "openpass --version", expected = "{{version}}" }
+test = { cmd = "openpass --version", expected = "openpass version {{version}}" }

--- a/registry/openpass.toml
+++ b/registry/openpass.toml
@@ -1,0 +1,3 @@
+backends = ["github:ProfDrJu/OpenPass"]
+description = "CLI password manager with age encryption"
+test = { cmd = "openpass --version", expected = "{{version}}" }

--- a/registry/openpass.toml
+++ b/registry/openpass.toml
@@ -1,3 +1,3 @@
-backends = ["github:ProfDrJu/OpenPass"]
+backends = ["github:danieljustus/OpenPass"]
 description = "CLI password manager with age encryption"
 test = { cmd = "openpass --version", expected = "openpass version {{version}}" }


### PR DESCRIPTION
Add OpenPass to the mise registry for installation via `mise use openpass`.

This uses the canonical repository owner `danieljustus/OpenPass` and matches the smoke test to the actual `openpass --version` output:

```text
openpass version 1.0.0
```

Validated locally with:

```sh
mise x github:danieljustus/OpenPass@1.0.0 -- openpass --version
```