### PR TITLE
chore(ci): downgrade noisy hyperfine regressions

### DIFF
--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -70,7 +70,9 @@ jobs:
       - uses: ./.github/actions/mise-tools
       - run: |
           set -x
+          set -o pipefail
           failed=false
+          outlier_warning="Statistical outliers were detected"
           CMDS=(
             "x -- echo"
             "env"
@@ -79,14 +81,19 @@ jobs:
           )
           echo "## Hyperfine Performance" >> comment.md
           for cmd in "${CMDS[@]}"; do
+            hyperfine_log="$(mktemp)"
             if [ -n "${MISE_ALT:-}" ]; then
-              mise x hyperfine -- hyperfine -N -w 10 -r 500 --export-markdown out.md --reference "$MISE_ALT $cmd" "mise $cmd"
+              mise x hyperfine -- hyperfine -N -w 10 -r 500 --export-markdown out.md --reference "$MISE_ALT $cmd" "mise $cmd" 2>&1 | tee "$hyperfine_log"
             else
-              mise x hyperfine -- hyperfine -N -w 10 -r 500 --export-markdown out.md --reference "mise-${{ steps.versions.outputs.release }} $cmd" "mise $cmd"
+              mise x hyperfine -- hyperfine -N -w 10 -r 500 --export-markdown out.md --reference "mise-${{ steps.versions.outputs.release }} $cmd" "mise $cmd" 2>&1 | tee "$hyperfine_log"
             fi
             echo "### \`mise $cmd\`" >> comment.md
             cat out.md >> comment.md
             cat out.md
+            noisy=false
+            if grep -q "$outlier_warning" "$hyperfine_log"; then
+              noisy=true
+            fi
             
             # Extract relative performance from hyperfine output
             variance=$(grep "±.*±" out.md | awk '{print $(NF-3)}' | sed 's/%//')
@@ -103,11 +110,15 @@ jobs:
             if [ "$variance_scaled" -gt 1100 ]; then
               if grep -q "mise-${{ steps.versions.outputs.release }}.*±.*±" out.md; then
                 echo "✅  Performance improvement for \`$cmd\` is ${variance}%" >> comment.md
+              elif [ "$noisy" = true ]; then
+                echo "::warning title=Noisy hyperfine result::mise $cmd measured ${variance}% slower, but hyperfine reported statistical outliers. Treating this benchmark as inconclusive." >&2
+                echo "⚠️  Inconclusive: \`$cmd\` measured ${variance}% slower, but hyperfine reported statistical outliers." >> comment.md
               else
                 echo "⚠️  Warning: Performance variance for \`$cmd\` is ${variance}%" >> comment.md
                 failed=true
               fi
             fi
+            rm -f "$hyperfine_log"
           done
           if [ "$failed" = true ]; then
             exit 1

--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -69,8 +69,7 @@ jobs:
       - run: cargo build --profile serious && mv target/serious/mise "$HOME/bin"
       - uses: ./.github/actions/mise-tools
       - run: |
-          set -x
-          set -o pipefail
+          set -exo pipefail
           failed=false
           outlier_warning="Statistical outliers were detected"
           CMDS=(
@@ -111,7 +110,7 @@ jobs:
               if grep -q "mise-${{ steps.versions.outputs.release }}.*±.*±" out.md; then
                 echo "✅  Performance improvement for \`$cmd\` is ${variance}%" >> comment.md
               elif [ "$noisy" = true ]; then
-                echo "::warning title=Noisy hyperfine result::mise $cmd measured ${variance}% slower, but hyperfine reported statistical outliers. Treating this benchmark as inconclusive." >&2
+                echo "::warning title=Noisy hyperfine result::mise $cmd measured ${variance}% slower, but hyperfine reported statistical outliers. Treating this benchmark as inconclusive."
                 echo "⚠️  Inconclusive: \`$cmd\` measured ${variance}% slower, but hyperfine reported statistical outliers." >> comment.md
               else
                 echo "⚠️  Warning: Performance variance for \`$cmd\` is ${variance}%" >> comment.md


### PR DESCRIPTION
## Summary
- capture hyperfine output in the benchmark workflow so statistical outlier warnings can be detected
- treat >10% slower measurements with hyperfine outlier warnings as inconclusive warnings instead of failing the check
- keep clean >10% slower measurements failing, and keep pipefail so hyperfine command failures still fail

## Testing
- `sed -n '71,125p' .github/workflows/hyperfine.yml | sed 's/^          //' | bash -n`\n- `actionlint .github/workflows/hyperfine.yml`\n- `git diff --check`\n\n*This PR was generated by an AI coding assistant.*