### PR TITLE
fix(patrons): point sponsor link to https://en.dev

### DIFF
--- a/docs/cli/patrons.md
+++ b/docs/cli/patrons.md
@@ -10,7 +10,7 @@ Lists the individuals on the Patron tier from &lt;<https://en.dev/patrons.json>>
 The list refreshes daily; supporting terminals will render each patron's
 name as a clickable link via OSC 8 hyperlinks.
 
-To appear here, become a patron at &lt;<https://en.dev/sponsor>>.
+To appear here, become a patron at &lt;<https://en.dev>>.
 
 ## Flags
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1756,7 +1756,7 @@ Lists the individuals on the Patron tier from <https://en.dev/patrons.json>.
 The list refreshes daily; supporting terminals will render each patron's
 name as a clickable link via OSC 8 hyperlinks.
 
-To appear here, become a patron at <https://en.dev/sponsor>.
+To appear here, become a patron at <https://en.dev>.
 .PP
 \fBUsage:\fR mise patrons [OPTIONS]
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -720,7 +720,7 @@ cmd outdated help="Shows outdated tool versions" {
     arg "[TOOL@VERSION]…" help="Tool(s) to show outdated versions for\ne.g.: node@20 python@3.10\nIf not specified, all tools in global and local configs will be shown" required=#false var=#true
 }
 cmd patrons help="Show the individuals supporting mise as Patron-tier members" {
-    long_help "Show the individuals supporting mise as Patron-tier members\n\nLists the individuals on the Patron tier from <https://en.dev/patrons.json>.\nThe list refreshes daily; supporting terminals will render each patron's\nname as a clickable link via OSC 8 hyperlinks.\n\nTo appear here, become a patron at <https://en.dev/sponsor>."
+    long_help "Show the individuals supporting mise as Patron-tier members\n\nLists the individuals on the Patron tier from <https://en.dev/patrons.json>.\nThe list refreshes daily; supporting terminals will render each patron's\nname as a clickable link via OSC 8 hyperlinks.\n\nTo appear here, become a patron at <https://en.dev>."
     after_long_help "Examples:\n\n    $ mise patrons\n    $ mise patrons -J\n    $ mise patrons --refresh"
     flag "-J --json" help="Output in JSON format"
     flag --refresh help="Bypass the local cache and re-fetch"

--- a/src/cli/patrons.rs
+++ b/src/cli/patrons.rs
@@ -13,7 +13,7 @@ use crate::{dirs, duration, file};
 /// The list refreshes daily; supporting terminals will render each patron's
 /// name as a clickable link via OSC 8 hyperlinks.
 ///
-/// To appear here, become a patron at <https://en.dev/sponsor>.
+/// To appear here, become a patron at <https://en.dev>.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Patrons {
@@ -44,7 +44,7 @@ struct Patron {
 }
 
 const PATRONS_URL: &str = "https://en.dev/patrons.json";
-const SPONSOR_URL: &str = "https://en.dev/sponsor";
+const SPONSOR_URL: &str = "https://en.dev";
 const CACHE_TTL: Duration = duration::DAILY;
 
 impl Patrons {


### PR DESCRIPTION
## Summary
- `mise patrons` now links to `https://en.dev` instead of `https://en.dev/sponsor` for the "become a patron" message
- Updates the doc comment, the `SPONSOR_URL` constant, and regenerated `mise.usage.kdl`, `docs/cli/patrons.md`, and `man/man1/mise.1`

## Test plan
- [ ] `mise patrons` prints the new URL in the empty-list and footer branches
- [ ] OSC 8 hyperlink still renders correctly in a supporting terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the patron/sponsor URL used in `mise patrons` output and its generated docs/manpage, with no behavioral changes beyond the displayed link.
> 
> **Overview**
> Updates `mise patrons` to direct users to `https://en.dev` (instead of `https://en.dev/sponsor`) in the “become a patron” hyperlink/message.
> 
> Regenerates the associated help text in `mise.usage.kdl`, `docs/cli/patrons.md`, and the `mise(1)` man page to keep documentation consistent with the new URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208354f5ca9abe44a2aedf58b6908927565d9f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->