### PR TITLE
registry: add bpftop (jfernandez/bpftop)

### DIFF
--- a/registry/bpftop.toml
+++ b/registry/bpftop.toml
@@ -1,0 +1,4 @@
+backends = ["aqua:jfernandez/bpftop", "github:jfernandez/bpftop"]
+description = "A dynamic real-time view of running eBPF programs"
+os = ["linux"]
+test = { cmd = "bpftop --version", expected = "{{version}}" }


### PR DESCRIPTION
## Summary

Add `bpftop` to the mise registry using `aqua:jfernandez/bpftop` with `github:jfernandez/bpftop` as a fallback backend.

`bpftop` is Linux-only, so the registry entry is restricted with `os = ["linux"]`.

## Popularity

- GitHub: 2,674 stars, 129 forks
- Latest release: `v0.9.0` on 2026-05-02
- Activity: pushed 2026-05-03
- Ecosystem: packaged by Fedora, Arch Linux, and Nix
- Registry support: already present in upstream aqua registry
- Note: latest-release GitHub binary download counts are currently low

## Test

- `cargo test registry::tests`
- `cargo run --quiet -- registry bpftop`
- `MISE_AQUA_BAKED_REGISTRY=false MISE_AQUA_REGISTRY_URL=https://github.com/aquaproj/aqua-registry target/debug/mise test-tool bpftop`
- `MISE_DISABLE_BACKENDS=aqua target/debug/mise test-tool bpftop`
