### PR TITLE
registry: enable symlink_bins for elixir-ls

### DIFF
--- a/registry/elixir-ls.toml
+++ b/registry/elixir-ls.toml
@@ -1,3 +1,6 @@
-backends = ["aqua:elixir-lsp/elixir-ls", "asdf:mise-plugins/mise-elixir-ls"]
+backends = [
+  { full = "aqua:elixir-lsp/elixir-ls", options = { symlink_bins = "true" } },
+  "asdf:mise-plugins/mise-elixir-ls",
+]
 description = "A frontend-independent IDE 'smartness' server for Elixir. Implements the 'Language Server Protocol' standard and provides debugger support via the 'Debug Adapter Protocol'"
 test = { cmd = "which elixir-ls", expected = "elixir-ls" }


### PR DESCRIPTION
In the switch to the aqua backend, `elixir-ls` accidentally began to expose internal binaries that are not meant to be called directly; this fixes that problem