### PR TITLE
fix(install): skip remote-versions refresh in prefer-offline mode

### DIFF
--- a/e2e/cli/test_install_prefer_offline_no_refresh
+++ b/e2e/cli/test_install_prefer_offline_no_refresh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Regression test for the prefer-offline auto-install path.
+#
+# In prefer-offline mode (set on shim/hook-env/activate paths), install-time
+# version resolution must reuse the on-disk remote-versions cache populated
+# by an earlier non-prefer-offline command, NOT bypass it with a forced
+# refresh. The forced-refresh path falls through to the backend's own
+# listing, which for many backends returns far fewer versions (e.g. the
+# GitHub releases listing returns only the most recent ~30) — turning
+# previously-resolvable prefix queries into "no versions found for <tool>"
+# in a project whose `mise.toml` pins an older prefix.
+#
+# Reported on aafe53f19 (#9545):
+# https://github.com/jdx/mise/commit/aafe53f19#commitcomment-184356367
+
+# 1. Pre-warm the on-disk remote_versions cache. The dummy plugin's list-all
+#    writes [1.0.0 1.1.0 2.0.0] to the cache.
+mise install dummy@2.0.0
+
+# 2. Pin a prefix that has no installed match. install_single_tool sees no
+#    installed version matching "1.0", so the buggy code path would set
+#    refresh_remote_versions=true and force a re-fetch.
+cat >mise.toml <<EOF
+[tools]
+dummy = "prefix:1.0"
+EOF
+
+# 3. Make any call to list-all fail, and force prefer-offline mode.
+#    With the fix: the on-disk cache is reused and 1.0.0 is resolved and
+#    installed without re-running list-all.
+#    Without the fix: refresh_async re-runs list-all → exits 1 → the install
+#    aborts with "no versions found for dummy".
+RTX_FAILURE=1 MISE_PREFER_OFFLINE=1 mise install
+
+# 4. Confirm the prefix resolved from cache to 1.0.0 and was installed.
+assert_contains "mise ls dummy" "1.0.0"

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -590,12 +590,19 @@ impl Toolset {
 /// cached answer is either correct or harmless, and refreshing is wasted
 /// network traffic. Users who want to pull the absolute latest matching a
 /// prefix can run `mise upgrade` or pin to `@latest`.
+///
+/// Skipped in `prefer_offline` mode (shims, hook-env, activate, etc.) because
+/// the versions host is disabled there, so a refresh would bypass the
+/// on-disk cache populated by an earlier non-prefer-offline command and fall
+/// through to a backend listing that often has far fewer versions (e.g. the
+/// GitHub releases listing only returns the most recent ~30), turning a
+/// previously-resolvable prefix query into "no versions found".
 fn should_refresh_remote_versions(
     tr: &ToolRequest,
     backend: &crate::backend::ABackend,
     opts: &ResolveOptions,
 ) -> bool {
-    if opts.refresh_remote_versions || opts.offline || Settings::get().offline() {
+    if opts.refresh_remote_versions || opts.offline || Settings::get().prefer_offline() {
         return false;
     }
     match tr {


### PR DESCRIPTION
## Summary

- `should_refresh_remote_versions` (added in #9545) now bails on `prefer_offline()` instead of just `offline()`.
- Fixes a regression in v2026.5.0 where shim auto-install of a `prefix:` request fails after pre-warming with `mise install <tool>`.

## Why

In `prefer_offline` mode (set by shims, hook-env, activate, etc.) the versions host is disabled (`versions_host.rs:71`). The post-#9545 install path was forcing a cache refresh whenever no installed version matched a prefix request, which:

1. Bypassed the on-disk version cache populated by an earlier non-prefer-offline command (e.g. `mise install terraform`).
2. Hit the versions host → returned `None` because of `prefer_offline`.
3. Fell through to the backend's own listing — for many backends this is the GitHub releases API, which only returns the most recent ~30 versions.
4. Older but valid prefix queries (e.g. `terraform = \"prefix:1.10\"`) failed with `no versions found for terraform`.

`prefer_offline()` already returns true whenever `offline()` is true, so the guard's existing offline behavior is preserved; this just additionally suppresses the cache-busting refresh on the fast paths where it would always make things worse. The original #9545 motivation (`mise use <tool>` getting a stale cached `latest`) is unaffected — `mise use` doesn't run with `PREFER_OFFLINE` set.

Reported on commit aafe53f19: https://github.com/jdx/mise/commit/aafe53f19d63e71ca411dca963ce72c78b91137c#commitcomment-184356367

## Test plan

- [ ] `mise install terraform` (latest), then in a project with `terraform = \"prefix:1.10\"` invoke a terraform shim — the older prefix should resolve from cache and auto-install rather than erroring.
- [ ] `mise use terraform@latest` in a fresh shell still refreshes upstream when the cached `latest` is stale (no regression on #9545's fix).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time version resolution behavior for prefix/latest selectors under `prefer_offline`, which could affect when remote caches are refreshed and which versions get selected. Scope is small and covered by a new e2e regression test, but it touches core install resolution logic.
> 
> **Overview**
> Prevents install-time resolution from forcing a remote-versions cache refresh when running in **`prefer_offline`** mode, so prefix-based requests can resolve from the existing on-disk cache instead of falling back to limited backend listings.
> 
> Adds an e2e regression test (`test_install_prefer_offline_no_refresh`) that pre-warms the remote versions cache, pins a `prefix:` tool version, forces `MISE_PREFER_OFFLINE=1`, and asserts the install succeeds without re-running `list-all`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741cf17978efa81948a94c55f44004d2f2fb79ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->