### PR TITLE
fix(ci): pass UTF-8 locale through to e2e tests

### DIFF
--- a/e2e/run_test
+++ b/e2e/run_test
@@ -88,6 +88,8 @@ within_isolated_env() {
     GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
     GOPROXY="${GOPROXY:-}" \
     HOME="$TEST_HOME" \
+    LANG="${LANG:-C.UTF-8}" \
+    LC_ALL="${LC_ALL:-C.UTF-8}" \
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" \
     LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-}" \
     ${proxy_vars[@]+"${proxy_vars[@]}"} \

--- a/e2e/run_test
+++ b/e2e/run_test
@@ -89,7 +89,7 @@ within_isolated_env() {
     GOPROXY="${GOPROXY:-}" \
     HOME="$TEST_HOME" \
     LANG="${LANG:-C.UTF-8}" \
-    LC_ALL="${LC_ALL:-C.UTF-8}" \
+    LC_ALL="${LC_ALL:-}" \
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" \
     LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-}" \
     ${proxy_vars[@]+"${proxy_vars[@]}"} \


### PR DESCRIPTION
## Summary

- Add `LANG` and `LC_ALL` (defaulting to `C.UTF-8`) to the env passthrough in [e2e/run_test:90-91](e2e/run_test:90).

## Why

Follow-up to [#9820](https://github.com/jdx/mise/pull/9820), which set `LANG=C.UTF-8` / `LC_ALL=C.UTF-8` in the e2e Docker image — but `backend/test_gem_slow` kept failing because `within_isolated_env()` uses `env -i` to clear the environment before each test, and the locale wasn't on the pass-through list. The Dockerfile defaults were stripped before the test process ever started.

Symptom: ruby 4.0.4 source build fails at the `rdoc` step with `(ArgumentError) invalid byte sequence in US-ASCII` when rdoc's C parser hits non-ASCII bytes in `object.c`.

Reproduced inside `ghcr.io/jdx/mise:e2e` on bamboo (Ubuntu 24.04 host):
- `env -i ... mise install ruby@4.0.4` → fails identically to CI
- `env -i ... LANG=C.UTF-8 LC_ALL=C.UTF-8 mise install ruby@4.0.4` → succeeds

## Test plan

- [ ] Re-run failed `e2e-3` on release PR [#9780](https://github.com/jdx/mise/pull/9780) and confirm `backend/test_gem_slow` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts environment variables for e2e test execution, with no production code or data-path changes.
> 
> **Overview**
> E2E test runner now preserves locale settings when running tests in a fully cleared environment (`env -i`) by explicitly passing through `LANG` (defaulting to `C.UTF-8`) and `LC_ALL`.
> 
> This prevents locale-dependent failures (e.g., tooling assuming US-ASCII) during source builds inside CI and the e2e Docker image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d7f06ad731b9bdca2a5a0d79019feeb3ad9e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->