### PR TITLE
fix(cli): retrieve token from github helper for `self-update` command

### DIFF
--- a/docs/cli/self-update.md
+++ b/docs/cli/self-update.md
@@ -8,7 +8,7 @@ Updates mise itself.
 
 Uses the GitHub Releases API to find the latest release and binary.
 By default, this will also update any installed plugins.
-Uses the `GITHUB_API_TOKEN` environment variable if set for higher rate limits.
+Uses mise's GitHub token resolution chain for authenticated requests.
 
 This command is not available if mise is installed via a package manager.
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2082,7 +2082,7 @@ Updates mise itself.
 
 Uses the GitHub Releases API to find the latest release and binary.
 By default, this will also update any installed plugins.
-Uses the `GITHUB_API_TOKEN` environment variable if set for higher rate limits.
+Uses mise's GitHub token resolution chain for authenticated requests.
 
 This command is not available if mise is installed via a package manager.
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -828,7 +828,7 @@ cmd search help="Search for tools in the registry" {
     arg "[NAME]" help="The tool to search for" required=#false
 }
 cmd self-update help="Updates mise itself." {
-    long_help "Updates mise itself.\n\nUses the GitHub Releases API to find the latest release and binary.\nBy default, this will also update any installed plugins.\nUses the `GITHUB_API_TOKEN` environment variable if set for higher rate limits.\n\nThis command is not available if mise is installed via a package manager."
+    long_help "Updates mise itself.\n\nUses the GitHub Releases API to find the latest release and binary.\nBy default, this will also update any installed plugins.\nUses mise's GitHub token resolution chain for authenticated requests.\n\nThis command is not available if mise is installed via a package manager."
     flag "-f --force" help="Update even if already up to date"
     flag "-y --yes" help="Skip confirmation prompt"
     flag --no-plugins help="Disable auto-updating plugins"

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -57,7 +57,7 @@ pub fn append_self_update_instructions(mut message: String) -> String {
 ///
 /// Uses the GitHub Releases API to find the latest release and binary.
 /// By default, this will also update any installed plugins.
-/// Uses the `GITHUB_API_TOKEN` environment variable if set for higher rate limits.
+/// Uses mise's GitHub token resolution chain for authenticated requests.
 ///
 /// This command is not available if mise is installed via a package manager.
 #[derive(Debug, Default, clap::Args)]

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -115,8 +115,8 @@ impl SelfUpdate {
 
     fn do_update_blocking(&self) -> Result<Status> {
         let mut update = Update::configure();
-        if let Some(token) = &*env::GITHUB_TOKEN {
-            update.auth_token(token);
+        if let Some((token, _)) = crate::github::resolve_token("github.com") {
+            update.auth_token(&token);
         }
         #[cfg(windows)]
         let bin_path_in_archive = "mise/bin/mise.exe";


### PR DESCRIPTION
The `mise self-update` command now retrieves the GitHub API token via an internal helper rather than directly from environment variables.
This ensures the token is fetched from the supported sources listed at https://mise.jdx.dev/dev-tools/github-tokens.html.