### PR TITLE
chore: release 2026.4.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [2026.4.23](https://github.com/jdx/mise/compare/v2026.4.22..v2026.4.23) - 2026-04-26
+
+### 🚀 Features
+
+- **(backend)** add global libc preference by @jdx in [#9404](https://github.com/jdx/mise/pull/9404)
+- opt-in to pre-release versions for github and aqua backends by @jakedgy in [#9329](https://github.com/jdx/mise/pull/9329)
+
+### 🐛 Bug Fixes
+
+- **(backend)** allow unresolved latest opt-in by @jdx in [#9401](https://github.com/jdx/mise/pull/9401)
+- **(install)** stop rewriting healthy runtime symlinks by @jdx in [#9410](https://github.com/jdx/mise/pull/9410)
+- **(node)** route musl tarball URLs to unofficial-builds by @jdx in [#9409](https://github.com/jdx/mise/pull/9409)
+- **(prune)** skip remote version resolution for tracked configs by @jdx in [#9406](https://github.com/jdx/mise/pull/9406)
+- **(schema)** allow array values in tool additionalProperties by @JP-Ellis in [#9400](https://github.com/jdx/mise/pull/9400)
+
+### 📦️ Dependency Updates
+
+- bump communique to 1.1.2 by @jdx in [#9402](https://github.com/jdx/mise/pull/9402)
+
+### 📦 Registry
+
+- use aqua for rumdl by @scop in [#9397](https://github.com/jdx/mise/pull/9397)
+
+### Chore
+
+- **(ci)** improve pr-closer workflow by @jdx in [#9403](https://github.com/jdx/mise/pull/9403)
+- **(docs)** switch canonical domain to mise.en.dev by @jdx in [#9411](https://github.com/jdx/mise/pull/9411)
+- **(release)** stop appending sponsor blurb when communique succeeds by @jdx in [#9395](https://github.com/jdx/mise/pull/9395)
+
+### New Contributors
+
+- @JP-Ellis made their first contribution in [#9400](https://github.com/jdx/mise/pull/9400)
+
 ## [2026.4.22](https://github.com/jdx/mise/compare/v2026.4.21..v2026.4.22) - 2026-04-25
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.4.22"
+version = "2026.4.23"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.4.22"
+version = "2026.4.23"
 edition = "2024"
 description = "The front-end to your dev env"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.4.22 macos-arm64 (2026-04-25)
+2026.4.23 macos-arm64 (2026-04-26)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_22.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_23.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_22.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_4_23.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_4_22.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_4_23.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_4_22.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_4_23.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.4.22";
+  version = "2026.4.23";
 
   src = lib.cleanSource ./.;
 

--- a/mise.lock
+++ b/mise.lock
@@ -138,9 +138,9 @@ url = "https://github.com/endevco/aube/releases/download/v1.1.0/aube-v1.1.0-x86_
 url_api = "https://api.github.com/repos/endevco/aube/releases/assets/404654425"
 
 [tools.aube."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:7ba3551a7b63f82d9aa4734791db66167b3905e940e749db297372422c82933a"
-url = "https://github.com/endevco/aube/releases/download/v1.1.0/aube-v1.1.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/endevco/aube/releases/assets/404654853"
+checksum = "sha256:447f14e9edad5f212ad029758c5ea416437d225592ca8d716b8d1933b020cf4c"
+url = "https://github.com/endevco/aube/releases/download/v1.1.0/aube-v1.1.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/404654425"
 
 [tools.aube."platforms.macos-arm64"]
 checksum = "sha256:4d77b4f54c78297e6aef6da4ccb8a2327c31297f1a9f37b84fb746928129c4b2"
@@ -307,9 +307,9 @@ url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964691"
 
 [tools.communique."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:5e74ead7037f42940c7dba4f6aa4ed968920cbb55a047aa0d291b0c675c65676"
-url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405963914"
+checksum = "sha256:01a6a8b49e635a5a209fdaf6c7b2e976374debc2db1c846c033f567fdba0d86c"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964691"
 
 [tools.communique."platforms.macos-arm64"]
 checksum = "sha256:459993e31a6c4ccbd09882f5679a2bc1ea5d9068701ecefc411a00fb69ce82e6"
@@ -442,8 +442,8 @@ checksum = "sha256:0dbca69b6d2141bf60aa9b5cd54e59232ba5b10855a9c7b52426a96452118
 url = "https://github.com/jdx/hk/releases/download/v1.44.0/hk-aarch64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.linux-arm64-musl"]
-checksum = "sha256:0dbca69b6d2141bf60aa9b5cd54e59232ba5b10855a9c7b52426a9645211809f"
-url = "https://github.com/jdx/hk/releases/download/v1.44.0/hk-aarch64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:0f6bf44d490a17cc57c04738e28ccd89e9784fd4047d10b9f19dfe2405fe9270"
+url = "https://github.com/jdx/hk/releases/download/v1.44.0/hk-aarch64-unknown-linux-musl.tar.gz"
 
 [tools.hk."platforms.linux-x64"]
 checksum = "sha256:cb093bf2d31f0d21c3166b143fe671ddb22cd2cad5069596bfa22d7a541f2270"
@@ -454,12 +454,12 @@ checksum = "sha256:cb093bf2d31f0d21c3166b143fe671ddb22cd2cad5069596bfa22d7a541f2
 url = "https://github.com/jdx/hk/releases/download/v1.44.0/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.linux-x64-musl"]
-checksum = "sha256:cb093bf2d31f0d21c3166b143fe671ddb22cd2cad5069596bfa22d7a541f2270"
-url = "https://github.com/jdx/hk/releases/download/v1.44.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:f96f5f9eb99fa21ab0de8389722bd3eb05c003b9c46fcc75c3fccbe155f33b8b"
+url = "https://github.com/jdx/hk/releases/download/v1.44.0/hk-x86_64-unknown-linux-musl.tar.gz"
 
 [tools.hk."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:cb093bf2d31f0d21c3166b143fe671ddb22cd2cad5069596bfa22d7a541f2270"
-url = "https://github.com/jdx/hk/releases/download/v1.44.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:f96f5f9eb99fa21ab0de8389722bd3eb05c003b9c46fcc75c3fccbe155f33b8b"
+url = "https://github.com/jdx/hk/releases/download/v1.44.0/hk-x86_64-unknown-linux-musl.tar.gz"
 
 [tools.hk."platforms.macos-arm64"]
 checksum = "sha256:6a1de3c576487983e46d0458b3c9f20af51c4c785d22b96e3396be5c164a1e04"
@@ -922,8 +922,8 @@ checksum = "sha256:21908eec45ff9666d4ae72825b81faa7fc4119124ed656eb1d470cbf9ed41
 url = "https://github.com/JohnnyMorganz/StyLua/releases/download/v2.3.1/stylua-linux-aarch64.zip"
 
 [tools.stylua."platforms.linux-arm64-musl"]
-checksum = "sha256:21908eec45ff9666d4ae72825b81faa7fc4119124ed656eb1d470cbf9ed41bc9"
-url = "https://github.com/JohnnyMorganz/StyLua/releases/download/v2.3.1/stylua-linux-aarch64.zip"
+checksum = "sha256:3a5fef8220f3d482fd9f4c1d2655827c90e42197a11a28da6c7b42e7ddde8be6"
+url = "https://github.com/JohnnyMorganz/StyLua/releases/download/v2.3.1/stylua-linux-aarch64-musl.zip"
 
 [tools.stylua."platforms.linux-x64"]
 checksum = "sha256:1b3ca3f577e584e19a0ad2264a0ab87f4133818e35700a094416ca98251ffb4a"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: The front-end to your dev env
 Name: mise
-Version: 2026.4.22
+Version: 2026.4.23
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.4.22"
+version: "2026.4.23"
 summary: The front-end to your dev env
 description: |
   mise-en-place is a command line tool to manage your development environment.


### PR DESCRIPTION
### 🚀 Features

- **(backend)** add global libc preference by @jdx in [#9404](https://github.com/jdx/mise/pull/9404)
- opt-in to pre-release versions for github and aqua backends by @jakedgy in [#9329](https://github.com/jdx/mise/pull/9329)

### 🐛 Bug Fixes

- **(backend)** allow unresolved latest opt-in by @jdx in [#9401](https://github.com/jdx/mise/pull/9401)
- **(install)** stop rewriting healthy runtime symlinks by @jdx in [#9410](https://github.com/jdx/mise/pull/9410)
- **(node)** route musl tarball URLs to unofficial-builds by @jdx in [#9409](https://github.com/jdx/mise/pull/9409)
- **(prune)** skip remote version resolution for tracked configs by @jdx in [#9406](https://github.com/jdx/mise/pull/9406)
- **(schema)** allow array values in tool additionalProperties by @JP-Ellis in [#9400](https://github.com/jdx/mise/pull/9400)

### 📦️ Dependency Updates

- bump communique to 1.1.2 by @jdx in [#9402](https://github.com/jdx/mise/pull/9402)

### 📦 Registry

- use aqua for rumdl by @scop in [#9397](https://github.com/jdx/mise/pull/9397)

### Chore

- **(ci)** improve pr-closer workflow by @jdx in [#9403](https://github.com/jdx/mise/pull/9403)
- **(docs)** switch canonical domain to mise.en.dev by @jdx in [#9411](https://github.com/jdx/mise/pull/9411)
- **(release)** stop appending sponsor blurb when communique succeeds by @jdx in [#9395](https://github.com/jdx/mise/pull/9395)

### New Contributors

- @JP-Ellis made their first contribution in [#9400](https://github.com/jdx/mise/pull/9400)