### PR TITLE
chore(ci): smoke test registry workflow changes

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -105,9 +105,11 @@ jobs:
       - id: determine-tools
         run: |
           if [ "${{ steps.workflow-check.outputs.modified }}" == "true" ]; then
-            echo "Workflow modified, running all tests"
-            echo "tools=" >> "$GITHUB_OUTPUT"
-            echo "tranches=8" >> "$GITHUB_OUTPUT"
+            # Exercise the registry workflow path without expanding PRs to the full registry.
+            workflow_test_tools="actionlint bat delta difftastic eza fd fzf jaq jq ripgrep shellcheck shfmt starship usage yq zoxide"
+            echo "Workflow modified, testing representative tools: $workflow_test_tools"
+            echo "tools=$workflow_test_tools" >> "$GITHUB_OUTPUT"
+            echo "tranches=1" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- replace the registry workflow-change fallback from all tool tests to a 16-tool representative smoke set
- keep the workflow regression path exercised without expanding every registry workflow PR to the full registry matrix

Smoke tools: `actionlint bat delta difftastic eza fd fzf jaq jq ripgrep shellcheck shfmt starship usage yq zoxide`

## Testing
- `actionlint .github/workflows/registry.yml`
- `git diff --check`
- verified all 16 smoke tools exist and define `test =`

CI is intentionally skipped by the commit message; I will run it manually later.

*This PR was generated by an AI coding assistant.*