### PR TITLE
fix(lock): resolve @latest and prune poisoned lockfile entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,24 @@ If the replacement has been available for a long time, the CLI warning can start
 ### Backend System
 When implementing new tool backends, follow the pattern in `src/backend/mod.rs`. Each backend must implement the `Backend` trait with methods for listing versions, installing tools, and managing tool metadata.
 
+### DO NOT ASSUME SEMVER
+**Do not assume tool versions follow semver or any other orderable scheme.** mise manages hundreds of tools with wildly different versioning conventions:
+
+- Date-based: `2024.01.15`, `20241015`
+- Pre-release / ref / tag versions: `tip`, `HEAD`, `nightly`, `edge`, `canary`, `ref:main`, `tag:v1`, `sub-X.Y:...`
+- Non-numeric tags: Python `3.12.0a1`, Ruby `3.2.0-preview1`, Go `1.22rc1`, Node `lts/hydrogen`, `lts-iron`
+- Tool-specific meanings of `latest` (e.g. some exclude pre-releases, some don't)
+
+**Rules:**
+1. Do not call `versions::Versioning::new(...)` (or any other semver comparator) at a new call site to pick the "newest" version, "resolve latest", or sort a version list. That crate silently returns `None` / arbitrary ordering for non-semver strings, which means wrong versions get chosen for many tools.
+2. To resolve a version request (`latest`, a prefix, a channel name), delegate to the backend via `Backend::latest_version`, `Backend::latest_installed_version`, `Backend::list_versions_matching`, or `ToolRequest::resolve` — the backend knows what "latest" means for its tool.
+3. To list installed versions in a meaningful order, use `Backend::list_installed_versions_matching` or the toolset's resolved versions. Do not reorder them yourself.
+4. Lockfile version strings must be treated as opaque — compare with `==`, never with a version ordering. Never write a non-concrete string (`latest`, `lts/*`, a prefix) into the lockfile; resolve first.
+
+A few existing call sites (e.g. runtime symlinks) do use `Versioning` ordering today, but that's legacy behavior and arguably also wrong — do not point at them to justify new semver assumptions.
+
+If you think you need to pick "the newest installed version" at a new call site, stop and ask — that call almost always belongs on the backend, not inline.
+
 ### Plugin Development
 - Core tools are implemented in `src/plugins/core/`
 - External plugins use ASDF or vfox compatibility layers

--- a/e2e/cli/test_lock_latest
+++ b/e2e/cli/test_lock_latest
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Tests for `mise lock` with `tool@latest` and poisoned "latest" lockfiles.
+# Regression coverage for bugs where:
+#   - `mise lock tool@latest` wrote the literal string "latest" to the lockfile
+#     instead of resolving it to a concrete installed version.
+#   - `mise lock tool` (or `mise lock`) with a lockfile that already held
+#     `version = "latest"` produced a duplicate entry alongside the concrete
+#     installed version.
+
+export MISE_LOCKFILE=1
+
+cat <<'EOF' >mise.toml
+[tools]
+tiny = "latest"
+EOF
+mise uninstall tiny --all 2>/dev/null || true
+mise install tiny@3.0.0
+mise install tiny@3.1.0
+
+# ------------------------------------------------------------------
+# `mise lock tool@latest` must resolve to the newest installed
+# concrete version, never write the literal "latest".
+# ------------------------------------------------------------------
+cat <<'EOF' >mise.lock
+# @generated
+[[tools.tiny]]
+version = "3.0.0"
+EOF
+mise lock tiny@latest --platform linux-x64
+assert_contains "cat mise.lock" 'version = "3.1.0"'
+assert_not_contains "cat mise.lock" 'version = "latest"'
+assert_not_contains "cat mise.lock" 'version = "3.0.0"'
+
+# ------------------------------------------------------------------
+# A poisoned lockfile containing `version = "latest"` must be cleaned up
+# on a single `mise lock` run and replaced with the concrete version,
+# never producing a duplicate entry.
+# ------------------------------------------------------------------
+cat <<'EOF' >mise.lock
+# @generated
+[[tools.tiny]]
+version = "latest"
+EOF
+mise lock tiny --platform linux-x64
+assert_contains "cat mise.lock" 'version = "3.1.0"'
+assert_not_contains "cat mise.lock" 'version = "latest"'
+# There should be exactly one [[tools.tiny]] entry.
+assert "[ \"$(grep -c '^\[\[tools.tiny\]\]' mise.lock)\" = \"1\" ]"
+
+# ------------------------------------------------------------------
+# Refresh semantics: `mise lock tool` with a valid lockfile must
+# preserve the current version (not introduce a newer one via the
+# "latest" fallback).
+# ------------------------------------------------------------------
+cat <<'EOF' >mise.lock
+# @generated
+[[tools.tiny]]
+version = "3.0.0"
+EOF
+mise lock tiny --platform linux-x64
+assert_contains "cat mise.lock" 'version = "3.0.0"'
+assert_not_contains "cat mise.lock" 'version = "3.1.0"'
+assert "[ \"$(grep -c '^\[\[tools.tiny\]\]' mise.lock)\" = \"1\" ]"
+
+rm -f mise.toml mise.lock
+unset MISE_LOCKFILE

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -483,10 +483,13 @@ impl Lock {
                             }
                             // For "latest" requests where nothing was resolved (e.g., tool was
                             // overridden by a higher-priority config, or the lockfile holds a
-                            // bogus "latest" literal), fall back to the best installed version.
-                            if !matched_resolved && request.version() == "latest"
-                                && let Some(latest_version) =
-                                    best_installed_version_for_backend(&backend)
+                            // bogus "latest" literal), ask the backend to resolve `latest`
+                            // against installed versions. Deliberately not sorting version
+                            // strings ourselves — each backend knows its own versioning scheme.
+                            if !matched_resolved
+                                && request.version() == "latest"
+                                && let Ok(Some(latest_version)) =
+                                    backend.latest_installed_version(Some("latest".to_string()))
                                 {
                                     let key = (ba.short.clone(), latest_version.clone());
                                     if seen.insert(key) {
@@ -515,16 +518,22 @@ impl Lock {
                     (t.ba.short.clone(), version)
                 })
                 .collect();
-            // For `tool@latest`, we want upgrade semantics: resolve "latest" to the
-            // best installed version and lock that. Writing the literal "latest" string
-            // to the lockfile would be a bug.
+            // For `tool@latest`, we want upgrade semantics: resolve "latest" to an
+            // installed concrete version and lock that. Writing the literal "latest"
+            // string to the lockfile would be a bug. Use the backend's own resolver so
+            // we don't impose a semver ordering on tools that don't follow semver.
             let mut tools: Vec<LockTool> = all_tools
                 .into_iter()
                 .filter(|(ba, _)| specified_versions.contains_key(&ba.short))
                 .map(|(ba, mut tv)| {
                     if let Some(Some(version)) = specified_versions.get(&ba.short) {
                         if version == "latest" {
-                            if let Some(latest_version) = best_installed_version(&ba) {
+                            if let Some(latest_version) = crate::backend::get(&ba)
+                                .and_then(|b| {
+                                    b.latest_installed_version(Some("latest".to_string())).ok()
+                                })
+                                .flatten()
+                            {
                                 tv.version = latest_version;
                             }
                         } else {
@@ -651,19 +660,6 @@ impl Lock {
 
         Ok((results, provenance_errors))
     }
-}
-
-/// Return the newest installed version for a given backend, or None if nothing is installed.
-fn best_installed_version_for_backend(backend: &crate::backend::ABackend) -> Option<String> {
-    backend
-        .list_installed_versions()
-        .into_iter()
-        .max_by(|a, b| versions::Versioning::new(a).cmp(&versions::Versioning::new(b)))
-}
-
-/// Resolve "latest" to the newest installed version for a given backend arg.
-fn best_installed_version(ba: &crate::cli::args::BackendArg) -> Option<String> {
-    crate::backend::get(ba).and_then(|b| best_installed_version_for_backend(&b))
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -484,8 +484,8 @@ impl Lock {
                             // For "latest" requests where nothing was resolved (e.g., tool was
                             // overridden by a higher-priority config, or the lockfile holds a
                             // bogus "latest" literal), fall back to the best installed version.
-                            if !matched_resolved && request.version() == "latest" {
-                                if let Some(latest_version) =
+                            if !matched_resolved && request.version() == "latest"
+                                && let Some(latest_version) =
                                     best_installed_version_for_backend(&backend)
                                 {
                                     let key = (ba.short.clone(), latest_version.clone());
@@ -497,7 +497,6 @@ impl Lock {
                                         all_tools.push((ba.as_ref().clone(), tv));
                                     }
                                 }
-                            }
                         }
                     }
                 }

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -490,16 +490,16 @@ impl Lock {
                                 && request.version() == "latest"
                                 && let Ok(Some(latest_version)) =
                                     backend.latest_installed_version(Some("latest".to_string()))
-                                {
-                                    let key = (ba.short.clone(), latest_version.clone());
-                                    if seen.insert(key) {
-                                        let tv = crate::toolset::ToolVersion::new(
-                                            request.clone(),
-                                            latest_version,
-                                        );
-                                        all_tools.push((ba.as_ref().clone(), tv));
-                                    }
+                            {
+                                let key = (ba.short.clone(), latest_version.clone());
+                                if seen.insert(key) {
+                                    let tv = crate::toolset::ToolVersion::new(
+                                        request.clone(),
+                                        latest_version,
+                                    );
+                                    all_tools.push((ba.as_ref().clone(), tv));
                                 }
+                            }
                         }
                     }
                 }

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -445,6 +445,11 @@ impl Lock {
                     continue;
                 }
             }
+            // Skip unresolved symbolic versions (e.g., a lockfile poisoned with "latest"
+            // as the version). Pass 2's fallback will resolve these to a concrete version.
+            if tv.version == "latest" {
+                continue;
+            }
             let key = (backend.ba().short.clone(), tv.version.clone());
             if seen.insert(key) {
                 all_tools.push((backend.ba().as_ref().clone(), tv));
@@ -462,9 +467,13 @@ impl Lock {
                     for request in requests {
                         if let Ok(backend) = ba.backend() {
                             // Check if the resolved toolset has a matching version
+                            let mut matched_resolved = false;
                             if let Some(resolved_tv) = ts.versions.get(ba.as_ref()) {
                                 for tv in &resolved_tv.versions {
-                                    if tv.request.version() == request.version() {
+                                    if tv.request.version() == request.version()
+                                        && tv.version != "latest"
+                                    {
+                                        matched_resolved = true;
                                         let key = (ba.short.clone(), tv.version.clone());
                                         if seen.insert(key) {
                                             all_tools.push((ba.as_ref().clone(), tv.clone()));
@@ -472,18 +481,18 @@ impl Lock {
                                     }
                                 }
                             }
-                            // For "latest" or prefix requests not yet matched, find the
-                            // best installed version (handles overridden tools)
-                            if request.version() == "latest" {
-                                let installed = backend.list_installed_versions();
-                                if let Some(latest_version) = installed.iter().max_by(|a, b| {
-                                    versions::Versioning::new(a).cmp(&versions::Versioning::new(b))
-                                }) {
+                            // For "latest" requests where nothing was resolved (e.g., tool was
+                            // overridden by a higher-priority config, or the lockfile holds a
+                            // bogus "latest" literal), fall back to the best installed version.
+                            if !matched_resolved && request.version() == "latest" {
+                                if let Some(latest_version) =
+                                    best_installed_version_for_backend(&backend)
+                                {
                                     let key = (ba.short.clone(), latest_version.clone());
                                     if seen.insert(key) {
                                         let tv = crate::toolset::ToolVersion::new(
                                             request.clone(),
-                                            latest_version.clone(),
+                                            latest_version,
                                         );
                                         all_tools.push((ba.as_ref().clone(), tv));
                                     }
@@ -507,17 +516,29 @@ impl Lock {
                     (t.ba.short.clone(), version)
                 })
                 .collect();
-            all_tools
+            // For `tool@latest`, we want upgrade semantics: resolve "latest" to the
+            // best installed version and lock that. Writing the literal "latest" string
+            // to the lockfile would be a bug.
+            let mut tools: Vec<LockTool> = all_tools
                 .into_iter()
                 .filter(|(ba, _)| specified_versions.contains_key(&ba.short))
                 .map(|(ba, mut tv)| {
-                    // If a specific version was requested, override the resolved version
                     if let Some(Some(version)) = specified_versions.get(&ba.short) {
-                        tv.version.clone_from(version);
+                        if version == "latest" {
+                            if let Some(latest_version) = best_installed_version(&ba) {
+                                tv.version = latest_version;
+                            }
+                        } else {
+                            tv.version.clone_from(version);
+                        }
                     }
                     (ba, tv)
                 })
-                .collect()
+                .collect();
+            // Deduplicate after potential "latest" -> concrete-version resolution.
+            let mut seen_after: BTreeSet<(String, String)> = BTreeSet::new();
+            tools.retain(|(ba, tv)| seen_after.insert((ba.short.clone(), tv.version.clone())));
+            tools
         }
     }
 
@@ -631,6 +652,19 @@ impl Lock {
 
         Ok((results, provenance_errors))
     }
+}
+
+/// Return the newest installed version for a given backend, or None if nothing is installed.
+fn best_installed_version_for_backend(backend: &crate::backend::ABackend) -> Option<String> {
+    backend
+        .list_installed_versions()
+        .into_iter()
+        .max_by(|a, b| versions::Versioning::new(a).cmp(&versions::Versioning::new(b)))
+}
+
+/// Resolve "latest" to the newest installed version for a given backend arg.
+fn best_installed_version(ba: &crate::cli::args::BackendArg) -> Option<String> {
+    crate::backend::get(ba).and_then(|b| best_installed_version_for_backend(&b))
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(


### PR DESCRIPTION
## Summary

Fixes two bugs in `mise lock` reported in [jdx/mise#8980 (comment)](https://github.com/jdx/mise/discussions/8980#discussioncomment-16654283):

1. **`mise lock tool@latest`** wrote the literal string `"latest"` into the lockfile instead of a concrete installed version.
2. **`mise lock tool`** (or `mise lock`) could produce a duplicate `[[tools.<name>]]` entry — one with the existing locked version and one with the newest installed version — whenever the config used `tool = "latest"`. A lockfile already poisoned with `version = "latest"` also required two `mise lock` runs to clean up.

### Root causes
- The pass-2 "latest" fallback in `get_tools_to_lock` fired *unconditionally* whenever a config said `tool = "latest"`, appending the newest installed version to `all_tools` even when pass 1 had already contributed the currently-locked version. On a refresh, this produced two entries.
- The `@version` override in the filter path blindly copied the request string into `tv.version`, so `cmake@latest` became `tv.version = "latest"` — then written verbatim into the lockfile.
- Pass 1 could also echo a poisoned `"latest"` literal straight out of the current toolset.

### Fix
- Pass 2 tracks whether the resolved toolset supplied a concrete match; the fallback now only fires when it didn't (restores the original intent of "handles overridden tools" without double-counting refresh runs).
- Pass 1 skips any `tv.version == "latest"` so poisoned lockfiles are cleaned up in a single run.
- The filter override resolves `@latest` to the newest installed version via a shared helper, preserving upgrade semantics.

## Test plan

- [x] Added `e2e/cli/test_lock_latest` covering all three cases (upgrade to latest, refresh with poisoned lockfile, refresh preserves current version).
- [x] Existing `e2e/cli/test_lock_version` still passes.
- [x] `mise run test:e2e` for `test_lockfile_lock_filtered_prune_stale_versions`, `test_lockfile_lock_unfiltered_prune_stale_versions`, `test_lockfile_upgrade_prune`, `test_lockfile_prune_stale_tools`, `test_lockfile_auto_lock`, `test_lockfile_install`, `test_lockfile_use`, `test_lockfile_v_prefix` — all pass.
- [x] `cargo test --bin mise cli::lock` — 10/10 pass.
- [x] Reproduced both bugs locally on `cmake` with `aqua:Kitware/CMake` and verified the fix writes concrete versions in one run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `mise lock` resolves and deduplicates versions when configs/args use `latest`, which can affect lockfile contents across tools/backends. Risk is mitigated by new E2E coverage but touches core lockfile generation logic.
> 
> **Overview**
> Fixes `mise lock` handling of `tool@latest` and lockfiles polluted with `version = "latest"` by **always resolving `latest` to a concrete installed version** and preventing duplicate tool entries during refresh runs.
> 
> The lock command now skips unresolved `latest` versions from the current toolset, only triggers the pass-2 `latest` fallback when no concrete resolved match exists, and delegates `latest` resolution to `Backend::latest_installed_version` (avoiding semver assumptions). Adds an E2E regression test (`e2e/cli/test_lock_latest`) and updates `CLAUDE.md` guidance to explicitly forbid new semver-based version ordering call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d275edb7b575c3e8638525a8ed9edee770cd4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->