### PR TITLE
refactor(schema): use $defs in schema files

### DIFF
--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -24,13 +24,13 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/optionValue"
+            "$ref": "#/$defs/optionValue"
           }
         },
         {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/optionValue"
+            "$ref": "#/$defs/optionValue"
           }
         }
       ]
@@ -82,13 +82,13 @@
                       "type": "object",
                       "description": "Platform-specific configuration",
                       "additionalProperties": {
-                        "$ref": "#/definitions/optionValue"
+                        "$ref": "#/$defs/optionValue"
                       }
                     }
                   }
                 },
                 "additionalProperties": {
-                  "$ref": "#/definitions/optionValue"
+                  "$ref": "#/$defs/optionValue"
                 }
               }
             },

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -4,7 +4,7 @@
   "title": "mise registry tool schema",
   "description": "Schema for individual tool files in the mise registry",
   "type": "object",
-  "definitions": {
+  "$defs": {
     "backendFull": {
       "type": "string",
       "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|gem|github|gitlab|go|http|npm|pipx|spm|ubi|vfox):([^\\[\\]]|\\[[^\\]=]*\\])+$"
@@ -50,14 +50,14 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "#/definitions/backendFull",
+            "$ref": "#/$defs/backendFull",
             "description": "Backend specification as a string (e.g., 'aqua:owner/repo')"
           },
           {
             "type": "object",
             "properties": {
               "full": {
-                "$ref": "#/definitions/backendFull",
+                "$ref": "#/$defs/backendFull",
                 "description": "Full backend specification"
               },
               "platforms": {

--- a/schema/mise-settings.json
+++ b/schema/mise-settings.json
@@ -8,13 +8,13 @@
     "^[a-zA-Z0-9_]+$": {
       "oneOf": [
         {
-          "$ref": "#/definitions/setting"
+          "$ref": "#/$defs/setting"
         },
         {
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]+$": {
-              "$ref": "#/definitions/setting"
+              "$ref": "#/$defs/setting"
             }
           },
           "unevaluatedProperties": false
@@ -23,7 +23,7 @@
     }
   },
   "unevaluatedProperties": false,
-  "definitions": {
+  "$defs": {
     "setting": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Why
#9582 moved the generated schemas onto the JSON Schema draft 2020-12 shape we need for `allOf` + `unevaluatedProperties`. Once we rely on that behavior, the remaining schema files should use the draft 2020-12 definition namespace consistently.

Keeping `definitions` around works in some validators as legacy compatibility, but it leaves these files half-migrated: new reusable schema pieces are expected to live under `$defs`, while older local refs still point at `#/definitions/...`. This PR finishes that migration for the settings and registry-tool schemas so follow-up schema refactors can add shared definitions without mixing two local-ref conventions.

## What changed
- Migrates `schema/mise-settings.json` and `schema/mise-registry-tool.json` from `definitions` to `$defs`.
- Updates local refs from `#/definitions/...` to `#/$defs/...`.
- Keeps the accepted schema values unchanged; this is a namespace/ref cleanup for draft 2020-12 consistency.

## Validation
- `jq empty schema/mise-settings.json schema/mise-registry-tool.json`
- `git diff --check`

This PR was generated by an AI coding assistant.