### PR TITLE
fix(backend): scope PEP 440 prerelease detection to Python backends

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -24,7 +24,7 @@ use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::path_env::PathEnv;
 use crate::platform::Platform;
 use crate::plugins::core::CORE_PLUGINS;
-use crate::plugins::{PluginType, VERSION_REGEX};
+use crate::plugins::{PEP440_PRERELEASE_REGEX, PluginType, VERSION_REGEX};
 use crate::registry::{REGISTRY, full_to_url, normalize_remote, tool_enabled};
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::tera::get_tera;
@@ -448,6 +448,33 @@ mod tests {
     }
 
     #[test]
+    fn test_fuzzy_match_versions_pep440_drops_alphas_but_honors_exact_match() {
+        let versions = vec![
+            "3.13.0".to_string(),
+            "3.14.0a1".to_string(),
+            "3.14.0".to_string(),
+            "3.15.0a8".to_string(),
+        ];
+        // `latest` resolution skips PEP 440 prereleases.
+        assert_eq!(
+            fuzzy_match_versions_pep440(versions.clone(), "latest", true),
+            vec!["3.13.0".to_string(), "3.14.0".to_string()]
+        );
+        // Explicit prerelease request still resolves — preserves the
+        // exact-match bypass that `fuzzy_match_versions` already provides for
+        // generic prereleases like `1.0.0-rc1`.
+        assert_eq!(
+            fuzzy_match_versions_pep440(versions.clone(), "3.14.0a1", true),
+            vec!["3.14.0a1".to_string()]
+        );
+        // Opting in to prereleases keeps the full list.
+        assert_eq!(
+            fuzzy_match_versions_pep440(versions.clone(), "latest", false),
+            versions
+        );
+    }
+
+    #[test]
     fn test_filter_cached_prereleases_drops_flagged_entries_by_default() {
         // The cache stores the pre-release superset; `prerelease = false` (the
         // default) must filter out entries flagged by the upstream so the user
@@ -518,6 +545,26 @@ mod tests {
             ..Default::default()
         });
         assert!(already_flagged.prerelease);
+
+        // Go pseudo-version (`-DATE-HASH`) must not false-positive on the
+        // `[abc][0-9]+` alternative — that pattern lives in
+        // PEP440_PRERELEASE_REGEX (pipx-only), not the general regex.
+        let go_pseudo = mark_prerelease(VersionInfo {
+            version: "2.0.0-20260404020628-f149714c1d54".into(),
+            ..Default::default()
+        });
+        assert!(
+            !go_pseudo.prerelease,
+            "Go pseudo-version must not be flagged by the general regex"
+        );
+
+        // PEP 440 separator-less alpha is similarly not the general regex's
+        // concern — pipx applies that rule itself.
+        let py_alpha = mark_prerelease(VersionInfo {
+            version: "3.12.0a1".into(),
+            ..Default::default()
+        });
+        assert!(!py_alpha.prerelease);
     }
 
     #[test]
@@ -2455,6 +2502,30 @@ pub(crate) fn include_prereleases(opts: &crate::toolset::ToolVersionOptions) -> 
         toml::Value::String(s) => s.parse::<bool>().unwrap_or(false),
         _ => false,
     })
+}
+
+/// Fuzzy-match `versions` against `query` with PEP 440 prerelease detection
+/// applied on top of the shared filter. Used by Python-flavored backends
+/// (`pipx`, the `python` core plugin) so `3.15.0a8`-style versions are dropped
+/// from `latest` resolution and partial-prefix queries when the user hasn't
+/// opted in to prereleases.
+pub(crate) fn fuzzy_match_versions_pep440(
+    versions: Vec<String>,
+    query: &str,
+    filter_prereleases: bool,
+) -> Vec<String> {
+    let versions = if filter_prereleases {
+        // Mirror the exact-match bypass in `fuzzy_match_versions` so an
+        // explicit prerelease request (`python@3.14.0a1`) still resolves even
+        // when filter_prereleases is on.
+        versions
+            .into_iter()
+            .filter(|v| query == v || !PEP440_PRERELEASE_REGEX.is_match(v))
+            .collect()
+    } else {
+        versions
+    };
+    fuzzy_match_versions(versions, query, filter_prereleases)
 }
 
 /// Fuzzy-match `versions` against `query`. When `filter_prereleases` is true,

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -10,6 +10,7 @@ use crate::file;
 use crate::github::{self, GithubRelease};
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
+use crate::plugins::PEP440_PRERELEASE_REGEX;
 use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset, ToolsetBuilder};
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -56,6 +57,18 @@ impl Backend for PIPXBackend {
         true
     }
 
+    /// PyPI versions follow PEP 440, so the shared filter alone (which only
+    /// knows about `-rc1`/`-dev` separators) would let `3.12.0a1`-style
+    /// versions slip through. See `fuzzy_match_versions_pep440`.
+    fn fuzzy_match_filter(
+        &self,
+        versions: Vec<String>,
+        query: &str,
+        filter_prereleases: bool,
+    ) -> Vec<String> {
+        crate::backend::fuzzy_match_versions_pep440(versions, query, filter_prereleases)
+    }
+
     /// Pipx installs packages from PyPI or Git using version specs (e.g., black==24.3.0).
     /// It doesn't support installing from direct URLs, so lockfile URLs are not applicable.
     fn supports_lockfile_url(&self) -> bool {
@@ -63,7 +76,7 @@ impl Backend for PIPXBackend {
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
-        match self.tool_name().parse()? {
+        let versions: Vec<VersionInfo> = match self.tool_name().parse()? {
             PipxRequest::Pypi(package) => {
                 let registry_url = Self::get_registry_url()?;
                 if registry_url.contains("/json") {
@@ -72,8 +85,7 @@ impl Backend for PIPXBackend {
                     let data: PypiPackage = HTTP_FETCH.json(url).await?;
 
                     // Get versions sorted and attach timestamps from the first file in each release
-                    let versions = data
-                        .releases
+                    data.releases
                         .into_iter()
                         .sorted_by_cached_key(|(v, _)| Versioning::new(v))
                         .map(|(version, files)| {
@@ -89,9 +101,7 @@ impl Backend for PIPXBackend {
                                 ..Default::default()
                             }
                         })
-                        .collect();
-
-                    Ok(versions)
+                        .collect()
                 } else {
                     debug!("Fetching HTML for {}", package);
                     let url = registry_url.replace("{}", &package);
@@ -102,7 +112,7 @@ impl Backend for PIPXBackend {
                         r#"href=["'][^"']*/([^/]+)\.tar\.gz(?:#(md5|sha1|sha224|sha256|sha384|sha512)=[0-9A-Fa-f]+)?["']"#
                     );
 
-                    let versions: Vec<VersionInfo> = version_re
+                    version_re
                         .captures_iter(&html)
                         .filter_map(|cap| {
                             let filename = cap.get(1)?.as_str();
@@ -118,18 +128,29 @@ impl Backend for PIPXBackend {
                             })
                         })
                         .sorted_by_cached_key(|v| Versioning::new(&v.version))
-                        .collect();
-
-                    Ok(versions)
+                        .collect()
                 }
             }
             PipxRequest::Git(url) if url.starts_with("https://github.com/") => {
                 let repo = url.strip_prefix("https://github.com/").unwrap();
                 let data = github::list_releases(repo).await?;
-                Ok(Self::versions_from_github_releases(data))
+                Self::versions_from_github_releases(data)
             }
-            PipxRequest::Git { .. } => Ok(vec![]),
-        }
+            PipxRequest::Git { .. } => vec![],
+        };
+        // PyPI versions follow PEP 440. Stamp the separator-less alpha/beta/rc
+        // suffixes (`3.12.0a1`, `1.0.0c1`) here rather than in the shared
+        // regex so the rule stays scoped to Python — hex commit hashes used
+        // by other ecosystems (e.g. Go pseudo-versions) would false-positive.
+        Ok(versions
+            .into_iter()
+            .map(|mut v| {
+                if !v.prerelease && PEP440_PRERELEASE_REGEX.is_match(&v.version) {
+                    v.prerelease = true;
+                }
+                v
+            })
+            .collect())
     }
 
     async fn latest_stable_version(&self, _config: &Arc<Config>) -> eyre::Result<Option<String>> {

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -708,6 +708,18 @@ impl Backend for PythonPlugin {
         ])
     }
 
+    /// Python versions follow PEP 440, so `3.15.0a8`-style separator-less
+    /// alpha suffixes are pre-releases that the shared filter wouldn't catch
+    /// on its own. See `fuzzy_match_versions_pep440`.
+    fn fuzzy_match_filter(
+        &self,
+        versions: Vec<String>,
+        query: &str,
+        filter_prereleases: bool,
+    ) -> Vec<String> {
+        crate::backend::fuzzy_match_versions_pep440(versions, query, filter_prereleases)
+    }
+
     async fn security_info(&self) -> Vec<crate::backend::SecurityFeature> {
         use crate::backend::SecurityFeature;
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -243,10 +243,25 @@ pub fn warn_if_env_plugin_shadows_registry(name: &str, plugin_path: &Path) {
 
 pub static VERSION_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
     Regex::new(
-        r"(?i)(^Available versions:|-src|[-\\.]dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|-test|-nightly|-canary|-experimental|-insider|-edge|([abc])[0-9]+|snapshot|SNAPSHOT|master)"
+        r"(?i)(^Available versions:|-src|[-\\.]dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|-test|-nightly|-canary|-experimental|-insider|-edge|snapshot|SNAPSHOT|master)"
     )
         .unwrap()
 });
+
+/// PEP 440 separator-less pre-release segment, grounded in the canonical
+/// public version grammar:
+///
+/// > `[N!]N(.N)*[{a|b|rc}N][.postN][.devN]`
+///
+/// The pre-release segment (`{a|b|rc}N`) must follow the release segment, so
+/// the regex requires a leading digit. `c` is included as PEP 440's recognized
+/// alternate spelling for `rc`. The trailing boundary `(?:$|[^a-z0-9])` keeps
+/// it from matching inside hex hashes or other identifiers.
+///
+/// Only consulted by Python-flavored backends (currently `pipx`); other
+/// backends would false-positive on hex hashes like `f149714c1d54`.
+pub static PEP440_PRERELEASE_REGEX: Lazy<regex::Regex> =
+    Lazy::new(|| Regex::new(r"(?i)[0-9](?:a|b|c|rc)[0-9]+(?:$|[^a-z0-9])").unwrap());
 
 pub fn get(short: &str) -> Result<PluginEnum> {
     let (name, full) = short.split_once(':').unwrap_or((short, short));
@@ -553,5 +568,51 @@ mod tests {
         assert!(!VERSION_REGEX.is_match("1.0.0"));
         assert!(!VERSION_REGEX.is_match("2026.3.3"));
         assert!(!VERSION_REGEX.is_match("22.6.0"));
+
+        // PEP 440 separator-less suffixes (`3.12.0a1`, `1.2.3c1`) live in
+        // PEP440_PRERELEASE_REGEX, not the general regex — see that test below.
+        assert!(!VERSION_REGEX.is_match("3.12.0a1"));
+        assert!(!VERSION_REGEX.is_match("1.2.3c1"));
+
+        // Go pseudo-versions and other identifiers with incidental `[abc]\d`
+        // substrings (commit hashes) must not be flagged.
+        assert!(!VERSION_REGEX.is_match("2.0.0-20260404020628-f149714c1d54"));
+    }
+
+    #[test]
+    fn test_pep440_prerelease_regex() {
+        // Canonical PEP 440 pre-release segments: `aN`, `bN`, `rcN`, plus the
+        // recognized `cN` alias for `rcN`.
+        assert!(PEP440_PRERELEASE_REGEX.is_match("3.12.0a1"));
+        assert!(PEP440_PRERELEASE_REGEX.is_match("3.12.0b2"));
+        assert!(PEP440_PRERELEASE_REGEX.is_match("1.2.3c1"));
+        assert!(PEP440_PRERELEASE_REGEX.is_match("1.2.3rc1"));
+        assert!(PEP440_PRERELEASE_REGEX.is_match("1.0.0c1+build"));
+        assert!(PEP440_PRERELEASE_REGEX.is_match("1.0.0a1.dev0"));
+
+        // Stable releases — including `.postN`, which PEP 440 specifies as a
+        // post-release (after a stable), NOT a pre-release.
+        assert!(!PEP440_PRERELEASE_REGEX.is_match("1.0.0"));
+        assert!(!PEP440_PRERELEASE_REGEX.is_match("3.12.0"));
+        assert!(!PEP440_PRERELEASE_REGEX.is_match("1.0.0.post1"));
+
+        // The `{a|b|rc}N` segment must follow the release segment per the
+        // PEP 440 grammar — the leading-digit anchor enforces that. Identifiers
+        // whose hex hashes happen to contain `c1` / `a1` / `b2` substrings
+        // (e.g. Go pseudo-versions) do not match because the `[abc]` is
+        // preceded by a hex letter, not a digit.
+        assert!(
+            !PEP440_PRERELEASE_REGEX.is_match("2.0.0-20260404020628-f149714c1d54"),
+            "Go pseudo-version with `c1` in hash should not match"
+        );
+        assert!(
+            !PEP440_PRERELEASE_REGEX.is_match("1.0.0-20240101000000-a1b2c3d4e5f6"),
+            "Go pseudo-version with `a1`/`b2`/`c3` in hash should not match"
+        );
+
+        // Bare `aN` / `bN` / `cN` not attached to a release segment (uncommon
+        // but possible identifier shapes) is also rejected.
+        assert!(!PEP440_PRERELEASE_REGEX.is_match("a1"));
+        assert!(!PEP440_PRERELEASE_REGEX.is_match("b1234567"));
     }
 }


### PR DESCRIPTION
## Summary

Two regressions visible in the release PR (#9485):
- `mise install go:.../@latest` returns "no versions found" when the latest is a Go pseudo-version (e.g. `go:github.com/go-kratos/kratos/cmd/kratos/v2`) — the e2e-0 / `backend/test_go_install_slow` failure.
- (After narrowing the rule too aggressively in earlier revs of this PR: `mise latest python` returned `3.15.0a8` instead of a stable. Fixed below.)

## Cause

The `([abc])[0-9]+` alternative in the shared `VERSION_REGEX` was unanchored, so it false-positived on any `a`/`b`/`c` followed by a digit anywhere in a string — including the random hex hash inside Go pseudo-versions (e.g. `c1` inside `f149714c1d54`).

#9500 enabled `mark_prereleases_from_version_pattern: true` for the `go` backend on May 1, which is what made it user-visible — the regex was already over-permissive but no Go-flavored input had been feeding it before.

## Fix

The rule is PEP 440-specific (Python's separator-less alpha/beta/rc shorthand). Move it out of the general regex into `PEP440_PRERELEASE_REGEX` and consult it only from Python-flavored backends.

- `VERSION_REGEX` (in `src/plugins/mod.rs`): drop the `([abc])[0-9]+` alternative.
- `PEP440_PRERELEASE_REGEX` (new): `(?i)[0-9](?:a|b|c|rc)[0-9]+(?:\$|[^a-z0-9])` — grounded in PEP 440's canonical grammar `[N!]N(.N)*[{a|b|rc}N][.postN][.devN]`. The leading digit anchors the prerelease segment to follow the release segment (so it can't trigger inside arbitrary identifiers); `c` is included as PEP 440's recognized alternate spelling for `rc`; the trailing boundary stops it from matching inside hex hashes even when those start with a digit.
- `pipx`:
  - Stamps PEP 440 prereleases on `VersionInfo` in `_list_remote_versions` so the cache reflects it.
  - Overrides `fuzzy_match_filter` to drop them from match results.
- `python` core plugin: same `fuzzy_match_filter` override (`python-build` returns `3.15.0a8`-style alphas).
- Both share a new `fuzzy_match_versions_pep440` helper in `src/backend/mod.rs` so the override is one line each.

## Test plan

- [x] `cargo test test_pep440_prerelease_regex` (new) — Python suffixes match, Go pseudo-versions and bare-`b` identifiers don't, `.post` doesn't.
- [x] `cargo test test_version_regex_filters_prerelease` — confirms PEP 440 cases now negative on the general regex.
- [x] `cargo test test_mark_prerelease_flags_regex_matches` — added a Go pseudo-version case and a PEP 440 case (both should *not* be flagged by the general path).
- [x] `cargo test test_fuzzy_match_versions_*`, `test_filter_cached_prereleases_*`, `pipx::tests::*`.
- [x] Local repro: `mise ls-remote 'go:github.com/go-kratos/kratos/cmd/kratos/v2'` returns `2.0.0-20260404020628-f149714c1d54`.
- [x] Local repro: `mise latest python` returns `3.14.4` (was `3.15.0a8` after the earlier rev of this PR).
- [ ] Wait on CI for `e2e-0 / test_go_install_slow` and `e2e-6 / test_latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts prerelease detection and fuzzy version resolution logic, which can change what versions are considered installable/latest across multiple backends; mistakes could hide valid versions or surface prereleases unexpectedly.
> 
> **Overview**
> Fixes prerelease filtering regressions by removing the unanchored `([abc])[0-9]+` clause from the shared `VERSION_REGEX` (which was incorrectly flagging strings like Go pseudo-versions) and introducing a new Python-scoped `PEP440_PRERELEASE_REGEX`.
> 
> Python-flavored backends (`pipx` and the core `python` plugin) now apply PEP 440 prerelease handling explicitly: `pipx` stamps PEP 440 alphas/betas/rcs onto cached `VersionInfo.prerelease`, and both backends override fuzzy matching via a new shared helper `fuzzy_match_versions_pep440` so `latest`/prefix queries skip `3.15.0a8`-style versions unless explicitly requested.
> 
> Adds focused tests to ensure Go pseudo-versions are not filtered by the general regex and that PEP 440 prerelease detection works only where intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287f01d1f4571155879afbbd4192b537abffcfc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->