### PR TITLE
registry: expose more aqua-backed shorthands

### DIFF
--- a/registry/codespell.toml
+++ b/registry/codespell.toml
@@ -1,0 +1,3 @@
+backends = ["pipx:codespell"]
+description = "Check code for common misspellings"
+test = { cmd = "codespell --version", expected = "{{version}}" }

--- a/registry/google-java-format.toml
+++ b/registry/google-java-format.toml
@@ -1,4 +1,4 @@
 backends = ["aqua:google/google-java-format"]
 depends = ["java"]
 description = "Reformats Java source code to comply with Google Java Style"
-test = { cmd = "google-java-format --version", expected = "google-java-format" }
+test = { cmd = "google-java-format --version", expected = "google-java-format: Version {{version}}" }

--- a/registry/google-java-format.toml
+++ b/registry/google-java-format.toml
@@ -1,0 +1,2 @@
+backends = ["aqua:google/google-java-format"]
+description = "Reformats Java source code to comply with Google Java Style"

--- a/registry/google-java-format.toml
+++ b/registry/google-java-format.toml
@@ -1,2 +1,4 @@
 backends = ["aqua:google/google-java-format"]
+depends = ["java"]
 description = "Reformats Java source code to comply with Google Java Style"
+test = { cmd = "google-java-format --version", expected = "google-java-format" }

--- a/registry/renovate.toml
+++ b/registry/renovate.toml
@@ -1,0 +1,3 @@
+backends = ["npm:renovate"]
+description = "Automate dependency updates across repositories"
+test = { cmd = "renovate --version", expected = "{{version}}" }

--- a/registry/ryl.toml
+++ b/registry/ryl.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:owenlamont/ryl"]
 description = "A YAML linter written in Rust"
+test = { cmd = "ryl --version", expected = "ryl" }

--- a/registry/ryl.toml
+++ b/registry/ryl.toml
@@ -1,0 +1,2 @@
+backends = ["aqua:owenlamont/ryl"]
+description = "A YAML linter written in Rust"

--- a/registry/ryl.toml
+++ b/registry/ryl.toml
@@ -1,3 +1,3 @@
 backends = ["aqua:owenlamont/ryl"]
 description = "A YAML linter written in Rust"
-test = { cmd = "ryl --version", expected = "ryl" }
+test = { cmd = "ryl --version", expected = "ryl {{version}}" }

--- a/registry/shellcheck.toml
+++ b/registry/shellcheck.toml
@@ -1,4 +1,3 @@
 backends = ["aqua:koalaman/shellcheck", "asdf:luizm/asdf-shellcheck"]
 description = "ShellCheck, a static analysis tool for shell scripts"
-os = ["linux", "macos"]
 test = { cmd = "shellcheck --version", expected = "version: {{version}}" }

--- a/registry/xmllint.toml
+++ b/registry/xmllint.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:jonwiggins/xmloxide"]
-description = "A pure Rust reimplementation of libxml2"
+description = "A Rust reimplementation of the xmllint command-line XML tool"
+test = { cmd = "xmllint --version", expected = "xmllint" }

--- a/registry/xmllint.toml
+++ b/registry/xmllint.toml
@@ -1,3 +1,3 @@
 backends = ["aqua:jonwiggins/xmloxide"]
 description = "A Rust reimplementation of the xmllint command-line XML tool"
-test = { cmd = "xmllint --version", expected = "xmllint" }
+test = { cmd = "xmllint --version", expected = "xmllint {{version}}" }

--- a/registry/xmllint.toml
+++ b/registry/xmllint.toml
@@ -1,0 +1,2 @@
+backends = ["aqua:jonwiggins/xmloxide"]
+description = "A pure Rust reimplementation of libxml2"


### PR DESCRIPTION
## Summary
- remove the Windows OS gate from the existing `shellcheck` shorthand
- add Aqua-backed shorthands for `google-java-format`, `xmllint`, and `ryl`

## Why
I'm trying to converge Flint-managed tools on Aqua-backed `mise` shorthands where possible.

Three of the blockers are already solved upstream in Aqua Registry:
- `google/google-java-format` was added in aquaproj/aqua-registry#52681
- `jonwiggins/xmloxide` (which installs the `xmllint` binary) was added in aquaproj/aqua-registry#52682
- `owenlamont/ryl` is already available in Aqua today

For `shellcheck`, the Aqua package itself already works on Windows, but the current `mise` shorthand still has:

```toml
os = ["linux", "macos"]
```

in `registry/shellcheck.toml`, which keeps the bare key Windows-gated.

## Notes
- This PR only updates `registry/*.toml` shorthands.
- I did not change backend ordering beyond keeping the existing Aqua-first preference.
