### PR TITLE
chore(ci): make vendored-file-warning a failing check

### DIFF
--- a/.github/workflows/vendored-file-warning.yml
+++ b/.github/workflows/vendored-file-warning.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   warn:
-    if: github.actor != 'jdx' && github.actor != 'mise-en-dev'
+    if: github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev'
     runs-on: ubuntu-latest
     steps:
       - name: Comment on PR

--- a/.github/workflows/vendored-file-warning.yml
+++ b/.github/workflows/vendored-file-warning.yml
@@ -1,7 +1,7 @@
 name: vendored-file-warning
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "crates/aqua-registry/aqua-registry/**"
 
@@ -12,18 +12,16 @@ jobs:
     if: github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev'
     runs-on: ubuntu-latest
     steps:
-      - name: Comment on PR
-        env:
-          GH_TOKEN: ${{ secrets.MISE_PR_COMMENT_TOKEN }}
+      - name: Fail on vendored file changes
         run: |
-          existing=$(gh pr view "${{ github.event.pull_request.number }}" \
-            -R "${{ github.repository }}" \
-            --json comments --jq '.comments[].body' \
-            | grep -c "vendored from the upstream" || true)
-          if [ "$existing" = "0" ]; then
-            gh pr comment "${{ github.event.pull_request.number }}" \
-              -R "${{ github.repository }}" \
-              --body "The aqua registry files under \`crates/aqua-registry/aqua-registry/\` are vendored from the upstream [aqua-registry](https://github.com/aquaproj/aqua-registry) and should not be modified directly in this repo. Please submit package definition changes to the upstream aqua-registry instead, and they will be picked up here when we next update the vendored copy.
+          cat <<'EOF'
+          The aqua registry files under `crates/aqua-registry/aqua-registry/` are vendored
+          from the upstream aqua-registry (https://github.com/aquaproj/aqua-registry) and
+          should not be modified directly in this repo. Please submit package definition
+          changes to the upstream aqua-registry instead, and they will be picked up here
+          when we next update the vendored copy.
 
-          The \`registry/*.toml\` files are fine to add here, but the backend should reference the package after it's been accepted upstream."
-          fi
+          The `registry/*.toml` files are fine to add here, but the backend should
+          reference the package after it's been accepted upstream.
+          EOF
+          exit 1


### PR DESCRIPTION
## Summary

- Replace the PR-comment step in `vendored-file-warning.yml` with a plain failing status check, dropping the need for `MISE_PR_COMMENT_TOKEN` and `pull_request_target`.
- Switch the skip condition from `github.actor` to `github.event.pull_request.user.login` so re-triggers from bots like `autofix-ci` on release PRs (opened by `mise-en-dev`) don't run the job.

Both fix the failing check seen on [#9463](https://github.com/jdx/mise/pull/9463), where `autofix-ci[bot]` re-triggered the workflow on a release PR and the comment step then errored with `Resource not accessible by personal access token (addComment)`.

## Test plan

- [ ] Verify this PR's own checks pass (vendored-file-warning should not trigger — no aqua-registry files are touched).
- [ ] On the next aqua-registry sync PR opened by `mise-en-dev`, confirm the workflow is skipped.
- [ ] On a contributor PR that edits `crates/aqua-registry/aqua-registry/**`, confirm the check fails with the explanatory log message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no production code impact; main risk is unintended job triggering/skipping due to the updated event and allowlist condition.
> 
> **Overview**
> Switches the `vendored-file-warning` workflow from `pull_request_target` to `pull_request` and replaces the PR-commenting behavior (and required token) with a simple failing check that prints guidance when vendored `crates/aqua-registry/aqua-registry/**` files are modified.
> 
> Updates the skip condition to key off `github.event.pull_request.user.login` (instead of `github.actor`) so bot re-runs don’t bypass the intended allowlist for `jdx`/`mise-en-dev`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4446d1a6b39bb93f0ef05d41f8c43f9e125d6a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->