### PR TITLE
test(tasks): migrate test_task_help atask to usage field

### DIFF
--- a/e2e/tasks/test_task_help
+++ b/e2e/tasks/test_task_help
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-cat <<EOF >mise.toml
+cat <<'EOF' >mise.toml
 [tasks.atask]
-run = 'echo {{arg(name="myarg")}}'
+usage = 'arg "<myarg>"'
+run = 'echo $usage_myarg'
 [tasks.npm]
 run = 'echo npm'
 EOF


### PR DESCRIPTION
## Summary

The `tera_template_task_args` deprecation has `warn_at = 2026.5.0`, which is the version being released in [#9485](https://github.com/jdx/mise/pull/9485). Once the warning starts firing, `tasks/test_task_help` fails:

```
$ mise run atask --help 2>&1 || true
mise WARN  deprecated [tera_template_task_args]: Task 'atask' uses deprecated Tera template functions...
Usage: atask <myarg>
...
```

The first assertion in the test is an exact equality check, so the prepended warning breaks it ([CI run](https://github.com/jdx/mise/actions/runs/25257720207/job/74060047308)).

This migrates the test's `atask` from the deprecated `{{arg(...)}}` Tera form to the `usage` field. Both produce identical help output, and using the non-deprecated form is the future-correct shape anyway.

## Test plan

- [x] `mise run test:e2e tasks/test_task_help` passes locally (all 13 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates an e2e test fixture to avoid deprecated arg templating and resulting warning output that breaks an exact help assertion.
> 
> **Overview**
> Updates the `e2e/tasks/test_task_help` fixture to stop using deprecated Tera `{{arg(...)}}` templating for task args.
> 
> The `atask` definition now declares args via the `usage` field and references the parsed value (`$usage_myarg`) in `run`, keeping `mise run atask --help` output stable and preventing warning-prefixed output from failing the exact-match assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b259f4d3c48b4835237a1417d0872093d7b8f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->