### PR TITLE
fix(lockfile): don't propagate ad-hoc CLI overrides into the project lockfile

### DIFF
--- a/e2e/cli/test_exec_lockfile
+++ b/e2e/cli/test_exec_lockfile
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# `mise x` should only touch the project lockfile when the install resolves
+# the same version specifier as the config. CLI overrides
+# (`mise x tool@<version>`) carry a different specifier, so pairing the
+# config's request with their installed version would produce a nonsensical
+# lockfile entry.
+
+export MISE_LOCKFILE=1
+
+cat <<EOF >mise.toml
+[tools]
+dummy = "1"
+EOF
+
+mise uninstall dummy --all
+mise install dummy@1.0.0
+touch mise.lock
+mise lock --platform linux-x64
+assert_contains "cat mise.lock" "1.0.0"
+
+# `mise x dummy@2.0.0` resolves to 2.0.0 — an explicit CLI override that
+# doesn't satisfy `dummy = "1"`. Lockfile must stay at 1.0.0.
+mise x dummy@2.0.0 -- dummy
+assert_contains "cat mise.lock" "1.0.0"
+assert_not_contains "cat mise.lock" "2.0.0"
+
+# Same for `mise x dummy@latest` — the latest is 2.0.0, and the lockfile
+# must not adopt it under the `"1"` request.
+mise x dummy@latest -- dummy
+assert_contains "cat mise.lock" "1.0.0"
+assert_not_contains "cat mise.lock" "2.0.0"
+
+# `mise x dummy` (no version) carries the config's `"1"` specifier, so it
+# isn't an override. Verify it still resolves and runs against the locked
+# 1.0.0 (and would be allowed to populate the lockfile entry — exercised by
+# the empty-lockfile case below).
+mise x dummy -- dummy
+assert_contains "cat mise.lock" "1.0.0"
+
+# Env-var overrides (`MISE_<TOOL>_VERSION=...`) are the same class of
+# override as CLI args — they carry a `ToolSource::Environment` and a
+# version specifier that may not match the config's. The version-match
+# check covers them too: with mise.toml `dummy = "1"`, setting
+# `MISE_DUMMY_VERSION=2` must not pair the "1" request with a 2.x install.
+MISE_DUMMY_VERSION=2 mise install
+assert_contains "cat mise.lock" "1.0.0"
+assert_not_contains "cat mise.lock" "2.0.0"
+
+# `mise upgrade` is the supported way to explicitly bump the lockfile and
+# *should* update it (it remaps Argument → MiseToml before update_lockfiles).
+mise upgrade dummy@1.1.0
+assert_contains "cat mise.lock" "1.1.0"
+assert_not_contains "cat mise.lock" "1.0.0"
+
+# `mise x dummy` against an empty (but existing) lockfile must populate the
+# entry — the install satisfies the config's `"1"` request, so propagation
+# is correct.
+mise uninstall dummy --all
+echo "" >mise.lock
+mise x dummy -- dummy
+assert_contains "cat mise.lock" "dummy"
+assert_contains "cat mise.lock" "1.1.0"

--- a/mise.lock
+++ b/mise.lock
@@ -583,12 +583,8 @@ checksum = "sha256:795670a80d35b23e7ecf932ede742609f2267314f2df64054b020698fcc8a
 url = "https://github.com/LuaLS/lua-language-server/releases/download/3.17.1/lua-language-server-3.17.1-win32-x64.zip"
 
 [[tools.node]]
-version = "25.9.0"
+version = "24.15.0"
 backend = "core:node"
-
-[tools.node."platforms.linux-x64"]
-checksum = "sha256:134e55b2408448a219760fe04dc44d6851f9de8a79549021ffd870e9082d9e7b"
-url = "https://nodejs.org/dist/v25.9.0/node-v25.9.0-linux-x64.tar.gz"
 
 [[tools."npm:ajv-cli"]]
 version = "5.0.0"

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -989,6 +989,25 @@ pub fn update_lockfiles(config: &Config, ts: &Toolset, new_versions: &[ToolVersi
                     .ok()
                     .map(|(idx, tv)| (idx, tv.request.clone()))
                 {
+                    // Only propagate when the new install resolves the same
+                    // version specifier as the config. `mise x node` (no
+                    // version) is rewritten by `with_default_to_latest` to
+                    // carry the config's version string, so it matches and
+                    // updates the lockfile as expected. `mise x node@latest`
+                    // with mise.toml `node = "24"` carries a "latest"
+                    // specifier that doesn't match — that's an ad-hoc CLI
+                    // override and pairing the "24" request with a 25.x
+                    // install would produce a nonsensical lockfile entry.
+                    if new_version.request.version() != request.version() {
+                        trace!(
+                            "skipping lockfile update for {}@{} in {}: CLI override does not match config request {}",
+                            new_version.short(),
+                            new_version.version,
+                            display_path(&lockfile_path),
+                            request.version(),
+                        );
+                        continue;
+                    }
                     let mut new_version = new_version.clone();
                     new_version.request = request;
                     versions.remove(idx);


### PR DESCRIPTION
## Summary

`mise x node@latest -- ...` (and `mise run`-spawned `mise x` calls) is an ephemeral CLI override. With `MISE_LOCKFILE=1`, that install was being merged into the project's `mise.lock` *under the config's existing request* — e.g. `mise.toml` `node = "24"` paired with a freshly-installed `25.9.0`. The lockfile entry then claimed the `"24"` request resolved to a 25.x version, which is nonsensical and breaks subsequent resolutions.

## Why this matters

This is what was producing the recurring `[autofix.ci] apply automated fixes` commit on every `release-plz` PR (e.g. [PR #9485 / ea7affd8eb3f46374a9451550e7b08f1bbcf6e07](https://github.com/jdx/mise/pull/9485/commits/ea7affd8eb3f46374a9451550e7b08f1bbcf6e07): node 24.15.0 → 25.9.0, platforms 11 → 1). `mise run render` calls `mise x node@latest -- npx markdown-magic`; on the autofix runner with `MISE_LOCKFILE=1` set, that install bumped `mise.lock`'s node entry every release cycle. If autofix is ever blocked or fails on the release branch, the release would ship with a stale/wrong lockfile.

## Root cause

`update_lockfiles`'s else-if branch (added in #9442 to support `mise upgrade` propagating to the lockfile) overwrites a config tool's lockfile entry with any newly installed `ToolSource::Argument` version that shares the short name. But `upgrade.rs` already remaps `Argument` → `MiseToml(...)` *before* calling `update_lockfiles` (`src/cli/upgrade.rs:383-396`), so its tools go through the path-source `if` branch. The else-if branch only fires for tools that *kept* `ToolSource::Argument` — exactly the ad-hoc CLI overrides that shouldn't be persisted.

## Fix

Compare the new install's request specifier to the config's. Only propagate if they match.

- ✅ `mise x node` (no version) — `with_default_to_latest` rewrites the request to carry the config's version string, so the specifiers match and a legitimate fuzzy refresh still populates `mise.lock` (e.g. against an empty lockfile)
- ✅ `mise x node@24` when `mise.toml` says `node = "24"` — same specifier, propagates
- ❌ `mise x node@latest` when `mise.toml` says `node = "24"` — `"latest" != "24"`, skipped
- ❌ `mise x node@25` when `mise.toml` says `node = "24"` — `"25" != "24"`, skipped
- ✅ `mise upgrade` keeps working — its remap → `MiseToml` hits the if-branch, never the else-if
- ✅ `mise install` (no args) keeps working — sources are `MiseToml`
- ✅ `mise install <tool>` for a configured tool keeps working — `get_requested_tool_versions` (`src/cli/install.rs:264-298`) pulls the config's request when no version is given, so the source is `MiseToml`

## Test plan

- New e2e: `e2e/cli/test_exec_lockfile` — covers both directions:
  - `mise x dummy@2.0.0` and `mise x dummy@latest` must NOT mutate `mise.lock` when `mise.toml` says `dummy = "1"`
  - `mise x dummy` (no version) MUST populate an empty lockfile from the config-derived install
  - `mise upgrade dummy@1.1.0` MUST update the lockfile (regression check)
- `mise run test:e2e e2e/cli/test_upgrade e2e/cli/test_upgrade_latest_stale` — green (regression check for #9442)
- `mise run test:e2e e2e/cli/test_lock e2e/cli/test_lock_global e2e/cli/test_lock_latest e2e/cli/test_lock_creation e2e/cli/test_lock_local_config e2e/cli/test_lock_version e2e/cli/test_exec_latest` — green
- `cargo test --all-features lockfile` — 29 lockfile unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `update_lockfiles` behavior so some installs triggered by `mise x`/env overrides will no longer update `mise.lock`; this could affect workflows that relied on the previous (incorrect) propagation but is guarded by an e2e regression test.
> 
> **Overview**
> Prevents `mise.lock` from being updated by *ad-hoc version overrides* (e.g. `mise x tool@latest` or `MISE_<TOOL>_VERSION=...`) when the override’s version specifier doesn’t match the project config’s requested specifier.
> 
> `update_lockfiles` now compares the new install’s request string against the config-derived request before propagating into the lockfile, skipping mismatches and logging a trace message. Adds an e2e test (`e2e/cli/test_exec_lockfile`) covering override non-propagation, expected propagation for `mise x tool` without a version, and `mise upgrade` still updating the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7233a684a4f373304d6cd56fbbf3671a2e3523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->