### PR TITLE
fix(docs): fix theme flicker on docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -422,6 +422,12 @@ export default withMermaid(
         },
       ]);
     },
+    async transformHtml(code) {
+      return code.replace(
+        '<script id="check-dark-mode">',
+        '<script id="check-dark-mode" data-cfasync="false">',
+      );
+    },
   }),
 );
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -422,9 +422,9 @@ export default withMermaid(
         },
       ]);
     },
-    async transformHtml(code) {
+    transformHtml(code) {
       return code.replace(
-        '<script id="check-dark-mode">',
+        /<script id="check-dark-mode">/,
         '<script id="check-dark-mode" data-cfasync="false">',
       );
     },


### PR DESCRIPTION
Inject `data-cfasync="false"` attribute into the injected anti-flickering script provided by VitePress, thus avoiding it getting deferred by Cloudflare's Rocket Loader.

this HTML injection method is provided by VitePress itself, but I still think it's a little hacky because we depend on an HTML tag that might change. Because of this, I'll be opening a PR on VitePress itself to add native functionality to add arbitrary attribute to their injected script.

fixes discussion [#9393](https://github.com/jdx/mise/discussions/9393)