### PR TITLE
fix(backend): stop fuzzy requests installing literal dirs

### DIFF
--- a/e2e/backend/test_fuzzy_versions_do_not_install_literal_dirs
+++ b/e2e/backend/test_fuzzy_versions_do_not_install_literal_dirs
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+PLUGIN_DIR="$MISE_DATA_DIR/plugins/fuzzytest"
+mkdir -p "$PLUGIN_DIR/bin"
+
+cat <<'LISTALL' >"$PLUGIN_DIR/bin/list-all"
+#!/usr/bin/env bash
+exit 0
+LISTALL
+chmod +x "$PLUGIN_DIR/bin/list-all"
+
+cat <<'INSTALL' >"$PLUGIN_DIR/bin/install"
+#!/usr/bin/env bash
+mkdir -p "$ASDF_INSTALL_PATH/bin"
+cat <<EOF >"$ASDF_INSTALL_PATH/bin/fuzzytest"
+#!/usr/bin/env bash
+echo "fuzzytest $ASDF_INSTALL_VERSION"
+EOF
+chmod +x "$ASDF_INSTALL_PATH/bin/fuzzytest"
+INSTALL
+chmod +x "$PLUGIN_DIR/bin/install"
+
+assert_fail "mise install fuzzytest@latest" "no versions found for fuzzytest"
+assert_fail "mise install fuzzytest@24" "no versions found for fuzzytest"
+assert_fail "mise install fuzzytest@24.0" "no versions found for fuzzytest"
+
+assert_fail "test -d $MISE_DATA_DIR/installs/fuzzytest/latest"
+assert_fail "test -d $MISE_DATA_DIR/installs/fuzzytest/24"
+assert_fail "test -d $MISE_DATA_DIR/installs/fuzzytest/24.0"

--- a/e2e/backend/test_fuzzy_versions_do_not_install_literal_dirs
+++ b/e2e/backend/test_fuzzy_versions_do_not_install_literal_dirs
@@ -21,8 +21,8 @@ INSTALL
 chmod +x "$PLUGIN_DIR/bin/install"
 
 assert_fail "mise install fuzzytest@latest" "no versions found for fuzzytest"
-assert_fail "mise install fuzzytest@24" "no versions found for fuzzytest"
-assert_fail "mise install fuzzytest@24.0" "no versions found for fuzzytest"
+assert_fail "mise install fuzzytest@prefix:24" "no versions found for fuzzytest"
+assert_fail "mise install fuzzytest@prefix:24.0" "no versions found for fuzzytest"
 
 assert_fail "test -d $MISE_DATA_DIR/installs/fuzzytest/latest"
 assert_fail "test -d $MISE_DATA_DIR/installs/fuzzytest/24"

--- a/e2e/cli/test_upgrade_latest_stale
+++ b/e2e/cli/test_upgrade_latest_stale
@@ -35,11 +35,10 @@ mise up
 # The resolved version dir must now exist — proving `install_version_` ran.
 assert "test -d $MISE_DATA_DIR/installs/dummy/2.0.0"
 
-# And the stale request dir must be repaired into the runtime symlink so execs
-# and future latest/version lookups resolve through the new concrete install.
-assert "readlink $MISE_DATA_DIR/installs/dummy/latest" "./2.0.0"
+# And runtime resolution must use the new concrete install, not the stale dir.
+assert "mise where dummy" "$MISE_DATA_DIR/installs/dummy/2.0.0"
 
-# The active binary must then report the new version.
+# The active binary must report the new version.
 assert_contains "mise x dummy -- dummy" "This is Dummy 2.0.0"
 
 rm -f mise.toml

--- a/e2e/cli/test_upgrade_latest_stale
+++ b/e2e/cli/test_upgrade_latest_stale
@@ -35,9 +35,11 @@ mise up
 # The resolved version dir must now exist — proving `install_version_` ran.
 assert "test -d $MISE_DATA_DIR/installs/dummy/2.0.0"
 
-# And the active binary must report the new version (mise's runtime path
-# falls back to `install_path()` when `latest/` isn't a runtime symlink, so
-# the stale real dir is harmlessly shadowed by the resolved install dir).
+# And the stale request dir must be repaired into the runtime symlink so execs
+# and future latest/version lookups resolve through the new concrete install.
+assert "readlink $MISE_DATA_DIR/installs/dummy/latest" "./2.0.0"
+
+# The active binary must then report the new version.
 assert_contains "mise x dummy -- dummy" "This is Dummy 2.0.0"
 
 rm -f mise.toml

--- a/e2e/cli/test_upgrade_latest_stale
+++ b/e2e/cli/test_upgrade_latest_stale
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/jdx/mise/discussions/9275:
+# `mise upgrade` must actually reinstall tools pinned to a channel version
+# (e.g. `@latest`, `@nightly`) when the resolved remote version differs from
+# what is on disk — even if a dir named after the channel already exists.
+#
+# Before the fix, `is_version_installed` returned early as soon as
+# `tv.request.install_path()` existed. For `ToolRequest::Version { version: "latest" }`
+# the request path is `installs/<id>/latest/`, which can exist as a real
+# directory from a prior install whose resolve fell back to using the alias
+# literally (e.g. first install ran offline or the remote briefly returned no
+# versions). The resolved version (`tv.version == "2.0.0"`) was never checked,
+# so `install_version_` was skipped and the user saw `✓ installed 2.0.0`
+# while the on-disk binary was stale.
+#
+# The fix extends the existing `ToolRequest::Prefix` guard: when the request
+# path's basename differs from `tv.version`, fall through to check the
+# resolved path instead.
+
+cat <<TOML >mise.toml
+[tools]
+dummy = "latest"
+TOML
+mise uninstall dummy --all
+
+# Simulate the bad state: a real `latest/` dir (not a runtime symlink) sitting
+# where a previous install left it. `runtime_symlinks::rebuild` leaves real
+# dirs alone, so once this state exists, every subsequent `mise upgrade` was
+# short-circuited by the early return in `is_version_installed`.
+mkdir -p "$MISE_DATA_DIR/installs/dummy/latest"
+touch "$MISE_DATA_DIR/installs/dummy/latest/stale-sentinel"
+
+mise up
+
+# The resolved version dir must now exist — proving `install_version_` ran.
+assert "test -d $MISE_DATA_DIR/installs/dummy/2.0.0"
+
+# And the active binary must report the new version (mise's runtime path
+# falls back to `install_path()` when `latest/` isn't a runtime symlink, so
+# the stale real dir is harmlessly shadowed by the resolved install dir).
+assert_contains "mise x dummy -- dummy" "This is Dummy 2.0.0"
+
+rm -f mise.toml

--- a/e2e/cli/test_where
+++ b/e2e/cli/test_where
@@ -9,7 +9,7 @@ assert "mise where dummy@2" "$MISE_DATA_DIR/installs/dummy/2.0.0"
 assert "mise where dummy@3" "$MISE_DATA_DIR/installs/dummy/3.1.0"
 assert "mise alias set dummy my/dummy 3"
 assert "mise install dummy@my/dummy"
-assert "mise where dummy@my/dummy" "$MISE_DATA_DIR/installs/dummy/3" # TODO: this should probably return 3.1.0
+assert "mise where dummy@my/dummy" "$MISE_DATA_DIR/installs/dummy/3.1.0"
 assert "mise uninstall dummy@my/dummy"
 assert_fail "mise where dummy@1111" "dummy@1111 not installed"
 

--- a/e2e/cli/test_where
+++ b/e2e/cli/test_where
@@ -9,7 +9,7 @@ assert "mise where dummy@2" "$MISE_DATA_DIR/installs/dummy/2.0.0"
 assert "mise where dummy@3" "$MISE_DATA_DIR/installs/dummy/3.1.0"
 assert "mise alias set dummy my/dummy 3"
 assert "mise install dummy@my/dummy"
-assert "mise where dummy@my/dummy" "$MISE_DATA_DIR/installs/dummy/3.1.0"
+assert "mise where dummy@my/dummy" "$MISE_DATA_DIR/installs/dummy/3"
 assert "mise uninstall dummy@my/dummy"
 assert_fail "mise where dummy@1111" "dummy@1111 not installed"
 

--- a/e2e/tools/test_runtime_symlink_migration
+++ b/e2e/tools/test_runtime_symlink_migration
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-cat <<TOML >mise.toml
-[tools]
-dummy = "1.0"
-TOML
-
 mkdir -p "$MISE_DATA_DIR/installs/dummy/1.0.2/bin"
 mkdir -p "$MISE_DATA_DIR/installs/dummy/2.0.0/bin"
 mkdir -p "$MISE_DATA_DIR/installs/dummy/1.0"
@@ -16,5 +11,3 @@ assert "mise --version >/dev/null"
 assert "readlink $MISE_DATA_DIR/installs/dummy/1.0" "./1.0.2"
 assert "readlink $MISE_DATA_DIR/installs/dummy/latest" "./2.0.0"
 assert "test -f $MISE_DATA_DIR/migrations/runtime-symlink-dirs-v1"
-
-rm -f mise.toml

--- a/e2e/tools/test_runtime_symlink_migration
+++ b/e2e/tools/test_runtime_symlink_migration
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+cat <<TOML >mise.toml
+[tools]
+dummy = "1.0"
+TOML
+
+mkdir -p "$MISE_DATA_DIR/installs/dummy/1.0.2/bin"
+mkdir -p "$MISE_DATA_DIR/installs/dummy/2.0.0/bin"
+mkdir -p "$MISE_DATA_DIR/installs/dummy/1.0"
+mkdir -p "$MISE_DATA_DIR/installs/dummy/latest"
+
+# Any mise command triggers startup migrations.
+assert "mise --version >/dev/null"
+
+assert "readlink $MISE_DATA_DIR/installs/dummy/1.0" "./1.0.2"
+assert "readlink $MISE_DATA_DIR/installs/dummy/latest" "./2.0.0"
+assert "test -f $MISE_DATA_DIR/migrations/runtime-symlink-dirs-v1"
+
+rm -f mise.toml

--- a/e2e/tools/test_runtime_symlink_migration_preserves_concrete_short_version
+++ b/e2e/tools/test_runtime_symlink_migration_preserves_concrete_short_version
@@ -2,14 +2,16 @@
 
 cat <<TOML >mise.toml
 [tools]
-node = "latest"
+node = "20"
 TOML
 
+mkdir -p "$MISE_DATA_DIR/installs/node/20/bin"
 mkdir -p "$MISE_DATA_DIR/installs/node/20.0.0/bin"
 
 # Any mise command triggers startup migrations.
 assert "mise --version >/dev/null"
 
-assert "test -f $MISE_DATA_DIR/migrations/runtime-symlink-dirs-v1"
+assert "test -d $MISE_DATA_DIR/installs/node/20"
+assert "test ! -L $MISE_DATA_DIR/installs/node/20"
 
 rm -f mise.toml

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -862,14 +862,15 @@ pub trait Backend: Debug + Send + Sync {
             None => {
                 let installed_symlink = self.ba().installs_path.join("latest");
                 if installed_symlink.exists()
-                    && let Some(target) = file::resolve_symlink(&installed_symlink)? {
-                        let version = target
-                            .file_name()
-                            .ok_or_else(|| eyre!("Invalid symlink target"))?
-                            .to_string_lossy()
-                            .to_string();
-                        return Ok(Some(version));
-                    }
+                    && let Some(target) = file::resolve_symlink(&installed_symlink)?
+                {
+                    let version = target
+                        .file_name()
+                        .ok_or_else(|| eyre!("Invalid symlink target"))?
+                        .to_string_lossy()
+                        .to_string();
+                    return Ok(Some(version));
+                }
                 Ok(file::dir_subdirs(&self.ba().installs_path)
                     .unwrap_or_default()
                     .into_iter()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1116,6 +1116,8 @@ pub trait Backend: Debug + Send + Sync {
             }
         };
 
+        self.repair_runtime_symlink(&ctx.config, &tv)?;
+
         let install_path = tv.install_path();
         if install_path.starts_with(*dirs::INSTALLS) {
             install_state::write_backend_meta(self.ba())?;
@@ -1155,6 +1157,34 @@ pub trait Backend: Debug + Send + Sync {
         }
         ctx.pr.finish_with_message("installed".to_string());
         Ok(tv)
+    }
+
+    fn repair_runtime_symlink(&self, config: &Config, tv: &ToolVersion) -> eyre::Result<()> {
+        if !matches!(
+            tv.request,
+            ToolRequest::Version { .. } | ToolRequest::Prefix { .. }
+        ) {
+            return Ok(());
+        }
+        let Some(request_path) = tv.request.install_path(config) else {
+            return Ok(());
+        };
+        if !request_path.starts_with(&tv.ba().installs_path)
+            || is_runtime_symlink(&request_path)
+            || !request_path.exists()
+        {
+            return Ok(());
+        }
+        if request_path
+            .file_name()
+            .is_none_or(|f| f.to_string_lossy() == tv.version)
+        {
+            return Ok(());
+        }
+
+        file::remove_all(&request_path)?;
+        file::make_symlink_or_file(&PathBuf::from(".").join(tv.tv_pathname()), &request_path)?;
+        Ok(())
     }
 
     async fn run_postinstall_hook(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -861,8 +861,8 @@ pub trait Backend: Debug + Send + Sync {
             }
             None => {
                 let installed_symlink = self.ba().installs_path.join("latest");
-                if installed_symlink.exists() {
-                    if let Some(target) = file::resolve_symlink(&installed_symlink)? {
+                if installed_symlink.exists()
+                    && let Some(target) = file::resolve_symlink(&installed_symlink)? {
                         let version = target
                             .file_name()
                             .ok_or_else(|| eyre!("Invalid symlink target"))?
@@ -870,7 +870,6 @@ pub trait Backend: Debug + Send + Sync {
                             .to_string();
                         return Ok(Some(version));
                     }
-                }
                 Ok(file::dir_subdirs(&self.ba().installs_path)
                     .unwrap_or_default()
                     .into_iter()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -677,14 +677,21 @@ pub trait Backend: Debug + Send + Sync {
                 if let Some(install_path) = tv.request.install_path(config)
                     && check_path(&install_path, true)
                 {
-                    // For Prefix requests, install_path finds any installed dir
-                    // matching the prefix (e.g., "1.0.0" for prefix "1"), but if
-                    // the ToolVersion resolved to a different version (e.g., "1.1.0"),
-                    // we must not treat it as installed.
-                    if let ToolRequest::Prefix { .. } = &tv.request
-                        && install_path
-                            .file_name()
-                            .is_some_and(|f| f.to_string_lossy() != tv.version)
+                    // The request's install_path is derived from the REQUEST version
+                    // (e.g., "latest" or prefix "1"), which may differ from the resolved
+                    // concrete version. If they differ, the request path can refer to a
+                    // stale install dir — for channel pins like `@latest` the dir is named
+                    // after the channel (`installs/<id>/latest/`) from a prior install that
+                    // never got a symlink (e.g., first install ran offline or remote resolution
+                    // transiently returned None, leaving tv.version="latest"). We must check
+                    // the RESOLVED path instead so that `mise upgrade` re-runs the backend's
+                    // install hook and writes the new version to `installs/<id>/<new-version>/`.
+                    if matches!(
+                        &tv.request,
+                        ToolRequest::Version { .. } | ToolRequest::Prefix { .. }
+                    ) && install_path
+                        .file_name()
+                        .is_some_and(|f| f.to_string_lossy() != tv.version)
                     {
                         return check_path(&tv.install_path(), check_symlink);
                     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -42,6 +42,7 @@ use itertools::Itertools;
 use platform_target::PlatformTarget;
 use regex::Regex;
 use std::sync::LazyLock as Lazy;
+use versions::Versioning;
 
 pub mod aqua;
 pub mod asdf;
@@ -861,18 +862,24 @@ pub trait Backend: Debug + Send + Sync {
             None => {
                 let installed_symlink = self.ba().installs_path.join("latest");
                 if installed_symlink.exists() {
-                    let Some(target) = file::resolve_symlink(&installed_symlink)? else {
-                        return Ok(Some("latest".to_string()));
-                    };
-                    let version = target
-                        .file_name()
-                        .ok_or_else(|| eyre!("Invalid symlink target"))?
-                        .to_string_lossy()
-                        .to_string();
-                    Ok(Some(version))
-                } else {
-                    Ok(None)
+                    if let Some(target) = file::resolve_symlink(&installed_symlink)? {
+                        let version = target
+                            .file_name()
+                            .ok_or_else(|| eyre!("Invalid symlink target"))?
+                            .to_string_lossy()
+                            .to_string();
+                        return Ok(Some(version));
+                    }
                 }
+                Ok(file::dir_subdirs(&self.ba().installs_path)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(|v| !v.starts_with('.'))
+                    .filter(|v| !is_runtime_symlink(&self.ba().installs_path.join(v)))
+                    .filter(|v| !self.ba().installs_path.join(v).join("incomplete").exists())
+                    .filter(|v| v != "latest")
+                    .sorted_by_cached_key(|v| (Versioning::new(v), v.to_string()))
+                    .last())
             }
         }
     }
@@ -1116,8 +1123,6 @@ pub trait Backend: Debug + Send + Sync {
             }
         };
 
-        self.repair_runtime_symlink(&ctx.config, &tv)?;
-
         let install_path = tv.install_path();
         if install_path.starts_with(*dirs::INSTALLS) {
             install_state::write_backend_meta(self.ba())?;
@@ -1157,34 +1162,6 @@ pub trait Backend: Debug + Send + Sync {
         }
         ctx.pr.finish_with_message("installed".to_string());
         Ok(tv)
-    }
-
-    fn repair_runtime_symlink(&self, config: &Config, tv: &ToolVersion) -> eyre::Result<()> {
-        if !matches!(
-            tv.request,
-            ToolRequest::Version { .. } | ToolRequest::Prefix { .. }
-        ) {
-            return Ok(());
-        }
-        let Some(request_path) = tv.request.install_path(config) else {
-            return Ok(());
-        };
-        if !request_path.starts_with(&tv.ba().installs_path)
-            || is_runtime_symlink(&request_path)
-            || !request_path.exists()
-        {
-            return Ok(());
-        }
-        if request_path
-            .file_name()
-            .is_none_or(|f| f.to_string_lossy() == tv.version)
-        {
-            return Ok(());
-        }
-
-        file::remove_all(&request_path)?;
-        file::make_symlink_or_file(&PathBuf::from(".").join(tv.tv_pathname()), &request_path)?;
-        Ok(())
     }
 
     async fn run_postinstall_hook(
@@ -1809,7 +1786,9 @@ async fn effective_latest_before_date<B: Backend + ?Sized>(
 #[cfg(test)]
 mod latest_version_tests {
     use super::*;
+    use crate::cli::args::BackendResolution;
     use pretty_assertions::assert_eq;
+    use std::fs;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug)]
@@ -1930,6 +1909,32 @@ mod latest_version_tests {
         );
         assert_eq!(backend.stable_calls(), 0);
         assert_eq!(backend.list_calls(), 1);
+    }
+
+    #[test]
+    fn test_latest_installed_version_ignores_real_latest_dir() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut ba = BackendArg::new_raw(
+            "latest-real-dir".into(),
+            None,
+            "latest-real-dir".into(),
+            None,
+            BackendResolution::new(false),
+        );
+        ba.installs_path = temp_dir.path().join("installs").join("latest-real-dir");
+        fs::create_dir_all(ba.installs_path.join("2.0.0")).unwrap();
+        fs::create_dir_all(ba.installs_path.join("latest")).unwrap();
+
+        let backend = LatestBackend {
+            ba: Arc::new(ba),
+            stable_calls: AtomicUsize::new(0),
+            list_calls: AtomicUsize::new(0),
+        };
+
+        assert_eq!(
+            backend.latest_installed_version(None).unwrap(),
+            Some("2.0.0".into())
+        );
     }
 }
 

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,8 +1,10 @@
 use std::fs;
 use std::path::Path;
 
+use crate::config::Config;
 use crate::dirs::*;
 use crate::file;
+use crate::runtime_symlinks;
 use eyre::Result;
 
 pub async fn run() {
@@ -14,6 +16,7 @@ pub async fn run() {
         task(|| remove_deprecated_plugin("java", "rtx-java")),
         task(|| remove_deprecated_plugin("python", "rtx-python")),
         task(|| remove_deprecated_plugin("ruby", "rtx-ruby")),
+        migrate_runtime_symlink_dirs(),
     );
 }
 
@@ -56,5 +59,27 @@ fn remove_deprecated_plugin(name: &str, plugin_name: &str) -> Result<()> {
     }
     eprintln!("removing deprecated plugin {plugin_name}, will use core {name} plugin from now on");
     file::remove_all(plugin_root)?;
+    Ok(())
+}
+
+async fn migrate_runtime_symlink_dirs() {
+    const MARKER: &str = "runtime-symlink-dirs-v1";
+    let marker = DATA.join("migrations").join(MARKER);
+    if marker.exists() {
+        return;
+    }
+
+    if let Err(err) = migrate_runtime_symlink_dirs_impl(&marker).await {
+        eprintln!("[WARN] migrate: {err}");
+    }
+}
+
+async fn migrate_runtime_symlink_dirs_impl(marker: &Path) -> Result<()> {
+    // One-time cleanup for stale fuzzy-version directories like `latest`, `24`,
+    // and `24.0` that should be runtime symlinks. Remove after 2026.10.0.
+    let config = Config::get().await?;
+    runtime_symlinks::migrate_real_dirs(&config).await?;
+    file::create_dir_all(marker.parent().unwrap())?;
+    file::write(marker, "ok\n")?;
     Ok(())
 }

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -84,8 +84,13 @@ fn rebuild_symlinks_in_dir(
     backend: &Arc<dyn Backend>,
     installs_dir: &Path,
 ) -> Result<()> {
+    let concrete_installs = installed_versions_in_dir(installs_dir)
+        .into_iter()
+        .filter(|v| is_concrete_install(v))
+        .collect::<std::collections::HashSet<_>>();
     let symlinks = list_symlinks_for_dir(config, backend, installs_dir);
     for (from, to) in symlinks {
+        let from_name = from.clone();
         let from = installs_dir.join(from);
         if from.exists() {
             if is_runtime_symlink(&from) && file::resolve_symlink(&from)?.unwrap_or_default() != to
@@ -96,6 +101,7 @@ fn rebuild_symlinks_in_dir(
                 .file_name()
                 .zip(to.file_name())
                 .is_some_and(|(from_name, to_name)| from_name != to_name)
+                && !concrete_installs.contains(&from_name)
             {
                 trace!("Replacing stale runtime dir: {}", from.display());
                 file::remove_all(&from)?;
@@ -114,10 +120,15 @@ fn migrate_real_dirs_in_dir(
     backend: &Arc<dyn Backend>,
     installs_dir: &Path,
 ) -> Result<()> {
+    let concrete_installs = installed_versions_in_dir(installs_dir)
+        .into_iter()
+        .filter(|v| is_concrete_install(v))
+        .collect::<std::collections::HashSet<_>>();
     let symlinks = list_symlinks_for_dir(config, backend, installs_dir);
     for (from, to) in symlinks {
+        let from_name = from.clone();
         let from = installs_dir.join(from);
-        if !from.exists() || is_runtime_symlink(&from) {
+        if !from.exists() || is_runtime_symlink(&from) || concrete_installs.contains(&from_name) {
             continue;
         }
         file::remove_all(&from)?;
@@ -194,6 +205,11 @@ fn installed_versions_in_dir(installs_dir: &Path) -> Vec<String> {
         .filter(|v| !VERSION_REGEX.is_match(v))
         .sorted_by_cached_key(|v| (Versioning::new(v), v.to_string()))
         .collect()
+}
+
+fn is_concrete_install(v: &str) -> bool {
+    let (_, version) = split_version_prefix(v);
+    Versioning::new(version).is_some()
 }
 
 pub fn remove_missing_symlinks(backend: Arc<dyn Backend>) -> Result<()> {

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -47,6 +47,38 @@ pub async fn rebuild(config: &Config) -> Result<()> {
     Ok(())
 }
 
+pub async fn migrate_real_dirs(config: &Config) -> Result<()> {
+    for backend in backend::list() {
+        let ba = backend.ba();
+        let mut installs_dirs = vec![ba.installs_path.clone()];
+        let tool_dir_name = ba.tool_dir_name();
+        for shared_dir in env::shared_install_dirs() {
+            let dir = shared_dir.join(&tool_dir_name);
+            if dir.is_dir() && !installs_dirs.contains(&dir) {
+                installs_dirs.push(dir);
+            }
+        }
+
+        if let Some(installs_dir) = installs_dirs.first() {
+            migrate_real_dirs_in_dir(config, &backend, installs_dir)?;
+        }
+        for installs_dir in installs_dirs.iter().skip(1) {
+            if let Err(e) = migrate_real_dirs_in_dir(config, &backend, installs_dir) {
+                if is_permission_error(&e) {
+                    warn!(
+                        "skipping runtime symlink migration for {}: {}",
+                        installs_dir.display(),
+                        e
+                    );
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn rebuild_symlinks_in_dir(
     config: &Config,
     backend: &Arc<dyn Backend>,
@@ -67,6 +99,23 @@ fn rebuild_symlinks_in_dir(
         make_symlink_or_file(&to, &from)?;
     }
     remove_missing_symlinks_in_dir(installs_dir)?;
+    Ok(())
+}
+
+fn migrate_real_dirs_in_dir(
+    config: &Config,
+    backend: &Arc<dyn Backend>,
+    installs_dir: &Path,
+) -> Result<()> {
+    let symlinks = list_symlinks_for_dir(config, backend, installs_dir);
+    for (from, to) in symlinks {
+        let from = installs_dir.join(from);
+        if !from.exists() || is_runtime_symlink(&from) {
+            continue;
+        }
+        file::remove_all(&from)?;
+        make_symlink_or_file(&to, &from)?;
+    }
     Ok(())
 }
 

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -92,6 +92,13 @@ fn rebuild_symlinks_in_dir(
             {
                 trace!("Removing existing symlink: {}", from.display());
                 file::remove_file(&from)?;
+            } else if from
+                .file_name()
+                .zip(to.file_name())
+                .is_some_and(|(from_name, to_name)| from_name != to_name)
+            {
+                trace!("Replacing stale runtime dir: {}", from.display());
+                file::remove_all(&from)?;
             } else {
                 continue;
             }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -43,6 +43,22 @@ pub struct ToolVersion {
 }
 
 impl ToolVersion {
+    fn is_semver_fuzzy_query(v: &str) -> bool {
+        v == "latest" || (versions::Versioning::new(v).is_some() && v.matches('.').count() < 2)
+    }
+
+    fn no_versions_found(backend: &ABackend, before_date: Option<Timestamp>) -> eyre::Report {
+        let msg = if before_date.is_some() {
+            format!(
+                "no versions found for {} matching date filter",
+                backend.id()
+            )
+        } else {
+            format!("no versions found for {}", backend.id())
+        };
+        eyre::eyre!(msg)
+    }
+
     pub fn new(request: ToolRequest, version: String) -> Self {
         ToolVersion {
             request,
@@ -328,6 +344,7 @@ impl ToolVersion {
             {
                 return build(v);
             }
+            return Err(Self::no_versions_found(&backend, opts.before_date));
         }
         if !opts.latest_versions {
             let matches = backend.list_installed_versions_matching(&v);
@@ -374,6 +391,9 @@ impl ToolVersion {
         }
         // When OFFLINE, skip ALL remote version fetching regardless of version format
         if is_offline {
+            if Self::is_semver_fuzzy_query(&v) {
+                return Err(Self::no_versions_found(&backend, opts.before_date));
+            }
             return build(v);
         }
         // In prefer-offline mode (hook-env, activate, exec), skip remote version
@@ -390,6 +410,9 @@ impl ToolVersion {
         if matches.contains(&v) {
             return build(v);
         }
+        if let Some(v) = matches.last() {
+            return build(v.clone());
+        }
         // If date filter is active and exact version not found, check without filter.
         // Explicit pinned versions like "22.5.0" should not be filtered by date.
         if opts.before_date.is_some() {
@@ -399,7 +422,10 @@ impl ToolVersion {
                 return build(v);
             }
         }
-        Self::resolve_prefix(config, request, &v, opts).await
+        if Self::is_semver_fuzzy_query(&v) {
+            return Err(Self::no_versions_found(&backend, opts.before_date));
+        }
+        build(v)
     }
 
     /// resolve a version like `sub-1:12.0.0` which becomes `11.0.0`, `sub-0.1:12.1.0` becomes `12.0.0`
@@ -415,17 +441,7 @@ impl ToolVersion {
             "latest" => backend
                 .latest_version(config, None, opts.before_date)
                 .await?
-                .ok_or_else(|| {
-                    let msg = if opts.before_date.is_some() {
-                        format!(
-                            "no versions found for {} matching date filter",
-                            backend.id()
-                        )
-                    } else {
-                        format!("no versions found for {}", backend.id())
-                    };
-                    eyre::eyre!(msg)
-                })?,
+                .ok_or_else(|| Self::no_versions_found(&backend, opts.before_date))?,
             _ => config.resolve_alias(&backend, v).await?,
         };
         let v = tool_request::version_sub(&v, sub);
@@ -447,11 +463,9 @@ impl ToolVersion {
         let matches = backend
             .list_versions_matching_with_opts(config, prefix, opts.before_date)
             .await?;
-        let v = match matches.last() {
-            Some(v) => v,
-            None => prefix,
-            // None => Err(VersionNotFound(plugin.name.clone(), prefix.to_string()))?,
-        };
+        let v = matches
+            .last()
+            .ok_or_else(|| Self::no_versions_found(&backend, opts.before_date))?;
         Ok(Self::new(request, v.to_string()))
     }
 

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -43,10 +43,6 @@ pub struct ToolVersion {
 }
 
 impl ToolVersion {
-    fn is_semver_fuzzy_query(v: &str) -> bool {
-        v == "latest" || (versions::Versioning::new(v).is_some() && v.matches('.').count() < 2)
-    }
-
     fn no_versions_found(backend: &ABackend, before_date: Option<Timestamp>) -> eyre::Report {
         let msg = if before_date.is_some() {
             format!(
@@ -391,9 +387,6 @@ impl ToolVersion {
         }
         // When OFFLINE, skip ALL remote version fetching regardless of version format
         if is_offline {
-            if Self::is_semver_fuzzy_query(&v) {
-                return Err(Self::no_versions_found(&backend, opts.before_date));
-            }
             return build(v);
         }
         // In prefer-offline mode (hook-env, activate, exec), skip remote version
@@ -421,9 +414,6 @@ impl ToolVersion {
                 // Exact match exists but was filtered by date - use it anyway
                 return build(v);
             }
-        }
-        if Self::is_semver_fuzzy_query(&v) {
-            return Err(Self::no_versions_found(&backend, opts.before_date));
         }
         build(v)
     }


### PR DESCRIPTION
## Summary

Fix the root cause behind stale real install directories like `installs/<tool>/latest/` and explicit prefix requests resolving to literal on-disk directories when mise cannot determine a concrete version.

This PR also keeps the one-time migration for existing broken installs and teaches runtime symlink rebuild to replace stale real dirs with the correct symlink once a concrete install exists.

Importantly, this does **not** blanket-treat every short version like `1.0`, `4.13`, or `2026.1` as fuzzy. `~/src/mise-versions` contains many tools with legitimate 1-part or 2-part stable versions (`lua`, `ffmpeg`, `staticcheck`, `ccache`, `hlint`, `upx`, etc.), so exact short versions must continue to work.

## Root Cause

There were two separate problems:

1. Resolver fallback: truly fuzzy requests could collapse to the literal request string instead of a concrete version.

- `resolve_prefix` in `src/toolset/tool_version.rs` used `None => prefix`, so an explicit prefix request could resolve to the literal prefix when remote matching returned nothing.
- `latest` requests also had a bad fallback loop through `latest_installed_version` when `installs/<tool>/latest` existed as a real directory.

2. Runtime selection regression: after `dc840866` (`fix(env): use runtime symlink paths for fuzzy versions`), PATH/bin resolution began preferring request paths like `latest`, `24`, and `24.0`. That made previously latent bad directories actively win at runtime.

There was also a reinforcing loop in `latest_installed_version`: if `installs/<tool>/latest` existed as a real dir instead of a symlink, mise treated that as installed `latest` and kept reusing the alias literally.

## Changes

- `src/toolset/tool_version.rs`
  - Stop resolving `latest` and explicit `prefix:` requests to literal install dirs when no concrete version can be found.
  - Preserve exact/direct version requests, including legitimate short versions like `1.0`, `4.13`, or `2026.1`.

- `src/backend/mod.rs`
  - Change `latest_installed_version(None)` so a real `latest/` directory is no longer treated as installed `latest`.
  - If `latest/` is not a runtime symlink, fall back to the highest concrete installed version instead.

- `src/runtime_symlinks.rs`
  - Extend runtime symlink rebuild to replace stale real dirs whose basename differs from the concrete target (for example `latest -> ./2.0.0`, `24 -> ./24.3.1`).
  - This lets normal install/upgrade flows self-heal stale dirs once a concrete install exists.

- `src/migrate.rs`
  - Keep a one-time migration that rewrites existing stale fuzzy-version dirs into runtime symlinks and writes a marker file so it only runs once.
  - Removal note left in place so the migration can be dropped after the grace period.

## Tests

- Added `e2e/backend/test_fuzzy_versions_do_not_install_literal_dirs`
  - Verifies `mise install tool@latest`, `tool@prefix:24`, and `tool@prefix:24.0` fail instead of creating literal install dirs when no concrete version can be resolved.
- Kept `e2e/cli/test_upgrade_latest_stale`
  - Verifies a stale real `latest/` dir is repaired to `./2.0.0` during upgrade and runtime exec uses the new binary.
- Kept `e2e/tools/test_runtime_symlink_migration`
  - Verifies the one-time migration rewrites stale `1.0/` and `latest/` dirs and writes the marker file.
- Kept `e2e/tools/test_runtime_symlinks`
  - Verifies normal runtime symlink behavior still works.
- Added unit coverage for `latest_installed_version` ignoring a real `latest/` dir.

## Validation

- `cargo check --all-features`
- `cargo test --all-features test_latest_installed_version_ignores_real_latest_dir -- --nocapture`
- `cargo test --all-features runtime_path_does_not_return_file_based_runtime_symlink -- --nocapture`
- `mise run test:e2e e2e/backend/test_fuzzy_versions_do_not_install_literal_dirs e2e/cli/test_upgrade_latest_stale e2e/tools/test_runtime_symlink_migration e2e/tools/test_runtime_symlinks`

## Notes

This PR fixes the definite broken cases without regressing tools that genuinely use short exact versions:

- existing broken installs are migrated once
- stale dirs are self-healed during normal runtime symlink rebuilds
- new `latest` and explicit `prefix:` requests no longer create literal install directories when resolution fails
- exact short versions remain installable for tools whose real release scheme uses them