### PR TITLE
fix(plugins): support remote git subdirectory sources

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ mod plugins;
 mod rand;
 mod redactions;
 mod registry;
+mod remote_source;
 pub(crate) mod result;
 mod runtime_symlinks;
 mod sandbox;

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -1,9 +1,11 @@
 use crate::config::{Config, Settings};
 use crate::errors::Error::PluginNotInstalled;
 use crate::file::{display_path, remove_all_with_progress};
-use crate::git::{CloneOptions, Git};
+use crate::git::Git;
 use crate::http::HTTP;
-use crate::plugins::{Plugin, PluginSource, PluginType, Script, ScriptManager};
+use crate::plugins::{
+    Plugin, PluginSource, PluginType, Script, ScriptManager, install_git_plugin_source,
+};
 use crate::result::Result;
 use crate::timeout::run_with_timeout;
 use crate::toolset::install_state;
@@ -365,6 +367,7 @@ impl Plugin for AsdfPlugin {
             PluginSource::Git {
                 url: repo_url,
                 git_ref,
+                subdir,
             } => {
                 if regex!(r"^[/~]").is_match(&repo_url) {
                     Err(eyre!(
@@ -373,13 +376,14 @@ If you are trying to link to a local directory, use `mise plugins link` instead.
 Plugins could support local directories in the future but for now a symlink is required which `mise plugins link` will create for you."#
                     ))?;
                 }
-                let git = Git::new(&self.plugin_path);
-                pr.set_message(format!("clone {repo_url}"));
-                git.clone(&repo_url, CloneOptions::default().pr(pr))?;
-                if let Some(ref_) = &git_ref {
-                    pr.set_message(format!("check out {ref_}"));
-                    git.update(Some(ref_.to_string()))?;
-                }
+                let git = install_git_plugin_source(
+                    &self.name,
+                    &self.plugin_path,
+                    &repo_url,
+                    git_ref.as_deref(),
+                    subdir.as_deref(),
+                    pr,
+                )?;
                 self.exec_hook(pr, "post-plugin-add")?;
 
                 let sha = git.current_sha_short()?;

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -1,10 +1,11 @@
 use crate::config::{Config, Settings};
 use crate::errors::Error::PluginNotInstalled;
-use crate::file::{display_path, remove_all_with_progress};
+use crate::file::display_path;
 use crate::git::Git;
 use crate::http::HTTP;
 use crate::plugins::{
     Plugin, PluginSource, PluginType, Script, ScriptManager, install_git_plugin_source,
+    managed_git_plugin_repo_path, remove_git_plugin_source,
 };
 use crate::result::Result;
 use crate::timeout::run_with_timeout;
@@ -309,14 +310,19 @@ impl Plugin for AsdfPlugin {
 
     async fn update(&self, pr: &dyn SingleReport, gitref: Option<String>) -> Result<()> {
         let plugin_path = self.plugin_path.to_path_buf();
-        if plugin_path.is_symlink() {
-            warn!(
-                "plugin:{} is a symlink, not updating",
-                style(&self.name).blue().for_stderr()
-            );
-            return Ok(());
-        }
-        let git = Git::new(plugin_path);
+        let git_path =
+            if let Some(repo_path) = managed_git_plugin_repo_path(&self.name, &plugin_path)? {
+                repo_path
+            } else if plugin_path.is_symlink() {
+                warn!(
+                    "plugin:{} is a symlink, not updating",
+                    style(&self.name).blue().for_stderr()
+                );
+                return Ok(());
+            } else {
+                plugin_path
+            };
+        let git = Git::new(git_path);
         if !git.is_repo() {
             warn!(
                 "plugin:{} is not a git repository, not updating",
@@ -343,7 +349,7 @@ impl Plugin for AsdfPlugin {
         self.exec_hook(pr, "pre-plugin-remove")?;
         pr.set_message("uninstall".into());
 
-        remove_all_with_progress(&self.plugin_path, pr)?;
+        remove_git_plugin_source(&self.name, &self.plugin_path, pr)?;
 
         Ok(())
     }

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -211,7 +211,14 @@ impl RubyPlugin {
                     git.update(Some(ref_.to_string()))?;
                 }
                 if let Some(subdir) = subdir {
-                    return Ok(tmp.join(subdir));
+                    let subdir_path = tmp.join(subdir);
+                    if !subdir_path.is_dir() {
+                        return Err(eyre!(
+                            "plugin subdirectory does not exist: {}",
+                            file::display_path(&subdir_path)
+                        ));
+                    }
+                    return Ok(subdir_path);
                 }
             }
         }

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -198,7 +198,8 @@ impl RubyPlugin {
             }
             PluginSource::Git {
                 url: repo_url,
-                git_ref: _,
+                git_ref,
+                subdir,
             } => {
                 let git = Git::new(tmp.clone());
                 let mut clone_options = CloneOptions::default();
@@ -206,6 +207,12 @@ impl RubyPlugin {
                     clone_options = clone_options.pr(pr);
                 }
                 git.clone(&repo_url, clone_options)?;
+                if let Some(ref_) = &git_ref {
+                    git.update(Some(ref_.to_string()))?;
+                }
+                if let Some(subdir) = subdir {
+                    return Ok(tmp.join(subdir));
+                }
             }
         }
         Ok(tmp)

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -15,6 +15,7 @@ use eyre::{Result, eyre};
 use heck::ToKebabCase;
 use regex::Regex;
 pub use script_manager::{Script, ScriptManager};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock as Lazy;
 use std::vec;
@@ -381,6 +382,13 @@ pub enum PluginSource {
 
 impl PluginSource {
     pub fn parse(repository: &str) -> Self {
+        if let Some(source) = RemoteSource::parse_git(repository) {
+            return PluginSource::Git {
+                url: source.url,
+                git_ref: source.git_ref,
+                subdir: Some(source.path),
+            };
+        }
         // Split Parameters
         let url_path = repository
             .split('?')
@@ -395,13 +403,6 @@ impl PluginSource {
                 url: repository.to_string(),
             };
         }
-        if let Some(source) = RemoteSource::parse_git(repository) {
-            return PluginSource::Git {
-                url: source.url,
-                git_ref: source.git_ref,
-                subdir: Some(source.path),
-            };
-        }
         // Otherwise treat as git repository
         let (url, git_ref) = Git::split_url_and_ref(repository);
         PluginSource::Git {
@@ -410,6 +411,46 @@ impl PluginSource {
             subdir: None,
         }
     }
+}
+
+pub fn git_plugin_repo_path(plugin_name: &str) -> PathBuf {
+    dirs::DATA
+        .join("plugin-repos")
+        .join(plugin_name.to_kebab_case())
+}
+
+pub fn managed_git_plugin_repo_path(
+    plugin_name: &str,
+    plugin_path: &Path,
+) -> Result<Option<PathBuf>> {
+    if !plugin_path.is_symlink() {
+        return Ok(None);
+    }
+
+    let target = fs::read_link(plugin_path)?;
+    let target = if target.is_absolute() {
+        target
+    } else {
+        plugin_path
+            .parent()
+            .unwrap_or_else(|| Path::new(""))
+            .join(target)
+    };
+    let repo_path = git_plugin_repo_path(plugin_name);
+    Ok(target.starts_with(&repo_path).then_some(repo_path))
+}
+
+pub fn remove_git_plugin_source(
+    plugin_name: &str,
+    plugin_path: &Path,
+    pr: &dyn SingleReport,
+) -> Result<()> {
+    let repo_path = managed_git_plugin_repo_path(plugin_name, plugin_path)?;
+    file::remove_all_with_progress(plugin_path, pr)?;
+    if let Some(repo_path) = repo_path {
+        file::remove_all_with_progress(repo_path, pr)?;
+    }
+    Ok(())
 }
 
 pub fn install_git_plugin_source(
@@ -421,9 +462,7 @@ pub fn install_git_plugin_source(
     pr: &dyn SingleReport,
 ) -> Result<Git> {
     if let Some(subdir) = subdir {
-        let repo_path = dirs::DATA
-            .join("plugin-repos")
-            .join(plugin_name.to_kebab_case());
+        let repo_path = git_plugin_repo_path(plugin_name);
         file::remove_all_with_progress(plugin_path, pr)?;
         file::remove_all_with_progress(&repo_path, pr)?;
 
@@ -522,6 +561,25 @@ mod tests {
                 );
             }
             _ => panic!("Expected a Zip source"),
+        }
+    }
+
+    #[test]
+    fn test_plugin_source_parse_remote_git_zip_subdir() {
+        let source = PluginSource::parse(
+            "git::https://github.com/user/plugin.git//plugins/my-plugin.zip?ref=main",
+        );
+        match source {
+            PluginSource::Git {
+                url,
+                git_ref,
+                subdir,
+            } => {
+                assert_eq!(url, "https://github.com/user/plugin.git");
+                assert_eq!(git_ref, Some("main".to_string()));
+                assert_eq!(subdir, Some("plugins/my-plugin.zip".to_string()));
+            }
+            _ => panic!("Expected a git plugin"),
         }
     }
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,8 +1,10 @@
 use crate::errors::Error::PluginNotInstalled;
-use crate::git::Git;
+use crate::file;
+use crate::git::{CloneOptions, Git};
 use crate::plugins::asdf_plugin::AsdfPlugin;
 use crate::plugins::vfox_plugin::VfoxPlugin;
 use crate::registry::REGISTRY;
+use crate::remote_source::RemoteSource;
 use crate::toolset::install_state;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
@@ -371,6 +373,7 @@ pub enum PluginSource {
     Git {
         url: String,
         git_ref: Option<String>,
+        subdir: Option<String>,
     },
     /// Zip file accessible via HTTPS
     Zip { url: String },
@@ -392,12 +395,65 @@ impl PluginSource {
                 url: repository.to_string(),
             };
         }
+        if let Some(source) = RemoteSource::parse_git(repository) {
+            return PluginSource::Git {
+                url: source.url,
+                git_ref: source.git_ref,
+                subdir: Some(source.path),
+            };
+        }
         // Otherwise treat as git repository
         let (url, git_ref) = Git::split_url_and_ref(repository);
         PluginSource::Git {
             url: url.to_string(),
             git_ref: git_ref.map(|s| s.to_string()),
+            subdir: None,
         }
+    }
+}
+
+pub fn install_git_plugin_source(
+    plugin_name: &str,
+    plugin_path: &Path,
+    repo_url: &str,
+    git_ref: Option<&str>,
+    subdir: Option<&str>,
+    pr: &dyn SingleReport,
+) -> Result<Git> {
+    if let Some(subdir) = subdir {
+        let repo_path = dirs::DATA
+            .join("plugin-repos")
+            .join(plugin_name.to_kebab_case());
+        file::remove_all_with_progress(plugin_path, pr)?;
+        file::remove_all_with_progress(&repo_path, pr)?;
+
+        let git = Git::new(&repo_path);
+        pr.set_message(format!("clone {repo_url}"));
+        git.clone(repo_url, CloneOptions::default().pr(pr))?;
+        if let Some(ref_) = git_ref {
+            pr.set_message(format!("check out {ref_}"));
+            git.update(Some(ref_.to_string()))?;
+        }
+
+        let subdir_path = repo_path.join(subdir);
+        if !subdir_path.is_dir() {
+            return Err(eyre!(
+                "plugin subdirectory does not exist: {}",
+                file::display_path(&subdir_path)
+            ));
+        }
+        pr.set_message(format!("link {}", file::display_path(plugin_path)));
+        file::make_symlink(&subdir_path, plugin_path)?;
+        Ok(Git::new(plugin_path))
+    } else {
+        let git = Git::new(plugin_path);
+        pr.set_message(format!("clone {repo_url}"));
+        git.clone(repo_url, CloneOptions::default().pr(pr))?;
+        if let Some(ref_) = git_ref {
+            pr.set_message(format!("check out {ref_}"));
+            git.update(Some(ref_.to_string()))?;
+        }
+        Ok(git)
     }
 }
 
@@ -410,9 +466,14 @@ mod tests {
         // Test parsing Git URL
         let source = PluginSource::parse("https://github.com/user/plugin.git");
         match source {
-            PluginSource::Git { url, git_ref } => {
+            PluginSource::Git {
+                url,
+                git_ref,
+                subdir,
+            } => {
                 assert_eq!(url, "https://github.com/user/plugin.git");
                 assert_eq!(git_ref, None);
+                assert_eq!(subdir, None);
             }
             _ => panic!("Expected a git plugin"),
         }
@@ -423,9 +484,14 @@ mod tests {
         // Test parsing Git URL with refs
         let source = PluginSource::parse("https://github.com/user/plugin.git#v1.0.0");
         match source {
-            PluginSource::Git { url, git_ref } => {
+            PluginSource::Git {
+                url,
+                git_ref,
+                subdir,
+            } => {
                 assert_eq!(url, "https://github.com/user/plugin.git");
                 assert_eq!(git_ref, Some("v1.0.0".to_string()));
+                assert_eq!(subdir, None);
             }
             _ => panic!("Expected a git plugin"),
         }
@@ -465,6 +531,44 @@ mod tests {
         let source = PluginSource::parse("https://example.com/.zip/plugin");
         match source {
             PluginSource::Git { .. } => {}
+            _ => panic!("Expected a git plugin"),
+        }
+    }
+
+    #[test]
+    fn test_plugin_source_parse_remote_git_https() {
+        let source = PluginSource::parse(
+            "git::https://github.com/org/repo.git//dev/plugins/tool?ref=feature/test",
+        );
+        match source {
+            PluginSource::Git {
+                url,
+                git_ref,
+                subdir,
+            } => {
+                assert_eq!(url, "https://github.com/org/repo.git");
+                assert_eq!(git_ref, Some("feature/test".to_string()));
+                assert_eq!(subdir, Some("dev/plugins/tool".to_string()));
+            }
+            _ => panic!("Expected a git plugin"),
+        }
+    }
+
+    #[test]
+    fn test_plugin_source_parse_remote_git_ssh() {
+        let source = PluginSource::parse(
+            "git::ssh://git@git.acme.com:1222/org/repo.git//plugins/tool?ref=main",
+        );
+        match source {
+            PluginSource::Git {
+                url,
+                git_ref,
+                subdir,
+            } => {
+                assert_eq!(url, "ssh://git@git.acme.com:1222/org/repo.git");
+                assert_eq!(git_ref, Some("main".to_string()));
+                assert_eq!(subdir, Some("plugins/tool".to_string()));
+            }
             _ => panic!("Expected a git plugin"),
         }
     }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -476,6 +476,7 @@ pub fn install_git_plugin_source(
 
         let subdir_path = repo_path.join(subdir);
         if !subdir_path.is_dir() {
+            let _ = file::remove_all(&repo_path);
             return Err(eyre!(
                 "plugin subdirectory does not exist: {}",
                 file::display_path(&subdir_path)

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -1,10 +1,12 @@
 use crate::config::{Config, Settings};
 use crate::errors::Error::PluginNotInstalled;
-use crate::file::remove_all_with_progress;
 use crate::git::Git;
 use crate::http::HTTP;
 use crate::plugins::warn_if_env_plugin_shadows_registry;
-use crate::plugins::{Plugin, PluginSource, PluginType, install_git_plugin_source};
+use crate::plugins::{
+    Plugin, PluginSource, PluginType, install_git_plugin_source, managed_git_plugin_repo_path,
+    remove_git_plugin_source,
+};
 use crate::result::Result;
 use crate::toolset::install_state;
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -300,14 +302,19 @@ impl Plugin for VfoxPlugin {
         }
 
         let plugin_path = self.plugin_path.to_path_buf();
-        if plugin_path.is_symlink() {
-            warn!(
-                "plugin:{} is a symlink, not updating",
-                style(&self.name).blue().for_stderr()
-            );
-            return Ok(());
-        }
-        let git = Git::new(plugin_path);
+        let git_path =
+            if let Some(repo_path) = managed_git_plugin_repo_path(&self.name, &plugin_path)? {
+                repo_path
+            } else if plugin_path.is_symlink() {
+                warn!(
+                    "plugin:{} is a symlink, not updating",
+                    style(&self.name).blue().for_stderr()
+                );
+                return Ok(());
+            } else {
+                plugin_path
+            };
+        let git = Git::new(git_path);
         if !git.is_repo() {
             warn!(
                 "plugin:{} is not a git repository, not updating",
@@ -341,7 +348,7 @@ impl Plugin for VfoxPlugin {
         }
         pr.set_message("uninstall".into());
 
-        remove_all_with_progress(&self.plugin_path, pr)?;
+        remove_git_plugin_source(&self.name, &self.plugin_path, pr)?;
 
         Ok(())
     }

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -1,10 +1,10 @@
 use crate::config::{Config, Settings};
 use crate::errors::Error::PluginNotInstalled;
 use crate::file::remove_all_with_progress;
-use crate::git::{CloneOptions, Git};
+use crate::git::Git;
 use crate::http::HTTP;
 use crate::plugins::warn_if_env_plugin_shadows_registry;
-use crate::plugins::{Plugin, PluginSource, PluginType};
+use crate::plugins::{Plugin, PluginSource, PluginType, install_git_plugin_source};
 use crate::result::Result;
 use crate::toolset::install_state;
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -62,15 +62,15 @@ impl VfoxPlugin {
         self.repo.lock().unwrap()
     }
 
-    fn get_repo_url(&self, config: &Config) -> eyre::Result<Url> {
+    fn get_repo_url(&self, config: &Config) -> eyre::Result<String> {
         if let Some(url) = self.repo_url.lock().unwrap().clone() {
-            return Ok(Url::parse(&url)?);
+            return Ok(url);
         }
         if let Some(url) = self.repo().get_remote_url() {
-            return Ok(Url::parse(&url)?);
+            return Ok(url);
         }
         if let Some(url) = config.get_repo_url(&self.name) {
-            return Ok(Url::parse(&url)?);
+            return Ok(url);
         }
         let url = self
             .full
@@ -79,7 +79,7 @@ impl VfoxPlugin {
             .split_once(':')
             .map(|f| f.1)
             .unwrap_or(&self.name);
-        vfox_to_url(url)
+        Ok(vfox_to_url(url)?.to_string())
     }
 
     pub async fn mise_env(
@@ -364,6 +364,7 @@ impl Plugin for VfoxPlugin {
             PluginSource::Git {
                 url: repo_url,
                 git_ref,
+                subdir,
             } => {
                 if regex!(r"^[/~]").is_match(&repo_url) {
                     Err(eyre!(
@@ -372,13 +373,14 @@ If you are trying to link to a local directory, use `mise plugins link` instead.
 Plugins could support local directories in the future but for now a symlink is required which `mise plugins link` will create for you."#
                     ))?;
                 }
-                let git = Git::new(&self.plugin_path);
-                pr.set_message(format!("clone {repo_url}"));
-                git.clone(&repo_url, CloneOptions::default().pr(pr))?;
-                if let Some(ref_) = &git_ref {
-                    pr.set_message(format!("git update {ref_}"));
-                    git.update(Some(ref_.to_string()))?;
-                }
+                let git = install_git_plugin_source(
+                    &self.name,
+                    &self.plugin_path,
+                    &repo_url,
+                    git_ref.as_deref(),
+                    subdir.as_deref(),
+                    pr,
+                )?;
 
                 let sha = git.current_sha_short()?;
                 pr.finish_with_message(format!(

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::sync::LazyLock as Lazy;
 
 static SSH_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?]+))?$").unwrap()
+    Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)?(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?]+))?$").unwrap()
 });
 
 static HTTPS_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
@@ -41,9 +41,16 @@ impl RemoteSource {
 
 fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
     let captures = regex.captures(file)?;
+    let path = captures.name("path").unwrap().as_str();
+    if path
+        .split('/')
+        .any(|component| component.is_empty() || component == "." || component == "..")
+    {
+        return None;
+    }
     Some(RemoteGitSource {
         url: captures.name("url").unwrap().as_str().to_string(),
-        path: captures.name("path").unwrap().as_str().to_string(),
+        path: path.to_string(),
         git_ref: captures.name("ref").map(|m| m.as_str().to_string()),
     })
 }
@@ -64,6 +71,16 @@ mod tests {
     }
 
     #[test]
+    fn parses_git_ssh_sources_without_user() {
+        let source =
+            RemoteSource::parse_git("git::ssh://github.com/myorg/example.git//terraform/myfile")
+                .unwrap();
+        assert_eq!(source.url, "ssh://github.com/myorg/example.git");
+        assert_eq!(source.path, "terraform/myfile");
+        assert_eq!(source.git_ref, None);
+    }
+
+    #[test]
     fn parses_git_https_sources() {
         let source = RemoteSource::parse_git(
             "git::https://git.acme.com:8080/myorg/example.git//terraform/myfile?ref=master",
@@ -80,6 +97,25 @@ mod tests {
             RemoteSource::parse_git("git::https://myserver.com/example.git?ref=master").is_none()
         );
         assert!(RemoteSource::parse_git("git::ssh://user@myserver.com/example.git").is_none());
+    }
+
+    #[test]
+    fn rejects_git_sources_with_unsafe_paths() {
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//../plugin").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//plugin/../other")
+                .is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//plugin//other")
+                .is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git//plugin/./other")
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -2,11 +2,11 @@ use regex::Regex;
 use std::sync::LazyLock as Lazy;
 
 static SSH_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)?(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?]+))?$").unwrap()
+    Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)?(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
 });
 
 static HTTPS_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^git::(?P<url>https?://(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?]+))?$").unwrap()
+    Regex::new(r"^git::(?P<url>https?://(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
 });
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,7 +25,15 @@ pub struct RemoteSource;
 
 impl RemoteSource {
     pub fn parse_git(file: &str) -> Option<RemoteGitSource> {
-        parse_git_with(&SSH_GIT_REGEX, file).or_else(|| parse_git_with(&HTTPS_GIT_REGEX, file))
+        Self::parse_git_ssh(file).or_else(|| Self::parse_git_https(file))
+    }
+
+    pub(crate) fn parse_git_ssh(file: &str) -> Option<RemoteGitSource> {
+        parse_git_with(&SSH_GIT_REGEX, file)
+    }
+
+    pub(crate) fn parse_git_https(file: &str) -> Option<RemoteGitSource> {
+        parse_git_with(&HTTPS_GIT_REGEX, file)
     }
 
     pub fn parse_http(file: &str) -> Option<RemoteHttpSource> {
@@ -88,6 +96,15 @@ mod tests {
         .unwrap();
         assert_eq!(source.url, "https://git.acme.com:8080/myorg/example.git");
         assert_eq!(source.path, "terraform/myfile");
+        assert_eq!(source.git_ref, Some("master".to_string()));
+    }
+
+    #[test]
+    fn parses_git_ref_before_additional_query_params() {
+        let source = RemoteSource::parse_git(
+            "git::https://git.acme.com/myorg/example.git//terraform/myfile?ref=master&depth=1",
+        )
+        .unwrap();
         assert_eq!(source.git_ref, Some("master".to_string()));
     }
 

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -1,0 +1,96 @@
+use regex::Regex;
+use std::sync::LazyLock as Lazy;
+
+static SSH_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?]+))?$").unwrap()
+});
+
+static HTTPS_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^git::(?P<url>https?://(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?]+))?$").unwrap()
+});
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteGitSource {
+    pub url: String,
+    pub path: String,
+    pub git_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteHttpSource {
+    pub url: String,
+}
+
+pub struct RemoteSource;
+
+impl RemoteSource {
+    pub fn parse_git(file: &str) -> Option<RemoteGitSource> {
+        parse_git_with(&SSH_GIT_REGEX, file).or_else(|| parse_git_with(&HTTPS_GIT_REGEX, file))
+    }
+
+    pub fn parse_http(file: &str) -> Option<RemoteHttpSource> {
+        let url = url::Url::parse(file).ok()?;
+        ((url.scheme() == "http" || url.scheme() == "https")
+            && url.path().len() > 1
+            && !url.path().ends_with('/'))
+        .then(|| RemoteHttpSource {
+            url: file.to_string(),
+        })
+    }
+}
+
+fn parse_git_with(regex: &Regex, file: &str) -> Option<RemoteGitSource> {
+    let captures = regex.captures(file)?;
+    Some(RemoteGitSource {
+        url: captures.name("url").unwrap().as_str().to_string(),
+        path: captures.name("path").unwrap().as_str().to_string(),
+        git_ref: captures.name("ref").map(|m| m.as_str().to_string()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_git_ssh_sources() {
+        let source = RemoteSource::parse_git(
+            "git::ssh://git@github.com/myorg/example.git//terraform/myfile?ref=master",
+        )
+        .unwrap();
+        assert_eq!(source.url, "ssh://git@github.com/myorg/example.git");
+        assert_eq!(source.path, "terraform/myfile");
+        assert_eq!(source.git_ref, Some("master".to_string()));
+    }
+
+    #[test]
+    fn parses_git_https_sources() {
+        let source = RemoteSource::parse_git(
+            "git::https://git.acme.com:8080/myorg/example.git//terraform/myfile?ref=master",
+        )
+        .unwrap();
+        assert_eq!(source.url, "https://git.acme.com:8080/myorg/example.git");
+        assert_eq!(source.path, "terraform/myfile");
+        assert_eq!(source.git_ref, Some("master".to_string()));
+    }
+
+    #[test]
+    fn rejects_git_sources_without_paths() {
+        assert!(
+            RemoteSource::parse_git("git::https://myserver.com/example.git?ref=master").is_none()
+        );
+        assert!(RemoteSource::parse_git("git::ssh://user@myserver.com/example.git").is_none());
+    }
+
+    #[test]
+    fn parses_http_sources() {
+        assert!(RemoteSource::parse_http("http://myhost.com/test.txt").is_some());
+        assert!(RemoteSource::parse_http("https://myhost.com/test.txt?query=1").is_some());
+    }
+
+    #[test]
+    fn rejects_http_directories() {
+        assert!(RemoteSource::parse_http("https://myhost.com/js/").is_none());
+        assert!(RemoteSource::parse_http("https://myhost.com").is_none());
+    }
+}

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -78,21 +78,19 @@ impl RemoteTaskGit {
     }
 
     fn get_repo_structure(&self, file: &str) -> GitRepoStructure {
-        if let Some(repo) = Self::parse_ssh(file) {
-            return repo;
-        }
-        Self::parse_https(file).unwrap()
+        RemoteSource::parse_git(file)
+            .map(|source| source.into())
+            .unwrap()
     }
 
+    #[cfg(test)]
     fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
-        let source = RemoteSource::parse_git(file)?;
-        source.url.starts_with("ssh://").then(|| source.into())
+        RemoteSource::parse_git_ssh(file).map(|source| source.into())
     }
 
+    #[cfg(test)]
     fn parse_https(file: &str) -> Option<GitRepoStructure> {
-        let source = RemoteSource::parse_git(file)?;
-        (source.url.starts_with("http://") || source.url.starts_with("https://"))
-            .then(|| source.into())
+        RemoteSource::parse_git_https(file).map(|source| source.into())
     }
 }
 

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -189,6 +189,7 @@ mod tests {
             "git::ssh://git@git.acme.com:1222/myorg/example.git//terraform/myfile?ref=master",
             "git::ssh://git@myserver.com/example.git//terraform/myfile",
             "git::ssh://user@myserver.com/example.git//myfile?ref=master",
+            "git::ssh://myserver.com/example.git//myfile?ref=master",
         ];
 
         for url in test_cases {
@@ -203,7 +204,6 @@ mod tests {
     #[test]
     fn test_invalid_parse_ssh() {
         let test_cases = vec![
-            "git::ssh://myserver.com/example.git//myfile?ref=master",
             "git::ssh://user@myserver.com/example.git?ref=master",
             "git::ssh://user@myserver.com/example.git",
             "git::https://github.com/myorg/example.git//myfile?ref=v1.0.0",

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -1,7 +1,5 @@
 use crate::Result;
-use regex::Regex;
 use std::path::PathBuf;
-use std::sync::LazyLock as Lazy;
 
 use async_trait::async_trait;
 
@@ -11,17 +9,10 @@ use crate::{
     git::{self, CloneOptions},
     hash,
     lock_file::LockFile,
+    remote_source::{RemoteGitSource, RemoteSource},
 };
 
 use super::TaskFileProvider;
-
-static SSH_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<branch>[^?]+))?$").unwrap()
-});
-
-static HTTPS_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^git::(?P<url>https?://(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<branch>[^?]+))?$").unwrap()
-});
 
 #[derive(Debug)]
 pub struct RemoteTaskGitBuilder {
@@ -94,26 +85,27 @@ impl RemoteTaskGit {
     }
 
     fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
-        let captures = SSH_REGEX.captures(file)?;
-        let url_without_path = captures.name("url").unwrap().as_str();
-        let path = captures.name("path").unwrap().as_str();
-        let branch = captures.name("branch").map(|m| m.as_str().to_string());
-        Some(GitRepoStructure::new(url_without_path, path, branch))
+        let source = RemoteSource::parse_git(file)?;
+        source.url.starts_with("ssh://").then(|| source.into())
     }
 
     fn parse_https(file: &str) -> Option<GitRepoStructure> {
-        let captures = HTTPS_REGEX.captures(file)?;
-        let url_without_path = captures.name("url").unwrap().as_str();
-        let path = captures.name("path").unwrap().as_str();
-        let branch = captures.name("branch").map(|m| m.as_str().to_string());
-        Some(GitRepoStructure::new(url_without_path, path, branch))
+        let source = RemoteSource::parse_git(file)?;
+        (source.url.starts_with("http://") || source.url.starts_with("https://"))
+            .then(|| source.into())
+    }
+}
+
+impl From<RemoteGitSource> for GitRepoStructure {
+    fn from(source: RemoteGitSource) -> Self {
+        GitRepoStructure::new(&source.url, &source.path, source.git_ref)
     }
 }
 
 #[async_trait]
 impl TaskFileProvider for RemoteTaskGit {
     fn is_match(&self, file: &str) -> bool {
-        SSH_REGEX.is_match(file) || HTTPS_REGEX.is_match(file)
+        RemoteSource::parse_git(file).is_some()
     }
 
     async fn get_local_path(&self, file: &str) -> Result<PathBuf> {

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 
-use crate::{Result, dirs, env, file, hash, http::HTTP};
+use crate::{Result, dirs, env, file, hash, http::HTTP, remote_source::RemoteSource};
 
 use super::TaskFileProvider;
 
@@ -58,16 +58,7 @@ impl RemoteTaskHttp {
 #[async_trait]
 impl TaskFileProvider for RemoteTaskHttp {
     fn is_match(&self, file: &str) -> bool {
-        let url = url::Url::parse(file);
-
-        // Check if the URL is valid and the scheme is http or https
-        // and the path is not empty
-        // and the path is not a directory
-        url.is_ok_and(|url| {
-            (url.scheme() == "http" || url.scheme() == "https")
-                && url.path().len() > 1
-                && !url.path().ends_with('/')
-        })
+        RemoteSource::parse_http(file).is_some()
     }
 
     async fn get_local_path(&self, file: &str) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
- add shared remote source parsing for git:: and HTTP task-style sources
- reuse the parser from remote task Git/HTTP providers
- support plugin installs from git::...git//subdir?ref=... by cloning the repo and linking the plugin directory

## Details
This fixes plugin config values like git::https://host/repo.git//path/to/plugin?ref=branch, which previously fell through as a plain Git URL and did not register the plugin root correctly. The shared parser keeps plugin and remote task source handling aligned.

## Validation
- cargo fmt --check
- cargo test -q remote_source
- cargo test -q test_plugin_source_parse
- cargo test -q task_file_providers
- cargo check -q
- pre-commit hk suite during commit

Related discussion: https://github.com/jdx/mise/discussions/9869

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes plugin install/update/uninstall flows to clone repositories into a managed cache and symlink a subdirectory, which can impact filesystem layout and git update behavior if paths/ref parsing is wrong.
> 
> **Overview**
> Adds shared `RemoteSource` parsing for `git::...//path?ref=...` and HTTP URLs, and reuses it across task file providers to keep matching/parsing consistent.
> 
> Extends `PluginSource::Git` with an optional `subdir` and updates plugin installers (asdf/vfox, plus ruby tool fetch) to support cloning a repo and linking the plugin root to a subdirectory; plugin update/uninstall now detect and clean up these managed repo-backed symlinks under `data/plugin-repos/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342eb1ee52f113d8b1fa68c80582e35662b5f75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->