### PR TITLE
[codex] add sponsor feed to docs

### DIFF
--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -1,0 +1,122 @@
+<template>
+  <section
+    v-if="sponsors.length"
+    aria-labelledby="endev-sponsors-title"
+    class="EndevSponsors"
+  >
+    <div class="EndevSponsorsInner">
+      <p id="endev-sponsors-title" class="EndevSponsorsTitle">
+        Company sponsors
+      </p>
+      <div class="EndevSponsorsLogos">
+        <a
+          v-for="sponsor in sponsors"
+          :key="sponsor.name"
+          :aria-label="sponsor.name"
+          class="EndevSponsorsLogo"
+          :href="sponsor.url"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <img :alt="sponsor.name" :src="sponsor.logo" />
+        </a>
+      </div>
+      <a class="EndevSponsorsCta" href="https://en.dev/#contact">
+        Sponsor the work
+      </a>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { onMounted, ref } from "vue";
+
+const sponsors = ref([]);
+
+onMounted(async () => {
+  try {
+    const res = await fetch("https://en.dev/sponsors.json", {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return;
+
+    const payload = await res.json();
+    sponsors.value = (Array.isArray(payload.sponsors) ? payload.sponsors : [])
+      .filter((sponsor) =>
+        sponsor?.kind !== "infrastructure" &&
+        sponsor?.name &&
+        sponsor?.url &&
+        sponsor?.logo
+      );
+  } catch {
+    sponsors.value = [];
+  }
+});
+</script>
+
+<style scoped>
+.EndevSponsors {
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 22px 24px;
+}
+
+.EndevSponsorsInner {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 960px;
+}
+
+.EndevSponsorsTitle {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.EndevSponsorsLogos {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.EndevSponsorsLogo {
+  align-items: center;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  display: inline-flex;
+  height: 40px;
+  justify-content: center;
+  padding: 8px 12px;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.EndevSponsorsLogo:hover {
+  background: var(--vp-c-bg-soft);
+  border-color: var(--vp-c-brand-1);
+}
+
+.EndevSponsorsLogo img {
+  display: block;
+  max-height: 22px;
+  max-width: 120px;
+}
+
+.EndevSponsorsCta {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.EndevSponsorsCta:hover {
+  color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -72,6 +72,7 @@
     </template>
 
     <template #layout-bottom>
+      <EndevSponsors />
       <EndevFooter />
     </template>
   </DefaultTheme.Layout>
@@ -81,6 +82,7 @@
 import DefaultTheme from "vitepress/theme";
 import { ref } from "vue";
 import EndevFooter from "./EndevFooter.vue";
+import EndevSponsors from "./EndevSponsors.vue";
 
 const copied = ref(false);
 const installCommand = "curl https://mise.run | sh";


### PR DESCRIPTION
## Summary

Adds an en.dev company sponsor block to the docs footer.

## Changes

- Adds `EndevSponsors.vue`, which fetches `https://en.dev/sponsors.json` client-side.
- Renders the feed's default `sponsors` list, which is paid company sponsors only.
- Places the sponsor block above the existing en.dev footer.

## Validation

- `npm install --no-package-lock --ignore-scripts`
- `npm run docs:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only UI with optional client-side fetch; failures are silent and do not affect site builds or core product behavior.
> 
> **Overview**
> Adds a **company sponsors** strip to the VitePress docs layout, placed **above** the existing en.dev footer on every page.
> 
> A new `EndevSponsors` component loads `https://en.dev/sponsors.json` in the browser after mount, keeps entries that have name/url/logo and are not `kind: "infrastructure"`, and hides the whole section when the list is empty or the request fails. Logos link out with a **Sponsor the work** CTA to en.dev.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb41dcf9e7453eaa5539d352bd9f00522f8e406e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->