### PR TITLE
feat(registry): add neo4j

### DIFF
--- a/registry/neo4j.toml
+++ b/registry/neo4j.toml
@@ -1,0 +1,10 @@
+description = "Neo4j is a high-performance, native graph database with full ACID transactions, Cypher query language, and a flexible property graph model"
+
+[[backends]]
+full = "http:neo4j"
+
+[backends.options]
+url = "https://dist.neo4j.org/neo4j-community-{{ version }}-unix.tar.gz"
+strip_components = 1
+version_list_url = "https://search.maven.org/solrsearch/select?q=g:org.neo4j+AND+a:neo4j&core=gav&rows=200&wt=json"
+version_json_path = ".response.docs[].v"

--- a/registry/neo4j.toml
+++ b/registry/neo4j.toml
@@ -1,4 +1,5 @@
 description = "Neo4j is a high-performance, native graph database with full ACID transactions, Cypher query language, and a flexible property graph model"
+test = { cmd = "neo4j --version", expected = "{{version}}" }
 
 [[backends]]
 full = "http:neo4j"

--- a/registry/neo4j.toml
+++ b/registry/neo4j.toml
@@ -6,7 +6,7 @@ full = "http:neo4j"
 platforms = ["linux", "macos"]
 
 [backends.options]
-strip_components = 1
+strip_components = "1"
 url = "https://dist.neo4j.org/neo4j-community-{{ version }}-unix.tar.gz"
 version_json_path = ".response.docs[].v"
 # Maven Central's solrsearch caps responses at 200 rows with no pagination,

--- a/registry/neo4j.toml
+++ b/registry/neo4j.toml
@@ -3,6 +3,7 @@ test = { cmd = "neo4j --version", expected = "{{version}}" }
 
 [[backends]]
 full = "http:neo4j"
+platforms = ["linux", "macos"]
 
 [backends.options]
 url = "https://dist.neo4j.org/neo4j-community-{{ version }}-unix.tar.gz"

--- a/registry/neo4j.toml
+++ b/registry/neo4j.toml
@@ -6,11 +6,11 @@ full = "http:neo4j"
 platforms = ["linux", "macos"]
 
 [backends.options]
-url = "https://dist.neo4j.org/neo4j-community-{{ version }}-unix.tar.gz"
 strip_components = 1
+url = "https://dist.neo4j.org/neo4j-community-{{ version }}-unix.tar.gz"
+version_json_path = ".response.docs[].v"
 # Maven Central's solrsearch caps responses at 200 rows with no pagination,
 # so this lists only the 200 most recent versions (currently down to 3.5.0-rc01).
 # All 4.x / 5.x / calver releases are covered; pre-3.5 versions can still be
 # installed by pinning explicitly.
 version_list_url = "https://search.maven.org/solrsearch/select?q=g:org.neo4j+AND+a:neo4j&core=gav&rows=200&wt=json"
-version_json_path = ".response.docs[].v"

--- a/registry/neo4j.toml
+++ b/registry/neo4j.toml
@@ -8,5 +8,9 @@ platforms = ["linux", "macos"]
 [backends.options]
 url = "https://dist.neo4j.org/neo4j-community-{{ version }}-unix.tar.gz"
 strip_components = 1
+# Maven Central's solrsearch caps responses at 200 rows with no pagination,
+# so this lists only the 200 most recent versions (currently down to 3.5.0-rc01).
+# All 4.x / 5.x / calver releases are covered; pre-3.5 versions can still be
+# installed by pinning explicitly.
 version_list_url = "https://search.maven.org/solrsearch/select?q=g:org.neo4j+AND+a:neo4j&core=gav&rows=200&wt=json"
 version_json_path = ".response.docs[].v"


### PR DESCRIPTION
Adds [Neo4j](https://neo4j.com) community to the mise registry via the `http` backend.

Neo4j is a high-performance, native graph database with full ACID transactions, the Cypher query language, and a flexible property graph model.

The unix tarball is downloaded from `dist.neo4j.org` (the canonical S3-backed download host that `neo4j.com/artifact.php` redirects to). Versions are listed via Maven Central's solrsearch API for `org.neo4j:neo4j`.

Tested with version `2026.04.0`:

```
$ mise install http:neo4j@2026.04.0
$ neo4j --version
2026.04.0
$ mise uninstall http:neo4j@2026.04.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)