### PR TITLE
fix(backend): retry ubi installs without v prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5679,6 +5679,7 @@ version = "2026.5.5"
 dependencies = [
  "age",
  "aho-corasick",
+ "anyhow",
  "aqua-registry",
  "async-backtrace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ opt-level = 3
 [dependencies]
 age = { version = "0.11", features = ["ssh"] }
 aho-corasick = "1"
+anyhow = "1"
 async-backtrace = "0.2"
 async-trait = "0.1"
 aws-config = { version = "1.5", default-features = false, features = [

--- a/e2e/backend/test_ubi
+++ b/e2e/backend/test_ubi
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 assert "mise x ubi:goreleaser/goreleaser@v1.25.0 -- goreleaser -v | grep -o 1.25.0" "1.25.0"
+assert "mise x ubi:metalbear-co/mirrord@3.209.1 -- mirrord --version | grep -o 3.209.1" "3.209.1"
 
 mise use ubi:kellyjonbrazil/jc@1.25.3
 assert_contains "$MISE_DATA_DIR/shims/jc --version" "jc version:  1.25.3"

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -555,6 +555,9 @@ impl UbiInstallError {
     }
 
     fn message_indicates_missing_asset(message: &str) -> bool {
+        // UBI exposes asset-selection misses as anyhow strings, not typed errors.
+        // Keep these substrings in sync with UBI 0.9.0's picker errors:
+        // https://github.com/houseabsolute/ubi/blob/v0.9.0/src/picker.rs
         message.contains("404")
             || message.contains("could not find a release asset")
             || message.contains("the asset isn't found")

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -1,7 +1,7 @@
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::platform_target::PlatformTarget;
-use crate::backend::static_helpers::{lookup_platform_key, try_with_v_prefix};
+use crate::backend::static_helpers::{VerifiableError, lookup_platform_key, try_with_v_prefix};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
 use crate::env::{
@@ -16,6 +16,7 @@ use async_trait::async_trait;
 use eyre::bail;
 use regex::Regex;
 use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -230,9 +231,13 @@ impl Backend for UbiBackend {
 
         // Use lockfile URL if available, otherwise fall back to standard resolution
         if let Some(url) = &lockfile_url {
-            install(url, &v, &bin_dir, extract_all, &opts).await?;
+            install(url, &v, &bin_dir, extract_all, &opts)
+                .await
+                .map_err(|e| e.into_eyre())?;
         } else if name_is_url(&self.tool_name()) {
-            install(&self.tool_name(), &v, &bin_dir, extract_all, &opts).await?;
+            install(&self.tool_name(), &v, &bin_dir, extract_all, &opts)
+                .await
+                .map_err(|e| e.into_eyre())?;
         } else {
             try_with_v_prefix(&v, None, |candidate| {
                 let opts = opts.clone();
@@ -462,7 +467,7 @@ async fn install(
     bin_dir: &Path,
     extract_all: bool,
     opts: &ToolVersionOptions,
-) -> eyre::Result<()> {
+) -> std::result::Result<(), UbiInstallError> {
     let mut builder = UbiBuilder::new().install_dir(bin_dir);
 
     if name_is_url(name) {
@@ -490,7 +495,7 @@ async fn install(
     }
 
     let forge = match opts.get("provider") {
-        Some(forge) => ForgeType::from_str(forge)?,
+        Some(forge) => ForgeType::from_str(forge).map_err(UbiInstallError::from_display)?,
         None => ForgeType::default(),
     };
     builder = builder.forge(forge.clone());
@@ -504,7 +509,7 @@ async fn install(
         builder = set_enterprise_token(builder, &forge);
     }
 
-    let mut ubi = builder.build().map_err(|e| eyre::eyre!("{e:#}"))?;
+    let mut ubi = builder.build().map_err(UbiInstallError::from_anyhow)?;
 
     // TODO: hacky but does not compile without it
     tokio::task::block_in_place(|| {
@@ -515,6 +520,59 @@ async fn install(
                 .unwrap()
         });
         RT.block_on(async { ubi.install_binary().await })
-            .map_err(|e| eyre::eyre!("{e:#}"))
+            .map_err(UbiInstallError::from_anyhow)
     })
+}
+
+#[derive(Debug)]
+struct UbiInstallError {
+    message: String,
+    retry_without_v: bool,
+}
+
+impl UbiInstallError {
+    fn from_anyhow(error: anyhow::Error) -> Self {
+        let retry_without_v = error.chain().any(|cause| {
+            cause
+                .downcast_ref::<reqwest::Error>()
+                .is_some_and(|err| err.status() == Some(reqwest::StatusCode::NOT_FOUND))
+        });
+        let message = format!("{error:#}");
+        let retry_without_v = retry_without_v || Self::message_indicates_missing_asset(&message);
+        Self {
+            message,
+            retry_without_v,
+        }
+    }
+
+    fn from_display(error: impl Display) -> Self {
+        let message = format!("{error:#}");
+        let retry_without_v = Self::message_indicates_missing_asset(&message);
+        Self {
+            message,
+            retry_without_v,
+        }
+    }
+
+    fn message_indicates_missing_asset(message: &str) -> bool {
+        message.contains("404")
+            || message.contains("could not find a release asset")
+            || message.contains("the asset isn't found")
+    }
+}
+
+impl Display for UbiInstallError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl VerifiableError for UbiInstallError {
+    fn is_not_found(&self) -> bool {
+        self.retry_without_v
+    }
+
+    fn into_eyre(self) -> eyre::Report {
+        eyre::eyre!("{}", self.message)
+    }
 }


### PR DESCRIPTION
## Summary
- Preserve UBI install failures as retryable errors for `try_with_v_prefix`, so `vX` can fall back to raw `X` when the release tag is missing or has no usable asset.
- Keep direct URL and lockfile URL UBI installs terminal instead of applying tag fallback to them.
- Add an e2e regression for `ubi:metalbear-co/mirrord@3.209.1`, which is published under the raw tag `3.209.1`.

## Investigation
- `aqua` CLI installs `metalbear-co/mirrord@3.209.1`, `3.209.2`, and `3.171.0` successfully.
- mise's aqua backend installs the same mirrord versions on the reported 2026.5.0 build and current main, including `latest` resolved with `--before 2026-05-05` to match the report window.
- The exact `releases/tags/v3.209.1` failure comes from the deprecated UBI path. UBI returns an `anyhow::Error`, and mise was flattening it into an `eyre` string before the shared prefix fallback could classify it as retryable.
- This also covers releases where `vX` exists but has no matching platform asset, such as mirrord `v3.171.0` on Linux, while raw `3.171.0` is installable.

## Tests
- `mise run format`
- `git diff --check`
- `cargo fmt --all -- --check`
- `mise run test:e2e e2e/backend/test_ubi`
- Manual: `target/debug/mise x ubi:metalbear-co/mirrord@3.171.0 -- mirrord --version`

*This PR was generated by an AI coding assistant.*
