### PR TITLE
feat(schema): add backend-specific tool options

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -14,6 +14,7 @@ mise use -g tombi@$TOMBI_VERSION
 SCHEMA_PATH="$ROOT/schema/mise.json"
 TASK_SCHEMA_PATH="$ROOT/schema/mise-task.json"
 TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
+TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
 assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
 
 # Set up tombi config pointing to local schema
@@ -70,11 +71,11 @@ TOML
 
 cat >"$HOME/workdir/mise-os.toml" <<'TOML'
 [tools]
-node = { version = "latest", os = ["linux", "macos/arm64", "darwin/aarch64", "win/amd64"] }
+node = { version = "latest", os = ["linux", "macos/arm64", "darwin/aarch64", "win/amd64"], backend_options = { nested = true } }
 go = { version = "latest", os = "linux/x64" }
 
 [tasks.build.tools]
-rust = { version = "latest", os = ["linux/x64", "macos/arm64"] }
+rust = { version = "latest", os = ["linux/x64", "macos/arm64"], profile = "release" }
 TOML
 
 cat >"$HOME/workdir/mise-task-os.toml" <<'TOML'
@@ -82,15 +83,15 @@ cat >"$HOME/workdir/mise-task-os.toml" <<'TOML'
 run = "echo ok"
 
 [build.tools]
-node = { version = "latest", os = ["linux/x64", "macos/arm64"] }
+node = { version = "latest", os = ["linux/x64", "macos/arm64"], profile = "release" }
 TOML
 
 # tombi lint should succeed with no errors (warnings about table order are ok)
 cd "$HOME/workdir"
-assert_succeed "$TOMBI lint --offline --no-cache --quiet mise.toml"
-assert_succeed "$TOMBI lint --offline --no-cache --quiet mise-age.toml"
-assert_succeed "$TOMBI lint --offline --no-cache --quiet mise-os.toml"
-assert_succeed "$TOMBI lint --offline --no-cache --quiet mise-task-os.toml"
+assert_succeed "$TOMBI_LINT mise.toml"
+assert_succeed "$TOMBI_LINT mise-age.toml"
+assert_succeed "$TOMBI_LINT mise-os.toml"
+assert_succeed "$TOMBI_LINT mise-task-os.toml"
 
 # Verify that invalid properties on tasks are rejected
 cat >"$HOME/workdir/mise-bad.toml" <<'TOML'
@@ -113,10 +114,10 @@ include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-tmpl.toml", "mise-bad
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
-include = ["mise-bad-task-os.toml"]
+include = ["mise-bad-task-os.toml", "mise-bad-task-tool-extra.toml"]
 EOF
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad.toml"
+assert_fail "$TOMBI_LINT mise-bad.toml"
 
 # Verify that options for complex age values must be nested inside age
 cat >"$HOME/workdir/mise-bad-age.toml" <<'TOML'
@@ -124,7 +125,7 @@ cat >"$HOME/workdir/mise-bad-age.toml" <<'TOML'
 SECRET = { age = { value = "AGE-SECRET" }, tools = true }
 TOML
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad-age.toml"
+assert_fail "$TOMBI_LINT mise-bad-age.toml"
 
 # Verify that extends is rejected on task_templates (not supported at runtime)
 cat >"$HOME/workdir/mise-bad-tmpl.toml" <<'TOML'
@@ -133,14 +134,14 @@ extends = "base"
 quiet = true
 TOML
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad-tmpl.toml"
+assert_fail "$TOMBI_LINT mise-bad-tmpl.toml"
 
 cat >"$HOME/workdir/mise-bad-os.toml" <<'TOML'
 [tools]
 node = { version = "latest", os = true }
 TOML
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad-os.toml"
+assert_fail "$TOMBI_LINT mise-bad-os.toml"
 
 cat >"$HOME/workdir/mise-bad-task-os.toml" <<'TOML'
 [build]
@@ -150,4 +151,14 @@ run = "echo ok"
 node = { version = "latest", os = true }
 TOML
 
-assert_fail "$TOMBI lint --offline --no-cache --quiet mise-bad-task-os.toml"
+assert_fail "$TOMBI_LINT mise-bad-task-os.toml"
+
+cat >"$HOME/workdir/mise-bad-task-tool-extra.toml" <<'TOML'
+[build]
+run = "echo ok"
+
+[build.tools]
+node = { version = "latest", os = "linux/x64", backend_options = { nested = true } }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-task-tool-extra.toml"

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -73,6 +73,22 @@ cat >"$HOME/workdir/mise-os.toml" <<'TOML'
 [tools]
 node = { version = "latest", os = ["linux", "macos/arm64", "darwin/aarch64", "win/amd64"], backend_options = { nested = true } }
 go = { version = "latest", os = "linux/x64" }
+"aqua:casey/just" = { version = "1.46.0", symlink_bins = true, vars = { channel = "stable" }, prerelease = true }
+"cargo:cargo-edit" = { version = "latest", features = "add", default-features = false, locked = false, bin = "cargo-add", crate = "cargo-edit" }
+"conda:ruff" = { version = "latest", channel = "conda-forge" }
+"github:jdx/mise-test-fixtures" = { version = "1.0.0", asset_pattern = "hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", platforms = { linux-x64 = { asset_pattern = "hello-world-1.0.0.tar.gz", checksum = "sha256:abc123" } } }
+"gitlab:jdxcode/mise-test-fixtures" = { version = "1.0.0", asset_pattern = "hello-world-1.0.0.tar.gz", filter_bins = "hello-world", api_url = "https://gitlab.com/api/v4" }
+"forgejo:roele/mise-test-fixtures" = { version = "1.0.0", asset_pattern = "hello-world-1.0.0.tar.gz", strip_components = 1, no_app = true }
+"go:github.com/golang-migrate/migrate/v4/cmd/migrate" = { version = "latest", tags = "postgres" }
+"http:hello" = { version = "1.0.0", url = "https://example.com/hello-{{ version }}.tar.gz", checksum = "sha256:abc123", size = 12345, strip_components = 1, bin = "hello", rename_exe = "hello", format = "tar.gz", version_list_url = "https://example.com/versions.json", version_json_path = ".[].version", version_expr = "split(body, '\\n')", platforms = { linux-x64-musl = { url = "https://example.com/hello-linux.tar.gz", size = 12345 } } }
+"npm:prettier" = { version = "latest", npm_args = "--omit=dev", pnpm_args = "--config.foo=bar", bun_args = "--verbose", aube_args = "--reporter append-only" }
+"pipx:black" = { version = "latest", extras = "colorama", pipx_args = "--include-deps", uvx = false, uvx_args = "--with rich" }
+"s3:internal" = { version = "latest", url = "s3://bucket/hello-{{ version }}.tar.gz", endpoint = "http://localhost:9000", region = "us-east-1", version_list_url = "s3://bucket/versions.json", version_prefix = "hello-", version_regex = "hello-(.*)", version_json_path = ".[].version", version_expr = "split(body, '\\n')", platforms = { linux-x64 = { url = "s3://bucket/hello-linux.tar.gz", checksum = "sha256:abc123" } } }
+"spm:swiftlang/swiftly" = { version = "latest", provider = "github", api_url = "https://api.github.com", filter_bins = ["swiftly"] }
+"ubi:cli/cli" = { version = "latest", exe = "gh", rename_exe = "github", matching = "linux", matching_regex = "linux.*x86_64", provider = "github", api_url = "https://api.github.com", extract_all = true, bin_path = "bin", tag_regex = "^v" }
+python = { version = "3.12", virtualenv = ".venv", patch_sysconfig = false }
+rust = { version = "latest", profile = "minimal", components = "rustfmt,clippy", targets = "wasm32-unknown-unknown" }
+dotnet = { version = "latest", runtime = "dotnet" }
 
 [tasks.build.tools]
 rust = { version = "latest", os = ["linux/x64", "macos/arm64"], profile = "release" }
@@ -110,7 +126,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-tmpl.toml", "mise-bad-os.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-tmpl.toml", "mise-bad-os.toml", "mise-bad-tool-opts.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -142,6 +158,15 @@ node = { version = "latest", os = true }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-os.toml"
+
+cat >"$HOME/workdir/mise-bad-tool-opts.toml" <<'TOML'
+[tools]
+"aqua:casey/just" = { version = "latest", vars = { channel = true } }
+"cargo:cargo-edit" = { version = "latest", features = ["add"] }
+dotnet = { version = "latest", runtime = "invalid-runtime" }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-tool-opts.toml"
 
 cat >"$HOME/workdir/mise-bad-task-os.toml" <<'TOML'
 [build]

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -154,18 +154,13 @@
                 "type": "string"
               },
               {
-                "properties": {
-                  "version": {
-                    "description": "version of the tool to install",
-                    "type": "string"
-                  },
-                  "os": {
-                    "$ref": "#/$defs/os_filter"
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/tool_options"
                   }
-                },
-                "required": ["version"],
+                ],
                 "type": "object",
-                "additionalProperties": {
+                "unevaluatedProperties": {
                   "oneOf": [
                     {
                       "type": "string"
@@ -837,6 +832,19 @@
           "unevaluatedProperties": false
         }
       ]
+    },
+    "tool_options": {
+      "properties": {
+        "version": {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        "os": {
+          "$ref": "#/$defs/os_filter"
+        }
+      },
+      "required": ["version"],
+      "type": "object"
     },
     "os_filter": {
       "description": "operating system filters to install on",

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -846,20 +846,6 @@
       "required": ["version"],
       "type": "object"
     },
-    "os_filter": {
-      "description": "operating system filters to install on",
-      "oneOf": [
-        {
-          "$ref": "#/$defs/os_filter_item"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/os_filter_item"
-          }
-        }
-      ]
-    },
     "env_directive": {
       "type": "object",
       "properties": {
@@ -922,6 +908,20 @@
             }
           },
           "required": ["paths"]
+        }
+      ]
+    },
+    "os_filter": {
+      "description": "operating system filters to install on",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/os_filter_item"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/os_filter_item"
+          }
         }
       ]
     },

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -75,11 +75,21 @@
                 },
                 "default": {
                   "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": ["yes", "no", "y", "n", "true", "false"],
+                  "enum": [
+                    "yes",
+                    "no",
+                    "y",
+                    "n",
+                    "true",
+                    "false"
+                  ],
                   "type": "string"
                 }
               },
-              "required": ["message", "default"],
+              "required": [
+                "message",
+                "default"
+              ],
               "unevaluatedProperties": false,
               "type": "object"
             }
@@ -196,11 +206,15 @@
               "properties": {
                 "auto": {
                   "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [true],
+                  "enum": [
+                    true
+                  ],
                   "type": "boolean"
                 }
               },
-              "required": ["auto"],
+              "required": [
+                "auto"
+              ],
               "type": "object"
             }
           ]
@@ -218,7 +232,10 @@
               "type": "boolean"
             },
             {
-              "enum": ["stdout", "stderr"],
+              "enum": [
+                "stdout",
+                "stderr"
+              ],
               "type": "string"
             }
           ]
@@ -424,7 +441,9 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": ["age"],
+            "required": [
+              "age"
+            ],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -440,7 +459,10 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": ["raw", "zstd"],
+                    "enum": [
+                      "raw",
+                      "zstd"
+                    ],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -465,12 +487,16 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": ["value"],
+                "required": [
+                  "value"
+                ],
                 "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": ["age"],
+            "required": [
+              "age"
+            ],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -564,7 +590,9 @@
                           ]
                         }
                       },
-                      "required": ["path"]
+                      "required": [
+                        "path"
+                      ]
                     },
                     {
                       "type": "object",
@@ -576,7 +604,9 @@
                           }
                         }
                       },
-                      "required": ["paths"]
+                      "required": [
+                        "paths"
+                      ]
                     }
                   ]
                 },
@@ -660,7 +690,9 @@
                           }
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "type": "object"
                     }
                   ]
@@ -778,7 +810,9 @@
               }
             }
           },
-          "required": ["task"]
+          "required": [
+            "task"
+          ]
         },
         {
           "type": "object",
@@ -793,7 +827,9 @@
               "type": "array"
             }
           },
-          "required": ["tasks"]
+          "required": [
+            "tasks"
+          ]
         }
       ]
     },
@@ -828,7 +864,9 @@
               }
             }
           },
-          "required": ["task"],
+          "required": [
+            "task"
+          ],
           "unevaluatedProperties": false
         }
       ]
@@ -841,9 +879,24 @@
         },
         "os": {
           "$ref": "#/$defs/os_filter"
+        },
+        "minimum_release_age": {
+          "description": "minimum age a tool release must have before mise will install it",
+          "type": "string"
+        },
+        "install_before": {
+          "deprecated": true,
+          "description": "deprecated alias for minimum_release_age",
+          "type": "string"
+        },
+        "prerelease": {
+          "$ref": "#/$defs/tool_bool_or_string",
+          "description": "include prerelease versions when resolving this tool"
         }
       },
-      "required": ["version"],
+      "required": [
+        "version"
+      ],
       "type": "object"
     },
     "env_directive": {
@@ -898,7 +951,9 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": ["path"]
+          "required": [
+            "path"
+          ]
         },
         {
           "type": "object",
@@ -907,7 +962,9 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": ["paths"]
+          "required": [
+            "paths"
+          ]
         }
       ]
     },
@@ -925,11 +982,27 @@
         }
       ]
     },
+    "tool_bool_or_string": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
     "os_filter_item": {
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
+      "examples": [
+        "linux",
+        "macos",
+        "windows",
+        "macos/arm64",
+        "linux/x64"
+      ]
     }
   }
 }

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -75,21 +75,11 @@
                 },
                 "default": {
                   "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": [
-                    "yes",
-                    "no",
-                    "y",
-                    "n",
-                    "true",
-                    "false"
-                  ],
+                  "enum": ["yes", "no", "y", "n", "true", "false"],
                   "type": "string"
                 }
               },
-              "required": [
-                "message",
-                "default"
-              ],
+              "required": ["message", "default"],
               "unevaluatedProperties": false,
               "type": "object"
             }
@@ -206,15 +196,11 @@
               "properties": {
                 "auto": {
                   "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [
-                    true
-                  ],
+                  "enum": [true],
                   "type": "boolean"
                 }
               },
-              "required": [
-                "auto"
-              ],
+              "required": ["auto"],
               "type": "object"
             }
           ]
@@ -232,10 +218,7 @@
               "type": "boolean"
             },
             {
-              "enum": [
-                "stdout",
-                "stderr"
-              ],
+              "enum": ["stdout", "stderr"],
               "type": "string"
             }
           ]
@@ -441,9 +424,7 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": [
-              "age"
-            ],
+            "required": ["age"],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -459,10 +440,7 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": [
-                      "raw",
-                      "zstd"
-                    ],
+                    "enum": ["raw", "zstd"],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -487,16 +465,12 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": [
-                  "value"
-                ],
+                "required": ["value"],
                 "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": [
-              "age"
-            ],
+            "required": ["age"],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -590,9 +564,7 @@
                           ]
                         }
                       },
-                      "required": [
-                        "path"
-                      ]
+                      "required": ["path"]
                     },
                     {
                       "type": "object",
@@ -604,9 +576,7 @@
                           }
                         }
                       },
-                      "required": [
-                        "paths"
-                      ]
+                      "required": ["paths"]
                     }
                   ]
                 },
@@ -690,9 +660,7 @@
                           }
                         }
                       },
-                      "required": [
-                        "path"
-                      ],
+                      "required": ["path"],
                       "type": "object"
                     }
                   ]
@@ -810,9 +778,7 @@
               }
             }
           },
-          "required": [
-            "task"
-          ]
+          "required": ["task"]
         },
         {
           "type": "object",
@@ -827,9 +793,7 @@
               "type": "array"
             }
           },
-          "required": [
-            "tasks"
-          ]
+          "required": ["tasks"]
         }
       ]
     },
@@ -864,9 +828,7 @@
               }
             }
           },
-          "required": [
-            "task"
-          ],
+          "required": ["task"],
           "unevaluatedProperties": false
         }
       ]
@@ -894,9 +856,7 @@
           "description": "include prerelease versions when resolving this tool"
         }
       },
-      "required": [
-        "version"
-      ],
+      "required": ["version"],
       "type": "object"
     },
     "env_directive": {
@@ -951,9 +911,7 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": [
-            "path"
-          ]
+          "required": ["path"]
         },
         {
           "type": "object",
@@ -962,9 +920,7 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": [
-            "paths"
-          ]
+          "required": ["paths"]
         }
       ]
     },
@@ -996,13 +952,7 @@
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": [
-        "linux",
-        "macos",
-        "windows",
-        "macos/arm64",
-        "linux/x64"
-      ]
+      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
     }
   }
 }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2378,6 +2378,9 @@
     "tool_release_options": {
       "allOf": [
         {
+          "$ref": "#/$defs/tool_artifact_platform_options"
+        },
+        {
           "properties": {
             "asset_pattern": {
               "description": "release asset pattern to install",
@@ -2387,33 +2390,9 @@
               "description": "version tag prefix used by releases",
               "type": "string"
             },
-            "checksum": {
-              "description": "checksum for the downloaded asset",
-              "type": "string"
-            },
-            "size": {
-              "$ref": "#/$defs/tool_string_or_number",
-              "description": "downloaded asset size"
-            },
-            "strip_components": {
-              "$ref": "#/$defs/tool_string_or_number",
-              "description": "number of directory components to strip when extracting"
-            },
-            "bin": {
-              "description": "binary name to install or expose",
-              "type": "string"
-            },
-            "rename_exe": {
-              "description": "rename an extracted executable",
-              "type": "string"
-            },
             "no_app": {
               "$ref": "#/$defs/tool_bool_or_string",
               "description": "skip macOS .app bundle assets during autodetection"
-            },
-            "bin_path": {
-              "description": "directory containing binaries within the extracted archive",
-              "type": "string"
             },
             "filter_bins": {
               "description": "comma-separated binaries to expose on PATH",
@@ -2421,14 +2400,6 @@
             },
             "api_url": {
               "description": "custom API URL for self-hosted forge instances",
-              "type": "string"
-            },
-            "url": {
-              "description": "direct platform asset URL",
-              "type": "string"
-            },
-            "format": {
-              "description": "archive format to use when auto-detection is insufficient",
               "type": "string"
             },
             "platforms": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -35,9 +35,7 @@
               }
             }
           },
-          "required": [
-            "task"
-          ],
+          "required": ["task"],
           "unevaluatedProperties": false
         }
       ]
@@ -46,13 +44,7 @@
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": [
-        "linux",
-        "macos",
-        "windows",
-        "macos/arm64",
-        "linux/x64"
-      ]
+      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
     },
     "os_filter": {
       "description": "operating system filters to install on",
@@ -120,9 +112,7 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": [
-            "path"
-          ]
+          "required": ["path"]
         },
         {
           "type": "object",
@@ -131,9 +121,7 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": [
-            "paths"
-          ]
+          "required": ["paths"]
         }
       ]
     },
@@ -209,9 +197,7 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": [
-              "age"
-            ],
+            "required": ["age"],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -227,10 +213,7 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": [
-                      "raw",
-                      "zstd"
-                    ],
+                    "enum": ["raw", "zstd"],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -255,16 +238,12 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": [
-                  "value"
-                ],
+                "required": ["value"],
                 "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": [
-              "age"
-            ],
+            "required": ["age"],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -358,9 +337,7 @@
                           ]
                         }
                       },
-                      "required": [
-                        "path"
-                      ]
+                      "required": ["path"]
                     },
                     {
                       "type": "object",
@@ -372,9 +349,7 @@
                           }
                         }
                       },
-                      "required": [
-                        "paths"
-                      ]
+                      "required": ["paths"]
                     }
                   ]
                 },
@@ -458,9 +433,7 @@
                           }
                         }
                       },
-                      "required": [
-                        "path"
-                      ],
+                      "required": ["path"],
                       "type": "object"
                     }
                   ]
@@ -663,13 +636,7 @@
           "default": "default",
           "description": "Theme for interactive prompts (default/charm, base16, catppuccin, dracula)",
           "type": "string",
-          "enum": [
-            "default",
-            "charm",
-            "base16",
-            "catppuccin",
-            "dracula"
-          ]
+          "enum": ["default", "charm", "base16", "catppuccin", "dracula"]
         },
         "conda": {
           "type": "object",
@@ -1082,11 +1049,7 @@
         "libc": {
           "description": "Libc implementation to use for precompiled Linux binaries.",
           "type": "string",
-          "enum": [
-            "glibc",
-            "gnu",
-            "musl"
-          ]
+          "enum": ["glibc", "gnu", "musl"]
         },
         "libgit2": {
           "default": true,
@@ -1118,13 +1081,7 @@
           "default": "info",
           "description": "Show more/less output.",
           "type": "string",
-          "enum": [
-            "trace",
-            "debug",
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["trace", "debug", "info", "warn", "error"]
         },
         "minimum_release_age": {
           "description": "Minimum release age / supply chain protection — only install versions older than this threshold",
@@ -1238,13 +1195,7 @@
               "default": "auto",
               "description": "Package manager to use for installing npm packages.",
               "type": "string",
-              "enum": [
-                "auto",
-                "npm",
-                "aube",
-                "bun",
-                "pnpm"
-              ]
+              "enum": ["auto", "npm", "aube", "bun", "pnpm"]
             }
           }
         },
@@ -1373,12 +1324,7 @@
             "uv_venv_auto": {
               "default": false,
               "description": "Integrate with uv to manage project venvs when uv.lock is present.",
-              "enum": [
-                false,
-                "source",
-                "create|source",
-                true
-              ],
+              "enum": [false, "source", "create|source", true],
               "oneOf": [
                 {
                   "type": "boolean"
@@ -1800,14 +1746,7 @@
           "type": "string"
         },
         "windows_executable_extensions": {
-          "default": [
-            "exe",
-            "bat",
-            "cmd",
-            "com",
-            "ps1",
-            "vbs"
-          ],
+          "default": ["exe", "bat", "cmd", "com", "ps1", "vbs"],
           "description": "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on.",
           "type": "array",
           "items": {
@@ -1865,9 +1804,7 @@
               }
             }
           },
-          "required": [
-            "task"
-          ]
+          "required": ["task"]
         },
         {
           "type": "object",
@@ -1882,9 +1819,7 @@
               "type": "array"
             }
           },
-          "required": [
-            "tasks"
-          ]
+          "required": ["tasks"]
         }
       ]
     },
@@ -2109,9 +2044,7 @@
           "description": "include prerelease versions when resolving this tool"
         }
       },
-      "required": [
-        "version"
-      ],
+      "required": ["version"],
       "type": "object"
     },
     "tool_install_options": {
@@ -2586,11 +2519,7 @@
         "runtime": {
           "description": "runtime-only .NET install type",
           "type": "string",
-          "enum": [
-            "dotnet",
-            "aspnetcore",
-            "windowsdesktop"
-          ]
+          "enum": ["dotnet", "aspnetcore", "windowsdesktop"]
         }
       },
       "type": "object"
@@ -3204,9 +3133,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "task"
-            ],
+            "required": ["task"],
             "type": "object"
           },
           {
@@ -3239,9 +3166,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "task"
-                  ],
+                  "required": ["task"],
                   "type": "object"
                 }
               ]
@@ -3277,14 +3202,10 @@
         },
         "oneOf": [
           {
-            "required": [
-              "run"
-            ]
+            "required": ["run"]
           },
           {
-            "required": [
-              "task"
-            ]
+            "required": ["task"]
           }
         ]
       }
@@ -3393,21 +3314,11 @@
                 },
                 "default": {
                   "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": [
-                    "yes",
-                    "no",
-                    "y",
-                    "n",
-                    "true",
-                    "false"
-                  ],
+                  "enum": ["yes", "no", "y", "n", "true", "false"],
                   "type": "string"
                 }
               },
-              "required": [
-                "message",
-                "default"
-              ],
+              "required": ["message", "default"],
               "unevaluatedProperties": false,
               "type": "object"
             }
@@ -3524,15 +3435,11 @@
               "properties": {
                 "auto": {
                   "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [
-                    true
-                  ],
+                  "enum": [true],
                   "type": "boolean"
                 }
               },
-              "required": [
-                "auto"
-              ],
+              "required": ["auto"],
               "type": "object"
             }
           ]
@@ -3550,10 +3457,7 @@
               "type": "boolean"
             },
             {
-              "enum": [
-                "stdout",
-                "stderr"
-              ],
+              "enum": ["stdout", "stderr"],
               "type": "string"
             }
           ]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -35,7 +35,9 @@
               }
             }
           },
-          "required": ["task"],
+          "required": [
+            "task"
+          ],
           "unevaluatedProperties": false
         }
       ]
@@ -44,7 +46,13 @@
       "description": "operating system or os/arch pair to install on",
       "type": "string",
       "pattern": "^[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)?$",
-      "examples": ["linux", "macos", "windows", "macos/arm64", "linux/x64"]
+      "examples": [
+        "linux",
+        "macos",
+        "windows",
+        "macos/arm64",
+        "linux/x64"
+      ]
     },
     "os_filter": {
       "description": "operating system filters to install on",
@@ -112,7 +120,9 @@
               "$ref": "#/$defs/env_directive/properties/path"
             }
           },
-          "required": ["path"]
+          "required": [
+            "path"
+          ]
         },
         {
           "type": "object",
@@ -121,7 +131,9 @@
               "$ref": "#/$defs/env_directive/properties/paths"
             }
           },
-          "required": ["paths"]
+          "required": [
+            "paths"
+          ]
         }
       ]
     },
@@ -197,7 +209,9 @@
                 "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
               }
             },
-            "required": ["age"],
+            "required": [
+              "age"
+            ],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -213,7 +227,10 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": ["raw", "zstd"],
+                    "enum": [
+                      "raw",
+                      "zstd"
+                    ],
                     "description": "[experimental] compression format for the encrypted value"
                   },
                   "tools": {
@@ -238,12 +255,16 @@
                     "description": "require this environment variable to be defined before mise runs or in a later config file. Cannot be used with empty string values or value=false. Can be a boolean or a help string."
                   }
                 },
-                "required": ["value"],
+                "required": [
+                  "value"
+                ],
                 "unevaluatedProperties": false,
                 "description": "[experimental] age-encrypted value (complex format)"
               }
             },
-            "required": ["age"],
+            "required": [
+              "age"
+            ],
             "unevaluatedProperties": false,
             "description": "[experimental] age-encrypted environment variable"
           },
@@ -337,7 +358,9 @@
                           ]
                         }
                       },
-                      "required": ["path"]
+                      "required": [
+                        "path"
+                      ]
                     },
                     {
                       "type": "object",
@@ -349,7 +372,9 @@
                           }
                         }
                       },
-                      "required": ["paths"]
+                      "required": [
+                        "paths"
+                      ]
                     }
                   ]
                 },
@@ -433,7 +458,9 @@
                           }
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "type": "object"
                     }
                   ]
@@ -636,7 +663,13 @@
           "default": "default",
           "description": "Theme for interactive prompts (default/charm, base16, catppuccin, dracula)",
           "type": "string",
-          "enum": ["default", "charm", "base16", "catppuccin", "dracula"]
+          "enum": [
+            "default",
+            "charm",
+            "base16",
+            "catppuccin",
+            "dracula"
+          ]
         },
         "conda": {
           "type": "object",
@@ -1049,7 +1082,11 @@
         "libc": {
           "description": "Libc implementation to use for precompiled Linux binaries.",
           "type": "string",
-          "enum": ["glibc", "gnu", "musl"]
+          "enum": [
+            "glibc",
+            "gnu",
+            "musl"
+          ]
         },
         "libgit2": {
           "default": true,
@@ -1081,7 +1118,13 @@
           "default": "info",
           "description": "Show more/less output.",
           "type": "string",
-          "enum": ["trace", "debug", "info", "warn", "error"]
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "minimum_release_age": {
           "description": "Minimum release age / supply chain protection — only install versions older than this threshold",
@@ -1195,7 +1238,13 @@
               "default": "auto",
               "description": "Package manager to use for installing npm packages.",
               "type": "string",
-              "enum": ["auto", "npm", "aube", "bun", "pnpm"]
+              "enum": [
+                "auto",
+                "npm",
+                "aube",
+                "bun",
+                "pnpm"
+              ]
             }
           }
         },
@@ -1324,7 +1373,12 @@
             "uv_venv_auto": {
               "default": false,
               "description": "Integrate with uv to manage project venvs when uv.lock is present.",
-              "enum": [false, "source", "create|source", true],
+              "enum": [
+                false,
+                "source",
+                "create|source",
+                true
+              ],
               "oneOf": [
                 {
                   "type": "boolean"
@@ -1746,7 +1800,14 @@
           "type": "string"
         },
         "windows_executable_extensions": {
-          "default": ["exe", "bat", "cmd", "com", "ps1", "vbs"],
+          "default": [
+            "exe",
+            "bat",
+            "cmd",
+            "com",
+            "ps1",
+            "vbs"
+          ],
           "description": "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on.",
           "type": "array",
           "items": {
@@ -1804,7 +1865,9 @@
               }
             }
           },
-          "required": ["task"]
+          "required": [
+            "task"
+          ]
         },
         {
           "type": "object",
@@ -1819,7 +1882,9 @@
               "type": "array"
             }
           },
-          "required": ["tasks"]
+          "required": [
+            "tasks"
+          ]
         }
       ]
     },
@@ -1942,80 +2007,83 @@
         }
       }
     },
-    "tool": {
+    "tool_option_scalar": {
       "oneOf": [
         {
-          "description": "version of the tool to install",
           "type": "string"
         },
         {
-          "allOf": [
-            {
-              "$ref": "#/$defs/tool_options"
-            },
-            {
-              "properties": {
-                "install_env": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "boolean"
-                      }
-                    ]
-                  },
-                  "description": "environment variables during tool installation"
-                },
-                "depends": {
-                  "oneOf": [
-                    {
-                      "description": "tools that must be installed before this tool",
-                      "type": "string"
-                    },
-                    {
-                      "description": "tools that must be installed before this tool",
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  ]
-                },
-                "postinstall": {
-                  "description": "command to run after tool installation",
-                  "type": "string"
-                }
-              }
-            }
-          ],
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "tool_option_value": {
+      "description": "backend option value",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "array"
+        },
+        {
           "type": "object",
-          "unevaluatedProperties": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "array"
-              },
-              {
-                "type": "object",
-                "additionalProperties": true
-              }
-            ]
+          "additionalProperties": true
+        }
+      ]
+    },
+    "tool_bool_or_string": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "tool_string_or_number": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "tool_string_or_string_array": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
+      ]
+    },
+    "tool_platform_key": {
+      "description": "platform key for platform-specific tool options",
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.+-]+-[A-Za-z0-9_.+-]+(-[A-Za-z0-9_.+-]+)*$",
+      "examples": [
+        "linux-x64",
+        "linux-x64-musl",
+        "macos-arm64",
+        "darwin-aarch64",
+        "windows-amd64"
       ]
     },
     "tool_options": {
@@ -2026,10 +2094,1113 @@
         },
         "os": {
           "$ref": "#/$defs/os_filter"
+        },
+        "minimum_release_age": {
+          "description": "minimum age a tool release must have before mise will install it",
+          "type": "string"
+        },
+        "install_before": {
+          "deprecated": true,
+          "description": "deprecated alias for minimum_release_age",
+          "type": "string"
+        },
+        "prerelease": {
+          "$ref": "#/$defs/tool_bool_or_string",
+          "description": "include prerelease versions when resolving this tool"
         }
       },
-      "required": ["version"],
+      "required": [
+        "version"
+      ],
       "type": "object"
+    },
+    "tool_install_options": {
+      "properties": {
+        "install_env": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/tool_option_scalar"
+          },
+          "description": "environment variables during tool installation"
+        },
+        "depends": {
+          "oneOf": [
+            {
+              "description": "tools that must be installed before this tool",
+              "type": "string"
+            },
+            {
+              "description": "tools that must be installed before this tool",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "postinstall": {
+          "description": "command to run after tool installation",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tool_artifact_platform_options": {
+      "properties": {
+        "url": {
+          "description": "platform-specific download URL",
+          "type": "string"
+        },
+        "checksum": {
+          "description": "platform-specific checksum",
+          "type": "string"
+        },
+        "size": {
+          "$ref": "#/$defs/tool_string_or_number",
+          "description": "platform-specific download size"
+        },
+        "strip_components": {
+          "$ref": "#/$defs/tool_string_or_number",
+          "description": "number of directory components to strip when extracting"
+        },
+        "bin": {
+          "description": "binary name to install or expose",
+          "type": "string"
+        },
+        "rename_exe": {
+          "description": "rename an extracted executable",
+          "type": "string"
+        },
+        "format": {
+          "description": "archive format to use when auto-detection is insufficient",
+          "type": "string"
+        },
+        "bin_path": {
+          "description": "directory containing binaries within the extracted archive",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tool_release_platform_options": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_artifact_platform_options"
+        },
+        {
+          "properties": {
+            "asset_pattern": {
+              "description": "release asset pattern to install on this platform",
+              "type": "string"
+            },
+            "filter_bins": {
+              "description": "comma-separated binaries to expose on PATH",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "tool_s3_platform_options": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_artifact_platform_options"
+        },
+        {
+          "properties": {
+            "endpoint": {
+              "description": "custom S3-compatible endpoint",
+              "type": "string"
+            },
+            "region": {
+              "description": "AWS region for the S3 bucket",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "tool_platform_map_artifact": {
+      "description": "platform-specific artifact options",
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/tool_platform_key"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/tool_artifact_platform_options"
+      }
+    },
+    "tool_platform_map_release": {
+      "description": "platform-specific release asset options",
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/tool_platform_key"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/tool_release_platform_options"
+      }
+    },
+    "tool_platform_map_s3": {
+      "description": "platform-specific S3 artifact options",
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/tool_platform_key"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/tool_s3_platform_options"
+      }
+    },
+    "tool_platform_map_cargo": {
+      "description": "platform-specific cargo options",
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/tool_platform_key"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "bin": {
+            "description": "binary name to install for this platform",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "tool_aqua_options": {
+      "properties": {
+        "symlink_bins": {
+          "$ref": "#/$defs/tool_bool_or_string",
+          "description": "symlink aqua package binaries instead of copying them"
+        },
+        "vars": {
+          "type": "object",
+          "description": "aqua registry variables",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "type": "object"
+    },
+    "tool_cargo_options": {
+      "properties": {
+        "features": {
+          "description": "cargo features to enable",
+          "type": "string"
+        },
+        "default-features": {
+          "$ref": "#/$defs/tool_bool_or_string",
+          "description": "whether cargo default features are enabled"
+        },
+        "bin": {
+          "description": "binary name to install",
+          "type": "string"
+        },
+        "crate": {
+          "description": "crate name to install from a git repository",
+          "type": "string"
+        },
+        "locked": {
+          "$ref": "#/$defs/tool_bool_or_string",
+          "description": "whether to pass --locked to cargo install"
+        },
+        "platforms": {
+          "$ref": "#/$defs/tool_platform_map_cargo"
+        },
+        "platform": {
+          "$ref": "#/$defs/tool_platform_map_cargo"
+        }
+      },
+      "type": "object"
+    },
+    "tool_conda_options": {
+      "properties": {
+        "channel": {
+          "description": "conda channel to install from",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tool_go_options": {
+      "properties": {
+        "tags": {
+          "description": "build tags to pass to go install",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tool_npm_options": {
+      "properties": {
+        "npm_args": {
+          "description": "additional arguments to pass to npm installs",
+          "type": "string"
+        },
+        "pnpm_args": {
+          "description": "additional arguments to pass to pnpm installs",
+          "type": "string"
+        },
+        "bun_args": {
+          "description": "additional arguments to pass to bun installs",
+          "type": "string"
+        },
+        "aube_args": {
+          "description": "additional arguments to pass to aube installs",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tool_pipx_options": {
+      "properties": {
+        "extras": {
+          "description": "pip extras to install",
+          "type": "string"
+        },
+        "pipx_args": {
+          "description": "additional arguments to pass to pipx",
+          "type": "string"
+        },
+        "uvx": {
+          "$ref": "#/$defs/tool_bool_or_string",
+          "description": "whether to use uv tool install when uv is available"
+        },
+        "uvx_args": {
+          "description": "additional arguments to pass to uv tool install",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tool_release_options": {
+      "allOf": [
+        {
+          "properties": {
+            "asset_pattern": {
+              "description": "release asset pattern to install",
+              "type": "string"
+            },
+            "version_prefix": {
+              "description": "version tag prefix used by releases",
+              "type": "string"
+            },
+            "checksum": {
+              "description": "checksum for the downloaded asset",
+              "type": "string"
+            },
+            "size": {
+              "$ref": "#/$defs/tool_string_or_number",
+              "description": "downloaded asset size"
+            },
+            "strip_components": {
+              "$ref": "#/$defs/tool_string_or_number",
+              "description": "number of directory components to strip when extracting"
+            },
+            "bin": {
+              "description": "binary name to install or expose",
+              "type": "string"
+            },
+            "rename_exe": {
+              "description": "rename an extracted executable",
+              "type": "string"
+            },
+            "no_app": {
+              "$ref": "#/$defs/tool_bool_or_string",
+              "description": "skip macOS .app bundle assets during autodetection"
+            },
+            "bin_path": {
+              "description": "directory containing binaries within the extracted archive",
+              "type": "string"
+            },
+            "filter_bins": {
+              "description": "comma-separated binaries to expose on PATH",
+              "type": "string"
+            },
+            "api_url": {
+              "description": "custom API URL for self-hosted forge instances",
+              "type": "string"
+            },
+            "url": {
+              "description": "direct platform asset URL",
+              "type": "string"
+            },
+            "format": {
+              "description": "archive format to use when auto-detection is insufficient",
+              "type": "string"
+            },
+            "platforms": {
+              "$ref": "#/$defs/tool_platform_map_release"
+            },
+            "platform": {
+              "$ref": "#/$defs/tool_platform_map_release"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "tool_http_options": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_artifact_platform_options"
+        },
+        {
+          "properties": {
+            "version_list_url": {
+              "description": "URL used to discover available versions",
+              "type": "string"
+            },
+            "version_regex": {
+              "description": "regular expression used to extract versions",
+              "type": "string"
+            },
+            "version_json_path": {
+              "description": "JSON path used to extract versions",
+              "type": "string"
+            },
+            "version_expr": {
+              "description": "expr-lang expression used to extract versions",
+              "type": "string"
+            },
+            "platforms": {
+              "$ref": "#/$defs/tool_platform_map_artifact"
+            },
+            "platform": {
+              "$ref": "#/$defs/tool_platform_map_artifact"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "tool_s3_options": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_artifact_platform_options"
+        },
+        {
+          "properties": {
+            "endpoint": {
+              "description": "custom S3-compatible endpoint",
+              "type": "string"
+            },
+            "region": {
+              "description": "AWS region for the S3 bucket",
+              "type": "string"
+            },
+            "version_list_url": {
+              "description": "S3 URL used to discover available versions",
+              "type": "string"
+            },
+            "version_prefix": {
+              "description": "S3 object key prefix used to discover versions",
+              "type": "string"
+            },
+            "version_regex": {
+              "description": "regular expression used to extract versions",
+              "type": "string"
+            },
+            "version_json_path": {
+              "description": "JSON path used to extract versions",
+              "type": "string"
+            },
+            "version_expr": {
+              "description": "expr-lang expression used to extract versions",
+              "type": "string"
+            },
+            "platforms": {
+              "$ref": "#/$defs/tool_platform_map_s3"
+            },
+            "platform": {
+              "$ref": "#/$defs/tool_platform_map_s3"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "tool_spm_options": {
+      "properties": {
+        "provider": {
+          "description": "forge provider to use for release information",
+          "type": "string"
+        },
+        "api_url": {
+          "description": "custom provider API URL",
+          "type": "string"
+        },
+        "filter_bins": {
+          "$ref": "#/$defs/tool_string_or_string_array",
+          "description": "binaries to expose on PATH"
+        }
+      },
+      "type": "object"
+    },
+    "tool_ubi_options": {
+      "properties": {
+        "exe": {
+          "description": "executable to install from the release artifact",
+          "type": "string"
+        },
+        "rename_exe": {
+          "description": "rename the installed executable",
+          "type": "string"
+        },
+        "matching": {
+          "description": "substring used to match release assets",
+          "type": "string"
+        },
+        "matching_regex": {
+          "description": "regular expression used to match release assets",
+          "type": "string"
+        },
+        "provider": {
+          "description": "forge provider to use for releases",
+          "type": "string"
+        },
+        "api_url": {
+          "description": "custom provider API URL",
+          "type": "string"
+        },
+        "extract_all": {
+          "$ref": "#/$defs/tool_bool_or_string",
+          "description": "extract all files from the release artifact"
+        },
+        "bin_path": {
+          "description": "directory containing binaries within the extracted archive",
+          "type": "string"
+        },
+        "tag_regex": {
+          "description": "regular expression used to filter release tags",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tool_core_python_options": {
+      "properties": {
+        "virtualenv": {
+          "description": "virtualenv path to activate with this Python",
+          "type": "string"
+        },
+        "patch_sysconfig": {
+          "$ref": "#/$defs/tool_bool_or_string",
+          "description": "whether to patch sysconfig for precompiled Python installs"
+        }
+      },
+      "type": "object"
+    },
+    "tool_core_rust_options": {
+      "properties": {
+        "profile": {
+          "description": "rustup profile to install",
+          "type": "string"
+        },
+        "components": {
+          "description": "comma-separated rustup components to install",
+          "type": "string"
+        },
+        "targets": {
+          "description": "comma-separated rustup targets to install",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tool_core_dotnet_options": {
+      "properties": {
+        "runtime": {
+          "description": "runtime-only .NET install type",
+          "type": "string",
+          "enum": [
+            "dotnet",
+            "aspnetcore",
+            "windowsdesktop"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "tool_object_base": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_options"
+        },
+        {
+          "$ref": "#/$defs/tool_install_options"
+        }
+      ],
+      "type": "object"
+    },
+    "tool_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_object"
+        }
+      ]
+    },
+    "tool_value": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool"
+        }
+      ]
+    },
+    "tool_aqua_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_aqua_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_aqua": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_aqua_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_aqua_item"
+        }
+      ]
+    },
+    "tool_aqua_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_aqua_object"
+        }
+      ]
+    },
+    "tool_cargo_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_cargo_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_cargo": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_cargo_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_cargo_item"
+        }
+      ]
+    },
+    "tool_cargo_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_cargo_object"
+        }
+      ]
+    },
+    "tool_conda_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_conda_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_conda": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_conda_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_conda_item"
+        }
+      ]
+    },
+    "tool_conda_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_conda_object"
+        }
+      ]
+    },
+    "tool_go_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_go_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_go": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_go_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_go_item"
+        }
+      ]
+    },
+    "tool_go_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_go_object"
+        }
+      ]
+    },
+    "tool_npm_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_npm_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_npm": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_npm_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_npm_item"
+        }
+      ]
+    },
+    "tool_npm_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_npm_object"
+        }
+      ]
+    },
+    "tool_pipx_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_pipx_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_pipx": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_pipx_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_pipx_item"
+        }
+      ]
+    },
+    "tool_pipx_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_pipx_object"
+        }
+      ]
+    },
+    "tool_release_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_release_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_release": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_release_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_release_item"
+        }
+      ]
+    },
+    "tool_release_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_release_object"
+        }
+      ]
+    },
+    "tool_http_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_http_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_http": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_http_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_http_item"
+        }
+      ]
+    },
+    "tool_http_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_http_object"
+        }
+      ]
+    },
+    "tool_s3_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_s3_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_s3": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_s3_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_s3_item"
+        }
+      ]
+    },
+    "tool_s3_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_s3_object"
+        }
+      ]
+    },
+    "tool_spm_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_spm_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_spm": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_spm_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_spm_item"
+        }
+      ]
+    },
+    "tool_spm_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_spm_object"
+        }
+      ]
+    },
+    "tool_ubi_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_ubi_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_ubi": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_ubi_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_ubi_item"
+        }
+      ]
+    },
+    "tool_ubi_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_ubi_object"
+        }
+      ]
+    },
+    "tool_core_python_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_core_python_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_core_python": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_core_python_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_core_python_item"
+        }
+      ]
+    },
+    "tool_core_python_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_core_python_object"
+        }
+      ]
+    },
+    "tool_core_rust_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_core_rust_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_core_rust": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_core_rust_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_core_rust_item"
+        }
+      ]
+    },
+    "tool_core_rust_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_core_rust_object"
+        }
+      ]
+    },
+    "tool_core_dotnet_object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_object_base"
+        },
+        {
+          "$ref": "#/$defs/tool_core_dotnet_options"
+        }
+      ],
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/tool_option_value"
+      }
+    },
+    "tool_core_dotnet": {
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/tool_core_dotnet_item"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/tool_core_dotnet_item"
+        }
+      ]
+    },
+    "tool_core_dotnet_item": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/tool_core_dotnet_object"
+        }
+      ]
     },
     "hooks": {
       "description": "hooks to run",
@@ -2062,7 +3233,9 @@
                 "type": "string"
               }
             },
-            "required": ["task"],
+            "required": [
+              "task"
+            ],
             "type": "object"
           },
           {
@@ -2095,7 +3268,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["task"],
+                  "required": [
+                    "task"
+                  ],
                   "type": "object"
                 }
               ]
@@ -2131,10 +3306,14 @@
         },
         "oneOf": [
           {
-            "required": ["run"]
+            "required": [
+              "run"
+            ]
           },
           {
-            "required": ["task"]
+            "required": [
+              "task"
+            ]
           }
         ]
       }
@@ -2243,11 +3422,21 @@
                 },
                 "default": {
                   "description": "default value for confirmation (yes/no/true/false)",
-                  "enum": ["yes", "no", "y", "n", "true", "false"],
+                  "enum": [
+                    "yes",
+                    "no",
+                    "y",
+                    "n",
+                    "true",
+                    "false"
+                  ],
                   "type": "string"
                 }
               },
-              "required": ["message", "default"],
+              "required": [
+                "message",
+                "default"
+              ],
               "unevaluatedProperties": false,
               "type": "object"
             }
@@ -2364,11 +3553,15 @@
               "properties": {
                 "auto": {
                   "description": "automatically touch an internal tracked file instead of specifying outputs",
-                  "enum": [true],
+                  "enum": [
+                    true
+                  ],
                   "type": "boolean"
                 }
               },
-              "required": ["auto"],
+              "required": [
+                "auto"
+              ],
               "type": "object"
             }
           ]
@@ -2386,7 +3579,10 @@
               "type": "boolean"
             },
             {
-              "enum": ["stdout", "stderr"],
+              "enum": [
+                "stdout",
+                "stderr"
+              ],
               "type": "string"
             }
           ]
@@ -2828,17 +4024,57 @@
     },
     "tools": {
       "additionalProperties": {
-        "oneOf": [
-          {
-            "items": {
-              "$ref": "#/$defs/tool"
-            },
-            "type": "array"
-          },
-          {
-            "$ref": "#/$defs/tool"
-          }
-        ]
+        "$ref": "#/$defs/tool_value"
+      },
+      "patternProperties": {
+        "^aqua:.+": {
+          "$ref": "#/$defs/tool_aqua"
+        },
+        "^cargo:.+": {
+          "$ref": "#/$defs/tool_cargo"
+        },
+        "^conda:.+": {
+          "$ref": "#/$defs/tool_conda"
+        },
+        "^forgejo:.+": {
+          "$ref": "#/$defs/tool_release"
+        },
+        "^github:.+": {
+          "$ref": "#/$defs/tool_release"
+        },
+        "^gitlab:.+": {
+          "$ref": "#/$defs/tool_release"
+        },
+        "^go:.+": {
+          "$ref": "#/$defs/tool_go"
+        },
+        "^http:.+": {
+          "$ref": "#/$defs/tool_http"
+        },
+        "^npm:.+": {
+          "$ref": "#/$defs/tool_npm"
+        },
+        "^pipx:.+": {
+          "$ref": "#/$defs/tool_pipx"
+        },
+        "^s3:.+": {
+          "$ref": "#/$defs/tool_s3"
+        },
+        "^spm:.+": {
+          "$ref": "#/$defs/tool_spm"
+        },
+        "^ubi:.+": {
+          "$ref": "#/$defs/tool_ubi"
+        },
+        "^(core:)?python$": {
+          "$ref": "#/$defs/tool_core_python"
+        },
+        "^(core:)?rust$": {
+          "$ref": "#/$defs/tool_core_rust"
+        },
+        "^(core:)?dotnet$": {
+          "$ref": "#/$defs/tool_core_dotnet"
+        }
       },
       "description": "dev tools to use",
       "type": "object"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1949,54 +1949,53 @@
           "type": "string"
         },
         {
-          "properties": {
-            "version": {
-              "description": "version of the tool to install",
-              "type": "string"
+          "allOf": [
+            {
+              "$ref": "#/$defs/tool_options"
             },
-            "os": {
-              "$ref": "#/$defs/os_filter"
-            },
-            "install_env": {
-              "type": "object",
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "string"
+            {
+              "properties": {
+                "install_env": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
                   },
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "boolean"
-                  }
-                ]
-              },
-              "description": "environment variables during tool installation"
-            },
-            "depends": {
-              "oneOf": [
-                {
-                  "description": "tools that must be installed before this tool",
-                  "type": "string"
+                  "description": "environment variables during tool installation"
                 },
-                {
-                  "description": "tools that must be installed before this tool",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                "depends": {
+                  "oneOf": [
+                    {
+                      "description": "tools that must be installed before this tool",
+                      "type": "string"
+                    },
+                    {
+                      "description": "tools that must be installed before this tool",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "postinstall": {
+                  "description": "command to run after tool installation",
+                  "type": "string"
                 }
-              ]
-            },
-            "postinstall": {
-              "description": "command to run after tool installation",
-              "type": "string"
+              }
             }
-          },
-          "required": ["version"],
+          ],
           "type": "object",
-          "additionalProperties": {
+          "unevaluatedProperties": {
             "oneOf": [
               {
                 "type": "string"
@@ -2018,6 +2017,19 @@
           }
         }
       ]
+    },
+    "tool_options": {
+      "properties": {
+        "version": {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        "os": {
+          "$ref": "#/$defs/os_filter"
+        }
+      },
+      "required": ["version"],
+      "type": "object"
     },
     "hooks": {
       "description": "hooks to run",
@@ -2310,18 +2322,13 @@
                 "type": "string"
               },
               {
-                "properties": {
-                  "version": {
-                    "description": "version of the tool to install",
-                    "type": "string"
-                  },
-                  "os": {
-                    "$ref": "#/$defs/os_filter"
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/tool_options"
                   }
-                },
-                "required": ["version"],
+                ],
                 "type": "object",
-                "additionalProperties": {
+                "unevaluatedProperties": {
                   "oneOf": [
                     {
                       "type": "string"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2201,6 +2201,54 @@
         }
       }
     },
+    "tool_platform_aliases_artifact": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "platforms": {
+          "$ref": "#/$defs/tool_platform_map_artifact"
+        },
+        "platform": {
+          "$ref": "#/$defs/tool_platform_map_artifact"
+        }
+      }
+    },
+    "tool_platform_aliases_release": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "platforms": {
+          "$ref": "#/$defs/tool_platform_map_release"
+        },
+        "platform": {
+          "$ref": "#/$defs/tool_platform_map_release"
+        }
+      }
+    },
+    "tool_platform_aliases_s3": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "platforms": {
+          "$ref": "#/$defs/tool_platform_map_s3"
+        },
+        "platform": {
+          "$ref": "#/$defs/tool_platform_map_s3"
+        }
+      }
+    },
+    "tool_platform_aliases_cargo": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "platforms": {
+          "$ref": "#/$defs/tool_platform_map_cargo"
+        },
+        "platform": {
+          "$ref": "#/$defs/tool_platform_map_cargo"
+        }
+      }
+    },
     "tool_aqua_options": {
       "properties": {
         "symlink_bins": {
@@ -2218,34 +2266,35 @@
       "type": "object"
     },
     "tool_cargo_options": {
-      "properties": {
-        "features": {
-          "description": "cargo features to enable",
-          "type": "string"
+      "allOf": [
+        {
+          "$ref": "#/$defs/tool_platform_aliases_cargo"
         },
-        "default-features": {
-          "$ref": "#/$defs/tool_bool_or_string",
-          "description": "whether cargo default features are enabled"
-        },
-        "bin": {
-          "description": "binary name to install",
-          "type": "string"
-        },
-        "crate": {
-          "description": "crate name to install from a git repository",
-          "type": "string"
-        },
-        "locked": {
-          "$ref": "#/$defs/tool_bool_or_string",
-          "description": "whether to pass --locked to cargo install"
-        },
-        "platforms": {
-          "$ref": "#/$defs/tool_platform_map_cargo"
-        },
-        "platform": {
-          "$ref": "#/$defs/tool_platform_map_cargo"
+        {
+          "properties": {
+            "features": {
+              "description": "cargo features to enable",
+              "type": "string"
+            },
+            "default-features": {
+              "$ref": "#/$defs/tool_bool_or_string",
+              "description": "whether cargo default features are enabled"
+            },
+            "bin": {
+              "description": "binary name to install",
+              "type": "string"
+            },
+            "crate": {
+              "description": "crate name to install from a git repository",
+              "type": "string"
+            },
+            "locked": {
+              "$ref": "#/$defs/tool_bool_or_string",
+              "description": "whether to pass --locked to cargo install"
+            }
+          }
         }
-      },
+      ],
       "type": "object"
     },
     "tool_conda_options": {
@@ -2314,6 +2363,9 @@
           "$ref": "#/$defs/tool_artifact_platform_options"
         },
         {
+          "$ref": "#/$defs/tool_platform_aliases_release"
+        },
+        {
           "properties": {
             "asset_pattern": {
               "description": "release asset pattern to install",
@@ -2334,12 +2386,6 @@
             "api_url": {
               "description": "custom API URL for self-hosted forge instances",
               "type": "string"
-            },
-            "platforms": {
-              "$ref": "#/$defs/tool_platform_map_release"
-            },
-            "platform": {
-              "$ref": "#/$defs/tool_platform_map_release"
             }
           }
         }
@@ -2350,6 +2396,9 @@
       "allOf": [
         {
           "$ref": "#/$defs/tool_artifact_platform_options"
+        },
+        {
+          "$ref": "#/$defs/tool_platform_aliases_artifact"
         },
         {
           "properties": {
@@ -2368,12 +2417,6 @@
             "version_expr": {
               "description": "expr-lang expression used to extract versions",
               "type": "string"
-            },
-            "platforms": {
-              "$ref": "#/$defs/tool_platform_map_artifact"
-            },
-            "platform": {
-              "$ref": "#/$defs/tool_platform_map_artifact"
             }
           }
         }
@@ -2384,6 +2427,9 @@
       "allOf": [
         {
           "$ref": "#/$defs/tool_artifact_platform_options"
+        },
+        {
+          "$ref": "#/$defs/tool_platform_aliases_s3"
         },
         {
           "properties": {
@@ -2414,12 +2460,6 @@
             "version_expr": {
               "description": "expr-lang expression used to extract versions",
               "type": "string"
-            },
-            "platforms": {
-              "$ref": "#/$defs/tool_platform_map_s3"
-            },
-            "platform": {
-              "$ref": "#/$defs/tool_platform_map_s3"
             }
           }
         }


### PR DESCRIPTION
Stacked on #9649.

Note: this branch is based on #9649. GitHub would not let me open the PR with `codex/schema-tool-options` as the base because that branch only exists on the fork, and I do not have permission to create the matching base branch on `jdx/mise`.

## Summary
- add backend-specific schema branches for explicit `[tools]` keys using `patternProperties`
- cover known backend options for `aqua:`, `cargo:`, `conda:`, `forgejo:`, `github:`, `gitlab:`, `go:`, `http:`, `npm:`, `pipx:`, `s3:`, `spm:`, and `ubi:`
- cover core tool options for `python`, `rust`, and `dotnet`
- keep registry shorthand, `[tool_alias]`, `vfox`, and `asdf` plugin tools on the generic fallback because standalone JSON Schema cannot resolve those to a concrete backend
- expand the Tombi schema regression to exercise valid backend-specific opts and invalid typed values

## Validation
- `mise run render:schema`
- `jq empty schema/mise.json schema/mise-task.json`
- `git diff --check`
- `mise run test:e2e e2e/config/test_schema_tombi`

This PR was generated by an AI coding assistant.
