### PR TITLE
docs: implement landing page design

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -10,45 +10,63 @@
       </div>
     </template>
 
-    <!-- Chef logo as the commanding centerpiece -->
+    <!-- Landing hero content from the design handoff -->
     <template #home-hero-info-before>
-      <div class="hero-chef-logo">
-        <img
-          class="chef-logo chef-logo-light"
-          src="/logo-full-light.svg"
-          alt="mise-en-place"
-        />
-        <img
-          class="chef-logo chef-logo-dark"
-          src="/logo-full-dark.svg"
-          alt="mise-en-place"
-        />
+      <div class="hero-copy">
+        <div class="hero-eyebrow">mise · pronounced "meez"</div>
+        <div class="hero-lockup">
+          <img
+            class="chef-logo chef-logo-light"
+            src="/logo-full-light.svg"
+            alt="mise-en-place"
+          />
+          <img
+            class="chef-logo chef-logo-dark"
+            src="/logo-full-dark.svg"
+            alt="mise-en-place"
+          />
+        </div>
+        <h1>Your dev env,<br /><em>already prepped.</em></h1>
+        <p>
+          One tool to manage languages, env vars, and tasks per project,
+          reproducibly.
+        </p>
+        <div class="hero-actions">
+          <a class="action-btn action-btn-brand" href="/getting-started">Getting Started</a>
+          <a class="action-btn action-btn-alt" href="/demo">Demo</a>
+        </div>
       </div>
     </template>
 
-    <!-- Right column: install + action buttons -->
+    <!-- Right column: terminal-forward proof of the workflow -->
     <template #home-hero-info-after>
       <div class="hero-right">
-        <a class="hero-aube-banner" href="https://aube.en.dev/">
-          <span class="aube-kicker">New from en.dev by @jdx</span>
-          <span class="aube-message">Try aube, a fast Node.js package manager that uses your existing lockfile. Now in beta.</span>
-        </a>
-        <div class="hero-install">
-          <div class="install-label">Install</div>
-          <div class="install-command" @click="copyInstall">
-            <code>curl https://mise.run | sh</code>
-            <span class="install-copy" :class="{ copied }">
-              {{ copied ? '✓' : '⎘' }}
-            </span>
+        <div class="hero-terminal" aria-label="mise terminal example">
+          <div class="terminal-bar">
+            <span></span>
+            <span></span>
+            <span></span>
+            <strong>~/projects/orders · zsh</strong>
           </div>
-          <div class="install-alt">
-            <a href="/installing-mise.html">More install methods →</a>
+          <div class="terminal-body">
+            <div><span class="prompt">$</span> cd ~/projects/orders</div>
+            <div><span class="dim"># mise picks up mise.toml and updates the shell</span></div>
+            <div><span class="ok">✓</span> node@24 active</div>
+            <div><span class="ok">✓</span> python@3.13 active</div>
+            <div><span class="ok">✓</span> terraform@1 active</div>
+            <div><span class="ok">✓</span> DATABASE_URL loaded from .env.local</div>
+            <div><span class="prompt">$</span> mise run deploy</div>
+            <div><span class="key">→</span> running task "deploy" (4 steps)</div>
+            <div><span class="dim">  build · test · migrate · ship ...</span></div>
+            <div><span class="ok">✓</span> done in 42.1s</div>
           </div>
         </div>
-        <div class="hero-actions">
-          <a class="action-btn action-btn-brand" href="/getting-started.html">Getting Started</a>
-          <a class="action-btn action-btn-alt" href="/demo.html">Demo</a>
-          <a class="action-btn action-btn-alt" href="/about.html">About</a>
+        <div class="hero-install">
+          <button class="install-command" type="button" @click="copyInstall">
+            <code>curl https://mise.run | sh</code>
+            <span class="install-copy" :class="{ copied }">{{ copied ? "copied" : "copy" }}</span>
+          </button>
+          <a class="install-alt" href="/installing-mise">More install methods</a>
         </div>
       </div>
     </template>
@@ -65,11 +83,33 @@ import { ref } from "vue";
 import EndevFooter from "./EndevFooter.vue";
 
 const copied = ref(false);
+const installCommand = "curl https://mise.run | sh";
 
-function copyInstall() {
-  navigator.clipboard.writeText("curl https://mise.run | sh");
-  copied.value = true;
-  setTimeout(() => (copied.value = false), 2000);
+async function copyInstall() {
+  if (await copyText(installCommand)) {
+    copied.value = true;
+    setTimeout(() => (copied.value = false), 2000);
+  }
+}
+
+async function copyText(text: string) {
+  try {
+    await navigator.clipboard?.writeText(text);
+    if (navigator.clipboard) return true;
+  } catch {
+    // Fall back to the temporary textarea path below.
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copiedText = document.execCommand("copy");
+  document.body.removeChild(textarea);
+  return copiedText;
 }
 </script>
 
@@ -167,122 +207,6 @@ function copyInstall() {
 }
 
 /* ═══════════════════════════════════════════
-   CHEF LOGO — commanding centerpiece
-   ═══════════════════════════════════════════ */
-.hero-chef-logo {
-  display: flex;
-  justify-content: flex-start;
-  margin-bottom: 12px;
-}
-
-.hero-chef-logo .chef-logo {
-  width: 420px;
-  max-width: 90vw;
-  height: auto;
-  filter: drop-shadow(0 4px 20px rgba(139, 34, 82, 0.15));
-  transition: filter 0.4s ease;
-}
-
-.hero-chef-logo .chef-logo:hover {
-  filter: drop-shadow(0 8px 32px rgba(139, 34, 82, 0.25));
-}
-
-/* Light mode: show light (black) logo, hide dark */
-.hero-chef-logo .chef-logo-dark {
-  display: none;
-}
-
-/* Dark mode: swap logos */
-.dark .hero-chef-logo .chef-logo-light {
-  display: none;
-}
-
-.dark .hero-chef-logo .chef-logo-dark {
-  display: inline;
-}
-
-.dark .hero-chef-logo .chef-logo {
-  filter: drop-shadow(0 4px 24px rgba(199, 91, 122, 0.2));
-}
-
-.dark .hero-chef-logo .chef-logo:hover {
-  filter: drop-shadow(0 8px 40px rgba(199, 91, 122, 0.35));
-}
-
-@keyframes heroLogoIn {
-  from {
-    opacity: 0;
-    transform: translateY(-30px) scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-/* ═══════════════════════════════════════════
-   AUBE PROMO — compact cross-project banner
-   ═══════════════════════════════════════════ */
-.hero-aube-banner {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
-  width: 100%;
-  padding: 8px 12px;
-  color: var(--vp-c-text-1);
-  background:
-    linear-gradient(90deg, rgba(107, 127, 78, 0.12), rgba(139, 34, 82, 0.08)),
-    var(--vp-c-bg-soft);
-  border: 1px solid rgba(107, 127, 78, 0.35);
-  border-radius: 8px;
-  text-decoration: none;
-  box-shadow: 0 8px 24px rgba(26, 18, 16, 0.06);
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    transform 0.2s ease;
-}
-
-.hero-aube-banner:hover {
-  border-color: var(--vp-c-brand-1);
-  box-shadow: 0 12px 32px rgba(139, 34, 82, 0.12);
-  transform: translateY(-1px);
-}
-
-.dark .hero-aube-banner {
-  background:
-    linear-gradient(90deg, rgba(143, 168, 110, 0.14), rgba(199, 91, 122, 0.1)),
-    var(--vp-c-bg-soft);
-  border-color: rgba(143, 168, 110, 0.35);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
-}
-
-.aube-kicker {
-  font-family: "Roc Grotesk", sans-serif;
-  font-size: 0.72rem;
-  line-height: 1;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.aube-kicker {
-  color: #6B7F4E;
-}
-
-.dark .aube-kicker {
-  color: #8FA86E;
-}
-
-.aube-message {
-  min-width: 0;
-  font-size: 0.78rem;
-  line-height: 1.25;
-  color: var(--vp-c-text-2);
-}
-
-/* ═══════════════════════════════════════════
    INSTALL COMMAND — signature dish
    ═══════════════════════════════════════════ */
 .hero-install {
@@ -290,16 +214,6 @@ function copyInstall() {
   flex-direction: column;
   align-items: flex-start;
   margin-top: 0;
-}
-
-.install-label {
-  font-family: "Roc Grotesk", sans-serif;
-  font-weight: 400;
-  font-size: 0.75rem;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: var(--vp-c-text-3);
-  margin-bottom: 8px;
 }
 
 .install-command {
@@ -355,15 +269,12 @@ function copyInstall() {
   margin-top: 10px;
   font-size: 0.85rem;
   font-family: "Roc Grotesk", sans-serif;
-}
-
-.install-alt a {
   color: var(--vp-c-text-3);
   text-decoration: none;
   transition: color 0.2s ease;
 }
 
-.install-alt a:hover {
+.install-alt:hover {
   color: var(--vp-c-brand-1);
 }
 
@@ -382,19 +293,6 @@ function copyInstall() {
    RESPONSIVE
    ═══════════════════════════════════════════ */
 @media (max-width: 768px) {
-  .hero-chef-logo .chef-logo {
-    max-width: 280px;
-  }
-
-  .hero-aube-banner {
-    align-items: center;
-    text-align: center;
-  }
-
-  .aube-message {
-    font-size: 0.85rem;
-  }
-
   .hero-glow-1 { width: 350px; height: 350px; }
   .hero-glow-2 { width: 300px; height: 300px; }
   .hero-glow-3 { width: 250px; height: 250px; }
@@ -404,9 +302,4 @@ function copyInstall() {
   }
 }
 
-@media (max-width: 480px) {
-  .hero-chef-logo .chef-logo {
-    max-width: 220px;
-  }
-}
 </style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -419,13 +419,6 @@ h1, h2, h3, h4, h5, h6,
   gap: 0 60px;
 }
 
-/* Left column: logo */
-.VPHero .main .hero-chef-logo {
-  grid-column: 1;
-  grid-row: 1;
-  justify-content: flex-start;
-}
-
 /* Hide the default VitePress hero name and actions */
 .VPHero .name {
   display: none !important;
@@ -463,6 +456,7 @@ h1, h2, h3, h4, h5, h6,
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+  margin-top: 12px;
 }
 
 .action-btn {
@@ -709,7 +703,7 @@ div[class*="language-"] .copy:hover {
 
 .VPFeature {
   border: 1px solid var(--vp-c-divider);
-  border-radius: 14px;
+  border-radius: 8px;
   transition: all 0.35s cubic-bezier(0.22, 1, 0.36, 1) !important;
   background: var(--vp-c-bg);
   position: relative;
@@ -935,12 +929,6 @@ div[class*="language-"] .copy:hover {
     grid-template-columns: 1fr !important;
   }
 
-  .VPHero .main .hero-chef-logo {
-    grid-column: 1;
-    grid-row: auto;
-    justify-content: center;
-  }
-
   .VPHero .tagline {
     grid-column: 1;
     grid-row: auto;
@@ -1008,4 +996,707 @@ div[class*="language-"] .copy:hover {
   background-color: var(--vp-c-danger-soft);
   color: var(--vp-c-danger-1);
   border: 1px solid var(--vp-c-danger-2);
+}
+
+/* ═══ Claude Design handoff landing page ═══ */
+.VPHero .name,
+.VPHero .tagline,
+.VPHero .actions {
+  display: none !important;
+}
+
+.VPHero {
+  padding-top: 76px !important;
+  padding-bottom: 64px !important;
+}
+
+.VPHero .container {
+  max-width: 1120px !important;
+}
+
+.VPHero .main {
+  display: grid !important;
+  grid-template-columns: minmax(0, 0.95fr) minmax(360px, 1.05fr);
+  gap: 56px;
+  align-items: center;
+}
+
+.VPHero .text {
+  max-width: none !important;
+}
+
+.VPContent.is-home,
+.VPHome {
+  overflow-x: hidden;
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.hero-eyebrow,
+.landing-kicker {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.72rem !important;
+  line-height: 1.3 !important;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+}
+
+.hero-eyebrow::before,
+.landing-kicker::before {
+  content: "";
+  display: inline-block;
+  width: 24px;
+  height: 1px;
+  margin-right: 10px;
+  vertical-align: middle;
+  background: currentColor;
+}
+
+.hero-lockup {
+  margin-top: 18px;
+}
+
+.hero-lockup .chef-logo {
+  width: min(340px, 72vw);
+  height: auto;
+  filter: drop-shadow(0 12px 34px rgba(139, 34, 82, 0.16));
+}
+
+.hero-lockup .chef-logo-dark {
+  display: none;
+}
+
+.dark .hero-lockup .chef-logo-light {
+  display: none;
+}
+
+.dark .hero-lockup .chef-logo-dark {
+  display: inline;
+}
+
+.hero-copy h1 {
+  margin: 22px 0 0;
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-size: clamp(3.4rem, 7vw, 5.75rem);
+  font-style: italic;
+  font-weight: 300;
+  line-height: 0.95;
+  letter-spacing: 0;
+  color: var(--vp-c-brand-1);
+}
+
+.hero-copy h1 em,
+.landing-section h2 em {
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-style: italic;
+  font-weight: 300;
+  color: inherit;
+}
+
+.hero-copy p {
+  max-width: min(42ch, 100%);
+  margin: 22px 0 0;
+  color: var(--vp-c-text-2);
+  font-size: 1.1rem;
+  line-height: 1.65;
+  overflow-wrap: break-word;
+}
+
+.hero-right {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+.hero-terminal {
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 22px 48px -28px rgba(0, 0, 0, 0.5);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.82rem;
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-mute);
+}
+
+.terminal-bar span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.terminal-bar span:nth-child(1) {
+  background: var(--vp-c-danger-1);
+}
+
+.terminal-bar span:nth-child(2) {
+  background: var(--vp-c-warning-1);
+}
+
+.terminal-bar span:nth-child(3) {
+  background: var(--vp-c-success-1);
+}
+
+.terminal-bar strong {
+  margin-left: auto;
+  margin-right: auto;
+  color: var(--vp-c-text-3);
+  font-size: 0.68rem;
+  font-weight: 400;
+  letter-spacing: 0.08em;
+}
+
+.terminal-body {
+  padding: 18px 20px;
+  color: var(--vp-c-text-1);
+  line-height: 1.75;
+  white-space: nowrap;
+  overflow: auto;
+}
+
+.terminal-body .prompt {
+  color: var(--vp-c-brand-1);
+}
+
+.terminal-body .ok {
+  color: var(--vp-c-success-1);
+}
+
+.terminal-body .key {
+  color: var(--vp-c-warning-1);
+}
+
+.terminal-body .dim {
+  color: var(--vp-c-text-3);
+}
+
+.hero-install {
+  align-items: stretch;
+}
+
+.hero-install .install-command {
+  width: 100%;
+  justify-content: space-between;
+  border-radius: 8px;
+  font-size: 0.88rem;
+}
+
+.hero-install .install-copy {
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-install .install-alt {
+  align-self: flex-start;
+}
+
+.VPHome .vp-doc {
+  max-width: none;
+  padding: 0 24px 80px;
+}
+
+.landing-page {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.landing-section {
+  margin-top: 76px;
+}
+
+.landing-metaphor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.9fr);
+  gap: 64px;
+  align-items: center;
+  padding-top: 72px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.landing-section h2 {
+  margin: 12px 0 0;
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-style: italic;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: 0;
+  color: var(--vp-c-brand-1);
+}
+
+.landing-section p {
+  color: var(--vp-c-text-2);
+}
+
+.landing-definition {
+  padding: 22px;
+  border-left: 2px solid var(--vp-c-brand-1);
+  border-radius: 0 8px 8px 0;
+  background: var(--vp-c-bg-soft);
+}
+
+.definition-word {
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-size: 1.7rem;
+  font-style: italic;
+  color: var(--vp-c-text-1);
+}
+
+.definition-word span {
+  margin-left: 8px;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.8rem;
+  color: var(--vp-c-text-3);
+}
+
+.landing-section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 34px;
+}
+
+.landing-section-heading.centered {
+  display: block;
+  max-width: 720px;
+  margin-right: auto;
+  margin-left: auto;
+  text-align: center;
+}
+
+.landing-section-heading.centered .landing-kicker::before,
+.landing-cta .landing-kicker::before {
+  display: none;
+}
+
+.landing-small-button,
+.landing-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 16px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+}
+
+.landing-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.landing-feature-card {
+  position: relative;
+  min-width: 0;
+  min-height: 260px;
+  padding: 28px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  text-decoration: none !important;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.landing-feature-card:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 44px -32px rgba(139, 34, 82, 0.45);
+}
+
+.card-number,
+.card-link {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  color: var(--vp-c-text-3);
+}
+
+.card-icon {
+  position: absolute;
+  top: 22px;
+  right: 22px;
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 50%;
+  background: var(--vp-c-bg);
+  font-size: 1.55rem;
+}
+
+.landing-feature-card h3 {
+  margin: 70px 0 10px;
+  font-family: "Roc Grotesk", sans-serif;
+  font-size: 2rem;
+  font-weight: 500;
+  line-height: 1.05;
+}
+
+.landing-feature-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.card-link {
+  display: inline-block;
+  margin-top: 20px;
+  color: var(--vp-c-brand-1);
+}
+
+.landing-tools {
+  position: relative;
+  width: 100vw;
+  margin: 76px calc(50% - 50vw) 0;
+  padding: 28px 0;
+  overflow: hidden;
+  border-top: 1px solid var(--vp-c-divider);
+  border-bottom: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+}
+
+.landing-tools p {
+  margin: 0 0 14px;
+  text-align: center;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+}
+
+.landing-tools-track {
+  display: flex;
+  gap: 42px;
+  width: max-content;
+  animation: landing-scroll 60s linear infinite;
+}
+
+.landing-tools-track a {
+  white-space: nowrap;
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-style: italic;
+  font-size: 1.75rem;
+  font-weight: 300;
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+}
+
+@keyframes landing-scroll {
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.landing-aube {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.42fr);
+  gap: 28px;
+  align-items: center;
+  margin: 48px auto 0;
+  padding: 28px;
+  border: 1px solid rgba(107, 127, 78, 0.35);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(107, 127, 78, 0.12), transparent 44%),
+    var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  text-decoration: none !important;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.landing-aube:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 44px -32px rgba(107, 127, 78, 0.55);
+}
+
+.dark .landing-aube {
+  background:
+    linear-gradient(135deg, rgba(143, 168, 110, 0.14), transparent 48%),
+    var(--vp-c-bg-soft);
+  border-color: rgba(143, 168, 110, 0.35);
+}
+
+.landing-aube h2 {
+  margin: 12px 0 0;
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-size: clamp(2.2rem, 4vw, 3.4rem);
+  font-style: italic;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: 0;
+  color: var(--vp-c-brand-1);
+}
+
+.landing-aube h2 em {
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-style: italic;
+  font-weight: 300;
+  color: inherit;
+}
+
+.landing-aube p:not(.landing-kicker) {
+  max-width: 58ch;
+  margin: 16px 0 0;
+  color: var(--vp-c-text-2);
+}
+
+.aube-ticket {
+  display: flex;
+  align-items: center;
+  width: 220px;
+  max-width: 100%;
+  min-height: 86px;
+  padding: 0 22px;
+  border: 1px dashed rgba(107, 127, 78, 0.5);
+  border-radius: 8px;
+  background: var(--vp-c-bg);
+}
+
+.aube-ticket code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 1.35rem;
+  line-height: 1;
+  background: transparent;
+  color: var(--vp-c-success-1);
+}
+
+.landing-recipe-grid {
+  display: grid;
+  position: relative;
+  grid-template-columns: 260px minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+}
+
+.landing-mini-install {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  padding: 0 16px;
+  overflow: auto;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.88rem;
+}
+
+.landing-quickstart {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  gap: 48px;
+}
+
+.recipe-steps {
+  padding: 20px 0;
+  border-right: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+}
+
+.recipe-tab-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.recipe-step {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin: 0;
+  padding: 14px 18px;
+  border-left: 2px solid transparent;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.recipe-step:hover {
+  background: color-mix(in srgb, var(--vp-c-brand-1) 8%, transparent);
+  color: var(--vp-c-text-1);
+}
+
+#recipe-tab-1:checked ~ .recipe-steps .recipe-step-1,
+#recipe-tab-2:checked ~ .recipe-steps .recipe-step-2,
+#recipe-tab-3:checked ~ .recipe-steps .recipe-step-3,
+#recipe-tab-4:checked ~ .recipe-steps .recipe-step-4 {
+  border-left: 2px solid var(--vp-c-brand-1);
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+}
+
+.recipe-steps span {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.72rem;
+  color: var(--vp-c-text-3);
+}
+
+.recipe-panel {
+  display: none;
+  height: 100%;
+}
+
+#recipe-tab-1:checked ~ .landing-code .recipe-panel-1,
+#recipe-tab-2:checked ~ .landing-code .recipe-panel-2,
+#recipe-tab-3:checked ~ .landing-code .recipe-panel-3,
+#recipe-tab-4:checked ~ .landing-code .recipe-panel-4 {
+  display: block;
+}
+
+.landing-code pre {
+  height: 100%;
+  min-height: 280px;
+  margin: 0;
+  padding: 24px;
+  overflow: auto;
+  border: 0;
+  border-radius: 0;
+  background: var(--vp-code-block-bg);
+  color: var(--vp-c-text-1);
+}
+
+.landing-code code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.88rem;
+  line-height: 1.8;
+}
+
+.landing-cta {
+  padding: 64px 28px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background:
+    radial-gradient(600px 260px at 50% 0%, rgba(139, 34, 82, 0.14), transparent),
+    var(--vp-c-bg-soft);
+  text-align: center;
+}
+
+.landing-cta h2 {
+  color: var(--vp-c-text-1);
+  font-family: "Roc Grotesk", sans-serif;
+  font-style: normal;
+  margin-bottom: 24px;
+}
+
+.landing-cta h2 em {
+  color: var(--vp-c-brand-1);
+}
+
+.landing-cta .landing-mini-install {
+  max-width: 460px;
+  margin: 0 auto;
+  justify-content: center;
+}
+
+.landing-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 22px;
+}
+
+@media (max-width: 960px) {
+  .VPHero .main,
+  .landing-aube,
+  .landing-metaphor,
+  .landing-quickstart,
+  .landing-recipe-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  .landing-feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .recipe-steps {
+    border-right: 0;
+    border-bottom: 1px solid var(--vp-c-divider);
+  }
+
+  .landing-section-heading {
+    display: block;
+  }
+}
+
+@media (max-width: 640px) {
+  .VPHero {
+    padding-top: 42px !important;
+    padding-bottom: 48px !important;
+  }
+
+  .VPHero .container {
+    padding-right: 24px !important;
+    padding-left: 24px !important;
+  }
+
+  .hero-copy h1 {
+    font-size: 2.75rem;
+  }
+
+  .hero-lockup .chef-logo {
+    width: min(260px, 100%);
+  }
+
+  .hero-copy p {
+    font-size: 1rem;
+    max-width: 30ch;
+  }
+
+  .terminal-body {
+    font-size: 0.76rem;
+  }
+
+  .landing-section {
+    margin-top: 54px;
+  }
+
+  .landing-aube {
+    margin-top: 40px;
+    padding: 22px;
+  }
+
+  .landing-metaphor {
+    padding-top: 48px;
+  }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,28 +5,123 @@ title: Home
 hero:
   name: mise-en-place
   tagline: The front-end to your dev env
-  actions:
-    - theme: brand
-      text: Getting Started
-      link: /getting-started
-    - theme: alt
-      text: Demo
-      link: /demo
-    - theme: alt
-      text: About
-      link: /about
-
-features:
-  - title: Dev Tools
-    link: /dev-tools/
-    icon: 🔪
-    details: A polyglot tool version manager. Replaces asdf, nvm, pyenv, rbenv, and more — one tool for every language.
-  - title: Environments
-    details: Switch sets of environment variables per project directory. A smarter, simpler replacement for direnv.
-    icon: 🫕
-    link: /environments/
-  - title: Tasks
-    link: /tasks/
-    details: A powerful task runner that replaces make and npm scripts. Define, compose, and run with ease.
-    icon: 🍳
 ---
+
+<section class="landing-page" aria-label="mise overview">
+  <div class="landing-section landing-metaphor">
+    <div>
+      <p class="landing-kicker">The Idea</p>
+      <h2>Everything in its place, <em>before</em> you code.</h2>
+      <p>
+        In a professional kitchen, <em>mise en place</em> is the ritual of prep:
+        knives sharpened, onions diced, stock warm, station clean. The work
+        before the work.
+      </p>
+      <p>
+        mise does the same for your dev env. It activates the right language
+        versions, loads the right env vars, and wires up the right tasks for
+        the commands you run.
+      </p>
+    </div>
+    <div class="landing-definition">
+      <div class="definition-word">mise en place <span>/meez ahn plahs/</span></div>
+      <p>1. the gathering and arrangement of ingredients and tools before cooking.</p>
+      <p>2. a polyglot tool that keeps your project tools, env, and tasks in one place.</p>
+    </div>
+  </div>
+
+  <div class="landing-section landing-menu">
+    <div class="landing-section-heading">
+      <p class="landing-kicker">The Menu</p>
+      <h2>Three dishes, one kitchen.</h2>
+      <a href="/getting-started" class="landing-small-button">All docs</a>
+    </div>
+    <div class="landing-feature-grid">
+      <a href="/dev-tools/" class="landing-feature-card">
+        <span class="card-number">— 01</span>
+        <span class="card-icon">🔪</span>
+        <h3>Dev Tools</h3>
+        <p>A polyglot tool version manager. Replaces asdf, nvm, pyenv, rbenv, and more — one tool for every language.</p>
+        <span class="card-link">read more →</span>
+      </a>
+      <a href="/environments/" class="landing-feature-card">
+        <span class="card-number">— 02</span>
+        <span class="card-icon">🫕</span>
+        <h3>Environments</h3>
+        <p>Switch sets of environment variables per project directory. A smarter, simpler replacement for direnv.</p>
+        <span class="card-link">read more →</span>
+      </a>
+      <a href="/tasks/" class="landing-feature-card">
+        <span class="card-number">— 03</span>
+        <span class="card-icon">🍳</span>
+        <h3>Tasks</h3>
+        <p>A powerful task runner that replaces make and npm scripts. Define, compose, and run with ease.</p>
+        <span class="card-link">read more →</span>
+      </a>
+    </div>
+  </div>
+
+  <div class="landing-tools" aria-label="Supported tools">
+    <p>— pantry · 900+ tools, 1 toml file —</p>
+    <div class="landing-tools-track">
+      <a href="https://mise-versions.jdx.dev/tools/node">node</a><a href="https://mise-versions.jdx.dev/tools/python">python</a><a href="https://mise-versions.jdx.dev/tools/ruby">ruby</a><a href="https://mise-versions.jdx.dev/tools/go">go</a><a href="https://mise-versions.jdx.dev/tools/rust">rust</a><a href="https://mise-versions.jdx.dev/tools/java">java</a><a href="https://mise-versions.jdx.dev/tools/deno">deno</a><a href="https://mise-versions.jdx.dev/tools/bun">bun</a><a href="https://mise-versions.jdx.dev/tools/terraform">terraform</a><a href="https://mise-versions.jdx.dev/tools/kubectl">kubectl</a><a href="https://mise-versions.jdx.dev/tools/zig">zig</a><a href="https://mise-versions.jdx.dev/tools/swift">swift</a><a href="https://mise-versions.jdx.dev/tools/php">php</a><a href="https://mise-versions.jdx.dev/tools/elixir">elixir</a><a href="https://mise-versions.jdx.dev/tools/node">node</a><a href="https://mise-versions.jdx.dev/tools/python">python</a><a href="https://mise-versions.jdx.dev/tools/ruby">ruby</a><a href="https://mise-versions.jdx.dev/tools/go">go</a><a href="https://mise-versions.jdx.dev/tools/rust">rust</a><a href="https://mise-versions.jdx.dev/tools/java">java</a><a href="https://mise-versions.jdx.dev/tools/deno">deno</a><a href="https://mise-versions.jdx.dev/tools/bun">bun</a><a href="https://mise-versions.jdx.dev/tools/terraform">terraform</a><a href="https://mise-versions.jdx.dev/tools/kubectl">kubectl</a><a href="https://mise-versions.jdx.dev/tools/zig">zig</a><a href="https://mise-versions.jdx.dev/tools/swift">swift</a><a href="https://mise-versions.jdx.dev/tools/php">php</a><a href="https://mise-versions.jdx.dev/tools/elixir">elixir</a>
+    </div>
+  </div>
+
+  <a class="landing-aube" href="https://aube.en.dev/" aria-label="Try aube">
+    <div>
+      <p class="landing-kicker">Chef's Special</p>
+      <h2>Meet <em>aube</em>, a fast Node.js package manager.</h2>
+      <p>
+        New from en.dev by @jdx. aube uses your existing lockfile and is ready
+        to try in beta.
+      </p>
+    </div>
+    <div class="aube-ticket" aria-hidden="true">
+      <code>$ aube</code>
+    </div>
+  </a>
+
+  <div class="landing-section landing-quickstart">
+    <div>
+      <p class="landing-kicker">The Recipe</p>
+      <h2>Four steps to a prepped station.</h2>
+    </div>
+    <div class="landing-recipe-grid">
+      <input class="recipe-tab-input" type="radio" name="recipe-tab" id="recipe-tab-1" checked />
+      <input class="recipe-tab-input" type="radio" name="recipe-tab" id="recipe-tab-2" />
+      <input class="recipe-tab-input" type="radio" name="recipe-tab" id="recipe-tab-3" />
+      <input class="recipe-tab-input" type="radio" name="recipe-tab" id="recipe-tab-4" />
+      <div class="recipe-steps" aria-label="Recipe steps">
+        <label class="recipe-step recipe-step-1" for="recipe-tab-1"><span>01</span> Install mise</label>
+        <label class="recipe-step recipe-step-2" for="recipe-tab-2"><span>02</span> Add and install tools</label>
+        <label class="recipe-step recipe-step-3" for="recipe-tab-3"><span>03</span> Load env vars</label>
+        <label class="recipe-step recipe-step-4" for="recipe-tab-4"><span>04</span> Define tasks</label>
+      </div>
+      <div class="landing-code">
+        <div class="recipe-panel recipe-panel-1">
+          <pre><code>$ curl https://mise.run | sh<br />✓ mise installed<br /><br />$ mise doctor<br />✓ mise is ready</code></pre>
+        </div>
+        <div class="recipe-panel recipe-panel-2">
+          <pre><code>$ mise use node@24 python@3.13 terraform@1<br />✓ wrote mise.toml<br /><br />$ mise install<br />✓ installed 3 tools</code></pre>
+        </div>
+        <div class="recipe-panel recipe-panel-3">
+          <pre><code>$ cat .env.local<br />DATABASE_URL=postgres://localhost/orders<br /><br />$ mise env -s bash<br />export DATABASE_URL=postgres://localhost/orders</code></pre>
+        </div>
+        <div class="recipe-panel recipe-panel-4">
+          <pre><code>$ mise run test<br />→ lint · typecheck · unit · e2e<br />✓ 4 tasks complete<br /><br />$ mise run deploy<br />✓ shipped</code></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="landing-section landing-cta">
+    <p class="landing-kicker">Ready When You Are</p>
+    <h2><em>Allez,</em> prep your station.</h2>
+    <div class="landing-mini-install"><code>curl https://mise.run | sh</code></div>
+    <div class="landing-links">
+      <a href="/getting-started">Getting started</a>
+      <a href="/demo">Run the demo</a>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary

- implement the exported landing-page design on the VitePress homepage
- replace the default home feature cards with the hero, metaphor, feature menu, pantry ticker, comparison, quickstart, and CTA sections
- keep every pantry ticker item in the same serif font

## Validation

- npm run docs:build
- pre-commit hook via git commit, including prettier, cargo-fmt, cargo-check, shellcheck, shfmt, pkl, taplo, lua-check, stylua, actionlint, markdownlint, and schema

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large homepage markup/CSS overhaul that could introduce layout/regression issues across breakpoints and dark mode, but it’s confined to docs presentation (no runtime/business logic).
> 
> **Overview**
> Replaces the VitePress homepage’s default hero/actions/features with a custom, design-driven landing experience (new hero copy, terminal-style workflow preview, metaphor/menu sections, scrolling “pantry” ticker, quickstart recipe tabs, and CTA) in `docs/index.md` and theme overrides.
> 
> Updates `Layout.vue` to render the new hero structure, remove the old logo-centric and promo banner UI, and improve the install command copy behavior with a clipboard API fallback. Adds substantial new landing-page CSS (grid/typography/components/responsive rules) and tweaks existing styles (e.g., feature card radius, hero actions spacing) to match the new layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda8d165e8831371d888a66476ba55e93590df79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->