### PR TITLE
registry: add dexter (aqua:remoteoss/dexter)

### DIFF
--- a/registry/dexter.toml
+++ b/registry/dexter.toml
@@ -1,0 +1,4 @@
+backends = ["aqua:remoteoss/dexter", "github:remoteoss/dexter"]
+description = "A fast, full-featured Elixir LSP optimized for large codebases."
+os = ["linux", "macos"]
+test = { cmd = "dexter version", expected = "{{version}}" }


### PR DESCRIPTION
Adds [Dexter](https://github.com/remoteoss/dexter), a language server for Elixir built in Go