### PR TITLE
chore(ci): use crates.io trusted publishing in release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: release-plz
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -62,8 +63,10 @@ jobs:
       - run: cargo build --all-features && cp target/debug/mise "$HOME"/bin
       - uses: ./.github/actions/mise-tools
       - run: mise x -- bun i
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: crates-io-auth
       - run: mise run release-plz
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       - run: sccache --show-stats
         if: always()

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,10 +1,5 @@
 name: release-plz
 
-permissions:
-  pull-requests: write
-  contents: write
-  id-token: write
-
 on:
   workflow_dispatch:
   push:
@@ -28,6 +23,10 @@ jobs:
     if: github.repository == 'jdx/mise'
     timeout-minutes: 20
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-release-plz-rust-linux
+    permissions:
+      pull-requests: write
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary
- Switches the release-plz workflow from a long-lived `CARGO_REGISTRY_TOKEN` secret to an OIDC-minted, 30-minute token via [`rust-lang/crates-io-auth-action`](https://github.com/rust-lang/crates-io-auth-action).
- Adds `id-token: write` permission and wires the action's `token` output into `cargo publish` (called from `xtasks/release-plz`).
- Action is SHA-pinned to v1.0.4 to match the rest of the workflow.

## Required crates.io setup (before this merges)
For **each** crate published from this repo — `mise`, `vfox`, `aqua-registry`, `mise-interactive-config` — go to crates.io → crate Settings → Trusted Publishing → Add → GitHub, and fill in:
- Repository owner: `jdx`
- Repository name: `mise`
- Workflow filename: `release-plz.yml`
- Environment: *(leave blank — release-plz runs unattended on cron, an environment with required reviewers would block it)*

Both auth methods work simultaneously, so `secrets.CARGO_REGISTRY_TOKEN` can stay configured during rollout and be deleted after the first successful release on the new flow.

## Test plan
- [ ] Trusted publisher configured for `mise` on crates.io before merge
- [ ] Trusted publisher configured for `vfox`, `aqua-registry`, `mise-interactive-config`
- [ ] Watch the next release-plz run; verify `crates-io-auth` step mints a token and `cargo publish` succeeds for each crate
- [ ] After one clean release: delete the `CARGO_REGISTRY_TOKEN` repo secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow’s crates.io authentication mechanism, which could break automated publishing if OIDC/trusted publishing isn’t configured correctly. Permissions are adjusted to allow OIDC (`id-token: write`), increasing the blast radius of misconfiguration.
> 
> **Overview**
> Switches the `release-plz` workflow from using `secrets.CARGO_REGISTRY_TOKEN` to `rust-lang/crates-io-auth-action` and wires its minted token into `CARGO_REGISTRY_TOKEN` for the release step.
> 
> Moves workflow permissions to the job level and adds **`id-token: write`** to enable OIDC-based authentication during publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab3726b7b8ea4fd92fd06450cfbc083e9c893322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->