### PR TITLE
docs(node): add tips for enabling node idiomatic

### DIFF
--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -70,6 +70,7 @@ Or in `~/.config/mise/config.toml`:
 [settings]
 idiomatic_version_file_enable_tools = ["node"]
 ```
+
 :::
 
 ## Default node packages

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -57,6 +57,21 @@ It also supports `.tool-versions`, `.nvmrc` or `.node-version` file to find out 
 
 This makes it a drop-in replacement for `nvm`. See [idiomatic version files](/configuration.html#idiomatic-version-files) for more information.
 
+::: tip
+`.nvmrc` and `.node-version` are disabled by default and must be explicitly enabled:
+
+```sh
+mise settings add idiomatic_version_file_enable_tools node
+```
+
+Or in `~/.config/mise/config.toml`:
+
+```toml
+[settings]
+idiomatic_version_file_enable_tools = ["node"]
+```
+:::
+
 ## Default node packages
 
 mise-node can automatically install a default set of npm packages right after installing a node version. To enable this feature, provide a `$HOME/.default-npm-packages` file that lists one package per line, for example:

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -53,12 +53,12 @@ always return the version specified in `mise.toml`.
 
 By default, mise uses a `mise.toml` file for auto-switching between software versions.
 
-It also supports `.tool-versions` file to specify versions for ASDF compatibility. Additionally, `.nvmrc`, `.node-version`, and the `engines` field in `package.json` are supported but require explicit enabling (see tip below).
+It also supports `.tool-versions` file to specify versions for ASDF compatibility. Additionally, `.nvmrc`, `.node-version`, and the `devEngines` field in `package.json` are supported but require explicit enabling (see tip below).
 
 This makes it a drop-in replacement for `nvm`. See [idiomatic version files](/configuration.html#idiomatic-version-files) for more information.
 
 ::: tip
-Idiomatic version files (`.nvmrc`, `.node-version`, `engines` field in `package.json`) are disabled by default and must be explicitly enabled:
+Idiomatic version files (`.nvmrc`, `.node-version`, `devEngines` field in `package.json`) are disabled by default and must be explicitly enabled:
 
 ```sh
 mise settings add idiomatic_version_file_enable_tools node

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -49,16 +49,16 @@ npm = "11.12.1"
 The pinned npm version takes precedence over the one bundled with Node, so `npm --version` will
 always return the version specified in `mise.toml`.
 
-## `.nvmrc` and `.node-version` support
+## `.nvmrc`, `.node-version` and `package.json` support
 
 By default, mise uses a `mise.toml` file for auto-switching between software versions.
 
-It also supports `.tool-versions`, `.nvmrc` or `.node-version` file to find out what version of Node.js should be used. This will be used if `node` isn't defined in `mise.toml`.
+It also supports `.tool-versions` file to specify versions for ASDF compatibility. Additionally, `.nvmrc`, `.node-version`, and the `engines` field in `package.json` are supported but require explicit enabling (see tip below).
 
 This makes it a drop-in replacement for `nvm`. See [idiomatic version files](/configuration.html#idiomatic-version-files) for more information.
 
 ::: tip
-`.nvmrc` and `.node-version` are disabled by default and must be explicitly enabled:
+Idiomatic version files (`.nvmrc`, `.node-version`, `engines` field in `package.json`) are disabled by default and must be explicitly enabled:
 
 ```sh
 mise settings add idiomatic_version_file_enable_tools node


### PR DESCRIPTION
## Summary

Fix misleading documentation about `.nvmrc` support in Node.js plugin.

## Problem

The documentation at `docs/lang/node.md` claimed that mise supports `.nvmrc` and `.node-version` files for auto-switching Node.js versions, implying they work out of the box. However, these files are [idiomatic version files](https://mise.en.dev/configuration.html#idiomatic-version-files) which are **disabled by default** and require explicit enabling via `idiomatic_version_file_enable_tools` setting.
This created a confusing user experience where:

1. Users creating a `.nvmrc` file expected it to work (as documented)
2. mise ignored the file silently with no feedback
3. Users had to dig into configuration docs to understand why

## Solution

Updated `docs/lang/node.md` to clarify: `.nvmrc` and `.node-version` require enabling via `mise settings add idiomatic_version_file_enable_tools node` or equivalent config.

Added a tip box with explicit instructions on how to enable idiomatic version files for Node.js.