### PR TITLE
refactor(deps): remove urlencoding dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5771,7 +5771,6 @@ dependencies = [
  "toml_edit",
  "ubi",
  "url",
- "urlencoding",
  "usage-lib",
  "versions",
  "vfox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,6 @@ toml = { version = "1.0", features = ["parse", "preserve_order"] }
 toml_edit = { version = "0.25", features = ["parse"] }
 ubi = { version = "0.9", default-features = false }
 url = "2"
-urlencoding = "2"
 usage-lib = { version = "3", features = ["clap", "docs"] }
 versions = { version = "7", features = ["serde"] }
 vfox = { path = "crates/vfox", default-features = false }

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -402,9 +402,7 @@ pub fn get_filename_from_url(url_str: &str) -> String {
             .unwrap_or(url_str)
             .to_string()
     };
-    urlencoding::decode(&filename)
-        .map(|s| s.to_string())
-        .unwrap_or(filename)
+    crate::url_encoding::decode_component(&filename).unwrap_or(filename)
 }
 
 pub fn install_artifact(

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -127,7 +127,7 @@ async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GitlabRelease>>
     let url = format!(
         "{}/projects/{}/releases",
         api_url,
-        urlencoding::encode(repo)
+        crate::url_encoding::encode_component(repo)
     );
 
     let headers = get_headers(&url);
@@ -173,7 +173,7 @@ async fn list_tags_(api_url: &str, repo: &str) -> Result<Vec<String>> {
     let url = format!(
         "{}/projects/{}/repository/tags",
         api_url,
-        urlencoding::encode(repo)
+        crate::url_encoding::encode_component(repo)
     );
     let headers = get_headers(&url);
     let (mut tags, mut headers) = crate::http::HTTP_FETCH
@@ -218,7 +218,7 @@ async fn get_release_(api_url: &str, repo: &str, tag: &str) -> Result<GitlabRele
     let url = format!(
         "{}/projects/{}/releases/{}",
         api_url,
-        urlencoding::encode(repo),
+        crate::url_encoding::encode_component(repo),
         tag
     );
     let headers = get_headers(&url);

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ mod tokens;
 mod toml;
 mod toolset;
 mod ui;
+mod url_encoding;
 mod uv;
 mod versions_host;
 mod watch_files;

--- a/src/url_encoding.rs
+++ b/src/url_encoding.rs
@@ -7,12 +7,52 @@ pub fn encode_component(input: &str) -> String {
 }
 
 pub fn decode_component(input: &str) -> Option<String> {
-    let input = input.replace('+', "%2B").replace('&', "%26");
-    let query = format!("x={input}");
-    url::form_urlencoded::parse(query.as_bytes())
-        .next()
-        .filter(|(key, _)| key == "x")
-        .map(|(_, value)| value.into_owned())
+    let bytes = input.as_bytes();
+    if !bytes.contains(&b'%') {
+        return Some(input.to_string());
+    }
+
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'%' {
+            decoded.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+
+        match bytes.get(i + 1..i + 3) {
+            Some(&[first, second]) => match (hex_digit(first), hex_digit(second)) {
+                (Some(first), Some(second)) => {
+                    decoded.push((first << 4) | second);
+                    i += 3;
+                }
+                (Some(_), None) => {
+                    decoded.extend_from_slice(&bytes[i..i + 2]);
+                    i += 2;
+                }
+                (None, _) => {
+                    decoded.push(b'%');
+                    i += 1;
+                }
+            },
+            _ => {
+                decoded.extend_from_slice(&bytes[i..]);
+                break;
+            }
+        }
+    }
+
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_digit(digit: u8) -> Option<u8> {
+    match digit {
+        b'0'..=b'9' => Some(digit - b'0'),
+        b'A'..=b'F' => Some(digit - b'A' + 10),
+        b'a'..=b'f' => Some(digit - b'a' + 10),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -33,6 +73,15 @@ mod tests {
         assert_eq!(
             decode_component("file%20with+plus%26amp.tgz").as_deref(),
             Some("file with+plus&amp.tgz")
+        );
+    }
+
+    #[test]
+    fn decode_component_rejects_invalid_utf8() {
+        assert_eq!(decode_component("file-%FF.tgz"), None);
+        assert_eq!(
+            decode_component("file-%zz-%A.tgz").as_deref(),
+            Some("file-%zz-%A.tgz")
         );
     }
 }

--- a/src/url_encoding.rs
+++ b/src/url_encoding.rs
@@ -1,0 +1,38 @@
+pub fn encode_component(input: &str) -> String {
+    url::form_urlencoded::byte_serialize(input.as_bytes())
+        .collect::<String>()
+        .replace('+', "%20")
+        .replace('*', "%2A")
+        .replace("%7E", "~")
+}
+
+pub fn decode_component(input: &str) -> Option<String> {
+    let input = input.replace('+', "%2B").replace('&', "%26");
+    let query = format!("x={input}");
+    url::form_urlencoded::parse(query.as_bytes())
+        .next()
+        .filter(|(key, _)| key == "x")
+        .map(|(_, value)| value.into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_component_matches_existing_component_semantics() {
+        assert_eq!(
+            encode_component("ubi:https://example.com/foo/bar"),
+            "ubi%3Ahttps%3A%2F%2Fexample.com%2Ffoo%2Fbar"
+        );
+        assert_eq!(encode_component("a b+c*d~e"), "a%20b%2Bc%2Ad~e");
+    }
+
+    #[test]
+    fn decode_component_keeps_plus_literal() {
+        assert_eq!(
+            decode_component("file%20with+plus%26amp.tgz").as_deref(),
+            Some("file with+plus&amp.tgz")
+        );
+    }
+}

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -192,7 +192,7 @@ async fn track_install_async(tool: &str, full: &str, version: &str) -> eyre::Res
 fn track_install_url(tool: &str) -> String {
     format!(
         "https://mise-versions.jdx.dev/api/tools/{}",
-        urlencoding::encode(tool)
+        crate::url_encoding::encode_component(tool)
     )
 }
 


### PR DESCRIPTION
## Summary
- replace direct `urlencoding` usage with a local component encoder/decoder built on `url::form_urlencoded`
- preserve existing component semantics for spaces, `+`, `*`, and `~`
- update GitLab project paths, versions-host tracking URLs, and artifact filename decoding

## Dependency audit
- `rg urlencoding Cargo.toml src crates build.rs` has no direct hits after the change
- `cargo tree -p mise --depth 1 --edges normal,build,dev` no longer lists `urlencoding` as a direct `mise` dependency
- `urlencoding` remains in `Cargo.lock` transitively through `self_update`/AWS dependencies

## Verification
- `cargo fmt --check`
- `cargo test -p mise url_encoding`
- `cargo test -p mise test_track_install_url`
- `cargo check -p mise --all-targets`

*This PR was generated by an AI coding assistant.*