### PR TITLE
feat(vfox): add stat function to lua file module

### DIFF
--- a/crates/vfox/src/lua_mod/file.rs
+++ b/crates/vfox/src/lua_mod/file.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
-use mlua::{ExternalResult, Lua, MultiValue, Table};
+use mlua::{ExternalResult, Lua, MultiValue, Table, Value};
 #[cfg(unix)]
-use std::os::unix::fs::symlink as _symlink;
+use std::os::unix::fs::{PermissionsExt, symlink as _symlink};
 #[cfg(windows)]
 use std::os::windows::fs::symlink_dir;
 #[cfg(windows)]
@@ -45,6 +45,12 @@ pub fn mod_file(lua: &Lua) -> Result<()> {
                     exists(&_lua, input).await
                 })?,
             ),
+            (
+                "stat",
+                lua.create_async_function(|_lua: mlua::Lua, path: String| async move {
+                    stat(&_lua, path).await
+                })?,
+            ),
         ])?,
     )?)
 }
@@ -85,6 +91,47 @@ async fn exists(_lua: &Lua, input: MultiValue) -> mlua::Result<bool> {
         .collect::<mlua::Result<_>>()?;
     let path = Path::new(&args[0]);
     std::fs::exists(path).into_lua_err()
+}
+
+async fn stat(lua: &Lua, path: String) -> mlua::Result<Value> {
+    let path = Path::new(&path);
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Value::Nil),
+        Err(e) => return Err(mlua::Error::external(e)),
+    };
+    let modified = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64);
+    let accessed = meta
+        .accessed()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64);
+    let created = meta
+        .created()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64);
+    let table = lua.create_table()?;
+    table.set("size", meta.len())?;
+    table.set("is_file", meta.is_file())?;
+    table.set("is_dir", meta.is_dir())?;
+    table.set("is_symlink", meta.is_symlink())?;
+    table.set("modified", modified)?;
+    table.set("accessed", accessed)?;
+    table.set("created", created)?;
+    #[cfg(unix)]
+    {
+        table.set("mode", format!("{:o}", meta.permissions().mode() & 0o7777))?;
+    }
+    #[cfg(not(unix))]
+    {
+        table.set("mode", Value::Nil)?;
+    }
+    Ok(Value::Table(table))
 }
 
 #[cfg(test)]
@@ -165,5 +212,63 @@ mod tests {
         })
         .exec()
         .unwrap();
+    }
+
+    #[test]
+    fn test_stat() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("stat-file.txt");
+        let file_path_str = file_path.to_string_lossy().to_string();
+        let file_path_str_clone = file_path_str.clone();
+        let dir_path = temp_dir.path().join("stat-dir");
+        let dir_path_str = dir_path.to_string_lossy().to_string();
+        let nonexistent_path_str = temp_dir
+            .path()
+            .join("nonexistent.txt")
+            .to_string_lossy()
+            .to_string();
+
+        fs::write(&file_path, "test content").unwrap();
+        fs::create_dir(&dir_path).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o644);
+            fs::set_permissions(&file_path, perms).unwrap();
+        }
+        let lua = Lua::new();
+        mod_file(&lua).unwrap();
+
+        lua.load(mlua::chunk! {
+            local file = require("file")
+
+            local st = file.stat($file_path_str)
+            assert(st ~= nil, "stat should return a table for existing file")
+            assert(st.is_file == true, "should be a file")
+            assert(st.is_dir == false, "should not be a directory")
+            assert(st.is_symlink == false, "should not be a symlink")
+            assert(st.size == string.len("test content"), "size should match content length")
+            assert(type(st.modified) == "number", "modified should be a number")
+
+            local st2 = file.stat($dir_path_str)
+            assert(st2.is_dir == true, "should be a directory")
+            assert(st2.is_file == false, "should not be a file")
+
+            local st3 = file.stat($nonexistent_path_str)
+            assert(st3 == nil, "stat should return nil for nonexistent")
+        })
+        .exec()
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            lua.load(mlua::chunk! {
+                local file = require("file")
+                local st = file.stat($file_path_str_clone)
+                assert(st.mode == "644", "mode should be permission bits only, got: " .. (st.mode or "nil"))
+            })
+            .exec()
+            .unwrap();
+        }
     }
 }

--- a/crates/vfox/types/mise-plugin.lua
+++ b/crates/vfox/types/mise-plugin.lua
@@ -166,11 +166,22 @@ local json = {}
 
 -- file module --------------------------------------------------------
 
+---@class FileStat
+---@field size integer File size in bytes
+---@field is_file boolean Whether this is a regular file
+---@field is_dir boolean Whether this is a directory
+---@field is_symlink boolean Whether this is a symlink
+---@field modified integer|nil Last modification time (Unix seconds since epoch, nil if unavailable)
+---@field accessed integer|nil Last access time (Unix seconds since epoch, nil if unavailable)
+---@field created integer|nil Creation time (Unix seconds since epoch, nil if unavailable)
+---@field mode string|nil Octal permission mode string (Unix only, e.g. "755", nil on Windows)
+
 ---@class file
 ---@field read fun(path: string): string Read file contents
 ---@field exists fun(path: string): boolean Check if a file exists
 ---@field symlink fun(src: string, dst: string) Create a symbolic link
 ---@field join_path fun(...: string): string Join path components
+---@field stat fun(path: string): FileStat|nil Get file metadata or nil if not found
 local file = {}
 
 -- cmd module ---------------------------------------------------------


### PR DESCRIPTION
This PR adds a stat function so that custom plugins written in Lua can obtain metadata about files (e.g. in the case of the Pixi env plugin for checking against the cache whether to run `pixi shell-hook --json` or not, which is an expensive operation)