### PR TITLE
fix(config): resolve relative path: tool versions against config root

### DIFF
--- a/e2e/cli/test_tool_version_path
+++ b/e2e/cli/test_tool_version_path
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Test that `path:` values in [tools] resolve correctly:
+# - relative paths are resolved against the config file's directory
+# - `./` prefix is stripped
+# - `~/` is expanded to $HOME
+# See: https://github.com/jdx/mise/discussions/9288
+
+workdir="$HOME/workdir"
+
+mkdir -p "$workdir/packages/dummy"
+
+cat >mise.toml <<EOF
+[tools]
+dummy = "path:./packages/dummy"
+EOF
+
+# `mise where` should print the absolute path to the directory.
+# It must NOT contain the install-state path "installs/dummy/".
+assert "mise where dummy" "$workdir/packages/dummy"
+assert_not_contains "mise where dummy" "installs/dummy/"
+
+# mise ls should display the path with ~/ substitution via display_user.
+assert_contains "mise ls dummy" "path:~/workdir/packages/dummy"
+
+# A path without the ./ prefix should also resolve against the config root.
+cat >mise.toml <<EOF
+[tools]
+dummy = "path:packages/dummy"
+EOF
+assert "mise where dummy" "$workdir/packages/dummy"
+
+# A ~/ path should expand to $HOME.
+mkdir -p "$HOME/extra-dummy"
+cat >mise.toml <<EOF
+[tools]
+dummy = "path:~/extra-dummy"
+EOF
+assert "mise where dummy" "$HOME/extra-dummy"
+
+# An absolute path should pass through unchanged.
+cat >mise.toml <<EOF
+[tools]
+dummy = "path:$workdir/packages/dummy"
+EOF
+assert "mise where dummy" "$workdir/packages/dummy"

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{
     fmt::{Display, Formatter},
     sync::Arc,
@@ -11,8 +11,11 @@ use xx::file;
 
 use crate::backend::platform_target::PlatformTarget;
 use crate::cli::args::BackendArg;
+use crate::config::config_file::config_root;
+use crate::dirs;
 use crate::env;
 use crate::lockfile::LockfileTool;
+use crate::path::PathExt;
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::tool_version::ResolveOptions;
 use crate::toolset::{ToolSource, ToolVersion, ToolVersionOptions};
@@ -80,12 +83,15 @@ impl ToolRequest {
                 backend,
                 source,
             },
-            Some(("path", p)) => Self::Path {
-                path: PathBuf::from(p),
-                options: backend.opts(),
-                backend,
-                source,
-            },
+            Some(("path", p)) => {
+                let path = resolve_path(p, &source);
+                Self::Path {
+                    path,
+                    options: backend.opts(),
+                    backend,
+                    source,
+                }
+            }
             Some((p, v)) if p.starts_with("sub-") => Self::Sub {
                 sub: p.split_once('-').unwrap().1.to_string(),
                 options: backend.opts(),
@@ -189,7 +195,7 @@ impl ToolRequest {
             Self::Ref {
                 ref_: r, ref_type, ..
             } => format!("{ref_type}:{r}"),
-            Self::Path { path: p, .. } => format!("path:{}", p.display()),
+            Self::Path { path: p, .. } => format!("path:{}", p.display_user()),
             Self::Sub {
                 sub, orig_version, ..
             } => format!("sub-{sub}:{orig_version}"),
@@ -371,6 +377,33 @@ impl ToolRequest {
         }
         self.ba().is_os_supported()
     }
+}
+
+/// Resolve a `path:` tool version request value against the config file's directory.
+///
+/// - `~/` is expanded to `$HOME`
+/// - a leading `./` is stripped
+/// - remaining relative paths are joined with `config_root(source)` when the
+///   source is a file-based config; otherwise they fall back to the current
+///   working directory so CLI usage (e.g. `mise use tool@path:./x`) behaves
+///   the way users expect.
+fn resolve_path(p: &str, source: &ToolSource) -> PathBuf {
+    let p = Path::new(p);
+    if let Ok(rest) = p.strip_prefix("~/") {
+        return dirs::HOME.join(rest);
+    }
+    if p.is_absolute() {
+        return p.to_path_buf();
+    }
+    let p = p.strip_prefix("./").unwrap_or(p);
+    let base = match source.path() {
+        Some(src) => config_root::config_root(src),
+        None => dirs::CWD
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| PathBuf::from(".")),
+    };
+    base.join(p)
 }
 
 /// Normalize OS name aliases to the canonical form used by `std::env::consts::OS`.


### PR DESCRIPTION
## Summary

Fixes https://github.com/jdx/mise/discussions/9288.

`path:` values in `[tools]` were stored as-is, then later joined with the tool's `installs_path` when resolving the install directory. For absolute paths this works because `Path::join` replaces when given an absolute path, but for relative paths like `path:./packages/logr` it produced garbage:

`~/.local/share/mise/installs/logr/./packages/logr`

Now `ToolRequest::new` resolves `path:` at parse time:
- absolute paths pass through unchanged
- `~/` expands to `$HOME`
- a leading `./` is stripped
- any remaining relative path is joined with `config_root(source)` when the source is a config file, or CWD for CLI args

`ToolRequest::version()` now renders the stored PathBuf via `display_user()` so `~/` substitution is preserved in `mise ls` output and lockfiles.

## Test plan

- [x] New e2e test `e2e/cli/test_tool_version_path` covering `path:./x`, bare relative `path:x`, `path:~/x`, and absolute paths
- [x] Existing `e2e/cli/test_use` `path:~/workdir/mydummy` assertion still passes
- [x] `cargo check` and `mise run lint-fix` clean
- [x] Unit tests in `toolset::tool_request` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `path:` tool versions are parsed and displayed, which can affect tool resolution, lockfile entries, and `mise where/ls` output for existing configs using relative paths.
> 
> **Overview**
> Fixes `path:` tool versions so relative paths are **resolved at parse time** against the config file’s root (or CWD for CLI usage), with `~/` expansion and `./` stripping, preventing bogus install-path joins.
> 
> Updates `ToolRequest::version()` to render `path:` values via `display_user()` (preserving `~/` in output/lockfiles) and adds an e2e test covering relative, `~/`, and absolute `path:` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e0c90e0105db5ee68cb4f887895e64ace6e8f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->