### PR TITLE
chore(release): strip pre-existing sponsor block before appending canonical one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,6 +359,15 @@ jobs:
             mise x -- git cliff --strip all --latest > /tmp/release-notes.txt 2>/dev/null || echo "Release $VERSION" > /tmp/release-notes.txt
             echo "RELEASE_TITLE=$VERSION" >> "$GITHUB_ENV"
           fi
+          # Strip any pre-existing sponsor section from the generated notes
+          # (communique has at times included its own) and trim trailing blanks,
+          # so the heredoc below always produces exactly one canonical block.
+          awk '
+            /^## (💚 )?Sponsor mise[[:space:]]*$/ { exit }
+            /^[[:space:]]*$/ { blanks++; next }
+            { while (blanks-- > 0) print ""; blanks = 0; print }
+          ' /tmp/release-notes.txt > /tmp/release-notes-trimmed.txt
+          mv /tmp/release-notes-trimmed.txt /tmp/release-notes.txt
           cat >> /tmp/release-notes.txt <<'EOF'
 
           ## 💚 Sponsor mise


### PR DESCRIPTION
## Summary

The release workflow has been ping-ponging on whether `communique` already includes a sponsor section in its output, and we've shipped two broken releases as a result:

- **v2026.4.22 / v2026.5.0** — #9395 assumed `communique` would include the block on success, so the workflow stopped appending it; `communique` did **not** include it, and those releases shipped with **no sponsor block**.
- **v2026.5.4** — #9580 reverted to "always append," but `communique` had since started inserting its own `## Sponsor mise` block, so the release shipped with **two** sponsor sections.

The pattern: every fix encodes an assumption about `communique`'s output, and that assumption later drifts.

## Fix

Make the step idempotent. Before appending the canonical block, run a small `awk` filter over the generated notes that:

1. Stops at the first `## Sponsor mise` or `## 💚 Sponsor mise` heading (drops everything from there to EOF), and
2. Trims trailing blank lines so the heredoc's leading blank gives exactly one blank line of separation.

Result: exactly one canonical `## 💚 Sponsor mise` block regardless of whether `communique` includes its own, includes a different variant, or the `git-cliff` fallback runs.

I also already manually fixed [v2026.5.4's release notes on GitHub](https://github.com/jdx/mise/releases/tag/v2026.5.4) to remove the duplicate.

## Test plan

Simulated all four input shapes locally and confirmed each produces exactly one `## 💚 Sponsor mise` heading with correct spacing:

- `communique` output that already contains its own `## Sponsor mise` block (the v2026.5.4 case)
- `communique` output with no sponsor block (the v2026.5.3-style case)
- `git-cliff` fallback output with trailing blank lines
- `communique` output that already contains a `## 💚 Sponsor mise` variant (idempotent re-run sanity check)

`actionlint` is clean on the modified workflow.

- [ ] Next tagged release shows exactly one `## 💚 Sponsor mise` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to the GitHub Actions release-notes generation step and only affect release note formatting/content. Main risk is unintended trimming if the `awk` pattern matches an unrelated heading.
> 
> **Overview**
> Makes release note generation idempotent by **removing any pre-existing `## Sponsor mise` / `## 💚 Sponsor mise` section** (and trimming trailing blank lines) before appending the canonical sponsor block.
> 
> This prevents releases from shipping with either **missing** or **duplicate** sponsor sections regardless of whether `communique` or the `git-cliff` fallback includes one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e613177981575981e6ca94b45c2f093a56f5f8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->