### PR TITLE
registry: add scalafmt (github:scalameta/scalafmt)

### DIFF
--- a/registry/scalafmt.toml
+++ b/registry/scalafmt.toml
@@ -1,0 +1,3 @@
+backends = ["github:scalameta/scalafmt"]
+description = "Code formatter for Scala"
+test = { cmd = "scalafmt --version", expected = "scalafmt {{version}}" }


### PR DESCRIPTION
Add official formatter for scala: [scalafmt](https://github.com/scalameta/scalafmt) (1.5k stars, last release 1 month ago).

Test output:

```
$ cargo run --all-features -- test-tool scalafmt

...

scalafmt 3.11.0
mise scalafmt: OK
```

Note: does not exist on aqua registry.