### PR TITLE
fix(backend): use full token chain for all sigstore attestation calls

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -23,7 +23,7 @@ use crate::{
     cache::{CacheManager, CacheManagerBuilder},
 };
 use crate::{backend::Backend, config::Config};
-use crate::{env, file, github, minisign};
+use crate::{file, github, minisign};
 use async_trait::async_trait;
 use eyre::{ContextCompat, Result, bail, eyre};
 use indexmap::IndexSet;
@@ -936,12 +936,12 @@ impl AquaBackend {
             .as_ref()
             .and_then(|att| att.signer_workflow.clone());
 
-        match sigstore_verification::verify_github_attestation(
+        match crate::github::sigstore::verify_attestation(
             artifact_path,
             &pkg.repo_owner,
             &pkg.repo_name,
-            env::GITHUB_TOKEN.as_deref(),
             signer_workflow.as_deref(),
+            None,
         )
         .await
         {
@@ -1005,7 +1005,7 @@ impl AquaBackend {
         HTTP.download_file(&provenance_url, &provenance_path, pr)
             .await?;
 
-        match sigstore_verification::verify_slsa_provenance(artifact_path, &provenance_path, 1u8)
+        match crate::github::sigstore::verify_slsa_provenance(artifact_path, &provenance_path, 1u8)
             .await
         {
             Ok(true) => {
@@ -1122,7 +1122,7 @@ impl AquaBackend {
                 checksum_path.with_extension("sig")
             };
 
-            match sigstore_verification::verify_cosign_signature_with_key(
+            match crate::github::sigstore::verify_cosign_signature_with_key(
                 checksum_path,
                 &sig_path,
                 &key_path,
@@ -1153,7 +1153,8 @@ impl AquaBackend {
             let bundle_path = download_dir.join(get_filename_from_url(&bundle_url));
             HTTP.download_file(&bundle_url, &bundle_path, pr).await?;
 
-            match sigstore_verification::verify_cosign_signature(checksum_path, &bundle_path).await
+            match crate::github::sigstore::verify_cosign_signature(checksum_path, &bundle_path)
+                .await
             {
                 Ok(true) => {
                     debug!("cosign (bundle) verified");

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -481,7 +481,13 @@ impl UnifiedGitBackend {
                 {
                     Ok(true) => return Some(ProvenanceType::GithubAttestations),
                     Ok(false) => {}
-                    Err(e) => {
+                    Err(crate::github::sigstore::DetectError::SourceCreation(e)) => {
+                        warn!(
+                            "Failed to create GitHub attestation source for {owner}/{repo_name}: {e}. \
+                             Lockfile may not record github-attestations provenance."
+                        );
+                    }
+                    Err(crate::github::sigstore::DetectError::Fetch(e)) => {
                         warn!(
                             "GitHub attestation API query failed for {owner}/{repo_name}: {e}. \
                              Lockfile may not record github-attestations provenance."

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -51,10 +51,10 @@ enum VerificationStatus {
 /// Check if an SLSA verification error indicates a format/parsing issue rather than
 /// an actual verification failure. Some provenance files (e.g., BuildKit raw provenance)
 /// exist but aren't in a sigstore-verifiable format.
-fn is_slsa_format_issue(e: &sigstore_verification::AttestationError) -> bool {
+fn is_slsa_format_issue(e: &crate::github::sigstore::AttestationError) -> bool {
     match e {
-        sigstore_verification::AttestationError::NoAttestations => true,
-        sigstore_verification::AttestationError::Verification(msg) => {
+        crate::github::sigstore::AttestationError::NoAttestations => true,
+        crate::github::sigstore::AttestationError::Verification(msg) => {
             msg.contains("does not contain valid attestations")
                 || msg.contains("No certificate found")
                 || msg.contains("neither DSSE envelope nor message signature")
@@ -474,31 +474,16 @@ impl UnifiedGitBackend {
             let parts: Vec<&str> = repo.split('/').collect();
             if parts.len() == 2 {
                 let (owner, repo_name) = (parts[0], parts[1]);
-                match sigstore_verification::sources::github::GitHubSource::with_base_url(
-                    owner,
-                    repo_name,
-                    github::resolve_token_for_api_url(api_url).as_deref(),
-                    api_url,
-                ) {
-                    Ok(source) => {
-                        use sigstore_verification::AttestationSource;
-                        let artifact_ref = sigstore_verification::ArtifactRef::from_digest(digest);
-                        match source.fetch_attestations(&artifact_ref).await {
-                            Ok(attestations) if !attestations.is_empty() => {
-                                return Some(ProvenanceType::GithubAttestations);
-                            }
-                            Ok(_) => {}
-                            Err(e) => {
-                                warn!(
-                                    "GitHub attestation API query failed for {owner}/{repo_name}: {e}. \
-                                     Lockfile may not record github-attestations provenance."
-                                );
-                            }
-                        }
-                    }
+                match crate::github::sigstore::detect_attestations(
+                    owner, repo_name, api_url, digest,
+                )
+                .await
+                {
+                    Ok(true) => return Some(ProvenanceType::GithubAttestations),
+                    Ok(false) => {}
                     Err(e) => {
                         warn!(
-                            "Failed to create GitHub attestation source for {owner}/{repo_name}: {e}. \
+                            "GitHub attestation API query failed for {owner}/{repo_name}: {e}. \
                              Lockfile may not record github-attestations provenance."
                         );
                     }
@@ -572,13 +557,12 @@ impl UnifiedGitBackend {
             let parts: Vec<&str> = repo.split('/').collect();
             if parts.len() == 2 {
                 let (owner, repo_name) = (parts[0], parts[1]);
-                match sigstore_verification::verify_github_attestation_with_base_url(
+                match crate::github::sigstore::verify_attestation(
                     &artifact_path,
                     owner,
                     repo_name,
-                    github::resolve_token_for_api_url(api_url).as_deref(),
                     None,
-                    api_url,
+                    Some(api_url),
                 )
                 .await
                 {
@@ -591,7 +575,7 @@ impl UnifiedGitBackend {
                             "GitHub artifact attestations verification returned false"
                         ));
                     }
-                    Err(sigstore_verification::AttestationError::NoAttestations) => {
+                    Err(crate::github::sigstore::AttestationError::NoAttestations) => {
                         debug!("no GitHub attestations found at lock time, trying SLSA");
                     }
                     Err(e) => {
@@ -639,7 +623,7 @@ impl UnifiedGitBackend {
                 .await?;
 
                 let provenance_url = provenance_asset.browser_download_url.clone();
-                match sigstore_verification::verify_slsa_provenance(
+                match crate::github::sigstore::verify_slsa_provenance(
                     &artifact_path,
                     &provenance_path,
                     1u8,
@@ -1567,13 +1551,12 @@ impl UnifiedGitBackend {
         let (owner, repo_name) = (parts[0], parts[1]);
         let api_url = self.get_api_url(&tv.request.options());
 
-        match sigstore_verification::verify_github_attestation_with_base_url(
+        match crate::github::sigstore::verify_attestation(
             file_path,
             owner,
             repo_name,
-            github::resolve_token_for_api_url(&api_url).as_deref(),
             None, // We don't know the expected workflow
-            &api_url,
+            Some(&api_url),
         )
         .await
         {
@@ -1585,7 +1568,7 @@ impl UnifiedGitBackend {
                 }
                 Ok(verified)
             }
-            Err(sigstore_verification::AttestationError::NoAttestations) => {
+            Err(crate::github::sigstore::AttestationError::NoAttestations) => {
                 Err(VerificationStatus::NoAttestations)
             }
             Err(e) => Err(VerificationStatus::Error(e.to_string())),
@@ -1676,7 +1659,7 @@ impl UnifiedGitBackend {
 
         // Verify the provenance
         let provenance_download_url = provenance_asset.browser_download_url.clone();
-        match sigstore_verification::verify_slsa_provenance(
+        match crate::github::sigstore::verify_slsa_provenance(
             file_path,
             &provenance_path,
             1, // Minimum SLSA level
@@ -1921,14 +1904,14 @@ mod tests {
 
     #[test]
     fn test_is_slsa_format_issue_no_attestations() {
-        let err = sigstore_verification::AttestationError::NoAttestations;
+        let err = crate::github::sigstore::AttestationError::NoAttestations;
         assert!(is_slsa_format_issue(&err));
     }
 
     #[test]
     fn test_is_slsa_format_issue_invalid_format() {
         // This is the exact error from BuildKit raw provenance files parsed line-by-line
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = crate::github::sigstore::AttestationError::Verification(
             "File does not contain valid attestations or SLSA provenance".to_string(),
         );
         assert!(is_slsa_format_issue(&err));
@@ -1936,7 +1919,7 @@ mod tests {
 
     #[test]
     fn test_is_slsa_format_issue_no_certificate() {
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = crate::github::sigstore::AttestationError::Verification(
             "No certificate found in attestation bundle".to_string(),
         );
         assert!(is_slsa_format_issue(&err));
@@ -1944,7 +1927,7 @@ mod tests {
 
     #[test]
     fn test_is_slsa_format_issue_no_dsse_envelope() {
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = crate::github::sigstore::AttestationError::Verification(
             "Bundle has neither DSSE envelope nor message signature".to_string(),
         );
         assert!(is_slsa_format_issue(&err));
@@ -1953,7 +1936,7 @@ mod tests {
     #[test]
     fn test_is_slsa_format_issue_real_verification_failure() {
         // Digest mismatch = real verification failure, NOT a format issue
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = crate::github::sigstore::AttestationError::Verification(
             "Artifact digest mismatch: expected abc123".to_string(),
         );
         assert!(!is_slsa_format_issue(&err));
@@ -1962,7 +1945,7 @@ mod tests {
     #[test]
     fn test_is_slsa_format_issue_signature_failure() {
         // Signature verification failure = real failure, NOT a format issue
-        let err = sigstore_verification::AttestationError::Verification(
+        let err = crate::github::sigstore::AttestationError::Verification(
             "P-256 signature verification failed: invalid signature".to_string(),
         );
         assert!(!is_slsa_format_issue(&err));
@@ -1970,7 +1953,7 @@ mod tests {
 
     #[test]
     fn test_is_slsa_format_issue_api_error() {
-        let err = sigstore_verification::AttestationError::Api("connection refused".to_string());
+        let err = crate::github::sigstore::AttestationError::Api("connection refused".to_string());
         assert!(!is_slsa_format_issue(&err));
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -440,6 +440,17 @@ pub static PATH_NON_PRISTINE: Lazy<Vec<PathBuf>> = Lazy::new(|| match var(&*PATH
 });
 pub static DIRENV_DIFF: Lazy<Option<String>> = Lazy::new(|| var("DIRENV_DIFF").ok());
 
+/// GitHub token resolved from environment variables ONLY
+/// (`MISE_GITHUB_TOKEN`, `GITHUB_API_TOKEN`, `GITHUB_TOKEN`).
+///
+/// Intended for subprocess env-var plumbing — passing a token to child processes such as
+/// `cargo install` or `ruby-build` that read it themselves.
+///
+/// **Do not use for mise's own HTTP or sigstore calls.** Use
+/// [`crate::github::resolve_token_for_api_url`] (which walks env vars,
+/// `credential_command`, `github_tokens.toml`, gh CLI, and git credentials) or the
+/// [`crate::github::sigstore`] wrapper (which calls it internally). Passing this static
+/// to attestation verification is the original cause of the lock-time rate-limit bug.
 pub static GITHUB_TOKEN: Lazy<Option<String>> =
     Lazy::new(|| get_token(&["MISE_GITHUB_TOKEN", "GITHUB_API_TOKEN", "GITHUB_TOKEN"]));
 pub static MISE_GITHUB_ENTERPRISE_TOKEN: Lazy<Option<String>> =

--- a/src/github.rs
+++ b/src/github.rs
@@ -15,6 +15,8 @@ use tokio::sync::RwLock;
 use tokio::sync::RwLockReadGuard;
 use xx::regex;
 
+pub mod sigstore;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GithubRelease {
     pub tag_name: String,

--- a/src/github.rs
+++ b/src/github.rs
@@ -478,6 +478,12 @@ pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
     }
 
     // 4. github_tokens.toml
+    #[cfg(test)]
+    if let Some((token, source)) = test_support::lookup_tokens_file_override(&lookup_hosts)
+        .map(|t| (t, TokenSource::TokensFile))
+    {
+        return Some((token, source));
+    }
     for lookup_host in &lookup_hosts {
         if let Some(token) = MISE_GITHUB_TOKENS.get(*lookup_host) {
             return Some((token.clone(), TokenSource::TokensFile));
@@ -630,6 +636,33 @@ struct GhHostEntry {
 /// racing.
 #[cfg(test)]
 pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    //! Test-only hooks that let sibling modules seed non-env-var token sources without
+    //! spinning up global configuration infrastructure. Only consulted from `resolve_token`
+    //! under `#[cfg(test)]`; production builds never see these statics.
+
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+
+    /// Overrides the `github_tokens.toml` path (source #4 in [`super::resolve_token`]).
+    /// Keyed by the same lookup hosts `resolve_token` walks — e.g. `"github.com"`.
+    /// Hold [`super::TEST_ENV_LOCK`] while mutating; always clear before returning.
+    pub(crate) static TOKENS_FILE_OVERRIDE: RwLock<Option<HashMap<String, String>>> =
+        RwLock::new(None);
+
+    pub(crate) fn lookup_tokens_file_override(lookup_hosts: &[&str]) -> Option<String> {
+        let guard = TOKENS_FILE_OVERRIDE.read().ok()?;
+        let map = guard.as_ref()?;
+        for host in lookup_hosts {
+            if let Some(token) = map.get(*host) {
+                return Some(token.clone());
+            }
+        }
+        None
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/github.rs
+++ b/src/github.rs
@@ -15,7 +15,7 @@ use tokio::sync::RwLock;
 use tokio::sync::RwLockReadGuard;
 use xx::regex;
 
-pub mod sigstore;
+pub(crate) mod sigstore;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GithubRelease {
@@ -623,17 +623,23 @@ struct GhHostEntry {
     oauth_token: Option<String>,
 }
 
+/// Serializes env-var mutations across every `#[cfg(test)]` module that touches GitHub token
+/// environment variables. `github::tests` and `github::sigstore::tests` both mutate the same
+/// four tokens (`MISE_GITHUB_TOKEN`, `GITHUB_API_TOKEN`, `GITHUB_TOKEN`,
+/// `MISE_GITHUB_ENTERPRISE_TOKEN`); sharing a single lock prevents parallel test runs from
+/// racing.
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn with_github_token<F, R>(test_fn: F) -> R
     where
         F: FnOnce() -> R,
     {
-        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let _guard = super::TEST_ENV_LOCK.lock().unwrap();
         let orig_mise = std::env::var("MISE_GITHUB_TOKEN").ok();
         let orig_api = std::env::var("GITHUB_API_TOKEN").ok();
         let orig_gh = std::env::var("GITHUB_TOKEN").ok();

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -78,6 +78,32 @@ pub async fn verify_attestation(
     }
 }
 
+/// Reason the pre-download attestation probe could not complete.
+///
+/// Preserved as two variants so callers can log distinct warnings for a misconfigured
+/// endpoint (source creation) versus an API/network error (fetch). The original inline
+/// pre-wrapper code at `src/backend/github.rs` emitted different messages for each; the
+/// wrapper keeps that signal instead of flattening both into one error string.
+#[derive(Debug)]
+pub enum DetectError {
+    /// `GitHubSource::with_base_url` rejected the (owner, repo, api_url) tuple — usually a
+    /// malformed base URL.
+    SourceCreation(AttestationError),
+    /// The attestations endpoint returned an error (403 rate-limit, 5xx, network failure).
+    Fetch(AttestationError),
+}
+
+impl std::fmt::Display for DetectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DetectError::SourceCreation(e) => write!(f, "{e}"),
+            DetectError::Fetch(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for DetectError {}
+
 /// Probe the GitHub attestation API for the given digest without downloading the artifact.
 ///
 /// Returns `Ok(true)` if any attestations exist for the digest. Used at lock time to decide
@@ -88,11 +114,15 @@ pub async fn detect_attestations(
     repo: &str,
     api_url: &str,
     digest: &str,
-) -> AttestationResult<bool> {
+) -> Result<bool, DetectError> {
     let token = resolve_token_for_wrapper(Some(api_url));
-    let source = GitHubSource::with_base_url(owner, repo, token.as_deref(), api_url)?;
+    let source = GitHubSource::with_base_url(owner, repo, token.as_deref(), api_url)
+        .map_err(DetectError::SourceCreation)?;
     let artifact_ref = ArtifactRef::from_digest(digest);
-    let attestations = source.fetch_attestations(&artifact_ref).await?;
+    let attestations = source
+        .fetch_attestations(&artifact_ref)
+        .await
+        .map_err(DetectError::Fetch)?;
     Ok(!attestations.is_empty())
 }
 
@@ -221,5 +251,70 @@ mod tests {
             Some("ghp_public_only"),
             "default api_url should still resolve the public token"
         );
+    }
+
+    /// Guard that seeds the `github_tokens.toml` test override and clears it on drop.
+    struct TokensFileOverrideGuard;
+
+    impl TokensFileOverrideGuard {
+        fn set(host: &str, token: &str) -> Self {
+            let mut map = std::collections::HashMap::new();
+            map.insert(host.to_string(), token.to_string());
+            *crate::github::test_support::TOKENS_FILE_OVERRIDE
+                .write()
+                .unwrap() = Some(map);
+            Self
+        }
+    }
+
+    impl Drop for TokensFileOverrideGuard {
+        fn drop(&mut self) {
+            *crate::github::test_support::TOKENS_FILE_OVERRIDE
+                .write()
+                .unwrap() = None;
+        }
+    }
+
+    #[test]
+    fn test_resolve_token_wrapper_uses_github_tokens_toml_source() {
+        // Proves the wrapper delegates all the way through `resolve_token` to the
+        // non-env-var sources — here, the `github_tokens.toml` path (source #4). Without
+        // this, a future regression could short-circuit on env vars and silently pass all
+        // prior tests.
+        let _lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let _env = TokenEnvGuard::new();
+        let _tokens_file = TokensFileOverrideGuard::set("github.com", "ghp_from_tokens_file");
+
+        let resolved = resolve_token_for_wrapper(None);
+        assert_eq!(
+            resolved.as_deref(),
+            Some("ghp_from_tokens_file"),
+            "wrapper should resolve tokens from github_tokens.toml when env vars are empty"
+        );
+    }
+
+    /// Regression marker for the stacked follow-up that adds `gh auth token` / macOS
+    /// Keychain support.
+    ///
+    /// On macOS, `gh auth login` stores the OAuth token in the system Keychain by default,
+    /// leaving `~/.config/gh/hosts.yml` with no `oauth_token` field. mise's current gh CLI
+    /// reader ([`crate::github::read_gh_hosts`]) filters those entries out, so
+    /// `resolve_token_for_wrapper` returns `None` for users who rely on `gh auth` —
+    /// exactly the scenario the original bug report surfaced for github-backend tools.
+    ///
+    /// This test is ignored so CI stays green while the fix is pending. Running
+    /// `cargo test -- --ignored` surfaces it. When the follow-up branch (see workpad
+    /// Deferred Items) lands, the implementer should:
+    ///   1. Replace the `unimplemented!()` with assertions that seed a hosts.yml entry
+    ///      without `oauth_token` and an override simulating the Keychain/gh-auth-token
+    ///      return value.
+    ///   2. Remove the `#[ignore]` attribute.
+    #[test]
+    #[ignore = "stacked follow-up: gh CLI macOS Keychain / `gh auth token` support is not yet \
+                implemented — tracked under workpad Deferred Items"]
+    fn test_wrapper_resolves_gh_cli_token_from_macos_keychain_after_fix() {
+        unimplemented!(
+            "pending macOS Keychain / `gh auth token` support in the stacked follow-up PR"
+        )
     }
 }

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -1,0 +1,229 @@
+//! Sole mise-internal bridge to the `sigstore-verification` crate.
+//!
+//! Every call mise makes into `sigstore_verification` goes through this module. Callers never
+//! touch the external crate directly and never pass a GitHub token — the token is resolved
+//! internally via [`crate::github::resolve_token_for_api_url`], which walks the full chain
+//! (env vars → `credential_command` → `github_tokens.toml` → gh CLI → git credential fill).
+//!
+//! ## Why this exists
+//!
+//! Before this module, three sigstore call sites (`src/backend/aqua.rs`,
+//! `src/plugins/core/python.rs`, `src/plugins/core/ruby.rs`) passed
+//! `crate::env::GITHUB_TOKEN.as_deref()` — env vars only — while the github backend used the
+//! full chain. That asymmetry left `mise lock` issuing unauthenticated attestation requests,
+//! which hit GitHub's 60/hour IP rate limit after the second run.
+//!
+//! Concentrating the `sigstore_verification` surface here makes the asymmetry
+//! structurally impossible: wrapper signatures omit the token argument, so callers cannot
+//! re-introduce the bug without first editing this file.
+//!
+//! ## Default API URL
+//!
+//! Functions that accept `api_url: Option<&str>` fall back to [`crate::github::API_URL`]
+//! (`"https://api.github.com"`) when `None` is passed. The default must be a full URL so
+//! [`crate::github::resolve_token_for_api_url`] can parse the host correctly; a bare hostname
+//! would be silently misrouted for GitHub Enterprise Server tenants.
+
+use std::path::Path;
+
+use sigstore_verification::sources::github::GitHubSource;
+use sigstore_verification::{ArtifactRef, AttestationSource};
+
+pub use sigstore_verification::AttestationError;
+
+/// Result alias that matches `sigstore_verification`'s internal convention.
+type AttestationResult<T> = std::result::Result<T, AttestationError>;
+
+/// Resolve a GitHub token for an optional API base URL, defaulting to [`crate::github::API_URL`].
+fn resolve_token_for_wrapper(api_url: Option<&str>) -> Option<String> {
+    let url = api_url.unwrap_or(crate::github::API_URL);
+    crate::github::resolve_token_for_api_url(url)
+}
+
+/// Verify a GitHub artifact attestation for a file on disk.
+///
+/// Dispatches to [`sigstore_verification::verify_github_attestation_with_base_url`] when
+/// `api_url` is `Some` (to support GitHub Enterprise) and to
+/// [`sigstore_verification::verify_github_attestation`] otherwise.
+pub async fn verify_attestation(
+    artifact_path: &Path,
+    owner: &str,
+    repo: &str,
+    expected_workflow: Option<&str>,
+    api_url: Option<&str>,
+) -> AttestationResult<bool> {
+    let token = resolve_token_for_wrapper(api_url);
+    match api_url {
+        Some(base_url) => {
+            sigstore_verification::verify_github_attestation_with_base_url(
+                artifact_path,
+                owner,
+                repo,
+                token.as_deref(),
+                expected_workflow,
+                base_url,
+            )
+            .await
+        }
+        None => {
+            sigstore_verification::verify_github_attestation(
+                artifact_path,
+                owner,
+                repo,
+                token.as_deref(),
+                expected_workflow,
+            )
+            .await
+        }
+    }
+}
+
+/// Probe the GitHub attestation API for the given digest without downloading the artifact.
+///
+/// Returns `Ok(true)` if any attestations exist for the digest. Used at lock time to decide
+/// whether `ProvenanceType::GithubAttestations` should be recorded before committing to a
+/// full download + verify.
+pub async fn detect_attestations(
+    owner: &str,
+    repo: &str,
+    api_url: &str,
+    digest: &str,
+) -> AttestationResult<bool> {
+    let token = resolve_token_for_wrapper(Some(api_url));
+    let source = GitHubSource::with_base_url(owner, repo, token.as_deref(), api_url)?;
+    let artifact_ref = ArtifactRef::from_digest(digest);
+    let attestations = source.fetch_attestations(&artifact_ref).await?;
+    Ok(!attestations.is_empty())
+}
+
+/// Verify SLSA provenance for an already-downloaded artifact. Passthrough — no token needed.
+pub async fn verify_slsa_provenance(
+    artifact_path: &Path,
+    provenance_path: &Path,
+    min_level: u8,
+) -> AttestationResult<bool> {
+    sigstore_verification::verify_slsa_provenance(artifact_path, provenance_path, min_level).await
+}
+
+/// Verify a keyless Cosign signature or bundle. Passthrough — no token needed.
+pub async fn verify_cosign_signature(
+    artifact_path: &Path,
+    sig_or_bundle_path: &Path,
+) -> AttestationResult<bool> {
+    sigstore_verification::verify_cosign_signature(artifact_path, sig_or_bundle_path).await
+}
+
+/// Verify a Cosign signature against a public key. Passthrough — no token needed.
+pub async fn verify_cosign_signature_with_key(
+    artifact_path: &Path,
+    sig_or_bundle_path: &Path,
+    public_key_path: &Path,
+) -> AttestationResult<bool> {
+    sigstore_verification::verify_cosign_signature_with_key(
+        artifact_path,
+        sig_or_bundle_path,
+        public_key_path,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env as mise_env;
+
+    /// Serializes env-var mutations across tests in this module.
+    static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    const TOKEN_ENV_VARS: &[&str] = &[
+        "MISE_GITHUB_TOKEN",
+        "GITHUB_API_TOKEN",
+        "GITHUB_TOKEN",
+        "MISE_GITHUB_ENTERPRISE_TOKEN",
+    ];
+
+    fn snapshot_token_env_vars() -> Vec<(&'static str, Option<String>)> {
+        TOKEN_ENV_VARS
+            .iter()
+            .map(|name| (*name, std::env::var(name).ok()))
+            .collect()
+    }
+
+    fn clear_token_env_vars() {
+        for name in TOKEN_ENV_VARS {
+            mise_env::remove_var(name);
+        }
+    }
+
+    fn restore_token_env_vars(saved: Vec<(&'static str, Option<String>)>) {
+        for (name, value) in saved {
+            match value {
+                Some(v) => mise_env::set_var(name, v),
+                None => mise_env::remove_var(name),
+            }
+        }
+    }
+
+    #[test]
+    fn test_resolve_token_wrapper_uses_env_var_with_default_url() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let saved = snapshot_token_env_vars();
+        clear_token_env_vars();
+        mise_env::set_var("GITHUB_TOKEN", "ghp_wrapper_default");
+
+        let resolved = resolve_token_for_wrapper(None);
+        assert_eq!(
+            resolved.as_deref(),
+            Some("ghp_wrapper_default"),
+            "env var should flow through the wrapper with the default API URL"
+        );
+
+        restore_token_env_vars(saved);
+    }
+
+    #[test]
+    fn test_resolve_token_wrapper_uses_env_var_with_explicit_api_url() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let saved = snapshot_token_env_vars();
+        clear_token_env_vars();
+        mise_env::set_var("MISE_GITHUB_TOKEN", "ghp_explicit_api");
+
+        let resolved = resolve_token_for_wrapper(Some(crate::github::API_URL));
+        assert_eq!(
+            resolved.as_deref(),
+            Some("ghp_explicit_api"),
+            "explicit api.github.com URL should resolve identically to the default"
+        );
+
+        restore_token_env_vars(saved);
+    }
+
+    #[test]
+    fn test_resolve_token_wrapper_respects_enterprise_api_url() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let saved = snapshot_token_env_vars();
+        clear_token_env_vars();
+        mise_env::set_var("GITHUB_TOKEN", "ghp_public_only");
+        mise_env::set_var("MISE_GITHUB_ENTERPRISE_TOKEN", "ghp_enterprise_only");
+
+        // An enterprise API URL must parse and route to the enterprise token, proving the
+        // wrapper passes a full URL (not a bare hostname) to `resolve_token_for_api_url`.
+        let resolved =
+            resolve_token_for_wrapper(Some("https://github.enterprise.example.com/api/v3"));
+        assert_eq!(
+            resolved.as_deref(),
+            Some("ghp_enterprise_only"),
+            "enterprise api_url should resolve the enterprise token, not the public one"
+        );
+
+        // And the default (None) must still pick the public token.
+        let resolved_default = resolve_token_for_wrapper(None);
+        assert_eq!(
+            resolved_default.as_deref(),
+            Some("ghp_public_only"),
+            "default api_url should still resolve the public token"
+        );
+
+        restore_token_env_vars(saved);
+    }
+}

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -299,29 +299,4 @@ mod tests {
             "wrapper should resolve tokens from github_tokens.toml when env vars are empty"
         );
     }
-
-    /// Regression marker for the stacked follow-up that adds `gh auth token` / macOS
-    /// Keychain support.
-    ///
-    /// On macOS, `gh auth login` stores the OAuth token in the system Keychain by default,
-    /// leaving `~/.config/gh/hosts.yml` with no `oauth_token` field. mise's current gh CLI
-    /// reader ([`crate::github::read_gh_hosts`]) filters those entries out, so
-    /// `resolve_token_for_wrapper` returns `None` for users who rely on `gh auth` —
-    /// exactly the scenario the original bug report surfaced for github-backend tools.
-    ///
-    /// This test is ignored so CI stays green while the fix is pending. Running
-    /// `cargo test -- --ignored` surfaces it. When the follow-up branch (see workpad
-    /// Deferred Items) lands, the implementer should:
-    ///   1. Replace the `unimplemented!()` with assertions that seed a hosts.yml entry
-    ///      without `oauth_token` and an override simulating the Keychain/gh-auth-token
-    ///      return value.
-    ///   2. Remove the `#[ignore]` attribute.
-    #[test]
-    #[ignore = "stacked follow-up: gh CLI macOS Keychain / `gh auth token` support is not yet \
-                implemented — tracked under workpad Deferred Items"]
-    fn test_wrapper_resolves_gh_cli_token_from_macos_keychain_after_fix() {
-        unimplemented!(
-            "pending macOS Keychain / `gh auth token` support in the stacked follow-up PR"
-        )
-    }
 }

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -132,9 +132,6 @@ mod tests {
     use super::*;
     use crate::env as mise_env;
 
-    /// Serializes env-var mutations across tests in this module.
-    static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     const TOKEN_ENV_VARS: &[&str] = &[
         "MISE_GITHUB_TOKEN",
         "GITHUB_API_TOKEN",
@@ -142,33 +139,40 @@ mod tests {
         "MISE_GITHUB_ENTERPRISE_TOKEN",
     ];
 
-    fn snapshot_token_env_vars() -> Vec<(&'static str, Option<String>)> {
-        TOKEN_ENV_VARS
-            .iter()
-            .map(|name| (*name, std::env::var(name).ok()))
-            .collect()
+    /// RAII guard: snapshots the tracked token env vars on construction, clears them for the
+    /// test body, and restores the original values on drop — including when a test panics.
+    struct TokenEnvGuard {
+        saved: Vec<(&'static str, Option<String>)>,
     }
 
-    fn clear_token_env_vars() {
-        for name in TOKEN_ENV_VARS {
-            mise_env::remove_var(name);
+    impl TokenEnvGuard {
+        fn new() -> Self {
+            let saved: Vec<_> = TOKEN_ENV_VARS
+                .iter()
+                .map(|name| (*name, std::env::var(name).ok()))
+                .collect();
+            for name in TOKEN_ENV_VARS {
+                mise_env::remove_var(name);
+            }
+            Self { saved }
         }
     }
 
-    fn restore_token_env_vars(saved: Vec<(&'static str, Option<String>)>) {
-        for (name, value) in saved {
-            match value {
-                Some(v) => mise_env::set_var(name, v),
-                None => mise_env::remove_var(name),
+    impl Drop for TokenEnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in std::mem::take(&mut self.saved) {
+                match value {
+                    Some(v) => mise_env::set_var(name, v),
+                    None => mise_env::remove_var(name),
+                }
             }
         }
     }
 
     #[test]
     fn test_resolve_token_wrapper_uses_env_var_with_default_url() {
-        let _guard = TEST_ENV_LOCK.lock().unwrap();
-        let saved = snapshot_token_env_vars();
-        clear_token_env_vars();
+        let _lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let _env = TokenEnvGuard::new();
         mise_env::set_var("GITHUB_TOKEN", "ghp_wrapper_default");
 
         let resolved = resolve_token_for_wrapper(None);
@@ -177,15 +181,12 @@ mod tests {
             Some("ghp_wrapper_default"),
             "env var should flow through the wrapper with the default API URL"
         );
-
-        restore_token_env_vars(saved);
     }
 
     #[test]
     fn test_resolve_token_wrapper_uses_env_var_with_explicit_api_url() {
-        let _guard = TEST_ENV_LOCK.lock().unwrap();
-        let saved = snapshot_token_env_vars();
-        clear_token_env_vars();
+        let _lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let _env = TokenEnvGuard::new();
         mise_env::set_var("MISE_GITHUB_TOKEN", "ghp_explicit_api");
 
         let resolved = resolve_token_for_wrapper(Some(crate::github::API_URL));
@@ -194,15 +195,12 @@ mod tests {
             Some("ghp_explicit_api"),
             "explicit api.github.com URL should resolve identically to the default"
         );
-
-        restore_token_env_vars(saved);
     }
 
     #[test]
     fn test_resolve_token_wrapper_respects_enterprise_api_url() {
-        let _guard = TEST_ENV_LOCK.lock().unwrap();
-        let saved = snapshot_token_env_vars();
-        clear_token_env_vars();
+        let _lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let _env = TokenEnvGuard::new();
         mise_env::set_var("GITHUB_TOKEN", "ghp_public_only");
         mise_env::set_var("MISE_GITHUB_ENTERPRISE_TOKEN", "ghp_enterprise_only");
 
@@ -223,7 +221,5 @@ mod tests {
             Some("ghp_public_only"),
             "default api_url should still resolve the public token"
         );
-
-        restore_token_env_vars(saved);
     }
 }

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -102,7 +102,14 @@ impl std::fmt::Display for DetectError {
     }
 }
 
-impl std::error::Error for DetectError {}
+impl std::error::Error for DetectError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            DetectError::SourceCreation(e) => Some(e),
+            DetectError::Fetch(e) => Some(e),
+        }
+    }
+}
 
 /// Probe the GitHub attestation API for the given digest without downloading the artifact.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,8 +252,7 @@ mod tests {
             std::io::ErrorKind::Interrupted,
             "user cancelled"
         ))));
-        assert!(!is_interrupted_io_error(&eyre!(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        assert!(!is_interrupted_io_error(&eyre!(std::io::Error::other(
             "user cancelled"
         ))));
     }

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -14,7 +14,7 @@ use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::toolset::{ToolRequest, ToolVersion, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{Result, lock_file::LockFile};
-use crate::{dirs, env, file, plugins, sysconfig};
+use crate::{dirs, file, plugins, sysconfig};
 use async_trait::async_trait;
 use eyre::{bail, eyre};
 use flate2::read::GzDecoder;
@@ -625,12 +625,12 @@ impl PythonPlugin {
         ctx.pr
             .set_message("verify GitHub artifact attestations".to_string());
 
-        match sigstore_verification::verify_github_attestation(
+        match crate::github::sigstore::verify_attestation(
             tarball_path,
             "astral-sh",
             "python-build-standalone",
-            env::GITHUB_TOKEN.as_deref(),
             None, // Accept any workflow from repo
+            None,
         )
         .await
         {
@@ -646,7 +646,7 @@ impl PythonPlugin {
             Ok(false) => Err(eyre!(
                 "GitHub artifact attestations verification failed for python@{version}\n{ATTESTATION_HELP}"
             )),
-            Err(sigstore_verification::AttestationError::NoAttestations) => Err(eyre!(
+            Err(crate::github::sigstore::AttestationError::NoAttestations) => Err(eyre!(
                 "No GitHub artifact attestations found for python@{version}\n{ATTESTATION_HELP}"
             )),
             Err(e) => Err(eyre!(

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -14,7 +14,7 @@ use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::duration::DAILY;
-use crate::env::{self, PATH_KEY};
+use crate::env::PATH_KEY;
 use crate::git::{CloneOptions, Git};
 use crate::github::{self, GithubRelease};
 use crate::http::{HTTP, HTTP_FETCH};
@@ -802,12 +802,12 @@ impl RubyPlugin {
         ctx.pr
             .set_message("verify GitHub artifact attestations".to_string());
 
-        match sigstore_verification::verify_github_attestation(
+        match crate::github::sigstore::verify_attestation(
             tarball_path,
             owner,
             repo,
-            env::GITHUB_TOKEN.as_deref(),
             None, // Accept any workflow from repo
+            None,
         )
         .await
         {
@@ -823,7 +823,7 @@ impl RubyPlugin {
             Ok(false) => Err(eyre!(
                 "GitHub artifact attestations verification failed for ruby@{version}\n{ATTESTATION_HELP}"
             )),
-            Err(sigstore_verification::AttestationError::NoAttestations) => Err(eyre!(
+            Err(crate::github::sigstore::AttestationError::NoAttestations) => Err(eyre!(
                 "No GitHub artifact attestations found for ruby@{version}\n{ATTESTATION_HELP}"
             )),
             Err(e) => Err(eyre!(


### PR DESCRIPTION
## Summary

`mise lock` runs GitHub attestation verification unauthenticated because three of four sigstore call sites — aqua backend (`src/backend/aqua.rs:939`), python core plugin (`src/plugins/core/python.rs:628`), ruby core plugin (`src/plugins/core/ruby.rs:805`) — bypass mise's full token resolution chain by passing `env::GITHUB_TOKEN.as_deref()`, which only reads the `MISE_GITHUB_TOKEN` / `GITHUB_API_TOKEN` / `GITHUB_TOKEN` env vars. The fourth call path (github backend) already uses the full chain via `github::resolve_token_for_api_url`. On a repo with many GitHub-sourced tools, the unauthenticated calls exhaust the 60/hour IP rate limit on the second `mise lock`.

This PR unifies all four call sites through a new wrapper whose signatures structurally prevent re-introducing the bug.

## Approach

Introduce a crate-internal wrapper at `src/github/sigstore.rs` that owns every `sigstore_verification` import (verified by `rg -l 'use sigstore_verification\b|sigstore_verification::' src/` returning exactly that one file). The wrapper's functions (`verify_attestation`, `detect_attestations`, `verify_slsa_provenance`, `verify_cosign_signature`, `verify_cosign_signature_with_key`) resolve the token internally via `github::resolve_token_for_api_url`, using `github::API_URL` as the default. Callers can't pass a token at all. `env::GITHUB_TOKEN` stays — it's still needed for subprocess env-var plumbing in `cargo.rs` and `asdf_plugin.rs` — and gains a doc comment steering future authors away from HTTP use.

A local `DetectError` enum in the wrapper preserves the original "source creation" vs "API fetch" warning distinction that pre-wrapper code emitted. Its `Error::source()` implementation lets callers inspect the wrapped `AttestationError`.

## Test plan

- [x] 4 passing unit tests in `src/github/sigstore.rs` cover env-var, explicit and enterprise `api_url`, and the non-env-var `github_tokens.toml` source (via a new `#[cfg(test)] test_support::TOKENS_FILE_OVERRIDE` hook).
- [x] Pre-existing `is_slsa_format_issue` tests still pass after the `AttestationError` signature switch to the re-export.
- [x] `mise run lint` passes locally (runs the clippy check that was failing in CI).
- [x] `mise run ci` passes locally (runs format, build, and the full test suite).
- [ ] Manual: `mise lock` on a repo with many github/aqua-backed tools should authenticate all attestation requests when a token source is configured (env var, `github_tokens.toml`, or `credential_command`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)