### PR TITLE
registry: add SonarQube CLI (aqua:SonarSource/sonarqube-cli)

### DIFF
--- a/registry/sonarqube-cli.toml
+++ b/registry/sonarqube-cli.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:SonarSource/sonarqube-cli"]
+description = "CLI tool to provide access to Sonar features"
+test = { cmd = "sonar --version", expected = "{{ version | split(pat='.') | slice(start=0, end=3) | join(sep='.') }}" }


### PR DESCRIPTION
## Summary

Adding SonarQube CLI to mise using aqua

## Popularity

- **GIthub** (SonarSource/sonarqube-cli): 140 stars, 5 forks, last release 0.12.0.1512 on 2026-05-11
- **Aqua registry**: already tracked (`pkgs/SonarSource/sonarqube-cli/pkg.yaml`)
- CLI for SonarQube, one of the most used static analysis tool 