### PR TITLE
fix(task): skip shebang line in displayed task command

### DIFF
--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -734,8 +734,7 @@ impl TaskExecutor {
         } else {
             script
         };
-        let cmd =
-            format!("$ {display_script} {args}", args = args.join(" ")).to_string();
+        let cmd = format!("$ {display_script} {args}", args = args.join(" "));
         if !self.quiet(Some(task)) {
             let msg = style::ebold(trunc(prefix, config.redact(&cmd).trim()))
                 .bright()

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -737,7 +737,13 @@ impl TaskExecutor {
                     && !t.starts_with("set ")
             })
             .unwrap_or(script);
-        let cmd = format!("$ {display_script} {args}", args = args.join(" "));
+        let args_str = args.join(" ");
+        let cmd = match (display_script.is_empty(), args_str.is_empty()) {
+            (true, true) => "$".to_string(),
+            (true, false) => format!("$ {args_str}"),
+            (false, true) => format!("$ {display_script}"),
+            (false, false) => format!("$ {display_script} {args_str}"),
+        };
         if !self.quiet(Some(task)) {
             let msg = style::ebold(trunc(prefix, config.redact(&cmd).trim()))
                 .bright()

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -731,10 +731,7 @@ impl TaskExecutor {
             .lines()
             .find(|line| {
                 let t = line.trim_start();
-                !t.is_empty()
-                    && !t.starts_with("#!")
-                    && t != "set"
-                    && !t.starts_with("set ")
+                !t.is_empty() && !t.starts_with("#!") && t != "set" && !t.starts_with("set ")
             })
             .unwrap_or(script);
         let args_str = args.join(" ");

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -724,16 +724,19 @@ impl TaskExecutor {
     ) -> Result<()> {
         let config = Config::get().await?;
         let script = script.trim_start();
-        // For display, skip a leading shebang so the user sees the actual
-        // command instead of e.g. "#!/usr/bin/env bash".
-        let display_script = if script.starts_with("#!") {
-            script
-                .split_once('\n')
-                .map_or("", |(_, body)| body)
-                .trim_start()
-        } else {
-            script
-        };
+        // For display, skip leading shebang/blank/`set ...` boilerplate so
+        // the user sees the first real command instead of e.g.
+        // "#!/usr/bin/env bash" or "set -Eeuo pipefail".
+        let display_script = script
+            .lines()
+            .find(|line| {
+                let t = line.trim_start();
+                !t.is_empty()
+                    && !t.starts_with("#!")
+                    && t != "set"
+                    && !t.starts_with("set ")
+            })
+            .unwrap_or(script);
         let cmd = format!("$ {display_script} {args}", args = args.join(" "));
         if !self.quiet(Some(task)) {
             let msg = style::ebold(trunc(prefix, config.redact(&cmd).trim()))

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -724,7 +724,18 @@ impl TaskExecutor {
     ) -> Result<()> {
         let config = Config::get().await?;
         let script = script.trim_start();
-        let cmd = format!("$ {script} {args}", args = args.join(" ")).to_string();
+        // For display, skip a leading shebang so the user sees the actual
+        // command instead of e.g. "#!/usr/bin/env bash".
+        let display_script = if script.starts_with("#!") {
+            script
+                .split_once('\n')
+                .map_or("", |(_, body)| body)
+                .trim_start()
+        } else {
+            script
+        };
+        let cmd =
+            format!("$ {display_script} {args}", args = args.join(" ")).to_string();
         if !self.quiet(Some(task)) {
             let msg = style::ebold(trunc(prefix, config.redact(&cmd).trim()))
                 .bright()


### PR DESCRIPTION
## Summary

When a task's `run` body starts with a shebang (e.g. `#!/usr/bin/env bash`) and/or shell-option lines like `set -Eeuo pipefail`, the command echo ends up showing only that boilerplate:

```
[generate-completions] $ #!/usr/bin/env bash
```

That's the only thing the user sees for the entire task — every following line of the body is hidden because [`trunc`](src/task/task_output.rs:33) keeps just the first line of the displayed command, and for these scripts the first line is boilerplate.

This PR skips leading shebang, blank, and `set ...` lines when building the displayed command, so the first real command shows up. Execution is unchanged — the script (shebang and all) is still written to the temp file and run normally.

### Before / after

```
# before
[generate-completions] $ #!/usr/bin/env bash

# after
[generate-completions] $ fzf --fish > ~/.config/fish/completions/fzf.fish
```

Verified locally across several variants:

```
[repro] $ echo "real command"                  # was: #!/usr/bin/env bash
[with-shebang] $ echo "after set -e"           # shebang + set skipped
[set-without-shebang] $ echo "after set"       # bare set skipped
[shebang-only] $ echo "after blank line"       # blank line skipped
[no-skip] $ echo 'simple one-liner'            # unchanged
```

Fixes #9842.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --bin mise task::` — 124 task unit tests pass
- [x] Manual smoke test across shebang, set, blank-line, and plain variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect how inline task scripts are *displayed* (echoed) before execution, not how they run. Main risk is minor formatting edge cases for empty scripts/args.
> 
> **Overview**
> Task command echoing for inline `run` scripts now **skips leading boilerplate** (blank lines, shebangs, and `set ...`) so the first *real* command is shown instead of just the header.
> 
> The displayed `$ ...` string construction was adjusted to handle empty script/argument combinations without producing awkward output; execution behavior remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb6e59a4c7eb12ce44c9ad32fa658b9353e2de3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->