### PR TITLE
registry: remove bashly asdf fallback

### DIFF
--- a/registry/bashly.toml
+++ b/registry/bashly.toml
@@ -1,4 +1,3 @@
-backends = ["gem:bashly", "asdf:mise-plugins/mise-bashly"]
-depends = ["ruby"]
+backends = ["gem:bashly"]
 description = "Bashly is a command line application (written in Ruby) that lets you generate feature-rich bash command line tools"
 # test = ["bashly --version", "{{version}}"]  # not working in CI


### PR DESCRIPTION
## Summary
- Remove the `asdf:mise-plugins/mise-bashly` fallback from `bashly`
- Remove the explicit `ruby` dependency because the `gem` backend already depends on Ruby

## Tests
- `cargo test registry`
- `cargo run -- registry bashly`