### PR TITLE
fix(plugin): detect plugin types after cloning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,8 +212,9 @@ node = "https://github.com/my-org/mise-node.git#DEADBEEF" # supports specific gi
 "vfox-backend:myplugin" = "https://github.com/jdx/vfox-npm"
 ```
 
-The plugin type prefix (e.g., `asdf:`, `vfox:` or `vfox-backend:`) is optional. If omitted, mise will fall back to
-either using `asdf` or `vfox` if the URL contains `vfox-` in the repo name.
+The plugin type prefix (e.g., `asdf:`, `vfox:` or `vfox-backend:`) is optional.
+If omitted, mise clones the plugin first and then detects the plugin type from
+the installed plugin files.
 
 If you simply want to install a plugin from a specific URL once, it's better to use
 `mise plugin install <NAME> <GIT_URL>`. Add this section to `mise.toml` if you want

--- a/e2e/plugins/test_backend_plugin_install
+++ b/e2e/plugins/test_backend_plugin_install
@@ -1,15 +1,10 @@
 #!/usr/bin/env bash
 
 cat >mise.toml <<EOF
-[tools]
-"myplugin:eslint" = "9.38.0"
-"myplugin:prettier" = "3.6.2"
-
 [plugins]
-"vfox-backend:myplugin" = "https://github.com/jdx/vfox-npm"
+myplugin = "https://github.com/jbadeau/mise-nix"
 EOF
 
-mise install
+assert_matches "mise latest myplugin:hello" '^[0-9]'
 assert_contains "mise plugin ls" "myplugin"
-assert "mise current myplugin:eslint" "9.38.0"
-assert "mise current myplugin:prettier" "3.6.2"
+assert_contains "mise plugin ls --urls" "https://github.com/jbadeau/mise-nix"

--- a/e2e/plugins/test_plugin_type_lazy
+++ b/e2e/plugins/test_plugin_type_lazy
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+cat <<EOF >mise.toml
+[plugins]
+tiny-ref = "https://github.com/mise-plugins/rtx-tiny#c532b140abd4ca00d3e76651b9bd32a980bd483c"
+aws-sso-cli = "https://github.com/mise-plugins/mise-aws-sso-cli"
+EOF
+
+assert_contains "mise latest tiny-ref" "3.1.0"
+assert_matches "mise latest aws-sso-cli" '^[0-9]+\.[0-9]+\.[0-9]+'

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -261,9 +261,11 @@ pub fn get(ba: &BackendArg) -> Option<ABackend> {
 
 pub fn remove(short: &str) {
     let mut tools = TOOLS.lock().unwrap();
-    let mut tools_ = tools.as_ref().unwrap().deref().clone();
-    tools_.remove(short);
-    *tools = Some(Arc::new(tools_));
+    if let Some(current) = tools.as_ref() {
+        let mut tools_ = current.deref().clone();
+        tools_.remove(short);
+        *tools = Some(Arc::new(tools_));
+    }
 }
 
 pub fn arg_to_backend(ba: BackendArg) -> Option<ABackend> {

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -318,10 +318,8 @@ impl BackendArg {
         if let Ok(backend_type) = backend.parse() {
             return backend_type;
         }
-        if config::is_loaded()
-            && let Some(repo_url) = Config::get_().get_repo_url(&self.short)
-        {
-            return match PluginType::from_plugin_url(&repo_url) {
+        if config::is_loaded() && Config::get_().get_repo_url(&self.short).is_some() {
+            return match install_state::get_plugin_type(&self.short).unwrap_or(PluginType::Asdf) {
                 PluginType::Vfox => BackendType::Vfox,
                 PluginType::VfoxBackend => BackendType::VfoxBackend(self.short.to_string()),
                 PluginType::Asdf => BackendType::Asdf,
@@ -349,7 +347,11 @@ impl BackendArg {
                 return full;
             }
             if let Some(url) = Config::get_().repo_urls.get(short) {
-                return format!("asdf:{url}");
+                return match install_state::get_plugin_type(short).unwrap_or(PluginType::Asdf) {
+                    PluginType::Asdf => format!("asdf:{url}"),
+                    PluginType::Vfox => format!("vfox:{short}"),
+                    PluginType::VfoxBackend => short.to_string(),
+                };
             }
 
             let config = Config::get_();

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -321,11 +321,10 @@ impl BackendArg {
         if config::is_loaded()
             && let Some(repo_url) = Config::get_().get_repo_url(&self.short)
         {
-            return if repo_url.contains("vfox-") {
-                BackendType::Vfox
-            } else {
-                // TODO: maybe something more intelligent?
-                BackendType::Asdf
+            return match PluginType::from_plugin_url(&repo_url) {
+                PluginType::Vfox => BackendType::Vfox,
+                PluginType::VfoxBackend => BackendType::VfoxBackend(self.short.to_string()),
+                PluginType::Asdf => BackendType::Asdf,
             };
         }
         BackendType::Unknown

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -50,10 +50,11 @@ impl Latest {
             _ => bail!("invalid version: {}", tool.style()),
         };
 
-        let backend = tool.ba.backend()?;
+        let mut backend = tool.ba.backend()?;
         let mpr = MultiProgressReport::get();
         if let Some(plugin) = backend.plugin() {
             plugin.ensure_installed(&config, &mpr, false, false).await?;
+            backend = tool.ba.backend()?;
         }
         if let Some(v) = prefix {
             prefix = Some(config.resolve_alias(&backend, &v).await?);

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -144,10 +144,11 @@ impl LsRemote {
     async fn get_plugin(&self, config: &Arc<Config>) -> Result<Option<Arc<dyn Backend>>> {
         match &self.plugin {
             Some(tool_arg) => {
-                let backend = tool_arg.ba.backend()?;
+                let mut backend = tool_arg.ba.backend()?;
                 let mpr = MultiProgressReport::get();
                 if let Some(plugin) = backend.plugin() {
                     plugin.ensure_installed(config, &mpr, false, false).await?;
+                    backend = tool_arg.ba.backend()?;
                 }
                 Ok(Some(backend))
             }

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -133,16 +133,9 @@ impl PluginsInstall {
         name: String,
         git_url: Option<String>,
     ) -> Result<()> {
+        let (plugin_type, name) = PluginType::from_plugin_config(&name);
+        let name = name.to_string();
         let path = dirs::PLUGINS.join(name.to_kebab_case());
-        let plugin_type = git_url
-            .as_deref()
-            .map(PluginType::from_plugin_url)
-            .unwrap_or_else(|| {
-                config
-                    .get_repo_url(&name)
-                    .map(|url| PluginType::from_plugin_url(&url))
-                    .unwrap_or(PluginType::Asdf)
-            });
         let plugin = plugin_type.plugin(name.clone());
         if let Some(url) = git_url {
             plugin.set_remote_url(url);

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -8,8 +8,7 @@ use url::Url;
 
 use crate::config::Config;
 use crate::dirs;
-use crate::plugins::Plugin;
-use crate::plugins::asdf_plugin::AsdfPlugin;
+use crate::plugins::PluginType;
 use crate::plugins::core::CORE_PLUGINS;
 use crate::plugins::warn_if_env_plugin_shadows_registry;
 use crate::toolset::ToolsetBuilder;
@@ -135,8 +134,16 @@ impl PluginsInstall {
         git_url: Option<String>,
     ) -> Result<()> {
         let path = dirs::PLUGINS.join(name.to_kebab_case());
-        // TODO: detect vfox plugins and use VfoxPlugin instead of always using AsdfPlugin
-        let plugin = AsdfPlugin::new(name.clone(), path.clone());
+        let plugin_type = git_url
+            .as_deref()
+            .map(PluginType::from_plugin_url)
+            .unwrap_or_else(|| {
+                config
+                    .get_repo_url(&name)
+                    .map(|url| PluginType::from_plugin_url(&url))
+                    .unwrap_or(PluginType::Asdf)
+            });
+        let plugin = plugin_type.plugin(name.clone());
         if let Some(url) = git_url {
             plugin.set_remote_url(url);
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -226,8 +226,8 @@ impl Config {
         time!("load done");
 
         measure!("config::load install_state", {
-            for (plugin, url) in &config.repo_urls {
-                let (plugin_type, plugin) = PluginType::from_plugin_config(plugin, url);
+            for plugin in config.repo_urls.keys() {
+                let (plugin_type, plugin) = PluginType::from_plugin_config(plugin);
                 install_state::add_plugin(plugin, plugin_type).await?;
             }
         });

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -227,24 +227,7 @@ impl Config {
 
         measure!("config::load install_state", {
             for (plugin, url) in &config.repo_urls {
-                // check plugin type, fallback to asdf
-                let (mut plugin_type, has_explicit_prefix) = match plugin {
-                    p if p.starts_with("vfox:") => (PluginType::Vfox, true),
-                    p if p.starts_with("vfox-backend:") => (PluginType::VfoxBackend, true),
-                    p if p.starts_with("asdf:") => (PluginType::Asdf, true),
-                    _ => (PluginType::Asdf, false),
-                };
-                // keep backward compatibility for vfox plugins, but only if no explicit prefix
-                if !has_explicit_prefix && url.contains("vfox-") {
-                    plugin_type = PluginType::Vfox;
-                }
-
-                let plugin = plugin
-                    .strip_prefix("vfox:")
-                    .or_else(|| plugin.strip_prefix("vfox-backend:"))
-                    .or_else(|| plugin.strip_prefix("asdf:"))
-                    .unwrap_or(plugin);
-
+                let (plugin_type, plugin) = PluginType::from_plugin_config(plugin, url);
                 install_state::add_plugin(plugin, plugin_type).await?;
             }
         });

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -3,13 +3,14 @@ use crate::errors::Error::PluginNotInstalled;
 use crate::file::{display_path, remove_all_with_progress};
 use crate::git::{CloneOptions, Git};
 use crate::http::HTTP;
-use crate::plugins::{Plugin, PluginSource, Script, ScriptManager};
+use crate::plugins::{Plugin, PluginSource, PluginType, Script, ScriptManager};
 use crate::result::Result;
 use crate::timeout::run_with_timeout;
+use crate::toolset::install_state;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
 use crate::ui::prompt;
-use crate::{dirs, env, exit, file, lock_file, registry};
+use crate::{backend, dirs, env, exit, file, lock_file, registry};
 use async_trait::async_trait;
 use clap::Command;
 use console::style;
@@ -293,7 +294,12 @@ impl Plugin for AsdfPlugin {
         let pr = mpr.add_with_options(&prefix, dry_run);
         if !dry_run {
             let _lock = lock_file::get(&self.plugin_path, force)?;
-            self.install(config, pr.as_ref()).await
+            self.install(config, pr.as_ref()).await?;
+            let plugin_type =
+                PluginType::from_plugin_path(&self.plugin_path).unwrap_or(PluginType::Asdf);
+            install_state::add_plugin(&self.name, plugin_type).await?;
+            backend::remove(&self.name);
+            Ok(())
         } else {
             Ok(())
         }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -189,7 +189,7 @@ impl PluginType {
         }
     }
 
-    pub fn from_plugin_config<'a>(key: &'a str, url: &str) -> (Self, &'a str) {
+    pub fn from_plugin_config(key: &str) -> (Self, &str) {
         if let Some(name) = key.strip_prefix("vfox:") {
             (Self::Vfox, name)
         } else if let Some(name) = key.strip_prefix("vfox-backend:") {
@@ -197,26 +197,23 @@ impl PluginType {
         } else if let Some(name) = key.strip_prefix("asdf:") {
             (Self::Asdf, name)
         } else {
-            (Self::from_plugin_url(url), key)
+            let path = dirs::PLUGINS.join(key.to_kebab_case());
+            (Self::from_plugin_path(&path).unwrap_or(Self::Asdf), key)
         }
     }
 
-    pub fn from_plugin_url(url: &str) -> Self {
-        if url.starts_with("vfox-backend:") {
-            Self::VfoxBackend
-        } else if url.starts_with("vfox:") {
-            Self::Vfox
-        } else if url.starts_with("asdf:") {
-            Self::Asdf
-        } else if Self::looks_like_vfox_url(url) {
-            Self::Vfox
+    pub fn from_plugin_path(path: &Path) -> Option<Self> {
+        if path.join("metadata.lua").exists() {
+            if path.join("hooks").join("backend_install.lua").exists() {
+                Some(Self::VfoxBackend)
+            } else {
+                Some(Self::Vfox)
+            }
+        } else if path.join("bin").join("list-all").exists() {
+            Some(Self::Asdf)
         } else {
-            Self::Asdf
+            None
         }
-    }
-
-    fn looks_like_vfox_url(url: &str) -> bool {
-        url.contains("vfox-")
     }
 
     pub fn plugin(&self, short: String) -> PluginEnum {
@@ -460,45 +457,50 @@ mod tests {
     #[test]
     fn test_plugin_type_from_plugin_config() {
         assert_eq!(
-            PluginType::from_plugin_config("vfox:node", "https://github.com/foo/asdf-node.git"),
+            PluginType::from_plugin_config("vfox:node"),
             (PluginType::Vfox, "node")
         );
         assert_eq!(
-            PluginType::from_plugin_config(
-                "vfox-backend:npm",
-                "https://github.com/foo/asdf-npm.git"
-            ),
+            PluginType::from_plugin_config("vfox-backend:npm"),
             (PluginType::VfoxBackend, "npm")
         );
         assert_eq!(
-            PluginType::from_plugin_config("asdf:node", "https://github.com/foo/vfox-node.git"),
+            PluginType::from_plugin_config("asdf:node"),
             (PluginType::Asdf, "node")
         );
         assert_eq!(
-            PluginType::from_plugin_config("node", "https://github.com/foo/vfox-node.git"),
-            (PluginType::Vfox, "node")
-        );
-        assert_eq!(
-            PluginType::from_plugin_config("node", "https://github.com/foo/asdf-node.git"),
-            (PluginType::Asdf, "node")
+            PluginType::from_plugin_config("missing-test-plugin"),
+            (PluginType::Asdf, "missing-test-plugin")
         );
     }
 
     #[test]
-    fn test_plugin_type_from_plugin_url() {
+    fn test_plugin_type_from_plugin_path() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(PluginType::from_plugin_path(dir.path()), None);
+
+        let asdf = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(asdf.path().join("bin")).unwrap();
+        std::fs::write(asdf.path().join("bin").join("list-all"), "").unwrap();
         assert_eq!(
-            PluginType::from_plugin_url("vfox-backend:npm"),
-            PluginType::VfoxBackend
+            PluginType::from_plugin_path(asdf.path()),
+            Some(PluginType::Asdf)
         );
-        assert_eq!(PluginType::from_plugin_url("vfox:node"), PluginType::Vfox);
-        assert_eq!(PluginType::from_plugin_url("asdf:node"), PluginType::Asdf);
+
+        let vfox = tempfile::tempdir().unwrap();
+        std::fs::write(vfox.path().join("metadata.lua"), "").unwrap();
         assert_eq!(
-            PluginType::from_plugin_url("https://github.com/jbox-web/vfox-crystalline.git"),
-            PluginType::Vfox
+            PluginType::from_plugin_path(vfox.path()),
+            Some(PluginType::Vfox)
         );
+
+        let backend = tempfile::tempdir().unwrap();
+        std::fs::write(backend.path().join("metadata.lua"), "").unwrap();
+        std::fs::create_dir_all(backend.path().join("hooks")).unwrap();
+        std::fs::write(backend.path().join("hooks").join("backend_install.lua"), "").unwrap();
         assert_eq!(
-            PluginType::from_plugin_url("https://github.com/mise-plugins/mise-tiny.git"),
-            PluginType::Asdf
+            PluginType::from_plugin_path(backend.path()),
+            Some(PluginType::VfoxBackend)
         );
     }
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -189,6 +189,36 @@ impl PluginType {
         }
     }
 
+    pub fn from_plugin_config<'a>(key: &'a str, url: &str) -> (Self, &'a str) {
+        if let Some(name) = key.strip_prefix("vfox:") {
+            (Self::Vfox, name)
+        } else if let Some(name) = key.strip_prefix("vfox-backend:") {
+            (Self::VfoxBackend, name)
+        } else if let Some(name) = key.strip_prefix("asdf:") {
+            (Self::Asdf, name)
+        } else {
+            (Self::from_plugin_url(url), key)
+        }
+    }
+
+    pub fn from_plugin_url(url: &str) -> Self {
+        if url.starts_with("vfox-backend:") {
+            Self::VfoxBackend
+        } else if url.starts_with("vfox:") {
+            Self::Vfox
+        } else if url.starts_with("asdf:") {
+            Self::Asdf
+        } else if Self::looks_like_vfox_url(url) {
+            Self::Vfox
+        } else {
+            Self::Asdf
+        }
+    }
+
+    fn looks_like_vfox_url(url: &str) -> bool {
+        url.contains("vfox-")
+    }
+
     pub fn plugin(&self, short: String) -> PluginEnum {
         let path = dirs::PLUGINS.join(short.to_kebab_case());
         match self {
@@ -425,6 +455,51 @@ mod tests {
             PluginSource::Git { .. } => {}
             _ => panic!("Expected a git plugin"),
         }
+    }
+
+    #[test]
+    fn test_plugin_type_from_plugin_config() {
+        assert_eq!(
+            PluginType::from_plugin_config("vfox:node", "https://github.com/foo/asdf-node.git"),
+            (PluginType::Vfox, "node")
+        );
+        assert_eq!(
+            PluginType::from_plugin_config(
+                "vfox-backend:npm",
+                "https://github.com/foo/asdf-npm.git"
+            ),
+            (PluginType::VfoxBackend, "npm")
+        );
+        assert_eq!(
+            PluginType::from_plugin_config("asdf:node", "https://github.com/foo/vfox-node.git"),
+            (PluginType::Asdf, "node")
+        );
+        assert_eq!(
+            PluginType::from_plugin_config("node", "https://github.com/foo/vfox-node.git"),
+            (PluginType::Vfox, "node")
+        );
+        assert_eq!(
+            PluginType::from_plugin_config("node", "https://github.com/foo/asdf-node.git"),
+            (PluginType::Asdf, "node")
+        );
+    }
+
+    #[test]
+    fn test_plugin_type_from_plugin_url() {
+        assert_eq!(
+            PluginType::from_plugin_url("vfox-backend:npm"),
+            PluginType::VfoxBackend
+        );
+        assert_eq!(PluginType::from_plugin_url("vfox:node"), PluginType::Vfox);
+        assert_eq!(PluginType::from_plugin_url("asdf:node"), PluginType::Asdf);
+        assert_eq!(
+            PluginType::from_plugin_url("https://github.com/jbox-web/vfox-crystalline.git"),
+            PluginType::Vfox
+        );
+        assert_eq!(
+            PluginType::from_plugin_url("https://github.com/mise-plugins/mise-tiny.git"),
+            PluginType::Asdf
+        );
     }
 
     #[test]

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -62,6 +62,9 @@ impl VfoxPlugin {
     }
 
     fn get_repo_url(&self, config: &Config) -> eyre::Result<Url> {
+        if let Some(url) = self.repo_url.lock().unwrap().clone() {
+            return Ok(Url::parse(&url)?);
+        }
         if let Some(url) = self.repo().get_remote_url() {
             return Ok(Url::parse(&url)?);
         }
@@ -157,6 +160,10 @@ impl VfoxPlugin {
     pub fn is_embedded(&self) -> bool {
         embedded_plugins::get_embedded_plugin(&self.name).is_some()
     }
+
+    fn has_repo_url_override(&self) -> bool {
+        self.repo_url.lock().unwrap().is_some()
+    }
 }
 
 #[async_trait]
@@ -203,8 +210,9 @@ impl Plugin for VfoxPlugin {
     }
 
     fn is_installed(&self) -> bool {
-        // Embedded plugins are always "installed"
-        self.is_embedded() || self.plugin_path.exists()
+        // Embedded plugins are installed unless an explicit URL is being installed
+        // as a filesystem override.
+        (self.is_embedded() && !self.has_repo_url_override()) || self.plugin_path.exists()
     }
 
     fn is_installed_err(&self) -> eyre::Result<()> {
@@ -222,8 +230,9 @@ impl Plugin for VfoxPlugin {
         force: bool,
         dry_run: bool,
     ) -> Result<()> {
-        // Skip installation for embedded plugins
-        if self.is_embedded() {
+        // Skip installation for embedded plugins unless an explicit URL is being
+        // installed as a filesystem override.
+        if self.is_embedded() && !self.has_repo_url_override() {
             return Ok(());
         }
 

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -4,12 +4,13 @@ use crate::file::remove_all_with_progress;
 use crate::git::{CloneOptions, Git};
 use crate::http::HTTP;
 use crate::plugins::warn_if_env_plugin_shadows_registry;
-use crate::plugins::{Plugin, PluginSource};
+use crate::plugins::{Plugin, PluginSource, PluginType};
 use crate::result::Result;
+use crate::toolset::install_state;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
 use crate::ui::prompt;
-use crate::{dirs, file, lock_file, registry};
+use crate::{backend, dirs, file, lock_file, registry};
 use async_trait::async_trait;
 use console::style;
 use contracts::requires;
@@ -270,6 +271,10 @@ impl Plugin for VfoxPlugin {
         if !dry_run {
             let _lock = lock_file::get(&self.plugin_path, force)?;
             self.install(config, pr.as_ref()).await?;
+            let plugin_type =
+                PluginType::from_plugin_path(&self.plugin_path).unwrap_or(PluginType::Vfox);
+            install_state::add_plugin(&self.name, plugin_type).await?;
+            backend::remove(&self.name);
             warn_if_env_plugin_shadows_registry(&self.name, &self.plugin_path);
         }
         Ok(())

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -170,16 +170,8 @@ async fn init_plugins() -> MutexResult<InstallStatePlugins> {
                 info!("removing banned plugin {d}");
                 let _ = file::remove_all(&path);
                 None
-            } else if path.join("metadata.lua").exists() {
-                if has_backend_methods(&path) {
-                    Some((d, PluginType::VfoxBackend))
-                } else {
-                    Some((d, PluginType::Vfox))
-                }
-            } else if path.join("bin").join("list-all").exists() {
-                Some((d, PluginType::Asdf))
             } else {
-                None
+                PluginType::from_plugin_path(&path).map(|plugin_type| (d, plugin_type))
             }
         })
         .collect();
@@ -426,14 +418,6 @@ fn is_banned_plugin(path: &Path) -> bool {
         }
     }
     false
-}
-
-fn has_backend_methods(plugin_path: &Path) -> bool {
-    // to be a backend plugin, it must have a backend_install.lua file so we don't need to check for other files
-    plugin_path
-        .join("hooks")
-        .join("backend_install.lua")
-        .exists()
 }
 
 pub fn get_tool_full(short: &str) -> Option<String> {

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -552,8 +552,8 @@ impl Toolset {
 
         let mpr = MultiProgressReport::get();
 
-        for (plugin_key, url) in &config.repo_urls {
-            let (plugin_type, name) = Self::parse_plugin_key(plugin_key, url);
+        for plugin_key in config.repo_urls.keys() {
+            let (plugin_type, name) = Self::parse_plugin_key(plugin_key);
 
             // Skip empty plugin names (e.g., from malformed keys like "" or "vfox:")
             if name.is_empty() {
@@ -572,7 +572,7 @@ impl Toolset {
         Ok(())
     }
 
-    fn parse_plugin_key<'a>(key: &'a str, url: &str) -> (PluginType, &'a str) {
-        PluginType::from_plugin_config(key, url)
+    fn parse_plugin_key(key: &str) -> (PluginType, &str) {
+        PluginType::from_plugin_config(key)
     }
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -573,17 +573,6 @@ impl Toolset {
     }
 
     fn parse_plugin_key<'a>(key: &'a str, url: &str) -> (PluginType, &'a str) {
-        if let Some(name) = key.strip_prefix("vfox:") {
-            (PluginType::Vfox, name)
-        } else if let Some(name) = key.strip_prefix("vfox-backend:") {
-            (PluginType::VfoxBackend, name)
-        } else if let Some(name) = key.strip_prefix("asdf:") {
-            (PluginType::Asdf, name)
-        } else if url.contains("vfox-") {
-            // Match existing behavior from config/mod.rs:226-228
-            (PluginType::Vfox, key)
-        } else {
-            (PluginType::Asdf, key)
-        }
+        PluginType::from_plugin_config(key, url)
     }
 }


### PR DESCRIPTION
## Summary

- remove URL-name plugin type heuristics for unprefixed plugin config and installs
- detect asdf/vfox/vfox-backend plugins from cloned plugin files (`metadata.lua`, `hooks/backend_install.lua`, `bin/list-all`)
- update install state and clear backend cache after plugin clone so commands can continue with the detected backend
- refresh plugin-backed `latest` and `ls-remote` backends after auto-install
- add e2e coverage with mise-plugins asdf/vfox plugins and the allowed `jbadeau/mise-nix` backend plugin

Fixes discussion #9333.

## Validation

- `/home/risu/.cargo/bin/cargo fmt --check`
- `/home/risu/.cargo/bin/cargo test --bin mise plugins::tests::test_plugin_type -- --nocapture`
- `/home/risu/.cargo/bin/cargo test --bin mise backend_arg -- --nocapture`
- `MISE_TRUSTED_CONFIG_PATHS=/tmp/mise-plugin-type-detection/mise.toml ./target/debug/mise run test:e2e e2e/plugins/test_plugin_type_lazy e2e/plugins/test_backend_plugin_install`
- `git diff --check`

*This PR was generated by an AI coding assistant.*