### PR TITLE
fix(exec): demote parent mise paths for nested exec

### DIFF
--- a/e2e/cli/test_exec_nested_mise_run_path
+++ b/e2e/cli/test_exec_nested_mise_run_path
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# Regression test: nested `mise exec` inside a `mise run` task should put the
+# nested target tool before the outer task's mise-managed tool path, while still
+# preserving the outer path as a fallback.
+
+mise install dummy@1.0.0 dummy@2.0.0
+
+old_dir="$HOME/old"
+new_dir="$HOME/new"
+mkdir -p "$old_dir/.mise/tasks" "$new_dir"
+
+cat >"$old_dir/mise.toml" <<'EOF'
+[tools]
+dummy = "1.0.0"
+EOF
+
+cat >"$new_dir/mise.toml" <<'EOF'
+[tools]
+dummy = "2.0.0"
+EOF
+
+old_bin="$MISE_DATA_DIR/installs/dummy/1.0.0/bin"
+new_bin="$MISE_DATA_DIR/installs/dummy/2.0.0/bin"
+new_dummy="$new_bin/dummy"
+shims="$MISE_DATA_DIR/shims"
+original_path="$PATH"
+non_mise_bin="$HOME/non-mise-bin"
+mkdir -p "$non_mise_bin"
+
+cat >"$old_dir/.mise/tasks/probe" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+newdir="$1"
+old_bin="$2"
+new_bin="$3"
+shims="$4"
+
+actual=$(mise -C "$newdir" exec -- bash -c 'command -v dummy')
+if [[ $actual != "$new_bin/dummy" ]]; then
+  echo "expected nested dummy at $new_bin/dummy, got $actual" >&2
+  exit 1
+fi
+
+nested_path=$(mise -C "$newdir" exec -- printenv PATH)
+IFS=: read -r -a parts <<<"$nested_path"
+old_pos=
+new_pos=
+shims_pos=
+for i in "${!parts[@]}"; do
+  case "${parts[$i]}" in
+    "$old_bin") old_pos=$i ;;
+    "$new_bin") new_pos=$i ;;
+    "$shims") shims_pos=$i ;;
+  esac
+done
+
+if [[ -z $new_pos || -z $old_pos || -z $shims_pos ]]; then
+  echo "expected new, old, and shims paths in nested PATH" >&2
+  echo "$nested_path" >&2
+  exit 1
+fi
+
+if (( new_pos >= old_pos )); then
+  echo "expected nested tool path before inherited outer path" >&2
+  echo "$nested_path" >&2
+  exit 1
+fi
+
+if (( old_pos >= shims_pos )); then
+  echo "expected inherited outer path before shims as a direct fallback" >&2
+  echo "$nested_path" >&2
+  exit 1
+fi
+
+printf '%s\n' "$actual"
+EOF
+chmod +x "$old_dir/.mise/tasks/probe"
+
+# Simulate an activated/outer mise environment where the current task's tool bin
+# is already before shims in PATH. The nested exec should still prefer the tool
+# resolved from $new_dir, but keep the inherited tool path as a fallback.
+export PATH="$old_bin:$shims:$original_path"
+
+assert "mise -C '$old_dir' run probe '$new_dir' '$old_bin' '$new_bin' '$shims'" "$new_dummy"
+
+assert_path_order() {
+  local label="$1"
+  local path="$2"
+  local before="$3"
+  local after="$4"
+
+  python3 - "$label" "$path" "$before" "$after" <<'PY'
+import sys
+label, path, before, after = sys.argv[1:]
+parts = path.split(':')
+try:
+    before_pos = parts.index(before)
+    after_pos = parts.index(after)
+except ValueError:
+    print(f"{label}: expected both paths in PATH", file=sys.stderr)
+    print(path, file=sys.stderr)
+    raise SystemExit(1)
+if before_pos >= after_pos:
+    print(f"{label}: expected {before} before {after}", file=sys.stderr)
+    print(path, file=sys.stderr)
+    raise SystemExit(1)
+PY
+}
+
+# Without an effective shims boundary, PathEnv already places the nested config's
+# paths before inherited PATH. Do not additionally demote inherited mise install
+# paths ahead of earlier non-mise PATH entries.
+no_shims_path=$(PATH="$non_mise_bin:$old_bin:$original_path" mise -C "$new_dir" exec -- printenv PATH)
+assert_path_order "no shims" "$no_shims_path" "$non_mise_bin" "$old_bin"
+
+# activate_aggressive intentionally disables PathEnv's shims boundary. Preserve
+# inherited PATH ordering there as well.
+aggressive_path=$(MISE_ACTIVATE_AGGRESSIVE=1 PATH="$non_mise_bin:$old_bin:$shims:$original_path" mise -C "$new_dir" exec -- printenv PATH)
+assert_path_order "activate aggressive" "$aggressive_path" "$non_mise_bin" "$old_bin"

--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -4,7 +4,7 @@ use std::env::{join_paths, split_paths};
 use std::ffi::OsString;
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 pub struct PathEnv {
@@ -28,6 +28,22 @@ impl PathEnv {
         for part in split_paths(&path) {
             self.mise.push(part);
         }
+    }
+
+    pub fn take_pre_matching<F>(&mut self, predicate: F) -> Vec<PathBuf>
+    where
+        F: Fn(&Path) -> bool,
+    {
+        let mut taken = Vec::new();
+        self.pre.retain(|path| {
+            if predicate(path) {
+                taken.push(path.clone());
+                false
+            } else {
+                true
+            }
+        });
+        taken
     }
 
     pub fn to_vec(&self) -> Vec<PathBuf> {
@@ -128,6 +144,21 @@ mod tests {
         assert_eq!(
             path_env.to_string(),
             format!("/before-1:/before-2:/before-3:/1:/2:/3:{shims}:/after-1:/after-2:/after-3")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_path_env_take_pre_matching() {
+        let _config = Config::get().await.unwrap();
+        let shims = dirs::SHIMS.to_str().unwrap();
+        let mut path_env =
+            PathEnv::from_iter(["/before-1", "/before-2", shims, "/after-1"].map(PathBuf::from));
+        let taken = path_env.take_pre_matching(|p| p == Path::new("/before-2"));
+        path_env.add("/tool".into());
+        assert_eq!(taken, vec![PathBuf::from("/before-2")]);
+        assert_eq!(
+            path_env.to_string(),
+            format!("/before-1:/tool:{shims}:/after-1")
         );
     }
 

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -14,6 +14,61 @@ use crate::toolset::Toolset;
 use crate::toolset::env_cache::{CachedEnv, compute_settings_hash, get_file_mtime};
 use crate::toolset::tool_request::ToolRequest;
 use crate::{env, parallel, uv};
+
+fn base_path_env() -> (PathEnv, Vec<PathBuf>) {
+    // A nested mise process can inherit the parent task's direct install paths
+    // before shims. Treat those as prior mise output, not user pre-PATH: current
+    // config paths should win, while inherited install paths remain fallbacks.
+    let shared_install_dirs = env::shared_install_dirs();
+    let mut path_env = PathEnv::from_iter(env::PATH.clone());
+    let demoted_mise_install_paths =
+        path_env.take_pre_matching(|p| is_mise_install_path(p, &shared_install_dirs));
+    (path_env, demoted_mise_install_paths)
+}
+
+fn add_demoted_mise_install_fallbacks(
+    path_env: &mut PathEnv,
+    demoted_mise_install_paths: &[PathBuf],
+) {
+    for path in demoted_mise_install_paths {
+        path_env.add(path.clone());
+    }
+}
+
+fn is_mise_install_path(path: &Path, shared_install_dirs: &[PathBuf]) -> bool {
+    let path = crate::file::replace_path(path);
+    path_starts_with(&path, &env::MISE_INSTALLS_DIR)
+        || path_starts_with(&path, &env::MISE_SYSTEM_INSTALLS_DIR)
+        || shared_install_dirs
+            .iter()
+            .any(|d| path_starts_with(&path, d))
+}
+
+fn path_starts_with(path: &Path, prefix: &Path) -> bool {
+    #[cfg(any(windows, target_os = "macos"))]
+    {
+        let mut path_components = path.components();
+        let prefix_components = prefix.components();
+        for prefix_component in prefix_components {
+            let Some(path_component) = path_components.next() else {
+                return false;
+            };
+            if path_component.as_os_str().to_string_lossy().to_lowercase()
+                != prefix_component
+                    .as_os_str()
+                    .to_string_lossy()
+                    .to_lowercase()
+            {
+                return false;
+            }
+        }
+        true
+    }
+    #[cfg(all(not(windows), not(target_os = "macos")))]
+    {
+        path.starts_with(prefix)
+    }
+}
 
 impl Toolset {
     pub async fn full_env(&self, config: &Arc<Config>) -> Result<EnvMap> {
@@ -38,7 +93,7 @@ impl Toolset {
     /// dependency_env to avoid triggering module hooks on a partial PATH.
     pub async fn env_with_path_without_tools(&self, config: &Arc<Config>) -> Result<EnvMap> {
         let (mut env, add_paths) = self.env(config).await?;
-        let mut path_env = PathEnv::from_iter(env::PATH.clone());
+        let (mut path_env, demoted_mise_install_paths) = base_path_env();
         for p in config.path_dirs().await?.clone() {
             path_env.add(p);
         }
@@ -48,6 +103,7 @@ impl Toolset {
         for p in self.list_paths(config).await {
             path_env.add(p);
         }
+        add_demoted_mise_install_fallbacks(&mut path_env, &demoted_mise_install_paths);
         env.insert(PATH_KEY.to_string(), path_env.to_string());
         Ok(env)
     }
@@ -63,7 +119,7 @@ impl Toolset {
         }
 
         let (mut env, env_results) = self.final_env(config).await?;
-        let mut path_env = PathEnv::from_iter(env::PATH.clone());
+        let (mut path_env, demoted_mise_install_paths) = base_path_env();
         // Use split paths so we save a cache compatible with env_with_path_and_split
         let (user_paths, tool_paths) = self
             .list_final_paths_split(config, env_results.clone())
@@ -71,6 +127,7 @@ impl Toolset {
         for p in user_paths.iter().chain(tool_paths.iter()) {
             path_env.add(p.clone());
         }
+        add_demoted_mise_install_fallbacks(&mut path_env, &demoted_mise_install_paths);
         env.insert(PATH_KEY.to_string(), path_env.to_string());
 
         // Save to cache if enabled and no uncacheable directives
@@ -100,10 +157,11 @@ impl Toolset {
             trace!("env_cache: using cached environment with split paths");
             let mut env = cached.env;
             // Reconstruct PATH from cached paths
-            let mut path_env = PathEnv::from_iter(env::PATH.clone());
+            let (mut path_env, demoted_mise_install_paths) = base_path_env();
             for p in cached.user_paths.iter().chain(cached.tool_paths.iter()) {
                 path_env.add(p.clone());
             }
+            add_demoted_mise_install_fallbacks(&mut path_env, &demoted_mise_install_paths);
             env.insert(PATH_KEY.to_string(), path_env.to_string());
             return Ok((
                 env,
@@ -120,10 +178,11 @@ impl Toolset {
             .await?;
 
         // Build PATH
-        let mut path_env = PathEnv::from_iter(env::PATH.clone());
+        let (mut path_env, demoted_mise_install_paths) = base_path_env();
         for p in user_paths.iter().chain(tool_paths.iter()) {
             path_env.add(p.clone());
         }
+        add_demoted_mise_install_fallbacks(&mut path_env, &demoted_mise_install_paths);
         env.insert(PATH_KEY.to_string(), path_env.to_string());
 
         // Save to cache if enabled and no uncacheable directives
@@ -153,10 +212,11 @@ impl Toolset {
             Some(cached) => {
                 let mut env = cached.env;
                 // Reconstruct PATH from cached paths
-                let mut path_env = PathEnv::from_iter(env::PATH.clone());
+                let (mut path_env, demoted_mise_install_paths) = base_path_env();
                 for p in cached.user_paths.into_iter().chain(cached.tool_paths) {
                     path_env.add(p);
                 }
+                add_demoted_mise_install_fallbacks(&mut path_env, &demoted_mise_install_paths);
                 env.insert(PATH_KEY.to_string(), path_env.to_string());
                 Ok(Some(env))
             }
@@ -337,7 +397,7 @@ impl Toolset {
         let (mut env, add_paths) = self.env(config).await?;
         let mut tera_env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
         tera_env.extend(env.clone());
-        let mut path_env = PathEnv::from_iter(env::PATH.clone());
+        let (mut path_env, demoted_mise_install_paths) = base_path_env();
 
         for p in config.path_dirs().await?.clone() {
             path_env.add(p);
@@ -348,6 +408,7 @@ impl Toolset {
         for p in self.list_paths(config).await {
             path_env.add(p);
         }
+        add_demoted_mise_install_fallbacks(&mut path_env, &demoted_mise_install_paths);
         tera_env.insert(PATH_KEY.to_string(), path_env.to_string());
         let mut ctx = config.tera_ctx.clone();
         ctx.insert("env", &tera_env);


### PR DESCRIPTION
## Summary

Nested `mise exec`/`mise env` calls inside an existing `mise run` task can inherit the outer task's direct install path before shims. `PathEnv::from_iter()` treats everything before shims as user/system `pre` paths, so the outer task's tool version can keep winning over the nested config's resolved tool version.

This reclassifies inherited mise-managed install paths that `PathEnv` places in `pre`:

- build the inherited PATH through `PathEnv` first, preserving its existing shims/no-shims/`activate_aggressive` semantics
- remove mise-managed install paths from `pre`
- add the current/nested user/tool paths first
- re-add the inherited mise install paths after them, but still before shims, so they remain direct fallbacks

That makes the nested config's selected tool win without dropping the parent task's tool path from the child environment.

Safety boundary: this only reorders paths under mise install roots that `PathEnv` would otherwise classify as pre-shims entries. Non-mise pre-PATH entries, no-shims PATHs, and `activate_aggressive` keep their existing inherited ordering.

Discussion: https://github.com/jdx/mise/discussions/9754

## Validation

- `cargo fmt --check`
- `cargo build --bin mise`
- `cargo test path_env`
- `mise run lint`
- `./e2e/run_test cli/test_exec_nested_mise_run_path`
- `./e2e/run_test cli/test_exec_venv_path_order`
- `./e2e/run_test cli/test_exec_wrapper_recursion_with_shims`
- `./e2e/run_test env/test_path_reorder_after_activate`
- Original discussion repro with `target/debug/mise` first in `PATH`:
  - `usage@3.0.0` task probing `usage@3.2.1` now resolves nested `mise exec -- command -v usage` to `usage@3.2.1`
  - `shiv:sessions@0.4.0` task probing `shiv:sessions@0.4.1` now resolves nested `mise exec -- command -v sessions` to `shiv:sessions@0.4.1`
