### PR TITLE
feat(registry): add rustfs

### DIFF
--- a/registry/rustfs.toml
+++ b/registry/rustfs.toml
@@ -1,0 +1,3 @@
+backends = ["github:rustfs/rustfs"]
+description = "High-performance, distributed, S3-compatible object storage system written in Rust"
+test = { cmd = "rustfs -V", expected = "rustfs {{version}}" }


### PR DESCRIPTION
Adds [RustFS](https://rustfs.com) to the mise registry via the `github` backend.

RustFS is an Apache-2.0, high-performance, S3-compatible object storage system written in Rust, positioned as a drop-in alternative to MinIO. The repo at [`rustfs/rustfs`](https://github.com/rustfs/rustfs) ships pre-compiled binaries with conventional asset names for **Linux** (`x86_64`/`aarch64`, `gnu`/`musl`), **macOS** (`x86_64`/`aarch64`), and **Windows** (`x86_64`):

```
rustfs-linux-aarch64-gnu-v{version}.zip
rustfs-linux-aarch64-musl-v{version}.zip
rustfs-linux-x86_64-gnu-v{version}.zip
rustfs-linux-x86_64-musl-v{version}.zip
rustfs-macos-aarch64-v{version}.zip
rustfs-macos-x86_64-v{version}.zip
rustfs-windows-x86_64-v{version}.zip
```

All releases are signed and ship with SLSA provenance attestations, so the github backend resolves them zero-config across all three platforms.

Tested with version `1.0.0-beta.1`:

```
$ mise install rustfs@1.0.0-beta.1
$ rustfs -V
rustfs 1.0.0-beta.1
$ mise uninstall rustfs@1.0.0-beta.1
```

`taplo format --check` and `taplo check` both pass on the new `registry/rustfs.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)