### PR TITLE
chore(deps): exclude taiki-e/install-action from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,11 @@
       "matchPackageNames": ["ghcr.io/jdx/mise"],
       "matchCurrentValue": "copr",
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["taiki-e/install-action"],
+      "matchManagers": ["github-actions"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Stop renovate from opening update PRs for `taiki-e/install-action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts Renovate configuration to stop proposing updates for a single GitHub Action, with no runtime code changes.
> 
> **Overview**
> Stops Renovate from opening update PRs for the GitHub Action `taiki-e/install-action` by adding a disabled `packageRules` entry for the `github-actions` manager in `.github/renovate.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57fa5ebc104003ce6c6cf9f806a7cc8c3cad0722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->