### PR TITLE
fix(backend): prevent real latest install dirs

### DIFF
--- a/e2e/cli/test_latest_real_dir
+++ b/e2e/cli/test_latest_real_dir
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+reset_dummy_plugin() {
+	rm -rf "$MISE_DATA_DIR/plugins/dummy"
+	cp -R "$ROOT/test/data/plugins/dummy" "$MISE_DATA_DIR/plugins/dummy"
+	rm -rf "$MISE_CACHE_DIR/dummy"
+}
+
+reset_dummy_plugin
+cat <<'SCRIPT' >"$MISE_DATA_DIR/plugins/dummy/bin/latest-stable"
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+cat <<'SCRIPT' >"$MISE_DATA_DIR/plugins/dummy/bin/list-all"
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+chmod +x "$MISE_DATA_DIR/plugins/dummy/bin/latest-stable"
+chmod +x "$MISE_DATA_DIR/plugins/dummy/bin/list-all"
+
+status=0
+output="$(mise install dummy@latest 2>&1)" || status=$?
+if [[ -e "$MISE_DATA_DIR/installs/dummy/latest" && ! -L "$MISE_DATA_DIR/installs/dummy/latest" ]]; then
+	fail "unresolved dummy@latest created a real latest directory: $output"
+fi
+if [[ $status -eq 0 ]]; then
+	fail "expected unresolved dummy@latest install to fail"
+fi
+
+reset_dummy_plugin
+mise uninstall dummy --all 2>/dev/null || true
+
+cat <<TOML >mise.toml
+[tools]
+dummy = "latest"
+TOML
+
+mkdir -p "$MISE_DATA_DIR/installs/dummy/latest/bin"
+cat <<'SCRIPT' >"$MISE_DATA_DIR/installs/dummy/latest/bin/dummy"
+#!/usr/bin/env bash
+echo "This is stale dummy"
+SCRIPT
+chmod +x "$MISE_DATA_DIR/installs/dummy/latest/bin/dummy"
+
+mise up
+
+assert "test -d '$MISE_DATA_DIR/installs/dummy/2.0.0'"
+assert "test -L '$MISE_DATA_DIR/installs/dummy/latest'"
+assert "readlink '$MISE_DATA_DIR/installs/dummy/latest'" "./2.0.0"
+
+output="$(mise x -- dummy)"
+if [[ $output != *"This is Dummy 2.0.0"* ]]; then
+	fail "expected dummy 2.0.0 output, got: $output"
+fi
+if [[ $output == *"This is stale dummy"* ]]; then
+	fail "stale dummy binary was used after upgrade"
+fi

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -692,14 +692,15 @@ pub trait Backend: Debug + Send + Sync {
                 if let Some(install_path) = tv.request.install_path(config)
                     && check_path(&install_path, true)
                 {
-                    // For Prefix requests, install_path finds any installed dir
-                    // matching the prefix (e.g., "1.0.0" for prefix "1"), but if
-                    // the ToolVersion resolved to a different version (e.g., "1.1.0"),
-                    // we must not treat it as installed.
-                    if let ToolRequest::Prefix { .. } = &tv.request
-                        && install_path
-                            .file_name()
-                            .is_some_and(|f| f.to_string_lossy() != tv.version)
+                    // The request path can be an alias/prefix path such as
+                    // "latest" or "1". If resolution selected a different
+                    // concrete version, only the resolved path counts.
+                    if matches!(
+                        &tv.request,
+                        ToolRequest::Version { .. } | ToolRequest::Prefix { .. }
+                    ) && install_path
+                        .file_name()
+                        .is_some_and(|f| f.to_string_lossy() != tv.version)
                     {
                         return check_path(&tv.install_path(), check_symlink);
                     }
@@ -869,8 +870,11 @@ pub trait Backend: Debug + Send + Sync {
             None => {
                 let installed_symlink = self.ba().installs_path.join("latest");
                 if installed_symlink.exists() {
+                    if !is_runtime_symlink(&installed_symlink) {
+                        return Ok(None);
+                    }
                     let Some(target) = file::resolve_symlink(&installed_symlink)? else {
-                        return Ok(Some("latest".to_string()));
+                        return Ok(None);
                     };
                     let version = target
                         .file_name()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -390,6 +390,9 @@ pub trait Backend: Debug + Send + Sync {
         BackendType::Core
     }
     fn ba(&self) -> &Arc<BackendArg>;
+    fn allows_literal_latest_version(&self) -> bool {
+        false
+    }
 
     /// Generates a platform key for lockfile storage.
     /// Default implementation uses the current platform key (os-arch or os-arch-qualifier),
@@ -653,7 +656,12 @@ pub trait Backend: Debug + Send + Sync {
         self.latest_version_for_query(config, "latest", None).await
     }
     fn list_installed_versions(&self) -> Vec<String> {
-        install_state::list_versions(&self.ba().short)
+        let versions = install_state::list_versions(&self.ba().short);
+        if self.allows_literal_latest_version() {
+            versions
+        } else {
+            versions.into_iter().filter(|v| v != "latest").collect()
+        }
     }
     fn is_version_installed(
         &self,
@@ -871,7 +879,9 @@ pub trait Backend: Debug + Send + Sync {
                 let installed_symlink = self.ba().installs_path.join("latest");
                 if installed_symlink.exists() {
                     if !is_runtime_symlink(&installed_symlink) {
-                        return Ok(None);
+                        return Ok(self
+                            .allows_literal_latest_version()
+                            .then(|| "latest".to_string()));
                     }
                     let Some(target) = file::resolve_symlink(&installed_symlink)? else {
                         return Ok(None);

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -39,6 +39,10 @@ impl Backend for UbiBackend {
         &self.ba
     }
 
+    fn allows_literal_latest_version(&self) -> bool {
+        name_is_url(&self.tool_name())
+    }
+
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         deprecated_at!(
             "2026.4.0",

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -60,6 +60,11 @@ fn rebuild_symlinks_in_dir(
             {
                 trace!("Removing existing symlink: {}", from.display());
                 file::remove_file(&from)?;
+            } else if from.file_name().is_some_and(|f| f == "latest")
+                && from.symlink_metadata()?.file_type().is_dir()
+            {
+                trace!("Removing stale latest install dir: {}", from.display());
+                file::remove_all(&from)?;
             } else {
                 continue;
             }
@@ -133,6 +138,7 @@ fn installed_versions_in_dir(installs_dir: &Path) -> Vec<String> {
         .unwrap_or_default()
         .into_iter()
         .filter(|v| !v.starts_with('.'))
+        .filter(|v| v != "latest")
         .filter(|v| !is_runtime_symlink(&installs_dir.join(v)))
         .filter(|v| !installs_dir.join(v).join("incomplete").exists())
         .filter(|v| !VERSION_REGEX.is_match(v))

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -220,6 +220,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             })
             .into_iter()
             .filter(|v| !v.starts_with('.'))
+            .filter(|v| v != "latest")
             .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
             .filter(|v| !dir.join(v).join("incomplete").exists())
             .sorted_by_cached_key(|v| {
@@ -326,6 +327,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 })
                 .into_iter()
                 .filter(|v| !v.starts_with('.'))
+                .filter(|v| v != "latest")
                 .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
                 .filter(|v| !dir.join(v).join("incomplete").exists())
                 .sorted_by_cached_key(|v| {

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -220,7 +220,6 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             })
             .into_iter()
             .filter(|v| !v.starts_with('.'))
-            .filter(|v| v != "latest")
             .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
             .filter(|v| !dir.join(v).join("incomplete").exists())
             .sorted_by_cached_key(|v| {
@@ -327,7 +326,6 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 })
                 .into_iter()
                 .filter(|v| !v.starts_with('.'))
-                .filter(|v| v != "latest")
                 .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
                 .filter(|v| !dir.join(v).join("incomplete").exists())
                 .sorted_by_cached_key(|v| {

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -323,8 +323,10 @@ impl ToolVersion {
             }
             let latest_error = if !is_offline {
                 match backend.latest_version(config, None, opts.before_date).await {
-                    Ok(Some(v)) => return build(v),
-                    Ok(None) => None,
+                    Ok(Some(v)) if v != "latest" || backend.allows_literal_latest_version() => {
+                        return build(v);
+                    }
+                    Ok(Some(_)) | Ok(None) => None,
                     Err(err) => Some(err),
                 }
             } else {

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -321,13 +321,28 @@ impl ToolVersion {
             {
                 return build(v);
             }
-            if !is_offline
-                && let Some(v) = backend
-                    .latest_version(config, None, opts.before_date)
-                    .await?
-            {
+            let latest_error = if !is_offline {
+                match backend.latest_version(config, None, opts.before_date).await {
+                    Ok(Some(v)) => return build(v),
+                    Ok(None) => None,
+                    Err(err) => Some(err),
+                }
+            } else {
+                None
+            };
+            if let Some(v) = backend.latest_installed_version(None)? {
                 return build(v);
             }
+            if let Some(err) = latest_error {
+                return Err(err);
+            }
+            if opts.before_date.is_some() {
+                bail!(
+                    "no versions found for {} matching date filter",
+                    backend.id()
+                );
+            }
+            bail!("no latest version found for {}", backend.id());
         }
         if !opts.latest_versions {
             let matches = backend.list_installed_versions_matching(&v);


### PR DESCRIPTION
## Summary

Fixes the root `@latest` install bug from #9276: if `latest` cannot be resolved to a concrete version, normal versioned backends no longer fall through to installing into `installs/<tool>/latest/` as a real directory. Existing stale real `latest/` directories are also repaired into runtime symlinks after a concrete version is installed.

## Root Cause

`ToolVersion::resolve_version` could leave `tv.version == "latest"` when latest resolution returned no concrete version. The generic install path then created a real `installs/<tool>/latest/` directory. That real directory was later treated as an installed version and could block upgrade/reshim/runtime symlink repair.

## Changes

- Add an e2e regression for unresolved `dummy@latest` proving no real `latest/` directory is created.
- Add a stale-state e2e case proving `mise up` installs `2.0.0`, replaces `latest/` with `latest -> ./2.0.0`, and runs the new binary.
- Make unresolved `@latest` fail unless a concrete latest version resolves or a valid installed runtime symlink exists.
- Ignore stale real `latest/` directories in normal installed-version discovery and `latest_installed_version(None)`.
- Replace stale real `latest/` directories during runtime symlink rebuild when a concrete version exists.
- Preserve the existing UBI direct-URL behavior where `latest` is the artifact identity, while keeping that exception scoped to UBI URL installs.

## CI Flow

- Test-only commit `6bb6d5465` was pushed first and opened as this draft PR.
- GitHub Actions failed on that test-only commit as expected (`e2e-4`).
- Fix commit `54387223f` was pushed after the failing CI signal.
- Follow-up commit `5c9488d3d` keeps UBI direct URL `latest` installs working after CI exposed that compatibility case.

## Local Validation

- `mise run test:e2e e2e/cli/test_latest_real_dir`
- `mise run test:unit`
- `mise run lint`
- Isolated UBI direct URL smoke test for the CI-exposed `ffmpeg` case

## Notes

The only non-versioned literal `latest` exception in this patch is UBI direct URLs, where the URL itself identifies the downloaded artifact. Normal `@latest` requests still need to resolve to a concrete version or an existing valid runtime symlink.