### PR TITLE
fix(release): purge mise.en.dev CDN zone after each S3 publish

### DIFF
--- a/scripts/publish-s3.sh
+++ b/scripts/publish-s3.sh
@@ -50,14 +50,21 @@ aws s3 cp artifacts/deb/dists/ "s3://$AWS_S3_BUCKET/deb/dists/" --cache-control 
 
 export CLOUDFLARE_ACCOUNT_ID=6e243906ff257b965bcae8025c2fc344
 
-# jdx.dev
-curl --fail-with-body -X POST "https://api.cloudflare.com/client/v4/zones/90dfd7997bdcfa8579c52d8ee8dd4cd1/purge_cache" \
-	-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-	-H "Content-Type: application/json" \
-	--data '{ "purge_everything": true }'
-
-# mise.run
-curl --fail-with-body -X POST "https://api.cloudflare.com/client/v4/zones/782fc08181b7bbd26c529a00df52a277/purge_cache" \
-	-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-	-H "Content-Type: application/json" \
-	--data '{ "purge_everything": true }'
+# Purge every CDN zone that fronts the release artifacts. install.sh and
+# install.sh.minisig are uploaded with `immutable` cache-control, so without
+# an explicit purge per zone the CDN keeps serving the previous release's
+# bytes while a sibling zone serves the new ones — which is how mise.en.dev
+# ended up serving v(N-1)/install.sh next to a v(N) install.sh.minisig.
+ZONES=(
+	"jdx.dev:90dfd7997bdcfa8579c52d8ee8dd4cd1"
+	"en.dev:531d003297f1f4ae2415b41f7f5da8fa"
+	"mise.run:782fc08181b7bbd26c529a00df52a277"
+)
+for entry in "${ZONES[@]}"; do
+	IFS=":" read -r HOST ZONE_ID <<<"$entry"
+	echo "Purging CDN cache for $HOST (zone=$ZONE_ID)"
+	curl --fail-with-body -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/purge_cache" \
+		-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+		-H "Content-Type: application/json" \
+		--data '{ "purge_everything": true }'
+done


### PR DESCRIPTION
## Summary

Add `mise.en.dev` to the list of Cloudflare zones purged at the end of `scripts/publish-s3.sh`. Previously only `jdx.dev` and `mise.run` were being purged.

## Why

`install.sh` and `install.sh.minisig` are uploaded to S3 with `cache-control: max-age=86400,s-maxage=86400,public,immutable`. Without an explicit purge per CDN zone, each zone keeps serving the previous release's bytes for up to 24 hours — even after S3 has the new bytes.

Since #9411 made `mise.en.dev` the canonical bootstrap host (used by `mise generate tool-stub --bootstrap` and `mise generate bootstrap`), this manifested as: `mise.en.dev/install.sh` serving the v(N-1) script next to a v(N) `install.sh.minisig`, causing minisign verification to fail. Caught today as recurring CI failures on [jdx/mise#9414](https://github.com/jdx/mise/pull/9414) (e2e-0 / e2e-1).

The other half — that `scripts/update-redirect.sh` was deleted in #9411 — turned out not to be related; that script only updated a `mise-latest-*` redirect rule, not the install.sh path. The real issue is just the missing purge.

## Test plan

- [x] Bash syntax check (`bash -n scripts/publish-s3.sh`)
- [x] Verified the en.dev zone ID `531d003297f1f4ae2415b41f7f5da8fa` matches the value previously used in the now-deleted `scripts/update-redirect.sh` (commit `68075d866`)
- [ ] On the next release, confirm in the workflow logs that all three purges run, and that `curl https://mise.en.dev/install.sh` returns the new version's content within seconds of the deploy completing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts post-publish CDN cache purging logic to include an additional zone and reduce duplication; no changes to artifact generation or upload behavior.
> 
> **Overview**
> After publishing release artifacts to S3, `scripts/publish-s3.sh` now purges Cloudflare cache for **all** relevant CDN zones via a looped `ZONES` list, adding the missing `en.dev`/`mise.en.dev` zone.
> 
> This replaces the two hardcoded purge calls with a single per-zone purge step to prevent mixed-version `install.sh`/signature artifacts being served from different zones under `immutable` caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e08335865d7df1d6268b6852d1952497aa3cee3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->