### PR TITLE
fix(backend): mark -nightly/-canary/-experimental as prereleases

### DIFF
--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -158,6 +158,7 @@ impl Backend for NPMBackend {
                         VersionInfo {
                             version: version.to_string(),
                             created_at,
+                            prerelease: is_semver_prerelease(version),
                             ..Default::default()
                         }
                     })
@@ -682,6 +683,21 @@ impl NPMBackend {
     }
 }
 
+/// Returns true if `version` is a semver pre-release.
+///
+/// npm enforces strict semver (rule 9): any hyphen-introduced identifier after
+/// the version core is a pre-release (`1.0.0-rc.1`, `0.42.0-nightly...`,
+/// `2.0.0-canary.1`, `3.0.0-foo`). Build metadata (`+...`) is stripped first so
+/// stable builds like `1.0.0+sha.abc` are not misclassified.
+///
+/// Stricter than the generic `VERSION_REGEX` channel-tag list — for npm it
+/// catches any pre-release tag the maintainer chooses, not just the well-known
+/// names mise happens to recognize.
+fn is_semver_prerelease(version: &str) -> bool {
+    let core_and_pre = version.split_once('+').map_or(version, |(v, _)| v);
+    core_and_pre.contains('-')
+}
+
 /// Returns install-time-only option keys for NPM backend.
 pub fn install_time_option_keys() -> Vec<String> {
     vec![
@@ -992,5 +1008,35 @@ mod tests {
             Some(&"--loglevel=warn".to_string())
         );
         assert!(!resolved.contains_key("install_env.NPM_CONFIG_REGISTRY"));
+    }
+
+    #[test]
+    fn test_is_semver_prerelease_flags_hyphen_suffix() {
+        // Per semver rule 9, any hyphen-introduced identifier is a pre-release.
+        // Covers GitHub discussion #9503 (-nightly slipping past channel-name regex).
+        assert!(is_semver_prerelease("0.42.0-nightly.20260429.g6d9911393"));
+        assert!(is_semver_prerelease("1.0.0-rc.1"));
+        assert!(is_semver_prerelease("2.0.0-canary"));
+        assert!(is_semver_prerelease("3.0.0-foo"));
+        // Maintainer-invented tag mise's regex doesn't know about — still flagged.
+        assert!(is_semver_prerelease("4.0.0-internal-build-7"));
+    }
+
+    #[test]
+    fn test_is_semver_prerelease_keeps_stable_versions() {
+        assert!(!is_semver_prerelease("1.0.0"));
+        assert!(!is_semver_prerelease("0.40.1"));
+        assert!(!is_semver_prerelease("v22.6.0"));
+        // Build metadata alone is not a pre-release.
+        assert!(!is_semver_prerelease("1.0.0+sha.abc1234"));
+    }
+
+    #[test]
+    fn test_is_semver_prerelease_strips_build_metadata_first() {
+        // `+build` after a `-pre` tag must still flag as pre-release.
+        assert!(is_semver_prerelease("1.0.0-rc.1+build.5"));
+        // Hyphen only inside build metadata (not legal semver, but be defensive)
+        // — we treat it as stable since the version core has no pre-release.
+        assert!(!is_semver_prerelease("1.0.0+build-5"));
     }
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -216,7 +216,7 @@ pub fn warn_if_env_plugin_shadows_registry(name: &str, plugin_path: &Path) {
 
 pub static VERSION_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
     Regex::new(
-        r"(?i)(^Available versions:|-src|[-\\.]dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|-test|([abc])[0-9]+|snapshot|SNAPSHOT|master)"
+        r"(?i)(^Available versions:|-src|[-\\.]dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|-test|-nightly|-canary|-experimental|-insider|-edge|([abc])[0-9]+|snapshot|SNAPSHOT|master)"
     )
         .unwrap()
 });
@@ -446,6 +446,20 @@ mod tests {
         assert!(
             VERSION_REGEX.is_match("2026.3.3.162408.dev0"),
             "PEP 440 .dev suffix with build number should be filtered"
+        );
+
+        // npm prerelease channels (GitHub discussion #9503)
+        assert!(
+            VERSION_REGEX.is_match("0.42.0-nightly.20260429.g6d9911393"),
+            "npm -nightly tag should be filtered"
+        );
+        assert!(
+            VERSION_REGEX.is_match("13.0.0-canary.1"),
+            "npm -canary tag should be filtered"
+        );
+        assert!(
+            VERSION_REGEX.is_match("18.0.0-experimental-abc1234"),
+            "npm -experimental tag should be filtered"
         );
 
         // Stable versions should NOT match

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -448,18 +448,28 @@ mod tests {
             "PEP 440 .dev suffix with build number should be filtered"
         );
 
-        // npm prerelease channels (GitHub discussion #9503)
+        // npm prerelease channels (GitHub discussion #9503).
+        // Use suffixes that don't accidentally match `([abc])[0-9]+`, so each
+        // assertion exercises only the channel-tag alternative it names.
         assert!(
             VERSION_REGEX.is_match("0.42.0-nightly.20260429.g6d9911393"),
             "npm -nightly tag should be filtered"
         );
         assert!(
-            VERSION_REGEX.is_match("13.0.0-canary.1"),
+            VERSION_REGEX.is_match("13.0.0-canary"),
             "npm -canary tag should be filtered"
         );
         assert!(
-            VERSION_REGEX.is_match("18.0.0-experimental-abc1234"),
+            VERSION_REGEX.is_match("18.0.0-experimental.1"),
             "npm -experimental tag should be filtered"
+        );
+        assert!(
+            VERSION_REGEX.is_match("1.99.0-insider"),
+            "npm -insider tag should be filtered"
+        );
+        assert!(
+            VERSION_REGEX.is_match("1.99.0-edge"),
+            "npm -edge tag should be filtered"
         );
 
         // Stable versions should NOT match


### PR DESCRIPTION
## Summary

When `minimum_release_age` is set, latest version resolution skips the backend's `latest_stable_version` fast path (e.g. npm dist-tags) and falls back to the shared version-list path, which relies on `VERSION_REGEX` to flag pre-releases. The regex did not catch `-nightly`, `-canary`, `-experimental`, `-insider`, or `-edge` channel tags, so npm packages like `@google/gemini-cli` resolved `latest` to a `-nightly` tarball instead of the stable maintainer-tagged release.

This adds those channel tags to `VERSION_REGEX` so they are filtered out of `latest` resolution and `ls-remote` (without `--prerelease`) on every backend that opts into pattern-based prerelease detection.

Fixes #9503

## Test plan

- [x] `cargo test test_version_regex_filters_prerelease`
- [x] `cargo test` (full unit suite, 796 passing)
- [ ] Manually verified `mise install npm:@google/gemini-cli@latest` with `MISE_MINIMUM_RELEASE_AGE=0d` no longer picks the `-nightly` tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prerelease detection used in version listing/resolution, which may alter which versions are considered installable as “stable” (especially for npm packages) and could inadvertently filter edge-case version strings.
> 
> **Overview**
> Improves prerelease filtering during version resolution so npm channel builds like `-nightly`, `-canary`, `-experimental`, `-insider`, and `-edge` are no longer treated as stable when `VERSION_REGEX`-based filtering is used.
> 
> The npm backend now explicitly marks versions as prereleases based on strict semver rule 9 (hyphen suffix, ignoring `+build` metadata), and adds focused unit tests covering both the new regex channels and semver prerelease parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92467940a64cc0a926f711a7a244cccdee4aa29c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->