### PR TITLE
fix(task): preserve essential env vars under deny_env on Linux

### DIFF
--- a/e2e/sandbox/test_sandbox_task
+++ b/e2e/sandbox/test_sandbox_task
@@ -6,9 +6,17 @@ cat >mise.toml <<'TOML'
 [tasks.env_test]
 run = "echo ${SANDBOX_TASK_SECRET:-empty}"
 deny_env = true
+
+[tasks.path_test]
+run = 'echo "PATH=${PATH:-unset} HOME=${HOME:-unset}"'
+deny_env = true
 TOML
 
 export SANDBOX_TASK_SECRET="should_not_see"
 
 # Task with deny_env should not see the var
 assert "mise run env_test" "empty"
+
+# deny_env should still let essential vars (PATH, HOME, ...) through
+assert_not_contains "mise run path_test" "PATH=unset"
+assert_not_contains "mise run path_test" "HOME=unset"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -622,9 +622,18 @@ impl<'a> CmdLineRunner<'a> {
 
         #[cfg(target_os = "linux")]
         {
-            // On Linux, clear inherited env before pre_exec so child only sees filtered vars
+            // On Linux, clear inherited env before pre_exec so child only sees filtered vars.
+            // env_clear() also wipes envs explicitly set via .envs(), so save and restore them.
             if sandbox.effective_deny_env() {
+                let saved: Vec<(std::ffi::OsString, std::ffi::OsString)> = self
+                    .cmd
+                    .get_envs()
+                    .filter_map(|(k, v)| v.map(|v| (k.to_os_string(), v.to_os_string())))
+                    .collect();
                 self.cmd.env_clear();
+                for (k, v) in saved {
+                    self.cmd.env(k, v);
+                }
             }
             // Use pre_exec to apply Landlock/seccomp in the child process
             // before it execs the target program. This avoids restricting the mise process.


### PR DESCRIPTION
## Summary

- Fixes [#9466](https://github.com/jdx/mise/discussions/9466): under `deny_env = true` on Linux, every env var was stripped from the child process — including the `PATH`/`HOME`/`USER`/`SHELL`/`TERM`/`LANG` that the docs and `filter_env` say should pass through.
- Root cause: `apply_sandbox()` called `Command::env_clear()` *after* `task_executor` had already populated the command via `.envs(filtered_env)`. `env_clear()` wipes both inherited and explicitly-set envs, leaving an empty environment. The macOS branch already handled this (it builds a new command and copies the envs over); the Linux branch did not.
- Fix: on Linux, snapshot the explicit envs, call `env_clear()` (still needed to prevent parent inheritance), then re-apply the saved envs.
- Extended `e2e/sandbox/test_sandbox_task` with a `path_test` task that asserts `PATH` and `HOME` are non-empty under `deny_env`, so this regression gets caught next time.

## Test plan

- [x] `cargo build`
- [x] `cargo test --bin mise sandbox::tests`
- [x] `mise run test:e2e sandbox/test_sandbox_task` (passes on macOS; new assertions exercise the Linux-only code path in CI)
- [x] `mise run lint-fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process execution/sandbox setup on Linux; mistakes could leak env vars or break task execution, but the change is small and covered by a new regression test.
> 
> **Overview**
> Fixes Linux `deny_env` sandbox behavior so clearing inherited environment variables no longer removes env vars explicitly set on the `Command` (e.g., filtered essentials like `PATH`/`HOME`). It snapshots `Command::get_envs()`, calls `env_clear()`, then restores the saved key/values before applying Landlock/seccomp.
> 
> Adds an e2e regression check (`sandbox/test_sandbox_task`) that verifies `deny_env` still preserves `PATH` and `HOME` while continuing to hide a secret env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6eca787265657df286f233b365aa152132463d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->