### PR TITLE
refactor(COPR): centralize chroots config

### DIFF
--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -5,11 +5,6 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      chroots:
-        description: "COPR chroots to target (space-separated)"
-        required: false
-        default: "fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 epel-9-aarch64 epel-9-x86_64"
-        type: string
       use_serious_profile:
         description: 'Use the "serious" profile for optimized builds (LTO enabled)'
         required: false
@@ -18,6 +13,7 @@ on:
 
 env:
   PACKAGE_NAME: mise
+  DEFAULT_CHROOTS: "fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 epel-9-aarch64 epel-9-x86_64"
 
 jobs:
   publish-copr:
@@ -36,15 +32,9 @@ jobs:
         run: |
           VERSION=$(./scripts/get-version.sh | sed 's/^v//')
 
-          if [ "${{ github.event_name }}" = "release" ]; then
-            CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 epel-9-aarch64 epel-9-x86_64"
-          else
-            CHROOTS="${{ inputs.chroots }}"
-          fi
-
           {
             echo "VERSION=${VERSION}"
-            echo "CHROOTS=${CHROOTS}"
+            echo "CHROOTS=${{ env.DEFAULT_CHROOTS }}"
             echo "PACKAGE_NAME=${PACKAGE_NAME}"
             echo "MAINTAINER_NAME=${{ vars.COPR_MAINTAINER_NAME || 'mise Release Bot' }}"
             echo "MAINTAINER_EMAIL=${{ vars.COPR_MAINTAINER_EMAIL || 'noreply@mise.jdx.dev' }}"

--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -5,6 +5,12 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      chroots:
+        description: "COPR chroots to target (space-separated)"
+        required: false
+        default: ""
+        type: string
+
       use_serious_profile:
         description: 'Use the "serious" profile for optimized builds (LTO enabled)'
         required: false
@@ -32,9 +38,15 @@ jobs:
         run: |
           VERSION=$(./scripts/get-version.sh | sed 's/^v//')
 
+          if [ "${{ github.event_name }}" = "release" ]; then
+            CHROOTS="${{ env.DEFAULT_CHROOTS }}"
+          else
+            CHROOTS="${{ inputs.chroots || env.DEFAULT_CHROOTS }}"
+          fi
+
           {
             echo "VERSION=${VERSION}"
-            echo "CHROOTS=${{ env.DEFAULT_CHROOTS }}"
+            echo "CHROOTS=${CHROOTS}"
             echo "PACKAGE_NAME=${PACKAGE_NAME}"
             echo "MAINTAINER_NAME=${{ vars.COPR_MAINTAINER_NAME || 'mise Release Bot' }}"
             echo "MAINTAINER_EMAIL=${{ vars.COPR_MAINTAINER_EMAIL || 'noreply@mise.jdx.dev' }}"

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 # Default values
 PACKAGE_NAME="${PACKAGE_NAME:-mise}"
-CHROOTS="${CHROOTS:-fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64}"
+DEFAULT_CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 epel-9-aarch64 epel-9-x86_64"
+CHROOTS="${CHROOTS:-$DEFAULT_CHROOTS}"
 BUILD_PROFILE="${BUILD_PROFILE:-release}"
 MAINTAINER_NAME="${MAINTAINER_NAME:-mise Release Bot}"
 MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-noreply@mise.jdx.dev}"
@@ -22,7 +23,7 @@ usage() {
 	echo "Options:"
 	echo "  -v, --version VERSION        Package version (required)"
 	echo "  -p, --profile PROFILE        Build profile (default: release)"
-	echo "  -c, --chroots CHROOTS        COPR chroots (default: fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64)"
+	echo "  -c, --chroots CHROOTS        COPR chroots (default: $DEFAULT_CHROOTS)"
 	echo "  -o, --owner OWNER            COPR owner (default: jdxcode)"
 	echo "  -j, --project PROJECT        COPR project (default: mise)"
 	echo "  -n, --name NAME              Package name (default: mise)"


### PR DESCRIPTION
Remove manual chroots input from workflow and move default chroots list to environment variable. This eliminates code duplication and simplifies the build configuration by using a single source of truth for target architectures across both the workflow and build script.