### PR TITLE
registry: add xmllint

### DIFF
--- a/registry/xmllint.toml
+++ b/registry/xmllint.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:jonwiggins/xmloxide"]
+description = "A Rust reimplementation of the xmllint command-line XML tool"
+test = { cmd = "xmllint --version", expected = "xmllint {{version}}" }


### PR DESCRIPTION
## Summary
- add a bare `xmllint` shorthand backed by Aqua via `jonwiggins/xmloxide`
- include a versioned install test based on actual `--version` output
