### PR TITLE
chore(release): stop appending sponsor blurb when communique succeeds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,8 +383,7 @@ jobs:
             echo "::warning::communique failed, falling back to git-cliff changelog"
             mise x -- git cliff --strip all --latest > /tmp/release-notes.txt 2>/dev/null || echo "Release $VERSION" > /tmp/release-notes.txt
             echo "RELEASE_TITLE=$VERSION" >> "$GITHUB_ENV"
-          fi
-          cat >> /tmp/release-notes.txt <<'EOF'
+            cat >> /tmp/release-notes.txt <<'EOF'
 
           ## 💚 Sponsor mise
 
@@ -392,6 +391,7 @@ jobs:
 
           If mise saves you or your team time, please consider sponsoring at [en.dev](https://en.dev). Individual and company sponsorships keep mise fast, free, and independent.
           EOF
+          fi
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       - name: Create Draft GitHub Release


### PR DESCRIPTION
## Summary

`communique` 1.0.3+ now generates its own `## Sponsor mise` section as part of the AI-editorialized release body. The appended `## 💚 Sponsor mise` heredoc added in [#9272](https://github.com/jdx/mise/pull/9272) therefore ends up duplicated whenever `communique` succeeds. Both v2026.4.20 and v2026.4.22 shipped with two sponsor sections side by side because of this — see the bottom of the [v2026.4.22 release notes](https://github.com/jdx/mise/releases/tag/v2026.4.22) for an example.

This moves the heredoc into the git-cliff fallback branch so the blurb is only appended when `communique` didn't already produce one. The success path is the common case and now gets exactly one sponsor section. The fallback path (rare — only when `communique generate` fails) still gets the blurb so a degraded release body still has a sponsor CTA.

The communique bump that introduced its own sponsor section landed in [#9332](https://github.com/jdx/mise/pull/9332) (1.0.3) and was first used by v2026.4.20 — exactly when the duplication started.

## Test plan

- [x] `actionlint .github/workflows/release.yml` passes
- [x] `yamllint .github/workflows/release.yml` passes
- [x] Extracted the bash script via PyYAML and verified the heredoc is now inside the `else` block with the `EOF` terminator at column 0; `bash -n` passes
- [x] Simulated the fallback path with a stub script — output ends with exactly one `## 💚 Sponsor mise` block
- [ ] Next tagged release where `communique` succeeds produces a body with exactly one `Sponsor mise` heading

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just moves when the sponsor blurb is appended; main risk is minor formatting/indentation mistakes affecting release note generation.
> 
> **Overview**
> Updates the `release` GitHub Actions workflow so the `## 💚 Sponsor mise` heredoc is appended **only** when `communique generate` fails and the workflow falls back to `git-cliff`, preventing duplicate sponsor sections in successful releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddff28e62e238bab934e19316e542d5b3d66818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->