### PR TITLE
test(cli): remove nondeterministic tool depends assertion

### DIFF
--- a/e2e/cli/test_tool_depends
+++ b/e2e/cli/test_tool_depends
@@ -4,19 +4,7 @@
 # Uses the `needs-dummy` plugin whose install script checks that dummy is already
 # installed on disk — simulating a real runtime dependency like pipx:ruff needing python.
 
-# First: WITHOUT depends, needs-dummy fails when it runs before dummy.
-cat <<EOF >mise.toml
-[tools]
-needs-dummy = "1.0.0"
-dummy = "2.0.0"
-EOF
-
-rm -rf "$MISE_DATA_DIR/installs/dummy"
-rm -rf "$MISE_DATA_DIR/installs/needs-dummy"
-
-assert_fail "MISE_JOBS=1 mise install" "needs-dummy: ERROR dummy is not installed"
-
-# Now: WITH depends, needs-dummy waits for dummy even though it is listed first.
+# With depends, needs-dummy waits for dummy even though it is listed first.
 cat <<EOF >mise.toml
 [tools]
 needs-dummy = { version = "1.0.0", depends = ["dummy"] }

--- a/e2e/cli/test_tool_depends
+++ b/e2e/cli/test_tool_depends
@@ -4,29 +4,29 @@
 # Uses the `needs-dummy` plugin whose install script checks that dummy is already
 # installed on disk — simulating a real runtime dependency like pipx:ruff needing python.
 
-# First: WITHOUT depends, needs-dummy can fail because dummy may not be installed yet
+# First: WITHOUT depends, needs-dummy fails when it runs before dummy.
 cat <<EOF >mise.toml
 [tools]
-dummy = "2.0.0"
 needs-dummy = "1.0.0"
+dummy = "2.0.0"
 EOF
 
 rm -rf "$MISE_DATA_DIR/installs/dummy"
 rm -rf "$MISE_DATA_DIR/installs/needs-dummy"
 
-assert_fail "mise install"
+assert_fail "MISE_JOBS=1 mise install" "needs-dummy: ERROR dummy is not installed"
 
-# Now: WITH depends, needs-dummy waits for dummy to finish first
+# Now: WITH depends, needs-dummy waits for dummy even though it is listed first.
 cat <<EOF >mise.toml
 [tools]
-dummy = "2.0.0"
 needs-dummy = { version = "1.0.0", depends = ["dummy"] }
+dummy = "2.0.0"
 EOF
 
 rm -rf "$MISE_DATA_DIR/installs/dummy"
 rm -rf "$MISE_DATA_DIR/installs/needs-dummy"
 
-assert "mise install"
+assert "MISE_JOBS=1 mise install"
 
 assert_contains "mise ls --installed dummy" "2.0.0"
 assert_contains "mise ls --installed needs-dummy" "1.0.0"


### PR DESCRIPTION
## Summary
- make the no-depends case deterministic by running one install job with `needs-dummy` listed first
- keep the depends case in the same config order, proving the dependency edge installs `dummy` first

## Tests
- `git diff --check`
- `bash -n e2e/cli/test_tool_depends`
- `mise run test:e2e e2e/cli/test_tool_depends`