### PR TITLE
refactor(aqua): store aqua var defaults as strings

### DIFF
--- a/crates/aqua-registry/build.rs
+++ b/crates/aqua-registry/build.rs
@@ -50,6 +50,7 @@ fn generate_baked_registry(out_dir: &str) -> Result<()> {
                 registry_file.display()
             )
         })?;
+    validate_var_defaults(packages)?;
     let registries = package_registries(packages)?;
     if registries.is_empty() {
         return Err(eyre!(
@@ -119,6 +120,66 @@ fn package_registries(packages: &[Value]) -> Result<Vec<PackageRegistry>> {
         });
     }
     Ok(registries)
+}
+
+fn validate_var_defaults(packages: &[Value]) -> Result<()> {
+    for package in packages {
+        let package_id = canonical_package_id(package).unwrap_or_else(|| "<unknown>".to_string());
+        validate_var_defaults_in_value(package, &package_id)?;
+    }
+    Ok(())
+}
+
+fn validate_var_defaults_in_value(value: &Value, package_id: &str) -> Result<()> {
+    match value {
+        Value::Mapping(mapping) => {
+            if let Some(vars) = value.get("vars").and_then(|vars| vars.as_sequence()) {
+                for var in vars {
+                    if let Some(default) = var.get("default")
+                        && !yaml_value_is_string(default)
+                    {
+                        let var_name =
+                            string_field(var, "name").unwrap_or_else(|| "<unnamed>".to_string());
+                        return Err(eyre!(
+                            "unsupported non-string aqua var default in package {package_id}, var {var_name}: got {}",
+                            yaml_value_kind(default)
+                        ));
+                    }
+                }
+            }
+            for child in mapping.values() {
+                validate_var_defaults_in_value(child, package_id)?;
+            }
+        }
+        Value::Sequence(values) => {
+            for child in values {
+                validate_var_defaults_in_value(child, package_id)?;
+            }
+        }
+        Value::Tagged(tagged) => validate_var_defaults_in_value(&tagged.value, package_id)?,
+        _ => {}
+    }
+    Ok(())
+}
+
+fn yaml_value_is_string(value: &Value) -> bool {
+    match value {
+        Value::String(_) => true,
+        Value::Tagged(tagged) => yaml_value_is_string(&tagged.value),
+        _ => false,
+    }
+}
+
+fn yaml_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::String(_) => "string",
+        Value::Number(_) => "number",
+        Value::Bool(_) => "boolean",
+        Value::Sequence(_) => "array",
+        Value::Mapping(_) => "object",
+        Value::Null => "null",
+        Value::Tagged(tagged) => yaml_value_kind(&tagged.value),
+    }
 }
 
 fn registry_files_code(registries: &[PackageRegistry]) -> String {

--- a/crates/aqua-registry/build.rs
+++ b/crates/aqua-registry/build.rs
@@ -50,7 +50,6 @@ fn generate_baked_registry(out_dir: &str) -> Result<()> {
                 registry_file.display()
             )
         })?;
-    validate_var_defaults(packages)?;
     let registries = package_registries(packages)?;
     if registries.is_empty() {
         return Err(eyre!(
@@ -120,66 +119,6 @@ fn package_registries(packages: &[Value]) -> Result<Vec<PackageRegistry>> {
         });
     }
     Ok(registries)
-}
-
-fn validate_var_defaults(packages: &[Value]) -> Result<()> {
-    for package in packages {
-        let package_id = canonical_package_id(package).unwrap_or_else(|| "<unknown>".to_string());
-        validate_var_defaults_in_value(package, &package_id)?;
-    }
-    Ok(())
-}
-
-fn validate_var_defaults_in_value(value: &Value, package_id: &str) -> Result<()> {
-    match value {
-        Value::Mapping(mapping) => {
-            if let Some(vars) = value.get("vars").and_then(|vars| vars.as_sequence()) {
-                for var in vars {
-                    if let Some(default) = var.get("default")
-                        && !yaml_value_is_string(default)
-                    {
-                        let var_name =
-                            string_field(var, "name").unwrap_or_else(|| "<unnamed>".to_string());
-                        return Err(eyre!(
-                            "unsupported non-string aqua var default in package {package_id}, var {var_name}: got {}",
-                            yaml_value_kind(default)
-                        ));
-                    }
-                }
-            }
-            for child in mapping.values() {
-                validate_var_defaults_in_value(child, package_id)?;
-            }
-        }
-        Value::Sequence(values) => {
-            for child in values {
-                validate_var_defaults_in_value(child, package_id)?;
-            }
-        }
-        Value::Tagged(tagged) => validate_var_defaults_in_value(&tagged.value, package_id)?,
-        _ => {}
-    }
-    Ok(())
-}
-
-fn yaml_value_is_string(value: &Value) -> bool {
-    match value {
-        Value::String(_) => true,
-        Value::Tagged(tagged) => yaml_value_is_string(&tagged.value),
-        _ => false,
-    }
-}
-
-fn yaml_value_kind(value: &Value) -> &'static str {
-    match value {
-        Value::String(_) => "string",
-        Value::Number(_) => "number",
-        Value::Bool(_) => "boolean",
-        Value::Sequence(_) => "array",
-        Value::Mapping(_) => "object",
-        Value::Null => "null",
-        Value::Tagged(tagged) => yaml_value_kind(&tagged.value),
-    }
 }
 
 fn registry_files_code(registries: &[PackageRegistry]) -> String {

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -2,8 +2,6 @@ use expr::{Context, Environment, Program, Value};
 use eyre::{Result, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
-use serde::Deserializer;
-use serde::de::Error as DeError;
 use serde_derive::Deserialize;
 use std::cmp::PartialEq;
 use std::collections::HashMap;
@@ -91,7 +89,7 @@ pub struct AquaVar {
     pub name: String,
     /// Aqua's schema allows arbitrary YAML defaults, but mise intentionally
     /// supports only string defaults to keep variable resolution simple.
-    #[serde(default, deserialize_with = "deserialize_aqua_var_default")]
+    #[serde(default)]
     pub default: Option<String>,
     #[serde(default)]
     pub required: bool,
@@ -610,42 +608,6 @@ fn normalize_libc(libc: Option<&str>) -> Option<&str> {
         _ => None,
     }
 }
-
-fn deserialize_aqua_var_default<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Option<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = <serde_yaml::Value as serde::Deserialize>::deserialize(deserializer)?;
-    aqua_var_default_from_yaml(value).map_err(D::Error::custom)
-}
-
-fn aqua_var_default_from_yaml(
-    value: serde_yaml::Value,
-) -> std::result::Result<Option<String>, String> {
-    match value {
-        serde_yaml::Value::String(s) => Ok(Some(s)),
-        serde_yaml::Value::Tagged(tagged) => aqua_var_default_from_yaml(tagged.value),
-        value => Err(format!(
-            "aqua var default must be a string, got {}",
-            yaml_value_kind(&value)
-        )),
-    }
-}
-
-fn yaml_value_kind(value: &serde_yaml::Value) -> &'static str {
-    match value {
-        serde_yaml::Value::String(_) => "string",
-        serde_yaml::Value::Number(_) => "number",
-        serde_yaml::Value::Bool(_) => "boolean",
-        serde_yaml::Value::Sequence(_) => "array",
-        serde_yaml::Value::Mapping(_) => "object",
-        serde_yaml::Value::Null => "null",
-        serde_yaml::Value::Tagged(tagged) => yaml_value_kind(&tagged.value),
-    }
-}
-
 /// splits a version number into an optional prefix and the remaining version string
 fn split_version_prefix(version: &str) -> (String, String) {
     version
@@ -1315,14 +1277,29 @@ packages:
     }
 
     #[test]
-    fn test_vars_non_string_defaults_fail_yaml_parse() {
-        for (yaml_default, kind) in [
-            ("null", "null"),
-            ("true", "boolean"),
-            ("123", "number"),
-            ("[stable, beta]", "array"),
-            ("{channel: stable}", "object"),
-        ] {
+    fn test_vars_scalar_defaults_deserialize_as_strings() {
+        for (yaml_default, expected) in [("true", "true"), ("123", "123")] {
+            let yml = format!(
+                r#"
+packages:
+  - vars:
+      - name: channel
+        default: {yaml_default}
+"#
+            );
+            let pkg = serde_yaml::from_str::<RegistryYaml>(&yml)
+                .unwrap()
+                .packages
+                .into_iter()
+                .next()
+                .unwrap();
+            assert_eq!(pkg.vars[0].default.as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn test_vars_sequence_and_mapping_defaults_fail_yaml_parse() {
+        for yaml_default in ["[stable, beta]", "{channel: stable}"] {
             let yml = format!(
                 r#"
 packages:
@@ -1333,11 +1310,28 @@ packages:
             );
             let err = serde_yaml::from_str::<RegistryYaml>(&yml).unwrap_err();
             assert!(
-                err.to_string()
-                    .contains(&format!("aqua var default must be a string, got {kind}")),
+                err.to_string().contains("invalid type"),
                 "unexpected error for {yaml_default}: {err}"
             );
         }
+    }
+
+    #[test]
+    fn test_vars_null_default_deserializes_as_none() {
+        let yml = r#"
+packages:
+  - vars:
+      - name: channel
+        default: null
+"#;
+        let pkg = serde_yaml::from_str::<RegistryYaml>(yml)
+            .unwrap()
+            .packages
+            .into_iter()
+            .next()
+            .unwrap();
+
+        assert_eq!(pkg.vars[0].default, None);
     }
 
     #[test]

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -2,6 +2,8 @@ use expr::{Context, Environment, Program, Value};
 use eyre::{Result, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
+use serde::Deserializer;
+use serde::de::Error as DeError;
 use serde_derive::Deserialize;
 use std::cmp::PartialEq;
 use std::collections::HashMap;
@@ -87,7 +89,10 @@ struct AquaRuntime<'a> {
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct AquaVar {
     pub name: String,
-    pub default: Option<serde_yaml::Value>,
+    /// Aqua's schema allows arbitrary YAML defaults, but mise intentionally
+    /// supports only string defaults to keep variable resolution simple.
+    #[serde(default, deserialize_with = "deserialize_aqua_var_default")]
+    pub default: Option<String>,
     #[serde(default)]
     pub required: bool,
 }
@@ -490,10 +495,7 @@ impl AquaPackage {
         if let Some(value) = self.var_values.get(&var.name) {
             return Ok(Some(value.clone()));
         }
-        var.default
-            .as_ref()
-            .map(|value| yaml_var_to_string(&var.name, value))
-            .transpose()
+        Ok(var.default.clone())
     }
 
     /// Set up version filter expression if configured
@@ -609,15 +611,25 @@ fn normalize_libc(libc: Option<&str>) -> Option<&str> {
     }
 }
 
-fn yaml_var_to_string(name: &str, value: &serde_yaml::Value) -> Result<String> {
+fn deserialize_aqua_var_default<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = <serde_yaml::Value as serde::Deserialize>::deserialize(deserializer)?;
+    aqua_var_default_from_yaml(value).map_err(D::Error::custom)
+}
+
+fn aqua_var_default_from_yaml(
+    value: serde_yaml::Value,
+) -> std::result::Result<Option<String>, String> {
     match value {
-        serde_yaml::Value::String(s) => Ok(s.clone()),
-        serde_yaml::Value::Null => Ok(String::new()),
-        serde_yaml::Value::Tagged(tagged) => yaml_var_to_string(name, &tagged.value),
-        value => Err(eyre!(
-            "aqua var `{}` must be a string, got {}",
-            name,
-            yaml_value_kind(value)
+        serde_yaml::Value::String(s) => Ok(Some(s)),
+        serde_yaml::Value::Tagged(tagged) => aqua_var_default_from_yaml(tagged.value),
+        value => Err(format!(
+            "aqua var default must be a string, got {}",
+            yaml_value_kind(&value)
         )),
     }
 }
@@ -1098,8 +1110,8 @@ impl AquaGithubArtifactAttestations {
 mod tests {
     use super::*;
 
-    fn default_str(value: &str) -> Option<serde_yaml::Value> {
-        Some(serde_yaml::Value::String(value.to_string()))
+    fn default_str(value: &str) -> Option<String> {
+        Some(value.to_string())
     }
 
     #[test]
@@ -1284,56 +1296,48 @@ mod tests {
     }
 
     #[test]
-    fn test_vars_default_scalar_value() {
-        let pkg = AquaPackage {
-            asset: "tool-go{{.Vars.go_version}}-{{.Version}}.tar.gz".to_string(),
-            vars: vec![AquaVar {
-                name: "go_version".to_string(),
-                default: Some(serde_yaml::from_str(r#""1.24""#).unwrap()),
-                required: false,
-            }],
-            ..Default::default()
-        };
+    fn test_vars_default_unquoted_yaml_string() {
+        let yml = r#"
+packages:
+  - asset: tool-{{.Vars.channel}}-{{.Version}}.tar.gz
+    vars:
+      - name: channel
+        default: stable
+"#;
+        let pkg = serde_yaml::from_str::<RegistryYaml>(yml)
+            .unwrap()
+            .packages
+            .into_iter()
+            .next()
+            .unwrap();
         let asset = pkg.asset("1.0.0", "linux", "amd64").unwrap();
-        assert_eq!(asset, "tool-go1.24-1.0.0.tar.gz");
+        assert_eq!(asset, "tool-stable-1.0.0.tar.gz");
     }
 
     #[test]
-    fn test_vars_default_array_errors() {
-        let pkg = AquaPackage {
-            asset: "tool-{{.Vars.channels}}-{{.Version}}.tar.gz".to_string(),
-            vars: vec![AquaVar {
-                name: "channels".to_string(),
-                default: Some(serde_yaml::from_str("[stable, beta]").unwrap()),
-                required: true,
-            }],
-            ..Default::default()
-        };
-        let err = pkg.asset("1.0.0", "linux", "amd64").unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("aqua var `channels` must be a string, got array"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn test_vars_default_object_errors() {
-        let pkg = AquaPackage {
-            asset: "tool-{{.Vars.config}}-{{.Version}}.tar.gz".to_string(),
-            vars: vec![AquaVar {
-                name: "config".to_string(),
-                default: Some(serde_yaml::from_str("{channel: stable, flavor: beta}").unwrap()),
-                required: true,
-            }],
-            ..Default::default()
-        };
-        let err = pkg.asset("1.0.0", "linux", "amd64").unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("aqua var `config` must be a string, got object"),
-            "unexpected error: {err}"
-        );
+    fn test_vars_non_string_defaults_fail_yaml_parse() {
+        for (yaml_default, kind) in [
+            ("null", "null"),
+            ("true", "boolean"),
+            ("123", "number"),
+            ("[stable, beta]", "array"),
+            ("{channel: stable}", "object"),
+        ] {
+            let yml = format!(
+                r#"
+packages:
+  - vars:
+      - name: channel
+        default: {yaml_default}
+"#
+            );
+            let err = serde_yaml::from_str::<RegistryYaml>(&yml).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains(&format!("aqua var default must be a string, got {kind}")),
+                "unexpected error for {yaml_default}: {err}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Store aqua var defaults as `Option<String>` instead of preserving arbitrary YAML values.
- Rely on Serde's normal `Option<String>` YAML deserialization; there is no custom default validator or tagged-value handling.
- Simplify runtime var resolution now that defaults are stored as strings.

## Notes
- Upstream aqua's schema/type allows arbitrary var default values.
- mise intentionally stores defaults as strings for implementation simplicity.
- With serde_yaml, scalar defaults deserialize into strings, explicit `null` deserializes as no default, and sequence/mapping defaults fail during typed YAML parsing.
- The vendored registry currently only uses string defaults or required vars without defaults.

## Test Plan
- [x] `cargo fmt --package aqua-registry --check`
- [x] `cargo check -p aqua-registry`
- [x] `cargo test -p aqua-registry`

*This PR body was generated by an AI coding assistant.*
