### PR TITLE
registry: enable shellcheck on windows

### DIFF
--- a/registry/shellcheck.toml
+++ b/registry/shellcheck.toml
@@ -1,4 +1,3 @@
 backends = ["aqua:koalaman/shellcheck", "asdf:luizm/asdf-shellcheck"]
 description = "ShellCheck, a static analysis tool for shell scripts"
-os = ["linux", "macos"]
 test = { cmd = "shellcheck --version", expected = "version: {{version}}" }


### PR DESCRIPTION
## Summary
- remove the `os = ["linux", "macos"]` gate from `shellcheck`

## Why
The Aqua-backed `shellcheck` package already works on Windows, but the current shorthand still hides the bare `shellcheck` key there.
