### PR TITLE
chore: release 2026.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [2026.5.1](https://github.com/jdx/mise/compare/v2026.5.0..v2026.5.1) - 2026-05-05
+
+### 🚀 Features
+
+- **(backend)** support top-level aqua cosign verification by @risu729 in [#9111](https://github.com/jdx/mise/pull/9111)
+
+### 🐛 Bug Fixes
+
+- **(schema)** validate all schema files with draft2020 and strict mode by @risu729 in [#9594](https://github.com/jdx/mise/pull/9594)
+- **(shim)** skip network resolution for installed tool dirs by @jdx in [#9599](https://github.com/jdx/mise/pull/9599)
+
+### 📚 Documentation
+
+- **(dev-tools)** clarify vfox metadata depends for install hooks by @risu729 in [#9573](https://github.com/jdx/mise/pull/9573)
+- **(plugins)** remove registry submission guidance by @risu729 in [#9577](https://github.com/jdx/mise/pull/9577)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by @renovate[bot] in [#9586](https://github.com/jdx/mise/pull/9586)
+
+### 📦 Registry
+
+- remove bashly asdf fallback by @risu729 in [#9578](https://github.com/jdx/mise/pull/9578)
+- use github backend for rebar by @risu729 in [#9576](https://github.com/jdx/mise/pull/9576)
+- add wasm-tools ([aqua:bytecodealliance/wasm-tools](https://github.com/bytecodealliance/wasm-tools)) by @2xdevv in [#9596](https://github.com/jdx/mise/pull/9596)
+- enable symlink_bins for elixir-ls by @AlternateRT in [#9592](https://github.com/jdx/mise/pull/9592)
+
+### Chore
+
+- **(release)** always append sponsor block to release notes by @jdx in [#9580](https://github.com/jdx/mise/pull/9580)
+- warn on vendored vfox embedded plugins by @risu729 in [#9588](https://github.com/jdx/mise/pull/9588)
+- prefer registry shorthands over cargo/npm backends in mise.toml by @risu729 in [#9595](https://github.com/jdx/mise/pull/9595)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (2)
+
+- [`salesforce/reactive-grpc/protoc-gen-reactor-grpc`](https://github.com/salesforce/reactive-grpc)
+- [`spinframework/spin`](https://github.com/spinframework/spin)
+
+#### Updated Packages (1)
+
+- [`pnpm/pnpm`](https://github.com/pnpm/pnpm)
+
 ## [2026.5.0](https://github.com/jdx/mise/compare/v2026.4.28..v2026.5.0) - 2026-05-03
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aqua-registry"
-version = "2026.4.11"
+version = "2026.5.0"
 dependencies = [
  "expr-lang",
  "eyre",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.5.0"
+version = "2026.5.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.5.0"
+version = "2026.5.1"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.5.0 macos-arm64 (2026-05-03)
+2026.5.1 macos-arm64 (2026-05-05)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_0.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_1.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_0.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_1.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_0.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_1.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_0.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_1.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/crates/aqua-registry/Cargo.toml
+++ b/crates/aqua-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aqua-registry"
-version = "2026.4.11"
+version = "2026.5.0"
 edition = "2024"
 description = "Aqua registry backend for mise"
 authors = ["Jeff Dickey (@jdx)"]

--- a/crates/aqua-registry/aqua-registry/metadata.json
+++ b/crates/aqua-registry/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "v4.505.0"
+  "tag": "v4.506.0"
 }

--- a/crates/aqua-registry/aqua-registry/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/registry.yaml
@@ -71816,7 +71816,7 @@ packages:
           darwin: macos
           windows: win
         github_immutable_release: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 11.0.4")
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -71828,6 +71828,24 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+      - version_constraint: "true"
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pnpm
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
+        github_immutable_release: true
+        supported_envs:
+          - linux
+          - windows
+          - darwin/arm64
   - type: github_release
     repo_owner: po3rin
     repo_name: github_link_creator
@@ -77013,6 +77031,23 @@ packages:
     complete_windows_ext: false
     format: raw
     asset: yamldiff-v{{.Version}}-{{.OS}}-amd64
+  - name: salesforce/reactive-grpc/protoc-gen-reactor-grpc
+    type: http
+    repo_owner: salesforce
+    repo_name: reactive-grpc
+    description: Reactor-gRPC is a set of gRPC bindings for reactive programming with Reactor
+    url: https://repo1.maven.org/maven2/com/salesforce/servicelibs/reactor-grpc/{{trimV .Version}}/reactor-grpc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.exe
+    format: raw
+    windows_arm_emulation: true
+    replacements:
+      darwin: osx
+      amd64: x86_64
+      arm64: aarch_64
+    checksum:
+      type: http
+      url: https://repo1.maven.org/maven2/com/salesforce/servicelibs/reactor-grpc/{{trimV .Version}}/reactor-grpc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.exe.sha1
+      file_format: raw
+      algorithm: sha1
   - type: github_release
     repo_owner: samuel-lucas6
     repo_name: Kryptor
@@ -81844,6 +81879,69 @@ packages:
           - darwin
         github_artifact_attestations:
           signer_workflow: spinel-coop/rv/.github/workflows/release.yml
+  - type: github_release
+    repo_owner: spinframework
+    repo_name: spin
+    description: Developer tool for building and running serverless WebAssembly applications
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0-rc.1"
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: Version == "v0.1.0-rc.4"
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.6.0")
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
   - name: spinnaker/spin
     type: http
     format: raw

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.5.0";
+  version = "2026.5.1";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "27.6k",
+      stars: "27.7k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.5.0
+Version: 2026.5.1
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.5.0"
+version: "2026.5.1"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.


### PR DESCRIPTION
### 🚀 Features

- **(backend)** support top-level aqua cosign verification by @risu729 in [#9111](https://github.com/jdx/mise/pull/9111)

### 🐛 Bug Fixes

- **(schema)** validate all schema files with draft2020 and strict mode by @risu729 in [#9594](https://github.com/jdx/mise/pull/9594)
- **(shim)** skip network resolution for installed tool dirs by @jdx in [#9599](https://github.com/jdx/mise/pull/9599)

### 📚 Documentation

- **(dev-tools)** clarify vfox metadata depends for install hooks by @risu729 in [#9573](https://github.com/jdx/mise/pull/9573)
- **(plugins)** remove registry submission guidance by @risu729 in [#9577](https://github.com/jdx/mise/pull/9577)

### 📦️ Dependency Updates

- lock file maintenance by @renovate[bot] in [#9586](https://github.com/jdx/mise/pull/9586)

### 📦 Registry

- remove bashly asdf fallback by @risu729 in [#9578](https://github.com/jdx/mise/pull/9578)
- use github backend for rebar by @risu729 in [#9576](https://github.com/jdx/mise/pull/9576)
- add wasm-tools ([aqua:bytecodealliance/wasm-tools](https://github.com/bytecodealliance/wasm-tools)) by @2xdevv in [#9596](https://github.com/jdx/mise/pull/9596)
- enable symlink_bins for elixir-ls by @AlternateRT in [#9592](https://github.com/jdx/mise/pull/9592)

### Chore

- **(release)** always append sponsor block to release notes by @jdx in [#9580](https://github.com/jdx/mise/pull/9580)
- warn on vendored vfox embedded plugins by @risu729 in [#9588](https://github.com/jdx/mise/pull/9588)
- prefer registry shorthands over cargo/npm backends in mise.toml by @risu729 in [#9595](https://github.com/jdx/mise/pull/9595)

## 📦 Aqua Registry Updates

### New Packages (2)

- [`salesforce/reactive-grpc/protoc-gen-reactor-grpc`](https://github.com/salesforce/reactive-grpc)
- [`spinframework/spin`](https://github.com/spinframework/spin)

### Updated Packages (1)

- [`pnpm/pnpm`](https://github.com/pnpm/pnpm)