### PR TITLE
fix(deps): respect -q flag for provider command stream

### DIFF
--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -55,6 +55,12 @@ assert_contains "mise deps --dry-run --only codegen 2>&1" "codegen"
 assert_not_contains "mise deps --dry-run --only codegen 2>&1" "npm"
 assert_contains "mise deps --force --only codegen 2>&1" "[deps.codegen] codegen"
 
+# Test -q/--quiet suppresses provider stream output and status messages.
+# Without -q the previous assertion proved "[deps.codegen] codegen" appears;
+# with -q neither the prefix-tagged echo nor the "Installed:" status should leak.
+assert_not_contains "mise deps --force --only codegen -q 2>&1" "[deps.codegen]"
+assert_not_contains "mise deps --force --only codegen -q 2>&1" "Installed:"
+
 # Test --skip flag
 assert_not_contains "mise deps --dry-run --skip npm 2>&1" "npm install"
 

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -763,10 +763,17 @@ impl DepsEngine {
         {
             let stdout_prefix = stdout_prefix.to_string();
             let stderr_prefix = stderr_prefix.to_string();
+            // Suppress provider command stream output when -q/--quiet is set,
+            // matching `mise install -q` behavior. The progress indicator and
+            // logger-routed status messages still respect the quiet level.
+            let quiet = Settings::get().quiet;
             runner = runner
                 .with_on_stdout(move |line| {
                     if let Some(progress) = progress {
                         progress.set_message(line.clone());
+                    }
+                    if quiet {
+                        return;
                     }
                     if console::colors_enabled() {
                         prefix_println!(stdout_prefix, "{line}\x1b[0m");
@@ -775,6 +782,9 @@ impl DepsEngine {
                     }
                 })
                 .with_on_stderr(move |line| {
+                    if quiet {
+                        return;
+                    }
                     if console::colors_enabled_stderr() {
                         prefix_eprintln!(stderr_prefix, "{line}\x1b[0m");
                     } else {


### PR DESCRIPTION
## Summary

Follow-up to [#8792](https://github.com/jdx/mise/pull/8792). After `mise prepare` was renamed to `mise deps`, `-q` started leaking provider command output again — running `mise deps install -q` against e.g. a `bundler` provider still streams `bundle install`'s stdout/stderr through the prefix-tagged tee in the deps engine.

\#8792 fixed the *summary* path (`Prepared:`/`Failed:`/`All dependencies are up to date`) by routing it through the logger via `info!`/`error!`, and that change carried over to `src/cli/deps/install.rs` after the rename. But the provider **command stream** is a separate path that bypasses the logger entirely, so `-q` never had any effect on it.

## Root cause

In `src/deps/engine.rs::execute_command`, the `with_on_stdout` / `with_on_stderr` callbacks unconditionally write captured lines via `prefix_println!` / `prefix_eprintln!`. Both macros expand to `calm_io::stdoutln!` / `calm_io::stderrln!` and never consult `Settings::quiet`, so the quiet flag passes straight through.

`mise install -q` does not have this issue because the install path uses `with_pr(...)` and routes output through `MultiProgressReport::add`, which returns a `QuietReport` (no-op `println` / `set_message`) when `Settings::quiet` is set. The deps engine instead sets explicit `on_stdout` / `on_stderr` callbacks that take precedence over the `pr` fallback in `CmdLineRunner` — so the `QuietReport` never sees the streamed lines.

## Fix

Read `Settings::get().quiet` once before the closures and skip the `prefix_println!` / `prefix_eprintln!` calls when set. The `progress.set_message` call is left in place: it is a no-op for `QuietReport` and still drives the spinner under `ProgressReport` in normal mode.

This matches `mise install -q` behavior — the provider command stream is suppressed, while logger-routed status (`Installed:`, `Failed:`) continues to follow the normal quiet level (errors only).

## Test plan

- [x] Added a regression assertion in `e2e/cli/test_deps`: with the existing `codegen` provider, `mise deps --force --only codegen -q` must contain neither the prefix-tagged stream output (`[deps.codegen]`) nor the info-level summary (`Installed:`). The assertion immediately above the new lines proves the same command without `-q` *does* emit `[deps.codegen] codegen`, so the pair anchors both directions.
- [x] `mise run test:e2e cli/test_deps cli/test_deps_depends cli/test_deps_tool_install` — could not run on this Windows machine (no MSVC `link.exe`, so even `cargo check` fails to link build scripts). Relying on CI for full verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)