### PR TITLE
chore: add `aqua` backend for `vector`

### DIFF
--- a/registry/vector.toml
+++ b/registry/vector.toml
@@ -1,3 +1,3 @@
-backends = ["github:vectordotdev/vector"]
+backends = ["aqua:vectordotdev/vector", "github:vectordotdev/vector"]
 description = "A high-performance observability data pipeline."
 test = { cmd = "vector --version", expected = "vector {{version}}" }


### PR DESCRIPTION
After https://github.com/aquaproj/aqua-registry/pull/53517 landed, I figured I should come back and update to point to both, aqua first in the list.

Test was quick/easy:

```shell
❯ rm -rf ~/.cache/mise/aqua-registry
❯ RUSTUP_TOOLCHAIN=1.91.0 MISE_DISABLE_TOOLS=1 mise run build
❯ MISE_DISABLE_TOOLS=1 MISE_AQUA_BAKED_REGISTRY=0 ./target/debug/mise x aqua:vectordotdev/vector@latest -- vector --version

aqua:vectordotdev/vector@0.55.0     extract vector-0.55.0-x86_64-unknown-li… ✔
vector 0.55.0 (x86_64-unknown-linux-musl cf8de83 2026-04-22 14:31:18.008404048)
```