### PR TITLE
registry: add diff-so-fancy (github:so-fancy/diff-so-fancy)

### DIFF
--- a/registry/diff-so-fancy.toml
+++ b/registry/diff-so-fancy.toml
@@ -1,0 +1,3 @@
+backends = ["github:so-fancy/diff-so-fancy"]
+description = "Make your diffs human readable instead of machine readable"
+test = { cmd = "diff-so-fancy --version", expected = "{{version}}" }

--- a/registry/diff-so-fancy.toml
+++ b/registry/diff-so-fancy.toml
@@ -1,11 +1,3 @@
+backends = ["npm:diff-so-fancy"]
 description = "Make your diffs human readable instead of machine readable"
-test = { cmd = "diff-so-fancy --debug", expected = "{{version}}" }
-
-[[backends]]
-full = "npm:diff-so-fancy"
-
-[[backends]]
-full = "github:so-fancy/diff-so-fancy"
-
-[backends.options]
-asset_pattern = "diff-so-fancy"
+test = { cmd = "diff-so-fancy --colors", expected = "diff-so-fancy" }

--- a/registry/diff-so-fancy.toml
+++ b/registry/diff-so-fancy.toml
@@ -1,3 +1,3 @@
 backends = ["npm:diff-so-fancy"]
 description = "Make your diffs human readable instead of machine readable"
-test = { cmd = "diff-so-fancy --colors", expected = "diff-so-fancy" }
+test = { cmd = "diff-so-fancy --version", expected = "{{version}}" }

--- a/registry/diff-so-fancy.toml
+++ b/registry/diff-so-fancy.toml
@@ -1,3 +1,3 @@
-backends = ["github:so-fancy/diff-so-fancy"]
+backends = ["github:so-fancy/diff-so-fancy", "npm:diff-so-fancy"]
 description = "Make your diffs human readable instead of machine readable"
-test = { cmd = "diff-so-fancy --version", expected = "{{version}}" }
+test = { cmd = "diff-so-fancy --version", expected = "Version      : {{version}}" }

--- a/registry/diff-so-fancy.toml
+++ b/registry/diff-so-fancy.toml
@@ -1,5 +1,5 @@
 description = "Make your diffs human readable instead of machine readable"
-test = { cmd = "diff-so-fancy --version", expected = "Version      : {{version}}" }
+test = { cmd = "diff-so-fancy --debug", expected = "{{version}}" }
 
 [[backends]]
 full = "npm:diff-so-fancy"

--- a/registry/diff-so-fancy.toml
+++ b/registry/diff-so-fancy.toml
@@ -1,3 +1,11 @@
-backends = ["github:so-fancy/diff-so-fancy", "npm:diff-so-fancy"]
 description = "Make your diffs human readable instead of machine readable"
 test = { cmd = "diff-so-fancy --version", expected = "Version      : {{version}}" }
+
+[[backends]]
+full = "npm:diff-so-fancy"
+
+[[backends]]
+full = "github:so-fancy/diff-so-fancy"
+
+[backends.options]
+asset_pattern = "diff-so-fancy"


### PR DESCRIPTION
## Summary

- Adds [diff-so-fancy](https://github.com/so-fancy/diff-so-fancy) to the mise registry
- Uses the `github:` backend to download the pre-built binary from GitHub releases
- diff-so-fancy makes git diffs human readable with word-level highlighting

## Test

```
mise use diff-so-fancy
diff-so-fancy --version
```

Expected output includes the installed version number.

## Notes

diff-so-fancy only publishes a single binary asset per release with no accompanying checksum file, so automatic hash verification via the `github:` backend's checksum fetcher is not possible until upstream adds one.