### PR TITLE
registry: add wasm-tools (aqua:bytecodealliance/wasm-tools)

### DIFF
--- a/registry/wasm-tools.toml
+++ b/registry/wasm-tools.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:bytecodealliance/wasm-tools"]
+description = "CLI and Rust libraries for low-level manipulation of WebAssembly modules"
+test = { cmd = "wasm-tools --version", expected = "wasm-tools {{version}}" }

--- a/registry/wasm-tools.toml
+++ b/registry/wasm-tools.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:bytecodealliance/wasm-tools"]
+backends = ["aqua:bytecodealliance/wasm-tools", "cargo:wasm-tools"]
 description = "CLI and Rust libraries for low-level manipulation of WebAssembly modules"
 test = { cmd = "wasm-tools --version", expected = "wasm-tools {{version}}" }


### PR DESCRIPTION
## Summary
Add `wasm-tools` to the mise registry using the `aqua:bytecodealliance/wasm-tools` backend.

## Popularity
- GitHub: 1,737 stars, 332 forks, latest release `v1.248.0` on 2026-04-28
- crates.io: 382,943 total downloads, 59,208 recent downloads
- Used by: Bytecode Alliance WebAssembly tooling ecosystem; referenced by WebAssembly Component Model docs; packaged by Arch Linux and Alpine

## Test
- `cargo run --quiet -- registry wasm-tools`
- `cargo test registry::tests`
- `MISE_DATA_DIR=/tmp/mise-wasm-tools-data MISE_CACHE_DIR=/tmp/mise-wasm-tools-cache target/debug/mise test-tool wasm-tools`
