### PR TITLE
fix(backend): repair latest runtime labels and go resolution

### DIFF
--- a/e2e/backend/test_go_install_slow
+++ b/e2e/backend/test_go_install_slow
@@ -33,6 +33,9 @@ assert "mise x go:github.com/jdx/go-example@e16a340 -- go-example" "hello world"
 
 # Deep sub-module with no tagged versions; proxy resolves a pseudo-version via @latest.
 assert_contains "mise x go:github.com/go-kratos/kratos/cmd/kratos/v2@latest -- bash -c 'kratos --help 2>&1'" "Kratos: An elegant toolkit for Go microservices."
+assert_matches \
+	"GOPROXY=direct mise install --dry-run 'go:github.com/go-kratos/kratos/cmd/kratos/v2@latest' 2>&1" \
+	'go:github.com/go-kratos/kratos/cmd/kratos/v2@2\.0\.0-[0-9]{14}-[0-9a-f]+'
 
 assert_contains "mise x go:github.com/golang-migrate/migrate/v4/cmd/migrate[tags=postgres]@4.18.2 -- bash -c 'migrate --help 2>&1'" "postgres"
 

--- a/e2e/backend/test_go_latest_empty_versions
+++ b/e2e/backend/test_go_latest_empty_versions
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-export GOPROXY="direct"
-
-assert_matches \
-	"mise install --dry-run 'go:github.com/go-kratos/kratos/cmd/kratos/v2@latest' 2>&1" \
-	'go:github.com/go-kratos/kratos/cmd/kratos/v2@2\.0\.0-[0-9]{14}-[0-9a-f]+'

--- a/e2e/backend/test_go_latest_empty_versions
+++ b/e2e/backend/test_go_latest_empty_versions
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export GOPROXY="direct"
+
+assert_matches \
+	"mise install --dry-run 'go:github.com/go-kratos/kratos/cmd/kratos/v2@latest' 2>&1" \
+	'go:github.com/go-kratos/kratos/cmd/kratos/v2@2\.0\.0-[0-9]{14}-[0-9a-f]+'

--- a/e2e/cli/test_install_before_ignores_stale_latest_dirs
+++ b/e2e/cli/test_install_before_ignores_stale_latest_dirs
@@ -1,32 +1,17 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
-export GOPROXY="https://proxy.golang.org,direct"
-
-cat <<'EOF' >mise.toml
-[settings]
-install_before = "7d"
-
-[tools]
-'go:golang.org/x/pkgsite/cmd/pkgsite' = "latest"
-'pipx:a13xp0p0v/kernel-hardening-checker' = "latest"
-EOF
-
-mkdir -p "$MISE_DATA_DIR/installs/go-golang-org-x-pkgsite-cmd-pkgsite/latest/bin"
-mkdir -p "$MISE_DATA_DIR/installs/pipx-a13xp0p0v-kernel-hardening-checker/latest/bin"
+mkdir -p "$MISE_DATA_DIR/installs/github-jdx-mise-test-fixtures/1.0.0/bin"
+mkdir -p "$MISE_DATA_DIR/installs/github-jdx-mise-test-fixtures/latest/bin"
 cat <<'EOF' >"$MISE_DATA_DIR/installs/.mise-installs.toml"
-[go-golang-org-x-pkgsite-cmd-pkgsite]
-short = "go:golang.org/x/pkgsite/cmd/pkgsite"
-full = "go:golang.org/x/pkgsite/cmd/pkgsite"
-explicit_backend = true
-
-[pipx-a13xp0p0v-kernel-hardening-checker]
-short = "pipx:a13xp0p0v/kernel-hardening-checker"
-full = "pipx:a13xp0p0v/kernel-hardening-checker"
+[github-jdx-mise-test-fixtures]
+short = "github:jdx/mise-test-fixtures"
+full = "github:jdx/mise-test-fixtures"
 explicit_backend = true
 EOF
 
-output=$(mise ls --verbose 2>&1)
-if [[ $output == *"mise ERROR"* ]]; then
-	fail "mise ls emitted an error: $output"
-fi
+output=$(mise ls github:jdx/mise-test-fixtures)
+latest_link="$MISE_DATA_DIR/installs/github-jdx-mise-test-fixtures/latest"
+link_target=$(readlink "$latest_link")
+assert "test '$link_target' = ./1.0.0"
+assert_not_contains "echo '$output'" "latest"
+assert_contains "echo '$output'" "1.0.0"

--- a/e2e/cli/test_install_before_ignores_stale_latest_dirs
+++ b/e2e/cli/test_install_before_ignores_stale_latest_dirs
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export GOPROXY="https://proxy.golang.org,direct"
+
+cat <<'EOF' >mise.toml
+[settings]
+install_before = "7d"
+
+[tools]
+'go:golang.org/x/pkgsite/cmd/pkgsite' = "latest"
+'pipx:a13xp0p0v/kernel-hardening-checker' = "latest"
+EOF
+
+mkdir -p "$MISE_DATA_DIR/installs/go-golang-org-x-pkgsite-cmd-pkgsite/latest/bin"
+mkdir -p "$MISE_DATA_DIR/installs/pipx-a13xp0p0v-kernel-hardening-checker/latest/bin"
+
+output=$(mise ls --verbose 2>&1)
+if [[ $output == *"mise ERROR"* ]]; then
+	fail "mise ls emitted an error: $output"
+fi

--- a/e2e/cli/test_install_before_ignores_stale_latest_dirs
+++ b/e2e/cli/test_install_before_ignores_stale_latest_dirs
@@ -14,6 +14,17 @@ EOF
 
 mkdir -p "$MISE_DATA_DIR/installs/go-golang-org-x-pkgsite-cmd-pkgsite/latest/bin"
 mkdir -p "$MISE_DATA_DIR/installs/pipx-a13xp0p0v-kernel-hardening-checker/latest/bin"
+cat <<'EOF' >"$MISE_DATA_DIR/installs/.mise-installs.toml"
+[go-golang-org-x-pkgsite-cmd-pkgsite]
+short = "go:golang.org/x/pkgsite/cmd/pkgsite"
+full = "go:golang.org/x/pkgsite/cmd/pkgsite"
+explicit_backend = true
+
+[pipx-a13xp0p0v-kernel-hardening-checker]
+short = "pipx:a13xp0p0v/kernel-hardening-checker"
+full = "pipx:a13xp0p0v/kernel-hardening-checker"
+explicit_backend = true
+EOF
 
 output=$(mise ls --verbose 2>&1)
 if [[ $output == *"mise ERROR"* ]]; then

--- a/e2e/cli/test_install_before_ignores_stale_latest_dirs
+++ b/e2e/cli/test_install_before_ignores_stale_latest_dirs
@@ -2,6 +2,7 @@
 
 mkdir -p "$MISE_DATA_DIR/installs/github-jdx-mise-test-fixtures/1.0.0/bin"
 mkdir -p "$MISE_DATA_DIR/installs/github-jdx-mise-test-fixtures/latest/bin"
+mkdir -p "$MISE_DATA_DIR/installs/node/latest/bin"
 cat <<'EOF' >"$MISE_DATA_DIR/installs/.mise-installs.toml"
 [github-jdx-mise-test-fixtures]
 short = "github:jdx/mise-test-fixtures"
@@ -13,5 +14,11 @@ output=$(mise ls github:jdx/mise-test-fixtures)
 latest_link="$MISE_DATA_DIR/installs/github-jdx-mise-test-fixtures/latest"
 link_target=$(readlink "$latest_link")
 assert "test '$link_target' = ./1.0.0"
-assert_not_contains "echo '$output'" "latest"
-assert_contains "echo '$output'" "1.0.0"
+assert "test -d '$MISE_DATA_DIR/installs/node/latest'"
+assert "test ! -L '$MISE_DATA_DIR/installs/node/latest'"
+if [[ $output == *latest* ]]; then
+	fail "mise ls included stale latest entry: $output"
+fi
+if [[ $output != *1.0.0* ]]; then
+	fail "mise ls did not include concrete version: $output"
+fi

--- a/e2e/tools/test_runtime_symlink_migration
+++ b/e2e/tools/test_runtime_symlink_migration
@@ -10,6 +10,6 @@ mkdir -p "$MISE_DATA_DIR/installs/node/20.0.0/bin"
 # Any mise command triggers startup migrations.
 assert "mise --version >/dev/null"
 
-assert "test -f $MISE_DATA_DIR/migrations/runtime-symlink-dirs-v1"
+assert "test -f $MISE_DATA_DIR/migrations/runtime-symlink-dirs-v2"
 
 rm -f mise.toml

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -14,6 +14,7 @@ use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion};
 use async_trait::async_trait;
 use dashmap::DashMap;
+use eyre::WrapErr;
 use serde_json::Deserializer;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
@@ -283,6 +284,10 @@ impl GoBackend {
                     Err(_) => return Ok(None),
                 };
 
+                if mod_info.versions.is_empty() {
+                    return self.fetch_go_module_latest_info(config, mod_path).await;
+                }
+
                 let versions = self
                     .fetch_go_module_version_infos(config, mod_path, &mod_info.versions)
                     .await;
@@ -291,6 +296,29 @@ impl GoBackend {
             })
             .await
             .cloned()
+    }
+
+    async fn fetch_go_module_latest_info(
+        &self,
+        config: &Arc<Config>,
+        mod_path: &str,
+    ) -> eyre::Result<Option<Vec<VersionInfo>>> {
+        let env = self.dependency_env(config).await?;
+        let raw = cmd!(
+            "go",
+            "list",
+            "-mod=readonly",
+            "-m",
+            "-json",
+            format!("{mod_path}@latest")
+        )
+        .full_env(env)
+        .read()
+        .wrap_err_with(|| format!("failed to resolve latest Go module version for {mod_path}"))?;
+        let info = serde_json::from_str::<GoModuleVersionMetadata>(&raw).wrap_err_with(|| {
+            format!("failed to parse latest Go module metadata for {mod_path}")
+        })?;
+        Ok(Some(vec![version_info_from_metadata(info)]))
     }
 
     async fn fetch_go_module_version_infos(

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -68,10 +68,12 @@ impl Backend for GoBackend {
                 }
 
                 // Fall back to `go list -m -versions` for GOPROXY=direct
-                if let Some(versions) = self.fetch_go_module_versions(config, &tool_name).await?
-                    && !versions.is_empty()
-                {
-                    return Ok(versions);
+                match self.fetch_go_module_versions(config, &tool_name).await {
+                    Ok(Some(versions)) if !versions.is_empty() => return Ok(versions),
+                    Ok(_) => {}
+                    Err(err) => {
+                        warn!("failed to list Go module versions for {tool_name}: {err:#}");
+                    }
                 }
 
                 Ok(vec![])

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use crate::backend;
 use crate::config::Config;
 use crate::dirs::*;
 use crate::file;
@@ -63,7 +64,7 @@ fn remove_deprecated_plugin(name: &str, plugin_name: &str) -> Result<()> {
 }
 
 async fn migrate_runtime_symlink_dirs() {
-    const MARKER: &str = "runtime-symlink-dirs-v1";
+    const MARKER: &str = "runtime-symlink-dirs-v2";
     let marker = DATA.join("migrations").join(MARKER);
     if marker.exists() {
         return;
@@ -79,6 +80,10 @@ async fn migrate_runtime_symlink_dirs_impl(marker: &Path) -> Result<()> {
     // and `24.0` that should be runtime symlinks. Remove after 2026.10.0.
     let config = Config::get().await?;
     runtime_symlinks::migrate_real_dirs(&config).await?;
+    // `backend::load_tools()` initializes install_state before migrations run in
+    // normal CLI startup. Refresh it after rewriting stale runtime dirs so this
+    // process does not keep using the pre-migration filesystem scan.
+    backend::reset().await?;
     file::create_dir_all(marker.parent().unwrap())?;
     file::write(marker, "ok\n")?;
     Ok(())

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,11 +1,11 @@
 use std::fs;
 use std::path::Path;
 
-use crate::backend;
 use crate::config::Config;
 use crate::dirs::*;
 use crate::file;
 use crate::runtime_symlinks;
+use crate::toolset::install_state;
 use eyre::Result;
 
 pub async fn run() {
@@ -81,9 +81,10 @@ async fn migrate_runtime_symlink_dirs_impl(marker: &Path) -> Result<()> {
     let config = Config::get().await?;
     runtime_symlinks::migrate_real_dirs(&config).await?;
     // `backend::load_tools()` initializes install_state before migrations run in
-    // normal CLI startup. Refresh it after rewriting stale runtime dirs so this
-    // process does not keep using the pre-migration filesystem scan.
-    backend::reset().await?;
+    // normal CLI startup. Refresh only install_state after rewriting stale dirs
+    // so config alias removals in the already-loaded backend map are preserved.
+    install_state::reset();
+    install_state::init().await?;
     file::create_dir_all(marker.parent().unwrap())?;
     file::write(marker, "ok\n")?;
     Ok(())

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -160,6 +160,9 @@ fn list_symlinks_for_dir(
     let mut symlinks = IndexMap::new();
     let rel_path = |x: &String| PathBuf::from(".").join(x.clone());
     for v in installed_versions_in_dir(installs_dir) {
+        if is_temporary_runtime_label(&v) {
+            continue;
+        }
         let (prefix, version) = split_version_prefix(&v);
         let Some(versions) = Versioning::new(version) else {
             continue;
@@ -213,6 +216,18 @@ fn installed_versions_in_dir(installs_dir: &Path) -> Vec<String> {
 fn is_concrete_install(v: &str) -> bool {
     let (_, version) = split_version_prefix(v);
     version.chars().any(|c| c.is_ascii_digit()) && Versioning::new(version).is_some()
+}
+
+fn is_temporary_runtime_label(v: &str) -> bool {
+    let remove_version = Versioning::new("2026.10.0").unwrap();
+    debug_assert!(
+        *crate::cli::version::V < remove_version,
+        "Temporary runtime symlink migration guard should be removed in version 2026.10.0."
+    );
+    // The 2026.4 runtime symlink regression created real "latest" dirs. Treat
+    // only that literal label as generated state: numeric prefixes like "25"
+    // may be concrete installs requested by users and must not be migrated.
+    v == "latest"
 }
 
 pub fn remove_missing_symlinks(backend: Arc<dyn Backend>) -> Result<()> {

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::backend::Backend;
+use crate::backend::backend_type::BackendType;
 use crate::config::{Alias, Config};
 use crate::file::make_symlink_or_file;
 use crate::plugins::VERSION_REGEX;
@@ -84,7 +85,7 @@ fn rebuild_symlinks_in_dir(
     backend: &Arc<dyn Backend>,
     installs_dir: &Path,
 ) -> Result<()> {
-    let concrete_installs = installed_versions_in_dir(installs_dir)
+    let concrete_installs = installed_versions_in_dir(installs_dir, backend.get_type())
         .into_iter()
         .filter(|v| is_concrete_install(v))
         .collect::<std::collections::HashSet<_>>();
@@ -120,7 +121,7 @@ fn migrate_real_dirs_in_dir(
     backend: &Arc<dyn Backend>,
     installs_dir: &Path,
 ) -> Result<()> {
-    let concrete_installs = installed_versions_in_dir(installs_dir)
+    let concrete_installs = installed_versions_in_dir(installs_dir, backend.get_type())
         .into_iter()
         .filter(|v| is_concrete_install(v))
         .collect::<std::collections::HashSet<_>>();
@@ -158,7 +159,7 @@ fn list_symlinks_for_dir(
 ) -> IndexMap<String, PathBuf> {
     let mut symlinks = IndexMap::new();
     let rel_path = |x: &String| PathBuf::from(".").join(x.clone());
-    for v in installed_versions_in_dir(installs_dir) {
+    for v in installed_versions_in_dir(installs_dir, backend.get_type()) {
         let (prefix, version) = split_version_prefix(&v);
         let versions = Versioning::new(version).unwrap_or_default();
         let mut partial = vec![];
@@ -192,7 +193,7 @@ fn list_symlinks_for_dir(
 }
 
 /// List real (non-symlink) installed versions in a specific directory.
-fn installed_versions_in_dir(installs_dir: &Path) -> Vec<String> {
+fn installed_versions_in_dir(installs_dir: &Path, backend_type: BackendType) -> Vec<String> {
     if !installs_dir.is_dir() {
         return vec![];
     }
@@ -200,7 +201,7 @@ fn installed_versions_in_dir(installs_dir: &Path) -> Vec<String> {
         .unwrap_or_default()
         .into_iter()
         .filter(|v| !v.starts_with('.'))
-        .filter(|v| !is_runtime_label(v))
+        .filter(|v| !is_runtime_label_for_backend(v, &backend_type))
         .filter(|v| !is_runtime_symlink(&installs_dir.join(v)))
         .filter(|v| !installs_dir.join(v).join("incomplete").exists())
         .filter(|v| !VERSION_REGEX.is_match(v))
@@ -209,10 +210,14 @@ fn installed_versions_in_dir(installs_dir: &Path) -> Vec<String> {
 }
 
 pub fn is_runtime_label(version: &str) -> bool {
-    // `latest` is a global runtime symlink label created for every concrete
-    // install. Other labels are version prefixes or config aliases that need
-    // per-backend/config context, so keep this early install-state filter narrow.
     version == "latest"
+}
+
+pub fn is_runtime_label_for_backend(version: &str, backend_type: &BackendType) -> bool {
+    // Some backends, like UBI direct URLs, still use `latest` as the actual
+    // install directory. Limit this stale-label filter to backends that resolve
+    // `latest` to a concrete version before installation.
+    matches!(backend_type, BackendType::Go | BackendType::Pipx) && is_runtime_label(version)
 }
 
 fn is_concrete_install(v: &str) -> bool {

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -200,11 +200,19 @@ fn installed_versions_in_dir(installs_dir: &Path) -> Vec<String> {
         .unwrap_or_default()
         .into_iter()
         .filter(|v| !v.starts_with('.'))
+        .filter(|v| !is_runtime_label(v))
         .filter(|v| !is_runtime_symlink(&installs_dir.join(v)))
         .filter(|v| !installs_dir.join(v).join("incomplete").exists())
         .filter(|v| !VERSION_REGEX.is_match(v))
         .sorted_by_cached_key(|v| (Versioning::new(v), v.to_string()))
         .collect()
+}
+
+pub fn is_runtime_label(version: &str) -> bool {
+    // `latest` is a global runtime symlink label created for every concrete
+    // install. Other labels are version prefixes or config aliases that need
+    // per-backend/config context, so keep this early install-state filter narrow.
+    version == "latest"
 }
 
 fn is_concrete_install(v: &str) -> bool {

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -219,9 +219,11 @@ fn is_concrete_install(v: &str) -> bool {
 }
 
 fn is_temporary_runtime_label(v: &str) -> bool {
-    let remove_version = Versioning::new("2026.10.0").unwrap();
     debug_assert!(
-        *crate::cli::version::V < remove_version,
+        {
+            let remove_version = Versioning::new("2026.10.0").unwrap();
+            *crate::cli::version::V < remove_version
+        },
         "Temporary runtime symlink migration guard should be removed in version 2026.10.0."
     );
     // The 2026.4 runtime symlink regression created real "latest" dirs. Treat

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::backend::Backend;
-use crate::backend::backend_type::BackendType;
 use crate::config::{Alias, Config};
 use crate::file::make_symlink_or_file;
 use crate::plugins::VERSION_REGEX;
@@ -85,7 +84,7 @@ fn rebuild_symlinks_in_dir(
     backend: &Arc<dyn Backend>,
     installs_dir: &Path,
 ) -> Result<()> {
-    let concrete_installs = installed_versions_in_dir(installs_dir, backend.get_type())
+    let concrete_installs = installed_versions_in_dir(installs_dir)
         .into_iter()
         .filter(|v| is_concrete_install(v))
         .collect::<std::collections::HashSet<_>>();
@@ -121,7 +120,7 @@ fn migrate_real_dirs_in_dir(
     backend: &Arc<dyn Backend>,
     installs_dir: &Path,
 ) -> Result<()> {
-    let concrete_installs = installed_versions_in_dir(installs_dir, backend.get_type())
+    let concrete_installs = installed_versions_in_dir(installs_dir)
         .into_iter()
         .filter(|v| is_concrete_install(v))
         .collect::<std::collections::HashSet<_>>();
@@ -132,6 +131,7 @@ fn migrate_real_dirs_in_dir(
         if !from.exists() || is_runtime_symlink(&from) || concrete_installs.contains(&from_name) {
             continue;
         }
+        trace!("Replacing stale runtime dir: {}", from.display());
         file::remove_all(&from)?;
         make_symlink_or_file(&to, &from)?;
     }
@@ -159,9 +159,11 @@ fn list_symlinks_for_dir(
 ) -> IndexMap<String, PathBuf> {
     let mut symlinks = IndexMap::new();
     let rel_path = |x: &String| PathBuf::from(".").join(x.clone());
-    for v in installed_versions_in_dir(installs_dir, backend.get_type()) {
+    for v in installed_versions_in_dir(installs_dir) {
         let (prefix, version) = split_version_prefix(&v);
-        let versions = Versioning::new(version).unwrap_or_default();
+        let Some(versions) = Versioning::new(version) else {
+            continue;
+        };
         let mut partial = vec![];
         while versions.nth(partial.len()).is_some() && versions.nth(partial.len() + 1).is_some() {
             let version = versions.nth(partial.len()).unwrap();
@@ -193,7 +195,7 @@ fn list_symlinks_for_dir(
 }
 
 /// List real (non-symlink) installed versions in a specific directory.
-fn installed_versions_in_dir(installs_dir: &Path, backend_type: BackendType) -> Vec<String> {
+fn installed_versions_in_dir(installs_dir: &Path) -> Vec<String> {
     if !installs_dir.is_dir() {
         return vec![];
     }
@@ -201,7 +203,6 @@ fn installed_versions_in_dir(installs_dir: &Path, backend_type: BackendType) -> 
         .unwrap_or_default()
         .into_iter()
         .filter(|v| !v.starts_with('.'))
-        .filter(|v| !is_runtime_label_for_backend(v, &backend_type))
         .filter(|v| !is_runtime_symlink(&installs_dir.join(v)))
         .filter(|v| !installs_dir.join(v).join("incomplete").exists())
         .filter(|v| !VERSION_REGEX.is_match(v))
@@ -209,20 +210,9 @@ fn installed_versions_in_dir(installs_dir: &Path, backend_type: BackendType) -> 
         .collect()
 }
 
-pub fn is_runtime_label(version: &str) -> bool {
-    version == "latest"
-}
-
-pub fn is_runtime_label_for_backend(version: &str, backend_type: &BackendType) -> bool {
-    // Some backends, like UBI direct URLs, still use `latest` as the actual
-    // install directory. Limit this stale-label filter to backends that resolve
-    // `latest` to a concrete version before installation.
-    matches!(backend_type, BackendType::Go | BackendType::Pipx) && is_runtime_label(version)
-}
-
 fn is_concrete_install(v: &str) -> bool {
     let (_, version) = split_version_prefix(v);
-    Versioning::new(version).is_some()
+    version.chars().any(|c| c.is_ascii_digit()) && Versioning::new(version).is_some()
 }
 
 pub fn remove_missing_symlinks(backend: Arc<dyn Backend>) -> Result<()> {

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -23,31 +23,17 @@ fn normalize_version_for_sort(v: &str) -> &str {
         .unwrap_or(v)
 }
 
-fn runtime_label_backend_type_from_dir(dir_name: &str) -> BackendType {
-    // Metadata is preferred when available. This fallback is only for legacy or
-    // manually created install dirs like the stale Go/Pipx `latest` dirs this
-    // PR cleans up.
-    if dir_name == "go" || dir_name.starts_with("go-") {
-        BackendType::Go
-    } else if dir_name == "pipx" || dir_name.starts_with("pipx-") {
-        BackendType::Pipx
-    } else {
-        BackendType::Unknown
-    }
-}
-
 fn runtime_label_backend_type_from_meta(
-    dir_name: &str,
     manifest_tool: Option<&ManifestTool>,
     legacy_meta: Option<&(String, Option<String>, bool)>,
-) -> BackendType {
+) -> Option<BackendType> {
     if let Some(full) = manifest_tool
         .and_then(|mt| mt.full.as_deref())
         .or_else(|| legacy_meta.and_then(|(_, full, _)| full.as_deref()))
     {
         let backend_type = BackendType::guess(full);
         if backend_type != BackendType::Unknown {
-            return backend_type;
+            return Some(backend_type);
         }
     }
 
@@ -57,15 +43,11 @@ fn runtime_label_backend_type_from_meta(
     {
         let backend_type = BackendType::guess(short);
         if backend_type != BackendType::Unknown {
-            return backend_type;
+            return Some(backend_type);
         }
     }
 
-    if manifest_tool.is_some() || legacy_meta.is_some() {
-        BackendType::Unknown
-    } else {
-        runtime_label_backend_type_from_dir(dir_name)
-    }
+    None
 }
 
 type InstallStatePlugins = BTreeMap<String, PluginType>;
@@ -263,7 +245,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             None
         };
         let runtime_label_backend_type =
-            runtime_label_backend_type_from_meta(&dir_name, manifest_tool, legacy_meta.as_ref());
+            runtime_label_backend_type_from_meta(manifest_tool, legacy_meta.as_ref());
 
         // Read versions from filesystem (1 syscall per tool — unavoidable)
         let versions: Vec<String> = file::dir_subdirs(&dir)
@@ -274,7 +256,11 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             .into_iter()
             .filter(|v| !v.starts_with('.'))
             .filter(|v| {
-                !runtime_symlinks::is_runtime_label_for_backend(v, &runtime_label_backend_type)
+                runtime_label_backend_type
+                    .as_ref()
+                    .is_none_or(|backend_type| {
+                        !runtime_symlinks::is_runtime_label_for_backend(v, backend_type)
+                    })
             })
             .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
             .filter(|v| !dir.join(v).join("incomplete").exists())
@@ -377,7 +363,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             let dir = shared_dir.join(&dir_name);
             let manifest_tool = shared_manifest.get(&dir_name);
             let runtime_label_backend_type =
-                runtime_label_backend_type_from_meta(&dir_name, manifest_tool, None);
+                runtime_label_backend_type_from_meta(manifest_tool, None);
             let versions: Vec<String> = file::dir_subdirs(&dir)
                 .unwrap_or_else(|err| {
                     warn!("reading versions in {} failed: {err:?}", display_path(&dir));
@@ -386,7 +372,11 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 .into_iter()
                 .filter(|v| !v.starts_with('.'))
                 .filter(|v| {
-                    !runtime_symlinks::is_runtime_label_for_backend(v, &runtime_label_backend_type)
+                    runtime_label_backend_type
+                        .as_ref()
+                        .is_none_or(|backend_type| {
+                            !runtime_symlinks::is_runtime_label_for_backend(v, backend_type)
+                        })
                 })
                 .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
                 .filter(|v| !dir.join(v).join("incomplete").exists())

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -24,12 +24,47 @@ fn normalize_version_for_sort(v: &str) -> &str {
 }
 
 fn runtime_label_backend_type_from_dir(dir_name: &str) -> BackendType {
+    // Metadata is preferred when available. This fallback is only for legacy or
+    // manually created install dirs like the stale Go/Pipx `latest` dirs this
+    // PR cleans up.
     if dir_name == "go" || dir_name.starts_with("go-") {
         BackendType::Go
     } else if dir_name == "pipx" || dir_name.starts_with("pipx-") {
         BackendType::Pipx
     } else {
         BackendType::Unknown
+    }
+}
+
+fn runtime_label_backend_type_from_meta(
+    dir_name: &str,
+    manifest_tool: Option<&ManifestTool>,
+    legacy_meta: Option<&(String, Option<String>, bool)>,
+) -> BackendType {
+    if let Some(full) = manifest_tool
+        .and_then(|mt| mt.full.as_deref())
+        .or_else(|| legacy_meta.and_then(|(_, full, _)| full.as_deref()))
+    {
+        let backend_type = BackendType::guess(full);
+        if backend_type != BackendType::Unknown {
+            return backend_type;
+        }
+    }
+
+    if let Some(short) = manifest_tool
+        .map(|mt| mt.short.as_str())
+        .or_else(|| legacy_meta.map(|(short, _, _)| short.as_str()))
+    {
+        let backend_type = BackendType::guess(short);
+        if backend_type != BackendType::Unknown {
+            return backend_type;
+        }
+    }
+
+    if manifest_tool.is_some() || legacy_meta.is_some() {
+        BackendType::Unknown
+    } else {
+        runtime_label_backend_type_from_dir(dir_name)
     }
 }
 
@@ -221,6 +256,14 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
     let mut tools = BTreeMap::new();
     for dir_name in subdirs {
         let dir = dirs::INSTALLS.join(&dir_name);
+        let manifest_tool = manifest.get(&dir_name);
+        let legacy_meta = if manifest_tool.is_none() {
+            read_legacy_backend_meta(&dir_name)
+        } else {
+            None
+        };
+        let runtime_label_backend_type =
+            runtime_label_backend_type_from_meta(&dir_name, manifest_tool, legacy_meta.as_ref());
 
         // Read versions from filesystem (1 syscall per tool — unavoidable)
         let versions: Vec<String> = file::dir_subdirs(&dir)
@@ -231,10 +274,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             .into_iter()
             .filter(|v| !v.starts_with('.'))
             .filter(|v| {
-                !runtime_symlinks::is_runtime_label_for_backend(
-                    v,
-                    &runtime_label_backend_type_from_dir(&dir_name),
-                )
+                !runtime_symlinks::is_runtime_label_for_backend(v, &runtime_label_backend_type)
             })
             .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
             .filter(|v| !dir.join(v).join("incomplete").exists())
@@ -249,7 +289,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
         }
 
         // Get metadata: prefer manifest, fall back to legacy .mise.backend
-        let (short, full, explicit_backend, opts) = if let Some(mt) = manifest.get(&dir_name) {
+        let (short, full, explicit_backend, opts) = if let Some(mt) = manifest_tool {
             let mut full = mt.full.clone();
             let mut opts = mt.opts.clone();
             // Backward compat: if opts is empty but full contains [...], extract opts
@@ -279,7 +319,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 );
             }
             (mt.short.clone(), full, mt.explicit_backend, opts)
-        } else if let Some((s, full, explicit)) = read_legacy_backend_meta(&dir_name) {
+        } else if let Some((s, full, explicit)) = legacy_meta {
             // Migration: absorb into manifest (clone on first migration)
             let m = updated_manifest.get_or_insert_with(|| manifest.clone());
             m.insert(
@@ -335,6 +375,9 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
         };
         for dir_name in shared_subdirs {
             let dir = shared_dir.join(&dir_name);
+            let manifest_tool = shared_manifest.get(&dir_name);
+            let runtime_label_backend_type =
+                runtime_label_backend_type_from_meta(&dir_name, manifest_tool, None);
             let versions: Vec<String> = file::dir_subdirs(&dir)
                 .unwrap_or_else(|err| {
                     warn!("reading versions in {} failed: {err:?}", display_path(&dir));
@@ -343,10 +386,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 .into_iter()
                 .filter(|v| !v.starts_with('.'))
                 .filter(|v| {
-                    !runtime_symlinks::is_runtime_label_for_backend(
-                        v,
-                        &runtime_label_backend_type_from_dir(&dir_name),
-                    )
+                    !runtime_symlinks::is_runtime_label_for_backend(v, &runtime_label_backend_type)
                 })
                 .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
                 .filter(|v| !dir.join(v).join("incomplete").exists())
@@ -360,17 +400,16 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 continue;
             }
 
-            let (short, full, explicit_backend, opts) =
-                if let Some(mt) = shared_manifest.get(&dir_name) {
-                    (
-                        mt.short.clone(),
-                        mt.full.clone(),
-                        mt.explicit_backend,
-                        mt.opts.clone(),
-                    )
-                } else {
-                    (dir_name.clone(), None, true, BTreeMap::new())
-                };
+            let (short, full, explicit_backend, opts) = if let Some(mt) = manifest_tool {
+                (
+                    mt.short.clone(),
+                    mt.full.clone(),
+                    mt.explicit_backend,
+                    mt.opts.clone(),
+                )
+            } else {
+                (dir_name.clone(), None, true, BTreeMap::new())
+            };
 
             // Merge with existing tool entry or create new one
             let tool = tools

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -23,6 +23,16 @@ fn normalize_version_for_sort(v: &str) -> &str {
         .unwrap_or(v)
 }
 
+fn runtime_label_backend_type_from_dir(dir_name: &str) -> BackendType {
+    if dir_name == "go" || dir_name.starts_with("go-") {
+        BackendType::Go
+    } else if dir_name == "pipx" || dir_name.starts_with("pipx-") {
+        BackendType::Pipx
+    } else {
+        BackendType::Unknown
+    }
+}
+
 type InstallStatePlugins = BTreeMap<String, PluginType>;
 type InstallStateTools = BTreeMap<String, InstallStateTool>;
 type MutexResult<T> = Result<Arc<T>>;
@@ -220,7 +230,12 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             })
             .into_iter()
             .filter(|v| !v.starts_with('.'))
-            .filter(|v| !runtime_symlinks::is_runtime_label(v))
+            .filter(|v| {
+                !runtime_symlinks::is_runtime_label_for_backend(
+                    v,
+                    &runtime_label_backend_type_from_dir(&dir_name),
+                )
+            })
             .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
             .filter(|v| !dir.join(v).join("incomplete").exists())
             .sorted_by_cached_key(|v| {
@@ -327,7 +342,12 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 })
                 .into_iter()
                 .filter(|v| !v.starts_with('.'))
-                .filter(|v| !runtime_symlinks::is_runtime_label(v))
+                .filter(|v| {
+                    !runtime_symlinks::is_runtime_label_for_backend(
+                        v,
+                        &runtime_label_backend_type_from_dir(&dir_name),
+                    )
+                })
                 .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
                 .filter(|v| !dir.join(v).join("incomplete").exists())
                 .sorted_by_cached_key(|v| {

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -23,33 +23,6 @@ fn normalize_version_for_sort(v: &str) -> &str {
         .unwrap_or(v)
 }
 
-fn runtime_label_backend_type_from_meta(
-    manifest_tool: Option<&ManifestTool>,
-    legacy_meta: Option<&(String, Option<String>, bool)>,
-) -> Option<BackendType> {
-    if let Some(full) = manifest_tool
-        .and_then(|mt| mt.full.as_deref())
-        .or_else(|| legacy_meta.and_then(|(_, full, _)| full.as_deref()))
-    {
-        let backend_type = BackendType::guess(full);
-        if backend_type != BackendType::Unknown {
-            return Some(backend_type);
-        }
-    }
-
-    if let Some(short) = manifest_tool
-        .map(|mt| mt.short.as_str())
-        .or_else(|| legacy_meta.map(|(short, _, _)| short.as_str()))
-    {
-        let backend_type = BackendType::guess(short);
-        if backend_type != BackendType::Unknown {
-            return Some(backend_type);
-        }
-    }
-
-    None
-}
-
 type InstallStatePlugins = BTreeMap<String, PluginType>;
 type InstallStateTools = BTreeMap<String, InstallStateTool>;
 type MutexResult<T> = Result<Arc<T>>;
@@ -244,9 +217,6 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
         } else {
             None
         };
-        let runtime_label_backend_type =
-            runtime_label_backend_type_from_meta(manifest_tool, legacy_meta.as_ref());
-
         // Read versions from filesystem (1 syscall per tool — unavoidable)
         let versions: Vec<String> = file::dir_subdirs(&dir)
             .unwrap_or_else(|err| {
@@ -255,13 +225,6 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             })
             .into_iter()
             .filter(|v| !v.starts_with('.'))
-            .filter(|v| {
-                runtime_label_backend_type
-                    .as_ref()
-                    .is_none_or(|backend_type| {
-                        !runtime_symlinks::is_runtime_label_for_backend(v, backend_type)
-                    })
-            })
             .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
             .filter(|v| !dir.join(v).join("incomplete").exists())
             .sorted_by_cached_key(|v| {
@@ -362,8 +325,6 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
         for dir_name in shared_subdirs {
             let dir = shared_dir.join(&dir_name);
             let manifest_tool = shared_manifest.get(&dir_name);
-            let runtime_label_backend_type =
-                runtime_label_backend_type_from_meta(manifest_tool, None);
             let versions: Vec<String> = file::dir_subdirs(&dir)
                 .unwrap_or_else(|err| {
                     warn!("reading versions in {} failed: {err:?}", display_path(&dir));
@@ -371,13 +332,6 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 })
                 .into_iter()
                 .filter(|v| !v.starts_with('.'))
-                .filter(|v| {
-                    runtime_label_backend_type
-                        .as_ref()
-                        .is_none_or(|backend_type| {
-                            !runtime_symlinks::is_runtime_label_for_backend(v, backend_type)
-                        })
-                })
                 .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
                 .filter(|v| !dir.join(v).join("incomplete").exists())
                 .sorted_by_cached_key(|v| {

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -220,6 +220,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             })
             .into_iter()
             .filter(|v| !v.starts_with('.'))
+            .filter(|v| !runtime_symlinks::is_runtime_label(v))
             .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
             .filter(|v| !dir.join(v).join("incomplete").exists())
             .sorted_by_cached_key(|v| {
@@ -326,6 +327,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
                 })
                 .into_iter()
                 .filter(|v| !v.starts_with('.'))
+                .filter(|v| !runtime_symlinks::is_runtime_label(v))
                 .filter(|v| !runtime_symlinks::is_runtime_symlink(&dir.join(v)))
                 .filter(|v| !dir.join(v).join("incomplete").exists())
                 .sorted_by_cached_key(|v| {


### PR DESCRIPTION
## Summary

Fixes two separate `@latest` regressions that were getting conflated:

- Go modules that enumerate zero versions now resolve `@latest` with `go list -m -json <module>@latest`, so modules that only have pseudo-versions still resolve to a concrete install version.
- Stale real runtime-label directories like `installs/<tool>/latest/` are repaired generically by the runtime symlink migration, instead of filtering specific backends. The migration reruns with a new marker and refreshes only `install_state` after rewriting dirs, so the current process sees the repaired scan without rebuilding the backend map and breaking config aliases.
- The one-time migration treats only literal `latest` as temporary generated state, with a debug-time removal guard for `2026.10.0`. Numeric partial-version dirs such as `installs/<tool>/25/` are left alone because users can request them directly with config like `foo = "25"`.

Real direct-URL `latest` installs, such as UBI URL installs, are preserved when there is no concrete version target to replace them with.

Rebased onto `origin/main` at `364f7fea2`.

Related:

- https://github.com/jdx/mise/discussions/9376
- https://github.com/jdx/mise/discussions/9381

## Validation

- `cargo fmt --check`
- `cargo check --all-features`
- `mise run test:e2e e2e/config/test_config_alias`
- `mise run test:e2e e2e/config/test_config_plugins`
- `mise run test:e2e e2e/cli/test_install_before_ignores_stale_latest_dirs`
- `mise run test:e2e e2e/tools/test_runtime_symlink_migration`
- `mise run test:e2e e2e/tools/test_runtime_symlink_migration_preserves_concrete_short_version`
- `mise run test:e2e e2e/backend/test_ubi`
- `mise run test:e2e e2e/backend/test_go_install_slow`
- pre-commit `hk` hook via `git commit`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f1837f17f251cc3e89be661893f7b34e26afae4d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->