### PR TITLE
fix(backend): skip versions host for direct-source backends

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -492,8 +492,29 @@ pub trait Backend: Debug + Send + Sync {
         let ba = self.ba().clone();
         let id = self.id();
 
+        // Some backends fetch versions from canonical, always-fresh sources
+        // (package registries, or http/s3 with an explicit version_list_url).
+        // For these, the versions host only adds latency and staleness risk,
+        // so skip it and query the source directly.
+        let backend_type = self.get_type();
+        let has_direct_source = matches!(
+            backend_type,
+            BackendType::Npm
+                | BackendType::Pipx
+                | BackendType::Cargo
+                | BackendType::Gem
+                | BackendType::Go
+        ) || (matches!(backend_type, BackendType::Http | BackendType::S3)
+            && ba.opts().contains_key("version_list_url"));
+
         // Check if this is an external plugin with a custom remote - skip versions host if so
-        let use_versions_host = if let Some(plugin) = self.plugin()
+        let use_versions_host = if has_direct_source {
+            trace!(
+                "Skipping versions host for {} because {} backend has a direct source",
+                ba.short, backend_type
+            );
+            false
+        } else if let Some(plugin) = self.plugin()
             && let Ok(Some(remote_url)) = plugin.get_remote_url()
         {
             // Check if remote matches the registry default

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -480,9 +480,12 @@ pub trait Backend: Debug + Send + Sync {
     /// Results are cached. Backends can override `_list_remote_versions_with_info`
     /// to provide timestamp information.
     ///
-    /// This method first tries the versions host (mise-versions.jdx.dev) which provides
-    /// version info with created_at timestamps. If that fails, it falls back to the
-    /// backend's `_list_remote_versions_with_info` implementation.
+    /// For backends that query canonical, always-fresh sources (npm, pipx, cargo,
+    /// gem, go, and http/s3 with `version_list_url`), the versions host cache is
+    /// skipped and the upstream is queried directly. For all other backends this
+    /// method first tries the versions host (mise-versions.jdx.dev) which provides
+    /// version info with created_at timestamps, and falls back to the backend's
+    /// `_list_remote_versions_with_info` implementation on failure.
     async fn list_remote_versions_with_info(
         &self,
         config: &Arc<Config>,
@@ -492,23 +495,38 @@ pub trait Backend: Debug + Send + Sync {
         let ba = self.ba().clone();
         let id = self.id();
 
-        // Some backends fetch versions from canonical, always-fresh sources
-        // (package registries, or http/s3 with an explicit version_list_url).
-        // For these, the versions host only adds latency and staleness risk,
-        // so skip it and query the source directly.
+        // Only a subset of backends benefit from the versions host cache —
+        // those whose upstream listing is rate-limited (github API) or not
+        // otherwise available. Package-registry backends (npm, pipx, cargo,
+        // gem, go, conda, dotnet, spm) and http/s3 with an explicit
+        // version_list_url already have canonical, always-fresh sources, so
+        // the cache would only add latency and staleness risk. Note: this
+        // asymmetrically overrides `settings.use_versions_host = true` — the
+        // setting can still disable the host globally, but cannot re-enable
+        // it for backends that are not on this allowlist.
         let backend_type = self.get_type();
-        let has_direct_source = matches!(
-            backend_type,
-            BackendType::Npm
-                | BackendType::Pipx
-                | BackendType::Cargo
-                | BackendType::Gem
-                | BackendType::Go
-        ) || (matches!(backend_type, BackendType::Http | BackendType::S3)
-            && ba.opts().contains_key("version_list_url"));
+        let has_version_list_url = matches!(backend_type, BackendType::Http | BackendType::S3)
+            && (ba.opts().contains_key("version_list_url")
+                || config
+                    .get_tool_opts(&ba)
+                    .await?
+                    .is_some_and(|o| o.contains_key("version_list_url")));
+        let versions_host_applies = match backend_type {
+            BackendType::Github
+            | BackendType::Gitlab
+            | BackendType::Forgejo
+            | BackendType::Aqua
+            | BackendType::Ubi
+            | BackendType::Core
+            | BackendType::Asdf
+            | BackendType::Vfox
+            | BackendType::VfoxBackend(_) => true,
+            BackendType::Http | BackendType::S3 => !has_version_list_url,
+            _ => false,
+        };
 
         // Check if this is an external plugin with a custom remote - skip versions host if so
-        let use_versions_host = if has_direct_source {
+        let use_versions_host = if !versions_host_applies {
             trace!(
                 "Skipping versions host for {} because {} backend has a direct source",
                 ba.short, backend_type


### PR DESCRIPTION
## Summary

- For backends that already query canonical, always-fresh upstream sources, skip the `mise-versions.jdx.dev` cache and query the source directly.
- Affected backends:
  - `npm` (npm registry), `pipx` (PyPI), `cargo` (crates.io), `gem` (RubyGems), `go` (Go module proxy)
  - `http` / `s3` backends when `version_list_url` is set (registry provides a canonical source)
- This avoids the failure mode observed for Flutter where the versions host's cached data had gone stale at `3.22.1-stable`, hiding newer releases until users set `MISE_USE_VERSIONS_HOST=0`.

Refs [discussion comment](https://github.com/jdx/mise/discussions/7863#discussioncomment-16612930).

## Test plan

- [ ] `mise ls-remote flutter` shows current releases (e.g. 3.38.x/3.41.x) without needing `MISE_USE_VERSIONS_HOST=0`
- [ ] `mise ls-remote` for an npm/pipx/cargo/gem/go tool still returns versions
- [ ] http backend tools *without* `version_list_url` still use the versions host (unchanged behavior)
- [ ] Existing unit + e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global remote-version listing behavior by conditionally bypassing `mise-versions.jdx.dev`, which could affect performance and rate-limiting characteristics across multiple backends (especially GitHub-like ones) if the allowlist/`version_list_url` detection is wrong.
> 
> **Overview**
> Adjusts `Backend::list_remote_versions_with_info` to **skip the `mise-versions.jdx.dev` versions-host cache** for backends that already have canonical, always-fresh upstream version sources (notably package registries and `http`/`s3` when `version_list_url` is set), querying the upstream directly instead.
> 
> Introduces backend-type gating and `version_list_url` detection (including tool/config opts) to decide whether the versions host applies, and adds trace logging to explain when/why the cache is bypassed; all other backends keep the existing “try versions host first, then fall back” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce79bc4ed4e9889afa9f83ff923b7651946e88c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->