### PR TITLE
docs: migrate website deploy to worker assets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,6 @@ jobs:
       - run: bun i
       - run: mise run docs:release
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: 6e243906ff257b965bcae8025c2fc344
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_DEPLOY_TOKEN }}
           DRY_RUN: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}

--- a/docs/wrangler.toml
+++ b/docs/wrangler.toml
@@ -1,0 +1,7 @@
+name = "mise-docs"
+compatibility_date = "2026-05-09"
+workers_dev = false
+
+[assets]
+directory = ".vitepress/dist"
+not_found_handling = "404-page"

--- a/xtasks/docs/release
+++ b/xtasks/docs/release
@@ -3,23 +3,19 @@ set -xeuo pipefail
 #MISE depends=["docs:build"]
 #MISE dir="docs"
 #MISE description="Release documentation site to production or remote"
+#MISE tools.wrangler="latest"
 
-aws --version
-export AWS_REGION=auto
-export AWS_ENDPOINT_URL=https://6e243906ff257b965bcae8025c2fc344.r2.cloudflarestorage.com
+wrangler --version
 
-if [ "${DRY_RUN:-true}" = "true" ]; then
-	aws() {
-		echo "DRY RUN: aws $*"
-	}
-fi
-
-if [ $((RANDOM % 30)) -eq 0 ]; then
-	# delete old assets only roughly 1/30 times
-	# deleting old assets can break the site for people currently on it
-	# but it's also good to keep things tidy
-	aws s3 rm --recursive s3://mise/assets/
-	aws s3 rm --recursive --exclude "*" --include "*.html" s3://mise/
-fi
-
-aws s3 cp --recursive --checksum-algorithm CRC32 .vitepress/dist s3://mise/
+case "${DRY_RUN:-true}" in
+true | 1)
+	wrangler deploy --dry-run
+	;;
+false | 0)
+	wrangler deploy
+	;;
+*)
+	echo "DRY_RUN must be true, false, 1, or 0" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
Sorry, I was thinking wrong. CloudFlare R2 is costing only for storing too many data, so this won't help as the docs file size is small. This might be helpful if Class A operation exceeds the free limit but not now I think.

~~I don't know how the docs website is affecting the cost, but it can be free by migrating from R2 to worker assets. I'm happy to fix this PR if you'd like to migrate the website.
It'll be kept as a fully static website. It's called "workers" assets but we can use it without any workers.~~

## Summary

- Switch the docs release task from the R2/S3 sync path to `wrangler deploy` with Workers Static Assets.
- Add a minimal `docs/wrangler.toml` that serves the VitePress output from `docs/.vitepress/dist`.
- Update the docs workflow to pass `CLOUDFLARE_ACCOUNT_ID` and a proposed `CLOUDFLARE_WORKERS_DEPLOY_TOKEN` secret instead of R2 access keys.

## Why this might be better

Today the docs site is uploaded to R2 through the S3-compatible API. R2 is a good fit for release artifacts, package repositories, and arbitrary object storage, but it is still object storage with billable storage/operations.

Workers Static Assets is closer to what the VitePress docs need: a static asset manifest deployed with a Worker version. Requests that match static assets are served as static assets rather than invoking Worker code, and Cloudflare documents static asset requests as free/unlimited with no additional asset storage cost. This keeps the website fully static while moving the website hosting path off R2.

This PR intentionally does not add a Worker script, an assets binding, or `run_worker_first`; the VitePress output is still just static files.

## Maintainer notes / open questions

- I did not add a production route/custom domain in `docs/wrangler.toml`. `mise.en.dev` also appears to serve release artifacts and package repo paths from the same R2 bucket (`install.sh`, `VERSION`, `schema/`, `deb/`, `rpm/`, versioned archives, etc.). Routing the entire hostname to this Worker would need a plan for those paths first.
- Please create a `CLOUDFLARE_WORKERS_DEPLOY_TOKEN` repository secret with enough permission to deploy the Workers Static Assets project, or rename the workflow env to an existing secret if you prefer.
- The Worker name here is `mise-docs`; that is only a suggestion and can be changed to match whatever project name you want in Cloudflare.
- Release artifacts are intentionally not migrated in this PR. R2 may still be the right backend for those paths, especially if any artifacts are awkward to split or exceed Workers Static Assets limits.

## Asset limit check

Cloudflare's current Workers Static Assets limits include a 25 MiB per-file limit, plus 20,000 files per Worker version on Free and 100,000 on Paid.

For the docs build output checked here:

- `docs/.vitepress/dist` contains 758 files.
- No built docs files exceed 25 MiB.
- The largest generated file was `assets/demo.BP9cL2Fi.mp4` at about 1.5 MB.

## Verification

- `mise run docs:build`
- `DRY_RUN=true mise run docs:release`
- `mise x actionlint -- actionlint .github/workflows/docs.yml`
- `mise x shellcheck -- shellcheck xtasks/docs/release`
- `mise x shfmt -- shfmt -d xtasks/docs/release`
- `git diff --check`

_This PR was generated by an AI coding assistant._
