### PR TITLE
fix(activate): guard bash chpwd hook under nounset

### DIFF
--- a/e2e/env/test_bash_chpwd_functions_nounset
+++ b/e2e/env/test_bash_chpwd_functions_nounset
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify that bash's zsh-like cd wrapper does not fail under nounset if the
+# chpwd_functions array is unset.
+
+eval "$(mise activate bash)"
+unset chpwd_functions
+cd .

--- a/src/assets/bash_zsh_support/chpwd/function.sh
+++ b/src/assets/bash_zsh_support/chpwd/function.sh
@@ -6,7 +6,7 @@ function __zsh_like_cd()
   if
     builtin "$@"
   then
-    for __zsh_like_cd_hook in chpwd "${chpwd_functions[@]}"
+    for __zsh_like_cd_hook in chpwd ${chpwd_functions[@]+"${chpwd_functions[@]}"}
     do
       if \typeset -f "$__zsh_like_cd_hook" >/dev/null 2>&1
       then "$__zsh_like_cd_hook" || break # finish on first failed hook

--- a/src/shell/snapshots/mise__shell__bash__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__activate.snap
@@ -81,7 +81,7 @@ function __zsh_like_cd()
   if
     builtin "$@"
   then
-    for __zsh_like_cd_hook in chpwd "${chpwd_functions[@]}"
+    for __zsh_like_cd_hook in chpwd ${chpwd_functions[@]+"${chpwd_functions[@]}"}
     do
       if \typeset -f "$__zsh_like_cd_hook" >/dev/null 2>&1
       then "$__zsh_like_cd_hook" || break # finish on first failed hook


### PR DESCRIPTION
## Summary
- Guard bash's zsh-like `chpwd_functions` array expansion with the same nounset-safe pattern used for `__MISE_FLAGS`.
- Update the bash activation snapshot.
- Add a focused bash e2e covering `cd` with `chpwd_functions` unset under `set -u`.

## Test plan
- [x] `shellcheck src/assets/bash_zsh_support/chpwd/function.sh e2e/env/test_bash_chpwd_functions_nounset`
- [x] `bash --noprofile --norc -euo pipefail e2e/env/test_bash_chpwd_functions_nounset`
- [x] `git diff --check`
- [x] `docker run --rm bash:3.2 ...` reproduces the old `chpwd_functions[@]: unbound variable` failure
- [x] `docker run --rm -v "$PWD:/work:ro" -w /work bash:3.2 ...` verifies the patched hook succeeds under Bash 3.2 nounset
- [x] `docker run --rm bash:3.2 ...` verifies array entries with spaces remain separate words

Fixes https://github.com/jdx/mise/discussions/9658

Note: This PR description was generated by an AI coding assistant.
