### PR TITLE
feat(shim): add experimental_lazy_shims for aqua-backed tools

### DIFF
--- a/e2e/backend/test_aqua_lazy_shims
+++ b/e2e/backend/test_aqua_lazy_shims
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Tests the experimental lazy-shims feature for aqua-backed tools.
+#
+# When `experimental = true` and `experimental_lazy_shims = true`, mise
+# generates shims for aqua-backed tools that are configured but not yet
+# installed (using executable names from the aqua registry metadata) and
+# auto-installs the tool on first invocation of the shim.
+
+export MISE_EXPERIMENTAL=1
+export MISE_EXPERIMENTAL_LAZY_SHIMS=1
+
+shimdir="$MISE_DATA_DIR/shims"
+mise_bin="$(which mise)"
+
+cat >mise.toml <<'EOF'
+[tools]
+"aqua:BurntSushi/ripgrep" = "14.0.0"
+EOF
+
+# Sanity: tool is configured but not installed.
+assert_not_contains "mise ls --installed" "ripgrep"
+
+# Generate shims. The lazy path should produce an `rg` shim even though
+# ripgrep is not installed.
+mise reshim
+
+assert "readlink $shimdir/rg" "$mise_bin"
+# The tool should still be uninstalled — only the shim was created.
+assert_not_contains "mise ls --installed" "ripgrep"
+
+# Disabling the experimental flag must NOT generate the lazy shim.
+rm -f "$shimdir/rg"
+MISE_EXPERIMENTAL_LAZY_SHIMS=0 mise reshim
+if [ -e "$shimdir/rg" ]; then
+  echo "rg shim should not exist when experimental_lazy_shims is off" >&2
+  exit 1
+fi
+
+# Re-enable and confirm the shim comes back.
+mise reshim
+assert "readlink $shimdir/rg" "$mise_bin"

--- a/e2e/backend/test_aqua_lazy_shims_hook_not_found
+++ b/e2e/backend/test_aqua_lazy_shims_hook_not_found
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Tests the experimental lazy-shims feature on the `mise hook-not-found`
+# code path used by `mise activate`'s `command_not_found_handler`.
+#
+# Users running in PATH-based activate mode (no shims on PATH) rely on the
+# shell's `command_not_found` hook to invoke `mise hook-not-found <bin>`,
+# which delegates to `Toolset::install_missing_bin`. This test verifies that
+# the lazy aqua fallback added to `install_missing_bin` makes a never-installed
+# aqua tool installable via this path — without a prior `reshim` and without
+# any installed version of the backend.
+
+export MISE_EXPERIMENTAL=1
+export MISE_EXPERIMENTAL_LAZY_SHIMS=1
+
+cat >mise.toml <<'EOF'
+[tools]
+"aqua:BurntSushi/ripgrep" = "14.0.0"
+EOF
+
+# Sanity: tool is configured but not installed.
+assert_not_contains "mise ls --installed" "ripgrep"
+
+# Drive the activate-mode path directly. `hook-not-found` should locate the
+# aqua-backed tool via lazy registry metadata and install it.
+mise hook-not-found -s zsh -- rg
+
+# Tool must now be installed without us ever generating a shim.
+assert_contains "mise ls --installed" "ripgrep"
+
+# When the experimental flag is off, the same call must NOT trigger an install
+# for a different never-installed tool — confirms the fallback is gated.
+cat >mise.toml <<'EOF'
+[tools]
+"aqua:sharkdp/hyperfine" = "1.18.0"
+EOF
+assert_not_contains "mise ls --installed" "hyperfine"
+
+# `hook-not-found` exits 127 when no provider is found; bash test harness
+# would abort on non-zero, so accept either path here.
+MISE_EXPERIMENTAL_LAZY_SHIMS=0 mise hook-not-found -s zsh -- hyperfine || true
+assert_not_contains "mise ls --installed" "hyperfine"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -775,6 +775,10 @@
           "description": "Enable experimental mise features which are incomplete or unstable—breakings changes may occur",
           "type": "boolean"
         },
+        "experimental_lazy_shims": {
+          "description": "[experimental] Generate shims for aqua-backed tools before they are installed and auto-install on first invocation.",
+          "type": "boolean"
+        },
         "fetch_remote_versions_cache": {
           "default": "1h",
           "description": "How long to cache remote versions for tools.",

--- a/settings.toml
+++ b/settings.toml
@@ -578,6 +578,31 @@ right, try disabling it if you can.
 env = "MISE_EXPERIMENTAL"
 type = "Bool"
 
+[experimental_lazy_shims]
+description = "[experimental] Generate shims for aqua-backed tools before they are installed and auto-install on first invocation."
+docs = """
+[experimental] When set together with `experimental = true`, mise will generate shims for
+aqua-backed tools that are configured but not yet installed, when the executable names
+can be determined unambiguously from the aqua registry metadata.
+
+When such a shim is executed, the underlying tool is installed automatically and then
+the requested binary is run. The same code path is used by `mise activate`'s
+`command_not_found_handler`, so users without shims on PATH are also covered.
+
+Currently this is limited to the aqua backend. The lazy shim is *not* generated when:
+
+- The aqua registry package has no `files` entry and no derivable name
+- Any of the package's files use the `link` field (per-platform template — too risky
+  to resolve ahead of install)
+- The package is unsupported on the current platform (`no_asset` / `error_message`)
+- Two or more configured aqua tools advertise the same executable name
+
+In any of these cases the existing behavior applies (no lazy shim, install required
+before the binary can be invoked).
+"""
+env = "MISE_EXPERIMENTAL_LAZY_SHIMS"
+type = "Bool"
+
 [fetch_remote_versions_cache]
 default = "1h"
 description = "How long to cache remote versions for tools."

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -545,6 +545,75 @@ impl Backend for AquaBackend {
         Ok(paths)
     }
 
+    /// Determine shim names from aqua registry metadata, *without* requiring
+    /// the package to be installed. Used by `experimental_lazy_shims`.
+    ///
+    /// Returns `Ok(None)` whenever names cannot be determined unambiguously
+    /// from registry data so the caller falls back to current behavior.
+    async fn lazy_shim_bin_names(
+        &self,
+        _config: &Arc<Config>,
+        tv: &ToolVersion,
+    ) -> Result<Option<Vec<String>>> {
+        let pkg = match self.package_with_options(tv, &[&tv.version]).await {
+            Ok(p) => p,
+            Err(e) => {
+                trace!(
+                    "lazy_shim_bin_names: failed to load aqua package {}: {:#}",
+                    self.id, e
+                );
+                return Ok(None);
+            }
+        };
+
+        if pkg.no_asset || pkg.error_message.is_some() {
+            return Ok(None);
+        }
+
+        // Skip when any file uses `link` — the install-time symlink-target
+        // resolution is non-trivial (template-evaluated per platform) and we
+        // don't want to risk producing the wrong shim name. Falling back is
+        // safe: the user gets current behavior.
+        if pkg.files.iter().any(|f| f.link.is_some()) {
+            return Ok(None);
+        }
+
+        let names: Vec<String> = if pkg.files.is_empty() {
+            // Single-binary fallback: aqua exposes the package as repo_name (or
+            // the last segment of `name` when set). Mirrors `srcs_for_platform`.
+            let fallback = pkg
+                .name
+                .as_deref()
+                .and_then(|n| n.split('/').next_back())
+                .filter(|n| !n.is_empty())
+                .map(str::to_string)
+                .or_else(|| {
+                    if pkg.repo_name.is_empty() {
+                        None
+                    } else {
+                        Some(pkg.repo_name.clone())
+                    }
+                });
+            match fallback {
+                Some(n) => vec![n],
+                None => return Ok(None),
+            }
+        } else {
+            // For multi-file packages, `files[*].name` is the user-facing
+            // command name (the symlink target / dst basename in `srcs_for_platform`).
+            pkg.files
+                .iter()
+                .map(|f| f.name.clone())
+                .filter(|n| !n.is_empty())
+                .collect()
+        };
+
+        if names.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(names))
+    }
+
     fn resolve_lockfile_options(
         &self,
         request: &ToolRequest,

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -601,11 +601,28 @@ impl Backend for AquaBackend {
         } else {
             // For multi-file packages, `files[*].name` is the user-facing
             // command name (the symlink target / dst basename in `srcs_for_platform`).
-            pkg.files
-                .iter()
-                .map(|f| f.name.clone())
-                .filter(|n| !n.is_empty())
-                .collect()
+            // Skip files where `src` evaluates to `None` for this platform —
+            // `file_link_for_version` skips them at install time, so producing
+            // a shim for them would point to a binary that's never on disk.
+            // (We've already returned early above when any `f.link` is set, so
+            // we don't need to handle the explicit_link branch here.)
+            // Template errors propagate as `Ok(None)` overall: safer to fall
+            // back than to make a half-correct prediction.
+            let mut acc = vec![];
+            for f in &pkg.files {
+                match f.src(&pkg, &tv.version, os(), arch()) {
+                    Ok(Some(_)) if !f.name.is_empty() => acc.push(f.name.clone()),
+                    Ok(_) => {}
+                    Err(e) => {
+                        trace!(
+                            "lazy_shim_bin_names: src template failed for {} {}: {:#}",
+                            self.id, f.name, e
+                        );
+                        return Ok(None);
+                    }
+                }
+            }
+            acc
         };
 
         if names.is_empty() {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1729,6 +1729,24 @@ pub trait Backend: Debug + Send + Sync {
         }
     }
 
+    /// Returns the executable shim names this tool would expose, *without* requiring
+    /// the tool to be installed.
+    ///
+    /// Used by the experimental lazy-shims feature
+    /// (`experimental_lazy_shims`) to generate shims for tools whose binary
+    /// names can be determined ahead of installation from registry metadata.
+    ///
+    /// Backends that cannot determine names without installation must return
+    /// `Ok(None)` (the default). Returning `Ok(Some(_))` is a promise that the
+    /// names are deterministic for this `tv`.
+    async fn lazy_shim_bin_names(
+        &self,
+        _config: &Arc<Config>,
+        _tv: &ToolVersion,
+    ) -> Result<Option<Vec<String>>> {
+        Ok(None)
+    }
+
     async fn exec_env(
         &self,
         _config: &Arc<Config>,

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use crate::backend::Backend;
+use crate::backend::backend_type::BackendType;
 use crate::cli::exec::Exec;
 use crate::config::{Config, Settings};
 use crate::file::display_path;
@@ -19,6 +20,7 @@ use eyre::WrapErr;
 use indoc::formatdoc;
 use itertools::Itertools;
 use path_absolutize::Absolutize;
+use std::collections::HashMap;
 use tokio::task::JoinSet;
 
 // executes as if it was a shim if the command is not "mise", e.g.: "node"
@@ -490,6 +492,10 @@ async fn get_desired_shims(
 ) -> Result<HashSet<String>> {
     let _mise_bin = mise_bin; // used on Windows only
     let mut shims = HashSet::new();
+    // shim name -> backend short id; tracks which tool owns each generated shim
+    // so lazy shims never overwrite an installed tool's shim.
+    let mut shim_owner: HashMap<String, String> = HashMap::new();
+
     for (t, tv) in toolset.list_installed_versions(config).await? {
         let bins = list_tool_bins(config, t.clone(), &tv)
             .await
@@ -497,12 +503,84 @@ async fn get_desired_shims(
                 warn!("Error listing bin paths for {}: {:#}", tv, e);
                 Vec::new()
             });
-        if cfg!(windows) {
-            #[cfg(windows)]
-            let shim_mode = effective_shim_mode(_mise_bin);
-            #[cfg(not(windows))]
-            let shim_mode = String::new();
-            shims.extend(bins.into_iter().flat_map(|b| {
+        for shim in shim_names_for_platform(bins, _mise_bin) {
+            shim_owner.insert(shim.clone(), t.id().to_string());
+            shims.insert(shim);
+        }
+    }
+
+    // experimental: lazy shims for configured-but-not-installed aqua tools
+    let settings = Settings::get();
+    if settings.experimental && settings.experimental_lazy_shims {
+        // Group lazy candidates by shim name to detect cross-tool conflicts
+        // (two configured aqua tools advertising the same exec name).
+        let mut lazy_candidates: HashMap<String, Vec<String>> = HashMap::new();
+        let mut lazy_buf: Vec<(String, Vec<String>)> = Vec::new();
+
+        for (t, tv) in toolset.list_current_versions() {
+            if t.get_type() != BackendType::Aqua {
+                continue;
+            }
+            if t.is_version_installed(config, &tv, true) {
+                continue;
+            }
+            let names = match t.lazy_shim_bin_names(config, &tv).await {
+                Ok(Some(names)) => names,
+                Ok(None) => continue,
+                Err(e) => {
+                    trace!("lazy shim names error for {tv}: {e:#}");
+                    continue;
+                }
+            };
+            let processed = shim_names_for_platform(names, _mise_bin);
+            for shim in &processed {
+                lazy_candidates
+                    .entry(shim.clone())
+                    .or_default()
+                    .push(t.id().to_string());
+            }
+            lazy_buf.push((t.id().to_string(), processed));
+        }
+
+        for (tool_id, names) in lazy_buf {
+            for shim in names {
+                // Skip if another (installed) tool already claims this shim.
+                if let Some(owner) = shim_owner.get(&shim)
+                    && owner != &tool_id
+                {
+                    trace!("skipping lazy shim {shim} for {tool_id} (owned by installed {owner})");
+                    continue;
+                }
+                // Skip if multiple configured aqua tools would advertise this name.
+                if let Some(claimants) = lazy_candidates.get(&shim) {
+                    let others: Vec<&String> =
+                        claimants.iter().filter(|id| *id != &tool_id).collect();
+                    if !others.is_empty() {
+                        trace!(
+                            "skipping lazy shim {shim} for {tool_id} (also claimed by {others:?})"
+                        );
+                        continue;
+                    }
+                }
+                shim_owner.insert(shim.clone(), tool_id.clone());
+                shims.insert(shim);
+            }
+        }
+    }
+
+    Ok(shims)
+}
+
+/// Apply platform-specific transformations (Windows extensions, macOS case)
+/// to a flat list of bin names.
+fn shim_names_for_platform(bins: Vec<String>, _mise_bin: &Path) -> Vec<String> {
+    if cfg!(windows) {
+        #[cfg(windows)]
+        let shim_mode = effective_shim_mode(_mise_bin);
+        #[cfg(not(windows))]
+        let shim_mode = String::new();
+        bins.into_iter()
+            .flat_map(|b| {
                 let p = PathBuf::from(&b);
                 match shim_mode.as_ref() {
                     "hardlink" | "symlink" => {
@@ -522,15 +600,14 @@ async fn get_desired_shims(
                     }
                     _ => panic!("Unknown shim mode"),
                 }
-            }));
-        } else if cfg!(macos) {
-            // some bins might be uppercased but on mac APFS is case insensitive
-            shims.extend(bins.into_iter().map(|b| b.to_lowercase()));
-        } else {
-            shims.extend(bins);
-        }
+            })
+            .collect()
+    } else if cfg!(macos) {
+        // some bins might be uppercased but on mac APFS is case insensitive
+        bins.into_iter().map(|b| b.to_lowercase()).collect()
+    } else {
+        bins
     }
-    Ok(shims)
 }
 
 // lists all the paths to bins in a tv that shims will be needed for

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -562,7 +562,6 @@ async fn get_desired_shims(
                         continue;
                     }
                 }
-                shim_owner.insert(shim.clone(), tool_id.clone());
                 shims.insert(shim);
             }
         }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -524,9 +524,18 @@ impl Toolset {
         // so a never-installed aqua tool can be discovered & auto-installed.
         // If multiple configured aqua tools advertise the same bin, skip
         // auto-install entirely — same determinism rule as `get_desired_shims`.
+        //
+        // Name matching mirrors the platform transformations done at shim
+        // generation time (`shim_names_for_platform`):
+        //   - macOS: APFS is case-insensitive and shim files are lowercased,
+        //     so a shim invocation may reach us with a case that differs from
+        //     `pkg.files[*].name` in the registry.
+        //   - Windows: shim names get `.exe`/`.cmd`/etc. appended; the bin
+        //     name from the shim entry point may carry that extension.
         if plugins.is_empty() {
             let settings = Settings::get();
             if settings.experimental && settings.experimental_lazy_shims {
+                let target = normalize_lazy_bin_name(bin_name);
                 let mut lazy_matches = vec![];
                 for (backend, tv) in self.list_current_versions() {
                     if backend.get_type() != BackendType::Aqua {
@@ -536,7 +545,7 @@ impl Toolset {
                         continue;
                     }
                     if let Ok(Some(names)) = backend.lazy_shim_bin_names(config, &tv).await
-                        && names.iter().any(|n| n == bin_name)
+                        && names.iter().any(|n| normalize_lazy_bin_name(n) == target)
                     {
                         lazy_matches.push(backend);
                     }
@@ -652,4 +661,24 @@ fn should_refresh_remote_versions(
         ToolRequest::Sub { orig_version, .. } => orig_version == "latest",
         ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => false,
     }
+}
+
+/// Normalize a binary name so a registry-declared name (e.g. "Fancy") and an
+/// invocation-time bin name (e.g. "fancy" on macOS, "fancy.exe" on Windows)
+/// compare equal. Mirrors the transformations applied by
+/// `shim_names_for_platform` in `src/shims.rs`.
+fn normalize_lazy_bin_name(name: &str) -> String {
+    let mut s = name.to_string();
+    if cfg!(windows) {
+        for ext in [".exe", ".cmd", ".bat", ".ps1"] {
+            if let Some(stripped) = s.strip_suffix(ext) {
+                s = stripped.to_string();
+                break;
+            }
+        }
+    }
+    if cfg!(macos) {
+        s = s.to_lowercase();
+    }
+    s
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -667,18 +667,25 @@ fn should_refresh_remote_versions(
 /// invocation-time bin name (e.g. "fancy" on macOS, "fancy.exe" on Windows)
 /// compare equal. Mirrors the transformations applied by
 /// `shim_names_for_platform` in `src/shims.rs`.
+///
+/// On macOS APFS is case-insensitive and shim files are lowercased.
+/// On Windows the filesystem is case-insensitive too, and shim files carry
+/// platform-configured executable extensions (`.exe`, `.cmd`, ...). We
+/// pull the list from `Settings::windows_executable_extensions` so it stays
+/// in sync with mise's overall executable detection.
 fn normalize_lazy_bin_name(name: &str) -> String {
     let mut s = name.to_string();
-    if cfg!(windows) {
-        for ext in [".exe", ".cmd", ".bat", ".ps1"] {
-            if let Some(stripped) = s.strip_suffix(ext) {
+    if cfg!(any(target_os = "macos", target_os = "windows")) {
+        s = s.to_lowercase();
+    }
+    if cfg!(target_os = "windows") {
+        for ext in &Settings::get().windows_executable_extensions {
+            let suffix = format!(".{}", ext.to_lowercase());
+            if let Some(stripped) = s.strip_suffix(&suffix) {
                 s = stripped.to_string();
                 break;
             }
         }
-    }
-    if cfg!(macos) {
-        s = s.to_lowercase();
     }
     s
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinSet;
 
+use crate::backend::backend_type::BackendType;
 use crate::config::Config;
 use crate::config::settings::Settings;
 use crate::errors::Error;
@@ -514,6 +515,44 @@ impl Toolset {
                 if let Ok(Some(_bin)) = backend.which(config, tv, bin_name).await {
                     plugins.insert(backend.clone());
                     break;
+                }
+            }
+        }
+
+        // experimental: when no installed backend can provide this bin and
+        // `experimental_lazy_shims` is on, fall back to aqua registry metadata
+        // so a never-installed aqua tool can be discovered & auto-installed.
+        // If multiple configured aqua tools advertise the same bin, skip
+        // auto-install entirely — same determinism rule as `get_desired_shims`.
+        if plugins.is_empty() {
+            let settings = Settings::get();
+            if settings.experimental && settings.experimental_lazy_shims {
+                let mut lazy_matches = vec![];
+                for (backend, tv) in self.list_current_versions() {
+                    if backend.get_type() != BackendType::Aqua {
+                        continue;
+                    }
+                    if backend.is_version_installed(config, &tv, true) {
+                        continue;
+                    }
+                    if let Ok(Some(names)) = backend.lazy_shim_bin_names(config, &tv).await
+                        && names.iter().any(|n| n == bin_name)
+                    {
+                        lazy_matches.push(backend);
+                    }
+                }
+                match lazy_matches.len() {
+                    1 => {
+                        plugins.insert(lazy_matches.into_iter().next().unwrap());
+                    }
+                    n if n > 1 => {
+                        let ids: Vec<_> = lazy_matches.iter().map(|b| b.id().to_string()).collect();
+                        trace!(
+                            "lazy auto-install for {bin_name} skipped: \
+                             advertised by multiple aqua tools {ids:?}"
+                        );
+                    }
+                    _ => {}
                 }
             }
         }


### PR DESCRIPTION
Related discussion: https://github.com/jdx/mise/discussions/9674

## Summary

Adds an experimental `experimental_lazy_shims` setting that generates shims for configured-but-not-installed aqua-backed tools using aqua registry metadata.

When such a shim (or a `command_not_found` event in `mise activate` mode) is invoked, mise auto-installs the tool and executes the requested binary.

The feature is gated behind:

```toml
experimental = true
experimental_lazy_shims = true
```

and currently limited to the aqua backend.

## Why aqua first

This PR starts with aqua because aqua registry metadata can provide executable names before installation, allowing mise to pre-generate deterministic shims without downloading the tool first.

A new `Backend::lazy_shim_bin_names` trait method is added as the extension point. The default implementation returns `Ok(None)`, and only `AquaBackend` overrides it in this PR.

## Unified lazy install path

The lazy auto-install logic lives in `Toolset::install_missing_bin`, which is used by both:

1. shim invocation (`handle_shim` → `which_shim`)
2. `mise activate`'s `hook-not-found`

This keeps shim-based and non-shim environments on the same code path.

## Falls back to current behavior when

* the aqua package uses `files[*].link`
* the package is unsupported on the current platform
* executable names cannot be derived safely
* multiple configured tools advertise the same executable name
* an installed tool already owns the same shim name

## Tests

Added e2e coverage for:

* lazy shim generation + feature flag gating
* activate-mode `hook-not-found` behavior

All existing tests pass and clippy is clean.

## Known limitations

* `pkg.supported_envs` is not checked yet
* `files[*].link` packages are skipped entirely
* `lazy_shim_bin_names` is currently sequential
* only e2e coverage exists for lazy shim resolution
