### PR TITLE
fix(exec): propagate __MISE_DIFF so nested mise recovers pristine PATH

### DIFF
--- a/e2e/cli/test_run_nested_exec_path
+++ b/e2e/cli/test_run_nested_exec_path
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Regression test for https://github.com/jdx/mise/discussions/9754
+#
+# Inside a `mise run` task whose toolset selected dummy@1.0.0, a nested
+# `mise -C <other> exec -- ...` should resolve <other>'s tool (dummy@2.0.0),
+# not the outer task's. The bug was that the outer task's install path
+# leaked into the inner mise's PATH ahead of shims, where PathEnv classified
+# it as user-pre-PATH and it outranked the inner toolset's resolved tool.
+#
+# Fix: the outer mise task now embeds __MISE_DIFF in its child env so the
+# nested mise can recover the pristine PATH (mirrors what `mise activate`
+# does for shells). See src/task/task_executor.rs and src/cli/exec.rs.
+
+mise install dummy@1.0.0 dummy@2.0.0
+
+old_dir="$HOME/old"
+new_dir="$HOME/new"
+mkdir -p "$old_dir/.mise/tasks" "$new_dir"
+
+cat >"$old_dir/mise.toml" <<EOF
+[tools]
+dummy = "1.0.0"
+EOF
+
+cat >"$new_dir/mise.toml" <<EOF
+[tools]
+dummy = "2.0.0"
+EOF
+
+new_bin="$MISE_DATA_DIR/installs/dummy/2.0.0/bin"
+
+cat >"$old_dir/.mise/tasks/probe" <<TASK
+#!/usr/bin/env bash
+set -euo pipefail
+mise -C "$new_dir" exec -- bash -c 'command -v dummy'
+TASK
+chmod +x "$old_dir/.mise/tasks/probe"
+
+# Put shims in PATH ahead of the rest. Without shims as a separator, PathEnv
+# wouldn't have classified the outer install dir as pre-PATH, so the bug
+# wouldn't manifest. With shims present, this is the discussion's scenario.
+shims="$MISE_DATA_DIR/shims"
+mkdir -p "$shims"
+export PATH="$shims:$PATH"
+
+assert "mise -C '$old_dir' run probe" "$new_bin/dummy"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -14,6 +14,7 @@ use crate::cmd;
 use crate::config::{Config, Settings};
 use crate::deps::{DepsEngine, DepsOptions};
 use crate::env;
+use crate::env_diff::EnvDiff;
 use crate::sandbox::SandboxConfig;
 use crate::toolset::env_cache::CachedEnv;
 use crate::toolset::{InstallOptions, ResolveOptions, ToolsetBuilder};
@@ -166,6 +167,15 @@ impl Exec {
         let (program, mut args) = parse_command(&env::SHELL, &self.command, &self.c);
 
         let mut env = measure!("env_with_path", { ts.env_with_path(&config).await? });
+
+        // Embed __MISE_DIFF so a nested mise invocation can recover the pristine
+        // env (and pristine PATH) instead of stacking our tool dirs on top of its
+        // own. Without this, `mise -C <new> exec -- ...` invoked from inside our
+        // child process would inherit our tool dirs as user-pre-PATH and they
+        // would outrank the inner toolset's resolved tool. See discussion #9754.
+        if let Ok(serialized) = EnvDiff::from_final_env(&env::PRISTINE_ENV, &env).serialize() {
+            env.insert("__MISE_DIFF".to_string(), serialized);
+        }
 
         // Run auto-enabled deps steps (unless --no-deps)
         if !self.no_deps {

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -168,15 +168,6 @@ impl Exec {
 
         let mut env = measure!("env_with_path", { ts.env_with_path(&config).await? });
 
-        // Embed __MISE_DIFF so a nested mise invocation can recover the pristine
-        // env (and pristine PATH) instead of stacking our tool dirs on top of its
-        // own. Without this, `mise -C <new> exec -- ...` invoked from inside our
-        // child process would inherit our tool dirs as user-pre-PATH and they
-        // would outrank the inner toolset's resolved tool. See discussion #9754.
-        if let Ok(serialized) = EnvDiff::from_final_env(&env::PRISTINE_ENV, &env).serialize() {
-            env.insert("__MISE_DIFF".to_string(), serialized);
-        }
-
         // Run auto-enabled deps steps (unless --no-deps)
         if !self.no_deps {
             let engine = DepsEngine::new(&config)?;
@@ -198,6 +189,17 @@ impl Exec {
         if Settings::get().env_cache && !self.fresh_env {
             let key = CachedEnv::ensure_encryption_key();
             env.insert("__MISE_ENV_CACHE_KEY".to_string(), key);
+        }
+
+        // Embed __MISE_DIFF so a nested mise invocation can recover the pristine
+        // env (and pristine PATH) instead of stacking our tool dirs on top of its
+        // own. Without this, `mise -C <new> exec -- ...` invoked from inside our
+        // child process would inherit our tool dirs as user-pre-PATH and they
+        // would outrank the inner toolset's resolved tool. See discussion #9754.
+        // Computed after all env modifications so the diff fully describes what
+        // mise added (matches task_executor.rs).
+        if let Ok(serialized) = EnvDiff::from_final_env(&env::PRISTINE_ENV, &env).serialize() {
+            env.insert("__MISE_DIFF".to_string(), serialized);
         }
 
         if program.rsplit('/').next() == Some("fish") {

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -167,6 +167,32 @@ impl EnvDiff {
             path: self.path.clone(),
         }
     }
+
+    /// Build an EnvDiff describing the transformation from `pristine` → `final_env`,
+    /// suitable for serialization into `__MISE_DIFF`. PATH is excluded from
+    /// `old`/`new` and instead tracked in `path` (entries present in `final_env`'s
+    /// PATH but not in `pristine`'s PATH). This mirrors what `mise hook-env` writes
+    /// during shell activation, so nested `mise` invocations can reverse it via
+    /// `get_pristine_env` and avoid stacking outer tool paths on top of inner ones.
+    pub fn from_final_env(pristine: &EnvMap, final_env: &EnvMap) -> EnvDiff {
+        use std::collections::HashSet;
+
+        let mut additions = final_env.clone();
+        additions.remove(PATH_KEY.as_str());
+        let mut diff = EnvDiff::new(pristine, additions);
+
+        let pristine_paths: HashSet<PathBuf> = pristine
+            .get(PATH_KEY.as_str())
+            .map(|p| crate::env::split_paths(p).collect())
+            .unwrap_or_default();
+        if let Some(final_path) = final_env.get(PATH_KEY.as_str()) {
+            diff.path = crate::env::split_paths(final_path)
+                .filter(|p| !pristine_paths.contains(p))
+                .collect();
+        }
+
+        diff
+    }
 }
 
 fn invalid_key(k: &str, opts: &EnvDiffOptions) -> bool {

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -394,8 +394,22 @@ mod tests {
     async fn test_from_final_env() {
         let _config = Config::get().await.unwrap();
         let path_key = PATH_KEY.as_str();
+        let pristine_paths = [PathBuf::from("/usr/bin"), PathBuf::from("/bin")];
+        let final_paths = [
+            PathBuf::from("/tool/bin"),
+            PathBuf::from("/usr/bin"),
+            PathBuf::from("/bin"),
+        ];
+        let pristine_path = std::env::join_paths(pristine_paths.iter())
+            .unwrap()
+            .into_string()
+            .unwrap();
+        let final_path = std::env::join_paths(final_paths.iter())
+            .unwrap()
+            .into_string()
+            .unwrap();
         let pristine: EnvMap = [
-            (path_key, "/usr/bin:/bin"),
+            (path_key, pristine_path.as_str()),
             ("EXISTING", "old"),
             ("__MISE_DIFF", "outer-diff"),
         ]
@@ -403,7 +417,7 @@ mod tests {
         .map(|(k, v)| (k.into(), v.into()))
         .collect();
         let final_env: EnvMap = [
-            (path_key, "/tool/bin:/usr/bin:/bin"),
+            (path_key, final_path.as_str()),
             ("EXISTING", "new"),
             ("ADDED", "yes"),
             ("__MISE_DIFF", "should-be-ignored"),
@@ -444,11 +458,10 @@ mod tests {
         assert_eq!(restored.get("EXISTING"), Some(&"old".to_string()));
         assert!(!restored.contains_key("ADDED"));
         let to_remove: std::collections::HashSet<_> = diff.path.iter().collect();
-        let restored_path: Vec<_> = crate::env::split_paths(&final_env[path_key])
+        let restored_path: Vec<PathBuf> = crate::env::split_paths(&final_env[path_key])
             .filter(|p| !to_remove.contains(p))
-            .map(|p| p.to_string_lossy().to_string())
             .collect();
-        assert_eq!(restored_path.join(":"), pristine[path_key]);
+        assert_eq!(restored_path, pristine_paths);
     }
 
     #[tokio::test]

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -171,21 +171,26 @@ impl EnvDiff {
     /// Build an EnvDiff describing the transformation from `pristine` → `final_env`,
     /// suitable for serialization into `__MISE_DIFF`. PATH is excluded from
     /// `old`/`new` and instead tracked in `path` (entries present in `final_env`'s
-    /// PATH but not in `pristine`'s PATH). This mirrors what `mise hook-env` writes
-    /// during shell activation, so nested `mise` invocations can reverse it via
-    /// `get_pristine_env` and avoid stacking outer tool paths on top of inner ones.
+    /// PATH but not in `pristine`'s PATH). `__MISE_DIFF` itself is also excluded
+    /// so an inherited value can't end up nested inside the diff we're about to
+    /// write. This mirrors what `mise hook-env` writes during shell activation,
+    /// so nested `mise` invocations can reverse it via `get_pristine_env` and
+    /// avoid stacking outer tool paths on top of inner ones.
     pub fn from_final_env(pristine: &EnvMap, final_env: &EnvMap) -> EnvDiff {
         use std::collections::HashSet;
 
-        let mut additions = final_env.clone();
-        additions.remove(PATH_KEY.as_str());
+        let path_key = PATH_KEY.as_str();
+        let additions = final_env
+            .iter()
+            .filter(|(k, _)| k.as_str() != path_key && k.as_str() != "__MISE_DIFF")
+            .map(|(k, v)| (k.clone(), v.clone()));
         let mut diff = EnvDiff::new(pristine, additions);
 
         let pristine_paths: HashSet<PathBuf> = pristine
-            .get(PATH_KEY.as_str())
+            .get(path_key)
             .map(|p| crate::env::split_paths(p).collect())
             .unwrap_or_default();
-        if let Some(final_path) = final_env.get(PATH_KEY.as_str()) {
+        if let Some(final_path) = final_env.get(path_key) {
             diff.path = crate::env::split_paths(final_path)
                 .filter(|p| !pristine_paths.contains(p))
                 .collect();
@@ -383,6 +388,67 @@ mod tests {
         let serialized = diff.serialize().unwrap();
         let deserialized = EnvDiff::deserialize(&serialized).unwrap();
         assert_debug_snapshot!(deserialized.to_patches());
+    }
+
+    #[tokio::test]
+    async fn test_from_final_env() {
+        let _config = Config::get().await.unwrap();
+        let path_key = PATH_KEY.as_str();
+        let pristine: EnvMap = [
+            (path_key, "/usr/bin:/bin"),
+            ("EXISTING", "old"),
+            ("__MISE_DIFF", "outer-diff"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect();
+        let final_env: EnvMap = [
+            (path_key, "/tool/bin:/usr/bin:/bin"),
+            ("EXISTING", "new"),
+            ("ADDED", "yes"),
+            ("__MISE_DIFF", "should-be-ignored"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect();
+
+        let diff = EnvDiff::from_final_env(&pristine, &final_env);
+
+        // PATH entries new in final_env land in diff.path; shared entries don't.
+        assert_eq!(diff.path, vec![PathBuf::from("/tool/bin")]);
+        // Non-PATH adds/changes are tracked in diff.new (with diff.old for changes).
+        assert_eq!(diff.new.get("ADDED"), Some(&"yes".to_string()));
+        assert_eq!(diff.new.get("EXISTING"), Some(&"new".to_string()));
+        assert_eq!(diff.old.get("EXISTING"), Some(&"old".to_string()));
+        // PATH and __MISE_DIFF are filtered out of old/new.
+        assert!(!diff.new.contains_key(path_key));
+        assert!(!diff.old.contains_key(path_key));
+        assert!(!diff.new.contains_key("__MISE_DIFF"));
+        assert!(!diff.old.contains_key("__MISE_DIFF"));
+
+        // Round-trip: applying the reversed diff to final_env should restore pristine
+        // for the keys we tracked, and stripping diff.path from final's PATH should
+        // give us pristine's PATH back.
+        let reversed = diff.reverse();
+        let mut restored: EnvMap = final_env.clone();
+        for patch in reversed.to_patches() {
+            match patch {
+                EnvDiffOperation::Add(k, v) | EnvDiffOperation::Change(k, v) => {
+                    restored.insert(k, v);
+                }
+                EnvDiffOperation::Remove(k) => {
+                    restored.remove(&k);
+                }
+            }
+        }
+        assert_eq!(restored.get("EXISTING"), Some(&"old".to_string()));
+        assert!(!restored.contains_key("ADDED"));
+        let to_remove: std::collections::HashSet<_> = diff.path.iter().collect();
+        let restored_path: Vec<_> = crate::env::split_paths(&final_env[path_key])
+            .filter(|p| !to_remove.contains(p))
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(restored_path.join(":"), pristine[path_key]);
     }
 
     #[tokio::test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -2,6 +2,7 @@ use crate::cli::args::ToolArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings, env_directive::EnvDirective};
 use crate::duration;
+use crate::env_diff::EnvDiff;
 use crate::file::{display_path, is_executable};
 use crate::sandbox::SandboxConfig;
 use crate::task::TaskKey;
@@ -320,6 +321,16 @@ impl TaskExecutor {
         if Settings::get().env_cache {
             let key = CachedEnv::ensure_encryption_key();
             env.insert("__MISE_ENV_CACHE_KEY".into(), key);
+        }
+
+        // Embed __MISE_DIFF so a nested `mise` invocation inside this task can
+        // recover the pristine env (and pristine PATH) instead of stacking our
+        // tool dirs on top of its own. Without this, nested `mise -C <new> exec`
+        // would inherit our tool dirs as user-pre-PATH and they would outrank
+        // the inner toolset's resolved tool. See discussion #9754.
+        if let Ok(serialized) = EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env).serialize()
+        {
+            env.insert("__MISE_DIFF".into(), serialized);
         }
 
         let timer = std::time::Instant::now();


### PR DESCRIPTION
## Summary

A nested `mise -C <new> exec -- <cmd>` invoked from inside a `mise run` task or `mise exec` child process was inheriting the outer toolset's install paths as user-pre-PATH and outranking the inner toolset's resolved tool. `mise which` saw the right answer because it reads the toolset directly; `mise exec`/`mise env` build PATH on top of `env::PATH` and stacked the inner tool dirs after the outer ones.

## The bug (from #9754)

With shims in PATH (the activated-shell case the discussion was filed against):

| | Outer task PATH | Inner `mise -C new exec` PATH | `command -v` finds |
|---|---|---|---|
| **Before** | `usage/3.0.0:…:shims:…` | `usage/3.0.0:usage/3.2.1:shims:…` | `usage/3.0.0` ❌ |
| **After**  | `usage/3.0.0:…:shims:…` | `usage/3.2.1:shims:…` (3.0.0 reverted) | `usage/3.2.1` ✓ |

`PathEnv::from_iter` classified the outer `usage/3.0.0` as user-pre-PATH (everything before shims), so the inner toolset's `usage/3.2.1`, added to the `mise` slot, ended up *behind* it.

## Fix

`mise exec` and `mise run` now embed `__MISE_DIFF` in the env they hand to children — the same mechanism `mise hook-env` already uses for activated shells. Nested mise reads it via the existing `get_pristine_env` machinery, reverses it, and builds its PATH from the pristine baseline. No new PATH zone, no path reclassification — just plumbing the existing env-diff mechanism into the spawn boundary it had been missing from.

The reusable bit (`EnvDiff::from_final_env`) extracts what `hook-env` was already doing inline.

## Alternatives considered

The author of #9754 also opened #9760, which fixes the same bug at the `PathEnv` layer by taking inherited mise-install paths out of the `pre` segment, then re-appending them after the new tool paths but still before shims as a "demoted fallback." That works but adds a third PATH zone and ~220 lines of new platform-specific path-prefix logic. This PR is +47/-0 and reuses the env-diff plumbing that's already production-tested.

A noticeable behavior difference: this PR **removes** the outer task's tool dir from the inner's PATH entirely instead of keeping it as a fallback. I think that's the right semantics — `mise -C <new> exec` advertises "the env for `<new>`," not "merge of outer+inner." If a user wants both, they'd merge configs. (Though if the project disagrees, #9760's fallback approach can be layered on top.)

## Test plan

- [x] `cargo build --bin mise`
- [x] `mise run lint`
- [x] `mise run test:unit` — 888 passed
- [x] `mise run test:e2e cli/test_run_nested_exec_path` — new regression test
- [x] Existing exec/run e2e tests pass: `test_exec_chdir`, `test_exec_latest`, `test_exec_lockfile`, `test_exec_shim_recursion`, `test_exec_venv_path_order`, `test_exec_wrapper_recursion`, `test_exec_wrapper_recursion_with_shims`
- [x] Existing activate/hook/env e2e tests pass: `test_activate_export`, `test_activate_aggressive`, `test_hook_env`, `test_hook_env_dir_mtime_stabilizes`, `test_hook_env_fast_path`, `test_run_subtask_jobs1`, `test_set_env`, `test_use_env`
- [x] Manually reproduced the discussion's scenario; confirmed the bug appears without the fix and is resolved with the fix
- [x] Edge cases verified: non-mise pre-PATH entries are preserved, no-shims PATH still works, tools not declared in either config remain findable via inherited PATH

Closes #9754

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `mise exec` and `mise run` tasks construct child-process environments by adding `__MISE_DIFF`, which can affect PATH resolution in nested invocations. Risk is moderate because it alters tool lookup precedence and could change behavior for workflows that implicitly relied on outer tool paths leaking into inner commands.
> 
> **Overview**
> Fixes nested `mise -C <dir> exec` invoked from within `mise exec` or `mise run` tasks so it no longer inherits and prioritizes the *outer* toolset’s install directories on `PATH`.
> 
> This propagates a serialized `__MISE_DIFF` to child environments (in `src/cli/exec.rs` and `src/task/task_executor.rs`) and adds `EnvDiff::from_final_env` to reliably compute that diff while excluding `PATH` and `__MISE_DIFF` itself. Adds an e2e regression test (`e2e/cli/test_run_nested_exec_path`) plus unit coverage for `from_final_env` to prevent PATH-leak regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4b3f83d134d6c74957c7bf039ca89ce743536a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->