### PR TITLE
chore(ci): use non-large runners for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   build-tarball-linux:
     if: github.event_name != 'pull_request' || github.head_ref == 'release'
     name: build-tarball-${{matrix.name}}
-    runs-on: namespace-profile-endev-linux-amd64-large
+    runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 45
     env:
       MINIO_AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_AWS_ACCESS_KEY_ID }}
@@ -71,7 +71,7 @@ jobs:
   build-tarball-macos:
     if: github.event_name != 'pull_request' || github.head_ref == 'release'
     name: build-tarball-${{matrix.name}}
-    runs-on: namespace-profile-endev-macos-arm64-large
+    runs-on: namespace-profile-endev-macos-arm64
     timeout-minutes: 90
     env:
       MINIO_AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary
- Drop `-large` from the Linux and macOS Namespace runner profiles used by the release tarball jobs in `.github/workflows/release.yml`.
- These jobs now use `namespace-profile-endev-linux-amd64` and `namespace-profile-endev-macos-arm64`, matching what the rest of the workflows (test, registry, docs, etc.) already use.

## Why
- Release builds don't need the larger instance profile, so this reduces CI cost for tag pushes without changing what gets built.

## Notes
- `hyperfine.yml` still uses `-large` since it's a benchmarking workflow, not a release build — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just switches the runner profiles for the Linux and macOS release tarball jobs; main impact is potential runtime/performance differences on smaller runners.
> 
> **Overview**
> Updates the `release` GitHub Actions workflow to run the Linux and macOS tarball build jobs on the standard Namespace runner profiles by removing the `-large` suffix.
> 
> This reduces resource usage/cost for release builds without changing build steps or artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25356601f636c240445fa48b62744fa6b22410dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->