### PR TITLE
fix(node): use matching node in npm shim

### DIFF
--- a/e2e/core/test_node_slow
+++ b/e2e/core/test_node_slow
@@ -14,6 +14,8 @@ mise settings set idiomatic_version_file_enable_tools node
 
 mise i node@lts/hydrogen
 mise i -f node
+hydrogen_path="$(mise where node@lts/hydrogen)"
+assert "mise x node@$corepack_version -- $hydrogen_path/bin/npm config get prefix" "$hydrogen_path"
 assert_contains "mise x node@lts/hydrogen -- node --version" "v18."
 assert "mise x -- node --version" "v$corepack_version"
 assert_contains "mise x -- which yarn" "yarn"

--- a/src/plugins/core/assets/node_npm_shim
+++ b/src/plugins/core/assets/node_npm_shim
@@ -69,12 +69,13 @@ should_reshim() {
 
 wrap_npm_if_reshim_is_needed() {
   local npm_cli="$plugin_dir/lib/node_modules/npm/bin/npm-cli.js"
+  local node_bin="$plugin_dir/bin/node"
   if should_reshim "$@"; then
-    node "$npm_cli" "$@"
+    "$node_bin" "$npm_cli" "$@"
     printf "Reshimming mise %s...\n" "$plugin_name" >&2
     mise reshim
   else
-    exec node "$npm_cli" "$@"
+    exec "$node_bin" "$npm_cli" "$@"
   fi
 }
 


### PR DESCRIPTION
## Summary

- update the generated Node npm shim to invoke the installed version's own `bin/node`
- keep npm prefix detection tied to the npm shim's install instead of whichever `node` appears first on `PATH`
- add a regression assertion for running one Node install's `npm` while another Node version is active

## Root Cause

The npm shim executed `node "$npm_cli"`, which allowed `PATH` lookup to select a different active Node version. npm then derived its global prefix from that other Node's `process.execPath`, so default packages could install into the wrong Node prefix.

## Validation

- `hk` pre-commit hook during commit, including `cargo check --all-features`
- `mise run test:e2e e2e/core/test_node_slow`

Fixes discussion #9748.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the `npm` shim selects the Node executable, which can affect npm behavior and global install locations across Node versions. Scope is small but touches core tooling invocation paths.
> 
> **Overview**
> Fixes the generated `node_npm_shim` to invoke npm via the **installed tool’s own** `bin/node` instead of resolving `node` from `PATH`, preventing cross-version prefix/global-install mismatches.
> 
> Adds an e2e regression check ensuring `npm config get prefix` for a specific Node install returns that install’s prefix even when another Node version is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527eeb6834208ade081cb7d3fcd3985a5aa41011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->