### PR TITLE
registry: prefer go: backend for minio

### DIFF
--- a/registry/minio.toml
+++ b/registry/minio.toml
@@ -1,3 +1,7 @@
-backends = ["conda:minio-server", "asdf:mise-plugins/mise-minio"]
+backends = [
+  "go:github.com/minio/minio",
+  "conda:minio-server",
+  "asdf:mise-plugins/mise-minio",
+]
 description = "MinIO AIStor is a high-performance S3-compatible object store licensed under the MinIO Commercial License"
 test = { cmd = "minio --version", expected = "minio" }


### PR DESCRIPTION
Reorders the `backends` list in `registry/minio.toml` to put `go:github.com/minio/minio` first, ahead of `conda:minio-server` and `asdf:mise-plugins/mise-minio`.

MinIO is a natively-Go tool, so users with a Go toolchain (which mise can also manage) can build it from source directly without a conda dependency. The conda and asdf backends remain as fallbacks for users without Go.

Tested with version `RELEASE.2025-10-15T17-29-55Z`:

```
$ mise install go:github.com/minio/minio@RELEASE.2025-10-15T17-29-55Z
$ minio --version
minio version DEVELOPMENT.GOGET (commit-id=DEVELOPMENT.GOGET)
Runtime: go1.26.2 darwin/arm64
License: GNU AGPLv3 - https://www.gnu.org/licenses/agpl-3.0.html
$ mise uninstall go:github.com/minio/minio@RELEASE.2025-10-15T17-29-55Z
```

`taplo format --check` and `taplo check` both pass on the modified `registry/minio.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)