### PR TITLE
docs(site): address release nav feedback

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -15,8 +15,11 @@ import miseTomlGrammar from "./grammars/mise-toml.tmLanguage.json";
 const configDir = dirname(fileURLToPath(import.meta.url));
 const cargoToml = readFileSync(resolve(configDir, "../../Cargo.toml"), "utf8");
 const versionMatch = cargoToml.match(
-  /\[package\][\s\S]*?\nversion\s*=\s*"([^"]+)"/,
+  /^\[package\][\s\S]*?^\s*version\s*=\s*"([^"]+)"/m,
 );
+if (!versionMatch) {
+  console.warn("Unable to find package version in Cargo.toml");
+}
 const latestVersion = versionMatch?.[1] ?? "0.0.0";
 
 // https://vitepress.dev/reference/site-config


### PR DESCRIPTION
## Summary

- make the Cargo version extraction anchor to the package version line
- warn during docs builds if the version cannot be found instead of silently falling back

## Validation

- `npm run docs:build` in `/home/jdx/src/mise-release-version`

_Note: build completed with existing VitePress warnings about missing syntax highlighters for `gitignore`, `query`, and `netrc`, plus a chunk-size warning._

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change: adjusts a regex used during VitePress config generation and adds a build-time warning when the version cannot be parsed.
> 
> **Overview**
> Updates `docs/.vitepress/config.ts` to make Cargo package version extraction more robust by anchoring the regex to the `version = "..."` line within `[package]` (multiline match).
> 
> If the version cannot be found, the docs build now emits a `console.warn` instead of silently falling back to `0.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a71dfc1ab982bab57ab7ef382772460ef1604c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->