### PR TITLE
fix(backend): suppress no-versions warning for unresolved-latest backends

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -854,7 +854,10 @@ pub trait Backend: Debug + Send + Sync {
                         }
                     })
                     .collect_vec();
-                if versions.is_empty() && self.get_type() != BackendType::Http {
+                if versions.is_empty()
+                    && self.get_type() != BackendType::Http
+                    && self.unresolved_latest_version().is_none()
+                {
                     warn!("No versions found for {id}");
                 }
                 Ok(versions)


### PR DESCRIPTION
## Summary

Backends that opt into installing an unresolved `latest` selector (today only `pipx` for git-backed requests) legitimately return an empty remote version list when their source has no discoverable versions — e.g. a GitHub repo with no releases (only tags). The hard-error path was already addressed in #9401 by falling back to the unresolved selector.

What's still left is noise: every command that touches such a tool emits 3–12 repeated `mise WARN No versions found for …` warnings. The repetition comes from #9444 (don't cache empty version lists) — every separate call site that asks for remote versions in the same process re-fetches and re-warns. Underlying GitHub API calls are still deduplicated by `RELEASE_CACHE`, so this is purely log noise, not extra HTTP traffic.

This change suppresses the warning when the backend opts into `unresolved_latest_version()`. For those backends an empty list is the expected steady state, not an error worth flagging. Other backends still warn as before, so the warning continues to catch real problems (typo'd repos, configs pointing at the wrong place).

Refs https://github.com/jdx/mise/discussions/9381.

## Reproduction

\`\`\`toml
# ~/.config/mise/conf.d/tools.toml
[tools]
"pipx:a13xp0p0v/kernel-hardening-checker" = "latest"
\`\`\`

`a13xp0p0v/kernel-hardening-checker` has 0 GitHub releases (14 tags). Before this PR:

\`\`\`
$ mise current
mise WARN  No versions found for pipx:a13xp0p0v/kernel-hardening-checker
mise WARN  No versions found for pipx:a13xp0p0v/kernel-hardening-checker
mise WARN  No versions found for pipx:a13xp0p0v/kernel-hardening-checker
pipx:a13xp0p0v/kernel-hardening-checker latest
\`\`\`

After:

\`\`\`
$ mise current
pipx:a13xp0p0v/kernel-hardening-checker latest
\`\`\`

`mise ls`, `mise outdated`, and `mise install` are similarly quiet now.

## Test plan

- [x] Manual repro with the discussion's tool — all warnings gone for `mise ls`, `mise current`, `mise outdated`, `mise install`
- [x] `mise run lint`
- [x] `cargo build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes warning emission logic when a backend opts into `unresolved_latest_version()`, with no effect on version fetching or installation behavior.
> 
> **Overview**
> Suppresses repeated `No versions found` warnings when `list_remote_versions_with_info` returns an empty list for backends that support installing an unresolved `latest` selector (via `unresolved_latest_version()`). Other backends still warn on empty remote version lists as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ca20e5b4c03ee814fda1510b4603d4306b0fb82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->