### PR TITLE
registry: deny inline backend options

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -81,7 +81,7 @@ fi
     }
     ["schema"] {
         glob = List("schema/**/*.json")
-        check = "ajv compile -s schema/mise.json --spec=draft2019 --strict-schema=true && ajv compile -s schema/mise-task.json --spec=draft2019 --strict-schema=true && ajv compile -s schema/mise.plugin.json --spec=draft2020 --strict-schema=true"
+        check = "ajv compile -s schema/mise.json --spec=draft2019 --strict-schema=true && ajv compile -s schema/mise-task.json --spec=draft2019 --strict-schema=true && ajv compile -s schema/mise.plugin.json --spec=draft2020 --strict-schema=true && ajv compile -s schema/mise-registry-tool.json --spec=draft7 --strict-schema=true"
     }
 }
 

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -4,6 +4,12 @@
   "title": "mise registry tool schema",
   "description": "Schema for individual tool files in the mise registry",
   "type": "object",
+  "definitions": {
+    "backendFull": {
+      "type": "string",
+      "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|gem|github|gitlab|go|http|npm|pipx|spm|ubi|vfox):([^\\[\\]]|\\[[^\\]=]*\\])+$"
+    }
+  },
   "properties": {
     "aliases": {
       "type": "array",
@@ -18,16 +24,14 @@
       "items": {
         "oneOf": [
           {
-            "type": "string",
-            "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|gem|github|gitlab|go|http|npm|pipx|spm|ubi|vfox):.+$",
+            "$ref": "#/definitions/backendFull",
             "description": "Backend specification as a string (e.g., 'aqua:owner/repo')"
           },
           {
             "type": "object",
             "properties": {
               "full": {
-                "type": "string",
-                "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|gem|github|gitlab|go|http|npm|pipx|spm|ubi|vfox):.+$",
+                "$ref": "#/definitions/backendFull",
                 "description": "Full backend specification"
               },
               "platforms": {


### PR DESCRIPTION
## Summary
- reject inline `[key=value]` backend options in registry tool schema
- reuse a single `backendFull` schema definition for string and object-form backends
- keep hk coverage through Taplo registry validation and AJV schema self-validation

## Validation
- `hk check --all --step taplo --glob 'registry/*.toml'`\n- `hk check --step pkl hk.pkl`\n- `hk check --step schema schema/mise-registry-tool.json`\n- `taplo` stdin spot checks for rejecting inline options and accepting `options` table form\n\nNote: `cargo fmt --all -- --check` currently fails on unrelated local edits in `src/toolset/tool_deps.rs`, outside this PR diff.\n\n*This PR was generated by an AI coding assistant.*