### PR TITLE
refactor(schema): reuse registry common types

### DIFF
--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -9,39 +9,30 @@
       "type": "string",
       "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|gem|github|gitlab|go|http|npm|pipx|spm|ubi|vfox):([^\\[\\]]|\\[[^\\]=]*\\])+$"
     },
-    "optionValue": {
-      "description": "Backend option value.",
-      "anyOf": [
+    "backendOptionValue": {
+      "oneOf": [
         {
           "type": "string"
         },
         {
-          "type": "number"
-        },
-        {
           "type": "boolean"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/optionValue"
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/optionValue"
-          }
         }
       ]
+    },
+    "os": {
+      "type": "string",
+      "enum": ["freebsd", "linux", "macos", "openbsd", "windows"]
+    },
+    "toolId": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_.-]+$"
     }
   },
   "properties": {
     "aliases": {
       "type": "array",
       "items": {
-        "type": "string",
-        "pattern": "^[a-zA-Z0-9_.-]+$"
+        "$ref": "#/definitions/toolId"
       },
       "description": "Alternative names for the tool"
     },
@@ -63,8 +54,7 @@
               "platforms": {
                 "type": "array",
                 "items": {
-                  "type": "string",
-                  "enum": ["freebsd", "linux", "macos", "openbsd", "windows"]
+                  "$ref": "#/definitions/os"
                 },
                 "description": "Operating systems this backend supports"
               },
@@ -82,13 +72,13 @@
                       "type": "object",
                       "description": "Platform-specific configuration",
                       "additionalProperties": {
-                        "$ref": "#/definitions/optionValue"
+                        "$ref": "#/definitions/backendOptionValue"
                       }
                     }
                   }
                 },
                 "additionalProperties": {
-                  "$ref": "#/definitions/optionValue"
+                  "$ref": "#/definitions/backendOptionValue"
                 }
               }
             },
@@ -121,16 +111,14 @@
     "os": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": ["freebsd", "linux", "macos", "openbsd", "windows"]
+        "$ref": "#/definitions/os"
       },
       "description": "Operating systems this tool supports (empty means all)"
     },
     "overrides": {
       "type": "array",
       "items": {
-        "type": "string",
-        "pattern": "^[a-zA-Z0-9_.-]+$"
+        "$ref": "#/definitions/toolId"
       },
       "description": "List of tool IDs that this tool overrides"
     },
@@ -148,8 +136,7 @@
         "tools": {
           "type": "array",
           "items": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9_.-]+$"
+            "$ref": "#/definitions/toolId"
           },
           "description": "Additional mise tools to install before running test.cmd. Used only by mise test-tool."
         }

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -9,13 +9,29 @@
       "type": "string",
       "pattern": "^(aqua|asdf|cargo|conda|core|dotnet|gem|github|gitlab|go|http|npm|pipx|spm|ubi|vfox):([^\\[\\]]|\\[[^\\]=]*\\])+$"
     },
-    "backendOptionValue": {
-      "oneOf": [
+    "optionValue": {
+      "description": "Backend option value.",
+      "anyOf": [
         {
           "type": "string"
         },
         {
+          "type": "number"
+        },
+        {
           "type": "boolean"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/optionValue"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/optionValue"
+          }
         }
       ]
     },
@@ -72,13 +88,13 @@
                       "type": "object",
                       "description": "Platform-specific configuration",
                       "additionalProperties": {
-                        "$ref": "#/definitions/backendOptionValue"
+                        "$ref": "#/definitions/optionValue"
                       }
                     }
                   }
                 },
                 "additionalProperties": {
-                  "$ref": "#/definitions/backendOptionValue"
+                  "$ref": "#/definitions/optionValue"
                 }
               }
             },


### PR DESCRIPTION
## Why
After #9582, the registry schema can lean on shared definitions without tripping Tombi's older `unevaluatedProperties` false positives. That means repeated primitive schema fragments no longer need to stay inline just to avoid validator issues.

The registry schema repeats the same tool-id, OS, and backend option value shapes in several places. Pulling them into shared definitions reduces drift risk: aliases, overrides, test tools, backend platforms, and backend options now validate against the same source of truth.

## What changed
- Extracts common registry schema definitions for tool IDs, OS names, and recursive backend option values.
- Reuses those definitions across aliases, overrides, test tools, platform lists, and backend options.
- Keeps the registry schema behavior the same while making future edits smaller and less error-prone.

## Validation
- `jq empty schema/mise-registry-tool.json`
- `git diff --check`

This PR was generated by an AI coding assistant.