### PR TITLE
registry: add tool betterleaks (backend:aqua/betterleaks/betterleaks)

### DIFF
--- a/registry/betterleaks.toml
+++ b/registry/betterleaks.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:betterleaks/betterleaks", "github:betterleaks/betterleaks"]
+description = "Betterleaks scans code, past or present, for secrets"
+test = { cmd = "betterleaks --version", expected = "betterleaks version {{version}}" }


### PR DESCRIPTION
Add `betterleaks`, drop-in replacement for `gitleaks` from the original author.

https://betterleaks.com/

