### PR TITLE
registry: add renovate

### DIFF
--- a/registry/renovate.toml
+++ b/registry/renovate.toml
@@ -1,0 +1,3 @@
+backends = ["npm:renovate"]
+description = "Automate dependency updates across repositories"
+test = { cmd = "renovate --version", expected = "{{version}}" }


### PR DESCRIPTION
## Summary
- add a bare `renovate` shorthand backed by `npm`
- include a versioned install test
