### PR TITLE
fix(ui): stop clearing screen for prompts

### DIFF
--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -24,7 +24,6 @@ pub fn confirm_with_default<S: Into<String>>(message: S, default_yes: bool) -> e
     let theme = get_theme();
     let result = Confirm::new(message)
         .selected(default_yes)
-        .clear_screen(true)
         .theme(&theme)
         .run()?;
     Ok(result)
@@ -51,7 +50,6 @@ pub fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<bool> {
             DialogButton::new("All"),
         ])
         .selected_button(1)
-        .clear_screen(true)
         .theme(&theme)
         .run()?;
 


### PR DESCRIPTION
## Summary
- Remove the explicit `clear_screen(true)` opt-in from shared confirmation prompts.
- Restore demand's default behavior so `mise prune` and other confirmation prompts do not wipe the terminal before rendering.

## Context
This reverts the prompt behavior introduced in #4990. That change was intended to avoid concurrent task output corrupting interactive prompts, but clearing the whole terminal is too broad and affects commands like `mise prune`.

## Validation
- `cargo fmt --check`
- pre-commit hook: `hk` lint set, including `cargo check --all-features`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to interactive prompting; main impact is that prompts will no longer wipe prior terminal output.
> 
> **Overview**
> **Interactive confirmation prompts no longer clear the screen.**
> 
> Removes the explicit `clear_screen(true)` setting from the shared `Confirm`/`Dialog` prompt helpers in `src/ui/prompt.rs`, restoring default prompt rendering for callers like `mise prune` and trust/plugin install confirmations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f08323147d6f3789eb254255e050a4c374b524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->