### PR TITLE
fix(pipx): filter yanked pypi releases

### DIFF
--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -21,6 +21,8 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use jiff::Timestamp;
 use regex::Regex;
+use serde::Deserialize;
+use serde_json::Value;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -148,7 +150,7 @@ impl Backend for PIPXBackend {
                                 debug!("Fetching JSON for {}", package);
                                 let url = registry_url.replace("{}", &package);
                                 let pkg: PypiPackage = HTTP_FETCH.json(url).await?;
-                                Ok(Some(pkg.info.version))
+                                Ok(Self::latest_stable_from_pypi_package(pkg))
                             } else {
                                 debug!("Fetching HTML for {}", package);
                                 let url = registry_url.replace("{}", &package);
@@ -298,8 +300,7 @@ pub fn install_time_option_keys() -> Vec<String> {
 impl PIPXBackend {
     fn versions_from_pypi_package(data: PypiPackage) -> Vec<VersionInfo> {
         // Releases with only yanked files are ignored so fuzzy/latest
-        // resolution mirrors pip's default yanked-file behavior. Preserve the
-        // existing timestamp behavior by using the earliest file upload time.
+        // resolution mirrors pip's default yanked-file behavior.
         data.releases
             .into_iter()
             .filter(|(_, files)| files.iter().any(|f| !f.yanked))
@@ -307,6 +308,7 @@ impl PIPXBackend {
             .map(|(version, files)| {
                 let created_at = files
                     .iter()
+                    .filter(|f| !f.yanked)
                     .filter_map(|f| f.upload_time.as_ref())
                     .min()
                     .cloned();
@@ -317,6 +319,14 @@ impl PIPXBackend {
                 }
             })
             .collect()
+    }
+
+    fn latest_stable_from_pypi_package(data: PypiPackage) -> Option<String> {
+        Self::versions_from_pypi_package(data)
+            .into_iter()
+            .rev()
+            .find(|v| !PEP440_PRERELEASE_REGEX.is_match(&v.version))
+            .map(|v| v.version)
     }
 
     fn versions_from_github_releases(releases: Vec<GithubRelease>) -> Vec<VersionInfo> {
@@ -530,19 +540,27 @@ impl PipxRequest {
 #[derive(serde::Deserialize)]
 struct PypiPackage {
     releases: IndexMap<String, Vec<PypiRelease>>,
-    info: PypiInfo,
-}
-
-#[derive(serde::Deserialize)]
-struct PypiInfo {
-    version: String,
 }
 
 #[derive(serde::Deserialize)]
 struct PypiRelease {
     upload_time: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_pypi_yanked")]
     yanked: bool,
+}
+
+fn deserialize_pypi_yanked<'de, D>(deserializer: D) -> std::result::Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<Value>::deserialize(deserializer)? {
+        None | Some(Value::Null) => Ok(false),
+        Some(Value::Bool(yanked)) => Ok(yanked),
+        Some(Value::String(_)) => Ok(true),
+        Some(value) => Err(serde::de::Error::custom(format!(
+            "expected bool or string for yanked, got {value}"
+        ))),
+    }
 }
 
 impl FromStr for PipxRequest {
@@ -706,7 +724,7 @@ fn fix_venv_python_symlink(_install_path: &Path, _pkg_name: &str) -> Result<()> 
 
 #[cfg(test)]
 mod tests {
-    use super::{PIPXBackend, PypiInfo, PypiPackage, PypiRelease};
+    use super::{PIPXBackend, PypiPackage, PypiRelease};
     use crate::github::GithubRelease;
     use indexmap::IndexMap;
     use pretty_assertions::assert_eq;
@@ -739,9 +757,44 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 ("1.0.0", Some("2024-01-01T00:00:00Z")),
-                ("1.2.0", Some("2024-03-01T00:00:00Z")),
+                ("1.2.0", Some("2024-03-01T00:01:00Z")),
             ]
         );
+    }
+
+    #[test]
+    fn test_latest_stable_from_pypi_package_skips_yanked_and_prerelease() {
+        let version = PIPXBackend::latest_stable_from_pypi_package(pypi_package(vec![
+            (
+                "1.0.0",
+                vec![pypi_release(Some("2024-01-01T00:00:00Z"), false)],
+            ),
+            (
+                "1.1.0",
+                vec![pypi_release(Some("2024-02-01T00:00:00Z"), false)],
+            ),
+            (
+                "1.2.0",
+                vec![pypi_release(Some("2024-03-01T00:00:00Z"), true)],
+            ),
+            (
+                "2.0.0a1",
+                vec![pypi_release(Some("2024-04-01T00:00:00Z"), false)],
+            ),
+        ]));
+
+        assert_eq!(version.as_deref(), Some("1.1.0"));
+    }
+
+    #[test]
+    fn test_pypi_release_deserializes_string_yanked_reason() {
+        let release: PypiRelease = serde_json::from_value(serde_json::json!({
+            "upload_time": "2024-01-01T00:00:00Z",
+            "yanked": "broken release"
+        }))
+        .unwrap();
+
+        assert!(release.yanked);
     }
 
     #[test]
@@ -849,9 +902,6 @@ mod tests {
                 .into_iter()
                 .map(|(version, files)| (version.to_string(), files))
                 .collect::<IndexMap<_, _>>(),
-            info: PypiInfo {
-                version: "1.0.0".to_string(),
-            },
         }
     }
 

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -84,24 +84,7 @@ impl Backend for PIPXBackend {
                     let url = registry_url.replace("{}", &package);
                     let data: PypiPackage = HTTP_FETCH.json(url).await?;
 
-                    // Get versions sorted and attach timestamps from the first file in each release
-                    data.releases
-                        .into_iter()
-                        .sorted_by_cached_key(|(v, _)| Versioning::new(v))
-                        .map(|(version, files)| {
-                            // Get the earliest upload_time from the release files
-                            let created_at = files
-                                .iter()
-                                .filter_map(|f| f.upload_time.as_ref())
-                                .min()
-                                .cloned();
-                            VersionInfo {
-                                version,
-                                created_at,
-                                ..Default::default()
-                            }
-                        })
-                        .collect()
+                    Self::versions_from_pypi_package(data)
                 } else {
                     debug!("Fetching HTML for {}", package);
                     let url = registry_url.replace("{}", &package);
@@ -313,6 +296,29 @@ pub fn install_time_option_keys() -> Vec<String> {
 }
 
 impl PIPXBackend {
+    fn versions_from_pypi_package(data: PypiPackage) -> Vec<VersionInfo> {
+        // Releases with only yanked files are ignored so fuzzy/latest
+        // resolution mirrors pip's default yanked-file behavior. Preserve the
+        // existing timestamp behavior by using the earliest file upload time.
+        data.releases
+            .into_iter()
+            .filter(|(_, files)| files.iter().any(|f| !f.yanked))
+            .sorted_by_cached_key(|(v, _)| Versioning::new(v))
+            .map(|(version, files)| {
+                let created_at = files
+                    .iter()
+                    .filter_map(|f| f.upload_time.as_ref())
+                    .min()
+                    .cloned();
+                VersionInfo {
+                    version,
+                    created_at,
+                    ..Default::default()
+                }
+            })
+            .collect()
+    }
+
     fn versions_from_github_releases(releases: Vec<GithubRelease>) -> Vec<VersionInfo> {
         releases
             .into_iter()
@@ -535,6 +541,8 @@ struct PypiInfo {
 #[derive(serde::Deserialize)]
 struct PypiRelease {
     upload_time: Option<String>,
+    #[serde(default)]
+    yanked: bool,
 }
 
 impl FromStr for PipxRequest {
@@ -698,10 +706,62 @@ fn fix_venv_python_symlink(_install_path: &Path, _pkg_name: &str) -> Result<()> 
 
 #[cfg(test)]
 mod tests {
-    use super::PIPXBackend;
+    use super::{PIPXBackend, PypiInfo, PypiPackage, PypiRelease};
     use crate::github::GithubRelease;
+    use indexmap::IndexMap;
     use pretty_assertions::assert_eq;
     use std::ffi::OsString;
+
+    #[test]
+    fn test_versions_from_pypi_package_skips_yanked_releases() {
+        let versions = PIPXBackend::versions_from_pypi_package(pypi_package(vec![
+            (
+                "1.0.0",
+                vec![pypi_release(Some("2024-01-01T00:00:00Z"), false)],
+            ),
+            (
+                "1.1.0",
+                vec![pypi_release(Some("2024-02-01T00:00:00Z"), true)],
+            ),
+            (
+                "1.2.0",
+                vec![
+                    pypi_release(Some("2024-03-01T00:00:00Z"), true),
+                    pypi_release(Some("2024-03-01T00:01:00Z"), false),
+                ],
+            ),
+        ]));
+
+        assert_eq!(
+            versions
+                .iter()
+                .map(|v| (v.version.as_str(), v.created_at.as_deref()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("1.0.0", Some("2024-01-01T00:00:00Z")),
+                ("1.2.0", Some("2024-03-01T00:00:00Z")),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_versions_from_pypi_package_skips_empty_releases() {
+        let versions = PIPXBackend::versions_from_pypi_package(pypi_package(vec![
+            ("1.0.0", vec![]),
+            (
+                "1.1.0",
+                vec![pypi_release(Some("2024-02-01T00:00:00Z"), false)],
+            ),
+        ]));
+
+        assert_eq!(
+            versions
+                .iter()
+                .map(|v| v.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1.1.0"]
+        );
+    }
 
     #[test]
     fn test_versions_from_empty_github_releases_stays_empty() {
@@ -780,6 +840,25 @@ mod tests {
             prerelease: false,
             created_at: created_at.to_string(),
             assets: vec![],
+        }
+    }
+
+    fn pypi_package(releases: Vec<(&str, Vec<PypiRelease>)>) -> PypiPackage {
+        PypiPackage {
+            releases: releases
+                .into_iter()
+                .map(|(version, files)| (version.to_string(), files))
+                .collect::<IndexMap<_, _>>(),
+            info: PypiInfo {
+                version: "1.0.0".to_string(),
+            },
+        }
+    }
+
+    fn pypi_release(upload_time: Option<&str>, yanked: bool) -> PypiRelease {
+        PypiRelease {
+            upload_time: upload_time.map(str::to_string),
+            yanked,
         }
     }
 }


### PR DESCRIPTION
## Summary
- ignore PyPI releases that have no non-yanked files when listing pipx versions
- preserve exact pinned behavior by keeping the filter in fuzzy/latest version listing
- add unit coverage for fully yanked, mixed, empty, and string-yanked PyPI releases

## How it works
- For PyPI packages, the pipx backend uses the PyPI JSON API, whose `releases` map contains each version and the files published for that version.
- Each file can carry `yanked` metadata. The backend filters out a release only when there are no usable files: either the file list is empty or every file for that release is yanked.
- Mixed releases are kept if at least one file is not yanked, and `created_at` is computed from non-yanked files so date filtering reflects usable artifacts.
- The JSON `latest_stable_version` fast path now derives latest from the same filtered version list instead of returning `info.version`, because `info.version` can still point at a yanked release.
- The `yanked` field is deserialized defensively because PyPI-compatible JSON can represent yanked metadata as either a bool or a string reason.

## Why this is required
- Yanked PyPI releases remain visible in JSON metadata, but pip avoids them unless the user asks for an exact pinned version. mise should follow that behavior for fuzzy/latest resolution.
- Filtering only during version listing keeps exact pinned installs available while preventing `latest` or prefix resolution from choosing a yanked release by default.

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test backend::pipx::tests`