### PR TITLE
fix(ls-remote): avoid degraded GitHub release metadata

### DIFF
--- a/docs/cli/ls-remote.md
+++ b/docs/cli/ls-remote.md
@@ -29,6 +29,14 @@ Show all installed plugins and versions
 
 Output in JSON format (includes version metadata like created_at timestamps when available)
 
+### `--strict-metadata`
+
+Fail instead of falling back when version metadata sources are unavailable
+
+This is intended for automation that writes canonical version metadata.
+It requires --json and prevents metadata source failures from silently
+degrading to less-authoritative fallback data.
+
 ### `--prerelease`
 
 Include pre-release versions in the output for backends that report
@@ -52,5 +60,8 @@ $ mise ls-remote node 20
 20.1.0
 
 $ mise ls-remote github:cli/cli --json
+[{"version":"2.62.0","created_at":"2024-11-14T15:40:35Z","prerelease":false},{"version":"2.61.0","created_at":"2024-10-23T19:22:15Z","prerelease":false}]
+
+$ mise ls-remote github:cli/cli --json --strict-metadata
 [{"version":"2.62.0","created_at":"2024-11-14T15:40:35Z","prerelease":false},{"version":"2.61.0","created_at":"2024-10-23T19:22:15Z","prerelease":false}]
 ```

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1512,6 +1512,13 @@ Show all installed plugins and versions
 \fB\-J, \-\-json\fR
 Output in JSON format (includes version metadata like created_at timestamps when available)
 .TP
+\fB\-\-strict\-metadata\fR
+Fail instead of falling back when version metadata sources are unavailable
+
+This is intended for automation that writes canonical version metadata.
+It requires \-\-json and prevents metadata source failures from silently
+degrading to less\-authoritative fallback data.
+.TP
 \fB\-\-prerelease\fR
 Include pre\-release versions in the output for backends that report
 an upstream prerelease flag (currently github + aqua). Equivalent to

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -592,9 +592,12 @@ cmd ls help="List installed and active tool versions" {
 cmd ls-remote help="List runtime versions available for install." {
     alias list-all list-remote hide=#true
     long_help "List runtime versions available for install.\n\nNote that the results may be cached, run `mise cache clean` to clear the cache and get fresh results."
-    after_long_help "Examples:\n\n    $ mise ls-remote node\n    18.0.0\n    20.0.0\n\n    $ mise ls-remote node@20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote node 20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote github:cli/cli --json\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]\n"
+    after_long_help "Examples:\n\n    $ mise ls-remote node\n    18.0.0\n    20.0.0\n\n    $ mise ls-remote node@20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote node 20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote github:cli/cli --json\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]\n\n    $ mise ls-remote github:cli/cli --json --strict-metadata\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]\n"
     flag --all help="Show all installed plugins and versions"
     flag "-J --json" help="Output in JSON format (includes version metadata like created_at timestamps when available)"
+    flag --strict-metadata help="Fail instead of falling back when version metadata sources are unavailable" {
+        long_help "Fail instead of falling back when version metadata sources are unavailable\n\nThis is intended for automation that writes canonical version metadata.\nIt requires --json and prevents metadata source failures from silently\ndegrading to less-authoritative fallback data."
+    }
     flag --prerelease help="Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command."
     arg "[TOOL@VERSION]" help="Tool to get versions for" required=#false
     arg "[PREFIX]" help="The version prefix to use when querying the latest version\nsame as the first argument after the \"@\"" required=#false

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -231,6 +231,7 @@ impl Backend for AquaBackend {
         // `VersionInfo.prerelease` based on the current tool opts.
         let tags_with_timestamps = match get_tags_with_created_at(&pkg).await {
             Ok(tags) => tags,
+            Err(e) if github::is_empty_releases_error(&e) => return Err(e),
             Err(e) => {
                 warn!("Remote versions cannot be fetched: {}", e);
                 return Ok(vec![]);
@@ -2402,9 +2403,7 @@ async fn get_tags_with_created_at(
     let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
     let releases = github::list_releases_including_prereleases(&repo).await?;
     if releases.is_empty() {
-        // Fall back to tags (no timestamps, no prerelease flag)
-        let versions = github::list_tags(&repo).await?;
-        return Ok(versions.into_iter().map(|v| (v, None, false)).collect());
+        bail!("GitHub returned no releases for {repo}");
     }
     Ok(releases
         .into_iter()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,7 +5,10 @@ use std::fs::File;
 use std::hash::Hash;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 use tokio::sync::Mutex as TokioMutex;
 
 use jiff::Timestamp;
@@ -72,6 +75,16 @@ pub type ABackend = Arc<dyn Backend>;
 pub type BackendMap = BTreeMap<String, ABackend>;
 pub type BackendList = Vec<ABackend>;
 pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
+
+static STRICT_METADATA: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn set_strict_metadata(strict: bool) {
+    STRICT_METADATA.store(strict, Ordering::Relaxed);
+}
+
+pub(crate) fn strict_metadata() -> bool {
+    STRICT_METADATA.load(Ordering::Relaxed)
+}
 
 /// Information about a GitHub/GitLab release for platform-specific tools
 #[derive(Debug, Clone)]

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -113,8 +113,15 @@ impl Backend for UbiBackend {
             let mut version_infos: Vec<VersionInfo> = match forge {
                 ForgeType::GitHub => {
                     let releases =
-                        github::list_releases_from_url(api_url, &self.tool_name()).await?;
+                        github::list_releases_from_url_allow_empty(api_url, &self.tool_name())
+                            .await?;
                     if releases.is_empty() {
+                        if super::strict_metadata() {
+                            bail!(
+                                "strict metadata requested but GitHub returned no releases for {}",
+                                self.tool_name()
+                            );
+                        }
                         // Fall back to tags (no created_at available)
                         github::list_tags_from_url(api_url, &self.tool_name())
                             .await?

--- a/src/cli/asdf.rs
+++ b/src/cli/asdf.rs
@@ -46,6 +46,7 @@ async fn list_versions(config: &Arc<Config>, args: &[String]) -> Result<()> {
             all: false,
             plugin: args.get(3).map(|s| s.parse()).transpose()?,
             json: false,
+            strict_metadata: false,
             prerelease: false,
         }
         .run()

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -47,6 +47,14 @@ pub struct LsRemote {
     #[clap(short = 'J', long, verbatim_doc_comment)]
     pub json: bool,
 
+    /// Fail instead of falling back when version metadata sources are unavailable
+    ///
+    /// This is intended for automation that writes canonical version metadata.
+    /// It requires --json and prevents metadata source failures from silently
+    /// degrading to less-authoritative fallback data.
+    #[clap(long, verbatim_doc_comment, requires = "json")]
+    pub strict_metadata: bool,
+
     /// Include pre-release versions in the output for backends that report
     /// an upstream prerelease flag (currently github + aqua). Equivalent to
     /// setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
@@ -59,6 +67,9 @@ impl LsRemote {
     pub async fn run(self) -> Result<()> {
         if self.prerelease {
             Settings::override_with(|s| s.prereleases = Some(true));
+        }
+        if self.strict_metadata {
+            backend::set_strict_metadata(true);
         }
         let config = Config::get().await?;
         if let Some(plugin) = self.get_plugin(&config).await? {
@@ -87,7 +98,6 @@ impl LsRemote {
             .into_iter()
             .filter(|v| matches_prefix(&v.version))
             .collect();
-
         if self.json {
             miseprintln!("{}", serde_json::to_string(&versions)?);
         } else {
@@ -102,7 +112,8 @@ impl LsRemote {
         let mut versions = vec![];
         for b in backend::list() {
             let tool = b.id().to_string();
-            for v in b.list_remote_versions_with_info(config).await? {
+            let backend_versions = b.list_remote_versions_with_info(config).await?;
+            for v in backend_versions {
                 versions.push(VersionOutputAll {
                     tool: tool.clone(),
                     version: v.version,
@@ -154,6 +165,9 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     20.1.0
 
     $ <bold>mise ls-remote github:cli/cli --json</bold>
+    [{"version":"2.62.0","created_at":"2024-11-14T15:40:35Z","prerelease":false},{"version":"2.61.0","created_at":"2024-10-23T19:22:15Z","prerelease":false}]
+
+    $ <bold>mise ls-remote github:cli/cli --json --strict-metadata</bold>
     [{"version":"2.62.0","created_at":"2024-11-14T15:40:35Z","prerelease":false},{"version":"2.61.0","created_at":"2024-10-23T19:22:15Z","prerelease":false}]
 "#
 );

--- a/src/github.rs
+++ b/src/github.rs
@@ -150,10 +150,11 @@ pub async fn list_releases_including_prereleases(repo: &str) -> Result<Vec<Githu
     let key = repo.to_kebab_case();
     let cache = get_releases_cache(&key).await;
     let cache = cache.get(&key).unwrap();
-    Ok(cache
+    let releases = cache
         .get_or_try_init_async(async || list_releases_(API_URL, repo).await)
         .await?
-        .to_vec())
+        .to_vec();
+    ensure_releases_not_empty(repo, releases)
 }
 
 pub async fn list_releases_including_prereleases_from_url(
@@ -163,13 +164,45 @@ pub async fn list_releases_including_prereleases_from_url(
     let key = format!("{api_url}-{repo}").to_kebab_case();
     let cache = get_releases_cache(&key).await;
     let cache = cache.get(&key).unwrap();
-    Ok(cache
+    let releases = cache
         .get_or_try_init_async(async || list_releases_(api_url, repo).await)
         .await?
-        .to_vec())
+        .to_vec();
+    ensure_releases_not_empty(repo, releases)
+}
+
+pub async fn list_releases_from_url_allow_empty(
+    api_url: &str,
+    repo: &str,
+) -> Result<Vec<GithubRelease>> {
+    let key = format!("{api_url}-{repo}-allow-empty").to_kebab_case();
+    let cache = get_releases_cache(&key).await;
+    let cache = cache.get(&key).unwrap();
+    Ok(cache
+        .get_or_try_init_async(async || list_releases_once(api_url, repo).await)
+        .await?
+        .to_vec()
+        .into_iter()
+        .filter(|r| !r.prerelease)
+        .collect())
 }
 
 async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GithubRelease>> {
+    let mut releases = vec![];
+    for attempt in 0..3 {
+        releases = list_releases_once(api_url, repo).await?;
+        if !releases.is_empty() {
+            return Ok(releases);
+        }
+        debug!(
+            "GitHub returned empty /releases for {repo} on attempt {}",
+            attempt + 1
+        );
+    }
+    ensure_releases_not_empty(repo, releases)
+}
+
+async fn list_releases_once(api_url: &str, repo: &str) -> Result<Vec<GithubRelease>> {
     let url = format!("{api_url}/repos/{repo}/releases");
     let headers = get_headers(&url);
     let (mut releases, mut headers) = crate::http::HTTP_FETCH
@@ -189,6 +222,25 @@ async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GithubRelease>>
     releases.retain(|r| !r.draft);
 
     Ok(releases)
+}
+
+fn ensure_releases_not_empty(
+    repo: &str,
+    releases: Vec<GithubRelease>,
+) -> Result<Vec<GithubRelease>> {
+    if releases.is_empty() {
+        eyre::bail!("{}", empty_releases_message(repo));
+    }
+    Ok(releases)
+}
+
+pub fn is_empty_releases_error(err: &eyre::Report) -> bool {
+    err.to_string()
+        .contains("github returned empty /releases for ")
+}
+
+fn empty_releases_message(repo: &str) -> String {
+    format!("github returned empty /releases for {repo}; likely transient")
 }
 
 pub async fn list_tags(repo: &str) -> Result<Vec<String>> {
@@ -690,6 +742,15 @@ pub(crate) mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn required_releases_reject_empty_results() {
+        let err = ensure_releases_not_empty("owner/repo", vec![]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("github returned empty /releases for owner/repo")
+        );
+    }
 
     fn with_github_token<F, R>(test_fn: F) -> R
     where

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1750,6 +1750,12 @@ const completionSpec: Fig.Spec = {
           isRepeatable: false,
         },
         {
+          name: "--strict-metadata",
+          description:
+            "Fail instead of falling back when version metadata sources are unavailable",
+          isRepeatable: false,
+        },
+        {
           name: "--prerelease",
           description:
             "Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command.",


### PR DESCRIPTION
## Summary

Fixes the path where transient empty GitHub `/releases` responses could silently turn into degraded version metadata and then be cached or persisted downstream.

- retry empty GitHub release lists, then fail instead of caching `[]`
- make `aqua:` propagate that GitHub empty-release error instead of falling back to tags and emitting `prerelease = false` for every version
- keep UBI's normal releases-to-tags fallback, but make `--strict-metadata` fail before using that lower-metadata fallback
- add `mise ls-remote --json --strict-metadata` for metadata-producing automation that should not silently fall back to less-authoritative data
- update generated CLI docs, manpage, and Fig completion metadata

## Validation

- `cargo test -p mise github::tests::required_releases_reject_empty_results`
- `cargo check -p mise`
- `cargo build -p mise`
- `mise run render:usage`
- `mise run render:mangen`
- `mise run render:fig`
- `target/debug/mise ls-remote --strict-metadata node` fails because `--json` is required
- `MISE_CACHE_DIR=$(mktemp -d) MISE_USE_VERSIONS_HOST=0 target/debug/mise ls-remote github:jdx/mise --json` now errors on the live empty `/releases` response instead of printing `[]`
- `MISE_CACHE_DIR=$(mktemp -d) MISE_USE_VERSIONS_HOST=0 MISE_PRERELEASES=1 MISE_LIST_ALL_VERSIONS=1 target/debug/mise ls-remote aqua:nektos/act --json` returned a non-zero prerelease count when GitHub returned releases, and errors loudly when GitHub returned empty `/releases`
- `git diff --check`
- commit hook: `hk` pass, including `cargo check --all-features`

## Notes

`--strict-metadata` intentionally does not reject empty final result sets, placeholder-looking version strings, or versions without `created_at`. It only prevents known metadata-degrading fallback behavior.

The targeted e2e command `mise run test:e2e cli/test_ls_remote backend/test_github_alias_versions` got through `cli/test_ls_remote`, then failed in `backend/test_github_alias_versions` because the local unauthenticated GitHub API quota was exhausted (`403 Forbidden` for `https://api.github.com/repos/jdx/mise-test-fixtures/releases`).
