### PR TITLE
chore(ci): restore -large runner for Linux release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   build-tarball-linux:
     if: github.event_name != 'pull_request' || github.head_ref == 'release'
     name: build-tarball-${{matrix.name}}
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64-large
     timeout-minutes: 45
     env:
       MINIO_AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary
- Revert the Linux portion of [#9786](https://github.com/jdx/mise/pull/9786): switch `build-tarball-linux` back to `namespace-profile-endev-linux-amd64-large`.
- macOS runners are left on the smaller profile (those jobs succeeded).

## Why
All 6 Linux release-tarball jobs in run [25739820241](https://github.com/jdx/mise/actions/runs/25739820241) failed identically: `rustc` got `SIGKILL`'d during the final LTO link of `mise`. The non-large Namespace runner reports as `4x8` (4 CPU / 8 GB RAM) in the runner setup log, and the `serious` profile enables LTO, which pushes the linker past available RAM. Output from a failed job:

```
error: could not compile `mise` (bin "mise")

Caused by:
  process didn't exit successfully: `rustc ... -C opt-level=3 -C lto ...` (signal: 9, SIGKILL: kill)
```

Windows and macOS builds were unaffected.

## Test plan
- [ ] Trigger a release workflow (next tag push, or manual dispatch of `release.yml`) and confirm all Linux tarball jobs succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just alters runner sizing; main impact is build stability/cost rather than product behavior.
> 
> **Overview**
> Updates the `release.yml` workflow so `build-tarball-linux` runs on `namespace-profile-endev-linux-amd64-large` instead of the smaller Linux runner profile, improving reliability of release tarball builds under memory-heavy Rust LTO linking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1549f914cd6834be62dd5180db99cfea2c7149b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->