### PR TITLE
refactor(schema): reuse task props with unevaluatedProperties

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 
 # Validate that the mise JSON schema works correctly with tombi (strict mode).
-# Regression test for https://github.com/jdx/mise/discussions/8254
-# where unevaluatedProperties caused tombi to reject valid task properties.
+# Tombi v0.9.19 fixed evaluated-property collection for allOf +
+# unevaluatedProperties in tombi-toml/tombi#1725, which lets the schema share
+# task properties through $refs without inlining them.
+
+TOMBI_VERSION="0.9.22"
 
 # Install a pinned tombi version so release asset packaging changes do not break
 # this schema regression test.
-mise use -g tombi@0.9.22
+mise use -g tombi@$TOMBI_VERSION
 
 SCHEMA_PATH="$ROOT/schema/mise.json"
 TASK_SCHEMA_PATH="$ROOT/schema/mise-task.json"
-TOMBI="mise x tombi@0.9.22 -- tombi"
+TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
+assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
 
 # Set up tombi config pointing to local schema
 cat >"$HOME/tombi.toml" <<EOF

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -81,7 +81,7 @@
               }
             },
             "required": ["full"],
-            "additionalProperties": false
+            "unevaluatedProperties": false
           }
         ]
       },
@@ -143,10 +143,10 @@
         }
       },
       "required": ["cmd", "expected"],
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "description": "Command to test the tool installation"
     }
   },
   "required": ["backends"],
-  "additionalProperties": false
+  "unevaluatedProperties": false
 }

--- a/schema/mise-settings.json
+++ b/schema/mise-settings.json
@@ -17,12 +17,12 @@
               "$ref": "#/definitions/setting"
             }
           },
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     }
   },
-  "additionalProperties": false,
+  "unevaluatedProperties": false,
   "definitions": {
     "setting": {
       "type": "object",
@@ -102,7 +102,7 @@
                   }
                 },
                 "required": ["value"],
-                "additionalProperties": false
+                "unevaluatedProperties": false
               }
             ]
           }
@@ -158,7 +158,7 @@
         }
       },
       "required": ["description"],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     }
   }
 }

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -75,11 +75,21 @@
                 },
                 "default": {
                   "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": ["yes", "no", "y", "n", "true", "false"],
+                  "enum": [
+                    "yes",
+                    "no",
+                    "y",
+                    "n",
+                    "true",
+                    "false"
+                  ],
                   "type": "string"
                 }
               },
-              "required": ["message", "default"],
+              "required": [
+                "message",
+                "default"
+              ],
               "unevaluatedProperties": false,
               "type": "object"
             }
@@ -163,7 +173,9 @@
                     "$ref": "#/$defs/os_filter"
                   }
                 },
-                "required": ["version"],
+                "required": [
+                  "version"
+                ],
                 "type": "object",
                 "additionalProperties": {
                   "oneOf": [
@@ -201,11 +213,15 @@
               "properties": {
                 "auto": {
                   "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [true],
+                  "enum": [
+                    true
+                  ],
                   "type": "boolean"
                 }
               },
-              "required": ["auto"],
+              "required": [
+                "auto"
+              ],
               "type": "object"
             }
           ]
@@ -223,7 +239,10 @@
               "type": "boolean"
             },
             {
-              "enum": ["stdout", "stderr"],
+              "enum": [
+                "stdout",
+                "stderr"
+              ],
               "type": "string"
             }
           ]
@@ -429,7 +448,9 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": ["age"],
+            "required": [
+              "age"
+            ],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -445,7 +466,10 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": ["raw", "zstd"],
+                    "enum": [
+                      "raw",
+                      "zstd"
+                    ],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -470,12 +494,16 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": ["value"],
+                "required": [
+                  "value"
+                ],
                 "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": ["age"],
+            "required": [
+              "age"
+            ],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -569,7 +597,9 @@
                           ]
                         }
                       },
-                      "required": ["path"]
+                      "required": [
+                        "path"
+                      ]
                     },
                     {
                       "type": "object",
@@ -581,7 +611,9 @@
                           }
                         }
                       },
-                      "required": ["paths"]
+                      "required": [
+                        "paths"
+                      ]
                     }
                   ]
                 },
@@ -665,7 +697,9 @@
                           }
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "type": "object"
                     }
                   ]
@@ -783,7 +817,9 @@
               }
             }
           },
-          "required": ["task"]
+          "required": [
+            "task"
+          ]
         },
         {
           "type": "object",
@@ -798,7 +834,9 @@
               "type": "array"
             }
           },
-          "required": ["tasks"]
+          "required": [
+            "tasks"
+          ]
         }
       ]
     },
@@ -833,7 +871,9 @@
               }
             }
           },
-          "required": ["task"],
+          "required": [
+            "task"
+          ],
           "unevaluatedProperties": false
         }
       ]
@@ -904,7 +944,9 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": ["path"]
+          "required": [
+            "path"
+          ]
         },
         {
           "type": "object",
@@ -913,7 +955,9 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": ["paths"]
+          "required": [
+            "paths"
+          ]
         }
       ]
     },
@@ -921,7 +965,13 @@
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
+      "examples": [
+        "linux",
+        "macos",
+        "windows",
+        "macos/arm64",
+        "linux/x64"
+      ]
     }
   }
 }

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -23,326 +23,358 @@
           "type": "array"
         },
         {
-          "properties": {
-            "alias": {
-              "oneOf": [
-                {
-                  "description": "alias for this task",
-                  "type": "string"
-                },
-                {
-                  "description": "alias for this task",
-                  "items": {
-                    "description": "alias for this task",
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
+          "allOf": [
+            {
+              "$ref": "#/$defs/task_props"
             },
-            "confirm": {
-              "oneOf": [
-                {
-                  "description": "confirmation message before running this task",
-                  "type": "string"
-                },
-                {
-                  "description": "confirmation message before running this task with default value",
-                  "properties": {
-                    "message": {
-                      "description": "confirmation message before running this task",
-                      "type": "string"
-                    },
-                    "default": {
-                      "description": "default value for confirmation (yes/no/true/false)",
-                      "enum": ["yes", "no", "y", "n", "true", "false"],
-                      "type": "string"
-                    }
-                  },
-                  "required": ["message", "default"],
-                  "additionalProperties": false,
-                  "type": "object"
-                }
-              ]
-            },
-            "depends": {
-              "oneOf": [
-                {
-                  "description": "task with args to run before this task",
-                  "type": "string"
-                },
-                {
-                  "description": "task with args to run before this task",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/task_dependency_item"
-                  }
-                }
-              ]
-            },
-            "depends_post": {
-              "oneOf": [
-                {
-                  "description": "task with args to run after this task",
-                  "type": "string"
-                },
-                {
-                  "description": "task with args to run after this task",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/task_dependency_item"
-                  }
-                }
-              ]
-            },
-            "wait_for": {
-              "oneOf": [
-                {
-                  "description": "task with args to wait for completion first",
-                  "type": "string"
-                },
-                {
-                  "description": "task with args to wait for completion first",
-                  "items": {
-                    "$ref": "#/$defs/task_dependency_item"
-                  },
-                  "type": "array"
-                }
-              ]
-            },
-            "description": {
-              "description": "description of task",
-              "type": "string"
-            },
-            "dir": {
-              "default": "{{ config_root }}",
-              "description": "directory to run script in, default is the project's base directory",
-              "type": "string"
-            },
-            "env": {
-              "$ref": "#/$defs/env"
-            },
-            "vars": {
-              "$ref": "#/$defs/vars"
-            },
-            "tools": {
-              "description": "tools to install/activate before running this task",
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "description": "version of the tool to install",
-                    "type": "string"
-                  },
-                  {
-                    "properties": {
-                      "version": {
-                        "description": "version of the tool to install",
-                        "type": "string"
-                      },
-                      "os": {
-                        "$ref": "#/$defs/os_filter"
-                      }
-                    },
-                    "required": ["version"],
-                    "type": "object",
-                    "additionalProperties": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              "type": "object"
-            },
-            "hide": {
-              "default": false,
-              "description": "do not display this task",
-              "type": "boolean"
-            },
-            "outputs": {
-              "oneOf": [
-                {
-                  "description": "files created by this task",
-                  "items": {
-                    "description": "glob pattern or path to files created by this task",
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "description": "glob pattern or path to files created by this task",
-                  "type": "string"
-                },
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "auto": {
-                      "description": "automatically touch an internal tracked file instead of specifying outputs",
-                      "enum": [true],
-                      "type": "boolean"
-                    }
-                  },
-                  "required": ["auto"],
-                  "type": "object"
-                }
-              ]
-            },
-            "quiet": {
-              "default": false,
-              "description": "do not display mise information for this task",
-              "type": "boolean"
-            },
-            "silent": {
-              "default": false,
-              "description": "suppress all output for this task",
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "enum": ["stdout", "stderr"],
+            {
+              "properties": {
+                "extends": {
+                  "description": "name of the task template to extend",
                   "type": "string"
                 }
-              ]
-            },
-            "interactive": {
-              "default": false,
-              "description": "mark task as interactive, acquiring exclusive terminal access while allowing other non-interactive tasks to run in parallel",
-              "type": "boolean"
-            },
-            "raw": {
-              "default": false,
-              "description": "directly connect task to stdin/stdout/stderr",
-              "type": "boolean"
-            },
-            "raw_args": {
-              "default": false,
-              "description": "skip mise's argument parsing for this task — all arguments (including --help/-h) are forwarded verbatim to the underlying command. Use for tasks that proxy a tool with its own argument parser.",
-              "type": "boolean"
-            },
-            "run": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/task_run_entry"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/task_run_entry"
-                  }
-                }
-              ]
-            },
-            "run_windows": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/task_run_entry"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/task_run_entry"
-                  }
-                }
-              ]
-            },
-            "file": {
-              "description": "Execute an external script",
-              "type": "string"
-            },
-            "sources": {
-              "oneOf": [
-                {
-                  "description": "files that this task depends on (entries starting with `!` are excluded; use `\\!` to escape a literal `!` prefix)",
-                  "items": {
-                    "description": "glob pattern or path to files that this task depends on (entries starting with `!` are excluded)",
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "description": "glob pattern or path to files that this task depends on (entries starting with `!` are excluded)",
-                  "type": "string"
-                }
-              ]
-            },
-            "shell": {
-              "description": "specify a shell command to run the script with",
-              "type": "string"
-            },
-            "usage": {
-              "description": "Specify usage (https://usage.jdx.dev/) specs for the task",
-              "type": "string"
-            },
-            "timeout": {
-              "description": "timeout for this task",
-              "type": "string"
-            },
-            "deny_all": {
-              "default": false,
-              "description": "block reads, writes, network, and env vars",
-              "type": "boolean"
-            },
-            "deny_read": {
-              "default": false,
-              "description": "block filesystem reads",
-              "type": "boolean"
-            },
-            "deny_write": {
-              "default": false,
-              "description": "block all filesystem writes",
-              "type": "boolean"
-            },
-            "deny_net": {
-              "default": false,
-              "description": "block all network access",
-              "type": "boolean"
-            },
-            "deny_env": {
-              "default": false,
-              "description": "block env var inheritance",
-              "type": "boolean"
-            },
-            "allow_read": {
-              "description": "allow reads from specific paths",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "allow_write": {
-              "description": "allow writes to specific paths",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "allow_net": {
-              "description": "allow network to specific hosts",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "allow_env": {
-              "description": "allow specific env vars through",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "extends": {
-              "description": "name of the task template to extend",
-              "type": "string"
+              }
             }
-          },
-          "additionalProperties": false,
+          ],
+          "unevaluatedProperties": false,
           "type": "object"
         }
       ]
+    },
+    "task_props": {
+      "description": "common task properties",
+      "properties": {
+        "alias": {
+          "oneOf": [
+            {
+              "description": "alias for this task",
+              "type": "string"
+            },
+            {
+              "description": "alias for this task",
+              "items": {
+                "description": "alias for this task",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "confirm": {
+          "oneOf": [
+            {
+              "description": "confirmation message before running this task",
+              "type": "string"
+            },
+            {
+              "description": "confirmation message before running this task with default value",
+              "properties": {
+                "message": {
+                  "description": "confirmation message before running this task",
+                  "type": "string"
+                },
+                "default": {
+                  "description": "default value for confirmation (yes/no/true/false)",
+                  "enum": [
+                    "yes",
+                    "no",
+                    "y",
+                    "n",
+                    "true",
+                    "false"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message",
+                "default"
+              ],
+              "unevaluatedProperties": false,
+              "type": "object"
+            }
+          ]
+        },
+        "depends": {
+          "oneOf": [
+            {
+              "description": "task with args to run before this task",
+              "type": "string"
+            },
+            {
+              "description": "task with args to run before this task",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/task_dependency_item"
+              }
+            }
+          ]
+        },
+        "depends_post": {
+          "oneOf": [
+            {
+              "description": "task with args to run after this task",
+              "type": "string"
+            },
+            {
+              "description": "task with args to run after this task",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/task_dependency_item"
+              }
+            }
+          ]
+        },
+        "wait_for": {
+          "oneOf": [
+            {
+              "description": "task with args to wait for completion first",
+              "type": "string"
+            },
+            {
+              "description": "task with args to wait for completion first",
+              "items": {
+                "$ref": "#/$defs/task_dependency_item"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "description": {
+          "description": "description of task",
+          "type": "string"
+        },
+        "dir": {
+          "default": "{{ config_root }}",
+          "description": "directory to run script in, default is the project's base directory",
+          "type": "string"
+        },
+        "env": {
+          "$ref": "#/$defs/env"
+        },
+        "vars": {
+          "$ref": "#/$defs/vars"
+        },
+        "tools": {
+          "description": "tools to install/activate before running this task",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "description": "version of the tool to install",
+                "type": "string"
+              },
+              {
+                "properties": {
+                  "version": {
+                    "description": "version of the tool to install",
+                    "type": "string"
+                  },
+                  "os": {
+                    "$ref": "#/$defs/os_filter"
+                  }
+                },
+                "required": [
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "type": "object"
+        },
+        "hide": {
+          "default": false,
+          "description": "do not display this task",
+          "type": "boolean"
+        },
+        "outputs": {
+          "oneOf": [
+            {
+              "description": "files created by this task",
+              "items": {
+                "description": "glob pattern or path to files created by this task",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "description": "glob pattern or path to files created by this task",
+              "type": "string"
+            },
+            {
+              "unevaluatedProperties": false,
+              "properties": {
+                "auto": {
+                  "description": "automatically touch an internal tracked file instead of specifying outputs",
+                  "enum": [
+                    true
+                  ],
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "auto"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "quiet": {
+          "default": false,
+          "description": "do not display mise information for this task",
+          "type": "boolean"
+        },
+        "silent": {
+          "default": false,
+          "description": "suppress all output for this task",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "enum": [
+                "stdout",
+                "stderr"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "interactive": {
+          "default": false,
+          "description": "mark task as interactive, acquiring exclusive terminal access while allowing other non-interactive tasks to run in parallel",
+          "type": "boolean"
+        },
+        "raw": {
+          "default": false,
+          "description": "directly connect task to stdin/stdout/stderr",
+          "type": "boolean"
+        },
+        "raw_args": {
+          "default": false,
+          "description": "skip mise's argument parsing for this task — all arguments (including --help/-h) are forwarded verbatim to the underlying command. Use for tasks that proxy a tool with its own argument parser.",
+          "type": "boolean"
+        },
+        "run": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/task_run_entry"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/task_run_entry"
+              }
+            }
+          ]
+        },
+        "run_windows": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/task_run_entry"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/task_run_entry"
+              }
+            }
+          ]
+        },
+        "file": {
+          "description": "Execute an external script",
+          "type": "string"
+        },
+        "sources": {
+          "oneOf": [
+            {
+              "description": "files that this task depends on (entries starting with `!` are excluded; use `\\!` to escape a literal `!` prefix)",
+              "items": {
+                "description": "glob pattern or path to files that this task depends on (entries starting with `!` are excluded)",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "description": "glob pattern or path to files that this task depends on (entries starting with `!` are excluded)",
+              "type": "string"
+            }
+          ]
+        },
+        "shell": {
+          "description": "specify a shell command to run the script with",
+          "type": "string"
+        },
+        "usage": {
+          "description": "Specify usage (https://usage.jdx.dev/) specs for the task",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "timeout for this task",
+          "type": "string"
+        },
+        "deny_all": {
+          "default": false,
+          "description": "block reads, writes, network, and env vars",
+          "type": "boolean"
+        },
+        "deny_read": {
+          "default": false,
+          "description": "block filesystem reads",
+          "type": "boolean"
+        },
+        "deny_write": {
+          "default": false,
+          "description": "block all filesystem writes",
+          "type": "boolean"
+        },
+        "deny_net": {
+          "default": false,
+          "description": "block all network access",
+          "type": "boolean"
+        },
+        "deny_env": {
+          "default": false,
+          "description": "block env var inheritance",
+          "type": "boolean"
+        },
+        "allow_read": {
+          "description": "allow reads from specific paths",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_write": {
+          "description": "allow writes to specific paths",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_net": {
+          "description": "allow network to specific hosts",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allow_env": {
+          "description": "allow specific env vars through",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
     },
     "env": {
       "additionalProperties": {
@@ -385,7 +417,7 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "additionalProperties": false
+            "unevaluatedProperties": false
           },
           {
             "type": "object",
@@ -416,8 +448,10 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": ["age"],
-            "additionalProperties": false,
+            "required": [
+              "age"
+            ],
+            "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
           {
@@ -432,7 +466,10 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": ["raw", "zstd"],
+                    "enum": [
+                      "raw",
+                      "zstd"
+                    ],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -457,13 +494,17 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": ["value"],
-                "additionalProperties": false,
+                "required": [
+                  "value"
+                ],
+                "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": ["age"],
-            "additionalProperties": false,
+            "required": [
+              "age"
+            ],
+            "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
           {
@@ -556,7 +597,9 @@
                           ]
                         }
                       },
-                      "required": ["path"]
+                      "required": [
+                        "path"
+                      ]
                     },
                     {
                       "type": "object",
@@ -568,7 +611,9 @@
                           }
                         }
                       },
-                      "required": ["paths"]
+                      "required": [
+                        "paths"
+                      ]
                     }
                   ]
                 },
@@ -652,7 +697,9 @@
                           }
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "type": "object"
                     }
                   ]
@@ -749,7 +796,7 @@
         },
         {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "task": {
               "description": "single task name to run",
@@ -770,11 +817,13 @@
               }
             }
           },
-          "required": ["task"]
+          "required": [
+            "task"
+          ]
         },
         {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "tasks": {
               "description": "parallel task group to run",
@@ -785,7 +834,9 @@
               "type": "array"
             }
           },
-          "required": ["tasks"]
+          "required": [
+            "tasks"
+          ]
         }
       ]
     },
@@ -820,8 +871,10 @@
               }
             }
           },
-          "required": ["task"],
-          "additionalProperties": false
+          "required": [
+            "task"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -891,7 +944,9 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": ["path"]
+          "required": [
+            "path"
+          ]
         },
         {
           "type": "object",
@@ -900,7 +955,9 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": ["paths"]
+          "required": [
+            "paths"
+          ]
         }
       ]
     },
@@ -908,7 +965,13 @@
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
+      "examples": [
+        "linux",
+        "macos",
+        "windows",
+        "macos/arm64",
+        "linux/x64"
+      ]
     }
   }
 }

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -75,21 +75,11 @@
                 },
                 "default": {
                   "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": [
-                    "yes",
-                    "no",
-                    "y",
-                    "n",
-                    "true",
-                    "false"
-                  ],
+                  "enum": ["yes", "no", "y", "n", "true", "false"],
                   "type": "string"
                 }
               },
-              "required": [
-                "message",
-                "default"
-              ],
+              "required": ["message", "default"],
               "unevaluatedProperties": false,
               "type": "object"
             }
@@ -173,9 +163,7 @@
                     "$ref": "#/$defs/os_filter"
                   }
                 },
-                "required": [
-                  "version"
-                ],
+                "required": ["version"],
                 "type": "object",
                 "additionalProperties": {
                   "oneOf": [
@@ -213,15 +201,11 @@
               "properties": {
                 "auto": {
                   "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [
-                    true
-                  ],
+                  "enum": [true],
                   "type": "boolean"
                 }
               },
-              "required": [
-                "auto"
-              ],
+              "required": ["auto"],
               "type": "object"
             }
           ]
@@ -239,10 +223,7 @@
               "type": "boolean"
             },
             {
-              "enum": [
-                "stdout",
-                "stderr"
-              ],
+              "enum": ["stdout", "stderr"],
               "type": "string"
             }
           ]
@@ -448,9 +429,7 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": [
-              "age"
-            ],
+            "required": ["age"],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -466,10 +445,7 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": [
-                      "raw",
-                      "zstd"
-                    ],
+                    "enum": ["raw", "zstd"],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -494,16 +470,12 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": [
-                  "value"
-                ],
+                "required": ["value"],
                 "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": [
-              "age"
-            ],
+            "required": ["age"],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -597,9 +569,7 @@
                           ]
                         }
                       },
-                      "required": [
-                        "path"
-                      ]
+                      "required": ["path"]
                     },
                     {
                       "type": "object",
@@ -611,9 +581,7 @@
                           }
                         }
                       },
-                      "required": [
-                        "paths"
-                      ]
+                      "required": ["paths"]
                     }
                   ]
                 },
@@ -697,9 +665,7 @@
                           }
                         }
                       },
-                      "required": [
-                        "path"
-                      ],
+                      "required": ["path"],
                       "type": "object"
                     }
                   ]
@@ -817,9 +783,7 @@
               }
             }
           },
-          "required": [
-            "task"
-          ]
+          "required": ["task"]
         },
         {
           "type": "object",
@@ -834,9 +798,7 @@
               "type": "array"
             }
           },
-          "required": [
-            "tasks"
-          ]
+          "required": ["tasks"]
         }
       ]
     },
@@ -871,9 +833,7 @@
               }
             }
           },
-          "required": [
-            "task"
-          ],
+          "required": ["task"],
           "unevaluatedProperties": false
         }
       ]
@@ -944,9 +904,7 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": [
-            "path"
-          ]
+          "required": ["path"]
         },
         {
           "type": "object",
@@ -955,9 +913,7 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": [
-            "paths"
-          ]
+          "required": ["paths"]
         }
       ]
     },
@@ -965,13 +921,7 @@
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": [
-        "linux",
-        "macos",
-        "windows",
-        "macos/arm64",
-        "linux/x64"
-      ]
+      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
     }
   }
 }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -35,7 +35,9 @@
               }
             }
           },
-          "required": ["task"],
+          "required": [
+            "task"
+          ],
           "unevaluatedProperties": false
         }
       ]
@@ -44,7 +46,13 @@
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
+      "examples": [
+        "linux",
+        "macos",
+        "windows",
+        "macos/arm64",
+        "linux/x64"
+      ]
     },
     "os_filter": {
       "description": "operating system filters to install on",
@@ -112,7 +120,9 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": ["path"]
+          "required": [
+            "path"
+          ]
         },
         {
           "type": "object",
@@ -121,7 +131,9 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": ["paths"]
+          "required": [
+            "paths"
+          ]
         }
       ]
     },
@@ -197,7 +209,9 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": ["age"],
+            "required": [
+              "age"
+            ],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -213,7 +227,10 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": ["raw", "zstd"],
+                    "enum": [
+                      "raw",
+                      "zstd"
+                    ],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -238,12 +255,16 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": ["value"],
+                "required": [
+                  "value"
+                ],
                 "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": ["age"],
+            "required": [
+              "age"
+            ],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -337,7 +358,9 @@
                           ]
                         }
                       },
-                      "required": ["path"]
+                      "required": [
+                        "path"
+                      ]
                     },
                     {
                       "type": "object",
@@ -349,7 +372,9 @@
                           }
                         }
                       },
-                      "required": ["paths"]
+                      "required": [
+                        "paths"
+                      ]
                     }
                   ]
                 },
@@ -433,7 +458,9 @@
                           }
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "type": "object"
                     }
                   ]
@@ -636,7 +663,13 @@
           "default": "default",
           "description": "Theme for interactive prompts (default/charm, base16, catppuccin, dracula)",
           "type": "string",
-          "enum": ["default", "charm", "base16", "catppuccin", "dracula"]
+          "enum": [
+            "default",
+            "charm",
+            "base16",
+            "catppuccin",
+            "dracula"
+          ]
         },
         "conda": {
           "type": "object",
@@ -1049,7 +1082,11 @@
         "libc": {
           "description": "Libc implementation to use for precompiled Linux binaries.",
           "type": "string",
-          "enum": ["glibc", "gnu", "musl"]
+          "enum": [
+            "glibc",
+            "gnu",
+            "musl"
+          ]
         },
         "libgit2": {
           "default": true,
@@ -1081,7 +1118,13 @@
           "default": "info",
           "description": "Show more/less output.",
           "type": "string",
-          "enum": ["trace", "debug", "info", "warn", "error"]
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "minimum_release_age": {
           "description": "Minimum release age / supply chain protection — only install versions older than this threshold",
@@ -1195,7 +1238,13 @@
               "default": "auto",
               "description": "Package manager to use for installing npm packages.",
               "type": "string",
-              "enum": ["auto", "npm", "aube", "bun", "pnpm"]
+              "enum": [
+                "auto",
+                "npm",
+                "aube",
+                "bun",
+                "pnpm"
+              ]
             }
           }
         },
@@ -1324,7 +1373,12 @@
             "uv_venv_auto": {
               "default": false,
               "description": "Integrate with uv to manage project venvs when uv.lock is present.",
-              "enum": [false, "source", "create|source", true],
+              "enum": [
+                false,
+                "source",
+                "create|source",
+                true
+              ],
               "oneOf": [
                 {
                   "type": "boolean"
@@ -1746,7 +1800,14 @@
           "type": "string"
         },
         "windows_executable_extensions": {
-          "default": ["exe", "bat", "cmd", "com", "ps1", "vbs"],
+          "default": [
+            "exe",
+            "bat",
+            "cmd",
+            "com",
+            "ps1",
+            "vbs"
+          ],
           "description": "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on.",
           "type": "array",
           "items": {
@@ -1804,7 +1865,9 @@
               }
             }
           },
-          "required": ["task"]
+          "required": [
+            "task"
+          ]
         },
         {
           "type": "object",
@@ -1819,7 +1882,9 @@
               "type": "array"
             }
           },
-          "required": ["tasks"]
+          "required": [
+            "tasks"
+          ]
         }
       ]
     },
@@ -1994,7 +2059,9 @@
               "type": "string"
             }
           },
-          "required": ["version"],
+          "required": [
+            "version"
+          ],
           "type": "object",
           "additionalProperties": {
             "oneOf": [
@@ -2050,7 +2117,9 @@
                 "type": "string"
               }
             },
-            "required": ["task"],
+            "required": [
+              "task"
+            ],
             "type": "object"
           },
           {
@@ -2083,7 +2152,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["task"],
+                  "required": [
+                    "task"
+                  ],
                   "type": "object"
                 }
               ]
@@ -2119,10 +2190,14 @@
         },
         "oneOf": [
           {
-            "required": ["run"]
+            "required": [
+              "run"
+            ]
           },
           {
-            "required": ["task"]
+            "required": [
+              "task"
+            ]
           }
         ]
       }
@@ -2231,11 +2306,21 @@
                 },
                 "default": {
                   "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": ["yes", "no", "y", "n", "true", "false"],
+                  "enum": [
+                    "yes",
+                    "no",
+                    "y",
+                    "n",
+                    "true",
+                    "false"
+                  ],
                   "type": "string"
                 }
               },
-              "required": ["message", "default"],
+              "required": [
+                "message",
+                "default"
+              ],
               "unevaluatedProperties": false,
               "type": "object"
             }
@@ -2319,7 +2404,9 @@
                     "$ref": "#/$defs/os_filter"
                   }
                 },
-                "required": ["version"],
+                "required": [
+                  "version"
+                ],
                 "type": "object",
                 "additionalProperties": {
                   "oneOf": [
@@ -2357,11 +2444,15 @@
               "properties": {
                 "auto": {
                   "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [true],
+                  "enum": [
+                    true
+                  ],
                   "type": "boolean"
                 }
               },
-              "required": ["auto"],
+              "required": [
+                "auto"
+              ],
               "type": "object"
             }
           ]
@@ -2379,7 +2470,10 @@
               "type": "boolean"
             },
             {
-              "enum": ["stdout", "stderr"],
+              "enum": [
+                "stdout",
+                "stderr"
+              ],
               "type": "string"
             }
           ]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -35,9 +35,7 @@
               }
             }
           },
-          "required": [
-            "task"
-          ],
+          "required": ["task"],
           "unevaluatedProperties": false
         }
       ]
@@ -46,13 +44,7 @@
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": [
-        "linux",
-        "macos",
-        "windows",
-        "macos/arm64",
-        "linux/x64"
-      ]
+      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
     },
     "os_filter": {
       "description": "operating system filters to install on",
@@ -120,9 +112,7 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": [
-            "path"
-          ]
+          "required": ["path"]
         },
         {
           "type": "object",
@@ -131,9 +121,7 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": [
-            "paths"
-          ]
+          "required": ["paths"]
         }
       ]
     },
@@ -209,9 +197,7 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": [
-              "age"
-            ],
+            "required": ["age"],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -227,10 +213,7 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": [
-                      "raw",
-                      "zstd"
-                    ],
+                    "enum": ["raw", "zstd"],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -255,16 +238,12 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": [
-                  "value"
-                ],
+                "required": ["value"],
                 "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": [
-              "age"
-            ],
+            "required": ["age"],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -358,9 +337,7 @@
                           ]
                         }
                       },
-                      "required": [
-                        "path"
-                      ]
+                      "required": ["path"]
                     },
                     {
                       "type": "object",
@@ -372,9 +349,7 @@
                           }
                         }
                       },
-                      "required": [
-                        "paths"
-                      ]
+                      "required": ["paths"]
                     }
                   ]
                 },
@@ -458,9 +433,7 @@
                           }
                         }
                       },
-                      "required": [
-                        "path"
-                      ],
+                      "required": ["path"],
                       "type": "object"
                     }
                   ]
@@ -663,13 +636,7 @@
           "default": "default",
           "description": "Theme for interactive prompts (default/charm, base16, catppuccin, dracula)",
           "type": "string",
-          "enum": [
-            "default",
-            "charm",
-            "base16",
-            "catppuccin",
-            "dracula"
-          ]
+          "enum": ["default", "charm", "base16", "catppuccin", "dracula"]
         },
         "conda": {
           "type": "object",
@@ -1082,11 +1049,7 @@
         "libc": {
           "description": "Libc implementation to use for precompiled Linux binaries.",
           "type": "string",
-          "enum": [
-            "glibc",
-            "gnu",
-            "musl"
-          ]
+          "enum": ["glibc", "gnu", "musl"]
         },
         "libgit2": {
           "default": true,
@@ -1118,13 +1081,7 @@
           "default": "info",
           "description": "Show more/less output.",
           "type": "string",
-          "enum": [
-            "trace",
-            "debug",
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["trace", "debug", "info", "warn", "error"]
         },
         "minimum_release_age": {
           "description": "Minimum release age / supply chain protection — only install versions older than this threshold",
@@ -1238,13 +1195,7 @@
               "default": "auto",
               "description": "Package manager to use for installing npm packages.",
               "type": "string",
-              "enum": [
-                "auto",
-                "npm",
-                "aube",
-                "bun",
-                "pnpm"
-              ]
+              "enum": ["auto", "npm", "aube", "bun", "pnpm"]
             }
           }
         },
@@ -1373,12 +1324,7 @@
             "uv_venv_auto": {
               "default": false,
               "description": "Integrate with uv to manage project venvs when uv.lock is present.",
-              "enum": [
-                false,
-                "source",
-                "create|source",
-                true
-              ],
+              "enum": [false, "source", "create|source", true],
               "oneOf": [
                 {
                   "type": "boolean"
@@ -1800,14 +1746,7 @@
           "type": "string"
         },
         "windows_executable_extensions": {
-          "default": [
-            "exe",
-            "bat",
-            "cmd",
-            "com",
-            "ps1",
-            "vbs"
-          ],
+          "default": ["exe", "bat", "cmd", "com", "ps1", "vbs"],
           "description": "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on.",
           "type": "array",
           "items": {
@@ -1865,9 +1804,7 @@
               }
             }
           },
-          "required": [
-            "task"
-          ]
+          "required": ["task"]
         },
         {
           "type": "object",
@@ -1882,9 +1819,7 @@
               "type": "array"
             }
           },
-          "required": [
-            "tasks"
-          ]
+          "required": ["tasks"]
         }
       ]
     },
@@ -2059,9 +1994,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "version"
-          ],
+          "required": ["version"],
           "type": "object",
           "additionalProperties": {
             "oneOf": [
@@ -2117,9 +2050,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "task"
-            ],
+            "required": ["task"],
             "type": "object"
           },
           {
@@ -2152,9 +2083,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "task"
-                  ],
+                  "required": ["task"],
                   "type": "object"
                 }
               ]
@@ -2190,14 +2119,10 @@
         },
         "oneOf": [
           {
-            "required": [
-              "run"
-            ]
+            "required": ["run"]
           },
           {
-            "required": [
-              "task"
-            ]
+            "required": ["task"]
           }
         ]
       }
@@ -2306,21 +2231,11 @@
                 },
                 "default": {
                   "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": [
-                    "yes",
-                    "no",
-                    "y",
-                    "n",
-                    "true",
-                    "false"
-                  ],
+                  "enum": ["yes", "no", "y", "n", "true", "false"],
                   "type": "string"
                 }
               },
-              "required": [
-                "message",
-                "default"
-              ],
+              "required": ["message", "default"],
               "unevaluatedProperties": false,
               "type": "object"
             }
@@ -2404,9 +2319,7 @@
                     "$ref": "#/$defs/os_filter"
                   }
                 },
-                "required": [
-                  "version"
-                ],
+                "required": ["version"],
                 "type": "object",
                 "additionalProperties": {
                   "oneOf": [
@@ -2444,15 +2357,11 @@
               "properties": {
                 "auto": {
                   "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [
-                    true
-                  ],
+                  "enum": [true],
                   "type": "boolean"
                 }
               },
-              "required": [
-                "auto"
-              ],
+              "required": ["auto"],
               "type": "object"
             }
           ]
@@ -2470,10 +2379,7 @@
               "type": "boolean"
             },
             {
-              "enum": [
-                "stdout",
-                "stderr"
-              ],
+              "enum": ["stdout", "stderr"],
               "type": "string"
             }
           ]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -35,8 +35,10 @@
               }
             }
           },
-          "required": ["task"],
-          "additionalProperties": false
+          "required": [
+            "task"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -44,7 +46,13 @@
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
+      "examples": [
+        "linux",
+        "macos",
+        "windows",
+        "macos/arm64",
+        "linux/x64"
+      ]
     },
     "os_filter": {
       "description": "operating system filters to install on",
@@ -112,7 +120,9 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": ["path"]
+          "required": [
+            "path"
+          ]
         },
         {
           "type": "object",
@@ -121,7 +131,9 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": ["paths"]
+          "required": [
+            "paths"
+          ]
         }
       ]
     },
@@ -166,7 +178,7 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "additionalProperties": false
+            "unevaluatedProperties": false
           },
           {
             "type": "object",
@@ -197,8 +209,10 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": ["age"],
-            "additionalProperties": false,
+            "required": [
+              "age"
+            ],
+            "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
           {
@@ -213,7 +227,10 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": ["raw", "zstd"],
+                    "enum": [
+                      "raw",
+                      "zstd"
+                    ],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -238,13 +255,17 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": ["value"],
-                "additionalProperties": false,
+                "required": [
+                  "value"
+                ],
+                "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": ["age"],
-            "additionalProperties": false,
+            "required": [
+              "age"
+            ],
+            "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
           {
@@ -337,7 +358,9 @@
                           ]
                         }
                       },
-                      "required": ["path"]
+                      "required": [
+                        "path"
+                      ]
                     },
                     {
                       "type": "object",
@@ -349,7 +372,9 @@
                           }
                         }
                       },
-                      "required": ["paths"]
+                      "required": [
+                        "paths"
+                      ]
                     }
                   ]
                 },
@@ -433,7 +458,9 @@
                           }
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "type": "object"
                     }
                   ]
@@ -475,7 +502,7 @@
     },
     "settings": {
       "type": "object",
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "properties": {
         "activate_aggressive": {
           "description": "Pushes tools' bin-paths to the front of PATH instead of allowing modifications of PATH after activation to take precedence.",
@@ -483,7 +510,7 @@
         },
         "age": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "identity_files": {
               "description": "[experimental] List of age identity files to use for decryption.",
@@ -524,7 +551,7 @@
         },
         "aqua": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "baked_registry": {
               "default": true,
@@ -592,7 +619,7 @@
         },
         "cargo": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "binstall": {
               "default": true,
@@ -636,11 +663,17 @@
           "default": "default",
           "description": "Theme for interactive prompts (default/charm, base16, catppuccin, dracula)",
           "type": "string",
-          "enum": ["default", "charm", "base16", "catppuccin", "dracula"]
+          "enum": [
+            "default",
+            "charm",
+            "base16",
+            "catppuccin",
+            "dracula"
+          ]
         },
         "conda": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "channel": {
               "default": "conda-forge",
@@ -693,7 +726,7 @@
         },
         "dotnet": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "cli_telemetry_optout": {
               "description": "Set DOTNET_CLI_TELEMETRY_OPTOUT to opt out of .NET CLI telemetry.",
@@ -758,7 +791,7 @@
         },
         "erlang": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "compile": {
               "description": "If true, compile erlang from source. If false, use precompiled binaries. If not set, use precompiled binaries if available.",
@@ -787,7 +820,7 @@
         },
         "forgejo": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "credential_command": {
               "default": "",
@@ -808,7 +841,7 @@
         },
         "github": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "credential_command": {
               "default": "",
@@ -844,7 +877,7 @@
         },
         "gitlab": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "credential_command": {
               "default": "",
@@ -878,7 +911,7 @@
         },
         "go": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "default_packages_file": {
               "default": "~/.default-go-packages",
@@ -956,7 +989,7 @@
         },
         "hook_env": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "cache_ttl": {
               "default": "0s",
@@ -1017,7 +1050,7 @@
         },
         "java": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "shorthand_vendor": {
               "default": "openjdk",
@@ -1049,7 +1082,11 @@
         "libc": {
           "description": "Libc implementation to use for precompiled Linux binaries.",
           "type": "string",
-          "enum": ["glibc", "gnu", "musl"]
+          "enum": [
+            "glibc",
+            "gnu",
+            "musl"
+          ]
         },
         "libgit2": {
           "default": true,
@@ -1081,7 +1118,13 @@
           "default": "info",
           "description": "Show more/less output.",
           "type": "string",
-          "enum": ["trace", "debug", "info", "warn", "error"]
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "minimum_release_age": {
           "description": "Minimum release age / supply chain protection — only install versions older than this threshold",
@@ -1106,7 +1149,7 @@
         },
         "node": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "cflags": {
               "description": "Additional CFLAGS options (e.g., to override -O3).",
@@ -1184,7 +1227,7 @@
         },
         "npm": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "bun": {
               "description": "Use bun instead of npm if bun is installed and on PATH.",
@@ -1195,13 +1238,19 @@
               "default": "auto",
               "description": "Package manager to use for installing npm packages.",
               "type": "string",
-              "enum": ["auto", "npm", "aube", "bun", "pnpm"]
+              "enum": [
+                "auto",
+                "npm",
+                "aube",
+                "bun",
+                "pnpm"
+              ]
             }
           }
         },
         "oci": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "default_from": {
               "default": "debian:bookworm-slim",
@@ -1249,7 +1298,7 @@
         },
         "pipx": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "registry_url": {
               "default": "https://pypi.org/pypi/{}/json",
@@ -1282,7 +1331,7 @@
         },
         "python": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "compile": {
               "description": "If true, compile python from source. If false, use precompiled binaries. If not set, use precompiled binaries if available.",
@@ -1324,7 +1373,12 @@
             "uv_venv_auto": {
               "default": false,
               "description": "Integrate with uv to manage project venvs when uv.lock is present.",
-              "enum": [false, "source", "create|source", true],
+              "enum": [
+                false,
+                "source",
+                "create|source",
+                true
+              ],
               "oneOf": [
                 {
                   "type": "boolean"
@@ -1364,7 +1418,7 @@
         },
         "ruby": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "apply_patches": {
               "description": "A list of patch files or URLs to apply to ruby source.",
@@ -1426,7 +1480,7 @@
         },
         "rust": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "cargo_home": {
               "description": "Path to the cargo home directory. Defaults to `~/.cargo` or `%USERPROFILE%\\.cargo`",
@@ -1465,7 +1519,7 @@
         },
         "sops": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "age_key": {
               "description": "The age private key to use for sops secret decryption. Takes precedence over standard SOPS_AGE_KEY environment variable.",
@@ -1493,7 +1547,7 @@
         },
         "status": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "missing_tools": {
               "default": "if_other_versions_installed",
@@ -1522,7 +1576,7 @@
         },
         "swift": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "gpg_verify": {
               "description": "Use gpg to verify swift tool signatures.",
@@ -1540,7 +1594,7 @@
         },
         "task": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "disable_paths": {
               "default": [],
@@ -1746,7 +1800,14 @@
           "type": "string"
         },
         "windows_executable_extensions": {
-          "default": ["exe", "bat", "cmd", "com", "ps1", "vbs"],
+          "default": [
+            "exe",
+            "bat",
+            "cmd",
+            "com",
+            "ps1",
+            "vbs"
+          ],
           "description": "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on.",
           "type": "array",
           "items": {
@@ -1764,7 +1825,7 @@
         },
         "zig": {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "use_community_mirrors": {
               "default": true,
@@ -1783,7 +1844,7 @@
         },
         {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "task": {
               "description": "single task name to run",
@@ -1804,11 +1865,13 @@
               }
             }
           },
-          "required": ["task"]
+          "required": [
+            "task"
+          ]
         },
         {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "tasks": {
               "description": "parallel task group to run",
@@ -1819,7 +1882,9 @@
               "type": "array"
             }
           },
-          "required": ["tasks"]
+          "required": [
+            "tasks"
+          ]
         }
       ]
     },
@@ -1838,323 +1903,20 @@
           "type": "array"
         },
         {
-          "properties": {
-            "alias": {
-              "oneOf": [
-                {
-                  "description": "alias for this task",
-                  "type": "string"
-                },
-                {
-                  "description": "alias for this task",
-                  "items": {
-                    "description": "alias for this task",
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
+          "allOf": [
+            {
+              "$ref": "#/$defs/task_props"
             },
-            "confirm": {
-              "oneOf": [
-                {
-                  "description": "confirmation message before running this task",
-                  "type": "string"
-                },
-                {
-                  "description": "confirmation message before running this task with default value",
-                  "properties": {
-                    "message": {
-                      "description": "confirmation message before running this task",
-                      "type": "string"
-                    },
-                    "default": {
-                      "description": "default value for confirmation (yes/no/true/false)",
-                      "enum": ["yes", "no", "y", "n", "true", "false"],
-                      "type": "string"
-                    }
-                  },
-                  "required": ["message", "default"],
-                  "additionalProperties": false,
-                  "type": "object"
-                }
-              ]
-            },
-            "depends": {
-              "oneOf": [
-                {
-                  "description": "task with args to run before this task",
-                  "type": "string"
-                },
-                {
-                  "description": "task with args to run before this task",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/task_dependency_item"
-                  }
-                }
-              ]
-            },
-            "depends_post": {
-              "oneOf": [
-                {
-                  "description": "task with args to run after this task",
-                  "type": "string"
-                },
-                {
-                  "description": "task with args to run after this task",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/task_dependency_item"
-                  }
-                }
-              ]
-            },
-            "wait_for": {
-              "oneOf": [
-                {
-                  "description": "task with args to wait for completion first",
-                  "type": "string"
-                },
-                {
-                  "description": "task with args to wait for completion first",
-                  "items": {
-                    "$ref": "#/$defs/task_dependency_item"
-                  },
-                  "type": "array"
-                }
-              ]
-            },
-            "description": {
-              "description": "description of task",
-              "type": "string"
-            },
-            "dir": {
-              "default": "{{ config_root }}",
-              "description": "directory to run script in, default is the project's base directory",
-              "type": "string"
-            },
-            "env": {
-              "$ref": "#/$defs/env"
-            },
-            "vars": {
-              "$ref": "#/$defs/vars"
-            },
-            "tools": {
-              "description": "tools to install/activate before running this task",
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "description": "version of the tool to install",
-                    "type": "string"
-                  },
-                  {
-                    "properties": {
-                      "version": {
-                        "description": "version of the tool to install",
-                        "type": "string"
-                      },
-                      "os": {
-                        "$ref": "#/$defs/os_filter"
-                      }
-                    },
-                    "required": ["version"],
-                    "type": "object",
-                    "additionalProperties": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              "type": "object"
-            },
-            "hide": {
-              "default": false,
-              "description": "do not display this task",
-              "type": "boolean"
-            },
-            "outputs": {
-              "oneOf": [
-                {
-                  "description": "files created by this task",
-                  "items": {
-                    "description": "glob pattern or path to files created by this task",
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "description": "glob pattern or path to files created by this task",
-                  "type": "string"
-                },
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "auto": {
-                      "description": "automatically touch an internal tracked file instead of specifying outputs",
-                      "enum": [true],
-                      "type": "boolean"
-                    }
-                  },
-                  "required": ["auto"],
-                  "type": "object"
-                }
-              ]
-            },
-            "quiet": {
-              "default": false,
-              "description": "do not display mise information for this task",
-              "type": "boolean"
-            },
-            "silent": {
-              "default": false,
-              "description": "suppress all output for this task",
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "enum": ["stdout", "stderr"],
+            {
+              "properties": {
+                "extends": {
+                  "description": "name of the task template to extend",
                   "type": "string"
                 }
-              ]
-            },
-            "interactive": {
-              "default": false,
-              "description": "mark task as interactive, acquiring exclusive terminal access while allowing other non-interactive tasks to run in parallel",
-              "type": "boolean"
-            },
-            "raw": {
-              "default": false,
-              "description": "directly connect task to stdin/stdout/stderr",
-              "type": "boolean"
-            },
-            "raw_args": {
-              "default": false,
-              "description": "skip mise's argument parsing for this task — all arguments (including --help/-h) are forwarded verbatim to the underlying command. Use for tasks that proxy a tool with its own argument parser.",
-              "type": "boolean"
-            },
-            "run": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/task_run_entry"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/task_run_entry"
-                  }
-                }
-              ]
-            },
-            "run_windows": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/task_run_entry"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/task_run_entry"
-                  }
-                }
-              ]
-            },
-            "file": {
-              "description": "Execute an external script",
-              "type": "string"
-            },
-            "sources": {
-              "oneOf": [
-                {
-                  "description": "files that this task depends on (entries starting with `!` are excluded; use `\\!` to escape a literal `!` prefix)",
-                  "items": {
-                    "description": "glob pattern or path to files that this task depends on (entries starting with `!` are excluded)",
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "description": "glob pattern or path to files that this task depends on (entries starting with `!` are excluded)",
-                  "type": "string"
-                }
-              ]
-            },
-            "shell": {
-              "description": "specify a shell command to run the script with",
-              "type": "string"
-            },
-            "usage": {
-              "description": "Specify usage (https://usage.jdx.dev/) specs for the task",
-              "type": "string"
-            },
-            "timeout": {
-              "description": "timeout for this task",
-              "type": "string"
-            },
-            "deny_all": {
-              "default": false,
-              "description": "block reads, writes, network, and env vars",
-              "type": "boolean"
-            },
-            "deny_read": {
-              "default": false,
-              "description": "block filesystem reads",
-              "type": "boolean"
-            },
-            "deny_write": {
-              "default": false,
-              "description": "block all filesystem writes",
-              "type": "boolean"
-            },
-            "deny_net": {
-              "default": false,
-              "description": "block all network access",
-              "type": "boolean"
-            },
-            "deny_env": {
-              "default": false,
-              "description": "block env var inheritance",
-              "type": "boolean"
-            },
-            "allow_read": {
-              "description": "allow reads from specific paths",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "allow_write": {
-              "description": "allow writes to specific paths",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "allow_net": {
-              "description": "allow network to specific hosts",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "allow_env": {
-              "description": "allow specific env vars through",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "extends": {
-              "description": "name of the task template to extend",
-              "type": "string"
+              }
             }
-          },
-          "additionalProperties": false,
+          ],
+          "unevaluatedProperties": false,
           "type": "object"
         }
       ]
@@ -2211,7 +1973,7 @@
     "task_config": {
       "description": "configuration for task execution/management",
       "type": "object",
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "properties": {
         "dir": {
           "description": "default directory to run tasks in defined in this file",
@@ -2234,7 +1996,7 @@
     "monorepo": {
       "description": "Configuration for monorepo task discovery",
       "type": "object",
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "properties": {
         "config_roots": {
           "description": "Explicit list of config root paths for monorepo task discovery. Supports single-level glob patterns (*). When set, skips filesystem walking for better performance.",
@@ -2297,7 +2059,9 @@
               "type": "string"
             }
           },
-          "required": ["version"],
+          "required": [
+            "version"
+          ],
           "type": "object",
           "additionalProperties": {
             "oneOf": [
@@ -2332,7 +2096,7 @@
             "type": "string"
           },
           {
-            "additionalProperties": false,
+            "unevaluatedProperties": false,
             "properties": {
               "script": {
                 "description": "script to run",
@@ -2346,14 +2110,16 @@
             "type": "object"
           },
           {
-            "additionalProperties": false,
+            "unevaluatedProperties": false,
             "properties": {
               "task": {
                 "description": "mise task to run",
                 "type": "string"
               }
             },
-            "required": ["task"],
+            "required": [
+              "task"
+            ],
             "type": "object"
           },
           {
@@ -2365,7 +2131,7 @@
                   "type": "string"
                 },
                 {
-                  "additionalProperties": false,
+                  "unevaluatedProperties": false,
                   "properties": {
                     "script": {
                       "description": "script to run",
@@ -2379,14 +2145,16 @@
                   "type": "object"
                 },
                 {
-                  "additionalProperties": false,
+                  "unevaluatedProperties": false,
                   "properties": {
                     "task": {
                       "description": "mise task to run",
                       "type": "string"
                     }
                   },
-                  "required": ["task"],
+                  "required": [
+                    "task"
+                  ],
                   "type": "object"
                 }
               ]
@@ -2402,7 +2170,7 @@
       "items": {
         "type": "object",
         "description": "file to watch for changes",
-        "additionalProperties": false,
+        "unevaluatedProperties": false,
         "properties": {
           "run": {
             "type": "string",
@@ -2422,10 +2190,14 @@
         },
         "oneOf": [
           {
-            "required": ["run"]
+            "required": [
+              "run"
+            ]
           },
           {
-            "required": ["task"]
+            "required": [
+              "task"
+            ]
           }
         ]
       }
@@ -2497,7 +2269,7 @@
           "description": "Timeout for the run command (e.g., \"30s\", \"5m\", \"1h\")"
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "description": "Prepare provider configuration"
     },
     "task_props": {
@@ -2534,12 +2306,22 @@
                 },
                 "default": {
                   "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": ["yes", "no", "y", "n", "true", "false"],
+                  "enum": [
+                    "yes",
+                    "no",
+                    "y",
+                    "n",
+                    "true",
+                    "false"
+                  ],
                   "type": "string"
                 }
               },
-              "required": ["message", "default"],
-              "additionalProperties": false,
+              "required": [
+                "message",
+                "default"
+              ],
+              "unevaluatedProperties": false,
               "type": "object"
             }
           ]
@@ -2622,7 +2404,9 @@
                     "$ref": "#/$defs/os_filter"
                   }
                 },
-                "required": ["version"],
+                "required": [
+                  "version"
+                ],
                 "type": "object",
                 "additionalProperties": {
                   "oneOf": [
@@ -2656,15 +2440,19 @@
               "type": "string"
             },
             {
-              "additionalProperties": false,
+              "unevaluatedProperties": false,
               "properties": {
                 "auto": {
                   "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [true],
+                  "enum": [
+                    true
+                  ],
                   "type": "boolean"
                 }
               },
-              "required": ["auto"],
+              "required": [
+                "auto"
+              ],
               "type": "object"
             }
           ]
@@ -2682,7 +2470,10 @@
               "type": "boolean"
             },
             {
-              "enum": ["stdout", "stderr"],
+              "enum": [
+                "stdout",
+                "stderr"
+              ],
               "type": "string"
             }
           ]
@@ -2818,323 +2609,16 @@
     },
     "task_template": {
       "description": "task template that can be extended by tasks",
-      "properties": {
-        "alias": {
-          "oneOf": [
-            {
-              "description": "alias for this task",
-              "type": "string"
-            },
-            {
-              "description": "alias for this task",
-              "items": {
-                "description": "alias for this task",
-                "type": "string"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "confirm": {
-          "oneOf": [
-            {
-              "description": "confirmation message before running this task",
-              "type": "string"
-            },
-            {
-              "description": "confirmation message before running this task with default value",
-              "properties": {
-                "message": {
-                  "description": "confirmation message before running this task",
-                  "type": "string"
-                },
-                "default": {
-                  "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": ["yes", "no", "y", "n", "true", "false"],
-                  "type": "string"
-                }
-              },
-              "required": ["message", "default"],
-              "additionalProperties": false,
-              "type": "object"
-            }
-          ]
-        },
-        "depends": {
-          "oneOf": [
-            {
-              "description": "task with args to run before this task",
-              "type": "string"
-            },
-            {
-              "description": "task with args to run before this task",
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/task_dependency_item"
-              }
-            }
-          ]
-        },
-        "depends_post": {
-          "oneOf": [
-            {
-              "description": "task with args to run after this task",
-              "type": "string"
-            },
-            {
-              "description": "task with args to run after this task",
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/task_dependency_item"
-              }
-            }
-          ]
-        },
-        "wait_for": {
-          "oneOf": [
-            {
-              "description": "task with args to wait for completion first",
-              "type": "string"
-            },
-            {
-              "description": "task with args to wait for completion first",
-              "items": {
-                "$ref": "#/$defs/task_dependency_item"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "description": {
-          "description": "description of task",
-          "type": "string"
-        },
-        "dir": {
-          "default": "{{ config_root }}",
-          "description": "directory to run script in, default is the project's base directory",
-          "type": "string"
-        },
-        "env": {
-          "$ref": "#/$defs/env"
-        },
-        "vars": {
-          "$ref": "#/$defs/vars"
-        },
-        "tools": {
-          "description": "tools to install/activate before running this task",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "description": "version of the tool to install",
-                "type": "string"
-              },
-              {
-                "properties": {
-                  "version": {
-                    "description": "version of the tool to install",
-                    "type": "string"
-                  },
-                  "os": {
-                    "$ref": "#/$defs/os_filter"
-                  }
-                },
-                "required": ["version"],
-                "type": "object",
-                "additionalProperties": {
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          "type": "object"
-        },
-        "hide": {
-          "default": false,
-          "description": "do not display this task",
-          "type": "boolean"
-        },
-        "outputs": {
-          "oneOf": [
-            {
-              "description": "files created by this task",
-              "items": {
-                "description": "glob pattern or path to files created by this task",
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "description": "glob pattern or path to files created by this task",
-              "type": "string"
-            },
-            {
-              "additionalProperties": false,
-              "properties": {
-                "auto": {
-                  "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [true],
-                  "type": "boolean"
-                }
-              },
-              "required": ["auto"],
-              "type": "object"
-            }
-          ]
-        },
-        "quiet": {
-          "default": false,
-          "description": "do not display mise information for this task",
-          "type": "boolean"
-        },
-        "silent": {
-          "default": false,
-          "description": "suppress all output for this task",
-          "oneOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "enum": ["stdout", "stderr"],
-              "type": "string"
-            }
-          ]
-        },
-        "interactive": {
-          "default": false,
-          "description": "mark task as interactive, acquiring exclusive terminal access while allowing other non-interactive tasks to run in parallel",
-          "type": "boolean"
-        },
-        "raw": {
-          "default": false,
-          "description": "directly connect task to stdin/stdout/stderr",
-          "type": "boolean"
-        },
-        "raw_args": {
-          "default": false,
-          "description": "skip mise's argument parsing for this task — all arguments (including --help/-h) are forwarded verbatim to the underlying command. Use for tasks that proxy a tool with its own argument parser.",
-          "type": "boolean"
-        },
-        "run": {
-          "oneOf": [
-            {
-              "$ref": "#/$defs/task_run_entry"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/task_run_entry"
-              }
-            }
-          ]
-        },
-        "run_windows": {
-          "oneOf": [
-            {
-              "$ref": "#/$defs/task_run_entry"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/task_run_entry"
-              }
-            }
-          ]
-        },
-        "file": {
-          "description": "Execute an external script",
-          "type": "string"
-        },
-        "sources": {
-          "oneOf": [
-            {
-              "description": "files that this task depends on (entries starting with `!` are excluded; use `\\!` to escape a literal `!` prefix)",
-              "items": {
-                "description": "glob pattern or path to files that this task depends on (entries starting with `!` are excluded)",
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "description": "glob pattern or path to files that this task depends on (entries starting with `!` are excluded)",
-              "type": "string"
-            }
-          ]
-        },
-        "shell": {
-          "description": "specify a shell command to run the script with",
-          "type": "string"
-        },
-        "usage": {
-          "description": "Specify usage (https://usage.jdx.dev/) specs for the task",
-          "type": "string"
-        },
-        "timeout": {
-          "description": "timeout for this task",
-          "type": "string"
-        },
-        "deny_all": {
-          "default": false,
-          "description": "block reads, writes, network, and env vars",
-          "type": "boolean"
-        },
-        "deny_read": {
-          "default": false,
-          "description": "block filesystem reads",
-          "type": "boolean"
-        },
-        "deny_write": {
-          "default": false,
-          "description": "block all filesystem writes",
-          "type": "boolean"
-        },
-        "deny_net": {
-          "default": false,
-          "description": "block all network access",
-          "type": "boolean"
-        },
-        "deny_env": {
-          "default": false,
-          "description": "block env var inheritance",
-          "type": "boolean"
-        },
-        "allow_read": {
-          "description": "allow reads from specific paths",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "allow_write": {
-          "description": "allow writes to specific paths",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "allow_net": {
-          "description": "allow network to specific hosts",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "allow_env": {
-          "description": "allow specific env vars through",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+      "allOf": [
+        {
+          "$ref": "#/$defs/task_props"
         }
-      },
-      "additionalProperties": false,
+      ],
+      "unevaluatedProperties": false,
       "type": "object"
     }
   },
-  "additionalProperties": false,
+  "unevaluatedProperties": false,
   "description": "config file for mise version manager (mise.toml)",
   "properties": {
     "alias": {
@@ -3268,7 +2752,7 @@
         },
         {
           "type": "object",
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "properties": {
             "hard": {
               "description": "error if current mise is lower than this version",
@@ -3353,7 +2837,7 @@
     },
     "oci": {
       "type": "object",
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "description": "configuration for `mise oci build`",
       "properties": {
         "from": {

--- a/schema/mise.plugin.json
+++ b/schema/mise.plugin.json
@@ -4,12 +4,12 @@
   "title": "mise-plugin",
   "description": "config file for a mise plugin",
   "type": "object",
-  "additionalProperties": false,
+  "unevaluatedProperties": false,
   "properties": {
     "list-aliases": {
       "description": "configuration for bin/list-aliases script",
       "type": "object",
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "properties": {
         "data": {
           "description": "list of aliases to add",
@@ -20,7 +20,7 @@
     "list-legacy-filenames": {
       "description": "configuration for bin/list-legacy-filenames script",
       "type": "object",
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "properties": {
         "data": {
           "description": "list of idiomatic filenames to check for",
@@ -31,7 +31,7 @@
     "list-bin-paths": {
       "description": "configuration for bin/list-bin-paths script",
       "type": "object",
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "properties": {
         "cache-key": {
           "description": "cache the results of bin/exec-env separately based on these values",
@@ -45,7 +45,7 @@
     "exec-env": {
       "description": "configuration for bin/exec-env script",
       "type": "object",
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "properties": {
         "cache-key": {
           "description": "cache the results of bin/exec-env separately based on these values",

--- a/schema/miserc.json
+++ b/schema/miserc.json
@@ -3,7 +3,7 @@
   "title": "mise rc config",
   "description": "Early initialization settings for mise. These settings are loaded before the main config files.",
   "type": "object",
-  "additionalProperties": false,
+  "unevaluatedProperties": false,
   "properties": {
     "ceiling_paths": {
       "default": [],

--- a/xtasks/render/schema.ts
+++ b/xtasks/render/schema.ts
@@ -37,7 +37,7 @@ type Element = {
 
 type NestedElement = {
   type: "object";
-  additionalProperties: false;
+  unevaluatedProperties: false;
   deprecated?: true;
   properties: Record<string, Element>;
 };
@@ -185,7 +185,7 @@ for (const key in doc) {
     for (const subkey in props) {
       settings[key] ??= {
         type: "object",
-        additionalProperties: false,
+        unevaluatedProperties: false,
         properties: {},
       };
       if (props.deprecated) {
@@ -202,28 +202,39 @@ for (const key in doc) {
 const schema = JSON.parse(fs.readFileSync("schema/mise.json", "utf-8"));
 schema["$defs"].settings.properties = settings;
 
-// Generate task and task_template from task_props to avoid unevaluatedProperties
-// (which Tombi doesn't support) while keeping extends only on tasks, not templates.
-const taskProps = schema["$defs"].task_props;
+// Keep task_props as the shared task-property definition. task and
+// task_template close over it with unevaluatedProperties so the property map is
+// only defined once.
+if (!schema["$defs"].task_props) {
+  throw new Error("schema/mise.json is missing $defs.task_props");
+}
 
-// task_template: task_props + additionalProperties: false
 schema["$defs"].task_template = {
   description: "task template that can be extended by tasks",
-  properties: { ...taskProps.properties },
-  additionalProperties: false,
+  allOf: [
+    {
+      $ref: "#/$defs/task_props",
+    },
+  ],
+  unevaluatedProperties: false,
   type: "object",
 };
 
-// task (object variant): task_props + extends + additionalProperties: false
 const taskObjectVariant = {
-  properties: {
-    ...taskProps.properties,
-    extends: {
-      description: "name of the task template to extend",
-      type: "string",
+  allOf: [
+    {
+      $ref: "#/$defs/task_props",
     },
-  },
-  additionalProperties: false,
+    {
+      properties: {
+        extends: {
+          description: "name of the task template to extend",
+          type: "string",
+        },
+      },
+    },
+  ],
+  unevaluatedProperties: false,
   type: "object",
 };
 
@@ -250,7 +261,7 @@ const misercSchema = {
   description:
     "Early initialization settings for mise. These settings are loaded before the main config files.",
   type: "object",
-  additionalProperties: false,
+  unevaluatedProperties: false,
   properties: misercSettings,
 };
 

--- a/xtasks/render/schema.ts
+++ b/xtasks/render/schema.ts
@@ -205,7 +205,7 @@ schema["$defs"].settings.properties = settings;
 // Keep task_props as the shared task-property definition. task and
 // task_template close over it with unevaluatedProperties so the property map is
 // only defined once.
-if (!schema["$defs"].task_props) {
+if (schema["$defs"].task_props === undefined) {
   throw new Error("schema/mise.json is missing $defs.task_props");
 }
 


### PR DESCRIPTION
## Summary
- Restore task and task template schemas to `allOf` + `unevaluatedProperties` now that Tombi supports the evaluated-property behavior needed here.
- Keep `task_props` in the generated included-task schema so task properties are defined once instead of duplicated into task and template objects.
- Use `unevaluatedProperties: false` consistently for closed object schemas across the other schema files too.
- Update the Tombi schema e2e test to assert the pinned Tombi version and document why the pin is new enough.

## Tombi support
- Tombi v0.9.19 includes `Fix issue 1719 unevaluatedProperties handling`: https://github.com/tombi-toml/tombi/releases/tag/v0.9.19
- The supporting Tombi PR is https://github.com/tombi-toml/tombi/pull/1725, which fixed evaluated-property collection for referenced schemas inside applicators so `allOf` + `unevaluatedProperties` does not report false diagnostics.
- The test remains pinned to Tombi v0.9.22, which is newer than v0.9.19, so no version bump was necessary.

## Test plan
- `mise run render:schema`
- `hk check schema/mise.json schema/mise-task.json schema/miserc.json schema/mise-settings.json schema/mise-registry-tool.json schema/mise.plugin.json xtasks/render/schema.ts`
- `taplo check settings.toml registry/*.toml test/fixtures/mise.plugin.toml`
- `mise run test:e2e config/test_schema_tombi`

This PR was generated by an AI coding assistant.
