### PR TITLE
test(e2e): wait for docker env cleanup

### DIFF
--- a/e2e/run_test
+++ b/e2e/run_test
@@ -55,7 +55,11 @@ create_isolated_env() {
 }
 
 remove_isolated_env() {
-  rm -rf "$TEST_ISOLATED_DIR" &
+  if [[ ${MISE_E2E_INSIDE_DOCKER:-0} == 1 ]]; then
+    rm -rf "$TEST_ISOLATED_DIR"
+  else
+    rm -rf "$TEST_ISOLATED_DIR" &
+  fi
 }
 
 within_isolated_env() {


### PR DESCRIPTION
## Summary
- wait for successful e2e test environment cleanup when the test is running inside Docker
- keep asynchronous cleanup outside Docker so local/non-Docker runs keep the existing fast path
- remove the need for a second cleanup container that chmods the Docker bind mounts

## Context
#9570 changed Docker e2e runs to bind-mount host-backed directories for `/tmp` and `/root` instead of using tmpfs. Inside the container, `mktemp -d` creates root-owned `0700` per-test directories under the bind-mounted `/tmp`.

For successful tests, `e2e/run_test` previously started `rm -rf "$TEST_ISOLATED_DIR"` in the background. When the Docker container exits before that background cleanup reliably finishes, root-owned `0700` test directories can be left behind on the host mount. The outer host-side cleanup then emits permission noise such as `rm: cannot remove`.

Waiting for `rm -rf` only when `MISE_E2E_INSIDE_DOCKER=1` fixes the source of that host-side cleanup noise without running a second container or broadly chmodding both mounts.

Failed tests keep the existing behavior: the isolated test environment is left in place and reported for inspection, and the returned test status remains unchanged.

## Tests
- `git diff --check`
- `bash -n e2e/run_test`
- `mise x shellcheck -- shellcheck -x e2e/run_test`
- `mise x shfmt -- shfmt -d e2e/run_test`
- `MISE_E2E_DOCKER=1 E2E_WAIT_FOR_GH_RATE_LIMIT=0 mise run test:e2e e2e/cli/test_version`
  - verified captured output had no `rm: cannot remove` lines
