### PR TITLE
fix(ci): set UTF-8 locale in e2e Docker image

### DIFF
--- a/packaging/e2e/Dockerfile
+++ b/packaging/e2e/Dockerfile
@@ -7,6 +7,8 @@ LABEL org.opencontainers.image.licenses=MIT
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/opt/node/bin:$PATH"
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
## Summary

- Set `LANG=C.UTF-8` and `LC_ALL=C.UTF-8` in [packaging/e2e/Dockerfile](packaging/e2e/Dockerfile) so the e2e image has a UTF-8 locale instead of the default `POSIX` / ASCII.

## Why

`backend/test_gem_slow` started failing on the release PR ([#9780](https://github.com/jdx/mise/pull/9780)) when ruby 4.0.4 (today's release) was selected as `latest`. The test runs `mise use ruby` with `MISE_RUBY_COMPILE=true`, which forces ruby-build to compile from source.

`make install` aborts during the `rdoc` target with:

```
(ArgumentError) invalid byte sequence in US-ASCII
.../rdoc-7.0.3/lib/rdoc/parser/c.rb:575:in 'String#scan'
make: *** [uncommon.mk:619: rdoc] Error 1
```

RDoc's C parser reads UTF-8 bytes from sources like `object.c`, but the container has `LC_CTYPE=POSIX` (both `LANG` and `LC_ALL` were unset), so Ruby treats the input as ASCII and the scan blows up.

Reproduced inside `ghcr.io/jdx/mise:e2e` on an Ubuntu 24.04 host: fails with `POSIX`, succeeds with `LC_ALL=C.UTF-8`. The `C.utf8` locale is already present in the image (`locale -a` confirms), so no extra install is required.

## Reviewer notes

- The `ghcr.io/jdx/mise:e2e` image is only rebuilt by [.github/workflows/docker.yml](.github/workflows/docker.yml), which fires on `v*` tag pushes or `workflow_dispatch`. After merging, the `docker` workflow needs to be dispatched (or wait for the next tagged release) before CI will pick up the new image.

## Test plan

- [ ] Merge, then dispatch `docker.yml` to rebuild and push `ghcr.io/jdx/mise:e2e`
- [ ] Re-run the failing `e2e-3` job on the release PR and confirm `backend/test_gem_slow` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only sets `LANG`/`LC_ALL` in the e2e Docker image, which should primarily affect locale-dependent behavior (e.g., string encoding) during tests.
> 
> **Overview**
> Sets `LANG=C.UTF-8` and `LC_ALL=C.UTF-8` in `packaging/e2e/Dockerfile` so the e2e test container runs with a UTF-8 locale instead of the default ASCII/`POSIX` locale, improving reliability for builds/tests that process non-ASCII source text (e.g., Ruby/RDoc during compilation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2723b4d5d071fb69fef0630964612c84535ea9a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->