### PR TITLE
chore(ci): stop release-plz from saving build cache

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: build
+          save-if: false
       - run: mkdir -p "$HOME/bin" && echo "$HOME/bin" >> "$GITHUB_PATH"
       - run: cargo build --all-features && cp target/debug/mise "$HOME"/bin
       - uses: ./.github/actions/mise-tools


### PR DESCRIPTION
## Summary
- keep `release-plz` restoring the shared Rust `build` cache
- stop `release-plz` from writing that cache back to GitHub Actions

## Why
- avoid having `release-plz` refresh the oversized shared Linux Rust cache on `main`
- keep cache reads for build speed while removing this workflow as a cache writer

## Testing
- not run (workflow-only change)

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that tweaks GitHub Actions caching behavior; low functional risk aside from potentially affecting build speed/cache freshness.
> 
> **Overview**
> The `release-plz` GitHub Actions workflow now configures `Swatinem/rust-cache` with `save-if: false`, so it will **restore** the shared `build` cache but **won’t save/update** that cache after the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b841ab258ee9acbdc178aa1090dee879261888ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->