### PR TITLE
test(config): pin tombi schema test version

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -4,12 +4,13 @@
 # Regression test for https://github.com/jdx/mise/discussions/8254
 # where unevaluatedProperties caused tombi to reject valid task properties.
 
-# Install tombi via mise
-mise use -g tombi
+# Install a pinned tombi version so release asset packaging changes do not break
+# this schema regression test.
+mise use -g tombi@0.9.22
 
 SCHEMA_PATH="$ROOT/schema/mise.json"
 TASK_SCHEMA_PATH="$ROOT/schema/mise-task.json"
-TOMBI="mise x tombi -- tombi"
+TOMBI="mise x tombi@0.9.22 -- tombi"
 
 # Set up tombi config pointing to local schema
 cat >"$HOME/tombi.toml" <<EOF


### PR DESCRIPTION
## Summary

Pins the Tombi version used by `e2e/config/test_schema_tombi` to `0.9.22`.

## Context

The `e2e-linux-1` job in https://github.com/jdx/mise/actions/runs/24928843145/job/73004276209 failed because `tombi@latest` resolved to `0.9.23`, whose Linux release asset changed from `.gz` to `.tar.gz`. The bundled aqua registry entry currently expects `.gz`, so installing `latest` failed before the schema regression test could run.

Pinning this test keeps it focused on validating the mise schema with Tombi and prevents unrelated upstream packaging changes from breaking CI.

## Validation

- `mise run test:e2e e2e/config/test_schema_tombi`
- commit hook: prettier, cargo-fmt, cargo-check, shellcheck, shfmt, pkl, taplo, lua-check, stylua, actionlint, markdownlint, schema

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the e2e schema regression test to use a fixed `tombi` version, reducing CI flakiness without changing production behavior.
> 
> **Overview**
> Pins the `e2e/config/test_schema_tombi` regression test to `tombi@0.9.22` instead of `latest`.
> 
> Updates the `mise use` and `mise x` invocations accordingly so the test is insulated from upstream `tombi` release asset packaging changes that can break CI before the schema assertions run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dde6ad93280beff2ea01d7e3a518b4a2667654d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->