### PR TITLE
fix(npm): filter deprecated versions during resolution

### DIFF
--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -22,8 +22,10 @@ assert_not_contains "mise latest npm:prettier" "2.8.8"
 assert_contains "mise latest npm:prettier --before 2023-06-01" "2.8.8"
 
 # Test: deprecated versions are skipped when resolving latest with --before.
-# glob 10.5.0 was released before this cutoff but deprecated; 12.0.0 is the
-# newest non-deprecated version before the cutoff.
+# At the time this regression test was added, glob 10.5.0 and 11.x were
+# deprecated upstream with "Glob versions prior to v9 are no longer supported"
+# or "Glob versions prior to v11 are no longer supported". 12.0.0 is the newest
+# non-deprecated version before the cutoff.
 assert "mise latest npm:glob --before 2025-11-18T12:00:00Z" "12.0.0"
 
 # Test: package-level deprecation does not filter every version out.

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -21,6 +21,14 @@ assert_not_contains "mise latest npm:prettier" "2.8.8"
 # Test: `mise latest --before` CLI flag should filter by date
 assert_contains "mise latest npm:prettier --before 2023-06-01" "2.8.8"
 
+# Test: deprecated versions are skipped when resolving latest with --before.
+# glob 10.5.0 was released before this cutoff but deprecated; 12.0.0 is the
+# newest non-deprecated version before the cutoff.
+assert "mise latest npm:glob --before 2025-11-18T12:00:00Z" "12.0.0"
+
+# Test: package-level deprecation does not filter every version out.
+assert_not_empty "mise latest npm:request --before 2020-01-01"
+
 # Test: CLI --before flag overrides the global minimum_release_age setting
 # Global is 2024-01-01 (would give 3.1.0), CLI is 2023-06-01 (gives 2.8.8)
 export MISE_MINIMUM_RELEASE_AGE="2024-01-01"

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -16,7 +16,7 @@ use crate::toolset::{ToolRequest, ToolVersion, Toolset};
 use async_trait::async_trait;
 use jiff::Timestamp;
 use serde_json::Value;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::OsString;
 use std::path::Path;
 use std::{fmt::Debug, sync::Arc};
@@ -147,6 +147,37 @@ impl Backend for NPMBackend {
                 let time = data["time"]
                     .as_object()
                     .ok_or_else(|| eyre::eyre!("invalid time"))?;
+                let deprecated_versions = match cmd!(
+                    NPM_PROGRAM,
+                    "view",
+                    Self::deprecated_versions_query(&self.tool_name()),
+                    "version",
+                    "deprecated",
+                    "--json"
+                )
+                .full_env(&env)
+                .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+                .read()
+                {
+                    Ok(raw) if raw.trim().is_empty() => HashSet::new(),
+                    Ok(raw) => match serde_json::from_str::<Value>(&raw) {
+                        Ok(data) => Self::deprecated_versions_from_npm_view(&data),
+                        Err(err) => {
+                            debug!(
+                                "failed to parse npm deprecated metadata for {}: {err:#}",
+                                self.tool_name()
+                            );
+                            HashSet::new()
+                        }
+                    },
+                    Err(err) => {
+                        debug!(
+                            "failed to fetch npm deprecated metadata for {}: {err:#}",
+                            self.tool_name()
+                        );
+                        HashSet::new()
+                    }
+                };
                 let version_info = versions
                     .iter()
                     .filter_map(|v| v.as_str())
@@ -164,7 +195,10 @@ impl Backend for NPMBackend {
                     })
                     .collect();
 
-                Ok(version_info)
+                Ok(Self::filter_deprecated_versions(
+                    version_info,
+                    &deprecated_versions,
+                ))
             },
             Settings::get().fetch_remote_versions_timeout(),
         )
@@ -672,6 +706,60 @@ impl NPMBackend {
         seconds.div_ceil(60)
     }
 
+    fn deprecated_versions_query(package: &str) -> String {
+        format!("{package}@>=0.0.0")
+    }
+
+    fn deprecated_versions_from_npm_view(data: &Value) -> HashSet<String> {
+        let mut versions = HashSet::new();
+        Self::collect_deprecated_versions(data, &mut versions);
+        versions
+    }
+
+    fn collect_deprecated_versions(data: &Value, versions: &mut HashSet<String>) {
+        match data {
+            Value::Array(entries) => {
+                for entry in entries {
+                    Self::collect_deprecated_versions(entry, versions);
+                }
+            }
+            Value::Object(entry) => {
+                if let Some(version) = entry.get("version").and_then(Value::as_str)
+                    && Self::is_deprecated_value(entry.get("deprecated"))
+                {
+                    versions.insert(version.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn is_deprecated_value(value: Option<&Value>) -> bool {
+        match value {
+            Some(Value::String(s)) => !s.trim().is_empty(),
+            Some(Value::Bool(true)) => true,
+            _ => false,
+        }
+    }
+
+    fn filter_deprecated_versions(
+        versions: Vec<VersionInfo>,
+        deprecated_versions: &HashSet<String>,
+    ) -> Vec<VersionInfo> {
+        if deprecated_versions.is_empty()
+            || versions
+                .iter()
+                .all(|v| deprecated_versions.contains(&v.version))
+        {
+            return versions;
+        }
+
+        versions
+            .into_iter()
+            .filter(|v| !deprecated_versions.contains(&v.version))
+            .collect()
+    }
+
     #[cfg(any(windows, test))]
     fn windows_bin_paths_for_install_path(install_path: &Path) -> Vec<std::path::PathBuf> {
         let bin_dir = install_path.join("bin");
@@ -1008,6 +1096,124 @@ mod tests {
             Some(&"--loglevel=warn".to_string())
         );
         assert!(!resolved.contains_key("install_env.NPM_CONFIG_REGISTRY"));
+    }
+
+    #[test]
+    fn test_deprecated_versions_query_handles_scoped_packages() {
+        assert_eq!(
+            NPMBackend::deprecated_versions_query("@scope/pkg"),
+            "@scope/pkg@>=0.0.0"
+        );
+    }
+
+    #[test]
+    fn test_deprecated_versions_from_npm_view_array_objects() {
+        let data: Value = serde_json::json!([
+            {
+                "version": "1.0.0",
+                "deprecated": "use a newer version"
+            },
+            {
+                "version": "1.1.0"
+            },
+            {
+                "version": "1.2.0",
+                "deprecated": ""
+            },
+            {
+                "version": "2.0.0",
+                "deprecated": "unsupported"
+            }
+        ]);
+
+        let versions = NPMBackend::deprecated_versions_from_npm_view(&data);
+
+        assert!(versions.contains("1.0.0"));
+        assert!(versions.contains("2.0.0"));
+        assert!(!versions.contains("1.1.0"));
+        assert!(!versions.contains("1.2.0"));
+    }
+
+    #[test]
+    fn test_deprecated_versions_from_npm_view_array_strings() {
+        let data: Value = serde_json::json!(["1.0.0", "1.1.0"]);
+
+        let versions = NPMBackend::deprecated_versions_from_npm_view(&data);
+
+        assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn test_deprecated_versions_from_npm_view_single_object() {
+        let data: Value = serde_json::json!({
+            "version": "1.0.0",
+            "deprecated": "use a newer version"
+        });
+
+        let versions = NPMBackend::deprecated_versions_from_npm_view(&data);
+
+        assert_eq!(versions, HashSet::from(["1.0.0".to_string()]));
+    }
+
+    #[test]
+    fn test_deprecated_versions_from_npm_view_null() {
+        let versions = NPMBackend::deprecated_versions_from_npm_view(&Value::Null);
+
+        assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn test_filter_deprecated_versions_drops_subset() {
+        let versions = vec![
+            VersionInfo {
+                version: "1.0.0".to_string(),
+                ..Default::default()
+            },
+            VersionInfo {
+                version: "1.1.0".to_string(),
+                ..Default::default()
+            },
+            VersionInfo {
+                version: "1.2.0".to_string(),
+                ..Default::default()
+            },
+        ];
+        let deprecated = HashSet::from(["1.1.0".to_string()]);
+
+        let filtered = NPMBackend::filter_deprecated_versions(versions, &deprecated);
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|v| v.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1.0.0", "1.2.0"]
+        );
+    }
+
+    #[test]
+    fn test_filter_deprecated_versions_keeps_package_level_deprecation() {
+        let versions = vec![
+            VersionInfo {
+                version: "1.0.0".to_string(),
+                ..Default::default()
+            },
+            VersionInfo {
+                version: "1.1.0".to_string(),
+                ..Default::default()
+            },
+        ];
+        let deprecated = HashSet::from(["1.0.0".to_string(), "1.1.0".to_string()]);
+
+        let filtered = NPMBackend::filter_deprecated_versions(versions, &deprecated);
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|v| v.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1.0.0", "1.1.0"]
+        );
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -129,17 +129,40 @@ impl Backend for NPMBackend {
             async || {
                 let env = self.dependency_env(config).await?;
 
-                let raw = cmd!(
-                    NPM_PROGRAM,
-                    "view",
-                    self.tool_name(),
-                    "versions",
-                    "time",
-                    "--json"
-                )
-                .full_env(&env)
-                .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-                .read()?;
+                let package = self.tool_name();
+                let package_for_versions = package.clone();
+                let package_for_logs = package.clone();
+                let deprecated_query = Self::deprecated_versions_query(&package);
+                let versions_env = env.clone();
+                let deprecated_env = env;
+                let versions_task = tokio::task::spawn_blocking(move || {
+                    cmd!(
+                        NPM_PROGRAM,
+                        "view",
+                        package_for_versions,
+                        "versions",
+                        "time",
+                        "--json"
+                    )
+                    .full_env(&versions_env)
+                    .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+                    .read()
+                });
+                let deprecated_task = tokio::task::spawn_blocking(move || {
+                    cmd!(
+                        NPM_PROGRAM,
+                        "view",
+                        deprecated_query,
+                        "version",
+                        "deprecated",
+                        "--json"
+                    )
+                    .full_env(&deprecated_env)
+                    .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+                    .read()
+                });
+                let (raw, deprecated_raw) = tokio::try_join!(versions_task, deprecated_task)?;
+                let raw = raw?;
                 let data: Value = serde_json::from_str(&raw)?;
                 let versions = data["versions"]
                     .as_array()
@@ -147,25 +170,14 @@ impl Backend for NPMBackend {
                 let time = data["time"]
                     .as_object()
                     .ok_or_else(|| eyre::eyre!("invalid time"))?;
-                let deprecated_versions = match cmd!(
-                    NPM_PROGRAM,
-                    "view",
-                    Self::deprecated_versions_query(&self.tool_name()),
-                    "version",
-                    "deprecated",
-                    "--json"
-                )
-                .full_env(&env)
-                .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-                .read()
-                {
+                let deprecated_versions = match deprecated_raw {
                     Ok(raw) if raw.trim().is_empty() => HashSet::new(),
                     Ok(raw) => match serde_json::from_str::<Value>(&raw) {
                         Ok(data) => Self::deprecated_versions_from_npm_view(&data),
                         Err(err) => {
                             debug!(
                                 "failed to parse npm deprecated metadata for {}: {err:#}",
-                                self.tool_name()
+                                package_for_logs
                             );
                             HashSet::new()
                         }
@@ -173,7 +185,7 @@ impl Backend for NPMBackend {
                     Err(err) => {
                         debug!(
                             "failed to fetch npm deprecated metadata for {}: {err:#}",
-                            self.tool_name()
+                            package_for_logs
                         );
                         HashSet::new()
                     }
@@ -707,7 +719,7 @@ impl NPMBackend {
     }
 
     fn deprecated_versions_query(package: &str) -> String {
-        format!("{package}@>=0.0.0")
+        format!("{package}@>=0.0.0-0")
     }
 
     fn deprecated_versions_from_npm_view(data: &Value) -> HashSet<String> {
@@ -1102,7 +1114,7 @@ mod tests {
     fn test_deprecated_versions_query_handles_scoped_packages() {
         assert_eq!(
             NPMBackend::deprecated_versions_query("@scope/pkg"),
-            "@scope/pkg@>=0.0.0"
+            "@scope/pkg@>=0.0.0-0"
         );
     }
 


### PR DESCRIPTION
## Summary
- fetch npm deprecated metadata while listing npm versions
- skip deprecated versions for fuzzy/latest resolution without hiding fully deprecated packages
- cover npm JSON shapes plus an install-before regression for glob

## How it works
- mise already asks npm for `versions` and `time` with `npm view <package> versions time --json` so custom npm registry configuration is respected.
- deprecated metadata is not included in that response, so the backend makes a second npm CLI request in parallel: `npm view <package>@>=0.0.0-0 version deprecated --json`.
- The explicit range is required for per-version metadata. `npm view <package>@* version deprecated --json` returns only the latest version in testing (`uuid@*`, `react@*`, and `glob@*`), so it would miss older deprecated versions. `>=0.0.0-0` also keeps npm prerelease versions in the metadata query.
- npm returns different JSON shapes depending on registry state: arrays of objects when metadata is present, arrays of strings when fields are absent, a single object for one match, or empty/null-like output. The parser only treats entries with a version plus a non-empty deprecated value as deprecated.
- If every listed version is deprecated, the filter is skipped. That covers package-level deprecation, where filtering all versions would make `mise latest npm:<package>` unusable.

## Why this is required
- npm keeps deprecated versions in the version list. Without this filter, mise can resolve `latest`, prefix matches, or `--before`/`minimum_release_age` requests to versions npm maintainers have explicitly deprecated.
- The `glob` regression covers the important case: older deprecated releases can be newer than the last usable release before a cutoff, so date-aware latest resolution needs both timestamps and deprecation metadata.

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test backend::npm::tests`
- `mise run test:e2e e2e/backend/test_npm_install_before`