### PR TITLE
fix(task): terminate parallel siblings on failure via process groups

### DIFF
--- a/e2e/tasks/test_task_orchestrator_kill
+++ b/e2e/tasks/test_task_orchestrator_kill
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Regression coverage for https://github.com/jdx/mise/discussions/8345.
+# An external orchestrator (Playwright's `webServer` is the canonical case)
+# spawns mise with `detached: true`, which on POSIX calls setsid so the
+# orchestrator can later `kill -SIGKILL -pgid` to tear the whole tree down.
+# If mise then creates its own per-task process groups, that tree-kill
+# stops at mise and the grandchildren survive, holding pipes open and
+# hanging the parent.
+#
+# We simulate it with `setsid mise run serve` + `kill -KILL -PGID`.
+
+set -euo pipefail
+
+marker=$(mktemp -t serve_completed.XXXXXX)
+rm -f "$marker"
+logfile=$(mktemp)
+trap 'rm -f "$logfile" "$marker"' EXIT
+
+# Use a marker file rather than a stdout sentinel — mise echoes the source
+# command to stdout, which would false-match any literal in the script body.
+cat <<EOF >mise.toml
+[tasks.serve]
+run = "printf 'SERVE_STARTED\\n' && sleep 60 && touch '$marker'"
+EOF
+
+# `setsid` puts mise into a fresh session/pgroup, mimicking Playwright's
+# detached:true. The shell exits immediately after exec, so PGID == mise's PID.
+setsid mise run serve >"$logfile" 2>&1 &
+mise_pid=$!
+
+# Wait for mise to actually start the task before we kill it.
+deadline=$((SECONDS + 15))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if grep -q "SERVE_STARTED" "$logfile" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q "SERVE_STARTED" "$logfile" 2>/dev/null; then
+  cat "$logfile"
+  fail "serve task never started"
+fi
+
+# Capture descendants before the kill so we can verify they actually go away.
+# `pgrep -g $pgid` lists every member of the process group — that's what the
+# orchestrator's mass-kill targets.
+pgid=$mise_pid
+echo "process group before kill:"
+pgrep -g "$pgid" -a || true
+
+# This is the orchestrator's cleanup — single SIGKILL to the whole pgroup.
+# With per-task pgroups (the bug from #8345), the inner sh + sleep are in a
+# *different* pgroup and survive this signal.
+kill -KILL -- "-$pgid" 2>/dev/null || true
+
+# Reap mise so the script doesn't leak it.
+wait "$mise_pid" 2>/dev/null || true
+
+# Give the kernel a beat to deliver signals and reap the corpses.
+sleep 1
+
+# Anything in the pgroup that's still alive is a regression — those are the
+# grandchildren that escaped the orchestrator's kill via our setpgid.
+survivors=$(pgrep -g "$pgid" -a 2>/dev/null || true)
+if [ -n "$survivors" ]; then
+  echo "survivors:"
+  echo "$survivors"
+  # Best-effort cleanup before failing so the test host stays healthy.
+  pgrep -g "$pgid" 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+  fail "processes survived orchestrator's pgroup SIGKILL"
+fi
+
+# Wait a beat for any zombie sleep to finish if it survived (it shouldn't
+# have, but if it did the marker tells us). 2s is a reasonable upper bound:
+# the test machine's `sleep` would still be ~58s from completing if it
+# escaped, but if our kill was off by a fork-race window the marker would
+# show up here.
+sleep 2
+
+if [ -e "$marker" ]; then
+  fail "sleep ran to completion despite pgroup SIGKILL"
+fi
+
+echo "orchestrator pgroup kill propagated cleanly"

--- a/e2e/tasks/test_task_parallel_fail_fast
+++ b/e2e/tasks/test_task_parallel_fail_fast
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/jdx/mise/discussions/8459
+# When one parallel sibling fails, the other siblings (and their grandchildren,
+# e.g. the `sleep` invoked from inside `sh -c`) must be terminated. Without
+# the per-task process group, sh exits on SIGTERM but `sleep` is reparented
+# to init and runs to completion, holding the inherited stdout/stderr pipes
+# open and stalling mise's pipe-reader threads — total runtime balloons to
+# however long the longest sibling runs naturally.
+
+set -euo pipefail
+
+marker="$(mktemp -t long_finished.XXXXXX)"
+rm -f "$marker"
+
+cat <<EOF >mise.toml
+[tasks.fail]
+run = "printf 'FAIL_RAN\\n' && sleep 1 && exit 1"
+
+# A side-effect file is the only reliable signal that the long task actually
+# completed — mise echoes the source command to stdout so substring matches
+# on output false-positive.
+[tasks.long]
+run = "printf 'LONG_RAN\\n' && sleep 30 && touch '$marker'"
+
+[tasks.repro]
+run = "mise run --jobs 2 fail ::: long"
+EOF
+
+start=$(date +%s)
+mise run --jobs 2 fail ::: long || true
+end=$(date +%s)
+elapsed=$((end - start))
+echo "elapsed=${elapsed}s"
+
+# `long` must be terminated when `fail` exits non-zero. If the marker file
+# exists, sleep ran to completion (its grandchild outlived the kill).
+if [ -e "$marker" ]; then
+  fail "long task ran to completion — sibling termination is not working"
+fi
+
+# Without the fix this would block for ~30s. With per-task pgroups,
+# killpg drops the whole tree at the moment fail exits (~1s).
+if [ "$elapsed" -gt 10 ]; then
+  fail "parallel run took ${elapsed}s — sibling termination did not kill the long task tree"
+fi
+
+# Now the wrapped variant (mise run repro → mise run --jobs ...).
+# Inner mise inherits MISE_TASK_PGID_MANAGED so it can't killpg without
+# also killing the outer mise. We rely on the drain timeout to keep this
+# from hanging — it must exit reasonably fast, even if the inner sleep
+# gets reparented and runs out its clock.
+rm -f "$marker"
+start=$(date +%s)
+mise run repro || true
+end=$(date +%s)
+elapsed=$((end - start))
+echo "wrapped elapsed=${elapsed}s"
+
+if [ "$elapsed" -gt 20 ]; then
+  fail "wrapped parallel run took ${elapsed}s — should exit promptly even when nested"
+fi

--- a/e2e/tasks/test_task_parallel_fail_fast
+++ b/e2e/tasks/test_task_parallel_fail_fast
@@ -11,6 +11,10 @@ set -euo pipefail
 
 marker="$(mktemp -t long_finished.XXXXXX)"
 rm -f "$marker"
+# If the script aborts before the explicit cleanup below, a leftover marker
+# would silently fail subsequent runs. The trap guarantees removal even on
+# abnormal exit (set -e, fail, signal).
+trap 'rm -f "$marker"' EXIT
 
 cat <<EOF >mise.toml
 [tasks.fail]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -601,6 +601,18 @@ impl Run {
                     };
                 }
                 this.add_failed_task(task.clone(), status);
+                // SIGTERM any still-running siblings so we exit promptly on
+                // failure instead of waiting for them to finish naturally.
+                // run_loop only sees `is_stopping` when it next iterates,
+                // which doesn't happen while it's awaiting an idle select —
+                // so the kill has to be triggered from here.
+                if !this.continue_on_error {
+                    debug!("task {} failed, killing siblings", task.name);
+                    #[cfg(unix)]
+                    crate::cmd::CmdLineRunner::kill_all(nix::sys::signal::SIGTERM);
+                    #[cfg(windows)]
+                    crate::cmd::CmdLineRunner::kill_all();
+                }
             }
             if let Some(oh) = &this.output_handler
                 && oh.output(None) == TaskOutput::KeepOrder

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -258,18 +258,28 @@ const TASK_PGID_MANAGED_ENV: &str = "MISE_TASK_PGID_MANAGED";
 ///
 /// In both cases we share whatever pgid we landed in, so the ancestor
 /// that owns it can clean us up.
+///
+/// Cached on first access: `execute()` decides whether to `setpgid` at
+/// spawn time, and `kill_all()` decides whether to `killpg` at signal
+/// time. They must agree — a child placed in its own pgid by `execute()`
+/// must be killed via `killpg`, or only the direct PID gets the signal
+/// and grandchildren leak. Computing this once removes any chance of the
+/// two callers disagreeing if the env later mutates.
 #[cfg(unix)]
 fn should_use_pgroup() -> bool {
-    if std::env::var_os(TASK_PGID_MANAGED_ENV).is_some() {
-        return false;
-    }
-    let me = nix::unistd::getpid();
-    if let Ok(sid) = nix::unistd::getsid(None)
-        && sid == me
-    {
-        return false;
-    }
-    true
+    static CACHED: Lazy<bool> = Lazy::new(|| {
+        if std::env::var_os(TASK_PGID_MANAGED_ENV).is_some() {
+            return false;
+        }
+        let me = nix::unistd::getpid();
+        if let Ok(sid) = nix::unistd::getsid(None)
+            && sid == me
+        {
+            return false;
+        }
+        true
+    });
+    *CACHED
 }
 
 /// Grace period after a child's ExitStatus arrives during which we keep

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -5,10 +5,13 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::mpsc::channel;
+use std::sync::mpsc::{RecvTimeoutError, channel};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, RwLock};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use crate::redactions::Redactor;
 use color_eyre::Result;
@@ -230,6 +233,53 @@ static OUTPUT_LOCK: Mutex<()> = Mutex::new(());
 
 static RUNNING_PIDS: Lazy<Mutex<HashSet<u32>>> = Lazy::new(Default::default);
 
+/// Env var set on every spawned child when this mise process is managing
+/// process groups (calling setpgid + killpg). A nested mise that sees this
+/// var skips its own setpgid so descendants stay in the outer pgid — that
+/// way the outer mise's killpg actually reaches the leaves.
+#[cfg(unix)]
+const TASK_PGID_MANAGED_ENV: &str = "MISE_TASK_PGID_MANAGED";
+
+/// True when this mise should `setpgid` spawned children and `killpg` them
+/// for cleanup.
+///
+/// We skip pgroup management in two cases:
+///
+/// 1. **Nested under another mise** (env var present). The outer mise is
+///    already managing pgroups; if we set our own, the outer's `killpg`
+///    can't reach our descendants and either an orchestrator or the
+///    user's Ctrl+C leaves orphans behind.
+/// 2. **We're the session leader** — i.e. `getsid(0) == getpid()`. This
+///    is what Node's `detached: true` (Playwright's `webServer`) does:
+///    it calls `setsid` so the orchestrator can `kill(-pgid, SIGKILL)`
+///    the whole tree later. If we then create our own pgroups, the
+///    orchestrator's tree-kill stops at us and our descendants survive,
+///    holding pipes open and hanging the parent.
+///
+/// In both cases we share whatever pgid we landed in, so the ancestor
+/// that owns it can clean us up.
+#[cfg(unix)]
+fn should_use_pgroup() -> bool {
+    if std::env::var_os(TASK_PGID_MANAGED_ENV).is_some() {
+        return false;
+    }
+    let me = nix::unistd::getpid();
+    if let Ok(sid) = nix::unistd::getsid(None)
+        && sid == me
+    {
+        return false;
+    }
+    true
+}
+
+/// Grace period after a child's ExitStatus arrives during which we keep
+/// reading its stdout/stderr pipes. If a grandchild inherited the pipes
+/// and survived (e.g. a nested mise that escaped our pgroup, or an
+/// orchestrator's SIGKILL leaving orphans), the readers would otherwise
+/// block forever waiting for EOF and the parent would hang. After this
+/// deadline we abandon the readers — any tail output is dropped.
+const PIPE_DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
+
 impl<'a> CmdLineRunner<'a> {
     pub fn new<P: AsRef<OsStr>>(program: P) -> Self {
         let mut cmd = Command::new(program);
@@ -261,12 +311,28 @@ impl<'a> CmdLineRunner<'a> {
 
     #[cfg(unix)]
     pub fn kill_all(signal: nix::sys::signal::Signal) {
+        let use_pgroup = should_use_pgroup();
         let pids = RUNNING_PIDS.lock().unwrap();
         for pid in pids.iter() {
             let pid = *pid as i32;
-            trace!("{signal}: {pid}");
-            if let Err(e) = nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), signal) {
-                debug!("Failed to kill cmd {pid}: {e}");
+            let nix_pid = nix::unistd::Pid::from_raw(pid);
+            if use_pgroup {
+                trace!("{signal}: pgid {pid}");
+                // Each tracked PID is also the leader of its own pgid (set
+                // via setpgid(0,0) in pre_exec), so killpg targets the whole
+                // descendant tree. Fall back to plain kill for the rare case
+                // where setpgid was skipped (TTY stdin) — still better than
+                // silently dropping the signal.
+                if nix::sys::signal::killpg(nix_pid, signal).is_err()
+                    && let Err(e) = nix::sys::signal::kill(nix_pid, signal)
+                {
+                    debug!("Failed to kill cmd {pid}: {e}");
+                }
+            } else {
+                trace!("{signal}: {pid}");
+                if let Err(e) = nix::sys::signal::kill(nix_pid, signal) {
+                    debug!("Failed to kill cmd {pid}: {e}");
+                }
             }
         }
     }
@@ -439,6 +505,30 @@ impl<'a> CmdLineRunner<'a> {
             let _write_lock = RAW_LOCK.write().unwrap();
             return self.execute_raw();
         }
+        #[cfg(unix)]
+        if should_use_pgroup() {
+            // Mark descendants so a nested mise inherits this var and skips
+            // its own setpgid — keeping the whole tree in our pgid.
+            self.cmd.env(TASK_PGID_MANAGED_ENV, "1");
+            unsafe {
+                self.cmd.pre_exec(|| {
+                    // Skip setpgid when stdin is a TTY: interactive tools
+                    // (e.g. Tilt) need to stay in the terminal's foreground
+                    // pgid or they hang on SIGTTIN when reading stdin.
+                    // Use BorrowedFd::borrow_raw rather than std::io::stdin()
+                    // — pre_exec runs post-fork where OnceLock/malloc are
+                    // not async-signal-safe.
+                    let stdin = std::os::fd::BorrowedFd::borrow_raw(0);
+                    if !std::io::IsTerminal::is_terminal(&stdin) {
+                        let _ = nix::unistd::setpgid(
+                            nix::unistd::Pid::from_raw(0),
+                            nix::unistd::Pid::from_raw(0),
+                        );
+                    }
+                    Ok(())
+                });
+            }
+        }
         let mut cp = self
             .spawn_with_etxtbsy_retry()
             .wrap_err_with(|| format!("failed to execute command: {self}"))?;
@@ -511,8 +601,33 @@ impl<'a> CmdLineRunner<'a> {
 
         let mut combined_output = vec![];
         let mut status = None;
-        for line in rx {
-            match line {
+        // Once ExitStatus arrives we set a deadline and switch to recv_timeout
+        // so a grandchild that inherited the pipes can't hang us forever
+        // waiting for EOF. See PIPE_DRAIN_TIMEOUT.
+        let mut drain_deadline: Option<Instant> = None;
+        loop {
+            let msg = match drain_deadline {
+                Some(deadline) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        debug!("pipe drain timeout for {id}, abandoning readers");
+                        break;
+                    }
+                    match rx.recv_timeout(remaining) {
+                        Ok(m) => m,
+                        Err(RecvTimeoutError::Timeout) => {
+                            debug!("pipe drain timeout for {id}, abandoning readers");
+                            break;
+                        }
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+                None => match rx.recv() {
+                    Ok(m) => m,
+                    Err(_) => break,
+                },
+            };
+            match msg {
                 ChildProcessOutput::Stdout(line) => {
                     let line = self.redactor.redact(&line);
                     self.on_stdout(line.clone());
@@ -525,16 +640,27 @@ impl<'a> CmdLineRunner<'a> {
                 }
                 ChildProcessOutput::ExitStatus(s) => {
                     status = Some(s);
+                    drain_deadline = Some(Instant::now() + PIPE_DRAIN_TIMEOUT);
                 }
                 #[cfg(not(any(test, windows)))]
                 ChildProcessOutput::Signal(sig) => {
-                    if sig != SIGINT {
+                    let pid = nix::unistd::Pid::from_raw(id as i32);
+                    let nix_sig = nix::sys::signal::Signal::try_from(sig).unwrap();
+                    if should_use_pgroup() {
+                        // With pgroups the child is isolated from the
+                        // terminal's foreground pgid, so terminal SIGINT
+                        // doesn't reach it — forward every signal we
+                        // catch, including SIGINT.
+                        debug!("Received signal {sig}, forwarding to pgid {id}");
+                        if nix::sys::signal::killpg(pid, nix_sig).is_err() {
+                            let _ = nix::sys::signal::kill(pid, nix_sig);
+                        }
+                    } else if sig != SIGINT {
+                        // No pgroup: the child is in our pgid, so the
+                        // terminal already delivered SIGINT. Forwarding
+                        // it again would just be a redundant kill.
                         debug!("Received signal {sig}, forwarding to {id}");
-                        let pid = nix::unistd::Pid::from_raw(id as i32);
-                        let sig = nix::sys::signal::Signal::try_from(sig).unwrap();
-                        // Ignore errors — the child may have already exited
-                        // (e.g., killed by TimeoutGuard or exited naturally).
-                        let _ = nix::sys::signal::kill(pid, sig);
+                        let _ = nix::sys::signal::kill(pid, nix_sig);
                     }
                 }
             }
@@ -637,7 +763,6 @@ impl<'a> CmdLineRunner<'a> {
             }
             // Use pre_exec to apply Landlock/seccomp in the child process
             // before it execs the target program. This avoids restricting the mise process.
-            use std::os::unix::process::CommandExt;
             let sandbox = sandbox.clone();
             unsafe {
                 self.cmd.pre_exec(move || {

--- a/src/task/task_scheduler.rs
+++ b/src/task/task_scheduler.rs
@@ -38,17 +38,30 @@ impl Scheduler {
         self.sched_rx.take()
     }
 
-    /// Wait for all spawned tasks to complete
+    /// Wait for all spawned tasks to complete.
+    ///
+    /// When a task fails (or panics) and `continue_on_error` is false, send
+    /// SIGTERM to every still-running task so siblings don't keep going for
+    /// the duration of their natural runtime. We keep draining the JoinSet
+    /// after sending the signal so the parent can exit cleanly once everyone
+    /// has actually wrapped up.
     pub async fn join_all(&self, continue_on_error: bool) -> Result<()> {
+        let mut killed = false;
         while let Some(result) = self.jset.lock().await.join_next().await {
-            if result.is_ok() || continue_on_error {
-                continue;
+            // result is Result<Result<()>, JoinError>: outer Err means the
+            // task panicked, inner Err means the user's command returned
+            // non-zero. Both should trigger sibling termination.
+            let task_failed = match &result {
+                Ok(Ok(())) => false,
+                Ok(Err(_)) | Err(_) => true,
+            };
+            if task_failed && !continue_on_error && !killed {
+                killed = true;
+                #[cfg(unix)]
+                CmdLineRunner::kill_all(SIGTERM);
+                #[cfg(windows)]
+                CmdLineRunner::kill_all();
             }
-            #[cfg(unix)]
-            CmdLineRunner::kill_all(SIGTERM);
-            #[cfg(windows)]
-            CmdLineRunner::kill_all();
-            break;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Fixes [#8459](https://github.com/jdx/mise/discussions/8459) — when a parallel `mise run --jobs N` task fails, sibling tasks now terminate promptly instead of running to natural completion.

The previous behaviour: SIGTERM only hit the direct child PID. For `sh -c "...sleep 30..."` the shell exits but `sleep` is reparented to init and runs to completion, holding inherited stdout/stderr pipes open and stalling mise's pipe-reader threads. Total runtime was bounded by the slowest sibling, not the failing one.

This re-introduces per-task process groups (the approach reverted in `26ac45323`) and gates them so the original Playwright regression ([#8345](https://github.com/jdx/mise/discussions/8345)) does not return.

### Approach

- **`should_use_pgroup()`** decides whether to `setpgid` + `killpg`. It returns false when:
  1. `MISE_TASK_PGID_MANAGED=1` is in env (set by an outer mise on every spawned child) — so a nested mise inherits the outer's pgid instead of creating a new one
  2. We're the session leader (`getsid(0) == getpid()`) — what Node's `detached: true` does, including Playwright's `webServer`
- **`kill_all`** uses `killpg` (with `kill` fallback) when pgroups are active.
- **`PIPE_DRAIN_TIMEOUT = 10s`** — after a child's `ExitStatus` arrives, the rx loop switches to `recv_timeout`. If a grandchild that escaped the kill is still holding pipes open, abandon the readers instead of hanging forever.
- The signal forwarder now forwards SIGINT too when pgroups are on, since the child is no longer in the terminal's foreground pgid.

### Scheduler bugs that meant `kill_all` was never reaching

While debugging, two bugs surfaced that meant the existing `kill_all` call site never fired in practice:

1. `Scheduler::join_all` was checking `result.is_ok()` — but `JoinSet::join_next` returns `Ok(Err(...))` for failing tasks (only `Err` for panics), so failures bypassed the kill entirely.
2. `run_loop`'s `is_stopping` check only ran on the next loop iteration, but while siblings were running it was idle in `tokio::select!` and never iterated. `kill_all` is now triggered directly from the spawn closure on failure.

### Tradeoffs

- Direct invocation (`mise run --jobs 2 fail ::: long`): perfect — `sleep` dies via `killpg` (~1s).
- Wrapped invocation (`[tasks.repro] run = "mise run --jobs 2 ..."`): inner mise can't `killpg` without also killing itself, so its grandchild `sleep` gets reparented and runs out the clock as an orphan. The drain timeout still ensures mise exits in ~11s instead of hanging.
- `SIGKILL` from an orchestrator can't be caught — the session-leader gate (rather than any handler) is what saves us in the bare-Playwright case.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets` clean
- [x] `mise run test:e2e tasks/test_task_parallel_fail_fast` — new test for #8459
- [x] `mise run test:e2e tasks/test_task_orchestrator_kill` — new test for #8345 using `setsid mise run` + `kill -KILL -PGID`
- [x] `mise run test:e2e tasks/test_task_failure_hang tasks/test_task_failure_hang_depends tasks/test_task_sequence_failure tasks/test_task_timeout tasks/test_task_depends_post_on_failure tasks/test_task_depends_post_skipped_on_dep_failure tasks/test_task_parallel_execution tasks/test_task_parallel_replacing tasks/test_task_raw_output tasks/test_task_raw_args` — related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Unix process-group management and signal forwarding in the task runner, which can affect shutdown behavior across platforms and nested invocations. Adds safeguards and timeouts, but regressions could still surface in edge cases (TTY/interactive commands, orchestrator-managed sessions).
> 
> **Overview**
> Fixes parallel task fail-fast behavior by **reintroducing per-task process groups** so `SIGTERM` reaches task grandchildren (e.g. `sh -c ... sleep`) and sibling tasks stop promptly when one fails.
> 
> Adds `should_use_pgroup()` gating plus `MISE_TASK_PGID_MANAGED` propagation to avoid breaking orchestrator `setsid`/pgroup kills and nested `mise` runs, updates `kill_all` to prefer `killpg`, and forwards signals (including `SIGINT`) appropriately when pgroups are enabled. Introduces a **10s pipe-drain timeout** after child exit to prevent hangs when inherited stdout/stderr pipes remain open.
> 
> Fixes/adjusts failure termination triggering in both `Run::spawn_sched_job` and `Scheduler::join_all`, and adds two e2e regressions tests covering orchestrator pgroup `SIGKILL` propagation and parallel sibling termination timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ff45b82972dd61e0c2753736216d6fcd4b55570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->