### PR TITLE
feat(task): add --name-only flag to mise tasks ls

### DIFF
--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -40,13 +40,13 @@ By default, only tasks from the current directory hierarchy are loaded.
 
 Show hidden tasks
 
-### `--no-header`
-
-Do not print table header
-
 ### `--name-only`
 
 Only show task names, one per line. Useful for piping to fzf and similar tools.
+
+### `--no-header`
+
+Do not print table header
 
 ### `--sort <COLUMN>`
 

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -64,6 +64,12 @@ Sort order. Default is asc.
 - `asc`
 - `desc`
 
+## Flags
+
+### `--name-only`
+
+Only show task names, one per line. Useful for piping to fzf and similar tools.
+
 ## Subcommands
 
 - [`mise tasks add [FLAGS] <TASK> [-- RUN]…`](/cli/tasks/add.md)

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -44,6 +44,10 @@ Show hidden tasks
 
 Do not print table header
 
+### `--name-only`
+
+Only show task names, one per line. Useful for piping to fzf and similar tools.
+
 ### `--sort <COLUMN>`
 
 Sort by column. Default is name.
@@ -63,12 +67,6 @@ Sort order. Default is asc.
 
 - `asc`
 - `desc`
-
-## Flags
-
-### `--name-only`
-
-Only show task names, one per line. Useful for piping to fzf and similar tools.
 
 ## Subcommands
 

--- a/docs/cli/tasks/ls.md
+++ b/docs/cli/tasks/ls.md
@@ -43,6 +43,10 @@ Show hidden tasks
 
 Do not print table header
 
+### `--name-only`
+
+Only show task names, one per line. Useful for piping to fzf and similar tools.
+
 ### `--sort <COLUMN>`
 
 Sort by column. Default is name.

--- a/docs/cli/tasks/ls.md
+++ b/docs/cli/tasks/ls.md
@@ -39,13 +39,13 @@ By default, only tasks from the current directory hierarchy are loaded.
 
 Show hidden tasks
 
-### `--no-header`
-
-Do not print table header
-
 ### `--name-only`
 
 Only show task names, one per line. Useful for piping to fzf and similar tools.
+
+### `--no-header`
+
+Do not print table header
 
 ### `--sort <COLUMN>`
 

--- a/e2e/tasks/test_task_ls_name_only
+++ b/e2e/tasks/test_task_ls_name_only
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+cat <<EOF >mise.toml
+[tasks.build]
+description = "build the project"
+run = 'echo build'
+[tasks.lint]
+description = "lint the code"
+run = 'echo lint'
+[tasks.test]
+description = "run the tests"
+run = 'echo test'
+EOF
+
+mkdir -p .mise/tasks
+cat <<'EOF' >.mise/tasks/deploy
+#!/usr/bin/env bash
+# mise description="deploy the app"
+echo deploy
+EOF
+chmod +x .mise/tasks/deploy
+
+assert "mise tasks ls --name-only" "build
+deploy
+lint
+test"
+
+# --no-header is harmless and the output is identical
+assert "mise tasks ls --name-only --no-header" "build
+deploy
+lint
+test"
+
+# Composes with --sort/--sort-order
+assert "mise tasks ls --name-only --sort name --sort-order desc" "test
+lint
+deploy
+build"
+
+# Local/global filtering still applies
+echo "tasks.myglobal = { run = 'echo myglobal' }" >~/.config/mise/config.toml
+assert "mise tasks ls --name-only --global" "myglobal"
+assert "mise tasks ls --name-only --local" "build
+deploy
+lint
+test"
+
+# Conflicts with other output formats
+assert_fail "mise tasks ls --name-only --json"
+assert_fail "mise tasks ls --name-only -x"

--- a/e2e/tasks/test_task_ls_name_only
+++ b/e2e/tasks/test_task_ls_name_only
@@ -48,3 +48,4 @@ test"
 # Conflicts with other output formats
 assert_fail "mise tasks ls --name-only --json"
 assert_fail "mise tasks ls --name-only -x"
+assert_fail "mise tasks ls --name-only --usage"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2648,6 +2648,9 @@ Display tasks for usage completion
 \fB\-\-hidden\fR
 Show hidden tasks
 .TP
+\fB\-\-name\-only\fR
+Only show task names, one per line. Useful for piping to fzf and similar tools.
+.TP
 \fB\-\-no\-header\fR
 Do not print table header
 .TP
@@ -2810,6 +2813,9 @@ Display tasks for usage completion
 .TP
 \fB\-\-hidden\fR
 Show hidden tasks
+.TP
+\fB\-\-name\-only\fR
+Only show task names, one per line. Useful for piping to fzf and similar tools.
 .TP
 \fB\-\-no\-header\fR
 Do not print table header

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1070,7 +1070,7 @@ cmd tasks help="Manage tasks" {
     flag --complete help="Display tasks for usage completion" hide=#true
     flag --hidden help="Show hidden tasks" global=#true
     flag --no-header help="Do not print table header" global=#true
-    flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools."
+    flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools." global=#true
     flag --sort help="Sort by column. Default is name." global=#true {
         arg <COLUMN> {
             choices name alias description source
@@ -1152,7 +1152,7 @@ cmd tasks help="Manage tasks" {
         flag --complete help="Display tasks for usage completion" hide=#true
         flag --hidden help="Show hidden tasks" global=#true
         flag --no-header help="Do not print table header" global=#true
-        flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools."
+        flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools." global=#true
         flag --sort help="Sort by column. Default is name." global=#true {
             arg <COLUMN> {
                 choices name alias description source

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1069,8 +1069,8 @@ cmd tasks help="Manage tasks" {
     flag --all help="Load all tasks from the entire monorepo, including sibling directories.\nBy default, only tasks from the current directory hierarchy are loaded." global=#true
     flag --complete help="Display tasks for usage completion" hide=#true
     flag --hidden help="Show hidden tasks" global=#true
-    flag --no-header help="Do not print table header" global=#true
     flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools." global=#true
+    flag --no-header help="Do not print table header" global=#true
     flag --sort help="Sort by column. Default is name." global=#true {
         arg <COLUMN> {
             choices name alias description source
@@ -1151,8 +1151,8 @@ cmd tasks help="Manage tasks" {
         flag --all help="Load all tasks from the entire monorepo, including sibling directories.\nBy default, only tasks from the current directory hierarchy are loaded." global=#true
         flag --complete help="Display tasks for usage completion" hide=#true
         flag --hidden help="Show hidden tasks" global=#true
-        flag --no-header help="Do not print table header" global=#true
         flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools." global=#true
+        flag --no-header help="Do not print table header" global=#true
         flag --sort help="Sort by column. Default is name." global=#true {
             arg <COLUMN> {
                 choices name alias description source

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1070,6 +1070,7 @@ cmd tasks help="Manage tasks" {
     flag --complete help="Display tasks for usage completion" hide=#true
     flag --hidden help="Show hidden tasks" global=#true
     flag --no-header help="Do not print table header" global=#true
+    flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools."
     flag --sort help="Sort by column. Default is name." global=#true {
         arg <COLUMN> {
             choices name alias description source
@@ -1151,6 +1152,7 @@ cmd tasks help="Manage tasks" {
         flag --complete help="Display tasks for usage completion" hide=#true
         flag --hidden help="Show hidden tasks" global=#true
         flag --no-header help="Do not print table header" global=#true
+        flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools."
         flag --sort help="Sort by column. Default is name." global=#true {
             arg <COLUMN> {
                 choices name alias description source

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -70,8 +70,9 @@ pub struct TasksLs {
     /// Only show task names, one per line. Useful for piping to fzf and similar tools.
     #[clap(
         long,
+        global = true,
         verbatim_doc_comment,
-        conflicts_with_all = ["json", "extended", "complete", "usage"]
+        conflicts_with_all = ["json", "extended", "usage"]
     )]
     pub name_only: bool,
 

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -63,10 +63,6 @@ pub struct TasksLs {
     #[clap(long, global = true, verbatim_doc_comment)]
     pub hidden: bool,
 
-    /// Do not print table header
-    #[clap(long, alias = "no-headers", global = true, verbatim_doc_comment)]
-    pub no_header: bool,
-
     /// Only show task names, one per line. Useful for piping to fzf and similar tools.
     #[clap(
         long,
@@ -75,6 +71,10 @@ pub struct TasksLs {
         conflicts_with_all = ["json", "extended", "usage"]
     )]
     pub name_only: bool,
+
+    /// Do not print table header
+    #[clap(long, alias = "no-headers", global = true, verbatim_doc_comment)]
+    pub no_header: bool,
 
     /// Sort by column. Default is name.
     #[clap(long, global = true, value_name = "COLUMN", verbatim_doc_comment)]

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -67,6 +67,14 @@ pub struct TasksLs {
     #[clap(long, alias = "no-headers", global = true, verbatim_doc_comment)]
     pub no_header: bool,
 
+    /// Only show task names, one per line. Useful for piping to fzf and similar tools.
+    #[clap(
+        long,
+        verbatim_doc_comment,
+        conflicts_with_all = ["json", "extended", "complete", "usage"]
+    )]
+    pub name_only: bool,
+
     /// Sort by column. Default is name.
     #[clap(long, global = true, value_name = "COLUMN", verbatim_doc_comment)]
     pub sort: Option<SortColumn>,
@@ -144,8 +152,17 @@ impl TasksLs {
             self.display_usage(&config, tasks).await?;
         } else if self.json {
             self.display_json(&config, tasks).await?;
+        } else if self.name_only {
+            self.display_name_only(tasks)?;
         } else {
             self.display(tasks)?;
+        }
+        Ok(())
+    }
+
+    fn display_name_only(&self, tasks: Vec<Task>) -> Result<()> {
+        for t in tasks {
+            calm_io::stdoutln!("{}", t.display_name)?;
         }
         Ok(())
     }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -3307,6 +3307,12 @@ const completionSpec: Fig.Spec = {
               isRepeatable: false,
             },
             {
+              name: "--name-only",
+              description:
+                "Only show task names, one per line. Useful for piping to fzf and similar tools.",
+              isRepeatable: false,
+            },
+            {
               name: "--no-header",
               description: "Do not print table header",
               isRepeatable: false,
@@ -3597,6 +3603,12 @@ const completionSpec: Fig.Spec = {
         {
           name: "--hidden",
           description: "Show hidden tasks",
+          isRepeatable: false,
+        },
+        {
+          name: "--name-only",
+          description:
+            "Only show task names, one per line. Useful for piping to fzf and similar tools.",
           isRepeatable: false,
         },
         {


### PR DESCRIPTION
## Summary

- Adds `--name-only` to `mise tasks ls` (and `mise tasks`) that prints one task name per line with no padding, header, or description column — drop-in for piping to `fzf` and similar tools without `sed`/`awk` cleanup.
- Conflicts with `--json`, `--extended`, `--usage` (clap rejects the combos). Composes with `--all`, `--global`/`--local`, `--hidden`, `--sort`/`--sort-order`, `--no-header`. The internal hidden `--complete` flag isn't in the conflicts list — making `--name-only` global while referencing the non-global `--complete` panics clap on sibling subcommands (`tasks info`, `tasks add`, …) that don't carry `--complete`. Practically a non-issue: `--complete` is a hidden flag used by shell completions, and the `run()` dispatch checks it before `--name-only`, so a stray combo just routes to `--complete` output.
- Closes discussion [#9434](https://github.com/jdx/mise/discussions/9434).

Before, the discussion's workaround was:

```sh
mise run `mise tasks ls --all --no-header | sed -E 's#^(//[a-z:]*).*#\1#' | fzf`
```

After:

```sh
mise run `mise tasks ls --name-only --all | fzf`
```

The new printer uses `calm_io::stdoutln!` (matching the existing `--complete` output path) so a broken pipe — common when fzf accepts a selection before all output is consumed — is swallowed cleanly.

## Test plan

- [x] `mise run build`
- [x] `mise run lint`
- [x] `mise run test:e2e test_task_ls_name_only test_task_ls test_task_ls_global test_task_ls_json_resolved_dir`
- [x] `cargo test --bin mise cli::tests::test_subcommands_are_sorted` (alphabetical flag ordering)
- [x] Manual: `mise tasks ls --name-only`, `mise tasks --name-only`, `mise tasks ls --name-only | fzf` work; default `mise tasks ls` table is unchanged
- [x] Manual: `mise tasks ls --name-only --json`, `--name-only -x`, `--name-only --usage` are rejected by clap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: introduces an additional CLI output mode with explicit flag conflicts and includes an e2e test, without changing task resolution or execution paths.
> 
> **Overview**
> Adds a new `--name-only` flag to `mise tasks ls` (and the top-level `mise tasks` wrapper) that prints just task names, one per line, for easy piping to tools like `fzf`.
> 
> The flag is enforced to **conflict** with other output formats (`--json`, `--extended`, `--usage`) and is covered by a new e2e test; autogenerated docs, manpage, usage spec (`mise.usage.kdl`), and Fig completion metadata are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146f3f5dbf7243bd6d0bff3842f5aeb255b3f6b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->