### PR TITLE
feat(registry): add --security flag to include security info in JSON output

### DIFF
--- a/docs/cli/registry.md
+++ b/docs/cli/registry.md
@@ -34,7 +34,7 @@ Output in JSON format
 
 Include security features for each tool's backends in JSON output.
 
-Has no effect without --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
+Requires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
 
 Examples:
 

--- a/docs/cli/registry.md
+++ b/docs/cli/registry.md
@@ -30,6 +30,12 @@ Hide aliased tools
 
 Output in JSON format
 
+### `--security`
+
+Include security features for each tool's backends in JSON output.
+
+Has no effect without --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
+
 Examples:
 
 ```

--- a/e2e/cli/test_registry
+++ b/e2e/cli/test_registry
@@ -8,3 +8,8 @@ assert "mise registry gh --json | jq -r '.short'" "gh"
 assert "mise registry gh --json | jq -r '.backends[0]'" "aqua:cli/cli"
 assert_contains "mise registry --json | jq -r '.[].short'" "gh"
 assert "mise registry --json | jq -r '.[] | select(.short == \"gh\") | .backends[0]'" "aqua:cli/cli"
+
+# --security implies JSON output and adds a security array per tool.
+assert "mise registry bun --json --security | jq -r 'if .security then \"has\" else \"none\" end'" "has"
+# Without --security the field should be absent.
+assert "mise registry bun --json | jq -r 'has(\"security\")'" "false"

--- a/e2e/cli/test_registry
+++ b/e2e/cli/test_registry
@@ -9,7 +9,7 @@ assert "mise registry gh --json | jq -r '.backends[0]'" "aqua:cli/cli"
 assert_contains "mise registry --json | jq -r '.[].short'" "gh"
 assert "mise registry --json | jq -r '.[] | select(.short == \"gh\") | .backends[0]'" "aqua:cli/cli"
 
-# --security implies JSON output and adds a security array per tool.
+# --security requires JSON output and adds a security array per tool.
 assert "mise registry bun --json --security | jq -r 'if .security then \"has\" else \"none\" end'" "has"
 # Without --security the field should be absent.
 assert "mise registry bun --json | jq -r 'has(\"security\")'" "false"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2024,7 +2024,7 @@ Output in JSON format
 \fB\-\-security\fR
 Include security features for each tool's backends in JSON output.
 
-Has no effect without \-\-json. Security info is de\-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
+Requires \-\-json. Security info is de\-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
 \fBArguments:\fR
 .PP
 .TP

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2020,6 +2020,11 @@ Hide aliased tools
 .TP
 \fB\-J, \-\-json\fR
 Output in JSON format
+.TP
+\fB\-\-security\fR
+Include security features for each tool's backends in JSON output.
+
+Has no effect without \-\-json. Security info is de\-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
 \fBArguments:\fR
 .PP
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -818,6 +818,9 @@ cmd registry help="List available tools to install" {
     flag --complete help="Print all tools with descriptions for shell completions" hide=#true
     flag --hide-aliased help="Hide aliased tools"
     flag "-J --json" help="Output in JSON format"
+    flag --security help="Include security features for each tool's backends in JSON output" {
+        long_help "Include security features for each tool's backends in JSON output.\n\nHas no effect without --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually."
+    }
     arg "[NAME]" help="Show only the specified tool's full name" required=#false
 }
 cmd render-help hide=#true help="internal command to generate markdown from help"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -819,7 +819,7 @@ cmd registry help="List available tools to install" {
     flag --hide-aliased help="Hide aliased tools"
     flag "-J --json" help="Output in JSON format"
     flag --security help="Include security features for each tool's backends in JSON output" {
-        long_help "Include security features for each tool's backends in JSON output.\n\nHas no effect without --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually."
+        long_help "Include security features for each tool's backends in JSON output.\n\nRequires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually."
     }
     arg "[NAME]" help="Show only the specified tool's full name" required=#false
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -136,7 +136,7 @@ impl VersionInfo {
 }
 
 /// Security feature information for a tool
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SecurityFeature {
     Checksum {

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -1,4 +1,6 @@
 use crate::backend::backend_type::BackendType;
+use crate::backend::{self, SecurityFeature};
+use crate::cli::args::BackendArg;
 use crate::config::Settings;
 use crate::registry::{REGISTRY, RegistryTool, tool_enabled};
 use crate::ui::table::MiseTable;
@@ -32,6 +34,14 @@ pub struct Registry {
     /// Output in JSON format
     #[clap(long, short = 'J')]
     json: bool,
+
+    /// Include security features for each tool's backends in JSON output.
+    ///
+    /// Has no effect without --json. Security info is de-duplicated across
+    /// all of a tool's backends. This can add noticeable time for large
+    /// listings since each backend's security info is resolved individually.
+    #[clap(long, requires = "json")]
+    security: bool,
 }
 
 #[derive(Serialize)]
@@ -42,6 +52,8 @@ struct RegistryToolOutput {
     description: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     aliases: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    security: Vec<SecurityFeature>,
 }
 
 impl Registry {
@@ -49,7 +61,7 @@ impl Registry {
         if let Some(name) = &self.name {
             if let Some(rt) = REGISTRY.get(name.as_str()) {
                 if self.json {
-                    let tool = self.to_output(name, rt);
+                    let tool = self.to_output(name, rt).await;
                     miseprintln!("{}", serde_json::to_string_pretty(&tool)?);
                 } else {
                     miseprintln!("{}", self.filter_backends(rt).join(" "));
@@ -60,7 +72,7 @@ impl Registry {
         } else if self.complete {
             self.complete()?;
         } else if self.json {
-            self.display_json()?;
+            self.display_json().await?;
         } else {
             self.display_table()?;
         }
@@ -78,16 +90,25 @@ impl Registry {
         }
     }
 
-    fn to_output(&self, short: &str, rt: &RegistryTool) -> RegistryToolOutput {
+    async fn to_output(&self, short: &str, rt: &RegistryTool) -> RegistryToolOutput {
+        let backends: Vec<String> = self
+            .filter_backends(rt)
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let security = if self.security {
+            collect_security(short, &backends).await
+        } else {
+            vec![]
+        };
+
         RegistryToolOutput {
             short: short.to_string(),
-            backends: self
-                .filter_backends(rt)
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
+            backends,
             description: rt.description.map(|s| s.to_string()),
             aliases: rt.aliases.iter().map(|s| s.to_string()).collect(),
+            security,
         }
     }
 
@@ -134,15 +155,57 @@ impl Registry {
         Ok(())
     }
 
-    fn display_json(&self) -> Result<()> {
-        let tools: Vec<RegistryToolOutput> = self
+    async fn display_json(&self) -> Result<()> {
+        // Collect (short, RegistryTool) pairs first so we can drop the
+        // REGISTRY lock borrow before hitting the async per-tool loop.
+        let tools: Vec<(&&'static str, &RegistryTool)> = self
             .filtered_tools()
-            .map(|(short, rt)| self.to_output(short, rt))
-            .filter(|tool| !tool.backends.is_empty())
-            .sorted_by(|a, b| a.short.cmp(&b.short))
+            .filter(|(_, rt)| !self.filter_backends(rt).is_empty())
             .collect();
-        miseprintln!("{}", serde_json::to_string_pretty(&tools)?);
+
+        let mut outputs: Vec<RegistryToolOutput> = Vec::with_capacity(tools.len());
+        for (short, rt) in tools {
+            outputs.push(self.to_output(short, rt).await);
+        }
+        outputs.sort_by(|a, b| a.short.cmp(&b.short));
+        miseprintln!("{}", serde_json::to_string_pretty(&outputs)?);
         Ok(())
+    }
+}
+
+/// Resolve and merge security features across every backend for a tool.
+/// Duplicate features (same variant + payload) are collapsed.
+async fn collect_security(short: &str, backends: &[String]) -> Vec<SecurityFeature> {
+    let mut features: Vec<SecurityFeature> = Vec::new();
+    for full in backends {
+        let ba = BackendArg::new(short.to_string(), Some(full.to_string()));
+        let Some(backend) = backend::get(&ba) else {
+            continue;
+        };
+        for feature in backend.security_info().await {
+            if !features
+                .iter()
+                .any(|existing| same_feature(existing, &feature))
+            {
+                features.push(feature);
+            }
+        }
+    }
+    features
+}
+
+fn same_feature(a: &SecurityFeature, b: &SecurityFeature) -> bool {
+    use SecurityFeature::*;
+    match (a, b) {
+        (Checksum { algorithm: x }, Checksum { algorithm: y }) => x == y,
+        (GithubAttestations { signer_workflow: x }, GithubAttestations { signer_workflow: y }) => {
+            x == y
+        }
+        (Slsa { level: x }, Slsa { level: y }) => x == y,
+        (Cosign, Cosign) => true,
+        (Minisign { public_key: x }, Minisign { public_key: y }) => x == y,
+        (Gpg, Gpg) => true,
+        _ => false,
     }
 }
 

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -7,6 +7,7 @@ use crate::ui::table::MiseTable;
 use eyre::{Result, bail};
 use itertools::Itertools;
 use serde_derive::Serialize;
+use tokio::task::JoinSet;
 
 /// List available tools to install
 ///
@@ -37,7 +38,7 @@ pub struct Registry {
 
     /// Include security features for each tool's backends in JSON output.
     ///
-    /// Has no effect without --json. Security info is de-duplicated across
+    /// Requires --json. Security info is de-duplicated across
     /// all of a tool's backends. This can add noticeable time for large
     /// listings since each backend's security info is resolved individually.
     #[clap(long, requires = "json")]
@@ -61,7 +62,9 @@ impl Registry {
         if let Some(name) = &self.name {
             if let Some(rt) = REGISTRY.get(name.as_str()) {
                 if self.json {
-                    let tool = self.to_output(name, rt).await;
+                    let (short, backends, description, aliases) = self.output_args(name, rt);
+                    let tool =
+                        to_output(short, backends, description, aliases, self.security).await;
                     miseprintln!("{}", serde_json::to_string_pretty(&tool)?);
                 } else {
                     miseprintln!("{}", self.filter_backends(rt).join(" "));
@@ -90,26 +93,22 @@ impl Registry {
         }
     }
 
-    async fn to_output(&self, short: &str, rt: &RegistryTool) -> RegistryToolOutput {
+    fn output_args(
+        &self,
+        short: &str,
+        rt: &RegistryTool,
+    ) -> (String, Vec<String>, Option<String>, Vec<String>) {
         let backends: Vec<String> = self
             .filter_backends(rt)
             .iter()
             .map(|s| s.to_string())
             .collect();
-
-        let security = if self.security {
-            collect_security(short, &backends).await
-        } else {
-            vec![]
-        };
-
-        RegistryToolOutput {
-            short: short.to_string(),
+        (
+            short.to_string(),
             backends,
-            description: rt.description.map(|s| s.to_string()),
-            aliases: rt.aliases.iter().map(|s| s.to_string()).collect(),
-            security,
-        }
+            rt.description.map(|s| s.to_string()),
+            rt.aliases.iter().map(|s| s.to_string()).collect(),
+        )
     }
 
     fn filtered_tools(&self) -> impl Iterator<Item = (&&'static str, &RegistryTool)> {
@@ -156,16 +155,27 @@ impl Registry {
     }
 
     async fn display_json(&self) -> Result<()> {
-        // Collect (short, RegistryTool) pairs first so we can drop the
-        // REGISTRY lock borrow before hitting the async per-tool loop.
-        let tools: Vec<(&&'static str, &RegistryTool)> = self
+        // Collect owned output args before async work so parallel tasks do not
+        // borrow from the static registry map.
+        let tools: Vec<(String, Vec<String>, Option<String>, Vec<String>)> = self
             .filtered_tools()
             .filter(|(_, rt)| !self.filter_backends(rt).is_empty())
+            .map(|(short, rt)| self.output_args(short, rt))
             .collect();
 
         let mut outputs: Vec<RegistryToolOutput> = Vec::with_capacity(tools.len());
-        for (short, rt) in tools {
-            outputs.push(self.to_output(short, rt).await);
+        if self.security {
+            let mut jset: JoinSet<RegistryToolOutput> = JoinSet::new();
+            for (short, backends, description, aliases) in tools {
+                jset.spawn(to_output(short, backends, description, aliases, true));
+            }
+            while let Some(result) = jset.join_next().await {
+                outputs.push(result?);
+            }
+        } else {
+            for (short, backends, description, aliases) in tools {
+                outputs.push(to_output(short, backends, description, aliases, false).await);
+            }
         }
         outputs.sort_by(|a, b| a.short.cmp(&b.short));
         miseprintln!("{}", serde_json::to_string_pretty(&outputs)?);
@@ -175,18 +185,15 @@ impl Registry {
 
 /// Resolve and merge security features across every backend for a tool.
 /// Duplicate features (same variant + payload) are collapsed.
-async fn collect_security(short: &str, backends: &[String]) -> Vec<SecurityFeature> {
+async fn collect_security(backends: &[String]) -> Vec<SecurityFeature> {
     let mut features: Vec<SecurityFeature> = Vec::new();
     for full in backends {
-        let ba = BackendArg::new(short.to_string(), Some(full.to_string()));
-        let Some(backend) = backend::get(&ba) else {
+        let ba = BackendArg::from(full.as_str());
+        let Some(backend) = backend::arg_to_backend(ba) else {
             continue;
         };
         for feature in backend.security_info().await {
-            if !features
-                .iter()
-                .any(|existing| same_feature(existing, &feature))
-            {
+            if !features.contains(&feature) {
                 features.push(feature);
             }
         }
@@ -194,18 +201,25 @@ async fn collect_security(short: &str, backends: &[String]) -> Vec<SecurityFeatu
     features
 }
 
-fn same_feature(a: &SecurityFeature, b: &SecurityFeature) -> bool {
-    use SecurityFeature::*;
-    match (a, b) {
-        (Checksum { algorithm: x }, Checksum { algorithm: y }) => x == y,
-        (GithubAttestations { signer_workflow: x }, GithubAttestations { signer_workflow: y }) => {
-            x == y
-        }
-        (Slsa { level: x }, Slsa { level: y }) => x == y,
-        (Cosign, Cosign) => true,
-        (Minisign { public_key: x }, Minisign { public_key: y }) => x == y,
-        (Gpg, Gpg) => true,
-        _ => false,
+async fn to_output(
+    short: String,
+    backends: Vec<String>,
+    description: Option<String>,
+    aliases: Vec<String>,
+    security: bool,
+) -> RegistryToolOutput {
+    let security = if security {
+        collect_security(&backends).await
+    } else {
+        vec![]
+    };
+
+    RegistryToolOutput {
+        short,
+        backends,
+        description,
+        aliases,
+        security,
     }
 }
 

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -7,7 +7,8 @@ use crate::ui::table::MiseTable;
 use eyre::{Result, bail};
 use itertools::Itertools;
 use serde_derive::Serialize;
-use tokio::task::JoinSet;
+use std::sync::Arc;
+use tokio::{sync::Semaphore, task::JoinSet};
 
 /// List available tools to install
 ///
@@ -57,14 +58,19 @@ struct RegistryToolOutput {
     security: Vec<SecurityFeature>,
 }
 
+struct RegistryToolOutputArgs {
+    short: String,
+    backends: Vec<String>,
+    description: Option<String>,
+    aliases: Vec<String>,
+}
+
 impl Registry {
     pub async fn run(self) -> Result<()> {
         if let Some(name) = &self.name {
             if let Some(rt) = REGISTRY.get(name.as_str()) {
                 if self.json {
-                    let (short, backends, description, aliases) = self.output_args(name, rt);
-                    let tool =
-                        to_output(short, backends, description, aliases, self.security).await;
+                    let tool = to_output(self.output_args(name, rt), self.security).await;
                     miseprintln!("{}", serde_json::to_string_pretty(&tool)?);
                 } else {
                     miseprintln!("{}", self.filter_backends(rt).join(" "));
@@ -93,22 +99,18 @@ impl Registry {
         }
     }
 
-    fn output_args(
-        &self,
-        short: &str,
-        rt: &RegistryTool,
-    ) -> (String, Vec<String>, Option<String>, Vec<String>) {
+    fn output_args(&self, short: &str, rt: &RegistryTool) -> RegistryToolOutputArgs {
         let backends: Vec<String> = self
             .filter_backends(rt)
             .iter()
             .map(|s| s.to_string())
             .collect();
-        (
-            short.to_string(),
+        RegistryToolOutputArgs {
+            short: short.to_string(),
             backends,
-            rt.description.map(|s| s.to_string()),
-            rt.aliases.iter().map(|s| s.to_string()).collect(),
-        )
+            description: rt.description.map(|s| s.to_string()),
+            aliases: rt.aliases.iter().map(|s| s.to_string()).collect(),
+        }
     }
 
     fn filtered_tools(&self) -> impl Iterator<Item = (&&'static str, &RegistryTool)> {
@@ -157,7 +159,7 @@ impl Registry {
     async fn display_json(&self) -> Result<()> {
         // Collect owned output args before async work so parallel tasks do not
         // borrow from the static registry map.
-        let tools: Vec<(String, Vec<String>, Option<String>, Vec<String>)> = self
+        let tools: Vec<RegistryToolOutputArgs> = self
             .filtered_tools()
             .filter(|(_, rt)| !self.filter_backends(rt).is_empty())
             .map(|(short, rt)| self.output_args(short, rt))
@@ -165,16 +167,21 @@ impl Registry {
 
         let mut outputs: Vec<RegistryToolOutput> = Vec::with_capacity(tools.len());
         if self.security {
+            let semaphore = Arc::new(Semaphore::new(Settings::get().jobs));
             let mut jset: JoinSet<RegistryToolOutput> = JoinSet::new();
-            for (short, backends, description, aliases) in tools {
-                jset.spawn(to_output(short, backends, description, aliases, true));
+            for tool in tools {
+                let permit = semaphore.clone().acquire_owned().await?;
+                jset.spawn(async move {
+                    let _permit = permit;
+                    to_output(tool, true).await
+                });
             }
             while let Some(result) = jset.join_next().await {
                 outputs.push(result?);
             }
         } else {
-            for (short, backends, description, aliases) in tools {
-                outputs.push(to_output(short, backends, description, aliases, false).await);
+            for tool in tools {
+                outputs.push(to_output(tool, false).await);
             }
         }
         outputs.sort_by(|a, b| a.short.cmp(&b.short));
@@ -201,24 +208,18 @@ async fn collect_security(backends: &[String]) -> Vec<SecurityFeature> {
     features
 }
 
-async fn to_output(
-    short: String,
-    backends: Vec<String>,
-    description: Option<String>,
-    aliases: Vec<String>,
-    security: bool,
-) -> RegistryToolOutput {
+async fn to_output(tool: RegistryToolOutputArgs, security: bool) -> RegistryToolOutput {
     let security = if security {
-        collect_security(&backends).await
+        collect_security(&tool.backends).await
     } else {
         vec![]
     };
 
     RegistryToolOutput {
-        short,
-        backends,
-        description,
-        aliases,
+        short: tool.short,
+        backends: tool.backends,
+        description: tool.description,
+        aliases: tool.aliases,
         security,
     }
 }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -2391,6 +2391,12 @@ const completionSpec: Fig.Spec = {
           description: "Output in JSON format",
           isRepeatable: false,
         },
+        {
+          name: "--security",
+          description:
+            "Include security features for each tool's backends in JSON output",
+          isRepeatable: false,
+        },
       ],
       args: {
         name: "name",


### PR DESCRIPTION
## Summary
- Adds a `--security` flag to `mise registry` (JSON-only, enforced via `requires = "json"`) that includes a `security` array for each tool.
- Each tool's security features are collected across all of its backends via `backend.security_info().await`, then de-duplicated by variant + payload.
- New field is omitted (`skip_serializing_if = "Vec::is_empty"`) when empty, so the default `--json` output is byte-identical for tools without security info.

## Why
Consumers that want a per-tool security catalog currently have to shell out to `mise tool <name> --json` once per tool because `mise registry --json` doesn't expose `security`. That's ~1000 process spawns per rebuild for e.g. https://github.com/jdx/mise-versions. Having it in the registry JSON collapses that to a single call.

## Why opt-in
`security_info()` for aqua backends reads the per-package aqua registry, which can fetch from GitHub on cold cache. Keeping `--security` opt-in preserves the default `mise registry --json` path at its current ~50 ms so existing consumers aren't slowed down.

Local timing (977 tools, warm cache, no rate limit):
- `mise registry --json` — ~50 ms (unchanged)
- `mise registry --json --security` — ~30 s

## Test plan
- [x] `cargo check` / `cargo clippy --bin mise --no-deps --tests` clean
- [x] `cargo fmt --check` clean
- [x] Added e2e assertions in `e2e/cli/test_registry`:
  - `mise registry bun --json --security` has a `security` field
  - `mise registry bun --json` does not
- [x] Regenerated `mise.usage.kdl` + `docs/cli/registry.md`
- [x] Manual: `target/debug/mise registry --json --security` produces ~436/1003 tools with a populated security array on my machine

## Notes
- `to_output` and `display_json` become `async` since `security_info()` is async; single-name lookup and bulk listing both thread through the same path.
- De-duplication is structural (same variant + same payload) so e.g. two backends both offering `Checksum { algorithm: Some("sha256") }` collapse to one entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an opt-in code path that performs per-backend async `security_info()` resolution (potentially network-bound) and parallelizes it, which could impact performance and error behavior when enabled.
> 
> **Overview**
> Adds a new `mise registry --security` flag (requires `--json`) that includes a per-tool `security` array in the JSON output, populated by collecting and de-duplicating `SecurityFeature` values across all of a tool’s backends.
> 
> To support this, `registry` JSON rendering is made async and, when `--security` is set, resolves security info concurrently (bounded by `Settings::jobs`). Documentation/man pages/completions and e2e coverage are updated accordingly, and `SecurityFeature` now derives `PartialEq`/`Eq` to enable structural de-duplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2944156420038a8af38df65f76a902a7bf210e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->