### PR TITLE
chore(release): publish snap to stable channel

### DIFF
--- a/.github/workflows/snapcraft-publish.yml
+++ b/.github/workflows/snapcraft-publish.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
         with:
-          snapcraft-channel: beta
+          snapcraft-channel: stable
         id: snapbuild
 
       - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
@@ -23,4 +23,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ steps.snapbuild.outputs.snap }}
-          release: beta
+          release: stable

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -30,7 +30,7 @@ contact:
 donation:
   - https://github.com/sponsors/jdx
 
-grade: devel
+grade: stable
 confinement: classic
 
 platforms:


### PR DESCRIPTION
## Summary
- Flip snap `grade` from `devel` to `stable` so the store will accept stable-channel uploads
- Change the release workflow to build/publish on the `stable` channel instead of `beta` (mise has no separate beta release stream, so every GitHub release corresponds to a stable mise build)

Requested in [#9308](https://github.com/jdx/mise/discussions/9308) by a Canonical maintainer — currently the snap only publishes to `beta`, which means `command-not-found` on Ubuntu doesn't surface mise.

## Test plan
- [ ] Next tagged release triggers `snapcraft-publish.yml` and uploads to the `stable` channel successfully
- [ ] `snap info mise` shows a recent version under `stable:` after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release/publishing channel for the Snap artifact, increasing blast radius if the packaging or workflow is misconfigured. No application runtime code is modified.
> 
> **Overview**
> Publishes the Snap to the **Snap Store stable channel** instead of `beta` by updating the release workflow (`snapcraft-channel` and `release` set to `stable`).
> 
> Updates `snapcraft.yaml` to set `grade: stable` (from `devel`) so stable-channel uploads are accepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8eadd35255b0727c1539c530a9ee0b86be7b30c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->