### PR TITLE
fix(hooks): align hook run syntax with tasks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -41,14 +41,17 @@ preinstall = "echo 'I am about to install tools'"
 postinstall = "echo 'I just installed tools'"
 ```
 
-String hooks are shorthand for `run` hooks. Use a hook table when you need to select the inline shell command:
+String hooks are shorthand for `run` hooks. Use a hook table when you need to select the inline shell command or use task-style run entries:
 
 ```toml
 [hooks]
 postinstall = { run = "echo 'installed'", shell = "bash -c" }
+preinstall = { run_windows = "Write-Output installing" }
 ```
 
-For `preinstall` and `postinstall`, `script = ...` is a legacy alias for `run = ...`. If a `shell` is also set on a `script` hook, mise warns that the shell is ignored and still runs the script with the default inline shell. Use `run = ...` with `shell = "bash -c"` to choose the inline shell command. The `script` alias for install hooks is deprecated.
+`run_windows` can be provided by itself for a Windows-only hook or alongside `run` as a Windows-specific override.
+
+For `preinstall` and `postinstall`, `script = ...` is a legacy alias for `run = ...`. If a `shell` is also set on a `script` hook, the shell is ignored and the script runs with the default inline shell. Use `run = ...` with `shell = "bash -c"` to choose the inline shell command. The `script` alias for install hooks is deprecated.
 
 The `postinstall` hook receives a `MISE_INSTALLED_TOOLS` environment variable containing a JSON array of the tools that were just installed:
 
@@ -78,9 +81,7 @@ Tool-level postinstall scripts receive the following environment variables:
 
 ## Task hooks
 
-Instead of inline scripts, hooks can reference mise tasks. The task is executed as a subprocess
-via `mise run`, so it reuses the full task system including dependencies, environment variables,
-and file-based task definitions.
+Instead of inline commands, hooks can reference mise tasks. `task = "name"` is shorthand for `run = [{ task = "name" }]`, so it reuses the same task run-entry semantics as `[tasks]`.
 
 ```toml
 [tasks.setup]
@@ -99,6 +100,20 @@ enter = ["echo 'entering project'", { task = "setup" }]
 ```
 
 Task hooks work with all hook types (`enter`, `leave`, `cd`, `preinstall`, `postinstall`).
+
+Hook `run` supports the same entry forms as task `run`: script strings, single task entries with `args`/`env`, and task groups.
+
+```toml
+[hooks]
+postinstall = { run = [
+  "echo first shell",
+  "echo second shell",
+  { task = "setup", args = ["--fast"], env = { CI = "1" } },
+  { tasks = ["lint", "test"] },
+] }
+```
+
+Each script string is executed in its own subprocess shell, matching task `run` behavior.
 
 ## Watch files hook
 
@@ -136,12 +151,17 @@ Hooks are executed with the following environment variables set:
 Inline `run` hooks can be written as `{ run = "..." }` for any hook type. The string shorthand
 (`enter = "echo hi"`) is equivalent to `{ run = "echo hi" }`.
 
-`run` hooks execute in a subprocess using the default inline shell:
+`run` hooks execute in subprocesses using the default inline shell:
 [`unix_default_inline_shell_args`](/configuration/settings.html#unix_default_inline_shell_args)
 or [`windows_default_inline_shell_args`](/configuration/settings.html#windows_default_inline_shell_args).
 Add `shell = "bash -c"` to a `run` hook table to choose a different inline shell command. Like task
-`shell`, the value should include both the program and the argument that evaluates the inline command
+`shell`, the value should include both the program and the argument that evaluates the inline command,
 such as `bash -c`, `zsh -c`, or `pwsh -Command`.
+
+When `run` is an array, each script string is a separate shell execution. Structured entries such as
+`{ task = "setup", args = ["--fast"] }` and `{ tasks = ["lint", "test"] }` use task run-entry
+semantics. `run_windows` can be provided by itself for a Windows-only hook or alongside `run` as a
+Windows-specific override.
 
 ## Shell hooks
 
@@ -156,6 +176,17 @@ script = "source completions.sh"
 `script` with `shell` is for current-shell hooks. Here, `shell` is a shell-name selector such as
 `bash`, `zsh`, or `fish`, not an inline shell command like `bash -c`. mise only prints the script
 when the active `mise activate` shell matches.
+
+`script` may be a string or an array of current-shell lines:
+
+```toml
+[[hooks.enter]]
+shell = "fish"
+script = [
+  "set -gx PROJECT_MODE dev",
+  "source completions.fish",
+]
+```
 
 Use `run` when the hook should execute as an inline command in a subprocess. `preinstall` and
 `postinstall` do not have a current shell, so `script` is only kept there as a legacy alias for `run`;
@@ -180,7 +211,8 @@ You can use arrays to define multiple hooks in the same file:
 [hooks]
 enter = [
   "echo 'I entered the project'",
-  { run = "echo 'I am in the project'" }
+  { run = "echo 'I am in the project'" },
+  { task = "setup" },
 ]
 
 [[hooks.cd]]

--- a/e2e/config/test_hooks_run
+++ b/e2e/config/test_hooks_run
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "1"
+
+[env]
+PREINSTALL_TOOL_EXEC = { value = "{{ exec(command='dummy') }}", tools = true }
+
+[tasks.setup]
+run = 'echo TASK-SETUP FOO=${FOO:-unset} "$@"'
+
+[tasks.alpha]
+run = "echo TASK-GROUP-ALPHA"
+
+[tasks.beta]
+run = "echo TASK-GROUP-BETA"
+
+[hooks]
+preinstall = { shell = "bash", script = "echo LEGACY-PREINSTALL-SHELL PREINSTALL_TOOL_EXEC=${PREINSTALL_TOOL_EXEC:-unset}" }
+postinstall = [
+  { shell = "bash", script = "echo LEGACY-SCRIPT-SHELL" },
+  { run = 'echo RUN-CUSTOM-${BASH_VERSION:+bash}', shell = "bash -c" },
+  { run = ["export HOOK_X=1", 'echo RUN-ARRAY-${HOOK_X:-unset}'] },
+  { run = 'echo RUN-TOOLS-{{ tools.dummy.version }}' },
+  { run = [
+    { task = "setup", args = ["one", "two"], env = { FOO = "bar" } },
+    { tasks = ["alpha", "beta"] },
+  ] },
+]
+EOF
+
+# shellcheck disable=SC2016
+preinstall_shell_warning='`shell` is ignored for preinstall hooks that use `script`'
+# shellcheck disable=SC2016
+postinstall_shell_warning='`shell` is ignored for postinstall hooks that use `script`'
+output="$(mise i dummy@1 2>&1)"
+assert_contains "echo '$output'" "LEGACY-PREINSTALL-SHELL"
+assert_contains "echo '$output'" "LEGACY-PREINSTALL-SHELL PREINSTALL_TOOL_EXEC=unset"
+assert_contains "echo '$output'" "$preinstall_shell_warning"
+assert_contains "echo '$output'" "LEGACY-SCRIPT-SHELL"
+assert_contains "echo '$output'" "$postinstall_shell_warning"
+assert_contains "echo '$output'" "RUN-CUSTOM-bash"
+assert_contains "echo '$output'" "RUN-ARRAY-unset"
+assert_contains "echo '$output'" "RUN-TOOLS-1.1.0"
+assert_contains "echo '$output'" "TASK-SETUP FOO=bar one two"
+assert_contains "echo '$output'" "TASK-GROUP-ALPHA"
+assert_contains "echo '$output'" "TASK-GROUP-BETA"
+
+cat <<'EOF' >mise.toml
+[hooks]
+enter = { run_windows = "Write-Output WIN-ONLY" }
+EOF
+
+assert_not_contains "mise hook-env -s bash --force 2>&1" "WIN-ONLY"
+
+cat <<'EOF' >mise.toml
+[hooks]
+[[hooks.enter]]
+shell = "fish"
+script = [
+  "set -gx HOOK_ARRAY_ONE one",
+  "set -gx HOOK_ARRAY_TWO two",
+]
+EOF
+
+eval "$(mise hook-env -s bash --force)"
+cd ~ || exit 1
+eval "$(mise hook-env -s bash)"
+cd ~/workdir || exit 1
+output="$(mise hook-env -s fish 2>&1)"
+assert_contains "echo '$output'" "set -gx HOOK_ARRAY_ONE one"
+assert_contains "echo '$output'" "set -gx HOOK_ARRAY_TWO two"

--- a/e2e/config/test_hooks_run
+++ b/e2e/config/test_hooks_run
@@ -8,6 +8,7 @@ dummy = "1"
 PREINSTALL_TOOL_EXEC = { value = "{{ exec(command='dummy') }}", tools = true }
 
 [tasks.setup]
+env = { FOO = "task" }
 run = 'echo TASK-SETUP FOO=${FOO:-unset} "$@"'
 
 [tasks.alpha]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2068,37 +2068,53 @@
       "additionalProperties": {
         "oneOf": [
           {
-            "description": "inline hook command to run",
+            "description": "hook run script to execute",
             "type": "string"
           },
           {
             "unevaluatedProperties": false,
             "properties": {
               "run": {
-                "description": "inline hook command to run",
-                "type": "string"
+                "description": "hook run entry or entries to execute",
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/task_run_entry"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/task_run_entry"
+                    }
+                  }
+                ]
+              },
+              "run_windows": {
+                "description": "Windows-specific hook run entry or entries to execute",
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/task_run_entry"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/task_run_entry"
+                    }
+                  }
+                ]
               },
               "shell": {
-                "description": "inline shell command to use for run hooks, such as \"bash -c\"",
+                "description": "inline shell command to use for run script entries, such as \"bash -c\"",
                 "type": "string"
               }
             },
-            "required": ["run"],
-            "type": "object"
-          },
-          {
-            "unevaluatedProperties": false,
-            "properties": {
-              "script": {
-                "description": "current-shell script for enter/leave/cd hooks",
-                "type": "string"
+            "anyOf": [
+              {
+                "required": ["run"]
               },
-              "shell": {
-                "description": "current shell name for script hooks, such as \"bash\"",
-                "type": "string"
+              {
+                "required": ["run_windows"]
               }
-            },
-            "required": ["script"],
+            ],
             "type": "object"
           },
           {
@@ -2113,41 +2129,82 @@
             "type": "object"
           },
           {
-            "description": "scripts/tasks to run",
+            "unevaluatedProperties": false,
+            "properties": {
+              "script": {
+                "description": "current-shell script for enter/leave/cd hooks",
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "shell": {
+                "description": "current shell name for script hooks, such as \"bash\"",
+                "type": "string"
+              }
+            },
+            "required": ["script"],
+            "type": "object"
+          },
+          {
+            "description": "hook entries to run in order",
             "items": {
               "oneOf": [
                 {
-                  "description": "inline hook command to run",
+                  "description": "hook run script to execute",
                   "type": "string"
                 },
                 {
                   "unevaluatedProperties": false,
                   "properties": {
                     "run": {
-                      "description": "inline hook command to run",
-                      "type": "string"
+                      "description": "hook run entry or entries to execute",
+                      "oneOf": [
+                        {
+                          "$ref": "#/$defs/task_run_entry"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/$defs/task_run_entry"
+                          }
+                        }
+                      ]
+                    },
+                    "run_windows": {
+                      "description": "Windows-specific hook run entry or entries to execute",
+                      "oneOf": [
+                        {
+                          "$ref": "#/$defs/task_run_entry"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/$defs/task_run_entry"
+                          }
+                        }
+                      ]
                     },
                     "shell": {
-                      "description": "inline shell command to use for run hooks, such as \"bash -c\"",
+                      "description": "inline shell command to use for run script entries, such as \"bash -c\"",
                       "type": "string"
                     }
                   },
-                  "required": ["run"],
-                  "type": "object"
-                },
-                {
-                  "unevaluatedProperties": false,
-                  "properties": {
-                    "script": {
-                      "description": "current-shell script for enter/leave/cd hooks",
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "required": ["run"]
                     },
-                    "shell": {
-                      "description": "current shell name for script hooks, such as \"bash\"",
-                      "type": "string"
+                    {
+                      "required": ["run_windows"]
                     }
-                  },
-                  "required": ["script"],
+                  ],
                   "type": "object"
                 },
                 {
@@ -2159,6 +2216,31 @@
                     }
                   },
                   "required": ["task"],
+                  "type": "object"
+                },
+                {
+                  "unevaluatedProperties": false,
+                  "properties": {
+                    "script": {
+                      "description": "current-shell script for enter/leave/cd hooks",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    },
+                    "shell": {
+                      "description": "current shell name for script hooks, such as \"bash\"",
+                      "type": "string"
+                    }
+                  },
+                  "required": ["script"],
                   "type": "object"
                 }
               ]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -701,6 +701,7 @@ impl Run {
             continue_on_error: self.continue_on_error,
             dry_run: self.dry_run,
             skip_deps: self.skip_deps,
+            stdout_to_stderr: false,
             sandbox: crate::sandbox::SandboxConfig {
                 deny_read: self.deny_all || self.deny_read,
                 deny_write: self.deny_all || self.deny_write,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -540,7 +540,7 @@ async fn execute(
         })
         .collect_vec();
     let mut task = Task {
-        name: format!("hook:{}", hook.hook),
+        name: hook_task_name(config, root, hook.hook),
         display_name: format!("hook:{}", hook.hook),
         config_source: root.join("mise.toml"),
         config_root: Some(root.to_path_buf()),
@@ -557,6 +557,11 @@ async fn execute(
     } else {
         render_run_entries_for_hook(config, ts, hook.hook, root, &env, &mut task.run).await?;
     }
+    let rendered_run_scripts = task
+        .run_script_strings()
+        .into_iter()
+        .map(|script| (script, vec![]))
+        .collect_vec();
     let output_handler = OutputHandler::new(OutputHandlerConfig {
         output: Some(TaskOutput::Quiet),
         silent: false,
@@ -581,34 +586,52 @@ async fn execute(
             sandbox: Default::default(),
         },
     );
-    if should_execute_entries_without_task_executor(config, root, hook.hook, task.run()) {
-        execute_run_entries_without_task_executor(root, &task, &env)?;
+    if should_execute_task_entries_with_mise_subprocess(config, root, task.run()) {
+        execute_run_entries_with_mise_subprocess(root, &task, &env)?;
     } else {
         executor
-            .run_task_run_entries(config, &task, &env, &task_env)
+            .run_task_run_entries(config, &task, &env, &task_env, rendered_run_scripts)
             .await?;
     }
     Ok(())
 }
 
-fn should_execute_entries_without_task_executor(
+fn hook_task_name(config: &Config, root: &Path, hook: Hooks) -> String {
+    let name = format!("hook:{hook}");
+    let Some(monorepo_root) = config.monorepo_root() else {
+        return name;
+    };
+    let Ok(path) = root.strip_prefix(monorepo_root) else {
+        return name;
+    };
+    let path = path
+        .to_string_lossy()
+        .replace(std::path::MAIN_SEPARATOR, "/");
+    format!("//{path}:{name}")
+}
+
+fn should_execute_task_entries_with_mise_subprocess(
     config: &Arc<Config>,
     root: &Path,
-    hook: Hooks,
     entries: &[RunEntry],
 ) -> bool {
-    if entries.is_empty() {
-        return false;
-    }
     let has_task_entries = entries
         .iter()
         .any(|entry| !matches!(entry, RunEntry::Script(_)));
-    // Preinstall runs before tools=true env directives are safe to resolve, so
-    // avoid the task executor's full task tera context for every run entry.
-    hook == Hooks::Preinstall || (has_task_entries && config.project_root.as_deref() != Some(root))
+    // Leave hooks can come from configs that were loaded in the previous shell
+    // session but are no longer part of the current Config. For those roots,
+    // the in-process task executor has no task graph to resolve against.
+    has_task_entries && !config_has_hook_root(config, root)
 }
 
-fn execute_run_entries_without_task_executor(
+fn config_has_hook_root(config: &Config, root: &Path) -> bool {
+    config.config_files.values().any(|cf| {
+        let hook_root = cf.project_root().unwrap_or_else(|| cf.config_root());
+        hook_root == root
+    })
+}
+
+fn execute_run_entries_with_mise_subprocess(
     root: &Path,
     task: &Task,
     env: &BTreeMap<String, String>,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,16 +1,25 @@
 use crate::cmd::cmd;
+use crate::config::config_file::mise_toml::EnvList;
+use crate::config::config_file::toml::deserialize_arr;
+use crate::config::env_directive::EnvDirective;
 use crate::config::{Config, Settings, config_file};
 use crate::shell::Shell;
+use crate::task::task_context_builder::TaskContextBuilder;
+use crate::task::task_executor::{TaskExecutor, TaskExecutorConfig};
+use crate::task::task_output::TaskOutput;
+use crate::task::task_output_handler::{OutputHandler, OutputHandlerConfig};
+use crate::task::{RunEntry, Task};
 use crate::tera::get_tera;
 use crate::toolset::{ToolVersion, Toolset};
 use crate::{dirs, hook_env};
 use eyre::Result;
 use indexmap::IndexSet;
 use itertools::Itertools;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::LazyLock as Lazy;
 use std::sync::Mutex;
-use std::{iter::once, sync::Arc};
 use tokio::sync::OnceCell;
 
 /// Represents installed tool info for hooks
@@ -54,69 +63,128 @@ pub enum Hooks {
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(untagged)]
 pub enum HookDef {
-    /// Simple run string: `enter = "echo hello"`
-    RunString(String),
-    /// Table with run: `enter = { run = "echo hello" }`
-    Run { run: String, shell: Option<String> },
-    /// Table with script and optional shell: `enter = { script = "echo hello", shell = "bash" }`
-    ScriptTable {
-        script: String,
-        shell: Option<String>,
-    },
-    /// Task reference: `enter = { task = "setup" }`
-    TaskRef { task: String },
-    /// Array of hook definitions: `enter = ["echo hello", { task = "setup" }]`
-    Array(Vec<HookDef>),
+    Entry(HookEntryDef),
+    Array(Vec<HookEntryDef>),
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged)]
+pub enum HookEntryDef {
+    Script(String),
+    Run(HookRunDef),
+    ScriptTable(HookScriptDef),
+    TaskRef(HookTaskRefDef),
+}
+
+#[derive(Debug, Clone)]
+pub struct HookRunDef {
+    run: Vec<RunEntry>,
+    run_windows: Vec<RunEntry>,
+    shell: Option<String>,
+}
+
+impl<'de> serde::Deserialize<'de> for HookRunDef {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawHookRunDef {
+            #[serde(default, deserialize_with = "deserialize_arr")]
+            run: Vec<RunEntry>,
+            #[serde(default, deserialize_with = "deserialize_arr")]
+            run_windows: Vec<RunEntry>,
+            shell: Option<String>,
+        }
+
+        let raw = RawHookRunDef::deserialize(deserializer)?;
+        if raw.run.is_empty() && raw.run_windows.is_empty() {
+            return Err(serde::de::Error::custom("expected `run` or `run_windows`"));
+        }
+
+        Ok(Self {
+            run: raw.run,
+            run_windows: raw.run_windows,
+            shell: raw.shell,
+        })
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HookScriptDef {
+    #[serde(deserialize_with = "deserialize_arr")]
+    script: Vec<String>,
+    shell: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HookTaskRefDef {
+    task: String,
 }
 
 impl HookDef {
-    /// Convert to a list of Hook structs with the given hook type
     pub fn into_hooks(self, hook_type: Hooks) -> Vec<Hook> {
         match self {
-            HookDef::RunString(script) => vec![Hook {
-                hook: hook_type,
-                action: HookAction::Run {
-                    run: script,
-                    shell: None,
-                    legacy_script: false,
-                    ignored_shell: None,
-                },
-                global: false,
-            }],
-            HookDef::Run { run, shell } => vec![Hook {
-                hook: hook_type,
-                action: HookAction::Run {
-                    run,
-                    shell,
-                    legacy_script: false,
-                    ignored_shell: None,
-                },
-                global: false,
-            }],
-            HookDef::ScriptTable { script, shell } => vec![Hook {
-                hook: hook_type,
-                action: match (hook_type, shell) {
-                    (Hooks::Enter | Hooks::Leave | Hooks::Cd, Some(shell)) => {
-                        HookAction::CurrentShell { script, shell }
-                    }
-                    (_, shell) => HookAction::Run {
-                        run: script,
-                        shell: None,
-                        legacy_script: true,
-                        ignored_shell: shell,
-                    },
-                },
-                global: false,
-            }],
-            HookDef::TaskRef { task } => vec![Hook {
-                hook: hook_type,
-                action: HookAction::Task { task_name: task },
-                global: false,
-            }],
+            HookDef::Entry(entry) => vec![entry.into_hook(hook_type)],
             HookDef::Array(arr) => arr
                 .into_iter()
-                .flat_map(|d| d.into_hooks(hook_type))
+                .map(|entry| entry.into_hook(hook_type))
                 .collect(),
+        }
+    }
+}
+
+impl HookEntryDef {
+    fn into_hook(self, hook: Hooks) -> Hook {
+        let action = match self {
+            HookEntryDef::Script(script) => HookAction::Run {
+                run: vec![RunEntry::Script(script)],
+                run_windows: vec![],
+                shell: None,
+                legacy_script: false,
+                ignored_shell: None,
+            },
+            HookEntryDef::Run(def) => HookAction::Run {
+                run: def.run,
+                run_windows: def.run_windows,
+                shell: def.shell,
+                legacy_script: false,
+                ignored_shell: None,
+            },
+            HookEntryDef::ScriptTable(def) => match (hook, def.shell) {
+                (Hooks::Enter | Hooks::Leave | Hooks::Cd, Some(shell)) => {
+                    HookAction::CurrentShell {
+                        script: def.script,
+                        shell,
+                    }
+                }
+                (_, shell) => HookAction::Run {
+                    run: def.script.into_iter().map(RunEntry::Script).collect(),
+                    run_windows: vec![],
+                    shell: None,
+                    legacy_script: true,
+                    ignored_shell: shell,
+                },
+            },
+            HookEntryDef::TaskRef(def) => HookAction::Run {
+                run: vec![RunEntry::SingleTask {
+                    task: def.task,
+                    args: vec![],
+                    env: Default::default(),
+                }],
+                run_windows: vec![],
+                shell: None,
+                legacy_script: false,
+                ignored_shell: None,
+            },
+        };
+        Hook {
+            hook,
+            action,
+            global: false,
         }
     }
 }
@@ -132,17 +200,15 @@ pub struct Hook {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum HookAction {
     Run {
-        run: String,
+        run: Vec<RunEntry>,
+        run_windows: Vec<RunEntry>,
         shell: Option<String>,
         legacy_script: bool,
         ignored_shell: Option<String>,
     },
     CurrentShell {
-        script: String,
+        script: Vec<String>,
         shell: String,
-    },
-    Task {
-        task_name: String,
     },
 }
 
@@ -153,12 +219,12 @@ impl Hook {
     {
         match &mut self.action {
             HookAction::Run {
-                run,
                 shell,
                 ignored_shell,
                 ..
             } => {
-                *run = render(run)?;
+                // Run entries are rendered at execution time with hook env vars
+                // and, for non-preinstall hooks, the resolved tools context.
                 if let Some(s) = shell {
                     *s = render(s)?;
                 }
@@ -167,11 +233,10 @@ impl Hook {
                 }
             }
             HookAction::CurrentShell { script, shell } => {
-                *script = render(script)?;
+                for s in script {
+                    *s = render(s)?;
+                }
                 *shell = render(shell)?;
-            }
-            HookAction::Task { task_name } => {
-                *task_name = render(task_name)?;
             }
         }
         Ok(())
@@ -339,11 +404,6 @@ async fn run_matched_hook(
 ) {
     let hook_type = hook.hook;
     match &hook.action {
-        HookAction::Task { task_name } => {
-            if let Err(e) = execute_task(config, ts, root, hook, task_name, installed_tools).await {
-                warn!("{hook_type} hook in {} failed: {e}", root.display());
-            }
-        }
         HookAction::CurrentShell { script, .. } => {
             if let Some(shell) = shell {
                 // Set hook environment variables so shell hooks can access them
@@ -373,7 +433,9 @@ async fn run_matched_hook(
                     println!("{}", shell.set_env("MISE_INSTALLED_TOOLS", &json));
                 }
             }
-            println!("{script}");
+            for line in script {
+                println!("{line}");
+            }
         }
         HookAction::Run { .. } => {
             if let Err(e) = execute(config, ts, root, hook, installed_tools).await {
@@ -402,6 +464,7 @@ async fn execute(
     Settings::get().ensure_experimental("hooks")?;
     let HookAction::Run {
         run,
+        run_windows,
         shell,
         legacy_script,
         ignored_shell,
@@ -424,45 +487,28 @@ async fn execute(
             hook_name
         );
     }
-    let shell = shell
-        .as_ref()
-        .map(|shell| shell_words::split(shell))
-        .transpose()?
-        .unwrap_or(Settings::get().default_inline_shell()?);
 
     // Preinstall hooks skip `tools=true` env directives since the tools
     // providing those env vars aren't installed yet (fixes #6162)
-    let (tera_ctx, mut env) = if hook.hook == Hooks::Preinstall {
-        let env = ts.full_env_without_tools(config).await?;
-        let mut ctx = config.tera_ctx.clone();
-        ctx.insert("env", &env);
-        (ctx, env)
+    let mut env = if hook.hook == Hooks::Preinstall {
+        ts.full_env_without_tools(config).await?
     } else {
-        let ctx = ts.tera_ctx(config).await?.clone();
-        let env = ts.full_env(config).await?;
-        (ctx, env)
+        ts.full_env(config).await?
     };
-    let mut tera = get_tera(Some(root));
-    let rendered_script = tera.render_str(run, &tera_ctx)?;
 
-    let args = shell
-        .iter()
-        .skip(1)
-        .map(|s| s.as_str())
-        .chain(once(rendered_script.as_str()))
-        .collect_vec();
+    let mut hook_vars = BTreeMap::new();
     if let Some(cwd) = dirs::CWD.as_ref() {
-        env.insert(
+        hook_vars.insert(
             "MISE_ORIGINAL_CWD".to_string(),
             cwd.to_string_lossy().to_string(),
         );
     }
-    env.insert(
+    hook_vars.insert(
         "MISE_PROJECT_ROOT".to_string(),
         root.to_string_lossy().to_string(),
     );
     if let Some((Some(old), _new)) = hook_env::dir_change() {
-        env.insert(
+        hook_vars.insert(
             "MISE_PREVIOUS_DIR".to_string(),
             old.to_string_lossy().to_string(),
         );
@@ -471,73 +517,237 @@ async fn execute(
     if let Some(tools) = installed_tools
         && let Ok(json) = serde_json::to_string(tools)
     {
-        env.insert("MISE_INSTALLED_TOOLS".to_string(), json);
+        hook_vars.insert("MISE_INSTALLED_TOOLS".to_string(), json);
     }
-    env.insert(
+    hook_vars.insert(
         "MISE_CONFIG_ROOT".to_string(),
         root.to_string_lossy().to_string(),
     );
     // Prevent recursive hook execution (e.g. hook runs `mise run` which spawns
     // a shell that activates mise and re-triggers hooks)
-    env.insert("MISE_NO_HOOKS".to_string(), "1".to_string());
-    cmd(&shell[0], args)
+    hook_vars.insert("MISE_NO_HOOKS".to_string(), "1".to_string());
+    env.extend(hook_vars.clone());
+
+    let hook_env_directives = hook_vars
+        .iter()
+        .map(|(k, v)| EnvDirective::Val(k.clone(), v.clone(), Default::default()))
+        .collect_vec();
+    let task_env = hook_env_directives
+        .iter()
+        .filter_map(|directive| match directive {
+            EnvDirective::Val(k, v, _) => Some((k.clone(), v.clone())),
+            _ => None,
+        })
+        .collect_vec();
+    let mut task = Task {
+        name: format!("hook:{}", hook.hook),
+        display_name: format!("hook:{}", hook.hook),
+        config_source: root.join("mise.toml"),
+        config_root: Some(root.to_path_buf()),
+        run: run.clone(),
+        run_windows: run_windows.clone(),
+        shell: shell.clone(),
+        quiet: true,
+        env: EnvList(hook_env_directives),
+        ..Default::default()
+    };
+    if cfg!(windows) && !task.run_windows.is_empty() {
+        render_run_entries_for_hook(config, ts, hook.hook, root, &env, &mut task.run_windows)
+            .await?;
+    } else {
+        render_run_entries_for_hook(config, ts, hook.hook, root, &env, &mut task.run).await?;
+    }
+    let output_handler = OutputHandler::new(OutputHandlerConfig {
+        output: Some(TaskOutput::Quiet),
+        silent: false,
+        quiet: true,
+        raw: false,
+        is_linear: true,
+        jobs: Some(1),
+    });
+    let executor = TaskExecutor::new(
+        TaskContextBuilder::default(),
+        output_handler,
+        TaskExecutorConfig {
+            force: true,
+            cd: None,
+            shell: None,
+            tool: vec![],
+            timings: false,
+            continue_on_error: false,
+            dry_run: false,
+            skip_deps: false,
+            stdout_to_stderr: true,
+            sandbox: Default::default(),
+        },
+    );
+    if should_execute_entries_without_task_executor(config, root, hook.hook, task.run()) {
+        execute_run_entries_without_task_executor(root, &task, &env)?;
+    } else {
+        executor
+            .run_task_run_entries(config, &task, &env, &task_env)
+            .await?;
+    }
+    Ok(())
+}
+
+fn should_execute_entries_without_task_executor(
+    config: &Arc<Config>,
+    root: &Path,
+    hook: Hooks,
+    entries: &[RunEntry],
+) -> bool {
+    if entries.is_empty() {
+        return false;
+    }
+    let has_task_entries = entries
+        .iter()
+        .any(|entry| !matches!(entry, RunEntry::Script(_)));
+    // Preinstall runs before tools=true env directives are safe to resolve, so
+    // avoid the task executor's full task tera context for every run entry.
+    hook == Hooks::Preinstall || (has_task_entries && config.project_root.as_deref() != Some(root))
+}
+
+fn execute_run_entries_without_task_executor(
+    root: &Path,
+    task: &Task,
+    env: &BTreeMap<String, String>,
+) -> Result<()> {
+    for entry in task.run() {
+        match entry {
+            RunEntry::Script(script) => {
+                run_script_entry(root, task, script, env)?;
+            }
+            RunEntry::SingleTask {
+                task: spec,
+                args,
+                env: entry_env,
+            } => {
+                let resolved = crate::task::resolve_task_pattern(spec, Some(task));
+                let (name, spec_args) = crate::task::task_list::split_task_spec(&resolved);
+                let task_args = if args.is_empty() {
+                    spec_args
+                } else {
+                    args.clone()
+                };
+                let mut cmd_env = env.clone();
+                cmd_env.extend(entry_env.iter().map(|(k, v)| (k.clone(), v.clone())));
+                run_mise_task(
+                    root,
+                    vec![name.to_string()].into_iter().chain(task_args),
+                    &cmd_env,
+                )?;
+            }
+            RunEntry::TaskGroup { tasks } => {
+                let mut args = vec![];
+                for (i, spec) in tasks.iter().enumerate() {
+                    if i > 0 {
+                        args.push(":::".to_string());
+                    }
+                    let resolved = crate::task::resolve_task_pattern(spec, Some(task));
+                    let (name, task_args) = crate::task::task_list::split_task_spec(&resolved);
+                    args.push(name.to_string());
+                    args.extend(task_args);
+                }
+                run_mise_task(root, args.into_iter(), env)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_script_entry(
+    root: &Path,
+    task: &Task,
+    script: &str,
+    env: &BTreeMap<String, String>,
+) -> Result<()> {
+    let shell = task
+        .shell()
+        .unwrap_or(Settings::get().default_inline_shell()?);
+    let mut shell = shell.into_iter();
+    let program = shell.next().unwrap();
+    let mut args = shell.collect_vec();
+    args.push(script.to_string());
+    cmd(program, args)
         .stdout_to_stderr()
-        // .dir(root)
+        .dir(root)
         .full_env(env)
         .run()?;
     Ok(())
 }
 
-async fn execute_task(
+fn run_mise_task(
+    root: &Path,
+    args: impl IntoIterator<Item = String>,
+    env: &BTreeMap<String, String>,
+) -> Result<()> {
+    let mise_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("mise"));
+    let root = root.to_string_lossy().to_string();
+    let args = ["--cd".to_string(), root, "run".to_string()]
+        .into_iter()
+        .chain(args)
+        .collect_vec();
+    cmd(mise_bin, args).stdout_to_stderr().full_env(env).run()?;
+    Ok(())
+}
+
+async fn render_run_entries_for_hook(
     config: &Arc<Config>,
     ts: &Toolset,
+    hook: Hooks,
     root: &Path,
-    hook: &Hook,
-    task_name: &str,
-    installed_tools: Option<&[InstalledToolInfo]>,
+    env: &BTreeMap<String, String>,
+    entries: &mut [RunEntry],
 ) -> Result<()> {
-    Settings::get().ensure_experimental("hooks")?;
-
-    let mise_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("mise"));
-
-    let mut env = if hook.hook == Hooks::Preinstall {
-        ts.full_env_without_tools(config).await?
+    let mut tera = get_tera(Some(root));
+    let mut tera_ctx = if hook == Hooks::Preinstall {
+        config.tera_ctx.clone()
     } else {
-        ts.full_env(config).await?
+        ts.tera_ctx(config).await?.clone()
     };
-    if let Some(cwd) = dirs::CWD.as_ref() {
-        env.insert(
-            "MISE_ORIGINAL_CWD".to_string(),
-            cwd.to_string_lossy().to_string(),
-        );
+    tera_ctx.insert("env", env);
+    tera_ctx.insert("config_root", &root.to_string_lossy().to_string());
+    for entry in entries {
+        *entry = render_run_entry_for_hook(entry, &mut tera, &tera_ctx)?;
     }
-    env.insert(
-        "MISE_PROJECT_ROOT".to_string(),
-        root.to_string_lossy().to_string(),
-    );
-    env.insert(
-        "MISE_CONFIG_ROOT".to_string(),
-        root.to_string_lossy().to_string(),
-    );
-    if let Some((Some(old), _new)) = hook_env::dir_change() {
-        env.insert(
-            "MISE_PREVIOUS_DIR".to_string(),
-            old.to_string_lossy().to_string(),
-        );
-    }
-    if let Some(tools) = installed_tools
-        && let Ok(json) = serde_json::to_string(tools)
-    {
-        env.insert("MISE_INSTALLED_TOOLS".to_string(), json);
-    }
-    env.insert("MISE_NO_HOOKS".to_string(), "1".to_string());
-
-    cmd(
-        mise_bin,
-        ["--cd", &root.to_string_lossy(), "run", task_name],
-    )
-    .stdout_to_stderr()
-    .full_env(env)
-    .run()?;
     Ok(())
+}
+
+fn render_run_entry_for_hook(
+    entry: &RunEntry,
+    tera: &mut tera::Tera,
+    tera_ctx: &tera::Context,
+) -> Result<RunEntry> {
+    match entry {
+        RunEntry::Script(script) => Ok(RunEntry::Script(render_hook_str(tera, tera_ctx, script)?)),
+        RunEntry::SingleTask { task, args, env } => {
+            let mut env = env.clone();
+            for value in env.values_mut() {
+                *value = render_hook_str(tera, tera_ctx, value)?;
+            }
+            Ok(RunEntry::SingleTask {
+                task: render_hook_str(tera, tera_ctx, task)?,
+                args: args
+                    .iter()
+                    .map(|arg| render_hook_str(tera, tera_ctx, arg))
+                    .collect::<Result<_>>()?,
+                env,
+            })
+        }
+        RunEntry::TaskGroup { tasks } => Ok(RunEntry::TaskGroup {
+            tasks: tasks
+                .iter()
+                .map(|task| render_hook_str(tera, tera_ctx, task))
+                .collect::<Result<_>>()?,
+        }),
+    }
+}
+
+fn render_hook_str(tera: &mut tera::Tera, tera_ctx: &tera::Context, value: &str) -> Result<String> {
+    if value.contains("{{") || value.contains("{%") || value.contains("{#") {
+        Ok(tera.render_str(value, tera_ctx)?)
+    } else {
+        Ok(value.to_string())
+    }
 }

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -47,6 +47,20 @@ pub fn task_key(task: &Task) -> TaskKey {
 
 /// manages a dependency graph of tasks so `mise run` knows what to run next
 impl Deps {
+    pub fn empty() -> Self {
+        let (tx, _) = mpsc::unbounded_channel();
+        Self {
+            graph: DiGraph::new(),
+            tx,
+            sent: HashSet::new(),
+            removed: HashSet::new(),
+            executed: HashSet::new(),
+            ran: HashSet::new(),
+            dep_edges: HashMap::new(),
+            post_dep_parents: HashMap::new(),
+        }
+    }
+
     pub async fn new(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
         let mut graph = DiGraph::new();
         let mut indexes = HashMap::new();

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -61,11 +61,13 @@ pub struct TaskExecutorConfig {
     pub continue_on_error: bool,
     pub dry_run: bool,
     pub skip_deps: bool,
+    pub stdout_to_stderr: bool,
     /// CLI-level sandbox overrides (merged with task-level sandbox config)
     pub sandbox: crate::sandbox::SandboxConfig,
 }
 
 /// Executes tasks with proper context, environment, and output handling
+#[derive(Clone)]
 pub struct TaskExecutor {
     pub context_builder: TaskContextBuilder,
     pub output_handler: OutputHandler,
@@ -80,6 +82,7 @@ pub struct TaskExecutor {
     pub continue_on_error: bool,
     pub dry_run: bool,
     pub skip_deps: bool,
+    pub stdout_to_stderr: bool,
     pub sandbox: crate::sandbox::SandboxConfig,
 }
 
@@ -101,6 +104,7 @@ impl TaskExecutor {
             continue_on_error: config.continue_on_error,
             dry_run: config.dry_run,
             skip_deps: config.skip_deps,
+            stdout_to_stderr: config.stdout_to_stderr,
             sandbox: config.sandbox,
         }
     }
@@ -112,6 +116,189 @@ impl TaskExecutor {
     pub fn add_failed_task(&self, task: Task, status: Option<i32>) {
         let mut failed = self.failed_tasks.lock().unwrap();
         failed.push((task, status.or(Some(1))));
+    }
+
+    pub async fn run_task_run_entries(
+        &self,
+        config: &Arc<Config>,
+        task: &Task,
+        env: &BTreeMap<String, String>,
+        task_env: &[(String, String)],
+    ) -> Result<()> {
+        let rendered_run_scripts = task
+            .render_run_scripts_with_args(config, self.cd.clone(), &task.args, env, None)
+            .await?;
+        let prefix = task.estyled_prefix();
+
+        let mut scheduler = crate::task::task_scheduler::Scheduler::new(self.output_handler.jobs());
+        let sched_tx = scheduler.sched_tx.clone();
+        let semaphore = scheduler.semaphore.clone();
+        let main_deps = Arc::new(Mutex::new(Deps::new(config, vec![]).await?));
+        let (main_done_tx, mut main_done_rx) = tokio::sync::watch::channel(false);
+        let spawn_context = scheduler.spawn_context(config.clone());
+        let executor = Arc::new(self.clone());
+        let scheduler_executor = executor.clone();
+        let scheduler_task = tokio::spawn(async move {
+            scheduler
+                .run_loop(
+                    &mut main_done_rx,
+                    main_deps,
+                    || scheduler_executor.is_stopping(),
+                    scheduler_executor.continue_on_error,
+                    |task, deps_for_remove| {
+                        let executor = scheduler_executor.clone();
+                        let spawn_context = spawn_context.clone();
+                        async move {
+                            Self::spawn_sched_job(executor, task, deps_for_remove, spawn_context)
+                                .await
+                        }
+                    },
+                )
+                .await?;
+            scheduler
+                .join_all(scheduler_executor.continue_on_error)
+                .await
+        });
+
+        let mut permit = None;
+        let run_result = executor
+            .exec_task_run_entries(
+                config,
+                task,
+                (env, task_env),
+                &prefix,
+                rendered_run_scripts,
+                sched_tx,
+                None,
+                &HashSet::new(),
+                semaphore,
+                &mut permit,
+            )
+            .await;
+        let _ = main_done_tx.send(true);
+        let scheduler_result = scheduler_task.await.map_err(|e| eyre!(e))?;
+        scheduler_result?;
+        run_result?;
+        if executor.is_stopping() && !executor.continue_on_error {
+            return Err(eyre!("task sequence aborted due to failure"));
+        }
+        Ok(())
+    }
+
+    async fn spawn_sched_job(
+        executor: Arc<Self>,
+        task: Task,
+        deps_for_remove: Arc<Mutex<Deps>>,
+        ctx: crate::task::task_scheduler::SpawnContext,
+    ) -> Result<()> {
+        if executor.is_stopping() && !executor.continue_on_error {
+            let mut deps = deps_for_remove.lock().await;
+            if !deps.is_runnable_post_dep(&task) {
+                trace!(
+                    "aborting spawn before start (not continue-on-error): {} {}",
+                    task.name,
+                    task.args.join(" ")
+                );
+                deps.remove(&task);
+                return Ok(());
+            }
+            drop(deps);
+        }
+
+        let needs_permit = crate::task::task_helpers::task_needs_permit(&task);
+        let permit_opt = if needs_permit {
+            let p = Some(ctx.semaphore.clone().acquire_owned().await?);
+            if executor.is_stopping() && !executor.continue_on_error {
+                let mut deps = deps_for_remove.lock().await;
+                if !deps.is_runnable_post_dep(&task) {
+                    trace!(
+                        "aborting spawn after failure (not continue-on-error): {} {}",
+                        task.name,
+                        task.args.join(" ")
+                    );
+                    deps.remove(&task);
+                    return Ok(());
+                }
+                drop(deps);
+            }
+            p
+        } else {
+            None
+        };
+
+        ctx.in_flight
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let in_flight = ctx.in_flight.clone();
+        deps_for_remove.lock().await.mark_executed(&task);
+        let semaphore = ctx.semaphore.clone();
+        ctx.jset.lock().await.spawn(async move {
+            let mut permit = permit_opt;
+            let (completed, dep_ran) = {
+                let deps = deps_for_remove.lock().await;
+                (deps.handled_task_keys(), deps.any_dep_ran(&task))
+            };
+            let result = executor
+                .run_task_sched(
+                    &task,
+                    &ctx.config,
+                    ctx.sched_tx.clone(),
+                    completed,
+                    dep_ran,
+                    semaphore,
+                    &mut permit,
+                )
+                .await;
+            if let Ok(true) = &result
+                && !task.sources.is_empty()
+            {
+                deps_for_remove.lock().await.mark_ran(&task);
+            }
+            if let Err(err) = &result {
+                let status = crate::errors::Error::get_exit_status(err);
+                if !executor.is_stopping() && status.is_none() {
+                    let prefix = task.estyled_prefix();
+                    if Settings::get().verbose {
+                        executor.eprint(
+                            &task,
+                            &prefix,
+                            &format!("{} {err:?}", style::ered("ERROR")),
+                        );
+                    } else {
+                        executor.eprint(&task, &prefix, &format!("{} {err}", style::ered("ERROR")));
+                        let mut current_err = err.source();
+                        while let Some(e) = current_err {
+                            executor.eprint(
+                                &task,
+                                &prefix,
+                                &format!("{} {e}", style::ered("ERROR")),
+                            );
+                            current_err = e.source();
+                        }
+                    };
+                }
+                executor.add_failed_task(task.clone(), status);
+                if !executor.continue_on_error {
+                    debug!("task {} failed, killing siblings", task.name);
+                    #[cfg(unix)]
+                    crate::cmd::CmdLineRunner::kill_all(nix::sys::signal::SIGTERM);
+                    #[cfg(windows)]
+                    crate::cmd::CmdLineRunner::kill_all();
+                }
+            }
+            if executor.output_handler.output(None) == TaskOutput::KeepOrder {
+                executor
+                    .output_handler
+                    .keep_order_state
+                    .lock()
+                    .unwrap()
+                    .on_task_finished(&task);
+            }
+            deps_for_remove.lock().await.remove(&task);
+            in_flight.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            result.map(|_| ())
+        });
+
+        Ok(())
     }
 
     fn eprint(&self, task: &Task, prefix: &str, line: &str) {
@@ -1037,7 +1224,18 @@ impl TaskExecutor {
                 cmd = cmd.stdout(Stdio::null()).stderr(Stdio::null());
             }
             TaskOutput::Quiet | TaskOutput::Interleave => {
-                if raw || redactions.is_empty() {
+                if self.stdout_to_stderr {
+                    if !task.silent.suppresses_stdout() {
+                        cmd = cmd.with_on_stdout(|line| {
+                            eprintln!("{line}");
+                        });
+                    } else {
+                        cmd = cmd.stdout(Stdio::null());
+                    }
+                    if task.silent.suppresses_stderr() {
+                        cmd = cmd.stderr(Stdio::null());
+                    }
+                } else if raw || redactions.is_empty() {
                     cmd = cmd.stdin(Stdio::inherit());
                     if !task.silent.suppresses_stdout() {
                         cmd = cmd.stdout(Stdio::inherit());

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -118,22 +118,25 @@ impl TaskExecutor {
         failed.push((task, status.or(Some(1))));
     }
 
+    /// Execute an already-rendered run-entry list for a synthetic task.
+    ///
+    /// Hooks render script entries before calling this so preinstall hooks can
+    /// use the preinstall-safe tera context without resolving `tools = true`
+    /// env directives.
     pub async fn run_task_run_entries(
         &self,
         config: &Arc<Config>,
         task: &Task,
         env: &BTreeMap<String, String>,
         task_env: &[(String, String)],
+        rendered_run_scripts: Vec<(String, Vec<String>)>,
     ) -> Result<()> {
-        let rendered_run_scripts = task
-            .render_run_scripts_with_args(config, self.cd.clone(), &task.args, env, None)
-            .await?;
         let prefix = task.estyled_prefix();
 
         let mut scheduler = crate::task::task_scheduler::Scheduler::new(self.output_handler.jobs());
         let sched_tx = scheduler.sched_tx.clone();
         let semaphore = scheduler.semaphore.clone();
-        let main_deps = Arc::new(Mutex::new(Deps::new(config, vec![]).await?));
+        let main_deps = Arc::new(Mutex::new(Deps::empty()));
         let (main_done_tx, mut main_done_rx) = tokio::sync::watch::channel(false);
         let spawn_context = scheduler.spawn_context(config.clone());
         let executor = Arc::new(self.clone());


### PR DESCRIPTION
## Summary
- Extend hook `run` from scalar inline commands to task-style run entries, including script strings, `{ task, args, env }`, and `{ tasks = [...] }`.
- Add `run_windows` as a Windows-specific hook run override.
- Keep string hook values as `run` shorthand, and keep `{ task = "name" }` as shorthand for `run = [{ task = "name" }]`.
- Keep `script + shell` as current-shell syntax for `enter`, `leave`, and `cd`, and allow `script` arrays for those hooks.
- Keep install-hook `script` as the legacy alias for `run`; when paired with `shell`, the shell value is ignored and the script runs through the default inline shell.
- Update docs and JSON schema for `run`, `run_windows`, task-style run entries, and current-shell `script` behavior.

Fixes #9636.
Fixes #8293.

## Hook Run Forms
Scalar `run` hooks continue to work:

```toml
[hooks]
postinstall = { run = "echo installed", shell = "bash -c" }
```

Hook `run` also accepts task-style entries:

```toml
[hooks]
postinstall = { run = [
  "echo first shell",
  "echo second shell",
  { task = "setup", args = ["--fast"], env = { CI = "1" } },
  { tasks = ["lint", "test"] },
] }
```

`run.shell` follows task `shell` semantics: it is an inline shell command such as `bash -c`, `zsh -c`, or `pwsh -Command`. Without `shell`, hook script entries use the default inline shell settings.

`run_windows` can be used by itself for a Windows-only hook or alongside `run` as the Windows-specific override:

```toml
[hooks]
preinstall = { run_windows = "Write-Output installing" }
```

Current-shell hooks continue to use `script + shell`; here `shell` is a shell-name selector, not an inline shell command:

```toml
[[hooks.enter]]
shell = "fish"
script = [
  "set -gx PROJECT_MODE dev",
  "source completions.fish",
]
```

## TaskExecutor Rationale
Hook `run` now accepts real task run entries, so hooks need to execute a synthetic `Task` with its `RunEntry` list instead of flattening those entries into generated `mise run` argv. Keeping the entries as Rust objects preserves task-entry `args`, high-priority `env`, task groups, dependency scheduling, and monorepo-relative task resolution.

The `TaskExecutor` change is the narrow in-process entry point for that existing run-entry executor and scheduler. Hook scripts are rendered before calling it, so preinstall hooks can keep using the preinstall-safe tera context and avoid resolving `tools = true` env directives before tools are installed.

The only remaining subprocess fallback is for task entries on hooks loaded from a previous shell session after the current `Config` no longer contains that root, such as leave hooks after changing out of a project. In that case there is no in-process task graph for the old root to resolve against, so preserving the old behavior still requires a `mise --cd <old-root> run ...` subprocess.

## Tests
- `cargo fmt --all`
- `cargo fmt --all --check`
- `jq empty schema/mise.json`
- `shellcheck -x e2e/config/test_hooks_run`
- `shfmt -d --apply-ignore e2e/config/test_hooks_run`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo check -q`
- `mise run test:e2e e2e/config/test_hooks_run`
- `mise run test:e2e e2e/config/test_hooks_task_ref`
- `mise run test:e2e e2e/config/test_hooks e2e/config/test_hooks_config_root e2e/config/test_hooks_error_handling e2e/config/test_hooks_global e2e/config/test_hooks_installed_tools e2e/config/test_hooks_postinstall_env e2e/config/test_hooks_shell_env e2e/config/test_hooks_tool_env e2e/config/test_hooks_trust_enter`
