### PR TITLE
fix(install): don't warn for configured tools when version is passed via CLI

### DIFF
--- a/e2e/cli/test_install_inactive_hint
+++ b/e2e/cli/test_install_inactive_hint
@@ -13,5 +13,12 @@ assert_contains "mise install tiny@3.1.0 2>&1" "mise use tiny"
 mise use dummy@1.0.0
 assert_not_contains "mise install dummy 2>&1" "not activated"
 
+# Test: Installing TOOL@VERSION for a tool that IS in config should NOT show
+# the hint (regression test for #9501 — CLI args were overriding the config
+# source in the merged tool request set, falsely flagging configured tools as
+# inactive).
+assert_not_contains "mise install dummy@1.0.0 2>&1" "not activated"
+assert_not_contains "mise install dummy@latest 2>&1" "not activated"
+
 # Clean up
 mise use --rm dummy

--- a/e2e/cli/test_install_inactive_hint
+++ b/e2e/cli/test_install_inactive_hint
@@ -30,9 +30,8 @@ MISE_DUMMY_VERSION=1.0.0 mise install dummy 2>&1 | tee /tmp/mise-install-env.log
 assert_not_contains "cat /tmp/mise-install-env.log" "not activated"
 MISE_DUMMY_VERSION=1.0.0 mise install dummy@1.0.0 2>&1 | tee /tmp/mise-install-env.log
 assert_not_contains "cat /tmp/mise-install-env.log" "not activated"
-
-# Test: env-var-configured tools are matched after backend aliasing — using
-# `MISE_NODEJS_VERSION` (unaliases to `node`) and then `mise install node@…`
-# should not warn.
-MISE_NODEJS_VERSION=22.0.0 mise install node@22.0.0 --dry-run 2>&1 | tee /tmp/mise-install-env.log
-assert_not_contains "cat /tmp/mise-install-env.log" "not activated"
+# (Backend-alias coverage for env-var-configured tools — e.g. that
+# MISE_NODEJS_VERSION matches `node` — lives in the tool_env_vars unit test
+# in src/toolset/tool_request_set.rs; we don't repeat it here because
+# installing node in e2e is expensive and `--dry-run` returns before the
+# inactive-tool warning would fire.)

--- a/e2e/cli/test_install_inactive_hint
+++ b/e2e/cli/test_install_inactive_hint
@@ -30,3 +30,9 @@ MISE_DUMMY_VERSION=1.0.0 mise install dummy 2>&1 | tee /tmp/mise-install-env.log
 assert_not_contains "cat /tmp/mise-install-env.log" "not activated"
 MISE_DUMMY_VERSION=1.0.0 mise install dummy@1.0.0 2>&1 | tee /tmp/mise-install-env.log
 assert_not_contains "cat /tmp/mise-install-env.log" "not activated"
+
+# Test: env-var-configured tools are matched after backend aliasing — using
+# `MISE_NODEJS_VERSION` (unaliases to `node`) and then `mise install node@…`
+# should not warn.
+MISE_NODEJS_VERSION=22.0.0 mise install node@22.0.0 --dry-run 2>&1 | tee /tmp/mise-install-env.log
+assert_not_contains "cat /tmp/mise-install-env.log" "not activated"

--- a/e2e/cli/test_install_inactive_hint
+++ b/e2e/cli/test_install_inactive_hint
@@ -22,3 +22,11 @@ assert_not_contains "mise install dummy@latest 2>&1" "not activated"
 
 # Clean up
 mise use --rm dummy
+
+# Test: Installing a tool that's only configured via MISE_<TOOL>_VERSION env
+# var should NOT show the hint (regression test for #9522 review feedback —
+# the config-files-only check was missing env-var-configured tools).
+MISE_DUMMY_VERSION=1.0.0 mise install dummy 2>&1 | tee /tmp/mise-install-env.log
+assert_not_contains "cat /tmp/mise-install-env.log" "not activated"
+MISE_DUMMY_VERSION=1.0.0 mise install dummy@1.0.0 2>&1 | tee /tmp/mise-install-env.log
+assert_not_contains "cat /tmp/mise-install-env.log" "not activated"

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -147,14 +147,31 @@ impl Install {
             .iter()
             .map(|ta| ta.ba.short.clone())
             .collect();
-        // Collect set of tools that appear in any config file. We can't use
-        // trs.sources here because load_runtime_args overrides the config-derived
-        // source with ToolSource::Argument whenever the user passes TOOL@VERSION.
+        // Collect set of tools that appear in any config file or in a
+        // MISE_<TOOL>_VERSION env var. We can't use trs.sources here because
+        // load_runtime_args overrides the underlying source with
+        // ToolSource::Argument whenever the user passes TOOL@VERSION, so config-
+        // and env-sourced tools become indistinguishable from CLI-only ones.
+        let env_configured = env::vars_safe().filter_map(|(k, _)| {
+            if !k.starts_with("MISE_") || !k.ends_with("_VERSION") || k == "MISE_VERSION" {
+                return None;
+            }
+            let plugin_name = k
+                .trim_start_matches("MISE_")
+                .trim_end_matches("_VERSION")
+                .to_lowercase();
+            // mirror load_runtime_env: ignore vars set during hooks
+            if plugin_name == "install" || plugin_name == "tool" {
+                return None;
+            }
+            Some(plugin_name)
+        });
         let configured_tools: HashSet<String> = config
             .config_files
             .values()
             .filter_map(|cf| cf.to_tool_request_set().ok())
             .flat_map(|cf_trs| cf_trs.tools.into_keys().map(|ba| ba.short.clone()))
+            .chain(env_configured)
             .collect();
         let inactive_tools: Vec<String> = tools
             .iter()

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -7,7 +7,9 @@ use crate::config::Config;
 use crate::config::Settings;
 use crate::duration::parse_into_timestamp;
 use crate::hooks::Hooks;
-use crate::toolset::{InstallOptions, ResolveOptions, ToolRequest, ToolSource, Toolset};
+use crate::toolset::{
+    InstallOptions, ResolveOptions, ToolRequest, ToolSource, Toolset, tool_env_vars,
+};
 use crate::{config, env, exit, hooks};
 use clap::ValueHint;
 use eyre::Result;
@@ -152,26 +154,12 @@ impl Install {
         // load_runtime_args overrides the underlying source with
         // ToolSource::Argument whenever the user passes TOOL@VERSION, so config-
         // and env-sourced tools become indistinguishable from CLI-only ones.
-        let env_configured = env::vars_safe().filter_map(|(k, _)| {
-            if !k.starts_with("MISE_") || !k.ends_with("_VERSION") || k == "MISE_VERSION" {
-                return None;
-            }
-            let plugin_name = k
-                .trim_start_matches("MISE_")
-                .trim_end_matches("_VERSION")
-                .to_lowercase();
-            // mirror load_runtime_env: ignore vars set during hooks
-            if plugin_name == "install" || plugin_name == "tool" {
-                return None;
-            }
-            Some(plugin_name)
-        });
         let configured_tools: HashSet<String> = config
             .config_files
             .values()
             .filter_map(|cf| cf.to_tool_request_set().ok())
             .flat_map(|cf_trs| cf_trs.tools.into_keys().map(|ba| ba.short.clone()))
-            .chain(env_configured)
+            .chain(tool_env_vars().map(|(name, _, _)| name))
             .collect();
         let inactive_tools: Vec<String> = tools
             .iter()

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -147,14 +147,24 @@ impl Install {
             .iter()
             .map(|ta| ta.ba.short.clone())
             .collect();
-        // Collect inactive tool names before trs borrow is consumed
+        // Collect set of tools that appear in any config file. We can't use
+        // trs.sources here because load_runtime_args overrides the config-derived
+        // source with ToolSource::Argument whenever the user passes TOOL@VERSION.
+        let configured_tools: HashSet<String> = config
+            .config_files
+            .values()
+            .filter_map(|cf| cf.to_tool_request_set().ok())
+            .flat_map(|cf_trs| {
+                cf_trs
+                    .tools
+                    .keys()
+                    .map(|ba| ba.short.clone())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
         let inactive_tools: Vec<String> = expanded_runtimes
             .iter()
-            .filter(|ta| {
-                trs.sources
-                    .get(ta.ba.as_ref())
-                    .is_none_or(|s| s.is_argument())
-            })
+            .filter(|ta| !configured_tools.contains(&ta.ba.short))
             .map(|ta| ta.ba.short.clone())
             .collect();
         let mut ts: Toolset = trs.filter_by_tool(tools).into();

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -154,18 +154,12 @@ impl Install {
             .config_files
             .values()
             .filter_map(|cf| cf.to_tool_request_set().ok())
-            .flat_map(|cf_trs| {
-                cf_trs
-                    .tools
-                    .keys()
-                    .map(|ba| ba.short.clone())
-                    .collect::<Vec<_>>()
-            })
+            .flat_map(|cf_trs| cf_trs.tools.into_keys().map(|ba| ba.short.clone()))
             .collect();
-        let inactive_tools: Vec<String> = expanded_runtimes
+        let inactive_tools: Vec<String> = tools
             .iter()
-            .filter(|ta| !configured_tools.contains(&ta.ba.short))
-            .map(|ta| ta.ba.short.clone())
+            .filter(|t| !configured_tools.contains(*t))
+            .cloned()
             .collect();
         let mut ts: Toolset = trs.filter_by_tool(tools).into();
         let tool_versions = self.get_requested_tool_versions(&ts, &expanded_runtimes)?;

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -30,7 +30,7 @@ use tokio::sync::OnceCell;
 
 pub use install_options::InstallOptions;
 pub use tool_request::ToolRequest;
-pub use tool_request_set::{ToolRequestSet, ToolRequestSetBuilder};
+pub use tool_request_set::{ToolRequestSet, ToolRequestSetBuilder, tool_env_vars};
 pub use tool_source::ToolSource;
 pub use tool_version::{ResolveOptions, ToolVersion};
 pub use tool_version_list::ToolVersionList;

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -204,8 +204,8 @@ impl ToolRequestSetBuilder {
     }
 
     fn load_runtime_env(&self, mut trs: ToolRequestSet) -> eyre::Result<ToolRequestSet> {
-        for (plugin_name, k, v) in tool_env_vars() {
-            let ba: Arc<BackendArg> = Arc::new(plugin_name.as_str().into());
+        for (short, k, v) in tool_env_vars() {
+            let ba: Arc<BackendArg> = Arc::new(short.as_str().into());
             let source = ToolSource::Environment(k, v.clone());
             let mut env_ts = ToolRequestSet::new();
             for v in v.split_whitespace() {
@@ -275,22 +275,24 @@ fn merge(mut a: ToolRequestSet, mut b: ToolRequestSet) -> ToolRequestSet {
     b
 }
 
-/// Yields `(plugin_name, key, value)` for each `MISE_<TOOL>_VERSION` env var
-/// that maps to a tool. Skips `MISE_VERSION` and the `MISE_INSTALL_VERSION` /
-/// `MISE_TOOL_VERSION` vars set during hooks.
+/// Yields `(short, key, value)` for each `MISE_<TOOL>_VERSION` env var that
+/// maps to a tool. `short` is the unaliased backend short name (so
+/// `MISE_NODEJS_VERSION` yields `"node"`). Skips `MISE_VERSION` and the
+/// `MISE_INSTALL_VERSION` / `MISE_TOOL_VERSION` vars set during hooks.
 pub fn tool_env_vars() -> impl Iterator<Item = (String, String, String)> {
     env::vars_safe().filter_map(|(k, v)| {
         if !k.starts_with("MISE_") || !k.ends_with("_VERSION") || k == "MISE_VERSION" {
             return None;
         }
-        let plugin_name = k
+        let raw = k
             .trim_start_matches("MISE_")
             .trim_end_matches("_VERSION")
             .to_lowercase();
-        if plugin_name == "install" || plugin_name == "tool" {
+        if raw == "install" || raw == "tool" {
             return None;
         }
-        Some((plugin_name, k, v))
+        let short = crate::backend::unalias_backend(&raw).to_string();
+        Some((short, k, v))
     })
 }
 

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -204,25 +204,15 @@ impl ToolRequestSetBuilder {
     }
 
     fn load_runtime_env(&self, mut trs: ToolRequestSet) -> eyre::Result<ToolRequestSet> {
-        for (k, v) in env::vars_safe() {
-            if k.starts_with("MISE_") && k.ends_with("_VERSION") && k != "MISE_VERSION" {
-                let plugin_name = k
-                    .trim_start_matches("MISE_")
-                    .trim_end_matches("_VERSION")
-                    .to_lowercase();
-                if plugin_name == "install" || plugin_name == "tool" {
-                    // ignore MISE_INSTALL_VERSION and MISE_TOOL_VERSION (set during hooks)
-                    continue;
-                }
-                let ba: Arc<BackendArg> = Arc::new(plugin_name.as_str().into());
-                let source = ToolSource::Environment(k, v.clone());
-                let mut env_ts = ToolRequestSet::new();
-                for v in v.split_whitespace() {
-                    let tvr = ToolRequest::new(ba.clone(), v, source.clone())?;
-                    env_ts.add_version(tvr, &source);
-                }
-                trs = merge(trs, env_ts);
+        for (plugin_name, k, v) in tool_env_vars() {
+            let ba: Arc<BackendArg> = Arc::new(plugin_name.as_str().into());
+            let source = ToolSource::Environment(k, v.clone());
+            let mut env_ts = ToolRequestSet::new();
+            for v in v.split_whitespace() {
+                let tvr = ToolRequest::new(ba.clone(), v, source.clone())?;
+                env_ts.add_version(tvr, &source);
             }
+            trs = merge(trs, env_ts);
         }
         Ok(trs)
     }
@@ -283,6 +273,25 @@ fn merge(mut a: ToolRequestSet, mut b: ToolRequestSet) -> ToolRequestSet {
     b.tools.extend(a.tools);
     b.sources.extend(a.sources);
     b
+}
+
+/// Yields `(plugin_name, key, value)` for each `MISE_<TOOL>_VERSION` env var
+/// that maps to a tool. Skips `MISE_VERSION` and the `MISE_INSTALL_VERSION` /
+/// `MISE_TOOL_VERSION` vars set during hooks.
+pub fn tool_env_vars() -> impl Iterator<Item = (String, String, String)> {
+    env::vars_safe().filter_map(|(k, v)| {
+        if !k.starts_with("MISE_") || !k.ends_with("_VERSION") || k == "MISE_VERSION" {
+            return None;
+        }
+        let plugin_name = k
+            .trim_start_matches("MISE_")
+            .trim_end_matches("_VERSION")
+            .to_lowercase();
+        if plugin_name == "install" || plugin_name == "tool" {
+            return None;
+        }
+        Some((plugin_name, k, v))
+    })
 }
 
 #[cfg(test)]

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -323,6 +323,58 @@ mod tests {
     }
 
     #[test]
+    fn test_tool_env_vars_unaliases_backend() {
+        // MISE_NODEJS_VERSION should yield "node" (the unaliased backend
+        // short name), not "nodejs" — otherwise the install command's
+        // configured-tool check fails to match unaliased ToolArg shorts.
+        unsafe {
+            std::env::set_var("MISE_NODEJS_VERSION", "22.0.0");
+            std::env::set_var("MISE_GOLANG_VERSION", "1.22.0");
+        }
+
+        let entries: Vec<(String, String, String)> = tool_env_vars()
+            .filter(|(_, k, _)| k == "MISE_NODEJS_VERSION" || k == "MISE_GOLANG_VERSION")
+            .collect();
+
+        let nodejs = entries
+            .iter()
+            .find(|(_, k, _)| k == "MISE_NODEJS_VERSION")
+            .expect("MISE_NODEJS_VERSION should yield an entry");
+        assert_eq!(nodejs.0, "node");
+
+        let golang = entries
+            .iter()
+            .find(|(_, k, _)| k == "MISE_GOLANG_VERSION")
+            .expect("MISE_GOLANG_VERSION should yield an entry");
+        assert_eq!(golang.0, "go");
+
+        unsafe {
+            std::env::remove_var("MISE_NODEJS_VERSION");
+            std::env::remove_var("MISE_GOLANG_VERSION");
+        }
+    }
+
+    #[test]
+    fn test_tool_env_vars_skips_non_tool_vars() {
+        unsafe {
+            std::env::set_var("MISE_VERSION", "2026.4.28");
+            std::env::set_var("MISE_INSTALL_VERSION", "1.0.0");
+            std::env::set_var("MISE_TOOL_VERSION", "1.0.0");
+        }
+
+        let keys: HashSet<String> = tool_env_vars().map(|(_, k, _)| k).collect();
+        assert!(!keys.contains("MISE_VERSION"));
+        assert!(!keys.contains("MISE_INSTALL_VERSION"));
+        assert!(!keys.contains("MISE_TOOL_VERSION"));
+
+        unsafe {
+            std::env::remove_var("MISE_VERSION");
+            std::env::remove_var("MISE_INSTALL_VERSION");
+            std::env::remove_var("MISE_TOOL_VERSION");
+        }
+    }
+
+    #[test]
     fn test_load_runtime_env_ignores_non_mise_vars() {
         // Non-MISE variables should be ignored, even with special characters
         unsafe {


### PR DESCRIPTION
## Summary

- Fixes [#9501](https://github.com/jdx/mise/discussions/9501): `mise install ruby@latest` warns "ruby installed but not activated — it is not in any config file" even when `ruby` is in the user's mise config
- Determines "configured" by walking `config.config_files` directly, instead of reading `trs.sources` after CLI args have been merged in

## Why

`Install::run` writes CLI args into `env::TOOL_ARGS` *before* the tool request set is built. `ToolRequestSetBuilder::load_runtime_args` then merges those args back in with `ToolSource::Argument`, and `merge` ([src/toolset/tool_request_set.rs:279](src/toolset/tool_request_set.rs#L279)) gives the right-hand-side precedence — overwriting the `MiseToml` source for the tool. The inactive-tool check then sees `ToolSource::Argument` and falsely fires for any `TOOL@VERSION` form, regardless of whether the tool is configured.

The bug only triggers when an explicit version is passed (`ruby@latest`, `ruby@4.0.3`); `mise install ruby` (no version) is unaffected because the merge skips that branch — which is why the existing e2e test missed it.

## Test plan

- [x] Added regression cases to `e2e/cli/test_install_inactive_hint` covering both `dummy@1.0.0` and `dummy@latest` against a configured tool
- [x] `mise run test:e2e test_install_inactive_hint` passes
- [x] `mise run test:e2e test_install_dry_run` still passes
- [x] `cargo build` and `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the logic that decides when to emit the “installed but not activated” warning, plus adds focused unit/e2e regression tests.
> 
> **Overview**
> Fixes false “not activated / not in any config file” warnings from `mise install TOOL@VERSION` by determining “configured” tools via config files and `MISE_<TOOL>_VERSION` env vars instead of `ToolRequestSet.sources` (which gets overwritten by CLI arg merging).
> 
> Introduces a reusable `tool_env_vars()` helper (with backend unaliasing and skip rules) and adds regression coverage in both e2e (`test_install_inactive_hint`) and unit tests for env-var parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 516d513c9952ba1d81909110c5285d0c3feff17d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->