### PR TITLE
feat(spm): add filter_bins option to restrict built executables

### DIFF
--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -67,3 +67,22 @@ Set the URL for the provider's API. This is useful when using a self-hosted inst
 [tools]
 "spm:acme/my-tool" = { version = "latest", provider = "gitlab", api_url = "https://gitlab.acme.com/api/v4" }
 ```
+
+### `filter_bins`
+
+Restrict which executable products are built and linked from the package. When unset, every
+executable product declared in `Package.swift` is built and symlinked into `bin/` (the default
+behavior).
+
+Useful when a package ships helper executables (e.g. test harnesses) that you don't want on your
+`PATH`. Filtering happens before `swift build`, so unwanted products are never built.
+
+Accepts a TOML array or a comma-separated string. If any listed name does not match an executable
+product in the package, installation fails with a clear error.
+
+```toml
+[tools]
+"spm:swiftlang/swiftly" = { version = "latest", filter_bins = ["swiftly"] }
+# or
+"spm:swiftlang/swiftly" = { version = "latest", filter_bins = "swiftly" }
+```

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -108,6 +108,7 @@ impl Backend for SPMBackend {
         if executables.is_empty() {
             return Err(eyre::eyre!("No executables found in the package"));
         }
+        let executables = self.apply_filter_bins(&tv, executables)?;
         let bin_path = tv.install_path().join("bin");
         file::create_dir_all(&bin_path)?;
         for executable in executables {
@@ -156,6 +157,15 @@ impl SPMBackend {
         repo.update_submodules()?;
 
         Ok(repo.dir)
+    }
+
+    fn apply_filter_bins(
+        &self,
+        tv: &ToolVersion,
+        executables: Vec<String>,
+    ) -> eyre::Result<Vec<String>> {
+        let opts = tv.request.options();
+        filter_executables(&opts, executables)
     }
 
     async fn get_executable_names(
@@ -236,6 +246,56 @@ impl SPMBackend {
         .read()?;
         Ok(PathBuf::from(bin_path.trim().to_string()).join(executable))
     }
+}
+
+/// Parses the `filter_bins` tool option if set.
+///
+/// Accepts either a comma-separated string (`filter_bins = "foo,bar"`) or a
+/// TOML array (`filter_bins = ["foo", "bar"]`). Empty entries are ignored.
+fn parse_filter_bins(opts: &crate::toolset::ToolVersionOptions) -> Option<Vec<String>> {
+    let value = opts.opts.get("filter_bins")?;
+    let bins: Vec<String> = match value {
+        toml::Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.trim().to_string()))
+            .filter(|s| !s.is_empty())
+            .collect(),
+        toml::Value::String(s) => s
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => return None,
+    };
+    if bins.is_empty() { None } else { Some(bins) }
+}
+
+/// Restricts `executables` to those listed in `filter_bins`, preserving order.
+/// Returns an error if any name in `filter_bins` does not match an available
+/// executable product.
+fn filter_executables(
+    opts: &crate::toolset::ToolVersionOptions,
+    executables: Vec<String>,
+) -> eyre::Result<Vec<String>> {
+    let Some(filter) = parse_filter_bins(opts) else {
+        return Ok(executables);
+    };
+    let missing: Vec<&str> = filter
+        .iter()
+        .filter(|b| !executables.contains(b))
+        .map(|s| s.as_str())
+        .collect();
+    if !missing.is_empty() {
+        return Err(eyre::eyre!(
+            "filter_bins references executable(s) not found in the package: {}. Available: {}",
+            missing.join(", "),
+            executables.join(", ")
+        ));
+    }
+    Ok(executables
+        .into_iter()
+        .filter(|e| filter.contains(e))
+        .collect())
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -548,6 +608,82 @@ mod tests {
             "https://gitlab.acme.com/acme/someuser/SwiftTool.git"
         );
         assert_str_eq!(package_repo.shorthand, "acme/someuser/SwiftTool");
+    }
+
+    fn opts_with_filter_bins(value: toml::Value) -> ToolVersionOptions {
+        ToolVersionOptions {
+            opts: indexmap!["filter_bins".to_string() => value],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_parse_filter_bins() {
+        assert_eq!(parse_filter_bins(&ToolVersionOptions::default()), None);
+
+        assert_eq!(
+            parse_filter_bins(&opts_with_filter_bins(toml::Value::String(
+                "swiftly".to_string()
+            ))),
+            Some(vec!["swiftly".to_string()])
+        );
+
+        assert_eq!(
+            parse_filter_bins(&opts_with_filter_bins(toml::Value::String(
+                " foo , bar , ".to_string()
+            ))),
+            Some(vec!["foo".to_string(), "bar".to_string()])
+        );
+
+        assert_eq!(
+            parse_filter_bins(&opts_with_filter_bins(toml::Value::Array(vec![
+                toml::Value::String("foo".to_string()),
+                toml::Value::String(" bar".to_string()),
+                toml::Value::String("".to_string()),
+            ]))),
+            Some(vec!["foo".to_string(), "bar".to_string()])
+        );
+
+        assert_eq!(
+            parse_filter_bins(&opts_with_filter_bins(toml::Value::String(
+                " , ".to_string()
+            ))),
+            None,
+            "whitespace-only entries should yield None"
+        );
+    }
+
+    #[test]
+    fn test_filter_executables_passthrough_when_unset() {
+        let executables = vec!["a".to_string(), "b".to_string()];
+        let result =
+            filter_executables(&ToolVersionOptions::default(), executables.clone()).unwrap();
+        assert_eq!(result, executables);
+    }
+
+    #[test]
+    fn test_filter_executables_restricts_and_preserves_order() {
+        let executables = vec![
+            "swiftly".to_string(),
+            "test-swiftly".to_string(),
+            "helper".to_string(),
+        ];
+        let opts = opts_with_filter_bins(toml::Value::Array(vec![
+            toml::Value::String("helper".to_string()),
+            toml::Value::String("swiftly".to_string()),
+        ]));
+        let result = filter_executables(&opts, executables).unwrap();
+        assert_eq!(result, vec!["swiftly".to_string(), "helper".to_string()]);
+    }
+
+    #[test]
+    fn test_filter_executables_errors_on_missing_name() {
+        let executables = vec!["swiftly".to_string(), "test-swiftly".to_string()];
+        let opts = opts_with_filter_bins(toml::Value::String("does-not-exist".to_string()));
+        let err = filter_executables(&opts, executables).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("does-not-exist"), "got: {msg}");
+        assert!(msg.contains("swiftly"), "got: {msg}");
     }
 }
 

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -270,9 +270,10 @@ fn parse_filter_bins(opts: &crate::toolset::ToolVersionOptions) -> Option<Vec<St
     if bins.is_empty() { None } else { Some(bins) }
 }
 
-/// Restricts `executables` to those listed in `filter_bins`, preserving order.
-/// Returns an error if any name in `filter_bins` does not match an available
-/// executable product.
+/// Restricts `executables` to those listed in `filter_bins`, preserving the
+/// original declaration order from `Package.swift` rather than the order in
+/// `filter_bins`. Returns an error if any name in `filter_bins` does not match
+/// an available executable product.
 fn filter_executables(
     opts: &crate::toolset::ToolVersionOptions,
     executables: Vec<String>,


### PR DESCRIPTION
## Summary

- Adds a `filter_bins` tool option to the `spm` backend so users can restrict which executable products are built and linked
- Filters before `swift build` runs, so unwanted products are never compiled (not just hidden from `PATH`)
- Accepts either a TOML array (`filter_bins = ["swiftly"]`) or a comma-separated string (`filter_bins = "swiftly"`) — the naming matches the existing `filter_bins` option on the github backend
- Returns a clear error if any listed name does not match an executable product in the package

Closes #9148

The motivating example is [`swiftlang/swiftly`](https://github.com/swiftlang/swiftly), which ships both `swiftly` and `test-swiftly` products. Without this option, mise builds and links both.

```toml
[tools]
"spm:swiftlang/swiftly" = { version = "latest", filter_bins = ["swiftly"] }
```

When unset, the existing behavior (build and link every executable product) is preserved.

## Test plan

- [x] Added unit tests for `parse_filter_bins` (string, array, empty, whitespace-only) and `filter_executables` (passthrough, restrict+preserve-order, error on missing name)
- [x] `cargo test backend::spm` — all 8 tests pass
- [x] `mise run test:unit` — all 712 unit tests pass
- [x] `mise run lint-fix` — clean
- [ ] Manual verification with an actual Swift package that has multiple executable products

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SPM install behavior to optionally filter and error on unknown executable names, which could impact tool installation when configured. Default behavior is preserved when `filter_bins` is unset.
> 
> **Overview**
> Adds a new SPM tool option, `filter_bins`, to restrict which Swift executable products are built and symlinked into `bin/` during installation.
> 
> The backend now parses `filter_bins` from either a TOML array or comma-separated string, validates the requested executables exist, preserves the package-declared order when filtering, and fails fast with a clear error on unknown names. Documentation and unit tests were added to cover parsing, passthrough, ordering, and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0a09aca7f411d52f754116431ba3ba39c0a2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->