### PR TITLE
fix(task): preserve task env across nested hook-env

### DIFF
--- a/e2e/cli/test_run_nested_exec_path
+++ b/e2e/cli/test_run_nested_exec_path
@@ -21,6 +21,9 @@ mkdir -p "$old_dir/.mise/tasks" "$new_dir"
 cat >"$old_dir/mise.toml" <<EOF
 [tools]
 dummy = "1.0.0"
+
+[tasks.probe]
+env = { PATH = "{{env.PATH}}" }
 EOF
 
 cat >"$new_dir/mise.toml" <<EOF

--- a/e2e/tasks/test_task_hook_env_preserves_task_env
+++ b/e2e/tasks/test_task_hook_env_preserves_task_env
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks.check]
+env = { TASK_ENV_VALUE = "from-task" }
+EOF
+
+mkdir -p .mise/tasks
+cat <<'EOF' >.mise/tasks/check
+#!/usr/bin/env bash
+set -euo pipefail
+
+eval "$(mise hook-env -s bash)"
+printf "dir=%s env=%s\n" "${MISE_TASK_DIR:-missing}" "${TASK_ENV_VALUE:-missing}"
+EOF
+chmod +x .mise/tasks/check
+
+assert "mise run check" "dir=$PWD/.mise/tasks env=from-task"

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -269,15 +269,36 @@ impl TaskExecutor {
             task.name,
             env_render_start.elapsed().as_millis()
         );
+        let mut nested_mise_diff_exclude_keys: HashSet<String> = task_env
+            .iter()
+            .map(|(key, _)| key.clone())
+            .filter(|key| key != &*crate::env::PATH_KEY)
+            .chain(once("__MISE_DIFF".to_string()))
+            .collect();
         if !self.timings {
-            env.insert("MISE_TASK_TIMINGS".to_string(), "0".to_string());
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_TASK_TIMINGS",
+                "0".to_string(),
+            );
         }
         // Propagate MISE_ENV to child tasks so -E flag works for nested mise invocations
         if !crate::env::MISE_ENV.is_empty() {
-            env.insert("MISE_ENV".to_string(), crate::env::MISE_ENV.join(","));
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_ENV",
+                crate::env::MISE_ENV.join(","),
+            );
         }
         if let Some(cwd) = &*crate::dirs::CWD {
-            env.insert("MISE_ORIGINAL_CWD".into(), cwd.display().to_string());
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_ORIGINAL_CWD",
+                cwd.display().to_string(),
+            );
         }
         // Prefer the task's own config_root so MISE_PROJECT_ROOT is the directory of the
         // mise.toml that defined the task. This keeps the value stable regardless of the
@@ -295,32 +316,64 @@ impl TaskExecutor {
             task.config_root.clone().or(config.project_root.clone())
         };
         if let Some(root) = project_root {
-            env.insert("MISE_PROJECT_ROOT".into(), root.display().to_string());
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_PROJECT_ROOT",
+                root.display().to_string(),
+            );
         }
         if let Some(monorepo_root) = config.monorepo_root() {
-            env.insert(
-                "MISE_MONOREPO_ROOT".into(),
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_MONOREPO_ROOT",
                 monorepo_root.display().to_string(),
             );
         }
-        env.insert("MISE_TASK_NAME".into(), task.name.clone());
+        Self::insert_env_excluded_from_nested_mise_diff(
+            &mut env,
+            &mut nested_mise_diff_exclude_keys,
+            "MISE_TASK_NAME",
+            task.name.clone(),
+        );
         let task_file = task
             .file_path(config)
             .await?
             .unwrap_or(task.config_source.clone());
-        env.insert("MISE_TASK_FILE".into(), task_file.display().to_string());
+        Self::insert_env_excluded_from_nested_mise_diff(
+            &mut env,
+            &mut nested_mise_diff_exclude_keys,
+            "MISE_TASK_FILE",
+            task_file.display().to_string(),
+        );
         if let Some(dir) = task_file.parent() {
-            env.insert("MISE_TASK_DIR".into(), dir.display().to_string());
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_TASK_DIR",
+                dir.display().to_string(),
+            );
         }
         if let Some(config_root) = &task.config_root {
-            env.insert("MISE_CONFIG_ROOT".into(), config_root.display().to_string());
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_CONFIG_ROOT",
+                config_root.display().to_string(),
+            );
         }
 
         // Ensure cache key exists for task subprocesses for nested mise invocations
         // This matches exec.rs behavior - enables caching for subprocesses
         if Settings::get().env_cache {
             let key = CachedEnv::ensure_encryption_key();
-            env.insert("__MISE_ENV_CACHE_KEY".into(), key);
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "__MISE_ENV_CACHE_KEY",
+                key,
+            );
         }
 
         // Embed __MISE_DIFF so a nested `mise` invocation inside this task can
@@ -328,7 +381,7 @@ impl TaskExecutor {
         // tool dirs on top of its own. Keep task-scoped vars out of the diff:
         // nested `mise hook-env` should not unset variables that belong to the
         // currently running task.
-        let env_for_diff = self.env_for_nested_mise_diff(&env, &task_env);
+        let env_for_diff = self.env_for_nested_mise_diff(&env, &nested_mise_diff_exclude_keys);
         if let Ok(serialized) =
             EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env_for_diff).serialize()
         {
@@ -416,26 +469,25 @@ impl TaskExecutor {
         Ok(true)
     }
 
+    fn insert_env_excluded_from_nested_mise_diff(
+        env: &mut BTreeMap<String, String>,
+        excluded_keys: &mut HashSet<String>,
+        key: &str,
+        value: String,
+    ) {
+        env.insert(key.to_string(), value);
+        if key != &*crate::env::PATH_KEY {
+            excluded_keys.insert(key.to_string());
+        }
+    }
+
     fn env_for_nested_mise_diff(
         &self,
         env: &BTreeMap<String, String>,
-        task_env: &[(String, String)],
+        excluded_keys: &HashSet<String>,
     ) -> BTreeMap<String, String> {
         let mut env = env.clone();
-        for key in [
-            "MISE_CONFIG_ROOT",
-            "MISE_ENV",
-            "MISE_MONOREPO_ROOT",
-            "MISE_ORIGINAL_CWD",
-            "MISE_PROJECT_ROOT",
-            "MISE_TASK_DIR",
-            "MISE_TASK_FILE",
-            "MISE_TASK_NAME",
-            "MISE_TASK_TIMINGS",
-        ] {
-            env.remove(key);
-        }
-        for (key, _) in task_env {
+        for key in excluded_keys {
             env.remove(key);
         }
         env

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -325,10 +325,12 @@ impl TaskExecutor {
 
         // Embed __MISE_DIFF so a nested `mise` invocation inside this task can
         // recover the pristine env (and pristine PATH) instead of stacking our
-        // tool dirs on top of its own. Without this, nested `mise -C <new> exec`
-        // would inherit our tool dirs as user-pre-PATH and they would outrank
-        // the inner toolset's resolved tool. See discussion #9754.
-        if let Ok(serialized) = EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env).serialize()
+        // tool dirs on top of its own. Keep task-scoped vars out of the diff:
+        // nested `mise hook-env` should not unset variables that belong to the
+        // currently running task.
+        let env_for_diff = self.env_for_nested_mise_diff(&env, &task_env);
+        if let Ok(serialized) =
+            EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env_for_diff).serialize()
         {
             env.insert("__MISE_DIFF".into(), serialized);
         }
@@ -412,6 +414,31 @@ impl TaskExecutor {
         save_checksum(task, config).await?;
 
         Ok(true)
+    }
+
+    fn env_for_nested_mise_diff(
+        &self,
+        env: &BTreeMap<String, String>,
+        task_env: &[(String, String)],
+    ) -> BTreeMap<String, String> {
+        let mut env = env.clone();
+        for key in [
+            "MISE_CONFIG_ROOT",
+            "MISE_ENV",
+            "MISE_MONOREPO_ROOT",
+            "MISE_ORIGINAL_CWD",
+            "MISE_PROJECT_ROOT",
+            "MISE_TASK_DIR",
+            "MISE_TASK_FILE",
+            "MISE_TASK_NAME",
+            "MISE_TASK_TIMINGS",
+        ] {
+            env.remove(key);
+        }
+        for (key, _) in task_env {
+            env.remove(key);
+        }
+        env
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -272,7 +272,7 @@ impl TaskExecutor {
         let mut nested_mise_diff_exclude_keys: HashSet<String> = task_env
             .iter()
             .map(|(key, _)| key.clone())
-            .filter(|key| key != &*crate::env::PATH_KEY)
+            .filter(|key| key.as_str() != crate::env::PATH_KEY.as_str())
             .chain(once("__MISE_DIFF".to_string()))
             .collect();
         if !self.timings {
@@ -476,7 +476,7 @@ impl TaskExecutor {
         value: String,
     ) {
         env.insert(key.to_string(), value);
-        if key != &*crate::env::PATH_KEY {
+        if key != crate::env::PATH_KEY.as_str() {
             excluded_keys.insert(key.to_string());
         }
     }


### PR DESCRIPTION
## Summary
- keep task-scoped variables out of the task `__MISE_DIFF` used by nested mise invocations
- preserve `MISE_TASK_*` metadata, project/config metadata, `MISE_ENV`, and task-declared env values when `mise hook-env` runs inside a task
- keep `PATH` represented in the diff even when a task declares `PATH`, preserving the nested tool PATH fix from #9765 / discussion #9754
- exclude internal nested-invocation state such as `__MISE_DIFF` and the env-cache key from the task diff

## Root Cause
`2026.5.6` started embedding `__MISE_DIFF` into task subprocess environments so a nested `mise` invocation could reconstruct the pristine environment. That fixed nested `mise -C <other> exec` cases where the outer task's tool directories were inherited as user-pre-PATH and could outrank the inner toolset.

The task diff was computed after task metadata and resolved task env were inserted into the child environment. When a task script then ran `eval "$(mise hook-env -s bash)"`, the nested `hook-env` reversed that diff to build `PRISTINE_ENV`. Any variable that existed only because the outer task added it was treated as mise-managed state and got removed, so task-local values like `MISE_TASK_DIR` and declared task env disappeared.

A broad exclusion of every task env key would have reintroduced the PATH bug: if a task declares `PATH`, nested mise still needs the outer task tool paths recorded in `__MISE_DIFF.path` so they can be removed before resolving the inner toolset. `PATH` is therefore handled as a deliberate special case.

## Implementation
- Build `nested_mise_diff_exclude_keys` from task-declared env keys, except `PATH`.
- Track task metadata keys through `insert_env_excluded_from_nested_mise_diff()` at the same call sites that insert them, avoiding a separate hardcoded metadata list.
- Compute `EnvDiff::from_final_env()` from a filtered environment snapshot so nested `hook-env` does not unset task-scoped values.
- Always exclude `__MISE_DIFF`; exclude `__MISE_ENV_CACHE_KEY` when task execution injects it for env caching.
- Leave `PATH` in the filtered snapshot so `EnvDiff::from_final_env()` can still populate `diff.path` with the paths nested mise must strip.

## Review Follow-up
- Gemini noted that excluding `PATH` would break the #9765 nested PATH behavior and that internal state vars should not be embedded recursively. Fixed by preserving `PATH` in the diff and excluding `__MISE_DIFF` / env-cache state.
- Greptile noted that a hardcoded task metadata exclusion list would be easy to forget when new task metadata is added. Fixed by building the exclusion set alongside the env insertions.

## Tests
- `cargo fmt --all -- --check`
- `shfmt -d --apply-ignore e2e/cli/test_run_nested_exec_path e2e/tasks/test_task_hook_env_preserves_task_env`
- `shellcheck -x e2e/cli/test_run_nested_exec_path e2e/tasks/test_task_hook_env_preserves_task_env`
- `mise run test:e2e e2e/tasks/test_task_hook_env_preserves_task_env e2e/cli/test_run_nested_exec_path`
