### PR TITLE
registry: add `git-filter-repo`

### DIFF
--- a/registry/git-filter-repo.toml
+++ b/registry/git-filter-repo.toml
@@ -1,0 +1,3 @@
+backends = ["pipx:git-filter-repo"]
+description = "Quickly rewrite git repository history (filter-branch replacement)"
+test = { cmd = "which git-filter-repo", expected = "git-filter-repo" }

--- a/registry/git-filter-repo.toml
+++ b/registry/git-filter-repo.toml
@@ -1,4 +1,3 @@
 backends = ["pipx:git-filter-repo"]
-depends = ["git"]
 description = "Quickly rewrite git repository history (filter-branch replacement)"
-test = { cmd = "git-filter-repo --version", expected = "{{version}}" }
+test = { cmd = "which git-filter-repo", expected = "git-filter-repo" }

--- a/registry/git-filter-repo.toml
+++ b/registry/git-filter-repo.toml
@@ -1,4 +1,4 @@
 backends = ["pipx:git-filter-repo"]
 depends = ["git"]
 description = "Quickly rewrite git repository history (filter-branch replacement)"
-test = { cmd = "which git-filter-repo", expected = "git-filter-repo" }
+test = { cmd = "git-filter-repo --version", expected = "{{version}}" }

--- a/registry/git-filter-repo.toml
+++ b/registry/git-filter-repo.toml
@@ -1,3 +1,4 @@
 backends = ["pipx:git-filter-repo"]
+depends = ["git"]
 description = "Quickly rewrite git repository history (filter-branch replacement)"
 test = { cmd = "which git-filter-repo", expected = "git-filter-repo" }


### PR DESCRIPTION
[`git-filter-repo`](https://github.com/newren/git-filter-repo) is the officially recommended replacement for `git filter-branch`, endorsed by the git project itself. It rewrites git repository history with far better performance and safety than alternatives.