### PR TITLE
feat: add --inactive option to outdated and upgrade commands for inactive tools

### DIFF
--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -31,6 +31,12 @@ show other 20.x versions, not 21.x or 22.x versions.
 
 Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
 
+### `--inactive`
+
+Show outdated tools including installed-but-inactive tools not present in the current config
+
+By default, `mise outdated` only shows tools that come from the current config.
+
 ### `--local`
 
 Only show outdated tools defined in local config files

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -67,6 +67,10 @@ Like --dry-run but exits with code 1 if there are outdated tools
 
 This is useful for scripts to check if tools need to be upgraded.
 
+### `--inactive`
+
+Upgrade all tools, including installed-but-inactive tools not present in the current config
+
 ### `--local`
 
 Only upgrade tools defined in local config files

--- a/docs/cli/use.md
+++ b/docs/cli/use.md
@@ -104,8 +104,8 @@ Directly pipe stdin/stdout/stderr from plugin to user Sets `--jobs=1`
 Remove the plugin(s) from config file
 
 Examples:
-```
 
+```
 # run with no arguments to use the interactive selector
 $ mise use
 

--- a/e2e/cli/test_outdated
+++ b/e2e/cli/test_outdated
@@ -33,8 +33,13 @@ assert_not_contains "mise outdated --local" "tiny"
 # without --local, both should appear
 assert_contains "mise outdated" "dummy"
 assert_contains "mise outdated" "tiny"
-rm -f .tool-versions
+
+# if tiny is installed but no longer active in config, --inactive should still show it
 rm -f "$MISE_CONFIG_DIR/config.toml"
+assert_not_contains "mise outdated" "tiny"
+assert_contains "mise outdated --inactive" "tiny"
+
+rm -f .tool-versions
 
 echo 'dummy 1' >.tool-versions
 mise uninstall dummy --all

--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -42,6 +42,19 @@ assert_not_contains "mise ls --installed tiny" "1.1.0"
 rm -f "$MISE_CONFIG_DIR/config.toml"
 rm -f mise.toml
 
+# if tiny is installed but no longer active in config, --inactive with a tool arg
+# should still upgrade it
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[tools]
+tiny = "1"
+EOF
+mise uninstall tiny --all
+mise install tiny@1.0.0
+rm -f "$MISE_CONFIG_DIR/config.toml"
+latest_tiny=$(mise latest tiny)
+mise upgrade tiny --inactive
+assert_contains "mise ls --installed tiny" "$latest_tiny"
+
 # ensure options are retained
 mise use "ubi:bazelbuild/buildtools[exe=buildifier,matching=buildifier]@7.1.2"
 assert "cat mise.toml" '[tools]

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1690,6 +1690,11 @@ show other 20.x versions, not 21.x or 22.x versions.
 
 Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
 .TP
+\fB\-\-inactive\fR
+Show outdated tools including installed\-but\-inactive tools not present in the current config
+
+By default, `mise outdated` only shows tools that come from the current config.
+.TP
 \fB\-\-local\fR
 Only show outdated tools defined in local config files
 
@@ -3340,6 +3345,9 @@ Explicitly pinned versions like "22.5.0" are not filtered.
 Like \-\-dry\-run but exits with code 1 if there are outdated tools
 
 This is useful for scripts to check if tools need to be upgraded.
+.TP
+\fB\-\-inactive\fR
+Upgrade all tools, including installed\-but\-inactive tools not present in the current config
 .TP
 \fB\-\-local\fR
 Only upgrade tools defined in local config files

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -689,6 +689,9 @@ cmd outdated help="Shows outdated tool versions" {
     flag "-l --bump" help="Compares against the latest versions available, not what matches the current config" {
         long_help "Compares against the latest versions available, not what matches the current config\n\nFor example, if you have `node = \"20\"` in your config by default `mise outdated` will only\nshow other 20.x versions, not 21.x or 22.x versions.\n\nUsing this flag, if there are 21.x or newer versions it will display those instead of 20.x."
     }
+    flag --inactive help="Show outdated tools including installed-but-inactive tools not present in the current config" {
+        long_help "Show outdated tools including installed-but-inactive tools not present in the current config\n\nBy default, `mise outdated` only shows tools that come from the current config."
+    }
     flag --local help="Only show outdated tools defined in local config files" {
         long_help "Only show outdated tools defined in local config files\n\nThis will only show tools that are defined in project-local mise.toml and\nwill skip tools defined in the global config (~/.config/mise/config.toml)."
     }
@@ -1354,6 +1357,7 @@ cmd upgrade help="Upgrades outdated tools" {
     flag --dry-run-code help="Like --dry-run but exits with code 1 if there are outdated tools" {
         long_help "Like --dry-run but exits with code 1 if there are outdated tools\n\nThis is useful for scripts to check if tools need to be upgraded."
     }
+    flag --inactive help="Upgrade all tools, including installed-but-inactive tools not present in the current config"
     flag --local help="Only upgrade tools defined in local config files" {
         long_help "Only upgrade tools defined in local config files\n\nThis will only upgrade tools that are defined in project-local mise.toml and\nwill skip tools defined in the global config (~/.config/mise/config.toml)."
     }
@@ -1366,7 +1370,7 @@ cmd usage hide=#true help="Generate a usage CLI spec" {
 cmd use help="Installs a tool and adds the version to mise.toml." {
     alias u
     long_help "Installs a tool and adds the version to mise.toml.\n\nThis will install the tool version if it is not already installed.\nBy default, this will use a `mise.toml` file in the current directory.\nIf multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),\nthe lowest precedence file (`mise.toml`) will be used.\nSee https://mise.en.dev/configuration.html#target-file-for-write-operations\n\nIn the following order:\n  - If `--global` is set, it will use the global config file.\n  - If `--path` is set, it will use the config file at the given path.\n  - If `--env` is set, it will use `mise.<env>.toml`.\n  - If `MISE_DEFAULT_CONFIG_FILENAME` is set, it will use that instead.\n  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.\n  - Otherwise just \"mise.toml\" or global config if cwd is home directory.\n\nUse the `--global` flag to use the global config file instead."
-    after_long_help "Examples:\n    \n    # run with no arguments to use the interactive selector\n    $ mise use\n\n    # set the current version of node to 20.x in mise.toml of current directory\n    # will write the fuzzy version (e.g.: 20)\n    $ mise use node@20\n\n    # set the current version of node to 20.x in ~/.config/mise/config.toml\n    # will write the precise version (e.g.: 20.0.0)\n    $ mise use -g --pin node@20\n\n    # sets .mise.local.toml (which is intended not to be committed to a project)\n    $ mise use --env local node@20\n\n    # sets .mise.staging.toml (which is used if MISE_ENV=staging)\n    $ mise use --env staging node@20\n"
+    after_long_help "Examples:\n\n    # run with no arguments to use the interactive selector\n    $ mise use\n\n    # set the current version of node to 20.x in mise.toml of current directory\n    # will write the fuzzy version (e.g.: 20)\n    $ mise use node@20\n\n    # set the current version of node to 20.x in ~/.config/mise/config.toml\n    # will write the precise version (e.g.: 20.0.0)\n    $ mise use -g --pin node@20\n\n    # sets .mise.local.toml (which is intended not to be committed to a project)\n    $ mise use --env local node@20\n\n    # sets .mise.staging.toml (which is used if MISE_ENV=staging)\n    $ mise use --env staging node@20\n"
     flag "-e --env" help="Create/modify an environment-specific config file like .mise.<env>.toml" {
         arg <ENV>
     }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -244,6 +244,7 @@ impl Install {
                 before_date: self.get_before_date()?,
                 offline: false,
                 refresh_remote_versions: false,
+                inactive: false,
             },
             dry_run: self.is_dry_run(),
             locked: Settings::get().locked,

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -35,6 +35,12 @@ pub struct Outdated {
     #[clap(long, short = 'l', verbatim_doc_comment)]
     pub bump: bool,
 
+    /// Show outdated tools including installed-but-inactive tools not present in the current config
+    ///
+    /// By default, `mise outdated` only shows tools that come from the current config.
+    #[clap(long, verbatim_doc_comment, conflicts_with = "local")]
+    pub inactive: bool,
+
     /// Only show outdated tools defined in local config files
     ///
     /// This will only show tools that are defined in project-local mise.toml and
@@ -68,7 +74,14 @@ impl Outdated {
         ts.versions
             .retain(|_, tvl| tool_set.is_empty() || tool_set.contains(&tvl.backend));
         let outdated = ts
-            .list_outdated_versions(&config, self.bump, &ResolveOptions::default())
+            .list_outdated_versions(
+                &config,
+                self.bump,
+                &ResolveOptions {
+                    inactive: self.inactive,
+                    ..Default::default()
+                },
+            )
             .await;
         self.display(outdated).await?;
         Ok(())

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -78,6 +78,10 @@ pub struct Upgrade {
     #[clap(long, verbatim_doc_comment)]
     dry_run_code: bool,
 
+    /// Upgrade all tools, including installed-but-inactive tools not present in the current config
+    #[clap(long, verbatim_doc_comment, conflicts_with = "local")]
+    inactive: bool,
+
     /// Only upgrade tools defined in local config files
     ///
     /// This will only upgrade tools that are defined in project-local mise.toml and
@@ -119,6 +123,7 @@ impl Upgrade {
             before_date,
             offline: false,
             refresh_remote_versions: false,
+            inactive: self.inactive,
         };
         // Filter tools to check before doing expensive version lookups
         let filter_tools = if !self.interactive && !self.tool.is_empty() {
@@ -264,6 +269,7 @@ impl Upgrade {
                 before_date,
                 offline: false,
                 refresh_remote_versions: false,
+                inactive: self.inactive,
             },
             ..Default::default()
         };

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -146,6 +146,7 @@ impl Use {
             before_date: self.get_before_date()?,
             offline: false,
             refresh_remote_versions: false,
+            inactive: false,
         };
         let versions: Vec<_> = self
             .tool
@@ -378,7 +379,7 @@ impl Use {
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
-    
+
     # run with no arguments to use the interactive selector
     $ <bold>mise use</bold>
 

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -274,8 +274,18 @@ impl Toolset {
         filter_tools: Option<&[crate::cli::args::ToolArg]>,
         exclude_tools: Option<&[crate::cli::args::ToolArg]>,
     ) -> Vec<OutdatedInfo> {
-        let versions = self
-            .list_current_versions()
+        let list_versions = if opts.inactive {
+            match self.list_all_versions(config).await {
+                Ok(v) => v,
+                Err(err) => {
+                    warn!("Failed to list all versions: {err:#}");
+                    vec![]
+                }
+            }
+        } else {
+            self.list_current_versions()
+        };
+        let versions = list_versions
             .into_iter()
             // Filter to only check specified tools if provided
             .filter(|(_, tv)| {

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -58,9 +58,11 @@ impl OutdatedInfo {
         let t = tv.backend()?;
         // prefix is something like "temurin-" or "corretto-"
         let (prefix, _) = split_version_prefix(&tv.request.version());
-        let latest_result = if bump {
-            // Note: Backend's latest_version takes individual parameters,
-            // not a ResolveOptions struct like ToolVersion's method
+        let use_backend_latest =
+            bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown);
+
+        let latest_result = if use_backend_latest {
+            // For bumps and installed-but-inactive tools (`--no-source`), use backend latest.
             t.latest_version(
                 config,
                 Some(prefix.clone()).filter(|s| !s.is_empty()),
@@ -84,6 +86,15 @@ impl OutdatedInfo {
             }
         };
         let mut oi = Self::new(config, tv, latest)?;
+        if opts.inactive && oi.source == ToolSource::Unknown {
+            // Installed-but-inactive tools have no config source, so their request
+            // is usually pinned to the currently installed version. With --no-source we
+            // want to install the discovered latest version instead.
+            let backend = oi.tool_request.ba().clone();
+            let source = oi.tool_request.source().clone();
+            let options = oi.tool_request.options();
+            oi.tool_request = ToolRequest::new_opts(backend, &oi.latest, options, source)?;
+        }
         if oi
             .current
             .as_ref()

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -236,6 +236,7 @@ impl ToolVersion {
             before_date: base_opts.before_date,
             offline: base_opts.offline,
             refresh_remote_versions: base_opts.refresh_remote_versions,
+            inactive: base_opts.inactive,
         };
         let tv = self.request.resolve(config, &opts).await?;
         // map cargo backend specific prefixes to ref
@@ -615,6 +616,10 @@ pub struct ResolveOptions {
     pub offline: bool,
     /// Ignore cached remote version lists while resolving this request.
     pub refresh_remote_versions: bool,
+    /// Include installed-but-inactive versions that do not have a known config source
+    /// (for example `ToolSource::Unknown`) when resolving tools for flows like
+    /// outdated/upgrade checks.
+    pub inactive: bool,
 }
 
 impl Default for ResolveOptions {
@@ -625,6 +630,7 @@ impl Default for ResolveOptions {
             before_date: None,
             offline: false,
             refresh_remote_versions: false,
+            inactive: false,
         }
     }
 }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -2021,6 +2021,12 @@ const completionSpec: Fig.Spec = {
           isRepeatable: false,
         },
         {
+          name: "--inactive",
+          description:
+            "Show outdated tools including installed-but-inactive tools not present in the current config",
+          isRepeatable: false,
+        },
+        {
           name: "--local",
           description: "Only show outdated tools defined in local config files",
           isRepeatable: false,
@@ -4019,6 +4025,12 @@ const completionSpec: Fig.Spec = {
           name: "--dry-run-code",
           description:
             "Like --dry-run but exits with code 1 if there are outdated tools",
+          isRepeatable: false,
+        },
+        {
+          name: "--inactive",
+          description:
+            "Upgrade all tools, including installed-but-inactive tools not present in the current config",
           isRepeatable: false,
         },
         {


### PR DESCRIPTION
Adds a new `--inactive` flag to `outdated` and `upgrade` command to allow to show/upgrade tools which are currently not active or  defined in a configuration.