### PR TITLE
fix(settings): distinguish unset known settings from unknown ones

### DIFF
--- a/e2e/cli/test_settings_set
+++ b/e2e/cli/test_settings_set
@@ -13,6 +13,7 @@ assert_contains "mise settings -T" "all_compile = true"
 mise settings unset all_compile
 assert "mise settings get all_compile" "false"
 assert_fail "mise settings get abcdefg" "mise ERROR Unknown setting: abcdefg"
+assert_fail "mise settings get python.compyle" "mise ERROR Unknown setting: python.compyle"
 assert_fail "mise settings get python.compile" "mise ERROR Setting [python.compile] is not set"
 assert_fail "mise settings get cargo.registry_name" "mise ERROR Setting [cargo.registry_name] is not set"
 assert "mise settings all_compile" "false"

--- a/e2e/cli/test_settings_set
+++ b/e2e/cli/test_settings_set
@@ -13,6 +13,8 @@ assert_contains "mise settings -T" "all_compile = true"
 mise settings unset all_compile
 assert "mise settings get all_compile" "false"
 assert_fail "mise settings get abcdefg" "mise ERROR Unknown setting: abcdefg"
+assert_fail "mise settings get python.compile" "mise ERROR Setting [python.compile] is not set"
+assert_fail "mise settings get cargo.registry_name" "mise ERROR Setting [cargo.registry_name] is not set"
 assert "mise settings all_compile" "false"
 assert "mise settings all_compile=1"
 assert "mise settings all_compile" "true"

--- a/e2e/cli/test_settings_unset
+++ b/e2e/cli/test_settings_unset
@@ -3,4 +3,4 @@
 mise settings set python.compile true
 assert "mise settings get python.compile" "true"
 mise settings unset python.compile
-assert_fail "mise settings get python.compile" "mise ERROR Unknown setting: python.compile"
+assert_fail "mise settings get python.compile" "mise ERROR Setting [python.compile] is not set"

--- a/src/cli/settings/get.rs
+++ b/src/cli/settings/get.rs
@@ -38,7 +38,7 @@ impl SettingsGet {
             if let Some(v) = value.as_table().and_then(|t| t.get(k.0)) {
                 key = k.1;
                 value = v.clone()
-            } else if SETTINGS_META.contains_key(self.setting.as_str()) {
+            } else if is_known_setting(&self.setting) {
                 bail!("Setting [{}] is not set", self.setting);
             } else {
                 bail!("Unknown setting: {}", self.setting);
@@ -51,6 +51,14 @@ impl SettingsGet {
 
         Ok(())
     }
+}
+
+fn is_known_setting(key: &str) -> bool {
+    if SETTINGS_META.contains_key(key) {
+        return true;
+    }
+    let prefix = format!("{key}.");
+    SETTINGS_META.keys().any(|k| k.starts_with(&prefix))
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/cli/settings/get.rs
+++ b/src/cli/settings/get.rs
@@ -1,5 +1,6 @@
 use crate::config;
 use crate::config::Settings;
+use crate::config::settings::SETTINGS_META;
 use eyre::bail;
 
 /// Show a current setting
@@ -37,6 +38,8 @@ impl SettingsGet {
             if let Some(v) = value.as_table().and_then(|t| t.get(k.0)) {
                 key = k.1;
                 value = v.clone()
+            } else if SETTINGS_META.contains_key(self.setting.as_str()) {
+                bail!("Setting [{}] is not set", self.setting);
             } else {
                 bail!("Unknown setting: {}", self.setting);
             }


### PR DESCRIPTION
## Summary
- `mise settings get <key>` walked the serialized current settings to look up a value, but `Option<T>` fields that are `None` are skipped by TOML serialization. That made unset-but-known settings indistinguishable from typos — both returned `Unknown setting`.
- Now: when the walk fails, check `SETTINGS_META` for the full key. If known, emit `Setting [<key>] is not set`; otherwise keep `Unknown setting`.

Reported in [#9817](https://github.com/jdx/mise/discussions/9817).

### Before
```
$ mise settings get python.compile
mise ERROR Unknown setting: python.compile
$ mise settings get not.a.real.setting
mise ERROR Unknown setting: not.a.real.setting
```

### After
```
$ mise settings get python.compile
mise ERROR Setting [python.compile] is not set
$ mise settings get not.a.real.setting
mise ERROR Unknown setting: not.a.real.setting
```

## Test plan
- [x] `mise settings get python.compile` → `Setting [python.compile] is not set` (exit 1)
- [x] `mise settings get cargo.registry_name` → `Setting [cargo.registry_name] is not set` (exit 1)
- [x] `mise settings get abcdefg` → `Unknown setting: abcdefg` (unchanged)
- [x] `mise settings get legacy_version_file` → `true` (unchanged)
- [x] `mise settings get python` (parent key) → inline table (unchanged)
- [x] E2E `cli/test_settings_set` extended and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to `mise settings get` error handling plus updated e2e expectations; main impact is different user-facing error text for missing known keys.
> 
> **Overview**
> `mise settings get` now distinguishes between a *known* setting that is currently unset vs a truly unknown key by consulting `SETTINGS_META` when a lookup fails.
> 
> E2E CLI tests are updated/extended to assert the new `Setting [<key>] is not set` error for known-but-unset keys (including dotted keys), while keeping `Unknown setting` for typos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51862338b248372bc89ea73be007e25b75ddc7d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->