### PR TITLE
fix(config): warn for missing package.json package managers

### DIFF
--- a/e2e/core/test_package_json
+++ b/e2e/core/test_package_json
@@ -43,21 +43,6 @@ EOF
 
 assert_contains "mise current pnpm" "10."
 
-# Test devEngines.packageManager warns when the package manager is missing
-cat >package.json <<'EOF'
-{
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "9999.9999.9999",
-      "onFail": "error"
-    }
-  }
-}
-EOF
-
-assert_contains "mise hook-env -s bash --force 2>&1" "missing: pnpm@9999.9999.9999"
-
 # Test package.json with no relevant fields doesn't break anything
 cat >package.json <<'EOF'
 {

--- a/e2e/core/test_package_json
+++ b/e2e/core/test_package_json
@@ -43,6 +43,21 @@ EOF
 
 assert_contains "mise current pnpm" "10."
 
+# Test devEngines.packageManager warns when the package manager is missing
+cat >package.json <<'EOF'
+{
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.33.0",
+      "onFail": "error"
+    }
+  }
+}
+EOF
+
+assert_contains "mise hook-env -s bash --force 2>&1" "missing: pnpm@10.33.0"
+
 # Test package.json with no relevant fields doesn't break anything
 cat >package.json <<'EOF'
 {

--- a/e2e/core/test_package_json
+++ b/e2e/core/test_package_json
@@ -49,14 +49,14 @@ cat >package.json <<'EOF'
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "10.33.0",
+      "version": "9999.9999.9999",
       "onFail": "error"
     }
   }
 }
 EOF
 
-assert_contains "mise hook-env -s bash --force 2>&1" "missing: pnpm@10.33.0"
+assert_contains "mise hook-env -s bash --force 2>&1" "missing: pnpm@9999.9999.9999"
 
 # Test package.json with no relevant fields doesn't break anything
 cat >package.json <<'EOF'

--- a/e2e/core/test_package_json_missing_package_manager
+++ b/e2e/core/test_package_json_missing_package_manager
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Test that package managers from package.json warn even before the package manager has been installed with mise
+
+mise settings set idiomatic_version_file_enable_tools "pnpm"
+
+cat >package.json <<'EOF'
+{
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "9999.9999.9999",
+      "onFail": "error"
+    }
+  }
+}
+EOF
+
+assert_contains "mise hook-env -s bash --force 2>&1" "missing: pnpm@9999.9999.9999"

--- a/src/config/config_file/idiomatic_version/package_json.rs
+++ b/src/config/config_file/idiomatic_version/package_json.rs
@@ -2,6 +2,7 @@ use crate::file;
 use eyre::Result;
 use serde::Deserialize;
 use serde::de::Deserializer;
+use std::collections::HashSet;
 use std::path::Path;
 
 #[derive(Debug, Deserialize)]
@@ -31,8 +32,14 @@ pub fn is_package_json(path: &Path) -> bool {
         .is_some_and(|file_name| file_name == "package.json")
 }
 
-pub fn has_package_manager_version(path: &Path, tool_name: &str) -> bool {
-    PackageJsonData::parse(path).is_ok_and(|pkg| pkg.package_manager_version(tool_name).is_some())
+pub fn is_package_manager_tool(tool_name: &str) -> bool {
+    matches!(tool_name, "bun" | "npm" | "pnpm" | "yarn")
+}
+
+pub fn package_manager_names(path: &Path) -> HashSet<String> {
+    PackageJsonData::parse(path)
+        .map(|pkg| pkg.package_manager_names())
+        .unwrap_or_default()
 }
 
 /// Deserialize a field that may be a single object or an array (take the first element).
@@ -100,6 +107,14 @@ impl PackageJsonData {
                 }
                 Some(version.to_string())
             })
+    }
+
+    fn package_manager_names(&self) -> HashSet<String> {
+        ["bun", "npm", "pnpm", "yarn"]
+            .into_iter()
+            .filter(|tool_name| self.package_manager_version(tool_name).is_some())
+            .map(str::to_string)
+            .collect()
     }
 }
 

--- a/src/config/config_file/idiomatic_version/package_json.rs
+++ b/src/config/config_file/idiomatic_version/package_json.rs
@@ -31,6 +31,10 @@ pub fn is_package_json(path: &Path) -> bool {
         .is_some_and(|file_name| file_name == "package.json")
 }
 
+pub fn has_package_manager_version(path: &Path, tool_name: &str) -> bool {
+    PackageJsonData::parse(path).is_ok_and(|pkg| pkg.package_manager_version(tool_name).is_some())
+}
+
 /// Deserialize a field that may be a single object or an array (take the first element).
 /// The npm devEngines spec allows both forms.
 fn deserialize_one_or_first<'de, D>(

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -550,7 +550,11 @@ impl Toolset {
         }
         let mut missing = vec![];
         for tv in missing_versions.into_iter() {
-            if Settings::get().status.missing_tools() == SettingsStatusMissingTools::Always {
+            // package.json package managers are project requirements even if the
+            // user has never installed that package manager with mise.
+            if Settings::get().status.missing_tools() == SettingsStatusMissingTools::Always
+                || is_package_json_package_manager(&tv)
+            {
                 missing.push(tv);
                 continue;
             }
@@ -582,6 +586,17 @@ impl Toolset {
         !ba.is_os_supported()
             || !tool_enabled(enable_tools.as_ref(), &disable_tools, &ba.short.to_string())
     }
+}
+
+fn is_package_json_package_manager(tv: &ToolVersion) -> bool {
+    let ToolSource::IdiomaticVersionFile(path) = tv.request.source() else {
+        return false;
+    };
+    crate::config::config_file::idiomatic_version::package_json::is_package_json(path)
+        && crate::config::config_file::idiomatic_version::package_json::has_package_manager_version(
+            path,
+            tv.short(),
+        )
 }
 
 impl Display for Toolset {

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -1,6 +1,7 @@
 use crate::backend::Backend;
 use crate::cli::args::BackendArg;
 use crate::config::Config;
+use crate::config::config_file::idiomatic_version::package_json;
 use crate::config::settings::{Settings, SettingsStatusMissingTools};
 use crate::env::TERM_WIDTH;
 use crate::lockfile::{Lockfile, lockfile_path_for_config};
@@ -545,15 +546,17 @@ impl Toolset {
     }
 
     pub fn notify_missing_versions(&self, missing_versions: Vec<ToolVersion>) {
-        if Settings::get().status.missing_tools() == SettingsStatusMissingTools::Never {
+        let missing_tools = Settings::get().status.missing_tools();
+        if missing_tools == SettingsStatusMissingTools::Never {
             return;
         }
         let mut missing = vec![];
+        let mut package_json_package_managers = HashMap::new();
         for tv in missing_versions.into_iter() {
             // package.json package managers are project requirements even if the
             // user has never installed that package manager with mise.
-            if Settings::get().status.missing_tools() == SettingsStatusMissingTools::Always
-                || is_package_json_package_manager(&tv)
+            if missing_tools == SettingsStatusMissingTools::Always
+                || is_package_json_package_manager(&tv, &mut package_json_package_managers)
             {
                 missing.push(tv);
                 continue;
@@ -588,15 +591,23 @@ impl Toolset {
     }
 }
 
-fn is_package_json_package_manager(tv: &ToolVersion) -> bool {
+fn is_package_json_package_manager(
+    tv: &ToolVersion,
+    package_json_package_managers: &mut HashMap<PathBuf, HashSet<String>>,
+) -> bool {
+    if !package_json::is_package_manager_tool(tv.short()) {
+        return false;
+    }
     let ToolSource::IdiomaticVersionFile(path) = tv.request.source() else {
         return false;
     };
-    crate::config::config_file::idiomatic_version::package_json::is_package_json(path)
-        && crate::config::config_file::idiomatic_version::package_json::has_package_manager_version(
-            path,
-            tv.short(),
-        )
+    if !package_json::is_package_json(path) {
+        return false;
+    }
+    let package_managers = package_json_package_managers
+        .entry(path.to_path_buf())
+        .or_insert_with(|| package_json::package_manager_names(path));
+    package_managers.contains(tv.short())
 }
 
 impl Display for Toolset {


### PR DESCRIPTION
## Summary
- warn for package managers declared in `package.json` even when no version of that package manager has been installed with mise yet
- add a `devEngines.packageManager` regression fixture for missing `pnpm`

## Source
- Discussion: https://github.com/jdx/mise/discussions/9230
- Project item: https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=183815547

## Testing
- `cargo fmt`
- `git diff --check`
- `cargo test config::config_file::idiomatic_version::package_json`
- `mise run test:e2e e2e/core/test_package_json`
