### PR TITLE
fix(deps): remove bundler .bundle output fallback

### DIFF
--- a/src/deps/providers/bundler.rs
+++ b/src/deps/providers/bundler.rs
@@ -32,15 +32,7 @@ impl DepsProvider for BundlerDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        let root = self.base.config_root();
-        // Check for vendor/bundle if using --path vendor/bundle
-        let vendor = root.join("vendor/bundle");
-        if vendor.exists() {
-            vec![vendor]
-        } else {
-            // Use .bundle directory as fallback indicator
-            vec![root.join(".bundle")]
-        }
+        vec![self.base.config_root().join("vendor/bundle")]
     }
 
     fn install_command(&self) -> Result<DepsCommand> {


### PR DESCRIPTION
`.bundle` is not written by `bundle install`, so this causes `bundle install` to run every time because it's always stale.

This change makes it look a bit more like `pip`.