### PR TITLE
fix(shims): compare PATH entries case-insensitively on macOS

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1708,32 +1708,18 @@ pub trait Backend: Debug + Send + Sync {
         // dependency tool (e.g., go) is configured but not installed. Without this,
         // the shim for the dependency would call `mise exec` which would call the
         // shim again infinitely.
+        //
+        // `paths_eq` handles case-insensitive matching on macOS/Windows: e.g. if
+        // `$HOME` is mixed-case in PATH (`/Users/Foo`) but lowercase in the
+        // resolved shims path, byte-equal comparison would miss it and the shim
+        // would survive in the child env.
         if let Some(path_val) = env.get(&*env::PATH_KEY) {
             let paths: Vec<_> = env::split_paths(path_val).collect();
             let original_len = paths.len();
-            #[cfg(not(windows))]
             let filtered: Vec<_> = paths
                 .into_iter()
-                .filter(|p| p.as_path() != *dirs::SHIMS)
+                .filter(|p| !file::paths_eq(&file::replace_path(p), &dirs::SHIMS))
                 .collect();
-            #[cfg(windows)]
-            let filtered: Vec<_> = {
-                // Pre-compute once; case-insensitive + separator-normalised to handle
-                // path variations such as ~/.local/share/mise\shims vs
-                // C:\Users\user\.local\share\mise\shims
-                let shims_normalized = dirs::SHIMS
-                    .to_string_lossy()
-                    .to_lowercase()
-                    .replace('/', "\\");
-                paths
-                    .into_iter()
-                    .filter(|p| {
-                        let expanded = file::replace_path(p);
-                        expanded.to_string_lossy().to_lowercase().replace('/', "\\")
-                            != shims_normalized
-                    })
-                    .collect()
-            };
             if filtered.len() != original_len {
                 let joined = env::join_paths(&filtered)?;
                 env.insert(

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -571,7 +571,10 @@ impl Doctor {
 }
 
 fn shims_on_path() -> bool {
-    env::PATH.contains(&dirs::SHIMS.to_path_buf())
+    let shims = &*dirs::SHIMS;
+    env::PATH
+        .iter()
+        .any(|p| crate::file::paths_eq(&crate::file::replace_path(p), shims))
 }
 
 fn yn(b: bool) -> String {

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -277,7 +277,11 @@ where
             // The child process still inherits the full unmodified PATH.
             let user_shims = &*crate::dirs::SHIMS;
             let sys_shims = crate::env::MISE_SYSTEM_DATA_DIR.join("shims");
-            let is_shims_dir = |p: &std::path::PathBuf| p == user_shims || p == &sys_shims;
+            let is_shims_dir = |p: &std::path::PathBuf| {
+                let expanded = crate::file::replace_path(p);
+                crate::file::paths_eq(&expanded, user_shims)
+                    || crate::file::paths_eq(&expanded, &sys_shims)
+            };
             let pristine: std::collections::HashSet<_> = crate::env::PATH.iter().collect();
             let all_paths: Vec<_> = std::env::split_paths(&OsString::from(path_val)).collect();
             // Mise-added paths first (preserving relative order)
@@ -339,19 +343,12 @@ where
     // Reorder PATH for program resolution: mise-added paths first, then
     // original system paths (minus shims). See Unix version for full rationale.
     let lookup_path = env.get(&*env::PATH_KEY).map(|path_val| {
-        let shims_normalized = crate::dirs::SHIMS
-            .to_string_lossy()
-            .to_lowercase()
-            .replace('/', "\\");
-        let sys_shims_normalized = crate::env::MISE_SYSTEM_DATA_DIR
-            .join("shims")
-            .to_string_lossy()
-            .to_lowercase()
-            .replace('/', "\\");
+        let user_shims = &*crate::dirs::SHIMS;
+        let sys_shims = crate::env::MISE_SYSTEM_DATA_DIR.join("shims");
         let is_shims = |p: &std::path::PathBuf| {
             let expanded = crate::file::replace_path(p);
-            let normalized = expanded.to_string_lossy().to_lowercase().replace('/', "\\");
-            normalized == shims_normalized || normalized == sys_shims_normalized
+            crate::file::paths_eq(&expanded, user_shims)
+                || crate::file::paths_eq(&expanded, &sys_shims)
         };
         let pristine: std::collections::HashSet<_> = crate::env::PATH
             .iter()

--- a/src/file.rs
+++ b/src/file.rs
@@ -304,6 +304,33 @@ pub fn replace_path<P: AsRef<Path>>(path: P) -> PathBuf {
     }
 }
 
+/// Compare two paths for filesystem equivalence, taking platform conventions
+/// into account. macOS volumes (HFS+/APFS) and Windows volumes are
+/// case-insensitive by default, so a byte-equal comparison can fail when
+/// inputs differ only by case (e.g. `/Users/Foo/...` vs `/Users/foo/...`
+/// when `$HOME` is mixed-case in the user's environment but the resolved
+/// path uses a different case). Windows additionally normalises `/` to `\`.
+///
+/// This is the right comparator for "is this PATH entry the shims
+/// directory?" checks, where a false negative leads to mise's shim being
+/// inherited by a child process and recursing infinitely.
+pub fn paths_eq(a: &Path, b: &Path) -> bool {
+    #[cfg(windows)]
+    {
+        let normalize = |p: &Path| p.to_string_lossy().to_lowercase().replace('/', "\\");
+        normalize(a) == normalize(b)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        a.as_os_str().to_string_lossy().to_lowercase()
+            == b.as_os_str().to_string_lossy().to_lowercase()
+    }
+    #[cfg(all(not(windows), not(target_os = "macos")))]
+    {
+        a == b
+    }
+}
+
 pub fn touch_file(file: &Path) -> Result<()> {
     if !file.exists() {
         create(file)?;
@@ -719,7 +746,7 @@ pub fn path_env_without_shims() -> std::ffi::OsString {
     let shim_dir = &*dirs::SHIMS;
     let filtered: Vec<_> = env::PATH_NON_PRISTINE
         .iter()
-        .filter(|p| p.as_path() != *shim_dir)
+        .filter(|p| !paths_eq(&replace_path(p), shim_dir))
         .cloned()
         .collect();
     std::env::join_paths(filtered)
@@ -731,7 +758,7 @@ pub fn path_env_without_shims() -> std::ffi::OsString {
 /// than inheriting the current process's PATH.
 pub fn strip_shims_from_path(path_val: &str) -> String {
     let shim_dir = &*dirs::SHIMS;
-    let filtered = env::split_paths(path_val).filter(|p| p.as_path() != *shim_dir);
+    let filtered = env::split_paths(path_val).filter(|p| !paths_eq(&replace_path(p), shim_dir));
     std::env::join_paths(filtered)
         .unwrap_or_else(|_| std::ffi::OsString::from(path_val))
         .to_string_lossy()
@@ -745,7 +772,7 @@ pub fn which_no_shims<P: AsRef<Path>>(name: P) -> Option<PathBuf> {
     let shim_dir = &*dirs::SHIMS;
     let paths: Vec<PathBuf> = env::PATH_NON_PRISTINE
         .iter()
-        .filter(|p| p.as_path() != *shim_dir)
+        .filter(|p| !paths_eq(&replace_path(p), shim_dir))
         .cloned()
         .collect();
     _which(name, &paths)
@@ -1370,6 +1397,42 @@ mod tests {
         let _config = Config::get().await.unwrap();
         assert_eq!(replace_path(Path::new("~/cwd")), dirs::HOME.join("cwd"));
         assert_eq!(replace_path(Path::new("/cwd")), Path::new("/cwd"));
+    }
+
+    #[test]
+    fn test_paths_eq_exact() {
+        assert!(paths_eq(Path::new("/foo/bar"), Path::new("/foo/bar")));
+        assert!(!paths_eq(Path::new("/foo/bar"), Path::new("/foo/baz")));
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", windows))]
+    fn test_paths_eq_case_insensitive() {
+        // macOS volumes (HFS+/APFS) and Windows volumes are case-insensitive by
+        // default. The comparator must treat `/Users/Foo` and `/Users/foo` as
+        // equal so that PATH stripping doesn't miss the shims dir when `$HOME`
+        // is mixed-case in the user's environment but the resolved shims path
+        // uses a different case (the cause of the npm-shim recursion bug).
+        assert!(paths_eq(
+            Path::new("/Users/Olfway/.local/share/mise/shims"),
+            Path::new("/Users/olfway/.local/share/mise/shims"),
+        ));
+    }
+
+    #[test]
+    #[cfg(all(not(windows), not(target_os = "macos")))]
+    fn test_paths_eq_case_sensitive_on_linux() {
+        // Linux paths are case-sensitive; `/foo` and `/Foo` are distinct files.
+        assert!(!paths_eq(Path::new("/foo/bar"), Path::new("/Foo/bar")));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_paths_eq_separator_normalization() {
+        assert!(paths_eq(
+            Path::new("C:/Users/foo/shims"),
+            Path::new("C:\\Users\\foo\\shims"),
+        ));
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -309,21 +309,24 @@ pub fn replace_path<P: AsRef<Path>>(path: P) -> PathBuf {
 /// case-insensitive by default, so a byte-equal comparison can fail when
 /// inputs differ only by case (e.g. `/Users/Foo/...` vs `/Users/foo/...`
 /// when `$HOME` is mixed-case in the user's environment but the resolved
-/// path uses a different case). Windows additionally normalises `/` to `\`.
+/// path uses a different case).
+///
+/// On case-insensitive platforms, comparison is done over `Path::components()`
+/// with each component lowercased — this also folds trailing slashes,
+/// redundant separators, and (on Windows) `/` vs `\` since `Path::components`
+/// treats both as separators.
 ///
 /// This is the right comparator for "is this PATH entry the shims
 /// directory?" checks, where a false negative leads to mise's shim being
 /// inherited by a child process and recursing infinitely.
 pub fn paths_eq(a: &Path, b: &Path) -> bool {
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "macos"))]
     {
-        let normalize = |p: &Path| p.to_string_lossy().to_lowercase().replace('/', "\\");
-        normalize(a) == normalize(b)
-    }
-    #[cfg(target_os = "macos")]
-    {
-        a.as_os_str().to_string_lossy().to_lowercase()
-            == b.as_os_str().to_string_lossy().to_lowercase()
+        let normalize =
+            |c: std::path::Component<'_>| c.as_os_str().to_string_lossy().to_lowercase();
+        a.components()
+            .map(normalize)
+            .eq(b.components().map(normalize))
     }
     #[cfg(all(not(windows), not(target_os = "macos")))]
     {
@@ -1417,6 +1420,16 @@ mod tests {
             Path::new("/Users/Olfway/.local/share/mise/shims"),
             Path::new("/Users/olfway/.local/share/mise/shims"),
         ));
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", windows))]
+    fn test_paths_eq_trailing_separator() {
+        // Component-based comparison should fold trailing separators and
+        // redundant double-separators so PATH entries like `/foo/shims/`
+        // still match `/foo/shims`.
+        assert!(paths_eq(Path::new("/foo/shims"), Path::new("/foo/shims/")));
+        assert!(paths_eq(Path::new("/foo/shims"), Path::new("/foo//shims"),));
     }
 
     #[test]

--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -63,7 +63,7 @@ impl FromIterator<PathBuf> for PathEnv {
         for path in paths {
             if path_env.seen_shims {
                 path_env.post.push(path);
-            } else if path == *dirs::SHIMS && !settings.activate_aggressive {
+            } else if crate::file::paths_eq(&path, &dirs::SHIMS) && !settings.activate_aggressive {
                 path_env.seen_shims = true;
                 if preserve_shims {
                     path_env.post.push(path);

--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -63,7 +63,9 @@ impl FromIterator<PathBuf> for PathEnv {
         for path in paths {
             if path_env.seen_shims {
                 path_env.post.push(path);
-            } else if crate::file::paths_eq(&path, &dirs::SHIMS) && !settings.activate_aggressive {
+            } else if crate::file::paths_eq(&crate::file::replace_path(&path), &dirs::SHIMS)
+                && !settings.activate_aggressive
+            {
                 path_env.seen_shims = true;
                 if preserve_shims {
                     path_env.post.push(path);


### PR DESCRIPTION
## Summary

- Fix infinite shim recursion on macOS when `$HOME` appears in PATH with different casing than the resolved `dirs::SHIMS` path.
- Introduce `file::paths_eq`, a platform-aware path comparator (case-insensitive on macOS/Windows, byte-equal on Linux, with separator normalisation on Windows), and route every "is this PATH entry the shims directory?" check through it.
- Reported in [discussion #9462](https://github.com/jdx/mise/discussions/9462).

## Background

A user on macOS hit a recursive `mise -> npm shim -> mise -> npm shim -> ...` loop while `mise up --bump` resolved npm package versions, sometimes crashing their session. Their PATH contained `/Users/Olfway/.local/share/mise/shims` but `dirs::SHIMS` resolved to `/Users/olfway/.local/share/mise/shims` via a lowercase `$HOME`. macOS volumes (HFS+/APFS) are case-insensitive by default, so both paths refer to the same directory — but mise compared PATH entries against the shims directory byte-equal.

The recursion site is `Backend::dependency_env`. When the npm backend ran `npm view <pkg> dist-tags --json` to resolve a "latest" version, it built a child env with the shims directory stripped from PATH so `npm` would resolve to the real binary. With the case mismatch the strip was a no-op, so `npm` re-resolved to the mise shim, which exec'd `mise … -- npm view …`, which spawned another `npm`, ad infinitum.

The same case-sensitivity bug existed at every other "compare against shims dir" call site, including the doctor's `shims_on_path` check (which incorrectly reported `no` for the affected user, masking the real problem).

## Changes

- New `file::paths_eq(a, b) -> bool` with `#[cfg]`-gated arms:
  - **Windows:** lowercase + `/` -> `\` normalisation (replaces a few inline copies of this logic).
  - **macOS:** lowercase compare.
  - **Linux:** byte-equal compare (case-sensitive filesystems are the norm).
- Routed through `paths_eq`:
  - `Backend::dependency_env` (the actual recursion-causing site)
  - `file::path_env_without_shims`, `file::strip_shims_from_path`, `file::which_no_shims`
  - `PathEnv::from_iter` shim partitioning
  - `doctor::shims_on_path`
  - Both Unix and Windows branches of `cli::exec::exec_program` program resolution
- Unit tests cover exact match, case-insensitivity (macOS/Windows), case-sensitivity (Linux), and `\`/`/` normalisation (Windows).

The Windows-specific normalisation block previously inlined in `Backend::dependency_env` and `cli::exec` is now collapsed into a single cross-platform call.

## Test plan

- [x] `cargo build --bin mise` clean
- [x] `cargo test --bin mise file::` — 94 tests pass, including new `paths_eq` tests
- [x] `mise run lint-fix` clean
- [ ] Manually verify on a macOS box with mixed-case `$HOME` that `mise up --bump` against npm packages no longer recurses (covered by the user's reproduction in the linked discussion)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple call sites that manipulate PATH and executable resolution, so subtle path-comparison behavior changes could affect tool lookup order across platforms despite the changes being narrowly scoped and well-tested.
> 
> **Overview**
> Prevents infinite shim recursion on macOS (and hardens Windows handling) by introducing `file::paths_eq` and switching all “is this PATH entry the shims dir?” checks to use case-insensitive, component-based path comparison (including `~/` expansion via `replace_path`).
> 
> This updates shim stripping and PATH reordering in `Backend::dependency_env`, `cli exec` program resolution (Unix+Windows), `PathEnv` shim partitioning, and `doctor`’s `shims_on_path`, and adds focused unit tests covering exact match, macOS/Windows case-insensitivity, separator/trailing-slash normalization, and Linux case-sensitivity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a341252cb778333ee7fab0d8c793e662a212ea63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->