### PR TITLE
registry: add systemctl-tui (aqua:rgwood/systemctl-tui)

### DIFF
--- a/registry/systemctl-tui.toml
+++ b/registry/systemctl-tui.toml
@@ -1,0 +1,4 @@
+backends = ["aqua:rgwood/systemctl-tui"]
+description = "A fast, simple TUI for interacting with systemd services and their logs"
+os = ["linux"]
+test = { cmd = "systemctl-tui --version", expected = "{{version}}" }


### PR DESCRIPTION
Adds `systemctl-tui` to the mise registry as a short name backed by aqua.

`systemctl-tui` is already available in aqua-registry as `rgwood/systemctl-tui`, so this lets users install it with:

```sh
mise use systemctl-tui
```

instead of:

```sh
mise use aqua:rgwood/systemctl-tui
```

The tool is Linux-only, so the registry entry includes:

```toml
os = ["linux"]
```

Tested with:

```sh
mise test-tool systemctl-tui
```