### PR TITLE
fix(docs): stack banner message and link on mobile

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -47,6 +47,8 @@
     text-wrap: balance;
   }
   .jdx-banner button {
+    top: 0.25rem;
     right: 0.25rem;
+    transform: none;
   }
 }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -39,7 +39,14 @@
 }
 @media (max-width: 640px) {
   .jdx-banner {
-    font-size: 0.85rem;
-    padding: 0.4rem 2.5rem;
+    flex-direction: column;
+    gap: 0.125rem;
+    font-size: 0.8rem;
+    padding: 0.5rem 2.25rem;
+    line-height: 1.3;
+    text-wrap: balance;
+  }
+  .jdx-banner button {
+    right: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- On narrow viewports the site banner rendered cramped: `flex-wrap: nowrap` forced the message onto two squeezed lines while the "Read more" link sat jammed against the text.
- At `<=640px`, switch the banner to `flex-direction: column` so the message and link stack cleanly. Also shrink the font slightly, tighten line-height, add `text-wrap: balance` for even two-line breaks, and nudge the close button flush to the corner.

Verified in-browser at a 375px viewport (iPhone SE) by swapping the CSS into a live mise.jdx.dev page — message now uses the full content width on two balanced lines, link sits centered on its own line below, and the close button no longer crowds the text.

## Test plan
- [ ] Visit mise.jdx.dev on a mobile device (or DevTools <=640px) after deploy and confirm the banner stacks cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CSS-only changes scoped to the docs banner’s <=640px responsive styling.
> 
> **Overview**
> Adjusts `docs/.vitepress/theme/banner.css` responsive rules so the banner content stacks vertically on <=640px viewports, with tighter spacing and balanced text wrapping to avoid cramped two-line layouts.
> 
> Also tweaks mobile typography/padding and moves the close button to the top-right corner (removing the vertical centering transform) to prevent overlap with the message/link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faf9e5ca14ead9cf2cb501adefd0fed63ea96c79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->