### PR TITLE
docs: update ruby compile msg

### DIFF
--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -946,7 +946,7 @@ impl Backend for RubyPlugin {
                 "ruby_precompiled",
                 "installing precompiled ruby from jdx/ruby\n\
                     if you experience issues, switch to ruby-build by running",
-                "mise settings ruby.compile=1"
+                "mise settings ruby.compile=true"
             );
             self.install_rubygems_hook(&installed_tv)?;
             if let Err(err) = self


### PR DESCRIPTION
Small update to the ruby compile message since `use` values are boolean.
```
To use precompiled binaries now: mise settings ruby.compile=false
To keep compiling from source: mise settings ruby.compile=true
```