### PR TITLE
chore(ci): increase autofix timeout

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,7 +25,7 @@ jobs:
   autofix:
     if: github.actor != 'renovate[bot]' && github.actor != 'mend[bot]'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2


### PR DESCRIPTION
## Summary
- double the `autofix` workflow timeout from 10 to 20 minutes
- give the autofix job more room to finish its build and lint-fix steps before GitHub cancels it

## Testing
- not run (workflow-only change)

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that just increases `autofix` job runtime allowance, with no code or security logic impact.
> 
> **Overview**
> Increases the GitHub Actions `autofix` workflow job timeout from **10 minutes to 20 minutes** to reduce premature cancellations during build/render/lint-fix steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b8d79789ac4852a7d094759b8d6fd1f12a3b61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->