### PR TITLE
fix(symlink): atomically replace runtime symlinks to fix concurrent install race

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use bzip2::read::BzDecoder;
 use color_eyre::eyre::{Context, Result};
-use eyre::bail;
+use eyre::{bail, eyre};
 use filetime::{FileTime, set_file_times};
 use flate2::read::GzDecoder;
 use itertools::Itertools;
@@ -455,11 +455,31 @@ pub fn recursive_ls(dir: &Path) -> Result<BTreeSet<PathBuf>> {
 #[cfg(unix)]
 pub fn make_symlink(target: &Path, link: &Path) -> Result<(PathBuf, PathBuf)> {
     trace!("ln -sf {} {}", target.display(), link.display());
-    if link.is_file() || link.is_symlink() {
-        fs::remove_file(link)?;
-    }
-    symlink(target, link)
+    // Create the symlink at a unique sibling path and atomically rename it
+    // into place. `rename(2)` replaces an existing file or symlink atomically,
+    // which makes this safe under concurrent `mise install` against a shared
+    // $MISE_DATA_DIR — for example, multiple Buildkite agents on a single
+    // host racing to install the same tool. The previous "remove then
+    // symlink" sequence had a TOCTOU window in which a sibling process could
+    // recreate the link between the check and the call, so the second
+    // `symlink(2)` failed with EEXIST surfaced as
+    // "failed to ln -sf … File exists (os error 17)".
+    let parent = link.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = link
+        .file_name()
+        .ok_or_else(|| eyre!("symlink path has no file name: {}", link.display()))?;
+    let tmp = parent.join(format!(
+        ".{}.tmp.{}",
+        file_name.to_string_lossy(),
+        std::process::id(),
+    ));
+    symlink(target, &tmp)
         .wrap_err_with(|| format!("failed to ln -sf {} {}", target.display(), link.display()))?;
+    if let Err(err) = fs::rename(&tmp, link) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err)
+            .wrap_err_with(|| format!("failed to ln -sf {} {}", target.display(), link.display()));
+    }
     Ok((target.to_path_buf(), link.to_path_buf()))
 }
 
@@ -1794,5 +1814,72 @@ mod tests {
 
         assert!(!src.exists());
         assert_eq!(fs::read(dst.join("nested/bun")).unwrap(), b"hello");
+    }
+
+    /// Regression test for the TOCTOU race in `make_symlink` that surfaced as
+    /// "failed to ln -sf … File exists (os error 17)" when multiple
+    /// `mise install` processes update the same `installs/<tool>/latest`
+    /// symlink concurrently against a shared $MISE_DATA_DIR — e.g. several
+    /// Buildkite agents on a single host writing to /opt/mise/data.
+    ///
+    /// The production race is genuinely cross-process. We `fork(2)` rather
+    /// than re-`exec`ing the test binary so the children inherit the
+    /// already-initialized mise test environment (`#[ctor::ctor] init`)
+    /// and don't race on the shared test HOME during startup.
+    #[test]
+    #[cfg(unix)]
+    fn make_symlink_concurrent_does_not_eexist() {
+        use nix::sys::wait::{WaitStatus, waitpid};
+        use nix::unistd::{ForkResult, fork};
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let target_a = dir.path().join("a");
+        let target_b = dir.path().join("b");
+        fs::create_dir(&target_a).unwrap();
+        fs::create_dir(&target_b).unwrap();
+        let link = dir.path().join("latest");
+
+        let n_procs = 8;
+        let n_iters = 200;
+
+        let mut child_pids = Vec::with_capacity(n_procs);
+        for i in 0..n_procs {
+            let target = if i % 2 == 0 { &target_a } else { &target_b };
+            // SAFETY: between fork and _exit we run only filesystem syscalls
+            // and exit. No allocator games, no panic unwinding back into
+            // libtest.
+            match unsafe { fork() }.expect("fork") {
+                ForkResult::Child => {
+                    for _ in 0..n_iters {
+                        if make_symlink(target, &link).is_err() {
+                            // Surface the error via a non-zero exit code —
+                            // formatting/printing isn't safe here.
+                            unsafe { nix::libc::_exit(1) };
+                        }
+                    }
+                    unsafe { nix::libc::_exit(0) };
+                }
+                ForkResult::Parent { child } => child_pids.push(child),
+            }
+        }
+
+        let mut failures = 0;
+        for pid in child_pids {
+            match waitpid(pid, None).expect("waitpid") {
+                WaitStatus::Exited(_, 0) => {}
+                other => {
+                    eprintln!("child {pid} did not exit cleanly: {other:?}");
+                    failures += 1;
+                }
+            }
+        }
+        assert_eq!(
+            failures, 0,
+            "{failures} child process(es) hit make_symlink races"
+        );
+
+        let resolved = fs::read_link(&link).unwrap();
+        assert!(resolved == target_a || resolved == target_b);
     }
 }


### PR DESCRIPTION
Hi,

We've been hitting this bug in our CI. We use mise to manage dev tools throughout our repositories, and so we use it as well on our CI machines.

We have multiple agents running on the same CI machine, and we're hitting a race condition in mise. The scenario is a new CI build starts, multiple agents from the same node pick up the job, and they all run `mise install` at the same time, on the same machine.

This PR & investigation was done using Claude Code. I have checked the written code and test and it looks reasonable. The test is a little wild, but it's the only way to reproduce that I have found.

Let us know if we're completely off base here and if we should change our approach.

mise is great ❤️ 

## Problem

`runtime_symlinks::rebuild` calls `file::make_symlink` to (re)create the `installs/<tool>/latest` (and major/minor) alias symlinks after every install. The Unix path does a check-then-act:

```rust
if link.is_file() || link.is_symlink() {
    fs::remove_file(link)?;
}
symlink(target, link)?;
```

`symlink(2)` is atomic-create-only — it does not overwrite, even when the existing entry is a symlink with the same target — and the gap between the check and the call is a TOCTOU window. When multiple `mise install` processes share a single `$MISE_DATA_DIR` (e.g. four Buildkite agents on one EC2 host all writing to `/opt/mise/data`), both observers can see the link as missing, and the loser of the `symlink(2)` race dies:

```
mise sops@3.12.2     [1/2] install
mise ERROR failed to rebuild runtime symlinks
mise ERROR failed to ln -sf ./3.12.2 /opt/mise/data/installs/sops/latest
mise ERROR File exists (os error 17)
```

The error message says \`ln -sf\`, but the implementation isn't doing \`-f\` semantics — coreutils \`ln -sf\` unlinks first; \`make_symlink\` only unlinks via the racy pre-check.

Same family of bug as #9250 (lockfile rename race) and #8947 (shim removal race), both already fixed.

## Reproduction (added as a test)

`make_symlink_concurrent_does_not_eexist` `fork(2)`s 8 children racing two targets onto a shared `latest` link. We fork rather than re-`exec`ing the test binary so the children inherit the already-initialized `#[ctor::ctor] init` test environment and don't race on the shared test HOME during startup.

Pre-fix:
```
test file::tests::make_symlink_concurrent_does_not_eexist ... child 38245 did not exit cleanly: Exited(Pid(38245), 1)
child 38246 did not exit cleanly: Exited(Pid(38246), 1)
... (7 of 8) ...
panicked at src/file.rs: assertion failed: 7 child process(es) hit make_symlink races
test result: FAILED. ... finished in 0.05s
```

Post-fix:
```
test file::tests::make_symlink_concurrent_does_not_eexist ... ok
test result: ok. ... finished in 0.86s
```

Hit in production on Buildkite (Elastic CI Stack agents, `BUILDKITE_AGENTS_PER_INSTANCE=4`, shared `/opt/mise/data`) — intermittent failures on whichever agent process lost the race.

## Fix

Build the new symlink at a unique sibling path (\`.<name>.tmp.<pid>\`, mirroring \`CondaBackend::temp_download_path\` and #9250's atomic-save idiom) and \`fs::rename\` it into place. \`rename(2)\` atomically replaces an existing file or symlink, so any number of concurrent processes can converge safely — last writer wins, link always points at one of the candidate targets.

The Windows variant (\`junction::create\` with retry on \`AlreadyExists\`) already handled this case; only the Unix path needed updating.

## Caveat

\`rename(2)\` will still fail if \`link\` is a non-empty real directory. The higher-level \`runtime_symlinks::rebuild_symlinks_in_dir\` already strips those (the legacy mise-2026.4 stale-\`latest\`-dir state) before calling \`make_symlink\`, so behavior is unchanged for that case.