### PR TITLE
fix(erlang): respect compile false for precompiled installs

### DIFF
--- a/e2e/core/test_erlang_precompiled_strict
+++ b/e2e/core/test_erlang_precompiled_strict
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings.erlang]
+compile = false
+EOF
+
+output="$(MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 ImageOS=nobara-43 mise install erlang@28.5 2>&1)" \
+  && fail "expected erlang install to fail when precompiled binaries are unavailable"
+
+[[ $output == *"precompiled erlang is not available: unsupported OS version: nobara-43"* ]] \
+  || fail "expected unsupported OS error, got: $output"
+
+[[ $output != *"build-install"* ]] \
+  || fail "erlang.compile=false should not fall back to kerl build-install: $output"

--- a/e2e/core/test_erlang_precompiled_strict
+++ b/e2e/core/test_erlang_precompiled_strict
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 
+if [[ "$(uname -s)" != "Linux" ]]; then
+	echo "Skipping Linux-specific test on non-Linux OS"
+	exit 0
+fi
+
 cat <<'EOF' >mise.toml
 [settings.erlang]
 compile = false
 EOF
 
-output="$(MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 ImageOS=nobara-43 mise install erlang@28.5 2>&1)" \
-  && fail "expected erlang install to fail when precompiled binaries are unavailable"
+if output="$(MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 ImageOS=nobara-43 mise install erlang@28.5 2>&1)"; then
+	fail "expected erlang install to fail when precompiled binaries are unavailable"
+fi
 
-[[ $output == *"precompiled erlang is not available: unsupported OS version: nobara-43"* ]] \
-  || fail "expected unsupported OS error, got: $output"
+[[ $output == *"precompiled erlang is not available: unsupported OS version: nobara-43"* ]] ||
+	fail "expected unsupported OS error, got: $output"
 
-[[ $output != *"build-install"* ]] \
-  || fail "erlang.compile=false should not fall back to kerl build-install: $output"
+[[ $output != *"build-install"* ]] ||
+	fail "erlang.compile=false should not fall back to kerl build-install: $output"

--- a/e2e/core/test_erlang_precompiled_strict
+++ b/e2e/core/test_erlang_precompiled_strict
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 if [[ "$(uname -s)" != "Linux" ]]; then
-	echo "Skipping Linux-specific test on non-Linux OS"
-	exit 0
+  echo "Skipping Linux-specific test on non-Linux OS"
+  exit 0
 fi
 
 cat <<'EOF' >mise.toml
@@ -11,11 +11,11 @@ compile = false
 EOF
 
 if output="$(MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 ImageOS=nobara-43 mise install erlang@28.5 2>&1)"; then
-	fail "expected erlang install to fail when precompiled binaries are unavailable"
+  fail "expected erlang install to fail when precompiled binaries are unavailable"
 fi
 
 [[ $output == *"precompiled erlang is not available: unsupported OS version: nobara-43"* ]] ||
-	fail "expected unsupported OS error, got: $output"
+  fail "expected unsupported OS error, got: $output"
 
 [[ $output != *"build-install"* ]] ||
-	fail "erlang.compile=false should not fall back to kerl build-install: $output"
+  fail "erlang.compile=false should not fall back to kerl build-install: $output"

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -15,7 +15,7 @@ use crate::lock_file::LockFile;
 use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{file, github, plugins};
 use async_trait::async_trait;
-use eyre::Result;
+use eyre::{Result, bail};
 use xx::regex;
 
 #[cfg(linux)]
@@ -84,6 +84,15 @@ impl ErlangPlugin {
         Ok(())
     }
 
+    fn precompiled_unavailable(&self, reason: impl Into<String>) -> Result<Option<ToolVersion>> {
+        let reason = reason.into();
+        if Settings::get().erlang.compile == Some(false) {
+            bail!("precompiled erlang is not available: {reason}");
+        }
+        debug!("{reason}");
+        Ok(None)
+    }
+
     #[cfg(linux)]
     async fn install_precompiled(
         &self,
@@ -100,8 +109,7 @@ impl ErlangPlugin {
             "x64" => "amd64".to_string(),
             "arm64" => "arm64".to_string(),
             other => {
-                debug!("Unsupported architecture: {}", other);
-                return Ok(None);
+                return self.precompiled_unavailable(format!("unsupported architecture: {other}"));
             }
         };
 
@@ -116,13 +124,12 @@ impl ErlangPlugin {
         } else if let Ok(os_release) = &*os_release::OS_RELEASE {
             os_ver = format!("{}-{}", os_release.id, os_release.version_id);
         } else {
-            return Ok(None);
+            return self.precompiled_unavailable("could not determine OS release");
         };
 
         // Currently, Bob only builds for Ubuntu, so we have to check that we're on ubuntu, and on a supported version
         if !["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04"].contains(&os_ver.as_str()) {
-            debug!("Unsupported OS version: {}", os_ver);
-            return Ok(None);
+            return self.precompiled_unavailable(format!("unsupported OS version: {os_ver}"));
         }
 
         let url: String =
@@ -190,8 +197,8 @@ impl ErlangPlugin {
         let gh_release = match github::get_release("erlef/otp_builds", &release_tag).await {
             Ok(release) => release,
             Err(e) => {
-                debug!("Failed to get release: {}", e);
-                return Ok(None);
+                return self
+                    .precompiled_unavailable(format!("failed to get release {release_tag}: {e}"));
             }
         };
         let settings = Settings::get();
@@ -208,8 +215,9 @@ impl ErlangPlugin {
         let asset = match gh_release.assets.iter().find(|a| a.name == tarball_name) {
             Some(asset) => asset,
             None => {
-                debug!("No asset found for {}", release_tag);
-                return Ok(None);
+                return self.precompiled_unavailable(format!(
+                    "no asset found for {tarball_name} in {release_tag}"
+                ));
             }
         };
         ctx.pr.set_message(format!("Downloading {tarball_name}"));
@@ -246,8 +254,8 @@ impl ErlangPlugin {
         let gh_release = match github::get_release("erlang/otp", &release_tag).await {
             Ok(release) => release,
             Err(e) => {
-                debug!("Failed to get release: {}", e);
-                return Ok(None);
+                return self
+                    .precompiled_unavailable(format!("failed to get release {release_tag}: {e}"));
             }
         };
         let settings = Settings::get();
@@ -259,8 +267,9 @@ impl ErlangPlugin {
         let asset = match gh_release.assets.iter().find(|a| a.name == zip_name) {
             Some(asset) => asset,
             None => {
-                debug!("No asset found for {}", release_tag);
-                return Ok(None);
+                return self.precompiled_unavailable(format!(
+                    "no asset found for {zip_name} in {release_tag}"
+                ));
             }
         };
         ctx.pr.set_message(format!("Downloading {}", zip_name));
@@ -280,10 +289,14 @@ impl ErlangPlugin {
     #[cfg(not(any(linux, macos, windows)))]
     async fn install_precompiled(
         &self,
-        ctx: &InstallContext,
-        tv: ToolVersion,
+        _ctx: &InstallContext,
+        _tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        Ok(None)
+        if Settings::get().erlang.compile == Some(true) {
+            Ok(None)
+        } else {
+            self.precompiled_unavailable("precompiled erlang is not supported on this platform")
+        }
     }
 
     async fn install_via_kerl(


### PR DESCRIPTION
## Summary
- make `core:erlang` treat `erlang.compile=false` as strict precompiled mode instead of falling back to `kerl`
- keep the existing fallback to `kerl` when `erlang.compile` is unset, and keep `compile=true` source-only
- add an e2e regression for an unsupported distro (`ImageOS=nobara-43`) that asserts no `build-install` fallback happens

## Investigation
Discussion #9433 shows `Unsupported OS version: nobara-43`, followed by `kerl build-install`. Python and Node already bail when `compile=false` cannot find a precompiled artifact. Ruby is different and currently documents fallback behavior for `ruby.compile=false`.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `shellcheck e2e/core/test_erlang_precompiled_strict`
- `mise run build`
- `mise run test:e2e e2e/core/test_erlang_precompiled_strict`

Discussion: #9433

This PR description was generated by an AI coding assistant.