### PR TITLE
registry: fix sourcery platform archive format

### DIFF
--- a/registry/sourcery.toml
+++ b/registry/sourcery.toml
@@ -1,10 +1,11 @@
 description = "Meta-programming for Swift, stop writing boilerplate code"
+os = ["linux", "macos"]
 # test = { cmd = "which sourcery", expected = "sourcery" }
 
 [[backends]]
 full = "github:krzysztofzablocki/Sourcery"
 
-[backends.options]
+[backends.options.platforms.linux-x64]
 format = "tar.gz"
 
 [[backends]]


### PR DESCRIPTION
## Summary
- Move Sourcery's `format = "tar.gz"` override to the Linux x64 platform only.
- Add `os = ["linux", "macos"]` because current Sourcery releases do not publish Windows assets.
- Leave macOS archive format detection to the selected `.zip` asset so macOS installs no longer try to extract zip files as gzip tar archives.

Fixes https://github.com/jdx/mise/discussions/9876.

## Popularity
No new registry tool is added in this PR. This only fixes the existing `sourcery` registry entry, so new-tool popularity data is not applicable.

Existing upstream signals:
- GitHub: `krzysztofzablocki/Sourcery` has 7,996 stars and 632 forks, pushed 2026-05-06.

## Release asset check
- Latest `2.3.0` assets: `sourcery-2.3.0-ubuntu-22.04.5-lts-jammy-x86_64.tar.xz`, `sourcery-2.3.0.artifactbundle.zip`, `sourcery-2.3.0.zip`.
- Reported `2.2.7` assets: `sourcery-2.2.7-ubuntu-22.04.5-lts-jammy-x86_64.tar.gz`, `sourcery-2.2.7.artifactbundle.zip`, `sourcery-2.2.7.zip`.
- No Windows assets were present in the current/recent release asset lists checked, so this registry entry is limited to Linux and macOS.

## Testing
- `taplo fmt --check registry/sourcery.toml && taplo check registry/sourcery.toml`
- `git diff --check`
- Linux extraction check with explicit backend options: `MISE_DATA_DIR=$(mktemp -d) MISE_CACHE_DIR="$MISE_DATA_DIR/cache" mise x 'github:krzysztofzablocki/Sourcery[format=tar.gz]@2.3.0' -- which sourcery`
- macOS asset extraction simulation: `MISE_DATA_DIR=$(mktemp -d) MISE_CACHE_DIR="$MISE_DATA_DIR/cache" MISE_OS=macos MISE_ARCH=x64 mise x 'github:krzysztofzablocki/Sourcery@2.3.0' -- true`

`mise run lint-fix` was attempted on the #9789 branch earlier, but its cargo-check phase was stopped after waiting behind unrelated Cargo build locks from other worktrees. The relevant TOML formatting/checks above passed for this PR.
