### PR TITLE
feat(spm): add artifact bundle support

### DIFF
--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -4,6 +4,8 @@ You may install executables managed by [Swift Package Manager](https://www.swift
 
 The code for this is inside of the mise repository at [`./src/backend/spm.rs`](https://github.com/jdx/mise/blob/main/src/backend/spm.rs).
 
+When a release publishes a SwiftPM artifact bundle (`*.artifactbundle.zip`), mise will use the prebuilt executable from the bundle when it matches the current Swift target triple. If no matching bundle is available, mise falls back to building the package from source unless artifact bundles are explicitly required.
+
 ## Dependencies
 
 This relies on having `swift` installed. You can either install it [manually](https://www.swift.org/install) or [with mise](/lang/swift).
@@ -30,6 +32,20 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 ```toml
 [tools]
 "spm:tuist/tuist" = "latest"
+```
+
+If the release provides only a SwiftPM artifact bundle, mise can install the bundle directly:
+
+```sh
+mise use -g spm:giginet/swift-testing-revolutionary@0.4.0
+swift-testing-revolutionary --help
+```
+
+The version will be set in `~/.config/mise/config.toml` with the following format:
+
+```toml
+[tools]
+"spm:giginet/swift-testing-revolutionary" = "0.4.0"
 ```
 
 ### Supported Syntax
@@ -68,14 +84,42 @@ Set the URL for the provider's API. This is useful when using a self-hosted inst
 "spm:acme/my-tool" = { version = "latest", provider = "gitlab", api_url = "https://gitlab.acme.com/api/v4" }
 ```
 
+### `artifactbundle`
+
+Control whether SwiftPM artifact bundles are used. When unset, mise tries a matching
+`*.artifactbundle.zip` release asset first and falls back to building from source if no matching
+bundle is available.
+
+Set `artifactbundle = true` to require an artifact bundle for a tool. If no bundle matches the
+current Swift target triple, installation fails instead of falling back to a source build.
+
+Set `artifactbundle = false` to skip artifact bundles and always build from source.
+
+```toml
+[tools]
+"spm:giginet/swift-testing-revolutionary" = { version = "0.4.0", artifactbundle = true }
+"spm:tuist/tuist" = { version = "latest", artifactbundle = false }
+```
+
+### `artifactbundle_asset`
+
+Select a specific artifact bundle release asset. This is required when a release contains multiple
+`*.artifactbundle.zip` assets.
+
+```toml
+[tools]
+"spm:giginet/swift-testing-revolutionary" = { version = "0.4.0", artifactbundle_asset = "swift-testing-revolutionary.artifactbundle.zip" }
+```
+
 ### `filter_bins`
 
-Restrict which executable products are built and linked from the package. When unset, every
-executable product declared in `Package.swift` is built and symlinked into `bin/` (the default
-behavior).
+Restrict which executable products are installed from the package or artifact bundle. When unset,
+every executable product declared in `Package.swift` is built and symlinked into `bin/`, or every
+matching executable artifact from an artifact bundle is symlinked into `bin/`.
 
 Useful when a package ships helper executables (e.g. test harnesses) that you don't want on your
-`PATH`. Filtering happens before `swift build`, so unwanted products are never built.
+`PATH`. For source builds, filtering happens before `swift build`, so unwanted products are never
+built.
 
 Accepts a TOML array or a comma-separated string. If any listed name does not match an executable
 product in the package, installation fails with a clear error.
@@ -86,3 +130,18 @@ product in the package, installation fails with a clear error.
 # or
 "spm:swiftlang/swiftly" = { version = "latest", filter_bins = "swiftly" }
 ```
+
+## Settings
+
+### `spm.artifactbundle_only`
+
+Set `spm.artifactbundle_only = true` to require SwiftPM artifact bundles for all `spm:` installs.
+This mirrors `cargo.binstall_only`: mise will fail if no matching artifact bundle is available
+instead of compiling from source.
+
+```toml
+[settings]
+spm.artifactbundle_only = true
+```
+
+This can also be set with `MISE_SPM_ARTIFACTBUNDLE_ONLY=1`.

--- a/e2e/core/test_swift_slow
+++ b/e2e/core/test_swift_slow
@@ -11,6 +11,8 @@ assert_matches "mise x -- swift --version" 'Swift version 6\.'
 #assert "mise x spm:nicklockwood/SwiftFormat@0.53.10 -- swiftformat --version" "0.53.10"
 #assert "mise x spm:https://github.com/nicklockwood/SwiftFormat.git@0.53.10 -- swiftformat --version" "0.53.10"
 
+assert "mise x spm:nicklockwood/SwiftFormat@0.61.1 -- swiftformat --version" "0.61.1"
+
 # test package with resources (`templates list` command depends on resources being installed)
 #assert "mise x spm:SwiftGen/SwiftGen@6.6.2 --verbose -- swiftgen templates list --only colors" "colors:
 #   - literals-swift4

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1475,6 +1475,17 @@
             }
           }
         },
+        "spm": {
+          "type": "object",
+          "unevaluatedProperties": false,
+          "properties": {
+            "artifactbundle_only": {
+              "default": false,
+              "description": "Only use SwiftPM artifact bundles for installation, fail if no matching bundle is available.",
+              "type": "boolean"
+            }
+          }
+        },
         "status": {
           "type": "object",
           "unevaluatedProperties": false,

--- a/settings.toml
+++ b/settings.toml
@@ -2089,6 +2089,12 @@ description = "If true, fail when sops decryption fails (including when sops is 
 env = "MISE_SOPS_STRICT"
 type = "Bool"
 
+[spm.artifactbundle_only]
+default = false
+description = "Only use SwiftPM artifact bundles for installation, fail if no matching bundle is available."
+env = "MISE_SPM_ARTIFACTBUNDLE_ONLY"
+type = "Bool"
+
 [status.missing_tools]
 default = "if_other_versions_installed"
 description = "Show a warning if tools are not installed when entering a directory with a mise.toml file."

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -654,6 +654,9 @@ fn select_artifactbundle_asset(
 ) -> eyre::Result<Option<ArtifactBundleReleaseAsset>> {
     let artifactbundle_asset = opts.get("artifactbundle_asset");
     if let Some(name) = artifactbundle_asset {
+        if !is_artifactbundle_zip(name) {
+            bail!("artifactbundle_asset must end with .artifactbundle.zip, got {name}");
+        }
         return assets
             .into_iter()
             .find(|a| a.name == name)
@@ -701,12 +704,15 @@ struct SwiftTarget {
 fn parse_swift_target_triples(json: &str) -> eyre::Result<Vec<String>> {
     let info = serde_json::from_str::<SwiftTargetInfo>(json)
         .wrap_err("Failed to parse swift target info")?;
-    let mut triples = vec![
+    let mut seen = std::collections::HashSet::new();
+    let triples = vec![
         info.target.unversioned_triple,
         info.target.triple,
         info.target.module_triple,
-    ];
-    triples.dedup();
+    ]
+    .into_iter()
+    .filter(|triple| seen.insert(triple.clone()))
+    .collect();
     Ok(triples)
 }
 
@@ -746,6 +752,7 @@ fn artifactbundle_binaries(
                         name: name.clone(),
                         path,
                     });
+                    break;
                 }
             }
         }
@@ -1097,6 +1104,16 @@ mod tests {
 
         assert!(
             select_artifactbundle_asset(
+                vec![release_asset("tool.tar.gz")],
+                &opts_with(
+                    "artifactbundle_asset",
+                    toml::Value::String("tool.tar.gz".to_string()),
+                ),
+            )
+            .is_err()
+        );
+        assert!(
+            select_artifactbundle_asset(
                 vec![release_asset("tool.artifactbundle.zip")],
                 &opts_with(
                     "artifactbundle_asset",
@@ -1148,6 +1165,27 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_swift_target_triples_deduplicates_non_consecutive_values() {
+        let triples = parse_swift_target_triples(
+            r#"{
+              "target": {
+                "triple": "arm64-apple-macosx26.0",
+                "unversionedTriple": "arm64-apple-macosx",
+                "moduleTriple": "arm64-apple-macosx"
+              }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            triples,
+            vec![
+                "arm64-apple-macosx".to_string(),
+                "arm64-apple-macosx26.0".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn test_artifactbundle_binaries() {
         let tmp = tempfile::tempdir().unwrap();
         let bundle = tmp.path().join("tool.artifactbundle");
@@ -1193,6 +1231,52 @@ mod tests {
         let binaries =
             artifactbundle_binaries(tmp.path(), &["x86_64-unknown-linux-gnu".to_string()]).unwrap();
         assert!(binaries.is_empty());
+    }
+
+    #[test]
+    fn test_artifactbundle_binaries_uses_first_matching_variant() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle = tmp.path().join("tool.artifactbundle");
+        let first_bin = bundle.join("tool-1.0.0-macosx/bin");
+        let second_bin = bundle.join("tool-1.0.0-macos/bin");
+        file::create_dir_all(&first_bin).unwrap();
+        file::create_dir_all(&second_bin).unwrap();
+        file::write(first_bin.join("tool"), "").unwrap();
+        file::write(second_bin.join("tool"), "").unwrap();
+        file::write(
+            bundle.join("info.json"),
+            r#"{
+              "schemaVersion": "1.0",
+              "artifacts": {
+                "tool": {
+                  "version": "1.0.0",
+                  "type": "executable",
+                  "variants": [
+                    {
+                      "path": "tool-1.0.0-macosx/bin/tool",
+                      "supportedTriples": ["arm64-apple-macosx"]
+                    },
+                    {
+                      "path": "tool-1.0.0-macos/bin/tool",
+                      "supportedTriples": ["arm64-apple-macos"]
+                    }
+                  ]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let binaries = artifactbundle_binaries(
+            tmp.path(),
+            &[
+                "arm64-apple-macosx".to_string(),
+                "arm64-apple-macos".to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(binaries.len(), 1);
+        assert_eq!(binaries[0].path, first_bin.join("tool"));
     }
 
     #[test]

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -5,15 +5,16 @@ use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::git::{CloneOptions, Git};
+use crate::http::HTTP;
 use crate::install_context::InstallContext;
 use crate::toolset::{ToolVersion, ToolVersionOptions};
 use crate::{dirs, file, github, gitlab};
 use async_trait::async_trait;
-use eyre::WrapErr;
+use eyre::{WrapErr, bail};
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::de::{MapAccess, Visitor};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{
     fmt::{self, Debug},
     sync::Arc,
@@ -49,7 +50,7 @@ impl Backend for SPMBackend {
     }
 
     fn remote_version_listing_tool_option_keys(&self) -> &'static [&'static str] {
-        &["provider", "api_url"]
+        &["provider", "api_url", "artifactbundle_asset"]
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
@@ -102,7 +103,9 @@ impl Backend for SPMBackend {
             Or install Swift via https://swift.org/download/",
         )
         .await;
-        let provider = GitProvider::from_ba_with_opts(&self.ba, &tv.request.options());
+        let mut tv = tv;
+        let opts = tv.request.options();
+        let provider = GitProvider::from_ba_with_opts(&self.ba, &opts);
         let repo = SwiftPackageRepo::new(&self.tool_name(), &provider)?;
         let revision = if tv.version == "latest" {
             self.latest_version(&ctx.config, None, ctx.before_date)
@@ -111,7 +114,62 @@ impl Backend for SPMBackend {
         } else {
             tv.version.clone()
         };
-        let repo_dir = self.clone_package_repo(ctx, &tv, &repo, &revision)?;
+
+        let artifactbundle_mode = resolve_artifactbundle_mode(&opts)?;
+        if artifactbundle_mode == ArtifactBundleMode::SourceOnly
+            && Settings::get().spm.artifactbundle_only
+        {
+            bail!("artifactbundle = false conflicts with spm.artifactbundle_only");
+        }
+        if artifactbundle_mode != ArtifactBundleMode::SourceOnly {
+            let artifactbundle_required = requires_artifactbundle(artifactbundle_mode, &opts);
+            match self
+                .try_install_artifactbundle(ctx, &mut tv, &provider, &repo, &revision, &opts)
+                .await
+            {
+                Ok(true) => return Ok(tv),
+                Ok(false) if artifactbundle_required => {
+                    bail!(
+                        "No matching SwiftPM artifact bundle found for {}",
+                        repo.shorthand
+                    );
+                }
+                Ok(false) if Settings::get().spm.artifactbundle_only => {
+                    bail!(
+                        "No matching SwiftPM artifact bundle found for {}, but spm.artifactbundle_only is set",
+                        repo.shorthand
+                    );
+                }
+                Ok(false) => {}
+                Err(err) if artifactbundle_required => return Err(err),
+                Err(err) if Settings::get().spm.artifactbundle_only => return Err(err),
+                Err(err) => {
+                    debug!(
+                        "SwiftPM artifact bundle install failed, falling back to source build: {err:?}"
+                    );
+                }
+            }
+        }
+
+        self.install_from_source(ctx, &tv, &repo, &revision).await?;
+
+        Ok(tv)
+    }
+}
+
+impl SPMBackend {
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
+    }
+
+    async fn install_from_source(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+        repo: &SwiftPackageRepo,
+        revision: &str,
+    ) -> eyre::Result<()> {
+        let repo_dir = self.clone_package_repo(ctx, tv, repo, revision)?;
 
         let executables = self.get_executable_names(ctx, &repo_dir, &tv).await?;
         if executables.is_empty() {
@@ -131,13 +189,7 @@ impl Backend for SPMBackend {
         file::remove_all(tv.install_path().join("repositories"))?;
         file::remove_all(tv.cache_path())?;
 
-        Ok(tv)
-    }
-}
-
-impl SPMBackend {
-    pub fn from_arg(ba: BackendArg) -> Self {
-        Self { ba: Arc::new(ba) }
+        Ok(())
     }
 
     fn clone_package_repo(
@@ -254,6 +306,79 @@ impl SPMBackend {
         .full_env(self.dependency_env(&ctx.config).await?)
         .read()?;
         Ok(PathBuf::from(bin_path.trim().to_string()).join(executable))
+    }
+
+    async fn try_install_artifactbundle(
+        &self,
+        ctx: &InstallContext,
+        tv: &mut ToolVersion,
+        provider: &GitProvider,
+        repo: &SwiftPackageRepo,
+        revision: &str,
+        opts: &ToolVersionOptions,
+    ) -> eyre::Result<bool> {
+        let Some(asset) = resolve_artifactbundle_asset(provider, repo, revision, opts).await?
+        else {
+            return Ok(false);
+        };
+
+        let bundle_dir = tv.cache_path().join("artifactbundle");
+        file::remove_all(&bundle_dir)?;
+        file::create_dir_all(&bundle_dir)?;
+        let download_path = tv.download_path().join(&asset.name);
+        let headers = match provider.kind {
+            GitProviderKind::GitLab => gitlab::get_headers(&asset.url),
+            GitProviderKind::GitHub => github::get_headers(&asset.url),
+        };
+        ctx.pr.set_message(format!("download {}", asset.name));
+        HTTP.download_file_with_headers(
+            &asset.url,
+            &download_path,
+            &headers,
+            Some(ctx.pr.as_ref()),
+        )
+        .await?;
+
+        let platform_key = self.get_platform_key();
+        let platform_info = tv.lock_platforms.entry(platform_key).or_default();
+        platform_info.url = Some(asset.url.clone());
+        platform_info.url_api = asset.url_api.clone();
+        if platform_info.checksum.is_none() {
+            platform_info.checksum = asset.digest.clone();
+        }
+        self.verify_checksum(ctx, tv, &download_path)?;
+
+        ctx.pr.set_message(format!("extract {}", asset.name));
+        file::untar(
+            &download_path,
+            &bundle_dir,
+            &file::TarOptions::new(file::TarFormat::Zip),
+        )?;
+
+        let triples = swift_target_triples(ctx, self).await?;
+        let binaries = artifactbundle_binaries(&bundle_dir, &triples)?;
+        if binaries.is_empty() {
+            file::remove_all(tv.cache_path())?;
+            return Ok(false);
+        }
+        let binaries = filter_artifactbundle_binaries(opts, binaries)?;
+        if binaries.is_empty() {
+            file::remove_all(tv.cache_path())?;
+            return Ok(false);
+        }
+
+        let bin_path = tv.install_path().join("bin");
+        let artifact_bin_path = tv.install_path().join("artifactbundle").join("bin");
+        file::create_dir_all(&bin_path)?;
+        file::create_dir_all(&artifact_bin_path)?;
+        for binary in binaries {
+            let installed_binary = artifact_bin_path.join(&binary.name);
+            file::copy(&binary.path, &installed_binary)?;
+            file::make_executable(&installed_binary)?;
+            file::make_symlink(&installed_binary, &bin_path.join(&binary.name))?;
+        }
+        file::remove_all(tv.cache_path())?;
+        Ok(true)
     }
 }
 
@@ -428,6 +553,257 @@ impl SwiftPackageRepo {
             shorthand: shorthand.to_string(),
         })
     }
+}
+
+async fn swift_target_triples(
+    ctx: &InstallContext,
+    backend: &SPMBackend,
+) -> eyre::Result<Vec<String>> {
+    let target_info = cmd!("swift", "-print-target-info")
+        .full_env(backend.dependency_env(&ctx.config).await?)
+        .read()?;
+    parse_swift_target_triples(&target_info)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ArtifactBundleMode {
+    Auto,
+    Required,
+    SourceOnly,
+}
+
+impl ArtifactBundleMode {
+    fn requires_artifactbundle(self) -> bool {
+        matches!(self, Self::Required)
+    }
+}
+
+fn resolve_artifactbundle_mode(opts: &ToolVersionOptions) -> eyre::Result<ArtifactBundleMode> {
+    match opts.get_string("artifactbundle").as_deref() {
+        None => Ok(ArtifactBundleMode::Auto),
+        Some("true") => Ok(ArtifactBundleMode::Required),
+        Some("false") => Ok(ArtifactBundleMode::SourceOnly),
+        Some(value) => bail!("artifactbundle must be true or false, got {value}"),
+    }
+}
+
+fn requires_artifactbundle(mode: ArtifactBundleMode, opts: &ToolVersionOptions) -> bool {
+    mode.requires_artifactbundle() || opts.get("artifactbundle_asset").is_some()
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ArtifactBundleReleaseAsset {
+    name: String,
+    url: String,
+    url_api: Option<String>,
+    digest: Option<String>,
+}
+
+async fn resolve_artifactbundle_asset(
+    provider: &GitProvider,
+    repo: &SwiftPackageRepo,
+    revision: &str,
+    opts: &ToolVersionOptions,
+) -> eyre::Result<Option<ArtifactBundleReleaseAsset>> {
+    let assets = match provider.kind {
+        GitProviderKind::GitLab => {
+            gitlab::list_releases_from_url(&provider.api_url, repo.shorthand.as_str())
+                .await?
+                .into_iter()
+                .find(|r| r.tag_name == revision)
+                .map(|r| {
+                    r.assets
+                        .links
+                        .into_iter()
+                        .map(|a| ArtifactBundleReleaseAsset {
+                            name: a.name,
+                            url: a.direct_asset_url,
+                            url_api: Some(a.url),
+                            digest: None,
+                        })
+                        .collect()
+                })
+        }
+        GitProviderKind::GitHub => {
+            github::list_releases_from_url(&provider.api_url, repo.shorthand.as_str())
+                .await?
+                .into_iter()
+                .find(|r| r.tag_name == revision)
+                .map(|r| {
+                    r.assets
+                        .into_iter()
+                        .map(|a| ArtifactBundleReleaseAsset {
+                            name: a.name,
+                            url: a.browser_download_url,
+                            url_api: Some(a.url),
+                            digest: a.digest,
+                        })
+                        .collect()
+                })
+        }
+    };
+    let Some(assets) = assets else {
+        return Ok(None);
+    };
+    select_artifactbundle_asset(assets, opts)
+}
+
+fn select_artifactbundle_asset(
+    assets: Vec<ArtifactBundleReleaseAsset>,
+    opts: &ToolVersionOptions,
+) -> eyre::Result<Option<ArtifactBundleReleaseAsset>> {
+    let artifactbundle_asset = opts.get("artifactbundle_asset");
+    if let Some(name) = artifactbundle_asset {
+        return assets
+            .into_iter()
+            .find(|a| a.name == name)
+            .map(Some)
+            .ok_or_else(|| {
+                eyre::eyre!("artifactbundle_asset not found in release assets: {name}")
+            });
+    }
+
+    let candidates = assets
+        .into_iter()
+        .filter(|a| is_artifactbundle_zip(&a.name))
+        .collect::<Vec<_>>();
+    match candidates.len() {
+        0 => Ok(None),
+        1 => Ok(candidates.into_iter().next()),
+        _ => bail!(
+            "multiple SwiftPM artifact bundles found: {}. Set artifactbundle_asset to choose one",
+            candidates
+                .into_iter()
+                .map(|a| a.name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn is_artifactbundle_zip(name: &str) -> bool {
+    name.to_lowercase().ends_with(".artifactbundle.zip")
+}
+
+#[derive(Debug, Deserialize)]
+struct SwiftTargetInfo {
+    target: SwiftTarget,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SwiftTarget {
+    triple: String,
+    unversioned_triple: String,
+    module_triple: String,
+}
+
+fn parse_swift_target_triples(json: &str) -> eyre::Result<Vec<String>> {
+    let info = serde_json::from_str::<SwiftTargetInfo>(json)
+        .wrap_err("Failed to parse swift target info")?;
+    let mut triples = vec![
+        info.target.unversioned_triple,
+        info.target.triple,
+        info.target.module_triple,
+    ];
+    triples.dedup();
+    Ok(triples)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ArtifactBundleBinary {
+    name: String,
+    path: PathBuf,
+}
+
+fn artifactbundle_binaries(
+    extract_dir: &Path,
+    target_triples: &[String],
+) -> eyre::Result<Vec<ArtifactBundleBinary>> {
+    let mut binaries = vec![];
+    for bundle in artifactbundle_dirs(extract_dir)? {
+        let info = file::read_to_string(bundle.join("info.json"))?;
+        let manifest = serde_json::from_str::<ArtifactBundleInfo>(&info)
+            .wrap_err("Failed to parse artifact bundle info.json")?;
+        for (name, artifact) in manifest.artifacts {
+            if artifact.r#type != "executable" {
+                continue;
+            }
+            for variant in artifact.variants {
+                if variant
+                    .supported_triples
+                    .iter()
+                    .any(|triple| target_triples.contains(triple))
+                {
+                    let path = bundle.join(&variant.path);
+                    if !path.is_file() {
+                        bail!(
+                            "artifact bundle executable does not exist: {}",
+                            path.display()
+                        );
+                    }
+                    binaries.push(ArtifactBundleBinary {
+                        name: name.clone(),
+                        path,
+                    });
+                }
+            }
+        }
+    }
+    Ok(binaries)
+}
+
+fn artifactbundle_dirs(extract_dir: &Path) -> eyre::Result<Vec<PathBuf>> {
+    let mut bundles = vec![];
+    if extract_dir.join("info.json").is_file() {
+        bundles.push(extract_dir.to_path_buf());
+    }
+
+    for entry in std::fs::read_dir(extract_dir)
+        .wrap_err_with(|| format!("failed to read_dir: {}", extract_dir.display()))?
+    {
+        let path = entry?.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if is_artifactbundle_dir(&path) {
+            bundles.push(path);
+        } else {
+            bundles.extend(direct_artifactbundle_dirs(&path)?);
+        }
+    }
+    bundles.sort();
+    Ok(bundles)
+}
+
+fn direct_artifactbundle_dirs(dir: &Path) -> eyre::Result<Vec<PathBuf>> {
+    let mut bundles = vec![];
+    for entry in
+        std::fs::read_dir(dir).wrap_err_with(|| format!("failed to read_dir: {}", dir.display()))?
+    {
+        let path = entry?.path();
+        if path.is_dir() && is_artifactbundle_dir(&path) {
+            bundles.push(path);
+        }
+    }
+    bundles.sort();
+    Ok(bundles)
+}
+
+fn is_artifactbundle_dir(path: &Path) -> bool {
+    path.extension().is_some_and(|ext| ext == "artifactbundle") && path.join("info.json").is_file()
+}
+
+fn filter_artifactbundle_binaries(
+    opts: &ToolVersionOptions,
+    binaries: Vec<ArtifactBundleBinary>,
+) -> eyre::Result<Vec<ArtifactBundleBinary>> {
+    let names = binaries.iter().map(|b| b.name.clone()).collect::<Vec<_>>();
+    let filtered = filter_executables(opts, names)?;
+    Ok(binaries
+        .into_iter()
+        .filter(|b| filtered.contains(&b.name))
+        .collect())
 }
 
 #[cfg(test)]
@@ -635,6 +1011,237 @@ mod tests {
         }
     }
 
+    fn opts_with(key: &str, value: toml::Value) -> ToolVersionOptions {
+        ToolVersionOptions {
+            opts: indexmap![key.to_string() => value].into(),
+            ..Default::default()
+        }
+    }
+
+    fn release_asset(name: &str) -> ArtifactBundleReleaseAsset {
+        ArtifactBundleReleaseAsset {
+            name: name.to_string(),
+            url: format!("https://example.com/{name}"),
+            url_api: None,
+            digest: None,
+        }
+    }
+
+    #[test]
+    fn test_resolve_artifactbundle_mode() {
+        assert_eq!(
+            resolve_artifactbundle_mode(&ToolVersionOptions::default()).unwrap(),
+            ArtifactBundleMode::Auto
+        );
+        assert_eq!(
+            resolve_artifactbundle_mode(&opts_with("artifactbundle", toml::Value::Boolean(true)))
+                .unwrap(),
+            ArtifactBundleMode::Required
+        );
+        assert_eq!(
+            resolve_artifactbundle_mode(&opts_with("artifactbundle", toml::Value::Boolean(false)))
+                .unwrap(),
+            ArtifactBundleMode::SourceOnly
+        );
+        assert!(
+            resolve_artifactbundle_mode(&opts_with(
+                "artifactbundle",
+                toml::Value::String("sometimes".to_string())
+            ))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_requires_artifactbundle() {
+        assert!(!requires_artifactbundle(
+            ArtifactBundleMode::Auto,
+            &ToolVersionOptions::default()
+        ));
+        assert!(requires_artifactbundle(
+            ArtifactBundleMode::Required,
+            &ToolVersionOptions::default()
+        ));
+        assert!(requires_artifactbundle(
+            ArtifactBundleMode::Auto,
+            &opts_with(
+                "artifactbundle_asset",
+                toml::Value::String("tool.artifactbundle.zip".to_string()),
+            )
+        ));
+    }
+
+    #[test]
+    fn test_select_artifactbundle_asset() {
+        let selected = select_artifactbundle_asset(
+            vec![release_asset("tool.artifactbundle.zip")],
+            &ToolVersionOptions::default(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(selected.name, "tool.artifactbundle.zip");
+
+        let selected = select_artifactbundle_asset(
+            vec![
+                release_asset("tool.artifactbundle.zip"),
+                release_asset("tool.tar.gz"),
+            ],
+            &opts_with(
+                "artifactbundle_asset",
+                toml::Value::String("tool.artifactbundle.zip".to_string()),
+            ),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(selected.name, "tool.artifactbundle.zip");
+
+        assert!(
+            select_artifactbundle_asset(
+                vec![release_asset("tool.artifactbundle.zip")],
+                &opts_with(
+                    "artifactbundle_asset",
+                    toml::Value::String("missing.artifactbundle.zip".to_string()),
+                ),
+            )
+            .is_err()
+        );
+        assert!(
+            select_artifactbundle_asset(
+                vec![
+                    release_asset("a.artifactbundle.zip"),
+                    release_asset("b.artifactbundle.zip"),
+                ],
+                &ToolVersionOptions::default(),
+            )
+            .is_err()
+        );
+        assert!(
+            select_artifactbundle_asset(
+                vec![release_asset("tool.tar.gz")],
+                &ToolVersionOptions::default(),
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_swift_target_triples() {
+        let triples = parse_swift_target_triples(
+            r#"{
+              "target": {
+                "triple": "arm64-apple-macosx26.0",
+                "unversionedTriple": "arm64-apple-macosx",
+                "moduleTriple": "arm64-apple-macos"
+              }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            triples,
+            vec![
+                "arm64-apple-macosx".to_string(),
+                "arm64-apple-macosx26.0".to_string(),
+                "arm64-apple-macos".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_artifactbundle_binaries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle = tmp.path().join("tool.artifactbundle");
+        let bin = bundle.join("tool-1.0.0-macosx/bin");
+        file::create_dir_all(&bin).unwrap();
+        file::write(bin.join("tool"), "").unwrap();
+        file::write(
+            bundle.join("info.json"),
+            r#"{
+              "schemaVersion": "1.0",
+              "artifacts": {
+                "tool": {
+                  "version": "1.0.0",
+                  "type": "executable",
+                  "variants": [
+                    {
+                      "path": "tool-1.0.0-macosx/bin/tool",
+                      "supportedTriples": ["arm64-apple-macosx"]
+                    }
+                  ]
+                },
+                "library": {
+                  "version": "1.0.0",
+                  "type": "library",
+                  "variants": [
+                    {
+                      "path": "lib",
+                      "supportedTriples": ["arm64-apple-macosx"]
+                    }
+                  ]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let binaries =
+            artifactbundle_binaries(tmp.path(), &["arm64-apple-macosx".to_string()]).unwrap();
+        assert_eq!(binaries.len(), 1);
+        assert_eq!(binaries[0].name, "tool");
+        assert_eq!(binaries[0].path, bin.join("tool"));
+
+        let binaries =
+            artifactbundle_binaries(tmp.path(), &["x86_64-unknown-linux-gnu".to_string()]).unwrap();
+        assert!(binaries.is_empty());
+    }
+
+    #[test]
+    fn test_artifactbundle_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        file::write(tmp.path().join("info.json"), "{}").unwrap();
+
+        let direct = tmp.path().join("direct.artifactbundle");
+        file::create_dir_all(&direct).unwrap();
+        file::write(direct.join("info.json"), "{}").unwrap();
+
+        let wrapped = tmp.path().join("wrapper").join("wrapped.artifactbundle");
+        file::create_dir_all(&wrapped).unwrap();
+        file::write(wrapped.join("info.json"), "{}").unwrap();
+
+        let deeper = tmp
+            .path()
+            .join("wrapper")
+            .join("too-deep")
+            .join("deep.artifactbundle");
+        file::create_dir_all(&deeper).unwrap();
+        file::write(deeper.join("info.json"), "{}").unwrap();
+
+        let dirs = artifactbundle_dirs(tmp.path()).unwrap();
+        assert_eq!(
+            dirs,
+            vec![tmp.path().to_path_buf(), direct, wrapped],
+            "search should be limited to the bundle root, direct children, and one wrapper directory"
+        );
+    }
+
+    #[test]
+    fn test_filter_artifactbundle_binaries() {
+        let binaries = vec![
+            ArtifactBundleBinary {
+                name: "a".to_string(),
+                path: PathBuf::from("/tmp/a"),
+            },
+            ArtifactBundleBinary {
+                name: "b".to_string(),
+                path: PathBuf::from("/tmp/b"),
+            },
+        ];
+        let opts = opts_with_filter_bins(toml::Value::String("b".to_string()));
+        let filtered = filter_artifactbundle_binaries(&opts, binaries).unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "b");
+    }
+
     #[test]
     fn test_parse_filter_bins() {
         assert_eq!(parse_filter_bins(&ToolVersionOptions::default()), None);
@@ -814,4 +1421,23 @@ impl PackageDescriptionProductType {
 
         deserializer.deserialize_map(TypeFieldVisitor)
     }
+}
+
+/// https://github.com/swiftlang/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md
+#[derive(Deserialize)]
+struct ArtifactBundleInfo {
+    artifacts: std::collections::BTreeMap<String, ArtifactBundleArtifact>,
+}
+
+#[derive(Deserialize)]
+struct ArtifactBundleArtifact {
+    r#type: String,
+    variants: Vec<ArtifactBundleVariant>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ArtifactBundleVariant {
+    path: String,
+    supported_triples: Vec<String>,
 }

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -171,16 +171,16 @@ impl SPMBackend {
     ) -> eyre::Result<()> {
         let repo_dir = self.clone_package_repo(ctx, tv, repo, revision)?;
 
-        let executables = self.get_executable_names(ctx, &repo_dir, &tv).await?;
+        let executables = self.get_executable_names(ctx, &repo_dir, tv).await?;
         if executables.is_empty() {
             return Err(eyre::eyre!("No executables found in the package"));
         }
-        let executables = self.apply_filter_bins(&tv, executables)?;
+        let executables = self.apply_filter_bins(tv, executables)?;
         let bin_path = tv.install_path().join("bin");
         file::create_dir_all(&bin_path)?;
         for executable in executables {
             let exe_path = self
-                .build_executable(&executable, &repo_dir, ctx, &tv)
+                .build_executable(&executable, &repo_dir, ctx, tv)
                 .await?;
             file::make_symlink(&exe_path, &bin_path.join(executable))?;
         }


### PR DESCRIPTION
## Summary

- add default-on SwiftPM artifact bundle installation with source-build fallback
- add `artifactbundle`, `artifactbundle_asset`, and `spm.artifactbundle_only` controls
- cover asset selection, target triple matching, artifact bundle executable filtering, and a SwiftFormat e2e install

## Tests

- `cargo fmt --check`
- `cargo test backend::spm`
- `mise run test:e2e e2e/core/test_swift_slow`
- `mise run lint`

Discussion: https://github.com/jdx/mise/discussions/9691

*This PR description was generated by an AI coding assistant.*
