### PR TITLE
fix(aqua): reject registry-invalid latest tags

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -401,8 +401,13 @@ impl AquaPackage {
         arch: &str,
         runtime: AquaRuntime<'_>,
     ) -> AquaPackage {
-        let version_override = self.version_override(versions).unwrap_or(&self).clone();
-        self = apply_override(self.clone(), &version_override);
+        if let Some(version_override) = self
+            .version_override(versions)
+            .filter(|version_override| !std::ptr::eq(*version_override, &self))
+            .cloned()
+        {
+            self = apply_override(self, &version_override);
+        }
         if let Some(pkg) = self
             .overrides
             .iter()

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -401,7 +401,8 @@ impl AquaPackage {
         arch: &str,
         runtime: AquaRuntime<'_>,
     ) -> AquaPackage {
-        self = apply_override(self.clone(), self.version_override(versions));
+        let version_override = self.version_override(versions).unwrap_or(&self).clone();
+        self = apply_override(self.clone(), &version_override);
         if let Some(pkg) = self
             .overrides
             .iter()
@@ -420,7 +421,11 @@ impl AquaPackage {
         Ok(self)
     }
 
-    fn version_override(&self, versions: &[&str]) -> &AquaPackage {
+    pub fn version_constraint_ok(&self, versions: &[&str]) -> bool {
+        self.version_override(versions).is_some()
+    }
+
+    fn version_override(&self, versions: &[&str]) -> Option<&AquaPackage> {
         let expressions = versions
             .iter()
             .map(|v| (self.expr_parser(v), self.expr_ctx(v)))
@@ -443,7 +448,6 @@ impl AquaPackage {
                     })
                 }
             })
-            .unwrap_or(self)
     }
 
     /// Detect the format of an archive based on its filename
@@ -1316,7 +1320,7 @@ packages:
             ..Default::default()
         };
 
-        let result = pkg.version_override(&["brew"]);
+        let result = pkg.version_override(&["brew"]).unwrap();
         // "brew" matches semver("<= 0.2.13") instead of "true",
         // because Versioning::new("brew") parses as General(Alphanum("brew"))
         // which sorts before numeric versions.

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -277,8 +277,8 @@ impl Backend for AquaBackend {
                 }
             };
 
-            // Validate the package has assets and supports this platform
-            if package_supported_on_target(&versioned_pkg, target_os, target_arch) {
+            // Validate the package has assets
+            if package_has_asset(&versioned_pkg) {
                 let release_url = format!(
                     "https://github.com/{}/{}/releases/tag/{}",
                     pkg.repo_owner, pkg.repo_name, tag
@@ -1437,9 +1437,7 @@ impl AquaBackend {
             target_arch,
             target_libc.as_deref(),
         ) {
-            Ok(Some((version, versioned_pkg)))
-                if package_supported_on_target(&versioned_pkg, target_os, target_arch) =>
-            {
+            Ok(Some((version, versioned_pkg))) if package_has_asset(&versioned_pkg) => {
                 Ok(Some(version))
             }
             Ok(Some(_)) | Ok(None) => Ok(None),
@@ -3038,7 +3036,7 @@ fn versioned_package_from_tag(
     target_arch: &str,
     target_libc: Option<&str>,
 ) -> Result<Option<(String, AquaPackage)>> {
-    if !pkg.version_filter_ok(tag)? {
+    if !pkg.version_filter_ok(tag)? || !pkg.version_constraint_ok(&[tag]) {
         return Ok(None);
     }
 
@@ -3058,10 +3056,6 @@ fn versioned_package_from_tag(
 
 fn package_has_asset(pkg: &AquaPackage) -> bool {
     !pkg.no_asset && pkg.error_message.is_none()
-}
-
-fn package_supported_on_target(pkg: &AquaPackage, os: &str, arch: &str) -> bool {
-    package_has_asset(pkg) && is_platform_supported(&pkg.supported_envs, os, arch)
 }
 
 /// Get tags with optional created_at timestamps and a pre-release flag.
@@ -3325,6 +3319,52 @@ mod lock_candidate_tests {
         assert_eq!(version_from_tag(&pkg, "other-1.2.3").unwrap(), None);
     }
 
+    fn pkg_from_yaml(yaml: &str) -> AquaPackage {
+        let mut pkg: AquaPackage = serde_yaml::from_str(yaml).unwrap();
+        pkg.setup_version_filter().unwrap();
+        pkg
+    }
+
+    #[test]
+    fn test_version_from_tag_rejects_version_filter_mismatch() {
+        let pkg = pkg_from_yaml(
+            r#"
+type: github_release
+repo_owner: owner
+repo_name: repo
+version_filter: semver(">= 1.0.0")
+"#,
+        );
+
+        assert_eq!(
+            version_from_tag(&pkg, "v1.0.0").unwrap(),
+            Some("1.0.0".to_string())
+        );
+        assert_eq!(version_from_tag(&pkg, "v0.9.0").unwrap(), None);
+    }
+
+    #[test]
+    fn test_version_from_tag_rejects_version_constraint_mismatch() {
+        let pkg = pkg_from_yaml(
+            r#"
+type: github_release
+repo_owner: owner
+repo_name: repo
+version_constraint: "false"
+version_overrides:
+  - version_constraint: Version == "v1.2.3"
+    asset: tool.tar.gz
+    format: tar.gz
+"#,
+        );
+
+        assert_eq!(
+            version_from_tag(&pkg, "v1.2.3").unwrap(),
+            Some("1.2.3".to_string())
+        );
+        assert_eq!(version_from_tag(&pkg, "v1.2.4").unwrap(), None);
+    }
+
     #[test]
     fn test_package_has_asset_rejects_no_asset_and_errors() {
         let mut pkg = AquaPackage::default();
@@ -3336,70 +3376,6 @@ mod lock_candidate_tests {
         pkg.no_asset = false;
         pkg.error_message = Some("unsupported version".to_string());
         assert!(!package_has_asset(&pkg));
-    }
-
-    fn pkg_with_supported_envs(supported_envs: &[&str]) -> AquaPackage {
-        let mut pkg = AquaPackage::default();
-        pkg.supported_envs = supported_envs.iter().map(|env| env.to_string()).collect();
-        pkg
-    }
-
-    #[test]
-    fn test_package_supported_on_target_accepts_empty_supported_envs() {
-        let pkg = AquaPackage::default();
-
-        assert!(package_supported_on_target(&pkg, os(), arch()));
-    }
-
-    #[test]
-    fn test_package_supported_on_target_accepts_matching_supported_envs() {
-        let target_os = os();
-        let target_arch = arch();
-        let target_os_arch = format!("{target_os}/{target_arch}");
-
-        for supported_envs in [
-            vec![target_os],
-            vec![target_arch],
-            vec![target_os_arch.as_str()],
-            vec!["all"],
-        ] {
-            let pkg = pkg_with_supported_envs(&supported_envs);
-
-            assert!(package_supported_on_target(&pkg, target_os, target_arch));
-        }
-    }
-
-    #[test]
-    fn test_package_supported_on_target_rejects_non_matching_supported_envs() {
-        let pkg = pkg_with_supported_envs(&["darwin/arm64"]);
-
-        assert!(!package_supported_on_target(&pkg, "linux", "amd64"));
-    }
-
-    #[test]
-    fn test_package_supported_on_target_rejects_no_asset_and_errors() {
-        let mut pkg = AquaPackage::default();
-        pkg.no_asset = true;
-
-        assert!(!package_supported_on_target(&pkg, os(), arch()));
-
-        pkg.no_asset = false;
-        pkg.error_message = Some("unsupported version".to_string());
-
-        assert!(!package_supported_on_target(&pkg, os(), arch()));
-    }
-
-    #[test]
-    fn test_package_supported_on_target_allows_windows_arm64_amd64_compatibility() {
-        let windows_amd64 = pkg_with_supported_envs(&["windows/amd64"]);
-        let amd64 = pkg_with_supported_envs(&["amd64"]);
-
-        assert!(package_supported_on_target(
-            &windows_amd64,
-            "windows",
-            "arm64"
-        ));
-        assert!(package_supported_on_target(&amd64, "windows", "arm64"));
     }
 
     fn asset(name: &str) -> GithubAsset {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -277,8 +277,8 @@ impl Backend for AquaBackend {
                 }
             };
 
-            // Validate the package has assets
-            if package_has_asset(&versioned_pkg) {
+            // Validate the package has assets and supports this platform
+            if package_supported_on_target(&versioned_pkg, target_os, target_arch) {
                 let release_url = format!(
                     "https://github.com/{}/{}/releases/tag/{}",
                     pkg.repo_owner, pkg.repo_name, tag
@@ -1437,7 +1437,9 @@ impl AquaBackend {
             target_arch,
             target_libc.as_deref(),
         ) {
-            Ok(Some((version, versioned_pkg))) if package_has_asset(&versioned_pkg) => {
+            Ok(Some((version, versioned_pkg)))
+                if package_supported_on_target(&versioned_pkg, target_os, target_arch) =>
+            {
                 Ok(Some(version))
             }
             Ok(Some(_)) | Ok(None) => Ok(None),
@@ -3058,6 +3060,10 @@ fn package_has_asset(pkg: &AquaPackage) -> bool {
     !pkg.no_asset && pkg.error_message.is_none()
 }
 
+fn package_supported_on_target(pkg: &AquaPackage, os: &str, arch: &str) -> bool {
+    package_has_asset(pkg) && is_platform_supported(&pkg.supported_envs, os, arch)
+}
+
 /// Get tags with optional created_at timestamps and a pre-release flag.
 /// Returns `(tag_name, Option<created_at>, prerelease)` triples.
 ///
@@ -3330,6 +3336,70 @@ mod lock_candidate_tests {
         pkg.no_asset = false;
         pkg.error_message = Some("unsupported version".to_string());
         assert!(!package_has_asset(&pkg));
+    }
+
+    fn pkg_with_supported_envs(supported_envs: &[&str]) -> AquaPackage {
+        let mut pkg = AquaPackage::default();
+        pkg.supported_envs = supported_envs.iter().map(|env| env.to_string()).collect();
+        pkg
+    }
+
+    #[test]
+    fn test_package_supported_on_target_accepts_empty_supported_envs() {
+        let pkg = AquaPackage::default();
+
+        assert!(package_supported_on_target(&pkg, os(), arch()));
+    }
+
+    #[test]
+    fn test_package_supported_on_target_accepts_matching_supported_envs() {
+        let target_os = os();
+        let target_arch = arch();
+        let target_os_arch = format!("{target_os}/{target_arch}");
+
+        for supported_envs in [
+            vec![target_os],
+            vec![target_arch],
+            vec![target_os_arch.as_str()],
+            vec!["all"],
+        ] {
+            let pkg = pkg_with_supported_envs(&supported_envs);
+
+            assert!(package_supported_on_target(&pkg, target_os, target_arch));
+        }
+    }
+
+    #[test]
+    fn test_package_supported_on_target_rejects_non_matching_supported_envs() {
+        let pkg = pkg_with_supported_envs(&["darwin/arm64"]);
+
+        assert!(!package_supported_on_target(&pkg, "linux", "amd64"));
+    }
+
+    #[test]
+    fn test_package_supported_on_target_rejects_no_asset_and_errors() {
+        let mut pkg = AquaPackage::default();
+        pkg.no_asset = true;
+
+        assert!(!package_supported_on_target(&pkg, os(), arch()));
+
+        pkg.no_asset = false;
+        pkg.error_message = Some("unsupported version".to_string());
+
+        assert!(!package_supported_on_target(&pkg, os(), arch()));
+    }
+
+    #[test]
+    fn test_package_supported_on_target_allows_windows_arm64_amd64_compatibility() {
+        let windows_amd64 = pkg_with_supported_envs(&["windows/amd64"]);
+        let amd64 = pkg_with_supported_envs(&["amd64"]);
+
+        assert!(package_supported_on_target(
+            &windows_amd64,
+            "windows",
+            "arm64"
+        ));
+        assert!(package_supported_on_target(&amd64, "windows", "arm64"));
     }
 
     fn asset(name: &str) -> GithubAsset {


### PR DESCRIPTION
I split the supported_envs behavior out of this PR. This PR only handles the #9277 follow-up where GitHub's latest release can point at a tag that aqua-registry rejects.

## Summary
- expose an aqua-registry version-constraint check without changing install-time fallback behavior
- skip release tags that fail `version_filter` or `version_constraint` before the GitHub latest fast path can return them
- leave `supported_envs` validation for a stacked follow-up PR

## Tests
- `cargo fmt --check`
- `git diff --check`
- `env RUSTC_WRAPPER= cargo test backend::aqua::lock_candidate_tests -- --nocapture`
- `env RUSTC_WRAPPER= cargo test -p aqua-registry -- --nocapture`

*This PR was generated by an AI coding assistant.*