### PR TITLE
registry: update entry for checkmake

### DIFF
--- a/registry/checkmake.toml
+++ b/registry/checkmake.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:mrtazz/checkmake"]
-description = "experimental linter/analyzer for Makefiles"
+backends = ["aqua:checkmake/checkmake"]
+description = "Linter/analyzer for Makefiles"
 test = { cmd = "checkmake --version", expected = "checkmake v{{version}}" }


### PR DESCRIPTION
Makes some updates to registry entry for `checkmake`.

https://github.com/mrtazz/checkmake now redirects to https://github.com/checkmake/checkmake.

The update is already reflected in the aqua registry: https://github.com/aquaproj/aqua-registry/tree/225ac1005b04cc751c564a52d1bacc3c9993abc2/pkgs/checkmake/checkmake.