### PR TITLE
registry: use symlink_bins in ibmcloud

### DIFF
--- a/registry/ibmcloud.toml
+++ b/registry/ibmcloud.toml
@@ -1,3 +1,5 @@
-backends = ["aqua:IBM-Cloud/ibm-cloud-cli-release"]
+backends = [
+  { full = "aqua:IBM-Cloud/ibm-cloud-cli-release", options = { symlink_bins = "true" } },
+]
 description = "ibmcloud cli"
 test = { cmd = "ibmcloud version", expected = "ibmcloud {{version}}" }


### PR DESCRIPTION
mise currently puts the whole folder on the $PATH so that inadvertently ends up shadowing /usr/bin/install with the 'install' binary from ibmcloud. Use symlink_bins so that only the `ibmcloud` binary ends up on the $PATH