### PR TITLE
chore: release 2026.4.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [2026.4.18](https://github.com/jdx/mise/compare/v2026.4.17..v2026.4.18) - 2026-04-19
+
+### 🚀 Features
+
+- **(latest)** add --before flag to mise latest by @risu729 in [#9168](https://github.com/jdx/mise/pull/9168)
+- **(npm)** add aube package manager support by @jdx in [#9256](https://github.com/jdx/mise/pull/9256)
+- **(spm)** add filter_bins option to restrict built executables by @jdx in [#9253](https://github.com/jdx/mise/pull/9253)
+- **(vfox)** support plugin-declared dependencies via metadata.lua by @ahemon in [#9051](https://github.com/jdx/mise/pull/9051)
+- rename `mise prepare` to `mise deps` and add package management by @jdx in [#9056](https://github.com/jdx/mise/pull/9056)
+
+### 🐛 Bug Fixes
+
+- **(backend)** skip versions host for direct-source backends by @jdx in [#9245](https://github.com/jdx/mise/pull/9245)
+- **(github)** route artifact attestation verification to custom api_url by @jdx in [#9254](https://github.com/jdx/mise/pull/9254)
+- **(lockfile)** use unique temp file for atomic save to avoid concurrent rename race by @jdx in [#9250](https://github.com/jdx/mise/pull/9250)
+- **(log)** drop noisy third-party debug/trace logs by @jdx in [#9248](https://github.com/jdx/mise/pull/9248)
+- **(progress)** disable animated clx output in ci by @jdx in [#9249](https://github.com/jdx/mise/pull/9249)
+- **(use)** honor --quiet and --silent flags by @jdx in [#9251](https://github.com/jdx/mise/pull/9251)
+- **(vfox)** opt backend plugins out of --locked URL check by @jdx in [#9252](https://github.com/jdx/mise/pull/9252)
+
+### 📦 Registry
+
+- add aqua backend for bitwarden-secrets-manager by @msuzoagu in [#9255](https://github.com/jdx/mise/pull/9255)
+
+### New Contributors
+
+- @ahemon made their first contribution in [#9051](https://github.com/jdx/mise/pull/9051)
+- @msuzoagu made their first contribution in [#9255](https://github.com/jdx/mise/pull/9255)
+
 ## [2026.4.17](https://github.com/jdx/mise/compare/v2026.4.16..v2026.4.17) - 2026-04-18
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5694,7 +5694,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.4.17"
+version = "2026.4.18"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.4.17"
+version = "2026.4.18"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.4.17 macos-arm64 (2026-04-18)
+2026.4.18 macos-arm64 (2026-04-19)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_17.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_18.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_17.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_18.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_4_17.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_4_18.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_4_17.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_4_18.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.4.17";
+  version = "2026.4.18";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "26.8k",
+      stars: "26.9k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2026.4.17
+Version: 2026.4.18
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.4.17"
+version: "2026.4.18"
 summary: The front-end to your dev env
 description: |
   mise-en-place is a command line tool to manage your development environment.


### PR DESCRIPTION
### 🚀 Features

- **(latest)** add --before flag to mise latest by @risu729 in [#9168](https://github.com/jdx/mise/pull/9168)
- **(npm)** add aube package manager support by @jdx in [#9256](https://github.com/jdx/mise/pull/9256)
- **(spm)** add filter_bins option to restrict built executables by @jdx in [#9253](https://github.com/jdx/mise/pull/9253)
- **(vfox)** support plugin-declared dependencies via metadata.lua by @ahemon in [#9051](https://github.com/jdx/mise/pull/9051)
- rename `mise prepare` to `mise deps` and add package management by @jdx in [#9056](https://github.com/jdx/mise/pull/9056)

### 🐛 Bug Fixes

- **(backend)** skip versions host for direct-source backends by @jdx in [#9245](https://github.com/jdx/mise/pull/9245)
- **(github)** route artifact attestation verification to custom api_url by @jdx in [#9254](https://github.com/jdx/mise/pull/9254)
- **(lockfile)** use unique temp file for atomic save to avoid concurrent rename race by @jdx in [#9250](https://github.com/jdx/mise/pull/9250)
- **(log)** drop noisy third-party debug/trace logs by @jdx in [#9248](https://github.com/jdx/mise/pull/9248)
- **(progress)** disable animated clx output in ci by @jdx in [#9249](https://github.com/jdx/mise/pull/9249)
- **(use)** honor --quiet and --silent flags by @jdx in [#9251](https://github.com/jdx/mise/pull/9251)
- **(vfox)** opt backend plugins out of --locked URL check by @jdx in [#9252](https://github.com/jdx/mise/pull/9252)

### 📦 Registry

- add aqua backend for bitwarden-secrets-manager by @msuzoagu in [#9255](https://github.com/jdx/mise/pull/9255)

### New Contributors

- @ahemon made their first contribution in [#9051](https://github.com/jdx/mise/pull/9051)
- @msuzoagu made their first contribution in [#9255](https://github.com/jdx/mise/pull/9255)