### PR TITLE
fix(cli): suppress error output after interactive cancel

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,8 +149,9 @@ fn handle_err(err: Report) -> eyre::Result<()> {
     {
         return Ok(());
     }
-    if is_user_cancelled(&err) {
-        return Ok(());
+    if is_interrupted_io_error(&err) {
+        stop_multi_progress();
+        exit(130);
     }
 
     // Check for miette diagnostic errors and render them specially
@@ -193,8 +194,18 @@ fn display_friendly_err(err: &Report) {
     error!("{msg}");
 }
 
-fn is_user_cancelled(err: &Report) -> bool {
-    err.chain().any(|err| err.to_string() == "user cancelled")
+fn is_interrupted_io_error(err: &Report) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|e| e.kind() == std::io::ErrorKind::Interrupted)
+    })
+}
+
+fn stop_multi_progress() {
+    if let Some(mpr) = MultiProgressReport::try_get() {
+        let _ = mpr.stop();
+    }
 }
 
 static ASYNC_PANIC_OCCURRED: AtomicBool = AtomicBool::new(false);
@@ -235,8 +246,14 @@ mod tests {
     use eyre::eyre;
 
     #[test]
-    fn detects_exact_user_cancelled_error() {
-        assert!(is_user_cancelled(&eyre!("user cancelled")));
-        assert!(!is_user_cancelled(&eyre!("download cancelled by user")));
+    fn detects_interrupted_io_error() {
+        assert!(is_interrupted_io_error(&eyre!(std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            "user cancelled"
+        ))));
+        assert!(!is_interrupted_io_error(&eyre!(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "user cancelled"
+        ))));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,9 @@ fn handle_err(err: Report) -> eyre::Result<()> {
     {
         return Ok(());
     }
+    if is_user_cancelled(&err) {
+        return Ok(());
+    }
 
     // Check for miette diagnostic errors and render them specially
     if let Some(diagnostic) = err.downcast_ref::<config::config_file::diagnostic::MiseDiagnostic>()
@@ -190,6 +193,10 @@ fn display_friendly_err(err: &Report) {
     error!("{msg}");
 }
 
+fn is_user_cancelled(err: &Report) -> bool {
+    err.chain().any(|err| err.to_string() == "user cancelled")
+}
+
 static ASYNC_PANIC_OCCURRED: AtomicBool = AtomicBool::new(false);
 
 pub fn install_panic_hook() {
@@ -220,4 +227,16 @@ pub fn install_panic_hook() {
 
         default_hook(panic_info);
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use eyre::eyre;
+
+    #[test]
+    fn detects_exact_user_cancelled_error() {
+        assert!(is_user_cancelled(&eyre!("user cancelled")));
+        assert!(!is_user_cancelled(&eyre!("download cancelled by user")));
+    }
 }


### PR DESCRIPTION
## Summary
- treat the exact `user cancelled` interactive picker error as a graceful exit in the top-level error handler
- avoid printing the friendly error footer when a user dismisses an interactive prompt
- add a focused unit test to keep broader cancellation errors unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, top-level error-handling change gated on `io::ErrorKind::Interrupted`; main risk is altering exit behavior/output for some cancellation paths.
> 
> **Overview**
> Treats `std::io::ErrorKind::Interrupted` anywhere in the error chain as a *graceful user cancel* in the top-level CLI error handler, stopping any active `MultiProgressReport` and exiting with code `130` instead of printing friendly/diagnostic output.
> 
> Adds small helpers (`is_interrupted_io_error`, `stop_multi_progress`) plus a focused unit test to ensure only `Interrupted` is handled this way (not other IO errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fae6762af71d3c3653c41f82575ae2daac7032f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->