### PR TITLE
registry: add google-java-format

### DIFF
--- a/registry/google-java-format.toml
+++ b/registry/google-java-format.toml
@@ -1,0 +1,4 @@
+backends = ["aqua:google/google-java-format"]
+depends = ["java"]
+description = "Reformats Java source code to comply with Google Java Style"
+test = { cmd = "google-java-format --version", expected = "google-java-format: Version {{version}}" }


### PR DESCRIPTION
## Summary
- add a bare `google-java-format` shorthand backed by Aqua
- declare `depends = ["java"]`
- include a versioned install test based on actual `--version` output
