### PR TITLE
chore(docs): remove shrill.en.dev analytics script

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -374,15 +374,6 @@ export default withMermaid(
       gtag('js', new Date());
       gtag('config', 'G-B69G389C8T');`,
       ],
-      [
-        "script",
-        {
-          defer: "",
-          "data-domain": "mise.en.dev",
-          "data-api": "https://shrill.en.dev/f5f1/event",
-          src: "https://shrill.en.dev/shrill/script.js",
-        },
-      ],
       // OpenGraph
       ["meta", { property: "og:site_name", content: "mise-en-place" }],
       ["meta", { property: "og:type", content: "website" }],


### PR DESCRIPTION
Removes the proxied shrill.en.dev analytics snippet from the VitePress docs config — the endpoint is going away. GA tracking remains in place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a third-party analytics script from the VitePress docs head with no impact on core app logic; Google Analytics remains unchanged.
> 
> **Overview**
> Removes the proxied `shrill.en.dev` analytics script injection from the VitePress docs `head` configuration, leaving the existing Google Analytics `gtag` snippet in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253deeeb319ea14d3a097641975de20bb5a2d9eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->