### PR TITLE
fix(backend): flag regex prerelease versions

### DIFF
--- a/docs/cli/ls-remote.md
+++ b/docs/cli/ls-remote.md
@@ -36,9 +36,9 @@ Disable checking the mise-versions host
 ### `--prerelease`
 
 Include pre-release versions in the output for backends that report
-an upstream prerelease flag (currently github + aqua). Equivalent to
-setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
-duration of this command.
+upstream prerelease metadata or opt in to regex-based prerelease
+detection. Equivalent to setting `MISE_PRERELEASES=1` or the
+`prereleases` setting for the duration of this command.
 
 ### `--strict-metadata`
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1517,9 +1517,9 @@ Disable checking the mise\-versions host
 .TP
 \fB\-\-prerelease\fR
 Include pre\-release versions in the output for backends that report
-an upstream prerelease flag (currently github + aqua). Equivalent to
-setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
-duration of this command.
+upstream prerelease metadata or opt in to regex\-based prerelease
+detection. Equivalent to setting `MISE_PRERELEASES=1` or the
+`prereleases` setting for the duration of this command.
 .TP
 \fB\-\-strict\-metadata\fR
 Fail if release metadata fetches fail

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -596,7 +596,7 @@ cmd ls-remote help="List runtime versions available for install." {
     flag --all help="Show all installed plugins and versions"
     flag "-J --json" help="Output in JSON format (includes version metadata like created_at timestamps when available)"
     flag --no-versions-host help="Disable checking the mise-versions host"
-    flag --prerelease help="Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command."
+    flag --prerelease help="Include pre-release versions in the output for backends that report\nupstream prerelease metadata or opt in to regex-based prerelease\ndetection. Equivalent to setting `MISE_PRERELEASES=1` or the\n`prereleases` setting for the duration of this command."
     flag --strict-metadata help="Fail if release metadata fetches fail" {
         long_help "Fail if release metadata fetches fail\n\nRequires --json and --no-versions-host.\n\nThis prevents metadata consumers from accepting empty fallback results\nwhen a backend's metadata-producing upstream request fails."
     }

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -248,6 +248,10 @@ impl Backend for AsdfBackend {
         Some(PluginType::Asdf)
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     /// ASDF plugins handle their own downloads through plugin scripts.
     /// Lockfile URLs are not applicable since installation is delegated to plugin scripts.
     fn supports_lockfile_url(&self) -> bool {

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -50,6 +50,10 @@ impl Backend for CargoBackend {
         false
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         if self.git_url().is_some() {
             // TODO: maybe fetch tags/branches from git?

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -1,6 +1,8 @@
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
-use crate::backend::{VersionInfo, mark_prerelease};
+use crate::backend::{
+    VersionInfo, filter_cached_prereleases, include_prereleases, mark_prerelease,
+};
 use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::Settings;
@@ -662,12 +664,18 @@ impl Backend for CondaBackend {
         &self,
         config: &Arc<Config>,
     ) -> Result<Vec<VersionInfo>> {
-        Ok(self
+        let opts = config
+            .get_tool_opts(&self.ba)
+            .await?
+            .unwrap_or_else(|| self.ba.opts());
+        let want_prereleases = include_prereleases(&opts);
+        let versions = self
             ._list_remote_versions(config)
             .await?
             .into_iter()
             .map(mark_prerelease)
-            .collect())
+            .collect();
+        Ok(filter_cached_prereleases(versions, want_prereleases))
     }
 
     async fn install_version_(

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -1,6 +1,6 @@
-use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
+use crate::backend::{VersionInfo, mark_prerelease};
 use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::Settings;
@@ -662,7 +662,12 @@ impl Backend for CondaBackend {
         &self,
         config: &Arc<Config>,
     ) -> Result<Vec<VersionInfo>> {
-        self._list_remote_versions(config).await
+        Ok(self
+            ._list_remote_versions(config)
+            .await?
+            .into_iter()
+            .map(mark_prerelease)
+            .collect())
     }
 
     async fn install_version_(

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -32,6 +32,10 @@ impl Backend for DotnetBackend {
         Ok(vec!["dotnet"])
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         let feed_url = self.get_search_url().await?;
 

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -39,6 +39,10 @@ impl Backend for GemBackend {
         Ok(vec!["ruby"])
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         // Get the gem source URL using the mise-managed Ruby environment
         let source_url = self.get_gem_source(config).await;

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -47,6 +47,10 @@ impl Backend for GoBackend {
         false
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         // Check if go is available
         self.warn_if_dependency_missing(

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -607,6 +607,10 @@ impl Backend for HttpBackend {
         &self.ba
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     async fn install_operation_count(&self, tv: &ToolVersion, _ctx: &InstallContext) -> usize {
         let opts = tv.request.options();
         super::http_install_operation_count(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -117,10 +117,10 @@ pub struct VersionInfo {
     /// Checksum of the release asset, used to detect changes in rolling releases
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub checksum: Option<String>,
-    /// Whether the upstream flagged this as a pre-release. Backends that have a
-    /// reliable signal (e.g. GitHub releases' `prerelease: true`) populate this
-    /// so the shared remote-versions cache can store the superset and apply the
-    /// `prerelease` tool option as a read-time filter.
+    /// Whether this is a pre-release. Backends with a reliable upstream signal
+    /// (e.g. GitHub releases' `prerelease: true`) populate this directly.
+    /// Metadata-free listing backends can opt in to stamping this from mise's
+    /// legacy pre-release pattern before caching.
     #[serde(default, skip_serializing_if = "is_false")]
     pub prerelease: bool,
 }
@@ -479,10 +479,8 @@ mod tests {
 
     #[test]
     fn test_filter_cached_prereleases_leaves_unflagged_backends_alone() {
-        // Backends that don't populate `VersionInfo.prerelease` (e.g. node,
-        // ruby, aqua's `github_tag` source) keep the legacy regex-based filter
-        // in `fuzzy_match_versions` for pre-release-shaped strings. The
-        // cache-layer filter must not strip those entries on its own.
+        // The cache-layer filter only trusts the metadata bit. Regex-shaped
+        // versions are stamped before they enter the cache.
         let cached = vec![
             VersionInfo {
                 version: "1.0.0".into(),
@@ -496,6 +494,28 @@ mod tests {
         let filtered = filter_cached_prereleases(cached.clone(), false);
         let versions: Vec<_> = filtered.iter().map(|v| v.version.as_str()).collect();
         assert_eq!(versions, vec!["1.0.0", "1.1.0-rc1"]);
+    }
+
+    #[test]
+    fn test_mark_prerelease_flags_regex_matches() {
+        let stable = mark_prerelease(VersionInfo {
+            version: "1.0.0".into(),
+            ..Default::default()
+        });
+        assert!(!stable.prerelease);
+
+        let rc = mark_prerelease(VersionInfo {
+            version: "1.1.0-rc1".into(),
+            ..Default::default()
+        });
+        assert!(rc.prerelease);
+
+        let already_flagged = mark_prerelease(VersionInfo {
+            version: "2.0.0".into(),
+            prerelease: true,
+            ..Default::default()
+        });
+        assert!(already_flagged.prerelease);
     }
 
     #[test]
@@ -622,6 +642,12 @@ pub trait Backend: Debug + Send + Sync {
     /// before installing this tool.
     fn get_dependencies(&self) -> Result<Vec<&str>> {
         Ok(vec![])
+    }
+
+    /// Whether this backend's version source lacks an upstream prerelease flag
+    /// and should mark regex-shaped versions as prereleases before caching.
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        false
     }
     /// dependencies which wait for install but do not warn, like cargo-binstall
     fn get_optional_dependencies(&self) -> Result<Vec<&str>> {
@@ -816,6 +842,10 @@ pub trait Backend: Debug + Send + Sync {
                     ._list_remote_versions(config)
                     .await?
                     .into_iter()
+                    .map(|v| match self.mark_prereleases_from_version_pattern() {
+                        true => mark_prerelease(v),
+                        false => v,
+                    })
                     .filter(|v| match v.version.parse::<ToolVersionType>() {
                         Ok(ToolVersionType::Version(_)) => true,
                         _ => {
@@ -2328,11 +2358,10 @@ fn find_match_in_list(list: &[String], query: &str) -> Option<String> {
 }
 
 /// Apply the read-time `prerelease` filter to the cached remote-versions
-/// superset. Backends that honor `prerelease` (github, aqua) cache the full
-/// list and stamp `VersionInfo.prerelease` per entry; this helper drops
-/// pre-release entries when the current tool opts don't opt in. Backends that
-/// don't populate the flag are unaffected because their entries default to
-/// `prerelease = false`.
+/// superset. Backends cache the full list and stamp `VersionInfo.prerelease`
+/// either from upstream metadata or, for metadata-free listing backends, mise's
+/// legacy pre-release pattern. This helper drops pre-release entries when the
+/// current tool opts don't opt in.
 pub(crate) fn filter_cached_prereleases(
     versions: Vec<VersionInfo>,
     want_prereleases: bool,
@@ -2342,6 +2371,13 @@ pub(crate) fn filter_cached_prereleases(
     } else {
         versions.into_iter().filter(|v| !v.prerelease).collect()
     }
+}
+
+pub(crate) fn mark_prerelease(mut version: VersionInfo) -> VersionInfo {
+    if !version.prerelease && VERSION_REGEX.is_match(&version.version) {
+        version.prerelease = true;
+    }
+    version
 }
 
 /// Whether pre-release versions should be included for the current tool.

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -52,6 +52,10 @@ impl Backend for NPMBackend {
         &self.ba
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     fn get_dependencies(&self) -> eyre::Result<Vec<&str>> {
         // npm CLI is always needed for version queries (npm view), plus the configured
         // package manager for installation. We avoid listing all package managers to

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -52,6 +52,10 @@ impl Backend for PIPXBackend {
         Ok(vec!["uv"])
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     /// Pipx installs packages from PyPI or Git using version specs (e.g., black==24.3.0).
     /// It doesn't support installing from direct URLs, so lockfile URLs are not applicable.
     fn supports_lockfile_url(&self) -> bool {

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -418,6 +418,10 @@ impl Backend for S3Backend {
         &self.ba
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     async fn install_operation_count(&self, tv: &ToolVersion, _ctx: &InstallContext) -> usize {
         let opts = tv.request.options();
         super::http_install_operation_count(

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -44,6 +44,10 @@ impl Backend for SPMBackend {
         Ok(vec!["swift"])
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         let provider = GitProvider::from_ba(&self.ba);
         let repo = SwiftPackageRepo::new(&self.tool_name(), &provider)?;

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -39,6 +39,10 @@ impl Backend for UbiBackend {
         &self.ba
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         deprecated_at!(
             "2026.4.0",

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -63,6 +63,10 @@ impl Backend for VfoxBackend {
         Ok(deps.iter().map(|s| s.as_str()).collect())
     }
 
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
     fn supports_lockfile_url(&self) -> bool {
         // TODO: expose a plugin hook (e.g. BackendLockInfo) so custom Lua backends
         // can surface a download URL + checksum, and flip this back on for them.

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -17,9 +17,8 @@ struct VersionOutputAll {
     version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     created_at: Option<String>,
-    /// Upstream pre-release flag, sourced from the versions host or the
-    /// backend (currently github + aqua report this). Always emitted so
-    /// JSON consumers can rely on its presence.
+    /// Pre-release flag, sourced from upstream metadata or backend opt-in
+    /// detection. Always emitted so JSON consumers can rely on its presence.
     prerelease: bool,
 }
 
@@ -52,9 +51,9 @@ pub struct LsRemote {
     pub no_versions_host: bool,
 
     /// Include pre-release versions in the output for backends that report
-    /// an upstream prerelease flag (currently github + aqua). Equivalent to
-    /// setting `MISE_PRERELEASES=1` or the `prereleases` setting for the
-    /// duration of this command.
+    /// upstream prerelease metadata or opt in to regex-based prerelease
+    /// detection. Equivalent to setting `MISE_PRERELEASES=1` or the
+    /// `prereleases` setting for the duration of this command.
     #[clap(long, verbatim_doc_comment)]
     pub prerelease: bool,
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -350,6 +350,7 @@ impl Backend for JavaPlugin {
             .map(|(v, m)| VersionInfo {
                 version: v.clone(),
                 created_at: m.created_at.clone(),
+                prerelease: VERSION_REGEX.is_match(v),
                 ..Default::default()
             })
             .unique_by(|v| v.version.clone())

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -55,12 +55,11 @@ struct VersionEntry {
     created_at: toml::value::Datetime,
     #[serde(default)]
     release_url: Option<String>,
-    /// Upstream pre-release flag, when the producing source can distinguish
-    /// it (currently github + aqua releases). Defaults to false so old
-    /// host data — and entries from sources that don't track prereleases —
-    /// stay correct without any schema upgrade. Old mise clients that don't
-    /// know about this field ignore it (toml-rs accepts unknown fields by
-    /// default), so populating it in mise-versions is forward-compatible.
+    /// Pre-release flag, when the producing source can distinguish it. Defaults
+    /// to false so old host data — and entries from sources that don't track
+    /// prereleases — stay correct without any schema upgrade. Old mise clients
+    /// that don't know about this field ignore it (toml-rs accepts unknown
+    /// fields by default), so populating it in mise-versions is forward-compatible.
     #[serde(default)]
     prerelease: bool,
 }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1757,7 +1757,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--prerelease",
           description:
-            "Include pre-release versions in the output for backends that report\nan upstream prerelease flag (currently github + aqua). Equivalent to\nsetting `MISE_PRERELEASES=1` or the `prereleases` setting for the\nduration of this command.",
+            "Include pre-release versions in the output for backends that report\nupstream prerelease metadata or opt in to regex-based prerelease\ndetection. Equivalent to setting `MISE_PRERELEASES=1` or the\n`prereleases` setting for the duration of this command.",
           isRepeatable: false,
         },
         {


### PR DESCRIPTION
## Summary

- add an opt-in `mark_prereleases_from_version_pattern` backend hook for version sources that do not already carry prerelease metadata
- enable regex stamping only for the metadata-free backends that return plain version lists through mise
- keep metadata-aware paths authoritative; Java continues to set prerelease from its own local regex path because it bypasses the shared backend cache
- update `ls-remote --prerelease` help/generated docs to describe metadata and opt-in regex detection

## Why

mise-versions should be able to consume prerelease metadata from mise, but mise should not overwrite or second-guess backends that already provide an explicit prerelease flag. This keeps #144 as the immediate hosted-data fix while making mise send the flag for legacy/plain-list backends where regex detection is still the only available signal.

## PR feedback addressed

- clarified stale `--prerelease` help text and regenerated usage/manpage docs
- skipped regex matching in `mark_prerelease` when upstream already flagged a version as prerelease
- removed conda's dead `mark_prereleases_from_version_pattern` override while keeping its direct stamping in the custom cache-bypass path

## Validation

- cargo fmt --all --check
- cargo test -q test_mark_prerelease_flags_regex_matches
- cargo test -q test_filter_cached_prereleases
- cargo build -q
- mise run render:usage
- mise run render:mangen
- mise run render:fig (reverted unrelated generated collapse; kept the targeted completion text update)
- commit hook: hk lint stack, including cargo check --all-features
- MISE_USE_VERSIONS_HOST=0 target/debug/mise ls-remote --prerelease --json gradle | jq -c 'map(select(.version == "9.6.0-M1" or .version == "9.5.0"))'
- MISE_USE_VERSIONS_HOST=0 target/debug/mise ls-remote --json gradle | jq -c 'map(select(.version | test("-M|-RC"))) | length'
- MISE_USE_VERSIONS_HOST=0 target/debug/mise ls-remote --prerelease --json java | jq 'map(select(has("prerelease"))) | length'

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remote version lists are cached/filtered for many backends by stamping `VersionInfo.prerelease` from a regex, which could affect `latest` resolution and `ls-remote` output if versions are misclassified.
> 
> **Overview**
> Extends pre-release handling to backends that don’t provide upstream prerelease metadata by adding a `Backend::mark_prereleases_from_version_pattern` hook and a shared `mark_prerelease` helper that stamps regex-shaped versions *before* they enter the remote-versions cache.
> 
> Enables this opt-in for several metadata-free backends (e.g. `asdf`, `cargo`, `npm`, `pipx`, `http`, `s3`, `ubi`, `vfox`, etc.) and updates `conda`’s cache-bypass path to apply the same stamping+filtering logic. `java` now explicitly sets `prerelease` when building its version list.
> 
> Updates `ls-remote --prerelease` help text and regenerates usage/manpage/completion docs to reflect that prereleases can come from upstream metadata *or* regex-based detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8d6261efc0d46591963195bf77a5f95638fb31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->