### PR TITLE
fix(forgejo): include prereleases when opted in

### DIFF
--- a/docs/dev-tools/backends/forgejo.md
+++ b/docs/dev-tools/backends/forgejo.md
@@ -171,6 +171,23 @@ When `version_prefix` is configured, mise will:
   - User specifies `1.0.0` → mise searches for `1.0.0` tag (no prefix)
   - Useful for repositories that don't use any prefix
 
+### `prerelease`
+
+By default, releases flagged `prerelease: true` on Forgejo are excluded from `mise ls-remote` and from `latest` resolution. Set `prerelease = true` to include them:
+
+```toml
+[tools]
+"forgejo:user/repo" = { version = "latest", prerelease = true }
+```
+
+When set:
+
+- Pre-release tags (e.g. `v1.0.0-rc1`, `v0.1.2-dev.86`) appear in `mise ls-remote`.
+- `latest` resolves to the newest version across stable and pre-releases, rather than taking the Forgejo `/repos/{owner}/{repo}/releases/latest` shortcut.
+- Fuzzy version queries (e.g. `1.2`) match pre-release tags under that prefix.
+
+Draft releases are always excluded.
+
 ### Platform-specific Asset Patterns
 
 For different asset patterns per platform:

--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -276,7 +276,7 @@ When set:
 - `latest` resolves to the newest version across stable **and** pre-releases, rather than taking the GitHub `/releases/latest` shortcut (which returns whichever release the repo owner has marked as "Latest" — usually the newest non-prerelease, but it can be any release they've pinned via the API).
 - Fuzzy version queries (e.g. `1.2`) match pre-release tags under that prefix.
 
-Useful for repositories whose active releases are all pre-releases (e.g. internal tools shipping continuous dev builds), or when you need to track a project's release candidates. Draft releases are always excluded. Has no effect on GitLab/Forgejo.
+Useful for repositories whose active releases are all pre-releases (e.g. internal tools shipping continuous dev builds), or when you need to track a project's release candidates. Draft releases are always excluded. Has no effect on GitLab.
 
 ## Self-hosted GitHub
 

--- a/settings.toml
+++ b/settings.toml
@@ -1712,9 +1712,9 @@ type = "Bool"
 [prereleases]
 description = "Include pre-release versions in `ls-remote`, `latest` resolution, and fuzzy matching for all tools."
 docs = """
-By default, releases flagged `prerelease: true` on GitHub are excluded from `mise ls-remote`,
+By default, releases flagged `prerelease: true` on GitHub/Forgejo are excluded from `mise ls-remote`,
 `latest` resolution, and fuzzy version matching. Per-tool opt-in is available via the
-`prerelease = true` tool option (currently honored by the `github:`, `aqua:`, and `dotnet:` backends).
+`prerelease = true` tool option (currently honored by the `github:`, `forgejo:`, `aqua:`, and `dotnet:` backends).
 
 Set `prereleases = true` (or `MISE_PRERELEASES=1`) to opt in globally for every tool —
 equivalent to setting `prerelease = true` on each one. Useful for build pipelines that

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -197,7 +197,7 @@ impl Backend for UnifiedGitBackend {
             format!("{}/{}", web_url, repo)
         };
 
-        // Get releases with full metadata from GitHub or GitLab
+        // Get releases with full metadata from GitHub, GitLab, or Forgejo
         let raw_versions: Vec<VersionInfo> = if self.is_gitlab() {
             gitlab::list_releases_from_url(api_url.as_str(), &repo)
                 .await?
@@ -211,7 +211,7 @@ impl Backend for UnifiedGitBackend {
                 })
                 .collect()
         } else if self.is_forgejo() {
-            forgejo::list_releases_from_url(api_url.as_str(), &repo)
+            forgejo::list_releases_including_prereleases_from_url(api_url.as_str(), &repo)
                 .await?
                 .into_iter()
                 .filter(|r| version_prefix.is_none_or(|p| r.tag_name.starts_with(p)))
@@ -219,6 +219,7 @@ impl Backend for UnifiedGitBackend {
                     version: self.strip_version_prefix(&r.tag_name, &opts),
                     created_at: Some(r.created_at),
                     release_url: Some(format!("{}/releases/tag/{}", web_url_base, r.tag_name)),
+                    prerelease: r.prerelease,
                     ..Default::default()
                 })
                 .collect()

--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -346,6 +346,7 @@ mod tests {
         assert!(is_published_release(&release("1.0.0", false, false)));
         assert!(is_published_release(&release("1.1.0-rc1", false, true)));
         assert!(!is_published_release(&release("1.2.0", true, false)));
+        assert!(!is_published_release(&release("1.2.0-rc1", true, true)));
     }
 
     #[test]

--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -46,7 +46,7 @@ async fn get_releases_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<Vec<For
         .await
         .entry(key.to_string())
         .or_insert_with(|| {
-            CacheManagerBuilder::new(cache_dir().join(format!("{key}-releases.msgpack.z")))
+            CacheManagerBuilder::new(cache_dir().join(format!("{key}-all-releases.msgpack.z")))
                 .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });
@@ -66,7 +66,14 @@ async fn get_release_cache<'a>(key: &str) -> RwLockReadGuard<'a, CacheGroup<Forg
     RELEASE_CACHE.read().await
 }
 
-pub async fn list_releases_from_url(api_url: &str, repo: &str) -> Result<Vec<ForgejoRelease>> {
+/// Lists releases, including releases flagged `prerelease: true`. Drafts are
+/// always filtered out. The cache stores this non-draft superset so callers can
+/// apply the current `prerelease` option at read time without invalidating
+/// cached release metadata.
+pub async fn list_releases_including_prereleases_from_url(
+    api_url: &str,
+    repo: &str,
+) -> Result<Vec<ForgejoRelease>> {
     let key = format!("{api_url}-{repo}").to_kebab_case();
     let cache = get_releases_cache(&key).await;
     let cache = cache.get(&key).unwrap();
@@ -93,9 +100,13 @@ async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<ForgejoRelease>
             headers = h;
         }
     }
-    releases.retain(|r| !r.draft && !r.prerelease);
+    releases.retain(is_published_release);
 
     Ok(releases)
+}
+
+fn is_published_release(release: &ForgejoRelease) -> bool {
+    !release.draft
 }
 
 pub async fn get_release_for_url(api_url: &str, repo: &str, tag: &str) -> Result<ForgejoRelease> {
@@ -318,6 +329,24 @@ fn parse_fj_keys(contents: &str) -> Option<HashMap<String, String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn release(tag_name: &str, draft: bool, prerelease: bool) -> ForgejoRelease {
+        ForgejoRelease {
+            id: 1,
+            tag_name: tag_name.to_string(),
+            draft,
+            prerelease,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            assets: vec![],
+        }
+    }
+
+    #[test]
+    fn test_is_published_release_keeps_prereleases() {
+        assert!(is_published_release(&release("1.0.0", false, false)));
+        assert!(is_published_release(&release("1.1.0-rc1", false, true)));
+        assert!(!is_published_release(&release("1.2.0", true, false)));
+    }
 
     #[test]
     fn test_parse_forgejo_tokens() {

--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -46,7 +46,7 @@ async fn get_releases_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<Vec<For
         .await
         .entry(key.to_string())
         .or_insert_with(|| {
-            CacheManagerBuilder::new(cache_dir().join(format!("{key}-all-releases.msgpack.z")))
+            CacheManagerBuilder::new(cache_dir().join(format!("{key}-releases.msgpack.z")))
                 .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .build()
         });


### PR DESCRIPTION
## Summary
- keep Forgejo prerelease releases in the cached remote release list while continuing to exclude drafts
- propagate Forgejo release `prerelease` metadata into `VersionInfo` so the shared `prerelease = true` / `MISE_PRERELEASES=1` filtering path works for `ls-remote`, `latest`, and fuzzy matching
- document the Forgejo `prerelease` tool option and update shared prerelease docs

## Forgejo docs
- https://forgejo.org/docs/latest/user/releases/

## Testing
- `cargo fmt --check`
- `cargo check --bins`
- `cargo test forgejo`
- `mise run render:schema` (ran successfully; generated schema diff was formatting-only because the changed settings text is not emitted into the JSON schema)