### PR TITLE
feat(conda): graduate conda backend out of experimental

### DIFF
--- a/docs/dev-tools/backends/conda.md
+++ b/docs/dev-tools/backends/conda.md
@@ -1,4 +1,4 @@
-# Conda Backend <Badge type="warning" text="experimental" />
+# Conda Backend
 
 You may install packages directly from [conda-forge](https://conda-forge.org/) and other
 Anaconda channels without needing conda or mamba installed.

--- a/docs/dev-tools/backends/index.md
+++ b/docs/dev-tools/backends/index.md
@@ -11,7 +11,7 @@ Below is a list of the available backends in mise:
 - [asdf](/dev-tools/backends/asdf) (provide tools through [plugins](/plugins.html))
 - [aqua](/dev-tools/backends/aqua)
 - [cargo](/dev-tools/backends/cargo)
-- [conda](/dev-tools/backends/conda) <Badge type="warning" text="experimental" />
+- [conda](/dev-tools/backends/conda)
 - [dotnet](/dev-tools/backends/dotnet) <Badge type="warning" text="experimental" />
 - [forgejo](/dev-tools/backends/forgejo)
 - [gem](/dev-tools/backends/gem)

--- a/src/backend/backend_type.rs
+++ b/src/backend/backend_type.rs
@@ -74,9 +74,8 @@ impl BackendType {
 
     /// Returns true if this backend requires experimental mode to be enabled
     pub fn is_experimental(&self) -> bool {
-        use super::{conda, dotnet, s3, spm};
+        use super::{dotnet, s3, spm};
         match self {
-            BackendType::Conda => conda::EXPERIMENTAL,
             BackendType::Dotnet => dotnet::EXPERIMENTAL,
             BackendType::S3 => s3::EXPERIMENTAL,
             BackendType::Spm => spm::EXPERIMENTAL,

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -42,9 +42,6 @@ pub struct CondaPackageInfo {
     pub checksum: Option<String>,
 }
 
-/// Conda backend requires experimental mode to be enabled
-pub const EXPERIMENTAL: bool = true;
-
 #[derive(Debug)]
 pub struct CondaBackend {
     ba: Arc<BackendArg>,
@@ -683,8 +680,6 @@ impl Backend for CondaBackend {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        Settings::get().ensure_experimental("conda backend")?;
-
         let platform_key = self.get_platform_key();
         let has_locked = tv
             .lock_platforms


### PR DESCRIPTION
## Summary

The conda backend has been stable in practice — install/uninstall, lockfile resolution, dependency handling, and library-path patching are all covered by the e2e suite (`e2e/backend/test_conda` exercises ruff, bat, jq with deps, and postgresql with ~23 transitive deps). Drop the experimental gate so users no longer need to set `MISE_EXPERIMENTAL=1` to use it.

Changes:

- Remove `conda::EXPERIMENTAL` constant and the `ensure_experimental("conda backend")` check in `install_version_`.
- Drop the `BackendType::Conda` branch in `is_experimental()`.
- Remove the experimental badge from `docs/dev-tools/backends/conda.md` and the backends index.

`dotnet`, `s3`, and `spm` remain experimental and are unchanged.

## Test plan

- [ ] `cargo check --all-features` (verified locally — clean).
- [ ] `mise run test:e2e test_conda` still passes (e2e harness sets `MISE_EXPERIMENTAL=1` globally so behavior is unchanged in CI; this PR's effect is for end users not setting that var).
- [ ] `mise install conda:ruff` works without `MISE_EXPERIMENTAL=1` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes the experimental gate for the `conda` backend and updates docs; no functional changes to install/solve logic beyond allowing it to run without `MISE_EXPERIMENTAL` enabled.
> 
> **Overview**
> Graduates the `conda` backend out of experimental by removing the experimental flag/constant, dropping `BackendType::Conda` from `is_experimental()`, and eliminating the `Settings::ensure_experimental("conda backend")` check during install.
> 
> Updates backend documentation to remove the experimental badge for `conda` in both `docs/dev-tools/backends/conda.md` and the backends index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d45eb5bd518fb9414ae37d8782415277c59400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->