### PR TITLE
fix(backend): use runtime paths for backend bin dirs

### DIFF
--- a/e2e/backend/test_aqua_symlink_bins
+++ b/e2e/backend/test_aqua_symlink_bins
@@ -45,3 +45,11 @@ just_root="$(mise where aqua:casey/just@1.46.0)"
 assert_directory_exists "$just_root/.mise-bins"
 assert "mise which just" "$just_root/.mise-bins/just"
 assert_contains "mise x -- just --version" "just 1.46.0"
+
+cat <<EOF >mise.toml
+[tools]
+"aqua:casey/just" = { version = "1.46", symlink_bins = true }
+EOF
+
+assert "mise bin-paths" "$MISE_DATA_DIR/installs/aqua-casey-just/1.46/.mise-bins"
+assert "mise which just" "$MISE_DATA_DIR/installs/aqua-casey-just/1.46/.mise-bins/just"

--- a/e2e/backend/test_github_alias_versions
+++ b/e2e/backend/test_github_alias_versions
@@ -23,3 +23,11 @@ mise install
 assert "mise where tiny" "$MISE_DATA_DIR/installs/tiny/1.0.0"
 assert "mise bin-paths tiny" "$MISE_DATA_DIR/installs/tiny/latest/hello-world-1.0.0/bin"
 assert_contains "mise x -- hello-world" "hello world"
+
+# Once the fuzzy request is recorded in the lockfile, PATH-facing bin paths
+# should use the concrete locked install path so the runtime label cannot drift.
+touch mise.lock
+mise install
+assert_contains "cat mise.lock" "1.0.0"
+assert "mise bin-paths tiny" "$MISE_DATA_DIR/installs/tiny/1.0.0/hello-world-1.0.0/bin"
+assert_contains "mise x -- hello-world" "hello world"

--- a/e2e/backend/test_github_alias_versions
+++ b/e2e/backend/test_github_alias_versions
@@ -21,4 +21,5 @@ assert_contains "mise ls-remote tiny" "1.0.0"
 # Installing with @latest should resolve to 1.0.0 from the github releases
 mise install
 assert "mise where tiny" "$MISE_DATA_DIR/installs/tiny/1.0.0"
+assert "mise bin-paths tiny" "$MISE_DATA_DIR/installs/tiny/latest/hello-world-1.0.0/bin"
 assert_contains "mise x -- hello-world" "hello world"

--- a/e2e/backend/test_http_upgrade
+++ b/e2e/backend/test_http_upgrade
@@ -64,6 +64,25 @@ if [[ ! -L $INSTALL_PATH ]]; then
 fi
 echo "Verified: Install path is a symlink (HTTP backend caching)"
 
+cat <<EOF >mise.toml
+[tools."http:hello-upgrade"]
+version = "1.0.0"
+url = "https://mise.en.dev/test-fixtures/hello-world-{{version}}.tar.gz"
+version_list_url = "http://localhost:$HTTP_PORT/versions.txt"
+bin_path = "hello-world-1.0.0/bin"
+postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world"
+
+[tools."http:hello-upgrade-latest"]
+version = "latest"
+url = "https://mise.en.dev/test-fixtures/hello-world-{{version}}.tar.gz"
+version_list_url = "http://localhost:$HTTP_PORT/versions.txt"
+bin_path = "hello-world-{{version}}/bin"
+postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-\$MISE_TOOL_VERSION/bin/hello-world"
+EOF
+
+mise install
+assert "mise bin-paths http:hello-upgrade-latest" "$MISE_DATA_DIR/installs/http-hello-upgrade-latest/latest/hello-world-2.0.0/bin"
+
 # Test 2: Verify mise latest sees the newer version
 echo "Test 2: Check that mise latest sees version 2.0.0"
 assert "mise latest http:hello-upgrade" "2.0.0"

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -23,7 +23,7 @@ use crate::{
     cache::{CacheManager, CacheManagerBuilder},
 };
 use crate::{
-    backend::{Backend, MISE_BINS_DIR, strict_metadata},
+    backend::{Backend, MISE_BINS_DIR, runtime_path_for_bin_paths, strict_metadata},
     config::Config,
 };
 use crate::{file, github, minisign};

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -500,9 +500,10 @@ impl Backend for AquaBackend {
         _config: &Arc<Config>,
         tv: &ToolVersion,
     ) -> Result<Vec<PathBuf>> {
+        let runtime_path = tv.runtime_path();
         let mise_bins_dir = tv.install_path().join(".mise-bins");
         if self.symlink_bins(tv) || mise_bins_dir.is_dir() {
-            return Ok(vec![mise_bins_dir]);
+            return Ok(vec![runtime_path.join(".mise-bins")]);
         }
 
         let install_path = tv.install_path();
@@ -550,7 +551,7 @@ impl Backend for AquaBackend {
             })
             .await?
             .iter()
-            .map(|p| p.mount(&install_path))
+            .map(|p| p.mount(&runtime_path))
             .collect();
         Ok(paths)
     }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -23,7 +23,7 @@ use crate::{
     cache::{CacheManager, CacheManagerBuilder},
 };
 use crate::{
-    backend::{Backend, MISE_BINS_DIR, runtime_path_for_bin_paths, strict_metadata},
+    backend::{Backend, MISE_BINS_DIR, strict_metadata},
     config::Config,
 };
 use crate::{file, github, minisign};

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -23,7 +23,7 @@ use crate::{
     cache::{CacheManager, CacheManagerBuilder},
 };
 use crate::{
-    backend::{Backend, strict_metadata},
+    backend::{Backend, MISE_BINS_DIR, strict_metadata},
     config::Config,
 };
 use crate::{file, github, minisign};
@@ -501,9 +501,9 @@ impl Backend for AquaBackend {
         tv: &ToolVersion,
     ) -> Result<Vec<PathBuf>> {
         let runtime_path = tv.runtime_path();
-        let mise_bins_dir = tv.install_path().join(".mise-bins");
+        let mise_bins_dir = tv.install_path().join(MISE_BINS_DIR);
         if self.symlink_bins(tv) || mise_bins_dir.is_dir() {
-            return Ok(vec![runtime_path.join(".mise-bins")]);
+            return Ok(vec![runtime_path.join(MISE_BINS_DIR)]);
         }
 
         let install_path = tv.install_path();
@@ -2261,7 +2261,7 @@ impl AquaBackend {
     /// Creates a `.mise-bins` directory with symlinks only to the binaries defined in the aqua registry.
     /// This prevents bundled dependencies (like Python in aws-cli) from being exposed on PATH.
     fn create_symlink_bin_dir(&self, tv: &ToolVersion, srcs: &[AquaFileLink]) -> Result<()> {
-        let symlink_dir = tv.install_path().join(".mise-bins");
+        let symlink_dir = tv.install_path().join(MISE_BINS_DIR);
         file::create_dir_all(&symlink_dir)?;
 
         for link in srcs {

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -1,6 +1,9 @@
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
-use crate::backend::{VersionInfo, filter_cached_prereleases, mark_prerelease};
+use crate::backend::{
+    MISE_BINS_DIR, VersionInfo, filter_cached_prereleases, mark_prerelease,
+    runtime_path_for_install_path,
+};
 use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::Settings;
@@ -541,7 +544,7 @@ impl CondaBackend {
     /// Uses the PathsEntry list returned by rattler's link_package to identify which files
     /// belong to the main package (excluding transitive dependency binaries).
     fn create_symlink_bin_dir(&self, tv: &ToolVersion, main_paths: &[PathsEntry]) -> Result<()> {
-        let symlink_dir = tv.install_path().join(".mise-bins");
+        let symlink_dir = tv.install_path().join(MISE_BINS_DIR);
         file::create_dir_all(&symlink_dir)?;
 
         let install_path = tv.install_path();
@@ -770,23 +773,28 @@ impl Backend for CondaBackend {
         _config: &Arc<Config>,
         tv: &ToolVersion,
     ) -> Result<Vec<PathBuf>> {
-        let mise_bins = tv.install_path().join(".mise-bins");
+        let install_path = tv.install_path();
+        let mise_bins = install_path.join(MISE_BINS_DIR);
         if mise_bins.exists() {
-            return Ok(vec![mise_bins]);
+            return Ok(vec![runtime_path_for_install_path(tv, mise_bins)]);
         }
 
         // Fallback for tools installed before this change
-        let install_path = tv.install_path();
-        if cfg!(windows) {
+        let bin_paths = if cfg!(windows) {
             // Conda packages on Windows can put binaries in either location
             // depending on the build variant (MSVC vs MSYS2/MinGW)
-            Ok(vec![
+            vec![
                 install_path.join("Library").join("bin"),
                 install_path.join("bin"),
-            ])
+            ]
         } else {
-            Ok(vec![install_path.join("bin")])
-        }
+            vec![install_path.join("bin")]
+        };
+
+        Ok(bin_paths
+            .into_iter()
+            .map(|path| runtime_path_for_install_path(tv, path))
+            .collect())
     }
 }
 

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1,4 +1,3 @@
-use crate::backend::SecurityFeature;
 use crate::backend::VersionInfo;
 use crate::backend::asset_matcher::{self, Asset, AssetPicker, ChecksumFetcher};
 use crate::backend::backend_type::BackendType;
@@ -7,6 +6,7 @@ use crate::backend::static_helpers::{
     get_filename_from_url, install_artifact, lookup_platform_key, lookup_platform_key_for_target,
     template_string, try_with_v_prefix, try_with_v_prefix_and_repo, verify_artifact,
 };
+use crate::backend::{SecurityFeature, runtime_path_for_install_path};
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::config::{Config, Settings};
 use crate::file;
@@ -355,10 +355,14 @@ impl Backend for UnifiedGitBackend {
     ) -> Result<Vec<std::path::PathBuf>> {
         let mise_bins_dir = tv.install_path().join(".mise-bins");
         if self.get_filter_bins(tv).is_some() || mise_bins_dir.is_dir() {
-            return Ok(vec![mise_bins_dir]);
+            return Ok(vec![runtime_path_for_install_path(tv, mise_bins_dir)]);
         }
 
-        self.discover_bin_paths(tv)
+        Ok(self
+            .discover_bin_paths(tv)?
+            .into_iter()
+            .map(|path| runtime_path_for_install_path(tv, path))
+            .collect())
     }
 
     fn resolve_lockfile_options(

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -355,7 +355,7 @@ impl Backend for UnifiedGitBackend {
     ) -> Result<Vec<std::path::PathBuf>> {
         let mise_bins_dir = tv.install_path().join(".mise-bins");
         if self.get_filter_bins(tv).is_some() || mise_bins_dir.is_dir() {
-            return Ok(vec![runtime_path_for_install_path(tv, mise_bins_dir)]);
+            return Ok(vec![tv.runtime_path().join(".mise-bins")]);
         }
 
         Ok(self

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -6,7 +6,7 @@ use crate::backend::static_helpers::{
     get_filename_from_url, install_artifact, lookup_platform_key, lookup_platform_key_for_target,
     template_string, try_with_v_prefix, try_with_v_prefix_and_repo, verify_artifact,
 };
-use crate::backend::{SecurityFeature, runtime_path_for_install_path};
+use crate::backend::{MISE_BINS_DIR, SecurityFeature, runtime_path_for_install_path};
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::config::{Config, Settings};
 use crate::file;
@@ -353,9 +353,9 @@ impl Backend for UnifiedGitBackend {
         _config: &Arc<Config>,
         tv: &ToolVersion,
     ) -> Result<Vec<std::path::PathBuf>> {
-        let mise_bins_dir = tv.install_path().join(".mise-bins");
+        let mise_bins_dir = tv.install_path().join(MISE_BINS_DIR);
         if self.get_filter_bins(tv).is_some() || mise_bins_dir.is_dir() {
-            return Ok(vec![tv.runtime_path().join(".mise-bins")]);
+            return Ok(vec![tv.runtime_path().join(MISE_BINS_DIR)]);
         }
 
         Ok(self
@@ -1396,7 +1396,7 @@ impl UnifiedGitBackend {
 
     /// Creates a `.mise-bins` directory with symlinks only to the binaries specified in filter_bins.
     fn create_symlink_bin_dir(&self, tv: &ToolVersion, bins: Vec<String>) -> Result<()> {
-        let symlink_dir = tv.install_path().join(".mise-bins");
+        let symlink_dir = tv.install_path().join(MISE_BINS_DIR);
         file::create_dir_all(&symlink_dir)?;
 
         // Find where the actual binaries are

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -6,7 +6,9 @@ use crate::backend::static_helpers::{
     get_filename_from_url, install_artifact, lookup_platform_key, lookup_platform_key_for_target,
     template_string, try_with_v_prefix, try_with_v_prefix_and_repo, verify_artifact,
 };
-use crate::backend::{MISE_BINS_DIR, SecurityFeature, runtime_path_for_install_path};
+use crate::backend::{
+    MISE_BINS_DIR, SecurityFeature, runtime_path_for_bin_paths, runtime_path_for_install_path,
+};
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::config::{Config, Settings};
 use crate::file;
@@ -355,7 +357,7 @@ impl Backend for UnifiedGitBackend {
     ) -> Result<Vec<std::path::PathBuf>> {
         let mise_bins_dir = tv.install_path().join(MISE_BINS_DIR);
         if self.get_filter_bins(tv).is_some() || mise_bins_dir.is_dir() {
-            return Ok(vec![tv.runtime_path().join(MISE_BINS_DIR)]);
+            return Ok(vec![runtime_path_for_bin_paths(tv).join(MISE_BINS_DIR)]);
         }
 
         Ok(self

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -6,9 +6,7 @@ use crate::backend::static_helpers::{
     get_filename_from_url, install_artifact, lookup_platform_key, lookup_platform_key_for_target,
     template_string, try_with_v_prefix, try_with_v_prefix_and_repo, verify_artifact,
 };
-use crate::backend::{
-    MISE_BINS_DIR, SecurityFeature, runtime_path_for_bin_paths, runtime_path_for_install_path,
-};
+use crate::backend::{MISE_BINS_DIR, SecurityFeature, runtime_path_for_install_path};
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::config::{Config, Settings};
 use crate::file;
@@ -357,7 +355,7 @@ impl Backend for UnifiedGitBackend {
     ) -> Result<Vec<std::path::PathBuf>> {
         let mise_bins_dir = tv.install_path().join(MISE_BINS_DIR);
         if self.get_filter_bins(tv).is_some() || mise_bins_dir.is_dir() {
-            return Ok(vec![runtime_path_for_bin_paths(tv).join(MISE_BINS_DIR)]);
+            return Ok(vec![tv.runtime_path().join(MISE_BINS_DIR)]);
         }
 
         Ok(self

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -1,12 +1,12 @@
 use crate::backend::Backend;
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
-use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
     clean_binary_name, get_filename_from_url, list_available_platforms_with_key,
     lookup_platform_key, rename_executable_in_dir, template_string, verify_artifact,
 };
 use crate::backend::version_list;
+use crate::backend::{runtime_path_for_bin_paths, runtime_path_for_install_path};
 use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::Settings;
@@ -745,13 +745,13 @@ impl Backend for HttpBackend {
         // Check for explicit bin_path
         if let Some(bin_path_template) = get_opt(&opts, "bin_path") {
             let bin_path = template_string(&bin_path_template, tv);
-            return Ok(vec![tv.runtime_path().join(bin_path)]);
+            return Ok(vec![runtime_path_for_bin_paths(tv).join(bin_path)]);
         }
 
         // Check for bin directory
         let bin_dir = install_path.join("bin");
         if bin_dir.exists() {
-            return Ok(vec![tv.runtime_path().join("bin")]);
+            return Ok(vec![runtime_path_for_bin_paths(tv).join("bin")]);
         }
 
         // Search subdirectories for bin directories
@@ -769,7 +769,7 @@ impl Backend for HttpBackend {
         }
 
         if paths.is_empty() {
-            Ok(vec![tv.runtime_path()])
+            Ok(vec![runtime_path_for_bin_paths(tv)])
         } else {
             Ok(paths
                 .into_iter()

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -745,16 +745,13 @@ impl Backend for HttpBackend {
         // Check for explicit bin_path
         if let Some(bin_path_template) = get_opt(&opts, "bin_path") {
             let bin_path = template_string(&bin_path_template, tv);
-            return Ok(vec![runtime_path_for_install_path(
-                tv,
-                install_path.join(bin_path),
-            )]);
+            return Ok(vec![tv.runtime_path().join(bin_path)]);
         }
 
         // Check for bin directory
         let bin_dir = install_path.join("bin");
         if bin_dir.exists() {
-            return Ok(vec![runtime_path_for_install_path(tv, bin_dir)]);
+            return Ok(vec![tv.runtime_path().join("bin")]);
         }
 
         // Search subdirectories for bin directories
@@ -772,7 +769,7 @@ impl Backend for HttpBackend {
         }
 
         if paths.is_empty() {
-            Ok(vec![runtime_path_for_install_path(tv, install_path)])
+            Ok(vec![tv.runtime_path()])
         } else {
             Ok(paths
                 .into_iter()

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -1,12 +1,12 @@
 use crate::backend::Backend;
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
+use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
     clean_binary_name, get_filename_from_url, list_available_platforms_with_key,
     lookup_platform_key, rename_executable_in_dir, template_string, verify_artifact,
 };
 use crate::backend::version_list;
-use crate::backend::{runtime_path_for_bin_paths, runtime_path_for_install_path};
 use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::Settings;
@@ -745,13 +745,13 @@ impl Backend for HttpBackend {
         // Check for explicit bin_path
         if let Some(bin_path_template) = get_opt(&opts, "bin_path") {
             let bin_path = template_string(&bin_path_template, tv);
-            return Ok(vec![runtime_path_for_bin_paths(tv).join(bin_path)]);
+            return Ok(vec![tv.runtime_path().join(bin_path)]);
         }
 
         // Check for bin directory
         let bin_dir = install_path.join("bin");
         if bin_dir.exists() {
-            return Ok(vec![runtime_path_for_bin_paths(tv).join("bin")]);
+            return Ok(vec![tv.runtime_path().join("bin")]);
         }
 
         // Search subdirectories for bin directories
@@ -769,7 +769,7 @@ impl Backend for HttpBackend {
         }
 
         if paths.is_empty() {
-            Ok(vec![runtime_path_for_bin_paths(tv)])
+            Ok(vec![tv.runtime_path()])
         } else {
             Ok(paths
                 .into_iter()

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -1,6 +1,7 @@
 use crate::backend::Backend;
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
+use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
     clean_binary_name, get_filename_from_url, list_available_platforms_with_key,
     lookup_platform_key, rename_executable_in_dir, template_string, verify_artifact,
@@ -739,22 +740,26 @@ impl Backend for HttpBackend {
         tv: &ToolVersion,
     ) -> Result<Vec<PathBuf>> {
         let opts = tv.request.options();
+        let install_path = tv.install_path();
 
         // Check for explicit bin_path
         if let Some(bin_path_template) = get_opt(&opts, "bin_path") {
             let bin_path = template_string(&bin_path_template, tv);
-            return Ok(vec![tv.install_path().join(bin_path)]);
+            return Ok(vec![runtime_path_for_install_path(
+                tv,
+                install_path.join(bin_path),
+            )]);
         }
 
         // Check for bin directory
-        let bin_dir = tv.install_path().join("bin");
+        let bin_dir = install_path.join("bin");
         if bin_dir.exists() {
-            return Ok(vec![bin_dir]);
+            return Ok(vec![runtime_path_for_install_path(tv, bin_dir)]);
         }
 
         // Search subdirectories for bin directories
         let mut paths = Vec::new();
-        if let Ok(entries) = std::fs::read_dir(tv.install_path()) {
+        if let Ok(entries) = std::fs::read_dir(&install_path) {
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path.is_dir() {
@@ -767,9 +772,12 @@ impl Backend for HttpBackend {
         }
 
         if paths.is_empty() {
-            Ok(vec![tv.install_path()])
+            Ok(vec![runtime_path_for_install_path(tv, install_path)])
         } else {
-            Ok(paths)
+            Ok(paths
+                .into_iter()
+                .map(|path| runtime_path_for_install_path(tv, path))
+                .collect())
         }
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -78,6 +78,8 @@ pub type BackendMap = BTreeMap<String, ABackend>;
 pub type BackendList = Vec<ABackend>;
 pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 
+pub(crate) const MISE_BINS_DIR: &str = ".mise-bins";
+
 const VERSIONS_HOST_LOCAL_OPT_SOURCES: &[ToolOptionSource] = &[
     ToolOptionSource::BackendAlias,
     ToolOptionSource::Config,
@@ -110,7 +112,6 @@ pub(crate) fn runtime_path_for_install_path(tv: &ToolVersion, path: PathBuf) -> 
     } else {
         path
     }
->>>>>>> f3aa315a9 (fix(backend): use runtime paths for backend bin dirs)
 }
 
 static STRICT_METADATA: AtomicBool = AtomicBool::new(false);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -45,6 +45,8 @@ use backend_type::BackendType;
 use eyre::{Result, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
+#[cfg(windows)]
+use path_absolutize::Absolutize;
 use platform_target::PlatformTarget;
 use regex::Regex;
 use std::sync::LazyLock as Lazy;
@@ -109,7 +111,24 @@ pub(crate) fn runtime_path_for_bin_paths(tv: &ToolVersion) -> PathBuf {
     .replace([':', '/'], "-");
 
     let path = tv.ba().installs_path.join(&pathname);
-    env::find_in_shared_installs(path, &tv.ba().tool_dir_name(), &pathname)
+    let path = env::find_in_shared_installs(path, &tv.ba().tool_dir_name(), &pathname);
+
+    #[cfg(windows)]
+    if path.is_file()
+        && is_runtime_symlink(&path)
+        && let Ok(Some(target)) = file::resolve_symlink(&path)
+        && let Some(parent) = path.parent()
+    {
+        let target = parent.join(target);
+        if target.is_dir() {
+            return target
+                .absolutize()
+                .expect("failed to absolutize path")
+                .to_path_buf();
+        }
+    }
+
+    path
 }
 
 /// Remaps a backend-discovered path from the concrete install dir to the

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -94,6 +94,24 @@ fn has_local_version_listing_option_override(
         .has_any_key_from_sources(version_listing_opt_keys, VERSIONS_HOST_LOCAL_OPT_SOURCES)
 }
 
+/// Returns the runtime-label path that `bin-paths` should expose.
+///
+/// This intentionally does not call `ToolVersion::runtime_path()`: when a
+/// lockfile resolves a fuzzy request to a concrete version, `runtime_path()`
+/// returns the concrete install dir, but `bin-paths` should still use the
+/// requested runtime label.
+pub(crate) fn runtime_path_for_bin_paths(tv: &ToolVersion) -> PathBuf {
+    let pathname = match &tv.request {
+        ToolRequest::Version { version, .. } if version != &tv.version => version,
+        ToolRequest::Prefix { prefix, .. } => prefix,
+        _ => return tv.runtime_path(),
+    }
+    .replace([':', '/'], "-");
+
+    let path = tv.ba().installs_path.join(&pathname);
+    env::find_in_shared_installs(path, &tv.ba().tool_dir_name(), &pathname)
+}
+
 /// Remaps a backend-discovered path from the concrete install dir to the
 /// runtime path users put on PATH.
 ///
@@ -103,7 +121,7 @@ fn has_local_version_listing_option_override(
 pub(crate) fn runtime_path_for_install_path(tv: &ToolVersion, path: PathBuf) -> PathBuf {
     let install_path = tv.install_path();
     if let Ok(relative_path) = path.strip_prefix(&install_path) {
-        let runtime_path = tv.runtime_path();
+        let runtime_path = runtime_path_for_bin_paths(tv);
         if relative_path.as_os_str().is_empty() {
             runtime_path
         } else {
@@ -542,6 +560,45 @@ mod tests {
         assert_eq!(
             runtime_path_for_install_path(&tv, external_path.clone()),
             external_path
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_runtime_path_for_install_path_uses_request_label_without_symlink() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let short = format!(
+            "runtime-remap-missing-symlink-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let mut backend = BackendArg::new_raw(
+            short.clone(),
+            None,
+            short.clone(),
+            None,
+            BackendResolution::new(false),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join(&short);
+        fs::create_dir_all(&backend.installs_path)?;
+
+        let install_path = backend.installs_path.join("1.0.1");
+        fs::create_dir_all(install_path.join("bin"))?;
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "latest".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "1.0.1".into());
+
+        assert_eq!(
+            runtime_path_for_install_path(&tv, install_path.join("bin")),
+            tv.ba().installs_path.join("latest").join("bin")
         );
 
         Ok(())
@@ -1861,7 +1918,7 @@ pub trait Backend: Debug + Send + Sync {
     ) -> Result<Vec<PathBuf>> {
         match tv.request {
             ToolRequest::System { .. } => Ok(vec![]),
-            _ => Ok(vec![tv.runtime_path().join("bin")]),
+            _ => Ok(vec![runtime_path_for_bin_paths(tv).join("bin")]),
         }
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -45,8 +45,6 @@ use backend_type::BackendType;
 use eyre::{Result, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
-#[cfg(windows)]
-use path_absolutize::Absolutize;
 use platform_target::PlatformTarget;
 use regex::Regex;
 use std::sync::LazyLock as Lazy;
@@ -95,56 +93,16 @@ fn has_local_version_listing_option_override(
     resolved_opts
         .has_any_key_from_sources(version_listing_opt_keys, VERSIONS_HOST_LOCAL_OPT_SOURCES)
 }
-
-/// Returns the runtime-label path that `bin-paths` should expose.
-///
-/// This intentionally does not call `ToolVersion::runtime_path()`: when a
-/// lockfile resolves a fuzzy request to a concrete version, `runtime_path()`
-/// returns the concrete install dir, but `bin-paths` should still use the
-/// requested runtime label once that label exists.
-pub(crate) fn runtime_path_for_bin_paths(tv: &ToolVersion) -> PathBuf {
-    let pathname = match &tv.request {
-        ToolRequest::Version { version, .. } if version != &tv.version => version,
-        ToolRequest::Prefix { prefix, .. } => prefix,
-        _ => return tv.runtime_path(),
-    }
-    .replace([':', '/'], "-");
-
-    let path = tv.ba().installs_path.join(&pathname);
-    let path = env::find_in_shared_installs(path, &tv.ba().tool_dir_name(), &pathname);
-
-    #[cfg(windows)]
-    if path.is_file()
-        && is_runtime_symlink(&path)
-        && let Ok(Some(target)) = file::resolve_symlink(&path)
-        && let Some(parent) = path.parent()
-    {
-        let target = parent.join(target);
-        if target.is_dir() {
-            return target
-                .absolutize()
-                .expect("failed to absolutize path")
-                .to_path_buf();
-        }
-    }
-
-    if path.is_dir() && is_runtime_symlink(&path) {
-        path
-    } else {
-        tv.runtime_path()
-    }
-}
-
 /// Remaps a backend-discovered path from the concrete install dir to the
 /// runtime path users put on PATH.
 ///
 /// For fuzzy requests like `latest` or `1.46`, backends may discover bins under
-/// the resolved version dir, but `bin-paths` should expose the stable runtime
-/// symlink. Paths outside the install dir are returned unchanged.
+/// the resolved version dir, but PATH-facing callers should use `runtime_path()`
+/// for the same version. Paths outside the install dir are returned unchanged.
 pub(crate) fn runtime_path_for_install_path(tv: &ToolVersion, path: PathBuf) -> PathBuf {
     let install_path = tv.install_path();
     if let Ok(relative_path) = path.strip_prefix(&install_path) {
-        let runtime_path = runtime_path_for_bin_paths(tv);
+        let runtime_path = tv.runtime_path();
         if relative_path.as_os_str().is_empty() {
             runtime_path
         } else {
@@ -1941,7 +1899,7 @@ pub trait Backend: Debug + Send + Sync {
     ) -> Result<Vec<PathBuf>> {
         match tv.request {
             ToolRequest::System { .. } => Ok(vec![]),
-            _ => Ok(vec![runtime_path_for_bin_paths(tv).join("bin")]),
+            _ => Ok(vec![tv.runtime_path().join("bin")]),
         }
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -78,7 +78,6 @@ pub type BackendMap = BTreeMap<String, ABackend>;
 pub type BackendList = Vec<ABackend>;
 pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 
-<<<<<<< HEAD
 const VERSIONS_HOST_LOCAL_OPT_SOURCES: &[ToolOptionSource] = &[
     ToolOptionSource::BackendAlias,
     ToolOptionSource::Config,
@@ -91,7 +90,14 @@ fn has_local_version_listing_option_override(
 ) -> bool {
     resolved_opts
         .has_any_key_from_sources(version_listing_opt_keys, VERSIONS_HOST_LOCAL_OPT_SOURCES)
-=======
+}
+
+/// Remaps a backend-discovered path from the concrete install dir to the
+/// runtime path users put on PATH.
+///
+/// For fuzzy requests like `latest` or `1.46`, backends may discover bins under
+/// the resolved version dir, but `bin-paths` should expose the stable runtime
+/// symlink. Paths outside the install dir are returned unchanged.
 pub(crate) fn runtime_path_for_install_path(tv: &ToolVersion, path: PathBuf) -> PathBuf {
     let install_path = tv.install_path();
     if let Ok(relative_path) = path.strip_prefix(&install_path) {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -78,6 +78,7 @@ pub type BackendMap = BTreeMap<String, ABackend>;
 pub type BackendList = Vec<ABackend>;
 pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 
+<<<<<<< HEAD
 const VERSIONS_HOST_LOCAL_OPT_SOURCES: &[ToolOptionSource] = &[
     ToolOptionSource::BackendAlias,
     ToolOptionSource::Config,
@@ -90,6 +91,20 @@ fn has_local_version_listing_option_override(
 ) -> bool {
     resolved_opts
         .has_any_key_from_sources(version_listing_opt_keys, VERSIONS_HOST_LOCAL_OPT_SOURCES)
+=======
+pub(crate) fn runtime_path_for_install_path(tv: &ToolVersion, path: PathBuf) -> PathBuf {
+    let install_path = tv.install_path();
+    if let Ok(relative_path) = path.strip_prefix(&install_path) {
+        let runtime_path = tv.runtime_path();
+        if relative_path.as_os_str().is_empty() {
+            runtime_path
+        } else {
+            runtime_path.join(relative_path)
+        }
+    } else {
+        path
+    }
+>>>>>>> f3aa315a9 (fix(backend): use runtime paths for backend bin dirs)
 }
 
 static STRICT_METADATA: AtomicBool = AtomicBool::new(false);
@@ -403,6 +418,10 @@ pub(crate) fn normalize_idiomatic_contents(contents: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::args::BackendResolution;
+    use crate::toolset::{ToolSource, ToolVersionOptions};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn test_normalize_idiomatic_contents() {
@@ -473,6 +492,52 @@ mod tests {
             &resolved,
             &["api_url", "version_prefix"],
         ));
+    }
+
+    #[test]
+    fn test_runtime_path_for_install_path_remaps_install_subpath() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let short = format!(
+            "runtime-remap-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let mut backend = BackendArg::new_raw(
+            short.clone(),
+            None,
+            short.clone(),
+            None,
+            BackendResolution::new(false),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join(&short);
+        fs::create_dir_all(&backend.installs_path)?;
+
+        let install_path = backend.installs_path.join("1.0.1");
+        fs::create_dir_all(install_path.join("bin"))?;
+        file::make_symlink_or_file(Path::new("./1.0.1"), &backend.installs_path.join("latest"))?;
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "latest".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "1.0.1".into());
+
+        assert_eq!(
+            runtime_path_for_install_path(&tv, install_path.join("bin")),
+            tv.runtime_path().join("bin")
+        );
+
+        let external_path = temp_dir.path().join("external").join("bin");
+        assert_eq!(
+            runtime_path_for_install_path(&tv, external_path.clone()),
+            external_path
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -101,7 +101,7 @@ fn has_local_version_listing_option_override(
 /// This intentionally does not call `ToolVersion::runtime_path()`: when a
 /// lockfile resolves a fuzzy request to a concrete version, `runtime_path()`
 /// returns the concrete install dir, but `bin-paths` should still use the
-/// requested runtime label.
+/// requested runtime label once that label exists.
 pub(crate) fn runtime_path_for_bin_paths(tv: &ToolVersion) -> PathBuf {
     let pathname = match &tv.request {
         ToolRequest::Version { version, .. } if version != &tv.version => version,
@@ -128,7 +128,11 @@ pub(crate) fn runtime_path_for_bin_paths(tv: &ToolVersion) -> PathBuf {
         }
     }
 
-    path
+    if path.is_dir() && is_runtime_symlink(&path) {
+        path
+    } else {
+        tv.runtime_path()
+    }
 }
 
 /// Remaps a backend-discovered path from the concrete install dir to the
@@ -585,7 +589,7 @@ mod tests {
     }
 
     #[test]
-    fn test_runtime_path_for_install_path_uses_request_label_without_symlink() -> Result<()> {
+    fn test_runtime_path_for_install_path_falls_back_without_symlink() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let short = format!(
             "runtime-remap-missing-symlink-{}",
@@ -617,7 +621,7 @@ mod tests {
 
         assert_eq!(
             runtime_path_for_install_path(&tv, install_path.join("bin")),
-            tv.ba().installs_path.join("latest").join("bin")
+            install_path.join("bin")
         );
 
         Ok(())

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -3,6 +3,8 @@ use crate::backend::Backend;
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
+#[cfg(windows)]
+use crate::backend::runtime_path_for_install_path;
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
@@ -336,7 +338,10 @@ impl Backend for NPMBackend {
         _config: &Arc<Config>,
         tv: &crate::toolset::ToolVersion,
     ) -> eyre::Result<Vec<std::path::PathBuf>> {
-        Ok(Self::windows_bin_paths_for_install_path(&tv.install_path()))
+        Ok(Self::windows_bin_paths_for_install_path(&tv.install_path())
+            .into_iter()
+            .map(|path| runtime_path_for_install_path(tv, path))
+            .collect())
     }
 }
 

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -42,7 +42,7 @@ use crate::backend::static_helpers::{
     get_filename_from_url, install_artifact, lookup_with_fallback, template_string, verify_artifact,
 };
 use crate::backend::version_list;
-use crate::backend::{Backend, VersionInfo};
+use crate::backend::{Backend, VersionInfo, runtime_path_for_install_path};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
 use crate::file;
@@ -526,13 +526,16 @@ impl Backend for S3Backend {
         // Check for explicit bin_path
         if let Some(bin_path_template) = lookup_with_fallback(&opts, "bin_path") {
             let bin_path = template_string(&bin_path_template, tv);
-            return Ok(vec![tv.install_path().join(bin_path)]);
+            return Ok(vec![runtime_path_for_install_path(
+                tv,
+                tv.install_path().join(bin_path),
+            )]);
         }
 
         // Check for bin directory
         let bin_dir = tv.install_path().join("bin");
         if bin_dir.exists() {
-            return Ok(vec![bin_dir]);
+            return Ok(vec![runtime_path_for_install_path(tv, bin_dir)]);
         }
 
         // Search subdirectories for bin directories
@@ -550,9 +553,12 @@ impl Backend for S3Backend {
         }
 
         if paths.is_empty() {
-            Ok(vec![tv.install_path()])
+            Ok(vec![tv.runtime_path()])
         } else {
-            Ok(paths)
+            Ok(paths
+                .into_iter()
+                .map(|path| runtime_path_for_install_path(tv, path))
+                .collect())
         }
     }
 }

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -42,9 +42,7 @@ use crate::backend::static_helpers::{
     get_filename_from_url, install_artifact, lookup_with_fallback, template_string, verify_artifact,
 };
 use crate::backend::version_list;
-use crate::backend::{
-    Backend, VersionInfo, runtime_path_for_bin_paths, runtime_path_for_install_path,
-};
+use crate::backend::{Backend, VersionInfo, runtime_path_for_install_path};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
 use crate::file;
@@ -555,7 +553,7 @@ impl Backend for S3Backend {
         }
 
         if paths.is_empty() {
-            Ok(vec![runtime_path_for_bin_paths(tv)])
+            Ok(vec![tv.runtime_path()])
         } else {
             Ok(paths
                 .into_iter()

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -42,7 +42,9 @@ use crate::backend::static_helpers::{
     get_filename_from_url, install_artifact, lookup_with_fallback, template_string, verify_artifact,
 };
 use crate::backend::version_list;
-use crate::backend::{Backend, VersionInfo, runtime_path_for_install_path};
+use crate::backend::{
+    Backend, VersionInfo, runtime_path_for_bin_paths, runtime_path_for_install_path,
+};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
 use crate::file;
@@ -553,7 +555,7 @@ impl Backend for S3Backend {
         }
 
         if paths.is_empty() {
-            Ok(vec![tv.runtime_path()])
+            Ok(vec![runtime_path_for_bin_paths(tv)])
         } else {
             Ok(paths
                 .into_iter()

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -1,6 +1,7 @@
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
+use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{lookup_platform_key, try_with_v_prefix};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
@@ -362,15 +363,18 @@ impl Backend for UbiBackend {
             .or_else(|| opts.get("bin_path").map(|s| s.to_string()))
         {
             // bin_path should always point to a directory containing binaries
-            Ok(vec![tv.install_path().join(&bin_path)])
+            Ok(vec![runtime_path_for_install_path(
+                tv,
+                tv.install_path().join(&bin_path),
+            )])
         } else if opts.get("extract_all").is_some_and(|v| v == "true") {
-            Ok(vec![tv.install_path()])
+            Ok(vec![tv.runtime_path()])
         } else {
             let bin_path = tv.install_path().join("bin");
             if bin_path.exists() {
-                Ok(vec![bin_path])
+                Ok(vec![runtime_path_for_install_path(tv, bin_path)])
             } else {
-                Ok(vec![tv.install_path()])
+                Ok(vec![tv.runtime_path()])
             }
         }
     }

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -1,8 +1,8 @@
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
-use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{lookup_platform_key, try_with_v_prefix};
+use crate::backend::{runtime_path_for_bin_paths, runtime_path_for_install_path};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
 use crate::env::{
@@ -368,13 +368,13 @@ impl Backend for UbiBackend {
                 tv.install_path().join(&bin_path),
             )])
         } else if opts.get("extract_all").is_some_and(|v| v == "true") {
-            Ok(vec![tv.runtime_path()])
+            Ok(vec![runtime_path_for_bin_paths(tv)])
         } else {
             let bin_path = tv.install_path().join("bin");
             if bin_path.exists() {
                 Ok(vec![runtime_path_for_install_path(tv, bin_path)])
             } else {
-                Ok(vec![tv.runtime_path()])
+                Ok(vec![runtime_path_for_bin_paths(tv)])
             }
         }
     }

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -1,8 +1,8 @@
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
+use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{lookup_platform_key, try_with_v_prefix};
-use crate::backend::{runtime_path_for_bin_paths, runtime_path_for_install_path};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
 use crate::env::{
@@ -368,13 +368,13 @@ impl Backend for UbiBackend {
                 tv.install_path().join(&bin_path),
             )])
         } else if opts.get("extract_all").is_some_and(|v| v == "true") {
-            Ok(vec![runtime_path_for_bin_paths(tv)])
+            Ok(vec![tv.runtime_path()])
         } else {
             let bin_path = tv.install_path().join("bin");
             if bin_path.exists() {
                 Ok(vec![runtime_path_for_install_path(tv, bin_path)])
             } else {
-                Ok(vec![runtime_path_for_bin_paths(tv)])
+                Ok(vec![tv.runtime_path()])
             }
         }
     }

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -9,10 +9,10 @@ use std::sync::{Arc, OnceLock};
 use std::thread;
 use tokio::sync::RwLock;
 
-use crate::backend::Backend;
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
+use crate::backend::{Backend, runtime_path_for_install_path};
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
@@ -251,9 +251,11 @@ impl Backend for VfoxBackend {
             .find(|(k, _)| k.to_uppercase() == "PATH")
             .map(|(_, v)| v.to_string());
         if let Some(path) = path {
-            Ok(env::split_paths(&path).collect())
+            Ok(env::split_paths(&path)
+                .map(|path| runtime_path_for_install_path(tv, path))
+                .collect())
         } else {
-            Ok(vec![tv.install_path().join("bin")])
+            Ok(vec![tv.runtime_path().join("bin")])
         }
     }
 

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -12,7 +12,7 @@ use tokio::sync::RwLock;
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
-use crate::backend::{Backend, runtime_path_for_bin_paths, runtime_path_for_install_path};
+use crate::backend::{Backend, runtime_path_for_install_path};
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
@@ -255,7 +255,7 @@ impl Backend for VfoxBackend {
                 .map(|path| runtime_path_for_install_path(tv, path))
                 .collect())
         } else {
-            Ok(vec![runtime_path_for_bin_paths(tv).join("bin")])
+            Ok(vec![tv.runtime_path().join("bin")])
         }
     }
 

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -12,7 +12,7 @@ use tokio::sync::RwLock;
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
-use crate::backend::{Backend, runtime_path_for_install_path};
+use crate::backend::{Backend, runtime_path_for_bin_paths, runtime_path_for_install_path};
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
@@ -255,7 +255,7 @@ impl Backend for VfoxBackend {
                 .map(|path| runtime_path_for_install_path(tv, path))
                 .collect())
         } else {
-            Ok(vec![tv.runtime_path().join("bin")])
+            Ok(vec![runtime_path_for_bin_paths(tv).join("bin")])
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1747,7 +1747,7 @@ pub async fn rebuild_shims_and_runtime_symlinks(
             .wrap_err("failed to rebuild shims")?;
     });
     measure!("rebuilding runtime symlinks", {
-        runtime_symlinks::rebuild(config)
+        runtime_symlinks::rebuild_for_toolset(config, ts)
             .await
             .wrap_err("failed to rebuild runtime symlinks")?;
     });

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -6,6 +6,7 @@ use crate::config::{Alias, Config};
 use crate::file::make_symlink_or_file;
 use crate::plugins::VERSION_REGEX;
 use crate::semver::split_version_prefix;
+use crate::toolset::Toolset;
 use crate::{backend, env, file};
 use eyre::Result;
 use indexmap::IndexMap;
@@ -14,6 +15,25 @@ use versions::Versioning;
 
 pub async fn rebuild(config: &Config) -> Result<()> {
     for backend in backend::list() {
+        for installs_dir in install_dirs_for(&backend) {
+            rebuild_symlinks_in_dir(config, &backend, &installs_dir)?;
+        }
+    }
+    Ok(())
+}
+
+pub async fn rebuild_for_toolset(config: &Config, ts: &Toolset) -> Result<()> {
+    let mut backends = backend::list();
+    for (backend, _) in ts.list_current_versions() {
+        if !backends
+            .iter()
+            .any(|b| b.ba().installs_path == backend.ba().installs_path)
+        {
+            backends.push(backend);
+        }
+    }
+
+    for backend in backends {
         for installs_dir in install_dirs_for(&backend) {
             rebuild_symlinks_in_dir(config, &backend, &installs_dir)?;
         }


### PR DESCRIPTION
## Summary

- map backend-discovered bin paths from concrete install dirs onto `ToolVersion::runtime_path()`
- align aqua, GitHub/GitLab/Forgejo, HTTP, S3, UBI, vfox, conda, and Windows npm `bin-paths` with runtime symlink labels for fuzzy versions
- centralize the `.mise-bins` directory name behind `MISE_BINS_DIR`
- add regression coverage for GitHub, HTTP, and aqua runtime-path `bin-paths`

## Why this matters

mise keeps a concrete install dir for the resolved version and, for fuzzy requests, a runtime path for the requested label. For example, `latest` might resolve to `1.0.0`, and `1.46` might resolve to `1.46.0`. The runtime path is the stable symlink users expect on `PATH`.

Before this PR, several backend `bin-paths` implementations could report bins from the concrete install path instead of the runtime path:

- GitHub alias example: `tiny = { version = "latest", bin_path = "hello-world-1.0.0/bin" }` resolved to `1.0.0`, but `mise bin-paths tiny` used the concrete `.../installs/tiny/1.0.0/.../bin` path instead of `.../installs/tiny/latest/.../bin`.
- HTTP example: `http:hello-upgrade-latest` resolved `latest` to `2.0.0`, but `bin-paths` could expose the concrete resolved install/cache path rather than `.../installs/http-hello-upgrade-latest/latest/.../bin`.
- Aqua prefix example: `aqua:casey/just` with version `1.46` resolves to `1.46.0`; with `symlink_bins = true`, `bin-paths` should use `.../installs/aqua-casey-just/1.46/.mise-bins`, not the concrete `1.46.0` directory.

`runtime_path_for_install_path` is needed for backend-discovered absolute paths: it strips the concrete install prefix and reattaches the same relative subpath under `tv.runtime_path()`. Explicit relative `bin_path` values can join `runtime_path()` directly; the helper covers paths found by scanning extracted archives while leaving unrelated paths unchanged.

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test test_runtime_path_for_install_path_remaps_install_subpath`
- `mise run test:e2e e2e/backend/test_github_alias_versions e2e/backend/test_http_upgrade e2e/backend/test_aqua_symlink_bins`
- after AI-review follow-up: `mise run test:e2e e2e/backend/test_http_upgrade e2e/backend/test_aqua_symlink_bins` (the preceding rerun passed `test_github_alias_versions`, then hit a transient `test_http_upgrade` server-port setup race before assertions)
- after const/re-review follow-up: `cargo fmt --all -- --check`, `git diff --check`, `cargo test test_runtime_path_for_install_path_remaps_install_subpath`, `mise run test:e2e e2e/backend/test_github_alias_versions e2e/backend/test_http_upgrade e2e/backend/test_aqua_symlink_bins`

Project item: https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=182730541

*This PR was generated by an AI coding assistant.*
