### PR TITLE
chore(ci): increase lint job timeout for clippy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
 
   lint:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: [build-ubuntu]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

The `lint` job runs `mise run lint`, two `cargo clippy` passes (default and `--all-features --all-targets`), plus `cargo deny`, MSRV, `cargo machete`, and the standalone script. The previous **15** minute cap was tight on cold or busy runners.

## Change

- `.github/workflows/test.yml`: bump `lint` `timeout-minutes` from **15** → **20**.

**20 minutes** matches the `autofix` workflow (`.github/workflows/autofix.yml`): that job already runs `cargo build --all-features`, render, and `mise run lint-fix` under the same timeout, so keeping `lint` at **20** aligns the two workflows without holding runners longer than autofix does.