### PR TITLE
registry: add tally (github:wharflab/tally)

### DIFF
--- a/registry/tally.toml
+++ b/registry/tally.toml
@@ -1,0 +1,3 @@
+backends = ["github:wharflab/tally", "npm:tally-cli", "pipx:tally-cli", "go:github.com/wharflab/tally", "gem:tally-cli"]
+description = "Dockerfile and Containerfile linter and formatter for best practices, security issues, and common mistakes"
+test = { cmd = "tally --version", expected = "tally version {{version}}" }

--- a/registry/tally.toml
+++ b/registry/tally.toml
@@ -1,3 +1,9 @@
-backends = ["github:wharflab/tally", "npm:tally-cli", "pipx:tally-cli", "go:github.com/wharflab/tally", "gem:tally-cli"]
+backends = [
+  "github:wharflab/tally",
+  "npm:tally-cli",
+  "pipx:tally-cli",
+  "go:github.com/wharflab/tally",
+  "gem:tally-cli",
+]
 description = "Dockerfile and Containerfile linter and formatter for best practices, security issues, and common mistakes"
 test = { cmd = "tally --version", expected = "tally version {{version}}" }


### PR DESCRIPTION
## Summary

Add `tally` to the mise registry with GitHub releases as the preferred backend and npm, pipx, Go, and RubyGems as fallback package-manager backends. tally is a modern Dockerfile and Containerfile linter with advanced auto-fixes for best-practice, security, and correctness issues, and its GitHub releases publish platform-specific assets that mise can autodetect and install directly.

## Validation

- `cargo +1.95.0 run --quiet -- registry tally`
- `env MISE_DISABLE_TOOLS=1 MISE_TRUSTED_CONFIG_PATHS=/Volumes/workplace/GitHub/wharflab/mise /Volumes/workplace/GitHub/wharflab/mise/target/debug/mise test-tool tally --jobs 1`

The tool test installed `tally@0.40.0`, verified GitHub artifact attestations, and matched `tally --version` output.