### PR TITLE
fix(use): honor --quiet and --silent flags

### DIFF
--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -2,26 +2,26 @@
 
 mise i dummy@1.0.0
 
-assert_contains "mise use dummy 2>&1" "dummy@1.0.0"
+assert_contains "mise use dummy" "dummy@1.0.0"
 assert "mise current dummy" "1.0.0"
 
-assert_contains "mise use dummy@2 2>&1" "dummy@2."
+assert_contains "mise use dummy@2" "dummy@2."
 assert "mise current dummy" "2.0.0"
 
-assert_contains "mise use --rm dummy 2>&1" "removed: dummy"
+assert_contains "mise use --rm dummy" "removed: dummy"
 assert "mise current dummy" ""
 
-assert_contains "mise use --env local dummy@2 2>&1" "dummy@2."
+assert_contains "mise use --env local dummy@2" "dummy@2."
 assert "cat mise.local.toml" '[tools]
 dummy = "2"'
 assert "mise current dummy" "2.0.0"
 rm mise.local.toml
 
-assert_contains "mise use --env local dummy@1 2>&1" "dummy@1."
+assert_contains "mise use --env local dummy@1" "dummy@1."
 assert "cat mise.local.toml" '[tools]
 dummy = "1"'
 mv mise.local.toml .mise.local.toml
-assert_contains "mise use --env local dummy@2 2>&1" "dummy@2."
+assert_contains "mise use --env local dummy@2" "dummy@2."
 assert_fail "test -f mise.local.toml"
 assert "cat .mise.local.toml" '[tools]
 dummy = "2"'
@@ -131,8 +131,8 @@ mise use "dummy@path:~/workdir/mydummy"
 assert_contains "mise ls dummy" "dummy  path:~/workdir/mydummy  ~/workdir/mise.toml  path:~/workdir/mydummy"
 
 cd "$HOME" || exit 1
-assert_contains "mise use dummy@system 2>&1" "mise ~/.config/mise/config.toml tools: dummy@system"
+assert_contains "mise use dummy@system" "mise ~/.config/mise/config.toml tools: dummy@system"
 
-assert_contains "mise use --path mise.path.toml dummy@1 2>&1" "dummy@1."
+assert_contains "mise use --path mise.path.toml dummy@1" "dummy@1."
 assert "cat mise.path.toml" '[tools]
 dummy = "1"'

--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -2,26 +2,26 @@
 
 mise i dummy@1.0.0
 
-assert_contains "mise use dummy" "dummy@1.0.0"
+assert_contains "mise use dummy 2>&1" "dummy@1.0.0"
 assert "mise current dummy" "1.0.0"
 
-assert_contains "mise use dummy@2" "dummy@2."
+assert_contains "mise use dummy@2 2>&1" "dummy@2."
 assert "mise current dummy" "2.0.0"
 
-assert_contains "mise use --rm dummy" "removed: dummy"
+assert_contains "mise use --rm dummy 2>&1" "removed: dummy"
 assert "mise current dummy" ""
 
-assert_contains "mise use --env local dummy@2" "dummy@2."
+assert_contains "mise use --env local dummy@2 2>&1" "dummy@2."
 assert "cat mise.local.toml" '[tools]
 dummy = "2"'
 assert "mise current dummy" "2.0.0"
 rm mise.local.toml
 
-assert_contains "mise use --env local dummy@1" "dummy@1."
+assert_contains "mise use --env local dummy@1 2>&1" "dummy@1."
 assert "cat mise.local.toml" '[tools]
 dummy = "1"'
 mv mise.local.toml .mise.local.toml
-assert_contains "mise use --env local dummy@2" "dummy@2."
+assert_contains "mise use --env local dummy@2 2>&1" "dummy@2."
 assert_fail "test -f mise.local.toml"
 assert "cat .mise.local.toml" '[tools]
 dummy = "2"'
@@ -131,8 +131,8 @@ mise use "dummy@path:~/workdir/mydummy"
 assert_contains "mise ls dummy" "dummy  path:~/workdir/mydummy  ~/workdir/mise.toml  path:~/workdir/mydummy"
 
 cd "$HOME" || exit 1
-assert_contains "mise use dummy@system" "mise ~/.config/mise/config.toml tools: dummy@system"
+assert_contains "mise use dummy@system 2>&1" "mise ~/.config/mise/config.toml tools: dummy@system"
 
-assert_contains "mise use --path mise.path.toml dummy@1" "dummy@1."
+assert_contains "mise use --path mise.path.toml dummy@1 2>&1" "dummy@1."
 assert "cat mise.path.toml" '[tools]
 dummy = "1"'

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -287,6 +287,7 @@ impl Use {
         remove: &[BackendArg],
     ) -> Result<()> {
         let path = display_path(cf.get_path());
+        let quiet = Settings::get().quiet;
 
         if self.is_dry_run() {
             let mut messages = vec![];
@@ -302,24 +303,32 @@ impl Use {
             }
 
             if !messages.is_empty() {
-                info!(
-                    "would update {} ({})",
-                    style(&path).cyan().for_stderr(),
-                    messages.join(", ")
-                );
+                if !quiet {
+                    miseprintln!(
+                        "{} would update {} ({})",
+                        style("mise").green(),
+                        style(&path).cyan().for_stderr(),
+                        messages.join(", ")
+                    );
+                }
                 if self.dry_run_code {
                     exit::exit(1);
                 }
             }
-        } else {
+        } else if !quiet {
             if !versions.is_empty() {
                 let tools = versions.iter().map(|t| t.style()).join(", ");
-                info!("{} tools: {tools}", style(&path).cyan().for_stderr());
+                miseprintln!(
+                    "{} {} tools: {tools}",
+                    style("mise").green(),
+                    style(&path).cyan().for_stderr(),
+                );
             }
             if !remove.is_empty() {
                 let tools_to_remove = remove.iter().map(|r| r.to_string()).join(", ");
-                info!(
-                    "{} removed: {tools_to_remove}",
+                miseprintln!(
+                    "{} {} removed: {tools_to_remove}",
+                    style("mise").green(),
                     style(&path).cyan().for_stderr(),
                 );
             }

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -302,9 +302,8 @@ impl Use {
             }
 
             if !messages.is_empty() {
-                miseprintln!(
-                    "{} would update {} ({})",
-                    style("mise").green(),
+                info!(
+                    "would update {} ({})",
                     style(&path).cyan().for_stderr(),
                     messages.join(", ")
                 );
@@ -315,17 +314,12 @@ impl Use {
         } else {
             if !versions.is_empty() {
                 let tools = versions.iter().map(|t| t.style()).join(", ");
-                miseprintln!(
-                    "{} {} tools: {tools}",
-                    style("mise").green(),
-                    style(&path).cyan().for_stderr(),
-                );
+                info!("{} tools: {tools}", style(&path).cyan().for_stderr());
             }
             if !remove.is_empty() {
                 let tools_to_remove = remove.iter().map(|r| r.to_string()).join(", ");
-                miseprintln!(
-                    "{} {} removed: {tools_to_remove}",
-                    style("mise").green(),
+                info!(
+                    "{} removed: {tools_to_remove}",
                     style(&path).cyan().for_stderr(),
                 );
             }


### PR DESCRIPTION
## Summary
- `mise use` was printing `mise <path> tools: ...` via `miseprintln!` (unconditional stdout), so `--quiet` and `--silent` had no effect on it.
- Switch the "tools:", "removed:", and "would update" messages to `info!` so they route through the logger and get suppressed when those flags raise the log level to `error`.

Fixes #9152

## Test plan
- [x] `mise use tiny@1.0.0` — still prints `mise <path> tools: tiny@1.0.0`
- [x] `mise use -q tiny@1.0.0` — silent
- [x] `mise use --silent tiny@1.0.0` — silent
- [x] `mise use -n tiny@1.0.1` — still prints `would update ...`
- [x] `mise use -qn tiny@1.0.1` — silent
- [x] `mise use --remove tiny` — still prints `removed: ...`
- [x] `mise use -q --remove tiny` — silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only gates `mise use` success/dry-run status messages behind the existing `Settings::quiet` flag, without changing install/remove behavior or config writes.
> 
> **Overview**
> `mise use` now respects the global `--quiet` setting by suppressing its post-action status output (the “would update…”, “tools: …”, and “removed: …” messages) when quiet mode is enabled.
> 
> Behavior for installs/removals, dry-run exit codes, and config saving is unchanged; only user-facing messaging is conditionally skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8fcc0c6ed8c1acb1778de015dfb77504549df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->