### PR TITLE
docs: add en.dev footer

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -240,11 +240,7 @@ export default withMermaid(
           insights: true,
         },
       },
-      footer: {
-        message:
-          'Licensed under the MIT License. Maintained by <a href="https://github.com/jdx">@jdx</a> and <a href="https://github.com/jdx/mise/graphs/contributors">friends</a>.',
-        copyright: `Copyright © ${new Date().getFullYear()} <a href="https://github.com/jdx">@jdx</a>`,
-      },
+      footer: false,
       carbonAds: {
         code: "CWYIPKQN",
         placement: "misejdxdev",

--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -1,0 +1,22 @@
+<template>
+  <footer class="EndevFooter">
+    <span>MIT License</span>
+    <span aria-hidden="true">·</span>
+    <span>Copyright © {{ year }}</span>
+    <span aria-hidden="true">·</span>
+    <a class="EndevFooterLink" href="https://en.dev">
+      <img
+        alt=""
+        class="EndevFooterLogo"
+        height="28"
+        src="https://github.com/endevco.png?size=96"
+        width="28"
+      />
+      <span>en.dev</span>
+    </a>
+  </footer>
+</template>
+
+<script setup lang="ts">
+const year = new Date().getFullYear();
+</script>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -48,12 +48,17 @@
         </div>
       </div>
     </template>
+
+    <template #layout-bottom>
+      <EndevFooter />
+    </template>
   </DefaultTheme.Layout>
 </template>
 
 <script setup lang="ts">
 import DefaultTheme from "vitepress/theme";
 import { ref } from "vue";
+import EndevFooter from "./EndevFooter.vue";
 
 const copied = ref(false);
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -235,6 +235,43 @@
   color: var(--vp-c-brand-1);
 }
 
+.EndevFooter {
+  align-items: center;
+  border-top: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 14px;
+  gap: 8px;
+  justify-content: center;
+  line-height: 28px;
+  margin-top: auto;
+  padding: 22px 24px 26px;
+  text-align: center;
+}
+
+.EndevFooterLink {
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  gap: 8px;
+  line-height: 28px;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.EndevFooterLink:hover {
+  color: var(--vp-c-brand-1);
+}
+
+.EndevFooterLogo {
+  border-radius: 8px;
+  display: inline-block;
+  height: 28px;
+  vertical-align: middle;
+  width: 28px;
+}
+
 /* Hide star count on mobile to save space */
 @media (max-width: 640px) {
   .VPSocialLinks .star-count {


### PR DESCRIPTION
## Summary

- Add a custom VitePress footer matching the aube.en.dev footer style.
- Keep the visible brand mention to a single `en.dev` by using `MIT License · Copyright © YEAR · en.dev`.
- Disable the built-in VitePress footer so only the custom footer renders.

## Validation

- `mise run docs:build`
- commit hook: `hk` lint suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation theme-only changes that affect site layout/styling but not runtime logic beyond the docs build.
> 
> **Overview**
> Replaces the built-in VitePress footer with a custom `EndevFooter` component that renders `MIT License · Copyright © YEAR · en.dev` (with logo/link) at the bottom of the docs layout.
> 
> Updates the docs theme layout to inject the new footer via `#layout-bottom`, and adds accompanying CSS styles for the new footer elements in `custom.css`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4678b1122732d9e870c0339ec95f8a274b143ff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->