### PR TITLE
fix(lockfile): use unique temp file for atomic save to avoid concurrent rename race

### DIFF
--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -12,6 +12,7 @@ use eyre::{Report, Result, bail, eyre};
 use itertools::Itertools;
 use serde_derive::{Deserialize, Serialize};
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock as Lazy;
 use std::sync::Mutex;
@@ -563,8 +564,9 @@ impl Lockfile {
             .parent()
             .ok_or_else(|| eyre!("lockfile path has no parent: {}", display_path(&target)))?;
         let mut tmp = tempfile::NamedTempFile::with_prefix_in(".mise.lock.", parent)?;
-        std::io::Write::write_all(tmp.as_file_mut(), content.as_bytes())?;
-        tmp.persist(&target).map_err(|e| e.error)?;
+        tmp.as_file_mut().write_all(content.as_bytes())?;
+        apply_lockfile_permissions(&tmp, &target)?;
+        persist_lockfile_tmp(tmp, &target)?;
 
         invalidate_caches();
         Ok(())
@@ -1570,6 +1572,54 @@ fn handle_lockfile_read_error(err: Report, lockfile_path: &Path) -> Lockfile {
     Lockfile::default()
 }
 
+#[cfg(unix)]
+fn apply_lockfile_permissions(tmp: &tempfile::NamedTempFile, target: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    match fs::metadata(target) {
+        Ok(metadata) => {
+            let mode = metadata.permissions().mode();
+            tmp.as_file()
+                .set_permissions(fs::Permissions::from_mode(mode))?;
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err.into()),
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn apply_lockfile_permissions(_tmp: &tempfile::NamedTempFile, _target: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn persist_lockfile_tmp(mut tmp: tempfile::NamedTempFile, target: &Path) -> Result<()> {
+    const RETRIES: u32 = 20;
+
+    for attempt in 0..=RETRIES {
+        match tmp.persist(target) {
+            Ok(_) => return Ok(()),
+            Err(err) if should_retry_lockfile_persist(&err.error) && attempt < RETRIES => {
+                tmp = err.file;
+                std::thread::sleep(std::time::Duration::from_millis(5 * u64::from(attempt + 1)));
+            }
+            Err(err) => return Err(err.error.into()),
+        }
+    }
+
+    unreachable!("lockfile persist retry loop should always return");
+}
+
+#[cfg(windows)]
+fn should_retry_lockfile_persist(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::PermissionDenied
+}
+
+#[cfg(not(windows))]
+fn should_retry_lockfile_persist(_err: &std::io::Error) -> bool {
+    false
+}
+
 impl TryFrom<toml::Value> for LockfileTool {
     type Error = Report;
     fn try_from(value: toml::Value) -> Result<Self> {
@@ -1914,6 +1964,22 @@ backend = "core:python"
             leftovers.is_empty(),
             "unexpected temp files left behind: {leftovers:?}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_save_preserves_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("mise.lock");
+        std::fs::write(&path, "").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o664)).unwrap();
+
+        Lockfile::default().save(&path).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o664);
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -552,12 +552,19 @@ impl Lockfile {
         } else {
             path.to_path_buf()
         };
-        // Use atomic write: write to temp file, then rename
-        // This prevents partial writes from corrupting the lockfile
-        // Write temp file alongside the real target (guarantees same-filesystem rename)
-        let temp_path = target.with_extension("lock.tmp");
-        file::write(&temp_path, &content)?;
-        fs::rename(&temp_path, target)?;
+        // Use atomic write: write to a uniquely-named temp file, then persist.
+        // - Prevents partial writes from corrupting the lockfile.
+        // - Unique temp name prevents races when multiple mise processes update
+        //   the same lockfile concurrently (e.g. parallel linters each triggering
+        //   `install_missing_bin`). A fixed `mise.lock.tmp` collided here and the
+        //   loser of the rename race got ENOENT.
+        // Write alongside the real target so the rename stays on the same filesystem.
+        let parent = target
+            .parent()
+            .ok_or_else(|| eyre!("lockfile path has no parent: {}", display_path(&target)))?;
+        let mut tmp = tempfile::NamedTempFile::with_prefix_in(".mise.lock.", parent)?;
+        std::io::Write::write_all(tmp.as_file_mut(), content.as_bytes())?;
+        tmp.persist(&target).map_err(|e| e.error)?;
 
         invalidate_caches();
         Ok(())
@@ -1869,6 +1876,44 @@ backend = "core:python"
 
         // Clean up
         let _ = std::fs::remove_file(&test_lockfile);
+    }
+
+    #[test]
+    fn test_concurrent_save_no_enoent() {
+        // Regression: two concurrent save() calls used to share a fixed
+        // `mise.lock.tmp` path, so the loser of the rename race got
+        // "No such file or directory". Each save must now use a unique
+        // temp file so concurrent writers never trip over each other.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = Arc::new(temp_dir.path().join("concurrent.lock"));
+        // Pre-create the file so this mirrors the real update path, where
+        // save() only runs on lockfiles that already exist.
+        std::fs::write(&*path, "").unwrap();
+
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..20 {
+                        Lockfile::default().save(&*path).unwrap();
+                    }
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        // Any leftover temp files would indicate persist() never ran.
+        let leftovers: Vec<_> = std::fs::read_dir(temp_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name() != std::ffi::OsStr::new("concurrent.lock"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "unexpected temp files left behind: {leftovers:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`Lockfile::save` writes to a fixed `mise.lock.tmp` path, then renames it over the real lockfile. When two mise processes update the same lockfile concurrently, the second rename finds no source file and fails with `No such file or directory (os error 2)`, surfaced as `failed to update lockfiles`.

This reproduces reliably via [`hk`](https://github.com/jdx/hk): its linter runner spawns multiple linters in parallel. If more than one linter's bin is missing, each invocation triggers `install_missing_bin` → `rebuild_shims_and_runtime_symlinks` → `update_lockfiles` → `save`. Two mise processes then race on the same `mise.lock.tmp`:

1. Both write `mise.lock.tmp` (second clobbers first — harmless, contents are the same).
2. Process A renames `mise.lock.tmp` → `mise.lock`.
3. Process B renames `mise.lock.tmp` → `mise.lock` → **ENOENT** (source already moved).

Caught in the wild during parallel `cargo-machete` + `cargo-msrv` auto-install in CI:

```
cargo-machete – mise cargo-binstall@1.17.9 ✓ installed
cargo-machete – mise ERROR failed to update lockfiles
cargo-machete – mise ERROR No such file or directory (os error 2)
cargo-machete – mise ERROR cargo-binstall failed
cargo-machete – mise ERROR Failed to install cargo:cargo-machete@0.9.1: cargo-binstall exited with non-zero status: exit code 1
```

The fixed-path temp pattern was introduced in #8589 (`fix(lockfile): Resolve symlink when updating lockfiles`).

## Fix

Switch to `tempfile::NamedTempFile::with_prefix_in(parent)` + `persist(target)`, matching the pattern already used in `src/http.rs`. Each save gets a random temp name, so concurrent writers never collide on the temp path. Persist remains atomic and same-filesystem.

Precedent in the codebase: `src/backend/conda.rs` already uses `dest.with_extension(format!("tmp.{}", std::process::id()))` for the same reason. `src/backend/s3.rs` still has a similar fixed-`.tmp` pattern — worth a follow-up but out of scope here.

## Test

Added `test_concurrent_save_no_enoent` which spawns 8 threads × 20 saves against the same lockfile and asserts none of them return ENOENT. The test fails on `main` and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the lockfile persistence path and retry behavior during atomic writes, which could affect correctness/permissions of `mise.lock` updates across platforms. Scope is localized to `Lockfile::save` and is covered by new concurrency and permission regression tests.
> 
> **Overview**
> Prevents concurrent `Lockfile::save` calls from failing with `ENOENT` by replacing the fixed `mise.lock.tmp` rename flow with a uniquely named `tempfile::NamedTempFile` written alongside the target and atomically `persist`ed.
> 
> Adds helpers to *preserve existing file permissions* on Unix and to *retry persist on Windows* for transient `PermissionDenied`, plus regression tests for concurrent saves and Unix permission preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49120aaabc68b1f960350f557362b5ac3b36b8f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->