### PR TITLE
chore(ci): skip hyperfine comments without permission

### DIFF
--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -125,9 +125,19 @@ jobs:
         run: sccache --show-stats
       - run: cat comment.md >> "$GITHUB_STEP_SUMMARY"
         if: always() && github.event_name == 'pull_request'
+      - name: Check PR comment permission
+        id: pr-comment-permission
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+            echo "can-comment=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "can-comment=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping PR comment because this pull request was opened from a fork." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && steps.pr-comment-permission.outputs.can-comment == 'true'
         continue-on-error: true
         with:
           file-path: comment.md

--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -115,29 +115,19 @@ jobs:
         env:
           SHELL: zsh
       - run: mise run test:perf
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           NUM_TOOLS: 200
           NUM_TASKS: 2000
           RUNS: 10
           MISE_ALT: mise-${{ steps.versions.outputs.release }}
-      - if: always()
+      - if: ${{ !cancelled() }}
         run: sccache --show-stats
       - run: cat comment.md >> "$GITHUB_STEP_SUMMARY"
-        if: always() && github.event_name == 'pull_request'
-      - name: Check PR comment permission
-        id: pr-comment-permission
-        if: always() && github.event_name == 'pull_request'
-        run: |
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
-            echo "can-comment=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "can-comment=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping PR comment because this pull request was opened from a fork." >> "$GITHUB_STEP_SUMMARY"
-          fi
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
-        if: always() && github.event_name == 'pull_request' && steps.pr-comment-permission.outputs.can-comment == 'true'
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         continue-on-error: true
         with:
           file-path: comment.md


### PR DESCRIPTION
## Summary
- skip the hyperfine PR comment action for forked pull requests where `pull_request` workflows do not receive write permissions
- keep writing `comment.md` to the step summary so benchmark details remain visible

## Tests
- `git diff --check`
- `mise x actionlint -- actionlint .github/workflows/hyperfine.yml`