### PR TITLE
fix(install): don't cache nonexistent install paths

### DIFF
--- a/e2e/cli/test_install_system_go_backend_slow
+++ b/e2e/cli/test_install_system_go_backend_slow
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/jdx/mise/discussions/9526
+#
+# When `mise install --system` installs both `go` and a `go:` backend tool
+# in the same invocation, the go-backend install must use the freshly
+# installed go (in the system installs dir), not a stale path that was
+# computed before go installed.
+#
+# The bug: tv.install_path() cached the user-dir path (returned because the
+# system dir didn't exist yet at the time of the first call). Subsequent
+# callers (core go's exec_env -> GOROOT/GOPATH) then exported the stale
+# path, and `go install ...` failed with "cannot find GOROOT directory".
+
+# Block any system-wide go so we can prove the install used the
+# mise-installed go.
+cat >"$HOME/bin/fail" <<'EOF'
+#!/usr/bin/env bash
+echo "CALL TO SYSTEM $(basename $0)! args: $*" >&2
+exit 1
+EOF
+chmod +x "$HOME/bin/fail"
+ln -s fail "$HOME/bin/go"
+export PATH="$HOME/bin:$PATH"
+assert_fail go
+
+export MISE_SYSTEM_DATA_DIR="$HOME/.local/share/mise-system"
+SYSTEM_INSTALLS="$MISE_SYSTEM_DATA_DIR/installs"
+
+cat >>.mise.toml <<EOF
+[tools]
+go = "prefix:1.24"
+"go:github.com/jdx/go-example" = "e16a340"
+[settings]
+experimental = true
+EOF
+
+# Both go and the go-backend tool must install in a single invocation.
+mise install --system --jobs 1
+
+# Verify both ended up in the system installs dir, not the user dir.
+assert_directory_exists "$SYSTEM_INSTALLS/go"
+assert_directory_exists "$SYSTEM_INSTALLS/go-github-com-jdx-go-example/e16a340"
+
+# Required to properly cleanup as go installs read-only sources
+chmod -R +w ~/go 2>/dev/null || true

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -172,7 +172,14 @@ impl ToolVersion {
             env::find_in_shared_installs(path, &self.ba().tool_dir_name(), &pathname)
         };
 
-        INSTALL_PATH_CACHE.insert(self.clone(), path.clone());
+        // Only cache the resolved path if it actually exists on disk. Otherwise
+        // the answer may change once the tool installs into a different
+        // location (e.g. a shared install dir created mid-run by `--system` /
+        // `--shared`), and the stale cache entry would be returned to callers
+        // like core go's `exec_env`, sending wrong values for GOROOT/GOPATH.
+        if path.exists() {
+            INSTALL_PATH_CACHE.insert(self.clone(), path.clone());
+        }
         path
     }
     pub fn runtime_path(&self) -> PathBuf {
@@ -707,6 +714,62 @@ mod tests {
         let runtime_path = tv.runtime_path();
         assert_eq!(runtime_path, install_path);
         assert!(runtime_path.is_dir());
+
+        Ok(())
+    }
+
+    /// Regression test for https://github.com/jdx/mise/discussions/9526
+    ///
+    /// `install_path()` must not cache a path that does not yet exist. If it
+    /// did, a tool that first asked for its install path before the install
+    /// completed would receive that cached path forever — even after the tool
+    /// installed somewhere else (e.g. via `--system` into a shared install
+    /// dir). Subsequent callers like core go's `exec_env` would then export
+    /// the wrong GOROOT/GOPATH, breaking go-backend tools that depend on go.
+    #[test]
+    fn install_path_does_not_cache_nonexistent_paths() -> Result<()> {
+        reset_install_path_cache();
+
+        let temp_dir = tempfile::tempdir()?;
+        let short = format!(
+            "dummy-cache-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let mut backend = BackendArg::new_raw(
+            short.clone(),
+            None,
+            short,
+            None,
+            BackendResolution::new(false),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join("dummy-cache");
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "1.0.0".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "1.0.0".into());
+
+        // First call: nothing exists yet. Should return the primary path but
+        // must NOT populate the cache.
+        let p1 = tv.install_path();
+        assert!(!p1.exists());
+        assert!(INSTALL_PATH_CACHE.get(&tv).is_none());
+
+        // Now "install" the tool by creating the dir.
+        fs::create_dir_all(&p1)?;
+
+        // Second call should still return the same path; this time it exists
+        // so the cache is populated.
+        let p2 = tv.install_path();
+        assert_eq!(p1, p2);
+        assert!(p2.exists());
+        assert!(INSTALL_PATH_CACHE.get(&tv).is_some());
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Fixes https://github.com/jdx/mise/discussions/9526: `mise install --system` failed when installing both `go` and a `go:` backend tool in the same invocation, with `go: cannot find GOROOT directory: $MISE_DATA_DIR/installs/go/<ver>`.
- `ToolVersion::install_path()` now only caches resolved paths that actually exist on disk, so pre-install lookups don't poison the cache with the user-dir fallback.

## Why

During `dependency_env` for the `go:` backend tool, mise resolved go's `install_path` *before* go was installed. At that point `find_in_shared_installs()` couldn't find go anywhere (the `--system` installs dir didn't exist yet) and returned the user-dir path — which `install_path()` then cached. After go installed at the system dir, callers like core go's `exec_env` got the stale user path back from the cache and exported it as `GOROOT`, breaking every go-backend install in the same run.

The cache key is `(backend, version)`, so a freshly-built `ToolVersion` from `dependency_toolset` collided with the earlier (stale) entry. The minimal correct fix is to only cache when the resolved path is real — pre-install lookups recompute on each call (cheap, only matters during install workflows) until the tool actually lands somewhere concrete.

## Test plan

- [x] New unit test `install_path_does_not_cache_nonexistent_paths` (`src/toolset/tool_version.rs`) verifies the cache stays empty for non-existent paths and populates after the dir exists.
- [x] New slow e2e `e2e/cli/test_install_system_go_backend_slow` reproduces the original scenario: `go` + `go:github.com/jdx/go-example` installed together with `--system --jobs 1`, asserts both end up in the system installs dir.
- [x] `cargo test` — all 819 unit tests pass.
- [x] `mise run lint` clean.
- [x] Existing `test_install_system`, `test_install_system_readonly`, `test_shared_install_dirs` still pass.
- [x] Manual reproduction of the discussion's repro now succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `ToolVersion::install_path()` path resolution/caching used broadly during installs, so mistakes could mis-route tool lookups; the change is small and covered by new unit/e2e regression tests.
> 
> **Overview**
> Fixes a regression where `mise install --system/--shared` could cache an install path *before* a tool was actually installed, causing later lookups (notably Go `GOROOT/GOPATH` for `go:` backends) to use a stale user-dir path.
> 
> `ToolVersion::install_path()` now only writes to `INSTALL_PATH_CACHE` when the resolved path exists on disk, and adds a unit test plus a new slow e2e test that installs `go` and a `go:` backend tool in the same `--system` invocation and asserts both land in the system installs dir.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c99fc3f949f9f12dfa6804e1f1d8c535a5dabd59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->