### PR TITLE
fix(backend): allow unresolved latest opt-in

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -671,6 +671,20 @@ pub trait Backend: Debug + Send + Sync {
     async fn latest_stable_version(&self, _config: &Arc<Config>) -> eyre::Result<Option<String>> {
         Ok(None)
     }
+
+    /// Backend opt-in for installing an unresolved `latest` request.
+    ///
+    /// Most backends must resolve `latest` to a concrete version before install.
+    /// Override this only when the backend can pass an unresolved selector through
+    /// to its installer, and only for requests where the selector is meaningful.
+    ///
+    /// `ToolVersion::resolve_version` uses this as a last resort after normal
+    /// latest resolution fails, and only when the backend's unfiltered remote
+    /// version list is empty. If remote versions exist but are all filtered out by
+    /// `minimum_release_age` / `--before`, this hook is not used.
+    fn unresolved_latest_version(&self) -> Option<String> {
+        None
+    }
     fn list_installed_versions(&self) -> Vec<String> {
         install_state::list_versions(&self.ba().short)
     }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -7,7 +7,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::env;
 use crate::file;
-use crate::github;
+use crate::github::{self, GithubRelease};
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
 use crate::timeout;
@@ -122,20 +122,9 @@ impl Backend for PIPXBackend {
             PipxRequest::Git(url) if url.starts_with("https://github.com/") => {
                 let repo = url.strip_prefix("https://github.com/").unwrap();
                 let data = github::list_releases(repo).await?;
-                Ok(data
-                    .into_iter()
-                    .rev()
-                    .map(|r| VersionInfo {
-                        version: r.tag_name,
-                        created_at: Some(r.created_at),
-                        ..Default::default()
-                    })
-                    .collect())
+                Ok(Self::versions_from_github_releases(data))
             }
-            PipxRequest::Git { .. } => Ok(vec![VersionInfo {
-                version: "latest".to_string(),
-                ..Default::default()
-            }]),
+            PipxRequest::Git { .. } => Ok(vec![]),
         }
     }
 
@@ -193,6 +182,13 @@ impl Backend for PIPXBackend {
         )
         .await
         .cloned()
+    }
+
+    fn unresolved_latest_version(&self) -> Option<String> {
+        match self.tool_name().parse() {
+            Ok(PipxRequest::Git(_)) => Some("latest".to_string()),
+            _ => None,
+        }
     }
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
@@ -292,6 +288,18 @@ pub fn install_time_option_keys() -> Vec<String> {
 }
 
 impl PIPXBackend {
+    fn versions_from_github_releases(releases: Vec<GithubRelease>) -> Vec<VersionInfo> {
+        releases
+            .into_iter()
+            .rev()
+            .map(|r| VersionInfo {
+                version: r.tag_name,
+                created_at: Some(r.created_at),
+                ..Default::default()
+            })
+            .collect()
+    }
+
     fn uv_exclude_newer_args(before_date: Option<Timestamp>) -> Vec<OsString> {
         match before_date {
             Some(before_date) => vec!["--exclude-newer".into(), before_date.to_string().into()],
@@ -666,8 +674,35 @@ fn fix_venv_python_symlink(_install_path: &Path, _pkg_name: &str) -> Result<()> 
 #[cfg(test)]
 mod tests {
     use super::PIPXBackend;
+    use crate::github::GithubRelease;
     use pretty_assertions::assert_eq;
     use std::ffi::OsString;
+
+    #[test]
+    fn test_versions_from_empty_github_releases_stays_empty() {
+        let versions = PIPXBackend::versions_from_github_releases(vec![]);
+
+        assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn test_versions_from_github_releases_preserves_tags() {
+        let versions = PIPXBackend::versions_from_github_releases(vec![
+            github_release("2.0.0", "2024-02-01T00:00:00Z"),
+            github_release("1.0.0", "2024-01-01T00:00:00Z"),
+        ]);
+
+        assert_eq!(
+            versions
+                .iter()
+                .map(|v| (v.version.as_str(), v.created_at.as_deref()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("1.0.0", Some("2024-01-01T00:00:00Z")),
+                ("2.0.0", Some("2024-02-01T00:00:00Z")),
+            ]
+        );
+    }
 
     #[test]
     fn test_uv_exclude_newer_args_with_cutoff() {
@@ -711,5 +746,15 @@ mod tests {
             PIPXBackend::pip_uploaded_prior_to_args(None),
             Vec::<OsString>::new()
         );
+    }
+
+    fn github_release(tag_name: &str, created_at: &str) -> GithubRelease {
+        GithubRelease {
+            tag_name: tag_name.to_string(),
+            draft: false,
+            prerelease: false,
+            created_at: created_at.to_string(),
+            assets: vec![],
+        }
     }
 }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -354,6 +354,14 @@ impl ToolVersion {
             {
                 return build(v);
             }
+            if !is_offline {
+                let versions = backend.list_remote_versions(config).await?;
+                if versions.is_empty()
+                    && let Some(v) = backend.unresolved_latest_version()
+                {
+                    return build(v);
+                }
+            }
             return Err(Self::no_versions_found(&backend, opts.before_date));
         }
         if !opts.latest_versions {


### PR DESCRIPTION
## Summary

Fixes `latest` resolution for backends that can install an unresolved selector when their remote version list is empty.

`minimum_release_age` cannot be evaluated when a backend has no version candidates, but falling back to literal `latest` for every empty-list backend is unsafe: some backends require concrete versions and must continue failing rather than creating literal `latest/` installs. This change keeps the fallback in the central resolver but makes it opt-in through `Backend::unresolved_latest_version()`.

The resolver now only falls back when the backend’s unfiltered remote version list is empty and the backend explicitly provides an unresolved selector. If versions exist but are all filtered out by `minimum_release_age`, mise still reports no matching version, preserving the age gate.

`pipx` opts in only for git-backed requests, where `latest` is an installable selector. Its remote version listing remains honest: GitHub repos with no releases return `[]` from `ls-remote` instead of reporting `latest` as a release. Tests also assert GitHub release timestamps are preserved for date filtering.

## Validation

- `cargo fmt --check`
- `cargo test backend::pipx::tests`
- `cargo build`
- `mise run test:e2e e2e/backend/test_fuzzy_versions_do_not_install_literal_dirs`
- clean-cache config check: `pipx:a13xp0p0v/kernel-hardening-checker@latest` resolves to `latest` without `minimum_release_age`
- clean-cache config check: `pipx:a13xp0p0v/kernel-hardening-checker@latest` with `minimum_release_age = "7d"` resolves to `latest`
- clean-cache guard check: `pipx:psf/black@latest` with `minimum_release_age = "1970-01-01"` still reports no matching version instead of falling back to HEAD
- clean-cache `ls-remote pipx:a13xp0p0v/kernel-hardening-checker --json` returns `[]`
- pre-commit hook during amend, including `cargo check --all-features`

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central `@latest` resolution behavior by allowing an unresolved selector fallback for opted-in backends when remote version listing is empty, which could affect install outcomes for `latest` requests. Scope is limited via explicit backend opt-in and only triggers in non-offline mode with no remote versions returned.
> 
> **Overview**
> Fixes `@latest` resolution for backends that can *install an unresolved selector* when no remote versions are discoverable.
> 
> Adds a new `Backend::unresolved_latest_version()` opt-in hook and updates `ToolVersion::resolve_version` to fall back to that value only when the backend’s unfiltered remote version list is empty (and only when not offline), preserving failure behavior when versions exist but don’t match date/age filters.
> 
> Updates `pipx` to opt in for git-based requests by returning `latest` as an installable unresolved selector, while making its remote version listing for non-GitHub git sources return an empty list (instead of a synthetic `latest` version), and adds tests for GitHub release->version mapping and timestamp preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483868de8969e6259328c8d96b78d3a7e34cee5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->