### PR TITLE
feat(ls-remote): add strict metadata mode

### DIFF
--- a/docs/cli/ls-remote.md
+++ b/docs/cli/ls-remote.md
@@ -36,6 +36,10 @@ an upstream prerelease flag (currently github + aqua). Equivalent to
 setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
 duration of this command.
 
+### `--no-versions-host`
+
+Disable checking the mise-versions host
+
 ### `--strict-metadata`
 
 Fail if release metadata fetches fail

--- a/docs/cli/ls-remote.md
+++ b/docs/cli/ls-remote.md
@@ -29,16 +29,16 @@ Show all installed plugins and versions
 
 Output in JSON format (includes version metadata like created_at timestamps when available)
 
+### `--no-versions-host`
+
+Disable checking the mise-versions host
+
 ### `--prerelease`
 
 Include pre-release versions in the output for backends that report
 an upstream prerelease flag (currently github + aqua). Equivalent to
 setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
 duration of this command.
-
-### `--no-versions-host`
-
-Disable checking the mise-versions host
 
 ### `--strict-metadata`
 

--- a/docs/cli/ls-remote.md
+++ b/docs/cli/ls-remote.md
@@ -38,10 +38,10 @@ duration of this command.
 
 ### `--strict-metadata`
 
-Fail if --json output cannot include complete version metadata
+Fail if release metadata fetches fail
 
-This prevents metadata consumers from accepting fallback lists that are
-missing created_at timestamps.
+This prevents metadata consumers from accepting empty fallback results
+when a backend's metadata-producing upstream request fails.
 
 Examples:
 

--- a/docs/cli/ls-remote.md
+++ b/docs/cli/ls-remote.md
@@ -44,6 +44,8 @@ Disable checking the mise-versions host
 
 Fail if release metadata fetches fail
 
+Requires --json and --no-versions-host.
+
 This prevents metadata consumers from accepting empty fallback results
 when a backend's metadata-producing upstream request fails.
 

--- a/docs/cli/ls-remote.md
+++ b/docs/cli/ls-remote.md
@@ -36,6 +36,13 @@ an upstream prerelease flag (currently github + aqua). Equivalent to
 setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
 duration of this command.
 
+### `--strict-metadata`
+
+Fail if --json output cannot include complete version metadata
+
+This prevents metadata consumers from accepting fallback lists that are
+missing created_at timestamps.
+
 Examples:
 
 ```

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1517,6 +1517,12 @@ Include pre\-release versions in the output for backends that report
 an upstream prerelease flag (currently github + aqua). Equivalent to
 setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
 duration of this command.
+.TP
+\fB\-\-strict\-metadata\fR
+Fail if \-\-json output cannot include complete version metadata
+
+This prevents metadata consumers from accepting fallback lists that are
+missing created_at timestamps.
 \fBArguments:\fR
 .PP
 .TP

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1524,6 +1524,8 @@ Disable checking the mise\-versions host
 \fB\-\-strict\-metadata\fR
 Fail if release metadata fetches fail
 
+Requires \-\-json and \-\-no\-versions\-host.
+
 This prevents metadata consumers from accepting empty fallback results
 when a backend's metadata\-producing upstream request fails.
 \fBArguments:\fR

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1518,6 +1518,9 @@ an upstream prerelease flag (currently github + aqua). Equivalent to
 setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
 duration of this command.
 .TP
+\fB\-\-no\-versions\-host\fR
+Disable checking the mise\-versions host
+.TP
 \fB\-\-strict\-metadata\fR
 Fail if release metadata fetches fail
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1519,10 +1519,10 @@ setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
 duration of this command.
 .TP
 \fB\-\-strict\-metadata\fR
-Fail if \-\-json output cannot include complete version metadata
+Fail if release metadata fetches fail
 
-This prevents metadata consumers from accepting fallback lists that are
-missing created_at timestamps.
+This prevents metadata consumers from accepting empty fallback results
+when a backend's metadata\-producing upstream request fails.
 \fBArguments:\fR
 .PP
 .TP

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1512,14 +1512,14 @@ Show all installed plugins and versions
 \fB\-J, \-\-json\fR
 Output in JSON format (includes version metadata like created_at timestamps when available)
 .TP
+\fB\-\-no\-versions\-host\fR
+Disable checking the mise\-versions host
+.TP
 \fB\-\-prerelease\fR
 Include pre\-release versions in the output for backends that report
 an upstream prerelease flag (currently github + aqua). Equivalent to
 setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
 duration of this command.
-.TP
-\fB\-\-no\-versions\-host\fR
-Disable checking the mise\-versions host
 .TP
 \fB\-\-strict\-metadata\fR
 Fail if release metadata fetches fail

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -596,6 +596,9 @@ cmd ls-remote help="List runtime versions available for install." {
     flag --all help="Show all installed plugins and versions"
     flag "-J --json" help="Output in JSON format (includes version metadata like created_at timestamps when available)"
     flag --prerelease help="Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command."
+    flag --strict-metadata help="Fail if --json output cannot include complete version metadata" {
+        long_help "Fail if --json output cannot include complete version metadata\n\nThis prevents metadata consumers from accepting fallback lists that are\nmissing created_at timestamps."
+    }
     arg "[TOOL@VERSION]" help="Tool to get versions for" required=#false
     arg "[PREFIX]" help="The version prefix to use when querying the latest version\nsame as the first argument after the \"@\"" required=#false
 }

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -598,7 +598,7 @@ cmd ls-remote help="List runtime versions available for install." {
     flag --prerelease help="Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command."
     flag --no-versions-host help="Disable checking the mise-versions host"
     flag --strict-metadata help="Fail if release metadata fetches fail" {
-        long_help "Fail if release metadata fetches fail\n\nThis prevents metadata consumers from accepting empty fallback results\nwhen a backend's metadata-producing upstream request fails."
+        long_help "Fail if release metadata fetches fail\n\nRequires --json and --no-versions-host.\n\nThis prevents metadata consumers from accepting empty fallback results\nwhen a backend's metadata-producing upstream request fails."
     }
     arg "[TOOL@VERSION]" help="Tool to get versions for" required=#false
     arg "[PREFIX]" help="The version prefix to use when querying the latest version\nsame as the first argument after the \"@\"" required=#false

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -596,6 +596,7 @@ cmd ls-remote help="List runtime versions available for install." {
     flag --all help="Show all installed plugins and versions"
     flag "-J --json" help="Output in JSON format (includes version metadata like created_at timestamps when available)"
     flag --prerelease help="Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command."
+    flag --no-versions-host help="Disable checking the mise-versions host"
     flag --strict-metadata help="Fail if release metadata fetches fail" {
         long_help "Fail if release metadata fetches fail\n\nThis prevents metadata consumers from accepting empty fallback results\nwhen a backend's metadata-producing upstream request fails."
     }

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -595,8 +595,8 @@ cmd ls-remote help="List runtime versions available for install." {
     after_long_help "Examples:\n\n    $ mise ls-remote node\n    18.0.0\n    20.0.0\n\n    $ mise ls-remote node@20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote node 20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote github:cli/cli --json\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]\n"
     flag --all help="Show all installed plugins and versions"
     flag "-J --json" help="Output in JSON format (includes version metadata like created_at timestamps when available)"
-    flag --prerelease help="Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command."
     flag --no-versions-host help="Disable checking the mise-versions host"
+    flag --prerelease help="Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command."
     flag --strict-metadata help="Fail if release metadata fetches fail" {
         long_help "Fail if release metadata fetches fail\n\nRequires --json and --no-versions-host.\n\nThis prevents metadata consumers from accepting empty fallback results\nwhen a backend's metadata-producing upstream request fails."
     }

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -596,8 +596,8 @@ cmd ls-remote help="List runtime versions available for install." {
     flag --all help="Show all installed plugins and versions"
     flag "-J --json" help="Output in JSON format (includes version metadata like created_at timestamps when available)"
     flag --prerelease help="Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command."
-    flag --strict-metadata help="Fail if --json output cannot include complete version metadata" {
-        long_help "Fail if --json output cannot include complete version metadata\n\nThis prevents metadata consumers from accepting fallback lists that are\nmissing created_at timestamps."
+    flag --strict-metadata help="Fail if release metadata fetches fail" {
+        long_help "Fail if release metadata fetches fail\n\nThis prevents metadata consumers from accepting empty fallback results\nwhen a backend's metadata-producing upstream request fails."
     }
     arg "[TOOL@VERSION]" help="Tool to get versions for" required=#false
     arg "[PREFIX]" help="The version prefix to use when querying the latest version\nsame as the first argument after the \"@\"" required=#false

--- a/registry/liqoctl.toml
+++ b/registry/liqoctl.toml
@@ -1,2 +1,0 @@
-backends = ["aqua:liqotech/liqo", "asdf:pdemagny/asdf-liqoctl"]
-description = "Enable dynamic and seamless Kubernetes multi-cluster topologies"

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -22,10 +22,10 @@ use crate::{
     },
     cache::{CacheManager, CacheManagerBuilder},
 };
-use crate::{backend::Backend, config::Config};
+use crate::{backend::Backend, backend::strict_metadata, config::Config};
 use crate::{file, github, minisign};
 use async_trait::async_trait;
-use eyre::{ContextCompat, Result, bail, eyre};
+use eyre::{ContextCompat, Result, WrapErr, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use regex::Regex;
@@ -213,6 +213,11 @@ impl Backend for AquaBackend {
         let pkg = match AQUA_REGISTRY.package(&self.id).await {
             Ok(pkg) => pkg,
             Err(e) => {
+                if strict_metadata() {
+                    return Err(e).wrap_err_with(|| {
+                        format!("failed to fetch aqua package metadata for {}", self.id)
+                    });
+                }
                 warn!("Remote versions cannot be fetched: {}", e);
                 return Ok(vec![]);
             }
@@ -232,6 +237,11 @@ impl Backend for AquaBackend {
         let tags_with_timestamps = match get_tags_with_created_at(&pkg).await {
             Ok(tags) => tags,
             Err(e) => {
+                if strict_metadata() {
+                    return Err(e).wrap_err_with(|| {
+                        format!("failed to fetch aqua release metadata for {}", self.id)
+                    });
+                }
                 warn!("Remote versions cannot be fetched: {}", e);
                 return Ok(vec![]);
             }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -213,11 +213,6 @@ impl Backend for AquaBackend {
         let pkg = match AQUA_REGISTRY.package(&self.id).await {
             Ok(pkg) => pkg,
             Err(e) => {
-                if strict_metadata() {
-                    return Err(e).wrap_err_with(|| {
-                        format!("failed to fetch aqua package metadata for {}", self.id)
-                    });
-                }
                 warn!("Remote versions cannot be fetched: {}", e);
                 return Ok(vec![]);
             }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -40,7 +40,7 @@ use crate::{
 use crate::{dirs, env, file, hash, lock_file, versions_host};
 use async_trait::async_trait;
 use backend_type::BackendType;
-use eyre::{Result, WrapErr, bail, eyre};
+use eyre::{Result, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use platform_target::PlatformTarget;
@@ -803,14 +803,6 @@ pub trait Backend: Debug + Send + Sync {
                         }
                         Ok(None) => {}
                         Err(e) => {
-                            if strict_metadata() {
-                                return Err(e).wrap_err_with(|| {
-                                    eyre!(
-                                        "failed to fetch version metadata from versions host for {}",
-                                        ba.to_string()
-                                    )
-                                });
-                            }
                             debug!("Error getting versions from versions host: {:#}", e);
                         }
                     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,7 +5,10 @@ use std::fs::File;
 use std::hash::Hash;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 use tokio::sync::Mutex as TokioMutex;
 
 use jiff::Timestamp;
@@ -37,7 +40,7 @@ use crate::{
 use crate::{dirs, env, file, hash, lock_file, versions_host};
 use async_trait::async_trait;
 use backend_type::BackendType;
-use eyre::{Result, bail, eyre};
+use eyre::{Result, WrapErr, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use platform_target::PlatformTarget;
@@ -72,6 +75,16 @@ pub type ABackend = Arc<dyn Backend>;
 pub type BackendMap = BTreeMap<String, ABackend>;
 pub type BackendList = Vec<ABackend>;
 pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
+
+static STRICT_METADATA: AtomicBool = AtomicBool::new(false);
+
+pub fn set_strict_metadata(strict: bool) {
+    STRICT_METADATA.store(strict, Ordering::Relaxed);
+}
+
+pub fn strict_metadata() -> bool {
+    STRICT_METADATA.load(Ordering::Relaxed)
+}
 
 /// Information about a GitHub/GitLab release for platform-specific tools
 #[derive(Debug, Clone)]
@@ -790,6 +803,14 @@ pub trait Backend: Debug + Send + Sync {
                         }
                         Ok(None) => {}
                         Err(e) => {
+                            if strict_metadata() {
+                                return Err(e).wrap_err_with(|| {
+                                    eyre!(
+                                        "failed to fetch version metadata from versions host for {}",
+                                        ba.to_string()
+                                    )
+                                });
+                            }
                             debug!("Error getting versions from versions host: {:#}", e);
                         }
                     }

--- a/src/cli/asdf.rs
+++ b/src/cli/asdf.rs
@@ -47,6 +47,7 @@ async fn list_versions(config: &Arc<Config>, args: &[String]) -> Result<()> {
             plugin: args.get(3).map(|s| s.parse()).transpose()?,
             json: false,
             prerelease: false,
+            strict_metadata: false,
         }
         .run()
         .await;

--- a/src/cli/asdf.rs
+++ b/src/cli/asdf.rs
@@ -47,6 +47,7 @@ async fn list_versions(config: &Arc<Config>, args: &[String]) -> Result<()> {
             plugin: args.get(3).map(|s| s.parse()).transpose()?,
             json: false,
             prerelease: false,
+            no_versions_host: false,
             strict_metadata: false,
         }
         .run()

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use eyre::Result;
+use eyre::{Result, bail};
 use serde::Serialize;
 
-use crate::backend::Backend;
+use crate::backend::{Backend, VersionInfo};
 use crate::cli::args::ToolArg;
 use crate::config::Settings;
 use crate::toolset::{ToolRequest, tool_request};
@@ -53,6 +53,13 @@ pub struct LsRemote {
     /// duration of this command.
     #[clap(long, verbatim_doc_comment)]
     pub prerelease: bool,
+
+    /// Fail if --json output cannot include complete version metadata
+    ///
+    /// This prevents metadata consumers from accepting fallback lists that are
+    /// missing created_at timestamps.
+    #[clap(long, verbatim_doc_comment, requires = "json")]
+    pub strict_metadata: bool,
 }
 
 impl LsRemote {
@@ -60,6 +67,7 @@ impl LsRemote {
         if self.prerelease {
             Settings::override_with(|s| s.prereleases = Some(true));
         }
+        backend::set_strict_metadata(self.strict_metadata);
         let config = Config::get().await?;
         if let Some(plugin) = self.get_plugin(&config).await? {
             self.run_single(&config, plugin).await
@@ -89,6 +97,9 @@ impl LsRemote {
             .collect();
 
         if self.json {
+            if self.strict_metadata {
+                ensure_complete_metadata(plugin.id(), &versions)?;
+            }
             miseprintln!("{}", serde_json::to_string(&versions)?);
         } else {
             for v in versions {
@@ -102,7 +113,11 @@ impl LsRemote {
         let mut versions = vec![];
         for b in backend::list() {
             let tool = b.id().to_string();
-            for v in b.list_remote_versions_with_info(config).await? {
+            let tool_versions = b.list_remote_versions_with_info(config).await?;
+            if self.strict_metadata {
+                ensure_complete_metadata(&tool, &tool_versions)?;
+            }
+            for v in tool_versions {
                 versions.push(VersionOutputAll {
                     tool: tool.clone(),
                     version: v.version,
@@ -135,6 +150,44 @@ impl LsRemote {
             }
             None => Ok(None),
         }
+    }
+}
+
+fn ensure_complete_metadata(tool: &str, versions: &[VersionInfo]) -> Result<()> {
+    if let Some(version) = versions.iter().find(|v| v.created_at.is_none()) {
+        bail!(
+            "{}@{} is missing created_at metadata; rerun without --strict-metadata to allow incomplete metadata",
+            tool,
+            version.version
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ensure_complete_metadata_accepts_created_at() {
+        let versions = vec![VersionInfo {
+            version: "1.0.0".into(),
+            created_at: Some("2024-01-01T00:00:00Z".into()),
+            ..Default::default()
+        }];
+
+        assert!(ensure_complete_metadata("test", &versions).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_complete_metadata_rejects_missing_created_at() {
+        let versions = vec![VersionInfo {
+            version: "1.0.0".into(),
+            ..Default::default()
+        }];
+
+        let err = ensure_complete_metadata("test", &versions).unwrap_err();
+        assert!(err.to_string().contains("test@1.0.0"));
     }
 }
 

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -60,6 +60,8 @@ pub struct LsRemote {
 
     /// Fail if release metadata fetches fail
     ///
+    /// Requires --json and --no-versions-host.
+    ///
     /// This prevents metadata consumers from accepting empty fallback results
     /// when a backend's metadata-producing upstream request fails.
     #[clap(long, verbatim_doc_comment, requires_all = ["json", "no_versions_host"])]

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -47,16 +47,16 @@ pub struct LsRemote {
     #[clap(short = 'J', long, verbatim_doc_comment)]
     pub json: bool,
 
+    /// Disable checking the mise-versions host
+    #[clap(long, verbatim_doc_comment)]
+    pub no_versions_host: bool,
+
     /// Include pre-release versions in the output for backends that report
     /// an upstream prerelease flag (currently github + aqua). Equivalent to
     /// setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
     /// duration of this command.
     #[clap(long, verbatim_doc_comment)]
     pub prerelease: bool,
-
-    /// Disable checking the mise-versions host
-    #[clap(long, verbatim_doc_comment)]
-    pub no_versions_host: bool,
 
     /// Fail if release metadata fetches fail
     ///

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -54,11 +54,15 @@ pub struct LsRemote {
     #[clap(long, verbatim_doc_comment)]
     pub prerelease: bool,
 
+    /// Disable checking the mise-versions host
+    #[clap(long, verbatim_doc_comment)]
+    pub no_versions_host: bool,
+
     /// Fail if release metadata fetches fail
     ///
     /// This prevents metadata consumers from accepting empty fallback results
     /// when a backend's metadata-producing upstream request fails.
-    #[clap(long, verbatim_doc_comment, requires = "json")]
+    #[clap(long, verbatim_doc_comment, requires_all = ["json", "no_versions_host"])]
     pub strict_metadata: bool,
 }
 
@@ -66,6 +70,9 @@ impl LsRemote {
     pub async fn run(self) -> Result<()> {
         if self.prerelease {
             Settings::override_with(|s| s.prereleases = Some(true));
+        }
+        if self.no_versions_host {
+            Settings::override_with(|s| s.use_versions_host = Some(false));
         }
         backend::set_strict_metadata(self.strict_metadata);
         let config = Config::get().await?;

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use eyre::{Result, bail};
+use eyre::Result;
 use serde::Serialize;
 
-use crate::backend::{Backend, VersionInfo};
+use crate::backend::Backend;
 use crate::cli::args::ToolArg;
 use crate::config::Settings;
 use crate::toolset::{ToolRequest, tool_request};
@@ -54,10 +54,10 @@ pub struct LsRemote {
     #[clap(long, verbatim_doc_comment)]
     pub prerelease: bool,
 
-    /// Fail if --json output cannot include complete version metadata
+    /// Fail if release metadata fetches fail
     ///
-    /// This prevents metadata consumers from accepting fallback lists that are
-    /// missing created_at timestamps.
+    /// This prevents metadata consumers from accepting empty fallback results
+    /// when a backend's metadata-producing upstream request fails.
     #[clap(long, verbatim_doc_comment, requires = "json")]
     pub strict_metadata: bool,
 }
@@ -97,9 +97,6 @@ impl LsRemote {
             .collect();
 
         if self.json {
-            if self.strict_metadata {
-                ensure_complete_metadata(plugin.id(), &versions)?;
-            }
             miseprintln!("{}", serde_json::to_string(&versions)?);
         } else {
             for v in versions {
@@ -114,9 +111,6 @@ impl LsRemote {
         for b in backend::list() {
             let tool = b.id().to_string();
             let tool_versions = b.list_remote_versions_with_info(config).await?;
-            if self.strict_metadata {
-                ensure_complete_metadata(&tool, &tool_versions)?;
-            }
             for v in tool_versions {
                 versions.push(VersionOutputAll {
                     tool: tool.clone(),
@@ -150,44 +144,6 @@ impl LsRemote {
             }
             None => Ok(None),
         }
-    }
-}
-
-fn ensure_complete_metadata(tool: &str, versions: &[VersionInfo]) -> Result<()> {
-    if let Some(version) = versions.iter().find(|v| v.created_at.is_none()) {
-        bail!(
-            "{}@{} is missing created_at metadata; rerun without --strict-metadata to allow incomplete metadata",
-            tool,
-            version.version
-        );
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_ensure_complete_metadata_accepts_created_at() {
-        let versions = vec![VersionInfo {
-            version: "1.0.0".into(),
-            created_at: Some("2024-01-01T00:00:00Z".into()),
-            ..Default::default()
-        }];
-
-        assert!(ensure_complete_metadata("test", &versions).is_ok());
-    }
-
-    #[test]
-    fn test_ensure_complete_metadata_rejects_missing_created_at() {
-        let versions = vec![VersionInfo {
-            version: "1.0.0".into(),
-            ..Default::default()
-        }];
-
-        let err = ensure_complete_metadata("test", &versions).unwrap_err();
-        assert!(err.to_string().contains("test@1.0.0"));
     }
 }
 

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use xx::regex;
 
 use crate::backend::platform_target::PlatformTarget;
-use crate::backend::{Backend, VersionInfo, normalize_idiomatic_contents};
+use crate::backend::{Backend, VersionInfo, normalize_idiomatic_contents, strict_metadata};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
@@ -651,7 +651,7 @@ impl RubyPlugin {
     }
 
     /// Fetch created_at timestamps for Ruby versions from GitHub releases
-    async fn fetch_ruby_release_dates(&self) -> HashMap<String, String> {
+    async fn fetch_ruby_release_dates(&self) -> Result<HashMap<String, String>> {
         let mut dates = HashMap::new();
         match github::list_releases("ruby/ruby").await {
             Ok(releases) => {
@@ -662,10 +662,13 @@ impl RubyPlugin {
                 }
             }
             Err(err) => {
+                if strict_metadata() {
+                    return Err(err).wrap_err("failed to fetch Ruby release metadata");
+                }
                 debug!("Failed to fetch Ruby release dates: {err}");
             }
         }
-        dates
+        Ok(dates)
     }
 
     /// Try to install from precompiled binary
@@ -869,7 +872,7 @@ impl Backend for RubyPlugin {
                 }
 
                 // Fetch Ruby release dates from GitHub in parallel with version list
-                let release_dates = self.fetch_ruby_release_dates().await;
+                let release_dates = self.fetch_ruby_release_dates().await?;
 
                 let ruby_build_bin = self.ruby_build_bin();
                 let ruby_build_str = ruby_build_bin.to_string_lossy().to_string();

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1756,6 +1756,11 @@ const completionSpec: Fig.Spec = {
           isRepeatable: false,
         },
         {
+          name: "--no-versions-host",
+          description: "Disable checking the mise-versions host",
+          isRepeatable: false,
+        },
+        {
           name: "--strict-metadata",
           description: "Fail if release metadata fetches fail",
           isRepeatable: false,

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1750,14 +1750,14 @@ const completionSpec: Fig.Spec = {
           isRepeatable: false,
         },
         {
-          name: "--prerelease",
-          description:
-            "Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command.",
+          name: "--no-versions-host",
+          description: "Disable checking the mise-versions host",
           isRepeatable: false,
         },
         {
-          name: "--no-versions-host",
-          description: "Disable checking the mise-versions host",
+          name: "--prerelease",
+          description:
+            "Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command.",
           isRepeatable: false,
         },
         {

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1757,8 +1757,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--strict-metadata",
-          description:
-            "Fail if --json output cannot include complete version metadata",
+          description: "Fail if release metadata fetches fail",
           isRepeatable: false,
         },
       ],

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1755,6 +1755,12 @@ const completionSpec: Fig.Spec = {
             "Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command.",
           isRepeatable: false,
         },
+        {
+          name: "--strict-metadata",
+          description:
+            "Fail if --json output cannot include complete version metadata",
+          isRepeatable: false,
+        },
       ],
       args: [
         {


### PR DESCRIPTION
## Summary

- add `mise ls-remote --no-versions-host` to explicitly bypass `mise-versions` for direct backend checks
- require `--strict-metadata` to be used with both `--json` and `--no-versions-host`, so strict mode validates direct backend metadata behavior instead of cached rows
- keep non-metadata backends usable under strict mode instead of rejecting valid all-null `created_at` output
- make Aqua release/tag GitHub API failures and Ruby release-date GitHub API failures surface in strict mode instead of silently returning empty or partial metadata
- remove `liqoctl` from the registry because its default `aqua:liqotech/liqo` package does not exist in aqua-registry
- regenerate usage metadata, CLI docs, manpage, and Fig spec

## Why

The `mise-versions` update job needs a mode that does not silently accept empty fallback results when metadata-producing upstream calls fail. Requiring every backend row to contain `created_at` is too broad because some registry defaults are not GitHub-backed and cannot provide timestamps.

`--no-versions-host` keeps the direct-upstream behavior explicit instead of baking backend allowlists into strict metadata mode.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo build`
- `cargo build --all-features`
- `target/debug/mise run render:usage`
- `target/debug/mise run render:mangen`
- `target/debug/mise run render:fig`
- `target/debug/mise ls-remote github:cli/cli --json --strict-metadata` fails because `--no-versions-host` is required
- `target/debug/mise ls-remote github:cli/cli --no-versions-host --strict-metadata` fails because `--json` is required
- `target/debug/mise ls-remote github:cli/cli --json --no-versions-host --strict-metadata | jq 'length, .[0]'`
- `target/debug/mise ls-remote bun --json --no-versions-host --strict-metadata | jq 'length, .[0]'`
- `target/debug/mise ls-remote ruby --json --no-versions-host --strict-metadata | jq 'length, .[0]'`
- pre-commit `hk` suite, including all-features `cargo check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior changes are gated behind new `ls-remote` flags, but strict mode alters error handling by surfacing upstream metadata failures (aqua/ruby) that previously returned empty/partial results.
> 
> **Overview**
> `mise ls-remote` now supports `--no-versions-host` to force direct backend checks and `--strict-metadata` (requires `--json` + `--no-versions-host`) to **fail instead of silently falling back** when metadata-producing upstream calls fail.
> 
> Introduces a shared strict-metadata toggle in `backend` and updates the Aqua backend and Ruby core plugin to propagate GitHub/aqua metadata fetch errors in strict mode. Removes the `liqoctl` registry entry due to an invalid default aqua package, and regenerates usage docs, the manpage, and the Fig completion spec to document the new flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af4202ab345b6989dde1d4525a7e45be0f2cfb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->