### PR TITLE
registry: add oc and openshift-install (http backend)

### DIFF
--- a/registry/oc.toml
+++ b/registry/oc.toml
@@ -1,3 +1,32 @@
-backends = ["conda:openshift-cli", "asdf:mise-plugins/mise-oc"]
 description = "OpenShift Client CLI (oc)"
+os = ["linux", "macos", "windows"]
 test = { cmd = "oc version --client", expected = "{{version}}" }
+
+[[backends]]
+full = "http:oc"
+
+[backends.options]
+bin = "oc"
+version_regex = 'href="(\d+\.\d+\.\d+)/"'
+version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
+
+[backends.options.platforms.linux-x64]
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-linux-{{ version }}.tar.gz"
+
+[backends.options.platforms.linux-arm64]
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-linux-arm64-{{ version }}.tar.gz"
+
+[backends.options.platforms.macos-x64]
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-mac-{{ version }}.tar.gz"
+
+[backends.options.platforms.macos-arm64]
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-mac-arm64-{{ version }}.tar.gz"
+
+[backends.options.platforms.windows-x64]
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-windows-{{ version }}.zip"
+
+[[backends]]
+full = "conda:openshift-cli"
+
+[[backends]]
+full = "asdf:mise-plugins/mise-oc"

--- a/registry/oc.toml
+++ b/registry/oc.toml
@@ -7,8 +7,8 @@ full = "http:oc"
 
 [backends.options]
 bin = "oc"
-version_regex = 'href="(\d+\.\d+\.\d+)/"'
 version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
+version_regex = 'href="(\d+\.\d+\.\d+)/"'
 
 [backends.options.platforms.linux-x64]
 url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-linux-{{ version }}.tar.gz"

--- a/registry/openshift-install.toml
+++ b/registry/openshift-install.toml
@@ -1,0 +1,23 @@
+description = "OpenShift installer for deploying OpenShift clusters"
+os = ["linux", "macos"]
+test = { cmd = "openshift-install version", expected = "{{version}}" }
+
+[[backends]]
+full = "http:openshift-install"
+
+[backends.options]
+bin = "openshift-install"
+version_regex = 'href="(\d+\.\d+\.\d+)/"'
+version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
+
+[backends.options.platforms.linux-x64]
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-install-linux-{{ version }}.tar.gz"
+
+[backends.options.platforms.linux-arm64]
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-install-linux-arm64-{{ version }}.tar.gz"
+
+[backends.options.platforms.macos-x64]
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-install-mac-{{ version }}.tar.gz"
+
+[backends.options.platforms.macos-arm64]
+url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-install-mac-arm64-{{ version }}.tar.gz"

--- a/registry/openshift-install.toml
+++ b/registry/openshift-install.toml
@@ -7,8 +7,8 @@ full = "http:openshift-install"
 
 [backends.options]
 bin = "openshift-install"
-version_regex = 'href="(\d+\.\d+\.\d+)/"'
 version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
+version_regex = 'href="(\d+\.\d+\.\d+)/"'
 
 [backends.options.platforms.linux-x64]
 url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-install-linux-{{ version }}.tar.gz"

--- a/src/backend/version_list.rs
+++ b/src/backend/version_list.rs
@@ -95,9 +95,13 @@ pub fn parse_version_list(
         }
     }
 
-    // If no versions extracted yet, treat as line-separated or single version
-    // This provides fallback for all cases including failed JSON parsing
-    if versions.is_empty() {
+    // If no versions extracted yet and no explicit extraction method was provided,
+    // treat as line-separated or single version.
+    // When version_regex or version_expr is set, zero matches means the content
+    // didn't contain the expected data — don't fall through to line-splitting
+    // which would emit garbage (e.g. raw HTML lines as "versions").
+    let explicit_method = version_regex.is_some() || version_expr.is_some();
+    if versions.is_empty() && !explicit_method {
         for line in trimmed.lines() {
             let line = line.trim();
             // Skip empty lines and comments

--- a/src/backend/version_list.rs
+++ b/src/backend/version_list.rs
@@ -27,9 +27,16 @@ pub async fn fetch_versions(
 ) -> Result<Vec<String>> {
     use crate::http::HTTP;
 
-    // Fetch the content
-    let response = HTTP.get_text(version_list_url).await?;
-    let content = response.trim();
+    let content = if version_regex.is_some() {
+        // When a regex is provided, the caller expects to parse arbitrary
+        // content (including HTML directory listings), so bypass the HTML rejection
+        // in get_text.
+        let resp = HTTP.get_async(version_list_url).await?;
+        resp.text().await?
+    } else {
+        HTTP.get_text(version_list_url).await?
+    };
+    let content = content.trim();
 
     // Parse versions based on format
     parse_version_list(content, version_regex, version_json_path, version_expr)


### PR DESCRIPTION
  ---
  ## Summary

  - Add `http:` backend to existing `oc` registry entry (keeps conda/asdf as fallbacks)
  - Add new `openshift-install` registry entry with `http:` backend
  - Both tools download from the official OpenShift mirror at `https://mirror.openshift.com/pub/openshift-v4/clients/ocp/`
  - Allow `version_regex` to parse HTML responses in `version_list.rs`, since the OpenShift mirror serves an Apache-style HTML directory listing as its version index

  ### Why the `version_list.rs` change is needed

  The OpenShift mirror (`https://mirror.openshift.com/pub/openshift-v4/clients/ocp/`) serves an HTML directory listing as the only available version index — there is no JSON API, GitHub Releases, or plain-text endpoint. Currently, `fetch_versions` uses `HTTP.get_text()`,
  which rejects any response starting with `<!DOCTYPE html>`. When `version_regex` is specified, the caller explicitly intends to parse arbitrary content (including HTML directory listings from Apache/nginx), so this change bypasses the HTML rejection in that case only.

  ## Popularity

  ### oc (OpenShift CLI)
  - Already registered in mise (`conda:openshift-cli`, `asdf:mise-plugins/mise-oc`) — this PR adds a better backend
  - GitHub ([openshift/oc](https://github.com/openshift/oc)): 239 stars, 442 forks, last push 2026-05-05
  - Official CLI for Red Hat OpenShift, one of the leading enterprise Kubernetes distributions

  ### openshift-install
  - GitHub ([openshift/installer](https://github.com/openshift/installer)): 1.5k stars, 1.5k forks, last push 2026-05-06
  - Official installer for deploying OpenShift clusters

  ## Test results (macOS ARM64)

  ### Version listing
  ```
  $ mise ls-remote oc
  4.1.0
  4.1.11
  ...
  4.9.8
  4.9.9
  ```
  
### Install & verify
  ```
  $ mise exec oc@4.17.0 -- oc version --client
  Client Version: 4.17.0
  Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3

  $ mise exec openshift-install@4.17.0 -- openshift-install version
  openshift-install 4.17.0
  built from commit dfd4c085a7210e49111fa8d6747016d78f98ecf2
```
  ### Unit tests
  ```
  $ cargo test version_list
  test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 840 filtered out
  ```