### PR TITLE
fix(vfox): opt backend plugins out of --locked URL check

### DIFF
--- a/e2e/backend/test_vfox_backend_npm
+++ b/e2e/backend/test_vfox_backend_npm
@@ -14,6 +14,20 @@ mise install "vfox-npm:prettier@$latest_version"
 assert "mise use vfox-npm:prettier@$latest_version"
 assert_contains "mise exec -- prettier --version" "$latest_version"
 
+# Test --locked works with a version-only lockfile entry. Backend plugins have
+# no hook for supplying URLs, so --locked should accept version-only entries
+# rather than failing with "No lockfile URL found".
+cat <<EOF >mise.toml
+[tools]
+"vfox-npm:prettier" = "$latest_version"
+EOF
+cat <<EOF >mise.lock
+[[tools."vfox-npm:prettier"]]
+version = "$latest_version"
+backend = "vfox-npm:prettier"
+EOF
+assert "mise install --locked --dry-run"
+
 # Test uninstall functionality
 assert "mise uninstall vfox-npm:prettier@$latest_version"
 assert_directory_not_exists "$MISE_DATA_DIR/installs/vfox-npm/prettier/$latest_version"

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -49,6 +49,10 @@ impl Backend for VfoxBackend {
         &self.ba
     }
 
+    fn supports_lockfile_url(&self) -> bool {
+        !self.is_backend_plugin()
+    }
+
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         let this = self;
         timeout::run_with_timeout_async(

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -50,6 +50,8 @@ impl Backend for VfoxBackend {
     }
 
     fn supports_lockfile_url(&self) -> bool {
+        // TODO: expose a plugin hook (e.g. BackendLockInfo) so custom Lua backends
+        // can surface a download URL + checksum, and flip this back on for them.
         !self.is_backend_plugin()
     }
 


### PR DESCRIPTION
## Summary

- Custom Lua backend plugins (those using `BackendInstall` instead of a `PreInstall` hook) have no way to surface a download URL to mise. As a result, `mise lock` writes a version-only entry and `mise install --locked` then fails with `No lockfile URL found`.
- Override `supports_lockfile_url` on `VfoxBackend` to return `false` when the plugin is a backend plugin. Same semantics as asdf / cargo / npm / pipx: when the backend can't provide a URL, the pinned version is the lock.

Reported by @bishopmatthew in [#7308](https://github.com/jdx/mise/discussions/7308#discussioncomment-16607356).

## Test plan

- [ ] Added `--locked --dry-run` assertion with a version-only lockfile entry to `e2e/backend/test_vfox_backend_npm`.
- [ ] `mise run lint-fix` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrows the `--locked` URL validation for vfox *backend* plugins only, plus adds an e2e regression test. Main risk is allowing locked installs to proceed without per-platform URLs for these plugins, matching their current lockfile capabilities.
> 
> **Overview**
> Fixes `mise install --locked` for vfox custom backend plugins by making `VfoxBackend::supports_lockfile_url()` return `false` when the plugin is a backend plugin, so version-only lockfile entries no longer fail with "No lockfile URL found".
> 
> Adds an e2e assertion in `test_vfox_backend_npm` that `--locked --dry-run` succeeds with a version-only `mise.lock` entry for `vfox-npm:prettier`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ba299f5a3f3159e38c260c64225f4a0a74b42d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->