### PR TITLE
fix(backend): skip versions host for custom remote options

### DIFF
--- a/e2e/cli/test_ls_cache
+++ b/e2e/cli/test_ls_cache
@@ -7,3 +7,14 @@ export MISE_USE_VERSIONS_HOST=1
 assert_contains "mise -v use bat 2>&1" "GET https://mise-versions.jdx.dev/tools/bat.toml 200 OK"
 touch -t 202001010000 "$MISE_CACHE_DIR/bat/"*
 assert_not_contains "mise -v ls bat 2>&1" "GET https://mise-versions.jdx.dev/tools/bat.toml 200 OK"
+
+# Registry tools with config options that change remote version listing must skip
+# the versions host because it cannot account for per-config backend options.
+cat >mise.toml <<EOF
+[tools.wait-for-gh-rate-limit]
+version = "latest"
+version_prefix = ""
+EOF
+
+assert_not_contains "mise -v ls-remote wait-for-gh-rate-limit 2>&1" "mise-versions.jdx.dev/tools/wait-for-gh-rate-limit.toml"
+assert_contains "mise ls-remote wait-for-gh-rate-limit" "1.1.1"

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -2090,6 +2090,11 @@ pub fn install_time_option_keys() -> Vec<String> {
     vec!["vars".into()]
 }
 
+/// Returns options that affect Aqua remote version listing.
+pub fn list_remote_versions_option_keys() -> Vec<String> {
+    vec!["prerelease".into()]
+}
+
 pub fn is_install_time_option_key(key: &str) -> bool {
     key != "symlink_bins"
 }

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -73,6 +73,15 @@ pub fn install_time_option_keys() -> Vec<String> {
     ]
 }
 
+/// Returns options that affect GitHub/GitLab/Forgejo remote version listing.
+pub fn list_remote_versions_option_keys() -> Vec<String> {
+    vec![
+        "api_url".into(),
+        "version_prefix".into(),
+        "prerelease".into(),
+    ]
+}
+
 #[async_trait]
 impl Backend for UnifiedGitBackend {
     fn get_type(&self) -> BackendType {

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -597,6 +597,16 @@ pub fn install_time_option_keys() -> Vec<String> {
     ]
 }
 
+/// Returns options that affect HTTP remote version listing.
+pub fn list_remote_versions_option_keys() -> Vec<String> {
+    vec![
+        "version_list_url".into(),
+        "version_regex".into(),
+        "version_json_path".into(),
+        "version_expr".into(),
+    ]
+}
+
 #[async_trait]
 impl Backend for HttpBackend {
     fn get_type(&self) -> BackendType {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -27,7 +27,8 @@ use crate::runtime_symlinks::is_runtime_symlink;
 use crate::tera::get_tera;
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{
-    ResolveOptions, ToolRequest, ToolVersion, Toolset, install_state, is_outdated_version,
+    ResolveOptions, ToolRequest, ToolVersion, ToolVersionOptions, Toolset, install_state,
+    is_outdated_version,
 };
 use crate::ui::progress_report::SingleReport;
 use crate::{
@@ -288,7 +289,9 @@ pub fn install_time_option_keys_for_type(backend_type: &BackendType) -> Vec<Stri
     match backend_type {
         BackendType::Http => http::install_time_option_keys(),
         BackendType::S3 => s3::install_time_option_keys(),
-        BackendType::Github | BackendType::Gitlab => github::install_time_option_keys(),
+        BackendType::Github | BackendType::Gitlab | BackendType::Forgejo => {
+            github::install_time_option_keys()
+        }
         BackendType::Ubi => ubi::install_time_option_keys(),
         BackendType::Cargo => cargo::install_time_option_keys(),
         BackendType::Go => go::install_time_option_keys(),
@@ -310,6 +313,54 @@ pub fn is_install_time_option_key_for_type(backend_type: &BackendType, key: &str
         || install_time_keys
             .iter()
             .any(|itk| key.starts_with("platforms.") && key.ends_with(&format!(".{itk}")))
+}
+
+/// Returns option keys that change the remote version list for a backend type.
+/// When these are customized, the versions host must be skipped because it is
+/// keyed only by tool short name and cannot account for per-config options.
+pub fn list_remote_versions_option_keys_for_type(backend_type: &BackendType) -> Vec<String> {
+    match backend_type {
+        BackendType::Http => http::list_remote_versions_option_keys(),
+        BackendType::S3 => s3::list_remote_versions_option_keys(),
+        BackendType::Github | BackendType::Gitlab | BackendType::Forgejo => {
+            github::list_remote_versions_option_keys()
+        }
+        BackendType::Ubi => ubi::list_remote_versions_option_keys(),
+        BackendType::Aqua => aqua::list_remote_versions_option_keys(),
+        _ => vec![],
+    }
+}
+
+fn has_custom_list_remote_versions_options(
+    ba: &BackendArg,
+    backend_type: &BackendType,
+    opts: &ToolVersionOptions,
+) -> bool {
+    let option_keys = list_remote_versions_option_keys_for_type(backend_type);
+    if option_keys.is_empty() {
+        return false;
+    }
+
+    let default_opts = default_list_remote_versions_options(ba);
+    option_keys.into_iter().any(|key| {
+        let configured = opts.opts.get(&key);
+        configured.is_some() && configured != default_opts.opts.get(&key)
+    })
+}
+
+fn default_list_remote_versions_options(ba: &BackendArg) -> ToolVersionOptions {
+    let Some(rt) = REGISTRY.get(ba.short.as_str()) else {
+        return ToolVersionOptions::default();
+    };
+
+    let full_without_opts = ba.full_without_opts();
+    rt.backends()
+        .into_iter()
+        .find_map(|full| {
+            let registry_ba = BackendArg::new(ba.short.clone(), Some(full.to_string()));
+            (registry_ba.full_without_opts() == full_without_opts).then(|| registry_ba.opts())
+        })
+        .unwrap_or_default()
 }
 
 /// Normalize idiomatic file contents by removing comments and empty lines.
@@ -525,12 +576,15 @@ pub trait Backend: Debug + Send + Sync {
         // setting can still disable the host globally, but cannot re-enable
         // it for backends that are not on this allowlist.
         let backend_type = self.get_type();
+        let config_tool_opts = config.get_tool_opts(&ba).await?;
         let has_version_list_url = matches!(backend_type, BackendType::Http | BackendType::S3)
             && (ba.opts().contains_key("version_list_url")
-                || config
-                    .get_tool_opts(&ba)
-                    .await?
+                || config_tool_opts
+                    .as_ref()
                     .is_some_and(|o| o.contains_key("version_list_url")));
+        let customized_list_remote_versions_options = config_tool_opts
+            .as_ref()
+            .is_some_and(|opts| has_custom_list_remote_versions_options(&ba, &backend_type, opts));
         let versions_host_applies = match backend_type {
             BackendType::Github
             | BackendType::Gitlab
@@ -550,6 +604,12 @@ pub trait Backend: Debug + Send + Sync {
             trace!(
                 "Skipping versions host for {} because {} backend has a direct source",
                 ba.short, backend_type
+            );
+            false
+        } else if customized_list_remote_versions_options {
+            trace!(
+                "Skipping versions host for {} because remote version options are customized",
+                ba.short
             );
             false
         } else if let Some(plugin) = self.plugin()

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -365,6 +365,16 @@ pub fn install_time_option_keys() -> Vec<String> {
     ]
 }
 
+/// Returns options that affect S3 remote version listing.
+pub fn list_remote_versions_option_keys() -> Vec<String> {
+    vec![
+        "version_list_url".into(),
+        "version_regex".into(),
+        "version_json_path".into(),
+        "version_expr".into(),
+    ]
+}
+
 /// Create an S3 client with the given configuration
 async fn create_s3_client(region: Option<&str>, endpoint: Option<&str>) -> Result<S3Client> {
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -401,6 +401,16 @@ pub fn install_time_option_keys() -> Vec<String> {
     ]
 }
 
+/// Returns options that affect UBI remote version listing.
+pub fn list_remote_versions_option_keys() -> Vec<String> {
+    vec![
+        "api_url".into(),
+        "provider".into(),
+        "tag_regex".into(),
+        "prerelease".into(),
+    ]
+}
+
 impl UbiBackend {
     pub fn from_arg(ba: BackendArg) -> Self {
         Self { ba: Arc::new(ba) }


### PR DESCRIPTION
## Summary

- add list-remote option key hooks for backends whose remote version list depends on config
- skip `mise-versions.jdx.dev` when those options differ from registry/default backend options
- add an e2e regression for a registry GitHub tool with a custom `version_prefix`

## Why

The versions host is keyed only by tool short name, so it cannot represent config-specific backend options such as `version_prefix`, `api_url`, or the planned `prerelease` option (in https://github.com/jdx/mise/pull/9329). Registry tools with those overrides need to query the backend directly for `ls-remote`/version resolution.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo build`
- `e2e/run_test cli/test_ls_cache`

Note: `mise run test:e2e cli/test_ls_cache` was attempted first, but this local checkout's task discovery returned `no tasks defined`; the repository e2e harness was run directly after building the local binary.

*This PR was generated by an AI coding assistant.*
