### PR TITLE
fix(copr): drop epel-9 chroots since rust >= 1.91 is unavailable

### DIFF
--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -8,7 +8,7 @@ on:
       chroots:
         description: "COPR chroots to target (space-separated)"
         required: false
-        default: "fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 epel-9-aarch64 epel-9-x86_64"
+        default: "fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64"
         type: string
       use_serious_profile:
         description: 'Use the "serious" profile for optimized builds (LTO enabled)'
@@ -37,7 +37,7 @@ jobs:
           VERSION=$(./scripts/get-version.sh | sed 's/^v//')
 
           if [ "${{ github.event_name }}" = "release" ]; then
-            CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 epel-9-aarch64 epel-9-x86_64"
+            CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64"
           else
             CHROOTS="${{ inputs.chroots }}"
           fi


### PR DESCRIPTION
## Summary

- EPEL 9 / RHEL 9 ship rust below 1.91, so the spec's `BuildRequires: rust >= 1.91` (set after the MSRV bump in #9295) makes every `epel-9-aarch64` / `epel-9-x86_64` build fail at dependency resolution before `rpmbuild` ever runs.
- Drop both `epel-9` chroots from the release event list and the `workflow_dispatch` default in `copr-publish.yml`. EPEL 10 stays — it has rust 1.91+.

Example failure ([epel-9-aarch64 build 10411552](https://download.copr.fedorainfracloud.org/results/jdxcode/mise/epel-9-aarch64/10411552-mise/builder-live.log.gz)):

> No matching package to install: 'rust >= 1.91'
> Not all dependencies satisfied
> Error: Some packages could not be found.

The `epel-9-*` chroots may also want to be disabled in the COPR project's web settings to clean up the prior failed build state — that's outside this repo.

## Test plan

- [ ] Next release-triggered (or manually dispatched) `copr-publish` run no longer attempts `epel-9-aarch64` / `epel-9-x86_64`
- [ ] Fedora 42/43/44/rawhide and EPEL 10 builds still complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just narrows the COPR build matrix; main risk is reduced build coverage for EPEL 9 rather than functional regressions.
> 
> **Overview**
> `copr-publish` no longer targets `epel-9-aarch64`/`epel-9-x86_64` by default. The workflow’s `workflow_dispatch` default `chroots` list and the release-triggered `CHROOTS` env now only include Fedora (rawhide/42-44) and `epel-10` chroots, avoiding EPEL 9 builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab13549c566b2915030b75218ffd1e43fc98f78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->