### PR TITLE
docs(site): show release version in nav

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitepress";
 import { Command, commands } from "./cli_commands";
 import {
@@ -8,6 +11,13 @@ import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 import { withMermaid } from "vitepress-plugin-mermaid";
 import kdlGrammar from "./grammars/kdl.tmLanguage.json";
 import miseTomlGrammar from "./grammars/mise-toml.tmLanguage.json";
+
+const configDir = dirname(fileURLToPath(import.meta.url));
+const cargoToml = readFileSync(resolve(configDir, "../../Cargo.toml"), "utf8");
+const versionMatch = cargoToml.match(
+  /\[package\][\s\S]*?\nversion\s*=\s*"([^"]+)"/,
+);
+const latestVersion = versionMatch?.[1] ?? "0.0.0";
 
 // https://vitepress.dev/reference/site-config
 export default withMermaid(
@@ -30,6 +40,10 @@ export default withMermaid(
         { text: "Dev Tools", link: "/dev-tools/" },
         { text: "Environments", link: "/environments/" },
         { text: "Tasks", link: "/tasks/" },
+        {
+          text: `v${latestVersion}`,
+          link: "https://github.com/jdx/mise/releases",
+        },
       ],
       sidebar: [
         {


### PR DESCRIPTION
## Summary

- read the latest site release label from `Cargo.toml`
- add a versioned releases nav item beside the existing GitHub star counter

## Validation

- `npm run docs:build` in `/home/jdx/src/mise-release-version`

_Note: build completed with existing VitePress warnings about missing syntax highlighters for `query`, `gitignore`, and `netrc`, plus a chunk-size warning._

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-site change that only affects VitePress build-time config by reading `Cargo.toml` to display a version label; main risk is a build failure if the file path or version regex stops matching.
> 
> **Overview**
> **Docs site nav now shows the current release version.** `docs/.vitepress/config.ts` reads `version` from the repo’s `Cargo.toml` at build time and adds a new nav item labeled `v${latestVersion}` that links to the GitHub releases page (falling back to `0.0.0` if parsing fails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9e31f2a2f6b37a710c6646c97c373aab5485d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->