### PR TITLE
chore(deps): bump communique to 1.0.2

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -229,54 +229,53 @@ version = "3.1.0"
 backend = "cargo:usage-cli"
 
 [[tools.communique]]
-version = "1.0.1"
+version = "1.0.2"
 backend = "github:jdx/communique"
 
 [tools.communique."platforms.linux-arm64"]
-checksum = "sha256:7be8c2a327212b41e7d39c9866f49c09c26beddfcdfbde1289804c836c45797b"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318499"
+checksum = "sha256:5eb07c9d6b71c2e43b009c51150616937f21bca098ead69c54cbe04f105784e6"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268923"
 
 [tools.communique."platforms.linux-arm64-musl"]
-checksum = "sha256:7be8c2a327212b41e7d39c9866f49c09c26beddfcdfbde1289804c836c45797b"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318499"
+checksum = "sha256:5eb07c9d6b71c2e43b009c51150616937f21bca098ead69c54cbe04f105784e6"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268923"
 
 [tools.communique."platforms.linux-x64"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
-provenance = "github-attestations"
+checksum = "sha256:0b1fc485a8a388b8fa6f3bf198e5053ce7c7f47418e9a31893a369a95d411dbc"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268760"
 
 [tools.communique."platforms.linux-x64-baseline"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+checksum = "sha256:0b1fc485a8a388b8fa6f3bf198e5053ce7c7f47418e9a31893a369a95d411dbc"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268760"
 
 [tools.communique."platforms.linux-x64-musl"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+checksum = "sha256:0b1fc485a8a388b8fa6f3bf198e5053ce7c7f47418e9a31893a369a95d411dbc"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268760"
 
 [tools.communique."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+checksum = "sha256:0b1fc485a8a388b8fa6f3bf198e5053ce7c7f47418e9a31893a369a95d411dbc"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268760"
 
 [tools.communique."platforms.macos-arm64"]
-checksum = "sha256:9adcd413f3377b98aa12df003ffa4c24f084e7bea549104e29088a3b79892dd8"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318491"
+checksum = "sha256:3696f3d4ed046bf023aa3dac48892ee8705e83916378c8d5a7e911fbb2c61093"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268880"
 
 [tools.communique."platforms.windows-x64"]
-checksum = "sha256:2474f4ed704c9a94bb9dd357452275b8efe92df132ab81b642055c858441a905"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400319696"
+checksum = "sha256:5108ddc80650f28be27d231b5fa9bfb43075d3ac2f6bd7526c32aa08ab7ca534"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401269462"
 
 [tools.communique."platforms.windows-x64-baseline"]
-checksum = "sha256:2474f4ed704c9a94bb9dd357452275b8efe92df132ab81b642055c858441a905"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400319696"
+checksum = "sha256:5108ddc80650f28be27d231b5fa9bfb43075d3ac2f6bd7526c32aa08ab7ca534"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401269462"
 
 [[tools.fd]]
 version = "10.3.0"

--- a/mise.lock
+++ b/mise.lock
@@ -246,6 +246,7 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268923
 checksum = "sha256:0b1fc485a8a388b8fa6f3bf198e5053ce7c7f47418e9a31893a369a95d411dbc"
 url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268760"
+provenance = "github-attestations"
 
 [tools.communique."platforms.linux-x64-baseline"]
 checksum = "sha256:0b1fc485a8a388b8fa6f3bf198e5053ce7c7f47418e9a31893a369a95d411dbc"


### PR DESCRIPTION
## Summary
- update the `communique` lockfile entry from `1.0.1` to `1.0.2`
- refresh the release artifact URLs and checksums for the supported platforms
- use the current `mise` release behavior, which now allows this lockfile refresh to complete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change updating a pinned dev tool binary; main impact is build/tooling reproducibility if the new upstream artifacts are incorrect.
> 
> **Overview**
> Updates `mise.lock` to bump `communique` from `1.0.1` to `1.0.2`, refreshing the pinned release artifact URLs, GitHub asset IDs, and per-platform checksums for Linux/macOS/Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89c65c89e47e4b5503d40284be4ce2d0cb59860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->