### PR TITLE
feat: add gsudo (Sudo for Windows) to registry

### DIFF
--- a/registry/gsudo.toml
+++ b/registry/gsudo.toml
@@ -1,0 +1,10 @@
+description = "Sudo for Windows - a privilege elevation tool"
+os = ["windows"]
+test = { cmd = "gsudo --version", expected = "gsudo v{{version}}" }
+
+[[backends]]
+full = "github:gerardog/gsudo"
+
+[backends.options]
+asset_pattern = "gsudo.portable.zip"
+bin_path = "{{ arch() }}"


### PR DESCRIPTION
Adds a registry definition for [gsudo](https://github.com/gerardog/gsudo), a privilege elevation tool for Windows. It supports cmd, PowerShell, WSL, and more.

The GitHub release ships a `gsudo.portable.zip` containing architecture-specific subdirectories (`x64`, `arm64`, `x86`, `net46-AnyCpu`), so the definition uses `asset_pattern` to select the portable zip and `bin_path = "{{ arch }}"` to point mise at the correct binary for the host platform.