### PR TITLE
feat(java): per-tool arch option for cross-arch installs on Apple Silicon

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1989,8 +1989,8 @@ pub trait Backend: Debug + Send + Sync {
         let filename = file.file_name().unwrap().to_string_lossy().to_string();
         let lockfile_enabled = settings.lockfile_enabled();
 
-        // Get the platform key for this tool and platform
-        let platform_key = self.get_platform_key();
+        // Get the platform key for this tool version, respecting per-tool arch options
+        let platform_key = tv.platform_key();
 
         // Get or create asset info for this platform
         let platform_info = tv.lock_platforms.entry(platform_key.clone()).or_default();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -399,9 +399,64 @@ pub(crate) fn normalize_idiomatic_contents(contents: &str) -> String {
         .join("\n")
 }
 
+/// Strip trailing known-arch segments (e.g. `-x64`, `-arm64`) from install
+/// directory names and deduplicate. This ensures version strings returned to
+/// callers never contain an arch suffix that `tv_pathname()` would re-add,
+/// which would produce double-suffixed paths like `corretto-8.462.08.1-x64-x64`.
+pub(crate) fn strip_arch_suffixes_from_versions(raw: Vec<String>) -> Vec<String> {
+    let mut seen = indexmap::IndexSet::new();
+    for v in raw {
+        let base = if let Some(pos) = v.rfind('-') {
+            if Settings::normalize_arch(&v[pos + 1..]).is_some() {
+                v[..pos].to_string()
+            } else {
+                v
+            }
+        } else {
+            v
+        };
+        seen.insert(base);
+    }
+    seen.into_iter().collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_strip_arch_suffixes_from_versions() {
+        // Cross-arch suffix is stripped, leaving canonical version
+        assert_eq!(
+            strip_arch_suffixes_from_versions(vec!["corretto-8.462.08.1-x64".into()]),
+            vec!["corretto-8.462.08.1"]
+        );
+        assert_eq!(
+            strip_arch_suffixes_from_versions(vec!["corretto-8.462.08.1-arm64".into()]),
+            vec!["corretto-8.462.08.1"]
+        );
+        // Non-arch suffixes are left intact
+        assert_eq!(
+            strip_arch_suffixes_from_versions(vec!["temurin-21.0.11+10.0.LTS".into()]),
+            vec!["temurin-21.0.11+10.0.LTS"]
+        );
+        // Native and cross-arch of same version deduplicate to one entry
+        assert_eq!(
+            strip_arch_suffixes_from_versions(vec![
+                "corretto-8.462.08.1".into(),
+                "corretto-8.462.08.1-x64".into(),
+            ]),
+            vec!["corretto-8.462.08.1"]
+        );
+        // Multiple distinct versions are preserved
+        let result = strip_arch_suffixes_from_versions(vec![
+            "corretto-8.462.08.1-x64".into(),
+            "temurin-21.0.11+10.0.LTS".into(),
+        ]);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&"corretto-8.462.08.1".to_string()));
+        assert!(result.contains(&"temurin-21.0.11+10.0.LTS".to_string()));
+    }
 
     #[test]
     fn test_normalize_idiomatic_contents() {
@@ -1059,25 +1114,8 @@ pub trait Backend: Debug + Send + Sync {
         None
     }
     fn list_installed_versions(&self) -> Vec<String> {
-        // Strip any arch suffix (e.g. -x64) from install directory names before
-        // returning them as version strings. Arch suffixes are an implementation
-        // detail of tv_pathname() — they must never appear in tv.version, or
-        // tv_pathname() would double-apply them.
         let raw = install_state::list_versions(&self.ba().short);
-        let mut seen = indexmap::IndexSet::new();
-        for v in raw {
-            let base = if let Some(pos) = v.rfind('-') {
-                if Settings::normalize_arch(&v[pos + 1..]).is_some() {
-                    v[..pos].to_string()
-                } else {
-                    v
-                }
-            } else {
-                v
-            };
-            seen.insert(base);
-        }
-        seen.into_iter().collect()
+        strip_arch_suffixes_from_versions(raw)
     }
     fn is_version_installed(
         &self,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1059,7 +1059,25 @@ pub trait Backend: Debug + Send + Sync {
         None
     }
     fn list_installed_versions(&self) -> Vec<String> {
-        install_state::list_versions(&self.ba().short)
+        // Strip any arch suffix (e.g. -x64) from install directory names before
+        // returning them as version strings. Arch suffixes are an implementation
+        // detail of tv_pathname() — they must never appear in tv.version, or
+        // tv_pathname() would double-apply them.
+        let raw = install_state::list_versions(&self.ba().short);
+        let mut seen = indexmap::IndexSet::new();
+        for v in raw {
+            let base = if let Some(pos) = v.rfind('-') {
+                if Settings::normalize_arch(&v[pos + 1..]).is_some() {
+                    v[..pos].to_string()
+                } else {
+                    v
+                }
+            } else {
+                v
+            };
+            seen.insert(base);
+        }
+        seen.into_iter().collect()
     }
     fn is_version_installed(
         &self,

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -2,13 +2,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::config::Config;
+use crate::config::{Config, Settings};
 use crate::file::display_path;
 use crate::lockfile::{self, LockResolutionResult, Lockfile};
 use crate::platform::Platform;
-use crate::toolset::Toolset;
+use crate::toolset::{ToolVersion, Toolset};
 use crate::ui::multi_progress_report::MultiProgressReport;
-use crate::{cli::args::ToolArg, config::Settings};
+use crate::cli::args::ToolArg;
 use console::style;
 use eyre::{Result, bail};
 use tokio::sync::Semaphore;
@@ -593,11 +593,28 @@ impl Lock {
         }
     }
 
+    /// Returns the effective platform list for a specific tool version.
+    /// When the tool has a per-tool `arch` option (e.g. `arch = "x86_64"`),
+    /// only its own platform key is used. Otherwise the global platform list
+    /// (from `--platform` or the lockfile) applies.
+    fn effective_platforms_for_tool<'a>(
+        tv: &ToolVersion,
+        global_platforms: &'a [Platform],
+    ) -> Vec<Platform> {
+        if tv.request.options().get("arch").and_then(Settings::normalize_arch).is_some() {
+            if let Ok(p) = Platform::parse(&tv.platform_key()) {
+                return vec![p];
+            }
+        }
+        global_platforms.to_vec()
+    }
+
     fn show_dry_run(&self, tools: &[LockTool], platforms: &[Platform]) -> Result<()> {
         miseprintln!("{} Dry run - would update:", style("→").yellow());
         for (ba, tv) in tools {
             let backend = crate::backend::get(ba);
-            for platform in platforms {
+            let effective = Self::effective_platforms_for_tool(tv, platforms);
+            for platform in &effective {
                 // Expand platform variants just like process_tools does
                 let variants = if let Some(ref backend) = backend {
                     backend.platform_variants(platform)
@@ -640,7 +657,8 @@ impl Lock {
         )> = Vec::new();
         for (ba, tv) in tools {
             let backend = crate::backend::get(ba);
-            for platform in platforms {
+            let effective = Self::effective_platforms_for_tool(tv, platforms);
+            for platform in &effective {
                 // Get all variants for this platform from the backend
                 let variants = if let Some(ref backend) = backend {
                     backend.platform_variants(platform)

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -212,7 +212,7 @@ impl Ls {
                 requested: if self.all_sources || source.is_unknown() {
                     None
                 } else {
-                    Some(tv.request.version())
+                    Some(display_requested(&tv))
                 },
                 source: if self.all_sources || source.is_unknown() {
                     None
@@ -479,7 +479,7 @@ fn collect_sources(ts: &Toolset) -> SourcesMap {
             let key = (ba.short.to_string(), tv.tv_pathname());
             let entry = SourceEntry {
                 source: tv.request.source().clone(),
-                requested: tv.request.version(),
+                requested: display_requested(tv),
             };
             let entries = sources_map.entry(key).or_default();
             if !entries.contains(&entry) {
@@ -533,7 +533,7 @@ async fn json_tool_version_from(
         requested_version: if all_sources || source.is_unknown() {
             None
         } else {
-            Some(tv.request.version())
+            Some(display_requested(&tv))
         },
         source: if all_sources || source.is_unknown() {
             None
@@ -575,6 +575,24 @@ async fn version_status_from_sources(
     resolve_version_status(config, ls, p, tv, has_sources).await
 }
 
+/// Returns the version string to display in `mise ls`, appending an arch
+/// label (e.g. `[x64]`) when the tool has a per-tool arch option that differs
+/// from the native arch.
+fn display_version(tv: &ToolVersion) -> String {
+    match tv.arch_label() {
+        Some(arch) => format!("{} [{arch}]", tv.version),
+        None => tv.version.clone(),
+    }
+}
+
+fn display_requested(tv: &ToolVersion) -> String {
+    let version = tv.request.version();
+    match tv.arch_label() {
+        Some(arch) => format!("{version} [{arch}]"),
+        None => version,
+    }
+}
+
 async fn resolve_version_status(
     config: &Arc<Config>,
     ls: &Ls,
@@ -583,10 +601,11 @@ async fn resolve_version_status(
     active: bool,
 ) -> VersionStatus {
     let install_path = tv.install_path();
+    let dv = display_version(tv);
     if install_path.is_symlink() && !is_runtime_symlink(&install_path) {
-        VersionStatus::Symlink(tv.version.clone(), active)
+        VersionStatus::Symlink(dv, active)
     } else if !p.is_version_installed(config, tv, true) {
-        VersionStatus::Missing(tv.version.clone())
+        VersionStatus::Missing(dv)
     } else {
         let category = env::install_path_category(&install_path);
         if category != env::InstallPathCategory::Local {
@@ -595,7 +614,7 @@ async fn resolve_version_status(
                 env::InstallPathCategory::Shared => "shared",
                 _ => unreachable!(),
             };
-            return VersionStatus::Shared(tv.version.clone(), active, label);
+            return VersionStatus::Shared(dv, active, label);
         }
         if active {
             let outdated = if ls.outdated {
@@ -603,9 +622,9 @@ async fn resolve_version_status(
             } else {
                 false
             };
-            VersionStatus::Active(tv.version.clone(), outdated)
+            VersionStatus::Active(dv, outdated)
         } else {
-            VersionStatus::Inactive(tv.version.clone())
+            VersionStatus::Inactive(dv)
         }
     }
 }

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -115,36 +115,46 @@ impl Uninstall {
         let mut tool_versions = Vec::new();
         for ta in runtimes {
             let backend = ta.ba.backend()?;
-            let query = ta.tvr.as_ref().map(|tvr| tvr.version()).unwrap_or_default();
-            let installed_versions = backend.list_installed_versions();
-            let exact_match = installed_versions.iter().find(|v| v == &&query);
-            let matches = match exact_match {
-                Some(m) => vec![m],
-                None => installed_versions
-                    .iter()
-                    .filter(|v| v.starts_with(&query))
-                    .collect_vec(),
-            };
-
             let mut tvs = Vec::new();
 
             if let Some(tvr) = &ta.tvr {
+                // Explicit version given — resolve it directly (no config lookup)
+                let query = tvr.version();
+                let installed_versions = backend.list_installed_versions();
+                let exact_match = installed_versions.iter().find(|v| v == &&query);
+                let matches = match exact_match {
+                    Some(m) => vec![m],
+                    None => installed_versions
+                        .iter()
+                        .filter(|v| v.starts_with(&query))
+                        .collect_vec(),
+                };
                 tvs.push((
                     backend.clone(),
                     tvr.resolve(config, &Default::default()).await?,
                 ));
+                tvs.extend(
+                    matches
+                        .into_iter()
+                        .map(|v| {
+                            let tvr =
+                                ToolRequest::new(backend.ba().clone(), v, ToolSource::Unknown)?;
+                            let tv = ToolVersion::new(tvr, v.into());
+                            Ok((backend.clone(), tv))
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                );
+            } else {
+                // No version given — resolve from the current config context so that
+                // tool options (e.g. arch = "x86_64") are respected. This makes
+                // `mise uninstall java` the exact inverse of `mise install java`.
+                let ts = config.get_toolset().await?;
+                if let Some(tvl) = ts.versions.get(ta.ba.as_ref()) {
+                    for tv in &tvl.versions {
+                        tvs.push((backend.clone(), tv.clone()));
+                    }
+                }
             }
-
-            tvs.extend(
-                matches
-                    .into_iter()
-                    .map(|v| {
-                        let tvr = ToolRequest::new(backend.ba().clone(), v, ToolSource::Unknown)?;
-                        let tv = ToolVersion::new(tvr, v.into());
-                        Ok((backend.clone(), tv))
-                    })
-                    .collect::<Result<Vec<_>>>()?,
-            );
 
             if tvs.is_empty() {
                 warn!(

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -723,6 +723,37 @@ impl Settings {
         }
     }
 
+    /// Normalizes an arch string to the canonical form used by mise.
+    /// Returns `None` for unrecognized arch strings.
+    pub fn normalize_arch(arch: &str) -> Option<&'static str> {
+        Some(match arch {
+            "x86_64" | "amd64" | "x64" => "x64",
+            "aarch64" | "arm64" => "arm64",
+            "arm" | "arm32" | "armhf" | "armv7l" | "armv6l" => "arm",
+            "x86" | "i386" | "i686" => "x86",
+            "ppc64le" | "powerpc64le" => "ppc64le",
+            "s390x" => "s390x",
+            "riscv64" | "riscv64gc" => "riscv64",
+            "loong64" | "loongarch64" => "loong64",
+            _ => return None,
+        })
+    }
+
+    /// Returns the install path suffix for a given raw arch string when it
+    /// differs from the native arch (e.g. `Some("x64")` on an arm64 machine
+    /// when `arch = "x86_64"`). Returns `None` for native or unknown arches.
+    pub fn arch_suffix_for(arch: &str) -> Option<&'static str> {
+        let normalized = Self::normalize_arch(arch)?;
+        let native = Self::normalize_arch(ARCH)?;
+        if normalized != native { Some(normalized) } else { None }
+    }
+
+    /// Returns the arch suffix when the globally configured arch differs from
+    /// the native arch. Returns `None` when they match.
+    pub fn arch_suffix(&self) -> Option<&'static str> {
+        Self::arch_suffix_for(self.arch())
+    }
+
     pub fn libc(&self) -> Option<&str> {
         match self.libc.as_deref()?.to_ascii_lowercase().as_str() {
             "glibc" | "gnu" => Some("gnu"),
@@ -1201,5 +1232,51 @@ mod tests {
         );
         let result: BTreeSet<PathBuf> = list_by_os_path_separator(input).unwrap();
         assert_eq!(result, [a, b].into_iter().collect());
+    }
+
+    #[test]
+    fn test_normalize_arch() {
+        // x86_64 family
+        assert_eq!(Settings::normalize_arch("x86_64"), Some("x64"));
+        assert_eq!(Settings::normalize_arch("amd64"), Some("x64"));
+        assert_eq!(Settings::normalize_arch("x64"), Some("x64"));
+        // arm64 family
+        assert_eq!(Settings::normalize_arch("aarch64"), Some("arm64"));
+        assert_eq!(Settings::normalize_arch("arm64"), Some("arm64"));
+        // arm32 family
+        assert_eq!(Settings::normalize_arch("arm"), Some("arm"));
+        assert_eq!(Settings::normalize_arch("armhf"), Some("arm"));
+        assert_eq!(Settings::normalize_arch("armv7l"), Some("arm"));
+        assert_eq!(Settings::normalize_arch("armv6l"), Some("arm"));
+        // x86 32-bit
+        assert_eq!(Settings::normalize_arch("x86"), Some("x86"));
+        assert_eq!(Settings::normalize_arch("i386"), Some("x86"));
+        assert_eq!(Settings::normalize_arch("i686"), Some("x86"));
+        // other known arches
+        assert_eq!(Settings::normalize_arch("ppc64le"), Some("ppc64le"));
+        assert_eq!(Settings::normalize_arch("powerpc64le"), Some("ppc64le"));
+        assert_eq!(Settings::normalize_arch("s390x"), Some("s390x"));
+        assert_eq!(Settings::normalize_arch("riscv64"), Some("riscv64"));
+        assert_eq!(Settings::normalize_arch("riscv64gc"), Some("riscv64"));
+        assert_eq!(Settings::normalize_arch("loong64"), Some("loong64"));
+        assert_eq!(Settings::normalize_arch("loongarch64"), Some("loong64"));
+        // unknown
+        assert_eq!(Settings::normalize_arch("mips"), None);
+        assert_eq!(Settings::normalize_arch(""), None);
+    }
+
+    #[test]
+    fn test_arch_suffix_for() {
+        // On any machine, requesting the native arch should produce no suffix.
+        // We can only assert the cross-arch direction portably.
+        // x86_64 aliases all normalize to x64
+        assert_eq!(Settings::normalize_arch("x86_64"), Settings::normalize_arch("amd64"));
+        assert_eq!(Settings::normalize_arch("x86_64"), Settings::normalize_arch("x64"));
+        // arm64 aliases normalize consistently
+        assert_eq!(Settings::normalize_arch("aarch64"), Settings::normalize_arch("arm64"));
+        // unknown arch produces no suffix
+        assert_eq!(Settings::arch_suffix_for("mips"), None);
+        // native arch (whatever the test machine is) produces no suffix
+        assert_eq!(Settings::arch_suffix_for(std::env::consts::ARCH), None);
     }
 }

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -112,7 +112,7 @@ impl JavaPlugin {
         pr.set_message(format!("download {filename}"));
         HTTP.download_file(&m.url, &tarball_path, Some(pr)).await?;
 
-        let platform_key = self.get_platform_key();
+        let platform_key = tv.platform_key();
         if !tv.lock_platforms.contains_key(&platform_key) {
             let platform_info = tv.lock_platforms.entry(platform_key).or_default();
             platform_info.url = Some(m.url.clone());
@@ -256,15 +256,49 @@ impl JavaPlugin {
         }
     }
 
-    async fn tv_to_metadata(&self, tv: &ToolVersion) -> Result<&JavaMetadata> {
-        let v: String = self.tv_to_java_version(tv);
+    async fn tv_to_metadata(&self, tv: &ToolVersion) -> Result<JavaMetadata> {
+        let v = self.tv_to_java_version(tv);
         let release_type = self.tv_release_type(tv);
-        let m = self
-            .fetch_java_metadata(&release_type)
+        let settings = Settings::get();
+        let java_arch = tv_arch(tv, &settings);
+        let native_arch = arch(&settings);
+
+        if java_arch == native_arch {
+            self.fetch_java_metadata(&release_type)
+                .await?
+                .get(&v)
+                .ok_or_else(|| eyre!("no metadata found for version {}", tv.version))
+                .cloned()
+        } else {
+            self.download_java_metadata_for_arch(&release_type, java_arch)
+                .await?
+                .remove(&v)
+                .ok_or_else(|| eyre!("no metadata found for version {} (arch: {})", tv.version, java_arch))
+        }
+    }
+
+    async fn download_java_metadata_for_arch(
+        &self,
+        release_type: &str,
+        java_api_arch: &str,
+    ) -> Result<HashMap<String, JavaMetadata>> {
+        let url = format!(
+            "https://mise-java.jdx.dev/jvm/{}/{}/{}.json",
+            release_type,
+            os(),
+            java_api_arch,
+        );
+        let versions = HTTP_FETCH
+            .json::<Vec<JavaMetadata>, _>(url)
             .await?
-            .get(&v)
-            .ok_or_else(|| eyre!("no metadata found for version {}", tv.version))?;
-        Ok(m)
+            .into_iter()
+            .filter(|m| {
+                m.file_type
+                    .as_ref()
+                    .is_some_and(|ft| JAVA_FILE_TYPES.contains(ft))
+            })
+            .collect();
+        Ok(build_java_metadata_map(versions))
     }
 
     async fn download_java_metadata(&self, release_type: &str) -> Result<Vec<JavaMetadata>> {
@@ -442,8 +476,8 @@ impl Backend for JavaPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> eyre::Result<ToolVersion> {
-        // Check if URL already exists in lockfile platforms first
-        let platform_key = self.get_platform_key();
+        // Use per-tool arch when building the lockfile platform key
+        let platform_key = tv.platform_key();
         let (metadata, tarball_path) =
             if let Some(platform_info) = tv.lock_platforms.get(&platform_key) {
                 if let Some(ref url) = platform_info.url {
@@ -469,20 +503,20 @@ impl Backend for JavaPlugin {
                     // No URL in lockfile, fallback to metadata
                     let metadata = self.tv_to_metadata(&tv).await?;
                     let tarball_path = self
-                        .download(ctx, &mut tv, ctx.pr.as_ref(), metadata)
+                        .download(ctx, &mut tv, ctx.pr.as_ref(), &metadata)
                         .await?;
                     (metadata, tarball_path)
                 }
             } else {
                 let metadata = self.tv_to_metadata(&tv).await?;
                 let tarball_path = self
-                    .download(ctx, &mut tv, ctx.pr.as_ref(), metadata)
+                    .download(ctx, &mut tv, ctx.pr.as_ref(), &metadata)
                     .await?;
                 (metadata, tarball_path)
             };
 
         ctx.pr.next_operation();
-        self.install(&tv, ctx.pr.as_ref(), &tarball_path, metadata)?;
+        self.install(&tv, ctx.pr.as_ref(), &tarball_path, &metadata)?;
         ctx.pr.next_operation();
         self.verify(&tv, ctx.pr.as_ref())?;
 
@@ -558,6 +592,41 @@ fn arch(settings: &Settings) -> &str {
     }
 }
 
+/// Maps a normalized mise arch (e.g. "x64", "arm64") to the Java metadata API arch string.
+fn to_java_api_arch(normalized_arch: &str) -> &str {
+    match normalized_arch {
+        "x64" => "x86_64",
+        "arm64" => "aarch64",
+        "arm" => "arm32-vfp-hflt",
+        "x86" => "x86",
+        "ppc64le" => "ppc64le",
+        "s390x" => "s390x",
+        other => other,
+    }
+}
+
+/// Returns the Java metadata API arch string for a tool version, respecting
+/// a per-tool `arch` option before falling back to the global settings arch.
+fn tv_arch<'a>(tv: &'a ToolVersion, settings: &'a Settings) -> &'a str {
+    if let Some(normalized) = tv.request.options().get("arch").and_then(Settings::normalize_arch) {
+        to_java_api_arch(normalized)
+    } else {
+        arch(settings)
+    }
+}
+
+
+fn build_java_metadata_map(versions: Vec<JavaMetadata>) -> HashMap<String, JavaMetadata> {
+    let mut map = HashMap::new();
+    for m in versions {
+        if m.vendor == Settings::get().java.shorthand_vendor {
+            map.insert(m.version.to_string(), m.clone());
+        }
+        map.insert(m.to_string(), m);
+    }
+    map
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(default)]
 struct JavaMetadata {
@@ -624,3 +693,122 @@ static JAVA_FILE_TYPES: Lazy<HashSet<String>> =
 #[cfg(windows)]
 static JAVA_FILE_TYPES: Lazy<HashSet<String>> =
     Lazy::new(|| HashSet::from(["zip"].map(|s| s.to_string())));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::BackendResolution;
+    use crate::toolset::{ToolSource, ToolVersionOptions};
+
+    fn make_tv(version: &str, arch_opt: Option<&str>) -> ToolVersion {
+        let mut opts = ToolVersionOptions::default();
+        if let Some(a) = arch_opt {
+            opts.opts.insert("arch".into(), toml::Value::String(a.into()));
+        }
+        let ba = Arc::new(crate::cli::args::BackendArg::new_raw(
+            "java".into(),
+            None,
+            "java".into(),
+            None,
+            BackendResolution::new(false),
+        ));
+        let request = crate::toolset::ToolRequest::Version {
+            backend: ba,
+            version: version.into(),
+            options: opts,
+            source: ToolSource::Argument,
+        };
+        ToolVersion::new(request, version.into())
+    }
+
+    #[test]
+    fn test_to_java_api_arch_all_types() {
+        assert_eq!(to_java_api_arch("x64"), "x86_64");
+        assert_eq!(to_java_api_arch("arm64"), "aarch64");
+        assert_eq!(to_java_api_arch("arm"), "arm32-vfp-hflt");
+        assert_eq!(to_java_api_arch("x86"), "x86");
+        assert_eq!(to_java_api_arch("ppc64le"), "ppc64le");
+        assert_eq!(to_java_api_arch("s390x"), "s390x");
+        assert_eq!(to_java_api_arch("riscv64"), "riscv64");
+    }
+
+    #[test]
+    fn test_tv_arch_uses_tool_option() {
+        let settings = Settings::get();
+        // x86_64 option → Java API uses "x86_64"
+        let tv = make_tv("corretto-8.462.08.1", Some("x86_64"));
+        assert_eq!(tv_arch(&tv, &settings), "x86_64");
+
+        // aarch64 option → Java API uses "aarch64"
+        let tv = make_tv("temurin-21", Some("aarch64"));
+        assert_eq!(tv_arch(&tv, &settings), "aarch64");
+
+        // arm option → Java API uses "arm32-vfp-hflt"
+        let tv = make_tv("temurin-21", Some("arm"));
+        assert_eq!(tv_arch(&tv, &settings), "arm32-vfp-hflt");
+
+        // armhf alias → normalizes to arm → Java API uses "arm32-vfp-hflt"
+        let tv = make_tv("temurin-21", Some("armhf"));
+        assert_eq!(tv_arch(&tv, &settings), "arm32-vfp-hflt");
+
+        // ppc64le option
+        let tv = make_tv("temurin-21", Some("ppc64le"));
+        assert_eq!(tv_arch(&tv, &settings), "ppc64le");
+
+        // s390x option
+        let tv = make_tv("temurin-21", Some("s390x"));
+        assert_eq!(tv_arch(&tv, &settings), "s390x");
+    }
+
+    #[test]
+    fn test_tv_arch_falls_back_to_settings() {
+        let settings = Settings::get();
+        let tv = make_tv("temurin-21", None);
+        // Without a tool option, uses the global settings arch mapped through Java's format.
+        assert_eq!(tv_arch(&tv, &settings), arch(&settings));
+    }
+
+    #[test]
+    fn test_tv_platform_key_with_arch_option() {
+        use std::env::consts::ARCH;
+        let cross_arch = if ARCH == "aarch64" { "x86_64" } else { "aarch64" };
+        let expected_arch_in_key = if ARCH == "aarch64" { "x64" } else { "arm64" };
+
+        let tv = make_tv("corretto-8.462.08.1", Some(cross_arch));
+        let key = tv.platform_key();
+        assert!(
+            key.contains(expected_arch_in_key),
+            "platform key '{key}' should contain arch '{expected_arch_in_key}'"
+        );
+    }
+
+    #[test]
+    fn test_tv_platform_key_no_option_matches_current() {
+        let tv = make_tv("temurin-21", None);
+        assert_eq!(tv.platform_key(), crate::platform::Platform::current().to_key());
+    }
+    #[test]
+    fn test_to_java_api_arch_roundtrips_all_types() {
+        // Ensures normalize_arch → to_java_api_arch covers every arch we claim to support
+        for (input, expected_java_arch) in [
+            ("x86_64", "x86_64"),
+            ("amd64", "x86_64"),
+            ("x64", "x86_64"),
+            ("aarch64", "aarch64"),
+            ("arm64", "aarch64"),
+            ("arm", "arm32-vfp-hflt"),
+            ("armhf", "arm32-vfp-hflt"),
+            ("x86", "x86"),
+            ("i386", "x86"),
+            ("ppc64le", "ppc64le"),
+            ("s390x", "s390x"),
+        ] {
+            let normalized = Settings::normalize_arch(input).expect(input);
+            assert_eq!(
+                to_java_api_arch(normalized),
+                expected_java_arch,
+                "input: {input}"
+            );
+        }
+    }
+}

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -640,6 +640,7 @@ fn to_java_api_arch(normalized_arch: &str) -> &str {
         "x86" => "x86",
         "ppc64le" => "ppc64le",
         "s390x" => "s390x",
+        "loong64" => "loongarch64",
         other => other,
     }
 }
@@ -769,6 +770,7 @@ mod tests {
         assert_eq!(to_java_api_arch("ppc64le"), "ppc64le");
         assert_eq!(to_java_api_arch("s390x"), "s390x");
         assert_eq!(to_java_api_arch("riscv64"), "riscv64");
+        assert_eq!(to_java_api_arch("loong64"), "loongarch64");
     }
 
     #[test]
@@ -841,6 +843,8 @@ mod tests {
             ("i386", "x86"),
             ("ppc64le", "ppc64le"),
             ("s390x", "s390x"),
+            ("loong64", "loongarch64"),
+            ("loongarch64", "loongarch64"),
         ] {
             let normalized = Settings::normalize_arch(input).expect(input);
             assert_eq!(

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::backend::{Backend, VersionInfo, normalize_idiomatic_contents};
+use crate::backend::platform_target::PlatformTarget;
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::cli::version::OS;
@@ -13,6 +14,7 @@ use crate::config::{Config, Settings};
 use crate::file::{TarFormat, TarOptions};
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
+use crate::lockfile::PlatformInfo;
 use crate::toolset::{ToolVersion, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{file, plugins};
@@ -534,6 +536,43 @@ impl Backend for JavaPlugin {
             tv.install_path().to_string_lossy().into(),
         )]);
         Ok(map)
+    }
+
+    async fn resolve_lock_info(
+        &self,
+        tv: &ToolVersion,
+        target: &PlatformTarget,
+    ) -> Result<PlatformInfo> {
+        let release_type = self.tv_release_type(tv);
+        let java_arch = to_java_api_arch(target.arch_name());
+        let java_os = match target.os_name() {
+            "macos" => "macosx",
+            other => other,
+        };
+        let url = format!(
+            "https://mise-java.jdx.dev/jvm/{}/{}/{}.json",
+            release_type, java_os, java_arch,
+        );
+        let versions = HTTP_FETCH
+            .json::<Vec<JavaMetadata>, _>(url)
+            .await?
+            .into_iter()
+            .filter(|m| {
+                m.file_type
+                    .as_ref()
+                    .is_some_and(|ft| JAVA_FILE_TYPES.contains(ft))
+            })
+            .collect();
+        let map = build_java_metadata_map(versions);
+        let v = self.tv_to_java_version(tv);
+        match map.get(&v) {
+            Some(m) => Ok(PlatformInfo {
+                url: Some(m.url.clone()),
+                checksum: m.checksum.clone(),
+                ..Default::default()
+            }),
+            None => Ok(PlatformInfo::default()),
+        }
     }
 
     fn fuzzy_match_filter(

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -623,12 +623,7 @@ fn os() -> &'static str {
 }
 
 fn arch(settings: &Settings) -> &str {
-    match settings.arch() {
-        "x64" => "x86_64",
-        "arm64" => "aarch64",
-        "arm" => "arm32-vfp-hflt",
-        other => other,
-    }
+    to_java_api_arch(settings.arch())
 }
 
 /// Maps a normalized mise arch (e.g. "x64", "arm64") to the Java metadata API arch string.

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -238,3 +238,58 @@ pub fn is_runtime_symlink(path: &Path) -> bool {
     }
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_arch_suffix_known_arches() {
+        // Known arch suffixes are split off
+        assert_eq!(split_arch_suffix("corretto-8.462.08.1-x64"), ("corretto-8.462.08.1", "-x64"));
+        assert_eq!(split_arch_suffix("corretto-8.462.08.1-arm64"), ("corretto-8.462.08.1", "-arm64"));
+        assert_eq!(split_arch_suffix("tool-1.0.0-x86"), ("tool-1.0.0", "-x86"));
+        assert_eq!(split_arch_suffix("tool-1.0.0-ppc64le"), ("tool-1.0.0", "-ppc64le"));
+        assert_eq!(split_arch_suffix("tool-1.0.0-s390x"), ("tool-1.0.0", "-s390x"));
+    }
+
+    #[test]
+    fn test_split_arch_suffix_non_arch() {
+        // Non-arch suffixes are not split
+        assert_eq!(split_arch_suffix("temurin-21.0.11+10.0.LTS"), ("temurin-21.0.11+10.0.LTS", ""));
+        assert_eq!(split_arch_suffix("corretto-8.462.08.1"), ("corretto-8.462.08.1", ""));
+        assert_eq!(split_arch_suffix("tool-1.0.0-beta"), ("tool-1.0.0-beta", ""));
+        assert_eq!(split_arch_suffix("no-hyphen"), ("no-hyphen", ""));
+        assert_eq!(split_arch_suffix("1.0.0"), ("1.0.0", ""));
+    }
+
+    #[test]
+    fn test_symlink_names_include_arch_suffix() {
+        // Regression test for the bug where corretto-8.462.08.1-x64 generated
+        // symlinks named corretto-8, corretto-latest (no suffix), colliding with
+        // native-arch installs. The fix: strip the arch suffix before version
+        // parsing, then re-append it to every generated symlink name.
+        let (base, suffix) = split_arch_suffix("corretto-8.462.08.1-x64");
+        assert_eq!(base, "corretto-8.462.08.1");
+        assert_eq!(suffix, "-x64");
+
+        let (prefix, _version) = crate::semver::split_version_prefix(base);
+        assert_eq!(prefix, "corretto-");
+
+        // Partial version symlinks include the arch suffix
+        assert_eq!(format!("{prefix}8{suffix}"), "corretto-8-x64");
+        assert_eq!(format!("{prefix}8.462{suffix}"), "corretto-8.462-x64");
+        assert_eq!(format!("{prefix}latest{suffix}"), "corretto-latest-x64");
+
+        // Without our fix, Versioning would parse "8.462.08.1-x64" treating
+        // -x64 as a pre-release tag, producing corretto-8 (no suffix) which
+        // would collide with the native arm64 corretto-8 symlink.
+        let (prefix_native, _) = crate::semver::split_version_prefix("corretto-8.462.08.1");
+        assert_eq!(format!("{prefix_native}latest"), "corretto-latest");
+        // The two "latest" symlinks are distinct — no collision
+        assert_ne!(
+            format!("{prefix}latest{suffix}"),
+            format!("{prefix_native}latest")
+        );
+    }
+}

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::backend::Backend;
-use crate::config::{Alias, Config};
+use crate::config::{Alias, Config, Settings};
 use crate::file::make_symlink_or_file;
 use crate::plugins::VERSION_REGEX;
 use crate::semver::split_version_prefix;
@@ -112,6 +112,19 @@ fn migrate_real_dirs_in_dir(
     Ok(())
 }
 
+/// If the install directory name ends with a known arch suffix (e.g. `-x64`),
+/// returns the base name and the suffix string. Otherwise returns the name
+/// unchanged and an empty suffix.
+fn split_arch_suffix(v: &str) -> (&str, &str) {
+    if let Some(pos) = v.rfind('-') {
+        let candidate = &v[pos + 1..];
+        if Settings::normalize_arch(candidate).is_some() {
+            return (&v[..pos], &v[pos..]);
+        }
+    }
+    (v, "")
+}
+
 /// Build symlinks for versions found in a specific install directory.
 fn list_symlinks_for_dir(
     config: &Config,
@@ -124,7 +137,12 @@ fn list_symlinks_for_dir(
         if is_temporary_runtime_label(&v) {
             continue;
         }
-        let (prefix, version) = split_version_prefix(&v);
+        // Strip the arch suffix (e.g. "-x64") before version parsing so that
+        // Versioning does not treat it as a pre-release tag and generate
+        // wrong partial-version symlink names. The suffix is then appended to
+        // every generated symlink name so arch variants stay separate.
+        let (base_v, arch_suffix) = split_arch_suffix(&v);
+        let (prefix, version) = split_version_prefix(base_v);
         let Some(versions) = Versioning::new(version) else {
             continue;
         };
@@ -132,10 +150,10 @@ fn list_symlinks_for_dir(
         while versions.nth(partial.len()).is_some() && versions.nth(partial.len() + 1).is_some() {
             let version = versions.nth(partial.len()).unwrap();
             partial.push(version.to_string());
-            let from = format!("{}{}", prefix, partial.join("."));
+            let from = format!("{}{}{}", prefix, partial.join("."), arch_suffix);
             symlinks.insert(from, rel_path(&v));
         }
-        symlinks.insert(format!("{prefix}latest"), rel_path(&v));
+        symlinks.insert(format!("{prefix}latest{arch_suffix}"), rel_path(&v));
         for (from, to) in &config
             .all_aliases
             .get(&backend.ba().short)
@@ -145,10 +163,10 @@ fn list_symlinks_for_dir(
             if from.contains('/') {
                 continue;
             }
-            if !v.starts_with(to) {
+            if !base_v.starts_with(to) {
                 continue;
             }
-            symlinks.insert(format!("{prefix}{from}"), rel_path(&v));
+            symlinks.insert(format!("{prefix}{from}{arch_suffix}"), rel_path(&v));
         }
     }
     symlinks = symlinks

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -20,7 +20,7 @@ use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::tool_version::ResolveOptions;
 use crate::toolset::{ToolSource, ToolVersion, ToolVersionOptions};
 use crate::{backend, lockfile};
-use crate::{backend::ABackend, config::Config};
+use crate::{backend::ABackend, config::Config, config::Settings};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ToolRequest {
@@ -231,13 +231,21 @@ impl ToolRequest {
     pub fn install_path(&self, config: &Config) -> Option<PathBuf> {
         match self {
             Self::Version {
-                backend, version, ..
+                backend, version, options, ..
             } => {
-                let path = backend.installs_path.join(version);
+                let settings = Settings::get();
+                let suffix = options.get("arch")
+                    .and_then(Settings::arch_suffix_for)
+                    .or_else(|| settings.arch_suffix());
+                let pathname = match suffix {
+                    Some(arch) => format!("{version}-{arch}"),
+                    None => version.clone(),
+                };
+                let path = backend.installs_path.join(&pathname);
                 Some(env::find_in_shared_installs(
                     path,
                     &backend.tool_dir_name(),
-                    version,
+                    &pathname,
                 ))
             }
             Self::Ref {

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -8,6 +8,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use crate::backend::{ABackend, VersionInfo};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
+use crate::platform::Platform;
 use crate::env;
 #[cfg(windows)]
 use crate::file;
@@ -247,15 +248,42 @@ impl ToolVersion {
         };
         Ok(version)
     }
+    /// Returns the cross-arch suffix for display (e.g. `"x64"`) when this
+    /// tool version targets a non-native arch, or `None` for native arch.
+    pub fn arch_label(&self) -> Option<&'static str> {
+        let settings = Settings::get();
+        self.request.options().get("arch")
+            .and_then(Settings::arch_suffix_for)
+            .or_else(|| settings.arch_suffix())
+    }
+
+    /// Returns the lockfile platform key for this tool version, using a
+    /// per-tool `arch` option when present instead of the global platform arch.
+    pub fn platform_key(&self) -> String {
+        if let Some(normalized) = self.request.options().get("arch")
+            .and_then(Settings::normalize_arch)
+        {
+            let mut platform = Platform::current();
+            platform.arch = normalized.to_string();
+            platform.to_key()
+        } else {
+            Platform::current().to_key()
+        }
+    }
+
     pub fn style(&self) -> String {
+        let arch = self.arch_label()
+            .map(|a| format!(" [{a}]"))
+            .unwrap_or_default();
         format!(
-            "{}{}",
+            "{}{}{}",
             style(&self.ba().short).blue().for_stderr(),
-            style(&format!("@{}", &self.version)).for_stderr()
+            style(&format!("@{}", &self.version)).for_stderr(),
+            style(&arch).dim().for_stderr(),
         )
     }
     pub fn tv_pathname(&self) -> String {
-        match &self.request {
+        let base = match &self.request {
             ToolRequest::Version { .. } => self.version.to_string(),
             ToolRequest::Prefix { .. } => self.version.to_string(),
             ToolRequest::Sub { .. } => self.version.to_string(),
@@ -275,7 +303,15 @@ impl ToolVersion {
                 "system".to_string()
             }
         }
-        .replace([':', '/'], "-")
+        .replace([':', '/'], "-");
+        let settings = Settings::get();
+        let suffix = self.request.options().get("arch")
+            .and_then(Settings::arch_suffix_for)
+            .or_else(|| settings.arch_suffix());
+        match suffix {
+            Some(arch) => format!("{base}-{arch}"),
+            None => base,
+        }
     }
     fn runtime_pathname(&self) -> Option<String> {
         let pathname = match &self.request {
@@ -283,7 +319,15 @@ impl ToolVersion {
             ToolRequest::Prefix { prefix, .. } => prefix,
             _ => return None,
         };
-        Some(pathname.replace([':', '/'], "-"))
+        let base = pathname.replace([':', '/'], "-");
+        let settings = Settings::get();
+        let suffix = self.request.options().get("arch")
+            .and_then(Settings::arch_suffix_for)
+            .or_else(|| settings.arch_suffix());
+        Some(match suffix {
+            Some(arch) => format!("{base}-{arch}"),
+            None => base,
+        })
     }
     async fn resolve_version(
         config: &Arc<Config>,
@@ -677,6 +721,61 @@ mod tests {
     use super::*;
     use crate::cli::args::BackendResolution;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn make_tv_with_opts(version: &str, opts: ToolVersionOptions) -> ToolVersion {
+        let ba = Arc::new(BackendArg::new_raw(
+            "test-java".into(),
+            None,
+            "test-java".into(),
+            None,
+            BackendResolution::new(false),
+        ));
+        let request = ToolRequest::Version {
+            backend: ba,
+            version: version.into(),
+            options: opts,
+            source: ToolSource::Argument,
+        };
+        ToolVersion::new(request, version.into())
+    }
+
+    #[test]
+    fn tv_pathname_no_arch_option() {
+        let tv = make_tv_with_opts("21.0.3", ToolVersionOptions::default());
+        // Without any arch option or global arch override the pathname is just the version.
+        // On any machine where the global arch setting is native this holds.
+        let pathname = tv.tv_pathname();
+        // The pathname must start with the version string.
+        assert!(pathname.starts_with("21.0.3"), "got: {pathname}");
+    }
+
+    #[test]
+    fn tv_pathname_cross_arch_option() {
+        use std::env::consts::ARCH;
+        // Pick an arch that is NOT the native one so arch_suffix_for returns Some.
+        let cross_arch = if ARCH == "aarch64" { "x86_64" } else { "aarch64" };
+        let expected_suffix = if ARCH == "aarch64" { "x64" } else { "arm64" };
+
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert("arch".into(), toml::Value::String(cross_arch.into()));
+
+        let tv = make_tv_with_opts("corretto-8.462.08.1", opts);
+        let pathname = tv.tv_pathname();
+        assert_eq!(pathname, format!("corretto-8.462.08.1-{expected_suffix}"));
+    }
+
+    #[test]
+    fn tv_pathname_native_arch_option_no_suffix() {
+        use std::env::consts::ARCH;
+        // Requesting the native arch explicitly should produce the same pathname
+        // as having no arch option at all (no extra suffix appended).
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert("arch".into(), toml::Value::String(ARCH.into()));
+
+        let tv_with = make_tv_with_opts("temurin-21.0.3", opts);
+        let tv_without = make_tv_with_opts("temurin-21.0.3", ToolVersionOptions::default());
+        assert_eq!(tv_with.tv_pathname(), tv_without.tv_pathname());
+    }
 
     #[test]
     fn runtime_path_does_not_return_file_based_runtime_symlink() -> Result<()> {


### PR DESCRIPTION
## The problem: Apple Silicon teams are not done with x86_64

The conventional wisdom is \"just wait, everything will be recompiled for ARM.\" In practice this is not true for a large class of software that teams depend on today and will depend on for years:

- **Closed-source third-party SDKs and native libraries** — hardware vendors, analytics providers, and data platform vendors regularly ship only x86_64 JNI/JNA binaries. They have no ARM release, no announced timeline, and no obligation to provide one.
- **Legacy in-house native code** — JNI wrappers around C/C++ code compiled years ago. Recompiling requires expertise, testing, and budget that is often unavailable.
- **Platform-specific toolchains** — certain build tools, compilers, and licensed software components that only run on x86_64.

On Apple Silicon machines these cases are handled by Rosetta 2, which transparently runs x86_64 binaries. But Rosetta 2 is **not** transparent when the JVM is involved: if native code was compiled for x86_64, the JVM that loads it must also be x86_64. An arm64 JVM will fail with `UnsatisfiedLinkError` at the point of JNI load, not at startup — making the failure confusing and hard to diagnose.

### Why the global `arch` setting does not solve this

Mise already has a global `arch` setting, but it cannot solve this problem. Consider a developer with two projects on the same machine:

- **Project A** — modern greenfield service, uses `corretto-21`, native arm64
- **Project B** — legacy service with x86_64 JNI dependencies, also uses `corretto-21`, must be x86_64

With the global `arch = "x86_64"` approach:
- Both projects share the same install directory `corretto-21.0.3/`
- Whichever project ran `mise install` first determines whether that directory contains the arm64 or x86_64 binary
- The other project silently gets the wrong binary — the JNI failure happens at runtime, not at install
- Switching between projects requires manually running `mise install` each time to overwrite the binary
- **There is no way to have both installed simultaneously**

Additionally, the global `arch` setting affects every tool, causing all other tools (node, python, etc.) to appear as missing until reinstalled as x86_64, and contaminating their install paths with arch suffixes they don't need.

Today the only workarounds are:
1. Use a system-installed Java outside mise's management — breaking mise's value as the single tool manager.
2. Set `[settings] arch = "x86_64"` globally and accept the limitations above.
3. Maintain a second tool manager alongside mise just for Java — the opposite of mise's goal.

Without a clean solution, any team with a single x86_64 native Java dependency cannot use mise as their sole tool manager. This PR removes that blocker.

## Solution: `arch` as a per-tool option

```toml
[tools]
java = {version = "corretto-21", arch = "x86_64"}  # runs via Rosetta 2
node = "22"                                         # native arm64, unaffected
```

Both projects can now coexist on the same machine with different arches of the same Java version — `corretto-21.0.3/` (arm64) and `corretto-21.0.3-x64/` (x86_64) live side by side. Switching projects just works.

The `arch` option uses the same canonical values as the global `arch` setting and `--platform` flag (`x64`, `arm64`, `arm`, `x86`, `ppc64le`, `s390x`, `riscv64`), so the two are consistent. Common aliases (`x86_64` → `x64`, `aarch64` → `arm64`) are accepted and normalized, matching the global setting's existing behaviour.

## What changes

### Install path separation
Cross-arch installs land in a suffixed directory so native and cross-arch versions coexist without conflict:

```
~/.local/share/mise/installs/java/
  corretto-21.0.3/          ← native arm64
  corretto-21.0.3-x64/      ← x86_64 via Rosetta 2
```

`tv_pathname()` is the single place the suffix is added. `list_installed_versions()` strips it back off so `tv.version` is always the canonical version string — preventing double-suffix paths like `corretto-21.0.3-x64-x64`.

### Runtime symlinks are namespaced
Partial-version symlinks include the arch suffix so they cannot collide:

```
corretto-21        → ./corretto-21.0.3          (native)
corretto-latest    → ./corretto-21.0.3          (native)
corretto-21-x64    → ./corretto-21.0.3-x64      (x64)
corretto-latest-x64 → ./corretto-21.0.3-x64     (x64)
```

### `mise ls` shows the arch label
```
Tool  Version                    Source        Requested
java  corretto-21.0.3 [x64]     mise.toml     corretto-21 [x64]
java  temurin-21.0.11+10.0.LTS               temurin-21
```

### `mise lock` respects per-tool arch
`mise lock java` automatically targets the correct platform for that tool (`macos-x64` for an x86_64 java on an Apple Silicon machine), instead of the host platform (`macos-arm64`). Other tools without an `arch` option continue to target the host platform as before.

The Java backend now also implements `resolve_lock_info()` so `mise lock java` actually fetches and records the download URL and checksum — previously it fell through to the empty fallback and produced lockfile entries with no platform data.

### `mise install` / `mise uninstall` are inverses
`mise uninstall java` (no explicit version) resolves through the current config context — the same path as `mise install java` — so it uninstalls the arch-specific variant, leaving any native install untouched.

## Architecture

The arch-suffix logic is anchored in `Settings::normalize_arch()` and `Settings::arch_suffix_for()` — the same normalization used by the global `arch` setting. Every layer that needs to know about arch calls these; `tv_pathname()` remains the single place that appends the suffix to a path.

`ToolVersion::arch_label()` is the single source of truth for display formatting (`[x64]`), used by `mise ls`, `style()`, and progress output.

`ToolVersion::platform_key()` computes the lockfile platform key with per-tool arch, used by `verify_checksum()`, `download()`, and `install_version_()`.

## Potential breaking change

`list_installed_versions()` in the default `Backend` trait implementation now strips known arch suffixes (`x64`, `arm64`, `x86`, `ppc64le`, `s390x`, `riscv64`, `arm`, etc.) from the end of installed directory names before returning them. This is necessary so that the canonical version string stored in `tv.version` never includes the suffix — without it, `tv_pathname()` would double-append the suffix.

The risk is that a tool whose version strings genuinely end with one of those tokens (e.g., a hypothetical `sdk-2.3-arm` where `-arm` is a build flavor, not an arch) would have the suffix silently stripped. This would make the version appear under a different name in `mise ls` and version matching. No data is lost — the install directory is untouched — but the version may appear missing or match incorrectly.

In practice the risk is low: the tokens are specific CPU architecture names unlikely to appear as semantic version segments or release flavors. And scoping the stripping to Java-only would be wrong — the per-tool `arch` option is a general mechanism (consistent with the existing global `arch` setting), so any backend can use it and any backend therefore needs the stripping.

## Files changed

- `src/config/settings.rs` — `normalize_arch()`, `arch_suffix_for()`, refactored `arch_suffix()`
- `src/toolset/tool_version.rs` — `arch_label()`, `platform_key()`, updated `tv_pathname()`, `runtime_pathname()`, `style()`
- `src/toolset/tool_request.rs` — `install_path()` Version case applies arch suffix
- `src/backend/mod.rs` — `verify_checksum()` uses `tv.platform_key()`; `list_installed_versions()` strips arch suffixes; `strip_arch_suffixes_from_versions()` extracted as testable function
- `src/plugins/core/java.rs` — `tv_arch()`, `to_java_api_arch()`, `tv_to_metadata()` cross-arch fetch, `resolve_lock_info()` implementation
- `src/cli/ls.rs` — `display_version()`, `display_requested()` with arch label
- `src/runtime_symlinks.rs` — `split_arch_suffix()`, arch-namespaced symlink names
- `src/cli/lock.rs` — `effective_platforms_for_tool()` per-tool platform override
- `src/cli/uninstall.rs` — config-context resolution when no version given

## Tests

20 unit tests covering:
- `normalize_arch` and `arch_suffix_for` with all supported arch aliases
- `tv_pathname` with cross-arch, native-arch, and no-arch options
- Java `tv_arch` and `tv_platform_key` for all arch types
- `strip_arch_suffixes_from_versions` including deduplication
- `split_arch_suffix` for known and unknown arch strings
- Symlink name collision regression (the `corretto-8` → `corretto-8.462.08.1-x64` bug)

## Manual test summary

Tested on Apple Silicon (arm64) macOS with `arch = "x86_64"` tool option alongside a native arm64 Java install:

- ✅ `mise install java` downloads and installs the x86_64 binary to the `-x64` suffixed directory
- ✅ `file bin/java` confirms the installed binary is `Mach-O 64-bit executable x86_64`
- ✅ `JAVA_HOME` points to the x64 install path
- ✅ `mise ls` shows `[x64]` label in both Version and Requested columns
- ✅ Other tools (node, grails, etc.) with no `arch` option install normally and are unaffected in behaviour (note: if the global `arch` setting is also configured, `mise ls` will show arch labels for those tools too, since the setting genuinely affects their install paths — this is intentional and accurate)
- ✅ Runtime symlinks are correctly namespaced (`corretto-8-x64`, `corretto-latest-x64`)
- ✅ `mise lock java` writes only the `macos-x64` platform entry with correct URL/checksum
- ✅ Uninstalling native arm64 leaves x64 install and symlinks intact
- ✅ `mise uninstall java` from project context removes x64 variant, leaves native intact
- ✅ Native arch option (`arch = "arm64"` on arm64) produces no label and no suffix
- ✅ Both native and cross-arch versions of the same Java version installed simultaneously