### PR TITLE
fix(task): resolve bash deterministically on Windows to avoid WSL launcher

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -145,6 +145,29 @@ mise ERROR command failed: exit code 1
 mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
 ```
 
+### `shell = "bash -c"` task fails with `command not found` from PowerShell
+
+If a task pinned to `shell = "bash -c"` works from Git Bash but fails with
+`command not found` from PowerShell, mise is most likely resolving `bash` to
+the WSL launcher at `C:\Windows\System32\bash.exe` instead of a real POSIX
+bash. The launcher dispatches into the WSL distribution's Linux user-space,
+where mise-managed Windows tools aren't visible.
+
+mise prefers a real POSIX bash (Git Bash / MSYS2) automatically when it can
+find one in a standard install location. If yours is installed elsewhere, set
+`MISE_BASH_PATH` to override:
+
+```powershell
+$env:MISE_BASH_PATH = "C:\tools\msys64\usr\bin\bash.exe"
+mise run my-bash-task
+```
+
+```toml
+# Alternatively, scope it to one project from mise.toml
+[env]
+MISE_BASH_PATH = "C:/tools/msys64/usr/bin/bash.exe"
+```
+
 ## mise isn't working when calling from tmux or another shell initialization script
 
 `mise activate` will not update PATH until the shell prompt is displayed. So if you need to access a

--- a/src/path.rs
+++ b/src/path.rs
@@ -107,28 +107,34 @@ fn append_single_windows_path_to_unix(out: &mut String, entry: &str) {
     }
 }
 
-/// Returns true if `program` is the path or basename of a POSIX-style shell that
-/// expects a Unix-style PATH. Used on Windows to decide whether to convert the
-/// child's PATH before spawning.
+/// Returns the lowercase stem of `program`'s basename, with any final `.exe`
+/// (case-insensitive) stripped. Splits on both `/` and `\` so the result is the
+/// same regardless of host `Path` separator — important since this is
+/// unit-tested on Linux/macOS too. Does not stat the file — input may be a bare
+/// name like `"bash"` that resolves later via the launcher's PATH search.
 ///
-/// Matches by basename (case-insensitive, `.exe` stripped) against a fixed list.
-/// Splits on both `/` and `\` so the result is the same regardless of the host
-/// `Path` separator — important since this is unit-tested on Linux/macOS too.
-/// Does not stat the file — input may be a bare name like `"bash"` that resolves
-/// later via the launcher's PATH search.
+/// Returns `None` only when `program` is not valid UTF-8.
 #[cfg_attr(not(windows), allow(dead_code))]
-pub fn is_posix_shell_program(program: &Path) -> bool {
-    const POSIX_SHELLS: &[&str] = &["bash", "sh", "zsh", "fish", "ksh", "dash"];
-    let Some(s) = program.to_str() else {
-        return false;
-    };
+pub fn program_stem(program: &Path) -> Option<String> {
+    let s = program.to_str()?;
     let basename = s.rsplit(['/', '\\']).next().unwrap_or(s);
     let stem = match basename.rsplit_once('.') {
         Some((stem, ext)) if ext.eq_ignore_ascii_case("exe") => stem,
         _ => basename,
     };
-    let stem_lower = stem.to_ascii_lowercase();
-    POSIX_SHELLS.iter().any(|name| *name == stem_lower)
+    Some(stem.to_ascii_lowercase())
+}
+
+/// Returns true if `program` is the path or basename of a POSIX-style shell that
+/// expects a Unix-style PATH. Used on Windows to decide whether to convert the
+/// child's PATH before spawning.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub fn is_posix_shell_program(program: &Path) -> bool {
+    const POSIX_SHELLS: &[&str] = &["bash", "sh", "zsh", "fish", "ksh", "dash"];
+    let Some(stem) = program_stem(program) else {
+        return false;
+    };
+    POSIX_SHELLS.iter().any(|name| *name == stem)
 }
 
 #[cfg(test)]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1234,17 +1234,21 @@ fn shell_from_extension(path: &Path) -> Option<Vec<String>> {
 /// the spawned task body runs inside a separate Linux filesystem where
 /// mise-managed Windows tools aren't visible. Resolution order:
 ///   1. `MISE_BASH_PATH` env var (explicit override).
-///   2. Common Git Bash install locations (`C:\Program Files\Git\bin\bash.exe`,
-///      `C:\Program Files (x86)\Git\bin\bash.exe`, `%LOCALAPPDATA%\Programs\Git\bin\bash.exe`).
-///   3. `which::which_in` over the task env's PATH, with the WSL launcher
-///      excluded from acceptable results.
+///   2. Common Git Bash and MSYS2 install locations
+///      (`C:\Program Files\Git\bin\bash.exe`,
+///      `C:\Program Files (x86)\Git\bin\bash.exe`,
+///      `%LOCALAPPDATA%\Programs\Git\bin\bash.exe`,
+///      `C:\msys64\usr\bin\bash.exe`, `C:\msys32\usr\bin\bash.exe`).
+///   3. `which::which_in_all` over the task env's PATH, picking the first
+///      entry that isn't the WSL launcher. This rescues setups where a real
+///      POSIX bash is on PATH but appears after `C:\Windows\System32`.
 ///
 /// Returns `None` when the program is not a POSIX shell, the env has no PATH,
 /// the PATH is already in Unix form (no `;` and no `\`, so no conversion will
-/// fire), `which` fails to locate the binary, or only a WSL launcher could be
-/// found for `bash` — in those cases the caller keeps the original program
-/// string and lets the stdlib spawn it (which will then fail loudly rather
-/// than silently routing into WSL).
+/// fire), `which` finds nothing, or every PATH match for `bash` is the WSL
+/// launcher — in those cases the caller keeps the original program string and
+/// lets the stdlib spawn it (which will then fail loudly rather than silently
+/// routing into WSL).
 #[cfg(windows)]
 fn resolve_posix_shell_program_path(
     program: &std::ffi::OsStr,
@@ -1258,7 +1262,9 @@ fn resolve_posix_shell_program_path(
         return None;
     }
 
-    if is_bash_basename(program) {
+    let is_bash = is_bash_basename(program);
+
+    if is_bash {
         let override_path = env
             .get("MISE_BASH_PATH")
             .cloned()
@@ -1271,7 +1277,7 @@ fn resolve_posix_shell_program_path(
             }
             warn!("MISE_BASH_PATH={p} does not exist; falling back to other candidates");
         }
-        for candidate in git_bash_candidates(env) {
+        for candidate in bash_candidates(env) {
             if candidate.is_file() {
                 return Some(candidate.into_os_string());
             }
@@ -1279,17 +1285,26 @@ fn resolve_posix_shell_program_path(
     }
 
     let cwd = std::env::current_dir().ok()?;
-    let resolved = which::which_in(program, Some(path_val.as_str()), cwd).ok()?;
 
-    if is_bash_basename(program) && is_wsl_launcher_bash(&resolved) {
+    if is_bash {
+        // For bash, walk every PATH match and pick the first that isn't the
+        // WSL launcher. This rescues setups where a real POSIX bash sits later
+        // on PATH than `C:\Windows\System32\bash.exe` — common under PowerShell
+        // when Git Bash is installed somewhere `bash_candidates` doesn't probe.
+        let mut all = which::which_in_all(program, Some(path_val.as_str()), cwd).ok()?;
+        if let Some(p) = all.find(|p| !is_wsl_launcher_bash(p)) {
+            return Some(p.into_os_string());
+        }
         warn!(
-            "ignoring WSL launcher at {} when resolving bash for a task; \
-             install Git Bash or set MISE_BASH_PATH to a real POSIX bash to silence this",
-            resolved.display()
+            "no real POSIX bash found on PATH (only the WSL launcher) when resolving bash for a task; \
+             install Git Bash or MSYS2, or set MISE_BASH_PATH to a real POSIX bash to silence this"
         );
         return None;
     }
-    Some(resolved.into_os_string())
+
+    which::which_in(program, Some(path_val.as_str()), cwd)
+        .ok()
+        .map(|p| p.into_os_string())
 }
 
 /// Returns true if `program`'s basename (case-insensitive, `.exe` stripped) is `bash`.
@@ -1298,22 +1313,15 @@ fn resolve_posix_shell_program_path(
 /// they don't fire for other POSIX shells we might gain support for later.
 #[cfg(windows)]
 fn is_bash_basename(program: &std::ffi::OsStr) -> bool {
-    let Some(s) = program.to_str() else {
-        return false;
-    };
-    let basename = s.rsplit(['/', '\\']).next().unwrap_or(s);
-    let stem = match basename.rsplit_once('.') {
-        Some((stem, ext)) if ext.eq_ignore_ascii_case("exe") => stem,
-        _ => basename,
-    };
-    stem.eq_ignore_ascii_case("bash")
+    crate::path::program_stem(Path::new(program)).as_deref() == Some("bash")
 }
 
-/// Common Git Bash install locations to probe for a real POSIX bash on Windows,
-/// in preference order. Pure given `env` (no filesystem access), so the caller
-/// can stat each candidate.
+/// Common real-POSIX-bash install locations on Windows (Git Bash + MSYS2), in
+/// preference order. Pure given `env` (no filesystem access), so the caller
+/// stats each candidate. `MISE_BASH_PATH` covers anything outside this list,
+/// including non-`C:` drive installs.
 #[cfg(windows)]
-fn git_bash_candidates(env: &BTreeMap<String, String>) -> Vec<PathBuf> {
+fn bash_candidates(env: &BTreeMap<String, String>) -> Vec<PathBuf> {
     let mut candidates = vec![
         PathBuf::from(r"C:\Program Files\Git\bin\bash.exe"),
         PathBuf::from(r"C:\Program Files (x86)\Git\bin\bash.exe"),
@@ -1325,6 +1333,9 @@ fn git_bash_candidates(env: &BTreeMap<String, String>) -> Vec<PathBuf> {
     if let Some(local) = local_appdata.filter(|s| !s.is_empty()) {
         candidates.push(PathBuf::from(local).join(r"Programs\Git\bin\bash.exe"));
     }
+    // MSYS2 standalone installs (default `C:\msys64`, 32-bit fallback `C:\msys32`).
+    candidates.push(PathBuf::from(r"C:\msys64\usr\bin\bash.exe"));
+    candidates.push(PathBuf::from(r"C:\msys32\usr\bin\bash.exe"));
     candidates
 }
 
@@ -1545,22 +1556,31 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    fn test_git_bash_candidates_includes_program_files() {
+    fn test_bash_candidates_includes_program_files() {
         let env = BTreeMap::new();
-        let candidates = git_bash_candidates(&env);
+        let candidates = bash_candidates(&env);
         assert!(candidates.contains(&PathBuf::from(r"C:\Program Files\Git\bin\bash.exe")));
         assert!(candidates.contains(&PathBuf::from(r"C:\Program Files (x86)\Git\bin\bash.exe")));
     }
 
     #[test]
     #[cfg(windows)]
-    fn test_git_bash_candidates_uses_localappdata_from_env() {
+    fn test_bash_candidates_includes_msys2() {
+        let env = BTreeMap::new();
+        let candidates = bash_candidates(&env);
+        assert!(candidates.contains(&PathBuf::from(r"C:\msys64\usr\bin\bash.exe")));
+        assert!(candidates.contains(&PathBuf::from(r"C:\msys32\usr\bin\bash.exe")));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_bash_candidates_uses_localappdata_from_env() {
         let mut env = BTreeMap::new();
         env.insert(
             "LOCALAPPDATA".to_string(),
             r"C:\Users\me\AppData\Local".to_string(),
         );
-        let candidates = git_bash_candidates(&env);
+        let candidates = bash_candidates(&env);
         assert!(candidates.contains(&PathBuf::from(
             r"C:\Users\me\AppData\Local\Programs\Git\bin\bash.exe"
         )));

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1228,10 +1228,23 @@ fn shell_from_extension(path: &Path) -> Option<Vec<String>> {
 /// the child process gets an absolute path argument and does not need PATH
 /// search at the OS level.
 ///
+/// For `bash` specifically, prefer a real POSIX bash (Git Bash / MSYS2) over
+/// the WSL launcher at `C:\Windows\System32\bash.exe`. The WSL launcher is on
+/// PATH first when mise is invoked from PowerShell, and routing into WSL means
+/// the spawned task body runs inside a separate Linux filesystem where
+/// mise-managed Windows tools aren't visible. Resolution order:
+///   1. `MISE_BASH_PATH` env var (explicit override).
+///   2. Common Git Bash install locations (`C:\Program Files\Git\bin\bash.exe`,
+///      `C:\Program Files (x86)\Git\bin\bash.exe`, `%LOCALAPPDATA%\Programs\Git\bin\bash.exe`).
+///   3. `which::which_in` over the task env's PATH, with the WSL launcher
+///      excluded from acceptable results.
+///
 /// Returns `None` when the program is not a POSIX shell, the env has no PATH,
 /// the PATH is already in Unix form (no `;` and no `\`, so no conversion will
-/// fire), or `which` fails to locate the binary — in those cases the caller
-/// keeps the original program string and lets the stdlib spawn it.
+/// fire), `which` fails to locate the binary, or only a WSL launcher could be
+/// found for `bash` — in those cases the caller keeps the original program
+/// string and lets the stdlib spawn it (which will then fail loudly rather
+/// than silently routing into WSL).
 #[cfg(windows)]
 fn resolve_posix_shell_program_path(
     program: &std::ffi::OsStr,
@@ -1244,10 +1257,90 @@ fn resolve_posix_shell_program_path(
     if !path_val.contains(';') && !path_val.contains('\\') {
         return None;
     }
+
+    if is_bash_basename(program) {
+        let override_path = env
+            .get("MISE_BASH_PATH")
+            .cloned()
+            .or_else(|| std::env::var("MISE_BASH_PATH").ok())
+            .filter(|s| !s.is_empty());
+        if let Some(p) = override_path {
+            let path = PathBuf::from(&p);
+            if path.is_file() {
+                return Some(path.into_os_string());
+            }
+            warn!("MISE_BASH_PATH={p} does not exist; falling back to other candidates");
+        }
+        for candidate in git_bash_candidates(env) {
+            if candidate.is_file() {
+                return Some(candidate.into_os_string());
+            }
+        }
+    }
+
     let cwd = std::env::current_dir().ok()?;
-    which::which_in(program, Some(path_val.as_str()), cwd)
-        .ok()
-        .map(|p| p.into_os_string())
+    let resolved = which::which_in(program, Some(path_val.as_str()), cwd).ok()?;
+
+    if is_bash_basename(program) && is_wsl_launcher_bash(&resolved) {
+        warn!(
+            "ignoring WSL launcher at {} when resolving bash for a task; \
+             install Git Bash or set MISE_BASH_PATH to a real POSIX bash to silence this",
+            resolved.display()
+        );
+        return None;
+    }
+    Some(resolved.into_os_string())
+}
+
+/// Returns true if `program`'s basename (case-insensitive, `.exe` stripped) is `bash`.
+/// More specific than [`crate::path::is_posix_shell_program`], which also accepts
+/// sh/zsh/fish/ksh/dash. Used to scope the Windows bash-resolution heuristics so
+/// they don't fire for other POSIX shells we might gain support for later.
+#[cfg(windows)]
+fn is_bash_basename(program: &std::ffi::OsStr) -> bool {
+    let Some(s) = program.to_str() else {
+        return false;
+    };
+    let basename = s.rsplit(['/', '\\']).next().unwrap_or(s);
+    let stem = match basename.rsplit_once('.') {
+        Some((stem, ext)) if ext.eq_ignore_ascii_case("exe") => stem,
+        _ => basename,
+    };
+    stem.eq_ignore_ascii_case("bash")
+}
+
+/// Common Git Bash install locations to probe for a real POSIX bash on Windows,
+/// in preference order. Pure given `env` (no filesystem access), so the caller
+/// can stat each candidate.
+#[cfg(windows)]
+fn git_bash_candidates(env: &BTreeMap<String, String>) -> Vec<PathBuf> {
+    let mut candidates = vec![
+        PathBuf::from(r"C:\Program Files\Git\bin\bash.exe"),
+        PathBuf::from(r"C:\Program Files (x86)\Git\bin\bash.exe"),
+    ];
+    let local_appdata = env
+        .get("LOCALAPPDATA")
+        .cloned()
+        .or_else(|| std::env::var("LOCALAPPDATA").ok());
+    if let Some(local) = local_appdata.filter(|s| !s.is_empty()) {
+        candidates.push(PathBuf::from(local).join(r"Programs\Git\bin\bash.exe"));
+    }
+    candidates
+}
+
+/// Returns true if `path` looks like the Windows-shipped WSL launcher rather
+/// than a real POSIX bash. Matches `C:\Windows\System32\bash.exe` and the
+/// `WindowsApps\bash.exe` shim that App Execution Aliases install. Both
+/// dispatch into a WSL distribution's Linux userspace, which is the wrong
+/// place to run a task that uses mise-managed Windows tools.
+#[cfg(windows)]
+fn is_wsl_launcher_bash(path: &Path) -> bool {
+    let Some(s) = path.to_str() else {
+        return false;
+    };
+    let lower = s.to_ascii_lowercase().replace('/', "\\");
+    lower.ends_with(r"\windows\system32\bash.exe")
+        || lower.contains(r"\microsoft\windowsapps\bash.exe")
 }
 
 /// On Windows, when spawning a POSIX-style shell (bash/sh/zsh/...) for a task, the
@@ -1380,5 +1473,133 @@ mod tests {
         let env = env_with_path("/usr/bin:/bin");
         let out = maybe_convert_env_for_msys_shell(Path::new("bash"), &env);
         assert_eq!(out.get(&*crate::env::PATH_KEY).unwrap(), "/usr/bin:/bin");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_is_bash_basename_accepts_bash_variants() {
+        use std::ffi::OsStr;
+        assert!(is_bash_basename(OsStr::new("bash")));
+        assert!(is_bash_basename(OsStr::new("bash.exe")));
+        assert!(is_bash_basename(OsStr::new("BASH.EXE")));
+        assert!(is_bash_basename(OsStr::new(
+            r"C:\Program Files\Git\bin\bash.exe"
+        )));
+        assert!(is_bash_basename(OsStr::new("/usr/bin/bash")));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_is_bash_basename_rejects_other_shells() {
+        use std::ffi::OsStr;
+        assert!(!is_bash_basename(OsStr::new("sh")));
+        assert!(!is_bash_basename(OsStr::new("zsh.exe")));
+        assert!(!is_bash_basename(OsStr::new("fish")));
+        assert!(!is_bash_basename(OsStr::new("dash")));
+        assert!(!is_bash_basename(OsStr::new("cmd.exe")));
+        assert!(!is_bash_basename(OsStr::new("bashfoo")));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_is_wsl_launcher_bash_detects_system32() {
+        assert!(is_wsl_launcher_bash(Path::new(
+            r"C:\Windows\System32\bash.exe"
+        )));
+        assert!(is_wsl_launcher_bash(Path::new(
+            r"C:\WINDOWS\system32\bash.exe"
+        )));
+        assert!(is_wsl_launcher_bash(Path::new(
+            r"D:\Windows\System32\bash.exe"
+        )));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_is_wsl_launcher_bash_detects_windows_apps() {
+        assert!(is_wsl_launcher_bash(Path::new(
+            r"C:\Users\me\AppData\Local\Microsoft\WindowsApps\bash.exe"
+        )));
+        // Forward slashes still match — `which::which_in` may produce them.
+        assert!(is_wsl_launcher_bash(Path::new(
+            "C:/Users/me/AppData/Local/Microsoft/WindowsApps/bash.exe"
+        )));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_is_wsl_launcher_bash_accepts_real_bash() {
+        assert!(!is_wsl_launcher_bash(Path::new(
+            r"C:\Program Files\Git\bin\bash.exe"
+        )));
+        assert!(!is_wsl_launcher_bash(Path::new(
+            r"C:\Program Files\Git\usr\bin\bash.exe"
+        )));
+        assert!(!is_wsl_launcher_bash(Path::new(
+            r"C:\msys64\usr\bin\bash.exe"
+        )));
+        assert!(!is_wsl_launcher_bash(Path::new(
+            r"C:\Users\me\scoop\apps\git\current\bin\bash.exe"
+        )));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_git_bash_candidates_includes_program_files() {
+        let env = BTreeMap::new();
+        let candidates = git_bash_candidates(&env);
+        assert!(candidates.contains(&PathBuf::from(r"C:\Program Files\Git\bin\bash.exe")));
+        assert!(candidates.contains(&PathBuf::from(r"C:\Program Files (x86)\Git\bin\bash.exe")));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_git_bash_candidates_uses_localappdata_from_env() {
+        let mut env = BTreeMap::new();
+        env.insert(
+            "LOCALAPPDATA".to_string(),
+            r"C:\Users\me\AppData\Local".to_string(),
+        );
+        let candidates = git_bash_candidates(&env);
+        assert!(candidates.contains(&PathBuf::from(
+            r"C:\Users\me\AppData\Local\Programs\Git\bin\bash.exe"
+        )));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_resolve_posix_shell_program_path_uses_mise_bash_path_override() {
+        // SAFETY: tests in this module run sequentially within the cargo test runner;
+        // env mutation is scoped via a guard.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bash_path = tmp.path().join("custom-bash.exe");
+        std::fs::write(&bash_path, b"").expect("write fake bash");
+
+        let mut env = env_with_path(r"C:\Windows\System32;C:\Program Files\Git\bin");
+        env.insert(
+            "MISE_BASH_PATH".to_string(),
+            bash_path.to_string_lossy().into_owned(),
+        );
+
+        let resolved = resolve_posix_shell_program_path(std::ffi::OsStr::new("bash"), &env)
+            .expect("override should resolve");
+        assert_eq!(PathBuf::from(&resolved), bash_path);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_resolve_posix_shell_program_path_skips_when_not_posix_shell() {
+        let env = env_with_path(r"C:\Windows\System32");
+        assert!(resolve_posix_shell_program_path(std::ffi::OsStr::new("cmd.exe"), &env).is_none());
+        assert!(
+            resolve_posix_shell_program_path(std::ffi::OsStr::new("notepad.exe"), &env).is_none()
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_resolve_posix_shell_program_path_skips_when_path_already_unix() {
+        let env = env_with_path("/c/foo:/d/bar");
+        assert!(resolve_posix_shell_program_path(std::ffi::OsStr::new("bash"), &env).is_none());
     }
 }


### PR DESCRIPTION
## Summary

When mise spawns `bash -c` for a task on Windows, prefer a real POSIX bash
(Git Bash / MSYS2) over the WSL launcher at `C:\Windows\System32\bash.exe`.
The WSL launcher is on PATH first when mise is invoked from PowerShell, and
routing into WSL means the spawned task body runs inside a separate Linux
user-space where mise-managed Windows tools aren't visible — tasks fail with
`command not found` even though `mise install` succeeded.

## Reproduction

```toml
[tools]
bun = "latest"

[tasks.bun-via-bash]
shell = "bash -c"
run = "bun --version"
```

### From Git Bash — works

```
$ MISE_VERBOSE=1 mise run bun-via-bash
[bun-via-bash] $ bun --version
DEBUG $ C:\Program Files\Git\usr\bin\bash.exe -c bun --version
1.3.13
```

### From PowerShell — fails

```
PS> $env:MISE_VERBOSE='1'; mise run bun-via-bash
[bun-via-bash] $ bun --version
DEBUG $ C:\WINDOWS\system32\bash.exe -c bun --version
/bin/bash: line 1: bun: command not found
[bun-via-bash] ERROR task failed
```

`uname -s` inside the spawned bash returns `Linux`, confirming the body ran
inside WSL rather than on Windows. Same `mise.toml` works or fails based
purely on which terminal the user ran `mise` from.

## Why

`src/task/task_executor.rs::resolve_posix_shell_program_path` calls
`which::which_in(&task_env_PATH)` to make `bash` an absolute path before
spawning. Under PowerShell, `C:\Windows\System32` precedes any Git Bash
directory on `PATH`, so the WSL launcher wins. Under Git Bash, `MSYSTEM`
ordering puts `/usr/bin` first, so the real bash wins. The previous code had
no Git Bash preference and no WSL-launcher rejection.

## Resolution order

The `bash`-specific path inside `resolve_posix_shell_program_path`:

1. `MISE_BASH_PATH` env var — explicit user override (task env, then process env).
2. Common Git Bash install locations:
   - `C:\Program Files\Git\bin\bash.exe`
   - `C:\Program Files (x86)\Git\bin\bash.exe`
   - `%LOCALAPPDATA%\Programs\Git\bin\bash.exe`
3. The existing `which::which_in(&task_env_PATH)` search.
4. Final guard: if PATH search returns the WSL launcher
   (`...\Windows\System32\bash.exe` or `...\Microsoft\WindowsApps\bash.exe`),
   reject it with a warning and let the spawn fail loudly rather than silently
   routing into WSL.

## Scope

- **Bash only.** `sh`/`zsh`/`fish`/`ksh`/`dash` keep the existing behavior.
- **Windows only.** The relevant code path is already `#[cfg(windows)]`; Linux
  and macOS builds are unaffected — both `resolve_posix_shell_program_path`
  and `maybe_convert_env_for_msys_shell` sit behind `#[cfg(windows)]` gates.

## Test plan

- [x] `cargo fmt --check` clean
- [x] Unit tests added (Windows-gated):
  - [x] `is_bash_basename` — accepts `bash` / `bash.exe` / `BASH.EXE` / absolute paths; rejects `sh` / `zsh.exe` / `fish` / `dash` / `cmd.exe` / `bashfoo`
  - [x] `is_wsl_launcher_bash` — detects `C:\Windows\System32\bash.exe` (any drive, any case) and `...\Microsoft\WindowsApps\bash.exe` (forward or back slash); accepts `C:\Program Files\Git\bin\bash.exe`, `C:\Program Files\Git\usr\bin\bash.exe`, `C:\msys64\usr\bin\bash.exe`, scoop / per-user installs
  - [x] `git_bash_candidates` — emits Program Files paths; appends a `LOCALAPPDATA\Programs\Git\bin\bash.exe` candidate when `LOCALAPPDATA` is in the task env
  - [x] `resolve_posix_shell_program_path` — `MISE_BASH_PATH` override is honored via tempdir; non-POSIX shells skip the path; Unix-form PATH skips the path
- [x] All 15 tests in `task::task_executor::tests::*` pass on Windows MSVC build
- [x] Manual verification on Windows 11 with locally built mise:

  | Invoker | Before fix | After fix |
  | --- | --- | --- |
  | PowerShell | resolves WSL launcher → `command not found` | resolves Git Bash → task succeeds |
  | Git Bash | resolves Git Bash → task succeeds | resolves Git Bash → task succeeds (unchanged) |

WSL Linux build of mise was not exercised because the relevant code is
`#[cfg(windows)]` and is not compiled on Linux targets.

## Adjacent / related

- #5563 — Activating mise on Windows from WSL (opposite direction)
- #7507 / #7941 — file-based tasks with bash on Windows (partial fix; this is the inline `shell = "bash -c"` flavor of the same family)
- #7642 — Prevent mise from using Windows-hosted backends in WSL (opposite direction)
- #4048 — Git Bash detection + dual shim generation (does not cover task-spawn bash resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)