### PR TITLE
registry: remove openshift-install

### DIFF
--- a/registry/openshift-install.toml
+++ b/registry/openshift-install.toml
@@ -1,2 +1,0 @@
-backends = ["asdf:mise-plugins/mise-openshift-install"]
-description = "Install an OpenShift 4.x cluster"


### PR DESCRIPTION
## Summary

Remove the `openshift-install` shorthand from the registry. The registry entry points only at `asdf:mise-plugins/mise-openshift-install`, and that plugin currently fails normal version discovery.

`mise ls-remote openshift-install` fails with `error running list-all: exited with code 1`, and `mise install openshift-install@stable` fails for the same reason. Exact numeric versions can still install, but the shorthand gives a broken registry experience for normal discovery and channel-style usage.

## Validation

- `rg -n "openshift-install" registry docs src e2e settings.toml`
- `git diff --check`
- pre-commit `hk` lint suite during commit, including `cargo fmt --all -- --check`, `cargo check --all-features`, taplo, schema, shellcheck, shfmt, actionlint, markdownlint, prettier, stylua, and lua-language-server

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a broken registry alias and does not change runtime logic or data handling.
> 
> **Overview**
> Removes the `openshift-install` registry entry (which pointed to `asdf:mise-plugins/mise-openshift-install`), effectively disabling the shorthand and avoiding a broken `ls-remote`/channel install experience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f961e0c667593028c38b97ec71d3a4b81c087abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->