### PR TITLE
docs: prefix GitHub star count with ★ glyph

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -231,6 +231,12 @@
   line-height: 1;
 }
 
+.VPSocialLinks .star-count .star-glyph {
+  font-family: -apple-system, "Segoe UI Symbol", sans-serif;
+  line-height: 1;
+  margin-right: 0.2em;
+}
+
 .VPSocialLinks a[href*="github.com/jdx/mise"]:hover .star-count {
   color: var(--vp-c-brand-1);
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -25,8 +25,12 @@ export default {
         if (githubLink && !githubLink.querySelector(".star-count")) {
           const starBadge = document.createElement("span");
           starBadge.className = "star-count";
-          starBadge.textContent = `★ ${starsData.stars}`;
           starBadge.title = "GitHub Stars";
+          const glyph = document.createElement("span");
+          glyph.className = "star-glyph";
+          glyph.textContent = "★";
+          glyph.setAttribute("aria-hidden", "true");
+          starBadge.append(glyph, starsData.stars);
           githubLink.appendChild(starBadge);
         }
       };

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -25,7 +25,7 @@ export default {
         if (githubLink && !githubLink.querySelector(".star-count")) {
           const starBadge = document.createElement("span");
           starBadge.className = "star-count";
-          starBadge.innerHTML = starsData.stars;
+          starBadge.textContent = `★ ${starsData.stars}`;
           starBadge.title = "GitHub Stars";
           githubLink.appendChild(starBadge);
         }


### PR DESCRIPTION
Adds a small ★ (U+2605) before the GitHub stargazer count in the top-nav social link, so it reads "★ 27.2k" instead of just "27.2k".

While here, switches the star badge from `innerHTML` to `textContent` — no behavior change for a plain-string value, slightly safer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, docs-theme-only UI tweak that just adjusts rendered text/CSS for the GitHub star badge and slightly hardens DOM insertion against HTML injection.
> 
> **Overview**
> Updates the docs nav GitHub social link star badge to render as `★ <count>` by inserting a dedicated `.star-glyph` span before the star count.
> 
> Adds styling for the glyph in `custom.css` and switches the badge population away from `innerHTML` to DOM nodes/text content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 305c2e3c15f7a51de1cacd8601e96b5630bc2025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->