### PR TITLE
fix(config): restore MISE_ENV_FILE setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -499,7 +499,7 @@ This is the path which is used as `{{config_root}}` for the global config file.
 ### `MISE_ENV_FILE`
 
 Set to a filename to read env from a dotenv file. e.g.: `MISE_ENV_FILE=.env`.
-This searches for the file in the current directory and then parent directories.
+This searches for and loads all matching files in the current directory and parent directories.
 Uses [dotenvy](https://crates.io/crates/dotenvy) under the hood.
 
 ### `MISE_${PLUGIN}_VERSION`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -326,12 +326,11 @@ trusted_config_paths = [
     '~/work/my-trusted-projects',
 ]
 
+env_file = '.env' # load env vars from a dotenv file, see `MISE_ENV_FILE`
+
 [settings.status]
 show_env = false
 show_tools = false
-
-[env]
-_.file = '.env'
 
 # "_" is a special key for information you'd like to put into mise.toml that mise will never parse
 [_]
@@ -499,9 +498,8 @@ This is the path which is used as `{{config_root}}` for the global config file.
 
 ### `MISE_ENV_FILE`
 
-Deprecated. Use `env._.file` in `mise.toml` or `~/.config/mise/config.toml` instead.
-
-Set to a filename to read from env from a dotenv file. e.g.: `MISE_ENV_FILE=.env`.
+Set to a filename to read env from a dotenv file. e.g.: `MISE_ENV_FILE=.env`.
+This searches for the file in the current directory and then parent directories.
 Uses [dotenvy](https://crates.io/crates/dotenvy) under the hood.
 
 ### `MISE_${PLUGIN}_VERSION`

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -361,7 +361,7 @@ _.file = [
 ]
 ```
 
-To automatically load a dotenv file from the current directory or a parent directory, set
+To automatically load dotenv files from the current directory and parent directories, set
 [`MISE_ENV_FILE=.env`](/configuration#mise-env-file) or `env_file = ".env"` under `[settings]`
 in `~/.config/mise/config.toml`. This is different from `env._.file`, which resolves paths
 relative to the config file that declares it.

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -361,8 +361,10 @@ _.file = [
 ]
 ```
 
-The legacy [`MISE_ENV_FILE=.env`](/configuration#mise-env-file) setting can also load dotenv
-files automatically, but it is deprecated. Use `env._.file` in a config file instead.
+To automatically load a dotenv file from the current directory or a parent directory, set
+[`MISE_ENV_FILE=.env`](/configuration#mise-env-file) or `env_file = ".env"` under `[settings]`
+in `~/.config/mise/config.toml`. This is different from `env._.file`, which resolves paths
+relative to the config file that declares it.
 
 See [secrets](/environments/secrets/) for ways to read encrypted files with `env._.file`.
 

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -704,8 +704,7 @@
         },
         "env_file": {
           "description": "Path to a file containing environment variables to automatically load.",
-          "type": "string",
-          "deprecated": true
+          "type": "string"
         },
         "env_shell_expand": {
           "description": "Enable shell-style variable expansion in env values (e.g., $FOO, ${BAR:-default})",

--- a/settings.toml
+++ b/settings.toml
@@ -1730,7 +1730,7 @@ env = "MISE_PRERELEASES"
 type = "Bool"
 
 [profile]
-deprecated = "Use MISE_ENV_FILE instead."
+deprecated = "Use MISE_ENV instead."
 description = "Profile to use for mise.${MISE_PROFILE}.toml files."
 env = "MISE_PROFILE"
 hide = true

--- a/settings.toml
+++ b/settings.toml
@@ -519,9 +519,6 @@ env = "MISE_ENV_CACHE_TTL"
 type = "Duration"
 
 [env_file]
-deprecated = "Use env._.file instead."
-deprecated_remove_at = "2027.11.0"
-deprecated_warn_at = "2026.11.0"
 description = "Path to a file containing environment variables to automatically load."
 env = "MISE_ENV_FILE"
 optional = true
@@ -1733,7 +1730,7 @@ env = "MISE_PRERELEASES"
 type = "Bool"
 
 [profile]
-deprecated = "Use env._.file instead."
+deprecated = "Use MISE_ENV_FILE instead."
 description = "Profile to use for mise.${MISE_PROFILE}.toml files."
 env = "MISE_PROFILE"
 hide = true


### PR DESCRIPTION
## Summary
- remove the deprecation metadata from the `env_file` setting / `MISE_ENV_FILE`
- restore global config docs for `[settings] env_file = ".env"`
- clarify that `MISE_ENV_FILE` loads all matching files found from the current directory upward, unlike `env._.file` paths in config files

## Context
Discussion: https://github.com/jdx/mise/discussions/9897

`env._.file` is still the right replacement for legacy top-level `env_file` entries in `mise.toml`, but it is not a behaviorally equivalent replacement for `MISE_ENV_FILE=.env` because the setting uses `FindUp` from the current directory.

## Testing
- `mise run render:schema`
- PR CI passed: docs, lint, Linux/macOS/Windows unit and e2e jobs, nightly, benchmark, registry, release, and Socket checks.
- A local focused e2e run was attempted, but I stopped it after it sat behind shared Cargo build contention for ~19 minutes; the PR CI covered those paths.

*This pull request was generated by an AI coding assistant.*