### PR TITLE
fix(backend): reject bare package backend names

### DIFF
--- a/e2e/backend/test_bare_backend_names
+++ b/e2e/backend/test_bare_backend_names
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+assert_fail "mise install cargo" "cargo not found in mise tool registry"
+assert_fail "mise install gem" "gem not found in mise tool registry"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -314,8 +314,9 @@ impl BackendArg {
         }
 
         let full = self.full();
-        let backend = full.split(':').next().unwrap();
-        if let Ok(backend_type) = backend.parse() {
+        if let Some((backend, _)) = full.split_once(':')
+            && let Ok(backend_type) = backend.parse()
+        {
             return backend_type;
         }
         if config::is_loaded() && Config::get_().get_repo_url(&self.short).is_some() {
@@ -646,6 +647,27 @@ mod tests {
             "vfox:version-fox/vfox-nodejs",
             "version-fox/vfox-nodejs",
         );
+    }
+
+    #[tokio::test]
+    async fn test_bare_package_backend_names_are_not_implicit_tools() {
+        let _config = Config::get().await.unwrap();
+
+        for name in ["cargo", "gem"] {
+            let fa: BackendArg = name.into();
+            assert_str_eq!(name, fa.full());
+            assert_eq!(BackendType::Unknown, fa.backend_type());
+        }
+
+        let fa: BackendArg = "cargo:ripgrep".into();
+        assert_eq!(BackendType::Cargo, fa.backend_type());
+
+        let fa: BackendArg = "gem:bashly".into();
+        assert_eq!(BackendType::Gem, fa.backend_type());
+
+        let fa: BackendArg = "npm".into();
+        assert_str_eq!("npm:npm", fa.full());
+        assert_eq!(BackendType::Npm, fa.backend_type());
     }
 
     #[tokio::test]

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -441,7 +441,10 @@ pub fn backend_type(short: &str) -> Result<Option<BackendType>> {
     let backend_type = list_tools()
         .get(short)
         .and_then(|ist| ist.full.as_ref())
-        .map(|full| BackendType::guess(full));
+        .and_then(|full| {
+            full.split_once(':')
+                .map(|(backend, _)| BackendType::guess(backend))
+        });
     if let Some(BackendType::Unknown) = backend_type
         && let Some((plugin_name, _)) = short.split_once(':')
         && let Some(PluginType::VfoxBackend) = get_plugin_type(plugin_name)


### PR DESCRIPTION
## Summary
- stop resolving bare package-backend names like `cargo` and `gem` as implicit `cargo:cargo` / `gem:gem` tools
- keep explicit package backend syntax such as `cargo:ripgrep` and `gem:bashly` working
- preserve real registry shorthands such as `npm`

Fixes https://github.com/jdx/mise/discussions/5517

## Tests
- `cargo test backend_arg`
- `mise run test:e2e e2e/backend/test_bare_backend_names`
- `mise run lint`