### PR TITLE
chore(release): sync aqua-registry dependency sources

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -65,6 +65,15 @@ get_latest_crates_version() {
 	cargo info --registry "crates-io" --color never --quiet "$crate" 2>/dev/null | grep "^version:" | cut -d' ' -f2 || echo ""
 }
 
+use_published_aqua_registry() {
+	local version="$1"
+
+	cargo rm aqua-registry
+	cargo rm --build aqua-registry
+	cargo add "aqua-registry@$version"
+	cargo add --build "aqua-registry@$version"
+}
+
 # Check if a directory has uncommitted changes (staged or unstaged)
 has_uncommitted_changes() {
 	local dir="$1"
@@ -188,7 +197,7 @@ if [[ $cur_version != "$latest_version" ]]; then
 	cargo add "vfox@$VFOX_VERSION"
 
 	bump_and_publish_subcrate "aqua-registry" "crates/aqua-registry" "AQUA_REGISTRY_VERSION"
-	cargo add "aqua-registry@$AQUA_REGISTRY_VERSION"
+	use_published_aqua_registry "$AQUA_REGISTRY_VERSION"
 
 	# Copy schema into crate directory so cargo publish verification can find it
 	cp schema/mise.json crates/mise-interactive-config/mise.json


### PR DESCRIPTION
## Summary
- Fix `xtasks/release-plz` so `aqua-registry` is rewritten in both `[dependencies]` and `[build-dependencies]` after the subcrate is published.
- Avoid Cargo's mixed-source manifest error during release publishing by removing both local path entries before re-adding the published crates.io version.

## Root Cause
The release-plz job for `chore: release 2026.5.6 (#9764)` failed at https://github.com/jdx/mise/actions/runs/25666525627/job/75340319171 after publishing `aqua-registry v2026.5.5`.

The failing step was:

```text
+ cargo add aqua-registry@2026.5.5
error: failed to parse manifest at `/home/runner/work/mise/mise/Cargo.toml`

Caused by:
  Dependency 'aqua-registry' has different source paths depending on the build target. Each dependency must have a single canonical source path irrespective of build target.
```

PR #9535 introduced the new baked aqua registry pipeline. As part of that change, the root `mise` crate now depends on `aqua-registry` at runtime and also in `build.rs`, so `Cargo.toml` has `aqua-registry = { path = "crates/aqua-registry" }` in both `[dependencies]` and `[build-dependencies]`.

The release script already handled publishing the subcrate, but it only ran `cargo add aqua-registry@$AQUA_REGISTRY_VERSION` for the normal dependency. That made the normal dependency point to crates.io while the build dependency still pointed at the local workspace path, and Cargo rejects that mixed source state before the release can continue.

## Test Plan
- `bash -n xtasks/release-plz`
- `mise run lint-fix`
- Manually verified the dependency rewrite sequence: `cargo rm aqua-registry`, `cargo rm --build aqua-registry`, `cargo add aqua-registry@2026.5.5`, `cargo add --build aqua-registry@2026.5.5`, then restored the manifest.

*This PR body was generated by an AI coding assistant.*

Made with [Cursor](https://cursor.com)