### PR TITLE
refactor(schema): extract tool options definition

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -14,6 +14,7 @@ mise use -g tombi@$TOMBI_VERSION
 SCHEMA_PATH="$ROOT/schema/mise.json"
 TASK_SCHEMA_PATH="$ROOT/schema/mise-task.json"
 TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
+TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
 assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
 
 # Set up tombi config pointing to local schema
@@ -70,11 +71,11 @@ TOML
 
 cat >"$HOME/workdir/mise-os.toml" <<'TOML'
 [tools]
-node = { version = "latest", os = ["linux", "macos/arm64", "darwin/aarch64", "win/amd64"] }
+node = { version = "latest", os = ["linux", "macos/arm64", "darwin/aarch64", "win/amd64"], backend_options = { nested = true } }
 go = { version = "latest", os = "linux/x64" }
 
 [tasks.build.tools]
-rust = { version = "latest", os = ["linux/x64", "macos/arm64"] }
+rust = { version = "latest", os = ["linux/x64", "macos/arm64"], profile = "release" }
 TOML
 
 cat >"$HOME/workdir/mise-task-os.toml" <<'TOML'
@@ -82,15 +83,15 @@ cat >"$HOME/workdir/mise-task-os.toml" <<'TOML'
 run = "echo ok"
 
 [build.tools]
-node = { version = "latest", os = ["linux/x64", "macos/arm64"] }
+node = { version = "latest", os = ["linux/x64", "macos/arm64"], profile = "release" }
 TOML
 
 # tombi lint should succeed with no errors (warnings about table order are ok)
 cd "$HOME/workdir"
-assert_succeed "$TOMBI lint --offline --no-cache --quiet mise.toml"
-assert_succeed "$TOMBI lint --offline --no-cache --quiet mise-age.toml"
-assert_succeed "$TOMBI lint --offline --no-cache --quiet mise-os.toml"
-assert_succeed "$TOMBI lint --offline --no-cache --quiet mise-task-os.toml"
+assert_succeed "$TOMBI_LINT mise.toml"
+assert_succeed "$TOMBI_LINT mise-age.toml"
+assert_succeed "$TOMBI_LINT mise-os.toml"
+assert_succeed "$TOMBI_LINT mise-task-os.toml"
 
 # Verify that invalid properties on tasks are rejected
 cat >"$HOME/workdir/mise-bad.toml" <<'TOML'
@@ -113,10 +114,10 @@ include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-tmpl.toml", "mise-bad
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
-include = ["mise-bad-task-os.toml"]
+include = ["mise-bad-task-os.toml", "mise-bad-task-tool-extra.toml"]
 EOF
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad.toml"
+assert_fail "$TOMBI_LINT mise-bad.toml"
 
 # Verify that options for complex age values must be nested inside age
 cat >"$HOME/workdir/mise-bad-age.toml" <<'TOML'
@@ -124,7 +125,7 @@ cat >"$HOME/workdir/mise-bad-age.toml" <<'TOML'
 SECRET = { age = { value = "AGE-SECRET" }, tools = true }
 TOML
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad-age.toml"
+assert_fail "$TOMBI_LINT mise-bad-age.toml"
 
 # Verify that extends is rejected on task_templates (not supported at runtime)
 cat >"$HOME/workdir/mise-bad-tmpl.toml" <<'TOML'
@@ -133,14 +134,14 @@ extends = "base"
 quiet = true
 TOML
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad-tmpl.toml"
+assert_fail "$TOMBI_LINT mise-bad-tmpl.toml"
 
 cat >"$HOME/workdir/mise-bad-os.toml" <<'TOML'
 [tools]
 node = { version = "latest", os = true }
 TOML
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad-os.toml"
+assert_fail "$TOMBI_LINT mise-bad-os.toml"
 
 cat >"$HOME/workdir/mise-bad-task-os.toml" <<'TOML'
 [build]
@@ -150,4 +151,14 @@ run = "echo ok"
 node = { version = "latest", os = true }
 TOML
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad-task-os.toml"
+assert_fail "$TOMBI_LINT mise-bad-task-os.toml"
+
+cat >"$HOME/workdir/mise-bad-task-tool-extra.toml" <<'TOML'
+[build]
+run = "echo ok"
+
+[build.tools]
+node = { version = "latest", os = "linux/x64", backend_options = { nested = true } }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-task-tool-extra.toml"

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -154,18 +154,13 @@
                 "type": "string"
               },
               {
-                "properties": {
-                  "version": {
-                    "description": "version of the tool to install",
-                    "type": "string"
-                  },
-                  "os": {
-                    "$ref": "#/$defs/os_filter"
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/tool_options"
                   }
-                },
-                "required": ["version"],
+                ],
                 "type": "object",
-                "additionalProperties": {
+                "unevaluatedProperties": {
                   "oneOf": [
                     {
                       "type": "string"
@@ -837,6 +832,19 @@
           "unevaluatedProperties": false
         }
       ]
+    },
+    "tool_options": {
+      "properties": {
+        "version": {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        "os": {
+          "$ref": "#/$defs/os_filter"
+        }
+      },
+      "required": ["version"],
+      "type": "object"
     },
     "os_filter": {
       "description": "operating system filters to install on",

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -846,20 +846,6 @@
       "required": ["version"],
       "type": "object"
     },
-    "os_filter": {
-      "description": "operating system filters to install on",
-      "oneOf": [
-        {
-          "$ref": "#/$defs/os_filter_item"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/os_filter_item"
-          }
-        }
-      ]
-    },
     "env_directive": {
       "type": "object",
       "properties": {
@@ -922,6 +908,20 @@
             }
           },
           "required": ["paths"]
+        }
+      ]
+    },
+    "os_filter": {
+      "description": "operating system filters to install on",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/os_filter_item"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/os_filter_item"
+          }
         }
       ]
     },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1949,54 +1949,53 @@
           "type": "string"
         },
         {
-          "properties": {
-            "version": {
-              "description": "version of the tool to install",
-              "type": "string"
+          "allOf": [
+            {
+              "$ref": "#/$defs/tool_options"
             },
-            "os": {
-              "$ref": "#/$defs/os_filter"
-            },
-            "install_env": {
-              "type": "object",
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "string"
+            {
+              "properties": {
+                "install_env": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
                   },
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "boolean"
-                  }
-                ]
-              },
-              "description": "environment variables during tool installation"
-            },
-            "depends": {
-              "oneOf": [
-                {
-                  "description": "tools that must be installed before this tool",
-                  "type": "string"
+                  "description": "environment variables during tool installation"
                 },
-                {
-                  "description": "tools that must be installed before this tool",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                "depends": {
+                  "oneOf": [
+                    {
+                      "description": "tools that must be installed before this tool",
+                      "type": "string"
+                    },
+                    {
+                      "description": "tools that must be installed before this tool",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "postinstall": {
+                  "description": "command to run after tool installation",
+                  "type": "string"
                 }
-              ]
-            },
-            "postinstall": {
-              "description": "command to run after tool installation",
-              "type": "string"
+              }
             }
-          },
-          "required": ["version"],
+          ],
           "type": "object",
-          "additionalProperties": {
+          "unevaluatedProperties": {
             "oneOf": [
               {
                 "type": "string"
@@ -2018,6 +2017,19 @@
           }
         }
       ]
+    },
+    "tool_options": {
+      "properties": {
+        "version": {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        "os": {
+          "$ref": "#/$defs/os_filter"
+        }
+      },
+      "required": ["version"],
+      "type": "object"
     },
     "hooks": {
       "description": "hooks to run",
@@ -2310,18 +2322,13 @@
                 "type": "string"
               },
               {
-                "properties": {
-                  "version": {
-                    "description": "version of the tool to install",
-                    "type": "string"
-                  },
-                  "os": {
-                    "$ref": "#/$defs/os_filter"
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/tool_options"
                   }
-                },
-                "required": ["version"],
+                ],
                 "type": "object",
-                "additionalProperties": {
+                "unevaluatedProperties": {
                   "oneOf": [
                     {
                       "type": "string"


### PR DESCRIPTION
## Why
#9582 restored the schema pattern we wanted for task objects: shared property definitions composed with `allOf`, then closed with `unevaluatedProperties`. With Tombi pinned to a version that handles evaluated properties correctly, we can use the same pattern for tool option objects.

The top-level `[tools]` schema and task `tools` schema both describe the same `{ version, os }` object shape, but with different extra-property rules. Duplicating the common part makes it easy for those two locations to drift. This PR extracts the shared `version`/`os` piece and lets each call site keep its own closure behavior.

## What changed
- Adds a shared `$defs.tool_options` schema for the common `version` and `os` fields.
- Reuses it from both top-level tool options and task tool options.
- Preserves the important difference between call sites: root tool objects still allow backend-specific values, while task tool objects still only allow string extras.
- Extends the Tombi regression test so warnings fail and the shared-schema behavior is covered.

## Validation
- `git diff --check`
- Direct Tombi validation with `tombi@0.9.22` and `--error-on-warnings` for valid root/task tool options and invalid task tool extra options.
- Full e2e should run in CI; my earlier local targeted e2e run was stopped after the build step stalled behind another active cargo build on this machine.

This PR was generated by an AI coding assistant.