### PR TITLE
chore(ci): require clear hyperfine regressions

### DIFF
--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -72,6 +72,20 @@ jobs:
           set -exo pipefail
           failed=false
           outlier_warning="Statistical outliers were detected"
+          threshold_scaled=1100
+
+          scale_decimal() {
+            local number="$1"
+            local whole fraction
+            whole=${number%%.*}
+            fraction=${number#*.}
+            if [ "$fraction" = "$number" ]; then
+              fraction=0
+            fi
+            fraction="${fraction}000"
+            echo $((10#$whole * 1000 + 10#${fraction:0:3}))
+          }
+
           CMDS=(
             "x -- echo"
             "env"
@@ -81,11 +95,9 @@ jobs:
           echo "## Hyperfine Performance" >> comment.md
           for cmd in "${CMDS[@]}"; do
             hyperfine_log="$(mktemp)"
-            if [ -n "${MISE_ALT:-}" ]; then
-              mise x hyperfine -- hyperfine -N -w 10 -r 500 --export-markdown out.md --reference "$MISE_ALT $cmd" "mise $cmd" 2>&1 | tee "$hyperfine_log"
-            else
-              mise x hyperfine -- hyperfine -N -w 10 -r 500 --export-markdown out.md --reference "mise-${{ steps.versions.outputs.release }} $cmd" "mise $cmd" 2>&1 | tee "$hyperfine_log"
-            fi
+            reference_cmd="${MISE_ALT:-mise-${{ steps.versions.outputs.release }}} $cmd"
+            current_cmd="mise $cmd"
+            mise x hyperfine -- hyperfine -N -w 10 -r 500 --export-markdown out.md --reference "$reference_cmd" "$current_cmd" 2>&1 | tee "$hyperfine_log"
             echo "### \`mise $cmd\`" >> comment.md
             cat out.md >> comment.md
             cat out.md
@@ -95,23 +107,35 @@ jobs:
             fi
             
             # Extract relative performance from hyperfine output
-            variance=$(grep "±.*±" out.md | awk '{print $(NF-3)}' | sed 's/%//')
-            whole=${variance%%.*}
-            fraction=${variance#*.}
-            if [ "$fraction" = "$variance" ]; then
-              fraction=0
+            relative_row="$(grep "±.*±" out.md || true)"
+            if [ -z "$relative_row" ]; then
+              echo "::warning title=Missing hyperfine relative result::Could not find a relative result for mise $cmd."
+              echo "⚠️  Inconclusive: could not find a relative result for \`$cmd\`." >> comment.md
+              rm -f "$hyperfine_log"
+              continue
             fi
-            fraction="${fraction}000"
-            variance_scaled=$((10#$whole * 1000 + 10#${fraction:0:3}))
+            variance=$(printf '%s\n' "$relative_row" | awk '{print $(NF-3)}' | sed 's/%//')
+            uncertainty=$(printf '%s\n' "$relative_row" | awk '{print $(NF-1)}' | sed 's/%//')
+            if [ -z "$variance" ] || [ -z "$uncertainty" ]; then
+              echo "::warning title=Malformed hyperfine relative result::Could not parse the relative result for mise $cmd."
+              echo "⚠️  Inconclusive: could not parse the relative result for \`$cmd\`." >> comment.md
+              rm -f "$hyperfine_log"
+              continue
+            fi
+            variance_scaled=$(scale_decimal "$variance")
+            uncertainty_scaled=$(scale_decimal "$uncertainty")
             variance=$(((variance_scaled - 1000) / 10))
             
             # Add warning if variance exceeds 10%
-            if [ "$variance_scaled" -gt 1100 ]; then
-              if grep -q "mise-${{ steps.versions.outputs.release }}.*±.*±" out.md; then
+            if [ "$variance_scaled" -gt "$threshold_scaled" ]; then
+              if printf '%s\n' "$relative_row" | grep -Fq "| \`$reference_cmd\` |"; then
                 echo "✅  Performance improvement for \`$cmd\` is ${variance}%" >> comment.md
               elif [ "$noisy" = true ]; then
                 echo "::warning title=Noisy hyperfine result::mise $cmd measured ${variance}% slower, but hyperfine reported statistical outliers. Treating this benchmark as inconclusive."
                 echo "⚠️  Inconclusive: \`$cmd\` measured ${variance}% slower, but hyperfine reported statistical outliers." >> comment.md
+              elif [ "$((variance_scaled - uncertainty_scaled))" -le "$threshold_scaled" ]; then
+                echo "::warning title=Inconclusive hyperfine result::mise $cmd measured ${variance}% slower, but the relative uncertainty overlaps the 10% threshold. Treating this benchmark as inconclusive."
+                echo "⚠️  Inconclusive: \`$cmd\` measured ${variance}% slower, but the relative uncertainty overlaps the 10% threshold." >> comment.md
               else
                 echo "⚠️  Warning: Performance variance for \`$cmd\` is ${variance}%" >> comment.md
                 failed=true


### PR DESCRIPTION
## Summary
- keep the hyperfine workflow on the Namespace runner, but stop failing on measurements whose relative uncertainty still overlaps the 10% regression threshold
- continue failing clear regressions, and continue reporting outlier/noisy results in the PR comment and annotations
- parse the hyperfine reference/current commands once so custom `MISE_ALT` comparisons use the same improvement detection path

## Investigation
The hyperfine workflow became much noisier after the Namespace runner migration in #9561 on 2026-05-03 15:44 UTC.

Completed, non-cancelled/action-required runs from 2026-04-25 through 2026-05-14:
- before #9561: 10 failures / 320 runs = 3.1%
- after #9561, before #9635: 22 failures / 137 runs = 16.1%
- after #9635, before #9629: 2 failures / 38 runs = 5.3%
- after #9629: 69 failures / 484 runs = 14.3%

Failed-log classification over the same window:
- 80 perf-gate failures
- 20 build/code failures
- 2 runner SIGKILL failures
- 1 follow-on comment failure after an earlier failure

After #9847, there were still 3 perf-gate failures in 27 completed runs. The current representative failure is not a deterministic benchmark regression: run 25871537929 failed on `mise ls` with `1.16 ± 0.17`, so the measured range overlaps the 10% threshold. Run 25871443106 similarly failed on a 13% `mise ls` result without a hyperfine outlier warning. This PR keeps real regressions failing, but treats these statistically unclear cases as inconclusive instead of red CI.

## Validation
- `sed -n '72,148p' .github/workflows/hyperfine.yml | sed 's/^          //' | sed 's/${{ steps\.versions\.outputs\.release }}/2026.5.7/g' | bash -n`
- `mise x actionlint -- actionlint .github/workflows/hyperfine.yml`
- `git diff --check --cached`

*This PR was generated by an AI coding assistant.*
