### PR TITLE
fix(deps): fall through to hash check when providers have no outputs

### DIFF
--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -161,22 +161,17 @@ assert_contains "mise deps --dry-run 2>&1" "aube"
 
 # Test go provider
 rm -f aube-lock.yaml
-cat >go.sum <<'EOF'
-github.com/foo/bar v1.0.0 h1:abc
-EOF
 cat >go.mod <<'EOF'
 module test
 go 1.21
 EOF
-# Ensure go.sum (output) is older than go.mod (source) to trigger staleness
-touch -t 202301010000 go.sum
 
 cat >mise.toml <<'EOF'
 [deps.go]
 EOF
 
 assert_contains "mise deps --list" "go"
-assert_contains "mise deps --list" "go.sum"
+assert_contains "mise deps --list" "go.mod"
 assert_contains "mise deps --dry-run 2>&1" "go"
 
 # Test pip provider
@@ -327,6 +322,32 @@ assert_contains "mise deps --dry-run 2>&1" "requirements.txt changed"
 # Clean up
 rm -rf .venv requirements.txt .mise
 rm -f composer.lock composer.json package.json mise.toml schema.graphql
+
+# Test that providers with no declared outputs fall through to hash-based
+# freshness instead of being perpetually stale (regression for #9585: bundler,
+# pip, go, poetry, uv all return empty outputs() when their install command
+# writes outside the project tree).
+cat >mise.toml <<'EOF'
+[deps.no_outputs]
+sources = ["sentinel.txt"]
+run = "echo NO_OUTPUTS_RAN"
+EOF
+
+echo "first" >sentinel.txt
+
+# First run: no stored state → stale, runs.
+assert_contains "mise deps --only no_outputs 2>&1" "Installed: no_outputs"
+
+# Second run: state stored, source unchanged → fresh (no perpetual re-run).
+assert_contains "mise deps --only no_outputs 2>&1" "up to date"
+assert_not_contains "mise deps --dry-run 2>&1" "no_outputs"
+
+# Source changes → stale again.
+echo "second" >sentinel.txt
+assert_contains "mise deps --dry-run 2>&1" "sentinel.txt changed"
+assert_contains "mise deps --only no_outputs 2>&1" "Installed: no_outputs"
+
+rm -rf sentinel.txt mise.toml .mise
 
 # Test --explain flag
 cat >mise.toml <<'EOF'

--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -349,6 +349,55 @@ assert_contains "mise deps --only no_outputs 2>&1" "Installed: no_outputs"
 
 rm -rf sentinel.txt mise.toml .mise
 
+# A provider with neither sources nor outputs declared (a custom hook) should
+# always run — there's no freshness signal to skip on.
+cat >mise.toml <<'EOF'
+[deps.always_run]
+run = "echo ALWAYS_RAN"
+EOF
+
+assert_contains "mise deps --only always_run 2>&1" "Installed: always_run"
+assert_contains "mise deps --only always_run 2>&1" "Installed: always_run"
+assert_contains "mise deps --dry-run 2>&1" "no sources or outputs defined"
+
+rm -rf mise.toml .mise
+
+# Built-in providers track their canonical optional output (e.g. .venv for
+# pip/uv/poetry, vendor/bundle for bundler, vendor/ for go) once it has been
+# observed on a successful run. Deleting the directory afterwards triggers a
+# re-run — but a project that never produces that output is not perpetually
+# stale.
+cat >requirements.txt <<'EOF'
+requests==2.31.0
+EOF
+
+cat >mise.toml <<'EOF'
+[deps.pip]
+run = "echo PIP_RAN"
+EOF
+
+# First run: no state → runs. .venv doesn't exist, so seen_outputs stays empty.
+assert_contains "mise deps --only pip 2>&1" "Installed: pip"
+
+# Second run: state stored, .venv was never observed, source unchanged → fresh.
+# This is the regression fix for #9585: previously perpetually stale.
+assert_contains "mise deps --only pip 2>&1" "up to date"
+
+# Now simulate the project gaining a local virtualenv. After the next
+# successful run, .venv is recorded in seen_outputs.
+echo "flask==3.0.0" >>requirements.txt
+mkdir -p .venv
+assert_contains "mise deps --only pip 2>&1" "Installed: pip"
+assert_contains "mise deps --only pip 2>&1" "up to date"
+
+# Deleting .venv after it has been observed should mark the provider stale,
+# even though the source hashes still match.
+rm -rf .venv
+assert_contains "mise deps --dry-run 2>&1" "outputs missing"
+assert_contains "mise deps --only pip 2>&1" "Installed: pip"
+
+rm -rf .venv requirements.txt mise.toml .mise
+
 # Test --explain flag
 cat >mise.toml <<'EOF'
 [deps.explain_test]

--- a/src/cli/deps/install.rs
+++ b/src/cli/deps/install.rs
@@ -161,6 +161,17 @@ impl DepsInstall {
             miseprintln!("  {} {}", marker, output.display());
         }
 
+        // Optional outputs (tracked but not required on first run)
+        let optional_outputs = provider.optional_outputs();
+        if !optional_outputs.is_empty() {
+            miseprintln!("Optional outputs:");
+            for output in &optional_outputs {
+                let exists = output.exists();
+                let marker = if exists { "+" } else { "-" };
+                miseprintln!("  {} {}", marker, output.display());
+            }
+        }
+
         // Command
         if let Ok(cmd) = provider.install_command() {
             miseprintln!("Command: {}", cmd.description);
@@ -200,6 +211,7 @@ impl DepsInstall {
             let outputs = provider
                 .outputs()
                 .iter()
+                .chain(provider.optional_outputs().iter())
                 .map(|p| p.display().to_string())
                 .collect::<Vec<_>>()
                 .join(", ");

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -652,27 +652,33 @@ impl DepsEngine {
     /// Uses blake3 content hashing with persistent state. On first run (no stored
     /// hashes), the provider is always considered stale. Session-based stale
     /// tracking (venv auto-creation) is always checked first.
+    ///
+    /// When a provider returns no outputs, the existence check is skipped and the
+    /// hash check decides freshness on its own. This lets providers whose install
+    /// command writes outside the project tree (e.g. `bundle install` to the
+    /// system gem path, `pip install` without a virtualenv) avoid being perpetually
+    /// stale.
     pub fn check_freshness(&self, provider: &dyn DepsProvider) -> Result<FreshnessResult> {
         let sources = provider.sources();
         let outputs = provider.outputs();
 
-        if outputs.is_empty() {
-            return Ok(FreshnessResult::NoOutputs);
-        }
-
-        // Check if any output was created this session (before deps ran)
-        for output in &outputs {
-            if super::is_output_stale(output) {
-                return Ok(FreshnessResult::Stale(
-                    "output created this session".to_string(),
-                ));
+        // Output-based checks only apply when the provider declares outputs.
+        // Empty outputs fall through to the hash-based check below.
+        if !outputs.is_empty() {
+            // Check if any output was created this session (before deps ran)
+            for output in &outputs {
+                if super::is_output_stale(output) {
+                    return Ok(FreshnessResult::Stale(
+                        "output created this session".to_string(),
+                    ));
+                }
             }
-        }
 
-        // Check if any output is missing
-        for output in &outputs {
-            if !output.exists() {
-                return Ok(FreshnessResult::OutputsMissing);
+            // Check if any output is missing
+            for output in &outputs {
+                if !output.exists() {
+                    return Ok(FreshnessResult::OutputsMissing);
+                }
             }
         }
 

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -339,7 +339,13 @@ impl DepsEngine {
 
             if !freshness.is_fresh() {
                 let cmd = provider.install_command()?;
-                let outputs = provider.outputs();
+                // Carry both required and optional outputs so session-staleness
+                // can be cleared on whichever paths actually exist after the run.
+                let outputs: Vec<PathBuf> = provider
+                    .outputs()
+                    .into_iter()
+                    .chain(provider.optional_outputs())
+                    .collect();
                 let depends = provider.depends();
                 let timeout = provider.timeout();
                 let reason = freshness.reason().to_string();
@@ -387,7 +393,8 @@ impl DepsEngine {
                 }
             }
 
-            // Save content hashes for all successfully ran providers
+            // Save content hashes and existing optional outputs for each
+            // successfully ran provider.
             for step in &results {
                 if let DepsStepResult::Ran(id) = step
                     && let Some(provider) = self.providers.iter().find(|p| p.id() == id)
@@ -395,8 +402,15 @@ impl DepsEngine {
                     let project_root = &provider.base().project_root;
                     let sources = provider.sources();
                     if let Ok(hashes) = state::hash_sources(&sources, project_root) {
+                        let seen: Vec<String> = provider
+                            .optional_outputs()
+                            .iter()
+                            .filter(|p| p.exists())
+                            .map(|p| state::relative_str(p, project_root))
+                            .collect();
                         let mut st = DepsState::load(project_root);
                         st.set_hashes(id, hashes);
+                        st.set_seen_outputs(id, seen);
                         if let Err(e) = st.save(project_root) {
                             warn!("failed to save deps state: {e}");
                         }
@@ -649,47 +663,65 @@ impl DepsEngine {
 
     /// Check if a provider's outputs are fresh relative to its sources.
     ///
-    /// Uses blake3 content hashing with persistent state. On first run (no stored
-    /// hashes), the provider is always considered stale. Session-based stale
-    /// tracking (venv auto-creation) is always checked first.
+    /// Required outputs (`provider.outputs()`) must always exist. Optional
+    /// outputs (`provider.optional_outputs()`) are only enforced once they've
+    /// been observed on a previous successful run — this lets built-in
+    /// providers declare a canonical output (`.venv`, `vendor/bundle`, etc.)
+    /// that detects post-install deletion without forcing a re-run for
+    /// projects that never produce that output.
     ///
-    /// When a provider returns no outputs, the existence check is skipped and the
-    /// hash check decides freshness on its own. This lets providers whose install
-    /// command writes outside the project tree (e.g. `bundle install` to the
-    /// system gem path, `pip install` without a virtualenv) avoid being perpetually
-    /// stale.
+    /// Uses blake3 content hashing with persistent state. On first run (no
+    /// stored hashes), the provider is always considered stale.
     pub fn check_freshness(&self, provider: &dyn DepsProvider) -> Result<FreshnessResult> {
         let sources = provider.sources();
         let outputs = provider.outputs();
+        let optional_outputs = provider.optional_outputs();
 
-        // Output-based checks only apply when the provider declares outputs.
-        // Empty outputs fall through to the hash-based check below.
-        if !outputs.is_empty() {
-            // Check if any output was created this session (before deps ran)
-            for output in &outputs {
-                if super::is_output_stale(output) {
-                    return Ok(FreshnessResult::Stale(
-                        "output created this session".to_string(),
-                    ));
-                }
+        let project_root = &provider.base().project_root;
+        let st = DepsState::load(project_root);
+        let provider_id = provider.id();
+
+        // Session-stale check applies to any output that currently exists,
+        // regardless of whether it was required or optional.
+        for output in outputs.iter().chain(optional_outputs.iter()) {
+            if super::is_output_stale(output) {
+                return Ok(FreshnessResult::Stale(
+                    "output created this session".to_string(),
+                ));
             }
+        }
 
-            // Check if any output is missing
-            for output in &outputs {
-                if !output.exists() {
+        // Required outputs must exist whenever they are declared.
+        for output in &outputs {
+            if !output.exists() {
+                return Ok(FreshnessResult::OutputsMissing);
+            }
+        }
+
+        // Optional outputs are enforced only for paths that existed at the
+        // last successful run (recorded in state). This catches deletion
+        // (e.g. `rm -rf .venv` after `uv sync`) without forcing a re-run for
+        // providers whose canonical output is intentionally absent.
+        if let Some(seen) = st.get_seen_outputs(provider_id) {
+            for output in &optional_outputs {
+                let rel = state::relative_str(output, project_root);
+                if seen.iter().any(|p| p == &rel) && !output.exists() {
                     return Ok(FreshnessResult::OutputsMissing);
                 }
             }
         }
 
+        // A provider with neither sources nor outputs has no freshness signal —
+        // always run it (matches pre-PR custom-hook behavior).
+        if sources.is_empty() && outputs.is_empty() && optional_outputs.is_empty() {
+            return Ok(FreshnessResult::Stale(
+                "no sources or outputs defined".to_string(),
+            ));
+        }
+
         if sources.is_empty() {
             return Ok(FreshnessResult::NoSources);
         }
-
-        // Use content-hash comparison via persistent state
-        let project_root = &provider.base().project_root;
-        let st = DepsState::load(project_root);
-        let provider_id = provider.id();
 
         let current_hashes = state::hash_sources(&sources, project_root)?;
 

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -22,8 +22,6 @@ pub mod state;
 pub enum FreshnessResult {
     /// Outputs are up to date with sources
     Fresh,
-    /// Provider has no outputs defined, always run to be safe
-    NoOutputs,
     /// One or more output paths don't exist
     OutputsMissing,
     /// Sources have changed since last successful run
@@ -44,7 +42,6 @@ impl FreshnessResult {
     pub fn reason(&self) -> &str {
         match self {
             FreshnessResult::Fresh => "outputs are up to date",
-            FreshnessResult::NoOutputs => "no outputs defined",
             FreshnessResult::OutputsMissing => "outputs missing",
             FreshnessResult::Stale(reason) => reason,
             FreshnessResult::NoSources => "no sources to check",

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -117,8 +117,28 @@ pub trait DepsProvider: Debug + Send + Sync {
     /// Returns the source files to check for freshness (lock files, config files)
     fn sources(&self) -> Vec<PathBuf>;
 
-    /// Returns the output files/directories that should be newer than sources
+    /// Returns the output files/directories that should be newer than sources.
+    ///
+    /// These are *required* outputs: once declared, they must exist for the
+    /// provider to be considered fresh. If any are missing, the install command
+    /// re-runs.
     fn outputs(&self) -> Vec<PathBuf>;
+
+    /// Returns optional output files/directories whose existence is tracked but
+    /// not required on first run.
+    ///
+    /// Used by built-in providers whose install command may or may not write to
+    /// a known location depending on configuration (e.g. `.venv` for pip, only
+    /// present when the project uses a local virtualenv; `vendor/bundle` for
+    /// bundler, only present with `--path vendor/bundle`).
+    ///
+    /// The engine records which optional outputs existed after a successful run
+    /// and enforces their continued existence thereafter — so deleting `.venv`
+    /// after `uv sync` triggers a re-run, but a project that never had `.venv`
+    /// doesn't re-run on every invocation.
+    fn optional_outputs(&self) -> Vec<PathBuf> {
+        vec![]
+    }
 
     /// The command to run when outputs are stale relative to sources
     fn install_command(&self) -> Result<DepsCommand>;

--- a/src/deps/providers/bundler.rs
+++ b/src/deps/providers/bundler.rs
@@ -32,14 +32,15 @@ impl DepsProvider for BundlerDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        let root = self.base.config_root();
-        // Check for vendor/bundle if using --path vendor/bundle
-        let vendor = root.join("vendor/bundle");
+        // `bundle install` writes to the system/user gem path by default and
+        // only populates `vendor/bundle` when `--path vendor/bundle` is used.
+        // For non-vendored projects we have no on-disk output to check, so
+        // return empty and let the engine fall back to source-hash freshness.
+        let vendor = self.base.config_root().join("vendor/bundle");
         if vendor.exists() {
             vec![vendor]
         } else {
-            // Use .bundle directory as fallback indicator
-            vec![root.join(".bundle")]
+            vec![]
         }
     }
 

--- a/src/deps/providers/bundler.rs
+++ b/src/deps/providers/bundler.rs
@@ -32,16 +32,15 @@ impl DepsProvider for BundlerDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
+    fn optional_outputs(&self) -> Vec<PathBuf> {
         // `bundle install` writes to the system/user gem path by default and
         // only populates `vendor/bundle` when `--path vendor/bundle` is used.
-        // For non-vendored projects we have no on-disk output to check, so
-        // return empty and let the engine fall back to source-hash freshness.
-        let vendor = self.base.config_root().join("vendor/bundle");
-        if vendor.exists() {
-            vec![vendor]
-        } else {
-            vec![]
-        }
+        // Track it as optional so vendored projects detect deletion of
+        // `vendor/bundle`, while non-vendored projects rely on source hashes.
+        vec![self.base.config_root().join("vendor/bundle")]
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/go.rs
+++ b/src/deps/providers/go.rs
@@ -32,14 +32,14 @@ impl DepsProvider for GoDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        let root = self.base.config_root();
-        // Go downloads modules to GOPATH/pkg/mod, but we can check vendor/ if used
-        let vendor = root.join("vendor");
+        // Go downloads modules to GOPATH/pkg/mod by default, leaving nothing in
+        // the project tree to check. Only treat `vendor/` as an output when the
+        // project is vendored; otherwise fall back to source-hash freshness.
+        let vendor = self.base.config_root().join("vendor");
         if vendor.exists() {
             vec![vendor]
         } else {
-            // go.sum gets updated after go mod download completes
-            vec![root.join("go.sum")]
+            vec![]
         }
     }
 

--- a/src/deps/providers/go.rs
+++ b/src/deps/providers/go.rs
@@ -27,20 +27,22 @@ impl DepsProvider for GoDepsProvider {
     }
 
     fn sources(&self) -> Vec<PathBuf> {
-        // go.mod defines dependencies - changes here trigger downloads
-        vec![self.base.config_root().join("go.mod")]
+        let root = self.base.config_root();
+        // Both go.mod and go.sum count as sources: go.mod declares the modules,
+        // go.sum pins their checksums. A `go mod tidy` that updates only go.sum
+        // should still trigger a re-run.
+        vec![root.join("go.mod"), root.join("go.sum")]
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        // Go downloads modules to GOPATH/pkg/mod by default, leaving nothing in
-        // the project tree to check. Only treat `vendor/` as an output when the
-        // project is vendored; otherwise fall back to source-hash freshness.
-        let vendor = self.base.config_root().join("vendor");
-        if vendor.exists() {
-            vec![vendor]
-        } else {
-            vec![]
-        }
+        vec![]
+    }
+
+    fn optional_outputs(&self) -> Vec<PathBuf> {
+        // Go downloads modules to GOPATH/pkg/mod by default. Track `vendor/` as
+        // optional so vendored projects detect deletion without forcing a
+        // re-run for non-vendored projects.
+        vec![self.base.config_root().join("vendor")]
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/pip.rs
+++ b/src/deps/providers/pip.rs
@@ -31,12 +31,15 @@ impl DepsProvider for PipDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        // `pip install` doesn't create `.venv` itself — it installs into whatever
-        // python is on PATH. Use `.venv` as an output only if it already exists
-        // (project is using a local virtualenv); otherwise fall back to
-        // source-hash freshness so we don't reinstall on every invocation.
-        let venv = self.base.config_root().join(".venv");
-        if venv.exists() { vec![venv] } else { vec![] }
+        vec![]
+    }
+
+    fn optional_outputs(&self) -> Vec<PathBuf> {
+        // `pip install` installs into whatever python is on PATH and doesn't
+        // create `.venv` itself. Track it as optional so projects that use a
+        // local venv detect deletion, without forcing a re-run for projects
+        // that don't.
+        vec![self.base.config_root().join(".venv")]
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/pip.rs
+++ b/src/deps/providers/pip.rs
@@ -31,8 +31,12 @@ impl DepsProvider for PipDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        // Check for .venv directory as output indicator
-        vec![self.base.config_root().join(".venv")]
+        // `pip install` doesn't create `.venv` itself — it installs into whatever
+        // python is on PATH. Use `.venv` as an output only if it already exists
+        // (project is using a local virtualenv); otherwise fall back to
+        // source-hash freshness so we don't reinstall on every invocation.
+        let venv = self.base.config_root().join(".venv");
+        if venv.exists() { vec![venv] } else { vec![] }
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/poetry.rs
+++ b/src/deps/providers/poetry.rs
@@ -32,7 +32,11 @@ impl DepsProvider for PoetryDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join(".venv")]
+        // Poetry only writes `.venv` in the project when `virtualenvs.in-project`
+        // is enabled; by default the venv lives elsewhere. Use `.venv` only when
+        // it exists; otherwise fall back to source-hash freshness.
+        let venv = self.base.config_root().join(".venv");
+        if venv.exists() { vec![venv] } else { vec![] }
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/poetry.rs
+++ b/src/deps/providers/poetry.rs
@@ -32,11 +32,14 @@ impl DepsProvider for PoetryDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
+    fn optional_outputs(&self) -> Vec<PathBuf> {
         // Poetry only writes `.venv` in the project when `virtualenvs.in-project`
-        // is enabled; by default the venv lives elsewhere. Use `.venv` only when
-        // it exists; otherwise fall back to source-hash freshness.
-        let venv = self.base.config_root().join(".venv");
-        if venv.exists() { vec![venv] } else { vec![] }
+        // is enabled; otherwise the venv lives elsewhere. Track as optional so
+        // in-project setups detect deletion without breaking the default mode.
+        vec![self.base.config_root().join(".venv")]
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/uv.rs
+++ b/src/deps/providers/uv.rs
@@ -32,7 +32,12 @@ impl DepsProvider for UvDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join(".venv")]
+        // `uv sync` creates `.venv` in the project root by default, but
+        // `UV_PROJECT_ENVIRONMENT` can redirect it elsewhere. Only treat
+        // `.venv` as an output when it exists; otherwise fall back to
+        // source-hash freshness.
+        let venv = self.base.config_root().join(".venv");
+        if venv.exists() { vec![venv] } else { vec![] }
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/uv.rs
+++ b/src/deps/providers/uv.rs
@@ -32,12 +32,15 @@ impl DepsProvider for UvDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
+    fn optional_outputs(&self) -> Vec<PathBuf> {
         // `uv sync` creates `.venv` in the project root by default, but
-        // `UV_PROJECT_ENVIRONMENT` can redirect it elsewhere. Only treat
-        // `.venv` as an output when it exists; otherwise fall back to
-        // source-hash freshness.
-        let venv = self.base.config_root().join(".venv");
-        if venv.exists() { vec![venv] } else { vec![] }
+        // `UV_PROJECT_ENVIRONMENT` can redirect it elsewhere. Track as optional
+        // so the default case detects deletion while custom-env-path setups
+        // still rely on source hashes.
+        vec![self.base.config_root().join(".venv")]
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/state.rs
+++ b/src/deps/state.rs
@@ -9,13 +9,19 @@ use crate::hash::{file_hash_blake3, hash_to_str};
 
 /// Persistent state for deps freshness checking.
 ///
-/// Stores blake3 content hashes of source files keyed by provider ID.
+/// Stores blake3 content hashes of source files keyed by provider ID, plus the
+/// set of optional output paths that existed at the last successful run.
 /// Persisted to `$MISE_STATE_DIR/deps/<hash>.toml`, keyed by project root.
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct DepsState {
     /// provider_id → (relative_path → blake3_hex)
     #[serde(default)]
     pub providers: BTreeMap<String, BTreeMap<String, String>>,
+    /// provider_id → list of optional output paths (relative to project root)
+    /// that existed after the last successful run. Used to detect when an
+    /// output that was previously present has been deleted.
+    #[serde(default)]
+    pub seen_outputs: BTreeMap<String, Vec<String>>,
 }
 
 impl DepsState {
@@ -58,6 +64,27 @@ impl DepsState {
     pub fn set_hashes(&mut self, provider_id: &str, hashes: BTreeMap<String, String>) {
         self.providers.insert(provider_id.to_string(), hashes);
     }
+
+    /// Get optional outputs that existed at the last successful run, or None
+    /// if not previously recorded.
+    pub fn get_seen_outputs(&self, provider_id: &str) -> Option<&Vec<String>> {
+        self.seen_outputs.get(provider_id)
+    }
+
+    /// Record optional outputs that exist after a successful run.
+    pub fn set_seen_outputs(&mut self, provider_id: &str, outputs: Vec<String>) {
+        self.seen_outputs.insert(provider_id.to_string(), outputs);
+    }
+}
+
+/// Stringify a path relative to the project root using the same convention as
+/// the stored state (forward-slash relative path, falling back to the absolute
+/// path when the path is not under `project_root`).
+pub fn relative_str(path: &Path, project_root: &Path) -> String {
+    path.strip_prefix(project_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
 }
 
 /// Compute blake3 hashes for a list of source files.
@@ -77,12 +104,7 @@ pub fn hash_sources(sources: &[PathBuf], project_root: &Path) -> Result<BTreeMap
             hash_dir_files(&mut hashes, source, project_root, 3)?;
         } else {
             let hash = file_hash_blake3(source, None)?;
-            let rel = source
-                .strip_prefix(project_root)
-                .unwrap_or(source)
-                .to_string_lossy()
-                .to_string();
-            hashes.insert(rel, hash);
+            hashes.insert(relative_str(source, project_root), hash);
         }
     }
 
@@ -106,12 +128,7 @@ fn hash_dir_files(
                 hash_dir_files(hashes, &path, project_root, max_depth - 1)?;
             } else {
                 let hash = file_hash_blake3(&path, None)?;
-                let rel = path
-                    .strip_prefix(project_root)
-                    .unwrap_or(&path)
-                    .to_string_lossy()
-                    .to_string();
-                hashes.insert(rel, hash);
+                hashes.insert(relative_str(&path, project_root), hash);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fixes #9585's underlying issue across all built-in providers, not just bundler.
- `check_freshness` in `src/deps/engine.rs` now skips the output existence / session-stale checks when a provider returns no outputs and lets the source-hash check decide freshness on its own. First run is still stale (no stored hashes); subsequent runs with unchanged sources are fresh.
- `bundler`, `pip`, `go`, `poetry`, and `uv` providers now return their conventional in-project output (`vendor/bundle`, `.venv`, `vendor/`) only when it actually exists; otherwise they return `vec![]` and rely on hashing. This stops `bundle install` / `pip install` / `go mod download` / `poetry install` / `uv sync` from re-running on every invocation for projects that don't keep deps in the project tree.
- `FreshnessResult::NoOutputs` is removed since it's no longer reachable.

## Background

The Greptile bot flagged this on #9585 — verified by tracing the flow:

`engine.rs::check_freshness` checked output existence before the hash check, returning `OutputsMissing` (not fresh) whenever any declared output didn't exist. `bundle install` to the system gem path, `pip install` without a venv, `go mod download` without `vendor/`, etc. all left nothing in the project tree, so the providers were perpetually stale and the source-hash mechanism was never reached.

## Test plan

- [x] `mise run lint` clean
- [x] `mise run test:unit` — 827 passed
- [x] `mise run test:e2e cli/test_deps cli/test_deps_depends cli/test_deps_tool_install` — all green
- [x] New e2e regression in `e2e/cli/test_deps` covers the empty-outputs path: first run stale → install runs, second run fresh, source change → stale again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deps freshness evaluation and persisted state, which can alter when dependency install steps run or are skipped across multiple built-in providers.
> 
> **Overview**
> Fixes deps providers that don’t write outputs inside the project tree from being **perpetually stale** by letting `check_freshness` fall back to **source hashing** when required outputs are empty.
> 
> Introduces `DepsProvider::optional_outputs()` and persists *seen optional outputs* in `DepsState`, so built-in providers can detect deletion of canonical directories (e.g. `.venv`, `vendor/`, `vendor/bundle`) **only after they’ve been observed**, without forcing reruns for projects that never create them. Updates `bundler`, `pip`, `go`, `poetry`, and `uv` to use optional outputs, extends `--list`/`--explain` to display them, and adds e2e coverage for empty-output providers and the “always run when no sources/outputs” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f18767b70954cece26c41d26cb48df47fc7d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->