### PR TITLE
chore: release 2026.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [2026.5.4](https://github.com/jdx/mise/compare/v2026.5.3..v2026.5.4) - 2026-05-09
+
+### 🚀 Features
+
+- **(java)** remove musl feature in favor of autom. musl detection and alpine-linux versions by @roele in [#9688](https://github.com/jdx/mise/pull/9688)
+
+### 🚜 Refactor
+
+- **(schema)** stop patching task_template in render script by @risu729 in [#9680](https://github.com/jdx/mise/pull/9680)
+
+### 📚 Documentation
+
+- **(deps)** drop codegen example from configuration section by @jdx in [6b2d851](https://github.com/jdx/mise/commit/6b2d8518c338b0176f82330e8fd85fb1ef16c697)
+
+### ⚡ Performance
+
+- avoid spawning process to set exit code by @vemoo in [#9723](https://github.com/jdx/mise/pull/9723)
+
+### 📦️ Dependency Updates
+
+- update ghcr.io/jdx/mise:rpm docker digest to b8b0b72 by @renovate[bot] in [#9711](https://github.com/jdx/mise/pull/9711)
+- update ghcr.io/jdx/mise:alpine docker digest to f130900 by @renovate[bot] in [#9709](https://github.com/jdx/mise/pull/9709)
+- update ghcr.io/jdx/mise:deb docker digest to 71bda11 by @renovate[bot] in [#9710](https://github.com/jdx/mise/pull/9710)
+- bump rattler crates together by @jdx in [#9721](https://github.com/jdx/mise/pull/9721)
+- update rust crate junction to v2 by @renovate[bot] in [#9726](https://github.com/jdx/mise/pull/9726)
+- update rust docker digest to 4d4ec51 by @renovate[bot] in [#9734](https://github.com/jdx/mise/pull/9734)
+
+### 📦 Registry
+
+- use symlink_bins in ibmcloud by @dnwe in [#9685](https://github.com/jdx/mise/pull/9685)
+
+### Chore
+
+- **(ci)** pass mise github token to tests by @risu729 in [#9684](https://github.com/jdx/mise/pull/9684)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (2)
+
+- [`DataDog/managed-kubernetes-auditing-toolkit`](https://github.com/DataDog/managed-kubernetes-auditing-toolkit)
+- `oracle.com/sqlcl`
+
+#### Updated Packages (3)
+
+- [`alltuner/mise-completions-sync`](https://github.com/alltuner/mise-completions-sync)
+- [`iann0036/iamlive`](https://github.com/iann0036/iamlive)
+- [`pnpm/pnpm`](https://github.com/pnpm/pnpm)
+
 ## [2026.5.3](https://github.com/jdx/mise/compare/v2026.5.2..v2026.5.3) - 2026-05-08
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aqua-registry"
-version = "2026.5.2"
+version = "2026.5.3"
 dependencies = [
  "expr-lang",
  "eyre",
@@ -5651,7 +5651,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.5.3"
+version = "2026.5.4"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.5.3"
+version = "2026.5.4"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.5.3 macos-arm64 (2026-05-08)
+2026.5.4 macos-arm64 (2026-05-09)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_3.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_4.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_3.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_4.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_3.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_4.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_3.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_4.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/crates/aqua-registry/Cargo.toml
+++ b/crates/aqua-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aqua-registry"
-version = "2026.5.2"
+version = "2026.5.3"
 edition = "2024"
 description = "Aqua registry backend for mise"
 authors = ["Jeff Dickey (@jdx)"]

--- a/crates/aqua-registry/aqua-registry/metadata.json
+++ b/crates/aqua-registry/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "v4.509.0"
+  "tag": "v4.510.0"
 }

--- a/crates/aqua-registry/aqua-registry/registry.yaml
+++ b/crates/aqua-registry/aqua-registry/registry.yaml
@@ -2327,6 +2327,42 @@ packages:
           - darwin
   - type: github_release
     repo_owner: DataDog
+    repo_name: managed-kubernetes-auditing-toolkit
+    aliases:
+      - name: datadog/managed-kubernetes-auditing-toolkit
+    description: All-in-one auditing toolkit for identifying common security issues in managed Kubernetes environments. Currently supports Amazon EKS
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.1")
+        asset: managed-kubernetes-auditing-toolkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: mkat
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: managed-kubernetes-auditing-toolkit_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: mkat
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: DataDog
     repo_name: pup
     aliases:
       - name: datadog-labs/pup
@@ -11767,7 +11803,7 @@ packages:
     description: Automatically sync shell completions for tools managed by mise
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.5.1")
         asset: mise-completions-sync-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -11787,6 +11823,17 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+      - version_constraint: "true"
+        asset: mise-completions-sync-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: allyring
     repo_name: pvw
@@ -29995,40 +30042,6 @@ packages:
           - darwin
           - amd64
   - type: github_release
-    repo_owner: datadog
-    repo_name: managed-kubernetes-auditing-toolkit
-    description: All-in-one auditing toolkit for identifying common security issues in managed Kubernetes environments. Currently supports Amazon EKS
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.1.1")
-        asset: managed-kubernetes-auditing-toolkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        files:
-          - name: mkat
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-      - version_constraint: "true"
-        asset: managed-kubernetes-auditing-toolkit_{{.OS}}_{{.Arch}}.{{.Format}}
-        files:
-          - name: mkat
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-  - type: github_release
     repo_owner: datanymizer
     repo_name: datanymizer
     asset: pg_datanymizer-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -47145,16 +47158,22 @@ packages:
   - type: github_release
     repo_owner: iann0036
     repo_name: iamlive
-    asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: zip
     description: Generate an IAM policy from AWS calls using client-side monitoring (CSM) or embedded proxy
-    overrides:
-      - goos: linux
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.1.27")
+        asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: "true"
+        asset: iamlive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
   - type: github_release
     repo_owner: iawia002
     repo_name: lux
@@ -69010,6 +69029,12 @@ packages:
           - darwin
           - windows
           - amd64
+  - type: http
+    name: oracle.com/sqlcl
+    url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.Version}}.zip
+    files:
+      - name: sql
+        src: sqlcl/bin/sql
   - type: github_release
     repo_owner: orangekame3
     repo_name: stree
@@ -71995,7 +72020,7 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
-      - version_constraint: semver("<= 10.33.2")
+      - version_constraint: semver("< 11.0.0")
         asset: pnpm-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.5.3";
+  version = "2026.5.4";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "27.9k",
+      stars: "28k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.5.3
+Version: 2026.5.4
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.5.3"
+version: "2026.5.4"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.


### PR DESCRIPTION
### 🚀 Features

- **(java)** remove musl feature in favor of autom. musl detection and alpine-linux versions by @roele in [#9688](https://github.com/jdx/mise/pull/9688)

### 🚜 Refactor

- **(schema)** stop patching task_template in render script by @risu729 in [#9680](https://github.com/jdx/mise/pull/9680)

### 📚 Documentation

- **(deps)** drop codegen example from configuration section by @jdx in [6b2d851](https://github.com/jdx/mise/commit/6b2d8518c338b0176f82330e8fd85fb1ef16c697)

### ⚡ Performance

- avoid spawning process to set exit code by @vemoo in [#9723](https://github.com/jdx/mise/pull/9723)

### 📦️ Dependency Updates

- update ghcr.io/jdx/mise:rpm docker digest to b8b0b72 by @renovate[bot] in [#9711](https://github.com/jdx/mise/pull/9711)
- update ghcr.io/jdx/mise:alpine docker digest to f130900 by @renovate[bot] in [#9709](https://github.com/jdx/mise/pull/9709)
- update ghcr.io/jdx/mise:deb docker digest to 71bda11 by @renovate[bot] in [#9710](https://github.com/jdx/mise/pull/9710)
- bump rattler crates together by @jdx in [#9721](https://github.com/jdx/mise/pull/9721)
- update rust crate junction to v2 by @renovate[bot] in [#9726](https://github.com/jdx/mise/pull/9726)
- update rust docker digest to 4d4ec51 by @renovate[bot] in [#9734](https://github.com/jdx/mise/pull/9734)

### 📦 Registry

- use symlink_bins in ibmcloud by @dnwe in [#9685](https://github.com/jdx/mise/pull/9685)

### Chore

- **(ci)** pass mise github token to tests by @risu729 in [#9684](https://github.com/jdx/mise/pull/9684)

## 📦 Aqua Registry Updates

### New Packages (2)

- [`DataDog/managed-kubernetes-auditing-toolkit`](https://github.com/DataDog/managed-kubernetes-auditing-toolkit)
- `oracle.com/sqlcl`

### Updated Packages (3)

- [`alltuner/mise-completions-sync`](https://github.com/alltuner/mise-completions-sync)
- [`iann0036/iamlive`](https://github.com/iann0036/iamlive)
- [`pnpm/pnpm`](https://github.com/pnpm/pnpm)