### PR TITLE
fix(upgrade): remove completed progress jobs to prevent duplicate output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00505ebcbbb9f5ce9e205e324db6c44518d97e9d6278f6dab8e0bff1937d2edf"
+checksum = "20daab9df9e49b0478215055d38362d5973043b7a4af836a58968760755e9a9f"
 dependencies = [
  "console",
  "nix 0.31.2",

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use clx::progress::{self, ProgressJobBuilder, ProgressOutput};
+use clx::progress::{self, ProgressJob, ProgressJobBuilder, ProgressOutput};
 
 use crate::cli::version::VERSION_PLAIN;
 use crate::config::Settings;
@@ -15,6 +15,11 @@ pub struct MultiProgressReport {
     completed_count: Mutex<usize>,
     /// Header job for updating progress display
     header_job: Mutex<Option<Arc<progress::ProgressJob>>>,
+    /// Jobs added via `add_with_options`, retained so they can be removed
+    /// from clx's global JOBS list in `footer_finish`. Without this, completed
+    /// jobs stay registered and get re-rendered when a subsequent job starts
+    /// (e.g. an uninstall after `mise upgrade` finishes installing).
+    tracked_jobs: Mutex<Vec<Arc<ProgressJob>>>,
 }
 
 static INSTANCE: Mutex<Option<Arc<MultiProgressReport>>> = Mutex::new(None);
@@ -79,6 +84,7 @@ impl MultiProgressReport {
             total_count: Mutex::new(0),
             completed_count: Mutex::new(0),
             header_job: Mutex::new(None),
+            tracked_jobs: Mutex::new(Vec::new()),
         }
     }
 
@@ -98,7 +104,9 @@ impl MultiProgressReport {
                 "add_with_options[{}]: creating ProgressReport with clx",
                 prefix
             );
-            Box::new(ProgressReport::new(prefix.into()))
+            let report = ProgressReport::new(prefix.into());
+            self.tracked_jobs.lock().unwrap().push(report.job.clone());
+            Box::new(report)
         } else {
             progress_trace!(
                 "add_with_options[{}]: creating VerboseReport (use_progress_ui={}, dry_run={})",
@@ -184,8 +192,18 @@ impl MultiProgressReport {
         // Stop clx progress
         progress::stop();
 
+        // Remove this session's jobs from clx's global JOBS list so they are
+        // not re-rendered when a subsequent job is added (e.g. an "uninstall"
+        // job after `mise upgrade` finishes installing). `progress::stop()`
+        // renders the final state but leaves completed jobs registered.
+        if let Some(header) = self.header_job.lock().unwrap().take() {
+            header.remove();
+        }
+        for job in self.tracked_jobs.lock().unwrap().drain(..) {
+            job.remove();
+        }
+
         // Reset state for subsequent install operations (e.g., in daemon mode)
-        *self.header_job.lock().unwrap() = None;
         *self.completed_count.lock().unwrap() = 0;
         *self.total_count.lock().unwrap() = 0;
     }

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -192,25 +192,29 @@ impl MultiProgressReport {
         // Stop clx progress
         progress::stop();
 
-        // Remove this session's jobs from clx's global JOBS list so they are
-        // not re-rendered when a subsequent job is added (e.g. an "uninstall"
-        // job after `mise upgrade` finishes installing). `progress::stop()`
-        // renders the final state but leaves completed jobs registered.
+        self.reset_jobs();
+    }
+
+    pub fn stop(&self) -> eyre::Result<()> {
+        progress::stop_clear();
+        self.reset_jobs();
+        Ok(())
+    }
+
+    /// Remove this MPR's jobs from clx's global JOBS list and reset session
+    /// counters. Neither `progress::stop()` nor `progress::stop_clear()`
+    /// removes jobs from clx, so without this a later `mpr.add(...)` would
+    /// re-render the previously-completed jobs (or `init_footer` would
+    /// silently no-op because `header_job` is still `Some`).
+    fn reset_jobs(&self) {
         if let Some(header) = self.header_job.lock().unwrap().take() {
             header.remove();
         }
         for job in self.tracked_jobs.lock().unwrap().drain(..) {
             job.remove();
         }
-
-        // Reset state for subsequent install operations (e.g., in daemon mode)
         *self.completed_count.lock().unwrap() = 0;
         *self.total_count.lock().unwrap() = 0;
-    }
-
-    pub fn stop(&self) -> eyre::Result<()> {
-        progress::stop_clear();
-        Ok(())
     }
 }
 

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use clx::progress::{self, ProgressJob, ProgressJobBuilder, ProgressOutput};
+use clx::progress::{self, ProgressJobBuilder, ProgressOutput};
 
 use crate::cli::version::VERSION_PLAIN;
 use crate::config::Settings;
@@ -15,11 +15,6 @@ pub struct MultiProgressReport {
     completed_count: Mutex<usize>,
     /// Header job for updating progress display
     header_job: Mutex<Option<Arc<progress::ProgressJob>>>,
-    /// Jobs added via `add_with_options`, retained so they can be removed
-    /// from clx's global JOBS list in `footer_finish`. Without this, completed
-    /// jobs stay registered and get re-rendered when a subsequent job starts
-    /// (e.g. an uninstall after `mise upgrade` finishes installing).
-    tracked_jobs: Mutex<Vec<Arc<ProgressJob>>>,
 }
 
 static INSTANCE: Mutex<Option<Arc<MultiProgressReport>>> = Mutex::new(None);
@@ -84,7 +79,6 @@ impl MultiProgressReport {
             total_count: Mutex::new(0),
             completed_count: Mutex::new(0),
             header_job: Mutex::new(None),
-            tracked_jobs: Mutex::new(Vec::new()),
         }
     }
 
@@ -104,9 +98,7 @@ impl MultiProgressReport {
                 "add_with_options[{}]: creating ProgressReport with clx",
                 prefix
             );
-            let report = ProgressReport::new(prefix.into());
-            self.tracked_jobs.lock().unwrap().push(report.job.clone());
-            Box::new(report)
+            Box::new(ProgressReport::new(prefix.into()))
         } else {
             progress_trace!(
                 "add_with_options[{}]: creating VerboseReport (use_progress_ui={}, dry_run={})",
@@ -201,18 +193,14 @@ impl MultiProgressReport {
         Ok(())
     }
 
-    /// Remove this MPR's jobs from clx's global JOBS list and reset session
-    /// counters. Neither `progress::stop()` nor `progress::stop_clear()`
-    /// removes jobs from clx, so without this a later `mpr.add(...)` would
-    /// re-render the previously-completed jobs (or `init_footer` would
-    /// silently no-op because `header_job` is still `Some`).
+    /// Reset clx's global job list and our session counters. Neither
+    /// `progress::stop()` nor `progress::stop_clear()` drops the completed
+    /// jobs on its own, so without this a later `mpr.add(...)` would
+    /// re-render the previously-completed jobs and `init_footer` would
+    /// silently no-op because `header_job` is still `Some`.
     fn reset_jobs(&self) {
-        if let Some(header) = self.header_job.lock().unwrap().take() {
-            header.remove();
-        }
-        for job in self.tracked_jobs.lock().unwrap().drain(..) {
-            job.remove();
-        }
+        *self.header_job.lock().unwrap() = None;
+        progress::clear_jobs();
         *self.completed_count.lock().unwrap() = 0;
         *self.total_count.lock().unwrap() = 0;
     }

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -79,7 +79,7 @@ fn normal_prefix(pad: usize, prefix: &str) -> String {
 /// clx-based progress report implementation
 #[derive(Debug)]
 pub struct ProgressReport {
-    pub(crate) job: Arc<ProgressJob>,
+    job: Arc<ProgressJob>,
 }
 
 impl ProgressReport {

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -79,7 +79,7 @@ fn normal_prefix(pad: usize, prefix: &str) -> String {
 /// clx-based progress report implementation
 #[derive(Debug)]
 pub struct ProgressReport {
-    job: Arc<ProgressJob>,
+    pub(crate) job: Arc<ProgressJob>,
 }
 
 impl ProgressReport {


### PR DESCRIPTION
## Summary

Fixes #9774 — `mise upgrade` (and its alias `mise up`) was printing the installed-tools block twice when it also needed to uninstall an old version.

## Root cause

`MultiProgressReport` is a process-global singleton on top of clx's global `JOBS` registry.

1. [`install_all_versions`](https://github.com/jdx/mise/blob/main/src/toolset/toolset_install.rs) calls `mpr.init_footer(...)` which pushes a header job + per-tool jobs into clx's `JOBS`. They run to completion and `mpr.footer_finish()` calls `progress::stop()`, which renders the final state and resets `LINES = 0` but does **not** remove jobs from `JOBS` (the default `ProgressJobDoneBehavior` is `Keep`).
2. [`upgrade.rs`](https://github.com/jdx/mise/blob/main/src/cli/upgrade.rs) then calls `mpr.add("uninstall ...")`. clx's background thread restarts, sees four jobs in `JOBS` (header + uv + python + uninstall), and renders them all. Because `LINES = 0`, the new render is appended *below* the previously-printed final state — producing the duplicate block reported.

## Fix

Track every job created via `add_with_options` in `MultiProgressReport`, and in `footer_finish` call `ProgressJob::remove()` on each (plus the header) after `progress::stop()`. Subsequent `mpr.add(...)` calls then start from a clean `JOBS` list and render only the new job.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --bin mise -- -D warnings` clean
- [ ] Manual: run `mise upgrade` against a tool that needs both an install and an uninstall — expect a single installed-tools block followed by the uninstall line
- [ ] Manual: confirm normal `mise install` and `mise upgrade` (no uninstalls) still render correctly

The bug only manifests when stderr is a real TTY (`use_progress_ui = true`), so the e2e harness can't easily assert on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to progress UI lifecycle, clearing clx’s global job registry after completion/stop to prevent duplicated output; main impact is on terminal rendering behavior.
> 
> **Overview**
> Prevents duplicated progress output across sequential operations by explicitly clearing clx’s global progress job list when a progress session ends.
> 
> `MultiProgressReport` now centralizes cleanup in `reset_jobs()`, called from both `footer_finish()` and `stop()`, which clears header state, resets counters, and calls `progress::clear_jobs()` so subsequent `mpr.add(...)` starts from a clean slate. Also bumps the `clx` dependency in `Cargo.lock` to `2.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80ee4ef866ee54dcb15cded16f4d175652441e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->