### PR TITLE
chore(release): add en.dev sponsor blurb to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,6 +384,16 @@ jobs:
             mise x -- git cliff --strip all --latest > /tmp/release-notes.txt 2>/dev/null || echo "Release $VERSION" > /tmp/release-notes.txt
             echo "RELEASE_TITLE=$VERSION" >> "$GITHUB_ENV"
           fi
+          cat >> /tmp/release-notes.txt <<'EOF'
+
+          ---
+
+          ## 💚 Sponsor mise
+
+          mise is built by [@jdx](https://github.com/jdx) under [**en.dev**](https://en.dev) — an independent studio making developer tooling (mise, [aube](https://aube.en.dev/), and more). Development is funded by sponsors.
+
+          If mise saves you or your team time, please consider sponsoring at [en.dev](https://en.dev). Individual and company sponsorships keep mise fast, free, and independent.
+          EOF
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       - name: Create Draft GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,8 +386,6 @@ jobs:
           fi
           cat >> /tmp/release-notes.txt <<'EOF'
 
-          ---
-
           ## 💚 Sponsor mise
 
           mise is built by [@jdx](https://github.com/jdx) under [**en.dev**](https://en.dev) — an independent studio making developer tooling (mise, [aube](https://aube.en.dev/), and more). Development is funded by sponsors.


### PR DESCRIPTION
## Summary

- Appends a short **en.dev** explainer + sponsor CTA to every GitHub Release body, so readers who land on a release (via install docs, changelog links, etc.) see how mise is funded and where to sponsor.
- Added in the `Generate release notes` step in [`.github/workflows/release.yml`](.github/workflows/release.yml) after both code paths — the `communique` output and the `git-cliff` fallback — so the blurb shows up regardless of which produced the notes.

## What it looks like

Rendered at the bottom of each release body:

> ## 💚 Sponsor mise
>
> mise is built by [@jdx](https://github.com/jdx) under [**en.dev**](https://en.dev) — an independent studio making developer tooling (mise, [aube](https://aube.en.dev/), and more). Development is funded by sponsors.
>
> If mise saves you or your team time, please consider sponsoring at [en.dev](https://en.dev). Individual and company sponsorships keep mise fast, free, and independent.

## Test plan

- [x] `actionlint .github/workflows/release.yml` passes
- [x] `yamllint .github/workflows/release.yml` passes
- [x] Simulated the heredoc locally to confirm bash strips YAML indentation and the markdown renders as intended
- [ ] Next tagged release produces a GitHub Release whose body ends with the sponsor section

🤖 Generated with [Claude Code](https://claude.com/claude-code)