### PR TITLE
registry: add codespell

### DIFF
--- a/registry/codespell.toml
+++ b/registry/codespell.toml
@@ -1,0 +1,3 @@
+backends = ["pipx:codespell"]
+description = "Check code for common misspellings"
+test = { cmd = "codespell --version", expected = "{{version}}" }


### PR DESCRIPTION
## Summary
- add a bare `codespell` shorthand backed by `pipx`
- include a versioned install test
