### PR TITLE
registry: add ryl

### DIFF
--- a/registry/ryl.toml
+++ b/registry/ryl.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:owenlamont/ryl"]
+description = "A YAML linter written in Rust"
+test = { cmd = "ryl --version", expected = "ryl {{version}}" }


### PR DESCRIPTION
## Summary
- add a bare `ryl` shorthand backed by Aqua
- include a versioned install test based on actual `--version` output
