### PR TITLE
docs(config): mark env_file setting deprecated

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -349,8 +349,6 @@ paranoid = false       # see MISE_PARANOID
 disable_default_registry = false   # disable the default registry, see `MISE_DISABLE_DEFAULT_REGISTRY`
 disable_tools = ['node']           # disable specific tools, generally used to turn off core tools
 
-env_file = '.env' # load env vars from a dotenv file, see `MISE_ENV_FILE`
-
 experimental = true # enable experimental features
 
 # configure messages displayed when entering directories with config files
@@ -359,6 +357,9 @@ status = {
   show_env = false,
   show_tools = false,
 }
+
+[env]
+_.file = '.env'
 
 # "_" is a special key for information you'd like to put into mise.toml that mise will never parse
 [_]
@@ -525,6 +526,8 @@ This is the path which is used as `{{config_root}}` for the global config file.
 :::
 
 ### `MISE_ENV_FILE`
+
+Deprecated. Use `env._.file` in `mise.toml` or `~/.config/mise/config.toml` instead.
 
 Set to a filename to read from env from a dotenv file. e.g.: `MISE_ENV_FILE=.env`.
 Uses [dotenvy](https://crates.io/crates/dotenvy) under the hood.

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -361,8 +361,8 @@ _.file = [
 ]
 ```
 
-You can set [`MISE_ENV_FILE=.env`](/configuration#mise-env-file) to automatically load dotenv files in any
-directory.
+The legacy [`MISE_ENV_FILE=.env`](/configuration#mise-env-file) setting can also load dotenv
+files automatically, but it is deprecated. Use `env._.file` in a config file instead.
 
 See [secrets](/environments/secrets/) for ways to read encrypted files with `env._.file`.
 

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -704,7 +704,8 @@
         },
         "env_file": {
           "description": "Path to a file containing environment variables to automatically load.",
-          "type": "string"
+          "type": "string",
+          "deprecated": true
         },
         "env_shell_expand": {
           "description": "Enable shell-style variable expansion in env values (e.g., $FOO, ${BAR:-default})",

--- a/settings.toml
+++ b/settings.toml
@@ -519,6 +519,9 @@ env = "MISE_ENV_CACHE_TTL"
 type = "Duration"
 
 [env_file]
+deprecated = "Use env._.file instead."
+deprecated_remove_at = "2027.4.0"
+deprecated_warn_at = "2026.4.17"
 description = "Path to a file containing environment variables to automatically load."
 env = "MISE_ENV_FILE"
 optional = true

--- a/settings.toml
+++ b/settings.toml
@@ -520,8 +520,8 @@ type = "Duration"
 
 [env_file]
 deprecated = "Use env._.file instead."
-deprecated_remove_at = "2027.4.0"
-deprecated_warn_at = "2026.4.17"
+deprecated_remove_at = "2027.11.0"
+deprecated_warn_at = "2026.11.0"
 description = "Path to a file containing environment variables to automatically load."
 env = "MISE_ENV_FILE"
 optional = true
@@ -1733,7 +1733,7 @@ env = "MISE_PRERELEASES"
 type = "Bool"
 
 [profile]
-deprecated = "Use MISE_ENV_FILE instead."
+deprecated = "Use env._.file instead."
 description = "Profile to use for mise.${MISE_PROFILE}.toml files."
 env = "MISE_PROFILE"
 hide = true


### PR DESCRIPTION
## Summary
- mark the `env_file` setting metadata as deprecated in `settings.toml` with a future warning/removal window
- regenerate `schema/mise.json` so `settings.env_file` gets the JSON Schema `deprecated` keyword
- update manual docs to point users at top-level `[env]` with `_.file` instead of `MISE_ENV_FILE`
- update the hidden deprecated `profile` setting guidance so it no longer points at `MISE_ENV_FILE`

## Tests
- `mise run render:schema`
- `git diff --check`
- `cargo fmt --check`
- `cargo test --all-features config::settings::tests::test_settings_toml_is_sorted`
- `mise run docs:build`
- `mise run test:e2e config/test_schema_tombi`

*This PR was generated by an AI coding assistant.*