### PR TITLE
fix(ls-remote): omit rolling/prerelease from JSON when false

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -99,7 +99,7 @@ pub struct VersionInfo {
     pub release_url: Option<String>,
     /// If true, this is a rolling release (like "nightly") that should always
     /// be considered potentially outdated for `mise up` purposes
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub rolling: bool,
     /// Checksum of the release asset, used to detect changes in rolling releases
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -108,8 +108,12 @@ pub struct VersionInfo {
     /// reliable signal (e.g. GitHub releases' `prerelease: true`) populate this
     /// so the shared remote-versions cache can store the superset and apply the
     /// `prerelease` tool option as a read-time filter.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub prerelease: bool,
+}
+
+fn is_false(v: &bool) -> bool {
+    !v
 }
 
 impl VersionInfo {


### PR DESCRIPTION
## Summary

- `mise ls-remote --json` previously emitted `"rolling":false,"prerelease":false` on every entry, e.g. `{"version":"1.0.0","rolling":false,"prerelease":false}` — noisy for the vast majority of versions where neither flag carries signal.
- Skip serialization of `rolling` and `prerelease` when `false`, matching the existing pattern used for the optional `created_at`, `release_url`, and `checksum` fields on `VersionInfo`.
- `#[serde(default)]` is preserved so previously-written remote-versions cache entries still deserialize cleanly.

After this change, dummy output is `[{"version":"1.0.0"},{"version":"1.1.0"},{"version":"2.0.0"}]`. Backends that legitimately set `rolling: true` (e.g. `rust` nightly/beta/stable) or `prerelease: true` (github/aqua) still emit the field.

## Test plan

- [x] `mise run test:e2e cli/test_ls_remote` — all assertions pass, including the existing `"created_at"` checks for github/npm/cargo/pipx backends
- [x] `cargo test --all-features --bin mise` — 785 passed, 0 failed
- [x] Manual: `mise ls-remote dummy --json` → fields omitted when false

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `serde` serialization for two boolean fields while preserving `#[serde(default)]` for backward-compatible deserialization.
> 
> **Overview**
> `VersionInfo` now **skips serializing** `rolling` and `prerelease` when they are `false`, so JSON outputs and cached remote-version entries no longer include noisy `"rolling":false`/`"prerelease":false` fields.
> 
> Deserialization behavior is preserved via `#[serde(default)]`, with a small helper (`is_false`) added to support the `skip_serializing_if` predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db84b9f59a29c749843063b6f729f1e887b1b96e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->