### PR TITLE
registry: use aqua backend for npm

### DIFF
--- a/registry/npm.toml
+++ b/registry/npm.toml
@@ -1,5 +1,4 @@
 backends = ["aqua:npm/cli", "npm:npm"]
-depends = ["node"]
 description = "the package manager for JavaScript"
 idiomatic_files = ["package.json"]
 overrides = ["node"]

--- a/registry/npm.toml
+++ b/registry/npm.toml
@@ -1,4 +1,5 @@
-backends = ["npm:npm"]
+backends = ["aqua:npm/cli", "npm:npm"]
+depends = ["node"]
 description = "the package manager for JavaScript"
 idiomatic_files = ["package.json"]
 overrides = ["node"]


### PR DESCRIPTION
## Summary
- Reopens https://github.com/jdx/mise/pull/8185 with only the `registry/npm.toml` change.
- Prefer `aqua:npm/cli` while keeping `npm:npm` as the fallback backend.
- Add the `node` dependency required to run the npm JavaScript entrypoint.
- Keep the registry test as `npm --version`; it should not check `node --version`.

## Notes
- The aqua registry entry has not merged yet: https://github.com/aquaproj/aqua-registry/pull/48803
- This relies on recent mise aqua file-link / `hard: true` support from https://github.com/jdx/mise/pull/9610
- This PR does not update `crates/aqua-registry`; that is handled by release-plz.

## Popularity
- GitHub: 9,735 stars, 4,316 forks, latest release v11.14.1 on 2026-05-08, pushed 2026-05-09
- npm package downloads: 57,146,804 from 2026-04-09 through 2026-05-08
- Used by: the Node.js ecosystem as the default JavaScript package manager bundled with Node.js distributions

## Testing
- `git diff --check`