### PR TITLE
fix(vfox): scope github auth to API URLs only

### DIFF
--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -139,31 +139,22 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
         return headers;
     };
 
-    // Release-download URLs on github.com 302 to a CDN host that rejects our
-    // Authorization header. We still attach auth on the initial github.com
-    // request (required for private-repo downloads) and rely on reqwest's
-    // default redirect policy to strip sensitive headers on the cross-origin
-    // hop to the CDN. Matches src/github.rs::is_github_release_asset_host.
-    let is_github = host == "api.github.com"
-        || host == "github.com"
-        || (host.ends_with(".githubusercontent.com")
-            && !matches!(
-                host,
-                "objects.githubusercontent.com"
-                    | "objects-origin.githubusercontent.com"
-                    | "release-assets.githubusercontent.com"
-            ));
+    // Only attach auth to GitHub REST API URLs. Sending auth to github.com
+    // release-download URLs causes GitHub to 302 to objects.githubusercontent.com
+    // (instead of the public release-assets host), which then 401s once
+    // reqwest strips the Authorization header on the cross-origin redirect.
+    // Mirrors src/github.rs::is_github_api_url.
+    let is_api =
+        host == "api.github.com" || (host.starts_with("api.") && host.ends_with(".ghe.com"));
 
-    if is_github && let Some(token) = github_token(lua) {
+    if is_api && let Some(token) = github_token(lua) {
         if let Ok(value) = HeaderValue::from_str(&format!("Bearer {token}")) {
             headers.insert(AUTHORIZATION, value);
         }
-        if host == "api.github.com" {
-            headers.insert(
-                "x-github-api-version",
-                HeaderValue::from_static("2022-11-28"),
-            );
-        }
+        headers.insert(
+            "x-github-api-version",
+            HeaderValue::from_static("2022-11-28"),
+        );
     }
 
     headers
@@ -490,9 +481,10 @@ mod tests {
     }
 
     #[test]
-    fn test_add_default_headers_sends_auth_on_github_release_download_url() {
-        // Private-repo release downloads require auth on the initial github.com
-        // request; reqwest strips it on the cross-origin redirect to the CDN.
+    fn test_add_default_headers_skips_github_release_download_url() {
+        // Sending auth to github.com release downloads makes GitHub redirect
+        // to objects.githubusercontent.com, which 401s once reqwest strips
+        // Authorization on the cross-origin hop.
         let lua = Lua::new();
         lua.set_named_registry_value("github_token", "ghp_registry")
             .unwrap();
@@ -503,16 +495,11 @@ mod tests {
             HeaderMap::default(),
         );
 
-        assert_eq!(
-            headers
-                .get(AUTHORIZATION)
-                .and_then(|value| value.to_str().ok()),
-            Some("Bearer ghp_registry")
-        );
+        assert!(!headers.contains_key(AUTHORIZATION));
     }
 
     #[test]
-    fn test_add_default_headers_only_sends_api_version_to_api_host() {
+    fn test_add_default_headers_skips_raw_githubusercontent() {
         let lua = Lua::new();
         lua.set_named_registry_value("github_token", "ghp_registry")
             .unwrap();
@@ -523,13 +510,34 @@ mod tests {
             HeaderMap::default(),
         );
 
+        assert!(!headers.contains_key(AUTHORIZATION));
+        assert!(!headers.contains_key("x-github-api-version"));
+    }
+
+    #[test]
+    fn test_add_default_headers_attaches_to_ghe_api_host() {
+        let lua = Lua::new();
+        lua.set_named_registry_value("github_token", "ghe_token")
+            .unwrap();
+
+        let headers = add_default_headers(
+            &lua,
+            "https://api.octocorp.ghe.com/repos/owner/repo/releases",
+            HeaderMap::default(),
+        );
+
         assert_eq!(
             headers
                 .get(AUTHORIZATION)
                 .and_then(|value| value.to_str().ok()),
-            Some("Bearer ghp_registry")
+            Some("Bearer ghe_token")
         );
-        assert!(!headers.contains_key("x-github-api-version"));
+        assert_eq!(
+            headers
+                .get("x-github-api-version")
+                .and_then(|value| value.to_str().ok()),
+            Some("2022-11-28")
+        );
     }
 
     #[tokio::test]

--- a/e2e/backend/test_go_install_slow
+++ b/e2e/backend/test_go_install_slow
@@ -16,7 +16,7 @@ assert_fail go
 cat >>.mise.toml <<EOF
 [tools]
 go = "prefix:1.24"
-"go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "latest"
+"go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "1.64.8"
 [settings]
 experimental = true
 EOF


### PR DESCRIPTION
## Summary

Two fixes for the e2e failures observed on [release PR #9258](https://github.com/jdx/mise/pull/9258) ([e2e-0](https://github.com/jdx/mise/actions/runs/24796601049/job/72569411836), [e2e-3](https://github.com/jdx/mise/actions/runs/24796601049/job/72569411825)):

- **vfox auth scoping (real bug):** when `GITHUB_TOKEN` is set and a vfox plugin (e.g. vfox-kotlin) calls `http.head` / `http.get` on a `github.com/.../releases/download/...` URL, GitHub redirects to `objects.githubusercontent.com` (not the public `release-assets.githubusercontent.com`). Once reqwest strips the `Authorization` header on the cross-origin hop, that URL 401s. The plugin's pre-install check then errors with "Current version information not detected." Mirror `src/github.rs::is_github_api_url` and only attach auth to `api.github.com` and `api.*.ghe.com` hosts.
- **golangci-lint pin:** `go:github.com/golangci/golangci-lint/cmd/golangci-lint@latest` resolution flaked in CI ("no versions found"). Pin to `1.64.8` — the kratos case on the next line still exercises subpath `@latest` resolution.

## Test plan

- [x] `cargo test -p vfox lua_mod::http -- --nocapture` (17 passed)
- [x] `mise run test:e2e e2e/backend/test_vfox_kotlin_slow` passes locally with `GITHUB_TOKEN` set (previously failed)
- [x] `mise run lint`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `Authorization`/`x-github-api-version` headers are added, which can affect private GitHub/GHE API access and plugin download flows. Also adjusts e2e tooling to avoid CI flakes by pinning `golangci-lint`.
> 
> **Overview**
> Fixes vfox Lua HTTP default header injection by **only** attaching GitHub `Authorization` and `x-github-api-version` headers for REST API hosts (`api.github.com` and `api.*.ghe.com`), avoiding auth on `github.com` release download and other non-API GitHub content URLs that can break redirects.
> 
> Updates unit tests to cover the new scoping (skip release downloads/raw content, include GHE API), and pins the e2e Go install test’s `golangci-lint` tool from `latest` to `1.64.8` to reduce CI resolution flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7f8008920f586ebf68726f4ca29ca3ae83d885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->