### PR TITLE
fix(git): support SHA refs for remote task cloning

### DIFF
--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -138,6 +138,7 @@ def create_test_repo(repo_path):
     # Configure repo for HTTP serving
     subprocess.run(['git', 'config', 'http.receivepack', 'true'], cwd=repo_path, check=True)
     subprocess.run(['git', 'config', 'http.uploadpack', 'true'], cwd=repo_path, check=True)
+    subprocess.run(['git', 'config', 'uploadpack.allowReachableSHA1InWant', 'true'], cwd=repo_path, check=True)
     subprocess.run(['git', 'update-server-info'], cwd=repo_path, check=True)
 
 def start_server(port=0):
@@ -167,9 +168,14 @@ def start_server(port=0):
         ready_file = Path('/tmp/mise_git_http_ready')
         ready_file.write_text('ready')
 
-        # Save cleanup info
+        # Save cleanup info (temp_dir path and HEAD SHA for tests)
+        head_sha = subprocess.run(
+            ['git', 'rev-parse', 'HEAD'],
+            cwd=str(repo_path),
+            capture_output=True, text=True, check=True
+        ).stdout.strip()
         with open('/tmp/mise_git_http_info', 'w') as f:
-            f.write(f"{temp_dir}\n")
+            f.write(f"{temp_dir}\n{head_sha}\n")
 
         try:
             httpd.serve_forever()

--- a/e2e/tasks/test_task_remote_git_https
+++ b/e2e/tasks/test_task_remote_git_https
@@ -132,3 +132,16 @@ assert_contains "mise tasks info remote_lint_https_ref --json" "remote-git-tasks
 
 # Validate should work with remote tasks
 assert_succeed "mise tasks validate remote_lint_https_ref"
+
+#################################################################################
+# Test remote tasks with SHA ref (regression: gix panicked on SHA refs)
+#################################################################################
+
+HEAD_SHA=$(sed -n '2p' /tmp/mise_git_http_info)
+
+cat <<EOF >mise.toml
+[tasks.remote_lint_https_sha]
+file  = "git::${LOCAL_GIT_URL}//xtasks/lint/ripgrep?ref=${HEAD_SHA}"
+EOF
+
+assert_succeed "mise run remote_lint_https_sha"

--- a/src/git.rs
+++ b/src/git.rs
@@ -145,10 +145,12 @@ impl Git {
                 .arg(&self.dir)
                 .args(["fetch", "--depth", "1", "origin", sha])
                 .execute()
-                .wrap_err_with(|| format!(
-                    "failed to fetch SHA {sha} from {url}; \
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to fetch SHA {sha} from {url}; \
                      self-hosted servers may need `uploadpack.allowReachableSHA1InWant=true`"
-                ))?;
+                    )
+                })?;
             CmdLineRunner::new("git")
                 .args(["-C"])
                 .arg(&self.dir)
@@ -388,24 +390,22 @@ mod tests {
     #[test]
     fn test_looks_like_git_sha() {
         assert!(looks_like_git_sha("abc1234")); // 7 chars — minimum short SHA
-        assert!(looks_like_git_sha("abc1234def5678901234567890123456789012ab")); // 40 chars — full SHA
+        assert!(looks_like_git_sha(
+            "abc1234def5678901234567890123456789012ab"
+        )); // 40 chars — full SHA
         assert!(looks_like_git_sha("deadbeef1234567")); // mid-length
         assert!(!looks_like_git_sha("abc123")); // 6 chars — too short
-        assert!(!looks_like_git_sha("abc1234def5678901234567890123456789012abc")); // 41 chars — too long
+        assert!(!looks_like_git_sha(
+            "abc1234def5678901234567890123456789012abc"
+        )); // 41 chars — too long
         assert!(!looks_like_git_sha("abc1234g")); // non-hex char
         assert!(!looks_like_git_sha("main")); // branch name
         assert!(!looks_like_git_sha("refs/heads/main")); // full ref
         assert!(!looks_like_git_sha("v1.0.0")); // tag
         assert!(!looks_like_git_sha("")); // empty
         // SHA-256 (64 hex chars) — used by git's new object format
-        assert!(looks_like_git_sha(
-            "a".repeat(64).as_str()
-        ));
-        assert!(!looks_like_git_sha(
-            "a".repeat(63).as_str()
-        )); // 63 chars — not a valid SHA-256
-        assert!(!looks_like_git_sha(
-            "a".repeat(65).as_str()
-        )); // 65 chars — too long
+        assert!(looks_like_git_sha("a".repeat(64).as_str()));
+        assert!(!looks_like_git_sha("a".repeat(63).as_str())); // 63 chars — not a valid SHA-256
+        assert!(!looks_like_git_sha("a".repeat(65).as_str())); // 65 chars — too long
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -119,6 +119,44 @@ impl Git {
         if let Some(parent) = self.dir.parent() {
             file::mkdirp(parent)?;
         }
+
+        // gix's with_ref_name panics on SHA hashes; use init+fetch+checkout instead
+        if let Some(sha) = options.branch.as_deref().filter(|b| looks_like_git_sha(b)) {
+            debug!(
+                "cloning {} to {} at SHA {} via init+fetch",
+                url,
+                self.dir.display(),
+                sha
+            );
+            if let Some(pr) = &options.pr {
+                pr.abandon();
+            }
+            CmdLineRunner::new("git")
+                .args(["-c", "core.autocrlf=false", "init", "-q"])
+                .arg(&self.dir)
+                .execute()?;
+            CmdLineRunner::new("git")
+                .args(["-C"])
+                .arg(&self.dir)
+                .args(["remote", "add", "origin", url])
+                .execute()?;
+            CmdLineRunner::new("git")
+                .args(["-C"])
+                .arg(&self.dir)
+                .args(["fetch", "--depth", "1", "origin", sha])
+                .execute()
+                .wrap_err_with(|| format!(
+                    "failed to fetch SHA {sha} from {url}; \
+                     self-hosted servers may need `uploadpack.allowReachableSHA1InWant=true`"
+                ))?;
+            CmdLineRunner::new("git")
+                .args(["-C"])
+                .arg(&self.dir)
+                .args(["-c", "advice.detachedHead=false", "checkout", "FETCH_HEAD"])
+                .execute()?;
+            return Ok(());
+        }
+
         if Settings::get().libgit2 || Settings::get().gix {
             debug!("cloning {} to {} with gix", url, self.dir.display());
             let mut prepare_clone = gix::prepare_clone(url, &self.dir)?;
@@ -314,6 +352,11 @@ fn get_git_version() -> Result<String> {
     Ok(version.trim().into())
 }
 
+fn looks_like_git_sha(s: &str) -> bool {
+    // SHA-1: 7–40 hex chars; SHA-256 (new-format git): exactly 64 hex chars
+    ((s.len() >= 7 && s.len() <= 40) || s.len() == 64) && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
 impl Debug for Git {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Git").field("dir", &self.dir).finish()
@@ -335,5 +378,34 @@ impl<'a> CloneOptions<'a> {
     pub fn branch(mut self, branch: &str) -> Self {
         self.branch = Some(branch.to_string());
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_looks_like_git_sha() {
+        assert!(looks_like_git_sha("abc1234")); // 7 chars — minimum short SHA
+        assert!(looks_like_git_sha("abc1234def5678901234567890123456789012ab")); // 40 chars — full SHA
+        assert!(looks_like_git_sha("deadbeef1234567")); // mid-length
+        assert!(!looks_like_git_sha("abc123")); // 6 chars — too short
+        assert!(!looks_like_git_sha("abc1234def5678901234567890123456789012abc")); // 41 chars — too long
+        assert!(!looks_like_git_sha("abc1234g")); // non-hex char
+        assert!(!looks_like_git_sha("main")); // branch name
+        assert!(!looks_like_git_sha("refs/heads/main")); // full ref
+        assert!(!looks_like_git_sha("v1.0.0")); // tag
+        assert!(!looks_like_git_sha("")); // empty
+        // SHA-256 (64 hex chars) — used by git's new object format
+        assert!(looks_like_git_sha(
+            "a".repeat(64).as_str()
+        ));
+        assert!(!looks_like_git_sha(
+            "a".repeat(63).as_str()
+        )); // 63 chars — not a valid SHA-256
+        assert!(!looks_like_git_sha(
+            "a".repeat(65).as_str()
+        )); // 65 chars — too long
     }
 }


### PR DESCRIPTION
# Bug: Remote task with SHA ref panics

Raised by @konstantinos-gkiris as a discussion [here](https://github.com/jdx/mise/discussions/9472)

## Summary

Calling a remote Mise task with a Git SHA as `?ref=<sha>` causes a panic. Branch and tag refs work correctly.

**Affects**: all users (gix is enabled by default via `MISE_GIX=true`)

## Reproduction

```toml
# mise.toml
[tasks.my-task]
run = "git::https://github.com/org/repo.git//tasks/my-task?ref=abc1234"
```

```
mise run my-task
```

**Crash output:**

```
The application panicked (crashed).
Message:  we map by name only and have no object-id in refspec
Location: gix-0.81.0/src/clone/fetch/util.rs:217
```

## Root cause

### Where it panics

`src/git.rs` — `Git::clone()`, gix path:

```rust
if Settings::get().libgit2 || Settings::get().gix {
    let mut prepare_clone = gix::prepare_clone(url, &self.dir)?;
    if let Some(branch) = &options.branch {
        prepare_clone = prepare_clone.with_ref_name(Some(branch))?;  // <-- panics for SHAs
    }
    ...
}
```

### Why it panics

`gix::PrepareClone::with_ref_name` only accepts **named refs** (e.g. `refs/heads/main`,
`refs/tags/v1.0.0`). It does not accept commit SHA hashes. Internally, gix builds a refspec
by mapping the given name against the server's ref advertisement. When the value is a SHA
(which has no corresponding name in the advertisement), an internal assertion fires:
`"we map by name only and have no object-id in refspec"`.

The git CLI path (`git clone -b <ref>`) would also fail for SHA refs — `-b` only accepts
named refs — but would return a proper error instead of panicking.

### History

- `3463ef185` (2025-01-25): gix introduced as replacement for git2
- `6ba5d3be1` (2025-03-01): `with_ref_name` added to fix gix/libgit2 clone for branches and
  tags — but SHA refs were not handled

This is **not caused by a gix version upgrade**. gix has been at 0.81.0 throughout. SHA refs
were simply never considered when the gix clone path was implemented.

## Fix

`src/git.rs` — detect SHA refs before entering either clone path and use
`git init` + `git fetch <sha>` + `git checkout FETCH_HEAD` instead:

```rust
// SHA refs can't be used with `git clone -b` or gix's with_ref_name (which only
// handles named refs). Use init+fetch+checkout instead, which works on any server
// that supports uploadpack.allowReachableSHA1InWant (GitHub, GitLab, etc.).
if let Some(sha) = options.branch.as_deref().filter(|b| looks_like_git_sha(b)) {
    CmdLineRunner::new("git").args(["init", "-q", "-c", "core.autocrlf=false"]).arg(&self.dir).execute()?;
    CmdLineRunner::new("git").args(["-C"]).arg(&self.dir).args(["remote", "add", "origin", url]).execute()?;
    CmdLineRunner::new("git").args(["-C"]).arg(&self.dir).args(["fetch", "--depth", "1", "origin", sha]).execute()?;
    CmdLineRunner::new("git").args(["-C"]).arg(&self.dir).args(["-c", "advice.detachedHead=false", "checkout", "FETCH_HEAD"]).execute()?;
    return Ok(());
}
```

```rust
fn looks_like_git_sha(s: &str) -> bool {
    s.len() >= 7 && s.len() <= 40 && s.bytes().all(|b| b.is_ascii_hexdigit())
}
```

`git fetch origin <sha>` (shallow, depth 1) works on GitHub, GitLab, Gitea, and any server
with `uploadpack.allowReachableSHA1InWant` enabled (the default on all major hosters). This
is the same pattern used by Terraform/OpenTofu for SHA-pinned module sources.

The SHA path is checked first, so it bypasses both gix and the `git clone -b` path
regardless of `MISE_GIX` / `MISE_LIBGIT2` settings.

# Manual tests

I reproduced the issue locally with a remote task using a SHA ref. Calling the following was raising the error.
```
mise failing-task --no-cache
```

Then, from this branch, I ran `mise run install-dev `.

And returned to my initial repo to try the command: `~/.cargo/bin/mise failing-task --no-cache`, and it worked.