### PR TITLE
chore(hk): drop jq from schema lint step

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -8,7 +8,6 @@ local linters = new Mapping<String, Step> {
         glob = List("schema/**/*.json")
         stdin = "{{ files_list | join(sep='\u{0}') }}"
         check = "xargs -0 -I {} ajv compile -s {} --spec=draft2020 --strict-types=true --strict-tuples=true"
-        fix = "xargs -0 -I {} sh -c 'tmp=\"$1.tmp\"; jq . < \"$1\" > \"$tmp\" && mv \"$tmp\" \"$1\" && ajv compile -s \"$1\" --spec=draft2020 --strict-types=true --strict-tuples=true' sh {}"
         check_first = false
     }
     // uses builtin prettier linter config; run via `mise x` so hk picks up


### PR DESCRIPTION
I thought `jq` is sorting the schema, but without `-S` no. We can sort, but it makes the schema hard to read I think.

## Summary

Remove `jq` from the `schema` hk step fix command. JSON under `schema/` is already included in the Prettier glob; the `prettier` step runs after `schema` (`depends = List("schema")`) and formats those files. Round-tripping through `jq .` was redundant with Prettier for layout and did not add semantic checks beyond what `ajv compile` already enforces.

Invalid JSON would still fail Prettier before write.

## Notes

No key sorting (`jq -S`); this keeps schema key order whatever Prettier preserves from the formatter output.

Made with [Cursor](https://cursor.com)