### PR TITLE
feat(task): add task.surface_tools setting to surface task tools in project toolset

### DIFF
--- a/e2e/tasks/test_task_surface_tools
+++ b/e2e/tasks/test_task_surface_tools
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Test that task.surface_tools = true makes task tools available in the project toolset
+
+# --- Scenario 1: tool only declared in task, surface_tools = true ---
+cat >mise.toml <<'EOF'
+[settings]
+task.surface_tools = true
+[task_config]
+includes = ["tasks.toml"]
+EOF
+cat >tasks.toml <<'EOF'
+[greet]
+run = "dummy --version"
+tools.dummy = "2.0.0"
+EOF
+
+mise install
+assert_contains "mise ls" "dummy"
+assert_contains "mise ls" "2.0.0"
+assert_contains "mise env" "dummy/2.0.0"
+
+# --- Scenario 2: conflict — [tools] in mise.toml wins ---
+cat >mise.toml <<'EOF'
+[settings]
+task.surface_tools = true
+[tools]
+dummy = "1.0.0"
+[task_config]
+includes = ["tasks.toml"]
+EOF
+
+mise install
+assert_contains "mise ls" "dummy"
+assert_contains "mise env" "dummy/1.0.0"
+assert_not_contains "mise env" "dummy/2.0.0"
+
+# --- Scenario 3: setting off (default) — task tools not in PATH ---
+cat >mise.toml <<'EOF'
+[settings]
+task.surface_tools = false
+[task_config]
+includes = ["tasks.toml"]
+EOF
+
+assert_not_contains "mise env" "dummy"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1587,6 +1587,11 @@
               "description": "Automatically install missing tools when executing tasks.",
               "type": "boolean"
             },
+            "surface_tools": {
+              "default": false,
+              "description": "Surface tools declared in task `tools` fields as project-level tools, installing them with `mise install` and adding them to the shell PATH. Tools in `[tools]` in mise.toml take priority on version conflicts.",
+              "type": "boolean"
+            },
             "show_full_cmd": {
               "description": "Disable truncation of command lines in task execution output. When true, the full command line will be shown.",
               "type": "boolean"

--- a/settings.toml
+++ b/settings.toml
@@ -2169,6 +2169,12 @@ description = "Automatically install missing tools when executing tasks."
 env = "MISE_TASK_RUN_AUTO_INSTALL"
 type = "Bool"
 
+[task.surface_tools]
+default = false
+description = "Surface tools declared in task `tools` fields as project-level tools, installing them with `mise install` and adding them to the shell PATH. Tools in `[tools]` in mise.toml take priority on version conflicts."
+env = "MISE_TASK_SURFACE_TOOLS"
+type = "Bool"
+
 [task.show_full_cmd]
 description = "Disable truncation of command lines in task execution output. When true, the full command line will be shown."
 env = "MISE_TASK_SHOW_CMD_NO_TRUNC"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2307,7 +2307,7 @@ fn is_glob_pattern(pattern: &str) -> bool {
 }
 
 /// Expand a task include pattern (which may be a glob) to a list of paths
-fn expand_task_include(dir: &Path, pattern: &str) -> Vec<PathBuf> {
+pub(crate) fn expand_task_include(dir: &Path, pattern: &str) -> Vec<PathBuf> {
     if is_glob_pattern(pattern) {
         match glob(dir, pattern) {
             Ok(paths) => paths,

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -4,11 +4,12 @@ use eyre::Result;
 use itertools::Itertools;
 
 use crate::cli::args::{BackendArg, ToolArg};
-use crate::config::{Config, ConfigMap};
+use crate::config::config_file::mise_toml::Tasks;
+use crate::config::{Config, ConfigMap, Settings, expand_task_include};
 use crate::env_diff::EnvMap;
 use crate::errors::Error;
 use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, Toolset};
-use crate::{config, env};
+use crate::{config, env, file};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigScope {
@@ -65,6 +66,9 @@ impl ToolsetBuilder {
         let mut toolset = Toolset {
             ..Default::default()
         };
+        measure!("toolset_builder::build::load_task_tools", {
+            self.load_task_tools(config, &mut toolset)?;
+        });
         measure!("toolset_builder::build::load_config_files", {
             self.load_config_files(config, &mut toolset)?;
         });
@@ -88,6 +92,72 @@ impl ToolsetBuilder {
 
         time!("toolset::builder::build");
         Ok(toolset)
+    }
+
+    /// Load tools declared in task `tools` fields as the lowest-priority layer.
+    /// Only runs when `settings.task.surface_tools = true`.
+    /// Reads task TOML files directly to avoid a circular dependency:
+    /// task.render() → tera_ctx() → config.get_toolset() → get_tool_request_set().
+    fn load_task_tools(&self, config: &Arc<Config>, ts: &mut Toolset) -> eyre::Result<()> {
+        if !Settings::get().task.surface_tools {
+            return Ok(());
+        }
+        if self.scope == ConfigScope::GlobalOnly {
+            return Ok(());
+        }
+        let config_files = self.config_files.as_ref().unwrap_or(&config.config_files);
+        for cf in config_files.values() {
+            let Some(includes) = cf.task_config().includes.as_ref() else {
+                continue;
+            };
+            let is_global = config::is_global_config(cf.get_path());
+            if self.scope == ConfigScope::LocalOnly && is_global {
+                continue;
+            }
+            let config_root = cf.config_root();
+            for include in includes {
+                if include.starts_with("git::") {
+                    continue;
+                }
+                let paths = expand_task_include(&config_root, include);
+                for path in paths {
+                    if !path.is_file()
+                        || path.extension().map(|e| e != "toml").unwrap_or(true)
+                    {
+                        continue;
+                    }
+                    let raw = match file::read_to_string(&path) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            warn!("surface_tools: failed to read {}: {e}", path.display());
+                            continue;
+                        }
+                    };
+                    let tasks = match toml::from_str::<Tasks>(&raw) {
+                        Ok(t) => t.0,
+                        Err(e) => {
+                            warn!("surface_tools: failed to parse {}: {e}", path.display());
+                            continue;
+                        }
+                    };
+                    let source = ToolSource::MiseToml(path.clone());
+                    let mut file_ts = Toolset::new(source.clone());
+                    for (_name, task) in tasks {
+                        for (tool, version) in &task.tools {
+                            let ba: Arc<BackendArg> = Arc::new(tool.as_str().into());
+                            match ToolRequest::new(ba.clone(), version, source.clone()) {
+                                Ok(tr) => file_ts.add_version(tr),
+                                Err(e) => {
+                                    warn!("surface_tools: invalid tool {tool}@{version}: {e}")
+                                }
+                            }
+                        }
+                    }
+                    ts.merge(file_ts);
+                }
+            }
+        }
+        Ok(())
     }
 
     fn load_config_files(&self, config: &Arc<Config>, ts: &mut Toolset) -> eyre::Result<()> {

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -4,12 +4,12 @@ use eyre::Result;
 use itertools::Itertools;
 
 use crate::cli::args::{BackendArg, ToolArg};
-use crate::config::config_file::mise_toml::Tasks;
 use crate::config::{Config, ConfigMap, Settings, expand_task_include};
 use crate::env_diff::EnvMap;
 use crate::errors::Error;
+use crate::toolset::tool_request_set::task_file_tool_requests;
 use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, Toolset};
-use crate::{config, env, file};
+use crate::{config, env};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigScope {
@@ -115,43 +115,15 @@ impl ToolsetBuilder {
                 continue;
             }
             let config_root = cf.config_root();
-            for include in includes {
-                if include.starts_with("git::") {
-                    continue;
-                }
-                let paths = expand_task_include(&config_root, include);
-                for path in paths {
-                    if !path.is_file()
-                        || path.extension().map(|e| e != "toml").unwrap_or(true)
-                    {
+            for include in includes.iter().filter(|i| !i.starts_with("git::")) {
+                for path in expand_task_include(&config_root, include) {
+                    if !path.is_file() || path.extension().map(|e| e != "toml").unwrap_or(true) {
                         continue;
                     }
-                    let raw = match file::read_to_string(&path) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            warn!("surface_tools: failed to read {}: {e}", path.display());
-                            continue;
-                        }
-                    };
-                    let tasks = match toml::from_str::<Tasks>(&raw) {
-                        Ok(t) => t.0,
-                        Err(e) => {
-                            warn!("surface_tools: failed to parse {}: {e}", path.display());
-                            continue;
-                        }
-                    };
                     let source = ToolSource::MiseToml(path.clone());
-                    let mut file_ts = Toolset::new(source.clone());
-                    for (_name, task) in tasks {
-                        for (tool, version) in &task.tools {
-                            let ba: Arc<BackendArg> = Arc::new(tool.as_str().into());
-                            match ToolRequest::new(ba.clone(), version, source.clone()) {
-                                Ok(tr) => file_ts.add_version(tr),
-                                Err(e) => {
-                                    warn!("surface_tools: invalid tool {tool}@{version}: {e}")
-                                }
-                            }
-                        }
+                    let mut file_ts = Toolset::new(source);
+                    for tr in task_file_tool_requests(&path) {
+                        file_ts.add_version(tr);
                     }
                     ts.merge(file_ts);
                 }

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -6,8 +6,11 @@ use std::{
 
 use crate::backend::backend_type::BackendType;
 use crate::cli::args::{BackendArg, ToolArg};
+use crate::config::config_file::mise_toml::Tasks;
+use crate::config::expand_task_include;
 use crate::config::{Config, Settings};
 use crate::env;
+use crate::file;
 use crate::registry::{REGISTRY, tool_enabled};
 use crate::toolset::{ToolRequest, ToolSource, Toolset};
 use indexmap::IndexMap;
@@ -165,6 +168,7 @@ impl ToolRequestSetBuilder {
 
     pub async fn build(&self, config: &Arc<Config>) -> eyre::Result<ToolRequestSet> {
         let mut trs = ToolRequestSet::default();
+        trs = self.load_task_tools(config, trs).await?;
         trs = self.load_config_files(config, trs).await?;
         trs = self.load_runtime_env(trs)?;
         trs = self.load_runtime_args(trs)?;
@@ -201,6 +205,81 @@ impl ToolRequestSetBuilder {
             trs = merge(trs, cf.to_tool_request_set()?);
         }
         Ok(trs)
+    }
+
+    /// Collect tools from explicitly-included TOML task files and add them as the
+    /// lowest-priority layer. Only runs when `settings.task.surface_tools = true`.
+    /// Reads task files directly (no render/tera) to avoid a circular dependency:
+    /// task.render() → tera_ctx() → config.get_toolset() → get_tool_request_set().
+    async fn load_task_tools(
+        &self,
+        config: &Arc<Config>,
+        trs: ToolRequestSet,
+    ) -> eyre::Result<ToolRequestSet> {
+        if !Settings::get().task.surface_tools {
+            return Ok(trs);
+        }
+        let mut task_trs = ToolRequestSet::default();
+        for cf in config.config_files.values() {
+            let Some(includes) = cf.task_config().includes.as_ref() else {
+                continue;
+            };
+            let config_root = cf.config_root();
+            for include in includes {
+                if include.starts_with("git::") {
+                    continue;
+                }
+                let paths = expand_task_include(&config_root, include);
+                for path in paths {
+                    if !path.is_file()
+                        || path.extension().map(|e| e != "toml").unwrap_or(true)
+                    {
+                        continue;
+                    }
+                    let raw = match file::read_to_string(&path) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            warn!("surface_tools: failed to read {}: {e}", path.display());
+                            continue;
+                        }
+                    };
+                    let tasks = match toml::from_str::<Tasks>(&raw) {
+                        Ok(t) => t.0,
+                        Err(e) => {
+                            warn!(
+                                "surface_tools: failed to parse {}: {e}",
+                                path.display()
+                            );
+                            continue;
+                        }
+                    };
+                    let source = ToolSource::MiseToml(path.clone());
+                    let mut tool_count = 0usize;
+                    for (_name, task) in tasks {
+                        for (tool, version) in &task.tools {
+                            let ba: Arc<BackendArg> = Arc::new(tool.as_str().into());
+                            match ToolRequest::new(ba.clone(), version, source.clone()) {
+                                Ok(tr) => {
+                                    task_trs.add_version(tr, &source);
+                                    tool_count += 1;
+                                }
+                                Err(e) => warn!(
+                                    "surface_tools: invalid tool {tool}@{version}: {e}"
+                                ),
+                            }
+                        }
+                    }
+                    trace!(
+                        "surface_tools: {} tools from {}",
+                        tool_count,
+                        path.display()
+                    );
+                }
+            }
+        }
+        // task_trs is 'a' in merge(a, b); load_config_files will pass config
+        // tools as 'b', so config tools always override task tools.
+        Ok(merge(task_trs, trs))
     }
 
     fn load_runtime_env(&self, mut trs: ToolRequestSet) -> eyre::Result<ToolRequestSet> {

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -225,55 +225,15 @@ impl ToolRequestSetBuilder {
                 continue;
             };
             let config_root = cf.config_root();
-            for include in includes {
-                if include.starts_with("git::") {
-                    continue;
-                }
-                let paths = expand_task_include(&config_root, include);
-                for path in paths {
-                    if !path.is_file()
-                        || path.extension().map(|e| e != "toml").unwrap_or(true)
-                    {
+            for include in includes.iter().filter(|i| !i.starts_with("git::")) {
+                for path in expand_task_include(&config_root, include) {
+                    if !path.is_file() || path.extension().map(|e| e != "toml").unwrap_or(true) {
                         continue;
                     }
-                    let raw = match file::read_to_string(&path) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            warn!("surface_tools: failed to read {}: {e}", path.display());
-                            continue;
-                        }
-                    };
-                    let tasks = match toml::from_str::<Tasks>(&raw) {
-                        Ok(t) => t.0,
-                        Err(e) => {
-                            warn!(
-                                "surface_tools: failed to parse {}: {e}",
-                                path.display()
-                            );
-                            continue;
-                        }
-                    };
-                    let source = ToolSource::MiseToml(path.clone());
-                    let mut tool_count = 0usize;
-                    for (_name, task) in tasks {
-                        for (tool, version) in &task.tools {
-                            let ba: Arc<BackendArg> = Arc::new(tool.as_str().into());
-                            match ToolRequest::new(ba.clone(), version, source.clone()) {
-                                Ok(tr) => {
-                                    task_trs.add_version(tr, &source);
-                                    tool_count += 1;
-                                }
-                                Err(e) => warn!(
-                                    "surface_tools: invalid tool {tool}@{version}: {e}"
-                                ),
-                            }
-                        }
+                    for tr in task_file_tool_requests(&path) {
+                        let source = tr.source().clone();
+                        task_trs.add_version(tr, &source);
                     }
-                    trace!(
-                        "surface_tools: {} tools from {}",
-                        tool_count,
-                        path.display()
-                    );
                 }
             }
         }
@@ -353,6 +313,43 @@ impl ToolRequestSetBuilder {
 
         Ok(trs)
     }
+}
+
+/// Parse a TOML task file and return all `ToolRequest`s found in task `tools` tables.
+/// Read/parse errors are warned about but do not abort the caller.
+pub(crate) fn task_file_tool_requests(path: &std::path::Path) -> Vec<ToolRequest> {
+    let raw = match file::read_to_string(path) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("surface_tools: failed to read {}: {e}", path.display());
+            return vec![];
+        }
+    };
+    let tasks = match toml::from_str::<Tasks>(&raw) {
+        Ok(t) => t.0,
+        Err(e) => {
+            warn!("surface_tools: failed to parse {}: {e}", path.display());
+            return vec![];
+        }
+    };
+    let source = ToolSource::MiseToml(path.to_path_buf());
+    let mut trs = vec![];
+    for (_name, task) in tasks {
+        for (tool, version) in &task.tools {
+            let spec = version.to_tool_spec(tool);
+            match spec.parse::<ToolArg>() {
+                Ok(ta) => {
+                    if let Some(mut tr) = ta.tvr {
+                        tr.set_source(source.clone());
+                        trs.push(tr);
+                    }
+                }
+                Err(e) => warn!("surface_tools: invalid tool {spec}: {e}"),
+            }
+        }
+    }
+    trace!("surface_tools: {} tools from {}", trs.len(), path.display());
+    trs
 }
 
 fn merge(mut a: ToolRequestSet, mut b: ToolRequestSet) -> ToolRequestSet {


### PR DESCRIPTION
## Summary

- Adds a new `task.surface_tools` boolean setting (default `false`). When enabled, tools declared in the `tools` table of task TOML files (via `task_config.includes`) are surfaced into the project toolset — made available in `PATH` and installed by `mise install`.
- Tools in `[tools]` of `mise.toml` always take precedence over task-declared tools (task tools are the lowest-priority layer).
- Reads task TOML files directly via `toml::from_str::<Tasks>` to avoid the circular dependency `task.render() → tera_ctx() → get_toolset()`.

## Implementation note

The logic for collecting task tools is duplicated across two builders:
- `ToolRequestSetBuilder::load_task_tools` in `src/toolset/tool_request_set.rs` — used by `Config::get_tool_request_set()` (feeds `mise ls`, tera context, etc.)
- `ToolsetBuilder::load_task_tools` in `src/toolset/builder.rs` — used directly by commands like `mise env`, `mise exec`, `mise run`, etc.

Both builders are needed to cover all call paths. The duplication is intentional and the implementations are kept in sync.

## Changed files

| File | Change |
|---|---|
| `settings.toml` | New `task.surface_tools` bool setting, default `false` |
| `schema/mise.json` | Regenerated to include new setting |
| `src/config/mod.rs` | `expand_task_include` made `pub(crate)` |
| `src/toolset/tool_request_set.rs` | `load_task_tools` on `ToolRequestSetBuilder` |
| `src/toolset/builder.rs` | `load_task_tools` on `ToolsetBuilder` |
| `e2e/tasks/test_task_surface_tools` | E2E test: 3 scenarios (basic, conflict resolution, setting off) |

## Test plan

- [ ] `mise run test:e2e test_task_surface_tools` — all 3 scenarios pass
- [ ] `mise run lint` — clean
- [ ] `mise run build` — clean
- [ ] No existing e2e tests regress

## Reviewer checklist

- [ ] `expand_task_include` visibility change is minimal and correct.
- [ ] `load_task_tools` is called before `load_config_files` in `build()`.
- [ ] `merge(task_trs, trs)` / `ts.merge(file_ts)` order is correct — task tools lose to everything that follows.
- [ ] No call to `config.tasks()`, `task.render()`, or `config.get_toolset()` inside `load_task_tools` (circular-dep guard).
- [ ] `git::` includes are skipped.
- [ ] Directories and non-`.toml` includes are silently skipped (no panic, no hard error).
- [ ] Parse/read errors warn but do not abort the build.
- [ ] Default-`false` setting — existing users see zero behaviour change.
- [ ] e2e scenario 2 (conflict resolution) is present and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)