### PR TITLE
chore: remove FUNDING.yml in favor of jdx/.github default

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: jdx


### PR DESCRIPTION
## Summary
- The [jdx/.github](https://github.com/jdx/.github) repo now provides a default `FUNDING.yml` that applies to every jdx-owned repo without its own.
- This repo's `.github/FUNDING.yml` is redundant with that default, so drop it.

## Test plan
- [ ] After merge, confirm the ♥ Sponsor button still appears on the repo (inherited from jdx/.github).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: deletes a GitHub metadata file only, with no runtime/code-path impact; main risk is the Sponsor button/funding links relying on repository defaults being misconfigured.
> 
> **Overview**
> Removes the repository-specific `.github/FUNDING.yml`, relying on the org-level default funding configuration instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ef82eb4c24abfd48f1acd864853e2536b5e24b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->