### PR TITLE
refactor(config): separate core and backend tool options

### DIFF
--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -176,7 +176,7 @@ impl AsdfBackend {
             let k = format!("MISE_TOOL_OPTS__{}", key.to_uppercase());
             sm = sm.with_env(k, value);
         }
-        for (key, value) in tv.request.options().install_env {
+        for (key, value) in tv.request.options().core.install_env {
             sm = sm.with_env(key, value.clone());
         }
         if let Some(project_root) = &config.project_root {

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -466,7 +466,8 @@ mod tests {
                 Some(ToolVersionOptions {
                     opts: indexmap![
                         "provider".to_string() => toml::Value::String("gitlab".to_string())
-                    ],
+                    ]
+                    .into(),
                     ..Default::default()
                 })
             )),
@@ -483,7 +484,8 @@ mod tests {
                     opts: indexmap![
                         "api_url".to_string() => toml::Value::String("https://gitlab.acme.com/api/v4".to_string()),
                         "provider".to_string() => toml::Value::String("gitlab".to_string()),
-                    ],
+                    ]
+                    .into(),
                     ..Default::default()
                 })
             )),
@@ -512,7 +514,8 @@ mod tests {
                 Some(ToolVersionOptions {
                     opts: indexmap![
                         "provider".to_string() => toml::Value::String("gitlab".to_string())
-                    ],
+                    ]
+                    .into(),
                     ..Default::default()
                 })
             )),
@@ -538,7 +541,8 @@ mod tests {
                 Some(ToolVersionOptions {
                     opts: indexmap![
                         "api_url".to_string() => toml::Value::String("https://custom-api.acme.com/v3".to_string())
-                    ],
+                    ]
+                    .into(),
                     ..Default::default()
                 })
             )),
@@ -626,7 +630,7 @@ mod tests {
 
     fn opts_with_filter_bins(value: toml::Value) -> ToolVersionOptions {
         ToolVersionOptions {
-            opts: indexmap!["filter_bins".to_string() => value],
+            opts: indexmap!["filter_bins".to_string() => value].into(),
             ..Default::default()
         }
     }

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -1183,7 +1183,7 @@ mod tests {
         );
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1233,7 +1233,7 @@ size = "5120"
         );
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1268,7 +1268,7 @@ size = "5120"
         opts.insert("size".to_string(), toml::Value::String("512".to_string()));
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1301,7 +1301,7 @@ bin_path = "."
         );
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1340,7 +1340,7 @@ bin = "xmake.exe"
         );
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1377,7 +1377,7 @@ bin = "tool.exe"
         );
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1401,7 +1401,7 @@ bin = "tool.exe"
         opts.insert("symlink_bins".to_string(), toml::Value::Boolean(true));
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1432,7 +1432,7 @@ bin = "tool.exe"
         );
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -96,7 +96,11 @@ impl Backend for VfoxBackend {
                     Settings::get().ensure_experimental("custom backends")?;
                     debug!("Using backend method for plugin: {}", this.pathname);
                     let tool_name = this.get_tool_name()?;
-                    let opts = config.get_tool_opts_with_overrides(&this.ba).await?.opts;
+                    let opts = config
+                        .get_tool_opts_with_overrides(&this.ba)
+                        .await?
+                        .into_backend_options()
+                        .into_map();
                     let versions = vfox
                         .backend_list_versions(&this.pathname, tool_name, opts)
                         .await
@@ -157,7 +161,7 @@ impl Backend for VfoxBackend {
                 &tv.version,
                 tv.install_path(),
                 tv.download_path(),
-                tool_opts.opts,
+                tool_opts.into_backend_options().into_map(),
             )
             .await
             .wrap_err("Backend install method failed")?;
@@ -469,12 +473,12 @@ impl VfoxBackend {
                         tool_name,
                         &tv.version,
                         tv.install_path(),
-                        opts.opts.clone(),
+                        opts.backend_options().clone().into_map(),
                     )
                     .await
                     .wrap_err("Backend exec env method failed")?
                 } else {
-                    vfox.env_keys(&self.pathname, &tv.version, &opts.opts)
+                    vfox.env_keys(&self.pathname, &tv.version, opts.backend_options().as_map())
                         .await?
                 };
 

--- a/src/cli/tool_stub.rs
+++ b/src/cli/tool_stub.rs
@@ -7,7 +7,9 @@ use crate::dirs;
 use crate::file;
 use crate::hash;
 use crate::lockfile::PlatformInfo;
-use crate::toolset::{InstallOptions, ToolRequest, ToolSource, ToolVersionOptions};
+use crate::toolset::{
+    CoreToolOptions, InstallOptions, ToolRequest, ToolSource, ToolVersionOptions,
+};
 use clap::Parser;
 use color_eyre::eyre::{Result, bail, eyre};
 use eyre::ensure;
@@ -198,10 +200,12 @@ impl ToolStubFile {
         }
 
         let options = ToolVersionOptions {
-            os: self.os.clone(),
-            depends: None,
-            install_env: self.install_env.clone(),
-            opts,
+            core: CoreToolOptions {
+                os: self.os.clone(),
+                depends: None,
+                install_env: self.install_env.clone(),
+            },
+            opts: opts.into(),
         };
 
         // Set options on the BackendArg so they're available to the backend

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -101,7 +101,8 @@ where
 }
 
 fn insert_core_options(table: &mut InlineTable, options: ToolVersionOptions) {
-    if let Some(os) = options.os
+    let core = options.core;
+    if let Some(os) = core.os
         && !os.is_empty()
     {
         let mut arr = Array::new();
@@ -110,7 +111,7 @@ fn insert_core_options(table: &mut InlineTable, options: ToolVersionOptions) {
         }
         table.insert("os", Value::Array(arr));
     }
-    if let Some(depends) = options.depends
+    if let Some(depends) = core.depends
         && !depends.is_empty()
     {
         let mut arr = Array::new();
@@ -119,9 +120,9 @@ fn insert_core_options(table: &mut InlineTable, options: ToolVersionOptions) {
         }
         table.insert("depends", Value::Array(arr));
     }
-    if !options.install_env.is_empty() {
+    if !core.install_env.is_empty() {
         let mut env = InlineTable::new();
-        for (k, v) in options.install_env {
+        for (k, v) in core.install_env {
             env.insert(k, v.into());
         }
         table.insert("install_env", env.into());
@@ -1925,7 +1926,7 @@ mod tests {
     use crate::dirs;
     use crate::file;
     use crate::test::replace_path;
-    use crate::toolset::ToolRequest;
+    use crate::toolset::{CoreToolOptions, ToolRequest};
     use crate::{config::Config, dirs::CWD};
 
     use super::*;
@@ -2552,8 +2553,11 @@ run = 'echo "template"'
         let cf = MiseToml::from_file(&p).unwrap();
         let needs_dummy = "needs-dummy".into();
         let mut options = ToolVersionOptions {
-            os: Some(vec!["linux".to_string()]),
-            depends: Some(vec!["dummy".to_string()]),
+            core: CoreToolOptions {
+                os: Some(vec!["linux".to_string()]),
+                depends: Some(vec!["dummy".to_string()]),
+                ..Default::default()
+            },
             ..Default::default()
         };
         options
@@ -2603,7 +2607,10 @@ run = 'echo "template"'
         let cf = MiseToml::from_file(&p).unwrap();
         let dummy = "dummy".into();
         let options = ToolVersionOptions {
-            os: Some(vec![]),
+            core: CoreToolOptions {
+                os: Some(vec![]),
+                ..Default::default()
+            },
             ..Default::default()
         };
 

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env_var_in_tool.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env_var_in_tool.snap
@@ -7,11 +7,15 @@ expression: "replace_path(&format!(\"{:#?}\", cf.to_tool_request_set().unwrap().
         Version {
             backend: BackendArg(terraform),
             version: "1.0.0",
-            options: ToolVersionOptions {
-                os: None,
-                depends: None,
-                install_env: {},
-                opts: {},
+            options: ToolOptions {
+                core: CoreToolOptions {
+                    os: None,
+                    depends: None,
+                    install_env: {},
+                },
+                opts: RawBackendOptions {
+                    values: {},
+                },
             },
             source: MiseToml(
                 "~/cwd/.test.mise.toml",
@@ -22,11 +26,15 @@ expression: "replace_path(&format!(\"{:#?}\", cf.to_tool_request_set().unwrap().
         Prefix {
             backend: BackendArg(jq),
             prefix: "1.6",
-            options: ToolVersionOptions {
-                os: None,
-                depends: None,
-                install_env: {},
-                opts: {},
+            options: ToolOptions {
+                core: CoreToolOptions {
+                    os: None,
+                    depends: None,
+                    install_env: {},
+                },
+                opts: RawBackendOptions {
+                    values: {},
+                },
             },
             source: MiseToml(
                 "~/cwd/.test.mise.toml",

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-3.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-3.snap
@@ -8,11 +8,15 @@ ToolRequestSet {
             Version {
                 backend: BackendArg(terraform),
                 version: "1.0.0",
-                options: ToolVersionOptions {
-                    os: None,
-                    depends: None,
-                    install_env: {},
-                    opts: {},
+                options: ToolOptions {
+                    core: CoreToolOptions {
+                        os: None,
+                        depends: None,
+                        install_env: {},
+                    },
+                    opts: RawBackendOptions {
+                        values: {},
+                    },
                 },
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
@@ -23,11 +27,15 @@ ToolRequestSet {
             Version {
                 backend: BackendArg(node),
                 version: "18",
-                options: ToolVersionOptions {
-                    os: None,
-                    depends: None,
-                    install_env: {},
-                    opts: {},
+                options: ToolOptions {
+                    core: CoreToolOptions {
+                        os: None,
+                        depends: None,
+                        install_env: {},
+                    },
+                    opts: RawBackendOptions {
+                        values: {},
+                    },
                 },
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
@@ -36,11 +44,15 @@ ToolRequestSet {
             Prefix {
                 backend: BackendArg(node),
                 prefix: "20",
-                options: ToolVersionOptions {
-                    os: None,
-                    depends: None,
-                    install_env: {},
-                    opts: {},
+                options: ToolOptions {
+                    core: CoreToolOptions {
+                        os: None,
+                        depends: None,
+                        install_env: {},
+                    },
+                    opts: RawBackendOptions {
+                        values: {},
+                    },
                 },
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
@@ -50,11 +62,15 @@ ToolRequestSet {
                 backend: BackendArg(node),
                 ref_: "master",
                 ref_type: "ref",
-                options: ToolVersionOptions {
-                    os: None,
-                    depends: None,
-                    install_env: {},
-                    opts: {},
+                options: ToolOptions {
+                    core: CoreToolOptions {
+                        os: None,
+                        depends: None,
+                        install_env: {},
+                    },
+                    opts: RawBackendOptions {
+                        values: {},
+                    },
                 },
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
@@ -63,11 +79,15 @@ ToolRequestSet {
             Path {
                 backend: BackendArg(node),
                 path: "~/.nodes/18",
-                options: ToolVersionOptions {
-                    os: None,
-                    depends: None,
-                    install_env: {},
-                    opts: {},
+                options: ToolOptions {
+                    core: CoreToolOptions {
+                        os: None,
+                        depends: None,
+                        install_env: {},
+                    },
+                    opts: RawBackendOptions {
+                        values: {},
+                    },
                 },
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
@@ -78,11 +98,15 @@ ToolRequestSet {
             Prefix {
                 backend: BackendArg(jq),
                 prefix: "1.6",
-                options: ToolVersionOptions {
-                    os: None,
-                    depends: None,
-                    install_env: {},
-                    opts: {},
+                options: ToolOptions {
+                    core: CoreToolOptions {
+                        os: None,
+                        depends: None,
+                        install_env: {},
+                    },
+                    opts: RawBackendOptions {
+                        values: {},
+                    },
                 },
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
@@ -93,11 +117,15 @@ ToolRequestSet {
             Version {
                 backend: BackendArg(shellcheck),
                 version: "0.9.0",
-                options: ToolVersionOptions {
-                    os: None,
-                    depends: None,
-                    install_env: {},
-                    opts: {},
+                options: ToolOptions {
+                    core: CoreToolOptions {
+                        os: None,
+                        depends: None,
+                        install_env: {},
+                    },
+                    opts: RawBackendOptions {
+                        values: {},
+                    },
                 },
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
@@ -108,14 +136,18 @@ ToolRequestSet {
             Version {
                 backend: BackendArg(python),
                 version: "3.10.0",
-                options: ToolVersionOptions {
-                    os: None,
-                    depends: None,
-                    install_env: {},
-                    opts: {
-                        "venv": String(
-                            ".venv",
-                        ),
+                options: ToolOptions {
+                    core: CoreToolOptions {
+                        os: None,
+                        depends: None,
+                        install_env: {},
+                    },
+                    opts: RawBackendOptions {
+                        values: {
+                            "venv": String(
+                                ".venv",
+                            ),
+                        },
                     },
                 },
                 source: MiseToml(
@@ -125,11 +157,15 @@ ToolRequestSet {
             Version {
                 backend: BackendArg(python),
                 version: "3.9.0",
-                options: ToolVersionOptions {
-                    os: None,
-                    depends: None,
-                    install_env: {},
-                    opts: {},
+                options: ToolOptions {
+                    core: CoreToolOptions {
+                        os: None,
+                        depends: None,
+                        install_env: {},
+                    },
+                    opts: RawBackendOptions {
+                        values: {},
+                    },
                 },
                 source: MiseToml(
                     "~/fixtures/.mise.toml",

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__replace_versions.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__replace_versions.snap
@@ -11,11 +11,15 @@ Toolset {
                 Version {
                     backend: BackendArg(node),
                     version: "16.0.1",
-                    options: ToolVersionOptions {
-                        os: None,
-                        depends: None,
-                        install_env: {},
-                        opts: {},
+                    options: ToolOptions {
+                        core: CoreToolOptions {
+                            os: None,
+                            depends: None,
+                            install_env: {},
+                        },
+                        opts: RawBackendOptions {
+                            values: {},
+                        },
                     },
                     source: MiseToml(
                         "/tmp/.mise.toml",
@@ -24,11 +28,15 @@ Toolset {
                 Version {
                     backend: BackendArg(node),
                     version: "18.0.1",
-                    options: ToolVersionOptions {
-                        os: None,
-                        depends: None,
-                        install_env: {},
-                        opts: {},
+                    options: ToolOptions {
+                        core: CoreToolOptions {
+                            os: None,
+                            depends: None,
+                            install_env: {},
+                        },
+                        opts: RawBackendOptions {
+                            values: {},
+                        },
                     },
                     source: MiseToml(
                         "/tmp/.mise.toml",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,8 +31,8 @@ use crate::task::{Task, TaskTemplate};
 use crate::tera::take_tera_accessed_files;
 use crate::toolset::env_cache::{CachedNonToolEnv, compute_settings_hash, get_file_mtime};
 use crate::toolset::{
-    ResolvedToolOptions, ToolOptionSource, ToolRequestSet, ToolRequestSetBuilder, ToolVersion,
-    ToolVersionOptions, Toolset, install_state,
+    ResolvedToolOptions, ToolOptionSource, ToolOptions, ToolRequestSet, ToolRequestSetBuilder,
+    ToolVersion, ToolVersionOptions, Toolset, install_state,
 };
 use crate::ui::style;
 use crate::{backend, dirs, env, file, lockfile, registry, runtime_symlinks, shims, timeout};
@@ -316,7 +316,7 @@ impl Config {
     pub async fn get_tool_opts(
         self: &Arc<Self>,
         backend_arg: &Arc<BackendArg>,
-    ) -> Result<Option<ToolVersionOptions>> {
+    ) -> Result<Option<ToolOptions>> {
         let trs = self.get_tool_request_set().await?;
         let short_match = trs.iter().find(|tr| tr.0.short == backend_arg.short);
         let tool_request = short_match.or_else(|| {
@@ -340,7 +340,7 @@ impl Config {
     pub async fn get_tool_opts_with_overrides(
         self: &Arc<Self>,
         backend_arg: &Arc<BackendArg>,
-    ) -> Result<ToolVersionOptions> {
+    ) -> Result<ToolOptions> {
         Ok(self
             .resolve_tool_opts_with_overrides(backend_arg)
             .await?

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,7 +1,7 @@
 use crate::backend::backend_type::BackendType;
 use crate::cli::args::BackendArg;
 use crate::config::Settings;
-use crate::toolset::ToolVersionOptions;
+use crate::toolset::{RawBackendOptions, ToolVersionOptions};
 use heck::ToShoutySnakeCase;
 use indexmap::IndexMap;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -145,7 +145,7 @@ impl RegistryTool {
         }
 
         ToolVersionOptions {
-            opts,
+            opts: RawBackendOptions::from(opts),
             ..Default::default()
         }
     }

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -35,8 +35,9 @@ pub use tool_source::ToolSource;
 pub use tool_version::{ResolveOptions, ToolVersion};
 pub use tool_version_list::ToolVersionList;
 pub use tool_version_options::{
-    EPHEMERAL_OPT_KEYS, ResolvedToolOptions, ToolOptionSource, ToolVersionOptions,
-    parse_tool_options, serialize_tool_options, try_parse_tool_options,
+    CoreToolOptions, EPHEMERAL_OPT_KEYS, RawBackendOptions, ResolvedToolOptions, ToolOptionSource,
+    ToolOptions, ToolVersionOptions, parse_tool_options, serialize_tool_options,
+    try_parse_tool_options,
 };
 
 mod builder;

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -1,9 +1,10 @@
 use indexmap::IndexMap;
+use std::ops::{Deref, DerefMut};
 
 /// Option keys that are only relevant during initial installation and should not
 /// be persisted in the manifest or included in `full_with_opts()`.
-// install_env is a named field on ToolVersionOptions (serde puts it in self.install_env),
-// but parse_tool_options() can still place it in opts, so we filter it here as well.
+// install_env is a core field on CoreToolOptions, but parse_tool_options()
+// can still place it in opts, so we filter it here as well.
 pub const EPHEMERAL_OPT_KEYS: &[&str] = &[
     "postinstall",
     "install_env",
@@ -12,18 +13,119 @@ pub const EPHEMERAL_OPT_KEYS: &[&str] = &[
     "minimum_release_age",
 ];
 
-#[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ToolVersionOptions {
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct CoreToolOptions {
+    #[serde(default)]
     pub os: Option<Vec<String>>,
+    #[serde(default)]
     pub depends: Option<Vec<String>>,
+    #[serde(default)]
     pub install_env: IndexMap<String, String>,
-    #[serde(flatten)]
-    pub opts: IndexMap<String, toml::Value>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct RawBackendOptions {
+    #[serde(flatten, default)]
+    pub values: IndexMap<String, toml::Value>,
+}
+
+impl Eq for RawBackendOptions {}
+
+impl RawBackendOptions {
+    pub fn as_map(&self) -> &IndexMap<String, toml::Value> {
+        &self.values
+    }
+
+    pub fn into_map(self) -> IndexMap<String, toml::Value> {
+        self.values
+    }
+}
+
+impl Deref for RawBackendOptions {
+    type Target = IndexMap<String, toml::Value>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
+impl DerefMut for RawBackendOptions {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.values
+    }
+}
+
+impl From<IndexMap<String, toml::Value>> for RawBackendOptions {
+    fn from(values: IndexMap<String, toml::Value>) -> Self {
+        Self { values }
+    }
+}
+
+impl FromIterator<(String, toml::Value)> for RawBackendOptions {
+    fn from_iter<T: IntoIterator<Item = (String, toml::Value)>>(iter: T) -> Self {
+        Self {
+            values: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a RawBackendOptions {
+    type Item = (&'a String, &'a toml::Value);
+    type IntoIter = indexmap::map::Iter<'a, String, toml::Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut RawBackendOptions {
+    type Item = (&'a String, &'a mut toml::Value);
+    type IntoIter = indexmap::map::IterMut<'a, String, toml::Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter_mut()
+    }
+}
+
+impl IntoIterator for RawBackendOptions {
+    type Item = (String, toml::Value);
+    type IntoIter = indexmap::map::IntoIter<String, toml::Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.into_iter()
+    }
+}
+
+/// User-specified tool options split into mise-owned core control-plane options
+/// and raw backend options. `ToolVersionOptions` remains as a compatibility
+/// alias while call sites move to the clearer names.
+#[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct ToolOptions {
+    #[serde(flatten, default)]
+    pub core: CoreToolOptions,
+    #[serde(flatten, default)]
+    pub opts: RawBackendOptions,
 }
 
 // toml::Value doesn't implement Eq (due to floats), but we control the values
 // and won't have NaN, so this is safe in practice.
-impl Eq for ToolVersionOptions {}
+impl Eq for ToolOptions {}
+
+pub type ToolVersionOptions = ToolOptions;
+
+impl Deref for ToolOptions {
+    type Target = CoreToolOptions;
+
+    fn deref(&self) -> &Self::Target {
+        &self.core
+    }
+}
+
+impl DerefMut for ToolOptions {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.core
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolOptionSource {
@@ -113,7 +215,7 @@ fn option_key_matches(key: &str, expected: &str) -> bool {
 }
 
 // Implement Hash manually to ensure deterministic hashing across IndexMap
-impl std::hash::Hash for ToolVersionOptions {
+impl std::hash::Hash for ToolOptions {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.os.hash(state);
         self.depends.hash(state);
@@ -153,7 +255,15 @@ fn hash_toml_value<H: std::hash::Hasher>(v: &toml::Value, state: &mut H) {
     }
 }
 
-impl ToolVersionOptions {
+impl ToolOptions {
+    pub fn backend_options(&self) -> &RawBackendOptions {
+        &self.opts
+    }
+
+    pub fn into_backend_options(self) -> RawBackendOptions {
+        self.opts
+    }
+
     pub fn is_empty(&self) -> bool {
         self.os.as_ref().is_none_or(|os| os.is_empty())
             && self.depends.as_ref().is_none_or(|d| d.is_empty())
@@ -809,6 +919,29 @@ mod tests {
     }
 
     #[test]
+    fn test_serde_splits_core_and_backend_options() {
+        let opts: ToolVersionOptions = toml::from_str(
+            r#"
+            os = ["linux"]
+            depends = ["node"]
+            install_env = { FOO = "bar" }
+            exe = "rg"
+            strip_components = 1
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(opts.os, Some(vec!["linux".to_string()]));
+        assert_eq!(opts.depends, Some(vec!["node".to_string()]));
+        assert_eq!(opts.install_env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(opts.get("exe"), Some("rg"));
+        assert_eq!(opts.get_string("strip_components"), Some("1".to_string()));
+        assert!(!opts.opts.contains_key("os"));
+        assert!(!opts.opts.contains_key("depends"));
+        assert!(!opts.opts.contains_key("install_env"));
+    }
+
+    #[test]
     fn test_serialize_tool_options_quotes_comma_strings() {
         let mut opts = IndexMap::new();
         opts.insert(
@@ -923,7 +1056,7 @@ mod tests {
         opts.insert("platforms".to_string(), toml::Value::Table(platforms));
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -970,7 +1103,7 @@ mod tests {
         opts.insert("config".to_string(), toml::Value::Table(config));
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1009,7 +1142,7 @@ mod tests {
         );
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1033,7 +1166,7 @@ mod tests {
         opts.insert("platforms".to_string(), toml::Value::Table(platforms));
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1045,15 +1178,17 @@ mod tests {
     #[test]
     fn test_contains_key_with_named_fields() {
         let tool_opts = ToolVersionOptions {
-            os: Some(vec!["linux".to_string()]),
-            depends: Some(vec!["node".to_string()]),
-            install_env: [(
-                "NPM_CONFIG_REGISTRY".to_string(),
-                "https://example.com".to_string(),
-            )]
-            .iter()
-            .cloned()
-            .collect(),
+            core: CoreToolOptions {
+                os: Some(vec!["linux".to_string()]),
+                depends: Some(vec!["node".to_string()]),
+                install_env: [(
+                    "NPM_CONFIG_REGISTRY".to_string(),
+                    "https://example.com".to_string(),
+                )]
+                .iter()
+                .cloned()
+                .collect(),
+            },
             ..Default::default()
         };
 
@@ -1067,19 +1202,25 @@ mod tests {
     #[test]
     fn test_resolved_tool_options_tracks_named_field_sources() {
         let config_opts = ToolVersionOptions {
-            os: Some(vec!["linux".to_string()]),
-            install_env: [("CONFIG_ONLY".to_string(), "1".to_string())]
-                .iter()
-                .cloned()
-                .collect(),
+            core: CoreToolOptions {
+                os: Some(vec!["linux".to_string()]),
+                install_env: [("CONFIG_ONLY".to_string(), "1".to_string())]
+                    .iter()
+                    .cloned()
+                    .collect(),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let inline_opts = ToolVersionOptions {
-            depends: Some(vec!["node".to_string()]),
-            install_env: [("INLINE_ONLY".to_string(), "2".to_string())]
-                .iter()
-                .cloned()
-                .collect(),
+            core: CoreToolOptions {
+                depends: Some(vec!["node".to_string()]),
+                install_env: [("INLINE_ONLY".to_string(), "2".to_string())]
+                    .iter()
+                    .cloned()
+                    .collect(),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -1120,7 +1261,7 @@ mod tests {
         opts.insert("platforms".to_string(), toml::Value::Table(platforms));
 
         let mut tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1150,7 +1291,7 @@ mod tests {
         opts.insert("platforms".to_string(), toml::Value::Table(platforms));
 
         let tool_opts = ToolVersionOptions {
-            opts,
+            opts: opts.into(),
             ..Default::default()
         };
 
@@ -1180,7 +1321,10 @@ mod tests {
     #[test]
     fn test_depends_field() {
         let tvo = ToolVersionOptions {
-            depends: Some(vec!["python".to_string(), "node".to_string()]),
+            core: CoreToolOptions {
+                depends: Some(vec!["python".to_string(), "node".to_string()]),
+                ..Default::default()
+            },
             ..Default::default()
         };
         assert_eq!(
@@ -1193,7 +1337,10 @@ mod tests {
     #[test]
     fn test_depends_none_is_empty() {
         let tvo = ToolVersionOptions {
-            depends: None,
+            core: CoreToolOptions {
+                depends: None,
+                ..Default::default()
+            },
             ..Default::default()
         };
         assert!(tvo.is_empty());
@@ -1202,7 +1349,10 @@ mod tests {
     #[test]
     fn test_depends_empty_vec_is_empty() {
         let tvo = ToolVersionOptions {
-            depends: Some(vec![]),
+            core: CoreToolOptions {
+                depends: Some(vec![]),
+                ..Default::default()
+            },
             ..Default::default()
         };
         assert!(tvo.is_empty());
@@ -1211,7 +1361,10 @@ mod tests {
     #[test]
     fn test_os_field_is_not_empty() {
         let tvo = ToolVersionOptions {
-            os: Some(vec!["linux".to_string()]),
+            core: CoreToolOptions {
+                os: Some(vec!["linux".to_string()]),
+                ..Default::default()
+            },
             ..Default::default()
         };
         assert!(!tvo.is_empty());
@@ -1220,12 +1373,14 @@ mod tests {
     #[test]
     fn test_apply_overrides_replaces_existing_values() {
         let mut base = ToolVersionOptions {
-            os: Some(vec!["linux".to_string()]),
-            depends: Some(vec!["node".to_string()]),
-            install_env: [("BASE".to_string(), "1".to_string())]
-                .iter()
-                .cloned()
-                .collect(),
+            core: CoreToolOptions {
+                os: Some(vec!["linux".to_string()]),
+                depends: Some(vec!["node".to_string()]),
+                install_env: [("BASE".to_string(), "1".to_string())]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            },
             opts: [
                 ("api_url".to_string(), s("https://config.example")),
                 ("version_prefix".to_string(), s("v")),
@@ -1235,12 +1390,14 @@ mod tests {
             .collect(),
         };
         let overrides = ToolVersionOptions {
-            os: Some(vec!["macos".to_string()]),
-            depends: Some(vec!["python".to_string()]),
-            install_env: [("BASE".to_string(), "2".to_string())]
-                .iter()
-                .cloned()
-                .collect(),
+            core: CoreToolOptions {
+                os: Some(vec!["macos".to_string()]),
+                depends: Some(vec!["python".to_string()]),
+                install_env: [("BASE".to_string(), "2".to_string())]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            },
             opts: [("api_url".to_string(), s("https://inline.example"))]
                 .iter()
                 .cloned()

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -344,6 +344,9 @@ impl ToolOptions {
         Ok(())
     }
 
+    /// Returns true for keys owned by mise's option parser. A few install-time
+    /// scalar keys are still stored in raw opts after validation because
+    /// downstream install code reads them from that map.
     fn insert_core_option(&mut self, key: &str, value: &toml::Value) -> Result<bool, String> {
         match key {
             "os" => {


### PR DESCRIPTION
## Summary
- Introduce `CoreToolOptions`, `RawBackendOptions`, and `ToolOptions` while keeping `ToolVersionOptions` as a compatibility alias.
- Store mise-owned control-plane options under `CoreToolOptions` and backend-specific TOML values under `RawBackendOptions`.
- Move call sites that need the raw backend map to explicit backend option accessors.
- Update test fixtures/snapshots and add a serde invariant test that core keys do not leak into raw backend options.

## Behavior changes
- None intended or found during review. This is a refactor of internal option storage/access; config parsing, option merging, version rewriting, backend option serialization, and install behavior should remain unchanged.
- Snapshot updates reflect internal Debug type names only: `ToolOptions`, `CoreToolOptions`, and `RawBackendOptions`.

## Review fixes
- The lenient parser skips only invalid core options instead of dropping all backend options.
- Template normalization does not rewrite core option values.
- The supported scalar error message for core option parsing lists datetime values.
- A parser-contract doc comment explains why some install-time scalar keys are validated by the core parser but stored in raw opts.

## Tests
- `cargo test --all-features tool_version_options`
- `cargo check --all-features`
