### PR TITLE
fix(prune): skip remote version resolution for tracked configs

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -233,6 +233,7 @@ impl Install {
                 use_locked_version: true,
                 latest_versions: true,
                 before_date: self.get_before_date()?,
+                offline: false,
             },
             dry_run: self.is_dry_run(),
             locked: Settings::get().locked,

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -109,7 +109,7 @@ pub async fn prunable_tools(
     }
 
     // Remove versions that are still needed by tracked configs
-    let needed_versions = get_versions_needed_by_tracked_configs(config, true).await?;
+    let needed_versions = get_versions_needed_by_tracked_configs(config, true, true).await?;
     for key in needed_versions {
         to_delete.remove(&key);
     }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -117,6 +117,7 @@ impl Upgrade {
             use_locked_version: false,
             latest_versions: true,
             before_date,
+            offline: false,
         };
         // Filter tools to check before doing expensive version lookups
         let filter_tools = if !self.interactive && !self.tool.is_empty() {
@@ -260,6 +261,7 @@ impl Upgrade {
                 use_locked_version: false,
                 latest_versions: true,
                 before_date,
+                offline: false,
             },
             ..Default::default()
         };
@@ -338,7 +340,7 @@ impl Upgrade {
         // Get versions needed by tracked configs AFTER upgrade
         // This ensures we don't uninstall versions still needed by other projects
         let versions_needed_by_tracked =
-            get_versions_needed_by_tracked_configs(config, false).await?;
+            get_versions_needed_by_tracked_configs(config, false, false).await?;
 
         // Only uninstall old versions of tools that were successfully upgraded
         // and are not needed by any tracked config

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -144,6 +144,7 @@ impl Use {
             latest_versions: false,
             use_locked_version: true,
             before_date: self.get_before_date()?,
+            offline: false,
         };
         let versions: Vec<_> = self
             .tool

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -602,13 +602,17 @@ impl From<ToolRequestSet> for Toolset {
 pub async fn get_versions_needed_by_tracked_configs(
     config: &Arc<Config>,
     use_locked_version: bool,
+    offline: bool,
 ) -> Result<std::collections::HashSet<(String, String)>> {
     let mut needed = std::collections::HashSet::new();
     // `mise prune` should keep versions pinned by lockfiles. `mise upgrade`
     // passes false because it checks what tracked configs resolve to after an
     // upgrade, before their lockfiles have been updated.
+    // Prune also passes offline=true: it only protects installed versions, so
+    // remote resolution can never affect the outcome and just adds latency.
     let opts = ResolveOptions {
         use_locked_version,
+        offline,
         ..Default::default()
     };
     for (path, cf) in config.get_tracked_config_files().await? {

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -643,6 +643,20 @@ pub async fn get_versions_needed_by_tracked_configs(
         ts.resolve_with_opts(config, &opts).await?;
         for (_, tv) in ts.list_current_versions() {
             needed.insert((tv.ba().short.to_string(), tv.tv_pathname()));
+            // Offline can't resolve `sub-N:latest` to a concrete version
+            // (no remote latest available). Conservatively protect every
+            // installed version of this backend so we don't delete the
+            // active one.
+            if offline
+                && let crate::toolset::ToolRequest::Sub { orig_version, .. } = &tv.request
+                && orig_version == "latest"
+                && let Ok(backend) = tv.backend()
+            {
+                let short = tv.ba().short.to_string();
+                for v in backend.list_installed_versions() {
+                    needed.insert((short.clone(), v));
+                }
+            }
         }
     }
     Ok(needed)

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -227,6 +227,7 @@ impl ToolVersion {
             latest_versions: true,
             use_locked_version: false,
             before_date: base_opts.before_date,
+            offline: base_opts.offline,
         };
         let tv = self.request.resolve(config, &opts).await?;
         // map cargo backend specific prefixes to ref
@@ -339,7 +340,7 @@ impl ToolVersion {
         }
 
         let settings = Settings::get();
-        let is_offline = settings.offline();
+        let is_offline = settings.offline() || opts.offline;
 
         if v == "latest" {
             if !opts.latest_versions
@@ -361,6 +362,12 @@ impl ToolVersion {
                 {
                     return build(v);
                 }
+            }
+            // When offline with nothing installed, leave "latest" unresolved
+            // rather than erroring — callers like prune treat the unresolved
+            // string as a no-op (it won't match any installed pathname).
+            if is_offline {
+                return build(v);
             }
             return Err(Self::no_versions_found(&backend, opts.before_date));
         }
@@ -472,6 +479,9 @@ impl ToolVersion {
         {
             return Ok(Self::new(request, v.to_string()));
         }
+        if Settings::get().offline() || opts.offline {
+            return Ok(Self::new(request, prefix.to_string()));
+        }
         let matches = backend
             .list_versions_matching_with_opts(config, prefix, opts.before_date)
             .await?;
@@ -553,6 +563,8 @@ pub struct ResolveOptions {
     pub use_locked_version: bool,
     /// Only consider versions released before this timestamp
     pub before_date: Option<Timestamp>,
+    /// Additive to `Settings::offline()` — either being true skips remote version listing.
+    pub offline: bool,
 }
 
 impl Default for ResolveOptions {
@@ -561,6 +573,7 @@ impl Default for ResolveOptions {
             latest_versions: false,
             use_locked_version: true,
             before_date: None,
+            offline: false,
         }
     }
 }
@@ -597,6 +610,9 @@ impl Display for ResolveOptions {
         }
         if let Some(ts) = &self.before_date {
             opts.push(format!("before_date={ts}"));
+        }
+        if self.offline {
+            opts.push("offline".to_string());
         }
         write!(f, "({})", opts.join(", "))
     }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -458,6 +458,17 @@ impl ToolVersion {
     ) -> Result<Self> {
         let backend = request.backend()?;
         if v == "latest" && opts.offline {
+            // Use the latest installed version as the basis for the sub
+            // computation so the resolved concrete version still matches an
+            // installed pathname (and gets protected from prune). Falling
+            // straight to the raw "sub-N:latest" string would never match
+            // anything in `to_delete`.
+            if !opts.latest_versions
+                && let Some(latest) = backend.latest_installed_version(None)?
+            {
+                let v = tool_request::version_sub(&latest, sub);
+                return Box::pin(Self::resolve_version(config, request, &v, opts)).await;
+            }
             let version = request.version();
             return Ok(Self::new(request, version));
         }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -363,10 +363,11 @@ impl ToolVersion {
                     return build(v);
                 }
             }
-            // When offline with nothing installed, leave "latest" unresolved
-            // rather than erroring — callers like prune treat the unresolved
-            // string as a no-op (it won't match any installed pathname).
-            if is_offline {
+            // Prune-style offline (opts.offline) wants a non-erroring no-op
+            // when nothing is installed — the literal "latest" can't match
+            // any installed pathname so it's safe. Global MISE_OFFLINE keeps
+            // the original error to avoid surprising upgrade/outdated callers.
+            if opts.offline {
                 return build(v);
             }
             return Err(Self::no_versions_found(&backend, opts.before_date));
@@ -456,7 +457,7 @@ impl ToolVersion {
         opts: &ResolveOptions,
     ) -> Result<Self> {
         let backend = request.backend()?;
-        if v == "latest" && (Settings::get().offline() || opts.offline) {
+        if v == "latest" && opts.offline {
             let version = request.version();
             return Ok(Self::new(request, version));
         }
@@ -483,7 +484,7 @@ impl ToolVersion {
         {
             return Ok(Self::new(request, v.to_string()));
         }
-        if Settings::get().offline() || opts.offline {
+        if opts.offline {
             return Ok(Self::new(request, prefix.to_string()));
         }
         let matches = backend

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -458,17 +458,11 @@ impl ToolVersion {
     ) -> Result<Self> {
         let backend = request.backend()?;
         if v == "latest" && opts.offline {
-            // Use the latest installed version as the basis for the sub
-            // computation so the resolved concrete version still matches an
-            // installed pathname (and gets protected from prune). Falling
-            // straight to the raw "sub-N:latest" string would never match
-            // anything in `to_delete`.
-            if !opts.latest_versions
-                && let Some(latest) = backend.latest_installed_version(None)?
-            {
-                let v = tool_request::version_sub(&latest, sub);
-                return Box::pin(Self::resolve_version(config, request, &v, opts)).await;
-            }
+            // Can't resolve sub-N:latest offline (no remote latest, and
+            // applying version_sub to latest_installed_version would shift
+            // one step too low). Return the raw spec; callers that care
+            // (`get_versions_needed_by_tracked_configs`) over-protect by
+            // keeping all installed versions of this backend.
             let version = request.version();
             return Ok(Self::new(request, version));
         }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -456,6 +456,10 @@ impl ToolVersion {
         opts: &ResolveOptions,
     ) -> Result<Self> {
         let backend = request.backend()?;
+        if v == "latest" && (Settings::get().offline() || opts.offline) {
+            let version = request.version();
+            return Ok(Self::new(request, version));
+        }
         let v = match v {
             "latest" => backend
                 .latest_version(config, None, opts.before_date)


### PR DESCRIPTION
## Summary

- `mise prune` was resolving every tracked config's tool versions against the network (npm registry, Go proxy, GitHub API), which could hang on slow or failing registries — see [#9405](https://github.com/jdx/mise/discussions/9405).
- The remote calls were wasted work: prune only protects *installed* versions from deletion, and the resolver's early-return paths (`latest_installed_version`, `list_installed_versions_matching`) already match installed versions without hitting the network. If no installed version matches, the remote-resolved result can't appear in the deletion set anyway.
- Adds an `offline` field to `ResolveOptions`, additive to `Settings::offline()`. Set to `true` in prune's path; left `false` for `mise upgrade` (which deliberately wants fresh remote data to decide what tracked configs would resolve to after an upgrade).
- Fixes the `latest` resolver path: with offline + nothing installed, returns the unresolved `"latest"` string instead of erroring (safe — won't match any installed pathname).
- Replaces the old workaround `MISE_OFFLINE=1 mise prune --yes` with default behavior.

Closes [#9405](https://github.com/jdx/mise/discussions/9405).

## Test plan

- [x] `cargo check` clean
- [x] `mise run lint-fix` clean
- [x] `mise run test:unit` (774 passed)
- [x] `mise run test:e2e test_prune` passes
- [ ] Reviewer: in a directory with multiple tracked configs containing prefix/latest/range versions (e.g. `node = "22"`, `npm = "^11"`, a `go:` tool), `MISE_DEBUG=1 mise prune --dry-run` should no longer show `DEBUG GET https://registry.npmjs.org/...`, `proxy.golang.org/...`, or `api.github.com/...` requests during resolution.
- [ ] Reviewer: `MISE_DEBUG=1 mise upgrade --dry-run` should still show remote version queries (verifying upgrade's behavior is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes version resolution behavior in offline paths (including `latest`/prefix/sub semantics), which can affect which tool versions are considered safe to delete during `prune` and after `upgrade`. Scope is contained to resolution options and tracked-config protection logic.
> 
> **Overview**
> **`mise prune` no longer performs network lookups** when resolving tracked config requirements, by threading a new `ResolveOptions.offline` flag through tracked-config resolution.
> 
> This updates `get_versions_needed_by_tracked_configs` to accept an `offline` parameter (used by prune, not upgrade) and adds conservative protection for `sub-N:latest` when offline by keeping all installed versions for that backend.
> 
> Resolver behavior is adjusted so `offline` resolution can return unresolved specs for `latest`, prefix, and `sub-N:latest` instead of erroring or fetching remotes, while leaving normal `upgrade`/`use`/`install` paths explicitly `offline: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5316331543dc807b187d33753f635d6c9e7be821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->