### PR TITLE
fix(ci): preserve vendor/aqua-registry/ in PPA publish workflow

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -113,7 +113,9 @@ jobs:
           [source.vendored-sources]
           directory = "vendor"
           EOF
-          cargo vendor vendor/
+          # --no-delete preserves the git-tracked vendor/aqua-registry/ directory
+          # (consumed by build.rs); without it, cargo vendor wipes the directory.
+          cargo vendor --no-delete vendor/
 
           # Clear all vendor checksums — dpkg-source strips .o, .a, .git*, *.orig and
           # other files, which breaks cargo's checksum verification. With --frozen cargo


### PR DESCRIPTION
## Summary

- `cargo vendor` deletes the target directory's contents by default, which was wiping out the git-tracked `vendor/aqua-registry/` directory (containing `registry.yml`, `metadata.json`, `LICENSE`).
- `build.rs` reads `vendor/aqua-registry/registry.yml` at compile time (added in [#9535](https://github.com/jdx/mise/pull/9535)), so the source tarball uploaded to Launchpad was missing this file and the build failed with `No such file or directory` at `build.rs:357`.
- Adding `--no-delete` to `cargo vendor` preserves the existing directory while still vendoring Rust crates alongside it.

Observed failure: [Launchpad build log for `mise_2026.5.6~resolute1`](https://launchpadlibrarian.net/860699557/buildlog_ubuntu-resolute-amd64.mise_2026.5.6~resolute1_BUILDING.txt.gz).

## Test plan

- [ ] Re-run the `ppa-publish` workflow manually and confirm `vendor/aqua-registry/registry.yml` is present in the uploaded source tarball.
- [ ] Confirm the resulting Launchpad build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters `cargo vendor` behavior during packaging; main risk is unexpected differences in the vendored directory contents affecting reproducibility.
> 
> **Overview**
> Updates the `ppa-publish` GitHub Actions workflow to run `cargo vendor` with `--no-delete`, preventing it from wiping the git-tracked `vendor/aqua-registry/` directory needed at build time.
> 
> Adds brief inline comments documenting why the flag is required; all other packaging steps remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47e7ad99a1109768407dea4032606fb4c44ed3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->