### PR TITLE
registry: remove go-sdk

### DIFF
--- a/registry/go-sdk.toml
+++ b/registry/go-sdk.toml
@@ -1,3 +1,0 @@
-backends = ["conda:go", "asdf:mise-plugins/mise-go-sdk"]
-description = "Install go sdk"
-test = { cmd = "go version", expected = "go version" }


### PR DESCRIPTION
## Summary

Remove the `go-sdk` shorthand from the registry. Its configured fallback behavior is misleading: the conda backend can install a Go toolchain only with experimental mode enabled, while the asdf fallback is a different SDK-management plugin and fails on a clean mise install.

## Validation

- `rg -n "go-sdk" registry docs src e2e settings.toml`
- `git diff --check`
- pre-commit `hk` lint suite during commit, including `cargo fmt --all -- --check`, `cargo check --all-features`, taplo, schema, shellcheck, shfmt, actionlint, markdownlint, prettier, stylua, and lua-language-server

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only deletes a registry definition and does not change runtime logic, but it may affect users who relied on `go-sdk` being available.
> 
> **Overview**
> Removes the `go-sdk` shorthand from the registry by deleting its definition (`registry/go-sdk.toml`), eliminating the previous fallback backend configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdeb5b64eadf8378c523981ee43ef46f2e62d7a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->