### PR TITLE
fix(Dockerfile): install copr-cli via dnf for better dependency management

### DIFF
--- a/packaging/copr/Dockerfile
+++ b/packaging/copr/Dockerfile
@@ -15,8 +15,8 @@ RUN dnf update -y && \
         gzip && \
     dnf clean all
 
-# Install copr-cli
-RUN pip3 install copr-cli
+# Install copr-cli via dnf to ensure dependencies are properly managed and to avoid potential issues with manual installation
+RUN dnf install copr-cli
 
 # Add mise to PATH
 ENV PATH="/root/.local/bin:${PATH}"

--- a/packaging/copr/Dockerfile
+++ b/packaging/copr/Dockerfile
@@ -16,7 +16,8 @@ RUN dnf update -y && \
     dnf clean all
 
 # Install copr-cli via dnf to ensure dependencies are properly managed and to avoid potential issues with manual installation
-RUN dnf install copr-cli
+RUN dnf install -y copr-cli && \
+    dnf clean all
 
 # Add mise to PATH
 ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
fix publish-copr workflow error ModuleNotFoundError: No module named 'rich'

https://github.com/jdx/mise/actions/runs/24938182716/job/73027289974