### PR TITLE
fix(vfox): use selected install path for env keys

### DIFF
--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -332,10 +332,32 @@ impl Vfox {
     ) -> Result<Vec<EnvKey>> {
         debug!("Getting env keys for {sdk} version {version}");
         let sdk = self.get_sdk_with_env(sdk)?;
-        let sdk_info = sdk.sdk_info(
-            version.to_string(),
-            self.install_dir.join(&sdk.name).join(version),
-        )?;
+        let install_dir = self.install_dir.join(&sdk.name).join(version);
+        self.env_keys_for_sdk_install_dir(sdk, version, install_dir, options)
+            .await
+    }
+
+    pub async fn env_keys_for_install_dir<T: serde::Serialize>(
+        &self,
+        sdk: &str,
+        version: &str,
+        install_dir: impl AsRef<Path>,
+        options: T,
+    ) -> Result<Vec<EnvKey>> {
+        debug!("Getting env keys for {sdk} version {version}");
+        let sdk = self.get_sdk_with_env(sdk)?;
+        self.env_keys_for_sdk_install_dir(sdk, version, install_dir, options)
+            .await
+    }
+
+    async fn env_keys_for_sdk_install_dir<T: serde::Serialize>(
+        &self,
+        sdk: Plugin,
+        version: &str,
+        install_dir: impl AsRef<Path>,
+        options: T,
+    ) -> Result<Vec<EnvKey>> {
+        let sdk_info = sdk.sdk_info(version.to_string(), install_dir.as_ref().to_path_buf())?;
         let ctx = EnvKeysContext {
             args: vec![],
             version: version.to_string(),
@@ -707,6 +729,27 @@ mod tests {
             "<INSTALL_DIR>",
         );
         assert_snapshot!(output);
+    }
+
+    #[tokio::test]
+    async fn test_env_keys_for_install_dir() {
+        let vfox = Vfox::test();
+        let install_dir = PathBuf::from("custom/installs/dummy/1.0.0");
+        let keys = vfox
+            .env_keys_for_install_dir(
+                "dummy",
+                "1.0.0",
+                &install_dir,
+                serde_json::Value::Object(Default::default()),
+            )
+            .await
+            .unwrap();
+        let expected = if cfg!(windows) {
+            install_dir
+        } else {
+            install_dir.join("bin")
+        };
+        assert_eq!(keys[0].value, expected.to_string_lossy().into_owned());
     }
 
     #[tokio::test]

--- a/e2e/backend/test_vfox_system_bin_paths
+++ b/e2e/backend/test_vfox_system_bin_paths
@@ -27,8 +27,12 @@ LUA
 
 cat >"$PLUGIN_DIR/hooks/env_keys.lua" <<'LUA'
 function PLUGIN:EnvKeys(ctx)
+	local bin_path = ctx.path .. "/bin"
+	if RUNTIME.osType == "windows" then
+		bin_path = ctx.path .. "\\bin"
+	end
 	return {
-		{ key = "PATH", value = ctx.path .. "/bin" },
+		{ key = "PATH", value = bin_path },
 	}
 end
 LUA

--- a/e2e/backend/test_vfox_system_bin_paths
+++ b/e2e/backend/test_vfox_system_bin_paths
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+export MISE_SYSTEM_DATA_DIR="$HOME/.local/share/mise-system"
+SYSTEM_INSTALL="$MISE_SYSTEM_DATA_DIR/installs/poetry/1.0.0"
+USER_INSTALL="$MISE_DATA_DIR/installs/poetry/1.0.0"
+PLUGIN_DIR="$MISE_DATA_DIR/plugins/poetry"
+
+mkdir -p "$MISE_SYSTEM_DIR" "$PLUGIN_DIR/hooks" "$SYSTEM_INSTALL/bin"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
+PLUGIN = {}
+PLUGIN.name = "poetry"
+PLUGIN.version = "0.1.0"
+PLUGIN.homepage = ""
+PLUGIN.license = "MIT"
+PLUGIN.description = "Dummy poetry vfox plugin"
+PLUGIN.minRuntimeVersion = "0.3.0"
+LUA
+
+cat >"$PLUGIN_DIR/hooks/available.lua" <<'LUA'
+function PLUGIN:Available(ctx)
+	return {
+		{ version = "1.0.0" },
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/env_keys.lua" <<'LUA'
+function PLUGIN:EnvKeys(ctx)
+	return {
+		{ key = "PATH", value = ctx.path .. "/bin" },
+	}
+end
+LUA
+
+cat >"$SYSTEM_INSTALL/bin/poetry" <<'SH'
+#!/usr/bin/env sh
+echo "poetry 1.0.0"
+SH
+chmod +x "$SYSTEM_INSTALL/bin/poetry"
+
+cat >"$MISE_SYSTEM_DIR/config.toml" <<'TOML'
+[tools]
+poetry = "1.0.0"
+TOML
+
+assert "mise bin-paths poetry" "$SYSTEM_INSTALL/bin"
+assert_not_contains "mise bin-paths poetry" "$USER_INSTALL/bin"

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -438,10 +438,12 @@ impl VfoxBackend {
         tv: &ToolVersion,
     ) -> eyre::Result<BTreeMap<String, String>> {
         let opts = tv.request.options();
+        let install_path = tv.install_path();
         let opts_hash = {
             use std::hash::{Hash, Hasher};
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
             opts.hash(&mut hasher);
+            install_path.hash(&mut hasher);
             hasher.finish()
         };
         let key = format!("{}:{:x}", tv, opts_hash);
@@ -453,7 +455,7 @@ impl VfoxBackend {
                 CacheManagerBuilder::new(tv.cache_path().join(&cache_file))
                     .with_fresh_file(dirs::DATA.to_path_buf())
                     .with_fresh_file(self.plugin.plugin_path.to_path_buf())
-                    .with_fresh_file(self.ba().installs_path.to_path_buf())
+                    .with_fresh_file(install_path.clone())
                     .build(),
             );
         }
@@ -480,8 +482,13 @@ impl VfoxBackend {
                     .await
                     .wrap_err("Backend exec env method failed")?
                 } else {
-                    vfox.env_keys(&self.pathname, &tv.version, opts.backend_options().as_map())
-                        .await?
+                    vfox.env_keys_for_install_dir(
+                        &self.pathname,
+                        &tv.version,
+                        &install_path,
+                        opts.backend_options().as_map(),
+                    )
+                    .await?
                 };
 
                 Ok(env_keys


### PR DESCRIPTION
## Summary
- pass the resolved `ToolVersion` install path into traditional vfox `EnvKeys` hooks
- key/cache vfox exec env by install path so shared/system installs do not reuse user-path cache entries
- add e2e coverage for a fake system-installed vfox `poetry` tool

Fixes part of https://github.com/jdx/mise/discussions/9857.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/mise-m7-vfox-test /home/risu/.rustup/toolchains/1.95.0-x86_64-unknown-linux-gnu/bin/cargo test -p vfox test_env_keys_for_install_dir`
- `CARGO_TARGET_DIR=/tmp/mise-m7-e2e-target mise run test:e2e e2e/backend/test_vfox_system_bin_paths`