### PR TITLE
chore: enable lockfile setting in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,9 @@
 #:schema ./schema/mise.json
 min_version = "2024.1.1"
 
+[settings]
+lockfile = true
+
 [env]
 _.path = ["./target/debug", "./node_modules/.bin"]
 


### PR DESCRIPTION
## Summary

- Set `[settings] lockfile = true` in `mise.toml` so the committed `mise.lock` is maintained with dev tool installs and upgrades.
- Ran `mise lock` against current `mise.toml`; the lockfile already matched resolved versions (no `mise.lock` diff).

## Test plan

- [ ] `mise install` in a clean environment
- [ ] CI lockfile-related checks (if any)

Made with [Cursor](https://cursor.com)