### PR TITLE
chore(config): deprecate shorthands_file setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,9 +219,8 @@ If you simply want to install a plugin from a specific URL once, it's better to 
 `mise plugin install <NAME> <GIT_URL>`. Add this section to `mise.toml` if you want
 to share the plugin location/revision with other developers in your project.
 
-This is similar
-to [`MISE_SHORTHANDS`](https://github.com/jdx/mise#mise_shorthands_fileconfigmiseshorthandstoml)
-but doesn't require a separate file.
+This replaces the deprecated `settings.shorthands_file` / `MISE_SHORTHANDS_FILE` mechanism: put the
+same `shortname = "backend-or-url"` entries under `[plugins]` instead of a separate TOML file.
 
 ### `[tool_alias]` - Tool version aliases
 
@@ -345,7 +344,7 @@ not_found_auto_install = true # see MISE_NOT_FOUND_AUTO_INSTALL
 task.output = "prefix" # see Tasks Runner for more information
 paranoid = false       # see MISE_PARANOID
 
-shorthands_file = '~/.config/mise/shorthands.toml' # path to the shorthands file, see `MISE_SHORTHANDS_FILE`
+# shorthands_file is deprecated - use [plugins] in this file (see "plugins" above)
 disable_default_registry = false   # disable the default registry, see `MISE_DISABLE_DEFAULT_REGISTRY`
 disable_tools = ['node']           # disable specific tools, generally used to turn off core tools
 

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1443,8 +1443,9 @@
           }
         },
         "shorthands_file": {
-          "description": "Path to a file containing custom tool shorthands.",
-          "type": "string"
+          "description": "[deprecated] Path to a file containing custom tool shorthands.",
+          "type": "string",
+          "deprecated": true
         },
         "silent": {
           "description": "Suppress all `mise run|watch` output except errors—including what tasks output.",

--- a/settings.toml
+++ b/settings.toml
@@ -1935,8 +1935,14 @@ rust_type = "Vec<PathBuf>"
 type = "ListPath"
 
 [shorthands_file]
-description = "Path to a file containing custom tool shorthands."
+deprecated = "Use [plugins] in mise.toml or ~/.config/mise/config.toml instead (same shortname = \"backend-or-url\" rows; see https://mise.en.dev/configuration.html#plugins)."
+deprecated_remove_at = "2026.12.0"
+deprecated_warn_at = "2026.6.0"
+description = "[deprecated] Path to a file containing custom tool shorthands."
 docs = """
+Deprecated: use `[plugins]` in mise.toml or ~/.config/mise/config.toml with the same `name = "url"`
+rows instead of a separate file.
+
 Use a custom file for the shorthand aliases. This is useful if you want to share plugins within
 an organization.
 
@@ -1954,6 +1960,7 @@ node = "https://github.com/my-org/mise-node.git"
 
 """
 env = "MISE_SHORTHANDS_FILE"
+hide = true
 optional = true
 type = "Path"
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -440,6 +440,9 @@ impl Settings {
         if self.npm.bun {
             self.npm.package_manager = NpmPackageManager::Bun;
         }
+        if self.shorthands_file.is_some() {
+            warn_deprecated("shorthands_file");
+        }
     }
 
     pub fn add_cli_matches(cli: &Cli) {


### PR DESCRIPTION
## Summary

- mark `settings.shorthands_file` / `MISE_SHORTHANDS_FILE` as deprecated with a warning in mise 2026.6.0 and removal in mise 2026.12.0
- warn when `shorthands_file` is configured while keeping the existing behavior unchanged
- update configuration docs and schema to point users to `[plugins]`

## Validation

- `cargo fmt --check`
- `TMPDIR=/tmp mise run render`
- `rg -n "shorthands_file|MISE_SHORTHANDS_FILE|shorthands\\.toml" e2e e2e-win` (no e2e coverage found)

*This PR was generated by an AI coding assistant.*