### PR TITLE
fix(task): stable MISE_PROJECT_ROOT for monorepo tasks, add MISE_MONOREPO_ROOT

### DIFF
--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -53,7 +53,8 @@ The following environment variables are passed to the task:
 
 - `MISE_ORIGINAL_CWD`: The original working directory from where the task was run.
 - `MISE_CONFIG_ROOT`: The directory containing the `mise.toml` file where the task was defined or if the config path is something like `~/src/myproj/.config/mise.toml`, it will be `~/src/myproj`.
-- `MISE_PROJECT_ROOT`: The root of the project.
+- `MISE_PROJECT_ROOT`: The root of the project that defines the task. For monorepo subproject tasks this is the subproject's directory and is stable regardless of the directory the task is invoked from.
+- `MISE_MONOREPO_ROOT`: The root of the monorepo (the directory containing the config with `experimental_monorepo_root = true`). Only set inside a monorepo.
 - `MISE_TASK_NAME`: The name of the task being run.
 - `MISE_TASK_DIR`: The directory containing the task script.
 - `MISE_TASK_FILE`: The full path to the task script.

--- a/e2e/tasks/test_task_monorepo_project_root
+++ b/e2e/tasks/test_task_monorepo_project_root
@@ -64,3 +64,22 @@ output_global_task_from_sub=$(cd projects/frontend && mise run global-show-root)
 echo "global task from subproject: $output_global_task_from_sub"
 # From inside the subproject the local project root is the subproject's mise.toml dir.
 assert_contains "echo $output_global_task_from_sub" "PROJECT_ROOT=$frontend_root"
+
+# Global *file* task (script under ~/.config/mise/tasks/) must also use the
+# local project root, not the global config dir. task.config_source for these
+# is the script path itself, which is why this case needs task.global rather
+# than is_global_config(&task.config_source).
+mkdir -p "$MISE_CONFIG_DIR/tasks"
+cat >"$MISE_CONFIG_DIR/tasks/global-file-show-root" <<'SH'
+#!/usr/bin/env bash
+echo "PROJECT_ROOT=$MISE_PROJECT_ROOT"
+SH
+chmod +x "$MISE_CONFIG_DIR/tasks/global-file-show-root"
+
+output_global_file_from_root=$(mise run global-file-show-root)
+echo "global file task from monorepo root: $output_global_file_from_root"
+assert_contains "echo $output_global_file_from_root" "PROJECT_ROOT=$monorepo_root"
+
+output_global_file_from_sub=$(cd projects/frontend && mise run global-file-show-root)
+echo "global file task from subproject: $output_global_file_from_sub"
+assert_contains "echo $output_global_file_from_sub" "PROJECT_ROOT=$frontend_root"

--- a/e2e/tasks/test_task_monorepo_project_root
+++ b/e2e/tasks/test_task_monorepo_project_root
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verify that MISE_PROJECT_ROOT for a monorepo task is the directory of the
+# mise.toml that defined the task (the subproject root) regardless of the
+# working directory the task is invoked from, and that MISE_MONOREPO_ROOT is
+# set to the monorepo root.
+export MISE_EXPERIMENTAL=1
+
+cat <<EOF >mise.toml
+experimental_monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+
+[tasks.root-task]
+run = 'echo "PROJECT_ROOT=\$MISE_PROJECT_ROOT MONOREPO_ROOT=\$MISE_MONOREPO_ROOT"'
+EOF
+
+mkdir -p projects/frontend
+cat <<EOF >projects/frontend/mise.toml
+[tasks.show-roots]
+run = 'echo "PROJECT_ROOT=\$MISE_PROJECT_ROOT MONOREPO_ROOT=\$MISE_MONOREPO_ROOT"'
+EOF
+
+monorepo_root="$PWD"
+frontend_root="$PWD/projects/frontend"
+
+# Invoked from the monorepo root: PROJECT_ROOT must be the subproject's dir.
+output_from_root=$(mise run '//projects/frontend:show-roots')
+echo "from monorepo root: $output_from_root"
+assert_contains "echo $output_from_root" "PROJECT_ROOT=$frontend_root"
+assert_contains "echo $output_from_root" "MONOREPO_ROOT=$monorepo_root"
+
+# Invoked from an intermediate dir: same result.
+output_from_intermediate=$(cd projects && mise run '//projects/frontend:show-roots')
+echo "from projects/: $output_from_intermediate"
+assert_contains "echo $output_from_intermediate" "PROJECT_ROOT=$frontend_root"
+assert_contains "echo $output_from_intermediate" "MONOREPO_ROOT=$monorepo_root"
+
+# Invoked from inside the subproject: same result.
+output_from_inside=$(cd projects/frontend && mise run '//projects/frontend:show-roots')
+echo "from projects/frontend/: $output_from_inside"
+assert_contains "echo $output_from_inside" "PROJECT_ROOT=$frontend_root"
+assert_contains "echo $output_from_inside" "MONOREPO_ROOT=$monorepo_root"
+
+# Root-defined task: PROJECT_ROOT and MONOREPO_ROOT both point at the monorepo root.
+output_root_task=$(mise run //:root-task)
+echo "root task: $output_root_task"
+assert_contains "echo $output_root_task" "PROJECT_ROOT=$monorepo_root"
+assert_contains "echo $output_root_task" "MONOREPO_ROOT=$monorepo_root"

--- a/e2e/tasks/test_task_monorepo_project_root
+++ b/e2e/tasks/test_task_monorepo_project_root
@@ -47,3 +47,20 @@ output_root_task=$(mise run //:root-task)
 echo "root task: $output_root_task"
 assert_contains "echo $output_root_task" "PROJECT_ROOT=$monorepo_root"
 assert_contains "echo $output_root_task" "MONOREPO_ROOT=$monorepo_root"
+
+# Global task invoked from a local project: MISE_PROJECT_ROOT must remain the
+# local project root, not the global config dir. Regression coverage for the
+# task-config-root fallback.
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[tasks.global-show-root]
+run = 'echo "PROJECT_ROOT=$MISE_PROJECT_ROOT"'
+TOML
+
+output_global_task=$(mise run global-show-root)
+echo "global task from monorepo root: $output_global_task"
+assert_contains "echo $output_global_task" "PROJECT_ROOT=$monorepo_root"
+
+output_global_task_from_sub=$(cd projects/frontend && mise run global-show-root)
+echo "global task from subproject: $output_global_task_from_sub"
+# From inside the subproject the local project root is the subproject's mise.toml dir.
+assert_contains "echo $output_global_task_from_sub" "PROJECT_ROOT=$frontend_root"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -419,6 +419,10 @@ impl Config {
         find_monorepo_root(&self.config_files).is_some()
     }
 
+    pub fn monorepo_root(&self) -> Option<PathBuf> {
+        find_monorepo_root(&self.config_files)
+    }
+
     pub async fn tasks(&self) -> Result<Arc<BTreeMap<String, Task>>> {
         self.tasks_with_context(None).await
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -282,7 +282,18 @@ impl TaskExecutor {
         // mise.toml that defined the task. This keeps the value stable regardless of the
         // cwd from which the task was invoked (important for monorepo subprojects, where
         // config.project_root depends on cwd).
-        if let Some(root) = task.config_root.clone().or(config.project_root.clone()) {
+        //
+        // Exception: for tasks defined in a global/system config, task.config_root points
+        // at the global config directory (e.g. ~/.config/mise) which is rarely what the
+        // task author wants. Fall back to config.project_root (the local project the user
+        // is in) for those, matching the pre-existing behavior.
+        let task_is_global = crate::config::is_global_config(&task.config_source);
+        let project_root = if task_is_global {
+            config.project_root.clone().or(task.config_root.clone())
+        } else {
+            task.config_root.clone().or(config.project_root.clone())
+        };
+        if let Some(root) = project_root {
             env.insert("MISE_PROJECT_ROOT".into(), root.display().to_string());
         }
         if let Some(monorepo_root) = config.monorepo_root() {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -278,8 +278,18 @@ impl TaskExecutor {
         if let Some(cwd) = &*crate::dirs::CWD {
             env.insert("MISE_ORIGINAL_CWD".into(), cwd.display().to_string());
         }
-        if let Some(root) = config.project_root.clone().or(task.config_root.clone()) {
+        // Prefer the task's own config_root so MISE_PROJECT_ROOT is the directory of the
+        // mise.toml that defined the task. This keeps the value stable regardless of the
+        // cwd from which the task was invoked (important for monorepo subprojects, where
+        // config.project_root depends on cwd).
+        if let Some(root) = task.config_root.clone().or(config.project_root.clone()) {
             env.insert("MISE_PROJECT_ROOT".into(), root.display().to_string());
+        }
+        if let Some(monorepo_root) = config.monorepo_root() {
+            env.insert(
+                "MISE_MONOREPO_ROOT".into(),
+                monorepo_root.display().to_string(),
+            );
         }
         env.insert("MISE_TASK_NAME".into(), task.name.clone());
         let task_file = task

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -283,12 +283,12 @@ impl TaskExecutor {
         // cwd from which the task was invoked (important for monorepo subprojects, where
         // config.project_root depends on cwd).
         //
-        // Exception: for tasks defined in a global/system config, task.config_root points
-        // at the global config directory (e.g. ~/.config/mise) which is rarely what the
-        // task author wants. Fall back to config.project_root (the local project the user
-        // is in) for those, matching the pre-existing behavior.
-        let task_is_global = crate::config::is_global_config(&task.config_source);
-        let project_root = if task_is_global {
+        // Exception: for global tasks (inline in ~/.config/mise/config.toml or scripts in
+        // ~/.config/mise/tasks/) and remote tasks (loaded from git/http), task.config_root
+        // points at the global/remote location rather than the user's project. Fall back
+        // to config.project_root (the local project the user is in) for those, matching
+        // the pre-existing behavior.
+        let project_root = if task.global || task.is_remote() {
             config.project_root.clone().or(task.config_root.clone())
         } else {
             task.config_root.clone().or(config.project_root.clone())


### PR DESCRIPTION
## Summary

- For monorepo tasks, `MISE_PROJECT_ROOT` was cwd-dependent: from inside the subproject it pointed at the subproject's directory, but from the monorepo root or an intermediate directory it pointed at the monorepo root. The value was sourced from `config.project_root` (which is the closest project to cwd) before falling back to the task's own `config_root`.
- Prefer the task's own `config_root` so `MISE_PROJECT_ROOT` is always the directory of the mise.toml that defined the task — stable regardless of where the task was invoked from. For non-monorepo configs `task.config_root == config.project_root`, so behavior is unchanged.
- Add `MISE_MONOREPO_ROOT` (the directory of the config with `experimental_monorepo_root = true`) so subproject tasks can reference the monorepo root without a cwd-dependent fallback.

Refs #9639.

## Test plan

- [x] New e2e test `e2e/tasks/test_task_monorepo_project_root` exercises a subproject task invoked from the monorepo root, an intermediate dir, and the subproject dir, and asserts `MISE_PROJECT_ROOT` and `MISE_MONOREPO_ROOT` both stay stable.
- [x] Existing monorepo task tests still pass (`test_task_monorepo_config_context`, `test_task_monorepo_run_project_tasks`, `test_task_monorepo_run_project_local_tasks`, `test_task_monorepo_global_tasks`).

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task execution environment variable semantics for `MISE_PROJECT_ROOT` (especially in monorepos) and adds a new `MISE_MONOREPO_ROOT`, which could affect scripts relying on prior cwd-dependent behavior despite added e2e coverage.
> 
> **Overview**
> Makes `MISE_PROJECT_ROOT` resolve to the task’s defining `mise.toml` directory (via `task.config_root`) so monorepo subproject tasks get a stable project root regardless of invocation cwd, while preserving prior behavior for *global* and *remote* tasks.
> 
> Adds `MISE_MONOREPO_ROOT` to the task environment (derived from the config with `experimental_monorepo_root = true`), updates task docs accordingly, and introduces a new e2e test covering monorepo/subproject/root/global task cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7f632ecae44ef64850104c8e2d7a748c4a47ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->