### PR TITLE
fix: quote `program` and `args` in debug message from `cmd::cmd(..)`

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -90,13 +90,11 @@ where
     let program = program.to_executable();
     let args: Vec<OsString> = args.into_iter().map(Into::<OsString>::into).collect();
 
-    let display_name = program.to_string_lossy();
-    let display_args = args
-        .iter()
-        .map(|s| s.to_string_lossy())
+    let display_command = std::iter::once(&program)
+        .chain(&args)
+        .map(|s| shell_escape::escape(s.to_string_lossy()))
         .collect::<Vec<_>>()
         .join(" ");
-    let display_command = [display_name.into(), display_args].join(" ");
     debug!("$ {display_command}");
 
     duct::cmd(program, args)


### PR DESCRIPTION
# Problem

While trying to understand an issue with the value of VISUAL in `mise -v tasks edit <task>` (see #9731, already addressed by PR #9752), I found the `debug!` message generated by `cmd::cmd(..)` to be less helpful than it could be. With `VISUAL='cat -n'`, the following information got logged:

``` log
...
DEBUG $ cat -n /home/kt/work/oss/mise/tasks.toml
Error:
   0: No such file or directory (os error 2)
...
```

Here, `cat -n` was interpreted as the program to execute. However, the `DEBUG ...` line, doesn't show that.

# Solution

Call `shell_escape::escape(..)` on `program` and `args` when generating the `debug!` message. This changes the logged information to:

```log
...
DEBUG $ 'cat -n' /home/kt/work/oss/mise/tasks.toml
Error:
   0: No such file or directory (os error 2)
...
```

This hopefully helps to understand the reason for the following error message from `duct::cmd(..)`).

---

Note: The error reported by `duct::cmd(..)`:

```log
Error:
   0: No such file or directory (os error 2)
```

also leaves room for improvement. This was already discussed in [issue 109: Include the command that failed in the error](https://github.com/oconnor663/duct.rs/issues/109) from 2023 in the *duct.rs repository*. A fix for this issue would potentially solve the problem addressed by this commit/PR. But so far, nobody stepped up to provide that fix.