### PR TITLE
fix(deps): update astral-tokio-tar advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",


### PR DESCRIPTION
## Summary

- update `astral-tokio-tar` from `0.6.0` to `0.6.1` in `Cargo.lock`
- resolve the cargo-deny advisory reported in the failing `lint` job

## Root Cause

The `lint` job failed in `cargo deny check` because `astral-tokio-tar 0.6.0` is affected by the PAX header desynchronization advisory. The dependency is pulled through `rattler_package_streaming`.

## Validation

- `rm -rf ~/.cargo/advisory-dbs && cargo deny check`
- `cargo check`
- pre-commit `hk` suite, including all-features `cargo check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump to address a known advisory; no application logic changes, with risk mainly limited to potential transitive behavior changes in tar extraction.
> 
> **Overview**
> Updates the locked Rust dependency `astral-tokio-tar` from `0.6.0` to `0.6.1` (checksum updated) to resolve the PAX header desynchronization advisory flagged by `cargo-deny`.
> 
> No source changes beyond `Cargo.lock`; behavior changes are limited to whatever `astral-tokio-tar` updates in this patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e4b93f4c00ed132e122ffadab5a0c47adb2292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->