### PR TITLE
registry: add umoci (aqua:opencontainers/umoci)

### DIFF
--- a/registry/umoci.toml
+++ b/registry/umoci.toml
@@ -1,0 +1,4 @@
+backends = ["aqua:opencontainers/umoci"]
+description = "umoci modifies Open Container images"
+os = ["linux"]
+test = { cmd = "umoci --version", expected = "umoci version {{version}}" }


### PR DESCRIPTION
Add `umoci` to mise registry using the aqua backend.