### PR TITLE
fix(github): route artifact attestation verification to custom api_url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8964,9 +8964,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verification"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234e57d0dbeea51543961991b61785d44ec7a6eb37d344a7f9ac47f1d7c9f8f0"
+checksum = "685b332c98c254f56357a41bc59e2b9aa503685dd11ae839efbee528e6a6bd1f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -474,10 +474,11 @@ impl UnifiedGitBackend {
             let parts: Vec<&str> = repo.split('/').collect();
             if parts.len() == 2 {
                 let (owner, repo_name) = (parts[0], parts[1]);
-                match sigstore_verification::sources::github::GitHubSource::new(
+                match sigstore_verification::sources::github::GitHubSource::with_base_url(
                     owner,
                     repo_name,
                     github::resolve_token_for_api_url(api_url).as_deref(),
+                    api_url,
                 ) {
                     Ok(source) => {
                         use sigstore_verification::AttestationSource;
@@ -571,12 +572,13 @@ impl UnifiedGitBackend {
             let parts: Vec<&str> = repo.split('/').collect();
             if parts.len() == 2 {
                 let (owner, repo_name) = (parts[0], parts[1]);
-                match sigstore_verification::verify_github_attestation(
+                match sigstore_verification::verify_github_attestation_with_base_url(
                     &artifact_path,
                     owner,
                     repo_name,
                     github::resolve_token_for_api_url(api_url).as_deref(),
                     None,
+                    api_url,
                 )
                 .await
                 {
@@ -1565,12 +1567,13 @@ impl UnifiedGitBackend {
         let (owner, repo_name) = (parts[0], parts[1]);
         let api_url = self.get_api_url(&tv.request.options());
 
-        match sigstore_verification::verify_github_attestation(
+        match sigstore_verification::verify_github_attestation_with_base_url(
             file_path,
             owner,
             repo_name,
             github::resolve_token_for_api_url(&api_url).as_deref(),
             None, // We don't know the expected workflow
+            &api_url,
         )
         .await
         {


### PR DESCRIPTION
## Summary

- When a github backend tool is configured with a custom `api_url` (e.g. a GitHub Enterprise Server instance like `https://github.enterprise.com/api/v3`), artifact downloads correctly hit the GHES API, but attestation verification was still dispatched to `api.github.com` — causing `401 Unauthorized` because the GHES token isn't valid there.
- Bumps `sigstore-verification` to 0.2.6 (which adds [`verify_github_attestation_with_base_url`](https://github.com/jdx/sigstore-verification/pull/45) and `GitHubSource::with_base_url`) and switches all three call sites in `src/backend/github.rs` to the new variants so the attestations API is queried against the same host that served the release.

## Motivation

Reported in https://github.com/jdx/mise/discussions/9176 — user configured `api_url = \"https://github.enterprise.com/api/v3\"` and `MISE_GITHUB_ENTERPRISE_TOKEN`, saw the download succeed, then the `[2/3] verify GitHub artifact attestations` step failed against `api.github.com` with a dotcom-only 401.

## Test plan

- [x] `cargo build` clean.
- [x] `mise run test:unit` — 708 passed.
- [x] `mise run lint` clean.
- [ ] Manual verification against a GHES instance with artifact attestations (no instance available in CI).

Closes https://github.com/jdx/mise/discussions/9176

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub attestation verification path and underlying `sigstore-verification` dependency, which affects supply-chain verification behavior and could cause new verification failures if the base URL is misconfigured.
> 
> **Overview**
> Ensures GitHub artifact attestation detection/verification uses the configured `api_url` (e.g., GitHub Enterprise) instead of implicitly querying `api.github.com`, by switching to `GitHubSource::with_base_url` and `verify_github_attestation_with_base_url` at all GitHub backend call sites.
> 
> Bumps `sigstore-verification` from `0.2.5` to `0.2.6` to pick up the new base-URL-aware APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ff8c388010262bb78ce40e2d8fe35541a7071e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->