### PR TITLE
registry: add tool yr (backend:github:VirusTotal/yara-x)

### DIFF
--- a/registry/yara-x.toml
+++ b/registry/yara-x.toml
@@ -1,0 +1,3 @@
+backends = ["github:VirusTotal/yara-x"]
+description = "The pattern matching swiss army knife"
+test = { cmd = "yr --version", expected = "{{version}}" }


### PR DESCRIPTION
Add `yr` (yara-x), the pattern matching swiss army knife from VirusTotal.
