### PR TITLE
fix(vfox): use github token for lua http requests

### DIFF
--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -36,14 +36,14 @@ pub fn mod_http(lua: &Lua) -> Result<()> {
             ),
             (
                 "download_file",
-                lua.create_async_function(|_lua: mlua::Lua, input| async move {
-                    download_file(&_lua, input).await
+                lua.create_async_function(|lua: mlua::Lua, input| async move {
+                    download_file(&lua, input).await
                 })?,
             ),
             (
                 "try_download_file",
-                lua.create_async_function(|_lua: mlua::Lua, input| async move {
-                    try_download_file(&_lua, input).await
+                lua.create_async_function(|lua: mlua::Lua, input| async move {
+                    try_download_file(&lua, input).await
                 })?,
             ),
         ])?,
@@ -69,19 +69,14 @@ fn github_token(lua: &Lua) -> Option<String> {
         return Some(token);
     }
 
-    [
-        "MISE_GITHUB_TOKEN",
-        "GITHUB_API_TOKEN",
-        "GITHUB_TOKEN",
-        "GH_TOKEN",
-    ]
-    .into_iter()
-    .find_map(|key| {
-        std::env::var(key)
-            .ok()
-            .map(|token| token.trim().to_string())
-            .filter(|token| !token.is_empty())
-    })
+    ["MISE_GITHUB_TOKEN", "GITHUB_API_TOKEN", "GITHUB_TOKEN"]
+        .into_iter()
+        .find_map(|key| {
+            std::env::var(key)
+                .ok()
+                .map(|token| token.trim().to_string())
+                .filter(|token| !token.is_empty())
+        })
 }
 
 fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMap {
@@ -111,10 +106,12 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
         if let Ok(value) = HeaderValue::from_str(&format!("Bearer {token}")) {
             headers.insert(AUTHORIZATION, value);
         }
-        headers.insert(
-            "x-github-api-version",
-            HeaderValue::from_static("2022-11-28"),
-        );
+        if host == "api.github.com" {
+            headers.insert(
+                "x-github-api-version",
+                HeaderValue::from_static("2022-11-28"),
+            );
+        }
     }
 
     headers
@@ -236,13 +233,13 @@ async fn try_head(lua: &Lua, input: Table) -> Result<MultiValue> {
     Ok(MultiValue::from_vec(vec![Value::Table(t), Value::Nil]))
 }
 
-async fn try_download_file(_lua: &Lua, input: MultiValue) -> Result<MultiValue> {
+async fn try_download_file(lua: &Lua, input: MultiValue) -> Result<MultiValue> {
     let t = match input.front().and_then(|v| v.as_table()) {
         Some(t) => t,
         None => {
             return Ok(MultiValue::from_vec(vec![
                 Value::Nil,
-                Value::String(_lua.create_string("first argument must be a table")?),
+                Value::String(lua.create_string("first argument must be a table")?),
             ]));
         }
     };
@@ -251,13 +248,13 @@ async fn try_download_file(_lua: &Lua, input: MultiValue) -> Result<MultiValue> 
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
-    let headers = add_default_headers(_lua, &url, headers);
+    let headers = add_default_headers(lua, &url, headers);
     let path = match input.get(1).and_then(|v| v.to_string().ok()) {
         Some(p) => p,
         None => {
             return Ok(MultiValue::from_vec(vec![
                 Value::Nil,
-                Value::String(_lua.create_string("second argument must be a string path")?),
+                Value::String(lua.create_string("second argument must be a string path")?),
             ]));
         }
     };
@@ -266,14 +263,14 @@ async fn try_download_file(_lua: &Lua, input: MultiValue) -> Result<MultiValue> 
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
                 Value::Nil,
-                Value::String(_lua.create_string(e.to_string())?),
+                Value::String(lua.create_string(e.to_string())?),
             ]));
         }
     };
     if let Err(e) = resp.error_for_status_ref() {
         return Ok(MultiValue::from_vec(vec![
             Value::Nil,
-            Value::String(_lua.create_string(e.to_string())?),
+            Value::String(lua.create_string(e.to_string())?),
         ]));
     }
     let bytes = match resp.bytes().await {
@@ -281,7 +278,7 @@ async fn try_download_file(_lua: &Lua, input: MultiValue) -> Result<MultiValue> 
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
                 Value::Nil,
-                Value::String(_lua.create_string(e.to_string())?),
+                Value::String(lua.create_string(e.to_string())?),
             ]));
         }
     };
@@ -290,14 +287,14 @@ async fn try_download_file(_lua: &Lua, input: MultiValue) -> Result<MultiValue> 
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
                 Value::Nil,
-                Value::String(_lua.create_string(e.to_string())?),
+                Value::String(lua.create_string(e.to_string())?),
             ]));
         }
     };
     if let Err(e) = tokio::io::AsyncWriteExt::write_all(&mut file, &bytes).await {
         return Ok(MultiValue::from_vec(vec![
             Value::Nil,
-            Value::String(_lua.create_string(e.to_string())?),
+            Value::String(lua.create_string(e.to_string())?),
         ]));
     }
     Ok(MultiValue::from_vec(vec![Value::Boolean(true), Value::Nil]))
@@ -316,38 +313,6 @@ mod tests {
     use super::*;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    struct EnvGuard {
-        vars: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn new(names: &[&'static str]) -> Self {
-            let vars = names
-                .iter()
-                .map(|name| (*name, std::env::var(name).ok()))
-                .collect();
-            Self { vars }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (name, value) in &self.vars {
-                match value {
-                    Some(value) => unsafe { std::env::set_var(name, value) },
-                    None => unsafe { std::env::remove_var(name) },
-                }
-            }
-        }
-    }
-
-    const GITHUB_TOKEN_VARS: &[&str] = &[
-        "MISE_GITHUB_TOKEN",
-        "GITHUB_API_TOKEN",
-        "GITHUB_TOKEN",
-        "GH_TOKEN",
-    ];
 
     #[tokio::test]
     async fn test_get() {
@@ -422,75 +387,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_default_headers_adds_github_token() {
-        let _guard = EnvGuard::new(GITHUB_TOKEN_VARS);
-        for name in GITHUB_TOKEN_VARS {
-            unsafe { std::env::remove_var(name) };
-        }
-        unsafe { std::env::set_var("MISE_GITHUB_TOKEN", "ghp_test") };
-
-        let lua = Lua::new();
-        let headers = add_default_headers(
-            &lua,
-            "https://api.github.com/repos/neovim/neovim/releases",
-            HeaderMap::default(),
-        );
-
-        assert_eq!(
-            headers
-                .get(AUTHORIZATION)
-                .and_then(|value| value.to_str().ok()),
-            Some("Bearer ghp_test")
-        );
-        assert_eq!(
-            headers
-                .get("x-github-api-version")
-                .and_then(|value| value.to_str().ok()),
-            Some("2022-11-28")
-        );
-    }
-
-    #[test]
-    fn test_add_default_headers_keeps_explicit_authorization() {
-        let _guard = EnvGuard::new(GITHUB_TOKEN_VARS);
-        unsafe { std::env::set_var("MISE_GITHUB_TOKEN", "ghp_default") };
-
-        let mut headers = HeaderMap::default();
-        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer explicit"));
-
-        let lua = Lua::new();
-        let headers = add_default_headers(&lua, "https://api.github.com/repos/owner/repo", headers);
-
-        assert_eq!(
-            headers
-                .get(AUTHORIZATION)
-                .and_then(|value| value.to_str().ok()),
-            Some("Bearer explicit")
-        );
-    }
-
-    #[test]
-    fn test_add_default_headers_skips_release_asset_hosts() {
-        let _guard = EnvGuard::new(GITHUB_TOKEN_VARS);
-        unsafe { std::env::set_var("MISE_GITHUB_TOKEN", "ghp_default") };
-
-        let lua = Lua::new();
-        let headers = add_default_headers(
-            &lua,
-            "https://release-assets.githubusercontent.com/github-production-release-asset/1/file",
-            HeaderMap::default(),
-        );
-
-        assert!(!headers.contains_key(AUTHORIZATION));
-    }
-
-    #[test]
     fn test_add_default_headers_uses_registry_token() {
-        let _guard = EnvGuard::new(GITHUB_TOKEN_VARS);
-        for name in GITHUB_TOKEN_VARS {
-            unsafe { std::env::remove_var(name) };
-        }
-
         let lua = Lua::new();
         lua.set_named_registry_value("github_token", "ghp_registry")
             .unwrap();
@@ -507,6 +404,64 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("Bearer ghp_registry")
         );
+        assert_eq!(
+            headers
+                .get("x-github-api-version")
+                .and_then(|value| value.to_str().ok()),
+            Some("2022-11-28")
+        );
+    }
+
+    #[test]
+    fn test_add_default_headers_keeps_explicit_authorization() {
+        let mut headers = HeaderMap::default();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer explicit"));
+
+        let lua = Lua::new();
+        let headers = add_default_headers(&lua, "https://api.github.com/repos/owner/repo", headers);
+
+        assert_eq!(
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer explicit")
+        );
+    }
+
+    #[test]
+    fn test_add_default_headers_skips_release_asset_hosts() {
+        let lua = Lua::new();
+        lua.set_named_registry_value("github_token", "ghp_registry")
+            .unwrap();
+
+        let headers = add_default_headers(
+            &lua,
+            "https://release-assets.githubusercontent.com/github-production-release-asset/1/file",
+            HeaderMap::default(),
+        );
+
+        assert!(!headers.contains_key(AUTHORIZATION));
+    }
+
+    #[test]
+    fn test_add_default_headers_only_sends_api_version_to_api_host() {
+        let lua = Lua::new();
+        lua.set_named_registry_value("github_token", "ghp_registry")
+            .unwrap();
+
+        let headers = add_default_headers(
+            &lua,
+            "https://raw.githubusercontent.com/owner/repo/main/file.txt",
+            HeaderMap::default(),
+        );
+
+        assert_eq!(
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer ghp_registry")
+        );
+        assert!(!headers.contains_key("x-github-api-version"));
     }
 
     #[tokio::test]

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -63,10 +63,11 @@ fn into_headers(table: &Table) -> Result<HeaderMap> {
 }
 
 fn github_token(lua: &Lua) -> Option<String> {
-    if let Ok(token) = lua.named_registry_value::<String>("github_token")
-        && !token.trim().is_empty()
-    {
-        return Some(token);
+    if let Ok(token) = lua.named_registry_value::<String>("github_token") {
+        let token = token.trim();
+        if !token.is_empty() {
+            return Some(token.to_string());
+        }
     }
 
     ["MISE_GITHUB_TOKEN", "GITHUB_API_TOKEN", "GITHUB_TOKEN"]
@@ -389,7 +390,7 @@ mod tests {
     #[test]
     fn test_add_default_headers_uses_registry_token() {
         let lua = Lua::new();
-        lua.set_named_registry_value("github_token", "ghp_registry")
+        lua.set_named_registry_value("github_token", " ghp_registry\n")
             .unwrap();
 
         let headers = add_default_headers(

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -1,5 +1,6 @@
 use mlua::{BorrowedStr, ExternalResult, Lua, MultiValue, Result, Table, Value};
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
+use url::Url;
 
 use crate::http::CLIENT;
 
@@ -61,12 +62,71 @@ fn into_headers(table: &Table) -> Result<HeaderMap> {
     Ok(map)
 }
 
+fn github_token(lua: &Lua) -> Option<String> {
+    if let Ok(token) = lua.named_registry_value::<String>("github_token")
+        && !token.trim().is_empty()
+    {
+        return Some(token);
+    }
+
+    [
+        "MISE_GITHUB_TOKEN",
+        "GITHUB_API_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key)
+            .ok()
+            .map(|token| token.trim().to_string())
+            .filter(|token| !token.is_empty())
+    })
+}
+
+fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMap {
+    if headers.contains_key(AUTHORIZATION) {
+        return headers;
+    }
+
+    let Ok(url) = Url::parse(url) else {
+        return headers;
+    };
+
+    let Some(host) = url.host_str() else {
+        return headers;
+    };
+
+    let is_github = host == "api.github.com"
+        || host == "github.com"
+        || (host.ends_with(".githubusercontent.com")
+            && !matches!(
+                host,
+                "objects.githubusercontent.com"
+                    | "objects-origin.githubusercontent.com"
+                    | "release-assets.githubusercontent.com"
+            ));
+
+    if is_github && let Some(token) = github_token(lua) {
+        if let Ok(value) = HeaderValue::from_str(&format!("Bearer {token}")) {
+            headers.insert(AUTHORIZATION, value);
+        }
+        headers.insert(
+            "x-github-api-version",
+            HeaderValue::from_static("2022-11-28"),
+        );
+    }
+
+    headers
+}
+
 async fn get(lua: &Lua, input: Table) -> Result<Table> {
     let url: String = input.get("url").into_lua_err()?;
     let headers = match input.get::<Option<Table>>("headers").into_lua_err()? {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
+    let headers = add_default_headers(lua, &url, headers);
     let resp = CLIENT
         .get(&url)
         .headers(headers)
@@ -80,13 +140,14 @@ async fn get(lua: &Lua, input: Table) -> Result<Table> {
     Ok(t)
 }
 
-async fn download_file(_lua: &Lua, input: MultiValue) -> Result<()> {
+async fn download_file(lua: &Lua, input: MultiValue) -> Result<()> {
     let t: &Table = input.iter().next().unwrap().as_table().unwrap();
     let url: String = t.get("url").into_lua_err()?;
     let headers = match t.get::<Option<Table>>("headers").into_lua_err()? {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
+    let headers = add_default_headers(lua, &url, headers);
     let path: String = input.iter().nth(1).unwrap().to_string()?;
     let resp = CLIENT
         .get(&url)
@@ -109,6 +170,7 @@ async fn head(lua: &Lua, input: Table) -> Result<Table> {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
+    let headers = add_default_headers(lua, &url, headers);
     let resp = CLIENT
         .head(&url)
         .headers(headers)
@@ -127,6 +189,7 @@ async fn try_get(lua: &Lua, input: Table) -> Result<MultiValue> {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
+    let headers = add_default_headers(lua, &url, headers);
     let resp = match CLIENT.get(&url).headers(headers).send().await {
         Ok(resp) => resp,
         Err(e) => {
@@ -157,6 +220,7 @@ async fn try_head(lua: &Lua, input: Table) -> Result<MultiValue> {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
+    let headers = add_default_headers(lua, &url, headers);
     let resp = match CLIENT.head(&url).headers(headers).send().await {
         Ok(resp) => resp,
         Err(e) => {
@@ -187,6 +251,7 @@ async fn try_download_file(_lua: &Lua, input: MultiValue) -> Result<MultiValue> 
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
+    let headers = add_default_headers(_lua, &url, headers);
     let path = match input.get(1).and_then(|v| v.to_string().ok()) {
         Some(p) => p,
         None => {
@@ -251,6 +316,38 @@ mod tests {
     use super::*;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    struct EnvGuard {
+        vars: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new(names: &[&'static str]) -> Self {
+            let vars = names
+                .iter()
+                .map(|name| (*name, std::env::var(name).ok()))
+                .collect();
+            Self { vars }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.vars {
+                match value {
+                    Some(value) => unsafe { std::env::set_var(name, value) },
+                    None => unsafe { std::env::remove_var(name) },
+                }
+            }
+        }
+    }
+
+    const GITHUB_TOKEN_VARS: &[&str] = &[
+        "MISE_GITHUB_TOKEN",
+        "GITHUB_API_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+    ];
 
     #[tokio::test]
     async fn test_get() {
@@ -322,6 +419,94 @@ mod tests {
         .exec_async()
         .await
         .unwrap();
+    }
+
+    #[test]
+    fn test_add_default_headers_adds_github_token() {
+        let _guard = EnvGuard::new(GITHUB_TOKEN_VARS);
+        for name in GITHUB_TOKEN_VARS {
+            unsafe { std::env::remove_var(name) };
+        }
+        unsafe { std::env::set_var("MISE_GITHUB_TOKEN", "ghp_test") };
+
+        let lua = Lua::new();
+        let headers = add_default_headers(
+            &lua,
+            "https://api.github.com/repos/neovim/neovim/releases",
+            HeaderMap::default(),
+        );
+
+        assert_eq!(
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer ghp_test")
+        );
+        assert_eq!(
+            headers
+                .get("x-github-api-version")
+                .and_then(|value| value.to_str().ok()),
+            Some("2022-11-28")
+        );
+    }
+
+    #[test]
+    fn test_add_default_headers_keeps_explicit_authorization() {
+        let _guard = EnvGuard::new(GITHUB_TOKEN_VARS);
+        unsafe { std::env::set_var("MISE_GITHUB_TOKEN", "ghp_default") };
+
+        let mut headers = HeaderMap::default();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer explicit"));
+
+        let lua = Lua::new();
+        let headers = add_default_headers(&lua, "https://api.github.com/repos/owner/repo", headers);
+
+        assert_eq!(
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer explicit")
+        );
+    }
+
+    #[test]
+    fn test_add_default_headers_skips_release_asset_hosts() {
+        let _guard = EnvGuard::new(GITHUB_TOKEN_VARS);
+        unsafe { std::env::set_var("MISE_GITHUB_TOKEN", "ghp_default") };
+
+        let lua = Lua::new();
+        let headers = add_default_headers(
+            &lua,
+            "https://release-assets.githubusercontent.com/github-production-release-asset/1/file",
+            HeaderMap::default(),
+        );
+
+        assert!(!headers.contains_key(AUTHORIZATION));
+    }
+
+    #[test]
+    fn test_add_default_headers_uses_registry_token() {
+        let _guard = EnvGuard::new(GITHUB_TOKEN_VARS);
+        for name in GITHUB_TOKEN_VARS {
+            unsafe { std::env::remove_var(name) };
+        }
+
+        let lua = Lua::new();
+        lua.set_named_registry_value("github_token", "ghp_registry")
+            .unwrap();
+
+        let headers = add_default_headers(
+            &lua,
+            "https://api.github.com/repos/neovim/neovim/releases",
+            HeaderMap::default(),
+        );
+
+        assert_eq!(
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer ghp_registry")
+        );
     }
 
     #[tokio::test]

--- a/crates/vfox/src/plugin.rs
+++ b/crates/vfox/src/plugin.rs
@@ -103,6 +103,12 @@ impl Plugin {
         Ok(())
     }
 
+    /// Store a GitHub token for the Lua http module.
+    pub fn set_github_token(&self, token: &str) -> Result<()> {
+        self.lua.set_named_registry_value("github_token", token)?;
+        Ok(())
+    }
+
     pub fn list() -> Result<Vec<String>> {
         let config = Config::get();
         if !config.plugin_dir.exists() {

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -53,6 +53,8 @@ pub struct Vfox {
     /// instead of inheriting the process environment. This allows dependency tools'
     /// bin paths to be on PATH during version resolution and installation.
     pub cmd_env: Option<IndexMap<String, String>>,
+    /// Optional GitHub token for Lua http requests to GitHub API endpoints.
+    pub github_token: Option<String>,
     log_tx: Option<mpsc::Sender<String>>,
 }
 
@@ -128,6 +130,9 @@ impl Vfox {
         let plugin = self.get_sdk(name)?;
         if let Some(env) = &self.cmd_env {
             plugin.set_cmd_env(env)?;
+        }
+        if let Some(token) = &self.github_token {
+            plugin.set_github_token(token)?;
         }
         Ok(plugin)
     }
@@ -575,6 +580,7 @@ impl Default for Vfox {
             install_dir: home().join(".version-fox/installs"),
             skip_verification: false,
             cmd_env: None,
+            github_token: None,
             log_tx: None,
         }
     }
@@ -601,6 +607,7 @@ mod tests {
                 install_dir: PathBuf::from("test/installs"),
                 skip_verification: false,
                 cmd_env: None,
+                github_token: None,
                 log_tx: None,
             }
         }

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -131,10 +131,15 @@ impl Vfox {
         if let Some(env) = &self.cmd_env {
             plugin.set_cmd_env(env)?;
         }
+        self.set_github_token(&plugin)?;
+        Ok(plugin)
+    }
+
+    fn set_github_token(&self, plugin: &Plugin) -> Result<()> {
         if let Some(token) = &self.github_token {
             plugin.set_github_token(token)?;
         }
-        Ok(plugin)
+        Ok(())
     }
 
     pub fn install_plugin(&self, sdk: &str) -> Result<Plugin> {
@@ -300,6 +305,7 @@ impl Vfox {
             }
         }
         plugin.set_cmd_env(env)?;
+        self.set_github_token(&plugin)?;
         let ctx = MiseEnvContext {
             args: vec![],
             options: opts,
@@ -371,6 +377,7 @@ impl Vfox {
             return Ok(vec![]);
         }
         plugin.set_cmd_env(env)?;
+        self.set_github_token(&plugin)?;
         let ctx = MisePathContext {
             args: vec![],
             options: opts,

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -117,6 +117,7 @@ impl VfoxPlugin {
         vfox.cache_dir = dirs::CACHE.to_path_buf();
         vfox.download_dir = dirs::DOWNLOADS.to_path_buf();
         vfox.install_dir = dirs::INSTALLS.to_path_buf();
+        vfox.github_token = crate::github::resolve_token("github.com").map(|(token, _)| token);
         let rx = vfox.log_subscribe();
         (vfox, rx)
     }


### PR DESCRIPTION
## Summary
- pass mise's resolved GitHub token into vfox plugin runtimes
- add default GitHub auth headers in the vfox Lua HTTP bridge for GitHub API requests
- preserve explicit plugin-provided Authorization headers and avoid auth on GitHub release asset hosts

## Root Cause
Embedded vfox plugins such as `vfox-neovim` call `api.github.com` through the Lua HTTP module. Those requests did not receive mise's configured GitHub token, so rate-limited users could hit `HTTP 403` while installing Neovim even when mise itself knew how to resolve a GitHub token.

## Validation
- `cargo fmt --check`
- `cargo test -p vfox lua_mod::http`
- `cargo check -p mise`
- `MISE_LOG_HTTP=1 cargo run -q -p mise -- ls-remote neovim | sed -n '1,20p'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound HTTP behavior by automatically adding `Authorization` headers for certain GitHub hosts, which could affect plugin networking and token exposure if host matching is wrong. Scope is limited and includes tests plus explicit opt-out when plugins already set `Authorization` and for GitHub release asset hosts.
> 
> **Overview**
> Ensures embedded vfox plugins can authenticate GitHub API calls by threading mise’s resolved GitHub token into the vfox Lua runtime and having the Lua `http` bridge auto-attach GitHub auth headers.
> 
> The Lua HTTP module now conditionally adds `Authorization: Bearer …` (and `x-github-api-version` for `api.github.com`) when a token is available, while **preserving explicit plugin-provided `Authorization`** and **skipping GitHub release asset hosts**; behavior is covered by new unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d9320728ac191f6fc52145fad2e734a33a727e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->