### PR TITLE
fix(aqua): fall back to tags when list_releases errors

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -2301,16 +2301,34 @@ async fn get_tags(pkg: &AquaPackage) -> Result<Vec<String>> {
 
 /// Get tags with optional created_at timestamps.
 /// Returns (tag_name, Option<created_at>) pairs.
+///
+/// On a transient `list_releases` failure (rate limit, 5xx, network blip),
+/// fall back to `list_tags` rather than letting the error propagate up and
+/// wipe the entire version list. Downstream consumers (e.g. `mise ls-remote
+/// --json`) would otherwise see `[]` from a momentary API hiccup and treat
+/// it as "no versions exist", which can cause version metadata regressions
+/// in pipelines that snapshot the output.
 async fn get_tags_with_created_at(pkg: &AquaPackage) -> Result<Vec<(String, Option<String>)>> {
+    let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
+
     if let Some("github_tag") = pkg.version_source.as_deref() {
         // Tags don't have created_at timestamps
-        let versions = github::list_tags(&format!("{}/{}", pkg.repo_owner, pkg.repo_name)).await?;
+        let versions = github::list_tags(&repo).await?;
         return Ok(versions.into_iter().map(|v| (v, None)).collect());
     }
-    let releases = github::list_releases(&format!("{}/{}", pkg.repo_owner, pkg.repo_name)).await?;
+
+    let releases = match github::list_releases(&repo).await {
+        Ok(r) => r,
+        Err(e) => {
+            debug!("aqua: list_releases({repo}) failed, falling back to tags: {e:#}");
+            let versions = github::list_tags(&repo).await?;
+            return Ok(versions.into_iter().map(|v| (v, None)).collect());
+        }
+    };
+
     if releases.is_empty() {
         // Fall back to tags (no timestamps)
-        let versions = github::list_tags(&format!("{}/{}", pkg.repo_owner, pkg.repo_name)).await?;
+        let versions = github::list_tags(&repo).await?;
         return Ok(versions.into_iter().map(|v| (v, None)).collect());
     }
     Ok(releases


### PR DESCRIPTION
## Summary

When `github::list_releases` fails transiently (rate limit, 5xx, network blip), `get_tags_with_created_at` previously bubbled the error. The caller in `_list_remote_versions` swallowed any error into an empty `Vec`, surfacing as `[]` from `mise ls-remote --json` — which downstream pipelines treat as "no versions exist".

This patches `get_tags_with_created_at` to fall back to `list_tags` on `list_releases` error, matching the shape of the existing `releases.is_empty()` fallback.

## Why

[mise-versions](https://github.com/jdx/mise-versions) snapshots `mise ls-remote --json` output every 15 minutes. When the JSON came back empty due to a transient API hiccup, the script fell back to plain-text version input (no metadata) and wrote new versions without `release_url` or a real `created_at`. Concretely, in [jdx/mise-versions@e1ff2c2f](https://github.com/jdx/mise-versions/commit/e1ff2c2fa31dec4871d88c21bdaff26f71b82d98) the entry for \`code\` 0.6.95 landed as:

\`\`\`
"0.6.95" = { created_at = 2026-04-25T13:31:32.512Z }
\`\`\`

(milliseconds in the timestamp give it away as the script's \`Date.now()\` fallback, not a real GitHub timestamp). The next run picked up the correct values, but the bad row was already committed.

## Behavior changes

- **list_releases errors** → now falls back to tags (no timestamps), returning all tag names instead of `Err`.
- **list_releases succeeds (empty)** → unchanged (already falls back to tags).
- **list_releases succeeds (non-empty)** → unchanged.
- **`pkg.version_source = "github_tag"`** → unchanged.

No new versions are surfaced — only the *error* path is widened.

## Test plan

- [x] `cargo check` clean
- [x] `cargo test backend::aqua` — 16/16 pass
- [x] Live smoke: `mise ls-remote --json code` returns 0.6.95 with both `created_at` and `release_url`
- [x] Pre-commit hooks (cargo-check, cargo-fmt, clippy, shellcheck, prettier, pkl) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to the Aqua remote version listing path; it only alters behavior on GitHub `list_releases` failures by returning tags instead of propagating an error that was later coerced into an empty result.
> 
> **Overview**
> Improves resiliency of Aqua version discovery by **falling back to `github::list_tags` when `github::list_releases` errors**, instead of bubbling the error up.
> 
> This prevents transient GitHub API failures (rate limits/5xx/network issues) from causing callers to see an empty version list; normal behavior when releases succeed or when `version_source` is `github_tag` remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f234769573ed1c9a26d5babb070956876d582b74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->