### PR TITLE
feat(release): list aqua package additions/updates in changelog

### DIFF
--- a/scripts/gen-aqua-changelog.sh
+++ b/scripts/gen-aqua-changelog.sh
@@ -1,73 +1,116 @@
 #!/usr/bin/env bash
 # Generate aqua-registry changelog section
 # Usage: gen-aqua-changelog.sh <old_tag> <new_tag> <heading_level>
+#
+# Lists packages added or modified in the upstream aqua-registry between
+# OLD_TAG and NEW_TAG by diffing the merged registry.yaml at each tag.
 set -euo pipefail
 
-OLD_TAG="$1"
-NEW_TAG="$2"
+OLD_TAG="${1:-}"
+NEW_TAG="${2:-}"
 HEADING_LEVEL="${3:-###}" # Default to ### for CHANGELOG.md sections
 REPO="aquaproj/aqua-registry"
+NEW_REGISTRY="crates/aqua-registry/aqua-registry/registry.yaml"
 
 if [[ -z $OLD_TAG ]] || [[ -z $NEW_TAG ]] || [[ $OLD_TAG == "$NEW_TAG" ]]; then
 	exit 0
 fi
 
-if ! command -v gh >/dev/null 2>&1; then
-	echo "gh is required to generate aqua-registry changelog entries" >&2
-	exit 1
-fi
-
-release_tags() {
-	local collecting=0
-	local found_old=0
-	local found_new=0
-	local -a tags=()
-
-	while IFS= read -r tag; do
-		if [[ $tag == "$OLD_TAG" ]]; then
-			found_old=1
-			break
-		fi
-		if [[ $tag == "$NEW_TAG" ]]; then
-			collecting=1
-			found_new=1
-		fi
-		if [[ $collecting -eq 1 ]]; then
-			tags+=("$tag")
-		fi
-	done < <(gh release list --repo "$REPO" --limit 1000 --json tagName --jq '.[].tagName')
-
-	if [[ $found_old -eq 0 ]]; then
-		return 0
-	fi
-
-	if [[ $found_new -eq 0 ]]; then
-		echo "Unable to find aqua-registry release $NEW_TAG" >&2
-		return 1
-	fi
-
-	if [[ ${#tags[@]} -eq 0 ]]; then
-		echo "Unable to find aqua-registry releases from $OLD_TAG to $NEW_TAG" >&2
-		return 1
-	fi
-
-	for ((i = ${#tags[@]} - 1; i >= 0; i--)); do
-		printf '%s\n' "${tags[$i]}"
-	done
-}
-
-RELEASE_TAGS="$(release_tags)"
-if [[ -z $RELEASE_TAGS ]]; then
+if [[ ! -f $NEW_REGISTRY ]]; then
+	echo "Expected $NEW_REGISTRY to exist" >&2
 	exit 0
 fi
 
-echo "$HEADING_LEVEL 📦 Aqua Registry"
-echo ""
-echo "Updated [aqua-registry](https://github.com/$REPO): [$OLD_TAG](https://github.com/$REPO/releases/tag/$OLD_TAG) -> [$NEW_TAG](https://github.com/$REPO/releases/tag/$NEW_TAG)."
-echo ""
-echo "Included aqua-registry releases:"
-echo ""
+OLD_REGISTRY="$(mktemp)"
+trap 'rm -f "$OLD_REGISTRY"' EXIT
 
-while IFS= read -r tag; do
-	echo "- [$tag](https://github.com/$REPO/releases/tag/$tag)"
-done <<<"$RELEASE_TAGS"
+if ! curl -fsSL "https://raw.githubusercontent.com/$REPO/$OLD_TAG/registry.yaml" -o "$OLD_REGISTRY"; then
+	echo "Failed to fetch aqua-registry $OLD_TAG/registry.yaml" >&2
+	exit 0
+fi
+
+python3 - "$OLD_REGISTRY" "$NEW_REGISTRY" "$HEADING_LEVEL" <<'PYEOF'
+import re
+import sys
+
+old_path, new_path, heading = sys.argv[1:4]
+
+
+def strip_quotes(v: str) -> str:
+	v = v.strip()
+	if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
+		return v[1:-1]
+	return v
+
+
+def parse(path: str) -> dict[str, tuple[str, str]]:
+	"""Return {canonical_id: (github_repo_or_empty, package_block_text)}.
+
+	github_repo is set when the package has repo_owner+repo_name (so the id
+	resolves to a github URL); empty for name-only or path-only packages.
+	"""
+	with open(path) as f:
+		text = f.read()
+	# Top-level packages start with '  - ' at column 0. Split on those boundaries.
+	parts = re.split(r'(?m)^  - ', text)
+	pkgs: dict[str, tuple[str, str]] = {}
+	for body in parts[1:]:
+		block = '  - ' + body
+		# Top-level package fields are at exactly 4-space indent. The first
+		# field also appears inline on the '  - ' line itself.
+		fields: dict[str, str] = {}
+		first_line, _, rest = body.partition('\n')
+		m = re.match(r'(name|repo_owner|repo_name|path|type):\s*(.*?)\s*$', first_line)
+		if m:
+			fields[m.group(1)] = strip_quotes(m.group(2))
+		for ln in rest.splitlines():
+			mm = re.match(r'^    (name|repo_owner|repo_name|path):\s*(.*?)\s*$', ln)
+			if mm:
+				fields.setdefault(mm.group(1), strip_quotes(mm.group(2)))
+		github_repo = ''
+		if fields.get('repo_owner') and fields.get('repo_name'):
+			github_repo = f"{fields['repo_owner']}/{fields['repo_name']}"
+		if fields.get('name'):
+			pkg_id = fields['name']
+		elif github_repo:
+			pkg_id = github_repo
+		elif fields.get('path'):
+			pkg_id = fields['path']
+		else:
+			continue
+		pkgs[pkg_id] = (github_repo, block)
+	return pkgs
+
+
+old = parse(old_path)
+new = parse(new_path)
+
+added = sorted(set(new) - set(old))
+updated = sorted(k for k in (set(old) & set(new)) if old[k][1] != new[k][1])
+
+if not added and not updated:
+	sys.exit(0)
+
+
+def link(pkg: str, github_repo: str) -> str:
+	if github_repo:
+		return f'[`{pkg}`](https://github.com/{github_repo})'
+	return f'`{pkg}`'
+
+
+out: list[str] = []
+out.append(f'{heading} 📦 Aqua Registry Updates')
+out.append('')
+if added:
+	out.append(f'#### New Packages ({len(added)})')
+	out.append('')
+	out.extend(f'- {link(p, new[p][0])}' for p in added)
+	out.append('')
+if updated:
+	out.append(f'#### Updated Packages ({len(updated)})')
+	out.append('')
+	out.extend(f'- {link(p, new[p][0])}' for p in updated)
+	out.append('')
+
+print('\n'.join(out))
+PYEOF

--- a/scripts/gen-aqua-changelog.sh
+++ b/scripts/gen-aqua-changelog.sh
@@ -37,7 +37,10 @@ old_path, new_path, heading = sys.argv[1:4]
 
 
 def strip_quotes(v: str) -> str:
-	v = v.strip()
+	# Strip an unquoted YAML inline comment (` #...`) before quote handling.
+	# A bare `#` with no leading space is part of the value (e.g. aqua names
+	# like `_go/sigsum.org/sigsum-go#cmd/sigsum-key`).
+	v = v.split(' #', 1)[0].strip()
 	if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
 		return v[1:-1]
 	return v

--- a/scripts/gen-aqua-changelog.sh
+++ b/scripts/gen-aqua-changelog.sh
@@ -98,16 +98,17 @@ def link(pkg: str, github_repo: str) -> str:
 	return f'`{pkg}`'
 
 
+sub = heading + '#'
 out: list[str] = []
 out.append(f'{heading} 📦 Aqua Registry Updates')
 out.append('')
 if added:
-	out.append(f'#### New Packages ({len(added)})')
+	out.append(f'{sub} New Packages ({len(added)})')
 	out.append('')
 	out.extend(f'- {link(p, new[p][0])}' for p in added)
 	out.append('')
 if updated:
-	out.append(f'#### Updated Packages ({len(updated)})')
+	out.append(f'{sub} Updated Packages ({len(updated)})')
 	out.append('')
 	out.extend(f'- {link(p, new[p][0])}' for p in updated)
 	out.append('')


### PR DESCRIPTION
## Summary

The release PR description was previously listing the aqua-registry release tags rolled into a mise release (e.g. `v4.491.0`, `v4.492.0`, ...), which reads as opaque version noise to users. This restores the pre-[#9043](https://github.com/jdx/mise/pull/9043) behavior of listing the actual added and updated packages, but adapted to work against the merged `registry.yaml` that #9043 introduced.

[`scripts/gen-aqua-changelog.sh`](https://github.com/jdx/mise/blob/main/scripts/gen-aqua-changelog.sh) now:
- Fetches the previous tag's `registry.yaml` from upstream `aquaproj/aqua-registry`.
- Parses both old and new files by canonical package id (`name` → `repo_owner/repo_name` → `path`), matching `crates/aqua-registry/build.rs::canonical_package_id`.
- Emits `#### New Packages (N)` and `#### Updated Packages (N)` sections (matching the original pre-#9043 format).
- Only links `repo_owner/repo_name` ids to GitHub, so name-only ids like `kiro.dev/kiro-cli` don't render as broken links.

YAML parsing is done by inline `python3` (stdlib only — no `PyYAML` / `yq` dependency). The release runner is `ubuntu-latest` which ships python3.

## Sample output (`v4.491.0` → `v4.499.0`)

```
### 📦 Aqua Registry Updates

#### New Packages (28)

- [`IBM-Cloud/ibm-cloud-cli-release`](https://github.com/IBM-Cloud/ibm-cloud-cli-release)
- [`controlplaneio-fluxcd/flux-operator/flux-operator-mcp`](https://github.com/controlplaneio-fluxcd/flux-operator)
- `kiro.dev/kiro-cli`
- ...

#### Updated Packages (13)

- [`gleam-lang/gleam`](https://github.com/gleam-lang/gleam)
- [`sigstore/cosign`](https://github.com/sigstore/cosign)
- ...
```

## Test plan

- [x] `bash -n scripts/gen-aqua-changelog.sh`
- [x] `mise run lint scripts/gen-aqua-changelog.sh` (shellcheck, shfmt, etc. clean)
- [x] `./scripts/gen-aqua-changelog.sh v4.498.0 v4.499.0 "###"` — 1 added, 1 updated
- [x] `./scripts/gen-aqua-changelog.sh v4.491.0 v4.499.0 "###"` — 28 added, 13 updated
- [x] `./scripts/gen-aqua-changelog.sh v4.499.0 v4.499.0 "###"` — silent exit 0
- [x] `./scripts/gen-aqua-changelog.sh "" v4.499.0 "###"` — silent exit 0
- [x] `./scripts/gen-aqua-changelog.sh v0.0.0-bogus v4.499.0 "###"` — fails curl, exits 0 with stderr (matches prior fail-soft contract; `xtasks/release-plz` wraps the call in `|| true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release/changelog generation logic and introduces custom YAML parsing, which could fail or mis-detect package changes if the registry format shifts, but does not affect runtime product behavior.
> 
> **Overview**
> Switches `scripts/gen-aqua-changelog.sh` from enumerating upstream `aqua-registry` release tags (via `gh`) to diffing the old vs current `registry.yaml` and printing **New Packages** and **Updated Packages** sections for the changelog.
> 
> The script now fetches the old tag’s `registry.yaml` via `curl`, parses both YAMLs with an inline `python3` stdlib parser to compute canonical package IDs, and only adds GitHub links when `repo_owner/repo_name` is present to avoid broken links for name-only entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b93531a99261cf7861d84dea9bd2f7ef5f88c3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->