### PR TITLE
fix(install): respect default inline shell in postinstall

### DIFF
--- a/e2e/cli/test_install_postinstall_default_inline_shell
+++ b/e2e/cli/test_install_postinstall_default_inline_shell
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Test that tool-level postinstall hooks use the configured default inline shell.
+
+shell="$PWD/default-inline-shell"
+cat >"$shell" <<'SCRIPT'
+#!/usr/bin/env bash
+if [[ "$1" != "-c" ]]; then
+  echo "unexpected shell args: $*" >&2
+  exit 1
+fi
+shift
+echo "CUSTOM_INLINE_SHELL=yes"
+exec sh -c "$@"
+SCRIPT
+chmod +x "$shell"
+
+cat <<EOF >mise.toml
+[tools]
+dummy = { version = "latest", postinstall = "echo POSTINSTALL_RAN=yes" }
+EOF
+
+rm -rf "$MISE_DATA_DIR/installs/dummy"
+
+output=$(MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS="$shell -c" mise install dummy 2>&1)
+
+if [[ $output == *"CUSTOM_INLINE_SHELL=yes"* && $output == *"POSTINSTALL_RAN=yes"* ]]; then
+  echo "tool-level postinstall used default inline shell"
+else
+  echo "tool-level postinstall did not use default inline shell"
+  echo "Output: $output"
+  exit 1
+fi

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1825,13 +1825,20 @@ pub trait Backend: Debug + Send + Sync {
         let mut tera = get_tera(dir);
         let rendered_script = tera.render_str(script, tera_ctx)?;
 
-        let mut runner = CmdLineRunner::new(&*env::SHELL)
+        let shell = Settings::get().default_inline_shell()?;
+        let (program, shell_args) = shell.split_first().ok_or_else(|| {
+            eyre!(
+                "default inline shell is empty; check unix_default_inline_shell_args / windows_default_inline_shell_args"
+            )
+        })?;
+
+        let mut runner = CmdLineRunner::new(program)
             .env(&*env::PATH_KEY, path_env.join())
             .env("MISE_TOOL_INSTALL_PATH", tv.install_path())
             .env("MISE_TOOL_NAME", tv.ba().short.clone())
             .env("MISE_TOOL_VERSION", tv.version.clone())
             .with_pr(ctx.pr.as_ref())
-            .arg(env::SHELL_COMMAND_FLAG)
+            .args(shell_args)
             .arg(&rendered_script)
             .envs(env_vars);
 


### PR DESCRIPTION
## Summary
- Run tool-level `postinstall` hooks through `Settings::default_inline_shell()` instead of `$SHELL -c`.
- Add an e2e regression that configures `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` with a custom wrapper and verifies the hook uses it.

## Tests
- `mise run format`
- `mise run test:e2e e2e/cli/test_install_postinstall_default_inline_shell`