### PR TITLE
fix(install): refresh latest before installing missing tools

### DIFF
--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -24,25 +24,30 @@ if ! command -v pnpm >/dev/null 2>&1; then
   assert_succeed "mise use pnpm@10.16.0"
 fi
 
-# Test 1: Default behavior (npm) - checks npm.package_manager="npm" implicitly
-echo "Testing npm backend with default settings (npm)..."
+# Test 1: npm.package_manager = "npm". Pin explicitly rather than relying
+# on the `auto` default — `auto` picks aube when aube is on PATH (including
+# system installs like Homebrew), which would emit `--minimum-release-age`
+# instead of npm's `--before` and break the assertion below on dev machines.
+echo "Testing npm backend with npm package manager..."
 unset MISE_NPM_BUN
-unset MISE_NPM_PACKAGE_MANAGER
+export MISE_NPM_PACKAGE_MANAGER=npm
 
 # Test listing versions - should succeed
 assert_succeed "mise ls-remote npm:tiny >/dev/null"
 echo "✓ npm backend lists versions using npm"
 
-# Test installation using npm (default)
+# Test installation using npm
 cat >.mise.toml <<EOF
 [tools]
 "npm:tiny" = { version = "latest", npm_args = "--foreground-scripts" }
 EOF
 mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
 assert_succeed "MISE_DEBUG=1 mise install >/tmp/npm_debug.log 2>&1"
-assert_contains "cat /tmp/npm_debug.log" "--before"
+# npm 11.10.0+ uses `--min-release-age={days}`; older npm uses `--before {ts}`.
+# Accept either since the underlying npm version varies between environments.
+assert_matches "cat /tmp/npm_debug.log" "--(before|min-release-age)"
 assert_contains "cat /tmp/npm_debug.log" "--foreground-scripts"
-echo "✓ npm backend successfully installs package using npm (default)"
+echo "✓ npm backend successfully installs package using npm"
 mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
 
 # Test 2: npm.package_manager = "bun"

--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -83,9 +83,12 @@ export MISE_NPM_PACKAGE_MANAGER=aube
 
 # Ensure aube is available after the default package manager test, since
 # npm.package_manager=auto uses aube when it is already installed.
+# Bypass MISE_MINIMUM_RELEASE_AGE for aube's install — the global filter is
+# set to test the package-manager flag plumbing below, but applying it to
+# aube itself can pin to a release that lacks platform-specific assets.
 if ! command -v aube >/dev/null 2>&1; then
   echo "aube not available in test environment, installing..."
-  assert_succeed "mise use aube@latest"
+  assert_succeed "env -u MISE_MINIMUM_RELEASE_AGE mise use aube@latest"
 fi
 
 cat >.mise.toml <<EOF

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -656,10 +656,14 @@ impl Backend for CondaBackend {
     }
 
     /// Override to bypass the shared remote_versions cache since conda's
-    /// channel option affects which versions are available.
-    async fn list_remote_versions_with_info(
+    /// channel option affects which versions are available. The override is
+    /// on `_with_refresh` so it applies to both cached and refresh-enabled
+    /// resolution paths; conda always queries the channel directly so the
+    /// `_refresh` flag is irrelevant.
+    async fn list_remote_versions_with_info_with_refresh(
         &self,
         config: &Arc<Config>,
+        _refresh: bool,
     ) -> Result<Vec<VersionInfo>> {
         let opts = config
             .get_tool_opts(&self.ba)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -682,7 +682,12 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     async fn list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<String>> {
-        self.list_remote_versions_with_refresh(config, false).await
+        Ok(self
+            .list_remote_versions_with_info(config)
+            .await?
+            .into_iter()
+            .map(|v| v.version)
+            .collect())
     }
 
     /// Like `list_remote_versions` but with explicit refresh control. Pass

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -690,6 +690,18 @@ pub trait Backend: Debug + Send + Sync {
             .collect())
     }
 
+    async fn list_remote_versions_refresh(
+        &self,
+        config: &Arc<Config>,
+    ) -> eyre::Result<Vec<String>> {
+        Ok(self
+            .list_remote_versions_with_info_refresh(config)
+            .await?
+            .into_iter()
+            .map(|v| v.version)
+            .collect())
+    }
+
     /// List remote versions with additional metadata like created_at timestamps.
     /// Results are cached. Backends can override `_list_remote_versions_with_info`
     /// to provide timestamp information.
@@ -706,6 +718,23 @@ pub trait Backend: Debug + Send + Sync {
     async fn list_remote_versions_with_info(
         &self,
         config: &Arc<Config>,
+    ) -> eyre::Result<Vec<VersionInfo>> {
+        self.list_remote_versions_with_info_with_refresh(config, false)
+            .await
+    }
+
+    async fn list_remote_versions_with_info_refresh(
+        &self,
+        config: &Arc<Config>,
+    ) -> eyre::Result<Vec<VersionInfo>> {
+        self.list_remote_versions_with_info_with_refresh(config, true)
+            .await
+    }
+
+    async fn list_remote_versions_with_info_with_refresh(
+        &self,
+        config: &Arc<Config>,
+        refresh: bool,
     ) -> eyre::Result<Vec<VersionInfo>> {
         let remote_versions = self.get_remote_version_cache();
         let mut remote_versions = remote_versions.lock().await;
@@ -816,56 +845,58 @@ pub trait Backend: Debug + Send + Sync {
             return Ok(vec![]);
         }
 
-        let versions = remote_versions
-            .get_or_try_init_async(|| async {
-                trace!("Listing remote versions for {}", ba.to_string());
-                // Try versions host first (now returns VersionInfo with timestamps)
-                if use_versions_host {
-                    match versions_host::list_versions(&ba.short).await {
-                        Ok(Some(versions)) => {
-                            trace!(
-                                "Got {} versions from versions host for {}",
-                                versions.len(),
-                                ba.to_string()
-                            );
-                            return Ok(versions);
-                        }
-                        Ok(None) => {}
-                        Err(e) => {
-                            debug!("Error getting versions from versions host: {:#}", e);
-                        }
+        let fetch = || async {
+            trace!("Listing remote versions for {}", ba.to_string());
+            // Try versions host first (now returns VersionInfo with timestamps)
+            if use_versions_host {
+                match versions_host::list_versions(&ba.short).await {
+                    Ok(Some(versions)) => {
+                        trace!(
+                            "Got {} versions from versions host for {}",
+                            versions.len(),
+                            ba.to_string()
+                        );
+                        return Ok(versions);
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        debug!("Error getting versions from versions host: {:#}", e);
                     }
                 }
-                trace!(
-                    "Calling backend to list remote versions for {}",
-                    ba.to_string()
-                );
-                let versions = self
-                    ._list_remote_versions(config)
-                    .await?
-                    .into_iter()
-                    .map(|v| match self.mark_prereleases_from_version_pattern() {
-                        true => mark_prerelease(v),
-                        false => v,
-                    })
-                    .filter(|v| match v.version.parse::<ToolVersionType>() {
-                        Ok(ToolVersionType::Version(_)) => true,
-                        _ => {
-                            warn!("Invalid version: {id}@{}", v.version);
-                            false
-                        }
-                    })
-                    .collect_vec();
-                if versions.is_empty()
-                    && self.get_type() != BackendType::Http
-                    && self.unresolved_latest_version().is_none()
-                {
-                    warn!("No versions found for {id}");
-                }
-                Ok(versions)
-            })
-            .await?
-            .clone();
+            }
+            trace!(
+                "Calling backend to list remote versions for {}",
+                ba.to_string()
+            );
+            let versions = self
+                ._list_remote_versions(config)
+                .await?
+                .into_iter()
+                .map(|v| match self.mark_prereleases_from_version_pattern() {
+                    true => mark_prerelease(v),
+                    false => v,
+                })
+                .filter(|v| match v.version.parse::<ToolVersionType>() {
+                    Ok(ToolVersionType::Version(_)) => true,
+                    _ => {
+                        warn!("Invalid version: {id}@{}", v.version);
+                        false
+                    }
+                })
+                .collect_vec();
+            if versions.is_empty()
+                && self.get_type() != BackendType::Http
+                && self.unresolved_latest_version().is_none()
+            {
+                warn!("No versions found for {id}");
+            }
+            Ok(versions)
+        };
+        let versions = if refresh {
+            remote_versions.refresh_async(fetch).await?
+        } else {
+            remote_versions.get_or_try_init_async(fetch).await?.clone()
+        };
         if versions.is_empty() {
             remote_versions.clear()?;
         }
@@ -1054,11 +1085,16 @@ pub trait Backend: Debug + Send + Sync {
         config: &Arc<Config>,
         query: &str,
         before_date: Option<Timestamp>,
+        refresh: bool,
     ) -> eyre::Result<Vec<String>> {
         let versions = match before_date {
             Some(before) => {
                 // Use version info to filter by date
-                let versions_with_info = self.list_remote_versions_with_info(config).await?;
+                let versions_with_info = if refresh {
+                    self.list_remote_versions_with_info_refresh(config).await?
+                } else {
+                    self.list_remote_versions_with_info(config).await?
+                };
                 let filtered = VersionInfo::filter_by_date(versions_with_info, before);
                 // Warn if no versions have timestamps
                 if filtered.iter().all(|v| v.created_at.is_none()) && !filtered.is_empty() {
@@ -1069,7 +1105,13 @@ pub trait Backend: Debug + Send + Sync {
                 }
                 filtered.into_iter().map(|v| v.version).collect()
             }
-            None => self.list_remote_versions(config).await?,
+            None => {
+                if refresh {
+                    self.list_remote_versions_refresh(config).await?
+                } else {
+                    self.list_remote_versions(config).await?
+                }
+            }
         };
         let opts = config
             .get_tool_opts(self.ba())
@@ -1084,21 +1126,32 @@ pub trait Backend: Debug + Send + Sync {
         config: &Arc<Config>,
         query: &str,
         before_date: Option<Timestamp>,
+        refresh: bool,
     ) -> eyre::Result<Option<String>> {
         let mut matches = self
-            .list_versions_matching_with_opts(config, query, before_date)
+            .list_versions_matching_with_opts(config, query, before_date, refresh)
             .await?;
         if matches.is_empty() && query == "latest" {
             // Fall back to all versions if no match
             matches = match before_date {
                 Some(before) => {
-                    let versions_with_info = self.list_remote_versions_with_info(config).await?;
+                    let versions_with_info = if refresh {
+                        self.list_remote_versions_with_info_refresh(config).await?
+                    } else {
+                        self.list_remote_versions_with_info(config).await?
+                    };
                     VersionInfo::filter_by_date(versions_with_info, before)
                         .into_iter()
                         .map(|v| v.version)
                         .collect()
                 }
-                None => self.list_remote_versions(config).await?,
+                None => {
+                    if refresh {
+                        self.list_remote_versions_refresh(config).await?
+                    } else {
+                        self.list_remote_versions(config).await?
+                    }
+                }
             };
         }
         Ok(find_match_in_list(&matches, query))
@@ -1122,16 +1175,37 @@ pub trait Backend: Debug + Send + Sync {
         match query.as_deref() {
             Some("latest") | None => match before_date {
                 Some(before) => {
-                    self.latest_version_for_query(config, "latest", Some(before))
+                    self.latest_version_for_query(config, "latest", Some(before), false)
                         .await
                 }
                 None => match self.latest_stable_version(config).await? {
                     Some(version) => Ok(Some(version)),
-                    None => self.latest_version_for_query(config, "latest", None).await,
+                    None => {
+                        self.latest_version_for_query(config, "latest", None, false)
+                            .await
+                    }
                 },
             },
             Some(query) => {
-                self.latest_version_for_query(config, query, before_date)
+                self.latest_version_for_query(config, query, before_date, false)
+                    .await
+            }
+        }
+    }
+    async fn latest_version_refresh(
+        &self,
+        config: &Arc<Config>,
+        query: Option<String>,
+        before_date: Option<Timestamp>,
+    ) -> eyre::Result<Option<String>> {
+        let before_date = effective_latest_before_date(self, config, before_date).await?;
+        match query.as_deref() {
+            Some("latest") | None => {
+                self.latest_version_for_query(config, "latest", before_date, true)
+                    .await
+            }
+            Some(query) => {
+                self.latest_version_for_query(config, query, before_date, true)
                     .await
             }
         }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -682,20 +682,20 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     async fn list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<String>> {
-        Ok(self
-            .list_remote_versions_with_info(config)
-            .await?
-            .into_iter()
-            .map(|v| v.version)
-            .collect())
+        self.list_remote_versions_with_refresh(config, false).await
     }
 
-    async fn list_remote_versions_refresh(
+    /// Like `list_remote_versions` but with explicit refresh control. Pass
+    /// `refresh = true` to bypass the cached remote-versions list and re-fetch
+    /// upstream. Used by install-time resolution for selectors whose answer
+    /// depends on the freshest upstream entry (e.g. `latest`).
+    async fn list_remote_versions_with_refresh(
         &self,
         config: &Arc<Config>,
+        refresh: bool,
     ) -> eyre::Result<Vec<String>> {
         Ok(self
-            .list_remote_versions_with_info_refresh(config)
+            .list_remote_versions_with_info_with_refresh(config, refresh)
             .await?
             .into_iter()
             .map(|v| v.version)
@@ -720,14 +720,6 @@ pub trait Backend: Debug + Send + Sync {
         config: &Arc<Config>,
     ) -> eyre::Result<Vec<VersionInfo>> {
         self.list_remote_versions_with_info_with_refresh(config, false)
-            .await
-    }
-
-    async fn list_remote_versions_with_info_refresh(
-        &self,
-        config: &Arc<Config>,
-    ) -> eyre::Result<Vec<VersionInfo>> {
-        self.list_remote_versions_with_info_with_refresh(config, true)
             .await
     }
 
@@ -1090,11 +1082,9 @@ pub trait Backend: Debug + Send + Sync {
         let versions = match before_date {
             Some(before) => {
                 // Use version info to filter by date
-                let versions_with_info = if refresh {
-                    self.list_remote_versions_with_info_refresh(config).await?
-                } else {
-                    self.list_remote_versions_with_info(config).await?
-                };
+                let versions_with_info = self
+                    .list_remote_versions_with_info_with_refresh(config, refresh)
+                    .await?;
                 let filtered = VersionInfo::filter_by_date(versions_with_info, before);
                 // Warn if no versions have timestamps
                 if filtered.iter().all(|v| v.created_at.is_none()) && !filtered.is_empty() {
@@ -1106,11 +1096,8 @@ pub trait Backend: Debug + Send + Sync {
                 filtered.into_iter().map(|v| v.version).collect()
             }
             None => {
-                if refresh {
-                    self.list_remote_versions_refresh(config).await?
-                } else {
-                    self.list_remote_versions(config).await?
-                }
+                self.list_remote_versions_with_refresh(config, refresh)
+                    .await?
             }
         };
         let opts = config
@@ -1135,22 +1122,17 @@ pub trait Backend: Debug + Send + Sync {
             // Fall back to all versions if no match
             matches = match before_date {
                 Some(before) => {
-                    let versions_with_info = if refresh {
-                        self.list_remote_versions_with_info_refresh(config).await?
-                    } else {
-                        self.list_remote_versions_with_info(config).await?
-                    };
+                    let versions_with_info = self
+                        .list_remote_versions_with_info_with_refresh(config, refresh)
+                        .await?;
                     VersionInfo::filter_by_date(versions_with_info, before)
                         .into_iter()
                         .map(|v| v.version)
                         .collect()
                 }
                 None => {
-                    if refresh {
-                        self.list_remote_versions_refresh(config).await?
-                    } else {
-                        self.list_remote_versions(config).await?
-                    }
+                    self.list_remote_versions_with_refresh(config, refresh)
+                        .await?
                 }
             };
         }
@@ -1171,44 +1153,33 @@ pub trait Backend: Debug + Send + Sync {
         query: Option<String>,
         before_date: Option<Timestamp>,
     ) -> eyre::Result<Option<String>> {
-        let before_date = effective_latest_before_date(self, config, before_date).await?;
-        match query.as_deref() {
-            Some("latest") | None => match before_date {
-                Some(before) => {
-                    self.latest_version_for_query(config, "latest", Some(before), false)
-                        .await
-                }
-                None => match self.latest_stable_version(config).await? {
-                    Some(version) => Ok(Some(version)),
-                    None => {
-                        self.latest_version_for_query(config, "latest", None, false)
-                            .await
-                    }
-                },
-            },
-            Some(query) => {
-                self.latest_version_for_query(config, query, before_date, false)
-                    .await
-            }
-        }
+        self.latest_version_with_refresh(config, query, before_date, false)
+            .await
     }
-    async fn latest_version_refresh(
+
+    /// Like `latest_version` but with explicit refresh control. Pass
+    /// `refresh = true` to bypass the cached remote-versions list. The
+    /// `latest_stable_version` fast path is skipped when refreshing — refresh
+    /// callers want the shared version-list path so they pick up new entries
+    /// the cached list (or backend-specific fast path) would miss.
+    async fn latest_version_with_refresh(
         &self,
         config: &Arc<Config>,
         query: Option<String>,
         before_date: Option<Timestamp>,
+        refresh: bool,
     ) -> eyre::Result<Option<String>> {
         let before_date = effective_latest_before_date(self, config, before_date).await?;
-        match query.as_deref() {
-            Some("latest") | None => {
-                self.latest_version_for_query(config, "latest", before_date, true)
-                    .await
-            }
-            Some(query) => {
-                self.latest_version_for_query(config, query, before_date, true)
-                    .await
-            }
+        let resolved_query = query.as_deref().unwrap_or("latest");
+        if !refresh
+            && resolved_query == "latest"
+            && before_date.is_none()
+            && let Some(version) = self.latest_stable_version(config).await?
+        {
+            return Ok(Some(version));
         }
+        self.latest_version_for_query(config, resolved_query, before_date, refresh)
+            .await
     }
     fn latest_installed_version(&self, query: Option<String>) -> eyre::Result<Option<String>> {
         match query {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1158,10 +1158,13 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     /// Like `latest_version` but with explicit refresh control. Pass
-    /// `refresh = true` to bypass the cached remote-versions list. The
-    /// `latest_stable_version` fast path is skipped when refreshing — refresh
-    /// callers want the shared version-list path so they pick up new entries
-    /// the cached list (or backend-specific fast path) would miss.
+    /// `refresh = true` to bypass the cached remote-versions list when falling
+    /// back to the full version-list path. The `latest_stable_version` fast
+    /// path is still tried first — it queries canonical upstream endpoints
+    /// (e.g. GitHub's `/releases/latest`, npm dist tags) which are
+    /// authoritative and not subject to the local version-list cache, so
+    /// skipping it would actually return *older* results than refreshing the
+    /// list (which itself may go through a versions-host cache).
     async fn latest_version_with_refresh(
         &self,
         config: &Arc<Config>,
@@ -1171,8 +1174,7 @@ pub trait Backend: Debug + Send + Sync {
     ) -> eyre::Result<Option<String>> {
         let before_date = effective_latest_before_date(self, config, before_date).await?;
         let resolved_query = query.as_deref().unwrap_or("latest");
-        if !refresh
-            && resolved_query == "latest"
+        if resolved_query == "latest"
             && before_date.is_none()
             && let Some(version) = self.latest_stable_version(config).await?
         {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -163,6 +163,24 @@ where
         Ok(val)
     }
 
+    /// Fetch fresh data, write it to disk, and return it without consulting the
+    /// in-memory or on-disk cache.
+    pub async fn refresh_async<F, Fut>(&self, fetch: F) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        let val = fetch().await?;
+        if let Err(err) = self.write(&val) {
+            warn!(
+                "failed to write cache file: {} {:#}",
+                self.cache_file_path.display(),
+                err
+            );
+        }
+        Ok(val)
+    }
+
     /// Read the cache file without checking freshness and without fetching or writing.
     pub fn get_cached(&self) -> Result<T>
     where
@@ -349,5 +367,22 @@ mod tests {
         assert_eq!(val, &1);
         let val = cache.get_or_try_init(|| Ok(2)).unwrap();
         assert_eq!(val, &1);
+    }
+
+    #[tokio::test]
+    async fn test_refresh_ignores_memory_and_file_cache() {
+        let _config = Config::get().await.unwrap();
+        let mut cache: CacheManager<i32> =
+            CacheManagerBuilder::new(dirs::CACHE.join("test-cache-refresh")).build();
+        cache.clear().unwrap();
+        let val = cache
+            .get_or_try_init_async(|| async { Ok(1) })
+            .await
+            .unwrap();
+        assert_eq!(val, &1);
+
+        let val = cache.refresh_async(|| async { Ok(2) }).await.unwrap();
+
+        assert_eq!(val, 2);
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -164,11 +164,14 @@ where
     }
 
     /// Fetch fresh data, write it to disk, and return it without consulting the
-    /// in-memory or on-disk cache.
-    pub async fn refresh_async<F, Fut>(&self, fetch: F) -> Result<T>
+    /// existing on-disk cache. The in-memory cache cells are reset so that
+    /// subsequent non-refresh reads see the fresh value rather than a stale
+    /// previously-cached one.
+    pub async fn refresh_async<F, Fut>(&mut self, fetch: F) -> Result<T>
     where
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<T>>,
+        T: Clone,
     {
         let val = fetch().await?;
         if let Err(err) = self.write(&val) {
@@ -178,6 +181,13 @@ where
                 err
             );
         }
+        // Replace the in-memory cells so future non-refresh reads observe the
+        // fresh value instead of a stale previously-initialized one.
+        *self.cache = OnceCell::new();
+        let async_cell = tokio::sync::OnceCell::new();
+        let _ = async_cell.set(val.clone());
+        *self.cache_async = async_cell;
+        let _ = self.cache.set(val.clone());
         Ok(val)
     }
 
@@ -384,5 +394,14 @@ mod tests {
         let val = cache.refresh_async(|| async { Ok(2) }).await.unwrap();
 
         assert_eq!(val, 2);
+
+        // After refresh, the in-memory cells must observe the fresh value too.
+        let val = cache
+            .get_or_try_init_async(|| async { Ok(3) })
+            .await
+            .unwrap();
+        assert_eq!(val, &2);
+        let val = cache.get_or_try_init(|| Ok(4)).unwrap();
+        assert_eq!(val, &2);
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -163,10 +163,10 @@ where
         Ok(val)
     }
 
-    /// Fetch fresh data, write it to disk, and return it without consulting the
-    /// existing on-disk cache. The in-memory cache cells are reset so that
-    /// subsequent non-refresh reads see the fresh value rather than a stale
-    /// previously-cached one.
+    /// Fetch fresh data, write it to disk, and return it without consulting
+    /// any cache. The in-memory cache cells are replaced with the fresh value
+    /// so future non-refresh reads observe it instead of a stale previously-
+    /// initialized one.
     pub async fn refresh_async<F, Fut>(&mut self, fetch: F) -> Result<T>
     where
         F: FnOnce() -> Fut,
@@ -181,13 +181,8 @@ where
                 err
             );
         }
-        // Replace the in-memory cells so future non-refresh reads observe the
-        // fresh value instead of a stale previously-initialized one.
-        *self.cache = OnceCell::new();
-        let async_cell = tokio::sync::OnceCell::new();
-        let _ = async_cell.set(val.clone());
-        *self.cache_async = async_cell;
-        let _ = self.cache.set(val.clone());
+        *self.cache = OnceCell::with_value(val.clone());
+        *self.cache_async = tokio::sync::OnceCell::new_with(Some(val.clone()));
         Ok(val)
     }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -243,6 +243,7 @@ impl Install {
                 latest_versions: true,
                 before_date: self.get_before_date()?,
                 offline: false,
+                refresh_remote_versions: false,
             },
             dry_run: self.is_dry_run(),
             locked: Settings::get().locked,

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -118,6 +118,7 @@ impl Upgrade {
             latest_versions: true,
             before_date,
             offline: false,
+            refresh_remote_versions: false,
         };
         // Filter tools to check before doing expensive version lookups
         let filter_tools = if !self.interactive && !self.tool.is_empty() {
@@ -262,6 +263,7 @@ impl Upgrade {
                 latest_versions: true,
                 before_date,
                 offline: false,
+                refresh_remote_versions: false,
             },
             ..Default::default()
         };

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -145,6 +145,7 @@ impl Use {
             use_locked_version: true,
             before_date: self.get_before_date()?,
             offline: false,
+            refresh_remote_versions: false,
         };
         let versions: Vec<_> = self
             .tool

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -359,11 +359,15 @@ impl Backend for JavaPlugin {
         Ok(versions)
     }
 
-    /// Override to bypass the shared remote_versions cache since Java has separate
-    /// caches for GA and EA release types in fetch_java_metadata.
-    async fn list_remote_versions_with_info(
+    /// Override to bypass the shared remote_versions cache since Java has
+    /// separate caches for GA and EA release types in `fetch_java_metadata`.
+    /// The override is on `_with_refresh` so install-time refresh paths also
+    /// reach the GA/EA-aware logic; the underlying fetch already handles
+    /// freshness, so the `_refresh` flag is irrelevant.
+    async fn list_remote_versions_with_info_with_refresh(
         &self,
         config: &Arc<Config>,
+        _refresh: bool,
     ) -> Result<Vec<VersionInfo>> {
         self._list_remote_versions(config).await
     }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -350,24 +350,21 @@ impl ToolVersion {
                 return build(v);
             }
             if !is_offline
-                && let Some(v) = if opts.refresh_remote_versions {
-                    backend
-                        .latest_version_refresh(config, None, opts.before_date)
-                        .await?
-                } else {
-                    backend
-                        .latest_version(config, None, opts.before_date)
-                        .await?
-                }
+                && let Some(v) = backend
+                    .latest_version_with_refresh(
+                        config,
+                        None,
+                        opts.before_date,
+                        opts.refresh_remote_versions,
+                    )
+                    .await?
             {
                 return build(v);
             }
             if !is_offline {
-                let versions = if opts.refresh_remote_versions {
-                    backend.list_remote_versions_refresh(config).await?
-                } else {
-                    backend.list_remote_versions(config).await?
-                };
+                let versions = backend
+                    .list_remote_versions_with_refresh(config, opts.refresh_remote_versions)
+                    .await?;
                 if versions.is_empty()
                     && let Some(v) = backend.unresolved_latest_version()
                 {
@@ -410,24 +407,21 @@ impl ToolVersion {
             if !is_offline {
                 let versions = match opts.before_date {
                     Some(before) => {
-                        let versions_with_info = if opts.refresh_remote_versions {
-                            backend
-                                .list_remote_versions_with_info_refresh(config)
-                                .await?
-                        } else {
-                            backend.list_remote_versions_with_info(config).await?
-                        };
+                        let versions_with_info = backend
+                            .list_remote_versions_with_info_with_refresh(
+                                config,
+                                opts.refresh_remote_versions,
+                            )
+                            .await?;
                         VersionInfo::filter_by_date(versions_with_info, before)
                             .into_iter()
                             .map(|v| v.version)
                             .collect()
                     }
                     None => {
-                        if opts.refresh_remote_versions {
-                            backend.list_remote_versions_refresh(config).await?
-                        } else {
-                            backend.list_remote_versions(config).await?
-                        }
+                        backend
+                            .list_remote_versions_with_refresh(config, opts.refresh_remote_versions)
+                            .await?
                     }
                 };
                 if let Some(matches) = crate::semver::npm_semver_range_filter(&versions, &v)
@@ -494,18 +488,15 @@ impl ToolVersion {
             return Ok(Self::new(request, version));
         }
         let v = match v {
-            "latest" => {
-                let latest = if opts.refresh_remote_versions {
-                    backend
-                        .latest_version_refresh(config, None, opts.before_date)
-                        .await?
-                } else {
-                    backend
-                        .latest_version(config, None, opts.before_date)
-                        .await?
-                };
-                latest.ok_or_else(|| Self::no_versions_found(&backend, opts.before_date))?
-            }
+            "latest" => backend
+                .latest_version_with_refresh(
+                    config,
+                    None,
+                    opts.before_date,
+                    opts.refresh_remote_versions,
+                )
+                .await?
+                .ok_or_else(|| Self::no_versions_found(&backend, opts.before_date))?,
             _ => config.resolve_alias(&backend, v).await?,
         };
         let v = tool_request::version_sub(&v, sub);

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -494,10 +494,18 @@ impl ToolVersion {
             return Ok(Self::new(request, version));
         }
         let v = match v {
-            "latest" => backend
-                .latest_version(config, None, opts.before_date)
-                .await?
-                .ok_or_else(|| Self::no_versions_found(&backend, opts.before_date))?,
+            "latest" => {
+                let latest = if opts.refresh_remote_versions {
+                    backend
+                        .latest_version_refresh(config, None, opts.before_date)
+                        .await?
+                } else {
+                    backend
+                        .latest_version(config, None, opts.before_date)
+                        .await?
+                };
+                latest.ok_or_else(|| Self::no_versions_found(&backend, opts.before_date))?
+            }
             _ => config.resolve_alias(&backend, v).await?,
         };
         let v = tool_request::version_sub(&v, sub);

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -228,6 +228,7 @@ impl ToolVersion {
             use_locked_version: false,
             before_date: base_opts.before_date,
             offline: base_opts.offline,
+            refresh_remote_versions: base_opts.refresh_remote_versions,
         };
         let tv = self.request.resolve(config, &opts).await?;
         // map cargo backend specific prefixes to ref
@@ -349,14 +350,24 @@ impl ToolVersion {
                 return build(v);
             }
             if !is_offline
-                && let Some(v) = backend
-                    .latest_version(config, None, opts.before_date)
-                    .await?
+                && let Some(v) = if opts.refresh_remote_versions {
+                    backend
+                        .latest_version_refresh(config, None, opts.before_date)
+                        .await?
+                } else {
+                    backend
+                        .latest_version(config, None, opts.before_date)
+                        .await?
+                }
             {
                 return build(v);
             }
             if !is_offline {
-                let versions = backend.list_remote_versions(config).await?;
+                let versions = if opts.refresh_remote_versions {
+                    backend.list_remote_versions_refresh(config).await?
+                } else {
+                    backend.list_remote_versions(config).await?
+                };
                 if versions.is_empty()
                     && let Some(v) = backend.unresolved_latest_version()
                 {
@@ -399,14 +410,25 @@ impl ToolVersion {
             if !is_offline {
                 let versions = match opts.before_date {
                     Some(before) => {
-                        let versions_with_info =
-                            backend.list_remote_versions_with_info(config).await?;
+                        let versions_with_info = if opts.refresh_remote_versions {
+                            backend
+                                .list_remote_versions_with_info_refresh(config)
+                                .await?
+                        } else {
+                            backend.list_remote_versions_with_info(config).await?
+                        };
                         VersionInfo::filter_by_date(versions_with_info, before)
                             .into_iter()
                             .map(|v| v.version)
                             .collect()
                     }
-                    None => backend.list_remote_versions(config).await?,
+                    None => {
+                        if opts.refresh_remote_versions {
+                            backend.list_remote_versions_refresh(config).await?
+                        } else {
+                            backend.list_remote_versions(config).await?
+                        }
+                    }
                 };
                 if let Some(matches) = crate::semver::npm_semver_range_filter(&versions, &v)
                     && let Some(v) = matches.last()
@@ -428,7 +450,12 @@ impl ToolVersion {
         }
         // First try with date filter (common case)
         let matches = backend
-            .list_versions_matching_with_opts(config, &v, opts.before_date)
+            .list_versions_matching_with_opts(
+                config,
+                &v,
+                opts.before_date,
+                opts.refresh_remote_versions,
+            )
             .await?;
         if matches.contains(&v) {
             return build(v);
@@ -493,7 +520,12 @@ impl ToolVersion {
             return Ok(Self::new(request, prefix.to_string()));
         }
         let matches = backend
-            .list_versions_matching_with_opts(config, prefix, opts.before_date)
+            .list_versions_matching_with_opts(
+                config,
+                prefix,
+                opts.before_date,
+                opts.refresh_remote_versions,
+            )
             .await?;
         let v = matches
             .last()
@@ -575,6 +607,8 @@ pub struct ResolveOptions {
     pub before_date: Option<Timestamp>,
     /// Additive to `Settings::offline()` — either being true skips remote version listing.
     pub offline: bool,
+    /// Ignore cached remote version lists while resolving this request.
+    pub refresh_remote_versions: bool,
 }
 
 impl Default for ResolveOptions {
@@ -584,6 +618,7 @@ impl Default for ResolveOptions {
             use_locked_version: true,
             before_date: None,
             offline: false,
+            refresh_remote_versions: false,
         }
     }
 }
@@ -623,6 +658,9 @@ impl Display for ResolveOptions {
         }
         if self.offline {
             opts.push("offline".to_string());
+        }
+        if self.refresh_remote_versions {
+            opts.push("refresh_remote_versions".to_string());
         }
         write!(f, "({})", opts.join(", "))
     }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -592,9 +592,14 @@ fn should_refresh_remote_versions(
     if opts.latest_versions {
         return true;
     }
+    // Only refresh for selectors whose result depends on the very latest
+    // upstream entry: `latest` and prefix queries (e.g. `node@20`). Fully-
+    // pinned exact versions (e.g. `node@20.15.1`) don't benefit — the
+    // cached list either contains that version or it doesn't, and a stale
+    // cache won't change the answer in a way the user cares about.
     match tr {
         ToolRequest::Version { version, .. } => {
-            backend.list_installed_versions_matching(version).is_empty()
+            version == "latest" && backend.list_installed_versions_matching(version).is_empty()
         }
         ToolRequest::Prefix { prefix, .. } => {
             backend.list_installed_versions_matching(prefix).is_empty()

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -454,7 +454,7 @@ impl Toolset {
         let mpr = MultiProgressReport::get();
         let backend = tr.backend()?;
         let mut resolve_options = opts.resolve_options.clone();
-        if should_refresh_remote_versions(tr, &resolve_options) {
+        if should_refresh_remote_versions(tr, &backend, &resolve_options) {
             resolve_options.refresh_remote_versions = true;
         }
         let mut tv = tr.resolve(config, &resolve_options).await?;
@@ -583,22 +583,26 @@ impl Toolset {
 
 /// Whether install-time resolution should refresh the remote-versions cache
 /// before picking a version. Only selectors whose meaning depends on the
-/// freshest upstream entry benefit: `latest`, prefix queries, and
-/// `sub-N:latest`. Fully-pinned exact versions, refs, paths, and `system` are
-/// unaffected by cache staleness — the cached list either contains the
-/// requested version or it doesn't, and refreshing doesn't change the answer.
-///
-/// The `latest_versions` flag (set by `mise install`/`use`/`upgrade`) is not
-/// consulted here: when a selector is freshness-sensitive we always refresh,
-/// and when it isn't, refreshing would be wasted network traffic regardless
-/// of the user's command.
-fn should_refresh_remote_versions(tr: &ToolRequest, opts: &ResolveOptions) -> bool {
+/// freshest upstream entry benefit: `latest`, `sub-N:latest`, and prefix
+/// queries that have no matching installed version. Fully-pinned exact
+/// versions, refs, paths, `system`, and prefix queries already satisfied by
+/// an installed version are unaffected by cache staleness — for those the
+/// cached answer is either correct or harmless, and refreshing is wasted
+/// network traffic. Users who want to pull the absolute latest matching a
+/// prefix can run `mise upgrade` or pin to `@latest`.
+fn should_refresh_remote_versions(
+    tr: &ToolRequest,
+    backend: &crate::backend::ABackend,
+    opts: &ResolveOptions,
+) -> bool {
     if opts.refresh_remote_versions || opts.offline || Settings::get().offline() {
         return false;
     }
     match tr {
         ToolRequest::Version { version, .. } => version == "latest",
-        ToolRequest::Prefix { .. } => true,
+        ToolRequest::Prefix { prefix, .. } => {
+            backend.list_installed_versions_matching(prefix).is_empty()
+        }
         ToolRequest::Sub { orig_version, .. } => orig_version == "latest",
         ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => false,
     }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -19,7 +19,7 @@ use crate::toolset::install_options::InstallOptions;
 use crate::toolset::tool_deps::{ToolDeps, tool_key};
 use crate::toolset::tool_request::ToolRequest;
 use crate::toolset::tool_source::ToolSource;
-use crate::toolset::tool_version::ToolVersion;
+use crate::toolset::tool_version::{ResolveOptions, ToolVersion};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{config, hooks};
 
@@ -452,12 +452,16 @@ impl Toolset {
         opts: &Arc<InstallOptions>,
     ) -> Result<ToolVersion> {
         let mpr = MultiProgressReport::get();
-        let mut tv = tr.resolve(config, &opts.resolve_options).await?;
+        let backend = tr.backend()?;
+        let mut resolve_options = opts.resolve_options.clone();
+        if should_refresh_remote_versions(tr, &backend, &resolve_options) {
+            resolve_options.refresh_remote_versions = true;
+        }
+        let mut tv = tr.resolve(config, &resolve_options).await?;
         if let Some(dir) = &opts.install_dir {
             let tool_dir_name = tv.ba().tool_dir_name();
             tv.install_path = Some(dir.join(tool_dir_name).join(tv.tv_pathname()));
         }
-        let backend = tr.backend()?;
         let before_date = tv.before_date;
 
         let ctx = InstallContext {
@@ -574,5 +578,28 @@ impl Toolset {
 
     fn parse_plugin_key(key: &str) -> (PluginType, &str) {
         PluginType::from_plugin_config(key)
+    }
+}
+
+fn should_refresh_remote_versions(
+    tr: &ToolRequest,
+    backend: &crate::backend::ABackend,
+    opts: &ResolveOptions,
+) -> bool {
+    if opts.refresh_remote_versions || opts.offline || Settings::get().offline() {
+        return false;
+    }
+    if opts.latest_versions {
+        return true;
+    }
+    match tr {
+        ToolRequest::Version { version, .. } => {
+            backend.list_installed_versions_matching(version).is_empty()
+        }
+        ToolRequest::Prefix { prefix, .. } => {
+            backend.list_installed_versions_matching(prefix).is_empty()
+        }
+        ToolRequest::Sub { orig_version, .. } => orig_version == "latest",
+        ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => false,
     }
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -454,7 +454,7 @@ impl Toolset {
         let mpr = MultiProgressReport::get();
         let backend = tr.backend()?;
         let mut resolve_options = opts.resolve_options.clone();
-        if should_refresh_remote_versions(tr, &backend, &resolve_options) {
+        if should_refresh_remote_versions(tr, &resolve_options) {
             resolve_options.refresh_remote_versions = true;
         }
         let mut tv = tr.resolve(config, &resolve_options).await?;
@@ -581,29 +581,24 @@ impl Toolset {
     }
 }
 
-fn should_refresh_remote_versions(
-    tr: &ToolRequest,
-    backend: &crate::backend::ABackend,
-    opts: &ResolveOptions,
-) -> bool {
+/// Whether install-time resolution should refresh the remote-versions cache
+/// before picking a version. Only selectors whose meaning depends on the
+/// freshest upstream entry benefit: `latest`, prefix queries, and
+/// `sub-N:latest`. Fully-pinned exact versions, refs, paths, and `system` are
+/// unaffected by cache staleness — the cached list either contains the
+/// requested version or it doesn't, and refreshing doesn't change the answer.
+///
+/// The `latest_versions` flag (set by `mise install`/`use`/`upgrade`) is not
+/// consulted here: when a selector is freshness-sensitive we always refresh,
+/// and when it isn't, refreshing would be wasted network traffic regardless
+/// of the user's command.
+fn should_refresh_remote_versions(tr: &ToolRequest, opts: &ResolveOptions) -> bool {
     if opts.refresh_remote_versions || opts.offline || Settings::get().offline() {
         return false;
     }
-    if opts.latest_versions {
-        return true;
-    }
-    // Only refresh for selectors whose result depends on the very latest
-    // upstream entry: `latest` and prefix queries (e.g. `node@20`). Fully-
-    // pinned exact versions (e.g. `node@20.15.1`) don't benefit — the
-    // cached list either contains that version or it doesn't, and a stale
-    // cache won't change the answer in a way the user cares about.
     match tr {
-        ToolRequest::Version { version, .. } => {
-            version == "latest" && backend.list_installed_versions_matching(version).is_empty()
-        }
-        ToolRequest::Prefix { prefix, .. } => {
-            backend.list_installed_versions_matching(prefix).is_empty()
-        }
+        ToolRequest::Version { version, .. } => version == "latest",
+        ToolRequest::Prefix { .. } => true,
         ToolRequest::Sub { orig_version, .. } => orig_version == "latest",
         ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => false,
     }


### PR DESCRIPTION
## What changed

- Added a scoped cache-bypass path for install-time version resolution.
- When installing an unresolved `latest` request, mise now refreshes remote version caches if no installed version can satisfy the request.
- Added a cache test covering fresh on-disk cache bypass behavior.

## Why

A stale remote-versions cache could make `mise use <tool>` install an older cached `latest` when the tool was not already installed. The install path should only reuse cache for `latest` when it can reuse an installed version; otherwise it should check upstream before choosing what to install.

## Validation

- `cargo check -q`
- `cargo test -q cache::tests`
- `cargo run -q -- use --dry-run --pin --path "$tmp/mise.toml" hk` resolved `hk@1.44.3`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core version-resolution and caching paths; mistakes could cause extra network calls or incorrect version selection across multiple backends, though the refresh is narrowly scoped and has added test coverage.
> 
> **Overview**
> Fixes install-time resolution so selectors that depend on *fresh upstream data* (notably `latest`, `sub-N:latest`, and some prefix requests) can **bypass stale `remote_versions` cache** before choosing what to install.
> 
> This introduces explicit refresh plumbing (`ResolveOptions.refresh_remote_versions`, `Backend::list_remote_versions*_with_refresh`, and `CacheManager::refresh_async`), updates resolution call sites to use it, and adds a scoped install-time heuristic (`should_refresh_remote_versions`) to trigger refresh only when needed.
> 
> Also adjusts backend overrides (`conda`, core `java`) to hook the new refresh-aware method, adds a cache refresh test, and hardens the npm package-manager e2e test to be deterministic across environments (explicitly pin npm manager, allow npm flag variations, and bypass `MISE_MINIMUM_RELEASE_AGE` when installing `aube`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b0eb955c2e10a66ccfc995068723786ca435e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->