### PR TITLE
fix(go): treat empty GOPROXY as default

### DIFF
--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -439,7 +439,11 @@ async fn query_proxy_version_metadata(
 }
 
 fn parse_goproxy() -> Vec<GoProxy> {
-    let goproxy = std::env::var("GOPROXY").unwrap_or_else(|_| DEFAULT_GOPROXY.to_string());
+    // Treat unset or empty GOPROXY as the default, matching `go env GOPROXY`.
+    let goproxy = std::env::var("GOPROXY")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_GOPROXY.to_string());
     parse_goproxy_value(&goproxy)
 }
 
@@ -655,5 +659,25 @@ mod tests {
             parse_goproxy_value("https://corp-proxy.example.com,off,https://proxy.golang.org");
         assert_eq!(proxies.len(), 1);
         assert_eq!(proxies[0].url, "https://corp-proxy.example.com");
+    }
+
+    #[test]
+    fn parse_goproxy_empty_uses_default() {
+        // SAFETY: test is single-threaded; matches `go env GOPROXY` behavior for GOPROXY=.
+        // The prev guard restores the previous value so parallel test runs stay stable.
+        struct EnvGuard(Option<String>);
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(v) => unsafe { std::env::set_var("GOPROXY", v) },
+                    None => unsafe { std::env::remove_var("GOPROXY") },
+                }
+            }
+        }
+        let _g = EnvGuard(std::env::var("GOPROXY").ok());
+        unsafe { std::env::set_var("GOPROXY", "") };
+        let proxies = parse_goproxy();
+        assert_eq!(proxies.len(), 1);
+        assert_eq!(proxies[0].url, "https://proxy.golang.org");
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `test_go_install_slow` failure on the 2026.4.19 release PR where `mise x go:github.com/go-kratos/kratos/cmd/kratos/v2@latest -- bash -c 'kratos --help 2>&1'` exits 127 (`kratos: command not found`).

## Root Cause

`parse_goproxy()` in [src/backend/go.rs](src/backend/go.rs:441) used `env::var(\"GOPROXY\").unwrap_or_else(...)`. `unwrap_or_else` only fires when the variable is *unset*; it does not fire when the variable is set to the empty string.

The e2e harness forwards `GOPROXY=\"\${GOPROXY:-}\"` in [e2e/run_test:84](e2e/run_test:84), which evaluates to an empty string inside the docker container. That empty string feeds into `parse_goproxy_value(\"\")`, which returns no proxies, so:

1. `fetch_proxy_versions` returns `None`.
2. The `go list -m -versions` fallback returns an empty `Versions` list for submodules without tagged releases (e.g. `github.com/go-kratos/kratos/cmd/kratos/v2`).
3. `_list_remote_versions` returns `[]` and mise prints `WARN No versions found for go:…`.

This bug was latent. Before [#9276](https://github.com/jdx/mise/pull/9276), `resolve_version` fell through to `resolve_prefix(\"latest\")`, which resolved to the literal string `\"latest\"` — and `go install …@latest` handled it natively. After #9276, resolution errors with `no versions found` and `mise x` never installs the tool, so `kratos` is not on PATH → `bash -c 'kratos --help'` exits 127.

Go's own tooling treats `GOPROXY=` identically to unset:

\`\`\`
\$ env GOPROXY= go env GOPROXY
https://proxy.golang.org,direct
\`\`\`

## Fix

Treat both unset and empty `GOPROXY` as the default.

\`\`\`rust
let goproxy = std::env::var(\"GOPROXY\")
    .ok()
    .filter(|s| !s.is_empty())
    .unwrap_or_else(|| DEFAULT_GOPROXY.to_string());
\`\`\`

Added unit test `parse_goproxy_empty_uses_default`.

## Validation

- \`cargo test --bin mise backend::go::tests\` — all 12 tests pass, including the new one.
- Reproduced the failure locally with \`env -i GOPROXY= … mise ls-remote go:github.com/go-kratos/kratos/cmd/kratos/v2\` (returned nothing before the fix, now returns \`2.0.0-20260404020628-f149714c1d54\`).

Failing run this fixes: https://github.com/jdx/mise/actions/runs/24803479152/job/72592666111

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to Go backend proxy parsing plus a unit test; behavior only changes when `GOPROXY` is set to an empty string.
> 
> **Overview**
> Fixes Go backend proxy resolution to treat `GOPROXY=` (empty) the same as an unset `GOPROXY`, defaulting to `https://proxy.golang.org,direct` to match `go env` behavior.
> 
> Adds a unit test (`parse_goproxy_empty_uses_default`) that temporarily sets `GOPROXY` to empty and asserts the default proxy is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d7c9fdcfe4dab4321f5c8fc6504ce8deb27ed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->