### PR TITLE
feat(aqua): support registry libc variants

### DIFF
--- a/crates/aqua-registry/src/registry.rs
+++ b/crates/aqua-registry/src/registry.rs
@@ -143,17 +143,6 @@ where
         CACHE.lock().await.insert(id.to_string(), pkg.clone());
         Ok(pkg)
     }
-
-    /// Get a package definition configured for specific versions
-    pub async fn package_with_version(
-        &self,
-        id: &str,
-        versions: &[&str],
-        os: &str,
-        arch: &str,
-    ) -> Result<AquaPackage> {
-        Ok(self.package(id).await?.with_version(versions, os, arch))
-    }
 }
 
 impl RegistryFetcher for DefaultRegistryFetcher {

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -67,6 +67,20 @@ struct AquaOverride {
     pkg: AquaPackage,
     goos: Option<String>,
     goarch: Option<String>,
+    #[serde(default)]
+    variants: Vec<AquaVariant>,
+}
+
+/// Runtime variant selector for an override.
+#[derive(Debug, Deserialize, Clone)]
+struct AquaVariant {
+    key: String,
+    value: String,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct AquaRuntime<'a> {
+    libc: Option<&'a str>,
 }
 
 /// Variable definition for Aqua templates
@@ -232,20 +246,36 @@ impl Default for AquaPackage {
 
 impl AquaPackage {
     /// Apply version-specific configurations and overrides
-    pub fn with_version(mut self, versions: &[&str], os: &str, arch: &str) -> AquaPackage {
+    pub fn with_version(self, versions: &[&str], os: &str, arch: &str) -> AquaPackage {
+        self.with_version_runtime(versions, os, arch, AquaRuntime::default())
+    }
+
+    /// Apply version-specific configurations and overrides for a libc runtime variant.
+    pub fn with_version_libc(
+        self,
+        versions: &[&str],
+        os: &str,
+        arch: &str,
+        libc: Option<&str>,
+    ) -> AquaPackage {
+        self.with_version_runtime(versions, os, arch, AquaRuntime { libc })
+    }
+
+    fn with_version_runtime(
+        mut self,
+        versions: &[&str],
+        os: &str,
+        arch: &str,
+        runtime: AquaRuntime<'_>,
+    ) -> AquaPackage {
         self = apply_override(self.clone(), self.version_override(versions));
-        if let Some(avo) = self.overrides.clone().into_iter().find(|o| {
-            if let (Some(goos), Some(goarch)) = (&o.goos, &o.goarch) {
-                goos == os && goarch == arch
-            } else if let Some(goos) = &o.goos {
-                goos == os
-            } else if let Some(goarch) = &o.goarch {
-                goarch == arch
-            } else {
-                false
-            }
-        }) {
-            self = apply_override(self, &avo.pkg)
+        if let Some(pkg) = self
+            .overrides
+            .iter()
+            .find(|o| o.matches(os, arch, runtime))
+            .map(|o| o.pkg.clone())
+        {
+            self = apply_override(self, &pkg)
         }
         self
     }
@@ -527,6 +557,52 @@ impl AquaPackage {
         let mut ctx = Context::default();
         ctx.insert("Version", v);
         ctx
+    }
+}
+
+impl AquaOverride {
+    fn matches(&self, os: &str, arch: &str, runtime: AquaRuntime<'_>) -> bool {
+        let platform_matches = if let (Some(goos), Some(goarch)) = (&self.goos, &self.goarch) {
+            goos == os && goarch == arch
+        } else if let Some(goos) = &self.goos {
+            goos == os
+        } else if let Some(goarch) = &self.goarch {
+            goarch == arch
+        } else {
+            false
+        };
+
+        platform_matches
+            && self
+                .variants
+                .iter()
+                .all(|variant| variant.matches(os, runtime))
+    }
+}
+
+impl AquaVariant {
+    fn matches(&self, os: &str, runtime: AquaRuntime<'_>) -> bool {
+        match self.key.as_str() {
+            "libc" => match (
+                normalize_libc(runtime.libc),
+                normalize_libc(Some(&self.value)),
+            ) {
+                (Some(actual), Some(expected)) => os == "linux" && actual == expected,
+                _ => false,
+            },
+            key => {
+                log::debug!("unsupported aqua override variant key: {key}");
+                false
+            }
+        }
+    }
+}
+
+fn normalize_libc(libc: Option<&str>) -> Option<&str> {
+    match libc? {
+        "glibc" | "gnu" => Some("gnu"),
+        "musl" => Some("musl"),
+        _ => None,
     }
 }
 
@@ -1319,5 +1395,103 @@ packages:
         let cosign = pkg.cosign.unwrap();
         assert!(cosign.bundle.is_some());
         assert!(cosign.key.is_some());
+    }
+
+    #[test]
+    fn test_override_variants_match_linux_libc() {
+        let yml = r#"
+packages:
+  - url: https://example.com/tool-{{.Version}}-{{.OS}}-{{.Arch}}-gnu
+    format: raw
+    overrides:
+      - goos: linux
+        variants:
+          - key: libc
+            value: gnu
+      - goos: linux
+        url: https://example.com/tool-{{.Version}}-{{.OS}}-{{.Arch}}-musl
+        variants:
+          - key: libc
+            value: musl
+"#;
+        let pkg = serde_yaml::from_str::<RegistryYaml>(yml)
+            .unwrap()
+            .packages
+            .into_iter()
+            .next()
+            .unwrap();
+
+        let gnu = pkg
+            .clone()
+            .with_version_libc(&["1.0.0"], "linux", "amd64", Some("gnu"));
+        let musl = pkg.with_version_libc(&["1.0.0"], "linux", "amd64", Some("musl"));
+
+        assert_eq!(
+            gnu.url("1.0.0", "linux", "amd64").unwrap(),
+            "https://example.com/tool-1.0.0-linux-amd64-gnu"
+        );
+        assert_eq!(
+            musl.url("1.0.0", "linux", "amd64").unwrap(),
+            "https://example.com/tool-1.0.0-linux-amd64-musl"
+        );
+    }
+
+    #[test]
+    fn test_override_variants_skip_unknown_keys() {
+        let yml = r#"
+packages:
+  - url: https://example.com/tool-default
+    format: raw
+    overrides:
+      - goos: linux
+        url: https://example.com/tool-avx2
+        variants:
+          - key: cpu
+            value: avx2
+      - goos: linux
+        url: https://example.com/tool-musl
+        variants:
+          - key: libc
+            value: musl
+"#;
+        let pkg = serde_yaml::from_str::<RegistryYaml>(yml)
+            .unwrap()
+            .packages
+            .into_iter()
+            .next()
+            .unwrap()
+            .with_version_libc(&["1.0.0"], "linux", "amd64", Some("musl"));
+
+        assert_eq!(
+            pkg.url("1.0.0", "linux", "amd64").unwrap(),
+            "https://example.com/tool-musl"
+        );
+    }
+
+    #[test]
+    fn test_override_variants_do_not_match_without_runtime_libc() {
+        let yml = r#"
+packages:
+  - url: https://example.com/tool-default
+    format: raw
+    overrides:
+      - goos: linux
+        url: https://example.com/tool-musl
+        variants:
+          - key: libc
+            value: musl
+"#;
+        let pkg = serde_yaml::from_str::<RegistryYaml>(yml)
+            .unwrap()
+            .packages
+            .into_iter()
+            .next()
+            .unwrap()
+            .with_version(&["1.0.0"], "linux", "amd64");
+
+        assert_eq!(
+            pkg.url("1.0.0", "linux", "amd64").unwrap(),
+            "https://example.com/tool-default"
+        );
     }
 }

--- a/scripts/test-standalone.sh
+++ b/scripts/test-standalone.sh
@@ -3,11 +3,11 @@ set -euxo pipefail
 
 BASE_DIR="$(pwd)"
 RELEASE_DIR="$(pwd)/tmp"
-MISE_VERSION="v$(curl -fsSL https://mise.en.dev/VERSION)"
+MISE_VERSION="v$(curl -fsSL --retry 3 --retry-all-errors --retry-delay 2 https://mise.en.dev/VERSION)"
 export BASE_DIR RELEASE_DIR MISE_VERSION
 
 mkdir -p "$RELEASE_DIR/$MISE_VERSION"
-curl -fsSL "https://mise.en.dev/$MISE_VERSION/SHASUMS256.txt" >"$RELEASE_DIR/$MISE_VERSION/SHASUMS256.txt"
+curl -fsSL --retry 3 --retry-all-errors --retry-delay 2 "https://mise.en.dev/$MISE_VERSION/SHASUMS256.txt" >"$RELEASE_DIR/$MISE_VERSION/SHASUMS256.txt"
 ./scripts/render-install.sh >tmp/install.sh
 chmod +x tmp/install.sh
 mise x shellcheck -- shellcheck tmp/install.sh

--- a/src/aqua/aqua_registry_wrapper.rs
+++ b/src/aqua/aqua_registry_wrapper.rs
@@ -1,4 +1,3 @@
-use crate::backend::aqua::{arch, os};
 use crate::config::Settings;
 use crate::git::{CloneOptions, Git};
 use crate::{dirs, duration::WEEKLY, file};
@@ -93,11 +92,6 @@ impl MiseAquaRegistry {
         let pkg = self.inner.package(id).await?;
         CACHE.lock().await.insert(id.to_string(), pkg.clone());
         Ok(pkg)
-    }
-
-    pub async fn package_with_version(&self, id: &str, versions: &[&str]) -> Result<AquaPackage> {
-        let pkg = self.package(id).await?;
-        Ok(pkg.with_version(versions, os(), arch()))
     }
 }
 

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -239,6 +239,9 @@ impl Backend for AquaBackend {
             }
         };
 
+        let target = PlatformTarget::from_current();
+        let (target_os, target_arch) = Self::to_aqua_platform(&target);
+        let target_libc = Self::target_variant_libc(&target);
         let mut versions = Vec::new();
         for (tag, created_at, prerelease) in tags_with_timestamps.into_iter().rev() {
             let mut version = tag.as_str();
@@ -250,7 +253,12 @@ impl Backend for AquaBackend {
                     continue;
                 }
             }
-            let versioned_pkg = pkg.clone().with_version(&[version], os(), arch());
+            let versioned_pkg = pkg.clone().with_version_libc(
+                &[version],
+                target_os,
+                target_arch,
+                target_libc.as_deref(),
+            );
             if let Some(prefix) = &versioned_pkg.version_prefix {
                 if let Some(_v) = version.strip_prefix(prefix) {
                     version = _v;
@@ -261,11 +269,7 @@ impl Backend for AquaBackend {
             version = version.strip_prefix('v').unwrap_or(version);
 
             // Validate the package has assets
-            let check_pkg = AQUA_REGISTRY
-                .package_with_version(&self.id, &[&tag])
-                .await
-                .unwrap_or_default();
-            if !check_pkg.no_asset && check_pkg.error_message.is_none() {
+            if !versioned_pkg.no_asset && versioned_pkg.error_message.is_none() {
                 let release_url = format!(
                     "https://github.com/{}/{}/releases/tag/{}",
                     pkg.repo_owner, pkg.repo_name, tag
@@ -611,7 +615,8 @@ impl Backend for AquaBackend {
         // platform first, which can leak host-specific overrides into cross-platform lock.
         let pkg = AQUA_REGISTRY.package(&self.id).await?;
         let opts = tv.request.options();
-        let pkg = pkg.with_version(&versions, target_os, target_arch);
+        let target_libc = Self::target_variant_libc(target);
+        let pkg = pkg.with_version_libc(&versions, target_os, target_arch, target_libc.as_deref());
         let pkg = Self::apply_aqua_libc_replacement(pkg, target_os, Self::target_libc(target));
         let pkg = Self::apply_var_options(pkg, &opts)?;
 
@@ -766,7 +771,8 @@ impl AquaBackend {
         let target = PlatformTarget::from_current();
         let (target_os, target_arch) = Self::to_aqua_platform(&target);
         let pkg = AQUA_REGISTRY.package(&self.id).await?;
-        let pkg = pkg.with_version(versions, target_os, target_arch);
+        let target_libc = Self::target_variant_libc(&target);
+        let pkg = pkg.with_version_libc(versions, target_os, target_arch, target_libc.as_deref());
         let pkg = Self::apply_aqua_libc_replacement(pkg, target_os, Self::target_libc(&target));
         Self::apply_var_options(pkg, &tv.request.options())
     }
@@ -791,6 +797,24 @@ impl AquaBackend {
                 None
             }
         })
+    }
+
+    fn target_variant_libc(target: &PlatformTarget) -> Option<String> {
+        if target.os_name() != "linux" {
+            return None;
+        }
+        let settings_libc = if target.is_current() {
+            Settings::get().libc().map(str::to_string)
+        } else {
+            None
+        };
+        Some(
+            target
+                .libc()
+                .map(str::to_string)
+                .or(settings_libc)
+                .unwrap_or_else(|| "gnu".to_string()),
+        )
     }
 
     fn apply_aqua_libc_replacement(
@@ -1300,6 +1324,9 @@ impl AquaBackend {
                     // current `prerelease` opt, since the user may have pinned
                     // a pre-release version under a project-local override.
                     let tags = get_tags(&pkg).await?;
+                    let target = PlatformTarget::from_current();
+                    let (target_os, target_arch) = Self::to_aqua_platform(&target);
+                    let target_libc = Self::target_variant_libc(&target);
                     for tag in tags.into_iter().rev() {
                         let mut version = tag.as_str();
                         match pkg.version_filter_ok(version) {
@@ -1310,7 +1337,12 @@ impl AquaBackend {
                                 continue;
                             }
                         }
-                        let pkg = pkg.clone().with_version(&[version], os(), arch());
+                        let pkg = pkg.clone().with_version_libc(
+                            &[version],
+                            target_os,
+                            target_arch,
+                            target_libc.as_deref(),
+                        );
                         if let Some(prefix) = &pkg.version_prefix {
                             if let Some(_v) = version.strip_prefix(prefix) {
                                 version = _v;


### PR DESCRIPTION
## Summary
- Parse aqua registry `overrides[].variants` entries using the new `{ key, value }` shape.
- Support `key: libc` matching for Linux `gnu` and `musl` targets while skipping unknown variant keys.
- Pass the target libc into aqua package override resolution, including cross-platform lock targets like `linux-x64-musl`.

## Validation
- `cargo fmt --check`
- `cargo test -p aqua-registry override_variants`
- `cargo check -p mise`
- pre-commit `hk` checks during commit, including `cargo check --all-features`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes platform override resolution for Aqua packages (including lockfile resolution and remote version listing), which can affect which release assets/URLs are selected on Linux. Risk is mitigated by added unit tests, but incorrect variant matching could cause install/lock mismatches.
> 
> **Overview**
> Adds support for aqua registry `overrides[].variants` and uses it to select Linux `gnu` vs `musl` assets when resolving package overrides.
> 
> `AquaPackage` now supports `with_version_libc(...)` and override matching incorporates runtime variants (currently `key: libc`, normalized), while unknown variant keys are ignored; backend call sites are updated to pass the target libc (including cross-platform lock targets) and remove the wrapper/registry `package_with_version` helper. Also hardens `scripts/test-standalone.sh` network fetches by adding curl retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9266173995d623eb4d415b323e6b913a2ceab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->