### PR TITLE
docs(dev-tools): clarify vfox metadata depends for install hooks

### DIFF
--- a/docs/backend-plugin-development.md
+++ b/docs/backend-plugin-development.md
@@ -137,7 +137,7 @@ PLUGIN = {
     description = "Backend plugin for npm packages",
     author = "Your Name",
 
-    -- mise short names of tools that must be on PATH during BackendInstall / hooks
+    -- mise tool names that must be on PATH during BackendInstall / hooks
     depends = { "node" },
 }
 ```

--- a/docs/backend-plugin-development.md
+++ b/docs/backend-plugin-development.md
@@ -135,7 +135,10 @@ PLUGIN = {
     name = "vfox-npm",
     version = "1.0.0",
     description = "Backend plugin for npm packages",
-    author = "Your Name"
+    author = "Your Name",
+
+    -- mise short names of tools that must be on PATH during BackendInstall / hooks
+    depends = { "node" },
 }
 ```
 

--- a/docs/backend-plugin-development.md
+++ b/docs/backend-plugin-development.md
@@ -135,10 +135,7 @@ PLUGIN = {
     name = "vfox-npm",
     version = "1.0.0",
     description = "Backend plugin for npm packages",
-    author = "Your Name",
-
-    -- mise tool names that must be on PATH during BackendInstall / hooks
-    depends = { "node" },
+    author = "Your Name"
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,7 +177,7 @@ You can also have environment specific config files like `.mise.production.toml`
 See [Tools](/dev-tools/). In addition to specifying versions, each tool entry can include options such as:
 
 - `os`: Restrict installation to certain operating systems
-- `depends`: Install order relative to other tools in this config only; use registry or vfox `metadata.lua` `depends` when another tool must be on `PATH` during install (see [Tool Dependencies](/dev-tools/#tool-dependencies))
+- `depends`: Install order relative to other tools in this config only; for vfox plugins, put `depends` in `metadata.lua` when another tool must be on `PATH` during install hooks (see [Tool Dependencies](/dev-tools/#tool-dependencies))
 - `install_env`: Environment vars used during install
 - `postinstall`: Command to run after installation completes for that specific tool
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,7 +177,7 @@ You can also have environment specific config files like `.mise.production.toml`
 See [Tools](/dev-tools/). In addition to specifying versions, each tool entry can include options such as:
 
 - `os`: Restrict installation to certain operating systems
-- `depends`: Tools that must be installed before this tool
+- `depends`: Install order relative to other tools in this config only; use registry or vfox `metadata.lua` `depends` when another tool must be on `PATH` during install (see [Tool Dependencies](/dev-tools/#tool-dependencies))
 - `install_env`: Environment vars used during install
 - `postinstall`: Command to run after installation completes for that specific tool
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,7 +177,7 @@ You can also have environment specific config files like `.mise.production.toml`
 See [Tools](/dev-tools/). In addition to specifying versions, each tool entry can include options such as:
 
 - `os`: Restrict installation to certain operating systems
-- `depends`: Install order relative to other tools in this config only; for vfox plugins, put `depends` in `metadata.lua` when another tool must be on `PATH` during install hooks (see [Tool Dependencies](/dev-tools/#tool-dependencies))
+- `depends`: Install order relative to other tools in this config only; vfox plugin hook dependencies belong in plugin `metadata.lua` (see [Tool Dependencies](/dev-tools/#tool-dependencies))
 - `install_env`: Environment vars used during install
 - `postinstall`: Command to run after installation completes for that specific tool
 

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -19,20 +19,6 @@ The code for this is inside the mise repository at [`./src/backend/vfox.rs`](htt
 
 No extra system packages are required to _run_ the vfox backend. Vfox Lua code is executed by the interpreter built into mise.
 
-### `depends` in `metadata.lua`
-
-If a plugin’s install hooks need another mise tool’s executables (for example `node` for `npm` in `BackendInstall`), declare them on the `PLUGIN` table in `metadata.lua`:
-
-```lua
-PLUGIN = {
-    name = "vfox-npm",
-    version = "1.0.0",
-    depends = { "node" },
-}
-```
-
-Use an array of **tool name strings** (the same identifiers you would use in `mise.toml`). mise treats them as install dependencies so those tools are ordered before this plugin and appear on `PATH` in the dependency environment used during installation. This is separate from `depends` on a `[tools]` entry in `mise.toml`, which only orders installs among tools you already listed in config.
-
 ## Usage
 
 The following installs the latest version of cmake and sets it as the active version on PATH:

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -31,7 +31,7 @@ PLUGIN = {
 }
 ```
 
-Use an array of **short tool names** (strings). mise merges these with backend and registry dependencies so installs run in the right order and those tools appear on `PATH` inside the dependency environment used during installation. This is separate from `depends` on a `[tools]` entry in `mise.toml`, which only orders installs among tools you already listed in config.
+Use an array of **tool name strings** (the same identifiers you would use in `mise.toml`, e.g. `node` or an explicit backend id when required). mise merges these with backend and registry dependencies so installs run in the right order and those tools appear on `PATH` inside the dependency environment used during installation. This is separate from `depends` on a `[tools]` entry in `mise.toml`, which only orders installs among tools you already listed in config.
 
 ## Usage
 

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -31,7 +31,7 @@ PLUGIN = {
 }
 ```
 
-Use an array of **tool name strings** (the same identifiers you would use in `mise.toml`). mise merges these with backend and registry dependencies so installs run in the right order and those tools appear on `PATH` inside the dependency environment used during installation. This is separate from `depends` on a `[tools]` entry in `mise.toml`, which only orders installs among tools you already listed in config.
+Use an array of **tool name strings** (the same identifiers you would use in `mise.toml`). mise treats them as install dependencies so those tools are ordered before this plugin and appear on `PATH` in the dependency environment used during installation. This is separate from `depends` on a `[tools]` entry in `mise.toml`, which only orders installs among tools you already listed in config.
 
 ## Usage
 

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -31,7 +31,7 @@ PLUGIN = {
 }
 ```
 
-Use an array of **tool name strings** (the same identifiers you would use in `mise.toml`, e.g. `node` or an explicit backend id when required). mise merges these with backend and registry dependencies so installs run in the right order and those tools appear on `PATH` inside the dependency environment used during installation. This is separate from `depends` on a `[tools]` entry in `mise.toml`, which only orders installs among tools you already listed in config.
+Use an array of **tool name strings** (the same identifiers you would use in `mise.toml`). mise merges these with backend and registry dependencies so installs run in the right order and those tools appear on `PATH` inside the dependency environment used during installation. This is separate from `depends` on a `[tools]` entry in `mise.toml`, which only orders installs among tools you already listed in config.
 
 ## Usage
 

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -17,7 +17,7 @@ The code for this is inside the mise repository at [`./src/backend/vfox.rs`](htt
 
 ## Dependencies
 
-No extra system packages are required to *run* the vfox backend. Vfox Lua code is executed by the interpreter built into mise.
+No extra system packages are required to _run_ the vfox backend. Vfox Lua code is executed by the interpreter built into mise.
 
 ### `depends` in `metadata.lua`
 

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -17,7 +17,21 @@ The code for this is inside the mise repository at [`./src/backend/vfox.rs`](htt
 
 ## Dependencies
 
-No dependencies are required for vfox. Vfox lua code is read via a lua interpreter built into mise.
+No extra system packages are required to *run* the vfox backend. Vfox Lua code is executed by the interpreter built into mise.
+
+### `depends` in `metadata.lua`
+
+If a plugin’s install hooks need another mise tool’s executables (for example `node` for `npm` in `BackendInstall`), declare them on the `PLUGIN` table in `metadata.lua`:
+
+```lua
+PLUGIN = {
+    name = "vfox-npm",
+    version = "1.0.0",
+    depends = { "node" },
+}
+```
+
+Use an array of **short tool names** (strings). mise merges these with backend and registry dependencies so installs run in the right order and those tools appear on `PATH` inside the dependency environment used during installation. This is separate from `depends` on a `[tools]` entry in `mise.toml`, which only orders installs among tools you already listed in config.
 
 ## Usage
 

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -238,11 +238,11 @@ The `depends` field accepts either a single string or an array of strings:
 "pipx:ruff" = { version = "latest", depends = ["python", "pipx"] }
 ```
 
-User-specified `depends` adds ordering constraints for tools already in the current install set.
+User-specified `depends` adds ordering constraints for tools already in the current install set. Use it when one configured tool install must finish before another configured tool install starts, especially when installs would otherwise run in parallel.
 
 ### vfox plugin hook dependencies
 
-`depends` in `[tools]` only affects install order. It does not by itself add those tools to the `PATH` used while a plugin's install hooks run.
+`depends` in `[tools]` only adds install graph ordering. It does not by itself declare hook-time dependencies or add those tools to the `PATH` used while vfox install hooks run.
 
 For vfox plugins, declare install-hook tool requirements on the `PLUGIN` table in `metadata.lua`:
 

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -247,7 +247,7 @@ This is in addition to the automatic dependencies that backends declare (e.g., `
 If your install step needs another tool’s executable during hooks (for example a compiler or package manager invoked from Lua), declare that dependency where mise can apply it globally:
 
 - **Curated registry tools**: add `depends` in [`registry/`](https://github.com/jdx/mise/tree/main/registry) for that tool (see each `*.toml` file).
-- **Vfox plugins** (classic or backend): add `depends = { "shortname", ... }` to the `PLUGIN` table in `metadata.lua`. See [Tool plugin development](/tool-plugin-development#_2-metadata-lua).
+- **Vfox plugins** (classic or backend): add `depends = { "<tool>", ... }` to the `PLUGIN` table in `metadata.lua` (tool names as in `mise.toml`). See [Tool plugin development](/tool-plugin-development#_2-metadata-lua).
 
 Those declarations are wired into backend dependencies and `dependency_env`, so required tools are installed first and are visible on `PATH` during install.
 

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -244,12 +244,9 @@ This is in addition to the automatic dependencies that backends declare (e.g., `
 
 `depends` in `[tools]` only affects **which tools finish installing before another starts** when both are listed in your config. It does **not** declare that those tools belong in the **dependency environment** mise builds for running install hooks—so it does not by itself put their `bin` directories on `PATH` while a plugin installs.
 
-If your install step needs another tool’s executable during hooks (for example a compiler or package manager invoked from Lua), declare that dependency where mise can apply it globally:
+If your install step needs another tool’s executable during **vfox** hooks (for example a compiler or package manager invoked from Lua), add `depends = { "<tool>", ... }` to the `PLUGIN` table in `metadata.lua` (tool names as in `mise.toml`). See [Tool plugin development](/tool-plugin-development#_2-metadata-lua).
 
-- **Curated registry tools**: add `depends` in [`registry/`](https://github.com/jdx/mise/tree/main/registry) for that tool (see each `*.toml` file).
-- **Vfox plugins** (classic or backend): add `depends = { "<tool>", ... }` to the `PLUGIN` table in `metadata.lua` (tool names as in `mise.toml`). See [Tool plugin development](/tool-plugin-development#_2-metadata-lua).
-
-Those declarations are wired into backend dependencies and `dependency_env`, so required tools are installed first and are visible on `PATH` during install.
+mise uses those entries when scheduling installs and when building `dependency_env`, so the listed tools are installed first and are on `PATH` while your hooks run.
 
 ## Caching and Performance
 

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -240,6 +240,17 @@ The `depends` field accepts either a single string or an array of strings:
 
 This is in addition to the automatic dependencies that backends declare (e.g., `pipx` automatically depends on `python` and `uv`). User-specified `depends` lets you add extra ordering constraints for your specific setup.
 
+### Config `depends` and install-time `PATH`
+
+`depends` in `[tools]` only affects **which tools finish installing before another starts** when both are listed in your config. It does **not** declare that those tools belong in the **dependency environment** mise builds for running install hooks—so it does not by itself put their `bin` directories on `PATH` while a plugin installs.
+
+If your install step needs another tool’s executable during hooks (for example a compiler or package manager invoked from Lua), declare that dependency where mise can apply it globally:
+
+- **Curated registry tools**: add `depends` in [`registry/`](https://github.com/jdx/mise/tree/main/registry) for that tool (see each `*.toml` file).
+- **Vfox plugins** (classic or backend): add `depends = { "shortname", ... }` to the `PLUGIN` table in `metadata.lua`. See [Tool plugin development](/tool-plugin-development#_2-metadata-lua).
+
+Those declarations are wired into backend dependencies and `dependency_env`, so required tools are installed first and are visible on `PATH` during install.
+
 ## Caching and Performance
 
 mise uses intelligent caching to minimize overhead:

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -238,15 +238,23 @@ The `depends` field accepts either a single string or an array of strings:
 "pipx:ruff" = { version = "latest", depends = ["python", "pipx"] }
 ```
 
-This is in addition to the automatic dependencies that backends declare (e.g., `pipx` automatically depends on `python` and `uv`). User-specified `depends` lets you add extra ordering constraints for your specific setup.
+User-specified `depends` adds ordering constraints for tools already in the current install set.
 
-### Config `depends` and install-time `PATH`
+### vfox plugin hook dependencies
 
-`depends` in `[tools]` only affects **which tools finish installing before another starts** when both are listed in your config. It does **not** declare that those tools belong in the **dependency environment** mise builds for running install hooks—so it does not by itself put their `bin` directories on `PATH` while a plugin installs.
+`depends` in `[tools]` only affects install order. It does not by itself add those tools to the `PATH` used while a plugin's install hooks run.
 
-If your install step needs another tool’s executable during **vfox** hooks (for example a compiler or package manager invoked from Lua), add `depends = { "<tool>", ... }` to the `PLUGIN` table in `metadata.lua` (tool names as in `mise.toml`). See [Tool plugin development](/tool-plugin-development#_2-metadata-lua).
+For vfox plugins, declare install-hook tool requirements on the `PLUGIN` table in `metadata.lua`:
 
-mise uses those entries when scheduling installs and when building `dependency_env`, so the listed tools are installed first and are on `PATH` while your hooks run.
+```lua
+PLUGIN = {
+    name = "example",
+    version = "1.0.0",
+    depends = { "go" },
+}
+```
+
+Use tool names as they would appear in `mise.toml`. When matching tools are configured, mise uses those metadata entries to order current install jobs and to build the hook environment. See [Tool plugin development](/tool-plugin-development#_2-metadata-lua).
 
 ## Caching and Performance
 

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -326,7 +326,7 @@ PLUGIN = {
 }
 ```
 
-Add `depends` to the `PLUGIN` table when install hooks need other mise-managed tools on `PATH` (short names only), for example `depends = { "go", "make" }`. Omit it if hooks do not shell out to other tools. The `depends` field in `[tools]` only affects install order among entries in your config; it does not declare hook-time `PATH` dependencies the way `metadata.lua` does.
+Add `depends` to the `PLUGIN` table when install hooks need other mise-managed tools on `PATH`, for example `depends = { "go", "make" }` (same tool names as in `mise.toml`, including explicit forms like `aqua:org/tool` when needed). Omit it if hooks do not shell out to other tools. The `depends` field in `[tools]` only affects install order among entries in your config; it does not declare hook-time `PATH` dependencies the way `metadata.lua` does.
 
 ### 3. Helper Libraries
 

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -322,11 +322,16 @@ PLUGIN = {
     legacyFilenames = {
         '.nvmrc',
         '.node-version'
-    }
+    },
+
+    -- Tools whose bin paths should be available during install hooks
+    depends = { "node" },
 }
 ```
 
-Add `depends` to the `PLUGIN` table when install hooks need other mise-managed tools on `PATH`, for example `depends = { "go", "make" }` — use the same tool names as in `mise.toml`. Omit it if hooks do not shell out to other tools. The `depends` field in `[tools]` only affects install order among entries in your config; it does not declare hook-time `PATH` dependencies the way `metadata.lua` does.
+Add `depends` to the `PLUGIN` table when install hooks need other mise-managed tools on `PATH`. Use tool names as they would appear in `mise.toml`, for example `depends = { "go", "make" }`. Omit it if hooks do not shell out to other tools.
+
+This is separate from `depends` in `[tools]`, which is only an install-order constraint for that config entry. vfox `metadata.lua` `depends` is plugin metadata; when matching tools are configured, mise uses it to order current install jobs and to build the hook environment.
 
 ### 3. Helper Libraries
 

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -331,7 +331,7 @@ PLUGIN = {
 
 Add `depends` to the `PLUGIN` table when install hooks need other mise-managed tools on `PATH`. Use tool names as they would appear in `mise.toml`, for example `depends = { "go", "make" }`. Omit it if hooks do not shell out to other tools.
 
-This is separate from `depends` in `[tools]`, which is only an install-order constraint for that config entry. vfox `metadata.lua` `depends` is plugin metadata; when matching tools are configured, mise uses it to order current install jobs and to build the hook environment.
+This is separate from `depends` in `[tools]`, which only makes one configured tool wait for another configured tool in the install graph. vfox `metadata.lua` `depends` is plugin metadata; when matching tools are configured, mise uses it to order current install jobs and to build the hook environment.
 
 ### 3. Helper Libraries
 

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -326,6 +326,8 @@ PLUGIN = {
 }
 ```
 
+Add `depends` to the `PLUGIN` table when install hooks need other mise-managed tools on `PATH` (short names only), for example `depends = { "go", "make" }`. Omit it if hooks do not shell out to other tools. The `depends` field in `[tools]` only affects install order among entries in your config; it does not declare hook-time `PATH` dependencies the way `metadata.lua` does.
+
 ### 3. Helper Libraries
 
 Create shared functions in the `lib/` directory:

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -326,7 +326,7 @@ PLUGIN = {
 }
 ```
 
-Add `depends` to the `PLUGIN` table when install hooks need other mise-managed tools on `PATH`, for example `depends = { "go", "make" }` (same tool names as in `mise.toml`, including explicit forms like `aqua:org/tool` when needed). Omit it if hooks do not shell out to other tools. The `depends` field in `[tools]` only affects install order among entries in your config; it does not declare hook-time `PATH` dependencies the way `metadata.lua` does.
+Add `depends` to the `PLUGIN` table when install hooks need other mise-managed tools on `PATH`, for example `depends = { "go", "make" }` — use the same tool names as in `mise.toml`. Omit it if hooks do not shell out to other tools. The `depends` field in `[tools]` only affects install order among entries in your config; it does not declare hook-time `PATH` dependencies the way `metadata.lua` does.
 
 ### 3. Helper Libraries
 


### PR DESCRIPTION
## Summary

- Clarify that `[tools]` `depends` is an install graph ordering constraint for configured tools.
- Document vfox `PLUGIN.depends` in `metadata.lua` as the hook-time dependency metadata for tool plugins.
- Keep the docs scoped to vfox plugin metadata and hook `PATH` behavior.

## Implementation Notes

Verified against mise's install scheduler and vfox hook environment code paths. `[tools]` `depends` is consumed by `ToolDeps` to add edges between tools in the current install set. vfox `metadata.lua` `depends` is parsed as an array of tool names; when matching tools are configured, mise uses those entries to order current install jobs and build the install-hook environment.

## Verification

- `git diff --check`