### PR TITLE
docs: Change exec command to use bash for variable echo

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -45,7 +45,7 @@ Environment variables are available when using [`mise x|exec`](/cli/exec.html), 
 
 ```shell
 mise set MY_VAR=123
-mise exec -- echo $MY_VAR
+mise exec -- bash -c 'echo $MY_VAR'
 # 123
 ```
 


### PR DESCRIPTION
https://mise.jdx.dev/environments/

bash parses `$MY_VAR` before mise exec.
This document does not work.

```bash
mise set MY_VAR=123
mise exec -- echo $MY_VAR
# 123
```