### PR TITLE
fix(pipx): declare python as a backend dependency

### DIFF
--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -48,7 +48,10 @@ impl Backend for PIPXBackend {
     }
 
     fn get_dependencies(&self) -> eyre::Result<Vec<&str>> {
-        Ok(vec!["pipx"])
+        // python is required because pipx.pyz uses `#!/usr/bin/env python3`
+        // and pipx_cmd relies on dependency_toolset to put python ahead of
+        // any system python on PATH.
+        Ok(vec!["pipx", "python"])
     }
 
     fn get_optional_dependencies(&self) -> eyre::Result<Vec<&str>> {


### PR DESCRIPTION
## Summary

Fixes `backend/test_pipx_deep_dependencies_slow` failing on release PRs (e.g. #9620 → run https://github.com/jdx/mise/actions/runs/25473978595).

#9571 removed registry-level `depends = ["python"]` from `registry/pipx.toml` and moved it to `test.tools` (which only feeds `mise test-tool`, not real installs). That broke `pipx_cmd`'s `dependency_toolset` PATH prepend: `pipx.pyz` uses `#!/usr/bin/env python3`, and without mise's python in front of `$HOME/bin` the kernel resolves whatever `python3` it finds first. In the failing test, that's the test's deliberate `fail` stub:

```
CALL TO SYSTEM python3! args: /tmp/.../mise/installs/pipx/1.5.0/pipx install mkdocs==1.6.0
mise ERROR pipx failed
```

The fix moves the dependency into `PIPXBackend::get_dependencies` itself, matching how `cargo` declares `"rust"`, `npm` declares `"node"`, `gem` declares `"ruby"`, `dotnet` declares `"dotnet"`, `go` declares `"go"`, and `spm` declares `"swift"`. pipx was the only language-package backend that wasn't declaring its runtime — it had been getting it transitively through the registry, which is now gone.

## Audit of other backends

I checked every backend that uses `dependency_toolset`/`dependency_which` to spawn subprocesses:

| Backend | Runtime declared | OK? |
|---|---|---|
| pipx | python (this PR) | fixed |
| cargo | rust | yes |
| npm | node | yes |
| gem | ruby | yes |
| dotnet | dotnet | yes |
| go | go | yes |
| spm | swift | yes |
| aqua/github/http/etc. | n/a (just download/extract) | yes |
| vfox | reads `PLUGIN.depends` from plugin metadata | yes |

So pipx was the only at-risk site.

## Test plan

- [x] `mise run test:e2e backend/test_pipx_deep_dependencies_slow` passes locally
- [x] Other pipx tests still pass: `test_pipx_extras`, `test_pipx_direct_dependencies`, `test_pipx_custom_registry`, `test_pipx_uvx`, `test_pipx_venv_symlink`, `test_pipx_postinstall_hook`
- [x] `mise run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small dependency-list change limited to the `pipx` backend, mainly affecting install/runtime PATH resolution.
> 
> **Overview**
> Ensures the `pipx` backend explicitly depends on `python` (in addition to `pipx`) so `pipx.pyz`’s `#!/usr/bin/env python3` resolves to mise-managed Python via `dependency_toolset` rather than an arbitrary system `python3` on `PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce5045d32aad9a8115ae742c7f0c7fc15a6aa3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->