### PR TITLE
fix: use /bin/cp on macos

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -1216,7 +1216,7 @@ pub fn desymlink_path(p: &Path) -> PathBuf {
 
 pub fn clone_dir(from: &PathBuf, to: &PathBuf) -> Result<()> {
     if cfg!(macos) {
-        cmd!("cp", "-cR", from, to).run()?;
+        cmd!("/bin/cp", "-cR", from, to).run()?;
     } else if cfg!(windows) {
         cmd!("robocopy", from, to, "/MIR").run()?;
     } else {


### PR DESCRIPTION
When running _mise sync_ on MacOS, mise execs `cp -cR`. On macs where the user has installed gnu cp (usually as part of homebrew) and prepends the gnu utils in $PATH, this fails, as gnu cp lacks the _-c_  option: 

> ❯ mise sync python --uv
Synced python@3.15 from uv to mise
Synced python@3.15.0a7 from uv to mise
cp: invalid option -- 'c'
Try 'cp --help' for more information.
mise ERROR command ["cp", "-cR", "/Users/pde/.local/share/mise/installs/python/3.14.3", "/Users/pde/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none"] exited with code 1
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information

We fix that here by hard coding `/bin/cp`