### PR TITLE
fix(schema): allow array values in tool additionalProperties

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2294,6 +2294,9 @@
                 "type": "boolean"
               },
               {
+                "type": "array"
+              },
+              {
                 "type": "object",
                 "additionalProperties": true
               }


### PR DESCRIPTION
Tool options like rust `components` accept arrays, e.g.:

```toml
[tools]
rust = { version = "1.77", components = ["rustfmt", "clippy"] }
```

The old schema though would say otherwise, and linters like tombi flag the above as invalid.