### PR TITLE
fix(http): update versions host tracking endpoint

### DIFF
--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -207,4 +207,12 @@ mod tests {
             "https://mise-versions.jdx.dev/api/tools/ubi%3Ahttps%3A%2F%2Fexample.com%2Ffoo%2Fbar"
         );
     }
+
+    #[test]
+    fn test_track_install_url_for_registered_tool_name() {
+        assert_eq!(
+            track_install_url("node"),
+            "https://mise-versions.jdx.dev/api/tools/node"
+        );
+    }
 }

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -168,10 +168,9 @@ pub fn track_install(tool: &str, full: &str, version: &str) {
 async fn track_install_async(tool: &str, full: &str, version: &str) -> eyre::Result<()> {
     use crate::cli::version::{ARCH, OS};
 
-    let url = "https://mise-versions.jdx.dev/api/track";
+    let url = track_install_url(tool);
 
     let body = serde_json::json!({
-        "tool": tool,
         "full": full,
         "version": version,
         "os": *OS,
@@ -188,4 +187,24 @@ async fn track_install_async(tool: &str, full: &str, version: &str) -> eyre::Res
     }
 
     Ok(())
+}
+
+fn track_install_url(tool: &str) -> String {
+    format!(
+        "https://mise-versions.jdx.dev/api/tools/{}",
+        urlencoding::encode(tool)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_track_install_url_encodes_tool_path_segment() {
+        assert_eq!(
+            track_install_url("ubi:https://example.com/foo/bar"),
+            "https://mise-versions.jdx.dev/api/tools/ubi%3Ahttps%3A%2F%2Fexample.com%2Ffoo%2Fbar"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- route anonymous install tracking through the tool-scoped mise-versions endpoint
- encode the tool path segment before POSTing
- add a small unit test covering path encoding for non-simple tool IDs

## Validation

- cargo fmt --check
- cargo test versions_host::tests::test_track_install_url_encodes_tool_path_segment
- pre-commit hook suite during commit, including cargo check --all-features

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the anonymous install-tracking POST URL (and removes the `tool` field from the payload), affecting telemetry rather than core install behavior.
> 
> **Overview**
> Routes install tracking requests to a new tool-scoped mise-versions endpoint by generating `https://mise-versions.jdx.dev/api/tools/{tool}` and URL-encoding the tool path segment.
> 
> Adds unit tests to ensure `track_install_url()` properly encodes complex tool IDs (e.g. `ubi:https://...`) while leaving simple names unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d69e7da599cdcb854abbd9626982d9e607a7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->