### PR TITLE
fix(hook-env): detect global config file created after activation

### DIFF
--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -81,7 +81,10 @@ impl HookEnv {
             .chain(PREV_SESSION.watch_files.iter().map(|p| p.as_path().into()))
             .collect();
 
-        if !self.force && hook_env::should_exit_early(slow_path_watch_files, self.reason) {
+        let loaded_configs: IndexSet<PathBuf> = config.config_files.keys().cloned().collect();
+        if !self.force
+            && hook_env::should_exit_early(slow_path_watch_files, &loaded_configs, self.reason)
+        {
             trace!("should_exit_early true");
             return Ok(());
         }

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -244,6 +244,7 @@ pub fn should_exit_early_fast() -> bool {
 /// the full config (watch_files, hook scheduling).
 pub fn should_exit_early(
     watch_files: impl IntoIterator<Item = WatchFilePattern>,
+    loaded_configs: &IndexSet<PathBuf>,
     reason: Option<HookReason>,
 ) -> bool {
     // Force hook-env to run at least once from precmd after activation
@@ -257,6 +258,13 @@ pub fn should_exit_early(
         hooks::schedule_hook(hooks::Hooks::Leave);
         hooks::schedule_hook(hooks::Hooks::Cd);
         hooks::schedule_hook(hooks::Hooks::Enter);
+        return false;
+    }
+    // Detect new or removed config files since last hook-env session.
+    // Catches creation of ~/.config/mise/config.toml (or any other config
+    // file) after shell activation when loaded_configs was previously empty.
+    if loaded_configs != &PREV_SESSION.loaded_configs {
+        trace!("loaded configs changed, not exiting early");
         return false;
     }
     // Check full watch_files list from config (may include more than config files)
@@ -377,6 +385,16 @@ pub fn deserialize<T: serde::de::DeserializeOwned>(raw: String) -> Result<T> {
 /// Used by both `should_exit_early_fast` and `build_session` to avoid divergence.
 fn config_search_dir_mtimes() -> Vec<SystemTime> {
     let mut mtimes = Vec::new();
+
+    // Always check global and system config directories regardless of CWD.
+    // This catches new config files (e.g. ~/.config/mise/config.toml) created
+    // after shell activation, even when CWD is outside $HOME.
+    for config_dir in [&*dirs::CONFIG, &*dirs::SYSTEM_CONFIG] {
+        if let Ok(Ok(modified)) = config_dir.metadata().map(|m| m.modified()) {
+            mtimes.push(modified);
+        }
+    }
+
     if let Some(cwd) = &*dirs::CWD
         && let Ok(ancestor_dirs) = file::all_dirs(cwd, &env::MISE_CEILING_PATHS)
     {


### PR DESCRIPTION
Right now, if the a user manually creates a global config file, `mise` won't detect it until the user changes directory. Re-evaluating the prompt won't apply the changes. This was confusing me, because I expected `mise` to detect the new global config after re-evaluating the shell prompt, even without having to change directory.

Example to reproduce the issue:
- The user is in a directory outside of $HOME, eg: `/mnt/work`
- The user has already activated mise with `mise activate`
-  `~/.config/mise/config.toml` doesn't exist yet.
- `echo -e "[tools]\nusage=\"latest\"" > ~/.config/mise/config.toml` to init the global config.
- The command `usage` is still not available
- By moving to another directory, suddenly the `usage` command becomes available.

Two fixes:
- `config_search_dir_mtimes()` now always monitors `dirs::CONFIG` and `dirs::SYSTEM_CONFIG` mtimes regardless of CWD, ensuring the fast-path catches new config files in e.g. ~/.config/mise/
- `should_exit_early()` now compares the current loaded_configs set against the previous session, catching new/removed config files in the slow path after config is loaded