### PR TITLE
registry: add vector (github:vectordotdev/vector)

### DIFF
--- a/registry/vector.toml
+++ b/registry/vector.toml
@@ -1,0 +1,3 @@
+backends = ["github:vectordotdev/vector"]
+description = "A high-performance observability data pipeline."
+test = { cmd = "vector --version", expected = "vector {{version}}" }

--- a/registry/vector.toml
+++ b/registry/vector.toml
@@ -1,4 +1,3 @@
 backends = ["github:vectordotdev/vector"]
 description = "A high-performance observability data pipeline."
-idiomatic_files = ["vector.yaml", "vector.json", "vector.toml"]
 test = { cmd = "vector --version", expected = "vector {{version}}" }

--- a/registry/vector.toml
+++ b/registry/vector.toml
@@ -1,3 +1,4 @@
 backends = ["github:vectordotdev/vector"]
 description = "A high-performance observability data pipeline."
+detect = ["vector.yaml", "vector.json", "vector.toml"]
 test = { cmd = "vector --version", expected = "vector {{version}}" }

--- a/registry/vector.toml
+++ b/registry/vector.toml
@@ -1,4 +1,4 @@
 backends = ["github:vectordotdev/vector"]
 description = "A high-performance observability data pipeline."
-detect = ["vector.yaml", "vector.json", "vector.toml"]
+idiomatic_files = ["vector.yaml", "vector.json", "vector.toml"]
 test = { cmd = "vector --version", expected = "vector {{version}}" }


### PR DESCRIPTION
## Summary

- Add [`vector`](https://github.com/vectordotdev/vector) to the registry using `github:vectordotdev/vector`.
  - A PR for aqua: https://github.com/aquaproj/aqua-registry/pull/53517
  - I would be OK either postponing this PR until the aqua PR is merged, or merging this PR first and then updating the `backends` field in the registry to include both backends. Up to maintainer(s) and timing on that PR.
- Add an install test using `vector --version`:

```shell
❯ ./vector --version
vector 0.55.0 (x86_64-unknown-linux-gnu cf8de83 2026-04-22 14:31:18.008404048)
```

Normally, `vector` would be installed onto production systems with k8s tooling or other configuration management tools, but it can be useful to have a simple install for local development and testing.
Vector is written in Rust and has a pretty strong focus on making things easy to test/combining tests right along side the code and configuration files.

I have a few `mise/task`s that use `vector` to test and debug various log ingest pipelines, and it would be nice to be able to install and version pin `vector` with `mise` for those tasks.

## Popularity

- GitHub: 21.8k stars, 2.1k forks
- Latest release: v0.55.0, published 2026-04-22
- Recent activity: pushed 2026-05-09, releases are cut ~ monthly
- Used for: observability data (logs, metrics, traces) pipelines

## Validation

Thanks for making it quick/easy to do this :)

```shell
❯ RUSTUP_TOOLCHAIN=1.91.0 MISE_DISABLE_TOOLS=1 mise run build
[build] $ cargo build --all-features
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.56s
❯ MISE_DISABLE_TOOLS=1 ./target/debug/mise test-tool --jobs=1 vector
mise Removing installs directory: /home/karl/.local/share/mise/installs/vector
mise Removing cache directory: /home/karl/.cache/mise/vector
mise Removing downloads directory: /home/karl/.local/share/mise/downloads/vector
cleaning vector                                                                                                                                                                             ✔
vector@0.55.0                       extract vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz                                                                                                   ✔
mise $ /home/karl/.local/share/mise/installs/vector/0.55.0/bin/vector --version
vector 0.55.0 (x86_64-unknown-linux-gnu cf8de83 2026-04-22 14:31:18.008404048)
mise vector: OK
```
