### PR TITLE
feat(deps): add aube provider

### DIFF
--- a/docs/dev-tools/deps.md
+++ b/docs/dev-tools/deps.md
@@ -36,6 +36,7 @@ auto = true  # Auto-run before mise x/run
 [deps.yarn]
 [deps.pnpm]
 [deps.bun]
+[deps.aube]
 [deps.go]
 [deps.pip]
 [deps.poetry]
@@ -65,6 +66,7 @@ mise includes built-in providers for common package managers:
 | `yarn`     | `package.json`, `yarn.lock`             | `node_modules/`       | `yarn install`                       |
 | `pnpm`     | `package.json`, `pnpm-lock.yaml`        | `node_modules/`       | `pnpm install`                       |
 | `bun`      | `package.json`, `bun.lock`, `bun.lockb` | `node_modules/`       | `bun install`                        |
+| `aube`     | `package.json`, `aube-lock.yaml`        | `node_modules/`       | `aube install`                       |
 | `go`       | `go.mod`                                | `vendor/` or `go.sum` | `go mod vendor` or `go mod download` |
 | `pip`      | `requirements.txt`                      | `.venv/`              | `pip install -r requirements.txt`    |
 | `poetry`   | `pyproject.toml`, `poetry.lock`         | `.venv/`              | `poetry install`                     |
@@ -90,7 +92,7 @@ mise deps remove npm:lodash
 ```
 
 The ecosystem prefix tells mise which package manager to use. Currently supported
-ecosystems for add/remove: `npm`, `yarn`, `pnpm`, `bun`.
+ecosystems for add/remove: `npm`, `yarn`, `pnpm`, `bun`, `aube`.
 
 ## Custom Providers
 

--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -139,8 +139,22 @@ EOF
 assert_contains "mise deps --list" "bun"
 assert_contains "mise deps --list" "bun.lock"
 
-# Test go provider
+# Test aube provider
 rm -f bun.lock
+cat >aube-lock.yaml <<'EOF'
+lockfileVersion: 1
+EOF
+
+cat >mise.toml <<'EOF'
+[deps.aube]
+EOF
+
+assert_contains "mise deps --list" "aube"
+assert_contains "mise deps --list" "aube-lock.yaml"
+assert_contains "mise deps --dry-run 2>&1" "aube"
+
+# Test go provider
+rm -f aube-lock.yaml
 cat >go.sum <<'EOF'
 github.com/foo/bar v1.0.0 h1:abc
 EOF

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -19,9 +19,9 @@ type JobOutput = Result<(String, DepsStepResult, Vec<PathBuf>), (String, eyre::R
 
 use super::deps_ordering::DepsOrdering;
 use super::providers::{
-    BunDepsProvider, BundlerDepsProvider, ComposerDepsProvider, CustomDepsProvider,
-    GitSubmoduleDepsProvider, GoDepsProvider, NpmDepsProvider, PipDepsProvider, PnpmDepsProvider,
-    PoetryDepsProvider, UvDepsProvider, YarnDepsProvider,
+    AubeDepsProvider, BunDepsProvider, BundlerDepsProvider, ComposerDepsProvider,
+    CustomDepsProvider, GitSubmoduleDepsProvider, GoDepsProvider, NpmDepsProvider, PipDepsProvider,
+    PnpmDepsProvider, PoetryDepsProvider, UvDepsProvider, YarnDepsProvider,
 };
 use super::rule::BUILTIN_PROVIDERS;
 use super::state::{self, DepsState};
@@ -176,6 +176,10 @@ impl DepsEngine {
                     provider_config,
                 ))),
                 "bun" => Some(Box::new(BunDepsProvider::new(config_root, provider_config))),
+                "aube" => Some(Box::new(AubeDepsProvider::new(
+                    config_root,
+                    provider_config,
+                ))),
                 "go" => Some(Box::new(GoDepsProvider::new(config_root, provider_config))),
                 "pip" => Some(Box::new(PipDepsProvider::new(config_root, provider_config))),
                 "poetry" => Some(Box::new(PoetryDepsProvider::new(

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -249,6 +249,10 @@ pub fn detect_applicable_providers(project_root: &Path) -> Vec<String> {
             Box::new(BunDepsProvider::new(project_root, default_config.clone())),
         ),
         (
+            "aube",
+            Box::new(AubeDepsProvider::new(project_root, default_config.clone())),
+        ),
+        (
             "go",
             Box::new(GoDepsProvider::new(project_root, default_config.clone())),
         ),

--- a/src/deps/providers/aube.rs
+++ b/src/deps/providers/aube.rs
@@ -1,0 +1,89 @@
+use std::path::{Path, PathBuf};
+
+use eyre::Result;
+
+use crate::deps::rule::DepsProviderConfig;
+use crate::deps::{DepsCommand, DepsProvider};
+
+use super::ProviderBase;
+
+/// Deps provider for aube (aube-lock.yaml)
+#[derive(Debug)]
+pub struct AubeDepsProvider {
+    base: ProviderBase,
+}
+
+impl AubeDepsProvider {
+    pub fn new(project_root: &Path, config: DepsProviderConfig) -> Self {
+        Self {
+            base: ProviderBase::new("aube", project_root, config),
+        }
+    }
+}
+
+impl DepsProvider for AubeDepsProvider {
+    fn base(&self) -> &ProviderBase {
+        &self.base
+    }
+
+    fn sources(&self) -> Vec<PathBuf> {
+        let root = self.base.config_root();
+        vec![root.join("aube-lock.yaml"), root.join("package.json")]
+    }
+
+    fn outputs(&self) -> Vec<PathBuf> {
+        vec![self.base.config_root().join("node_modules")]
+    }
+
+    fn install_command(&self) -> Result<DepsCommand> {
+        if let Some(run) = &self.base.config.run {
+            return DepsCommand::from_string(run, &self.base.project_root, &self.base.config);
+        }
+
+        Ok(DepsCommand {
+            program: "aube".to_string(),
+            args: vec!["install".to_string()],
+            env: self.base.config.env.clone(),
+            cwd: Some(self.base.config_root()),
+            description: self
+                .base
+                .config
+                .description
+                .clone()
+                .unwrap_or_else(|| "aube install".to_string()),
+        })
+    }
+
+    fn is_applicable(&self) -> bool {
+        self.base.config_root().join("aube-lock.yaml").exists()
+    }
+
+    fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {
+        let mut args = vec!["add".to_string()];
+        if dev {
+            args.push("-D".to_string());
+        }
+        args.extend(packages.iter().map(|p| p.to_string()));
+
+        Ok(DepsCommand {
+            program: "aube".to_string(),
+            args,
+            env: self.base.config.env.clone(),
+            cwd: Some(self.base.config_root()),
+            description: format!("aube add {}", packages.join(" ")),
+        })
+    }
+
+    fn remove_command(&self, packages: &[&str]) -> Result<DepsCommand> {
+        let mut args = vec!["remove".to_string()];
+        args.extend(packages.iter().map(|p| p.to_string()));
+
+        Ok(DepsCommand {
+            program: "aube".to_string(),
+            args,
+            env: self.base.config.env.clone(),
+            cwd: Some(self.base.config_root()),
+            description: format!("aube remove {}", packages.join(" ")),
+        })
+    }
+}

--- a/src/deps/providers/mod.rs
+++ b/src/deps/providers/mod.rs
@@ -1,3 +1,4 @@
+mod aube;
 mod bun;
 mod bundler;
 mod composer;
@@ -11,6 +12,7 @@ mod poetry;
 mod uv;
 mod yarn;
 
+pub use aube::AubeDepsProvider;
 pub use bun::BunDepsProvider;
 pub use bundler::BundlerDepsProvider;
 pub use composer::ComposerDepsProvider;

--- a/src/deps/rule.rs
+++ b/src/deps/rule.rs
@@ -8,6 +8,7 @@ pub const BUILTIN_PROVIDERS: &[&str] = &[
     "yarn",
     "pnpm",
     "bun",           // Node.js
+    "aube",          // Node.js
     "go",            // Go
     "pip",           // Python (requirements.txt)
     "poetry",        // Python (poetry)


### PR DESCRIPTION
## Summary

- Adds a built-in `aube` deps provider — auto-detects projects via `aube-lock.yaml`, runs `aube install` for freshness, and outputs to `node_modules/`.
- Wires `mise deps add aube:<pkg>` (with `-D` for dev) and `mise deps remove aube:<pkg>` so aube can manage individual packages alongside the existing npm/yarn/pnpm/bun ecosystems.
- Documents aube in `docs/dev-tools/deps.md` (provider table, ecosystem list, configuration example) and adds e2e coverage in `e2e/cli/test_deps`.

## Why

aube is a fast Rust-written Node.js package manager (https://github.com/endevco/aube) already in mise's registry. With this PR, an aube-backed project gets the same first-class `mise deps` experience as bun/pnpm: lockfile-aware freshness checks, optional `auto = true`, and add/remove via the `aube:` prefix.

## Implementation notes

- New provider lives at `src/deps/providers/aube.rs`, modeled after the bun provider. Detection is keyed on `aube-lock.yaml` (aube's native lockfile) — projects that use aube against an existing `pnpm-lock.yaml`/`bun.lock`/etc. continue to be detected by those providers.
- `aube` is registered in `BUILTIN_PROVIDERS`, in the `build_provider` dispatch in `engine.rs`, and in `detect_applicable_providers`.
- Dev-dependency flag uses aube's documented `-D` short form.

## Test plan

- [x] `mise run lint` passes
- [x] `cargo build` succeeds
- [x] `mise run test:e2e test_deps` — new aube assertions (`--list` shows `aube` + `aube-lock.yaml`, `--dry-run` mentions `aube`) all pass alongside existing provider coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change that registers a new deps provider and updates detection/listing logic; impact is limited to projects that opt into `[deps.aube]` and have `aube-lock.yaml` present.
> 
> **Overview**
> Adds first-class support for the `aube` Node.js package manager in `mise deps`, including lockfile-based applicability (`aube-lock.yaml`), default install command (`aube install`), and package management via `mise deps add/remove aube:<pkg>` (with `-D` for dev deps).
> 
> Wires the provider into built-in provider registration, discovery, and provider construction, updates docs to list/configure `aube`, and extends the `test_deps` e2e coverage to assert `--list` and `--dry-run` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da02da99860682b41122e4a839aca0f42d612ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->