### PR TITLE
fix(task): skip tool install for missing naked tasks

### DIFF
--- a/e2e/cli/test_naked_run_no_install
+++ b/e2e/cli/test_naked_run_no_install
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cat <<EOF >mise.toml
+[tools]
+dummy = "1.0.0"
+EOF
+
+assert_fail_contains "mise missing-task 2>&1" "no tasks defined"
+assert_fail "test -d $MISE_DATA_DIR/installs/dummy"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -291,7 +291,23 @@ impl Run {
             }
         }
 
-        // Build and install toolset so tools like npm are available for deps
+        if !self.skip_deps {
+            self.skip_deps = Settings::get().task.skip_depends;
+        }
+
+        time!("run init");
+        let tmpdir = tempfile::tempdir()?;
+        self.tmpdir = tmpdir.path().to_path_buf();
+
+        // Build args list - don't include args_last yet, they'll be added after task resolution
+        let args = once(self.task.clone())
+            .chain(self.args.clone())
+            .collect_vec();
+
+        let mut task_list = get_task_lists(&config, &args, true, self.skip_deps).await?;
+
+        // Build and install toolset only after tasks resolve. A naked run that
+        // does not match any task should fail without installing project tools.
         let mut ts = ToolsetBuilder::new()
             .with_args(&self.tool)
             .with_default_to_latest(true)
@@ -309,21 +325,6 @@ impl Run {
         if !self.skip_tools {
             let _ = ts.install_missing_versions(&mut config, &opts).await?;
         }
-
-        if !self.skip_deps {
-            self.skip_deps = Settings::get().task.skip_depends;
-        }
-
-        time!("run init");
-        let tmpdir = tempfile::tempdir()?;
-        self.tmpdir = tmpdir.path().to_path_buf();
-
-        // Build args list - don't include args_last yet, they'll be added after task resolution
-        let args = once(self.task.clone())
-            .chain(self.args.clone())
-            .collect_vec();
-
-        let mut task_list = get_task_lists(&config, &args, true, self.skip_deps).await?;
 
         // Args after -- go directly to tasks (no prefix). They are also
         // recorded on `trailing_args` so the task renderer can detect


### PR DESCRIPTION
## Summary
- resolve task names before installing project tools in `mise run`
- prevents naked runs with no matching task from auto-installing configured tools before failing
- add an e2e regression that proves a missing naked task does not install `dummy`

## Test
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `mise run test:e2e e2e/cli/test_naked_run_no_install`
- commit hook checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk reorder of initialization logic in `mise run`, mainly affecting error paths when no matching task exists; normal task execution still installs tools as before.
> 
> **Overview**
> `mise run` now resolves the requested task list (and initializes temp/run state) *before* building/installing the project toolset, so invoking a non-existent task fails without auto-installing configured tools.
> 
> Adds an e2e regression test (`e2e/cli/test_naked_run_no_install`) that asserts a missing task reports "no tasks defined" and does not create an install directory for a configured dummy tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9551c4fe6b463695eec79f850acc2498849baccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->