### PR TITLE
chore(ci): make build-copr.sh the single source of truth for COPR chroots

### DIFF
--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       chroots:
-        description: "COPR chroots to target (space-separated)"
+        description: "COPR chroots to target (space-separated). Leave empty to use the default list from packaging/copr/build-copr.sh."
         required: false
-        default: "fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64"
+        default: ""
         type: string
       use_serious_profile:
         description: 'Use the "serious" profile for optimized builds (LTO enabled)'
@@ -36,21 +36,20 @@ jobs:
         run: |
           VERSION=$(./scripts/get-version.sh | sed 's/^v//')
 
-          if [ "${{ github.event_name }}" = "release" ]; then
-            CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64"
-          else
-            CHROOTS="${{ inputs.chroots }}"
-          fi
-
           {
             echo "VERSION=${VERSION}"
-            echo "CHROOTS=${CHROOTS}"
             echo "PACKAGE_NAME=${PACKAGE_NAME}"
             echo "MAINTAINER_NAME=${{ vars.COPR_MAINTAINER_NAME || 'mise Release Bot' }}"
             echo "MAINTAINER_EMAIL=${{ vars.COPR_MAINTAINER_EMAIL || 'noreply@mise.jdx.dev' }}"
             echo "COPR_OWNER=${{ vars.COPR_OWNER || 'jdxcode' }}"
             echo "COPR_PROJECT=${{ vars.COPR_PROJECT || 'mise' }}"
           } >> "$GITHUB_ENV"
+
+          # Pass chroots through only when explicitly overridden via workflow_dispatch.
+          # Otherwise let build-copr.sh apply its own default list.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.chroots }}" ]; then
+            echo "CHROOTS=${{ inputs.chroots }}" >> "$GITHUB_ENV"
+          fi
 
           # Set build profile
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.use_serious_profile }}" = "true" ]; then
@@ -61,15 +60,19 @@ jobs:
 
       - name: Build and submit to COPR
         run: |
-          ./packaging/copr/build-copr.sh \
-            --version "${VERSION}" \
-            --profile "${BUILD_PROFILE}" \
-            --chroots "${CHROOTS}" \
-            --owner "${COPR_OWNER}" \
-            --project "${COPR_PROJECT}" \
-            --name "${PACKAGE_NAME}" \
-            --maintainer-name "${MAINTAINER_NAME}" \
+          args=(
+            --version "${VERSION}"
+            --profile "${BUILD_PROFILE}"
+            --owner "${COPR_OWNER}"
+            --project "${COPR_PROJECT}"
+            --name "${PACKAGE_NAME}"
+            --maintainer-name "${MAINTAINER_NAME}"
             --maintainer-email "${MAINTAINER_EMAIL}"
+          )
+          if [ -n "${CHROOTS:-}" ]; then
+            args+=(--chroots "${CHROOTS}")
+          fi
+          ./packaging/copr/build-copr.sh "${args[@]}"
         env:
           COPR_API_LOGIN: ${{ secrets.COPR_API_LOGIN }}
           COPR_API_TOKEN: ${{ secrets.COPR_API_TOKEN }}


### PR DESCRIPTION
## Summary

The COPR publish workflow hardcoded the chroot list in two places (the `workflow_dispatch` input default and the release-event branch) and always passed `--chroots` to `build-copr.sh`, so the script's own default `CHROOTS=` was unreachable. Any change to the chroot list had to be made in three files to actually take effect — a footgun that caused PR #9787's EL9 chroots to be set as a no-op until this lands.

Refactored to make `packaging/copr/build-copr.sh:9` the single source of truth:

- `workflow_dispatch.chroots` input default changed from the hardcoded list to `""`, with a description that explains the empty-string semantics.
- Removed the release-event branch's hardcoded `CHROOTS=...` line entirely.
- The build step now passes `--chroots` only when the workflow input was explicitly set (non-empty); otherwise the script falls through to its own default list.
- Switched the build step to a bash array for readable conditional arg passing.

After this, both the release-event path and the no-input `workflow_dispatch` path use whatever `packaging/copr/build-copr.sh` declares.

## Test plan

- [x] `actionlint .github/workflows/copr-publish.yml` passes locally.
- [ ] Next `workflow_dispatch` with empty input → COPR job logs the script default list (currently includes `epel-10-*` and `centos-stream+epel-next-9-*` after #9787 lands).
- [ ] Next `workflow_dispatch` with a custom value → COPR job logs that value instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the COPR publish workflow’s chroot selection logic, which can alter what targets get built on release/publish runs. Risk is limited to CI/release automation but could result in missing or unintended COPR builds if the default list or input handling is wrong.
> 
> **Overview**
> Makes `packaging/copr/build-copr.sh` the *single source of truth* for COPR chroots by removing the workflow’s hardcoded/default chroot list and only setting `CHROOTS` when `workflow_dispatch` provides a non-empty input.
> 
> Refactors the COPR submission step to build a bash `args` array and conditionally append `--chroots`, so release-triggered runs (and empty-input manual runs) fall back to the script’s internal default chroot list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454b531db335b832e8287b198a2b95bb55adaf65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->