### PR TITLE
refactor(core): centralize install_before resolution

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,6 +15,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::config_file::config_root;
 use crate::config::{Config, Settings};
 use crate::file::{display_path, remove_all_with_progress, remove_all_with_warning};
+use crate::install_before::resolve_before_date;
 use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::path_env::PathEnv;
@@ -853,7 +854,11 @@ pub trait Backend: Debug + Send + Sync {
         query: Option<String>,
         before_date: Option<Timestamp>,
     ) -> eyre::Result<Option<String>> {
-        let before_date = effective_latest_before_date(self, config, before_date).await?;
+        let opts = config
+            .get_tool_opts(self.ba())
+            .await?
+            .unwrap_or_else(|| self.ba().opts());
+        let before_date = resolve_before_date(before_date, opts.get("install_before"))?;
         match query.as_deref() {
             Some("latest") | None => match before_date {
                 Some(before) => {
@@ -1772,30 +1777,6 @@ pub trait Backend: Debug + Send + Sync {
             ..Default::default()
         })
     }
-}
-
-async fn effective_latest_before_date<B: Backend + ?Sized>(
-    backend: &B,
-    config: &Arc<Config>,
-    before_date: Option<Timestamp>,
-) -> eyre::Result<Option<Timestamp>> {
-    if before_date.is_some() {
-        return Ok(before_date);
-    }
-    if let Some(before) = backend.ba().opts().get("install_before") {
-        return Ok(Some(crate::duration::parse_into_timestamp(before)?));
-    }
-    if let Some(before) = config
-        .get_tool_opts(backend.ba())
-        .await?
-        .and_then(|opts| opts.get("install_before").map(str::to_string))
-    {
-        return Ok(Some(crate::duration::parse_into_timestamp(&before)?));
-    }
-    if let Some(before) = &Settings::get().install_before {
-        return Ok(Some(crate::duration::parse_into_timestamp(before)?));
-    }
-    Ok(None)
 }
 
 #[cfg(test)]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -854,11 +854,7 @@ pub trait Backend: Debug + Send + Sync {
         query: Option<String>,
         before_date: Option<Timestamp>,
     ) -> eyre::Result<Option<String>> {
-        let opts = config
-            .get_tool_opts(self.ba())
-            .await?
-            .unwrap_or_else(|| self.ba().opts());
-        let before_date = resolve_before_date(before_date, opts.get("install_before"))?;
+        let before_date = effective_latest_before_date(self, config, before_date).await?;
         match query.as_deref() {
             Some("latest") | None => match before_date {
                 Some(before) => {
@@ -1779,6 +1775,27 @@ pub trait Backend: Debug + Send + Sync {
     }
 }
 
+async fn effective_latest_before_date<B: Backend + ?Sized>(
+    backend: &B,
+    config: &Arc<Config>,
+    before_date: Option<Timestamp>,
+) -> eyre::Result<Option<Timestamp>> {
+    if before_date.is_some() {
+        return Ok(before_date);
+    }
+
+    let backend_opts = backend.ba().opts();
+    if let Some(before) = backend_opts.get("install_before") {
+        return resolve_before_date(None, Some(before));
+    }
+
+    let config_install_before = config
+        .get_tool_opts(backend.ba())
+        .await?
+        .and_then(|opts| opts.get("install_before").map(str::to_string));
+    resolve_before_date(None, config_install_before.as_deref())
+}
+
 #[cfg(test)]
 mod latest_version_tests {
     use super::*;
@@ -1931,6 +1948,25 @@ mod latest_version_tests {
             backend.latest_installed_version(None).unwrap(),
             Some("2.0.0".into())
         );
+    }
+
+    #[tokio::test]
+    async fn test_inline_install_before_wins_over_config_entry() {
+        let config = Config::get().await.unwrap();
+        // The test fixture has a `tiny` config entry without install_before.
+        // Inline backend opts must still win when a config entry exists.
+        let backend = LatestBackend::new("tiny[install_before=2024-06-01]");
+
+        assert_eq!(
+            backend
+                .latest_version(&config, Some("latest".to_string()), None)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.0.0")
+        );
+        assert_eq!(backend.stable_calls(), 0);
+        assert_eq!(backend.list_calls(), 1);
     }
 }
 

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -1,8 +1,7 @@
 use crate::cli::args::ToolArg;
 use crate::config::Config;
 use crate::install_context::InstallContext;
-use crate::toolset::tool_request::effective_before_date;
-use crate::toolset::{ResolveOptions, ToolsetBuilder};
+use crate::toolset::ToolsetBuilder;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use clap::ValueHint;
 use eyre::{Result, eyre};
@@ -27,14 +26,9 @@ pub struct InstallInto {
 impl InstallInto {
     pub async fn run(self) -> Result<()> {
         let config = Config::get().await?;
-        let before_date = effective_before_date(self.tool.tvr.as_ref(), &Default::default())?;
         let ts = Arc::new(
             ToolsetBuilder::new()
                 .with_args(std::slice::from_ref(&self.tool))
-                .with_resolve_options(ResolveOptions {
-                    before_date,
-                    ..Default::default()
-                })
                 .build(&config)
                 .await?,
         );
@@ -46,6 +40,7 @@ impl InstallInto {
             .first()
             .unwrap()
             .clone();
+        let before_date = tv.before_date;
         let backend = tv.backend()?;
         let mpr = MultiProgressReport::get();
         let install_ctx = InstallContext {

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -1,0 +1,104 @@
+use eyre::Result;
+use jiff::Timestamp;
+
+use crate::config::Settings;
+use crate::duration::parse_into_timestamp;
+
+/// Resolve the effective `install_before` cutoff.
+///
+/// Precedence (highest to lowest):
+/// 1. `before_date` - a pre-resolved `ResolveOptions` cutoff.
+/// 2. A per-tool, backend, or config `install_before` option.
+/// 3. The global `install_before` setting.
+///
+/// All string-based durations (e.g. `"3d"`) are resolved against
+/// [`crate::duration::process_now`] so that every call within a single mise
+/// invocation produces the same absolute timestamp. Downstream code can then
+/// use the resolved timestamp both to resolve which version to install *and*
+/// to build the corresponding package-manager CLI flag (e.g.
+/// `--min-release-age`) without the two drifting apart.
+pub fn resolve_before_date(
+    before_date: Option<Timestamp>,
+    install_before: Option<&str>,
+) -> Result<Option<Timestamp>> {
+    if let Some(before_date) = before_date {
+        return Ok(Some(before_date));
+    }
+    if let Some(before) = install_before {
+        return Ok(Some(parse_into_timestamp(before)?));
+    }
+    if let Some(before) = &Settings::get().install_before {
+        return Ok(Some(parse_into_timestamp(before)?));
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_before_date;
+    use crate::config::settings::{Settings, SettingsPartial};
+    use confique::Layer;
+    use jiff::Timestamp;
+    use test_log::test;
+
+    fn resolved_timestamp(
+        before_date: Option<Timestamp>,
+        install_before: Option<&str>,
+    ) -> Option<Timestamp> {
+        resolve_before_date(before_date, install_before).unwrap()
+    }
+
+    #[test]
+    fn test_effective_before_date_prefers_override() {
+        Settings::reset(None);
+        let cli_before = "2024-01-02T03:04:05Z".parse().unwrap();
+        assert_eq!(
+            resolved_timestamp(Some(cli_before), Some("7d")),
+            Some(cli_before)
+        );
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_before_date_prefers_tool_option() {
+        Settings::reset(None);
+        assert_eq!(
+            resolved_timestamp(None, Some("2024-01-02")),
+            Some(crate::duration::parse_into_timestamp("2024-01-02").unwrap())
+        );
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_before_date_falls_back_to_global_setting() {
+        let mut partial = SettingsPartial::empty();
+        partial.install_before = Some("2024-01-03".to_string());
+        Settings::reset(Some(partial));
+        assert_eq!(
+            resolved_timestamp(None, None),
+            Some(crate::duration::parse_into_timestamp("2024-01-03").unwrap())
+        );
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_before_date_none_when_unset() {
+        Settings::reset(None);
+        assert_eq!(resolved_timestamp(None, None), None);
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_before_date_stable_within_process() {
+        // Covers the invariant behind #9156: relative durations resolve
+        // identically across calls within one invocation.
+        Settings::reset(None);
+        let mut partial = SettingsPartial::empty();
+        partial.install_before = Some("3d".to_string());
+        Settings::reset(Some(partial));
+        let a = resolved_timestamp(None, None);
+        let b = resolved_timestamp(None, None);
+        assert_eq!(a, b);
+        Settings::reset(None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ mod hash;
 mod hook_env;
 mod hooks;
 mod http;
+mod install_before;
 mod install_context;
 mod lock_file;
 mod lockfile;

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -6,13 +6,11 @@ use std::{
 };
 
 use eyre::{Result, bail};
-use jiff::Timestamp;
 use versions::{Chunk, Version};
 use xx::file;
 
 use crate::backend::platform_target::PlatformTarget;
 use crate::cli::args::BackendArg;
-use crate::config::settings::Settings;
 use crate::env;
 use crate::lockfile::LockfileTool;
 use crate::runtime_symlinks::is_runtime_symlink;
@@ -352,9 +350,7 @@ impl ToolRequest {
         config: &Arc<Config>,
         opts: &ResolveOptions,
     ) -> Result<ToolVersion> {
-        let mut opts = opts.clone();
-        opts.before_date = effective_before_date(Some(self), &opts)?;
-        ToolVersion::resolve(config, self.clone(), &opts).await
+        ToolVersion::resolve(config, self.clone(), opts).await
     }
 
     pub fn is_os_supported(&self) -> bool {
@@ -393,38 +389,6 @@ fn normalize_arch(arch: &str) -> &str {
         "aarch64" | "arm64" => "arm64",
         other => other,
     }
-}
-
-/// Resolve the effective `install_before` cutoff to an absolute [`Timestamp`]
-/// in one canonical place.
-///
-/// Precedence (highest to lowest):
-/// 1. `opts.before_date` — typically the pre-resolved `--before` CLI flag.
-/// 2. The per-tool `install_before` option on `request`.
-/// 3. The global `install_before` setting.
-///
-/// All string-based durations (e.g. `"3d"`) are resolved against
-/// [`crate::duration::process_now`] so that every call within a single mise
-/// invocation produces the same absolute timestamp. Downstream code can then
-/// use this timestamp both to resolve which version to install *and* to build
-/// the corresponding package-manager CLI flag (e.g. `--min-release-age`)
-/// without the two drifting apart.
-pub fn effective_before_date(
-    request: Option<&ToolRequest>,
-    opts: &ResolveOptions,
-) -> Result<Option<Timestamp>> {
-    if let Some(before_date) = opts.before_date {
-        return Ok(Some(before_date));
-    }
-    if let Some(request) = request
-        && let Some(before) = request.options().get("install_before")
-    {
-        return Ok(Some(crate::duration::parse_into_timestamp(before)?));
-    }
-    if let Some(before) = &Settings::get().install_before {
-        return Ok(Some(crate::duration::parse_into_timestamp(before)?));
-    }
-    Ok(None)
 }
 
 /// subtracts sub from orig and removes suffix
@@ -467,110 +431,9 @@ impl Display for ToolRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::{ToolRequest, effective_before_date, version_sub};
-    use crate::cli::args::{BackendArg, BackendResolution};
-    use crate::config::settings::{Settings, SettingsPartial};
-    use crate::toolset::{ResolveOptions, ToolSource, parse_tool_options};
-    use confique::Layer;
+    use super::version_sub;
     use pretty_assertions::assert_str_eq;
-    use std::sync::Arc;
     use test_log::test;
-
-    fn make_request(opts: Option<&str>) -> ToolRequest {
-        let backend = Arc::new(BackendArg::new_raw(
-            "core:dummy".to_string(),
-            Some("core:dummy".to_string()),
-            "dummy".to_string(),
-            opts.map(parse_tool_options),
-            BackendResolution::new(true),
-        ));
-        ToolRequest::Version {
-            backend: backend.clone(),
-            version: "latest".to_string(),
-            options: backend.opts(),
-            source: ToolSource::Argument,
-        }
-    }
-
-    #[test]
-    fn test_effective_before_date_prefers_cli() {
-        Settings::reset(None);
-        let request = make_request(Some("install_before='7d'"));
-        let cli_before = "2024-01-02T03:04:05Z".parse().unwrap();
-        let opts = ResolveOptions {
-            before_date: Some(cli_before),
-            ..Default::default()
-        };
-        assert_eq!(
-            effective_before_date(Some(&request), &opts).unwrap(),
-            Some(cli_before)
-        );
-        Settings::reset(None);
-    }
-
-    #[test]
-    fn test_effective_before_date_prefers_tool_option() {
-        Settings::reset(None);
-        let request = make_request(Some("install_before='2024-01-02'"));
-        let opts = ResolveOptions::default();
-        assert_eq!(
-            effective_before_date(Some(&request), &opts).unwrap(),
-            Some(crate::duration::parse_into_timestamp("2024-01-02").unwrap())
-        );
-        Settings::reset(None);
-    }
-
-    #[test]
-    fn test_effective_before_date_falls_back_to_global_setting() {
-        let mut partial = SettingsPartial::empty();
-        partial.install_before = Some("2024-01-03".to_string());
-        Settings::reset(Some(partial));
-        let request = make_request(None);
-        let opts = ResolveOptions::default();
-        assert_eq!(
-            effective_before_date(Some(&request), &opts).unwrap(),
-            Some(crate::duration::parse_into_timestamp("2024-01-03").unwrap())
-        );
-        Settings::reset(None);
-    }
-
-    #[test]
-    fn test_effective_before_date_none_when_unset() {
-        Settings::reset(None);
-        let request = make_request(None);
-        let opts = ResolveOptions::default();
-        assert_eq!(effective_before_date(Some(&request), &opts).unwrap(), None);
-        Settings::reset(None);
-    }
-
-    #[test]
-    fn test_effective_before_date_handles_missing_request() {
-        let mut partial = SettingsPartial::empty();
-        partial.install_before = Some("2024-01-03".to_string());
-        Settings::reset(Some(partial));
-        let opts = ResolveOptions::default();
-        assert_eq!(
-            effective_before_date(None, &opts).unwrap(),
-            Some(crate::duration::parse_into_timestamp("2024-01-03").unwrap())
-        );
-        Settings::reset(None);
-    }
-
-    #[test]
-    fn test_effective_before_date_stable_within_process() {
-        // Covers the invariant behind #9156: relative durations resolve
-        // identically across calls within one invocation.
-        Settings::reset(None);
-        let mut partial = SettingsPartial::empty();
-        partial.install_before = Some("3d".to_string());
-        Settings::reset(Some(partial));
-        let request = make_request(None);
-        let opts = ResolveOptions::default();
-        let a = effective_before_date(Some(&request), &opts).unwrap();
-        let b = effective_before_date(Some(&request), &opts).unwrap();
-        assert_eq!(a, b);
-        Settings::reset(None);
-    }
 
     #[test]
     fn test_version_sub() {

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -12,6 +12,7 @@ use crate::env;
 #[cfg(windows)]
 use crate::file;
 use crate::hash::hash_to_str;
+use crate::install_before::resolve_before_date;
 use crate::lockfile::{CondaPackageInfo, LockfileTool, PlatformInfo};
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, tool_request};
@@ -35,6 +36,8 @@ pub fn reset_install_path_cache() {
 pub struct ToolVersion {
     pub request: ToolRequest,
     pub version: String,
+    /// Effective install-before cutoff used to resolve this version.
+    pub before_date: Option<Timestamp>,
     locked: bool,
     pub lock_platforms: BTreeMap<String, PlatformInfo>,
     pub install_path: Option<PathBuf>,
@@ -59,6 +62,7 @@ impl ToolVersion {
         ToolVersion {
             request,
             version,
+            before_date: None,
             locked: false,
             lock_platforms: Default::default(),
             install_path: None,
@@ -71,37 +75,47 @@ impl ToolVersion {
         request: ToolRequest,
         opts: &ResolveOptions,
     ) -> Result<Self> {
+        let install_before = request.options().get("install_before").map(str::to_string);
+        let mut opts = opts.clone();
+        opts.before_date = resolve_before_date(opts.before_date, install_before.as_deref())?;
+
         trace!("resolving {} {}", &request, opts);
         if opts.use_locked_version
             && !has_linked_version(request.ba())
             && let Some(lt) = request.lockfile_resolve(config)?
         {
-            return Ok(Self::from_lockfile(request.clone(), lt));
+            return Ok(Self::from_lockfile(request.clone(), lt).with_before_date(opts.before_date));
         }
         let backend = request.ba().backend()?;
         if let Some(plugin) = backend.plugin()
             && !plugin.is_installed()
         {
             let tv = Self::new(request.clone(), request.version());
-            return Ok(tv);
+            return Ok(tv.with_before_date(opts.before_date));
         }
         let tv = match request.clone() {
             ToolRequest::Version { version: v, .. } => {
-                Self::resolve_version(config, request, &v, opts).await?
+                Self::resolve_version(config, request, &v, &opts).await?
             }
             ToolRequest::Prefix { prefix, .. } => {
-                Self::resolve_prefix(config, request, &prefix, opts).await?
+                Self::resolve_prefix(config, request, &prefix, &opts).await?
             }
             ToolRequest::Sub {
                 sub, orig_version, ..
-            } => Self::resolve_sub(config, request, &sub, &orig_version, opts).await?,
+            } => Self::resolve_sub(config, request, &sub, &orig_version, &opts).await?,
             _ => {
                 let version = request.version();
                 Self::new(request, version)
             }
         };
+        let tv = tv.with_before_date(opts.before_date);
         trace!("resolved: {tv}");
         Ok(tv)
+    }
+
+    fn with_before_date(mut self, before_date: Option<Timestamp>) -> Self {
+        self.before_date = before_date;
+        self
     }
 
     fn from_lockfile(request: ToolRequest, lt: LockfileTool) -> Self {

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -17,7 +17,7 @@ use crate::toolset::Toolset;
 use crate::toolset::helpers::show_python_install_hint;
 use crate::toolset::install_options::InstallOptions;
 use crate::toolset::tool_deps::{ToolDeps, tool_key};
-use crate::toolset::tool_request::{ToolRequest, effective_before_date};
+use crate::toolset::tool_request::ToolRequest;
 use crate::toolset::tool_source::ToolSource;
 use crate::toolset::tool_version::ToolVersion;
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -452,16 +452,13 @@ impl Toolset {
         opts: &Arc<InstallOptions>,
     ) -> Result<ToolVersion> {
         let mpr = MultiProgressReport::get();
-        let before_date = effective_before_date(Some(tr), &opts.resolve_options)?;
-        let mut resolve_options = opts.resolve_options.clone();
-        resolve_options.before_date = before_date;
-
-        let mut tv = tr.resolve(config, &resolve_options).await?;
+        let mut tv = tr.resolve(config, &opts.resolve_options).await?;
         if let Some(dir) = &opts.install_dir {
             let tool_dir_name = tv.ba().tool_dir_name();
             tv.install_path = Some(dir.join(tool_dir_name).join(tv.tv_pathname()));
         }
         let backend = tr.backend()?;
+        let before_date = tv.before_date;
 
         let ctx = InstallContext {
             config: config.clone(),


### PR DESCRIPTION
## Summary

- centralize install_before timestamp precedence in a small helper
- compute the effective before_date during ToolVersion resolution and carry it on the resolved ToolVersion
- reuse the resolved ToolVersion before_date when building install context
- align backend latest resolution with the existing config-opts fallback pattern and call resolve_before_date once

## Validation

- cargo fmt --check
- git diff --check
- cargo test install_before --quiet
- cargo check --quiet
