### PR TITLE
refactor(schema): reuse plugin script config

### DIFF
--- a/schema/mise.plugin.json
+++ b/schema/mise.plugin.json
@@ -5,6 +5,21 @@
   "description": "config file for a mise plugin",
   "type": "object",
   "unevaluatedProperties": false,
+  "$defs": {
+    "plugin-script-config": {
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "cache-key": {
+          "description": "cache the script results separately based on these values",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "properties": {
     "list-aliases": {
       "description": "configuration for bin/list-aliases script",
@@ -30,31 +45,11 @@
     },
     "list-bin-paths": {
       "description": "configuration for bin/list-bin-paths script",
-      "type": "object",
-      "unevaluatedProperties": false,
-      "properties": {
-        "cache-key": {
-          "description": "cache the results of bin/exec-env separately based on these values",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
+      "$ref": "#/$defs/plugin-script-config"
     },
     "exec-env": {
       "description": "configuration for bin/exec-env script",
-      "type": "object",
-      "unevaluatedProperties": false,
-      "properties": {
-        "cache-key": {
-          "description": "cache the results of bin/exec-env separately based on these values",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
+      "$ref": "#/$defs/plugin-script-config"
     }
   }
 }


### PR DESCRIPTION
## Why
#9582 lets us safely reuse schema fragments through applicators and `unevaluatedProperties`. That makes duplicated object definitions more expensive to keep around: every duplicate has to be kept in sync when Tombi behavior, draft 2020-12 structure, or plugin-script fields change.

The plugin schema had the same script config shape repeated for `list-bin-paths` and `exec-env`. Reusing one definition makes those script hooks share the same validation contract, so future schema changes do not accidentally update one hook but not the other.

## What changed
- Adds a shared plugin script config definition for script hooks that support `cache-key`.
- Reuses it from both `list-bin-paths` and `exec-env`.
- Preserves the existing accepted properties and closed-object behavior.

## Validation
- `jq empty schema/mise.plugin.json`
- `git diff --check`

This PR was generated by an AI coding assistant.