### PR TITLE
fix(task): install monorepo subdir tools before running deps

### DIFF
--- a/e2e/tasks/test_task_monorepo_deps_tool_install
+++ b/e2e/tasks/test_task_monorepo_deps_tool_install
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Regression test for https://github.com/jdx/mise/discussions/9445
+#
+# When invoking a monorepo task from the root with `mise //sub:taskname`,
+# tools declared in the subdirectory's mise.toml must be installed BEFORE
+# any auto `[deps]` step runs — otherwise providers like `[deps.bun] auto=true`
+# fail because the tool isn't on PATH yet.
+#
+# Before the fix, the toolset was built only from the root config hierarchy,
+# so subdir tools were never installed and `mise //sub:taskname` failed at
+# the deps stage with "No such file or directory" on a clean checkout.
+
+export MISE_EXPERIMENTAL=1
+
+cat <<'EOF' >mise.toml
+experimental_monorepo_root = true
+
+[settings]
+experimental = true
+
+[monorepo]
+config_roots = ["sub"]
+EOF
+
+mkdir -p sub
+cat <<'EOF' >sub/mise.toml
+[tools]
+tiny = "1"
+
+[deps.needs_tiny]
+auto = true
+sources = ["input.txt"]
+outputs = ["output.txt"]
+run = "rtx-tiny > output.txt"
+
+[tasks.use-tiny]
+run = 'rtx-tiny'
+EOF
+
+touch sub/input.txt
+
+# Make sure tiny isn't already installed so we exercise the install path.
+rm -rf "${MISE_DATA_DIR}/installs/tiny/1"* 2>/dev/null || true
+
+# Running the monorepo task from the root should:
+#   1. install `tiny` (from sub/mise.toml)
+#   2. run [deps.needs_tiny] which uses `rtx-tiny`
+#   3. run the task, which also uses `rtx-tiny`
+assert_contains "mise run //sub:use-tiny" "rtx-tiny"
+assert_contains "cat sub/output.txt" "rtx-tiny"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -306,26 +306,6 @@ impl Run {
 
         let mut task_list = get_task_lists(&config, &args, true, self.skip_deps).await?;
 
-        // Build and install toolset only after tasks resolve. A naked run that
-        // does not match any task should fail without installing project tools.
-        let mut ts = ToolsetBuilder::new()
-            .with_args(&self.tool)
-            .with_default_to_latest(true)
-            .build(&config)
-            .await?;
-
-        let opts = InstallOptions {
-            jobs: self.jobs,
-            raw: self.raw,
-            missing_args_only: !Settings::get().task.run_auto_install,
-            skip_auto_install: !Settings::get().task.run_auto_install
-                || !Settings::get().auto_install,
-            ..Default::default()
-        };
-        if !self.skip_tools {
-            let _ = ts.install_missing_versions(&mut config, &opts).await?;
-        }
-
         // Args after -- go directly to tasks (no prefix). They are also
         // recorded on `trailing_args` so the task renderer can detect
         // `-- --help` / `-- -h` and bypass the usage parser for them.
@@ -363,19 +343,54 @@ impl Run {
 
         // Resolve transitive dependencies once upfront so we can:
         // 1. Discover deps providers from monorepo subdirectory configs
-        // 2. Reuse the resolved list for execution (avoiding duplicate work)
+        // 2. Include monorepo subdirectory tools in the toolset before installing
+        // 3. Reuse the resolved list for execution (avoiding duplicate work)
         let resolved_tasks = resolve_depends(&config, task_list).await?;
+
+        // Collect subdirectory config files from all resolved tasks. In
+        // monorepos these come from sub mise.toml files referenced via the
+        // `//sub:taskname` syntax — they aren't in `config.config_files`.
+        let subdir_configs: Vec<_> = resolved_tasks
+            .iter()
+            .filter_map(|task| task.cf.clone())
+            .collect();
+
+        // Build the toolset using root config files plus subdir configs from
+        // resolved tasks, so tools declared in monorepo subdirs are installed
+        // before deps (e.g. `[deps.bun] auto=true`) try to use them.
+        let mut combined_configs = config.config_files.clone();
+        for cf in &subdir_configs {
+            combined_configs
+                .entry(cf.get_path().to_path_buf())
+                .or_insert_with(|| cf.clone());
+        }
+
+        // Build and install toolset only after tasks resolve. A naked run that
+        // does not match any task should fail without installing project tools.
+        let mut ts = ToolsetBuilder::new()
+            .with_args(&self.tool)
+            .with_default_to_latest(true)
+            .with_config_files(combined_configs)
+            .build(&config)
+            .await?;
+
+        let opts = InstallOptions {
+            jobs: self.jobs,
+            raw: self.raw,
+            missing_args_only: !Settings::get().task.run_auto_install,
+            skip_auto_install: !Settings::get().task.run_auto_install
+                || !Settings::get().auto_install,
+            ..Default::default()
+        };
+        if !self.skip_tools {
+            let _ = ts.install_missing_versions(&mut config, &opts).await?;
+        }
 
         // Run auto-enabled deps steps (unless --no-deps)
         if !self.no_deps {
             let env = ts.env_with_path(&config).await?;
             let mut engine = DepsEngine::new(&config)?;
 
-            // Collect subdirectory config files from all resolved tasks
-            let subdir_configs: Vec<_> = resolved_tasks
-                .iter()
-                .filter_map(|task| task.cf.clone())
-                .collect();
             if !subdir_configs.is_empty() {
                 engine.add_config_files(subdir_configs);
             }


### PR DESCRIPTION
## Summary

Fixes [#9445](https://github.com/jdx/mise/discussions/9445): in a monorepo, running a task from the root via `mise //sub:taskname` failed when `sub/mise.toml` declared both a tool and an auto `[deps]` provider that used it (e.g. `bun = \"latest\"` + `[deps.bun] auto=true`). The deps step ran *before* the subdirectory's tool was installed, so `bun install` died with `No such file or directory`.

The user-reported workaround was running `mise -C sub/ deps` once so `.mise/deps-state.toml` skipped the broken path on subsequent runs.

## Root cause

In `Run::run` ([src/cli/run.rs](https://github.com/jdx/mise/blob/main/src/cli/run.rs)):
1. `get_task_lists` correctly loaded subdirectory tasks via `TaskLoadContext`.
2. `ToolsetBuilder::build(&config)` was then called against `config.config_files` only — which contains the **root** hierarchy when invoked from the monorepo root, not `sub/mise.toml`.
3. `install_missing_versions` ran on that incomplete toolset (no `bun`).
4. *Only then* did `resolve_depends` populate `task.cf` with the subdirectory configs, which were dutifully passed to `DepsEngine::add_config_files` — too late: install had already finished.
5. `engine.run({ auto_only: true })` invoked `bun install`, which couldn't find `bun`.

## Fix

Reorder so `resolve_depends` runs before the toolset is built, then collect subdirectory configs from the resolved tasks (`task.cf`), merge them into a `ConfigMap` together with `config.config_files`, and pass the result to the existing `ToolsetBuilder::with_config_files(...)` API. Subdir tools are now installed before any `[deps]` step runs. The deps engine continues to receive the same subdir configs as before.

No new APIs; `with_config_files` already existed on `ToolsetBuilder`.

The "naked run that does not match a task should fail without installing project tools" invariant still holds — `resolve_depends` runs after `get_task_lists`, and any failure short-circuits before the toolset is touched.

### Out of scope

`Config::get_toolset()` is a separate lazily-cached toolset used by usage-spec parsing; it still reflects only the root hierarchy. Extending it to monorepo subdirs has wider blast radius (env, aliases, every `parse_usage_values_from_task` call) and is not needed to fix this bug.

## Test plan

- [x] Reproduced the reported failure on the released mise (homebrew) and confirmed the fix resolves it on the worktree binary using a `tiny`/`rtx-tiny` minimal repro mirroring the discussion.
- [x] Added a regression e2e test: `e2e/tasks/test_task_monorepo_deps_tool_install` (uses the `tiny` tool + a `[deps]` step that invokes `rtx-tiny`, all from the monorepo root via `//sub:use-tiny`).
- [x] `mise run test:e2e tasks/test_task_monorepo` — all monorepo task tests pass.
- [x] `mise run test:e2e cli/test_deps cli/test_deps_tool_install cli/test_deps_depends tasks/test_task_deps` — pass.
- [x] `mise run test:unit` — 785/785 pass.
- [x] `mise run lint-fix` and `cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `mise run` execution ordering and toolset construction, which can affect tool installation and dependency steps across projects (especially monorepos). Scope is localized to the `run` path but touches core task/deps orchestration.
> 
> **Overview**
> Fixes `mise run //sub:task` in monorepos by **resolving task dependencies before building/installing the toolset**, then merging resolved tasks’ subdirectory config files into the toolset’s config map so subdir-declared tools are on `PATH` before auto `[deps]` steps execute.
> 
> Adds an e2e regression test that sets up a monorepo root + `sub/mise.toml` with a subdir tool (`tiny`) and an auto `[deps]` step that uses it, asserting the tool is installed and both deps and task execution succeed from the repo root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad6aec9272169077e0181bf6c83acbb4d60de54c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->