### PR TITLE
fix(cargo): Apply install_env during cargo install

### DIFF
--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -157,6 +157,7 @@ impl Backend for CargoBackend {
             .arg(tv.install_path())
             .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+            .envs(opts.install_env.clone())
             .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
             .prepend_path(
                 self.dependency_toolset(&ctx.config)


### PR DESCRIPTION
The cargo backend did not support the `install_env` tool option during installation.

`install_env` is documented in `docs/dev-tools/index.md` and the documentation suggests it should work with cargo, but it didn't.

This meant users had no consistent way to pass environment variables like RUSTFLAGS to `cargo install` via mise config.

For example, `cargo:xh` with `features = "http3"` requires `RUSTFLAGS='--cfg reqwest_unstable'` but there was no way to specify that in mise config. Now users can write:

```toml
[tools]
"cargo:xh" = { version = "latest", features = "http3", install_env = { RUSTFLAGS = "--cfg reqwest_unstable" } }
```

The mirrors how the asdf backend already applies install_env.