### PR TITLE
chore(ci): improve pr-closer workflow

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -8,22 +8,22 @@ on:
 jobs:
   close-stale-prs:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Close stale PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr list -R jdx/mise --state open --json number,author,labels,updatedAt,statusCheckRollup --limit 100 | \
-          jq -r '.[] | select(
-            (.updatedAt | fromdateiso8601) < (now - 30*24*60*60) and
-            .author.login != "jdx" and
-            ([.labels[].name] | index("keep-open") | not)
-          ) | [.number, (if (.statusCheckRollup | length > 0) and ([.statusCheckRollup[].conclusion] | index("FAILURE") or index("failure")) then "failing" else "passing" end)] | @tsv' | \
+          CUTOFF=$(date -u -d '30 days ago' +%Y-%m-%d)
+          gh pr list -R "$REPO" --state open --search "updated:<$CUTOFF -author:jdx -label:keep-open sort:updated-asc" --json number,statusCheckRollup --limit 500 | \
+          jq -r '.[] | [.number, (if (.statusCheckRollup | length > 0) and ([.statusCheckRollup[].conclusion] | index("FAILURE") or index("failure")) then "failing" else "passing" end)] | @tsv' | \
           while read -r pr status; do
             echo "Closing PR #$pr (checks: $status)"
             if [ "$status" = "failing" ]; then
-              gh pr close "$pr" -R jdx/mise -c "This PR has been open for more than 30 days without activity. Note: CI checks were failing, which may be why it wasn't reviewed. Feel free to reopen or create a new PR if you'd like to continue working on this."
+              gh pr close "$pr" -R "$REPO" -c "This PR has been open for more than 30 days without activity. Note: CI checks were failing, which may be why it wasn't reviewed. Feel free to reopen or create a new PR if you'd like to continue working on this."
             else
-              gh pr close "$pr" -R jdx/mise -c "This PR has been open for more than 30 days without activity. Feel free to reopen or create a new PR if you'd like to continue working on this."
+              gh pr close "$pr" -R "$REPO" -c "This PR has been open for more than 30 days without activity. Feel free to reopen or create a new PR if you'd like to continue working on this."
             fi
           done


### PR DESCRIPTION
## Summary
- Backports improvements made to the same workflow in jdx/hk#876.
- Adds explicit `permissions: pull-requests: write` so the job can't 403 on read-only default tokens.
- Replaces hardcoded `jdx/mise` with `${{ github.repository }}` (via `REPO` env).
- Filters stale PRs server-side via `--search "updated:<CUTOFF -author:jdx -label:keep-open sort:updated-asc"` and bumps `--limit` to 500. Only stale candidates are fetched, sorted oldest-first, so anything beyond the limit rolls into the next daily run instead of being silently skipped.

## Test plan
- [x] Verified the search query against jdx/mise — currently returns 0 stale candidates (workflow has been keeping things tidy)
- [ ] Trigger via `workflow_dispatch` once merged to confirm a clean run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to a GitHub Actions workflow and only changes how stale PRs are queried/closed; main risk is mis-filtering PRs and closing the wrong ones.
> 
> **Overview**
> Improves the `pr-closer` GitHub Actions workflow by granting explicit `pull-requests: write` permissions and removing the hardcoded repository in favor of `${{ github.repository }}`.
> 
> Changes stale-PR selection to be filtered server-side using a date cutoff search (sorted oldest-first) and increases the fetch limit to 500 before closing candidates, while keeping the “failing vs passing checks” close message behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae0b5f81191465df3edd6a3beaa599820f9b0722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->