### PR TITLE
chore(copr): publish EL9 builds via centos-stream+epel-next-9 chroot

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,7 @@ self-hosted-runner:
     - namespace-profile-endev-macos-arm64-large
     - namespace-profile-endev-macos-arm64;overrides.cache-tag=mise-pr-rust-macos
     - namespace-profile-endev-macos-arm64-large;overrides.cache-tag=mise-release-rust-macos
+    - namespace-profile-endev-linux-amd64
     - namespace-profile-endev-linux-amd64-large
     - namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     - namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux-nightly

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -169,10 +169,21 @@ cargo install mise --git https://github.com/jdx/mise --branch main
 
 ### dnf
 
-#### Fedora 41+, RHEL 9+, CentOS Stream 9+
+#### Fedora 41+, CentOS Stream 9+, RHEL 10+
 
 ```sh
 dnf copr enable jdxcode/mise
+dnf install mise
+```
+
+#### RHEL 9 / AlmaLinux 9 / Rocky 9
+
+RHEL 9 AppStream is currently frozen at Rust 1.88, which is older than mise's
+minimum supported Rust version. Use the CentOS Stream 9 build instead — the
+resulting binary works on RHEL 9 derivatives:
+
+```sh
+dnf copr enable jdxcode/mise centos-stream+epel-next-9
 dnf install mise
 ```
 

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Default values
 PACKAGE_NAME="${PACKAGE_NAME:-mise}"
-CHROOTS="${CHROOTS:-fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64}"
+CHROOTS="${CHROOTS:-fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 centos-stream+epel-next-9-aarch64 centos-stream+epel-next-9-x86_64}"
 BUILD_PROFILE="${BUILD_PROFILE:-release}"
 MAINTAINER_NAME="${MAINTAINER_NAME:-mise Release Bot}"
 MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-noreply@mise.jdx.dev}"
@@ -22,7 +22,7 @@ usage() {
 	echo "Options:"
 	echo "  -v, --version VERSION        Package version (required)"
 	echo "  -p, --profile PROFILE        Build profile (default: release)"
-	echo "  -c, --chroots CHROOTS        COPR chroots (default: fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64)"
+	echo "  -c, --chroots CHROOTS        COPR chroots (default: fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 centos-stream+epel-next-9-aarch64 centos-stream+epel-next-9-x86_64)"
 	echo "  -o, --owner OWNER            COPR owner (default: jdxcode)"
 	echo "  -j, --project PROJECT        COPR project (default: mise)"
 	echo "  -n, --name NAME              Package name (default: mise)"

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 # Default values
 PACKAGE_NAME="${PACKAGE_NAME:-mise}"
+# TODO(epel-9): drop centos-stream+epel-next-9-* and switch back to epel-9-*
+# once RHEL 9 AppStream ships rust >= mise's MSRV (currently EL9 = 1.88).
 CHROOTS="${CHROOTS:-fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 centos-stream+epel-next-9-aarch64 centos-stream+epel-next-9-x86_64}"
 BUILD_PROFILE="${BUILD_PROFILE:-release}"
 MAINTAINER_NAME="${MAINTAINER_NAME:-mise Release Bot}"


### PR DESCRIPTION
## Summary

- Restores EL9 (RHEL/AlmaLinux/Rocky 9) COPR coverage that dropped out after mise's MSRV bumped past 1.88 (#9484, see discussion #9783).
- Adds `centos-stream+epel-next-9-aarch64` and `centos-stream+epel-next-9-x86_64` to the default `CHROOTS` in `packaging/copr/build-copr.sh`. The chroots have already been enabled in the COPR project UI.
- Updates `docs/installing-mise.md` to split the dnf install instructions: the bare `dnf copr enable jdxcode/mise` form now correctly advertises only the distros where it works today (Fedora 41+, CentOS Stream 9+, RHEL 10+), and a separate RHEL 9 section uses the `dnf copr enable jdxcode/mise centos-stream+epel-next-9` chroot override.

## Why this works

RHEL 9 / Alma 9 / Rocky 9 AppStream is frozen at rust 1.88.0 (verified on `rockylinux:9` and `almalinux:9` containers). CentOS Stream 9 AppStream ships rust 1.91.0–1.95.0, so building against the Stream 9 chroot satisfies the MSRV. Stream 9 is the upstream of RHEL 9.x, so the resulting binary's glibc/openssl deps are ABI-forward of EL9 derivatives and should install cleanly on Alma/Rocky/RHEL 9.

A TODO comment is left in `build-copr.sh` so we remember to drop the workaround once a future RHEL 9 minor release ships a recent-enough rust in plain `epel-9`.

EL8 is intentionally not addressed here — CentOS Stream 8 is EOL and EL8's older glibc breaks the cross-chroot approach. If EL8 demand is real, the rustup-in-spec pattern outlined in discussion #9783 would be the path.

## Test plan

- [ ] Next COPR publish builds successfully into `centos-stream+epel-next-9-{x86_64,aarch64}`.
- [ ] On a stock `almalinux:9` container: `dnf copr enable jdxcode/mise centos-stream+epel-next-9 && dnf install -y mise && mise --version` succeeds.
- [ ] Same on `rockylinux:9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes COPR build targets and install instructions, which can affect release/publishing behavior and user installation flows, but does not touch runtime application code.
> 
> **Overview**
> Restores Enterprise Linux 9 RPM build coverage by adding `centos-stream+epel-next-9` (x86_64/aarch64) to the default COPR `CHROOTS` in `packaging/copr/build-copr.sh`, with a TODO to revert once EL9 Rust is new enough.
> 
> Updates `docs/installing-mise.md` to split `dnf` install guidance: the default COPR enable command is now scoped to Fedora/CentOS Stream 9/RHEL 10+, and a separate section documents using the `centos-stream+epel-next-9` override for RHEL/Alma/Rocky 9.
> 
> Also expands `.github/actionlint.yaml` allowed self-hosted runner labels to include `namespace-profile-endev-linux-amd64`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b814a1afc944d24aa1d10cea84b9f086a92cd7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->