### PR TITLE
fix(release): pass --no-git-checks to aube publish

### DIFF
--- a/scripts/release-npm.sh
+++ b/scripts/release-npm.sh
@@ -62,10 +62,10 @@ EOF
 	tree || true
 	if [ "${DRY_RUN:-1}" != "0" ]; then
 		echo DRY_RUN
-		echo aube publish --access public --tag "$dist_tag" --provenance
+		echo aube publish --access public --tag "$dist_tag" --provenance --no-git-checks
 		echo DRY_RUN
 	else
-		if ! aube publish --access public --tag "$dist_tag" --provenance 2>&1 | tee /tmp/npm-publish.log; then
+		if ! aube publish --access public --tag "$dist_tag" --provenance --no-git-checks 2>&1 | tee /tmp/npm-publish.log; then
 			if grep -qE "already (on|published)|previously published" /tmp/npm-publish.log; then
 				echo "Version already published, skipping..."
 			else
@@ -166,10 +166,10 @@ EOF
 pushd "$RELEASE_DIR/npm"
 if [ "${DRY_RUN:-1}" != "0" ]; then
 	echo DRY_RUN
-	echo aube publish --access public --tag "$dist_tag" --provenance
+	echo aube publish --access public --tag "$dist_tag" --provenance --no-git-checks
 	echo DRY_RUN
 else
-	if ! aube publish --access public --tag "$dist_tag" --provenance 2>&1 | tee /tmp/npm-publish.log; then
+	if ! aube publish --access public --tag "$dist_tag" --provenance --no-git-checks 2>&1 | tee /tmp/npm-publish.log; then
 		if grep -qE "already (on|published)|previously published" /tmp/npm-publish.log; then
 			echo "Version already published, skipping..."
 		else

--- a/scripts/release-npm.sh
+++ b/scripts/release-npm.sh
@@ -60,12 +60,13 @@ for platform in "${platforms[@]}"; do
 EOF
 	pushd "$RELEASE_DIR/npm"
 	tree || true
+	aube_publish_args=(--access public --tag "$dist_tag" --provenance --no-git-checks)
 	if [ "${DRY_RUN:-1}" != "0" ]; then
 		echo DRY_RUN
-		echo aube publish --access public --tag "$dist_tag" --provenance --no-git-checks
+		echo aube publish "${aube_publish_args[@]}"
 		echo DRY_RUN
 	else
-		if ! aube publish --access public --tag "$dist_tag" --provenance --no-git-checks 2>&1 | tee /tmp/npm-publish.log; then
+		if ! aube publish "${aube_publish_args[@]}" 2>&1 | tee /tmp/npm-publish.log; then
 			if grep -qE "already (on|published)|previously published" /tmp/npm-publish.log; then
 				echo "Version already published, skipping..."
 			else
@@ -164,12 +165,13 @@ cat <<EOF >"$RELEASE_DIR/npm/package.json"
 }
 EOF
 pushd "$RELEASE_DIR/npm"
+aube_publish_args=(--access public --tag "$dist_tag" --provenance --no-git-checks)
 if [ "${DRY_RUN:-1}" != "0" ]; then
 	echo DRY_RUN
-	echo aube publish --access public --tag "$dist_tag" --provenance --no-git-checks
+	echo aube publish "${aube_publish_args[@]}"
 	echo DRY_RUN
 else
-	if ! aube publish --access public --tag "$dist_tag" --provenance --no-git-checks 2>&1 | tee /tmp/npm-publish.log; then
+	if ! aube publish "${aube_publish_args[@]}" 2>&1 | tee /tmp/npm-publish.log; then
 		if grep -qE "already (on|published)|previously published" /tmp/npm-publish.log; then
 			echo "Version already published, skipping..."
 		else


### PR DESCRIPTION
## Summary

- The `npm-publish` workflow installs aube via `mise install aube`, which updates `mise.lock`. `aube publish` then aborts on the dirty working tree, failing the publish step.
- The npm package is constructed from downloaded GitHub release tarballs in `releases/npm/`, so the working tree state of the parent repo is irrelevant to what gets published.
- Added `--no-git-checks` to both `aube publish` invocations in `scripts/release-npm.sh` (the per-platform package publishes and the meta-package publish). aube's own error message recommends this flag.

Fixes the failure seen in https://github.com/jdx/mise/actions/runs/25163085007/job/73762238727:

\`\`\`
Error:   × aube publish: working tree has uncommitted changes:
  │  M mise.lock
  │ help: commit or stash them, or pass --no-git-checks to override
\`\`\`

## Test plan

- [ ] Re-run the failed `npm-publish` workflow (or wait for the next release) and confirm publish succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to the release script; it only relaxes `aube publish` git checks during packaging and should not affect built artifacts.
> 
> **Overview**
> Fixes npm publishing in CI by adding `--no-git-checks` to `aube publish` for both the per-platform packages and the final meta-package in `scripts/release-npm.sh`.
> 
> Also refactors the publish invocation to use a shared `aube_publish_args` array so dry-run output and real publishes stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d40378587204af4fc273264edb10ed98ec2ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->