### PR TITLE
fix(use): ignore system config for global shadow warning

### DIFF
--- a/e2e/cli/test_use_global_system_config_warning
+++ b/e2e/cli/test_use_global_system_config_warning
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+cat >"$MISE_SYSTEM_DIR/config.toml" <<EOF
+[tools]
+tiny = "1.0.0"
+EOF
+
+assert_not_contains "mise use -g tiny@1.0.0 --dry-run 2>&1" "overrides the global config"
+
+cat >mise.toml <<EOF
+[tools]
+tiny = "2.0.0"
+EOF
+
+assert_contains "mise use -g tiny@1.0.0 --dry-run 2>&1" "overrides the global config"

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -277,6 +277,7 @@ impl Use {
             if let Some(tv) = ts.versions.get(targ.ba.as_ref())
                 && let ToolSource::MiseToml(p) | ToolSource::ToolVersions(p) = &tv.source
                 && !file::same_file(p, global)
+                && !config::is_system_config(p)
             {
                 warn(targ, p);
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1262,7 +1262,7 @@ pub async fn load_config_hierarchy_from_dir(
 }
 
 pub fn is_global_config(path: &Path) -> bool {
-    global_config_files().contains(path) || system_config_files().contains(path)
+    global_config_files().contains(path) || is_system_config(path)
 }
 
 pub fn is_system_config(path: &Path) -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1265,6 +1265,10 @@ pub fn is_global_config(path: &Path) -> bool {
     global_config_files().contains(path) || system_config_files().contains(path)
 }
 
+pub fn is_system_config(path: &Path) -> bool {
+    system_config_files().contains(path)
+}
+
 /// Returns true if the path should be filtered out due to MISE_CONFIG_DIR override.
 /// When MISE_CONFIG_DIR is set to a non-default location, this filters out configs
 /// found under the default location (~/.config/mise) during traversal.


### PR DESCRIPTION
## Summary
- skip the `mise use -g` shadow warning when the active version comes from system config
- keep warning for local project config that actually overrides the global config target
- add e2e coverage for both cases

Fixes part of https://github.com/jdx/mise/discussions/9857.

## Testing
- `cargo fmt --check`
- `git diff --check`
- Attempted `mise run test:e2e e2e/cli/test_use_global_system_config_warning`; repeated runs were interrupted during the full `cargo build --all-features` rebuild before the test script executed.