### PR TITLE
fix(prune): respect tracked lockfiles

### DIFF
--- a/e2e/cli/test_prune
+++ b/e2e/cli/test_prune
@@ -22,3 +22,25 @@ assert "ls $MISE_DATA_DIR/installs/tiny/3.0.0"
 
 # Test: --dry-run-code should exit 0 when there is nothing to prune
 assert_succeed "mise prune --dry-run-code 2>&1"
+
+echo "=== prune keeps lockfile-pinned versions ==="
+locked_project="$(mktemp -d)"
+cd "$locked_project" || exit 1
+export MISE_LOCKFILE=1
+cat >mise.toml <<'EOF'
+[tools]
+dummy = "latest"
+EOF
+cat >mise.lock <<'EOF'
+# @generated
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+EOF
+assert "mise install"
+cd "$(mktemp -d)" || exit 1
+MISE_YES=1 assert "mise prune --tools"
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+cd "$locked_project" || exit 1
+assert_contains "mise install 2>&1" "all tools are installed"

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -109,7 +109,7 @@ pub async fn prunable_tools(
     }
 
     // Remove versions that are still needed by tracked configs
-    let needed_versions = get_versions_needed_by_tracked_configs(config).await?;
+    let needed_versions = get_versions_needed_by_tracked_configs(config, true).await?;
     for key in needed_versions {
         to_delete.remove(&key);
     }
@@ -133,14 +133,17 @@ async fn delete(
         if dry_run {
             prefix = format!("{} {} ", prefix, style("[dryrun]").bold());
         }
-        let pr = mpr.add(&prefix);
-        if dry_run || Settings::get().yes || prompt::confirm_with_all(format!("remove {} ?", &tv))?
+        if !dry_run
+            && !Settings::get().yes
+            && !prompt::confirm_with_all(format!("remove {} ?", &tv))?
         {
-            p.uninstall_version(config, &tv, pr.as_ref(), dry_run)
-                .await?;
-            runtime_symlinks::remove_missing_symlinks(p)?;
-            pr.finish();
+            continue;
         }
+        let pr = mpr.add(&prefix);
+        p.uninstall_version(config, &tv, pr.as_ref(), dry_run)
+            .await?;
+        runtime_symlinks::remove_missing_symlinks(p)?;
+        pr.finish();
     }
     Ok(())
 }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -337,7 +337,8 @@ impl Upgrade {
 
         // Get versions needed by tracked configs AFTER upgrade
         // This ensures we don't uninstall versions still needed by other projects
-        let versions_needed_by_tracked = get_versions_needed_by_tracked_configs(config).await?;
+        let versions_needed_by_tracked =
+            get_versions_needed_by_tracked_configs(config, false).await?;
 
         // Only uninstall old versions of tools that were successfully upgraded
         // and are not needed by any tracked config

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -634,6 +634,10 @@ impl Lockfile {
         platforms
     }
 
+    pub fn tools(&self) -> &BTreeMap<String, Vec<LockfileTool>> {
+        &self.tools
+    }
+
     /// Keep only tools matching configured short names or backend identifiers.
     /// Also removes conda packages that become unreferenced.
     pub fn retain_tools_by_short_or_backend(

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -3,6 +3,7 @@ use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::settings::{Settings, SettingsStatusMissingTools};
 use crate::env::TERM_WIDTH;
+use crate::lockfile::{Lockfile, lockfile_path_for_config};
 use crate::registry::REGISTRY;
 use crate::registry::tool_enabled;
 use crate::{backend, parallel};
@@ -600,16 +601,40 @@ impl From<ToolRequestSet> for Toolset {
 /// uninstalling versions that other projects still need.
 pub async fn get_versions_needed_by_tracked_configs(
     config: &Arc<Config>,
+    use_locked_version: bool,
 ) -> Result<std::collections::HashSet<(String, String)>> {
     let mut needed = std::collections::HashSet::new();
-    // Use use_locked_version: false to resolve based on what config files actually
-    // request, not what was previously locked. This is important during upgrade
-    // because the lockfile hasn't been updated yet when this is called.
+    // `mise prune` should keep versions pinned by lockfiles. `mise upgrade`
+    // passes false because it checks what tracked configs resolve to after an
+    // upgrade, before their lockfiles have been updated.
     let opts = ResolveOptions {
-        use_locked_version: false,
+        use_locked_version,
         ..Default::default()
     };
-    for cf in config.get_tracked_config_files().await?.values() {
+    for (path, cf) in config.get_tracked_config_files().await? {
+        // Prune should protect versions pinned by other tracked projects'
+        // lockfiles. Upgrade passes use_locked_version=false because it must
+        // decide whether old versions are still needed after upgrading.
+        if use_locked_version && Settings::get().lockfile_enabled() {
+            let (lockfile_path, _) = lockfile_path_for_config(&path);
+            match Lockfile::read(&lockfile_path) {
+                Ok(lockfile) => {
+                    for (short, tools) in lockfile.tools() {
+                        for tool in tools {
+                            let version = tool.version.replace([':', '/'], "-");
+                            needed.insert((short.clone(), version.clone()));
+                            if let Some(backend) = &tool.backend {
+                                needed.insert((backend.clone(), version));
+                            }
+                        }
+                    }
+                }
+                Err(err) => warn!(
+                    "error loading tracked lockfile {}: {err:#}",
+                    lockfile_path.display()
+                ),
+            }
+        }
         let mut ts = Toolset::from(cf.to_tool_request_set()?);
         ts.resolve_with_opts(config, &opts).await?;
         for (_, tv) in ts.list_current_versions() {


### PR DESCRIPTION
## Summary

- treat versions pinned in tracked projects' `mise.lock` files as needed during `mise prune`
- skip that explicit tracked-lockfile protection for `mise upgrade`, so old-version cleanup still checks post-upgrade config requests
- avoid starting the per-tool progress reporter until after the prune confirmation prompt accepts the removal

## Root Cause

Config tracking was working in the reported worktree: the repo's `mise.toml` was present in `tracked-configs` and trusted. The prune/install loop happened because `mise install` honors `mise.lock`, but prune's tracked-config safety check only re-resolved each tracked config. That means a tracked project with `dummy = "latest"` and `mise.lock` pinned to `dummy@1.0.0` could have `dummy@1.0.0` pruned when run from another directory, even though returning to that project and running `mise install` would immediately require it again.

The fix makes the prune tracked-config scan explicitly read each tracked config's adjacent lockfile and mark every pinned tool version as needed before pruning. `mise upgrade` still passes `use_locked_version=false`, and the explicit lockfile protection is gated on that flag so stale lockfile pins do not block old-version cleanup during upgrade.

The prompt redraw issue had a separate terminal UI cause: prune created a progress reporter before opening the yes/no/all prompt, so progress rendering and prompt rendering could overlap.

## Validation

- `mise run format`
- `cargo check -q`
- `mise run test:e2e e2e/cli/test_prune`
- `mise run test:e2e e2e/lockfile/test_lockfile_upgrade_prune`
- commit hook: `hk` lint suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pruning eligibility logic by incorporating tracked projects' lockfile-pinned versions, which can alter what gets deleted and must be correct to avoid unintended uninstalls. Also adjusts interactive prune flow and upgrade cleanup behavior, but stays within CLI maintenance paths with added e2e coverage.
> 
> **Overview**
> `mise prune` now treats versions pinned in *tracked projects’* `mise.lock` files as **needed**, preventing them from being deleted when pruning from another directory; this is implemented by extending `get_versions_needed_by_tracked_configs(..., use_locked_version)` to optionally read each tracked config’s adjacent lockfile and add those versions to the protected set.
> 
> `mise upgrade` is updated to call the same API with `use_locked_version=false` so its post-upgrade uninstall cleanup continues to be based on newly-resolved config requests rather than stale lockfiles. Separately, prune’s per-tool progress reporter is created **after** the confirmation prompt to avoid prompt/progress rendering overlap, and a new e2e test asserts lockfile-pinned versions survive `mise prune --tools`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69608b02f2a4040edcc75fd4bb37a7da38208c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->