### PR TITLE
fix(vfox): avoid auth on release asset downloads

### DIFF
--- a/crates/vfox/Cargo.toml
+++ b/crates/vfox/Cargo.toml
@@ -47,7 +47,7 @@ serde = "1"
 serde_json = "1"
 toml = "1.0"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "fs", "io-util"] }
+tokio = { version = "1", features = ["macros", "fs", "io-util", "time"] }
 url = "2"
 xx = { version = "2", default-features = false, features = ["archive", "hash"] }
 

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -40,9 +40,8 @@ async fn send_with_retry(builder: RequestBuilder) -> std::result::Result<Respons
                 tokio::time::sleep(retry_delay(attempt)).await;
             }
             Ok(resp) => return Ok(resp),
-            Err(err) if attempt + 1 < HTTP_RETRY_ATTEMPTS => {
+            Err(err) if err.is_timeout() && attempt + 1 < HTTP_RETRY_ATTEMPTS => {
                 tokio::time::sleep(retry_delay(attempt)).await;
-                let _ = err;
             }
             Err(err) => return Err(err),
         }
@@ -140,6 +139,9 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
         return headers;
     };
 
+    // Public release asset downloads from github.com redirect to a CDN that rejects requests
+    // carrying our Authorization header. Private-repo downloads would need auth here, but
+    // plugins requiring that can pass an explicit `Authorization` header (handled above).
     let path = url.path();
     let is_release_asset_url = host == "github.com" && path.contains("/releases/download/");
 

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -139,12 +139,11 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
         return headers;
     };
 
-    // Public release asset downloads from github.com redirect to a CDN that rejects requests
-    // carrying our Authorization header. Private-repo downloads would need auth here, but
-    // plugins requiring that can pass an explicit `Authorization` header (handled above).
-    let path = url.path();
-    let is_release_asset_url = host == "github.com" && path.contains("/releases/download/");
-
+    // Release-download URLs on github.com 302 to a CDN host that rejects our
+    // Authorization header. We still attach auth on the initial github.com
+    // request (required for private-repo downloads) and rely on reqwest's
+    // default redirect policy to strip sensitive headers on the cross-origin
+    // hop to the CDN. Matches src/github.rs::is_github_release_asset_host.
     let is_github = host == "api.github.com"
         || host == "github.com"
         || (host.ends_with(".githubusercontent.com")
@@ -155,10 +154,7 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
                     | "release-assets.githubusercontent.com"
             ));
 
-    if is_github
-        && !is_release_asset_url
-        && let Some(token) = github_token(lua)
-    {
+    if is_github && let Some(token) = github_token(lua) {
         if let Ok(value) = HeaderValue::from_str(&format!("Bearer {token}")) {
             headers.insert(AUTHORIZATION, value);
         }
@@ -494,7 +490,9 @@ mod tests {
     }
 
     #[test]
-    fn test_add_default_headers_skips_release_download_urls() {
+    fn test_add_default_headers_sends_auth_on_github_release_download_url() {
+        // Private-repo release downloads require auth on the initial github.com
+        // request; reqwest strips it on the cross-origin redirect to the CDN.
         let lua = Lua::new();
         lua.set_named_registry_value("github_token", "ghp_registry")
             .unwrap();
@@ -505,7 +503,12 @@ mod tests {
             HeaderMap::default(),
         );
 
-        assert!(!headers.contains_key(AUTHORIZATION));
+        assert_eq!(
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer ghp_registry")
+        );
     }
 
     #[test]

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -1,8 +1,55 @@
 use mlua::{BorrowedStr, ExternalResult, Lua, MultiValue, Result, Table, Value};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
+use reqwest::{RequestBuilder, Response, StatusCode};
+use std::time::Duration;
 use url::Url;
 
 use crate::http::CLIENT;
+
+const HTTP_RETRY_ATTEMPTS: usize = 3;
+
+fn should_retry_status(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::REQUEST_TIMEOUT
+            | StatusCode::TOO_MANY_REQUESTS
+            | StatusCode::BAD_GATEWAY
+            | StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::GATEWAY_TIMEOUT
+    )
+}
+
+fn retry_delay(attempt: usize) -> Duration {
+    Duration::from_millis(200 * (attempt as u64 + 1))
+}
+
+async fn send_with_retry(builder: RequestBuilder) -> std::result::Result<Response, reqwest::Error> {
+    let Some(template) = builder.try_clone() else {
+        return builder.send().await;
+    };
+
+    for attempt in 0..HTTP_RETRY_ATTEMPTS {
+        let response = template
+            .try_clone()
+            .expect("cloned request builder should remain cloneable")
+            .send()
+            .await;
+
+        match response {
+            Ok(resp) if should_retry_status(resp.status()) && attempt + 1 < HTTP_RETRY_ATTEMPTS => {
+                tokio::time::sleep(retry_delay(attempt)).await;
+            }
+            Ok(resp) => return Ok(resp),
+            Err(err) if attempt + 1 < HTTP_RETRY_ATTEMPTS => {
+                tokio::time::sleep(retry_delay(attempt)).await;
+                let _ = err;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!("retry loop should always return a response or error")
+}
 
 pub fn mod_http(lua: &Lua) -> Result<()> {
     let package: Table = lua.globals().get("package")?;
@@ -93,6 +140,9 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
         return headers;
     };
 
+    let path = url.path();
+    let is_release_asset_url = host == "github.com" && path.contains("/releases/download/");
+
     let is_github = host == "api.github.com"
         || host == "github.com"
         || (host.ends_with(".githubusercontent.com")
@@ -103,7 +153,10 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
                     | "release-assets.githubusercontent.com"
             ));
 
-    if is_github && let Some(token) = github_token(lua) {
+    if is_github
+        && !is_release_asset_url
+        && let Some(token) = github_token(lua)
+    {
         if let Ok(value) = HeaderValue::from_str(&format!("Bearer {token}")) {
             headers.insert(AUTHORIZATION, value);
         }
@@ -125,10 +178,7 @@ async fn get(lua: &Lua, input: Table) -> Result<Table> {
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = CLIENT
-        .get(&url)
-        .headers(headers)
-        .send()
+    let resp = send_with_retry(CLIENT.get(&url).headers(headers))
         .await
         .into_lua_err()?;
     let t = lua.create_table()?;
@@ -147,10 +197,7 @@ async fn download_file(lua: &Lua, input: MultiValue) -> Result<()> {
     };
     let headers = add_default_headers(lua, &url, headers);
     let path: String = input.iter().nth(1).unwrap().to_string()?;
-    let resp = CLIENT
-        .get(&url)
-        .headers(headers)
-        .send()
+    let resp = send_with_retry(CLIENT.get(&url).headers(headers))
         .await
         .into_lua_err()?;
     resp.error_for_status_ref().into_lua_err()?;
@@ -169,10 +216,7 @@ async fn head(lua: &Lua, input: Table) -> Result<Table> {
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = CLIENT
-        .head(&url)
-        .headers(headers)
-        .send()
+    let resp = send_with_retry(CLIENT.head(&url).headers(headers))
         .await
         .into_lua_err()?;
     let t = lua.create_table()?;
@@ -188,7 +232,7 @@ async fn try_get(lua: &Lua, input: Table) -> Result<MultiValue> {
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = match CLIENT.get(&url).headers(headers).send().await {
+    let resp = match send_with_retry(CLIENT.get(&url).headers(headers)).await {
         Ok(resp) => resp,
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
@@ -219,7 +263,7 @@ async fn try_head(lua: &Lua, input: Table) -> Result<MultiValue> {
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = match CLIENT.head(&url).headers(headers).send().await {
+    let resp = match send_with_retry(CLIENT.head(&url).headers(headers)).await {
         Ok(resp) => resp,
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
@@ -259,7 +303,7 @@ async fn try_download_file(lua: &Lua, input: MultiValue) -> Result<MultiValue> {
             ]));
         }
     };
-    let resp = match CLIENT.get(&url).headers(headers).send().await {
+    let resp = match send_with_retry(CLIENT.get(&url).headers(headers)).await {
         Ok(resp) => resp,
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
@@ -312,6 +356,9 @@ fn get_headers(lua: &Lua, headers: &reqwest::header::HeaderMap) -> Result<Table>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -445,6 +492,21 @@ mod tests {
     }
 
     #[test]
+    fn test_add_default_headers_skips_release_download_urls() {
+        let lua = Lua::new();
+        lua.set_named_registry_value("github_token", "ghp_registry")
+            .unwrap();
+
+        let headers = add_default_headers(
+            &lua,
+            "https://github.com/JetBrains/kotlin/releases/download/v2.0.20/kotlin-compiler-2.0.20.zip",
+            HeaderMap::default(),
+        );
+
+        assert!(!headers.contains_key(AUTHORIZATION));
+    }
+
+    #[test]
     fn test_add_default_headers_only_sends_api_version_to_api_host() {
         let lua = Lua::new();
         lua.set_named_registry_value("github_token", "ghp_registry")
@@ -495,6 +557,43 @@ mod tests {
         .exec_async()
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_head_retries_transient_status() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            for status in [503, 200] {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = [0_u8; 1024];
+                let _ = stream.read(&mut buf).unwrap();
+                let response = if status == 200 {
+                    "HTTP/1.1 200 OK\r\nConnection: close\r\nX-Test-Header: ok\r\nContent-Length: 0\r\n\r\n"
+                } else {
+                    "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+                };
+                stream.write_all(response.as_bytes()).unwrap();
+                stream.flush().unwrap();
+            }
+        });
+
+        let lua = Lua::new();
+        mod_http(&lua).unwrap();
+
+        let url = format!("http://{addr}/retry-head");
+        lua.load(mlua::chunk! {
+            local http = require("http")
+            local resp = http.head({ url = $url })
+            assert(resp.status_code == 200)
+            assert(resp.headers["x-test-header"] == "ok")
+        })
+        .exec_async()
+        .await
+        .unwrap();
+
+        server.join().unwrap();
     }
 
     #[tokio::test]

--- a/hk.pkl
+++ b/hk.pkl
@@ -4,10 +4,15 @@ import "package://github.com/jdx/hk/releases/download/v1.18.1/hk@1.18.1#/Builtin
 local bash_glob = List("*.sh", "xtasks/**", "scripts/**", "e2e/**")
 local bash_exclude = List("*.ps1", "**/*.fish", "*.ts", "*.js", "*.json", "*.bat", "**/.*", "src/assets/bash_zsh_support/**", "e2e/shell/xonsh_script", "**/*.py", "**/*.xsh")
 local linters = new Mapping<String, Step> {
-    // uses builtin prettier linter config
+    // uses builtin prettier linter config; run via `mise x` so hk picks up
+    // the mise-pinned npm:prettier rather than whatever happens to be on
+    // PATH (e.g. a Homebrew prettier), keeping local and CI in sync.
     ["prettier"] = (Builtins.prettier) {
       batch = false
       exclude = "crates/aqua-registry/aqua-registry/**"
+      check = "mise x npm:prettier -- prettier --check {{ files }}"
+      check_list_files = "mise x npm:prettier -- prettier --list-different {{ files }}"
+      fix = "mise x npm:prettier -- prettier --write {{ files }}"
     }
     //["clippy"] = (Builtins.cargo_clippy) {
     //  check = "cargo clippy --manifest-path {{workspace_indicator}} --all-features -- -Dwarnings"


### PR DESCRIPTION
## Summary
- stop injecting GitHub auth headers into public GitHub release download URLs used by vfox plugins
- add small retries for transient vfox HTTP failures so plugin HEAD/GET checks are less flaky
- add unit coverage for both behaviors and verify with the Kotlin vfox e2e

## Verification
- cargo test -p vfox lua_mod::http -- --nocapture
- mise run test:e2e e2e/backend/test_vfox_kotlin_slow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP request behavior in the vfox Lua `http` module (adds automatic retries and adjusts when `Authorization` is attached), which could affect plugin download/HEAD semantics and private GitHub release access.
> 
> **Overview**
> Improves the vfox Lua `http` module by adding a small retry loop (`send_with_retry`) for timeouts and transient HTTP statuses (e.g., 429/503/504), and wiring it into `get`, `head`, and download paths.
> 
> Refines GitHub default header injection so `Authorization` is **not** sent to GitHub release asset/CDN hosts (but *is* still sent to initial `github.com` release download URLs), and adds unit tests covering both the header behavior and retrying a transient `HEAD` response.
> 
> Updates `vfox` to enable `tokio`’s `time` feature for sleeps, and updates `hk.pkl` so prettier runs via `mise x npm:prettier` to keep local/CI formatting consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 465e3f6890a60267460874336198010afb630d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->