### PR TITLE
refactor(config): rename install_before setting

### DIFF
--- a/docs/cli/latest.md
+++ b/docs/cli/latest.md
@@ -25,7 +25,7 @@ Show latest installed instead of available version
 Only consider versions released before this date
 
 Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
-Overrides per-tool `install_before` options and the global `install_before` setting.
+Overrides per-tool `minimum_release_age` options and the global `minimum_release_age` setting.
 
 Examples:
 

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -14,11 +14,11 @@ similar to how the pipx backend uses `uv` when available.
 If you use `aube`, `bun`, or `pnpm` as the package manager, that package manager
 must also be installed.
 
-When [`install_before`](/configuration/settings.html#install_before) is set, the npm backend
+When [`minimum_release_age`](/configuration/settings.html#minimum_release_age) is set, the npm backend
 forwards that cutoff to transitive dependency resolution during install. This relies on the
 configured package manager supporting its native release-age flag:
 
-- `npm >= 11.10.0` using `--min-release-age=<days>`; `npm 6.9.0–11.9.x` using `--before <timestamp>` (sub-day `install_before` windows also use `--before` since `--min-release-age` is day-granular)
+- `npm >= 11.10.0` using `--min-release-age=<days>`; `npm 6.9.0–11.9.x` using `--before <timestamp>` (sub-day `minimum_release_age` windows also use `--before` since `--min-release-age` is day-granular)
 - `aube` using its `minimumReleaseAge` setting
 - `bun >= 1.3.0` using `--minimum-release-age <seconds>`
 - `pnpm >= 10.16.0` using `--config.minimumReleaseAge=<minutes>`

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -27,7 +27,7 @@ This relies on having `uv` (recommended) or `pipx` installed.
 
 If you have `uv` installed, mise will use `uv tool install` under the hood and you don't need to install `pipx` to run the commands containing "pipx:".
 
-When [`install_before`](/configuration/settings.html#install_before) is set, mise forwards the cutoff
+When [`minimum_release_age`](/configuration/settings.html#minimum_release_age) is set, mise forwards the cutoff
 to transitive Python dependency resolution during install. The uv install path uses uv's
 `--exclude-newer` flag, and the `pipx` fallback passes pip's `--uploaded-prior-to` flag.
 

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -351,14 +351,14 @@ When enabled, every `mise install` will cryptographically verify provenance rega
 
 ## Minimum Release Age
 
-In addition to lockfiles, mise supports the [`install_before`](/configuration/settings.html#install_before) setting to limit supply chain risk by only installing versions that have been available for a minimum amount of time:
+In addition to lockfiles, mise supports the [`minimum_release_age`](/configuration/settings.html#minimum_release_age) setting to limit supply chain risk by only installing versions that have been available for a minimum amount of time:
 
 ```toml
 [settings]
-install_before = "7d"  # only resolve to versions released more than 7 days ago
+minimum_release_age = "7d"  # only resolve to versions released more than 7 days ago
 ```
 
-This pairs well with lockfiles — use `install_before` to avoid picking up brand-new releases, and lockfiles to pin the exact versions you've vetted.
+This pairs well with lockfiles — use `minimum_release_age` to avoid picking up brand-new releases, and lockfiles to pin the exact versions you've vetted.
 
 Some package-manager backends also forward this cutoff into transitive dependency resolution during
 install. This includes `npm:` and `pipx:` tools.

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -175,7 +175,7 @@ To limit supply chain risk, you can restrict mise to only install versions relea
 ```toml
 # mise.toml
 [settings]
-install_before = "7d"  # only install versions released more than 7 days ago
+minimum_release_age = "7d"  # only install versions released more than 7 days ago
 ```
 
 Supports relative durations (`7d`, `6m`, `1y`) and absolute dates (`2024-06-01`). For most backends, this only affects fuzzy version resolution (e.g., `node@20` or `latest`) — explicitly pinned versions like `node@22.5.0` bypass the filter.
@@ -185,21 +185,21 @@ during install. Refer to the
 [npm backend docs](/dev-tools/backends/npm.html) and [pipx backend docs](/dev-tools/backends/pipx.html)
 for package-manager support details.
 
-You can also set `install_before` per-tool to override the global setting:
+You can also set `minimum_release_age` per-tool to override the global setting:
 
 ```toml
 # mise.toml
 [settings]
-install_before = "7d"  # default for all tools
+minimum_release_age = "7d"  # default for all tools
 
 [tools.trivy]
 version = "latest"
-install_before = "1d"  # trivy updates are time-sensitive, use a shorter window
+minimum_release_age = "1d"  # trivy updates are time-sensitive, use a shorter window
 ```
 
-Precedence: `--before` CLI flag > per-tool `install_before` > global `install_before` setting.
+Precedence: `--before` CLI flag > per-tool `minimum_release_age` > global `minimum_release_age` setting.
 
-See [`install_before`](/configuration/settings.html#install_before) for more details.
+See [`minimum_release_age`](/configuration/settings.html#minimum_release_age) for more details.
 
 ## [`mise up --bump`](/cli/upgrade.html)
 

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -1,47 +1,47 @@
 #!/usr/bin/env bash
-# Test install_before with npm backend (dist-tag fallback)
+# Test minimum_release_age with npm backend (dist-tag fallback)
 # Regression test for https://github.com/jdx/mise/discussions/9136
 
 export NPM_CONFIG_FUND=false
 
 mise use node
 
-# Test: mise latest with install_before should resolve to an older version
+# Test: mise latest with minimum_release_age should resolve to an older version
 # prettier 3.0.0 was released 2023-07-05, 2.8.8 was released 2023-05-23
-# Setting install_before to 2023-06-01 should give us 2.8.8 (not 3.x)
+# Setting minimum_release_age to 2023-06-01 should give us 2.8.8 (not 3.x)
 # This must bypass NPMBackend::latest_stable_version because npm dist-tags
 # always return the absolute latest version.
-export MISE_INSTALL_BEFORE="2023-06-01"
+export MISE_MINIMUM_RELEASE_AGE="2023-06-01"
 assert_contains "mise latest npm:prettier" "2.8.8"
-unset MISE_INSTALL_BEFORE
+unset MISE_MINIMUM_RELEASE_AGE
 
-# Test: without install_before, latest is the absolute latest (newer than 2.8.8)
+# Test: without minimum_release_age, latest is the absolute latest (newer than 2.8.8)
 assert_not_contains "mise latest npm:prettier" "2.8.8"
 
 # Test: `mise latest --before` CLI flag should filter by date
 assert_contains "mise latest npm:prettier --before 2023-06-01" "2.8.8"
 
-# Test: CLI --before flag overrides the global install_before setting
+# Test: CLI --before flag overrides the global minimum_release_age setting
 # Global is 2024-01-01 (would give 3.1.0), CLI is 2023-06-01 (gives 2.8.8)
-export MISE_INSTALL_BEFORE="2024-01-01"
+export MISE_MINIMUM_RELEASE_AGE="2024-01-01"
 assert_not_contains "mise latest npm:prettier" "2.8.8"
 assert_contains "mise latest npm:prettier --before 2023-06-01" "2.8.8"
-unset MISE_INSTALL_BEFORE
+unset MISE_MINIMUM_RELEASE_AGE
 
 # Test: CLI --before flag accepts relative durations.
 assert_not_empty "mise latest npm:prettier --before 5y"
 
-# Test: per-tool install_before also affects backend-level latest lookup.
+# Test: per-tool minimum_release_age also affects backend-level latest lookup.
 cat <<EOF >mise.toml
 [tools]
-"npm:prettier" = { version = "latest", install_before = "2023-06-01" }
+"npm:prettier" = { version = "latest", minimum_release_age = "2023-06-01" }
 EOF
 assert_contains "mise latest npm:prettier" "2.8.8"
 
-# Test: CLI --before flag overrides per-tool install_before.
+# Test: CLI --before flag overrides per-tool minimum_release_age.
 cat <<EOF >mise.toml
 [tools]
-"npm:prettier" = { version = "latest", install_before = "2024-01-01" }
+"npm:prettier" = { version = "latest", minimum_release_age = "2024-01-01" }
 EOF
 assert_not_contains "mise latest npm:prettier" "2.8.8"
 assert_contains "mise latest npm:prettier --before 2023-06-01" "2.8.8"

--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -2,7 +2,7 @@
 
 # Test that npm backend properly uses npm.package_manager settings
 
-export MISE_INSTALL_BEFORE=1d
+export MISE_MINIMUM_RELEASE_AGE=1d
 
 # Ensure npm is available by installing node if needed
 if ! command -v npm >/dev/null 2>&1; then

--- a/e2e/cli/test_install_before
+++ b/e2e/cli/test_install_before
@@ -21,12 +21,12 @@ output=$(mise use tiny@latest --before 2025-01-01 --dry-run 2>&1)
 assert_contains "echo '$output'" "tiny"
 rm -f mise.toml
 
-# Test: MISE_INSTALL_BEFORE environment variable works
+# Test: MISE_MINIMUM_RELEASE_AGE environment variable works
 mise uninstall tiny --all 2>/dev/null || true
-export MISE_INSTALL_BEFORE="2025-01-01"
+export MISE_MINIMUM_RELEASE_AGE="2025-01-01"
 mise install tiny@latest
 assert_contains "mise ls --installed tiny" "3.1.0"
-unset MISE_INSTALL_BEFORE
+unset MISE_MINIMUM_RELEASE_AGE
 
 # Test: upgrade --before with dry-run
 cat <<EOF >mise.toml
@@ -51,51 +51,64 @@ assert_contains "echo '$output'" "tiny"
 output=$(mise install tiny@latest --before 6m --dry-run 2>&1)
 assert_contains "echo '$output'" "tiny"
 
-# Test: MISE_INSTALL_BEFORE with relative duration
+# Test: MISE_MINIMUM_RELEASE_AGE with relative duration
 mise uninstall tiny --all 2>/dev/null || true
-export MISE_INSTALL_BEFORE="90d"
+export MISE_MINIMUM_RELEASE_AGE="90d"
 mise install tiny@latest
 assert_contains "mise ls --installed tiny" "3.1.0"
-unset MISE_INSTALL_BEFORE
+unset MISE_MINIMUM_RELEASE_AGE
 
-# Test: per-tool install_before is newer than global (per-tool wins)
+# Test: per-tool minimum_release_age is newer than global (per-tool wins)
 # global=2019-01-01 would give jq 1.6, per-tool=2024-01-01 gives jq 1.7.1
 mise uninstall jq --all 2>/dev/null || true
 rm -f mise.toml
 cat <<EOF >mise.toml
 [settings]
-install_before = "2019-01-01"
+minimum_release_age = "2019-01-01"
 
 [tools.jq]
 version = "latest"
-install_before = "2024-01-01"
+minimum_release_age = "2024-01-01"
 EOF
 mise install
 assert_contains "mise ls --installed jq" "1.7.1"
 
-# Test: per-tool install_before is older than global (per-tool wins)
+# Test: per-tool minimum_release_age is older than global (per-tool wins)
 # global=2024-01-01 would give jq 1.7.1, per-tool=2019-01-01 gives jq 1.6
 mise uninstall jq --all 2>/dev/null || true
 rm -f mise.toml
 cat <<EOF >mise.toml
 [settings]
-install_before = "2024-01-01"
+minimum_release_age = "2024-01-01"
 
 [tools.jq]
 version = "latest"
-install_before = "2019-01-01"
+minimum_release_age = "2019-01-01"
 EOF
 mise install
 assert_contains "mise ls --installed jq" "1.6"
 
-# Test: CLI --before flag overrides per-tool install_before
+# Test: CLI --before flag overrides per-tool minimum_release_age
 # per-tool=2024-01-01 would give jq 1.7.1, CLI --before=2019-01-01 gives jq 1.6
 mise uninstall jq --all 2>/dev/null || true
 rm -f mise.toml
 cat <<EOF >mise.toml
 [tools.jq]
 version = "latest"
-install_before = "2024-01-01"
+minimum_release_age = "2024-01-01"
 EOF
 mise install --before 2019-01-01
+assert_contains "mise ls --installed jq" "1.6"
+
+# Test: legacy install_before setting remains supported as a hidden alias
+mise uninstall jq --all 2>/dev/null || true
+rm -f mise.toml
+cat <<EOF >mise.toml
+[settings]
+install_before = "2019-01-01"
+
+[tools.jq]
+version = "latest"
+EOF
+mise install
 assert_contains "mise ls --installed jq" "1.6"

--- a/e2e/cli/test_install_before_explicit_go_backend
+++ b/e2e/cli/test_install_before_explicit_go_backend
@@ -5,20 +5,20 @@ export GOPROXY="https://proxy.golang.org,direct"
 
 cat <<'EOF' >mise.toml
 [settings]
-install_before = "2100-01-01"
+minimum_release_age = "2100-01-01"
 
 [tools]
-'go:github.com/roborev-dev/roborev/cmd/roborev' = { version = "latest", install_before = "2026-04-07" }
+'go:github.com/roborev-dev/roborev/cmd/roborev' = { version = "latest", minimum_release_age = "2026-04-07" }
 EOF
 
 assert_contains "mise install --dry-run 2>&1" "go:github.com/roborev-dev/roborev/cmd/roborev@0.50.0"
 
 cat <<'EOF' >mise.toml
 [settings]
-install_before = "2026-04-07"
+minimum_release_age = "2026-04-07"
 
 [tools]
-'go:github.com/roborev-dev/roborev/cmd/roborev' = { version = "latest", install_before = "2100-01-01" }
+'go:github.com/roborev-dev/roborev/cmd/roborev' = { version = "latest", minimum_release_age = "2100-01-01" }
 EOF
 
 assert_matches "mise install --dry-run 2>&1" "go:github.com/roborev-dev/roborev/cmd/roborev@[0-9]+\.[0-9]+\.[0-9]+"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1372,7 +1372,7 @@ Show latest installed instead of available version
 Only consider versions released before this date
 
 Supports absolute dates like "2024\-06\-01" and relative durations like "90d" or "1y".
-Overrides per\-tool `install_before` options and the global `install_before` setting.
+Overrides per\-tool `minimum_release_age` options and the global `minimum_release_age` setting.
 \fBArguments:\fR
 .PP
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -525,7 +525,7 @@ cmd latest help="Gets the latest available version for a plugin" {
     after_long_help "Examples:\n\n    $ mise latest node@20  # get the latest version of node 20\n    20.0.0\n\n    $ mise latest node     # get the latest stable version of node\n    20.0.0\n\n    $ mise latest node --before 2024-01-01  # latest stable node released before 2024-01-01\n"
     flag "-i --installed" help="Show latest installed instead of available version"
     flag --before help="Only consider versions released before this date" {
-        long_help "Only consider versions released before this date\n\nSupports absolute dates like \"2024-06-01\" and relative durations like \"90d\" or \"1y\".\nOverrides per-tool `install_before` options and the global `install_before` setting."
+        long_help "Only consider versions released before this date\n\nSupports absolute dates like \"2024-06-01\" and relative durations like \"90d\" or \"1y\".\nOverrides per-tool `minimum_release_age` options and the global `minimum_release_age` setting."
         arg <BEFORE>
     }
     arg <TOOL@VERSION> help="Tool to get the latest version of"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1012,7 +1012,8 @@
         },
         "install_before": {
           "description": "Minimum release age / supply chain protection — only install versions released before this date",
-          "type": "string"
+          "type": "string",
+          "deprecated": true
         },
         "java": {
           "type": "object",
@@ -1076,6 +1077,10 @@
           "description": "Show more/less output.",
           "type": "string",
           "enum": ["trace", "debug", "info", "warn", "error"]
+        },
+        "minimum_release_age": {
+          "description": "Minimum release age / supply chain protection — only install versions older than this threshold",
+          "type": "string"
         },
         "netrc": {
           "default": true,

--- a/settings.toml
+++ b/settings.toml
@@ -1025,45 +1025,12 @@ rust_type = "BTreeSet<PathBuf>"
 type = "ListPath"
 
 [install_before]
+deprecated = "Use minimum_release_age instead."
+deprecated_remove_at = "2027.10.0"
+deprecated_warn_at = "2026.10.0"
 description = "Minimum release age / supply chain protection — only install versions released before this date"
-docs = """
-Filter tool versions by release date to limit supply chain risk. Similar to Renovate's
-[minimum release age](https://docs.renovatebot.com/key-concepts/minimum-release-age/),
-this ensures newly published versions are ignored until they've been available for a
-configurable amount of time — giving the community time to discover compromised releases.
-
-Supports:
-
-- Relative durations: `7d` (7 days ago), `90d` (90 days ago), `6m` (6 months ago), `1y` (1 year ago)
-- Absolute dates: `2024-06-01`, `2024-06-01T12:00:00Z`
-
-Example:
-
-```toml
-[settings]
-install_before = "7d"  # only install versions released more than 7 days ago
-```
-
-Only affects backends that provide release timestamps (aqua, cargo, npm, pipx, and some core plugins).
-Versions without timestamps are included by default.
-
-**Behavior**: For most backends, this filter only applies when resolving fuzzy version requests
-like `node@20` or `latest`. Explicitly pinned versions like `node@22.5.0` are not filtered,
-allowing you to selectively use newer versions for specific tools while keeping others behind the
-cutoff date.
-
-Some package-manager backends also forward the cutoff to transitive dependency resolution during
-install. This includes `npm:` and `pipx:` tools.
-
-Can be overridden with the `--before` CLI flag or per-tool with the `install_before` tool option.
-
-```toml
-[tools.trivy]
-version = "latest"
-install_before = "7d"  # override for this tool only
-```
-"""
 env = "MISE_INSTALL_BEFORE"
+hide = true
 optional = true
 type = "String"
 
@@ -1224,6 +1191,51 @@ description = "Show more/less output."
 enum = ["trace", "debug", "info", "warn", "error"]
 env = "MISE_LOG_LEVEL"
 hide = true
+type = "String"
+
+[minimum_release_age]
+description = "Minimum release age / supply chain protection — only install versions older than this threshold"
+docs = """
+Filter tool versions by release date to limit supply chain risk. Similar to Renovate's
+[minimum release age](https://docs.renovatebot.com/key-concepts/minimum-release-age/),
+this ensures newly published versions are ignored until they've been available for a
+configurable amount of time — giving the community time to discover compromised releases.
+This name matches pnpm's `minimumReleaseAge` setting, though mise accepts both relative
+durations and absolute cutoff dates.
+
+Supports:
+
+- Relative durations: `7d` (7 days ago), `90d` (90 days ago), `6m` (6 months ago), `1y` (1 year ago)
+- Absolute dates: `2024-06-01`, `2024-06-01T12:00:00Z`
+
+Example:
+
+```toml
+[settings]
+minimum_release_age = "7d"  # only install versions released more than 7 days ago
+```
+
+Only affects backends that provide release timestamps (aqua, cargo, npm, pipx, and some core plugins).
+Versions without timestamps are included by default.
+
+**Behavior**: For most backends, this filter only applies when resolving fuzzy version requests
+like `node@20` or `latest`. Explicitly pinned versions like `node@22.5.0` are not filtered,
+allowing you to selectively use newer versions for specific tools while keeping others behind the
+cutoff date.
+
+Some package-manager backends also forward the cutoff to transitive dependency resolution during
+install. This includes `npm:` and `pipx:` tools.
+
+Can be overridden with the `--before` CLI flag or per-tool with the `minimum_release_age` tool option.
+
+```toml
+[tools.trivy]
+version = "latest"
+minimum_release_age = "7d"  # override for this tool only
+```
+"""
+env = "MISE_MINIMUM_RELEASE_AGE"
+optional = true
 type = "String"
 
 [netrc]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -662,7 +662,7 @@ pub trait Backend: Debug + Send + Sync {
     /// Backend-specific fast path for the absolute latest stable version.
     ///
     /// Do not call this from CLI/toolset code. Use `latest_version` instead so
-    /// `install_before` / `--before` cutoffs are resolved before this fast path
+    /// `minimum_release_age` / `--before` cutoffs are resolved before this fast path
     /// is used.
     ///
     /// Return `Ok(None)` when the backend does not have a fast path result.
@@ -1807,14 +1807,14 @@ async fn effective_latest_before_date<B: Backend + ?Sized>(
     }
 
     let backend_opts = backend.ba().opts();
-    if let Some(before) = backend_opts.get("install_before") {
+    if let Some(before) = backend_opts.minimum_release_age() {
         return resolve_before_date(None, Some(before));
     }
 
     let config_install_before = config
         .get_tool_opts(backend.ba())
         .await?
-        .and_then(|opts| opts.get("install_before").map(str::to_string));
+        .and_then(|opts| opts.minimum_release_age().map(str::to_string));
     resolve_before_date(None, config_install_before.as_deref())
 }
 
@@ -2096,6 +2096,12 @@ mod latest_version_tests {
         // The test fixture has a `tiny` config entry without install_before.
         // Inline backend opts must still win when a config entry exists.
         let backend = LatestBackend::new("tiny[install_before=2024-06-01]");
+        backend
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .clear()
+            .unwrap();
 
         assert_eq!(
             backend

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -22,7 +22,7 @@ use tokio::sync::Mutex as TokioMutex;
 
 /// Tolerance applied when converting an absolute `before_date` back to a
 /// relative duration for CLI flags. This ensures that a user-supplied
-/// `install_before = "3d"` never gets rounded up to `4d` due to small amounts
+/// `minimum_release_age = "3d"` never gets rounded up to `4d` due to small amounts
 /// of elapsed time between when mise resolved the cutoff and when it invoked
 /// the package manager.
 const BEFORE_DATE_TOLERANCE_SECS: u64 = 60;
@@ -185,7 +185,7 @@ impl Backend for NPMBackend {
             .await;
         self.check_install_deps(&ctx.config, package_manager, Some(&ctx.ts))
             .await;
-        let install_before_args = match ctx.before_date {
+        let release_age_args = match ctx.before_date {
             Some(before_date) => {
                 self.warn_if_package_manager_may_not_support_release_age(ctx, package_manager)
                     .await;
@@ -228,7 +228,7 @@ impl Backend for NPMBackend {
                     // https://github.com/jdx/mise/discussions/7541
                     .arg("--linker")
                     .arg("hoisted")
-                    .args(install_before_args)
+                    .args(release_age_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
                     .env("BUN_INSTALL_GLOBAL_DIR", tv.install_path())
@@ -254,7 +254,7 @@ impl Backend for NPMBackend {
                     .arg(tv.install_path())
                     .arg("--global-bin-dir")
                     .arg(&bin_dir)
-                    .args(install_before_args)
+                    .args(release_age_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
@@ -276,7 +276,7 @@ impl Backend for NPMBackend {
                     .arg(format!("{}@{}", self.tool_name(), tv.version))
                     .arg("--prefix")
                     .arg(tv.install_path())
-                    .args(install_before_args)
+                    .args(release_age_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
                     .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
@@ -392,7 +392,7 @@ impl NPMBackend {
 
         if semver_is_older_than(&version, required_version).unwrap_or(false) {
             warn!(
-                "install_before is set for npm:{} but {}@{} is older than the documented minimum {}@{} required for {}. Older versions may fail while processing the forwarded argument. See https://mise.jdx.dev/dev-tools/backends/npm.html",
+                "minimum_release_age is set for npm:{} but {}@{} is older than the documented minimum {}@{} required for {}. Older versions may fail while processing the forwarded argument. See https://mise.jdx.dev/dev-tools/backends/npm.html",
                 self.tool_name(),
                 tool,
                 version,

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -29,7 +29,7 @@ pub struct Latest {
     /// Only consider versions released before this date
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
-    /// Overrides per-tool `install_before` options and the global `install_before` setting.
+    /// Overrides per-tool `minimum_release_age` options and the global `minimum_release_age` setting.
     #[clap(long, verbatim_doc_comment, conflicts_with = "installed")]
     before: Option<String>,
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -364,6 +364,12 @@ impl Settings {
 
     /// Sets deprecated settings to new names
     fn set_hidden_configs(&mut self) {
+        if let Some(v) = self.install_before.take() {
+            warn_deprecated("install_before");
+            if self.minimum_release_age.is_none() {
+                self.minimum_release_age = Some(v);
+            }
+        }
         // Migrate task_* settings to task.* (must run before auto_install override below)
         if let Some(v) = self.task_disable_paths.take()
             && !v.is_empty()
@@ -509,8 +515,18 @@ impl Settings {
     }
 
     pub fn hidden_configs() -> &'static HashSet<&'static str> {
-        static HIDDEN_CONFIGS: Lazy<HashSet<&'static str>> =
-            Lazy::new(|| ["ci", "cd", "debug", "env_file", "trace", "log_level"].into());
+        static HIDDEN_CONFIGS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+            [
+                "ci",
+                "cd",
+                "debug",
+                "env_file",
+                "install_before",
+                "trace",
+                "log_level",
+            ]
+            .into()
+        });
         &HIDDEN_CONFIGS
     }
 
@@ -1026,6 +1042,16 @@ mod tests {
         assert!(settings.prefer_offline());
         // prefer_offline does NOT imply offline
         assert!(!settings.offline);
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_install_before_hidden_alias_sets_minimum_release_age() {
+        let mut partial = SettingsPartial::empty();
+        partial.install_before = Some("7d".to_string());
+        Settings::reset(Some(partial));
+        let settings = Settings::get();
+        assert_eq!(settings.minimum_release_age.as_deref(), Some("7d"));
         Settings::reset(None);
     }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -23,7 +23,7 @@ pub fn elapsed_seconds_ceil(from: Timestamp, to: Timestamp) -> u64 {
 
 /// Returns a stable "now" timestamp for the lifetime of the process.
 ///
-/// This is used for resolving relative durations (e.g. `install_before = "3d"`)
+/// This is used for resolving relative durations (e.g. `minimum_release_age = "3d"`)
 /// consistently: every resolution of the same relative duration within a single
 /// mise invocation produces the same absolute timestamp, and downstream code
 /// that converts the absolute timestamp back to a duration (e.g. for npm's

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -4,12 +4,12 @@ use jiff::Timestamp;
 use crate::config::Settings;
 use crate::duration::parse_into_timestamp;
 
-/// Resolve the effective `install_before` cutoff.
+/// Resolve the effective `minimum_release_age` cutoff.
 ///
 /// Precedence (highest to lowest):
 /// 1. `before_date` - a pre-resolved `ResolveOptions` cutoff.
-/// 2. A per-tool, backend, or config `install_before` option.
-/// 3. The global `install_before` setting.
+/// 2. A per-tool, backend, or config `minimum_release_age` option.
+/// 3. The global `minimum_release_age` setting.
 ///
 /// All string-based durations (e.g. `"3d"`) are resolved against
 /// [`crate::duration::process_now`] so that every call within a single mise
@@ -19,15 +19,15 @@ use crate::duration::parse_into_timestamp;
 /// `--min-release-age`) without the two drifting apart.
 pub fn resolve_before_date(
     before_date: Option<Timestamp>,
-    install_before: Option<&str>,
+    minimum_release_age: Option<&str>,
 ) -> Result<Option<Timestamp>> {
     if let Some(before_date) = before_date {
         return Ok(Some(before_date));
     }
-    if let Some(before) = install_before {
+    if let Some(before) = minimum_release_age {
         return Ok(Some(parse_into_timestamp(before)?));
     }
-    if let Some(before) = &Settings::get().install_before {
+    if let Some(before) = &Settings::get().minimum_release_age {
         return Ok(Some(parse_into_timestamp(before)?));
     }
     Ok(None)
@@ -43,9 +43,9 @@ mod tests {
 
     fn resolved_timestamp(
         before_date: Option<Timestamp>,
-        install_before: Option<&str>,
+        minimum_release_age: Option<&str>,
     ) -> Option<Timestamp> {
-        resolve_before_date(before_date, install_before).unwrap()
+        resolve_before_date(before_date, minimum_release_age).unwrap()
     }
 
     #[test]
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn test_effective_before_date_falls_back_to_global_setting() {
         let mut partial = SettingsPartial::empty();
-        partial.install_before = Some("2024-01-03".to_string());
+        partial.minimum_release_age = Some("2024-01-03".to_string());
         Settings::reset(Some(partial));
         assert_eq!(
             resolved_timestamp(None, None),
@@ -94,7 +94,7 @@ mod tests {
         // identically across calls within one invocation.
         Settings::reset(None);
         let mut partial = SettingsPartial::empty();
-        partial.install_before = Some("3d".to_string());
+        partial.minimum_release_age = Some("3d".to_string());
         Settings::reset(Some(partial));
         let a = resolved_timestamp(None, None);
         let b = resolved_timestamp(None, None);

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -75,9 +75,9 @@ impl ToolVersion {
         request: ToolRequest,
         opts: &ResolveOptions,
     ) -> Result<Self> {
-        let install_before = request.options().get("install_before").map(str::to_string);
+        let minimum_release_age = request.options().minimum_release_age().map(str::to_string);
         let mut opts = opts.clone();
-        opts.before_date = resolve_before_date(opts.before_date, install_before.as_deref())?;
+        opts.before_date = resolve_before_date(opts.before_date, minimum_release_age.as_deref())?;
 
         trace!("resolving {} {}", &request, opts);
         if opts.use_locked_version

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -4,8 +4,13 @@ use indexmap::IndexMap;
 /// be persisted in the manifest or included in `full_with_opts()`.
 // install_env is a named field on ToolVersionOptions (serde puts it in self.install_env),
 // but parse_tool_options() can still place it in opts, so we filter it here as well.
-pub const EPHEMERAL_OPT_KEYS: &[&str] =
-    &["postinstall", "install_env", "depends", "install_before"];
+pub const EPHEMERAL_OPT_KEYS: &[&str] = &[
+    "postinstall",
+    "install_env",
+    "depends",
+    "install_before",
+    "minimum_release_age",
+];
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ToolVersionOptions {
@@ -72,6 +77,22 @@ impl ToolVersionOptions {
     /// or None for non-string values.
     pub fn get(&self, key: &str) -> Option<&str> {
         self.opts.get(key).and_then(|v| v.as_str())
+    }
+
+    pub fn minimum_release_age(&self) -> Option<&str> {
+        if let Some(value) = self.get("minimum_release_age") {
+            return Some(value);
+        }
+        if let Some(value) = self.get("install_before") {
+            deprecated_at!(
+                "2026.10.0",
+                "2027.10.0",
+                "tool_option.install_before",
+                "`install_before` tool option is deprecated. Use `minimum_release_age` instead."
+            );
+            return Some(value);
+        }
+        None
     }
 
     /// Get a scalar value for a key as an owned string.


### PR DESCRIPTION
## Summary

- Rename the canonical release-age setting and per-tool option from `install_before` to `minimum_release_age`, matching pnpm's terminology.
- Keep `install_before` as a hidden deprecated alias with `deprecated_at!` behavior for legacy tool options and deprecated setting metadata for global config.
- Update generated schema, CLI/man output, docs, and e2e coverage to prefer `minimum_release_age` while preserving a legacy alias test.

## Validation

- `mise run render`
- `mise run format`
- `cargo test install_before --all-features`
- `cargo test config::settings::tests --all-features`
- `mise run test:e2e e2e/cli/test_install_before`
- commit hook: `hk` pre-commit suite, including `cargo check --all-features`, formatting, shell checks, markdown/schema validation

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches version-resolution cutoffs used by installs/`latest` across backends, so mis-wiring the new key could change which versions users resolve/install. Backward-compat aliasing reduces risk but needs careful review of precedence and deprecation paths.
> 
> **Overview**
> Renames the canonical “minimum release age” supply-chain cutoff from `install_before` to `minimum_release_age` across config, tool options, environment variables, and user-facing docs/man/usage output.
> 
> Adds compatibility shims so legacy `install_before` still works as a *hidden, deprecated alias*: global settings are migrated to `minimum_release_age` at load time, tool options resolve via `ToolVersionOptions::minimum_release_age()` with deprecation warnings, JSON schema marks `install_before` as deprecated and introduces `minimum_release_age`, and e2e/tests are updated (including a new legacy-alias test) to validate precedence (`--before` > per-tool > global).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96c4618cc143d4894776e3805918e10c06747497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->