### PR TITLE
fix(backend): repair stale latest runtime directory

### DIFF
--- a/e2e/cli/test_upgrade_latest_stale
+++ b/e2e/cli/test_upgrade_latest_stale
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+cat <<TOML >mise.toml
+[tools]
+dummy = "latest"
+TOML
+
+mise uninstall dummy --all
+
+mkdir -p "$MISE_DATA_DIR/installs/dummy/latest/bin"
+cat <<'SCRIPT' >"$MISE_DATA_DIR/installs/dummy/latest/bin/dummy"
+#!/usr/bin/env bash
+echo "This is stale dummy"
+SCRIPT
+chmod +x "$MISE_DATA_DIR/installs/dummy/latest/bin/dummy"
+
+mise up
+
+assert "test -d '$MISE_DATA_DIR/installs/dummy/2.0.0'"
+assert "test -L '$MISE_DATA_DIR/installs/dummy/latest'"
+assert "readlink '$MISE_DATA_DIR/installs/dummy/latest'" "./2.0.0"
+
+output="$(mise x -- dummy)"
+if [[ $output != *"This is Dummy 2.0.0"* ]]; then
+	fail "expected dummy 2.0.0 output, got: $output"
+fi
+
+if [[ $output == *"This is stale dummy"* ]]; then
+	fail "stale dummy binary was used after upgrade"
+fi

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -709,6 +709,50 @@ pub trait Backend: Debug + Send + Sync {
             }
         }
     }
+    fn cleanup_stale_request_install_path(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+    ) -> Result<()> {
+        let ToolRequest::Version {
+            version: requested_version,
+            ..
+        } = &tv.request
+        else {
+            return Ok(());
+        };
+        if requested_version == &tv.version {
+            return Ok(());
+        }
+        let Some(request_install_path) = tv.request.install_path(config) else {
+            return Ok(());
+        };
+        if request_install_path == tv.install_path()
+            || !request_install_path.starts_with(&self.ba().installs_path)
+            || request_install_path.parent() != Some(self.ba().installs_path.as_path())
+            || is_runtime_symlink(&request_install_path)
+        {
+            return Ok(());
+        }
+        let Ok(metadata) = request_install_path.symlink_metadata() else {
+            return Ok(());
+        };
+        let file_type = metadata.file_type();
+        if file_type.is_dir() {
+            trace!(
+                "removing stale request install dir: {}",
+                display_path(&request_install_path)
+            );
+            file::remove_all(&request_install_path)?;
+        } else if file_type.is_file() {
+            trace!(
+                "removing stale request install file: {}",
+                display_path(&request_install_path)
+            );
+            file::remove_file(&request_install_path)?;
+        }
+        Ok(())
+    }
     async fn is_version_outdated(&self, config: &Arc<Config>, tv: &ToolVersion) -> bool {
         let latest = match tv.latest_version(config).await {
             Ok(latest) => latest,
@@ -1081,6 +1125,8 @@ pub trait Backend: Debug + Send + Sync {
             tv.install_path = Some(tv.ba().installs_path.join(tv.tv_pathname()));
         }
 
+        self.cleanup_stale_request_install_path(&ctx.config, &tv)?;
+
         let will_uninstall = ctx.force && self.is_version_installed(&ctx.config, &tv, true);
 
         // Query backend for operation count and set up progress tracking
@@ -1123,6 +1169,8 @@ pub trait Backend: Debug + Send + Sync {
                 return Err(e);
             }
         };
+
+        self.cleanup_stale_request_install_path(&ctx.config, &tv)?;
 
         let install_path = tv.install_path();
         if install_path.starts_with(*dirs::INSTALLS) {


### PR DESCRIPTION
## Summary

Fixes stale real request directories such as `installs/<tool>/latest/` without including #9276.

## Changes:
- add `e2e/cli/test_upgrade_latest_stale` as a non-executable e2e regression test
- before real installs, remove stale request paths for `ToolRequest::Version` aliases where the requested version differs from the resolved concrete version, so the existing install-skip checks no longer treat stale `latest/` as installed
- after successful concrete installs, run the same cleanup before runtime symlink rebuild
- limit cleanup to direct real files/directories under the backend managed installs directory
- skip runtime symlinks and do not apply the cleanup to `ToolRequest::Prefix`

`runtime_symlinks::rebuild` remains responsible for recreating `latest -> ./<resolved-version>` after the stale blocker is gone.

## Validation

Red test before fix commit:
- `mise run test:e2e e2e/cli/test_upgrade_latest_stale` failed at `test -d .../installs/dummy/2.0.0`, showing the stale `latest/` directory still short-circuited install on `jdx/mise:main`

Passing checks after fix commit:
- `mise run test:e2e e2e/cli/test_upgrade_latest_stale`
- `cargo fmt --all -- --check`
- `shellcheck e2e/cli/test_upgrade_latest_stale`
- `shfmt -d -s e2e/cli/test_upgrade_latest_stale`
- `mise run test:e2e e2e/cli/test_latest_explicit_latest`

*This PR was generated by an AI coding assistant.*