### PR TITLE
docs(tasks): add bash shebang to conditional-dependencies example

### DIFF
--- a/docs/tasks/architecture.md
+++ b/docs/tasks/architecture.md
@@ -154,12 +154,20 @@ Use task arguments for conditional behavior:
 [tasks.test]
 depends = ["build"]
 run = '''
+#!/usr/bin/env bash
 if [ "$1" = "--with-lint" ]; then
   mise run lint
 fi
 npm test
 '''
 ```
+
+The shebang ensures the script runs under bash on every platform. Without
+it, mise uses the platform default inline shell (`sh -c` on Unix,
+`cmd /c` on Windows), so the bash `[ ... ]` test would fail to parse on a
+Windows host. For richer argument handling, prefer the
+[`usage` field](/tasks/task-arguments#usage-field) instead of positional
+parameters.
 
 ### Dynamic Dependencies
 


### PR DESCRIPTION
## Summary

The "Conditional Dependencies" example in `docs/tasks/architecture.md`
uses bash test syntax inside an inline `run` block:

```toml
[tasks.test]
depends = ["build"]
run = '''
if [ "$1" = "--with-lint" ]; then
  mise run lint
fi
npm test
'''
```

Without a shebang, mise runs the script under the platform default
inline shell — `sh -c -o errexit` on Unix, `cmd /c` on Windows.
`cmd` cannot parse `[ "$1" = ... ]`, so a Windows host running this
verbatim fails immediately:

```
[test] $ if [ "$1" = "--with-lint" ]; then
"$1" was unexpected at this time.
[test] ERROR task failed
```

That happens before the conditional is even evaluated, so the example
is essentially non-functional on Windows as written.

This patch adds `#!/usr/bin/env bash` to the example so it is portable
across Linux, macOS, and Windows hosts, and follows the recommendation
in [`docs/tasks/task-configuration.md`](https://github.com/jdx/mise/blob/main/docs/tasks/task-configuration.md#shell)
to "use a shebang instead" of the `shell` field.

It also adds a short paragraph pointing readers toward the
`usage` field for richer argument handling, since positional
parameters in inline `run` blocks have subtle cross-platform caveats
(see e.g. discussion [#9355](https://github.com/jdx/mise/discussions/9355)
about Windows quoting, and the comment at
[`e2e/tasks/test_task_raw_args:48-50`](https://github.com/jdx/mise/blob/main/e2e/tasks/test_task_raw_args)
noting that real positional parameters are only guaranteed for
file-based shebang scripts, not inline TOML scripts).

## Verification

Reproduced the failing case and the fix on a fresh `mise.toml` on
Windows 11 + mise 2026.5.2:

Before (verbatim from current docs, called from PowerShell or bash):
```
[test] $ if [ "$1" = "--with-lint" ]; then
"$1" was unexpected at this time.
[test] ERROR task failed
```

After (with the shebang added):
```
$ mise run test --with-lint
[build] $ echo build done
build done
[test] $ #!/usr/bin/env bash
running lint
running npm test
Finished in 137.5ms
```

Existing Linux/macOS behavior is unchanged: the shebang takes
precedence over the platform default inline shell, and bash
behaves the same way the previous example assumed.

## Scope

Documentation only. No code or test changes.