### PR TITLE
registry: add aube

### DIFF
--- a/registry/aube.toml
+++ b/registry/aube.toml
@@ -1,0 +1,1 @@
+backends = ["github:endevco/aube"]

--- a/registry/aube.toml
+++ b/registry/aube.toml
@@ -1,1 +1,2 @@
 backends = ["github:endevco/aube"]
+description = "A fast Node.js package manager"


### PR DESCRIPTION
## Summary
- Adds `aube` (github:endevco/aube) to the registry

No test block since the repo isn't published yet.

## Test plan
- [ ] Verify registry builds once the upstream repo publishes releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new registry metadata file only, with no changes to existing tooling logic.
> 
> **Overview**
> Adds a new `registry/aube.toml` entry to register the `aube` tool, pointing to the `github:endevco/aube` backend and providing a short description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b3820486793d4066b488a8800db6a531eba8af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->