### PR TITLE
chore(ci): remove cargo-vendor install from ppa publish

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -103,9 +103,6 @@ jobs:
           curl https://mise.run | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
-      - name: Install cargo-vendor
-        run: mise use -g cargo-binstall cargo:cargo-vendor
-
       - name: Vendor Rust dependencies
         run: |
           mkdir -p .cargo


### PR DESCRIPTION
## Summary
- remove the explicit `cargo:cargo-vendor` install from the PPA publish workflow
- rely on the built-in `cargo vendor` subcommand already available from the Rust toolchain
- avoid the current release failure where `cargo-vendor v0.1.23` no longer compiles on Rust 1.95

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that removes a third-party `cargo-vendor` install; failure risk is limited to the PPA publish workflow if `cargo vendor` behavior differs from the removed tool.
> 
> **Overview**
> The PPA publish GitHub Actions workflow no longer installs `cargo-vendor` via `mise` and instead relies on the Rust toolchain’s built-in `cargo vendor` when vendoring dependencies.
> 
> This reduces external toolchain churn and avoids CI breakage from `cargo-vendor` version/Rust compatibility issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c067a3e9f6484988f791f99e7017d5b246e346e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->