### PR TITLE
registry: add ifhj

### DIFF
--- a/registry/ifhj.toml
+++ b/registry/ifhj.toml
@@ -1,0 +1,2 @@
+backends = ["github:therealparmesh/ifhj"]
+description = "TUI for Jira — kanban board, issue editing, filters, and more from the terminal"


### PR DESCRIPTION
adds `ifhj` to the registry - it's a TUI for Jira I built. kanban board, issue editing, filters, transitions, comments, the whole thing from the terminal.

single binary, compiled with bun. releases follow the standard `{name}_{version}_{os}_{arch}.tar.gz` convention.