### PR TITLE
fix(install): treat empty install dirs as not installed

### DIFF
--- a/e2e/cli/test_install_empty_dir_detected
+++ b/e2e/cli/test_install_empty_dir_detected
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Regression test for https://github.com/jdx/mise/discussions/9324
+# mise previously treated any existing install dir (even an empty one) as
+# "installed", so a broken install silently passed all checks. Doctor reported
+# "No problems found", subsequent `mise install` runs skipped the retry, and
+# `mise which`/`mise where` disagreed about whether the tool was installed.
+#
+# With the fix, an empty install dir is treated as not installed, so doctor
+# flags it, `mise install` re-runs the install, and the state self-heals.
+
+assert "mise use dummy@1.0.0"
+
+install_dir="$MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# Sanity check: a fresh install produces a non-empty dir.
+assert_directory_not_empty "$install_dir"
+
+# Simulate the broken state: empty the install dir but leave it in place,
+# mimicking a backend that returned Ok without producing any files.
+rm -rf "${install_dir:?}"/*
+rm -rf "${install_dir:?}"/.[!.]* 2>/dev/null || true
+assert_directory_exists "$install_dir"
+assert_directory_empty "$install_dir"
+
+# `mise where` now reports the tool as not installed (previously: returned the
+# empty install dir path, masking the problem).
+assert_fail "mise where dummy"
+
+# `mise doctor` now flags the broken state (previously: "No problems found").
+assert_fail_contains "mise doctor" "dummy@1.0.0 is not installed"
+
+# `mise install` re-runs the install rather than short-circuiting on the empty
+# dir, self-healing the state.
+assert "mise install"
+assert_directory_not_empty "$install_dir"
+assert "mise where dummy"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -684,8 +684,14 @@ pub trait Backend: Debug + Send + Sync {
             let is_installed = install_path.exists();
             let is_not_incomplete = !self.incomplete_file_path(tv).exists();
             let is_valid_symlink = !check_symlink || !is_runtime_symlink(install_path);
+            // Treat an existing-but-empty install dir as not installed. This catches silent
+            // failures where a backend returned Ok without producing any files — see
+            // https://github.com/jdx/mise/discussions/9324.
+            let is_not_empty = !is_installed
+                || !install_path.is_dir()
+                || !file::is_empty_dir(install_path).unwrap_or(false);
 
-            let installed = is_installed && is_not_incomplete && is_valid_symlink;
+            let installed = is_installed && is_not_incomplete && is_valid_symlink && is_not_empty;
             if log::log_enabled!(log::Level::Trace) && !installed {
                 let mut msg = format!(
                     "{} is not installed, path: {}",
@@ -700,6 +706,9 @@ pub trait Backend: Debug + Send + Sync {
                 }
                 if !is_valid_symlink {
                     msg += " (runtime symlink)";
+                }
+                if !is_not_empty {
+                    msg += " (empty)";
                 }
                 trace!("{}", msg);
             }

--- a/src/file.rs
+++ b/src/file.rs
@@ -624,7 +624,7 @@ pub fn all_dirs<P: AsRef<Path>>(
         .collect())
 }
 
-fn is_empty_dir(path: &Path) -> Result<bool> {
+pub fn is_empty_dir(path: &Path) -> Result<bool> {
     path.read_dir()
         .map(|mut i| i.next().is_none())
         .wrap_err_with(|| format!("failed to read_dir: {}", display_path(path)))


### PR DESCRIPTION
## Summary

- Extend `Backend::is_version_installed` to reject an existing-but-empty install dir. Every downstream consumer (`mise doctor`, `mise which`, `mise where`, `mise ls`, the `mise install` skip-check, shim management) inherits the new behavior.
- Resulting self-heal: a broken install no longer reports "No problems found"; the next `mise install` retries instead of short-circuiting.

Closes https://github.com/jdx/mise/discussions/9324

## Why

The discussion reports that `mise install -y` silently succeeded for `vfox:mise-plugins/vfox-yarn@1.22.22` even though `installs/yarn/1.22.22/bin/` ended up empty. `mise doctor` said "No problems found" while `mise which yarn` said the tool was not installed — cost the user hours of CI debugging.

Per-tool-version locking already exists ([src/backend/mod.rs:1122](https://github.com/jdx/mise/blob/main/src/backend/mod.rs#L1122)) and an `incomplete` marker is written before install and removed after ([src/backend/mod.rs:1162-1172](https://github.com/jdx/mise/blob/main/src/backend/mod.rs#L1162)). The gap: nothing checked whether the install actually produced files. If a backend plugin returned `Ok(())` with an empty dir (broken plugin, swallowed error), mise treated it as installed forever.

Per user steer in discussion: the simplest fix is to treat totally empty dirs as not installed. One surgical change in `is_version_installed` fixes every user-visible symptom at once.

## Test plan

- [x] `mise run build` — clean compile
- [x] `mise run test:unit` — 747 pass
- [x] `mise run lint` — clean
- [x] New e2e test `e2e/cli/test_install_empty_dir_detected` — installs dummy, empties the install dir, verifies `mise where` fails, `mise doctor` flags it, and `mise install` self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `is_version_installed` check, which affects multiple CLI commands and install skipping behavior; could alter outcomes for any tool whose install path can legitimately be empty or transiently empty due to filesystem timing.
> 
> **Overview**
> Fixes a regression where an existing *but empty* install directory was treated as a successful install. `Backend::is_version_installed` now considers empty install dirs as *not installed*, adds trace context (`(empty)`), and exposes `file::is_empty_dir` to support this check.
> 
> Adds an e2e regression test that empties a tool’s install directory and verifies `mise where`/`mise doctor` fail and `mise install` re-runs to self-heal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0a7e6c690b88fa4cbb0b781a25cebb00c5cac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->