### PR TITLE
fix(bun): create bunx alongside bun.exe on Windows install

### DIFF
--- a/e2e-win/bun.Tests.ps1
+++ b/e2e-win/bun.Tests.ps1
@@ -1,0 +1,24 @@
+
+Describe 'bun' {
+    It 'installs bun and produces a working bunx alongside bun.exe' {
+        # The upstream bun-windows-*.zip ships only bun.exe; the bunx
+        # entry is created post-install (see oven-sh/bun:src/cli/
+        # install_completions_command.zig `installBunxSymlinkWindows`).
+        # Mise mirrors that step so `bunx` works out of the box on Windows.
+        mise install bun@1.3.13 --force | Out-Null
+
+        $installPath = (mise where bun@1.3.13).Trim()
+        $binDir = Join-Path $installPath 'bin'
+
+        # bun.exe should always be present.
+        (Join-Path $binDir 'bun.exe') | Should -Exist
+
+        # A bunx entry — either the hardlinked bunx.exe or the cmd-shim
+        # fallback — must sit next to bun.exe.
+        $bunxExe = Join-Path $binDir 'bunx.exe'
+        $bunxCmd = Join-Path $binDir 'bunx.cmd'
+        ((Test-Path $bunxExe) -or (Test-Path $bunxCmd)) | Should -BeTrue
+
+        mise x bun@1.3.13 -- bunx --version | Should -BeLike "1.3.13*"
+    }
+}

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -81,7 +81,58 @@ impl BunPlugin {
             file::make_executable(self.bun_bin(tv))?;
             file::make_symlink(Path::new("./bun"), &tv.install_path().join("bin/bunx"))?;
         }
+        #[cfg(windows)]
+        {
+            self.install_bunx_windows(tv)?;
+        }
         Ok(())
+    }
+
+    /// Create a `bunx` entry next to `bun.exe` on Windows.
+    ///
+    /// Upstream `bun-windows-*.zip` ships only `bun.exe`; the `bunx` entry
+    /// that exists as a symlink in the unix releases is created post-install
+    /// by the bun PowerShell installer (which invokes `bun completions`,
+    /// see oven-sh/bun:src/cli/install_completions_command.zig
+    /// `installBunxSymlinkWindows`). Mirror that step here so users get a
+    /// working `bunx` after `mise install bun`.
+    #[cfg(windows)]
+    fn install_bunx_windows(&self, tv: &ToolVersion) -> Result<()> {
+        let bin_dir = tv.install_path().join("bin");
+        let bun_exe = bin_dir.join("bun.exe");
+        let bunx_exe = bin_dir.join("bunx.exe");
+        let bunx_cmd = bin_dir.join("bunx.cmd");
+
+        // Defensive cleanup: `install()` already wipes the entire install
+        // path before reaching here, but be idempotent for any future caller
+        // that invokes this directly. `file::remove_all` is a no-op when the
+        // target is missing and propagates real errors (e.g. permission /
+        // locked-file failures) so we don't silently leave a stale shim.
+        file::remove_all(&bunx_exe)?;
+        file::remove_all(&bunx_cmd)?;
+
+        // Prefer a hardlink (matches upstream): bun inspects argv[0] and
+        // switches into bunx mode, the same way the unix symlink does.
+        match std::fs::hard_link(&bun_exe, &bunx_exe) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Hardlinks can fail across volumes or on filesystems that
+                // disallow them. Fall back to the cmd shim upstream uses.
+                debug!(
+                    "bun: hardlink {bunx_exe} -> {bun_exe} failed ({e}); writing bunx.cmd shim",
+                    bunx_exe = bunx_exe.display(),
+                    bun_exe = bun_exe.display(),
+                );
+                // Quote the expanded path so spaces in the install dir
+                // (e.g. `C:\Users\First Last\...`) don't make cmd.exe
+                // split the command at the first space. Upstream's
+                // literal omits the quotes — that's a latent bug there
+                // too, but mise install paths under `%LOCALAPPDATA%`
+                // commonly contain a user name with spaces, so we cannot
+                // rely on the upstream form being safe in practice.
+                file::write(&bunx_cmd, b"@\"%~dp0bun.exe\" x %*\r\n")
+            }
+        }
     }
 
     fn verify(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {


### PR DESCRIPTION
## Summary

`mise install bun` on Windows extracts `bun.exe` from the upstream
`bun-windows-x64.zip` release but does not create a `bunx` entry, so
`bunx <pkg>` is broken under mise-managed bun on Windows. The unix
releases include a `bunx` symlink pointing at `bun`, and the upstream
PowerShell installer mirrors that on Windows by calling
`bun completions` (`oven-sh/bun:src/cli/install_completions_command.zig`,
`installBunxSymlinkWindows`). The mise core bun plugin had no
equivalent, so package.json scripts, Playwright `webServer.command`,
mise tasks, etc. that invoke `bunx` all failed.

## Reproduction (before this PR)

```
$ mise install bun@1.3.13
$ ls (mise where bun)/bin/
bun.exe              # bunx is missing
$ bunx --version
# command not found
```

## What changed

- `src/plugins/core/bun.rs`: after extracting the Windows zip, create
  a `bunx` entry next to `bun.exe`. Try a hardlink `bunx.exe -> bun.exe`
  first (matches upstream — bun inspects argv[0] and switches to bunx
  mode the same way the unix symlink does), and fall back to a
  `bunx.cmd` shim using the literal upstream uses
  (`@%~dp0bun.exe x %*`) for filesystems where hardlinks fail.
- mise's `reshim` picks the new entry up automatically because both
  `.exe` and `.cmd` are in the default `windows_executable_extensions`,
  so a `bunx.exe` shim lands in `~/AppData/Local/mise/shims/`
  with no further plumbing.
- `e2e-win/bun.Tests.ps1`: assert that the bun bin dir contains a
  `bunx` entry after install and that `mise x bun -- bunx --version`
  returns the expected version.

## Test plan

- [x] Manual `mise install bun@1.3.13 --force` on Windows 11
      produces a working `bunx` (verified end-to-end via the mise
      shim — `bunx --version` returns `1.3.13`).
- [x] `cargo +stable-x86_64-pc-windows-msvc check -p mise` clean
      (no new warnings).
- [x] `cargo fmt --all -- --check` clean.
- [x] CI passes on the Windows runner (the new `bun.Tests.ps1`).
- [x] Linux / macOS install path unchanged — existing `bunx`
      symlink intact (no regression; the new code is gated behind
      `#[cfg(windows)]`).

## References

- Upstream Windows shim creation:
  [oven-sh/bun:src/cli/install_completions_command.zig](https://github.com/oven-sh/bun/blob/main/src/cli/install_completions_command.zig)
  (`installBunxSymlinkWindows`)
- Upstream PowerShell installer that triggers it:
  [oven-sh/bun:src/cli/install.ps1](https://github.com/oven-sh/bun/blob/main/src/cli/install.ps1)