### PR TITLE
fix(node): route musl tarball URLs to unofficial-builds

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -589,8 +589,8 @@ checksum = "sha256:f44740cd218de8127f1c44c41510a3a740fa5c9c8d1cdce1c3bedada79f3c
 url = "https://nodejs.org/dist/v24.14.0/node-v24.14.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
-checksum = "sha256:f44740cd218de8127f1c44c41510a3a740fa5c9c8d1cdce1c3bedada79f3cde7"
-url = "https://nodejs.org/dist/v24.14.0/node-v24.14.0-linux-arm64.tar.gz"
+checksum = "sha256:8f81d47b7f443455709d44eae8669591de2e58b37d3c2cb0aec667b6e6f826c1"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.14.0/node-v24.14.0-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
 checksum = "sha256:dbf5b8665dec15e59e6359a517fefb47b23fdb9152d8def975b9bca3dfc6d355"
@@ -601,12 +601,12 @@ checksum = "sha256:dbf5b8665dec15e59e6359a517fefb47b23fdb9152d8def975b9bca3dfc6d
 url = "https://nodejs.org/dist/v24.14.0/node-v24.14.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
-checksum = "sha256:dbf5b8665dec15e59e6359a517fefb47b23fdb9152d8def975b9bca3dfc6d355"
-url = "https://nodejs.org/dist/v24.14.0/node-v24.14.0-linux-x64.tar.gz"
+checksum = "sha256:bae0f2320448d5c744bcd4878081b483194d8b0f0eaab2b37d7f81df739c5a95"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.14.0/node-v24.14.0-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:dbf5b8665dec15e59e6359a517fefb47b23fdb9152d8def975b9bca3dfc6d355"
-url = "https://nodejs.org/dist/v24.14.0/node-v24.14.0-linux-x64.tar.gz"
+checksum = "sha256:bae0f2320448d5c744bcd4878081b483194d8b0f0eaab2b37d7f81df739c5a95"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.14.0/node-v24.14.0-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
 checksum = "sha256:a1a54f46a750d2523d628d924aab61758a51c9dad3e0238beb14141be9615dd3"

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -249,28 +249,50 @@ impl PlatformInfo {
     /// - Prefers sha256 checksums over blake3 (more portable/verifiable)
     /// - Preserves URL if missing in self
     /// - Preserves url_api if missing in self
+    /// - Drops the other side's checksum/size/url_api when URLs disagree, since
+    ///   those fields describe a specific artifact and become stale if the URL
+    ///   changes.
     pub fn merge_with(&self, other: &PlatformInfo) -> PlatformInfo {
+        let url_changed = self.url.is_some() && other.url.is_some() && self.url != other.url;
+
         // For checksums, prefer sha256 over blake3 since sha256 comes from
-        // official releases and is more portable/verifiable
-        let checksum = match (&self.checksum, &other.checksum) {
-            (Some(self_cs), Some(other_cs)) => {
-                let self_is_sha256 = self_cs.starts_with("sha256:");
-                let other_is_sha256 = other_cs.starts_with("sha256:");
-                match (self_is_sha256, other_is_sha256) {
-                    (true, _) => Some(self_cs.clone()),
-                    (false, true) => Some(other_cs.clone()),
-                    (false, false) => Some(self_cs.clone()), // both blake3, use self
+        // official releases and is more portable/verifiable. If URLs disagree,
+        // ignore the other side's artifact-bound fields entirely.
+        let checksum = if url_changed {
+            self.checksum.clone()
+        } else {
+            match (&self.checksum, &other.checksum) {
+                (Some(self_cs), Some(other_cs)) => {
+                    let self_is_sha256 = self_cs.starts_with("sha256:");
+                    let other_is_sha256 = other_cs.starts_with("sha256:");
+                    match (self_is_sha256, other_is_sha256) {
+                        (true, _) => Some(self_cs.clone()),
+                        (false, true) => Some(other_cs.clone()),
+                        (false, false) => Some(self_cs.clone()), // both blake3, use self
+                    }
                 }
+                (Some(cs), None) | (None, Some(cs)) => Some(cs.clone()),
+                (None, None) => None,
             }
-            (Some(cs), None) | (None, Some(cs)) => Some(cs.clone()),
-            (None, None) => None,
+        };
+
+        let size = if url_changed {
+            self.size
+        } else {
+            self.size.or(other.size)
+        };
+
+        let url_api = if url_changed {
+            self.url_api.clone()
+        } else {
+            self.url_api.clone().or_else(|| other.url_api.clone())
         };
 
         PlatformInfo {
             checksum,
-            size: self.size.or(other.size),
+            size,
             url: self.url.clone().or_else(|| other.url.clone()),
-            url_api: self.url_api.clone().or_else(|| other.url_api.clone()),
+            url_api,
             conda_deps: self.conda_deps.clone().or_else(|| other.conda_deps.clone()),
             provenance: match (self.provenance.clone(), other.provenance.clone()) {
                 (Some(a), Some(b)) => Some(a.merge(b)),
@@ -726,13 +748,35 @@ impl Lockfile {
             .iter_mut()
             .find(|t| t.version == version && &t.options == options)
         {
-            // Merge with existing platform info, preferring new values when present
+            // Merge with existing platform info, preferring new values when present.
+            // When the URL changes, drop existing checksum/size/url_api — those fields
+            // describe a specific artifact and are stale once the URL points elsewhere.
             let merged = if let Some(existing) = tool.platforms.get(platform_key) {
+                let url_changed = platform_info.url.is_some()
+                    && existing.url.is_some()
+                    && platform_info.url != existing.url;
+                let preserve_artifact_fields = !url_changed;
                 PlatformInfo {
-                    checksum: platform_info.checksum.or_else(|| existing.checksum.clone()),
-                    size: platform_info.size.or(existing.size),
+                    checksum: platform_info.checksum.or_else(|| {
+                        if preserve_artifact_fields {
+                            existing.checksum.clone()
+                        } else {
+                            None
+                        }
+                    }),
+                    size: platform_info.size.or(if preserve_artifact_fields {
+                        existing.size
+                    } else {
+                        None
+                    }),
                     url: platform_info.url.or_else(|| existing.url.clone()),
-                    url_api: platform_info.url_api.or_else(|| existing.url_api.clone()),
+                    url_api: platform_info.url_api.or_else(|| {
+                        if preserve_artifact_fields {
+                            existing.url_api.clone()
+                        } else {
+                            None
+                        }
+                    }),
                     // For conda_deps, always use the new value - None means "no dependencies"
                     // rather than "not computed", so we shouldn't preserve stale deps
                     conda_deps: platform_info.conda_deps,
@@ -2438,15 +2482,17 @@ backend = "conda:jq"
 
     #[test]
     fn test_platform_info_merge_prefers_sha256() {
-        // Test that merge_with prefers sha256 over blake3
+        // The sha256-vs-blake3 preference only matters when both checksums
+        // describe the same artifact, so use a shared URL here.
+        let url = Some("https://example.com/a".to_string());
         let sha256_info = PlatformInfo {
             checksum: Some("sha256:abc123".to_string()),
-            url: Some("https://example.com/a".to_string()),
+            url: url.clone(),
             ..Default::default()
         };
         let blake3_info = PlatformInfo {
             checksum: Some("blake3:def456".to_string()),
-            url: Some("https://example.com/b".to_string()),
+            url: url.clone(),
             ..Default::default()
         };
 
@@ -2461,6 +2507,7 @@ backend = "conda:jq"
         // blake3 + blake3 -> self (first)
         let another_blake3 = PlatformInfo {
             checksum: Some("blake3:ghi789".to_string()),
+            url: url.clone(),
             ..Default::default()
         };
         let merged = blake3_info.merge_with(&another_blake3);
@@ -2473,7 +2520,43 @@ backend = "conda:jq"
             ..Default::default()
         };
         let merged = no_url.merge_with(&blake3_info);
-        assert_eq!(merged.url, Some("https://example.com/b".to_string()));
+        assert_eq!(merged.url, url);
+    }
+
+    #[test]
+    fn test_platform_info_merge_drops_stale_checksum_on_url_change() {
+        // When URLs disagree, the other side's checksum/size/url_api describe
+        // a different artifact and must not be carried over (e.g. node musl
+        // URL bumped but old glibc checksum still on disk).
+        let new_info = PlatformInfo {
+            checksum: None,
+            size: None,
+            url: Some("https://example.com/v2.tar.gz".to_string()),
+            url_api: None,
+            ..Default::default()
+        };
+        let stale_info = PlatformInfo {
+            checksum: Some("sha256:OLD".to_string()),
+            size: Some(123),
+            url: Some("https://example.com/v1.tar.gz".to_string()),
+            url_api: Some("https://api.example.com/v1".to_string()),
+            ..Default::default()
+        };
+
+        let merged = new_info.merge_with(&stale_info);
+        assert_eq!(merged.url.as_deref(), Some("https://example.com/v2.tar.gz"));
+        assert_eq!(merged.checksum, None);
+        assert_eq!(merged.size, None);
+        assert_eq!(merged.url_api, None);
+
+        // Same artifact (matching URLs) preserves the missing fields.
+        let same_url = PlatformInfo {
+            url: Some("https://example.com/v1.tar.gz".to_string()),
+            ..Default::default()
+        };
+        let merged = same_url.merge_with(&stale_info);
+        assert_eq!(merged.checksum.as_deref(), Some("sha256:OLD"));
+        assert_eq!(merged.size, Some(123));
     }
 
     #[test]

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -857,10 +857,11 @@ impl BuildOpts {
 const UNOFFICIAL_NODE_MIRROR_URL: &str = "https://unofficial-builds.nodejs.org/download/release/";
 
 fn mirror_url_for(node: &crate::config::settings::SettingsNode, filename: &str) -> Url {
-    if node.mirror_url.is_none() && filename.contains("-musl") {
+    let mirror = node.mirror_url();
+    if filename.contains("-musl") && mirror.as_str() == DEFAULT_NODE_MIRROR_URL {
         return Url::parse(UNOFFICIAL_NODE_MIRROR_URL).unwrap();
     }
-    node.mirror_url()
+    mirror
 }
 
 fn os() -> &'static str {

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -260,13 +260,14 @@ impl NodePlugin {
         let tarball_name = tarball.file_name().unwrap().to_string_lossy().to_string();
         let shasums_file = tarball.parent().unwrap().join("SHASUMS256.txt");
         HTTP.download_file(
-            self.shasums_url(version)?,
+            self.shasums_url(version, &tarball_name)?,
             &shasums_file,
             Some(ctx.pr.as_ref()),
         )
         .await?;
         if Settings::get().node.gpg_verify != Some(false) && version.starts_with("2") {
-            self.verify_with_gpg(ctx, &shasums_file, version).await?;
+            self.verify_with_gpg(ctx, &shasums_file, version, &tarball_name)
+                .await?;
         }
         let shasums = file::read_to_string(&shasums_file)?;
         let shasums = hash::parse_shasums(&shasums);
@@ -279,13 +280,14 @@ impl NodePlugin {
         ctx: &InstallContext,
         shasums_file: &Path,
         v: &str,
+        tarball_name: &str,
     ) -> Result<()> {
         if file::which_non_pristine("gpg").is_none() && Settings::get().node.gpg_verify.is_none() {
             warn!("gpg not found, skipping verification");
             return Ok(());
         }
         let sig_file = shasums_file.with_extension("asc");
-        let sig_url = format!("{}.sig", self.shasums_url(v)?);
+        let sig_url = format!("{}.sig", self.shasums_url(v, tarball_name)?);
         if let Err(e) = HTTP
             .download_file(sig_url, &sig_file, Some(ctx.pr.as_ref()))
             .await
@@ -408,13 +410,11 @@ impl NodePlugin {
             .execute()
     }
 
-    fn shasums_url(&self, v: &str) -> Result<Url> {
+    fn shasums_url(&self, v: &str, tarball_name: &str) -> Result<Url> {
         // let url = MISE_NODE_MIRROR_URL.join(&format!("v{v}/SHASUMS256.txt.asc"))?;
         let settings = Settings::get();
-        let url = settings
-            .node
-            .mirror_url()
-            .join(&format!("v{v}/SHASUMS256.txt"))?;
+        let url =
+            mirror_url_for(&settings.node, tarball_name).join(&format!("v{v}/SHASUMS256.txt"))?;
         Ok(url)
     }
 
@@ -671,10 +671,9 @@ impl Backend for NodePlugin {
             format!("{slug}.tar.gz")
         };
 
-        // Use Node.js mirror URL to construct download URL
-        let url = settings
-            .node
-            .mirror_url()
+        // Use Node.js mirror URL to construct download URL.
+        // Musl tarballs live on unofficial-builds, not nodejs.org/dist.
+        let url = mirror_url_for(&settings.node, &filename)
             .join(&format!("v{version}/{filename}"))
             .map_err(|e| eyre::eyre!("Failed to construct Node.js download URL: {e}"))?;
 
@@ -725,18 +724,16 @@ impl Backend for NodePlugin {
             format!("{slug}.tar.gz")
         };
 
-        // Build download URL
-        let url = settings
-            .node
-            .mirror_url()
+        // Build download URL. Musl tarballs live on unofficial-builds; pick the
+        // mirror once and use it for both the tarball URL and SHASUMS so the
+        // recorded checksum matches the recorded URL.
+        let mirror = mirror_url_for(&settings.node, &filename);
+        let url = mirror
             .join(&format!("v{version}/{filename}"))
             .map_err(|e| eyre::eyre!("Failed to construct Node.js download URL: {e}"))?;
 
         // Fetch SHASUMS256.txt to get checksum without downloading the tarball
-        let shasums_url = settings
-            .node
-            .mirror_url()
-            .join(&format!("v{version}/SHASUMS256.txt"))?;
+        let shasums_url = mirror.join(&format!("v{version}/SHASUMS256.txt"))?;
         let checksum = fetch_checksum_from_shasums(shasums_url.as_str(), &filename).await;
 
         Ok(PlatformInfo {
@@ -845,14 +842,25 @@ impl BuildOpts {
                 .join(&format!("v{v}/{source_tarball_name}"))?,
             source_tarball_name,
             binary_tarball_path: tv.download_path().join(&binary_tarball_name),
-            binary_tarball_url: settings
-                .node
-                .mirror_url()
+            binary_tarball_url: mirror_url_for(&settings.node, &binary_tarball_name)
                 .join(&format!("v{v}/{binary_tarball_name}"))?,
             binary_tarball_name,
             install_path,
         })
     }
+}
+
+/// `nodejs.org/dist` does not host musl tarballs; they live at unofficial-builds.
+/// When a filename references a musl artifact and the user has not explicitly set
+/// `node.mirror_url`, route URL construction (and the matching `SHASUMS256.txt`)
+/// to the unofficial-builds host so the URL and checksum stay consistent.
+const UNOFFICIAL_NODE_MIRROR_URL: &str = "https://unofficial-builds.nodejs.org/download/release/";
+
+fn mirror_url_for(node: &crate::config::settings::SettingsNode, filename: &str) -> Url {
+    if node.mirror_url.is_none() && filename.contains("-musl") {
+        return Url::parse(UNOFFICIAL_NODE_MIRROR_URL).unwrap();
+    }
+    node.mirror_url()
 }
 
 fn os() -> &'static str {
@@ -892,4 +900,38 @@ struct NodeVersion {
     version: String,
     date: Option<String>,
     files: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::SettingsNode;
+
+    #[test]
+    fn test_mirror_url_for_routes_musl_to_unofficial_builds() {
+        let node = SettingsNode::default();
+        let url = mirror_url_for(&node, "node-v24.14.0-linux-x64-musl.tar.gz");
+        assert_eq!(url.as_str(), UNOFFICIAL_NODE_MIRROR_URL);
+    }
+
+    #[test]
+    fn test_mirror_url_for_keeps_default_for_glibc() {
+        let node = SettingsNode::default();
+        let url = mirror_url_for(&node, "node-v24.14.0-linux-x64.tar.gz");
+        assert_eq!(url.as_str(), DEFAULT_NODE_MIRROR_URL);
+    }
+
+    #[test]
+    fn test_mirror_url_for_respects_explicit_mirror() {
+        // If the user has a custom mirror, route everything through it —
+        // they may be using a corporate mirror that does host musl builds.
+        let node = SettingsNode {
+            mirror_url: Some("https://corp.example/node/".to_string()),
+            ..Default::default()
+        };
+        let glibc = mirror_url_for(&node, "node-v24.14.0-linux-x64.tar.gz");
+        let musl = mirror_url_for(&node, "node-v24.14.0-linux-x64-musl.tar.gz");
+        assert_eq!(glibc.as_str(), "https://corp.example/node/");
+        assert_eq!(musl.as_str(), "https://corp.example/node/");
+    }
 }


### PR DESCRIPTION
## Summary

[PR #9404](https://github.com/jdx/mise/pull/9404) (`feat(backend): add global libc preference`) taught Node's slug builder to append `-musl` for musl targets but kept routing through `nodejs.org/dist/`, which does not host musl tarballs (they live at `unofficial-builds.nodejs.org`). The visible symptom was in [PR #9396](https://github.com/jdx/mise/pull/9396)'s `mise.lock` diff: the URL gained a `-musl` suffix while the checksum stayed pinned to the original glibc tarball.

```toml
[tools.node."platforms.linux-x64-musl"]
checksum = "sha256:dbf5b8665..."   # ← still the glibc checksum
url = ".../v24.14.0/node-v24.14.0-linux-x64-musl.tar.gz"   # ← 404, wrong host
```

Mechanically: `resolve_lock_info` builds a 404'ing URL on `nodejs.org/dist`, fetches the wrong `SHASUMS256.txt` (which doesn't list `-musl.tar.gz`), gets `None` back, and the lockfile merge preserves the **stale glibc checksum** alongside the new URL. Anyone running `mise install` against that lockfile on a musl system would either 404 or hit a checksum mismatch.

The aqua/github-backed tools in the same release diff updated cleanly because their checksum source rotates with the artifact. Node is unique in fetching checksums from a separate `SHASUMS256.txt`.

## Changes

### `src/plugins/core/node.rs`

Add `mirror_url_for(&SettingsNode, filename)` that swaps to `https://unofficial-builds.nodejs.org/download/release/` when a filename references a musl artifact and the user has not set a custom `node.mirror_url`. Wire it into `resolve_lock_info`, `get_tarball_url`, `BuildOpts::new`, and `shasums_url` so the tarball URL and the matching `SHASUMS256.txt` always come from the same host. Three unit tests cover routing (default → glibc, musl → unofficial-builds, custom mirror passes through unchanged).

### `src/lockfile.rs`

Defense in depth: when merging `PlatformInfo` (both in `set_platform_info` and `merge_with`), drop the other side's `checksum`/`size`/`url_api` if URLs disagree — those fields describe a specific artifact and become stale once the URL changes. The pre-existing `test_platform_info_merge_prefers_sha256` was asserting that sha256 should win even across mismatched URLs, which is exactly the latent bug; updated it to use a shared URL and added `test_platform_info_merge_drops_stale_checksum_on_url_change`.

### `mise.lock`

Re-ran `mise lock node` to fix the three corrupted node musl entries. Checksums verified against upstream:

```sh
$ curl -fsSL https://unofficial-builds.nodejs.org/download/release/v24.14.0/SHASUMS256.txt | grep -E "linux-(arm64|x64)-musl\.tar\.gz"
8f81d47b7f...  node-v24.14.0-linux-arm64-musl.tar.gz
bae0f23204...  node-v24.14.0-linux-x64-musl.tar.gz
```

Both match what mise now writes.

## Test plan

- [x] `cargo test` — 778 passed, 0 failed (includes 3 new node tests + 1 new lockfile test, plus an updated test that previously asserted the latent bug).
- [x] `cargo clippy --all-features --tests` — clean.
- [x] `cargo fmt` — clean.
- [x] `mise lock node` against this branch produces correct URLs + checksums for all three node musl platform variants.
- [ ] Install on Alpine / musl host: `MISE_LIBC=musl mise install node@24.14.0` should download from `unofficial-builds.nodejs.org` and run.
- [ ] Glibc regression: same flow without `MISE_LIBC=musl` should still hit `nodejs.org/dist`.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Node.js download/checksum URL selection and lockfile merge behavior, which can affect installs and lockfile correctness across platforms; scope is contained with added tests.
> 
> **Overview**
> Fixes Node.js *musl* installs/lock resolution by routing musl tarball URLs (and their matching `SHASUMS256.txt`/signature URLs) to `unofficial-builds.nodejs.org` when using the default mirror, while still respecting user-configured `node.mirror_url`.
> 
> Hardens lockfile merging so when a platform artifact `url` changes, stale artifact-bound fields (`checksum`, `size`, `url_api`) from the other side are dropped instead of preserved, preventing mismatched URL+checksum pairs.
> 
> Regenerates `mise.lock` Node musl entries to use the unofficial-builds URLs with updated sha256 checksums, and adds/updates unit tests covering the new mirror routing and merge semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd687075ea88db5bca8826c3326dc3692b415d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->