### PR TITLE
registry: change aqua and vfox order in 1password.toml

### DIFF
--- a/registry/1password.toml
+++ b/registry/1password.toml
@@ -1,4 +1,4 @@
 aliases = ["1password-cli", "op"]
-backends = ["vfox:mise-plugins/vfox-1password", "aqua:1password/cli"]
+backends = ["aqua:1password/cli", "vfox:mise-plugins/vfox-1password"]
 description = "Password manager developed by AgileBits Inc"
 test = { cmd = "op --version", expected = "{{version}}" }


### PR DESCRIPTION
Change the order of registry to have aqua as first preference.

>Not accepted:
New vfox and asdf tools are not accepted for supply-chain security reasons — use aqua (preferred) or github instead. The ubi backend is deprecated and is not accepted for new registry entries. Users can still install via any backend themselves with explicit syntax (mise use vfox:owner/repo, mise use cargo:name, etc.) — they just don't get a registry shorthand for it.