### PR TITLE
chore(ci): pass mise github token to tests

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -18,6 +18,7 @@ env:
   MISE_LOCKFILE: 1
   MISE_USE_VERSIONS_HOST_TRACK: 0
   RUST_BACKTRACE: 1
+  MISE_GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
 
 jobs:
   check-changes:
@@ -177,8 +178,14 @@ jobs:
         uses: ./.github/actions/fetch-token
         with:
           api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Set pooled token for Docker
-        run: echo "POOL_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
+      - name: Set pooled token
+        if: steps.token.outputs.token
+        run: |
+          {
+            echo "POOL_TOKEN=${{ steps.token.outputs.token }}"
+            echo "MISE_GITHUB_TOKEN=${{ steps.token.outputs.token }}"
+            echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}"
+          } >> "$GITHUB_ENV"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: mise
@@ -222,7 +229,8 @@ jobs:
             -v "$PWD:/mise-src:ro" \
             -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
             -v "$summary_dir:/tmp/github-summary" \
-            -e GITHUB_TOKEN="${POOL_TOKEN:-}" \
+            -e MISE_GITHUB_TOKEN="${POOL_TOKEN:-${MISE_GITHUB_TOKEN:-}}" \
+            -e GITHUB_TOKEN="${POOL_TOKEN:-${GITHUB_TOKEN:-}}" \
             -e GITHUB_STEP_SUMMARY=/tmp/github-summary/summary.md \
             -e TEST_TOOL_JOBS="$TEST_TOOL_JOBS" \
             -e TEST_TRANCHE="$TEST_TRANCHE" \
@@ -284,7 +292,8 @@ jobs:
             -v "$PWD:/mise-src:ro" \
             -v "$PWD/target/debug/mise:/usr/local/bin/mise:ro" \
             -v "$summary_dir:/tmp/github-summary" \
-            -e GITHUB_TOKEN="${POOL_TOKEN:-}" \
+            -e MISE_GITHUB_TOKEN="${POOL_TOKEN:-${MISE_GITHUB_TOKEN:-}}" \
+            -e GITHUB_TOKEN="${POOL_TOKEN:-${GITHUB_TOKEN:-}}" \
             -e GITHUB_STEP_SUMMARY=/tmp/github-summary/summary.md \
             -e TEST_TOOL_JOBS="$TEST_TOOL_JOBS" \
             -e MISE_EXPERIMENTAL=1 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ env:
   MISE_EXPERIMENTAL: 1
   MISE_LOCKFILE: 1
   RUST_BACKTRACE: 1
+  MISE_GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
   FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
 
@@ -232,9 +233,13 @@ jobs:
         uses: ./.github/actions/fetch-token
         with:
           api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Set GITHUB_TOKEN from pool
+      - name: Set GitHub token from pool
         if: steps.token.outputs.token
-        run: echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
+        run: |
+          {
+            echo "MISE_GITHUB_TOKEN=${{ steps.token.outputs.token }}"
+            echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}"
+          } >> "$GITHUB_ENV"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: mise-ubuntu-latest

--- a/e2e/backend/test_cargo_binstall_token
+++ b/e2e/backend/test_cargo_binstall_token
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-unset GITHUB_TOKEN GITHUB_API_TOKEN
+unset MISE_GITHUB_TOKEN GITHUB_API_TOKEN GITHUB_TOKEN
 
 # Create a cargo-binstall stub that just outputs the value of GITHUB_TOKEN
 cat >~/bin/cargo-binstall <<'EOF'
@@ -18,3 +18,6 @@ assert_contains "GITHUB_API_TOKEN=foobar mise install -f cargo:eza@0.18.24 2>&1"
 
 # This should prefer GITHUB_API_TOKEN
 assert_contains "GITHUB_API_TOKEN=foobar GITHUB_TOKEN=barquz mise install -f cargo:eza@0.18.24 2>&1" "token=foobar"
+
+# This should prefer MISE_GITHUB_TOKEN
+assert_contains "MISE_GITHUB_TOKEN=foobar GITHUB_API_TOKEN=barquz GITHUB_TOKEN=barquz mise install -f cargo:eza@0.18.24 2>&1" "token=foobar"

--- a/e2e/run_test
+++ b/e2e/run_test
@@ -84,6 +84,7 @@ within_isolated_env() {
     GIT_COMMITTER_NAME="test" \
     GIT_COMMITTER_EMAIL="test@test.com" \
     GITHUB_ACTION="${GITHUB_ACTION:-}" \
+    MISE_GITHUB_TOKEN="${MISE_GITHUB_TOKEN:-}" \
     GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
     GOPROXY="${GOPROXY:-}" \
     HOME="$TEST_HOME" \
@@ -211,6 +212,7 @@ run_in_docker() {
     -e ROOT=/mise-src
     -e CI="${CI:-}"
     -e GITHUB_ACTION="${GITHUB_ACTION:-}"
+    -e MISE_GITHUB_TOKEN="${MISE_GITHUB_TOKEN:-}"
     -e GITHUB_TOKEN="${GITHUB_TOKEN:-}"
     -e MISE_DEBUG="${MISE_DEBUG:-0}"
     -e MISE_TRACE="${MISE_TRACE:-0}"


### PR DESCRIPTION
## Summary
- set `MISE_GITHUB_TOKEN` in the test and registry workflows alongside the existing GitHub token
- write pooled tokens into `MISE_GITHUB_TOKEN` for e2e and registry test jobs
- pass `MISE_GITHUB_TOKEN` through e2e isolated environments and Docker test containers
- add e2e coverage for `MISE_GITHUB_TOKEN` precedence over `GITHUB_API_TOKEN` and `GITHUB_TOKEN`

## Testing
- `bash -n e2e/run_test`
- `git diff --check`
- `mise run test:e2e backend/test_cargo_binstall_token`

## Follow-up
- This branch was merged into https://github.com/jdx/mise/pull/9587 for validation.
- #9587 passed all checks on 2026-05-08 at `891419410da51649a24c16f2d6015eef7f2aeef6`, including `test-ci`, `registry-ci`, all `e2e-*` shards, and all `test-tool-*` registry shards.
