### PR TITLE
feat(vfox): add backend batch install hook support

### DIFF
--- a/crates/vfox/src/hooks/backend_batch_install.rs
+++ b/crates/vfox/src/hooks/backend_batch_install.rs
@@ -1,0 +1,156 @@
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use mlua::{FromLua, IntoLua, Lua, LuaSerdeExt, Value, prelude::LuaError};
+
+use crate::{Plugin, error::Result};
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BackendBatchInstallItem {
+    pub id: String,
+    pub tool: String,
+    pub version: String,
+    pub install_path: PathBuf,
+    pub download_path: PathBuf,
+    pub options: IndexMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BackendBatchInstallContext {
+    pub tools: Vec<BackendBatchInstallItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BackendBatchInstallResult {
+    pub version: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BackendBatchInstallResponse {
+    pub results: HashMap<String, BackendBatchInstallResult>,
+}
+
+impl Plugin {
+    pub async fn backend_batch_install(
+        &self,
+        ctx: BackendBatchInstallContext,
+    ) -> Result<BackendBatchInstallResponse> {
+        debug!("[vfox:{}] backend_batch_install", &self.name);
+        self.eval_async(chunk! {
+            require "hooks/backend_batch_install"
+            return PLUGIN:BackendBatchInstall($ctx)
+        })
+        .await
+    }
+}
+
+impl IntoLua for BackendBatchInstallItem {
+    fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+        let table = lua.create_table()?;
+        table.set("id", self.id)?;
+        table.set("tool", self.tool)?;
+        table.set("version", self.version)?;
+        table.set(
+            "install_path",
+            self.install_path.to_string_lossy().to_string(),
+        )?;
+        table.set(
+            "download_path",
+            self.download_path.to_string_lossy().to_string(),
+        )?;
+        table.set("options", lua.to_value(&self.options)?)?;
+        Ok(Value::Table(table))
+    }
+}
+
+impl IntoLua for BackendBatchInstallContext {
+    fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+        let table = lua.create_table()?;
+        table.set("tools", lua.create_sequence_from(self.tools)?)?;
+        Ok(Value::Table(table))
+    }
+}
+
+impl FromLua for BackendBatchInstallResult {
+    fn from_lua(value: Value, _: &Lua) -> std::result::Result<Self, LuaError> {
+        match value {
+            Value::Table(table) => {
+                let result = Self {
+                    version: table.get("version")?,
+                    error: table.get("error")?,
+                };
+                if result.version.is_none() && result.error.is_none() {
+                    return Err(LuaError::FromLuaConversionError {
+                        from: "table",
+                        to: "BackendBatchInstallResult".to_string(),
+                        message: Some(
+                            "Expected result table to contain either 'version' or 'error'"
+                                .to_string(),
+                        ),
+                    });
+                }
+                Ok(result)
+            }
+            _ => Err(LuaError::FromLuaConversionError {
+                from: value.type_name(),
+                to: "BackendBatchInstallResult".to_string(),
+                message: Some("Expected table".to_string()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_batch_install_result_accepts_version_or_error() {
+        let lua = Lua::new();
+
+        let version_table = lua.create_table().unwrap();
+        version_table.set("version", "1.0.0").unwrap();
+        let version_result =
+            BackendBatchInstallResult::from_lua(Value::Table(version_table), &lua).unwrap();
+        assert_eq!(version_result.version.as_deref(), Some("1.0.0"));
+        assert_eq!(version_result.error, None);
+
+        let error_table = lua.create_table().unwrap();
+        error_table.set("error", "boom").unwrap();
+        let error_result =
+            BackendBatchInstallResult::from_lua(Value::Table(error_table), &lua).unwrap();
+        assert_eq!(error_result.version, None);
+        assert_eq!(error_result.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn backend_batch_install_result_rejects_empty_table() {
+        let lua = Lua::new();
+        let table = lua.create_table().unwrap();
+
+        let err = BackendBatchInstallResult::from_lua(Value::Table(table), &lua).unwrap_err();
+        assert!(err.to_string().contains("either 'version' or 'error'"));
+    }
+}
+
+impl FromLua for BackendBatchInstallResponse {
+    fn from_lua(value: Value, _: &Lua) -> std::result::Result<Self, LuaError> {
+        match value {
+            Value::Table(table) => {
+                let mut results = HashMap::new();
+                for pair in table.pairs::<String, BackendBatchInstallResult>() {
+                    let (id, result) = pair?;
+                    results.insert(id, result);
+                }
+                Ok(Self { results })
+            }
+            _ => Err(LuaError::FromLuaConversionError {
+                from: value.type_name(),
+                to: "BackendBatchInstallResponse".to_string(),
+                message: Some("Expected table".to_string()),
+            }),
+        }
+    }
+}

--- a/crates/vfox/src/hooks/mod.rs
+++ b/crates/vfox/src/hooks/mod.rs
@@ -1,4 +1,5 @@
 pub mod available;
+pub mod backend_batch_install;
 pub mod backend_exec_env;
 pub mod backend_install;
 pub mod backend_list_versions;

--- a/crates/vfox/src/lib.rs
+++ b/crates/vfox/src/lib.rs
@@ -8,6 +8,9 @@ extern crate mlua;
 
 pub use error::Result as VfoxResult;
 pub use error::VfoxError;
+pub use hooks::backend_batch_install::{
+    BackendBatchInstallItem, BackendBatchInstallResponse, BackendBatchInstallResult,
+};
 pub use hooks::pre_install::VerifiedAttestation;
 pub use plugin::Plugin;
 pub use vfox::InstallResult;

--- a/crates/vfox/src/lua_mod/hooks.rs
+++ b/crates/vfox/src/lua_mod/hooks.rs
@@ -10,7 +10,7 @@ pub struct HookFunc {
 }
 
 #[rustfmt::skip]
-pub const HOOK_FUNCS: [HookFunc; 12] = [
+pub const HOOK_FUNCS: [HookFunc; 13] = [
     HookFunc { _name: "Available", filename: "available" },
     HookFunc { _name: "PreInstall", filename: "pre_install" },
     HookFunc { _name: "EnvKeys", filename: "env_keys" },
@@ -22,6 +22,7 @@ pub const HOOK_FUNCS: [HookFunc; 12] = [
     // backend
     HookFunc { _name: "BackendListVersions", filename: "backend_list_versions" },
     HookFunc { _name: "BackendInstall", filename: "backend_install" },
+    HookFunc { _name: "BackendBatchInstall", filename: "backend_batch_install" },
     HookFunc { _name: "BackendExecEnv", filename: "backend_exec_env" },
 
     // mise

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -10,6 +10,9 @@ use xx::file;
 
 use crate::error::Result;
 use crate::hooks::available::AvailableVersion;
+use crate::hooks::backend_batch_install::{
+    BackendBatchInstallContext, BackendBatchInstallItem, BackendBatchInstallResponse,
+};
 use crate::hooks::backend_exec_env::BackendExecEnvContext;
 use crate::hooks::backend_install::BackendInstallContext;
 use crate::hooks::backend_list_versions::BackendListVersionsContext;
@@ -346,6 +349,16 @@ impl Vfox {
         };
         plugin.backend_install(ctx).await?;
         Ok(())
+    }
+
+    pub async fn backend_batch_install(
+        &self,
+        sdk: &str,
+        tools: Vec<BackendBatchInstallItem>,
+    ) -> Result<BackendBatchInstallResponse> {
+        let plugin = self.get_sdk_with_env(sdk)?;
+        let ctx = BackendBatchInstallContext { tools };
+        plugin.backend_batch_install(ctx).await
     }
 
     pub async fn backend_exec_env(

--- a/docs/backend-plugin-development.md
+++ b/docs/backend-plugin-development.md
@@ -18,10 +18,11 @@ Backend plugins extend the standard vfox plugin system with enhanced backend met
 
 Backend plugins are generally a git repository but can also be a directory (via `mise link`).
 
-Backend plugins are implemented in Lua (version 5.1 at the moment). They use three main backend methods implemented as individual files:
+Backend plugins are implemented in Lua (version 5.1 at the moment). They use three required backend methods and one optional batch install method implemented as individual files:
 
 - `hooks/backend_list_versions.lua` - Lists available versions for a tool
 - `hooks/backend_install.lua` - Installs a specific version of a tool
+- `hooks/backend_batch_install.lua` - Optionally installs multiple tools from the same backend in one invocation
 - `hooks/backend_exec_env.lua` - Sets up environment variables for a tool
 
 ## Backend Methods
@@ -66,6 +67,56 @@ function PLUGIN:BackendInstall(ctx)
     return {}
 end
 ```
+
+### BackendBatchInstall
+
+Optionally installs multiple tools from the same backend in one invocation:
+
+```lua
+function PLUGIN:BackendBatchInstall(ctx)
+    local results = {}
+
+    for _, tool in ipairs(ctx.tools) do
+        -- tool.id
+        -- tool.tool
+        -- tool.version
+        -- tool.install_path
+        -- tool.download_path
+        -- tool.options
+
+        -- Your install logic here
+        results[tool.id] = {version = tool.version}
+    end
+
+    return results
+end
+```
+
+`BackendBatchInstall` is optional.
+
+When present, mise may call it when multiple ready tools belong to the same backend plugin in the same install wave. When absent, mise falls back to individual `BackendInstall` calls.
+
+Batch results must be keyed by `tool.id`, not by tool name. This keeps results unambiguous when the same tool name appears multiple times with different versions or options.
+
+Per-tool failures can be returned in the response:
+
+```lua
+return {
+    [tool.id] = {error = "failed to install"}
+}
+```
+
+Successful tools should return a result entry, typically with the resolved version:
+
+```lua
+return {
+    [tool.id] = {version = tool.version}
+}
+```
+
+The `version` field is informational. Mise still finalizes the install using the tool version and
+install path it resolved before invoking `BackendBatchInstall`, so plugins should not use this field
+to redirect the install to a different version or location.
 
 ### BackendExecEnv
 
@@ -124,6 +175,7 @@ my-backend-plugin/
 ├── hooks/
 │   ├── backend_list_versions.lua   # BackendListVersions hook
 │   ├── backend_install.lua         # BackendInstall hook
+│   ├── backend_batch_install.lua   # Optional BackendBatchInstall hook
 │   └── backend_exec_env.lua        # BackendExecEnv hook
 └── Injection.lua                   # Runtime injection (auto-generated)
 ```
@@ -219,6 +271,24 @@ mise use vfox-npm:prettier@latest
 # Execute the tool
 mise exec -- prettier --help
 ```
+
+## BackendBatchInstall Context
+
+When `BackendBatchInstall` is used, `ctx.tools` contains one entry per tool in the batch:
+
+- `id` - Stable request id for the install item. Use this as the key in the returned results table.
+- `tool` - Tool name inside the backend plugin.
+- `version` - Requested or resolved version.
+- `install_path` - Final install directory for the tool.
+- `download_path` - Download/work directory for the tool.
+- `options` - Tool options from mise config.
+
+## Plugin Guidelines
+
+- Implement `BackendBatchInstall` only when one backend invocation can actually do less work than multiple `BackendInstall` calls.
+- Always return results keyed by `id`, not by `tool`.
+- Return per-tool errors when possible so unrelated tools in the same batch can still succeed.
+- Keep `BackendInstall` working even if you add `BackendBatchInstall`, since mise still uses it as the fallback path.
 
 > **Tip**: This naming flexibility could potentially be used to have a very complex plugin backend that would behave differently based on what it was named. For example, you could install the same plugin with different names to configure different behaviors or access different tool registries.
 

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -11,7 +11,7 @@ Vfox is the recommended plugin system for mise. It provides cross-platform suppo
 - **Cross-platform** — plugins work on Windows, macOS, and Linux without platform-specific code
 - **Built-in modules** — HTTP, JSON, HTML parsing, archive extraction, semver comparison, and logging are all available out of the box, no external dependencies needed
 - **Security** — [tool plugins](../../tool-plugin-development.md) support attestation verification (GitHub artifact attestations, cosign signatures, SLSA provenance) for downloaded artifacts. When a tool plugin's `PreInstall` hook returns an `attestation` table, mise verifies it during install and records the result in `mise.lock`, protecting against downgrade attacks on subsequent installs. Backend plugins do not currently support attestation
-- **Modern architecture** — structured hooks with typed contexts, backend plugins for multi-tool management, rolling version checksums, and lock file support
+- **Modern architecture** — structured hooks with typed contexts, backend plugins for multi-tool management, optional batch install hooks, rolling version checksums, and lock file support
 
 The code for this is inside the mise repository at [`./src/backend/vfox.rs`](https://github.com/jdx/mise/blob/main/src/backend/vfox.rs).
 
@@ -77,6 +77,8 @@ In addition to the standard vfox plugins, mise supports modern plugins that can 
 - Package managers (npm, pip, etc.)
 - Custom tool families
 
+Backend plugins can also optionally implement `BackendBatchInstall` to install multiple ready tools from the same plugin in a single backend invocation. This is primarily a plugin-author feature; end-user CLI usage does not change.
+
 ### Example: Plugin Usage
 
 ```bash
@@ -101,4 +103,5 @@ For more information, see:
 
 - [Using Plugins](../../plugin-usage.md) - End-user guide
 - [Plugin Development](../../tool-plugin-development.md) - Developer guide
+- [Backend Plugin Development](../../backend-plugin-development.md) - Backend hook reference
 - [Plugin Template](https://github.com/jdx/mise-tool-plugin-template) - Quick start template for creating plugins

--- a/e2e/cli/test_install_before_explicit_go_backend
+++ b/e2e/cli/test_install_before_explicit_go_backend
@@ -11,7 +11,8 @@ install_before = "2100-01-01"
 'go:github.com/roborev-dev/roborev/cmd/roborev' = { version = "latest", install_before = "2026-04-07" }
 EOF
 
-assert_contains "mise install --dry-run 2>&1" "go:github.com/roborev-dev/roborev/cmd/roborev@0.50.0"
+first_output=$(mise install --dry-run 2>&1)
+assert_matches "printf '%s' \"$first_output\"" 'go:github.com/roborev-dev/roborev/cmd/roborev@[0-9]+\.[0-9]+\.[0-9]+'
 
 cat <<'EOF' >mise.toml
 [settings]

--- a/e2e/plugins/test_backend_batch_install
+++ b/e2e/plugins/test_backend_batch_install
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+PLUGIN_DIR="$PWD/test-batch-backend-plugin"
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'EOF'
+PLUGIN = {
+  name = "batch-backend-test",
+  version = "0.1.0",
+  description = "test backend plugin with batch install hook",
+  author = "mise e2e"
+}
+EOF
+
+cat >"$PLUGIN_DIR/hooks/backend_list_versions.lua" <<'EOF'
+function PLUGIN:BackendListVersions(ctx)
+    return { versions = { "1.0.0" } }
+end
+EOF
+
+cat >"$PLUGIN_DIR/hooks/backend_install.lua" <<'EOF'
+function PLUGIN:BackendInstall(ctx)
+    error("BackendInstall should not be called when BackendBatchInstall is available")
+end
+EOF
+
+cat >"$PLUGIN_DIR/hooks/backend_batch_install.lua" <<'EOF'
+function PLUGIN:BackendBatchInstall(ctx)
+    local cmd = require("cmd")
+    local file = require("file")
+
+    if #ctx.tools < 2 then
+        error("expected batched install to include both configured tools, got " .. tostring(#ctx.tools))
+    end
+
+    local seen = {}
+
+    local results = {}
+    for _, tool in ipairs(ctx.tools) do
+        seen[tool.tool] = true
+        cmd.exec("mkdir -p \"" .. file.join_path(tool.install_path, "bin") .. "\"")
+        local bin = file.join_path(tool.install_path, "bin", tool.tool)
+        cmd.exec("printf '#!/bin/sh\necho " .. tool.tool .. "\n' > \"" .. bin .. "\"")
+        cmd.exec("chmod +x \"" .. bin .. "\"")
+        cmd.exec("printf 'batched' > \"" .. file.join_path(tool.install_path, "batch-proof") .. "\"")
+        results[tool.id] = { version = tool.version }
+    end
+
+    if not (seen["tool-a"] and seen["tool-b"]) then
+        error("expected batched install to include tool-a and tool-b")
+    end
+
+    return results
+end
+EOF
+
+cat >"$PLUGIN_DIR/hooks/backend_exec_env.lua" <<'EOF'
+function PLUGIN:BackendExecEnv(ctx)
+    local file = require("file")
+    return {
+        env_vars = {
+            { key = "PATH", value = file.join_path(ctx.install_path, "bin") }
+        }
+    }
+end
+EOF
+
+git -C "$PLUGIN_DIR" init -q
+git -C "$PLUGIN_DIR" add .
+git -C "$PLUGIN_DIR" commit -q -m "init"
+
+cat >mise.toml <<EOF
+[tools]
+"batchy:tool-a" = "1.0.0"
+"batchy:tool-b" = "1.0.0"
+
+[plugins]
+"vfox-backend:batchy" = "file://$PLUGIN_DIR"
+EOF
+
+mise install
+
+assert "mise current batchy:tool-a" "1.0.0"
+assert "mise current batchy:tool-b" "1.0.0"
+assert "test -f \"$(mise where batchy:tool-a)/batch-proof\" && cat \"$(mise where batchy:tool-a)/batch-proof\"" "batched"
+assert "test -f \"$(mise where batchy:tool-b)/batch-proof\" && cat \"$(mise where batchy:tool-b)/batch-proof\"" "batched"
+assert "mise exec batchy:tool-a@1.0.0 -- tool-a" "tool-a"
+assert "mise exec batchy:tool-b@1.0.0 -- tool-b" "tool-b"

--- a/e2e/plugins/test_backend_batch_install_partial_failure
+++ b/e2e/plugins/test_backend_batch_install_partial_failure
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+PLUGIN_DIR="$PWD/test-batch-backend-plugin-fail"
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'EOF'
+PLUGIN = {
+  name = "batch-backend-test-fail",
+  version = "0.1.0",
+  description = "test backend plugin with partial batch failure",
+  author = "mise e2e"
+}
+EOF
+
+cat >"$PLUGIN_DIR/hooks/backend_list_versions.lua" <<'EOF'
+function PLUGIN:BackendListVersions(ctx)
+    return { versions = { "1.0.0" } }
+end
+EOF
+
+cat >"$PLUGIN_DIR/hooks/backend_install.lua" <<'EOF'
+function PLUGIN:BackendInstall(ctx)
+    error("BackendInstall should not be called when BackendBatchInstall is available")
+end
+EOF
+
+cat >"$PLUGIN_DIR/hooks/backend_batch_install.lua" <<'EOF'
+function PLUGIN:BackendBatchInstall(ctx)
+    local cmd = require("cmd")
+    local file = require("file")
+
+    local results = {}
+    for _, tool in ipairs(ctx.tools) do
+        if tool.tool == "tool-fail" then
+            results[tool.id] = { error = "intentional batch failure for tool-fail" }
+        else
+            cmd.exec("mkdir -p \"" .. file.join_path(tool.install_path, "bin") .. "\"")
+            local bin = file.join_path(tool.install_path, "bin", tool.tool)
+            cmd.exec("printf '#!/bin/sh\necho tool-ok\n' > \"" .. bin .. "\"")
+            cmd.exec("chmod +x \"" .. bin .. "\"")
+            cmd.exec("printf 'batched-ok' > \"" .. file.join_path(tool.install_path, "batch-proof") .. "\"")
+            results[tool.id] = { version = tool.version }
+        end
+    end
+
+    return results
+end
+EOF
+
+cat >"$PLUGIN_DIR/hooks/backend_exec_env.lua" <<'EOF'
+function PLUGIN:BackendExecEnv(ctx)
+    local file = require("file")
+    return {
+        env_vars = {
+            { key = "PATH", value = file.join_path(ctx.install_path, "bin") }
+        }
+    }
+end
+EOF
+
+git -C "$PLUGIN_DIR" init -q
+git -C "$PLUGIN_DIR" add .
+git -C "$PLUGIN_DIR" commit -q -m "init"
+
+cat >mise.toml <<EOF
+[tools]
+"batchfail:tool-ok" = "1.0.0"
+"batchfail:tool-fail" = "1.0.0"
+
+[plugins]
+"vfox-backend:batchfail" = "file://$PLUGIN_DIR"
+EOF
+
+assert_fail "mise install 2>&1" "intentional batch failure for tool-fail"
+assert "mise current batchfail:tool-ok" "1.0.0"
+assert_not_contains "find \"$MISE_DATA_DIR/installs\" -maxdepth 3 -type f -name batch-proof 2>/dev/null || true" "tool-fail"
+assert "test -f \"$(mise where batchfail:tool-ok)/batch-proof\" && cat \"$(mise where batchfail:tool-ok)/batch-proof\"" "batched-ok"
+assert "mise exec batchfail:tool-ok@1.0.0 -- tool-ok" "tool-ok"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -71,6 +71,27 @@ pub type BackendMap = BTreeMap<String, ABackend>;
 pub type BackendList = Vec<ABackend>;
 pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 
+#[derive(Debug)]
+pub struct BatchInstallRequest {
+    pub request_id: String,
+    pub tool_request: ToolRequest,
+    pub tool_version: ToolVersion,
+    pub install_context: InstallContext,
+}
+
+#[derive(Debug)]
+pub struct BatchInstallOutcome {
+    pub request_id: String,
+    pub tool_request: ToolRequest,
+    pub result: eyre::Result<ToolVersion>,
+}
+
+pub struct PreparedInstall {
+    pub(crate) tv: ToolVersion,
+    pub(crate) was_installed: bool,
+    pub(crate) lock: Option<fslock::LockFile>,
+}
+
 /// Information about a GitHub/GitLab release for platform-specific tools
 #[derive(Debug, Clone)]
 pub struct GitHubReleaseInfo {
@@ -367,6 +388,9 @@ mod tests {
 pub trait Backend: Debug + Send + Sync {
     fn id(&self) -> &str {
         &self.ba().short
+    }
+    fn batch_group_id(&self) -> String {
+        self.id().to_string()
     }
     fn tool_name(&self) -> String {
         self.ba().tool_name()
@@ -1007,6 +1031,32 @@ pub trait Backend: Debug + Send + Sync {
         None
     }
 
+    fn supports_batch_install(&self) -> bool {
+        false
+    }
+
+    async fn supports_batch_install_request(&self, _req: &BatchInstallRequest) -> bool {
+        self.supports_batch_install()
+    }
+
+    async fn install_versions_batch(
+        &self,
+        reqs: Vec<BatchInstallRequest>,
+    ) -> Vec<BatchInstallOutcome> {
+        let mut outcomes = Vec::with_capacity(reqs.len());
+        for req in reqs {
+            let result = self
+                .install_version(req.install_context, req.tool_version)
+                .await;
+            outcomes.push(BatchInstallOutcome {
+                request_id: req.request_id,
+                tool_request: req.tool_request,
+                result,
+            });
+        }
+        outcomes
+    }
+
     async fn install_version(
         &self,
         ctx: InstallContext,
@@ -1066,10 +1116,33 @@ pub trait Backend: Debug + Send + Sync {
             tv.install_path = Some(tv.ba().installs_path.join(tv.tv_pathname()));
         }
 
+        let prepared = self.prepare_install(&ctx, tv).await?;
+        if prepared.was_installed {
+            return Ok(prepared.tv);
+        }
+
+        let old_tv = prepared.tv.clone();
+        let tv = match self.install_version_(&ctx, prepared.tv).await {
+            Ok(tv) => tv,
+            Err(e) => {
+                self.cleanup_install_dirs_on_error(&old_tv);
+                // Pass through the error - it will be wrapped at a higher level
+                return Err(e);
+            }
+        };
+
+        self.finalize_install(&ctx, tv).await
+    }
+
+    async fn prepare_install(
+        &self,
+        ctx: &InstallContext,
+        tv: ToolVersion,
+    ) -> eyre::Result<PreparedInstall> {
         let will_uninstall = ctx.force && self.is_version_installed(&ctx.config, &tv, true);
 
         // Query backend for operation count and set up progress tracking
-        let install_ops = self.install_operation_count(&tv, &ctx).await;
+        let install_ops = self.install_operation_count(&tv, ctx).await;
         let total_ops = if will_uninstall {
             install_ops + 1
         } else {
@@ -1082,7 +1155,11 @@ pub trait Backend: Debug + Send + Sync {
                 .await?;
             ctx.pr.next_operation();
         } else if self.is_version_installed(&ctx.config, &tv, true) {
-            return Ok(tv);
+            return Ok(PreparedInstall {
+                tv,
+                was_installed: true,
+                lock: None,
+            });
         }
 
         // Track the installation asynchronously (fire-and-forget)
@@ -1090,25 +1167,31 @@ pub trait Backend: Debug + Send + Sync {
         versions_host::track_install(tv.short(), &tv.ba().full(), &tv.version);
 
         ctx.pr.set_message("install".into());
-        let _lock = lock_file::get(&tv.install_path(), ctx.force)?;
+        let lock = lock_file::get(&tv.install_path(), ctx.force)?;
 
         // Double-checked (locking) that it wasn't installed while we were waiting for the lock
         if self.is_version_installed(&ctx.config, &tv, true) && !ctx.force {
-            return Ok(tv);
+            return Ok(PreparedInstall {
+                tv,
+                was_installed: true,
+                lock,
+            });
         }
 
         self.create_install_dirs(&tv)?;
 
-        let old_tv = tv.clone();
-        let tv = match self.install_version_(&ctx, tv).await {
-            Ok(tv) => tv,
-            Err(e) => {
-                self.cleanup_install_dirs_on_error(&old_tv);
-                // Pass through the error - it will be wrapped at a higher level
-                return Err(e);
-            }
-        };
+        Ok(PreparedInstall {
+            tv,
+            was_installed: false,
+            lock,
+        })
+    }
 
+    async fn finalize_install(
+        &self,
+        ctx: &InstallContext,
+        tv: ToolVersion,
+    ) -> eyre::Result<ToolVersion> {
         let install_path = tv.install_path();
         if install_path.starts_with(*dirs::INSTALLS) {
             install_state::write_backend_meta(self.ba())?;
@@ -1144,7 +1227,7 @@ pub trait Backend: Debug + Send + Sync {
         if let Some(script) = tv.request.options().get("postinstall") {
             ctx.pr
                 .finish_with_message("running custom postinstall hook".to_string());
-            self.run_postinstall_hook(&ctx, &tv, script).await?;
+            self.run_postinstall_hook(ctx, &tv, script).await?;
         }
         ctx.pr.finish_with_message("installed".to_string());
         Ok(tv)

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -13,6 +13,7 @@ use crate::backend::Backend;
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
+use crate::backend::{BatchInstallOutcome, BatchInstallRequest};
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
@@ -24,6 +25,47 @@ use crate::plugins::Plugin;
 use crate::plugins::vfox_plugin::VfoxPlugin;
 use crate::toolset::{ToolVersion, Toolset, install_state};
 use crate::ui::multi_progress_report::MultiProgressReport;
+use vfox::BackendBatchInstallItem;
+
+enum BatchPreparedInstall {
+    Ready(Box<ReadyBatchInstall>),
+    Outcome(Box<BatchInstallOutcome>),
+}
+
+struct ReadyBatchInstall {
+    request: BatchInstallRequest,
+    original_tv: ToolVersion,
+    _lock: Option<fslock::LockFile>,
+}
+
+impl BatchPreparedInstall {
+    fn ready(request: BatchInstallRequest, prepared: crate::backend::PreparedInstall) -> Self {
+        Self::Ready(Box::new(ReadyBatchInstall {
+            original_tv: prepared.tv.clone(),
+            request: BatchInstallRequest {
+                tool_version: prepared.tv,
+                ..request
+            },
+            _lock: prepared.lock,
+        }))
+    }
+
+    fn already_installed(request: BatchInstallRequest, tv: ToolVersion) -> Self {
+        Self::Outcome(Box::new(BatchInstallOutcome {
+            request_id: request.request_id,
+            tool_request: request.tool_request,
+            result: Ok(tv),
+        }))
+    }
+
+    fn failed(request: BatchInstallRequest, err: eyre::Error) -> Self {
+        Self::Outcome(Box::new(BatchInstallOutcome {
+            request_id: request.request_id,
+            tool_request: request.tool_request,
+            result: Err(err),
+        }))
+    }
+}
 
 #[derive(Debug)]
 pub struct VfoxBackend {
@@ -34,6 +76,7 @@ pub struct VfoxBackend {
     pathname: String,
     tool_name: Option<String>,
     metadata_deps: OnceLock<Vec<String>>,
+    batch_support: OnceLock<bool>,
 }
 
 #[async_trait]
@@ -227,6 +270,185 @@ impl Backend for VfoxBackend {
         Ok(tv)
     }
 
+    fn supports_batch_install(&self) -> bool {
+        self.is_backend_plugin()
+    }
+
+    fn batch_group_id(&self) -> String {
+        self.pathname.clone()
+    }
+
+    async fn supports_batch_install_request(&self, _req: &BatchInstallRequest) -> bool {
+        self.supports_backend_batch_install().await.unwrap_or(false)
+    }
+
+    async fn install_versions_batch(
+        &self,
+        reqs: Vec<BatchInstallRequest>,
+    ) -> Vec<BatchInstallOutcome> {
+        if !self.is_backend_plugin() || reqs.is_empty() {
+            return self.install_versions_batch_fallback(reqs).await;
+        }
+
+        if let Err(err) = Settings::get().ensure_experimental("custom backends") {
+            return reqs
+                .into_iter()
+                .map(|req| BatchInstallOutcome {
+                    request_id: req.request_id,
+                    tool_request: req.tool_request,
+                    result: Err(eyre!("{err:#}")),
+                })
+                .collect();
+        }
+
+        let dry_run = reqs[0].install_context.dry_run;
+        let locked = reqs[0].install_context.locked;
+
+        // If a mixed batch ever slips through, preserve per-request semantics by falling back
+        // to the single-install path instead of assuming all requests share the first request's flags.
+        if reqs.iter().any(|req| {
+            req.install_context.dry_run != dry_run || req.install_context.locked != locked
+        }) {
+            return self.install_versions_batch_fallback(reqs).await;
+        }
+
+        // Locked mode is already enforced by the single-install path,
+        // including lockfile feature checks and per-platform URL validation.
+        // Dry-run is already handled correctly by the single-install path,
+        // which avoids creating dirs, taking locks, or invoking backend hooks.
+        if dry_run || locked {
+            return self.install_versions_batch_fallback(reqs).await;
+        }
+
+        let mut prepared = Vec::with_capacity(reqs.len());
+        for req in reqs {
+            let BatchInstallRequest {
+                request_id,
+                tool_request,
+                mut tool_version,
+                install_context,
+            } = req;
+
+            // If --force and the install path resolved to a shared dir (but wasn't explicitly
+            // set via --system/--shared), redirect to primary dir to avoid modifying shared installs.
+            if install_context.force
+                && tool_version.install_path.is_none()
+                && env::install_path_category(&tool_version.install_path())
+                    != env::InstallPathCategory::Local
+            {
+                tool_version.install_path = Some(
+                    tool_version
+                        .ba()
+                        .installs_path
+                        .join(tool_version.tv_pathname()),
+                );
+            }
+
+            let req = BatchInstallRequest {
+                request_id,
+                tool_request,
+                tool_version: tool_version.clone(),
+                install_context,
+            };
+            match self
+                .prepare_install(&req.install_context, tool_version)
+                .await
+            {
+                Ok(prepared_install) if prepared_install.was_installed => {
+                    prepared.push(BatchPreparedInstall::already_installed(
+                        req,
+                        prepared_install.tv,
+                    ));
+                }
+                Ok(prepared_install) => {
+                    prepared.push(BatchPreparedInstall::ready(req, prepared_install));
+                }
+                Err(err) => {
+                    prepared.push(BatchPreparedInstall::failed(req, err));
+                }
+            }
+        }
+
+        let (ready, mut outcomes) = Self::split_prepared_batch(prepared);
+        if ready.is_empty() {
+            return outcomes;
+        }
+
+        let config = ready[0].request.install_context.config.clone();
+        if let Err(err) = self.ensure_plugin_installed(&config).await {
+            outcomes.extend(ready.into_iter().map(|prepared| {
+                self.cleanup_install_dirs_on_error(&prepared.original_tv);
+                BatchInstallOutcome {
+                    request_id: prepared.request.request_id,
+                    tool_request: prepared.request.tool_request,
+                    result: Err(eyre!("Failed to ensure plugin installed: {err:#}")),
+                }
+            }));
+            return outcomes;
+        }
+
+        let (mut vfox, log_rx) = self.plugin.vfox();
+        thread::spawn(|| {
+            for line in log_rx {
+                info!("{}", line);
+            }
+        });
+        if let Ok(dep_env) = self.dependency_env(&config).await {
+            vfox.cmd_env = Some(dep_env.into_iter().collect());
+        }
+
+        let payload = ready
+            .iter()
+            .map(|prepared| Self::to_backend_batch_item(&prepared.request))
+            .collect::<Vec<_>>();
+
+        let response = match vfox.backend_batch_install(&self.pathname, payload).await {
+            Ok(response) => response,
+            Err(err) => {
+                outcomes.extend(ready.into_iter().map(|prepared| {
+                    self.cleanup_install_dirs_on_error(&prepared.original_tv);
+                    BatchInstallOutcome {
+                        request_id: prepared.request.request_id,
+                        tool_request: prepared.request.tool_request,
+                        result: Err(eyre!("Backend batch install method failed: {err:#}")),
+                    }
+                }));
+                return outcomes;
+            }
+        };
+
+        for prepared in ready {
+            let req = prepared.request;
+            let result = match response.results.get(&req.request_id) {
+                Some(result) if result.error.is_some() => {
+                    self.cleanup_install_dirs_on_error(&prepared.original_tv);
+                    let err = result
+                        .error
+                        .clone()
+                        .unwrap_or_else(|| "backend batch install failed".to_string());
+                    Err(eyre!(err))
+                }
+                Some(_result) => {
+                    self.finalize_install(&req.install_context, req.tool_version)
+                        .await
+                }
+                None => {
+                    self.cleanup_install_dirs_on_error(&prepared.original_tv);
+                    Err(eyre!(
+                        "backend batch install response missing result for {}",
+                        req.request_id
+                    ))
+                }
+            };
+            outcomes.push(BatchInstallOutcome {
+                request_id: req.request_id,
+                tool_request: req.tool_request,
+                result,
+            });
+        }
+        outcomes
+    }
+
     async fn list_bin_paths(
         &self,
         config: &Arc<Config>,
@@ -352,6 +574,66 @@ impl VfoxBackend {
             .ok_or_else(|| eyre::eyre!("VfoxBackend requires a tool name (plugin:tool format)"))
     }
 
+    async fn supports_backend_batch_install(&self) -> eyre::Result<bool> {
+        if let Some(supported) = self.batch_support.get() {
+            return Ok(*supported);
+        }
+        let (vfox, _log_rx) = self.plugin.vfox();
+        let metadata = vfox.metadata(&self.pathname).await?;
+        let supported = metadata.hooks.contains("backend_batch_install");
+        let _ = self.batch_support.set(supported);
+        Ok(supported)
+    }
+
+    async fn install_versions_batch_fallback(
+        &self,
+        reqs: Vec<BatchInstallRequest>,
+    ) -> Vec<BatchInstallOutcome> {
+        let mut outcomes = Vec::with_capacity(reqs.len());
+        for req in reqs {
+            let result = self
+                .install_version(req.install_context, req.tool_version)
+                .await;
+            outcomes.push(BatchInstallOutcome {
+                request_id: req.request_id,
+                tool_request: req.tool_request,
+                result,
+            });
+        }
+        outcomes
+    }
+
+    fn to_backend_batch_item(req: &BatchInstallRequest) -> BackendBatchInstallItem {
+        BackendBatchInstallItem {
+            id: req.request_id.clone(),
+            tool: req
+                .tool_request
+                .ba()
+                .short
+                .split_once(':')
+                .map(|(_, tool)| tool.to_string())
+                .unwrap_or_else(|| req.tool_request.ba().short.clone()),
+            version: req.tool_version.version.clone(),
+            install_path: req.tool_version.install_path(),
+            download_path: req.tool_version.download_path(),
+            options: req.tool_request.options().opts.clone(),
+        }
+    }
+
+    fn split_prepared_batch(
+        prepared: Vec<BatchPreparedInstall>,
+    ) -> (Vec<ReadyBatchInstall>, Vec<BatchInstallOutcome>) {
+        let mut ready = Vec::new();
+        let mut outcomes = Vec::new();
+        for item in prepared {
+            match item {
+                BatchPreparedInstall::Ready(item) => ready.push(*item),
+                BatchPreparedInstall::Outcome(outcome) => outcomes.push(*outcome),
+            }
+        }
+        (ready, outcomes)
+    }
+
     pub fn from_arg(ba: BackendArg, backend_plugin_name: Option<String>) -> Self {
         let pathname = match &backend_plugin_name {
             Some(plugin_name) => plugin_name.clone(),
@@ -381,6 +663,7 @@ impl VfoxBackend {
             pathname,
             tool_name,
             metadata_deps: OnceLock::new(),
+            batch_support: OnceLock::new(),
         }
     }
 

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -5,6 +5,7 @@ use jiff::Timestamp;
 use crate::ui::progress_report::SingleReport;
 use crate::{config::Config, toolset::Toolset};
 
+#[derive(Debug)]
 pub struct InstallContext {
     pub config: Arc<Config>,
     pub ts: Arc<Toolset>,

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use eyre::Result;
@@ -7,6 +8,7 @@ use itertools::Itertools;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinSet;
 
+use crate::backend::{ABackend, BatchInstallOutcome, BatchInstallRequest};
 use crate::config::Config;
 use crate::config::settings::Settings;
 use crate::errors::Error;
@@ -22,6 +24,113 @@ use crate::toolset::tool_source::ToolSource;
 use crate::toolset::tool_version::ToolVersion;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{config, hooks};
+
+#[derive(Clone)]
+struct BackendBatchGroupKey {
+    backend: ABackend,
+    supports_batch: bool,
+    key: String,
+}
+
+impl BackendBatchGroupKey {
+    fn new(backend: &ABackend, supports_batch: bool) -> Self {
+        let key = backend.batch_group_id();
+        Self {
+            backend: backend.clone(),
+            supports_batch,
+            key,
+        }
+    }
+}
+
+impl PartialEq for BackendBatchGroupKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.supports_batch == other.supports_batch
+    }
+}
+
+impl Eq for BackendBatchGroupKey {}
+
+impl Hash for BackendBatchGroupKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+        self.supports_batch.hash(state);
+    }
+}
+
+enum InstallDispatchGroup {
+    Single {
+        backend: ABackend,
+        request: Box<BatchInstallRequest>,
+    },
+    Batch {
+        backend: ABackend,
+        requests: Vec<BatchInstallRequest>,
+    },
+    Failed {
+        tool_request: Box<ToolRequest>,
+        error: eyre::Error,
+    },
+}
+
+impl InstallDispatchGroup {
+    fn single(backend: ABackend, request: BatchInstallRequest) -> Self {
+        Self::Single {
+            backend,
+            request: Box::new(request),
+        }
+    }
+
+    fn batch(backend: ABackend, requests: Vec<BatchInstallRequest>) -> Self {
+        Self::Batch { backend, requests }
+    }
+
+    fn single_failed(tool_request: ToolRequest, error: eyre::Error) -> Self {
+        Self::Failed {
+            tool_request: Box::new(tool_request),
+            error,
+        }
+    }
+
+    fn requests(&self) -> Vec<ToolRequest> {
+        match self {
+            Self::Single { request, .. } => vec![request.tool_request.clone()],
+            Self::Batch { requests, .. } => {
+                requests.iter().map(|r| r.tool_request.clone()).collect()
+            }
+            Self::Failed { tool_request, .. } => vec![(**tool_request).clone()],
+        }
+    }
+
+    async fn install(self) -> Vec<(ToolRequest, Result<ToolVersion>)> {
+        match self {
+            Self::Single { backend, request } => {
+                vec![(
+                    request.tool_request,
+                    backend
+                        .install_version(request.install_context, request.tool_version)
+                        .await,
+                )]
+            }
+            Self::Batch { backend, requests } => backend
+                .install_versions_batch(requests)
+                .await
+                .into_iter()
+                .map(
+                    |BatchInstallOutcome {
+                         tool_request,
+                         result,
+                         ..
+                     }| (tool_request, result),
+                )
+                .collect(),
+            Self::Failed {
+                tool_request,
+                error,
+            } => vec![(*tool_request, Err(error))],
+        }
+    }
+}
 
 impl Toolset {
     #[async_backtrace::framed]
@@ -325,10 +434,13 @@ impl Toolset {
 
         let mut installed = vec![];
         let mut failed = vec![];
-        let mut jset: JoinSet<(ToolRequest, Result<ToolVersion>)> = JoinSet::new();
+        let mut jset: JoinSet<Vec<(ToolRequest, Result<ToolVersion>)>> = JoinSet::new();
         // Track in-flight tools to recover from task panics
-        let mut in_flight: HashMap<tokio::task::Id, ToolRequest> = HashMap::new();
+        let mut in_flight: HashMap<tokio::task::Id, Vec<ToolRequest>> = HashMap::new();
+        let mut pending_ready = VecDeque::new();
+        let mut pending_groups = VecDeque::new();
 
+        let mut done_emitting = false;
         loop {
             tokio::select! {
                 // Use `biased` to ensure completed installations are handled before starting new ones.
@@ -340,22 +452,29 @@ impl Toolset {
                 Some(result) = jset.join_next() => {
                     let mpr = MultiProgressReport::get();
                     match result {
-                        Ok((tr, Ok(tv))) => {
-                            mpr.footer_inc(1);
-                            installed.push(tv);
-                            tool_deps.lock().await.complete_success(&tr);
-                        }
-                        Ok((tr, Err(e))) => {
-                            mpr.footer_inc(1);
-                            failed.push((tr.clone(), e));
-                            tool_deps.lock().await.complete_failure(&tr);
+                        Ok(results) => {
+                            for (tr, result) in results {
+                                mpr.footer_inc(1);
+                                match result {
+                                    Ok(tv) => {
+                                        installed.push(tv);
+                                        tool_deps.lock().await.complete_success(&tr);
+                                    }
+                                    Err(e) => {
+                                        failed.push((tr.clone(), e));
+                                        tool_deps.lock().await.complete_failure(&tr);
+                                    }
+                                }
+                            }
                         }
                         Err(e) => {
                             // Task panicked - try to recover the tool request from in_flight tracking
-                            mpr.footer_inc(1);
-                            if let Some(tr) = in_flight.remove(&e.id()) {
-                                failed.push((tr.clone(), eyre::eyre!("Installation task panicked: {e:#}")));
-                                tool_deps.lock().await.complete_failure(&tr);
+                            if let Some(trs) = in_flight.remove(&e.id()) {
+                                for tr in trs {
+                                    mpr.footer_inc(1);
+                                    failed.push((tr.clone(), eyre::eyre!("Installation task panicked: {e:#}")));
+                                    tool_deps.lock().await.complete_failure(&tr);
+                                }
                             } else {
                                 warn!("Task panicked but tool request not found: {e:#}");
                             }
@@ -367,38 +486,54 @@ impl Toolset {
                 Some(maybe_tr) = rx.recv() => {
                     match maybe_tr {
                         Some(tr) => {
-                            // Spawn installation task
-                            let permit = match semaphore.clone().acquire_owned().await {
-                                Ok(p) => p,
-                                Err(e) => {
-                                    // Mark as failed and notify tool_deps so dependents are blocked
-                                    MultiProgressReport::get().footer_inc(1);
-                                    failed.push((tr.clone(), eyre::eyre!("Failed to acquire semaphore: {}", e)));
-                                    tool_deps.lock().await.complete_failure(&tr);
-                                    continue;
-                                }
-                            };
-
-                            let config = config.clone();
-                            let ts = ts.clone();
-                            let opts = opts.clone();
-                            let tr_clone = tr.clone();
-
-                            let handle = jset.spawn(async move {
-                                let _permit = permit;
-                                let result = Self::install_single_tool(&config, &ts, &tr, &opts).await;
-                                (tr, result)
-                            });
-                            in_flight.insert(handle.id(), tr_clone);
+                            pending_ready.push_back(tr);
                         }
                         None => {
-                            // All tools have been emitted, wait for remaining tasks
-                            break;
+                            done_emitting = true;
                         }
                     }
                 }
 
                 else => break,
+            }
+
+            if !pending_ready.is_empty() {
+                let ready_wave =
+                    Self::drain_ready_wave(&mut rx, &mut pending_ready, &mut done_emitting);
+                pending_groups
+                    .extend(Self::build_backend_groups(config, &ts, &opts, ready_wave).await);
+            }
+
+            while let Some(group) = pending_groups.pop_front() {
+                let permit = match semaphore.clone().try_acquire_owned() {
+                    Ok(p) => p,
+                    Err(tokio::sync::TryAcquireError::NoPermits) => {
+                        pending_groups.push_front(group);
+                        break;
+                    }
+                    Err(tokio::sync::TryAcquireError::Closed) => {
+                        for tr in group.requests() {
+                            MultiProgressReport::get().footer_inc(1);
+                            failed.push((
+                                tr.clone(),
+                                eyre::eyre!("Failed to acquire semaphore: semaphore closed"),
+                            ));
+                            tool_deps.lock().await.complete_failure(&tr);
+                        }
+                        continue;
+                    }
+                };
+
+                let requests = group.requests();
+                let handle = jset.spawn(async move {
+                    let _permit = permit;
+                    group.install().await
+                });
+                in_flight.insert(handle.id(), requests);
+            }
+
+            if done_emitting && pending_ready.is_empty() && pending_groups.is_empty() {
+                break;
             }
         }
 
@@ -406,21 +541,31 @@ impl Toolset {
         while let Some(result) = jset.join_next().await {
             let mpr = MultiProgressReport::get();
             match result {
-                Ok((tr, Ok(tv))) => {
-                    mpr.footer_inc(1);
-                    installed.push(tv);
-                    tool_deps.lock().await.complete_success(&tr);
-                }
-                Ok((tr, Err(e))) => {
-                    mpr.footer_inc(1);
-                    failed.push((tr.clone(), e));
-                    tool_deps.lock().await.complete_failure(&tr);
+                Ok(results) => {
+                    for (tr, result) in results {
+                        mpr.footer_inc(1);
+                        match result {
+                            Ok(tv) => {
+                                installed.push(tv);
+                                tool_deps.lock().await.complete_success(&tr);
+                            }
+                            Err(e) => {
+                                failed.push((tr.clone(), e));
+                                tool_deps.lock().await.complete_failure(&tr);
+                            }
+                        }
+                    }
                 }
                 Err(e) => {
-                    mpr.footer_inc(1);
-                    if let Some(tr) = in_flight.remove(&e.id()) {
-                        failed.push((tr.clone(), eyre::eyre!("Installation task panicked: {e:#}")));
-                        tool_deps.lock().await.complete_failure(&tr);
+                    if let Some(trs) = in_flight.remove(&e.id()) {
+                        for tr in trs {
+                            mpr.footer_inc(1);
+                            failed.push((
+                                tr.clone(),
+                                eyre::eyre!("Installation task panicked: {e:#}"),
+                            ));
+                            tool_deps.lock().await.complete_failure(&tr);
+                        }
                     } else {
                         warn!("Task panicked but tool request not found: {e:#}");
                     }
@@ -444,13 +589,67 @@ impl Toolset {
         (installed, failed)
     }
 
-    /// Install a single tool
-    async fn install_single_tool(
+    fn drain_ready_wave(
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<Option<ToolRequest>>,
+        pending_ready: &mut VecDeque<ToolRequest>,
+        done_emitting: &mut bool,
+    ) -> Vec<ToolRequest> {
+        loop {
+            match rx.try_recv() {
+                Ok(Some(tr)) => pending_ready.push_back(tr),
+                Ok(None) => {
+                    *done_emitting = true;
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+        pending_ready.drain(..).collect()
+    }
+
+    async fn build_backend_groups(
+        config: &Arc<Config>,
+        ts: &Arc<Toolset>,
+        opts: &Arc<InstallOptions>,
+        ready_wave: Vec<ToolRequest>,
+    ) -> Vec<InstallDispatchGroup> {
+        let mut fallback = Vec::new();
+        let mut grouped: HashMap<BackendBatchGroupKey, Vec<(ABackend, BatchInstallRequest)>> =
+            HashMap::new();
+
+        for tr in ready_wave {
+            match Self::resolve_install_request(config, ts, &tr, opts).await {
+                Ok((backend, req)) => {
+                    let supports_batch = backend.supports_batch_install_request(&req).await;
+                    let key = BackendBatchGroupKey::new(&backend, supports_batch);
+                    grouped.entry(key).or_default().push((backend, req));
+                }
+                Err(err) => {
+                    fallback.push(InstallDispatchGroup::single_failed(tr, err));
+                }
+            }
+        }
+
+        for (key, mut entries) in grouped {
+            if key.supports_batch && Self::batch_group_entries_are_safe(&entries) {
+                let batch_reqs = entries.into_iter().map(|(_, req)| req).collect();
+                fallback.push(InstallDispatchGroup::batch(key.backend, batch_reqs));
+            } else {
+                for (backend, req) in entries.drain(..) {
+                    fallback.push(InstallDispatchGroup::single(backend, req));
+                }
+            }
+        }
+
+        fallback
+    }
+
+    async fn resolve_install_request(
         config: &Arc<Config>,
         ts: &Arc<Toolset>,
         tr: &ToolRequest,
         opts: &Arc<InstallOptions>,
-    ) -> Result<ToolVersion> {
+    ) -> Result<(ABackend, BatchInstallRequest)> {
         let mpr = MultiProgressReport::get();
         let before_date = effective_before_date(Some(tr), &opts.resolve_options)?;
         let mut resolve_options = opts.resolve_options.clone();
@@ -462,6 +661,7 @@ impl Toolset {
             tv.install_path = Some(dir.join(tool_dir_name).join(tv.tv_pathname()));
         }
         let backend = tr.backend()?;
+        let request_id = Self::batch_request_id(&tv);
 
         let ctx = InstallContext {
             config: config.clone(),
@@ -473,7 +673,33 @@ impl Toolset {
             before_date,
         };
 
-        backend.install_version(ctx, tv).await
+        Ok((
+            backend,
+            BatchInstallRequest {
+                request_id,
+                tool_request: tr.clone(),
+                tool_version: tv,
+                install_context: ctx,
+            },
+        ))
+    }
+
+    fn batch_request_id(tv: &ToolVersion) -> String {
+        format!(
+            "{}@{}#{}",
+            tool_key(&tv.request),
+            tv.version,
+            tv.install_path().display()
+        )
+    }
+
+    fn batch_group_entries_are_safe(entries: &[(ABackend, BatchInstallRequest)]) -> bool {
+        let mut request_ids = HashSet::new();
+        let mut install_paths = HashSet::new();
+        entries.iter().all(|(_, req)| {
+            request_ids.insert(req.request_id.clone())
+                && install_paths.insert(req.tool_version.install_path())
+        })
     }
 
     pub async fn install_missing_bin(
@@ -588,5 +814,56 @@ impl Toolset {
         } else {
             (PluginType::Asdf, key)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::install_context::InstallContext;
+    use crate::toolset::{ToolSource, ToolVersionOptions};
+    use crate::ui::progress_report::QuietReport;
+
+    fn make_request(short: &str, version: &str) -> ToolRequest {
+        ToolRequest::Version {
+            backend: Arc::new(crate::cli::args::BackendArg::from(short)),
+            version: version.to_string(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_group_is_safe_rejects_duplicate_install_paths() {
+        let config = Config::get().await.unwrap();
+        let ts = Arc::new(Toolset::default());
+        let install_path = std::env::temp_dir().join("mise-batch-group-is-safe");
+
+        let entry = |tr: ToolRequest| {
+            let mut tv = ToolVersion::new(tr.clone(), "3.1.0".to_string());
+            tv.install_path = Some(install_path.clone());
+            let backend = tr.backend().unwrap();
+            let req = BatchInstallRequest {
+                request_id: format!("{}-dup", tr.ba().short),
+                tool_request: tr,
+                tool_version: tv,
+                install_context: InstallContext {
+                    config: config.clone(),
+                    ts: ts.clone(),
+                    pr: Box::new(QuietReport::new()),
+                    force: false,
+                    dry_run: false,
+                    locked: false,
+                    before_date: None,
+                },
+            };
+            (backend, req)
+        };
+
+        let req1 = entry(make_request("tiny", "3.1.0"));
+        let req2 = entry(make_request("tiny", "3.1.0"));
+
+        assert!(!Toolset::batch_group_entries_are_safe(&[req1, req2]));
     }
 }


### PR DESCRIPTION
## Summary
- add `BackendBatchInstall` support for `vfox-backend` plugins
- batch ready installs by backend while preserving the existing per-tool fallback path for plugins without the batch hook
- add focused e2e coverage for successful batched installs and partial per-item batch failures

## Details
This adds a new optional `backend_batch_install` hook to the vfox backend flow.
On the mise side, the install scheduler now groups ready tools by backend and dispatches batched installs when the backend supports them. For unsupported backends and plugins, installs continue through the existing per-tool path.
The vfox integration now:
- detects `backend_batch_install` from plugin metadata
- routes batch-capable `vfox-backend` plugins through the new hook
- preserves per-tool success/failure handling
- reuses the existing install wrapper semantics so lock handling, cleanup, and install state remain consistent

## Why
This is primarily for multi-tool backend plugins where one backend invocation can install several ready tools more efficiently than separate per-tool installs.
`mise-nix` is a good example:
- projects may define multiple `nix:` tools from nixpkgs or flakes
- without batching, mise calls the backend once per tool
- with batching, the backend can resolve/build multiple ready tools in a single `nix build` invocation
- that reduces repeated backend startup/work and makes multi-tool bootstrap and setup flows cheaper
This hook is also useful for other backend-style plugins that can naturally install several tools in one operation, such as:
- package-manager backends like npm/pnpm-style ecosystems
- custom organizational backends that fetch/build multiple tools from one registry or flake
- any `vfox-backend` plugin where one shared solver/download/build step is cheaper than repeating the same work per tool
The feature is intentionally opt-in:
- plugins without `BackendBatchInstall` continue using the existing per-tool path
- dependency ordering and per-tool success/failure behavior are preserved

## Documentation
- document `BackendBatchInstall` in backend plugin development docs
- document optional batch install support in the vfox backend docs

## Tests
- `cargo check`
- `mise run test:e2e e2e/plugins/test_backend_plugin_install`
- `mise run test:e2e e2e/plugins/test_backend_batch_install`
- `mise run test:e2e e2e/plugins/test_backend_batch_install_partial_failure`