### PR TITLE
refactor(deps): remove chrono dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,9 +1183,6 @@ name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
-dependencies = [
- "chrono",
-]
 
 [[package]]
 name = "bumpalo"
@@ -5671,7 +5668,6 @@ dependencies = [
  "calm_io",
  "cfg_aliases",
  "chacha20poly1305",
- "chrono",
  "ci_info",
  "clap",
  "clap-sort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,6 @@ aws-sdk-s3 = { version = "1", default-features = false, features = [
 base64 = "0.22"
 bzip2 = "0.6"
 calm_io = "0.1"
-chrono = { version = "0.4", default-features = false, features = [
-  "std",
-  "clock",
-] }
 ci_info = "0.14"
 clap = { version = "4", features = ["env", "derive", "string"] }
 color-eyre = "0.6"
@@ -228,13 +224,14 @@ sevenz-rust = "0.6"
 winapi = { version = "0.3.9", features = ["consoleapi", "minwindef"] }
 
 [build-dependencies]
-built = { version = "0.8", features = ["chrono"] }
+built = "0.8"
 cfg_aliases = "0.2"
 heck = "0.5"
 toml = "1.0"
 indexmap = "2"
 serde = "1"
 serde_yaml = "0.9"
+jiff = "0.2"
 
 [dev-dependencies]
 clap-sort = "1"

--- a/build.rs
+++ b/build.rs
@@ -11,10 +11,41 @@ fn main() {
         linux: { target_os = "linux" },
         vfox: { any(feature = "vfox", target_os = "windows") },
     }
+    set_build_time();
     built::write_built_file().expect("Failed to acquire build-time information");
 
     codegen_settings();
     codegen_registry();
+}
+
+fn set_build_time() {
+    const BUILD_TIME_FORMAT: &str = "%a, %-d %b %Y %H:%M:%S %z";
+    const BUILD_TIME_OVERRIDE: &str = "BUILT_OVERRIDE_mise_BUILT_TIME_UTC";
+
+    println!("cargo:rerun-if-env-changed={BUILD_TIME_OVERRIDE}");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
+    let build_time = env::var(BUILD_TIME_OVERRIDE)
+        .ok()
+        .filter(|s| jiff::Timestamp::strptime(BUILD_TIME_FORMAT, s).is_ok())
+        .or_else(|| {
+            let source_date_epoch = env::var("SOURCE_DATE_EPOCH").ok()?;
+            match source_date_epoch.parse::<i64>() {
+                Ok(seconds) => jiff::Timestamp::from_second(seconds).ok(),
+                Err(_) => {
+                    eprintln!("SOURCE_DATE_EPOCH defined, but not a i64");
+                    None
+                }
+            }
+            .map(|ts| ts.strftime(BUILD_TIME_FORMAT).to_string())
+        })
+        .unwrap_or_else(|| {
+            jiff::Timestamp::now()
+                .strftime(BUILD_TIME_FORMAT)
+                .to_string()
+        });
+
+    println!("cargo:rustc-env=MISE_BUILD_TIME_UTC={build_time}");
 }
 
 /// Generate a raw string literal that safely contains the given content.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -316,7 +316,7 @@ Some filters:
 - `str | date(format) -> String` – Converts a timestamp to
   a formatted date string using the provided format,
   such as <span v-pre>`{{ ts | date(format="%Y-%m-%d") }}`</span>.
-  Find a list of time format on [`chrono` documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html).
+  Find a list of time format on [`jiff` documentation](https://docs.rs/jiff/latest/jiff/fmt/strtime/index.html).
 - `str | split(pat) -> Array` – Splits a string by the given pattern and
   returns an array of substrings.
 - `str | default(value) -> String` – Returns the default value

--- a/src/build_time.rs
+++ b/src/build_time.rs
@@ -1,11 +1,12 @@
-use chrono::{DateTime, FixedOffset};
+use jiff::Timestamp;
 use std::sync::LazyLock as Lazy;
 
 pub mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
-pub static BUILD_TIME: Lazy<DateTime<FixedOffset>> =
-    Lazy::new(|| DateTime::parse_from_rfc2822(built_info::BUILT_TIME_UTC).unwrap());
+pub static BUILD_TIME: Lazy<Timestamp> = Lazy::new(|| {
+    Timestamp::strptime("%a, %-d %b %Y %H:%M:%S %z", env!("MISE_BUILD_TIME_UTC")).unwrap()
+});
 
 pub static TARGET: &str = built_info::TARGET;

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -687,7 +687,7 @@ fn build_info() -> IndexMap<String, &'static str> {
     let mut s = IndexMap::new();
     s.insert("Target".into(), built_info::TARGET);
     s.insert("Features".into(), built_info::FEATURES_STR);
-    s.insert("Built".into(), built_info::BUILT_TIME_UTC);
+    s.insert("Built".into(), env!("MISE_BUILD_TIME_UTC"));
     s.insert("Rust Version".into(), built_info::RUSTC_VERSION);
     s.insert("Profile".into(), built_info::PROFILE);
     s

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -41,7 +41,7 @@ impl Version {
             "latest": get_latest_version(duration::DAILY).await,
             "os": *OS,
             "arch": *ARCH,
-            "build_time": BUILD_TIME.to_string(),
+            "build_time": BUILD_TIME.strftime("%Y-%m-%d %H:%M:%S %:z").to_string(),
         });
         println!("{}", serde_json::to_string_pretty(&json)?);
         Ok(())
@@ -67,7 +67,7 @@ pub static VERSION_PLAIN: Lazy<String> = Lazy::new(|| {
 });
 
 pub static VERSION: Lazy<String> = Lazy::new(|| {
-    let build_time = BUILD_TIME.format("%Y-%m-%d");
+    let build_time = BUILD_TIME.strftime("%Y-%m-%d");
     let v = &*VERSION_PLAIN;
     format!("{v} {os}-{arch} ({build_time})", os = *OS, arch = *ARCH)
 });

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -423,7 +423,7 @@ fn find_expired_glab_tokens(contents: &str) -> Vec<(String, String)> {
     };
 
     let mut expired = vec![];
-    let now = chrono::Utc::now();
+    let now = jiff::Timestamp::now();
     for (k, entry) in hosts {
         let Some(host) = k.as_str() else { continue };
         if entry.get("oauth2_refresh_token").is_none() {
@@ -432,7 +432,7 @@ fn find_expired_glab_tokens(contents: &str) -> Vec<(String, String)> {
         let Some(expiry_str) = entry.get("oauth2_expiry_date").and_then(Value::as_str) else {
             continue;
         };
-        let Ok(expiry_date) = chrono::DateTime::parse_from_rfc3339(expiry_str) else {
+        let Ok(expiry_date) = expiry_str.parse::<jiff::Timestamp>() else {
             continue;
         };
         if expiry_date < now {

--- a/src/http.rs
+++ b/src/http.rs
@@ -626,11 +626,13 @@ fn display_github_rate_limit(resp: &Response) {
                 .get("x-ratelimit-reset")
                 .and_then(|h| h.to_str().ok())
                 .and_then(|s| s.parse::<i64>().ok())
-                .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+                .and_then(|ts| jiff::Timestamp::from_second(ts).ok())
             {
                 warn!(
                     "GitHub rate limit exceeded. Resets at {}",
-                    reset_time.with_timezone(&chrono::Local)
+                    reset_time
+                        .to_zoned(jiff::tz::TimeZone::system())
+                        .strftime("%Y-%m-%d %H:%M:%S %:z")
                 );
             }
             return;


### PR DESCRIPTION
## Summary
- replace runtime `chrono` usage with existing `jiff` APIs
- remove `built`'s chrono feature and set build time from `build.rs` with `jiff`
- preserve `SOURCE_DATE_EPOCH` and `BUILT_OVERRIDE_mise_BUILT_TIME_UTC` handling for build time
- update the template date-format docs link from chrono to jiff

## Dependency audit
- `rg chrono Cargo.toml src build.rs docs` has no direct hits after the change
- `cargo tree -p mise --depth 1 --edges normal,build,dev` no longer lists `chrono` as a direct `mise` dependency
- `chrono` remains in `Cargo.lock` transitively through dependencies such as `tera`, `rattler`, and `sigstore`

## Verification
- `cargo fmt --check`
- `cargo check -p mise --all-targets`
- `cargo test -p mise test_find_expired_glab_tokens`
- `SOURCE_DATE_EPOCH=0 cargo check -p mise --all-targets`

*This PR was generated by an AI coding assistant.*