### PR TITLE
fix(upgrade): preserve summary after progress cleanup

### DIFF
--- a/e2e/cli/test_upgrade_progress_summary
+++ b/e2e/cli/test_upgrade_progress_summary
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo 'dummy 1' >.tool-versions
-mise install dummy@1.0.0 >/dev/null 2>&1
+mise install dummy@1.0.0 >/dev/null 2>&1 || fail "pre-install of dummy@1.0.0 failed"
 
 output="$(MISE_FORCE_PROGRESS=1 mise up dummy 2>&1)"
 summary_line="  dummy 1.0.0 → 1.1.0"

--- a/e2e/cli/test_upgrade_progress_summary
+++ b/e2e/cli/test_upgrade_progress_summary
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo 'dummy 1' >.tool-versions
+mise install dummy@1.0.0 >/dev/null 2>&1
+
+output="$(MISE_FORCE_PROGRESS=1 mise up dummy 2>&1)"
+summary_line="  dummy 1.0.0 → 1.1.0"
+
+if [[ $output != *"$summary_line"* ]]; then
+  fail "upgrade summary did not include '$summary_line': $output"
+fi
+
+after_summary="${output#*"$summary_line"}"
+if grep -q $'\033\\[[0-9;]*J' <<<"$after_summary"; then
+  fail "upgrade summary was followed by a terminal clear sequence"
+fi

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -411,6 +411,7 @@ impl Upgrade {
                 });
         }
 
+        mpr.finish_progress();
         Self::print_summary(&outdated, &successful_versions)?;
 
         install_error

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -380,6 +380,7 @@ impl Upgrade {
             }
         }
 
+        mpr.finish_progress();
         let ts = config.get_toolset().await?;
 
         // Fix up sources and requests for lockfile update - CLI args produce

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -181,9 +181,13 @@ impl MultiProgressReport {
 
         progress_trace!("footer_finish: completed={}, total={}", completed, total);
 
-        // Stop clx progress
-        progress::stop();
+        self.finish_progress();
+    }
 
+    /// Render the final progress state, then clear clx's registered jobs so
+    /// later regular terminal output cannot be erased by process shutdown.
+    pub fn finish_progress(&self) {
+        progress::stop();
         self.reset_jobs();
     }
 


### PR DESCRIPTION
## Summary
- finish and reset progress jobs created after install/uninstall work before printing the upgrade summary
- add an e2e regression test that forces progress UI output and checks that no terminal clear sequence follows the summary row

## Root cause
PR #9779 fixed duplicate upgrade progress output by clearing the install progress session after `install_all_versions`. `mise upgrade` then creates fresh progress jobs for old-version uninstall cleanup, but those jobs were still registered when the command printed the final `Upgraded N tools:` summary. On process shutdown, `stop_clear()` cleared the remaining progress rows from the terminal, which could erase the summary detail lines and leave only the header visible.

Addresses discussion #9856. Likely regression from #9779.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `mise run test:e2e e2e/cli/test_upgrade_progress_summary`
- `mise run test:e2e e2e/cli/test_upgrade`

This PR was generated by an AI coding assistant.