### PR TITLE
registry: add expert (aqua:expert-lsp/expert)

### DIFF
--- a/registry/expert.toml
+++ b/registry/expert.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:expert-lsp/expert", "github:expert-lsp/expert"]
+description = "Official Elixir Language Server Protocol implementation"
+test = { cmd = "expert --version", expected = "{{version}}" }


### PR DESCRIPTION
Adds [Expert](https://expert-lsp.org), the official language server implementation for Elixir.