### PR TITLE
registry: add code-review-graph (pipx:code-review-graph)

### DIFF
--- a/registry/code-review-graph.toml
+++ b/registry/code-review-graph.toml
@@ -1,4 +1,3 @@
-aliases = ["code-review-graph"]
 description = "code-review-graph: Stop burning tokens. Start reviewing smarter."
 test = { cmd = "code-review-graph --version", expected = "code-review-graph {{version}}" }
 [[backends]]

--- a/registry/code-review-graph.toml
+++ b/registry/code-review-graph.toml
@@ -1,0 +1,5 @@
+aliases = ["code-review-graph"]
+description = "code-review-graph: Stop burning tokens. Start reviewing smarter."
+test = { cmd = "code-review-graph --version", expected = "code-review-graph {{version}}" }
+[[backends]]
+full = "pipx:code-review-graph"


### PR DESCRIPTION
This pull request adds a new entry for the `code-review-graph` tool to the `registry/code-review-graph.toml` file. The main changes are:

Registry entry for `code-review-graph`:

* Added aliases, a description, and a test command to the registry entry.
* Configured the backend to use `pipx:code-review-graph` for installation.