### PR TITLE
fix(aqua): drop empty-releases fallback to tags

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -2401,11 +2401,6 @@ async fn get_tags_with_created_at(
     }
     let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
     let releases = github::list_releases_including_prereleases(&repo).await?;
-    if releases.is_empty() {
-        // Fall back to tags (no timestamps, no prerelease flag)
-        let versions = github::list_tags(&repo).await?;
-        return Ok(versions.into_iter().map(|v| (v, None, false)).collect());
-    }
     Ok(releases
         .into_iter()
         .map(|r| (r.tag_name, Some(r.created_at), r.prerelease))

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1751,12 +1751,8 @@ pub trait Backend: Debug + Send + Sync {
             .unwrap()
             .entry(self.ba().full())
             .or_insert_with(|| {
-                // Bumped from `remote_versions.msgpack.z` to invalidate caches written
-                // before `VersionInfo.prerelease` existed: github/aqua now store the
-                // pre-release superset, and stale stable-only caches would otherwise
-                // mask pre-releases for `prerelease = true` users until TTL expiry.
                 let mut cm = CacheManagerBuilder::new(
-                    self.ba().cache_path.join("remote_versions_v2.msgpack.z"),
+                    self.ba().cache_path.join("remote_versions.msgpack.z"),
                 )
                 .with_fresh_duration(Settings::get().fetch_remote_versions_cache());
                 if let Some(plugin_path) = self.plugin().map(|p| p.path()) {


### PR DESCRIPTION
## Summary

Two related fixes from the prerelease feature aftermath:

### 1. `fix(aqua)`: drop empty-releases fallback to tags
When `list_releases_including_prereleases` returned `Ok([])` — paginated/cached edge case, throttled response, or a repo that genuinely has no releases — the fallback to `list_tags` pulled in every git tag in the repo. For monorepos that tag sub-crates, that meant non-release tags like ripgrep's `grep-regex-0.1.1` surfaced as candidate versions and got written into the shared `mise-versions` snapshot. End users hitting that snapshot then saw `ripgrep = "latest"` resolve to `grep-regex-0.1.1`, which 404s on the GitHub release URL.

Aqua packages that legitimately use git tags as their version source already opt in via `version_source = "github_tag"`; those continue to work. For everything else, an empty release list now propagates as an empty version list rather than masquerading as "all the tags".

`mise-versions` snapshots will need to be regenerated with a release that includes this fix.

### 2. `fix(backend)`: keep `remote_versions` cache filename stable
The bump to `remote_versions_v2.msgpack.z` invalidated every existing cache file with no real benefit. `VersionInfo` deserializes forwards-compatibly (`prerelease` defaults to `false` via `#[serde(default)]`), so old caches read fine. Users opting into pre-releases would just see no extra entries from a pre-feature cache until TTL expiry, which is the same staleness window any cache invalidation creates. Reverting to `remote_versions.msgpack.z`.

## Test plan
- [ ] `MISE_FETCH_REMOTE_VERSIONS_CACHE=0 mise ls-remote ripgrep` returns ripgrep release versions only (no `grep-regex-*`, `globset-*`, etc.)
- [ ] `mise install -f ripgrep@latest` resolves to a real release
- [ ] No regression for aqua packages with `version_source = "github_tag"`
- [ ] Existing `remote_versions.msgpack.z` cache files continue to be read

🤖 Generated with [Claude Code](https://claude.com/claude-code)