### PR TITLE
fix(backend): avoid release age cutoff for dependency envs

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2008,7 +2008,17 @@ pub trait Backend: Debug + Send + Sync {
             .await?
             .filter_by_tool(dependencies)
             .into();
-        ts.resolve(config).await?;
+        // Dependency envs only need PATH entries for tools that are already
+        // available. Resolving offline avoids applying global release-age
+        // cutoffs to helper tools like node/npm while querying another backend.
+        ts.resolve_with_opts(
+            config,
+            &ResolveOptions {
+                offline: true,
+                ..Default::default()
+            },
+        )
+        .await?;
         Ok(ts)
     }
 


### PR DESCRIPTION
## Summary
- resolve dependency toolsets in offline mode when building backend helper PATH/envs
- keep global/per-command release-age cutoffs scoped to the tool being resolved, not helper tools used to query it

## Why this is a bug
`dependency_toolset()` is used by backends like npm to put already-available helper tools on PATH before running commands such as `npm view`. When a global `minimum_release_age` is set, normal resolution applies that cutoff to every tool request, including configured helper tools like `node@latest`.

That can resolve `node@latest` to an older Node release selected by the cutoff. If the user already has a newer Node installed, the dependency toolset no longer points at the installed helper, so the PATH used for `npm view` can lose `npm` and backend version lookup fails. The release-age setting is meant to filter the target package version, not make helper tool discovery pick a different Node.

## Why this fix is safe
Dependency envs only need PATH entries for helper tools that are already available. `Toolset::list_paths()` and `Toolset::which()` both filter to installed/current versions, so resolving the dependency toolset offline only prevents remote release-age filtering from changing which installed helper is selected.

This does not change dependency installation. Missing dependencies are installed by the install dependency graph (`ToolDeps`) before dependents run. If a dependency is not installed and is not part of the install set, `dependency_toolset()` could not put it on PATH before this change either, because PATH generation already filtered out non-installed tools. Commands that need npm/node and do not have it installed still warn/fail the same way; once the dependency is installed, offline resolution can pick the installed version.

## Testing
- `git diff --check`
- Existing coverage: `e2e/backend/test_npm_install_before` exercises the npm release-age lookup that exposed this bug. Local execution was blocked by the shared Cargo build queue; CI should run it on this isolated branch.
