### PR TITLE
chore: warn on vendored vfox embedded plugins

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 zipsign.pub binary
 crates/aqua-registry/aqua-registry/** linguist-vendored
+crates/vfox/embedded-plugins/** linguist-vendored

--- a/.github/workflows/vendored-file-warning.yml
+++ b/.github/workflows/vendored-file-warning.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "crates/aqua-registry/aqua-registry/**"
+      - "crates/vfox/embedded-plugins/**"
 
 permissions: {}
 
@@ -23,5 +24,9 @@ jobs:
 
           The `registry/*.toml` files are fine to add here, but the backend should
           reference the package after it's been accepted upstream.
+
+          The vfox plugins under `crates/vfox/embedded-plugins/` are also vendored
+          from upstream repositories. Please submit changes to the upstream plugins
+          instead of modifying them directly in this repo.
           EOF
           exit 1


### PR DESCRIPTION
## Description
Adds a warning for modifications to vendored vfox embedded plugins under `crates/vfox/embedded-plugins/` in PRs, similarly to how we warn for `aqua-registry`. This also marks them as `linguist-vendored` in `.gitattributes`.

## Popularity
N/A - CI/infrastructure change.