### PR TITLE
docs(site): add self-hosted page tracker via Cloudflare Worker, drop GoatCounter

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -359,21 +359,14 @@ export default withMermaid(
           rel: "stylesheet",
         },
       ],
-      // Analytics (Plausible via Cloudflare Worker proxy)
       [
         "script",
         {
-          async: "",
+          defer: "",
+          "data-domain": "mise.jdx.dev",
+          "data-api": "https://shrill-1.en.dev/f5f1/event",
           src: "https://shrill-1.en.dev/shrill/script.js",
         },
-      ],
-      [
-        "script",
-        {},
-        `window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-      plausible.init({
-        endpoint: "https://shrill-1.en.dev/f5f1/event"
-      })`,
       ],
       // OpenGraph
       ["meta", { property: "og:site_name", content: "mise-en-place" }],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -362,8 +362,23 @@ export default withMermaid(
       [
         "script",
         {
+          async: "",
+          src: "https://www.googletagmanager.com/gtag/js?id=G-B69G389C8T",
+        },
+      ],
+      [
+        "script",
+        {},
+        `window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-B69G389C8T');`,
+      ],
+      [
+        "script",
+        {
           defer: "",
-          "data-domain": "mise.jdx.dev",
+          "data-domain": "mise.en.dev",
           "data-api": "https://shrill-1.en.dev/f5f1/event",
           src: "https://shrill-1.en.dev/shrill/script.js",
         },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -359,29 +359,21 @@ export default withMermaid(
           rel: "stylesheet",
         },
       ],
-      // Analytics
+      // Analytics (Plausible via Cloudflare Worker proxy)
       [
         "script",
         {
           async: "",
-          src: "https://www.googletagmanager.com/gtag/js?id=G-B69G389C8T",
+          src: "https://shrill-1.en.dev/shrill/script.js",
         },
       ],
       [
         "script",
         {},
-        `window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-B69G389C8T');`,
-      ],
-      [
-        "script",
-        {
-          "data-goatcounter": "https://jdx.goatcounter.com/count",
-          async: "",
-          src: "//gc.zgo.at/count.js",
-        },
+        `window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init({
+        endpoint: "https://shrill-1.en.dev/f5f1/event"
+      })`,
       ],
       // OpenGraph
       ["meta", { property: "og:site_name", content: "mise-en-place" }],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -379,8 +379,8 @@ export default withMermaid(
         {
           defer: "",
           "data-domain": "mise.en.dev",
-          "data-api": "https://shrill-1.en.dev/f5f1/event",
-          src: "https://shrill-1.en.dev/shrill/script.js",
+          "data-api": "https://shrill.en.dev/f5f1/event",
+          src: "https://shrill.en.dev/shrill/script.js",
         },
       ],
       // OpenGraph


### PR DESCRIPTION
## Summary
- Add a self-hosted page tracker proxied through a Cloudflare Worker at `shrill.en.dev`. Following the upstream proxy guide, the Worker exposes the script at `/shrill/script.js` and the event endpoint at `/f5f1/event` so neither path matches well-known content-blocker heuristics.
- Configure via `data-domain="mise.en.dev"` and `data-api="https://shrill.en.dev/f5f1/event"` on the script tag — pageview tracking is automatic, so no inline init block is needed.
- Keep GTM unchanged.
- Remove GoatCounter.

## Test plan
- [x] Confirm `https://shrill.en.dev/shrill/script.js` loads (200) and `https://shrill.en.dev/f5f1/event` records the pageview (POST 202).
- [x] Confirm GTM (`gtag/js?id=G-B69G389C8T`) still loads.
- [x] Confirm no GoatCounter requests remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)