### PR TITLE
fix(log): drop noisy third-party debug/trace logs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -566,6 +566,14 @@ to store the logs but not have them litter your display.
 
 Display HTTP requests/responses in the logs.
 
+### `MISE_LOG_VERBOSE_DEPS=1`
+
+By default, `mise -v` (debug level) suppresses debug logs from noisy
+third-party crates (`h2`, `hyper`, `reqwest`, `rustls`, etc.) that emit a line
+per HTTP/2 frame or socket read. Set this to `1` to let those logs through at
+debug level — or use `-vv`/`MISE_LOG_LEVEL=trace`, which always includes
+them.
+
 ### `MISE_QUIET=1`
 
 Equivalent to `MISE_LOG_LEVEL=warn`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -568,11 +568,10 @@ Display HTTP requests/responses in the logs.
 
 ### `MISE_LOG_VERBOSE_DEPS=1`
 
-By default, `mise -v` (debug level) suppresses debug logs from noisy
-third-party crates (`h2`, `hyper`, `reqwest`, `rustls`, etc.) that emit a line
-per HTTP/2 frame or socket read. Set this to `1` to let those logs through at
-debug level — or use `-vv`/`MISE_LOG_LEVEL=trace`, which always includes
-them.
+By default, debug and trace logs from noisy third-party crates (`h2`,
+`hyper`, `reqwest`, `rustls`, etc., which emit a line per HTTP/2 frame or
+socket read) are dropped — they would otherwise overwhelm `-v`/`-vv`
+output. Set this to `1` to let those logs through.
 
 ### `MISE_QUIET=1`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -568,10 +568,11 @@ Display HTTP requests/responses in the logs.
 
 ### `MISE_LOG_VERBOSE_DEPS=1`
 
-By default, debug and trace logs from noisy third-party crates (`h2`,
-`hyper`, `reqwest`, `rustls`, etc., which emit a line per HTTP/2 frame or
-socket read) are dropped — they would otherwise overwhelm `-v`/`-vv`
-output. Set this to `1` to let those logs through.
+Debug and trace logs from noisy third-party crates (`h2`, `hyper`,
+`reqwest`, `rustls`, etc., which emit a line per HTTP/2 frame or socket
+read) are always dropped — they would otherwise overwhelm debug/trace
+output. Set this to `1` to let those logs through; it is the only way to
+see them, including under `--log-level=trace`/`-vv`.
 
 ### `MISE_QUIET=1`
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -355,6 +355,7 @@ pub static MISE_SELF_UPDATE_DISABLED_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| 
     )
 });
 pub static MISE_LOG_HTTP: Lazy<bool> = Lazy::new(|| var_is_true("MISE_LOG_HTTP"));
+pub static MISE_LOG_VERBOSE_DEPS: Lazy<bool> = Lazy::new(|| var_is_true("MISE_LOG_VERBOSE_DEPS"));
 
 pub static __USAGE: Lazy<Option<String>> = Lazy::new(|| var("__USAGE").ok());
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,9 +1,10 @@
 use crate::config::{Config, Settings};
 use clx::progress;
 use eyre::Result;
+use std::collections::HashSet;
 use std::fs::{File, OpenOptions, create_dir_all};
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::thread;
 use std::{io::Write, sync::OnceLock};
 
@@ -18,30 +19,33 @@ struct Logger {
     log_file: Option<Mutex<File>>,
 }
 
-/// Third-party crate targets that emit very noisy debug logs (often per HTTP/2
-/// frame, per socket read, etc.) and would otherwise overwhelm `-v` output.
-/// These are suppressed at Debug level unless `MISE_LOG_VERBOSE_DEPS=1` is set.
-/// Trace level always lets them through.
-const NOISY_DEP_TARGETS: &[&str] = &[
-    "h2",
-    "hyper",
-    "hyper_util",
-    "mio",
-    "reqwest",
-    "rustls",
-    "tokio_util",
-    "tower",
-    "want",
-];
+/// Root crate names of third-party dependencies that emit very noisy debug
+/// logs (often per HTTP/2 frame, per socket read, etc.) and would otherwise
+/// overwhelm `-v` output. These are suppressed at Debug level unless
+/// `MISE_LOG_VERBOSE_DEPS=1` is set. Trace level always lets them through.
+static NOISY_DEP_TARGETS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        "h2",
+        "hyper",
+        "hyper_util",
+        "mio",
+        "reqwest",
+        "rustls",
+        "tokio_util",
+        "tower",
+        "want",
+    ]
+    .into_iter()
+    .collect()
+});
 
 fn is_noisy_dep_target(target: &str) -> bool {
-    // Allocation-free: check for exact match or a "<target>::" prefix by
-    // looking at the byte just past the candidate. Since `starts_with(t)`
-    // already matched, a following `:` byte can only be the first `:` of the
-    // `::` module-path separator used by `log` targets.
-    NOISY_DEP_TARGETS.iter().any(|t| {
-        target == *t || (target.starts_with(t) && target.as_bytes().get(t.len()) == Some(&b':'))
-    })
+    // `log` targets default to the module path (e.g. "h2::proto::streams").
+    // Match on the crate-root segment so we don't accidentally match an
+    // unrelated crate whose name happens to start with one of ours
+    // (e.g. "h2extra") — zero allocation: just splits the input slice.
+    let root = target.split_once("::").map_or(target, |(r, _)| r);
+    NOISY_DEP_TARGETS.contains(root)
 }
 
 impl log::Log for Logger {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -18,6 +18,28 @@ struct Logger {
     log_file: Option<Mutex<File>>,
 }
 
+/// Third-party crate targets that emit very noisy debug logs (often per HTTP/2
+/// frame, per socket read, etc.) and would otherwise overwhelm `-v` output.
+/// These are suppressed at Debug level unless `MISE_LOG_VERBOSE_DEPS=1` is set.
+/// Trace level always lets them through.
+const NOISY_DEP_TARGETS: &[&str] = &[
+    "h2",
+    "hyper",
+    "hyper_util",
+    "mio",
+    "reqwest",
+    "rustls",
+    "tokio_util",
+    "tower",
+    "want",
+];
+
+fn is_noisy_dep_target(target: &str) -> bool {
+    NOISY_DEP_TARGETS
+        .iter()
+        .any(|t| target == *t || target.starts_with(&format!("{t}::")))
+}
+
 impl log::Log for Logger {
     fn enabled(&self, metadata: &Metadata) -> bool {
         metadata.level() <= *self.level.lock().unwrap()
@@ -25,8 +47,23 @@ impl log::Log for Logger {
 
     fn log(&self, record: &Record) {
         let term_level = *self.term_level.lock().unwrap();
-        let will_log_file = record.level() <= self.file_level && self.log_file.is_some();
-        let will_log_term = record.level() <= term_level;
+        let mut will_log_file = record.level() <= self.file_level && self.log_file.is_some();
+        let mut will_log_term = record.level() <= term_level;
+
+        // Suppress Debug-level spam from noisy third-party crates (e.g. h2
+        // logging every received DATA frame). Trace still passes through, as
+        // does any level when MISE_LOG_VERBOSE_DEPS=1.
+        if record.level() == Level::Debug
+            && !*env::MISE_LOG_VERBOSE_DEPS
+            && is_noisy_dep_target(record.target())
+        {
+            if self.file_level < LevelFilter::Trace {
+                will_log_file = false;
+            }
+            if term_level < LevelFilter::Trace {
+                will_log_term = false;
+            }
+        }
 
         if !will_log_file && !will_log_term {
             return;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -35,9 +35,13 @@ const NOISY_DEP_TARGETS: &[&str] = &[
 ];
 
 fn is_noisy_dep_target(target: &str) -> bool {
-    NOISY_DEP_TARGETS
-        .iter()
-        .any(|t| target == *t || target.starts_with(&format!("{t}::")))
+    // Allocation-free: check for exact match or a "<target>::" prefix by
+    // looking at the byte just past the candidate. Since `starts_with(t)`
+    // already matched, a following `:` byte can only be the first `:` of the
+    // `::` module-path separator used by `log` targets.
+    NOISY_DEP_TARGETS.iter().any(|t| {
+        target == *t || (target.starts_with(t) && target.as_bytes().get(t.len()) == Some(&b':'))
+    })
 }
 
 impl log::Log for Logger {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -20,9 +20,10 @@ struct Logger {
 }
 
 /// Root crate names of third-party dependencies that emit very noisy debug
-/// logs (often per HTTP/2 frame, per socket read, etc.) and would otherwise
-/// overwhelm `-v` output. These are suppressed at Debug level unless
-/// `MISE_LOG_VERBOSE_DEPS=1` is set. Trace level always lets them through.
+/// and trace logs (often per HTTP/2 frame, per socket read, etc.) and would
+/// otherwise overwhelm `-v`/`-vv` output. Debug and Trace records from these
+/// crates are dropped entirely unless `MISE_LOG_VERBOSE_DEPS=1` is set.
+/// Info/Warn/Error still pass through — those are rare and worth seeing.
 static NOISY_DEP_TARGETS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     [
         "h2",
@@ -54,24 +55,19 @@ impl log::Log for Logger {
     }
 
     fn log(&self, record: &Record) {
-        let term_level = *self.term_level.lock().unwrap();
-        let mut will_log_file = record.level() <= self.file_level && self.log_file.is_some();
-        let mut will_log_term = record.level() <= term_level;
-
-        // Suppress Debug-level spam from noisy third-party crates (e.g. h2
-        // logging every received DATA frame). Trace still passes through, as
-        // does any level when MISE_LOG_VERBOSE_DEPS=1.
-        if record.level() == Level::Debug
+        // Drop Debug/Trace spam from noisy third-party crates (e.g. h2 logging
+        // every received DATA frame) regardless of terminal/file level. Opt
+        // back in with MISE_LOG_VERBOSE_DEPS=1.
+        if matches!(record.level(), Level::Debug | Level::Trace)
             && !*env::MISE_LOG_VERBOSE_DEPS
             && is_noisy_dep_target(record.target())
         {
-            if self.file_level < LevelFilter::Trace {
-                will_log_file = false;
-            }
-            if term_level < LevelFilter::Trace {
-                will_log_term = false;
-            }
+            return;
         }
+
+        let term_level = *self.term_level.lock().unwrap();
+        let will_log_file = record.level() <= self.file_level && self.log_file.is_some();
+        let will_log_term = record.level() <= term_level;
 
         if !will_log_file && !will_log_term {
             return;


### PR DESCRIPTION
## Summary

- `mise -v`/`-vv` emitted debug/trace logs from dependency crates (notably `h2` logging `DEBUG received frame=Data { stream_id: StreamId(7) }` per HTTP/2 frame — hundreds of lines per large download), drowning out mise's own output.
- The logger now drops **Debug and Trace** records whose target's crate root is one of: `h2`, `hyper`, `hyper_util`, `mio`, `reqwest`, `rustls`, `tokio_util`, `tower`, `want`. This applies regardless of `--log-level` / `MISE_LOG_LEVEL` — trace mode is clean too. Info/Warn/Error from these crates still pass through (rare and worth seeing).
- Added `MISE_LOG_VERBOSE_DEPS=1` as an escape hatch to re-enable them.
- Lookup is a single `HashSet<&'static str>::contains` on the crate-root segment of the target (split at `::`, allocation-free).

## Test plan

- [x] `cargo build` / `mise run lint-fix` clean
- [x] `mise -v ls-remote <github-backed-tool>` emits 0 `received frame` / `h2::` lines; `MISE_LOG_VERBOSE_DEPS=1` restores them
- [x] `mise --log-level=trace ls-remote <github-backed-tool>` also emits 0; opt-in restores them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes log filtering behavior by suppressing Debug/Trace output from select dependency crates, which could hide useful diagnostics unless the new opt-in env var is set.
> 
> **Overview**
> Reduces `-v`/`-vv` and `--log-level=trace` noise by **dropping Debug/Trace records** whose `record.target()` is from a set of chatty third-party crates (e.g. `h2`, `hyper`, `reqwest`, `rustls`), while still allowing their Info/Warn/Error logs through.
> 
> Adds `MISE_LOG_VERBOSE_DEPS=1` as an *escape hatch* to re-enable those suppressed dependency logs, and documents the new env var in `docs/configuration.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb86ae2d20b962710bdb88672beb55d6db456b33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->