### PR TITLE
fix(install): stop rewriting healthy runtime symlinks

### DIFF
--- a/e2e/cli/test_install_system_readonly
+++ b/e2e/cli/test_install_system_readonly
@@ -24,25 +24,27 @@ assert "readlink $SYSTEM_INSTALLS/tiny/latest" "./2.1.0"
 chmod -R a-w "$SYSTEM_INSTALLS"
 trap 'chmod -R u+w "$SYSTEM_INSTALLS" 2>/dev/null || true' EXIT
 
+assert_silent_install() {
+	local out
+	if ! out="$($1 2>&1)"; then
+		echo "$out"
+		fail "[$1] command failed"
+	fi
+	echo "$out"
+	if [[ $out == *"skipping symlink update"* || $out == *"Permission denied"* || $out == *"failed rm"* ]]; then
+		fail "[$1] unexpected system-dir warning during install"
+	fi
+}
+
 # Re-installing a tool that lives only in the user dir must succeed without
 # any warning about the system dir — the system-side runtime symlink already
 # matches the desired state, so nothing should be written or attempted there.
-out="$(mise install --force tiny@1.0.0 2>&1)"
-echo "$out"
-if [[ $out == *"skipping symlink update"* || $out == *"Permission denied"* || $out == *"failed rm"* ]]; then
-	echo "FAIL: unexpected system-dir warning during install"
-	exit 1
-fi
+assert_silent_install "mise install --force tiny@1.0.0"
 assert "readlink $USER_INSTALLS/tiny/latest" "./1.0.0"
 assert "readlink $SYSTEM_INSTALLS/tiny/latest" "./2.1.0"
 
 # Installing a different tool that doesn't touch the system dir at all must
 # also succeed silently.
-out="$(mise install dummy@1.0.0 2>&1)"
-echo "$out"
-if [[ $out == *"skipping symlink update"* || $out == *"Permission denied"* || $out == *"failed rm"* ]]; then
-	echo "FAIL: unexpected system-dir warning during install"
-	exit 1
-fi
+assert_silent_install "mise install dummy@1.0.0"
 assert_directory_exists "$USER_INSTALLS/dummy/1.0.0"
 assert "readlink $SYSTEM_INSTALLS/tiny/latest" "./2.1.0"

--- a/e2e/cli/test_install_system_readonly
+++ b/e2e/cli/test_install_system_readonly
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression test for the read-only system installs dir scenario:
+# When tools are installed in a system dir that the current user cannot
+# write to (e.g. a Docker image where root installed at build time and a
+# non-root user runs `mise install` at runtime), `mise install` of an
+# unrelated tool must NOT try to rewrite the system dir's runtime symlinks.
+# https://github.com/jdx/mise/discussions/8596
+
+export MISE_SYSTEM_DATA_DIR="$HOME/.local/share/mise-system"
+SYSTEM_INSTALLS="$MISE_SYSTEM_DATA_DIR/installs"
+USER_INSTALLS="$MISE_DATA_DIR/installs"
+
+# Install one version to user dir and another to "system" dir.
+mise install tiny@1.0.0
+mise install --system tiny@2.1.0
+
+# Sanity: both got their `latest` symlinks.
+assert "readlink $USER_INSTALLS/tiny/latest" "./1.0.0"
+assert "readlink $SYSTEM_INSTALLS/tiny/latest" "./2.1.0"
+
+# Drop write access to the system dir to simulate the "root-owned, non-root
+# runtime" Docker pattern. Trap restores write access so the harness can
+# clean up the test dir.
+chmod -R a-w "$SYSTEM_INSTALLS"
+trap 'chmod -R u+w "$SYSTEM_INSTALLS" 2>/dev/null || true' EXIT
+
+# Re-installing a tool that lives only in the user dir must succeed without
+# any warning about the system dir — the system-side runtime symlink already
+# matches the desired state, so nothing should be written or attempted there.
+out="$(mise install --force tiny@1.0.0 2>&1)"
+echo "$out"
+if [[ $out == *"skipping symlink update"* || $out == *"Permission denied"* || $out == *"failed rm"* ]]; then
+	echo "FAIL: unexpected system-dir warning during install"
+	exit 1
+fi
+assert "readlink $USER_INSTALLS/tiny/latest" "./1.0.0"
+assert "readlink $SYSTEM_INSTALLS/tiny/latest" "./2.1.0"
+
+# Installing a different tool that doesn't touch the system dir at all must
+# also succeed silently.
+out="$(mise install dummy@1.0.0 2>&1)"
+echo "$out"
+if [[ $out == *"skipping symlink update"* || $out == *"Permission denied"* || $out == *"failed rm"* ]]; then
+	echo "FAIL: unexpected system-dir warning during install"
+	exit 1
+fi
+assert_directory_exists "$USER_INSTALLS/dummy/1.0.0"
+assert "readlink $SYSTEM_INSTALLS/tiny/latest" "./2.1.0"

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -72,7 +72,7 @@ fn rebuild_symlinks_in_dir(
             } else if from
                 .file_name()
                 .zip(to.file_name())
-                .is_some_and(|(from_name, to_name)| from_name != to_name)
+                .is_some_and(|(f, t)| f != t)
                 && !concrete_installs.contains(&from_name)
             {
                 // Real (non-symlink) directory at a runtime-symlink slot —

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -14,34 +14,8 @@ use versions::Versioning;
 
 pub async fn rebuild(config: &Config) -> Result<()> {
     for backend in backend::list() {
-        let ba = backend.ba();
-        // Collect all install directories for this backend: user dir + shared/system dirs
-        let mut installs_dirs = vec![ba.installs_path.clone()];
-        let tool_dir_name = ba.tool_dir_name();
-        for shared_dir in env::shared_install_dirs() {
-            let dir = shared_dir.join(&tool_dir_name);
-            if dir.is_dir() && !installs_dirs.contains(&dir) {
-                installs_dirs.push(dir);
-            }
-        }
-
-        // Process user dir (first entry) with normal error propagation
-        if let Some(installs_dir) = installs_dirs.first() {
-            rebuild_symlinks_in_dir(config, &backend, installs_dir)?;
-        }
-        // Process shared/system dirs with permission error tolerance
-        for installs_dir in installs_dirs.iter().skip(1) {
-            if let Err(e) = rebuild_symlinks_in_dir(config, &backend, installs_dir) {
-                if is_permission_error(&e) {
-                    warn!(
-                        "skipping symlink update for {}: {}",
-                        installs_dir.display(),
-                        e
-                    );
-                } else {
-                    return Err(e);
-                }
-            }
+        for installs_dir in install_dirs_for(&backend) {
+            rebuild_symlinks_in_dir(config, &backend, &installs_dir)?;
         }
     }
     Ok(())
@@ -49,34 +23,29 @@ pub async fn rebuild(config: &Config) -> Result<()> {
 
 pub async fn migrate_real_dirs(config: &Config) -> Result<()> {
     for backend in backend::list() {
-        let ba = backend.ba();
-        let mut installs_dirs = vec![ba.installs_path.clone()];
-        let tool_dir_name = ba.tool_dir_name();
-        for shared_dir in env::shared_install_dirs() {
-            let dir = shared_dir.join(&tool_dir_name);
-            if dir.is_dir() && !installs_dirs.contains(&dir) {
-                installs_dirs.push(dir);
-            }
-        }
-
-        if let Some(installs_dir) = installs_dirs.first() {
-            migrate_real_dirs_in_dir(config, &backend, installs_dir)?;
-        }
-        for installs_dir in installs_dirs.iter().skip(1) {
-            if let Err(e) = migrate_real_dirs_in_dir(config, &backend, installs_dir) {
-                if is_permission_error(&e) {
-                    warn!(
-                        "skipping runtime symlink migration for {}: {}",
-                        installs_dir.display(),
-                        e
-                    );
-                } else {
-                    return Err(e);
-                }
-            }
+        for installs_dir in install_dirs_for(&backend) {
+            migrate_real_dirs_in_dir(config, &backend, &installs_dir)?;
         }
     }
     Ok(())
+}
+
+/// All install directories to consider for a backend: the backend's primary
+/// installs_path plus any shared/system dirs that contain the tool. Per-dir
+/// rebuilds are no-ops when desired state already matches actual state, so
+/// dirs we have no write access to (read-only system installs) only error
+/// out when we actually need to change something there.
+fn install_dirs_for(backend: &Arc<dyn Backend>) -> Vec<PathBuf> {
+    let ba = backend.ba();
+    let mut dirs = vec![ba.installs_path.clone()];
+    let tool_dir_name = ba.tool_dir_name();
+    for shared_dir in env::shared_install_dirs() {
+        let dir = shared_dir.join(&tool_dir_name);
+        if dir.is_dir() && !dirs.contains(&dir) {
+            dirs.push(dir);
+        }
+    }
+    dirs
 }
 
 fn rebuild_symlinks_in_dir(
@@ -93,8 +62,11 @@ fn rebuild_symlinks_in_dir(
         let from_name = from.clone();
         let from = installs_dir.join(from);
         if from.exists() {
-            if is_runtime_symlink(&from) && file::resolve_symlink(&from)?.unwrap_or_default() != to
-            {
+            if is_runtime_symlink(&from) {
+                // Existing runtime symlink: only rewrite if the target changed.
+                if file::resolve_symlink(&from)?.unwrap_or_default() == to {
+                    continue;
+                }
                 trace!("Removing existing symlink: {}", from.display());
                 file::remove_file(&from)?;
             } else if from
@@ -103,6 +75,8 @@ fn rebuild_symlinks_in_dir(
                 .is_some_and(|(from_name, to_name)| from_name != to_name)
                 && !concrete_installs.contains(&from_name)
             {
+                // Real (non-symlink) directory at a runtime-symlink slot —
+                // legacy stale state from the 2026.4 regression. Replace it.
                 trace!("Replacing stale runtime dir: {}", from.display());
                 file::remove_all(&from)?;
             } else {
@@ -136,19 +110,6 @@ fn migrate_real_dirs_in_dir(
         make_symlink_or_file(&to, &from)?;
     }
     Ok(())
-}
-
-fn is_permission_error(e: &eyre::Report) -> bool {
-    e.chain().any(|cause| {
-        cause
-            .downcast_ref::<std::io::Error>()
-            .is_some_and(|io_err| {
-                matches!(
-                    io_err.kind(),
-                    std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
-                )
-            })
-    })
 }
 
 /// Build symlinks for versions found in a specific install directory.


### PR DESCRIPTION
## Summary

Fixes the `mise install` regression where a non-root user gets `Permission denied` while rebuilding runtime symlinks against a read-only system installs dir (typical Docker pattern: root populates `/usr/local/share/mise/installs/` at build time, non-root user runs `mise install` at runtime). Reported in [#8596](https://github.com/jdx/mise/discussions/8596) and addressed by [#9408](https://github.com/jdx/mise/pull/9408) — this PR is an alternative.

## Root cause

`rebuild_symlinks_in_dir` always called `remove_all` + `make_symlink_or_file` on every existing runtime symlink, because the "stale runtime dir" branch fired for symlinks too:

```rust
if from.exists() {
    if is_runtime_symlink(&from) && file::resolve_symlink(&from)?.unwrap_or_default() != to {
        // Branch 1 — only fires when the symlink target is wrong
        ...
    } else if from.file_name() != to.file_name() && !concrete_installs.contains(&from_name) {
        // Branch 2 — fires for ANY symlink because file_name("latest") != file_name("22.5.0")
        file::remove_all(&from)?;
    }
    ...
}
```

For a perfectly healthy `latest -> ./22.5.0`:

- Branch 1 fails (`target == to`).
- Branch 2 enters because `from.file_name()` (`"latest"`) differs from `to.file_name()` (`"22.5.0"`) and `concrete_installs` doesn't include `"latest"`.
- `remove_all` then runs on a healthy symlink — wasted I/O on every install in the common case, hard failure when the dir is read-only.

## Fix

- Branch 1 now handles all runtime-symlink cases: rewrite if target differs, otherwise `continue`.
- Branch 2 only fires for non-symlink stale dirs (its actual purpose — cleanup for the 2026.4 regression that created real `latest/` directories).
- Drop the position-based permission tolerance added in #8722. With healthy symlinks taking the no-op path, read-only system dirs aren't touched at all. If a write IS genuinely required and can't happen, fail loudly so the user knows to fix permissions rather than silently ending up with a stale `latest` after `mise install --system`.

## Why not [#9408](https://github.com/jdx/mise/pull/9408)

That PR replaces position-based tolerance with category-based tolerance (any non-`Local` dir gets permission errors swallowed) and silently skips system/shared installs from user shims. Both:

- Mask the real bug (the false-positive `remove_all` above) instead of fixing it. Even with category-based tolerance the install does I/O it shouldn't, just hidden under a `debug!`.
- Trade one form of silent behavior for another. Reviewers (greptile, gemini) flagged the shims change as a regression for the "root installs once, all users get shims" pattern.
- Don't match the maintainer's stated policy: if `mise install` doesn't touch system tools, it should work fine; if it does and the dir isn't writable, it should fail loudly. This PR achieves both via a delta-based no-op rather than tolerance.

## Tests

- `e2e/cli/test_install_system_readonly` — sets up `tiny@1.0.0` in user dir, `tiny@2.1.0` in a fake system dir, `chmod -R a-w` the system dir, then runs `mise install --force tiny@1.0.0` and `mise install dummy@1.0.0`. Asserts both succeed AND that the `skipping symlink update` / `Permission denied` / `failed rm` warnings do NOT appear in output. Verified to fail before this fix (with `WARN skipping symlink update for ...: failed rm -rf ... Permission denied`) and pass after.

## Test plan

- [x] `cargo test --bin mise` — 774 pass
- [x] `mise run lint-fix` — clean
- [x] `mise run test:e2e test_install_system_readonly` — pass
- [x] `mise run test:e2e test_install_system test_shared_install_dirs test_install_before_ignores_stale_latest_dirs test_upgrade_latest_stale test_reshim_with_shims_on_path test_uninstall test_install_before test_install_short_ignores_full_backend_config test_install_dry_run test_install_concurrent_via_exec` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime symlink rebuild behavior across both user and shared/system install dirs, which could affect installs/reshims if edge cases exist. It also removes permission-error swallowing for shared dirs, so genuine mismatches in read-only system installs will now fail loudly.
> 
> **Overview**
> Prevents `mise install` from rewriting existing runtime symlinks when they already point at the desired target, avoiding unnecessary deletes/recreates that previously caused `Permission denied` failures on read-only system install directories.
> 
> Refactors shared/system install-dir enumeration into `install_dirs_for` and removes the prior "skip on permission error" behavior; shared/system dirs are now treated like user dirs, but the rebuild path should be a no-op unless a change is actually needed. Adds an E2E regression test (`test_install_system_readonly`) that simulates a read-only system installs dir and asserts installs succeed without system-dir warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf5798e39ab0b36076a89aeb3e290f4802493c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->