### PR TITLE
perf: avoid spawning process to set exit code

### DIFF
--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -75,12 +75,8 @@ impl Shell for Pwsh {
                             _mise_hook
                         }}
                         _reset_output_encoding
-                        # Pass down exit code from mise after _mise_hook
-                        if ($PSVersionTable.PSVersion.Major -ge 7) {{
-                            pwsh -NoProfile -Command exit $status
-                        }} else {{
-                            powershell -NoProfile -Command exit $status
-                        }}
+                        # restore exit code from mise after _mise_hook
+                        $global:LASTEXITCODE = $status
                     }}
                 }}
             }}

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -52,12 +52,8 @@ function mise {
                 _mise_hook
             }
             _reset_output_encoding
-            # Pass down exit code from mise after _mise_hook
-            if ($PSVersionTable.PSVersion.Major -ge 7) {
-                pwsh -NoProfile -Command exit $status
-            } else {
-                powershell -NoProfile -Command exit $status
-            }
+            # restore exit code from mise after _mise_hook
+            $global:LASTEXITCODE = $status
         }
     }
 }


### PR DESCRIPTION
I assumed `pwsh -NoProfile -Command exit $status` is being used to set the exit code, but on powershell `$LASTEXITCODE` can be assigned.

This is simpler and much faster because starting pwsh is quite slow, on my machine:
```
> (Measure-Command { pwsh -NoProfile -Command exit 0 }).TotalMilliseconds
267.2024
> (Measure-Command { powershell -NoProfile -Command exit 0 }).TotalMilliseconds
185.1042
```