### PR TITLE
fix(registry): correct sourcery format per-platform (regression from #9587)

### DIFF
--- a/registry/sourcery.toml
+++ b/registry/sourcery.toml
@@ -4,7 +4,20 @@ description = "Meta-programming for Swift, stop writing boilerplate code"
 [[backends]]
 full = "github:krzysztofzablocki/Sourcery"
 
-[backends.options]
+# macOS release asset is a real `.zip`; the Linux release asset is named
+# `.tar.xz` but is actually gzip-compressed (the upstream release workflow
+# uses `tar -zcvf` on a `.tar.xz`-named file:
+# https://github.com/krzysztofzablocki/Sourcery/blob/master/.github/workflows/release_ubuntu.yml#L43-L47).
+# `format` must therefore be set per-platform — applying `tar.gz` globally
+# (as the previous version of this entry did) breaks macOS installs with
+# `invalid gzip header` when extracting the `.zip` as a tar.gz.
+[backends.options.platforms.macos-arm64]
+format = "zip"
+
+[backends.options.platforms.macos-x64]
+format = "zip"
+
+[backends.options.platforms.linux-x64]
 format = "tar.gz"
 
 [[backends]]


### PR DESCRIPTION
## Summary

#9587 set `format = \"tar.gz\"` on the github backend so it could correctly extract Sourcery's Linux release asset (which is named `.tar.xz` but actually gzip-compressed — see [`release_ubuntu.yml#L43-L47`](https://github.com/krzysztofzablocki/Sourcery/blob/master/.github/workflows/release_ubuntu.yml#L43-L47)). But Sourcery's macOS release asset is a real `.zip`, so applying `tar.gz` to all platforms breaks every macOS install in v2026.5.7:

\`\`\`
mise ERROR Failed to install github:krzysztofzablocki/Sourcery@2.0.1:
failed to extract tar: ~/.local/share/mise/downloads/sourcery/2.0.1/Sourcery-2.0.1.zip
to ~/.local/share/mise/installs/sourcery/2.0.1: invalid gzip header
\`\`\`

Sourcery 2.0.1 only ships a macOS asset; 2.3.0 ships both — so the regression hits every version on macOS as of v2026.5.7.

## Fix

Move `format` into `[backends.options.platforms.*]` blocks: `zip` for macOS (real zip), `tar.gz` for Linux (the named-`.tar.xz`-but-gzipped asset). Mirrors the per-platform `format` pattern already used in `registry/flyway.toml`, `registry/julia.toml`, etc.

## Verification

macOS arm64, mise v2026.5.7 with this patch applied to `~/.local/share/mise/registry/sourcery.toml`:

\`\`\`
$ mise install sourcery@2.0.1
mise sourcery@2.0.1  [1/3] install
mise sourcery@2.0.1  [1/3] download Sourcery-2.0.1.zip
mise sourcery@2.0.1  [2/3] generate checksum Sourcery-2.0.1.zip
mise sourcery@2.0.1  ✓ installed

$ mise exec sourcery -- sourcery --version
2.0.1
\`\`\`

Reproducer (pre-patch, mise v2026.5.7, macOS):

\`\`\`
$ mise install sourcery@2.0.1
mise sourcery@2.0.1  [3/3] extract Sourcery-2.0.1.zip
mise ERROR Failed to install github:krzysztofzablocki/Sourcery@2.0.1: failed to extract tar: ...: invalid gzip header
\`\`\`

I don't have a Linux machine handy to re-verify the Linux path didn't regress, but the change keeps `format = \"tar.gz\"` for `linux-x64` exactly as #9587 introduced it. Happy to add `linux-arm64` too if Sourcery ships an arm64 asset in a future release.