### PR TITLE
docs(aliases): fix Aliased Versions example and drop stale asdf callout

### DIFF
--- a/docs/dev-tools/aliases.md
+++ b/docs/dev-tools/aliases.md
@@ -46,9 +46,9 @@ versions:
 ```bash
 #!/usr/bin/env bash
 
+echo "lts-krypton 24"
 echo "lts-jod 22"
 echo "lts-iron 20"
-echo "lts-hydrogen 18"
 ```
 
 (mise's built-in node plugin already ships these LTS aliases; the example above shows the format

--- a/docs/dev-tools/aliases.md
+++ b/docs/dev-tools/aliases.md
@@ -10,25 +10,34 @@ For shell command aliases (like `alias ll='ls -la'`), see [Shell Aliases](/shell
 ## Aliased Backends
 
 Tools can be aliased so that something like `node` which normally maps to `core:node` can be changed
-to something like `asdf:company/our-custom-node` instead.
+to a different backend instead.
 
 ```toml [~/.config/mise/config.toml]
 [tool_alias]
-node = 'asdf:company/our-custom-node' # shorthand for https://github.com/company/our-custom-node
-erlang = 'asdf:https://github.com/company/our-custom-erlang'
+node = 'github:company/our-custom-node'   # shorthand for https://github.com/company/our-custom-node
+erlang = 'aqua:company/our-custom-erlang' # use an aqua registry entry
 ```
 
 ## Aliased Versions
 
-mise supports aliasing the versions of runtimes. One use-case for this is to define aliases for LTS
-versions of runtimes. For example, you may want to specify `lts-hydrogen` as the version for <node@20.x>
-so you can use set it with `node lts-hydrogen` in `mise.toml`/`.tool-versions`.
+mise supports aliasing the versions of runtimes. One use-case for this is to define a stable name
+that points to a specific version, so you can reference it symbolically in
+`mise.toml`/`.tool-versions`. For example, you may want `lts-iron` to map to Node.js 20 so you can
+set it with `node = "lts-iron"`.
 
-User aliases can be created by adding a `tool_alias.<PLUGIN>` section to `~/.config/mise/config.toml`:
+User aliases can be created by adding a `tool_alias.<PLUGIN>.versions` section to
+`~/.config/mise/config.toml`:
 
 ```toml
 [tool_alias.node.versions]
-my_custom_20 = '20'
+lts-iron = '20'
+```
+
+Then reference the alias when pinning the tool:
+
+```toml
+[tools]
+node = "lts-iron"
 ```
 
 Plugins can also provide aliases via a `bin/list-aliases` script. Here is an example showing node.js
@@ -37,15 +46,13 @@ versions:
 ```bash
 #!/usr/bin/env bash
 
+echo "lts-jod 22"
+echo "lts-iron 20"
 echo "lts-hydrogen 18"
-echo "lts-gallium 16"
-echo "lts-fermium 14"
 ```
 
-::: info
-Because this is mise-specific functionality not currently used by asdf it isn't likely to be in any
-plugin currently, but plugin authors can add this script without impacting asdf users.
-:::
+(mise's built-in node plugin already ships these LTS aliases; the example above shows the format
+that other plugins can use.)
 
 ## Templates
 


### PR DESCRIPTION
## Summary

Fixes the confusion reported in [#9828](https://github.com/jdx/mise/discussions/9828) in the Tool Aliases docs.

In the "Aliased Versions" section:
- The prose referenced `lts-hydrogen` but the code example used an unrelated `my_custom_20 = '20'` — now the example is consistent.
- Fixed the broken sentence "so you can use set it with `node lts-hydrogen`" — now reads as proper TOML (`node = "lts-iron"`) with a follow-up code block showing the full `[tools]` usage.
- Corrected the version mismatch: the doc claimed `lts-hydrogen` maps to Node 20, but `lts-hydrogen` is Node 18. Switched the example to `lts-iron` (= 20).
- Refreshed the `bin/list-aliases` example to current LTS codenames (jod/iron/hydrogen instead of the EOL hydrogen/gallium/fermium).
- Removed the obsolete `::: info` callout about asdf not supporting `bin/list-aliases`.

Drive-by fix in "Aliased Backends":
- Replaced the `asdf:` examples with `github:` and `aqua:`, matching the recommended backend tiers.

## Test plan

- [ ] Render docs locally (`mise run docs`) and confirm the Aliased Versions section reads cleanly and the code blocks render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust examples and wording; no runtime behavior or security-sensitive code is modified.
> 
> **Overview**
> Clarifies *Aliased Backends* by switching examples from `asdf:` to recommended `github:`/`aqua:` backends and simplifying the wording.
> 
> Fixes and modernizes the *Aliased Versions* section by aligning prose and TOML examples around `tool_alias.<PLUGIN>.versions` (using `lts-iron = "20"`), adding a `[tools]` example showing how to pin the alias, refreshing `bin/list-aliases` outputs to current Node LTS codenames, and removing the stale asdf-related callout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a352fe41b3bfce83f364b478bb59da9acc4951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->