### PR TITLE
test(e2e): bind-mount /tmp on disk and surface failed tests in CI summary

### DIFF
--- a/e2e/run_all_tests
+++ b/e2e/run_all_tests
@@ -118,6 +118,7 @@ LOG_FILES=()
 SUMMARY_FILES=()
 STATUS_FILES=()
 FINISHED=()
+FAILED_TESTS=()
 ORIGINAL_GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-}"
 
 LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mise-e2e-logs.XXXXXX")"
@@ -197,6 +198,7 @@ while [[ $completed -lt $total ]]; do
     test_status="${test_status:-1}"
     if [[ $test_status != 0 ]]; then
       status=1
+      FAILED_TESTS+=("${RUN_FILES[$printed]}")
     fi
     test_count=$((test_count + 1))
     printed=$((printed + 1))
@@ -227,5 +229,29 @@ if ((${#SUMMARY_ENTRY_TYPES[@]} > 0)); then
 fi
 
 echo "E2E: ran $test_count tests, skipped $skipped_count tests" >&2
+
+if ((${#FAILED_TESTS[@]} > 0)); then
+  echo >&2
+  echo "Failed e2e tests (${#FAILED_TESTS[@]}):" >&2
+  for failed in "${FAILED_TESTS[@]}"; do
+    echo "  - $failed" >&2
+  done
+  if [[ -n ${GITHUB_ACTIONS:-} ]]; then
+    failed_joined="$(
+      IFS=,
+      echo "${FAILED_TESTS[*]}"
+    )"
+    echo "::error title=E2E failures (${#FAILED_TESTS[@]})::${failed_joined}" >&2
+    if [[ -n $ORIGINAL_GITHUB_STEP_SUMMARY ]]; then
+      {
+        echo
+        echo "### :x: Failed e2e tests (${#FAILED_TESTS[@]})"
+        for failed in "${FAILED_TESTS[@]}"; do
+          echo "- \`$failed\`"
+        done
+      } >>"$ORIGINAL_GITHUB_STEP_SUMMARY"
+    fi
+  fi
+fi
 
 exit "$status"

--- a/e2e/run_test
+++ b/e2e/run_test
@@ -187,11 +187,21 @@ run_in_docker() {
     return 1
   fi
 
+  # Bind-mount disk-backed host dirs for /tmp and /root instead of using
+  # `--tmpfs` (which is RAM-backed and capped at ~half of RAM). Multi-GB tool
+  # installs (e.g. swift) do not fit in tmpfs and fail with ENOSPC. On
+  # namespace/GHA runners RUNNER_TEMP lives on the workspace disk.
+  local host_tmp_root="${MISE_E2E_HOST_TMP:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}}"
+  local host_tmp host_root
+  host_tmp="$(mktemp -d "$host_tmp_root/mise-e2e-tmp.XXXXXX")"
+  host_root="$(mktemp -d "$host_tmp_root/mise-e2e-root.XXXXXX")"
+  chmod 777 "$host_tmp" "$host_root"
+
   local docker_args=(
     docker run --rm
     --read-only
-    --tmpfs /root:exec
-    --tmpfs /tmp:exec
+    -v "$host_root:/root"
+    -v "$host_tmp:/tmp"
     -v "$ROOT:/mise-src:ro"
     -v "$mise_bin:/usr/local/lib/mise/debug/mise:ro"
     -e ROOT=/mise-src
@@ -206,7 +216,10 @@ run_in_docker() {
     -e CARGO_TARGET_DIR=/usr/local/lib/mise
   )
 
-  "${docker_args[@]}" "$image" bash /mise-src/e2e/run_test "$TEST"
+  local rc=0
+  "${docker_args[@]}" "$image" bash /mise-src/e2e/run_test "$TEST" || rc=$?
+  rm -rf "$host_tmp" "$host_root"
+  return "$rc"
 }
 
 if [[ ${MISE_E2E_DOCKER:-0} == 1 ]]; then


### PR DESCRIPTION
## Summary
- **Fixes Swift e2e ENOSPC failure.** `e2e/run_test`'s Docker invocation mounted the container's `/tmp` and `/root` via `--tmpfs`, which is RAM-backed and capped at ~half of RAM. Multi-GB tool extractions (e.g. swift) blew past that limit (`No space left on device (os error 28)`). Replaced with disk-backed bind mounts under `RUNNER_TEMP`, mirroring the pattern already used in `.github/workflows/registry.yml`.
- **Surfaces failed e2e tests in the GitHub Actions UI.** With parallel e2e ([#9563](https://github.com/jdx/mise/pull/9563)), per-test `::group::` blocks are still replayed in order but the runner emitted no aggregate failure list, making it tedious to find which test failed in the GitHub Actions log. `e2e/run_all_tests` now tracks failed tests during the in-order replay and emits:
  - a stderr block at the bottom listing every failed test
  - an `::error title=E2E failures (N)::test1,test2,...` annotation that surfaces in the workflow's annotations panel
  - a `### :x: Failed e2e tests (N)` section in the GHA step summary

## Test plan
- [x] `bash -n` and `shellcheck -x` clean on `e2e/run_test` and `e2e/run_all_tests`
- [x] `mise run lint-fix` clean
- [x] Smoke test of the failure-summary tail (verified stderr, `::error::` line, and step-summary content shape)
- [ ] Confirm the e2e tranche that previously OOMed on swift now passes
- [ ] Confirm a deliberately-failing test surfaces in the annotations panel and step summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how e2e tests run in Docker (/tmp and /root mounts) and alters CI reporting; failures could show up as new CI flakiness or permission/cleanup issues rather than product behavior.
> 
> **Overview**
> Improves e2e CI ergonomics and reliability.
> 
> `e2e/run_test` replaces Docker `--tmpfs` usage for `/tmp` and `/root` with disk-backed bind mounts (created under `${MISE_E2E_HOST_TMP:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}}`) to avoid ENOSPC on large tool installs, and ensures those temp dirs are cleaned up while preserving the container exit code.
> 
> `e2e/run_all_tests` now tracks which parallel tests failed and, at the end of the run, emits an aggregated failure list to stderr and (on GitHub Actions) a `::error` annotation plus a “Failed e2e tests” section appended to the step summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ce6ec43a3b14dda697225eed081daa4e10180d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->