### PR TITLE
fix(backend): Don't cache empty version lists

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -679,7 +679,7 @@ pub trait Backend: Debug + Send + Sync {
         config: &Arc<Config>,
     ) -> eyre::Result<Vec<VersionInfo>> {
         let remote_versions = self.get_remote_version_cache();
-        let remote_versions = remote_versions.lock().await;
+        let mut remote_versions = remote_versions.lock().await;
         let ba = self.ba().clone();
         let id = self.id();
 
@@ -828,11 +828,12 @@ pub trait Backend: Debug + Send + Sync {
                 }
                 Ok(versions)
             })
-            .await?;
-        Ok(filter_cached_prereleases(
-            versions.clone(),
-            want_prereleases,
-        ))
+            .await?
+            .clone();
+        if versions.is_empty() {
+            remote_versions.clear()?;
+        }
+        Ok(filter_cached_prereleases(versions, want_prereleases))
     }
 
     /// Backend implementation for fetching remote versions with metadata.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -201,13 +201,14 @@ where
         Ok(())
     }
 
-    #[cfg(test)]
-    pub fn clear(&self) -> Result<()> {
+    pub fn clear(&mut self) -> Result<()> {
         let path = &self.cache_file_path;
         trace!("clearing cache {}", path.display());
         if path.exists() {
             file::remove_file(path)?;
         }
+        *self.cache = Default::default();
+        *self.cache_async = Default::default();
         Ok(())
     }
 
@@ -342,7 +343,7 @@ mod tests {
     #[tokio::test]
     async fn test_cache() {
         let _config = Config::get().await.unwrap();
-        let cache = CacheManagerBuilder::new(dirs::CACHE.join("test-cache")).build();
+        let mut cache = CacheManagerBuilder::new(dirs::CACHE.join("test-cache")).build();
         cache.clear().unwrap();
         let val = cache.get_or_try_init(|| Ok(1)).unwrap();
         assert_eq!(val, &1);


### PR DESCRIPTION
When _list_remote_versions returns no versions (e.g. invalid Go module path), the empty list was cached as a positive result via
get_or_try_init_async.

This poisons the cache for up to 1 hour, both on disk and in the in-memory OnceCell.

Clear both the disk cache file and the in-memory cells after fetching if the version list is empty so subsequent calls re-fetch instead of serving a stale empty result.

This is an alternative approach to my earlier attempt at fixing this because the previous approach ended up getting a bit complicated (required backend specific changes).