### PR TITLE
fix(task): populate usage.cmd for subcommand-only tasks; share make_usage_ctx

### DIFF
--- a/e2e/tasks/test_task_dep_args
+++ b/e2e/tasks/test_task_dep_args
@@ -117,3 +117,42 @@ assert_contains "mise run lint" "noop"
 assert_not_contains "mise run lint" "postlint ran"
 assert_contains "mise run lint --run-post" "postlint ran"
 assert_not_contains "mise run lint --run-post" "noop"
+
+# Test usage.cmd in dependency templates with subcommand-only spec
+# (regression test: previously the early-return for empty root args/flags meant
+# usage.cmd was never populated for tasks that only define subcommands)
+cat <<'EOF' >mise.toml
+[tasks.noop]
+run = 'echo "noop ran"'
+
+[tasks."deploy-staging"]
+run = 'echo "staging deploy"'
+
+[tasks."deploy-production"]
+run = 'echo "prod deploy"'
+
+[tasks.dispatch]
+usage = '''
+cmd "staging" {
+    arg "<version>"
+}
+cmd "production" {
+    arg "<version>"
+}
+'''
+depends = ['''
+    {%- if usage.cmd == "staging" -%}
+        deploy-staging
+    {%- elif usage.cmd == "production" -%}
+        deploy-production
+    {%- else -%}
+        noop
+    {%- endif -%}
+''']
+run = 'echo "dispatched"'
+EOF
+
+assert_contains "mise run dispatch staging v1" "staging deploy"
+assert_not_contains "mise run dispatch staging v1" "prod deploy"
+assert_contains "mise run dispatch production v2" "prod deploy"
+assert_not_contains "mise run dispatch production v2" "staging deploy"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -12,7 +12,6 @@ use eyre::{Result, bail, eyre};
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use globset::GlobBuilder;
-use heck::ToSnakeCase;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use petgraph::prelude::*;
@@ -2069,7 +2068,7 @@ pub async fn parse_usage_values_from_task(
     let (spec, _) = task
         .parse_usage_spec_with_vars(config, None, &env, None)
         .await?;
-    if spec.cmd.args.is_empty() && spec.cmd.flags.is_empty() {
+    if spec.cmd.args.is_empty() && spec.cmd.flags.is_empty() && spec.cmd.subcommands.is_empty() {
         return Ok(IndexMap::new());
     }
     // Build args list with empty first element (usage parser expects argv[0] to be the command)
@@ -2083,26 +2082,13 @@ pub async fn parse_usage_values_from_task(
             return Ok(IndexMap::new());
         }
     };
-    let mut values = IndexMap::new();
-    let to_tera_value = |val: &usage::parse::ParseValue| -> tera::Value {
-        use tera::Value;
-        use usage::parse::ParseValue::*;
-        match val {
-            MultiBool(v) => Value::Number(serde_json::Number::from(v.len())),
-            MultiString(v) => Value::Array(v.iter().map(|s| Value::String(s.clone())).collect()),
-            Bool(v) => Value::Bool(*v),
-            String(v) => Value::String(v.clone()),
-        }
-    };
-    for (arg, val) in &po.args {
-        values.insert(arg.name.to_snake_case(), to_tera_value(val));
-    }
-    for (flag, val) in &po.flags {
-        values.insert(flag.name.to_snake_case(), to_tera_value(val));
-    }
-    if !spec.cmd.subcommands.is_empty() {
-        let cmd = po.cmds.iter().skip(1).map(|c| c.name.clone()).join(" ");
-        values.insert("cmd".to_string(), tera::Value::String(cmd));
+    let mut values: IndexMap<String, tera::Value> =
+        TaskScriptParser::make_usage_ctx(&po).into_iter().collect();
+    // `make_usage_ctx` only inserts `cmd` when a subcommand was actually selected.
+    // Templates referencing `{{ usage.cmd }}` should still resolve (to "") when
+    // subcommands are defined in the spec but none was selected.
+    if !spec.cmd.subcommands.is_empty() && !values.contains_key("cmd") {
+        values.insert("cmd".to_string(), tera::Value::String(String::new()));
     }
     Ok(values)
 }

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -788,7 +788,9 @@ impl TaskScriptParser {
         Ok(out)
     }
 
-    fn make_usage_ctx(usage: &usage::parse::ParseOutput) -> HashMap<String, tera::Value> {
+    pub(crate) fn make_usage_ctx(
+        usage: &usage::parse::ParseOutput,
+    ) -> HashMap<String, tera::Value> {
         let mut usage_ctx: HashMap<String, tera::Value> = HashMap::new();
 
         // These values are not escaped or shell-quoted.


### PR DESCRIPTION
## Summary
Follow-up to [#9424](https://github.com/jdx/mise/pull/9424) addressing two issues raised in review (Cursor Bugbot):

1. **Early-return bug** — `parse_usage_values_from_task` returned an empty map when both `spec.cmd.args` and `spec.cmd.flags` were empty, *before* reaching the new subcommand handling. Tasks defined with only subcommands (no top-level args/flags) that referenced `{{ usage.cmd }}` in deps got an empty `IndexMap`, so the value never landed in the Tera context. Fixed by including `spec.cmd.subcommands.is_empty()` in the early-return condition.

2. **Duplicated conversion logic** — `to_tera_value` and the args/flags-to-snake-case iteration in `parse_usage_values_from_task` duplicated `TaskScriptParser::make_usage_ctx`, and the two had already drifted slightly. Promoted `make_usage_ctx` to `pub(crate)` and reused it. Preserved the defensive empty-`cmd` insertion when subcommands are defined but none was selected.

## Test plan
- [x] `mise run format`
- [x] `mise run lint`
- [x] `cargo test --bin mise task::tests` (34 tests pass)
- [x] `mise run test:e2e e2e/tasks/test_task_dep_args` (includes new regression test for subcommand-only deps via `{{ usage.cmd }}`)
- [x] `mise run test:e2e e2e/tasks/test_task_usage_cmd` (no regression in pre-existing subcommand behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to usage-context extraction plus an added e2e regression test; behavior only differs for tasks whose `usage` defines subcommands without root args/flags.
> 
> **Overview**
> Fixes dependency-template rendering for subcommand-only tasks by ensuring `parse_usage_values_from_task` no longer early-returns before considering subcommands, and by reusing `TaskScriptParser::make_usage_ctx` to build the `usage` map.
> 
> When a task defines subcommands but none is selected, the code now guarantees `usage.cmd` is present (as an empty string) so `{{ usage.cmd }}` references in dependency templates consistently resolve.
> 
> Adds an e2e regression test covering `depends` templates that branch on `usage.cmd` for subcommand-only `usage` specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97fa3ffd6f4b05c527e54fc3c8ca173b61a9ab46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->