### PR TITLE
fix(schema): validate all schema files with draft2020 and strict mode

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -81,14 +81,8 @@ fi
     }
     ["schema"] {
         glob = List("schema/**/*.json")
-        batch = false
-        check = """
-        failed=0
-        {% for file in files_list %}
-        ajv compile -s {{ file }} --spec=draft2020 --strict-types=true --strict-tuples=true || failed=1
-        {% endfor %}
-        exit $failed
-        """
+        stdin = "{{ files_list | join(sep='\u{0}') }}"
+        check = "xargs -0 -I {} ajv compile -s {} --spec=draft2020 --strict-types=true --strict-tuples=true"
     }
 }
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -81,7 +81,14 @@ fi
     }
     ["schema"] {
         glob = List("schema/**/*.json")
-        check = "ajv compile -s schema/mise.json --spec=draft2019 --strict-schema=true && ajv compile -s schema/mise-task.json --spec=draft2019 --strict-schema=true && ajv compile -s schema/mise.plugin.json --spec=draft2020 --strict-schema=true && ajv compile -s schema/mise-registry-tool.json --spec=draft7 --strict-schema=true"
+        batch = false
+        check = """
+        failed=0
+        {% for file in files_list %}
+        ajv compile -s {{ file }} --spec=draft2020 --strict-types=true --strict-tuples=true || failed=1
+        {% endfor %}
+        exit $failed
+        """
     }
 }
 

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://mise.en.dev/schema/mise-registry-tool.json",
   "title": "mise registry tool schema",
   "description": "Schema for individual tool files in the mise registry",
@@ -56,13 +56,13 @@
                       "type": "object",
                       "description": "Platform-specific configuration",
                       "additionalProperties": {
-                        "type": ["string", "boolean"]
+                        "oneOf": [{ "type": "string" }, { "type": "boolean" }]
                       }
                     }
                   }
                 },
                 "additionalProperties": {
-                  "type": ["string", "boolean"]
+                  "oneOf": [{ "type": "string" }, { "type": "boolean" }]
                 }
               }
             },

--- a/schema/mise-settings.json
+++ b/schema/mise-settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://mise.en.dev/schema/mise-settings.json",
   "title": "Mise Settings Schema",
   "description": "JSON schema for mise settings.toml configuration file",
@@ -84,9 +84,15 @@
                 "properties": {
                   "value": {
                     "oneOf": [
-                      { "type": "string" },
-                      { "type": "boolean" },
-                      { "type": "integer" }
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      }
                     ],
                     "description": "The enum value"
                   },

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://mise.en.dev/schema/mise-task.json",
-  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "mise-task-schema",
   "type": "object",
   "$defs": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://mise.en.dev/schema/mise.json",
-  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "mise",
   "type": "object",
   "$defs": {
@@ -1324,8 +1324,15 @@
             "uv_venv_auto": {
               "default": false,
               "description": "Integrate with uv to manage project venvs when uv.lock is present.",
-              "type": ["boolean", "string"],
-              "enum": [false, "source", "create|source", true]
+              "enum": [false, "source", "create|source", true],
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "uv_venv_create_args": {
               "description": "Arguments to pass to uv when creating a venv.",

--- a/xtasks/render/schema.ts
+++ b/xtasks/render/schema.ts
@@ -54,7 +54,7 @@ function buildElement(key: string, props: Props): Element {
     ListPath: "string[]",
     SetString: "string[]",
     "IndexMap<String, String>": "object",
-    BoolOrString: ["boolean", "string"],
+    BoolOrString: "__bool_or_string__",
   };
   const type = props.type ? typeMap[props.type] : undefined;
   if (!type) {
@@ -91,6 +91,16 @@ function buildElement(key: string, props: Props): Element {
     element.additionalProperties = {
       type: "string",
     };
+  }
+
+  // BoolOrString: use oneOf instead of union type array for AJV strictTypes
+  if (type === "__bool_or_string__") {
+    delete (element as Record<string, unknown>).type;
+    const oneOfTypes: Array<{ type: string }> = [
+      { type: "boolean" },
+      { type: "string" },
+    ];
+    (element as Record<string, unknown>).oneOf = oneOfTypes;
   }
 
   return element;


### PR DESCRIPTION
## Summary

- **Validate all `schema/` files** — previously only a hardcoded subset was validated; now the hk check iterates over all `schema/**/*.json` files
- **Use draft2020 for all schemas** — previously mixed draft-07 (`mise-registry-tool.json`, `mise-settings.json`) and draft2019 (`mise.json`, `mise-task.json`); now consistently uses `draft/2020-12`
- **Remove `--strict-schema` flag** — this flag doesn't exist in `ajv compile` (confirmed via `ajv help compile`); replaced with `--strict-types=true` and `--strict-tuples=true`
- **Replace union type arrays with `oneOf`** — union type syntax like `"type": ["string", "boolean"]` triggers AJV `strictTypes` errors; replaced with explicit `oneOf` constructs in both hand-written schemas and the `schema.ts` renderer for generated schemas (`BoolOrString` type)