### PR TITLE
chore(ci): use !cancelled() instead of always() for test-ci aggregator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,7 +248,9 @@ jobs:
       - e2e
       - windows-unit
       - windows-e2e
-    if: always()
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
     steps:
       - name: Check CI job results
         run: |


### PR DESCRIPTION
## Summary
- Combined with the workflow's `cancel-in-progress` group (active on PRs), `if: always()` overrides cancellation and runs the `test-ci` aggregator even on superseded commits.
- `!cancelled()` still runs on upstream success or failure but skips when the workflow is cancelled — saves a runner and avoids confusing error annotations on already-superseded shas.
- Same pattern as the `registry-ci` fix in #7435; this one was missed.
- Found while applying the same fix across sibling repos after Cursor Bugbot flagged it on endevco/pitchfork#413.

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only a GitHub Actions job condition to avoid running the `test-ci` aggregator when a workflow is cancelled, without affecting build/test logic.
> 
> **Overview**
> Updates the `test-ci` aggregator job in `.github/workflows/test.yml` to use `if: ${{ !cancelled() }}` instead of `always()`, so it still runs after upstream success/failure but is skipped when the workflow is cancelled (avoiding wasted runners and noisy failures on superseded runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f58b6b8fb81ebbd71f264c01a0b83ce7e0fa02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->