### PR TITLE
refactor(schema): reuse env directive property schemas

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -98,6 +98,7 @@ TOML
 cd "$HOME/workdir"
 assert_succeed "$TOMBI_LINT mise.toml"
 assert_succeed "$TOMBI_LINT mise-age.toml"
+assert_succeed "$TOMBI_LINT mise-env-directives.toml"
 assert_succeed "$TOMBI_LINT mise-os.toml"
 assert_succeed "$TOMBI_LINT mise-task-os.toml"
 

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -27,7 +27,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise.toml", "mise-age.toml", "mise-os.toml"]
+include = ["mise.toml", "mise-age.toml", "mise-env-directives.toml", "mise-os.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -65,8 +65,16 @@ TOML
 # placeholder values while running tombi through `mise x`.
 cat >"$HOME/workdir/mise-age.toml" <<'TOML'
 [env]
+VALUE_OBJECT = { value = 123, tools = true, redact = true, required = "set VALUE_OBJECT" }
 SECRET_SIMPLE = { age = "AGE-SECRET", tools = true }
 SECRET_COMPLEX = { age = { value = "AGE-SECRET", format = "raw", tools = true, redact = true } }
+TOML
+
+cat >"$HOME/workdir/mise-env-directives.toml" <<'TOML'
+[env]
+_.file = { path = ".env", tools = true, redact = true, required = true }
+_.source = [{ path = "env.sh", tools = true, redact = true, required = "source env.sh" }]
+_.path = { paths = ["./bin", "./scripts"], tools = true }
 TOML
 
 cat >"$HOME/workdir/mise-os.toml" <<'TOML'
@@ -110,7 +118,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-tmpl.toml", "mise-bad-os.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-directive.toml", "mise-bad-tmpl.toml", "mise-bad-os.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -123,9 +131,17 @@ assert_fail "$TOMBI_LINT mise-bad.toml"
 cat >"$HOME/workdir/mise-bad-age.toml" <<'TOML'
 [env]
 SECRET = { age = { value = "AGE-SECRET" }, tools = true }
+SECRET_FORMAT = { age = { value = "AGE-SECRET", format = "zip" } }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-age.toml"
+
+cat >"$HOME/workdir/mise-bad-env-directive.toml" <<'TOML'
+[env]
+_.file = { path = ".env", required = 123 }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-env-directive.toml"
 
 # Verify that extends is rejected on task_templates (not supported at runtime)
 cat >"$HOME/workdir/mise-bad-tmpl.toml" <<'TOML'

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -846,20 +846,6 @@
       "required": ["version"],
       "type": "object"
     },
-    "os_filter": {
-      "description": "operating system filters to install on",
-      "oneOf": [
-        {
-          "$ref": "#/$defs/os_filter_item"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/os_filter_item"
-          }
-        }
-      ]
-    },
     "env_value": {
       "oneOf": [
         {
@@ -963,6 +949,20 @@
             }
           },
           "required": ["paths"]
+        }
+      ]
+    },
+    "os_filter": {
+      "description": "operating system filters to install on",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/os_filter_item"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/os_filter_item"
+          }
         }
       ]
     },

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -846,71 +846,6 @@
       "required": ["version"],
       "type": "object"
     },
-    "env_directive": {
-      "type": "object",
-      "properties": {
-        "path": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          ]
-        },
-        "paths": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "tools": {
-          "type": "boolean",
-          "description": "load tools before resolving"
-        },
-        "redact": {
-          "type": "boolean",
-          "description": "redact the value from logs"
-        },
-        "required": {
-          "oneOf": [
-            {
-              "type": "boolean",
-              "description": "require this environment variable to be defined before mise runs or in a later config file"
-            },
-            {
-              "type": "string",
-              "description": "require this environment variable with user help text on how to set it"
-            }
-          ],
-          "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
-        }
-      },
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "path": {
-              "$ref": "#/$defs/env_directive/properties/path"
-            }
-          },
-          "required": ["path"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "paths": {
-              "$ref": "#/$defs/env_directive/properties/paths"
-            }
-          },
-          "required": ["paths"]
-        }
-      ]
-    },
     "os_filter": {
       "description": "operating system filters to install on",
       "oneOf": [
@@ -922,6 +857,112 @@
           "items": {
             "$ref": "#/$defs/os_filter_item"
           }
+        }
+      ]
+    },
+    "env_value": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "env_path": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "env_paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "env_tools": {
+      "type": "boolean",
+      "description": "load tools before resolving"
+    },
+    "env_redact": {
+      "type": "boolean",
+      "description": "redact the value from logs"
+    },
+    "env_required": {
+      "oneOf": [
+        {
+          "type": "boolean",
+          "description": "require this environment variable to be defined before mise runs or in a later config file"
+        },
+        {
+          "type": "string",
+          "description": "require this environment variable with user help text on how to set it"
+        }
+      ],
+      "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+    },
+    "env_age": {
+      "type": "string",
+      "description": "[experimental] age-encrypted value (simplified format)"
+    },
+    "env_age_value": {
+      "type": "string",
+      "description": "[experimental] age-encrypted value"
+    },
+    "env_age_format": {
+      "type": "string",
+      "enum": ["raw", "zstd"],
+      "description": "[experimental] compression format for the encrypted value"
+    },
+    "env_directive": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/env_path"
+        },
+        "paths": {
+          "$ref": "#/$defs/env_paths"
+        },
+        "tools": {
+          "$ref": "#/$defs/env_tools"
+        },
+        "redact": {
+          "$ref": "#/$defs/env_redact"
+        },
+        "required": {
+          "$ref": "#/$defs/env_required"
+        }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "$ref": "#/$defs/env_path"
+            }
+          },
+          "required": ["path"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "paths": {
+              "$ref": "#/$defs/env_paths"
+            }
+          },
+          "required": ["paths"]
         }
       ]
     },

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -359,38 +359,16 @@
             "type": "object",
             "properties": {
               "value": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "boolean"
-                  }
-                ]
+                "$ref": "#/$defs/env_value"
               },
               "tools": {
-                "type": "boolean",
-                "description": "load tools before resolving"
+                "$ref": "#/$defs/env_tools"
               },
               "redact": {
-                "type": "boolean",
-                "description": "redact the value from logs"
+                "$ref": "#/$defs/env_redact"
               },
               "required": {
-                "oneOf": [
-                  {
-                    "type": "boolean",
-                    "description": "require this environment variable to be defined before mise runs or in a later config file"
-                  },
-                  {
-                    "type": "string",
-                    "description": "require this environment variable with user help text on how to set it"
-                  }
-                ],
-                "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+                "$ref": "#/$defs/env_required"
               }
             },
             "unevaluatedProperties": false
@@ -399,29 +377,16 @@
             "type": "object",
             "properties": {
               "age": {
-                "type": "string",
-                "description": "[experimental] age-encrypted value (simplified format)"
+                "$ref": "#/$defs/env_age"
               },
               "tools": {
-                "type": "boolean",
-                "description": "load tools before resolving"
+                "$ref": "#/$defs/env_tools"
               },
               "redact": {
-                "type": "boolean",
-                "description": "redact the value from logs"
+                "$ref": "#/$defs/env_redact"
               },
               "required": {
-                "oneOf": [
-                  {
-                    "type": "boolean",
-                    "description": "require this environment variable to be defined before mise runs or in a later config file"
-                  },
-                  {
-                    "type": "string",
-                    "description": "require this environment variable with user help text on how to set it"
-                  }
-                ],
-                "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+                "$ref": "#/$defs/env_required"
               }
             },
             "required": ["age"],
@@ -435,34 +400,19 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "type": "string",
-                    "description": "[experimental] age-encrypted value"
+                    "$ref": "#/$defs/env_age_value"
                   },
                   "format": {
-                    "type": "string",
-                    "enum": ["raw", "zstd"],
-                    "description": "[experimental] compression format for the encrypted value"
+                    "$ref": "#/$defs/env_age_format"
                   },
                   "tools": {
-                    "type": "boolean",
-                    "description": "load tools before resolving"
+                    "$ref": "#/$defs/env_tools"
                   },
                   "redact": {
-                    "type": "boolean",
-                    "description": "redact the value from logs"
+                    "$ref": "#/$defs/env_redact"
                   },
                   "required": {
-                    "oneOf": [
-                      {
-                        "type": "boolean",
-                        "description": "require this environment variable to be defined before mise runs or in a later config file"
-                      },
-                      {
-                        "type": "string",
-                        "description": "require this environment variable with user help text on how to set it"
-                      }
-                    ],
-                    "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+                    "$ref": "#/$defs/env_required"
                   }
                 },
                 "required": ["value"],
@@ -523,27 +473,13 @@
                   "type": "object",
                   "properties": {
                     "path": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      ]
+                      "$ref": "#/$defs/env_path"
                     },
                     "paths": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref": "#/$defs/env_paths"
                     },
                     "tools": {
-                      "type": "boolean",
-                      "description": "load tools before resolving"
+                      "$ref": "#/$defs/env_tools"
                     }
                   },
                   "oneOf": [
@@ -551,17 +487,7 @@
                       "type": "object",
                       "properties": {
                         "path": {
-                          "oneOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          ]
+                          "$ref": "#/$defs/env_path"
                         }
                       },
                       "required": ["path"]
@@ -570,10 +496,7 @@
                       "type": "object",
                       "properties": {
                         "paths": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "$ref": "#/$defs/env_paths"
                         }
                       },
                       "required": ["paths"]
@@ -597,21 +520,10 @@
                         "type": "object",
                         "properties": {
                           "path": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              }
-                            ]
+                            "$ref": "#/$defs/env_path"
                           },
                           "tools": {
-                            "type": "boolean",
-                            "description": "load tools before resolving"
+                            "$ref": "#/$defs/env_tools"
                           }
                         }
                       }

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -859,25 +859,6 @@
         }
       ]
     },
-    "env_path": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "env_paths": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "env_tools": {
       "type": "boolean",
       "description": "load tools before resolving"
@@ -902,15 +883,6 @@
     "env_age": {
       "type": "string",
       "description": "[experimental] age-encrypted value (simplified format)"
-    },
-    "env_age_value": {
-      "type": "string",
-      "description": "[experimental] age-encrypted value"
-    },
-    "env_age_format": {
-      "type": "string",
-      "enum": ["raw", "zstd"],
-      "description": "[experimental] compression format for the encrypted value"
     },
     "env_directive": {
       "type": "object",
@@ -952,6 +924,15 @@
         }
       ]
     },
+    "env_age_value": {
+      "type": "string",
+      "description": "[experimental] age-encrypted value"
+    },
+    "env_age_format": {
+      "type": "string",
+      "enum": ["raw", "zstd"],
+      "description": "[experimental] compression format for the encrypted value"
+    },
     "os_filter": {
       "description": "operating system filters to install on",
       "oneOf": [
@@ -965,6 +946,25 @@
           }
         }
       ]
+    },
+    "env_path": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "env_paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "os_filter_item": {
       "description": "operating system or os/arch pair to install on",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -60,48 +60,89 @@
         }
       ]
     },
-    "env_directive": {
-      "type": "object",
-      "properties": {
-        "path": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          ]
+    "env_value": {
+      "oneOf": [
+        {
+          "type": "string"
         },
-        "paths": {
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "env_path": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
           "type": "array",
           "items": {
             "type": "string"
           }
+        }
+      ]
+    },
+    "env_paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "env_tools": {
+      "type": "boolean",
+      "description": "load tools before resolving"
+    },
+    "env_redact": {
+      "type": "boolean",
+      "description": "redact the value from logs"
+    },
+    "env_required": {
+      "oneOf": [
+        {
+          "type": "boolean",
+          "description": "require this environment variable to be defined before mise runs or in a later config file"
+        },
+        {
+          "type": "string",
+          "description": "require this environment variable with user help text on how to set it"
+        }
+      ],
+      "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+    },
+    "env_age": {
+      "type": "string",
+      "description": "[experimental] age-encrypted value (simplified format)"
+    },
+    "env_age_value": {
+      "type": "string",
+      "description": "[experimental] age-encrypted value"
+    },
+    "env_age_format": {
+      "type": "string",
+      "enum": ["raw", "zstd"],
+      "description": "[experimental] compression format for the encrypted value"
+    },
+    "env_directive": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/env_path"
+        },
+        "paths": {
+          "$ref": "#/$defs/env_paths"
         },
         "tools": {
-          "type": "boolean",
-          "description": "load tools before resolving"
+          "$ref": "#/$defs/env_tools"
         },
         "redact": {
-          "type": "boolean",
-          "description": "redact the value from logs"
+          "$ref": "#/$defs/env_redact"
         },
         "required": {
-          "oneOf": [
-            {
-              "type": "boolean",
-              "description": "require this environment variable to be defined before mise runs or in a later config file"
-            },
-            {
-              "type": "string",
-              "description": "require this environment variable with user help text on how to set it"
-            }
-          ],
-          "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+          "$ref": "#/$defs/env_required"
         }
       },
       "oneOf": [
@@ -109,7 +150,7 @@
           "type": "object",
           "properties": {
             "path": {
-              "$ref": "#/$defs/env_directive/properties/path"
+              "$ref": "#/$defs/env_path"
             }
           },
           "required": ["path"]
@@ -118,7 +159,7 @@
           "type": "object",
           "properties": {
             "paths": {
-              "$ref": "#/$defs/env_directive/properties/paths"
+              "$ref": "#/$defs/env_paths"
             }
           },
           "required": ["paths"]
@@ -132,38 +173,16 @@
             "type": "object",
             "properties": {
               "value": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "boolean"
-                  }
-                ]
+                "$ref": "#/$defs/env_value"
               },
               "tools": {
-                "type": "boolean",
-                "description": "load tools before resolving"
+                "$ref": "#/$defs/env_tools"
               },
               "redact": {
-                "type": "boolean",
-                "description": "redact the value from logs"
+                "$ref": "#/$defs/env_redact"
               },
               "required": {
-                "oneOf": [
-                  {
-                    "type": "boolean",
-                    "description": "require this environment variable to be defined before mise runs or in a later config file"
-                  },
-                  {
-                    "type": "string",
-                    "description": "require this environment variable with user help text on how to set it"
-                  }
-                ],
-                "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+                "$ref": "#/$defs/env_required"
               }
             },
             "unevaluatedProperties": false
@@ -172,29 +191,16 @@
             "type": "object",
             "properties": {
               "age": {
-                "type": "string",
-                "description": "[experimental] age-encrypted value (simplified format)"
+                "$ref": "#/$defs/env_age"
               },
               "tools": {
-                "type": "boolean",
-                "description": "load tools before resolving"
+                "$ref": "#/$defs/env_tools"
               },
               "redact": {
-                "type": "boolean",
-                "description": "redact the value from logs"
+                "$ref": "#/$defs/env_redact"
               },
               "required": {
-                "oneOf": [
-                  {
-                    "type": "boolean",
-                    "description": "require this environment variable to be defined before mise runs or in a later config file"
-                  },
-                  {
-                    "type": "string",
-                    "description": "require this environment variable with user help text on how to set it"
-                  }
-                ],
-                "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+                "$ref": "#/$defs/env_required"
               }
             },
             "required": ["age"],
@@ -208,34 +214,19 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "type": "string",
-                    "description": "[experimental] age-encrypted value"
+                    "$ref": "#/$defs/env_age_value"
                   },
                   "format": {
-                    "type": "string",
-                    "enum": ["raw", "zstd"],
-                    "description": "[experimental] compression format for the encrypted value"
+                    "$ref": "#/$defs/env_age_format"
                   },
                   "tools": {
-                    "type": "boolean",
-                    "description": "load tools before resolving"
+                    "$ref": "#/$defs/env_tools"
                   },
                   "redact": {
-                    "type": "boolean",
-                    "description": "redact the value from logs"
+                    "$ref": "#/$defs/env_redact"
                   },
                   "required": {
-                    "oneOf": [
-                      {
-                        "type": "boolean",
-                        "description": "require this environment variable to be defined before mise runs or in a later config file"
-                      },
-                      {
-                        "type": "string",
-                        "description": "require this environment variable with user help text on how to set it"
-                      }
-                    ],
-                    "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
+                    "$ref": "#/$defs/env_required"
                   }
                 },
                 "required": ["value"],
@@ -296,27 +287,13 @@
                   "type": "object",
                   "properties": {
                     "path": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      ]
+                      "$ref": "#/$defs/env_path"
                     },
                     "paths": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref": "#/$defs/env_paths"
                     },
                     "tools": {
-                      "type": "boolean",
-                      "description": "load tools before resolving"
+                      "$ref": "#/$defs/env_tools"
                     }
                   },
                   "oneOf": [
@@ -324,17 +301,7 @@
                       "type": "object",
                       "properties": {
                         "path": {
-                          "oneOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          ]
+                          "$ref": "#/$defs/env_path"
                         }
                       },
                       "required": ["path"]
@@ -343,10 +310,7 @@
                       "type": "object",
                       "properties": {
                         "paths": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "$ref": "#/$defs/env_paths"
                         }
                       },
                       "required": ["paths"]
@@ -370,21 +334,10 @@
                         "type": "object",
                         "properties": {
                           "path": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              }
-                            ]
+                            "$ref": "#/$defs/env_path"
                           },
                           "tools": {
-                            "type": "boolean",
-                            "description": "load tools before resolving"
+                            "$ref": "#/$defs/env_tools"
                           }
                         }
                       }


### PR DESCRIPTION
## Why
This is the same follow-up enabled by #9582 and extended by #9649: now that Tombi correctly tracks evaluated properties through referenced schemas, repeated env directive property schemas can be shared instead of copied into every object variant.

The env schema has many repeated pieces: primitive env values, path/path-array handling, `tools`, `redact`, `required`, and age encryption fields. Keeping those inline makes the schema large and makes it easy for one directive form to drift from another. Reusing definitions keeps env object validation consistent across the main config schema and the generated task schema.

## What changed
- Adds shared env schema definitions for primitive env values, path/path arrays, `tools`, `redact`, `required`, and age value/format fields.
- Replaces repeated inline env and env-directive property schemas with refs to those definitions.
- Expands Tombi coverage for env value objects, env file/source/path directives, age format validation, and directive `required` validation.
- Inherits the #9649 test harness change that treats Tombi warnings as failures.

## Validation
- `git diff --check`
- Direct Tombi validation with `tombi@0.9.22` and `--error-on-warnings` for valid env value/directive cases and invalid age/directive cases.
- Full e2e should run in CI; my earlier local targeted e2e run was stopped after the build step stalled behind another active cargo build on this machine.

This PR was generated by an AI coding assistant.