### PR TITLE
feat(oci): scope build to project config by default

### DIFF
--- a/docs/cli/oci/build.md
+++ b/docs/cli/oci/build.md
@@ -26,6 +26,12 @@ Output directory for the OCI image layout
 
 Base image reference (overrides [oci].from and the oci.default_from setting)
 
+### `--include-global`
+
+Also include tools from the global / system config (default: project-only)
+
+By default `mise oci build` only packages tools declared in the project's mise config (and any parent configs at-or-below the project root, e.g. a monorepo root config). Personal dev tools in `~/.config/mise/config.toml` are excluded so they don't bake into a project image. Pass `--include-global` to revert to the old "merge all loaded configs" behavior.
+
 ### `-t --tag <TAG>`
 
 Tag to record in the image index (the org.opencontainers.image.ref.name annotation)
@@ -57,6 +63,10 @@ $ skopeo copy oci:./mise-oci docker://ghcr.io/me/dev:latest
 Notes:
 
 ```
+- The image only contains tools from the project's mise config (and
+  any configs at-or-below the project root). Tools from
+  `~/.config/mise/config.toml` are not included; pass --include-global
+  to package them too.
 - asdf and vfox plugins are not supported in v1; use a different backend
   (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.
 - The host mise binary is embedded at /usr/local/bin/mise by default;

--- a/docs/cli/oci/push.md
+++ b/docs/cli/oci/push.md
@@ -31,6 +31,12 @@ Base image for the build (ignored with --image-dir)
 
 Push an already-built OCI image layout (skip the build step)
 
+### `--include-global`
+
+Also include tools from the global / system config (default: project-only)
+
+See `mise oci build --help` for details.
+
 ### `--mount-point <MOUNT_POINT>`
 
 Override in-image mount point (ignored with --image-dir)

--- a/docs/cli/oci/run.md
+++ b/docs/cli/oci/run.md
@@ -42,6 +42,12 @@ Base image reference for the build (ignored with --image-dir)
 
 Use an already-built OCI image layout instead of building fresh
 
+### `--include-global`
+
+Also include tools from the global / system config (default: project-only)
+
+See `mise oci build --help` for details.
+
 ### `--keep`
 
 Keep the loaded image in the engine's storage after the run

--- a/e2e/oci/test_oci_build_slow
+++ b/e2e/oci/test_oci_build_slow
@@ -84,9 +84,28 @@ assert "jq -r '[.layers[] | select(.annotations.\"dev.mise.tool.short\") | .anno
 # With the asdf plugin now back in scope, the asdf/vfox rejection should fire.
 assert_fail "mise oci build --include-global -o ./out-incl --from scratch" "does not support asdf/vfox"
 
-# --- 8. No project config + no --include-global → clear error ---
+# --- 8. [oci] settings from global config are also project-scoped by default ---
+# Replace the asdf-plugin-in-global with a bogus [oci].from that would fail to
+# resolve if it were inherited. With project-only scope (the default) the
+# project's own --from scratch wins, so the build succeeds. With
+# --include-global the global from would be merged in and shadowed by --from
+# anyway, so this test asserts the *non-include* path doesn't even read the
+# global [oci].
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[oci]
+mount_point = "/should-not-appear"
+EOF
+assert_succeed "mise oci build -o ./out-oci-scope --from scratch"
+mf_oci="$(jq -r '.manifests[0].digest | ltrimstr("sha256:")' ./out-oci-scope/index.json)"
+config_oci_digest="$(jq -r '.config.digest | ltrimstr("sha256:")' "./out-oci-scope/blobs/sha256/$mf_oci")"
+assert_not_contains "jq -r '.config.Env | join(\"\n\")' ./out-oci-scope/blobs/sha256/$config_oci_digest" "/should-not-appear"
+
+# --- 9. No project config + no --include-global → clear error ---
+# Error message is shared between build/run/push, so it must NOT name a
+# specific subcommand (just "mise oci").
 rm -f mise.toml
 assert_fail "mise oci build -o ./out-none --from scratch" "no project mise config"
+assert_fail "mise oci build -o ./out-none --from scratch" "mise oci:"
 
 # Cleanup so later assertions in this file (none currently, but also so a
 # rerun under the same workdir doesn't carry global state forward) start fresh.

--- a/e2e/oci/test_oci_build_slow
+++ b/e2e/oci/test_oci_build_slow
@@ -59,3 +59,35 @@ cat >mise.toml <<EOF
 "asdf:some-plugin" = "1.0.0"
 EOF
 assert_fail "mise oci build --from scratch -o ./out-bad" "does not support asdf/vfox"
+
+# --- 6. Global config tools are NOT packaged by default (#9690) ---
+# Pin mise.toml back to a buildable project, then drop a *different* tool
+# into the global config. The global tool isn't installed; if the project
+# scope filter regresses, mise oci build will try to package it and fail.
+cat >mise.toml <<EOF
+[tools]
+jq = "1.8.1"
+EOF
+mkdir -p "$MISE_CONFIG_DIR"
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[tools]
+"asdf:some-plugin" = "1.0.0"
+EOF
+assert_succeed "mise oci build -o ./out-scope --from scratch"
+# Only the project tool (jq) should be in the manifest — the asdf plugin from
+# the global config must be filtered out, both as a packaged layer and as a
+# trigger for the asdf/vfox rejection check.
+mf="$(jq -r '.manifests[0].digest | ltrimstr("sha256:")' ./out-scope/index.json)"
+assert "jq -r '[.layers[] | select(.annotations.\"dev.mise.tool.short\") | .annotations.\"dev.mise.tool.short\"] | sort | unique | join(\",\")' ./out-scope/blobs/sha256/$mf" "jq"
+
+# --- 7. --include-global reverses the scope filter ---
+# With the asdf plugin now back in scope, the asdf/vfox rejection should fire.
+assert_fail "mise oci build --include-global -o ./out-incl --from scratch" "does not support asdf/vfox"
+
+# --- 8. No project config + no --include-global → clear error ---
+rm -f mise.toml
+assert_fail "mise oci build -o ./out-none --from scratch" "no project mise config"
+
+# Cleanup so later assertions in this file (none currently, but also so a
+# rerun under the same workdir doesn't carry global state forward) start fresh.
+rm -f "$MISE_CONFIG_DIR/config.toml"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1570,6 +1570,11 @@ Output directory for the OCI image layout
 \fB\-\-from\fR \fI<FROM>\fR
 Base image reference (overrides [oci].from and the oci.default_from setting)
 .TP
+\fB\-\-include\-global\fR
+Also include tools from the global / system config (default: project\-only)
+
+By default `mise oci build` only packages tools declared in the project's mise config (and any parent configs at\-or\-below the project root, e.g. a monorepo root config). Personal dev tools in `~/.config/mise/config.toml` are excluded so they don't bake into a project image. Pass `\-\-include\-global` to revert to the old "merge all loaded configs" behavior.
+.TP
 \fB\-t, \-\-tag\fR \fI<TAG>\fR
 Tag to record in the image index (the org.opencontainers.image.ref.name annotation)
 .TP
@@ -1600,6 +1605,11 @@ Base image for the build (ignored with \-\-image\-dir)
 .TP
 \fB\-\-image\-dir\fR \fI<IMAGE_DIR>\fR
 Push an already\-built OCI image layout (skip the build step)
+.TP
+\fB\-\-include\-global\fR
+Also include tools from the global / system config (default: project\-only)
+
+See `mise oci build \-\-help` for details.
 .TP
 \fB\-\-mount\-point\fR \fI<MOUNT_POINT>\fR
 Override in\-image mount point (ignored with \-\-image\-dir)
@@ -1644,6 +1654,11 @@ Base image reference for the build (ignored with \-\-image\-dir)
 .TP
 \fB\-\-image\-dir\fR \fI<IMAGE_DIR>\fR
 Use an already\-built OCI image layout instead of building fresh
+.TP
+\fB\-\-include\-global\fR
+Also include tools from the global / system config (default: project\-only)
+
+See `mise oci build \-\-help` for details.
 .TP
 \fB\-\-keep\fR
 Keep the loaded image in the engine's storage after the run

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -615,12 +615,15 @@ cmd oci subcommand_required=#true help="[experimental] Build OCI container image
     long_help "[experimental] Build OCI container images from a mise.toml\n\nEach tool becomes its own OCI layer, so bumping any single tool version\nonly invalidates one content-addressable blob — unlike a Dockerfile where\nchanging an early `RUN` invalidates every layer above it.\n\nThis command is experimental and requires `mise settings experimental=true`\n(or `MISE_EXPERIMENTAL=1`). Behavior, flags, and output layout may change\nin future releases."
     cmd build help="[experimental] Build an OCI image from the current mise.toml" {
         long_help "[experimental] Build an OCI image from the current mise.toml\n\nEach tool version becomes its own content-addressable OCI layer. Bumping a\ntool version only invalidates that tool's layer — other tools, the base\nimage, and config are reused unchanged. The output directory conforms to\nthe OCI image-layout spec and can be consumed by `skopeo`, `crane`, or\n`podman load`.\n\nRequires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`)."
-        after_long_help "Examples:\n\n    Build with defaults (debian:bookworm-slim base):\n    $ mise oci build\n\n    Build with a specific base image and tag:\n    $ mise oci build --from ubuntu:24.04 --tag myorg/dev:latest -o ./img\n\n    Inspect the result with skopeo:\n    $ skopeo inspect oci:./mise-oci\n\n    Push to a registry:\n    $ skopeo copy oci:./mise-oci docker://ghcr.io/me/dev:latest\n\nNotes:\n\n    - asdf and vfox plugins are not supported in v1; use a different backend\n      (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.\n    - The host mise binary is embedded at /usr/local/bin/mise by default;\n      build on the same OS/arch as your target image (or pass --no-mise).\n"
+        after_long_help "Examples:\n\n    Build with defaults (debian:bookworm-slim base):\n    $ mise oci build\n\n    Build with a specific base image and tag:\n    $ mise oci build --from ubuntu:24.04 --tag myorg/dev:latest -o ./img\n\n    Inspect the result with skopeo:\n    $ skopeo inspect oci:./mise-oci\n\n    Push to a registry:\n    $ skopeo copy oci:./mise-oci docker://ghcr.io/me/dev:latest\n\nNotes:\n\n    - The image only contains tools from the project's mise config (and\n      any configs at-or-below the project root). Tools from\n      `~/.config/mise/config.toml` are not included; pass --include-global\n      to package them too.\n    - asdf and vfox plugins are not supported in v1; use a different backend\n      (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.\n    - The host mise binary is embedded at /usr/local/bin/mise by default;\n      build on the same OS/arch as your target image (or pass --no-mise).\n"
         flag "-o --output" help="Output directory for the OCI image layout" default="./mise-oci" {
             arg <OUTPUT>
         }
         flag --from help="Base image reference (overrides [oci].from and the oci.default_from setting)" {
             arg <FROM>
+        }
+        flag --include-global help="Also include tools from the global / system config (default: project-only)" {
+            long_help "Also include tools from the global / system config (default: project-only)\n\nBy default `mise oci build` only packages tools declared in the project's mise config (and any parent configs at-or-below the project root, e.g. a monorepo root config). Personal dev tools in `~/.config/mise/config.toml` are excluded so they don't bake into a project image. Pass `--include-global` to revert to the old \"merge all loaded configs\" behavior."
         }
         flag "-t --tag" help="Tag to record in the image index (the org.opencontainers.image.ref.name annotation)" {
             arg <TAG>
@@ -638,6 +641,9 @@ cmd oci subcommand_required=#true help="[experimental] Build OCI container image
         }
         flag --image-dir help="Push an already-built OCI image layout (skip the build step)" {
             arg <IMAGE_DIR>
+        }
+        flag --include-global help="Also include tools from the global / system config (default: project-only)" {
+            long_help "Also include tools from the global / system config (default: project-only)\n\nSee `mise oci build --help` for details."
         }
         flag --mount-point help="Override in-image mount point (ignored with --image-dir)" {
             arg <MOUNT_POINT>
@@ -663,6 +669,9 @@ cmd oci subcommand_required=#true help="[experimental] Build OCI container image
         }
         flag --image-dir help="Use an already-built OCI image layout instead of building fresh" {
             arg <IMAGE_DIR>
+        }
+        flag --include-global help="Also include tools from the global / system config (default: project-only)" {
+            long_help "Also include tools from the global / system config (default: project-only)\n\nSee `mise oci build --help` for details."
         }
         flag --keep help="Keep the loaded image in the engine's storage after the run" {
             long_help "Keep the loaded image in the engine's storage after the run\n\nBy default, both the container (`--rm`) and the loaded image are removed when the command exits, so repeated `mise oci run` calls don't accumulate images in podman / docker storage. Pass `--keep` to retain the image under the tag mise used (`mise-oci:run-*` for docker; the pulled image ID for podman)."

--- a/src/cli/oci/build.rs
+++ b/src/cli/oci/build.rs
@@ -28,6 +28,17 @@ pub struct Build {
     #[clap(long)]
     from: Option<String>,
 
+    /// Also include tools from the global / system config (default: project-only)
+    ///
+    /// By default `mise oci build` only packages tools declared in the
+    /// project's mise config (and any parent configs at-or-below the
+    /// project root, e.g. a monorepo root config). Personal dev tools in
+    /// `~/.config/mise/config.toml` are excluded so they don't bake into a
+    /// project image. Pass `--include-global` to revert to the old
+    /// "merge all loaded configs" behavior.
+    #[clap(long)]
+    include_global: bool,
+
     /// Tag to record in the image index (the org.opencontainers.image.ref.name annotation)
     #[clap(long, short)]
     tag: Option<String>,
@@ -52,7 +63,7 @@ impl Build {
             mount_point: self.mount_point.clone(),
             include_mise: !self.no_mise,
         };
-        let out = perform_build(opts).await?;
+        let out = perform_build(opts, self.include_global).await?;
 
         miseprintln!("wrote OCI image layout to {}", display_path(&out.out_dir));
         miseprintln!("manifest: {}", out.manifest_digest);
@@ -87,6 +98,10 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 <bold><underline>Notes:</underline></bold>
 
+    - The image only contains tools from the project's mise config (and
+      any configs at-or-below the project root). Tools from
+      `~/.config/mise/config.toml` are not included; pass --include-global
+      to package them too.
     - asdf and vfox plugins are not supported in v1; use a different backend
       (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.
     - The host mise binary is embedded at /usr/local/bin/mise by default;

--- a/src/cli/oci/common.rs
+++ b/src/cli/oci/common.rs
@@ -1,10 +1,10 @@
 //! Shared helpers for `mise oci` subcommands.
 
-use eyre::Result;
+use eyre::{Result, bail};
 
-use crate::config::Config;
+use crate::config::{Config, ConfigMap};
 use crate::oci::{BuildOptions, BuildOutput, Builder, OciConfig};
-use crate::toolset::ToolsetBuilder;
+use crate::toolset::{ConfigScope, ToolsetBuilder};
 
 /// Merge `[oci]` sections across all loaded config files, with more specific
 /// (closer to the current directory) configs winning per-field.
@@ -27,11 +27,59 @@ pub fn merged_oci_config(config: &Config) -> OciConfig {
 
 /// Load config + toolset, merge the `[oci]` section, and build the image.
 /// Used by `mise oci build`, `mise oci run`, and `mise oci push`.
-pub async fn perform_build(opts: BuildOptions) -> Result<BuildOutput> {
+///
+/// By default the toolset is scoped to configs at-or-below the project root
+/// — i.e. the user's global config, system config, and parent-directory
+/// configs above the project (e.g. a `~/mise.toml` setting personal Node
+/// defaults) are excluded. Rationale: `mise oci build` is conceptually
+/// "package *this project's* tools into a deployable image" — personal dev
+/// tools (neovim, ripgrep, …) sitting in `~/.config/mise/config.toml` have
+/// no business in a project image, and several of them (asdf/vfox plugins)
+/// would in fact be rejected by the v1 builder. See discussion #9690.
+///
+/// Set `include_global = true` to revert to the merge-everything behavior.
+pub async fn perform_build(opts: BuildOptions, include_global: bool) -> Result<BuildOutput> {
     let config = Config::get().await?;
-    let ts = ToolsetBuilder::new().build(&config).await?;
+    let ts = build_toolset(&config, include_global).await?;
     let oci = merged_oci_config(&config);
     Builder::new(config.clone(), ts, oci, opts).build().await
+}
+
+async fn build_toolset(
+    config: &std::sync::Arc<Config>,
+    include_global: bool,
+) -> Result<crate::toolset::Toolset> {
+    if include_global {
+        return ToolsetBuilder::new().build(config).await;
+    }
+    // `cf.project_root().is_some()` is the right scope: it's None for the
+    // global config, the system config, and parent-dir configs that live
+    // directly under $HOME (e.g. `~/mise.toml` someone uses to set their
+    // default Node). It's Some for any project config, including those
+    // walked up from CWD into a monorepo root — which we *do* want included
+    // (sub-project + monorepo root share the toolset of the deployable).
+    let project_files: ConfigMap = config
+        .config_files
+        .iter()
+        .filter(|(_, cf)| cf.project_root().is_some())
+        .map(|(p, cf)| (p.clone(), cf.clone()))
+        .collect();
+    if project_files.is_empty() {
+        bail!(
+            "mise oci build: no project mise config found in the current directory or any \
+             parent. Add a `mise.toml` to the project, or pass `--include-global` to package \
+             tools from your global config (note: asdf/vfox plugins remain unsupported)."
+        );
+    }
+    // ConfigScope::LocalOnly belt-and-suspenders: the project-files filter
+    // already drops global/system, but LocalOnly *also* drops MISE_*_VERSION
+    // ad-hoc overrides from the environment, which shouldn't bake into an
+    // image either.
+    ToolsetBuilder::new()
+        .with_config_files(project_files)
+        .with_scope(ConfigScope::LocalOnly)
+        .build(config)
+        .await
 }
 
 pub fn short_digest(d: &str) -> String {

--- a/src/cli/oci/common.rs
+++ b/src/cli/oci/common.rs
@@ -6,18 +6,21 @@ use crate::config::{Config, ConfigMap};
 use crate::oci::{BuildOptions, BuildOutput, Builder, OciConfig};
 use crate::toolset::{ConfigScope, ToolsetBuilder};
 
-/// Merge `[oci]` sections across all loaded config files, with more specific
+/// Merge `[oci]` sections from the given config files, with more specific
 /// (closer to the current directory) configs winning per-field.
 ///
 /// Uses "first-Some-wins" semantics via `OciConfig::fill_defaults_from`, so
-/// the result is correct as long as mise's `config_files` iterates
-/// most-specific-first — the convention at the time of writing. If that
-/// convention ever inverts, this logic still picks the first value it sees
-/// and just changes which config wins; it won't silently drop fields or
-/// return garbage.
-pub fn merged_oci_config(config: &Config) -> OciConfig {
+/// the result is correct as long as the iteration order is most-specific-first
+/// — the convention at the time of writing. If that convention ever inverts,
+/// this logic still picks the first value it sees and just changes which
+/// config wins; it won't silently drop fields or return garbage.
+pub fn merged_oci_config_from<'a>(
+    config_files: impl IntoIterator<
+        Item = &'a std::sync::Arc<dyn crate::config::config_file::ConfigFile>,
+    >,
+) -> OciConfig {
     let mut out = OciConfig::default();
-    for cf in config.config_files.values() {
+    for cf in config_files {
         if let Some(oci) = cf.oci_config() {
             out.fill_defaults_from(oci);
         }
@@ -25,39 +28,48 @@ pub fn merged_oci_config(config: &Config) -> OciConfig {
     out
 }
 
+/// Convenience wrapper that merges `[oci]` across *all* loaded configs.
+/// Used when the caller has explicitly opted into global/system scope.
+pub fn merged_oci_config(config: &Config) -> OciConfig {
+    merged_oci_config_from(config.config_files.values())
+}
+
 /// Load config + toolset, merge the `[oci]` section, and build the image.
 /// Used by `mise oci build`, `mise oci run`, and `mise oci push`.
 ///
-/// By default the toolset is scoped to configs at-or-below the project root
-/// — i.e. the user's global config, system config, and parent-directory
-/// configs above the project (e.g. a `~/mise.toml` setting personal Node
-/// defaults) are excluded. Rationale: `mise oci build` is conceptually
-/// "package *this project's* tools into a deployable image" — personal dev
-/// tools (neovim, ripgrep, …) sitting in `~/.config/mise/config.toml` have
-/// no business in a project image, and several of them (asdf/vfox plugins)
-/// would in fact be rejected by the v1 builder. See discussion #9690.
+/// By default both the toolset and the `[oci]` section are scoped to configs
+/// at-or-below the project root — i.e. the user's global config, system
+/// config, and parent-directory configs above the project (e.g. a `~/mise.toml`
+/// setting personal Node defaults) are excluded. Rationale: `mise oci build`
+/// is conceptually "package *this project's* tools into a deployable image" —
+/// personal dev tools (neovim, ripgrep, …) sitting in
+/// `~/.config/mise/config.toml` have no business in a project image, and
+/// several of them (asdf/vfox plugins) would in fact be rejected by the v1
+/// builder. See discussion #9690.
 ///
 /// Set `include_global = true` to revert to the merge-everything behavior.
 pub async fn perform_build(opts: BuildOptions, include_global: bool) -> Result<BuildOutput> {
     let config = Config::get().await?;
-    let ts = build_toolset(&config, include_global).await?;
-    let oci = merged_oci_config(&config);
+    if include_global {
+        let ts = ToolsetBuilder::new().build(&config).await?;
+        let oci = merged_oci_config(&config);
+        return Builder::new(config.clone(), ts, oci, opts).build().await;
+    }
+    let project_files = project_config_files(&config)?;
+    let ts = build_project_toolset(&config, project_files.clone()).await?;
+    let oci = merged_oci_config_from(project_files.values());
     Builder::new(config.clone(), ts, oci, opts).build().await
 }
 
-async fn build_toolset(
-    config: &std::sync::Arc<Config>,
-    include_global: bool,
-) -> Result<crate::toolset::Toolset> {
-    if include_global {
-        return ToolsetBuilder::new().build(config).await;
-    }
-    // `cf.project_root().is_some()` is the right scope: it's None for the
-    // global config, the system config, and parent-dir configs that live
-    // directly under $HOME (e.g. `~/mise.toml` someone uses to set their
-    // default Node). It's Some for any project config, including those
-    // walked up from CWD into a monorepo root — which we *do* want included
-    // (sub-project + monorepo root share the toolset of the deployable).
+/// Configs at-or-below the project root.
+///
+/// `cf.project_root().is_some()` is the right scope: it's None for the global
+/// config, the system config, and parent-dir configs that live directly under
+/// $HOME (e.g. `~/mise.toml` someone uses to set their default Node). It's
+/// Some for any project config, including those walked up from CWD into a
+/// monorepo root — which we *do* want included (sub-project + monorepo root
+/// share the toolset of the deployable).
+fn project_config_files(config: &Config) -> Result<ConfigMap> {
     let project_files: ConfigMap = config
         .config_files
         .iter()
@@ -66,11 +78,19 @@ async fn build_toolset(
         .collect();
     if project_files.is_empty() {
         bail!(
-            "mise oci build: no project mise config found in the current directory or any \
-             parent. Add a `mise.toml` to the project, or pass `--include-global` to package \
-             tools from your global config (note: asdf/vfox plugins remain unsupported)."
+            "mise oci: no project mise config found in the current directory or any parent. \
+             Add a `mise.toml` to the project, or pass `--include-global` to use tools and \
+             [oci] settings from your global config (note: asdf/vfox plugins remain \
+             unsupported)."
         );
     }
+    Ok(project_files)
+}
+
+async fn build_project_toolset(
+    config: &std::sync::Arc<Config>,
+    project_files: ConfigMap,
+) -> Result<crate::toolset::Toolset> {
     // ConfigScope::LocalOnly belt-and-suspenders: the project-files filter
     // already drops global/system, but LocalOnly *also* drops MISE_*_VERSION
     // ad-hoc overrides from the environment, which shouldn't bake into an

--- a/src/cli/oci/push.rs
+++ b/src/cli/oci/push.rs
@@ -32,8 +32,14 @@ pub struct Push {
     from: Option<String>,
 
     /// Push an already-built OCI image layout (skip the build step)
-    #[clap(long, value_hint = ValueHint::DirPath, conflicts_with_all = &["from", "mount_point", "no_mise"])]
+    #[clap(long, value_hint = ValueHint::DirPath, conflicts_with_all = &["from", "mount_point", "no_mise", "include_global"])]
     image_dir: Option<PathBuf>,
+
+    /// Also include tools from the global / system config (default: project-only)
+    ///
+    /// See `mise oci build --help` for details.
+    #[clap(long)]
+    include_global: bool,
 
     /// Override in-image mount point (ignored with --image-dir)
     #[clap(long)]
@@ -91,7 +97,7 @@ impl Push {
                     mount_point: self.mount_point.clone(),
                     include_mise: !self.no_mise,
                 };
-                let built = perform_build(opts).await?;
+                let built = perform_build(opts, self.include_global).await?;
                 info!("built image: {}", built.manifest_digest);
                 (out_dir, Some(td))
             };

--- a/src/cli/oci/run.rs
+++ b/src/cli/oci/run.rs
@@ -33,8 +33,14 @@ pub struct Run {
     from: Option<String>,
 
     /// Use an already-built OCI image layout instead of building fresh
-    #[clap(long, value_hint = ValueHint::DirPath, conflicts_with_all = &["from", "mount_point", "no_mise"])]
+    #[clap(long, value_hint = ValueHint::DirPath, conflicts_with_all = &["from", "mount_point", "no_mise", "include_global"])]
     image_dir: Option<PathBuf>,
+
+    /// Also include tools from the global / system config (default: project-only)
+    ///
+    /// See `mise oci build --help` for details.
+    #[clap(long)]
+    include_global: bool,
 
     /// Keep the loaded image in the engine's storage after the run
     ///
@@ -125,7 +131,7 @@ impl Run {
                     mount_point: self.mount_point.clone(),
                     include_mise: !self.no_mise,
                 };
-                let built = perform_build(opts).await?;
+                let built = perform_build(opts, self.include_global).await?;
                 info!("built image: {}", built.manifest_digest);
                 (out_dir, Some(td))
             };

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1830,6 +1830,12 @@ const completionSpec: Fig.Spec = {
               },
             },
             {
+              name: "--include-global",
+              description:
+                "Also include tools from the global / system config (default: project-only)",
+              isRepeatable: false,
+            },
+            {
               name: ["-t", "--tag"],
               description:
                 "Tag to record in the image index (the org.opencontainers.image.ref.name annotation)",
@@ -1878,6 +1884,12 @@ const completionSpec: Fig.Spec = {
                 name: "image_dir",
                 template: "folders",
               },
+            },
+            {
+              name: "--include-global",
+              description:
+                "Also include tools from the global / system config (default: project-only)",
+              isRepeatable: false,
             },
             {
               name: "--mount-point",
@@ -1948,6 +1960,12 @@ const completionSpec: Fig.Spec = {
                 name: "image_dir",
                 template: "folders",
               },
+            },
+            {
+              name: "--include-global",
+              description:
+                "Also include tools from the global / system config (default: project-only)",
+              isRepeatable: false,
             },
             {
               name: "--keep",


### PR DESCRIPTION
## Summary

`mise oci build` (and `oci run` / `oci push` when they build) used to include every tool from every loaded config — the user's global `~/.config/mise/config.toml`, the system config, and any parent-dir configs above the project. That made `mise oci build` unusable for people whose global config has personal dev tools (neovim, ripgrep, asdf/vfox plugins) that have no business in a deployable project image. The asdf/vfox plugins in particular hard-fail the v1 OCI builder, which is the symptom reported in #9690:

```
mise ERROR mise oci build does not support asdf/vfox plugins in v1 ...
Affected tools: neovim, lua, sqlite
```

…where `neovim`/`lua`/`sqlite` came from the user's global config, not the project's `mise.toml`.

## Change

Default is now project-only: keep configs whose `cf.project_root().is_some()` (project mise.toml plus any monorepo-root configs walked up from CWD), drop globals/system/parent-of-project home configs. The toolset is also built with `ConfigScope::LocalOnly` as belt-and-suspenders to drop ad-hoc `MISE_*_VERSION` env overrides that shouldn't bake into an image either.

`--include-global` opts back into the merge-everything behavior on `mise oci build`, `oci run`, and `oci push`.

If no project mise config exists, the command errors out with:
```
mise oci build: no project mise config found in the current directory or any
parent. Add a `mise.toml` to the project, or pass `--include-global` to package
tools from your global config (note: asdf/vfox plugins remain unsupported).
```

## Compatibility note

This is technically a behavior change for existing `mise oci build` users — but the prior behavior was buggy (silently packaging the user's personal tools into project images), and the most likely failure mode (asdf/vfox plugin in global config) was already a hard error. People who deliberately wanted the old behavior get `--include-global`.

## Test plan

- [x] `cargo build --bin mise`
- [x] `mise run lint`
- [x] `e2e/oci/test_oci_build_slow` — extended with four new scenarios:
  - global tool dropped into `~/.config/mise/config.toml` is **not** packaged by default; only the project's `jq` ends up in the manifest
  - `--include-global` reverses the filter and triggers the asdf/vfox rejection on the global tool
  - no project config + no `--include-global` → clear error message
  - existing positive/negative paths still pass

Closes #9690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for `mise oci build/run/push`: global/system configs and env version overrides are now excluded unless opted in, which may surprise users relying on implicit global tool inclusion. Scoped config selection also affects which `[oci]` settings are applied and introduces a new error path when no project config is found.
> 
> **Overview**
> **`mise oci build` (and `oci run`/`oci push` when building) now package only project-scoped tools and `[oci]` settings by default**, filtering config files to those at-or-below the project root and building the toolset with `ConfigScope::LocalOnly`.
> 
> Adds `--include-global` to `build`, `run`, and `push` to opt back into the previous global/system config merge behavior, and returns a clearer error when no project config is found. Updates CLI docs/manpage/completions and extends the OCI e2e test to cover the new scoping and flag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc41a55592badb8f384d32a2b236fc5e79bcf1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->