### PR TITLE
chore(release): always append sponsor block to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,7 +358,8 @@ jobs:
             echo "::warning::communique failed, falling back to git-cliff changelog"
             mise x -- git cliff --strip all --latest > /tmp/release-notes.txt 2>/dev/null || echo "Release $VERSION" > /tmp/release-notes.txt
             echo "RELEASE_TITLE=$VERSION" >> "$GITHUB_ENV"
-            cat >> /tmp/release-notes.txt <<'EOF'
+          fi
+          cat >> /tmp/release-notes.txt <<'EOF'
 
           ## 💚 Sponsor mise
 
@@ -366,7 +367,6 @@ jobs:
 
           If mise saves you or your team time, please consider sponsoring at [en.dev](https://en.dev). Individual and company sponsorships keep mise fast, free, and independent.
           EOF
-          fi
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       - name: Create Draft GitHub Release


### PR DESCRIPTION
## Summary
- The sponsor block was unintentionally limited to the communique-failure fallback in #9395, so successful releases (the normal case) lost the block starting with v2026.4.22.
- Move the `cat >> /tmp/release-notes.txt <<'EOF'` heredoc back outside the `if/else` so it runs in both branches, matching the behavior used for v2026.4.21.
- v2026.5.0 has been manually edited on GitHub to include the sponsor block; this PR ensures future releases get it automatically.

## Test plan
- [ ] Next release (or a draft release run) shows the "💚 Sponsor mise" section appended to the communique-generated notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only changes the generated GitHub release notes content by ensuring the sponsor section is appended regardless of which release-notes generator succeeds.
> 
> **Overview**
> Fixes the release workflow so the "💚 Sponsor mise" section is **always** appended to `/tmp/release-notes.txt`, whether release notes are generated via `communique` or the `git-cliff` fallback.
> 
> This restores consistent release-note output for normal (successful) releases by moving the sponsor heredoc outside the `if/else` in `.github/workflows/release.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115ac52c03790ad4fcdbe41c904ef5990e52d360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->