### PR TITLE
test(e2e): pin aube to known-good version in npm package_manager test

### DIFF
--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -91,12 +91,14 @@ export MISE_NPM_PACKAGE_MANAGER=aube
 
 # Ensure aube is available after the default package manager test, since
 # npm.package_manager=auto uses aube when it is already installed.
-# Bypass MISE_MINIMUM_RELEASE_AGE for aube's install — the global filter is
-# set to test the package-manager flag plumbing below, but applying it to
-# aube itself can pin to a release that lacks platform-specific assets.
+# Pin to a known-good aube version: `latest` has bitten us when a new
+# release goes out hours before CI runs (e.g. v1.11.0 on 2026-05-11 broke
+# `aube add --global` here). Bypass MISE_MINIMUM_RELEASE_AGE because the
+# global filter is set to test the package-manager flag plumbing below.
+AUBE_TEST_VERSION="1.10.4"
 if ! command -v aube >/dev/null 2>&1; then
   echo "aube not available in test environment, installing..."
-  assert_succeed "env -u MISE_MINIMUM_RELEASE_AGE mise use aube@latest"
+  assert_succeed "env -u MISE_MINIMUM_RELEASE_AGE mise use aube@$AUBE_TEST_VERSION"
 fi
 
 cat >.mise.toml <<EOF
@@ -104,7 +106,11 @@ cat >.mise.toml <<EOF
 "npm:tiny" = { version = "latest", aube_args = "--reporter append-only" }
 EOF
 AUBE_DEBUG_LOG="$TMPDIR/aube_debug.log"
-assert_succeed "MISE_DEBUG=1 mise install >'$AUBE_DEBUG_LOG' 2>&1"
+if ! MISE_DEBUG=1 mise install >"$AUBE_DEBUG_LOG" 2>&1; then
+  echo "Command failed. Output:"
+  cat "$AUBE_DEBUG_LOG"
+  exit 1
+fi
 assert_contains "cat '$AUBE_DEBUG_LOG'" "--reporter"
 assert_contains "cat '$AUBE_DEBUG_LOG'" "append-only"
 echo "✓ npm backend successfully installs package using aube (package_manager=aube)"


### PR DESCRIPTION
## Summary
The `aube` section of [test_npm_package_manager](e2e/backend/test_npm_package_manager) installed `aube@latest` while bypassing `MISE_MINIMUM_RELEASE_AGE`. aube v1.11.0 published on 2026-05-11T22:05Z broke `aube add --global npm:tiny@... --reporter append-only`, and the next `e2e-4` run on main (2026-05-12T00:37Z) failed — even though the previous main run at 19:58Z was green.

Two changes:
- **Pin to `aube@1.10.4`** (the last known-good release before 1.11.0). Matches the pinning style already used for `pnpm@10.16.0` in the same file.
- **Print the aube debug log on install failure** so future regressions are diagnosable from CI logs alone, mirroring the existing pattern in the pnpm block.

## Background
Symptom on main (run [25705764714 / e2e-4](https://github.com/jdx/mise/actions/runs/25705764714/job/75475700001)):
```
$ MISE_DEBUG=1 mise install >'.../aube_debug.log' 2>&1
##[error][MISE_DEBUG=1 mise install >...] command failed with status 1
```
The current test uses `assert_succeed` which doesn't print captured output on failure — the second change above fixes that.

This PR does **not** investigate the underlying aube v1.11.0 regression; that should be filed separately against endevco/aube. The pin keeps mise's own CI green in the meantime.

## Test plan
- [ ] e2e-4 turns green on this PR
- [ ] After this lands, re-run [PR #9793](https://github.com/jdx/mise/pull/9793) to confirm it goes green
- [ ] Open an issue (or PR) against endevco/aube for the v1.11.0 install regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to an e2e shell test and only affect CI diagnostics and dependency pinning, not production behavior.
> 
> **Overview**
> Pins the `aube` install used by `e2e/backend/test_npm_package_manager` to an explicit `AUBE_TEST_VERSION` instead of `@latest` (still bypassing `MISE_MINIMUM_RELEASE_AGE`) to avoid CI breakage from upstream releases.
> 
> Updates the `aube` install step to **dump the captured debug log and fail fast** when `mise install` errors, making CI failures diagnosable from logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e55ffc407fd0ce91c2eac1a407ff52e33a93280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->