### PR TITLE
perf(backend): avoid loading disabled idiomatic registry tools

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -192,11 +192,18 @@ pub async fn load_tools() -> Result<Arc<BackendMap>> {
     time!("load_tools start");
     let core_tools = CORE_PLUGINS.values().cloned().collect::<Vec<ABackend>>();
     let mut tools = core_tools;
-    // add tools with idiomatic files so they get parsed even if no versions are installed
+    // Add enabled registry tools with idiomatic files so they get parsed even
+    // if no versions are installed. Avoid eagerly constructing every registry
+    // tool that has idiomatic files when idiomatic parsing is disabled.
+    let idiomatic_enable_tools = Settings::get().idiomatic_version_file_enable_tools.clone();
     tools.extend(
         REGISTRY
             .values()
-            .filter(|rt| !rt.idiomatic_files.is_empty() && rt.is_supported_os())
+            .filter(|rt| {
+                !rt.idiomatic_files.is_empty()
+                    && idiomatic_enable_tools.contains(rt.short)
+                    && rt.is_supported_os()
+            })
             .filter_map(|rt| arg_to_backend(rt.short.into())),
     );
     time!("load_tools core");


### PR DESCRIPTION
## Summary

Avoid eagerly constructing registry backends with idiomatic files unless the corresponding tool is explicitly enabled in `idiomatic_version_file_enable_tools`.

This keeps package-manager registry entries like npm, pnpm, and yarn out of the startup path when idiomatic version-file parsing is disabled, while preserving parsing when those tools are enabled.

## Validation

- `cargo fmt --check`
- `mise run test:e2e e2e/core/test_package_json`
- `cargo check --all-features` via pre-commit hook passed

Note: the pre-commit hook as a whole failed because Prettier reported an unrelated existing formatting issue in `docs/components/settings.vue`.

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool-loading behavior so registry backends with idiomatic files are only constructed when explicitly enabled in `idiomatic_version_file_enable_tools`, which could affect idiomatic version-file parsing if configs rely on implicit loading.
> 
> **Overview**
> Reduces backend startup work by only instantiating registry tools with `idiomatic_files` when the tool is explicitly listed in `Settings::idiomatic_version_file_enable_tools` (while still respecting OS support).
> 
> This avoids eagerly constructing package-manager registry backends when idiomatic parsing is effectively disabled, but also narrows which registry tools get included early for idiomatic version-file parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88af5459628dd222ad47723fad392764cb9a834d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->