### PR TITLE
chore: release 2026.4.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,79 @@
 # Changelog
 
+## [2026.4.19](https://github.com/jdx/mise/compare/v2026.4.18..v2026.4.19) - 2026-04-22
+
+### 🚀 Features
+
+- **(backend)** support aqua vars templates by @risu729 in [#9110](https://github.com/jdx/mise/pull/9110)
+- **(oci)** build OCI images from mise.toml with per-tool layers by @jdx in [#9273](https://github.com/jdx/mise/pull/9273)
+- add gsudo (Sudo for Windows) to registry by @matracey in [#9281](https://github.com/jdx/mise/pull/9281)
+
+### 🐛 Bug Fixes
+
+- **(backend)** stop fuzzy requests installing literal dirs by @AsgardMuninn in [#9276](https://github.com/jdx/mise/pull/9276)
+- **(backend)** use full token chain for all sigstore attestation calls by @cameronbrill in [#9307](https://github.com/jdx/mise/pull/9307)
+- **(backend)** use remote version cache offline by @risu729 in [#9304](https://github.com/jdx/mise/pull/9304)
+- **(cli)** retrieve token from github helper for `self-update` command by @sushichan044 in [#9259](https://github.com/jdx/mise/pull/9259)
+- **(cli)** suppress error output after interactive cancel by @jdx in [#9294](https://github.com/jdx/mise/pull/9294)
+- **(conda)** avoid temp file collisions during parallel package downloads by @salim-b in [#9293](https://github.com/jdx/mise/pull/9293)
+- **(github)** scope auth headers to API URLs by @risu729 in [#9271](https://github.com/jdx/mise/pull/9271)
+- **(go)** treat empty GOPROXY as default by @jdx in [#9310](https://github.com/jdx/mise/pull/9310)
+- **(vfox)** use github token for lua http requests by @jdx in [#9257](https://github.com/jdx/mise/pull/9257)
+- **(vfox)** avoid auth on release asset downloads by @jdx in [#9299](https://github.com/jdx/mise/pull/9299)
+- **(vfox)** scope github auth to API URLs only by @jdx in [#9309](https://github.com/jdx/mise/pull/9309)
+
+### 🚜 Refactor
+
+- **(core)** centralize install_before resolution by @risu729 in [#9286](https://github.com/jdx/mise/pull/9286)
+- **(deps)** store deps state under $MISE_STATE_DIR by @jdx in [#9301](https://github.com/jdx/mise/pull/9301)
+
+### 📚 Documentation
+
+- add aube hero banner by @jdx in [#9265](https://github.com/jdx/mise/pull/9265)
+- add en.dev footer by @jdx in [#9267](https://github.com/jdx/mise/pull/9267)
+- implement landing page design by @jdx in [#9266](https://github.com/jdx/mise/pull/9266)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by @renovate[bot] in [#9268](https://github.com/jdx/mise/pull/9268)
+- bump msrv for aws smithy updates by @jdx in [#9295](https://github.com/jdx/mise/pull/9295)
+- bump sigstore-verification to 0.2.7 by @jdx in [#9302](https://github.com/jdx/mise/pull/9302)
+
+### 📦 Registry
+
+- add llama.cpp ([github:ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) by @igor-makarov in [#9282](https://github.com/jdx/mise/pull/9282)
+- add kiro-cli by @shalk in [#9274](https://github.com/jdx/mise/pull/9274)
+- add flux-operator & flux-operator-mcp by @monotek in [#8852](https://github.com/jdx/mise/pull/8852)
+
+### Chore
+
+- **(ci)** increase autofix timeout by @jdx in [#9296](https://github.com/jdx/mise/pull/9296)
+- **(ci)** stop release-plz from saving build cache by @jdx in [#9297](https://github.com/jdx/mise/pull/9297)
+- **(ci)** stop lint from saving build cache by @jdx in [#9298](https://github.com/jdx/mise/pull/9298)
+- **(ci)** restore lint as Linux build cache writer by @jdx in [#9305](https://github.com/jdx/mise/pull/9305)
+- **(release)** add en.dev sponsor blurb to release notes by @jdx in [#9272](https://github.com/jdx/mise/pull/9272)
+- bump communique to 1.0.1 by @jdx in [#9264](https://github.com/jdx/mise/pull/9264)
+
+### New Contributors
+
+- @AsgardMuninn made their first contribution in [#9276](https://github.com/jdx/mise/pull/9276)
+- @monotek made their first contribution in [#8852](https://github.com/jdx/mise/pull/8852)
+- @igor-makarov made their first contribution in [#9282](https://github.com/jdx/mise/pull/9282)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (3)
+
+- [`controlplaneio-fluxcd/flux-operator/flux-operator-mcp`](https://github.com/controlplaneio-fluxcd/flux-operator/flux-operator-mcp)
+- [`endevco/aube`](https://github.com/endevco/aube)
+- [`ricoberger/grafana-kubernetes-plugin`](https://github.com/ricoberger/grafana-kubernetes-plugin)
+
+#### Updated Packages (3)
+
+- [`controlplaneio-fluxcd/flux-operator`](https://github.com/controlplaneio-fluxcd/flux-operator)
+- [`go-delve/delve`](https://github.com/go-delve/delve)
+- [`graelo/pumas`](https://github.com/graelo/pumas)
+
 ## [2026.4.18](https://github.com/jdx/mise/compare/v2026.4.17..v2026.4.18) - 2026-04-19
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aqua-registry"
-version = "2026.4.7"
+version = "2026.4.8"
 dependencies = [
  "expr-lang",
  "eyre",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.4.18"
+version = "2026.4.19"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.4.18"
+version = "2026.4.19"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.4.18 macos-arm64 (2026-04-19)
+2026.4.19 macos-arm64 (2026-04-22)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_18.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_19.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_18.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_19.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_4_18.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_4_19.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_4_18.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_4_19.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/crates/aqua-registry/Cargo.toml
+++ b/crates/aqua-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aqua-registry"
-version = "2026.4.7"
+version = "2026.4.8"
 edition = "2024"
 description = "Aqua registry backend for mise"
 authors = ["Jeff Dickey (@jdx)"]

--- a/crates/aqua-registry/aqua-registry/pkgs/controlplaneio-fluxcd/flux-operator/flux-operator-mcp/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/controlplaneio-fluxcd/flux-operator/flux-operator-mcp/registry.yaml
@@ -1,29 +1,16 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
+  - name: controlplaneio-fluxcd/flux-operator/flux-operator-mcp
+    type: github_release
     repo_owner: controlplaneio-fluxcd
     repo_name: flux-operator
-    link: https://fluxoperator.dev/docs/guides/cli/
-    description: |
-      Flux Operator CLI allows you to manage the Flux Operator resources in your Kubernetes clusters.
-      It provides a convenient way to interact with the operator and perform various operations.
+    description: GitOps on Autopilot Mode
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.13.0")
-        no_asset: true
       - version_constraint: semver("<= 0.19.0")
-        asset: flux-operator_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: flux-operator_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
+        no_asset: true
       - version_constraint: semver("<= 0.46.0")
-        asset: flux-operator_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        asset: flux-operator-mcp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release
@@ -33,7 +20,7 @@ packages:
           - goos: windows
             format: zip
       - version_constraint: "true"
-        asset: flux-operator_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        asset: flux-operator-mcp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release

--- a/crates/aqua-registry/aqua-registry/pkgs/endevco/aube/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/endevco/aube/registry.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: endevco
+    repo_name: aube
+    description: A fast Node.js package manager
+    asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: darwin
+        replacements:
+          amd64: amd64
+      - goos: windows
+        format: zip
+    supported_envs:
+      - linux
+      - darwin/arm64
+      - windows

--- a/crates/aqua-registry/aqua-registry/pkgs/go-delve/delve/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/go-delve/delve/registry.yaml
@@ -1,12 +1,33 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: go_install
+  - type: github_release
     repo_owner: go-delve
     repo_name: delve
     description: Delve is a debugger for the Go programming language
+    files:
+      - name: dlv
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.26.1")
+        type: go_install
         path: github.com/go-delve/delve/cmd/dlv
-        files:
-          - name: dlv
+      - version_constraint: "true"
+        asset: dlv_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - https://github.com/go-delve/delve/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/go-delve/delve/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate
+              - https://github.com/go-delve/delve/releases/download/{{.Version}}/checksums.txt.cert
+        overrides:
+          - goos: windows
+            format: zip

--- a/crates/aqua-registry/aqua-registry/pkgs/graelo/pumas/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/graelo/pumas/registry.yaml
@@ -6,6 +6,17 @@ packages:
     description: Power Usage Monitor for Apple Silicon
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.4.0")
+        asset: pumas-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: pumas
+            src: target/release/pumas
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin/arm64
       - version_constraint: "true"
         asset: pumas-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -17,3 +28,5 @@ packages:
           darwin: apple-darwin
         supported_envs:
           - darwin/arm64
+        github_artifact_attestations:
+          signer_workflow: graelo/pumas/\.github/workflows/release\.yml

--- a/crates/aqua-registry/aqua-registry/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: ricoberger
+    repo_name: grafana-kubernetes-plugin
+    description: The Grafana Kubernetes Plugin allows you to explore your Kubernetes resources and logs directly within Grafana
+    files:
+      - name: kubectl-grafana
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.4.0")
+        asset: kubectl-grafana.tar.gz
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: kubectl-grafana
+            src: kubectl-grafana-{{.OS}}-{{.Arch}}
+      - version_constraint: "true"
+        asset: kubectl-grafana-{{.OS}}-{{.Arch}}.tar.gz
+        format: tar.gz
+        windows_arm_emulation: true

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.4.18";
+  version = "2026.4.19";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "26.9k",
+      stars: "27k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2026.4.18
+Version: 2026.4.19
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.4.18"
+version: "2026.4.19"
 summary: The front-end to your dev env
 description: |
   mise-en-place is a command line tool to manage your development environment.


### PR DESCRIPTION
### 🚀 Features

- **(backend)** support aqua vars templates by @risu729 in [#9110](https://github.com/jdx/mise/pull/9110)
- **(oci)** build OCI images from mise.toml with per-tool layers by @jdx in [#9273](https://github.com/jdx/mise/pull/9273)
- add gsudo (Sudo for Windows) to registry by @matracey in [#9281](https://github.com/jdx/mise/pull/9281)

### 🐛 Bug Fixes

- **(backend)** stop fuzzy requests installing literal dirs by @AsgardMuninn in [#9276](https://github.com/jdx/mise/pull/9276)
- **(backend)** use full token chain for all sigstore attestation calls by @cameronbrill in [#9307](https://github.com/jdx/mise/pull/9307)
- **(backend)** use remote version cache offline by @risu729 in [#9304](https://github.com/jdx/mise/pull/9304)
- **(cli)** retrieve token from github helper for `self-update` command by @sushichan044 in [#9259](https://github.com/jdx/mise/pull/9259)
- **(cli)** suppress error output after interactive cancel by @jdx in [#9294](https://github.com/jdx/mise/pull/9294)
- **(conda)** avoid temp file collisions during parallel package downloads by @salim-b in [#9293](https://github.com/jdx/mise/pull/9293)
- **(github)** scope auth headers to API URLs by @risu729 in [#9271](https://github.com/jdx/mise/pull/9271)
- **(go)** treat empty GOPROXY as default by @jdx in [#9310](https://github.com/jdx/mise/pull/9310)
- **(vfox)** use github token for lua http requests by @jdx in [#9257](https://github.com/jdx/mise/pull/9257)
- **(vfox)** avoid auth on release asset downloads by @jdx in [#9299](https://github.com/jdx/mise/pull/9299)
- **(vfox)** scope github auth to API URLs only by @jdx in [#9309](https://github.com/jdx/mise/pull/9309)

### 🚜 Refactor

- **(core)** centralize install_before resolution by @risu729 in [#9286](https://github.com/jdx/mise/pull/9286)
- **(deps)** store deps state under $MISE_STATE_DIR by @jdx in [#9301](https://github.com/jdx/mise/pull/9301)

### 📚 Documentation

- add aube hero banner by @jdx in [#9265](https://github.com/jdx/mise/pull/9265)
- add en.dev footer by @jdx in [#9267](https://github.com/jdx/mise/pull/9267)
- implement landing page design by @jdx in [#9266](https://github.com/jdx/mise/pull/9266)

### 📦️ Dependency Updates

- lock file maintenance by @renovate[bot] in [#9268](https://github.com/jdx/mise/pull/9268)
- bump msrv for aws smithy updates by @jdx in [#9295](https://github.com/jdx/mise/pull/9295)
- bump sigstore-verification to 0.2.7 by @jdx in [#9302](https://github.com/jdx/mise/pull/9302)

### 📦 Registry

- add llama.cpp ([github:ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) by @igor-makarov in [#9282](https://github.com/jdx/mise/pull/9282)
- add kiro-cli by @shalk in [#9274](https://github.com/jdx/mise/pull/9274)
- add flux-operator & flux-operator-mcp by @monotek in [#8852](https://github.com/jdx/mise/pull/8852)

### Chore

- **(ci)** increase autofix timeout by @jdx in [#9296](https://github.com/jdx/mise/pull/9296)
- **(ci)** stop release-plz from saving build cache by @jdx in [#9297](https://github.com/jdx/mise/pull/9297)
- **(ci)** stop lint from saving build cache by @jdx in [#9298](https://github.com/jdx/mise/pull/9298)
- **(ci)** restore lint as Linux build cache writer by @jdx in [#9305](https://github.com/jdx/mise/pull/9305)
- **(release)** add en.dev sponsor blurb to release notes by @jdx in [#9272](https://github.com/jdx/mise/pull/9272)
- bump communique to 1.0.1 by @jdx in [#9264](https://github.com/jdx/mise/pull/9264)

### New Contributors

- @AsgardMuninn made their first contribution in [#9276](https://github.com/jdx/mise/pull/9276)
- @monotek made their first contribution in [#8852](https://github.com/jdx/mise/pull/8852)
- @igor-makarov made their first contribution in [#9282](https://github.com/jdx/mise/pull/9282)

## 📦 Aqua Registry Updates

#### New Packages (3)

- [`controlplaneio-fluxcd/flux-operator/flux-operator-mcp`](https://github.com/controlplaneio-fluxcd/flux-operator/flux-operator-mcp)
- [`endevco/aube`](https://github.com/endevco/aube)
- [`ricoberger/grafana-kubernetes-plugin`](https://github.com/ricoberger/grafana-kubernetes-plugin)

#### Updated Packages (3)

- [`controlplaneio-fluxcd/flux-operator`](https://github.com/controlplaneio-fluxcd/flux-operator)
- [`go-delve/delve`](https://github.com/go-delve/delve)
- [`graelo/pumas`](https://github.com/graelo/pumas)