### PR TITLE
fix(github): chmod explicit archive bin

### DIFF
--- a/e2e/backend/test_github_zip_executable_permissions
+++ b/e2e/backend/test_github_zip_executable_permissions
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "Skipping Linux-specific test on non-Linux OS"
+  exit 0
+fi
+
+cat >mise.toml <<EOF
+[tools]
+"github:Kampfkarren/selene" = { version = "0.30.0", asset_pattern = "selene-0.30.0-linux.zip" }
+EOF
+
+mise install
+
+install_path="$(mise where github:Kampfkarren/selene)"
+assert_succeed "test -x '$install_path/selene'"
+assert_contains "mise x -- selene --version" "selene 0.30.0"

--- a/e2e/backend/test_github_zip_executable_permissions
+++ b/e2e/backend/test_github_zip_executable_permissions
@@ -8,7 +8,7 @@ fi
 
 cat >mise.toml <<EOF
 [tools]
-"github:Kampfkarren/selene" = { version = "0.30.0", asset_pattern = "selene-0.30.0-linux.zip" }
+"github:Kampfkarren/selene" = { version = "0.30.0", asset_pattern = "selene-0.30.0-linux.zip", bin = "selene" }
 EOF
 
 mise install

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -8,8 +8,6 @@ use crate::toolset::ToolVersionOptions;
 use crate::ui::progress_report::SingleReport;
 use eyre::{Result, bail};
 use indexmap::IndexSet;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::LazyLock;
@@ -515,7 +513,6 @@ pub fn install_artifact(
         file::untar(file_path, &install_path, &tar_opts)?;
 
         // Extract just the repo name from tool_name (e.g., "opsgenie/opsgenie-lamp" -> "opsgenie-lamp")
-        // This is needed for matching binary names in ZIP archives where exec bits are lost
         let full_tool_name = tv.ba().tool_name.as_str();
         let tool_name = full_tool_name.rsplit('/').next().unwrap_or(full_tool_name);
 
@@ -523,18 +520,11 @@ pub fn install_artifact(
         let explicit_bin_path = lookup_with_fallback(opts, "bin_path")
             .map(|t| install_path.join(template_string(&t, tv)));
 
-        if matches!(format, file::TarFormat::Zip | file::TarFormat::SevenZip) {
-            make_likely_archive_executables(
-                &install_path,
-                explicit_bin_path.as_deref(),
-                tool_name,
-            )?;
-        }
-
         // Handle bin= option for archives (renames executable to specified name)
         // bin= values are relative to install_path, so always use install_path or explicit bin_path
         if let Some(bin_name) = lookup_with_fallback(opts, "bin") {
             let search_dir = explicit_bin_path.as_deref().unwrap_or(&install_path);
+            make_configured_bin_executable(search_dir, &bin_name)?;
             rename_executable_in_dir(search_dir, &bin_name, Some(tool_name))?;
         }
 
@@ -558,140 +548,12 @@ pub fn install_artifact(
     Ok(())
 }
 
-fn make_likely_archive_executables(
-    install_path: &Path,
-    explicit_bin_path: Option<&Path>,
-    tool_name: &str,
-) -> Result<()> {
-    for dir in likely_archive_bin_dirs(install_path, explicit_bin_path)? {
-        for path in file::ls(&dir)? {
-            if !path.is_file() || file::is_executable(&path) {
-                continue;
-            }
-
-            let file_name = path.file_name().unwrap_or_default().to_string_lossy();
-            if should_skip_archive_executable_candidate(&file_name) {
-                continue;
-            }
-
-            if is_likely_executable_file(&path, &file_name, tool_name) {
-                file::make_executable(&path)?;
-            }
-        }
+fn make_configured_bin_executable(search_dir: &Path, bin_name: &str) -> Result<()> {
+    let bin_path = search_dir.join(bin_name);
+    if bin_path.is_file() {
+        file::make_executable(bin_path)?;
     }
-
     Ok(())
-}
-
-fn likely_archive_bin_dirs(
-    install_path: &Path,
-    explicit_bin_path: Option<&Path>,
-) -> Result<Vec<PathBuf>> {
-    let mut dirs = IndexSet::new();
-
-    if let Some(bin_path) = explicit_bin_path {
-        dirs.insert(bin_path.to_path_buf());
-        return Ok(dirs.into_iter().collect());
-    }
-
-    dirs.insert(install_path.to_path_buf());
-
-    let bin_dir = install_path.join("bin");
-    if bin_dir.is_dir() {
-        dirs.insert(bin_dir);
-    }
-
-    let contents_macos = install_path.join("Contents").join("MacOS");
-    if contents_macos.is_dir() {
-        dirs.insert(contents_macos);
-    }
-
-    for entry in file::ls(install_path)? {
-        if !entry.is_dir() {
-            continue;
-        }
-
-        let dir_name = entry.file_name().unwrap_or_default().to_string_lossy();
-        if dir_name.ends_with(".app") {
-            let macos_dir = entry.join("Contents").join("MacOS");
-            if macos_dir.is_dir() {
-                dirs.insert(macos_dir);
-            }
-        }
-
-        let sub_bin_dir = entry.join("bin");
-        if sub_bin_dir.is_dir() {
-            dirs.insert(sub_bin_dir);
-        }
-
-        dirs.insert(entry);
-    }
-
-    Ok(dirs.into_iter().collect())
-}
-
-fn is_likely_executable_file(path: &Path, file_name: &str, tool_name: &str) -> bool {
-    if has_executable_magic(path) {
-        return true;
-    }
-
-    if tool_name.is_empty() {
-        return false;
-    }
-
-    let file_name = file_name.to_lowercase();
-    let tool_name = tool_name.to_lowercase();
-
-    let executable_name = Path::new(&file_name)
-        .extension()
-        .is_none_or(|ext| EXECUTABLE_EXTENSIONS.contains(&ext.to_string_lossy().as_ref()));
-
-    executable_name && archive_candidate_matches_tool_name(&file_name, &tool_name)
-}
-
-fn archive_candidate_matches_tool_name(file_name: &str, tool_name: &str) -> bool {
-    file_name == tool_name
-        || file_name.starts_with(&format!("{tool_name}-"))
-        || file_name.starts_with(&format!("{tool_name}_"))
-        || file_name.starts_with(&format!("{tool_name}."))
-        || file_name.ends_with(&format!("-{tool_name}"))
-        || file_name.ends_with(&format!("_{tool_name}"))
-        || file_name.contains(&format!("-{tool_name}-"))
-        || file_name.contains(&format!("-{tool_name}_"))
-        || file_name.contains(&format!("_{tool_name}-"))
-        || file_name.contains(&format!("_{tool_name}_"))
-}
-
-fn has_executable_magic(path: &Path) -> bool {
-    let Ok(mut file) = File::open(path) else {
-        return false;
-    };
-    let mut buf = [0; 4];
-    let Ok(len) = file.read(&mut buf) else {
-        return false;
-    };
-
-    (len >= 2 && (&buf[..2] == b"#!" || &buf[..2] == b"MZ"))
-        || (len >= 4
-            && matches!(
-                buf,
-                [0x7f, b'E', b'L', b'F']
-                    | [0xfe, 0xed, 0xfa, 0xce]
-                    | [0xfe, 0xed, 0xfa, 0xcf]
-                    | [0xce, 0xfa, 0xed, 0xfe]
-                    | [0xcf, 0xfa, 0xed, 0xfe]
-                    | [0xca, 0xfe, 0xba, 0xbe]
-            ))
-}
-
-fn should_skip_archive_executable_candidate(file_name: &str) -> bool {
-    let lower = file_name.to_lowercase();
-
-    should_skip_file(&lower, true)
-        || ARCHIVE_EXECUTABLE_SKIP_EXTENSIONS
-            .iter()
-            .any(|ext| lower.ends_with(ext))
-        || lower.contains(".so.")
 }
 
 pub fn verify_artifact(
@@ -740,13 +602,6 @@ pub fn verify_checksum_str(
 
 /// File extensions that indicate non-binary files.
 const SKIP_EXTENSIONS: &[&str] = &[".txt", ".md", ".json", ".yml", ".yaml"];
-
-const ARCHIVE_EXECUTABLE_SKIP_EXTENSIONS: &[&str] = &[
-    ".a", ".class", ".dll", ".dylib", ".h", ".hpp", ".lib", ".pc", ".so", ".toml", ".xml",
-];
-
-const EXECUTABLE_EXTENSIONS: &[&str] =
-    &["appimage", "bat", "bin", "cmd", "exe", "ps1", "run", "sh"];
 
 /// File names (case-insensitive) that should be skipped when looking for executables.
 const SKIP_FILE_NAMES: &[&str] = &["LICENSE", "README"];
@@ -1593,37 +1448,30 @@ bin = "tool.exe"
 
     #[cfg(unix)]
     #[test]
-    fn test_make_likely_archive_executables_marks_matching_binary() {
+    fn test_make_configured_bin_executable_marks_only_exact_bin() {
         use std::os::unix::fs::PermissionsExt;
 
         let tmp = tempfile::tempdir().unwrap();
         let binary = tmp.path().join("selene");
         let readme = tmp.path().join("README.md");
         let config = tmp.path().join("selene.toml");
-        let class_file = tmp.path().join("Selene.class");
-        let shared_library = tmp.path().join("libselene.so.1");
         let unrelated = tmp.path().join("counselene");
-        std::fs::write(&binary, b"\x7fELFtest").unwrap();
-        std::fs::write(&readme, b"\x7fELFnot-a-binary").unwrap();
+        std::fs::write(&binary, b"not-a-binary").unwrap();
+        std::fs::write(&readme, b"not-a-binary").unwrap();
         std::fs::write(&config, b"not-a-binary").unwrap();
-        std::fs::write(&class_file, b"\xca\xfe\xba\xbetest").unwrap();
-        std::fs::write(&shared_library, b"\x7fELFtest").unwrap();
         std::fs::write(&unrelated, b"not-a-binary").unwrap();
 
         std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o644)).unwrap();
         std::fs::set_permissions(&readme, std::fs::Permissions::from_mode(0o644)).unwrap();
         std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o644)).unwrap();
-        std::fs::set_permissions(&class_file, std::fs::Permissions::from_mode(0o644)).unwrap();
-        std::fs::set_permissions(&shared_library, std::fs::Permissions::from_mode(0o644)).unwrap();
         std::fs::set_permissions(&unrelated, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-        make_likely_archive_executables(tmp.path(), None, "selene").unwrap();
+        make_configured_bin_executable(tmp.path(), "selene").unwrap();
+        make_configured_bin_executable(tmp.path(), "missing").unwrap();
 
         assert!(file::is_executable(&binary));
         assert!(!file::is_executable(&readme));
         assert!(!file::is_executable(&config));
-        assert!(!file::is_executable(&class_file));
-        assert!(!file::is_executable(&shared_library));
         assert!(!file::is_executable(&unrelated));
     }
 }

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -574,7 +574,7 @@ fn make_likely_archive_executables(
                 continue;
             }
 
-            if is_likely_executable_file(&path, &file_name, tool_name)? {
+            if is_likely_executable_file(&path, &file_name, tool_name) {
                 file::make_executable(&path)?;
             }
         }
@@ -630,13 +630,13 @@ fn likely_archive_bin_dirs(
     Ok(dirs.into_iter().collect())
 }
 
-fn is_likely_executable_file(path: &Path, file_name: &str, tool_name: &str) -> Result<bool> {
-    if has_executable_magic(path)? {
-        return Ok(true);
+fn is_likely_executable_file(path: &Path, file_name: &str, tool_name: &str) -> bool {
+    if has_executable_magic(path) {
+        return true;
     }
 
     if tool_name.is_empty() {
-        return Ok(false);
+        return false;
     }
 
     let file_name = file_name.to_lowercase();
@@ -646,15 +646,32 @@ fn is_likely_executable_file(path: &Path, file_name: &str, tool_name: &str) -> R
         .extension()
         .is_none_or(|ext| EXECUTABLE_EXTENSIONS.contains(&ext.to_string_lossy().as_ref()));
 
-    Ok(executable_name && (file_name == tool_name || file_name.contains(&tool_name)))
+    executable_name && archive_candidate_matches_tool_name(&file_name, &tool_name)
 }
 
-fn has_executable_magic(path: &Path) -> Result<bool> {
-    let mut file = File::open(path)?;
-    let mut buf = [0; 4];
-    let len = file.read(&mut buf)?;
+fn archive_candidate_matches_tool_name(file_name: &str, tool_name: &str) -> bool {
+    file_name == tool_name
+        || file_name.starts_with(&format!("{tool_name}-"))
+        || file_name.starts_with(&format!("{tool_name}_"))
+        || file_name.starts_with(&format!("{tool_name}."))
+        || file_name.ends_with(&format!("-{tool_name}"))
+        || file_name.ends_with(&format!("_{tool_name}"))
+        || file_name.contains(&format!("-{tool_name}-"))
+        || file_name.contains(&format!("-{tool_name}_"))
+        || file_name.contains(&format!("_{tool_name}-"))
+        || file_name.contains(&format!("_{tool_name}_"))
+}
 
-    Ok((len >= 2 && (&buf[..2] == b"#!" || &buf[..2] == b"MZ"))
+fn has_executable_magic(path: &Path) -> bool {
+    let Ok(mut file) = File::open(path) else {
+        return false;
+    };
+    let mut buf = [0; 4];
+    let Ok(len) = file.read(&mut buf) else {
+        return false;
+    };
+
+    (len >= 2 && (&buf[..2] == b"#!" || &buf[..2] == b"MZ"))
         || (len >= 4
             && matches!(
                 buf,
@@ -664,7 +681,7 @@ fn has_executable_magic(path: &Path) -> Result<bool> {
                     | [0xce, 0xfa, 0xed, 0xfe]
                     | [0xcf, 0xfa, 0xed, 0xfe]
                     | [0xca, 0xfe, 0xba, 0xbe]
-            )))
+            ))
 }
 
 fn should_skip_archive_executable_candidate(file_name: &str) -> bool {
@@ -674,6 +691,7 @@ fn should_skip_archive_executable_candidate(file_name: &str) -> bool {
         || ARCHIVE_EXECUTABLE_SKIP_EXTENSIONS
             .iter()
             .any(|ext| lower.ends_with(ext))
+        || lower.contains(".so.")
 }
 
 pub fn verify_artifact(
@@ -724,7 +742,7 @@ pub fn verify_checksum_str(
 const SKIP_EXTENSIONS: &[&str] = &[".txt", ".md", ".json", ".yml", ".yaml"];
 
 const ARCHIVE_EXECUTABLE_SKIP_EXTENSIONS: &[&str] = &[
-    ".a", ".dll", ".dylib", ".h", ".hpp", ".lib", ".pc", ".so", ".toml", ".xml",
+    ".a", ".class", ".dll", ".dylib", ".h", ".hpp", ".lib", ".pc", ".so", ".toml", ".xml",
 ];
 
 const EXECUTABLE_EXTENSIONS: &[&str] =
@@ -1582,18 +1600,30 @@ bin = "tool.exe"
         let binary = tmp.path().join("selene");
         let readme = tmp.path().join("README.md");
         let config = tmp.path().join("selene.toml");
+        let class_file = tmp.path().join("Selene.class");
+        let shared_library = tmp.path().join("libselene.so.1");
+        let unrelated = tmp.path().join("counselene");
         std::fs::write(&binary, b"\x7fELFtest").unwrap();
         std::fs::write(&readme, b"\x7fELFnot-a-binary").unwrap();
         std::fs::write(&config, b"not-a-binary").unwrap();
+        std::fs::write(&class_file, b"\xca\xfe\xba\xbetest").unwrap();
+        std::fs::write(&shared_library, b"\x7fELFtest").unwrap();
+        std::fs::write(&unrelated, b"not-a-binary").unwrap();
 
         std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o644)).unwrap();
         std::fs::set_permissions(&readme, std::fs::Permissions::from_mode(0o644)).unwrap();
         std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::set_permissions(&class_file, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::set_permissions(&shared_library, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::set_permissions(&unrelated, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         make_likely_archive_executables(tmp.path(), None, "selene").unwrap();
 
         assert!(file::is_executable(&binary));
         assert!(!file::is_executable(&readme));
         assert!(!file::is_executable(&config));
+        assert!(!file::is_executable(&class_file));
+        assert!(!file::is_executable(&shared_library));
+        assert!(!file::is_executable(&unrelated));
     }
 }

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -8,6 +8,8 @@ use crate::toolset::ToolVersionOptions;
 use crate::ui::progress_report::SingleReport;
 use eyre::{Result, bail};
 use indexmap::IndexSet;
+use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::LazyLock;
@@ -521,6 +523,14 @@ pub fn install_artifact(
         let explicit_bin_path = lookup_with_fallback(opts, "bin_path")
             .map(|t| install_path.join(template_string(&t, tv)));
 
+        if matches!(format, file::TarFormat::Zip | file::TarFormat::SevenZip) {
+            make_likely_archive_executables(
+                &install_path,
+                explicit_bin_path.as_deref(),
+                tool_name,
+            )?;
+        }
+
         // Handle bin= option for archives (renames executable to specified name)
         // bin= values are relative to install_path, so always use install_path or explicit bin_path
         if let Some(bin_name) = lookup_with_fallback(opts, "bin") {
@@ -546,6 +556,124 @@ pub fn install_artifact(
         }
     }
     Ok(())
+}
+
+fn make_likely_archive_executables(
+    install_path: &Path,
+    explicit_bin_path: Option<&Path>,
+    tool_name: &str,
+) -> Result<()> {
+    for dir in likely_archive_bin_dirs(install_path, explicit_bin_path)? {
+        for path in file::ls(&dir)? {
+            if !path.is_file() || file::is_executable(&path) {
+                continue;
+            }
+
+            let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+            if should_skip_archive_executable_candidate(&file_name) {
+                continue;
+            }
+
+            if is_likely_executable_file(&path, &file_name, tool_name)? {
+                file::make_executable(&path)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn likely_archive_bin_dirs(
+    install_path: &Path,
+    explicit_bin_path: Option<&Path>,
+) -> Result<Vec<PathBuf>> {
+    let mut dirs = IndexSet::new();
+
+    if let Some(bin_path) = explicit_bin_path {
+        dirs.insert(bin_path.to_path_buf());
+        return Ok(dirs.into_iter().collect());
+    }
+
+    dirs.insert(install_path.to_path_buf());
+
+    let bin_dir = install_path.join("bin");
+    if bin_dir.is_dir() {
+        dirs.insert(bin_dir);
+    }
+
+    let contents_macos = install_path.join("Contents").join("MacOS");
+    if contents_macos.is_dir() {
+        dirs.insert(contents_macos);
+    }
+
+    for entry in file::ls(install_path)? {
+        if !entry.is_dir() {
+            continue;
+        }
+
+        let dir_name = entry.file_name().unwrap_or_default().to_string_lossy();
+        if dir_name.ends_with(".app") {
+            let macos_dir = entry.join("Contents").join("MacOS");
+            if macos_dir.is_dir() {
+                dirs.insert(macos_dir);
+            }
+        }
+
+        let sub_bin_dir = entry.join("bin");
+        if sub_bin_dir.is_dir() {
+            dirs.insert(sub_bin_dir);
+        }
+
+        dirs.insert(entry);
+    }
+
+    Ok(dirs.into_iter().collect())
+}
+
+fn is_likely_executable_file(path: &Path, file_name: &str, tool_name: &str) -> Result<bool> {
+    if has_executable_magic(path)? {
+        return Ok(true);
+    }
+
+    if tool_name.is_empty() {
+        return Ok(false);
+    }
+
+    let file_name = file_name.to_lowercase();
+    let tool_name = tool_name.to_lowercase();
+
+    let executable_name = Path::new(&file_name)
+        .extension()
+        .is_none_or(|ext| EXECUTABLE_EXTENSIONS.contains(&ext.to_string_lossy().as_ref()));
+
+    Ok(executable_name && (file_name == tool_name || file_name.contains(&tool_name)))
+}
+
+fn has_executable_magic(path: &Path) -> Result<bool> {
+    let mut file = File::open(path)?;
+    let mut buf = [0; 4];
+    let len = file.read(&mut buf)?;
+
+    Ok((len >= 2 && (&buf[..2] == b"#!" || &buf[..2] == b"MZ"))
+        || (len >= 4
+            && matches!(
+                buf,
+                [0x7f, b'E', b'L', b'F']
+                    | [0xfe, 0xed, 0xfa, 0xce]
+                    | [0xfe, 0xed, 0xfa, 0xcf]
+                    | [0xce, 0xfa, 0xed, 0xfe]
+                    | [0xcf, 0xfa, 0xed, 0xfe]
+                    | [0xca, 0xfe, 0xba, 0xbe]
+            )))
+}
+
+fn should_skip_archive_executable_candidate(file_name: &str) -> bool {
+    let lower = file_name.to_lowercase();
+
+    should_skip_file(&lower, true)
+        || ARCHIVE_EXECUTABLE_SKIP_EXTENSIONS
+            .iter()
+            .any(|ext| lower.ends_with(ext))
 }
 
 pub fn verify_artifact(
@@ -594,6 +722,13 @@ pub fn verify_checksum_str(
 
 /// File extensions that indicate non-binary files.
 const SKIP_EXTENSIONS: &[&str] = &[".txt", ".md", ".json", ".yml", ".yaml"];
+
+const ARCHIVE_EXECUTABLE_SKIP_EXTENSIONS: &[&str] = &[
+    ".a", ".dll", ".dylib", ".h", ".hpp", ".lib", ".pc", ".so", ".toml", ".xml",
+];
+
+const EXECUTABLE_EXTENSIONS: &[&str] =
+    &["appimage", "bat", "bin", "cmd", "exe", "ps1", "run", "sh"];
 
 /// File names (case-insensitive) that should be skipped when looking for executables.
 const SKIP_FILE_NAMES: &[&str] = &["LICENSE", "README"];
@@ -1436,5 +1571,29 @@ bin = "tool.exe"
                 b
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_make_likely_archive_executables_marks_matching_binary() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let binary = tmp.path().join("selene");
+        let readme = tmp.path().join("README.md");
+        let config = tmp.path().join("selene.toml");
+        std::fs::write(&binary, b"\x7fELFtest").unwrap();
+        std::fs::write(&readme, b"\x7fELFnot-a-binary").unwrap();
+        std::fs::write(&config, b"not-a-binary").unwrap();
+
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::set_permissions(&readme, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        make_likely_archive_executables(tmp.path(), None, "selene").unwrap();
+
+        assert!(file::is_executable(&binary));
+        assert!(!file::is_executable(&readme));
+        assert!(!file::is_executable(&config));
     }
 }


### PR DESCRIPTION
## Summary
- chmod only the explicitly configured `bin` target, respecting `bin_path` when provided
- update the selene regression to use `bin = "selene"` as the opt-in workaround

Fixes https://github.com/jdx/mise/discussions/8271

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -q test_make_configured_bin_executable_marks_only_exact_bin`
- `MISE_TRUSTED_CONFIG_PATHS=/home/risu/mise/m9 mise run test:e2e e2e/backend/test_github_zip_executable_permissions`

*This PR was generated by an AI coding assistant.*