### PR TITLE
ci: remove caching from publishing workflows

### DIFF
--- a/.github/workflows/release-fig.yml
+++ b/.github/workflows/release-fig.yml
@@ -14,10 +14,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.MISE_GH_TOKEN }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: build
-          save-if: false
       - run: mkdir -p "$HOME/bin" && echo "$HOME/bin" >> "$GITHUB_PATH"
       - run: cargo build --all-features && cp target/debug/mise "$HOME"/bin
       - uses: ./.github/actions/mise-tools

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,26 +38,6 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           git_tag_gpgsign: true
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
-        with: { tool: sccache }
-      - name: Configure sccache
-        run: |
-          export RUSTC_WRAPPER=sccache
-          export SCCACHE_DIR="$HOME/.cache/sccache"
-          export SCCACHE_CACHE_SIZE=20G
-          {
-            echo "RUSTC_WRAPPER=$RUSTC_WRAPPER"
-            echo "SCCACHE_DIR=$SCCACHE_DIR"
-            echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
-          } >> "$GITHUB_ENV"
-          sccache --zero-stats
       - run: mkdir -p "$HOME/bin" && echo "$HOME/bin" >> "$GITHUB_PATH"
       - run: cargo build --all-features && cp target/debug/mise "$HOME"/bin
       - uses: ./.github/actions/mise-tools
@@ -67,5 +47,3 @@ jobs:
       - run: mise run release-plz
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-      - run: sccache --show-stats
-        if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,12 +294,6 @@ jobs:
           gpg_private_key: ${{ secrets.MISE_GPG_KEY }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-      - name: cache zipsign
-        id: cache-zipsign
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.cargo/bin/zipsign
-          key: cargo-zipsign
       - run: ./scripts/setup-zipsign.sh
         if: github.event_name != 'pull_request' || github.head_ref == 'release'
         env:


### PR DESCRIPTION
## Summary
- Strips cache actions (`nscloud-cache-action`, `Swatinem/rust-cache`, `actions/cache`) from release / release-plz / publishing workflows.
- These workflows have elevated permissions (write tokens, signing keys, registry credentials). Even with Namespace's protected-branches setting and GHA's ref-scoped cache enforcement, the simplest defense for the publishing surface is to not depend on any cache at all — builds re-run from clean each time.
- For mise's `release-plz.yml`, also removes the now-pointless sccache install/configure since it had no persistent backing store without the nscloud cache.

## Test plan
- [ ] Releases still build successfully (cold cache; expect slower but functional).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it modifies release/publishing GitHub Actions that run with signing keys and write tokens; functional impact should be limited to slower builds, but any workflow regression could block releases.
> 
> **Overview**
> Removes all build/cache usage from the publishing workflows so release jobs run from a clean environment each time.
> 
> Specifically drops `Swatinem/rust-cache`, Namespace cache + `sccache` setup/stats in `release-plz.yml`, and the `actions/cache` step that cached `zipsign` in `release.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6b31732f8bacc92bf6c876f1de44a3cf689372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->