### PR TITLE
fix(lock): scope targets to active project root

### DIFF
--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -23,8 +23,8 @@ If not specified, all tools in lockfile will be updated
 
 ### `-g --global`
 
-Include global config lockfile (~/.config/mise/mise.lock)
-By default, only project-level configs are locked
+Target only global config lockfiles (~/.config/mise/mise.lock and system config)
+By default, only the active project config root is locked
 
 ### `-j --jobs <JOBS>`
 
@@ -53,5 +53,5 @@ mise lock node python           # update only node and python
 mise lock --platform linux-x64  # update only linux-x64 platform
 mise lock --dry-run             # show what would be updated
 mise lock --local               # update mise.local.lock for local configs
-mise lock --global              # include global config lockfile
+mise lock --global              # update only global config lockfiles
 ```

--- a/e2e/cli/test_lock_global
+++ b/e2e/cli/test_lock_global
@@ -9,13 +9,20 @@ cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
 "aqua:jqlang/jq" = "1.7.1"
 EOF
 
+mkdir -p system-config
+cat >system-config/config.toml <<EOF
+[tools]
+"aqua:cli/cli" = "2.65.0"
+EOF
+export MISE_SYSTEM_CONFIG_FILE="$PWD/system-config/config.toml"
+
 # Set up a tool in the local project config
 cat >mise.toml <<EOF
 [tools]
 "aqua:mikefarah/yq" = "4.44.6"
 EOF
 
-rm -f mise.lock "$MISE_CONFIG_DIR/mise.lock"
+rm -f mise.lock "$MISE_CONFIG_DIR/mise.lock" system-config/mise.lock
 
 # Running mise lock should only create the project lockfile, not the global one
 output=$(mise lock --platform linux-x64 2>&1)
@@ -23,18 +30,20 @@ assert_contains "echo '$output'" "Processing 1 tool(s)"
 assert_contains "echo '$output'" "mikefarah/yq"
 assert "test -f mise.lock"
 assert "test ! -f $MISE_CONFIG_DIR/mise.lock"
+assert "test ! -f system-config/mise.lock"
 
-echo "=== Testing mise lock --global includes global config ==="
-rm -f mise.lock "$MISE_CONFIG_DIR/mise.lock"
+echo "=== Testing mise lock --global targets only global config ==="
+rm -f mise.lock "$MISE_CONFIG_DIR/mise.lock" system-config/mise.lock
 
 output=$(mise lock --global --platform linux-x64 2>&1)
-# Should process tools from both project and global configs
-assert "test -f mise.lock"
+# Should process only tools from global configs
+assert "test ! -f mise.lock"
 assert "test -f $MISE_CONFIG_DIR/mise.lock"
+assert "test -f system-config/mise.lock"
 assert_contains "cat $MISE_CONFIG_DIR/mise.lock" "jqlang/jq"
-assert_contains "cat mise.lock" "mikefarah/yq"
+assert_contains "cat system-config/mise.lock" "cli/cli"
 
 echo "=== Cleanup ==="
-rm -f mise.toml mise.lock "$MISE_CONFIG_DIR/config.toml" "$MISE_CONFIG_DIR/mise.lock"
+rm -rf mise.toml mise.lock "$MISE_CONFIG_DIR/config.toml" "$MISE_CONFIG_DIR/mise.lock" system-config
 
 echo "mise lock global tests passed!"

--- a/e2e/cli/test_lock_project_root_scope
+++ b/e2e/cli/test_lock_project_root_scope
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+
+echo "=== Testing mise lock only targets configs from the current project root ==="
+rm -rf scope-root
+mkdir -p scope-root/app/.config
+
+cat >scope-root/mise.toml <<'EOF'
+[tools]
+"aqua:cli/cli" = "2.65.0"
+EOF
+
+cat >scope-root/app/mise.toml <<'EOF'
+[tools]
+"aqua:mikefarah/yq" = "4.44.6"
+EOF
+
+cat >scope-root/app/mise.local.toml <<'EOF'
+[tools]
+"aqua:BurntSushi/ripgrep" = "14.1.1"
+EOF
+
+cat >scope-root/app/mise.test.toml <<'EOF'
+[tools]
+"aqua:sharkdp/fd" = "10.2.0"
+EOF
+
+cat >scope-root/app/.config/mise.toml <<'EOF'
+[tools]
+"aqua:jqlang/jq" = "1.7.1"
+EOF
+
+output=$(cd scope-root/app && env MISE_ENV=test mise lock --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "mikefarah/yq"
+assert_contains "echo '$output'" "BurntSushi/ripgrep"
+assert_contains "echo '$output'" "sharkdp/fd"
+assert_contains "echo '$output'" "jqlang/jq"
+assert_contains "echo '$output'" ".config/mise.lock"
+assert_not_contains "echo '$output'" "cli/cli"
+
+echo "=== Testing monorepo lock scope follows the active config root ==="
+mkdir -p monorepo-root/packages/api
+
+cat >monorepo-root/mise.toml <<'EOF'
+experimental_monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+
+[tools]
+"aqua:cli/cli" = "2.65.0"
+EOF
+
+cat >monorepo-root/packages/api/mise.toml <<'EOF'
+[tools]
+"aqua:mikefarah/yq" = "4.44.6"
+EOF
+
+output=$(cd monorepo-root/packages/api && env MISE_EXPERIMENTAL=1 mise lock --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "mikefarah/yq"
+assert_not_contains "echo '$output'" "cli/cli"
+
+output=$(cd monorepo-root && env MISE_EXPERIMENTAL=1 mise lock --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "cli/cli"
+assert_not_contains "echo '$output'" "mikefarah/yq"
+
+echo "=== Testing mise lock --global only targets the global config ==="
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[tools]
+"aqua:cli/cli" = "2.65.0"
+EOF
+mkdir -p system-config
+cat >system-config/config.toml <<'EOF'
+[tools]
+"aqua:sharkdp/bat" = "0.25.0"
+EOF
+export MISE_SYSTEM_CONFIG_FILE="$PWD/system-config/config.toml"
+
+output=$(cd scope-root/app && mise lock --global --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "cli/cli"
+assert_contains "echo '$output'" "sharkdp/bat"
+assert_not_contains "echo '$output'" "mikefarah/yq"
+assert_not_contains "echo '$output'" "jqlang/jq"
+
+mkdir -p global-only
+output=$(cd global-only && mise lock --global --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "cli/cli"
+assert_contains "echo '$output'" "sharkdp/bat"
+
+echo "=== Testing scoped explicit locks do not bump parent configs ==="
+rm -rf bump-root
+mkdir -p bump-root/app
+
+cat >bump-root/mise.toml <<'EOF'
+[tools]
+"aqua:cli/cli" = "1"
+EOF
+
+cat >bump-root/app/mise.toml <<'EOF'
+[tools]
+"aqua:mikefarah/yq" = "3"
+EOF
+
+output=$(cd bump-root/app && mise lock "aqua:mikefarah/yq@4.44.6" --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "Would update aqua:mikefarah/yq from 3 to 4"
+assert_contains "echo '$output'" "app/mise.toml"
+assert_not_contains "echo '$output'" "cli/cli"
+
+output=$(cd bump-root/app && mise lock "aqua:cli/cli@2.65.0" --platform linux-x64 --dry-run 2>&1)
+assert_not_contains "echo '$output'" "Would update"
+assert_not_contains "echo '$output'" "cli/cli"
+
+echo "=== Cleanup ==="
+rm -rf scope-root monorepo-root bump-root global-only system-config "$MISE_CONFIG_DIR/config.toml"
+
+echo "mise lock project root scope tests passed!"

--- a/e2e/cli/test_lock_project_root_scope
+++ b/e2e/cli/test_lock_project_root_scope
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+
+echo "=== Testing mise lock only targets configs from the current project root ==="
+rm -rf scope-root
+mkdir -p scope-root/app/.config
+
+cat >scope-root/mise.toml <<'EOF'
+[tools]
+"aqua:cli/cli" = "2.65.0"
+EOF
+
+cat >scope-root/app/mise.toml <<'EOF'
+[tools]
+"aqua:mikefarah/yq" = "4.44.6"
+EOF
+
+cat >scope-root/app/mise.local.toml <<'EOF'
+[tools]
+"aqua:BurntSushi/ripgrep" = "14.1.1"
+EOF
+
+cat >scope-root/app/mise.test.toml <<'EOF'
+[tools]
+"aqua:sharkdp/fd" = "10.2.0"
+EOF
+
+cat >scope-root/app/.config/mise.toml <<'EOF'
+[tools]
+"aqua:jqlang/jq" = "1.7.1"
+EOF
+
+output=$(cd scope-root/app && MISE_ENV=test mise lock --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "mikefarah/yq"
+assert_contains "echo '$output'" "BurntSushi/ripgrep"
+assert_contains "echo '$output'" "sharkdp/fd"
+assert_contains "echo '$output'" "jqlang/jq"
+assert_contains "echo '$output'" ".config/mise.lock"
+assert_not_contains "echo '$output'" "cli/cli"
+
+echo "=== Testing mise lock --global only targets the global config ==="
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[tools]
+"aqua:cli/cli" = "2.65.0"
+EOF
+mkdir -p system-config
+cat >system-config/config.toml <<'EOF'
+[tools]
+"aqua:sharkdp/bat" = "0.25.0"
+EOF
+export MISE_SYSTEM_CONFIG_FILE="$PWD/system-config/config.toml"
+
+output=$(cd scope-root/app && mise lock --global --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "cli/cli"
+assert_contains "echo '$output'" "sharkdp/bat"
+assert_not_contains "echo '$output'" "mikefarah/yq"
+assert_not_contains "echo '$output'" "jqlang/jq"
+
+mkdir -p global-only
+output=$(cd global-only && mise lock --global --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "cli/cli"
+assert_contains "echo '$output'" "sharkdp/bat"
+
+echo "=== Testing scoped explicit locks do not bump parent configs ==="
+rm -rf bump-root
+mkdir -p bump-root/app
+
+cat >bump-root/mise.toml <<'EOF'
+[tools]
+"aqua:cli/cli" = "1"
+EOF
+
+cat >bump-root/app/mise.toml <<'EOF'
+[tools]
+"aqua:mikefarah/yq" = "3"
+EOF
+
+output=$(cd bump-root/app && mise lock "aqua:mikefarah/yq@4.44.6" --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "Would update aqua:mikefarah/yq from 3 to 4"
+assert_contains "echo '$output'" "app/mise.toml"
+assert_not_contains "echo '$output'" "cli/cli"
+
+output=$(cd bump-root/app && mise lock "aqua:cli/cli@2.65.0" --platform linux-x64 --dry-run 2>&1)
+assert_not_contains "echo '$output'" "Would update"
+assert_not_contains "echo '$output'" "cli/cli"
+
+echo "=== Cleanup ==="
+rm -rf scope-root bump-root global-only system-config "$MISE_CONFIG_DIR/config.toml"
+
+echo "mise lock project root scope tests passed!"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1416,8 +1416,8 @@ Operates on the lockfile in the current config root. Use TOOL arguments to targe
 .PP
 .TP
 \fB\-g, \-\-global\fR
-Include global config lockfile (~/.config/mise/mise.lock)
-By default, only project\-level configs are locked
+Target only global config lockfiles (~/.config/mise/mise.lock and system config)
+By default, only the active project config root is locked
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -554,8 +554,8 @@ cmd local hide=#true help="Sets/gets tool version in local .tool-versions or mis
 }
 cmd lock help="Update lockfile checksums and URLs for all specified platforms" {
     long_help "Update lockfile checksums and URLs for all specified platforms\n\nUpdates checksums and download URLs for all platforms already specified in the lockfile.\nIf no lockfile exists, shows what would be created based on the current configuration.\nThis allows you to refresh lockfile data for platforms other than the one you're currently on.\nOperates on the lockfile in the current config root. Use TOOL arguments to target specific tools."
-    after_long_help "Examples:\n\n    $ mise lock                       # update lockfile for all common platforms\n    $ mise lock node python           # update only node and python\n    $ mise lock --platform linux-x64  # update only linux-x64 platform\n    $ mise lock --dry-run             # show what would be updated\n    $ mise lock --local               # update mise.local.lock for local configs\n    $ mise lock --global              # include global config lockfile\n"
-    flag "-g --global" help="Include global config lockfile (~/.config/mise/mise.lock)\nBy default, only project-level configs are locked"
+    after_long_help "Examples:\n\n    $ mise lock                       # update lockfile for all common platforms\n    $ mise lock node python           # update only node and python\n    $ mise lock --platform linux-x64  # update only linux-x64 platform\n    $ mise lock --dry-run             # show what would be updated\n    $ mise lock --local               # update mise.local.lock for local configs\n    $ mise lock --global              # update only global config lockfiles\n"
+    flag "-g --global" help="Target only global config lockfiles (~/.config/mise/mise.lock and system config)\nBy default, only the active project config root is locked"
     flag "-j --jobs" help="Number of jobs to run in parallel" {
         arg <JOBS>
     }

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -69,8 +69,8 @@ impl Lock {
 
         let ts = config.get_toolset().await?;
 
-        // Collect distinct lockfile targets from config files
-        let lockfile_targets = self.get_lockfile_targets(&config);
+        let scoped_config_paths = self.config_paths_in_lock_scope(&config);
+        let lockfile_targets = self.get_lockfile_targets(&config, &scoped_config_paths);
         let mut has_lock_targets = false;
         let mut all_provenance_errors: Vec<String> = Vec::new();
 
@@ -182,7 +182,9 @@ impl Lock {
         // Update config files when a specific version is requested that doesn't match
         // the current prefix (e.g., `mise lock tiny@3.0.1` when config has `tiny = "2"`)
         {
-            use crate::toolset::outdated_info::{apply_config_bumps, compute_config_bumps};
+            use crate::toolset::outdated_info::{
+                apply_config_bumps, compute_config_bumps_for_paths,
+            };
             let tool_versions: Vec<(String, String)> = self
                 .tool
                 .iter()
@@ -196,7 +198,7 @@ impl Lock {
                 .iter()
                 .map(|(n, v)| (n.as_str(), v.as_str()))
                 .collect();
-            let bumps = compute_config_bumps(&config, &refs);
+            let bumps = compute_config_bumps_for_paths(&config, &refs, &scoped_config_paths);
             if self.dry_run {
                 for bump in &bumps {
                     miseprintln!(
@@ -382,18 +384,71 @@ impl Lock {
         Ok(())
     }
 
+    fn config_paths_in_lock_scope(&self, config: &Config) -> BTreeSet<PathBuf> {
+        let global_config_files = crate::config::global_config_files();
+        let system_config_files = crate::config::system_config_files();
+        if self.global {
+            return config
+                .config_files
+                .keys()
+                .filter(|path| crate::config::is_global_config(path))
+                .cloned()
+                .collect();
+        }
+        let target_root =
+            Self::target_lock_scope_root(config, &global_config_files, &system_config_files);
+
+        config
+            .config_files
+            .iter()
+            .filter_map(|(path, cf)| {
+                if system_config_files.contains(path) {
+                    return None;
+                }
+                if global_config_files.contains(path) {
+                    return None;
+                }
+                let target_root = target_root.as_ref()?;
+                (cf.project_root()
+                    .unwrap_or_else(|| cf.config_root())
+                    .as_path()
+                    == target_root)
+                    .then(|| path.clone())
+            })
+            .collect()
+    }
+
+    fn target_lock_scope_root(
+        config: &Config,
+        global_config_files: &indexmap::IndexSet<PathBuf>,
+        system_config_files: &indexmap::IndexSet<PathBuf>,
+    ) -> Option<PathBuf> {
+        config.project_root.clone().or_else(|| {
+            config
+                .config_files
+                .iter()
+                .find(|(path, cf)| {
+                    cf.source().is_mise_toml()
+                        && !global_config_files.contains(*path)
+                        && !system_config_files.contains(*path)
+                })
+                .map(|(_, cf)| cf.config_root())
+        })
+    }
+
     /// Collect distinct lockfile targets from config files.
     /// Returns an ordered map of lockfile_path -> list of config paths that contribute to it.
-    fn get_lockfile_targets(&self, config: &Config) -> indexmap::IndexMap<PathBuf, Vec<PathBuf>> {
+    fn get_lockfile_targets(
+        &self,
+        config: &Config,
+        scoped_config_paths: &BTreeSet<PathBuf>,
+    ) -> indexmap::IndexMap<PathBuf, Vec<PathBuf>> {
         let mut targets: indexmap::IndexMap<PathBuf, Vec<PathBuf>> = indexmap::IndexMap::new();
         for (path, cf) in config.config_files.iter() {
+            if !scoped_config_paths.contains(path) {
+                continue;
+            }
             if !cf.source().is_mise_toml() {
-                continue;
-            }
-            if crate::config::system_config_files().contains(path) {
-                continue;
-            }
-            if !self.global && crate::config::global_config_files().contains(path) {
                 continue;
             }
             let (lockfile_path, is_local) = lockfile::lockfile_path_for_config(path);

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -32,8 +32,8 @@ pub struct Lock {
     #[clap(value_name = "TOOL", verbatim_doc_comment)]
     pub tool: Vec<ToolArg>,
 
-    /// Include global config lockfile (~/.config/mise/mise.lock)
-    /// By default, only project-level configs are locked
+    /// Target only global config lockfiles (~/.config/mise/mise.lock and system config)
+    /// By default, only the active project config root is locked
     #[clap(long, short, verbatim_doc_comment)]
     pub global: bool,
 
@@ -69,8 +69,8 @@ impl Lock {
 
         let ts = config.get_toolset().await?;
 
-        // Collect distinct lockfile targets from config files
-        let lockfile_targets = self.get_lockfile_targets(&config);
+        let scoped_config_paths = self.config_paths_in_lock_scope(&config);
+        let lockfile_targets = self.get_lockfile_targets(&config, &scoped_config_paths);
         let mut has_lock_targets = false;
         let mut all_provenance_errors: Vec<String> = Vec::new();
 
@@ -182,7 +182,9 @@ impl Lock {
         // Update config files when a specific version is requested that doesn't match
         // the current prefix (e.g., `mise lock tiny@3.0.1` when config has `tiny = "2"`)
         {
-            use crate::toolset::outdated_info::{apply_config_bumps, compute_config_bumps};
+            use crate::toolset::outdated_info::{
+                apply_config_bumps, compute_config_bumps_for_paths,
+            };
             let tool_versions: Vec<(String, String)> = self
                 .tool
                 .iter()
@@ -196,7 +198,7 @@ impl Lock {
                 .iter()
                 .map(|(n, v)| (n.as_str(), v.as_str()))
                 .collect();
-            let bumps = compute_config_bumps(&config, &refs);
+            let bumps = compute_config_bumps_for_paths(&config, &refs, &scoped_config_paths);
             if self.dry_run {
                 for bump in &bumps {
                     miseprintln!(
@@ -382,18 +384,59 @@ impl Lock {
         Ok(())
     }
 
+    fn config_paths_in_lock_scope(&self, config: &Config) -> BTreeSet<PathBuf> {
+        if self.global {
+            return config
+                .config_files
+                .keys()
+                .filter(|path| crate::config::is_global_config(path))
+                .cloned()
+                .collect();
+        }
+        let target_root = Self::target_lock_scope_root(config);
+
+        config
+            .config_files
+            .iter()
+            .filter_map(|(path, cf)| {
+                if crate::config::is_global_config(path) {
+                    return None;
+                }
+                let target_root = target_root.as_ref()?;
+                (cf.project_root()
+                    .unwrap_or_else(|| cf.config_root())
+                    .as_path()
+                    == target_root)
+                    .then(|| path.clone())
+            })
+            .collect()
+    }
+
+    fn target_lock_scope_root(config: &Config) -> Option<PathBuf> {
+        config.project_root.clone().or_else(|| {
+            config
+                .config_files
+                .iter()
+                .find(|(path, cf)| {
+                    cf.source().is_mise_toml() && !crate::config::is_global_config(path)
+                })
+                .map(|(_, cf)| cf.config_root())
+        })
+    }
+
     /// Collect distinct lockfile targets from config files.
     /// Returns an ordered map of lockfile_path -> list of config paths that contribute to it.
-    fn get_lockfile_targets(&self, config: &Config) -> indexmap::IndexMap<PathBuf, Vec<PathBuf>> {
+    fn get_lockfile_targets(
+        &self,
+        config: &Config,
+        scoped_config_paths: &BTreeSet<PathBuf>,
+    ) -> indexmap::IndexMap<PathBuf, Vec<PathBuf>> {
         let mut targets: indexmap::IndexMap<PathBuf, Vec<PathBuf>> = indexmap::IndexMap::new();
         for (path, cf) in config.config_files.iter() {
+            if !scoped_config_paths.contains(path) {
+                continue;
+            }
             if !cf.source().is_mise_toml() {
-                continue;
-            }
-            if crate::config::system_config_files().contains(path) {
-                continue;
-            }
-            if !self.global && crate::config::global_config_files().contains(path) {
                 continue;
             }
             let (lockfile_path, is_local) = lockfile::lockfile_path_for_config(path);
@@ -670,7 +713,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise lock --platform linux-x64</bold>  # update only linux-x64 platform
     $ <bold>mise lock --dry-run</bold>             # show what would be updated
     $ <bold>mise lock --local</bold>               # update mise.local.lock for local configs
-    $ <bold>mise lock --global</bold>              # include global config lockfile
+    $ <bold>mise lock --global</bold>              # update only global config lockfiles
 "#
 );
 

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -4,7 +4,9 @@ use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, ToolVersion};
 use crate::{Result, config::Config};
 use serde_derive::Serialize;
 use std::{
+    collections::BTreeSet,
     fmt::{Display, Formatter},
+    path::PathBuf,
     sync::Arc,
 };
 use tabled::Tabled;
@@ -241,10 +243,26 @@ pub fn compute_config_bumps(
     config: &Config,
     tool_versions: &[(&str, &str)], // (tool_short_name, cli_version)
 ) -> Vec<ConfigBump> {
+    let config_paths = config.config_files.keys().cloned().collect();
+    compute_config_bumps_for_paths(config, tool_versions, &config_paths)
+}
+
+/// Compute config bumps against a bounded set of config paths.
+///
+/// This lets callers that intentionally target a subset of the loaded config
+/// hierarchy avoid updating shadowed parent configs.
+pub fn compute_config_bumps_for_paths(
+    config: &Config,
+    tool_versions: &[(&str, &str)], // (tool_short_name, cli_version)
+    config_paths: &BTreeSet<PathBuf>,
+) -> Vec<ConfigBump> {
     let mut bumps = Vec::new();
 
     for &(tool_name, cli_version) in tool_versions {
         for (path, cf) in config.config_files.iter() {
+            if !config_paths.contains(path) {
+                continue;
+            }
             if crate::config::is_global_config(path) {
                 continue;
             }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1610,7 +1610,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-g", "--global"],
           description:
-            "Include global config lockfile (~/.config/mise/mise.lock)\nBy default, only project-level configs are locked",
+            "Target only global config lockfiles (~/.config/mise/mise.lock and system config)\nBy default, only the active project config root is locked",
           isRepeatable: false,
         },
         {


### PR DESCRIPTION
## Why

`mise lock` currently derives its lockfile targets from every loaded `mise.toml`-style config. That is too broad when the command is run from a nested project: the loaded hierarchy can include both a parent config and the current project's config, so a focused lock operation from the child can still update or prune the parent's lockfile.

That behavior is especially awkward for automation such as Renovate. Those tools usually operate on a specific config file or subproject and expect `mise lock <tool>` to refresh only the lockfiles owned by that target. If parent configs stay in scope, a narrow update can produce unrelated lockfile churn or inspect parent config entries during the explicit-version bump pass.

## Changes

- Compute one bounded config path set before collecting lockfile targets.
- By default, keep only `mise.toml`-style config files that belong to the active project config root.
- Keep supported config variants under that same root together, so `mise.toml`, `mise.local.toml`, `mise.<env>.toml`, `.config/mise.toml`, and related layouts still route to their normal lockfiles.
- Exclude parent project configs from the target set when running from a child project.
- Reuse the same scoped config path set for explicit-version config bumps, so `mise lock tool@version` cannot fall through to a parent config after lockfile targets are narrowed.
- Treat `--global` as an exclusive global/system scope, not an additive mode, and update the CLI help/generated docs to describe that behavior.

## Monorepos

Monorepo config roots remain separate lockfile ownership boundaries. Running `mise lock` from a monorepo package updates only that package's active config root lockfiles; shared tools defined in the monorepo root remain owned by the monorepo root lockfile and should be refreshed by running `mise lock` at the root.

Likewise, running `mise lock` at the monorepo root does not scan `[monorepo].config_roots` and update child package lockfiles. That keeps monorepo lock updates focused on the config root where the command is invoked and avoids unrelated package lockfile churn.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `shellcheck -x e2e/cli/test_lock_project_root_scope`
- `shfmt -d e2e/cli/test_lock_project_root_scope`
- `cargo test toolset::outdated_info`
- `mise run test:e2e e2e/cli/test_lock_project_root_scope e2e/cli/test_lock_global`

*This PR description was generated by an AI coding assistant.*