### PR TITLE
fix(python): skip redundant lockfile provenance verification

### DIFF
--- a/e2e/lockfile/test_lockfile_python_skip_provenance_verify
+++ b/e2e/lockfile/test_lockfile_python_skip_provenance_verify
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+export MISE_PYTHON_COMPILE=0
+export MISE_PYTHON_GITHUB_ATTESTATIONS=1
+export MISE_GITHUB_ATTESTATIONS=1
+
+detect_platform
+PLATFORM="$MISE_PLATFORM"
+
+mkdir -p fake-python/python/bin
+cat <<'EOF' >fake-python/python/bin/python
+#!/usr/bin/env bash
+echo "Python 3.13.5"
+EOF
+chmod +x fake-python/python/bin/python
+tar -czf python-3.13.5.tar.gz -C fake-python python
+
+if command -v sha256sum >/dev/null 2>&1; then
+  CHECKSUM=$(sha256sum python-3.13.5.tar.gz | cut -d' ' -f1)
+else
+  CHECKSUM=$(shasum -a 256 python-3.13.5.tar.gz | cut -d' ' -f1)
+fi
+SIZE=$(wc -c <python-3.13.5.tar.gz | tr -d ' ')
+
+HTTP_PORT_FILE="$TMPDIR/mise_python_tarball_port"
+python3 -u - "$PWD" "$HTTP_PORT_FILE" <<'PY' >/dev/null 2>&1 &
+import functools
+import http.server
+import socketserver
+import sys
+from pathlib import Path
+
+root = sys.argv[1]
+port_file = Path(sys.argv[2])
+handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=root)
+with socketserver.TCPServer(("127.0.0.1", 0), handler) as httpd:
+    port_file.write_text(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+
+cleanup() {
+  kill "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_file "$HTTP_PORT_FILE" "Python tarball server port file" 30 "$SERVER_PID"
+HTTP_PORT=$(cat "$HTTP_PORT_FILE")
+
+cat <<EOF >mise.toml
+[tools]
+python = { version = "3.13.5", patch_sysconfig = false }
+EOF
+
+cat <<EOF >mise.lock
+[[tools.python]]
+version = "3.13.5"
+backend = "core:python"
+"platforms.$PLATFORM" = { checksum = "sha256:$CHECKSUM", size = $SIZE, url = "http://127.0.0.1:$HTTP_PORT/python-3.13.5.tar.gz", provenance = "github-attestations" }
+EOF
+
+# If install re-verifies GitHub attestations, this fake tarball fails verification.
+# With checksum + provenance already in the lockfile, install should trust the
+# checksum and only ensure the provenance setting is still enabled.
+MISE_GITHUB_TOKEN=invalid GITHUB_TOKEN=invalid mise install python -f
+
+assert "$MISE_DATA_DIR/installs/python/3.13.5/bin/python --version" "Python 3.13.5"

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -644,7 +644,7 @@ impl PythonPlugin {
                 .lock_platforms
                 .get(platform_key)
                 .and_then(|pi| pi.provenance.as_ref());
-            if !got.is_some_and(|g| std::mem::discriminant(g) == std::mem::discriminant(expected)) {
+            if !got.is_some_and(|g| g == expected) {
                 let got_str = got
                     .map(|g| g.to_string())
                     .unwrap_or_else(|| "no verification".to_string());

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -307,42 +307,19 @@ impl PythonPlugin {
             .or_default()
             .url = Some(url.to_string());
 
+        // Check before verify_checksum, which may generate a new checksum from the
+        // downloaded file. We only skip provenance when the lockfile already had
+        // integrity data before this install.
+        let has_lockfile_integrity = Self::has_precompiled_lockfile_integrity(tv, &platform_key);
+
         self.verify_checksum(ctx, tv, &tarball_path)?;
 
-        // Check lockfile provenance expectation before verification
-        let locked_provenance = tv
-            .lock_platforms
-            .get_mut(&platform_key)
-            .and_then(|pi| pi.provenance.take());
-
-        // Verify GitHub artifact attestations for precompiled binaries
-        // Returns Ok(true) if verified, Ok(false) if skipped, Err if failed
-        let verified = self
-            .verify_github_artifact_attestations(ctx, &tarball_path, &tv.version)
-            .await?;
-
-        // Record provenance only if verification actually succeeded (not skipped)
-        if verified {
-            let pi = tv.lock_platforms.entry(platform_key.clone()).or_default();
-            pi.provenance = Some(ProvenanceType::GithubAttestations);
-        }
-
-        // Enforce lockfile provenance
-        if let Some(ref expected) = locked_provenance {
-            let got = tv
-                .lock_platforms
-                .get(&platform_key)
-                .and_then(|pi| pi.provenance.as_ref());
-            if !got.is_some_and(|g| std::mem::discriminant(g) == std::mem::discriminant(expected)) {
-                let got_str = got
-                    .map(|g| g.to_string())
-                    .unwrap_or_else(|| "no verification".to_string());
-                return Err(eyre!(
-                    "Lockfile requires {expected} provenance for {tv} but {got_str} was used. \
-                     This may indicate a downgrade attack. Enable the corresponding verification setting \
-                     or update the lockfile."
-                ));
-            }
+        let settings = Settings::get();
+        if has_lockfile_integrity && !settings.force_provenance_verify() {
+            Self::ensure_precompiled_provenance_setting_enabled(tv, &platform_key)?;
+        } else {
+            self.verify_precompiled_provenance(ctx, tv, &platform_key, &tarball_path)
+                .await?;
         }
 
         file::remove_all(&install)?;
@@ -610,6 +587,76 @@ impl PythonPlugin {
             return None;
         }
         Some(ProvenanceType::GithubAttestations)
+    }
+
+    fn has_precompiled_lockfile_integrity(tv: &ToolVersion, platform_key: &str) -> bool {
+        tv.lock_platforms
+            .get(platform_key)
+            .is_some_and(|pi| pi.checksum.is_some() && pi.provenance.is_some())
+    }
+
+    fn ensure_precompiled_provenance_setting_enabled(
+        tv: &ToolVersion,
+        platform_key: &str,
+    ) -> Result<()> {
+        crate::backend::ensure_provenance_setting_enabled(tv, platform_key, |provenance| {
+            match provenance {
+                ProvenanceType::GithubAttestations => Ok(!Self::github_attestations_enabled()),
+                _ => Err(eyre!(
+                    "Lockfile has unexpected provenance type {provenance} for python tool {tv}. \
+                     Update the lockfile to remove the stale provenance entry."
+                )),
+            }
+        })
+    }
+
+    async fn verify_precompiled_provenance(
+        &self,
+        ctx: &InstallContext,
+        tv: &mut ToolVersion,
+        platform_key: &str,
+        tarball_path: &std::path::Path,
+    ) -> Result<()> {
+        // Check lockfile provenance expectation before verification
+        let locked_provenance = tv
+            .lock_platforms
+            .get_mut(platform_key)
+            .and_then(|pi| pi.provenance.take());
+
+        // Verify GitHub artifact attestations for precompiled binaries
+        // Returns Ok(true) if verified, Ok(false) if skipped, Err if failed
+        let verified = self
+            .verify_github_artifact_attestations(ctx, tarball_path, &tv.version)
+            .await?;
+
+        // Record provenance only if verification actually succeeded (not skipped)
+        if verified {
+            let pi = tv
+                .lock_platforms
+                .entry(platform_key.to_string())
+                .or_default();
+            pi.provenance = Some(ProvenanceType::GithubAttestations);
+        }
+
+        // Enforce lockfile provenance
+        if let Some(ref expected) = locked_provenance {
+            let got = tv
+                .lock_platforms
+                .get(platform_key)
+                .and_then(|pi| pi.provenance.as_ref());
+            if !got.is_some_and(|g| std::mem::discriminant(g) == std::mem::discriminant(expected)) {
+                let got_str = got
+                    .map(|g| g.to_string())
+                    .unwrap_or_else(|| "no verification".to_string());
+                return Err(eyre!(
+                    "Lockfile requires {expected} provenance for {tv} but {got_str} was used. \
+                     This may indicate a downgrade attack. Enable the corresponding verification setting \
+                     or update the lockfile."
+                ));
+            }
+        }
+
+        Ok(())
     }
 
     async fn verify_github_artifact_attestations(

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -644,7 +644,7 @@ impl PythonPlugin {
                 .lock_platforms
                 .get(platform_key)
                 .and_then(|pi| pi.provenance.as_ref());
-            if !got.is_some_and(|g| g == expected) {
+            if got.is_none_or(|g| g != expected) {
                 let got_str = got
                     .map(|g| g.to_string())
                     .unwrap_or_else(|| "no verification".to_string());


### PR DESCRIPTION
## Summary
- Skip core Python GitHub Artifact Attestation re-verification when the lockfile already has checksum + `provenance = "github-attestations"` for the current platform
- Keep downgrade protection by checking that Python GitHub attestations are still enabled before trusting a provenance-bearing lockfile entry
- Keep `locked_verify_provenance` / `paranoid` as the opt-in path to force install-time re-verification
- Add a focused e2e using a local fake precompiled Python tarball that would fail if attestations were re-verified

## Policy alignment
The lockfile policy from #8688 and #8901 is that repeated installs may trust the lockfile checksum after provenance has already been established, while `locked_verify_provenance` / `paranoid` can force a fresh cryptographic check. The lockfile stores the provenance type, not the full attestation bundle.

This PR applies that same policy to `core:python`: checksum + positive `github-attestations` provenance is enough to skip the redundant GitHub attestation API call on normal installs. Missing provenance is not treated as verified and still goes through the existing verification path.

## Relation to #9741
#9741 handles unavailable GitHub Artifact Attestations for the aqua/github backends. It does not cover core Python, because precompiled Python uses `src/plugins/core/python.rs` rather than those backends. This PR is still needed for Python lockfiles that already contain positive `github-attestations` provenance.

## Related history
- Discussion #8677 reported locked installs still hitting GitHub APIs despite lockfile URLs/checksums.
- #8679 fixed locked aqua release URL resolution.
- #8688 established the checksum + provenance skip behavior for aqua/github/vfox.
- #8901 added lock-time current-platform provenance verification and `locked_verify_provenance` / `paranoid` re-verification.

## Source
- Project item: https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=185170046
- Discussion: https://github.com/jdx/mise/discussions/8677

## Tests
- `cargo fmt`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 /home/risu/.cargo/bin/cargo test --bin mise plugins::core::python::tests`
- `mise run test:e2e e2e/lockfile/test_lockfile_python_skip_provenance_verify`

*This PR was updated by an AI coding assistant.*
