### PR TITLE
test(e2e): pin uv to 0.11.8 around astral-sh/uv#19278

### DIFF
--- a/e2e/cli/test_activate_multiple_xonsh
+++ b/e2e/cli/test_activate_multiple_xonsh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-exec mise x uv -- uv tool run --with 'xonsh[full]' xonsh --no-rc "$TEST_DIR/activate_multiple_xonsh.xsh"
+# Pinned: uv 0.11.9 was manually published and lacks SLSA attestations
+# (astral-sh/uv#19278). Bump once 0.11.10 ships with attestations restored.
+exec mise x uv@0.11.8 -- uv tool run --with 'xonsh[full]' xonsh --no-rc "$TEST_DIR/activate_multiple_xonsh.xsh"

--- a/e2e/cli/test_deactivate_xonsh
+++ b/e2e/cli/test_deactivate_xonsh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-exec mise x uv -- uv tool run --with 'xonsh[full]' xonsh --no-rc "$TEST_DIR/deactivate_xonsh.xsh"
+# Pinned: uv 0.11.9 was manually published and lacks SLSA attestations
+# (astral-sh/uv#19278). Bump once 0.11.10 ships with attestations restored.
+exec mise x uv@0.11.8 -- uv tool run --with 'xonsh[full]' xonsh --no-rc "$TEST_DIR/deactivate_xonsh.xsh"

--- a/e2e/shell/test_xonsh
+++ b/e2e/shell/test_xonsh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-exec mise x uv -- uv tool run --with 'xonsh[full]' xonsh --no-rc "$TEST_DIR/xonsh_script"
+# Pinned: uv 0.11.9 was manually published and lacks SLSA attestations
+# (astral-sh/uv#19278). Bump once 0.11.10 ships with attestations restored.
+exec mise x uv@0.11.8 -- uv tool run --with 'xonsh[full]' xonsh --no-rc "$TEST_DIR/xonsh_script"

--- a/e2e/sync/test_sync_python_uv
+++ b/e2e/sync/test_sync_python_uv
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 export MISE_PYTHON_GITHUB_ATTESTATIONS=0
-assert "mise use -g uv python@3.11.3"
+# Pinned: uv 0.11.9 was manually published and lacks SLSA attestations
+# (astral-sh/uv#19278). Bump once 0.11.10 ships with attestations restored.
+assert "mise use -g uv@0.11.8 python@3.11.3"
 assert "mise x -- uv python install 3.11.1"
 export UV_PYTHON_DOWNLOADS=never
 assert "mise sync python --uv"


### PR DESCRIPTION
## Summary

- Pin `uv` to `0.11.8` in the four e2e tests that install it via the aqua backend (`shell/test_xonsh`, `cli/test_activate_multiple_xonsh`, `cli/test_deactivate_xonsh`, `sync/test_sync_python_uv`).
- Workaround for [astral-sh/uv#19278](https://github.com/astral-sh/uv/issues/19278): `uv 0.11.9` was manually published due to a crates.io timeout, which skipped GitHub Artifact Attestations generation. mise's aqua backend correctly rejects the unattested release with `Workflow verification failed: ... found certificate: None, provenance: None`, breaking these tests on `main` and on every open PR.
- Revert the pins once `uv 0.11.10` ships with attestations restored.

## Why pinning instead of disabling attestations

Disabling `MISE_AQUA_GITHUB_ATTESTATIONS` in the tests would silently mask the same class of regression in the future. Pinning the only known-bad version keeps attestation coverage intact and is trivially reverted once upstream is fixed.

## Test plan

- [ ] CI e2e runs that previously failed on `shell/test_xonsh`, `cli/test_activate_multiple_xonsh`, `cli/test_deactivate_xonsh`, `sync/test_sync_python_uv` now pass.
- [ ] Other e2e tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that pins a tool version to avoid a known-bad upstream release; no production code paths are affected.
> 
> **Overview**
> Pins `uv` to `0.11.8` in four e2e scripts so tests don’t pull `uv 0.11.9`, which was published without SLSA/GitHub attestations and is rejected by the aqua backend.
> 
> Adds inline comments referencing `astral-sh/uv#19278` and noting the pin should be removed once `0.11.10` restores attestations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e332ef671c456b28341fcb222c50442ed60096d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->