### PR TITLE
fix(vfox): skip github auth on release download URLs

### DIFF
--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -93,6 +93,8 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
         return headers;
     };
 
+    let is_release_asset_url = host == "github.com" && url.path().contains("/releases/download/");
+
     let is_github = host == "api.github.com"
         || host == "github.com"
         || (host.ends_with(".githubusercontent.com")
@@ -103,7 +105,10 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
                     | "release-assets.githubusercontent.com"
             ));
 
-    if is_github && let Some(token) = github_token(lua) {
+    if is_github
+        && !is_release_asset_url
+        && let Some(token) = github_token(lua)
+    {
         if let Ok(value) = HeaderValue::from_str(&format!("Bearer {token}")) {
             headers.insert(AUTHORIZATION, value);
         }
@@ -438,6 +443,21 @@ mod tests {
         let headers = add_default_headers(
             &lua,
             "https://release-assets.githubusercontent.com/github-production-release-asset/1/file",
+            HeaderMap::default(),
+        );
+
+        assert!(!headers.contains_key(AUTHORIZATION));
+    }
+
+    #[test]
+    fn test_add_default_headers_skips_release_download_urls() {
+        let lua = Lua::new();
+        lua.set_named_registry_value("github_token", "ghp_registry")
+            .unwrap();
+
+        let headers = add_default_headers(
+            &lua,
+            "https://github.com/JetBrains/kotlin/releases/download/v2.0.20/kotlin-compiler-2.0.20.zip",
             HeaderMap::default(),
         );
 


### PR DESCRIPTION
## Summary

- Skip adding the GitHub `Authorization` header in `vfox`'s Lua HTTP module when the URL is a GitHub release download URL (`github.com/.../releases/download/...`).
- These URLs 302-redirect to signed `release-assets.githubusercontent.com` URLs and don't need auth. Sending one can make `http.head` return non-200 in CI, breaking plugins like `vfox-kotlin` whose `PreInstall` does:

  ```lua
  local resp, err = http.head({ url = url })
  if err ~= nil or resp.status_code ~= 200 then
      error("Current version information not detected.")
  end
  ```

- This is the root cause of the `backend/test_vfox_kotlin_slow` failure on recent CI runs (e.g. [e2e-4 on PR #9258](https://github.com/jdx/mise/actions/runs/24753416607/job/72421841889?pr=9258)).

This is a narrower alternative to [#9299](https://github.com/jdx/mise/pull/9299) focused only on the auth fix (no retry changes).

## Test plan

- [x] `mise --cd crates/vfox run test` — new `test_add_default_headers_skips_release_download_urls` passes, all existing tests still pass
- [x] `mise --cd crates/vfox run lint` passes
- [ ] CI `backend/test_vfox_kotlin_slow` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly changes header injection logic to avoid sending `Authorization` on a specific GitHub release download URL pattern, plus a unit test to lock in behavior.
> 
> **Overview**
> Prevents `vfox`’s Lua HTTP client from attaching a GitHub `Authorization` header to `github.com/.../releases/download/...` URLs, while still sending auth for other GitHub hosts/paths.
> 
> Adds a focused regression test ensuring release download URLs do not receive the default auth header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbda9bbfa944c67e79e64b2170a3980f7e6bb00f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->