### PR TITLE
fix(task): label deps output by provider

### DIFF
--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -53,6 +53,7 @@ assert_contains "mise deps --list" "schema.graphql"
 # Test --only flag
 assert_contains "mise deps --dry-run --only codegen 2>&1" "codegen"
 assert_not_contains "mise deps --dry-run --only codegen 2>&1" "npm"
+assert_contains "mise deps --force --only codegen 2>&1" "[deps.codegen] codegen"
 
 # Test --skip flag
 assert_not_contains "mise deps --dry-run --skip npm 2>&1" "npm install"

--- a/src/cli/deps/add.rs
+++ b/src/cli/deps/add.rs
@@ -65,7 +65,7 @@ impl DepsAdd {
 
             let pkg_refs: Vec<&str> = packages.iter().map(|s| s.as_str()).collect();
             let cmd = provider.add_command(&pkg_refs, self.dev)?;
-            DepsEngine::execute_command(&cmd, &env, provider.timeout())?;
+            DepsEngine::execute_command(&cmd, &env, provider.timeout(), None, None)?;
         }
 
         Ok(())

--- a/src/cli/deps/remove.rs
+++ b/src/cli/deps/remove.rs
@@ -61,7 +61,7 @@ impl DepsRemove {
 
             let pkg_refs: Vec<&str> = packages.iter().map(|s| s.as_str()).collect();
             let cmd = provider.remove_command(&pkg_refs)?;
-            DepsEngine::execute_command(&cmd, &env, provider.timeout())?;
+            DepsEngine::execute_command(&cmd, &env, provider.timeout(), None, None)?;
         }
 
         Ok(())

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -11,6 +11,8 @@ use crate::config::config_file::ConfigFile;
 use crate::config::{Config, Settings};
 use crate::tera::{BASE_CONTEXT, get_tera};
 use crate::ui::multi_progress_report::MultiProgressReport;
+use crate::ui::progress_report::SingleReport;
+use crate::ui::style;
 
 type StepOutput = (DepsStepResult, Vec<PathBuf>);
 type JobOutput = Result<(String, DepsStepResult, Vec<PathBuf>), (String, eyre::Report)>;
@@ -405,14 +407,21 @@ impl DepsEngine {
             .collect();
 
         crate::parallel::parallel(to_run_with_context, |(job, mpr, toolset_env)| async move {
-            let pr = mpr.add(&job.cmd.description);
-            match Self::execute_command(&job.cmd, &toolset_env, job.timeout) {
+            let (stdout_prefix, stderr_prefix) = Self::deps_prefixes(&job.id);
+            let pr = mpr.add(&stderr_prefix);
+            match Self::execute_command(
+                &job.cmd,
+                &toolset_env,
+                job.timeout,
+                Some((&stdout_prefix, &stderr_prefix)),
+                Some(pr.as_ref()),
+            ) {
                 Ok(()) => {
-                    pr.finish_with_message(format!("{} done", job.cmd.description));
+                    pr.finish_with_message("done".to_string());
                     Ok((DepsStepResult::Ran(job.id), job.outputs))
                 }
                 Err(e) => {
-                    pr.finish_with_message(format!("{} failed: {}", job.cmd.description, e));
+                    pr.finish_with_message(format!("failed: {e}"));
                     Err(e)
                 }
             }
@@ -550,31 +559,32 @@ impl DepsEngine {
                     let toolset_env = toolset_env.clone();
 
                     let handle = join_set.spawn(async move {
-                        let pr = mpr.add(&job.cmd.description);
                         let id = job.id;
+                        let (stdout_prefix, stderr_prefix) = Self::deps_prefixes(&id);
+                        let pr = mpr.add(&stderr_prefix);
                         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            Self::execute_command(&job.cmd, &toolset_env, job.timeout)
+                            Self::execute_command(
+                                &job.cmd,
+                                &toolset_env,
+                                job.timeout,
+                                Some((&stdout_prefix, &stderr_prefix)),
+                                Some(pr.as_ref()),
+                            )
                         }));
                         drop(permit);
 
                         match result {
                             Ok(Ok(())) => {
-                                pr.finish_with_message(format!("{} done", job.cmd.description));
+                                pr.finish_with_message("done".to_string());
                                 let step = DepsStepResult::Ran(id.clone());
                                 Ok((id, step, job.outputs))
                             }
                             Ok(Err(e)) => {
-                                pr.finish_with_message(format!(
-                                    "{} failed: {}",
-                                    job.cmd.description, e
-                                ));
+                                pr.finish_with_message(format!("failed: {e}"));
                                 Err((id, e))
                             }
                             Err(_) => {
-                                pr.finish_with_message(format!(
-                                    "{} panicked",
-                                    job.cmd.description
-                                ));
+                                pr.finish_with_message("panicked".to_string());
                                 Err((id, eyre::eyre!("task panicked")))
                             }
                         }
@@ -696,6 +706,8 @@ impl DepsEngine {
         cmd: &super::DepsCommand,
         toolset_env: &BTreeMap<String, String>,
         timeout: Option<std::time::Duration>,
+        prefixes: Option<(&str, &str)>,
+        progress: Option<&dyn SingleReport>,
     ) -> Result<()> {
         let cwd = match cmd.cwd.clone() {
             Some(dir) => dir,
@@ -742,7 +754,41 @@ impl DepsEngine {
             runner = runner.raw(true);
         }
 
+        if let Some((stdout_prefix, stderr_prefix)) = prefixes
+            && !Settings::get().raw
+        {
+            let stdout_prefix = stdout_prefix.to_string();
+            let stderr_prefix = stderr_prefix.to_string();
+            runner = runner
+                .with_on_stdout(move |line| {
+                    if let Some(progress) = progress {
+                        progress.set_message(line.clone());
+                    }
+                    if console::colors_enabled() {
+                        prefix_println!(stdout_prefix, "{line}\x1b[0m");
+                    } else {
+                        prefix_println!(stdout_prefix, "{line}");
+                    }
+                })
+                .with_on_stderr(move |line| {
+                    if console::colors_enabled_stderr() {
+                        prefix_eprintln!(stderr_prefix, "{line}\x1b[0m");
+                    } else {
+                        prefix_eprintln!(stderr_prefix, "{line}");
+                    }
+                });
+        }
+
         runner.execute()?;
         Ok(())
+    }
+
+    fn deps_prefixes(id: &str) -> (String, String) {
+        let name = format!("deps.{id}");
+        let prefix = format!("[{name}]");
+        (
+            style::prefix(&prefix, &name, false),
+            style::prefix(prefix, name, true),
+        )
     }
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -7,7 +7,7 @@ use crate::task::task_script_parser::TaskScriptParser;
 use crate::tera::get_tera;
 use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};
-use console::{Color, measure_text_width, truncate_str};
+use console::{measure_text_width, truncate_str};
 use eyre::{Result, bail, eyre};
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
@@ -1026,18 +1026,7 @@ impl Task {
     }
 
     pub fn estyled_prefix(&self) -> String {
-        static COLORS: Lazy<Vec<Color>> =
-            Lazy::new(|| vec![Color::Blue, Color::Magenta, Color::Cyan, Color::Green]);
-        let hash = self.display_name.chars().map(|c| c as usize).sum::<usize>();
-        let mut styled = style::estyle(self.prefix()).fg(COLORS[hash % COLORS.len()]);
-        match (hash / COLORS.len()) % 4 {
-            1 => styled = styled.bold(),
-            2 => styled = styled.dim(),
-            3 => styled = styled.bright(),
-            _ => {}
-        }
-
-        style::ereset() + &styled.to_string()
+        style::prefix(self.prefix(), &self.display_name, true)
     }
 
     pub async fn dir(&self, config: &Arc<Config>) -> Result<Option<PathBuf>> {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -1,15 +1,8 @@
 use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::file::display_path;
-use console::{StyledObject, style};
-
-pub fn ereset() -> String {
-    if console::colors_enabled_stderr() {
-        "\x1b[0m".to_string()
-    } else {
-        "".to_string()
-    }
-}
+use console::{Color, StyledObject, style};
 
 pub fn estyle<D>(val: D) -> StyledObject<D> {
     style(val).for_stderr()
@@ -89,4 +82,26 @@ pub fn ndim<D>(val: D) -> StyledObject<D> {
 
 pub fn nbright<D>(val: D) -> StyledObject<D> {
     nstyle(val).bright()
+}
+
+pub fn prefix(label: impl Into<String>, hash_key: impl AsRef<str>, stderr: bool) -> String {
+    static COLORS: LazyLock<Vec<Color>> =
+        LazyLock::new(|| vec![Color::Blue, Color::Magenta, Color::Cyan, Color::Green]);
+
+    let label = label.into();
+    let hash = hash_key.as_ref().chars().map(|c| c as usize).sum::<usize>();
+    let styled = style(label).fg(COLORS[hash % COLORS.len()]);
+    let mut styled = if stderr {
+        styled.for_stderr()
+    } else {
+        styled.for_stdout()
+    };
+    match (hash / COLORS.len()) % 4 {
+        1 => styled = styled.bold(),
+        2 => styled = styled.dim(),
+        3 => styled = styled.bright(),
+        _ => {}
+    }
+
+    styled.to_string()
 }


### PR DESCRIPTION
## Summary

Fixes deps command output so dependency providers use a stable task-style label such as `[deps.codegen]` instead of using the raw `run` command as the progress/output prefix.

This makes repeated output from commands like `pip install -r requirements.txt` less misleading because the log identifies the deps provider that is running rather than repeating the command text as the label.

## Changes

- Add provider-based deps prefixes for both simple parallel deps and dependency-ordered deps.
- Prefix captured stdout/stderr with `[deps.<provider>]` outside raw mode.
- Keep `mise deps add/remove` direct command execution unprefixed.
- Add e2e coverage for custom deps output prefixes.

## Validation

- `cargo check -q`
- `cargo fmt --check`
- `git diff --check`
- `mise run test:e2e e2e/cli/test_deps`
- Commit hook: `hk` checks passed during commit, including `cargo-check`, formatters, shellcheck, schema validation, and markdownlint.

Related discussion: https://github.com/jdx/mise/discussions/9377

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `DepsEngine::execute_command` and the deps execution paths to inject prefixed stdout/stderr and progress updates, which could affect logging behavior and command output handling across providers. Core dependency installation behavior is unchanged, but output/UX and raw-mode interactions may regress in edge cases.
> 
> **Overview**
> Deps provider execution output is now labeled with a stable provider-based prefix (e.g. `deps.codegen` / `[deps.codegen]`) instead of using the raw command description, improving log clarity during repeated installs.
> 
> `DepsEngine::execute_command` was extended to optionally attach stdout/stderr line callbacks that prefix output (and update the progress message) when not in raw mode; both parallel and dependency-ordered deps runs now pass these prefixes, while `mise deps add/remove` explicitly opt out. Styling was centralized via a new `style::prefix(...)` helper, and an e2e test assertion was added to verify the new `[deps.<id>]` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e839cd0ebb1d13ce94abba356ff5ca28735e9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->