### PR TITLE
fix(github): retry ip allow list errors without auth

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -8,7 +8,8 @@ use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use eyre::{Report, Result, bail, ensure};
 use regex::Regex;
-use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
+use reqwest::StatusCode;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use reqwest::{ClientBuilder, IntoUrl, Method, Response};
 use std::sync::LazyLock as Lazy;
 use tokio::sync::OnceCell;
@@ -421,8 +422,8 @@ impl Client {
         let mut final_headers = headers.clone();
         final_headers.extend(netrc_headers(&url));
 
-        let mut req = self.reqwest.request(method, url.clone());
-        req = req.headers(final_headers);
+        let mut req = self.reqwest.request(method.clone(), url.clone());
+        req = req.headers(final_headers.clone());
         let resp = match req.send().await {
             Ok(resp) => resp,
             Err(err) => {
@@ -462,9 +463,37 @@ impl Client {
         }
         debug!("{} {url} {}", verb_label, resp.status());
         display_github_rate_limit(&resp);
+        if is_authenticated_github_forbidden(&url, &final_headers, &resp) {
+            let status = resp.status();
+            let status_error = resp
+                .error_for_status_ref()
+                .expect_err("403 response should be an error");
+            let body = resp.text().await?;
+            // Retry without auth when the response mentions IP allow lists: GitHub App
+            // installation tokens (`ghs_*`) get 403 on public API resources for orgs with IP
+            // allow lists; stripping auth avoids that path.
+            // https://github.com/orgs/community/discussions/191185
+            // https://github.com/jdx/mise/discussions/9119
+            if body.contains("IP allow list") {
+                let mut headers = final_headers;
+                headers.remove(AUTHORIZATION);
+                debug!(
+                    "{} {} retrying without GitHub auth git after {}",
+                    verb_label, &url, status
+                );
+                return Box::pin(self.send_once(method, url, &headers, verb_label)).await;
+            }
+            return Err(status_error.into());
+        }
         resp.error_for_status_ref()?;
         Ok(resp)
     }
+}
+
+fn is_authenticated_github_forbidden(url: &Url, headers: &HeaderMap, resp: &Response) -> bool {
+    resp.status() == StatusCode::FORBIDDEN
+        && url.host_str() == Some("api.github.com")
+        && headers.contains_key(AUTHORIZATION)
 }
 
 pub fn error_code(e: &Report) -> Option<u16> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -477,7 +477,7 @@ impl Client {
         }
         debug!("{} {url} {}", verb_label, resp.status());
         display_github_rate_limit(&resp);
-        if is_authenticated_github_forbidden(&url, headers, &resp) {
+        if is_authenticated_github_forbidden(&url, &final_headers, &resp) {
             let status = resp.status();
             let status_error = resp
                 .error_for_status_ref()

--- a/src/http.rs
+++ b/src/http.rs
@@ -411,16 +411,30 @@ impl Client {
     async fn send_once(
         &self,
         method: Method,
+        url: Url,
+        headers: &HeaderMap,
+        verb_label: &str,
+    ) -> Result<Response> {
+        self.send_once_inner(method, url, headers, verb_label, true)
+            .await
+    }
+
+    async fn send_once_inner(
+        &self,
+        method: Method,
         mut url: Url,
         headers: &HeaderMap,
         verb_label: &str,
+        use_netrc: bool,
     ) -> Result<Response> {
         apply_url_replacements(&mut url);
         debug!("{} {}", verb_label, &url);
 
         // Apply netrc credentials after URL replacement
         let mut final_headers = headers.clone();
-        final_headers.extend(netrc_headers(&url));
+        if use_netrc {
+            final_headers.extend(netrc_headers(&url));
+        }
 
         let mut req = self.reqwest.request(method.clone(), url.clone());
         req = req.headers(final_headers.clone());
@@ -463,12 +477,12 @@ impl Client {
         }
         debug!("{} {url} {}", verb_label, resp.status());
         display_github_rate_limit(&resp);
-        if is_authenticated_github_forbidden(&url, &final_headers, &resp) {
+        if is_authenticated_github_forbidden(&url, headers, &resp) {
             let status = resp.status();
             let status_error = resp
                 .error_for_status_ref()
                 .expect_err("403 response should be an error");
-            let body = resp.text().await?;
+            let body = resp.text().await.unwrap_or_default();
             // Retry without auth when the response mentions IP allow lists: GitHub App
             // installation tokens (`ghs_*`) get 403 on public API resources for orgs with IP
             // allow lists; stripping auth avoids that path.
@@ -478,10 +492,11 @@ impl Client {
                 let mut headers = final_headers;
                 headers.remove(AUTHORIZATION);
                 debug!(
-                    "{} {} retrying without GitHub auth git after {}",
+                    "{} {} retrying without GitHub auth after {}",
                     verb_label, &url, status
                 );
-                return Box::pin(self.send_once(method, url, &headers, verb_label)).await;
+                return Box::pin(self.send_once_inner(method, url, &headers, verb_label, false))
+                    .await;
             }
             return Err(status_error.into());
         }


### PR DESCRIPTION
## Summary
- keep GitHub API requests authenticated by default so installation-token/user-token rate limits still apply
- when an authenticated GitHub REST API request returns a 403 body containing "IP allow list", retry the same request without Authorization
- leave vfox GitHub header behavior unchanged

Fixes https://github.com/jdx/mise/discussions/9119

## Notes
mise-versions appears to use a user-token pool today, but its JSON enrichment path can still burn the workflow-level MISE_GITHUB_TOKEN because mise resolves MISE_GITHUB_TOKEN before the per-tool GITHUB_API_TOKEN override. This PR avoids making that worse by only falling back to anonymous requests after the specific IP allow-list 403.

## Tests
- cargo fmt --check
- cargo test github::tests
- cargo test http::tests
- cargo test -p vfox lua_mod::http::tests::test_add_default_headers