### PR TITLE
test(e2e): run test-tool targets in parallel

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -164,6 +164,13 @@ jobs:
       - uses: ./.github/actions/mise-tools
       - name: Pull e2e Docker image
         run: docker pull ghcr.io/jdx/mise:e2e
+      - name: Set test-tool jobs
+        run: |
+          jobs="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+          if ! [[ $jobs =~ ^[0-9]+$ ]] || [ "$jobs" -lt 1 ]; then
+            jobs=4
+          fi
+          echo "TEST_TOOL_JOBS=$jobs" >> "$GITHUB_ENV"
       - id: test-tools
         env:
           TEST_TRANCHE: ${{ matrix.tranche }}
@@ -189,7 +196,7 @@ jobs:
             -e MISE_USE_VERSIONS_HOST_TRACK=0 \
             -e RUST_BACKTRACE=1 \
             ghcr.io/jdx/mise:e2e \
-            mise test-tool ${{ needs.list-changed-tools.outputs.tools == '' && '--all' || needs.list-changed-tools.outputs.tools }}
+            mise test-tool --jobs "$TEST_TOOL_JOBS" ${{ needs.list-changed-tools.outputs.tools == '' && '--all' || needs.list-changed-tools.outputs.tools }}
           test_tool_status=$?
           set -e
 
@@ -226,7 +233,7 @@ jobs:
             -e MISE_USE_VERSIONS_HOST_TRACK=0 \
             -e RUST_BACKTRACE=1 \
             ghcr.io/jdx/mise:e2e \
-            mise test-tool ${{ steps.test-tools.outputs.failed_tools }}
+            mise test-tool --jobs "$TEST_TOOL_JOBS" ${{ steps.test-tools.outputs.failed_tools }}
           test_tool_status=$?
           set -e
 

--- a/docs/cli/test-tool.md
+++ b/docs/cli/test-tool.md
@@ -20,7 +20,7 @@ Test every tool specified in registry/
 
 ### `-j --jobs <JOBS>`
 
-Number of jobs to run in parallel
+Number of tool tests to run in parallel
 [default: 4]
 
 ### `--all-config`

--- a/e2e/cli/test_test_tool_parallel
+++ b/e2e/cli/test_test_tool_parallel
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+summary="$TMPDIR/test-tool-summary.md"
+GITHUB_STEP_SUMMARY="$summary" mise test-tool --jobs=2 shellcheck shfmt
+
+cat "$summary"
+
+failed_count=$(grep -c "Failed Tools" "$summary" || true)
+[ "$failed_count" = 0 ]
+
+grep -c '^| Tool | Duration | Status |$' "$summary" | grep '^1$'
+grep -c '^| shellcheck |' "$summary" | grep '^1$'
+grep -c '^| shfmt |' "$summary" | grep '^1$'

--- a/e2e/cli/test_test_tool_parallel
+++ b/e2e/cli/test_test_tool_parallel
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-summary="$TMPDIR/test-tool-summary.md"
+summary="${TMPDIR:-/tmp}/test-tool-summary.md"
 GITHUB_STEP_SUMMARY="$summary" mise test-tool --jobs=2 shellcheck shfmt
 
 cat "$summary"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3025,7 +3025,7 @@ Test a tool installs and executes
 Test every tool specified in registry/
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
-Number of jobs to run in parallel
+Number of tool tests to run in parallel
 [default: 4]
 .TP
 \fB\-\-all\-config\fR

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1244,7 +1244,7 @@ cmd tasks help="Manage tasks" {
 cmd test-tool help="Test a tool installs and executes" {
     after_long_help "Examples:\n\n    $ mise test-tool ripgrep\n"
     flag "-a --all" help="Test every tool specified in registry/"
-    flag "-j --jobs" help="Number of jobs to run in parallel\n[default: 4]" {
+    flag "-j --jobs" help="Number of tool tests to run in parallel\n[default: 4]" {
         arg <JOBS>
     }
     flag --all-config help="Test all tools specified in config files"

--- a/src/cli/test_tool.rs
+++ b/src/cli/test_tool.rs
@@ -1,4 +1,5 @@
 use crate::cli::args::ToolArg;
+use crate::cmd::cmd;
 use crate::config::Config;
 use crate::file::display_path;
 use crate::registry::{REGISTRY, RegistryTool};
@@ -9,9 +10,11 @@ use crate::{dirs, env, file};
 use eyre::{Result, bail, eyre};
 use std::path::{Path, PathBuf};
 use std::{collections::BTreeSet, sync::Arc};
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
 
 /// Test a tool installs and executes
-#[derive(Debug, clap::Args)]
+#[derive(Debug, Clone, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct TestTool {
     /// Tool(s) to test
@@ -52,37 +55,61 @@ impl TestTool {
         let mut config = Config::get().await?;
 
         let target_tools = self.get_target_tools(&config).await?;
+        let mut targets = vec![];
         for (i, (tool, rt)) in target_tools.into_iter().enumerate() {
             if *env::TEST_TRANCHE_COUNT > 0 && (i % *env::TEST_TRANCHE_COUNT) != *env::TEST_TRANCHE
             {
                 continue;
             }
             let (cmd, expected) = if let Some(test) = &rt.test {
-                (test.0.to_string(), test.1)
+                (test.0.to_string(), test.1.to_string())
             } else if self.include_non_defined {
-                (format!("{} --version", tool.short), "__TODO__")
+                (format!("{} --version", tool.short), "__TODO__".to_string())
             } else {
                 continue;
             };
-            let start = std::time::Instant::now();
-            match self.test(&mut config, &tool, &cmd, expected).await {
-                Ok(_) => {
-                    info!("{}: OK", tool.short);
-                    self.github_summary(vec![
-                        tool.short.clone(),
-                        time::format_duration(start.elapsed()).to_string(),
-                        ":white_check_mark:".to_string(),
-                    ])?;
+            targets.push(TestToolTarget {
+                index: targets.len(),
+                tool,
+                cmd,
+                expected,
+            });
+        }
+
+        if self.run_in_process(targets.len()) {
+            let mut cleaned_any = false;
+            for target in &targets {
+                cleaned_any |= self.clean(&target.tool)?;
+            }
+            if cleaned_any {
+                config = Config::reset().await?;
+            }
+        }
+
+        let results = self.test_targets(config, targets).await?;
+        for result in results {
+            if !result.output.is_empty() {
+                miseprintln!("{}", result.output);
+            }
+            if let Some(err) = result.error {
+                if !result.status_logged {
+                    error!("{}: {}", result.tool, err);
                 }
-                Err(err) => {
-                    error!("{}: {:?}", tool.short, err);
-                    errored.push(tool.short.clone());
-                    self.github_summary(vec![
-                        tool.short.clone(),
-                        time::format_duration(start.elapsed()).to_string(),
-                        ":x:".to_string(),
-                    ])?;
+                errored.push(result.tool.clone());
+                self.github_summary(vec![
+                    result.tool,
+                    time::format_duration(result.duration).to_string(),
+                    ":x:".to_string(),
+                ])?;
+            } else {
+                if !result.status_logged {
+                    info!("{}: OK", result.tool);
                 }
+                self.github_summary(vec![
+                    result.tool,
+                    time::format_duration(result.duration).to_string(),
+                    ":white_check_mark:".to_string(),
+                ])?;
             };
         }
         if let Ok(github_summary) = env::var("GITHUB_STEP_SUMMARY") {
@@ -96,6 +123,101 @@ impl TestTool {
             bail!("tools failed: {}", errored.join(", "));
         }
         Ok(())
+    }
+
+    async fn test_targets(
+        &self,
+        config: Arc<Config>,
+        targets: Vec<TestToolTarget>,
+    ) -> Result<Vec<TestToolResult>> {
+        if self.run_in_process(targets.len()) {
+            let mut results = vec![];
+            for target in targets {
+                let tool = target.tool.short.clone();
+                let start = std::time::Instant::now();
+                let result = match self
+                    .test(&config, &target.tool, &target.cmd, &target.expected)
+                    .await
+                {
+                    Ok(output) => TestToolResult {
+                        index: target.index,
+                        tool,
+                        duration: start.elapsed(),
+                        output,
+                        error: None,
+                        status_logged: false,
+                    },
+                    Err(err) => TestToolResult {
+                        index: target.index,
+                        tool,
+                        duration: start.elapsed(),
+                        output: String::new(),
+                        error: Some(format!("{err:?}")),
+                        status_logged: false,
+                    },
+                };
+                results.push(result);
+            }
+            return Ok(results);
+        }
+
+        let jobs = self.jobs();
+        let semaphore = Arc::new(Semaphore::new(jobs));
+        let mut jset = JoinSet::new();
+        let mut results = targets.iter().map(|_| None).collect::<Vec<_>>();
+
+        for target in targets {
+            let permit = semaphore.clone().acquire_owned().await?;
+            let this = self.clone();
+            jset.spawn(async move {
+                let _permit = permit;
+                this.test_child(target)
+            });
+        }
+
+        while let Some(result) = jset.join_next().await {
+            let result = result??;
+            let index = result.index;
+            results[index] = Some(result);
+        }
+
+        Ok(results.into_iter().flatten().collect())
+    }
+
+    fn test_child(&self, target: TestToolTarget) -> Result<TestToolResult> {
+        let start = std::time::Instant::now();
+        let exe = std::env::current_exe()?;
+        let mut args = vec![
+            "test-tool".to_string(),
+            "--jobs=1".to_string(),
+            target.tool.to_string(),
+        ];
+        if self.include_non_defined {
+            args.insert(1, "--include-non-defined".to_string());
+        }
+
+        let res = cmd(exe, args)
+            .env_remove("GITHUB_STEP_SUMMARY")
+            .env_remove("TEST_TRANCHE")
+            .env_remove("TEST_TRANCHE_COUNT")
+            .stderr_to_stdout()
+            .stdout_capture()
+            .unchecked()
+            .run()?;
+        let output = String::from_utf8(res.stdout)?.trim_end().to_string();
+        let error = match res.status.code() {
+            Some(0) => None,
+            Some(code) => Some(format!("command failed: exit code {code}")),
+            None => Some("command failed: terminated by signal".to_string()),
+        };
+        Ok(TestToolResult {
+            index: target.index,
+            tool: target.tool.short,
+            duration: start.elapsed(),
+            output,
+            error,
+            status_logged: true,
+        })
     }
 
     async fn get_target_tools(
@@ -148,13 +270,19 @@ impl TestTool {
         Ok(())
     }
 
-    async fn test(
-        &self,
-        config: &mut Arc<Config>,
-        tool: &ToolArg,
-        cmd: &str,
-        expected: &str,
-    ) -> Result<()> {
+    fn jobs(&self) -> usize {
+        if self.raw {
+            1
+        } else {
+            self.jobs.unwrap_or(4).max(1)
+        }
+    }
+
+    fn run_in_process(&self, target_count: usize) -> bool {
+        self.jobs() == 1 || target_count <= 1
+    }
+
+    fn clean(&self, tool: &ToolArg) -> Result<bool> {
         // First, clean all backend data by removing directories
         let pr = crate::ui::multi_progress_report::MultiProgressReport::get()
             .add(&format!("cleaning {}", tool.short));
@@ -189,12 +317,17 @@ impl TestTool {
         }
 
         pr.finish();
+        Ok(cleaned_any)
+    }
 
-        // Reset the config to clear in-memory backend metadata caches if we cleaned anything
-        if cleaned_any {
-            *config = Config::reset().await?;
-        }
-
+    async fn test(
+        &self,
+        config: &Arc<Config>,
+        tool: &ToolArg,
+        cmd: &str,
+        expected: &str,
+    ) -> Result<String> {
+        let mut config = config.clone();
         let mut args = vec![tool.clone()];
         args.extend(
             tool.ba
@@ -207,7 +340,7 @@ impl TestTool {
         let mut ts = ToolsetBuilder::new()
             .with_args(&args)
             .with_default_to_latest(true)
-            .build(config)
+            .build(&config)
             .await?;
         let opts = InstallOptions {
             missing_args_only: false,
@@ -215,7 +348,7 @@ impl TestTool {
             raw: self.raw,
             ..Default::default()
         };
-        let (_, missing) = ts.install_missing_versions(config, &opts).await?;
+        let (_, missing) = ts.install_missing_versions(&mut config, &opts).await?;
         ts.notify_missing_versions(missing);
         let tv = if let Some(tv) = ts
             .versions
@@ -225,14 +358,14 @@ impl TestTool {
             tv.clone()
         } else {
             warn!("no versions found for {tool}");
-            return Ok(());
+            return Ok(String::new());
         };
         let backend = tv.backend()?;
-        let env = ts.env_with_path(config).await?;
+        let env = ts.env_with_path(&config).await?;
         let mut which_parts = cmd.split_whitespace().collect::<Vec<_>>();
         let cmd = which_parts.remove(0);
         let mut which_cmd = backend
-            .which(config, &tv, cmd)
+            .which(&config, &tv, cmd)
             .await?
             .unwrap_or(PathBuf::from(cmd));
         if cfg!(windows) && which_cmd == Path::new("which") {
@@ -262,7 +395,7 @@ impl TestTool {
                             info!("command output:\n{stdout}");
                         }
                     }
-                    let bin_dirs = backend.list_bin_paths(config, &tv).await?;
+                    let bin_dirs = backend.list_bin_paths(&config, &tv).await?;
                     for bin_dir in &bin_dirs {
                         let bins = file::ls(bin_dir)?
                             .into_iter()
@@ -285,15 +418,30 @@ impl TestTool {
         let mut tera = get_tera(dirs::CWD.as_ref().map(|d| d.as_path()));
         let expected = tera.render_str(expected, &ctx)?;
         let stdout = String::from_utf8(res.stdout)?;
-        miseprintln!("{}", stdout.trim_end());
         let clean_stdout = console::strip_ansi_codes(&stdout);
         if !clean_stdout.contains(&expected) {
             return Err(eyre!(
                 "expected output not found: {expected}, got: {clean_stdout}"
             ));
         }
-        Ok(())
+        Ok(stdout.trim_end().to_string())
     }
+}
+
+struct TestToolTarget {
+    index: usize,
+    tool: ToolArg,
+    cmd: String,
+    expected: String,
+}
+
+struct TestToolResult {
+    index: usize,
+    tool: String,
+    duration: std::time::Duration,
+    output: String,
+    error: Option<String>,
+    status_logged: bool,
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/cli/test_tool.rs
+++ b/src/cli/test_tool.rs
@@ -10,7 +10,6 @@ use crate::{dirs, env, file};
 use eyre::{Result, bail, eyre};
 use std::path::{Path, PathBuf};
 use std::{collections::BTreeSet, sync::Arc};
-use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
 /// Test a tool installs and executes
@@ -23,9 +22,9 @@ pub struct TestTool {
     /// Test every tool specified in registry/
     #[clap(long, short, conflicts_with = "tools", conflicts_with = "all_config")]
     pub all: bool,
-    /// Number of jobs to run in parallel
+    /// Number of tool tests to run in parallel
     /// [default: 4]
-    #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
+    #[clap(long, short, env = "MISE_TEST_TOOL_JOBS", verbatim_doc_comment)]
     pub jobs: Option<usize>,
     /// Test all tools specified in config files
     #[clap(long, conflicts_with = "tools", conflicts_with = "all")]
@@ -162,26 +161,38 @@ impl TestTool {
         }
 
         let jobs = self.jobs();
-        let semaphore = Arc::new(Semaphore::new(jobs));
         let mut jset = JoinSet::new();
         let mut results = targets.iter().map(|_| None).collect::<Vec<_>>();
 
         for target in targets {
-            let permit = semaphore.clone().acquire_owned().await?;
+            while jset.len() >= jobs {
+                Self::collect_child_result(&mut jset, &mut results).await?;
+            }
             let this = self.clone();
             jset.spawn(async move {
-                let _permit = permit;
-                this.test_child(target)
+                tokio::task::spawn_blocking(move || this.test_child(target))
+                    .await
+                    .map_err(|err| eyre!("task panicked: {err}"))?
             });
         }
 
-        while let Some(result) = jset.join_next().await {
+        while !jset.is_empty() {
+            Self::collect_child_result(&mut jset, &mut results).await?;
+        }
+
+        Ok(results.into_iter().flatten().collect())
+    }
+
+    async fn collect_child_result(
+        jset: &mut JoinSet<Result<TestToolResult>>,
+        results: &mut [Option<TestToolResult>],
+    ) -> Result<()> {
+        if let Some(result) = jset.join_next().await {
             let result = result??;
             let index = result.index;
             results[index] = Some(result);
         }
-
-        Ok(results.into_iter().flatten().collect())
+        Ok(())
     }
 
     fn test_child(&self, target: TestToolTarget) -> Result<TestToolResult> {

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -3664,7 +3664,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: ["-j", "--jobs"],
-          description: "Number of jobs to run in parallel\n[default: 4]",
+          description: "Number of tool tests to run in parallel\n[default: 4]",
           isRepeatable: false,
           args: {
             name: "jobs",


### PR DESCRIPTION
## Summary
- Run multi-target `mise test-tool` invocations through a bounded child-process pool using `--jobs`.
- Wire registry CI to compute `TEST_TOOL_JOBS` from the runner processor count and pass it to `mise test-tool --jobs` for both initial runs and retries.
- Use dedicated `MISE_TEST_TOOL_JOBS` env control for test-tool parallelism instead of sharing broad `MISE_JOBS` behavior.
- Keep single-target and `--jobs=1`/`--raw` runs in-process so existing behavior and raw output stay simple.
- Remove `GITHUB_STEP_SUMMARY` and tranche env from child runs so the parent emits one ordered summary.
- Add e2e coverage for parallel `test-tool` summary output.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo build --all-features`
- `actionlint .github/workflows/registry.yml`
- `e2e/run_test cli/test_test_tool_clean`
- `e2e/run_test cli/test_test_tool_parallel`
- `bash -n e2e/cli/test_test_tool_parallel`
- `shellcheck -x e2e/cli/test_test_tool_parallel`
- `git diff --check`
- `target/debug/mise test-tool amazon-ecr-credential-helper`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces concurrent execution via child processes and changes CI invocation, which can surface new flakiness/race conditions or different logging/summary behavior, but is confined to tooling/test paths.
> 
> **Overview**
> Enables **parallel `mise test-tool` execution** for multi-target runs by spawning a bounded pool of child `mise test-tool --jobs=1` processes and collecting results in-order for a single GitHub summary.
> 
> Updates registry CI (`.github/workflows/registry.yml`) to compute `TEST_TOOL_JOBS` from runner CPU count and pass it to both the initial and retry `mise test-tool` runs.
> 
> Adds an e2e test (`e2e/cli/test_test_tool_parallel`) validating that parallel runs still emit a single well-formed summary table with entries for each tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc4004141a695b0782e2fea98377c5a092b6ebe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->