### PR TITLE
fix(task): resolve sandbox allow_read/allow_write against task dir

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -63,6 +63,8 @@ allow_write = ["./node_modules"]
 allow_net = ["registry.npmjs.org"]
 ```
 
+Relative paths in task-level `allow_read` and `allow_write` are resolved against the task's `dir` (or the directory containing `mise.toml` if `dir` is unset), matching how `dir` itself is resolved. CLI flags continue to be resolved against the shell's working directory.
+
 CLI flags on `mise run` override task-level config:
 
 ```bash

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -63,8 +63,6 @@ allow_write = ["./node_modules"]
 allow_net = ["registry.npmjs.org"]
 ```
 
-Relative paths in task-level `allow_read` and `allow_write` are resolved against the task's `dir` (or the directory containing `mise.toml` if `dir` is unset), matching how `dir` itself is resolved. CLI flags continue to be resolved against the shell's working directory.
-
 CLI flags on `mise run` override task-level config:
 
 ```bash

--- a/e2e/sandbox/test_sandbox_task_dir
+++ b/e2e/sandbox/test_sandbox_task_dir
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Regression test for https://github.com/jdx/mise/discussions/9423
+#
+# Task-level allow_read/allow_write paths must resolve against the task's
+# `dir`, not the invocation cwd. Place both directories under /var/tmp so
+# they're outside the sandbox's always-writable paths and rules actually apply.
+
+SANDBOX_DIR="/var/tmp/mise_sandbox_taskdir_test_$$"
+mkdir -p "$SANDBOX_DIR/foo" "$SANDBOX_DIR/bar"
+trap 'rm -rf "$SANDBOX_DIR"' EXIT
+
+cat >"$SANDBOX_DIR/foo/mise.toml" <<TOML
+[settings]
+experimental = true
+
+[tasks.write_dot]
+dir = "../bar"
+run = "touch written && echo OK"
+allow_write = ["."]
+TOML
+
+cd "$SANDBOX_DIR/foo"
+
+# allow_write = ["."] resolves to the task's dir (../bar). Writing in bar/
+# must succeed even though it's outside the always-writable paths (/tmp, /dev).
+assert "mise run write_dot" "OK"
+assert "test -f $SANDBOX_DIR/bar/written && echo found" "found"

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -130,7 +130,26 @@ impl TaskExecutor {
     }
 
     /// Build a SandboxConfig for a task by merging task-level config with CLI overrides.
-    fn build_sandbox_for_task(&self, task: &Task) -> SandboxConfig {
+    ///
+    /// Task-level relative `allow_read`/`allow_write` paths are resolved against the task's
+    /// effective working directory (`task.dir(config)`, falling back to `config_root`) so that
+    /// `allow_read = ["."]` means "the directory the task runs in", matching how `dir` itself
+    /// resolves. CLI-supplied paths are left as-is and resolved against cwd by `resolve_paths()`.
+    async fn build_sandbox_for_task(
+        &self,
+        task: &Task,
+        config: &Arc<Config>,
+    ) -> Result<SandboxConfig> {
+        let task_base = task.dir(config).await?.or_else(|| task.config_root.clone());
+        let resolve_task_path = |p: &PathBuf| -> PathBuf {
+            if p.is_absolute() {
+                p.clone()
+            } else if let Some(base) = &task_base {
+                base.join(p)
+            } else {
+                p.clone()
+            }
+        };
         let mut config = SandboxConfig {
             deny_read: task.deny_all || task.deny_read || self.sandbox.deny_read,
             deny_write: task.deny_all || task.deny_write || self.sandbox.deny_write,
@@ -139,14 +158,14 @@ impl TaskExecutor {
             allow_read: task
                 .allow_read
                 .iter()
-                .chain(self.sandbox.allow_read.iter())
-                .cloned()
+                .map(&resolve_task_path)
+                .chain(self.sandbox.allow_read.iter().cloned())
                 .collect(),
             allow_write: task
                 .allow_write
                 .iter()
-                .chain(self.sandbox.allow_write.iter())
-                .cloned()
+                .map(&resolve_task_path)
+                .chain(self.sandbox.allow_write.iter().cloned())
                 .collect(),
             allow_net: task
                 .allow_net
@@ -162,7 +181,7 @@ impl TaskExecutor {
                 .collect(),
         };
         config.resolve_paths();
-        config
+        Ok(config)
     }
 
     pub fn task_timings(&self) -> bool {
@@ -854,7 +873,7 @@ impl TaskExecutor {
         let program = program.to_executable();
         let redactions = config.redactions();
         let raw = self.raw(Some(task));
-        let sandbox = self.build_sandbox_for_task(task);
+        let sandbox = self.build_sandbox_for_task(task, &config).await?;
         let env = if sandbox.is_active() {
             Settings::get().ensure_experimental("sandbox")?;
             &sandbox.filter_env(env)

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -132,15 +132,15 @@ impl TaskExecutor {
     /// Build a SandboxConfig for a task by merging task-level config with CLI overrides.
     ///
     /// Task-level relative `allow_read`/`allow_write` paths are resolved against the task's
-    /// effective working directory (`task.dir(config)`, falling back to `config_root`) so that
-    /// `allow_read = ["."]` means "the directory the task runs in", matching how `dir` itself
+    /// effective working directory (`task.dir(config)`, which itself falls back to `config_root`)
+    /// so that `allow_read = ["."]` means "the directory the task runs in", matching how `dir`
     /// resolves. CLI-supplied paths are left as-is and resolved against cwd by `resolve_paths()`.
     async fn build_sandbox_for_task(
         &self,
         task: &Task,
         config: &Arc<Config>,
     ) -> Result<SandboxConfig> {
-        let task_base = task.dir(config).await?.or_else(|| task.config_root.clone());
+        let task_base = task.dir(config).await?;
         let resolve_task_path = |p: &PathBuf| -> PathBuf {
             if p.is_absolute() {
                 p.clone()
@@ -150,7 +150,7 @@ impl TaskExecutor {
                 p.clone()
             }
         };
-        let mut config = SandboxConfig {
+        let mut sandbox = SandboxConfig {
             deny_read: task.deny_all || task.deny_read || self.sandbox.deny_read,
             deny_write: task.deny_all || task.deny_write || self.sandbox.deny_write,
             deny_net: task.deny_all || task.deny_net || self.sandbox.deny_net,
@@ -180,8 +180,8 @@ impl TaskExecutor {
                 .cloned()
                 .collect(),
         };
-        config.resolve_paths();
-        Ok(config)
+        sandbox.resolve_paths();
+        Ok(sandbox)
     }
 
     pub fn task_timings(&self) -> bool {


### PR DESCRIPTION
## Summary

- Task-level `allow_read` / `allow_write` paths in `mise.toml` were resolved against the shell's pwd rather than the task's effective working directory. With `dir = "../bar"` and `allow_read = ["."]`, mise allowed reads in the caller's directory but the task itself ran in `bar/`, so reads got blocked.
- Pre-resolve task-level relative paths against `task.dir(config)` (falling back to `config_root`) before merging with CLI overrides. CLI flags (`mise run --allow-read=…` / `mise x --allow-read=…`) continue to resolve against shell cwd since those come from the user's shell.
- Added an e2e regression test under `e2e/sandbox/` and a one-line note in `docs/sandboxing.md` clarifying the semantics.

Fixes https://github.com/jdx/mise/discussions/9423

## Test plan

- [x] `mise run lint`
- [x] `mise run test:unit`
- [x] `mise run test:e2e test_sandbox_task_dir test_sandbox_task test_sandbox_deny_read test_sandbox_deny_write test_sandbox_deny_env test_sandbox_deny_all test_sandbox_deny_net`
- [x] Confirmed the new e2e test fails on the unfixed code and passes after the fix
- [x] Manual reproduction from the discussion: `dir = "../bar"` + `allow_read = ["."]` now works without duplicating the dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how sandbox filesystem allowlists are computed for tasks, which can affect which paths are permitted/denied at runtime. Risk is moderate because it alters security-relevant path resolution logic but is narrowly scoped and covered by a new e2e regression test.
> 
> **Overview**
> Fixes task sandboxing so task-level relative `allow_read`/`allow_write` entries are pre-resolved against the task’s effective working directory (`task.dir(...)`) before merging with CLI sandbox overrides, ensuring entries like `"."` refer to where the task actually runs.
> 
> Adds an e2e regression test (`e2e/sandbox/test_sandbox_task_dir`) that runs a task with `dir = "../bar"` and verifies `allow_write = ["."]` correctly permits writes in the task directory outside the default always-writable paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac33e0e198011c3c9a381bee0159ae0a99cdd11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->