### PR TITLE
fix(task): honor run --cd as task cwd

### DIFF
--- a/e2e/cli/test_cd_settings
+++ b/e2e/cli/test_cd_settings
@@ -9,6 +9,9 @@ experimental = true
 
 [tasks.read-marker]
 run = 'printf {{ read_file(path="marker") }}'
+
+[tasks.deps-python]
+run = 'printf target-task'
 EOF
 printf "from-project" >"$project/marker"
 
@@ -17,6 +20,11 @@ assert "env -u MISE_EXPERIMENTAL mise --env production -C '$project' settings ge
 assert "env -u MISE_EXPERIMENTAL mise --jobs 1 -C '$project' settings get experimental" "true"
 assert "env -u MISE_EXPERIMENTAL MISE_CD='$project' mise settings get experimental" "true"
 assert_succeed "env -u MISE_EXPERIMENTAL mise -C '$project' exec --deny-env -- true"
+
+# https://github.com/jdx/mise/discussions/5213
+# `mise --cd <dir> run <task>` must discover target-directory tasks even when
+# the caller's cwd has no task config.
+assert_contains "env -u MISE_EXPERIMENTAL mise --cd '$project' run deps-python" "target-task"
 assert_contains "env -u MISE_EXPERIMENTAL mise run -C project read-marker" "from-project"
 
 mise install dummy@1.0.0

--- a/e2e/cli/test_cd_settings
+++ b/e2e/cli/test_cd_settings
@@ -6,13 +6,18 @@ mkdir -p "$project"
 cat >"$project/mise.toml" <<EOF
 [settings]
 experimental = true
+
+[tasks.read-marker]
+run = 'printf {{ read_file(path="marker") }}'
 EOF
+printf "from-project" >"$project/marker"
 
 assert "env -u MISE_EXPERIMENTAL mise -C '$project' settings get experimental" "true"
 assert "env -u MISE_EXPERIMENTAL mise --env production -C '$project' settings get experimental" "true"
 assert "env -u MISE_EXPERIMENTAL mise --jobs 1 -C '$project' settings get experimental" "true"
 assert "env -u MISE_EXPERIMENTAL MISE_CD='$project' mise settings get experimental" "true"
 assert_succeed "env -u MISE_EXPERIMENTAL mise -C '$project' exec --deny-env -- true"
+assert_contains "env -u MISE_EXPERIMENTAL mise run -C project read-marker" "from-project"
 
 mise install dummy@1.0.0
 assert_contains "env -u MISE_EXPERIMENTAL mise -C '$project' exec dummy@1.0.0 -- dummy" "This is Dummy 1.0.0"

--- a/e2e/cli/test_cd_settings
+++ b/e2e/cli/test_cd_settings
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+project="$PWD/project"
+mkdir -p "$project"
+
+cat >"$project/mise.toml" <<EOF
+[settings]
+experimental = true
+EOF
+
+assert "env -u MISE_EXPERIMENTAL mise -C '$project' settings get experimental" "true"
+assert "env -u MISE_EXPERIMENTAL MISE_CD='$project' mise settings get experimental" "true"
+assert_succeed "env -u MISE_EXPERIMENTAL mise -C '$project' exec --deny-env -- true"

--- a/e2e/cli/test_cd_settings
+++ b/e2e/cli/test_cd_settings
@@ -7,6 +7,9 @@ cat >"$project/mise.toml" <<EOF
 [settings]
 experimental = true
 
+[env]
+CD_SETTINGS_TARGET = "project-env"
+
 [tasks.read-marker]
 run = 'printf {{ read_file(path="marker") }}'
 
@@ -20,6 +23,10 @@ assert "env -u MISE_EXPERIMENTAL mise --env production -C '$project' settings ge
 assert "env -u MISE_EXPERIMENTAL mise --jobs 1 -C '$project' settings get experimental" "true"
 assert "env -u MISE_EXPERIMENTAL MISE_CD='$project' mise settings get experimental" "true"
 assert_succeed "env -u MISE_EXPERIMENTAL mise -C '$project' exec --deny-env -- true"
+(
+  eval "$(mise hook-env -s bash)"
+  assert_contains "env -u MISE_EXPERIMENTAL MISE_CD='$project' mise hook-env -s bash" "CD_SETTINGS_TARGET=project-env"
+)
 
 # https://github.com/jdx/mise/discussions/5213
 # `mise --cd <dir> run <task>` must discover target-directory tasks even when

--- a/e2e/cli/test_cd_settings
+++ b/e2e/cli/test_cd_settings
@@ -27,5 +27,20 @@ assert_succeed "env -u MISE_EXPERIMENTAL mise -C '$project' exec --deny-env -- t
 assert_contains "env -u MISE_EXPERIMENTAL mise --cd '$project' run deps-python" "target-task"
 assert_contains "env -u MISE_EXPERIMENTAL mise run -C project read-marker" "from-project"
 
+# https://github.com/jdx/mise/discussions/4044
+# A relative run-level -C should affect task execution cwd exactly once.
+mkdir -p cd-repro/subdir
+cat >cd-repro/mise.toml <<EOF
+[tasks.pwd]
+run = 'pwd'
+EOF
+(
+  cd cd-repro
+  cd_repro="$PWD"
+  assert_contains "mise -C subdir run pwd" "$PWD/subdir"
+  cd subdir
+  assert_contains "mise -C .. run pwd" "$cd_repro"
+)
+
 mise install dummy@1.0.0
 assert_contains "env -u MISE_EXPERIMENTAL mise -C '$project' exec dummy@1.0.0 -- dummy" "This is Dummy 1.0.0"

--- a/e2e/cli/test_cd_settings
+++ b/e2e/cli/test_cd_settings
@@ -10,6 +10,7 @@ EOF
 
 assert "env -u MISE_EXPERIMENTAL mise -C '$project' settings get experimental" "true"
 assert "env -u MISE_EXPERIMENTAL mise --env production -C '$project' settings get experimental" "true"
+assert "env -u MISE_EXPERIMENTAL mise --jobs 1 -C '$project' settings get experimental" "true"
 assert "env -u MISE_EXPERIMENTAL MISE_CD='$project' mise settings get experimental" "true"
 assert_succeed "env -u MISE_EXPERIMENTAL mise -C '$project' exec --deny-env -- true"
 

--- a/e2e/cli/test_cd_settings
+++ b/e2e/cli/test_cd_settings
@@ -11,3 +11,6 @@ EOF
 assert "env -u MISE_EXPERIMENTAL mise -C '$project' settings get experimental" "true"
 assert "env -u MISE_EXPERIMENTAL MISE_CD='$project' mise settings get experimental" "true"
 assert_succeed "env -u MISE_EXPERIMENTAL mise -C '$project' exec --deny-env -- true"
+
+mise install dummy@1.0.0
+assert_contains "env -u MISE_EXPERIMENTAL mise -C '$project' exec dummy@1.0.0 -- dummy" "This is Dummy 1.0.0"

--- a/e2e/cli/test_cd_settings
+++ b/e2e/cli/test_cd_settings
@@ -9,6 +9,7 @@ experimental = true
 EOF
 
 assert "env -u MISE_EXPERIMENTAL mise -C '$project' settings get experimental" "true"
+assert "env -u MISE_EXPERIMENTAL mise --env production -C '$project' settings get experimental" "true"
 assert "env -u MISE_EXPERIMENTAL MISE_CD='$project' mise settings get experimental" "true"
 assert_succeed "env -u MISE_EXPERIMENTAL mise -C '$project' exec --deny-env -- true"
 

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -9,7 +9,7 @@ use crate::build_time::built_info;
 use crate::cli::self_update::SelfUpdate;
 use crate::cli::version;
 use crate::cli::version::VERSION;
-use crate::config::{Config, IGNORED_CONFIG_FILES, Settings};
+use crate::config::{self, Config, Settings};
 use crate::env::PATH_KEY;
 use crate::file::display_path;
 use crate::git::Git;
@@ -159,7 +159,7 @@ impl Doctor {
         );
         data.insert(
             "ignored_config_files".into(),
-            IGNORED_CONFIG_FILES
+            config::ignored_config_files()
                 .iter()
                 .map(|p| p.to_string_lossy().to_string())
                 .collect(),
@@ -308,13 +308,14 @@ impl Doctor {
     async fn analyze_config(&mut self, config: &Arc<Config>) -> eyre::Result<()> {
         info::section("config_files", render_config_files(config))?;
         info::section("env_files", render_env_files(config).await?)?;
-        if IGNORED_CONFIG_FILES.is_empty() {
+        let ignored_config_files = config::ignored_config_files();
+        if ignored_config_files.is_empty() {
             println!();
             info::inline_section("ignored_config_files", "(none)")?;
         } else {
             info::section(
                 "ignored_config_files",
-                IGNORED_CONFIG_FILES.iter().map(display_path).join("\n"),
+                ignored_config_files.iter().map(display_path).join("\n"),
             )?;
         }
         info::section("backends", render_backends())?;

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -1,5 +1,4 @@
 use crate::Result;
-use crate::config::ALL_TOML_CONFIG_FILES;
 use crate::{config, dirs, file};
 use eyre::bail;
 use std::io::{self, Read, Write};
@@ -41,7 +40,7 @@ impl Fmt {
 
         let cwd = dirs::CWD.clone().unwrap_or_default();
         let configs = if self.all {
-            ALL_TOML_CONFIG_FILES.clone()
+            config::all_toml_config_files()
         } else {
             config::config_files_in_dir(&cwd)
         };

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -829,9 +829,7 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
                     return Some(PathBuf::from(cd));
                 }
                 if subcommand.is_none() && !arg.starts_with('-') {
-                    let Some(sc) = cmd.find_subcommand(arg) else {
-                        return None;
-                    };
+                    let sc = cmd.find_subcommand(arg)?;
                     subcommand = Some(sc.get_name().to_string());
                     continue;
                 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -444,9 +444,13 @@ fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> Option<usiz
 }
 
 fn is_known_subcommand(cmd: &clap::Command, arg: &str) -> bool {
+    find_subcommand_name(cmd, arg).is_some()
+}
+
+fn find_subcommand_name<'a>(cmd: &'a clap::Command, arg: &str) -> Option<&'a str> {
     cmd.get_subcommands()
-        .flat_map(|s| std::iter::once(s.get_name()).chain(s.get_all_aliases()))
-        .any(|name| name == arg)
+        .find(|s| s.get_name() == arg || s.get_all_aliases().any(|alias| alias == arg))
+        .map(|s| s.get_name())
 }
 
 fn uses_deprecated_backends_alias(cmd: &clap::Command, args: &[String]) -> bool {
@@ -815,8 +819,12 @@ fn apply_early_cd(args: &[String]) -> Result<bool> {
 }
 
 fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
+    if !has_cd_arg(args) {
+        return None;
+    }
     let cmd = Cli::command();
-    let (flags_with_values, _) = get_global_flags(&cmd);
+    let (global_flags_with_values, _) = get_global_flags(&cmd);
+    let (run_flags_with_values, _) = get_all_run_flags(&cmd);
     let mut subcommand = None;
     let mut iter = args.iter().skip(1).peekable();
     while let Some(arg) = iter.next() {
@@ -832,6 +840,11 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
                 {
                     return Some(PathBuf::from(cd));
                 }
+                let flags_with_values = if subcommand.as_deref() == Some("run") {
+                    &run_flags_with_values
+                } else {
+                    &global_flags_with_values
+                };
                 if let Some(flag) = arg.split_once('=').map(|(flag, _)| flag)
                     && flags_with_values.iter().any(|f| f == flag)
                 {
@@ -848,8 +861,8 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
                     continue;
                 }
                 if subcommand.is_none() && !arg.starts_with('-') {
-                    let sc = cmd.find_subcommand(arg)?;
-                    subcommand = Some(sc.get_name().to_string());
+                    let sc = find_subcommand_name(&cmd, arg)?;
+                    subcommand = Some(sc.to_string());
                     continue;
                 }
                 if subcommand.as_deref() == Some("run") && !arg.starts_with('-') {
@@ -859,6 +872,20 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
         }
     }
     None
+}
+
+fn has_cd_arg(args: &[String]) -> bool {
+    args.iter()
+        .skip(1)
+        .take_while(|a| a.as_str() != "--")
+        .any(|a| is_cd_arg(a))
+}
+
+fn is_cd_arg(arg: &str) -> bool {
+    arg == "-C"
+        || arg == "--cd"
+        || arg.starts_with("--cd=")
+        || arg.strip_prefix("-C").is_some_and(|rest| !rest.is_empty())
 }
 
 /// Validate the --cd path if provided and return an error if it doesn't exist
@@ -1043,6 +1070,57 @@ mod tests {
     fn test_early_cd_arg_ignores_naked_task_args() {
         let args = vec![
             "mise".to_string(),
+            "mytask".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), None);
+    }
+
+    #[test]
+    fn test_early_cd_arg_skips_run_flag_values_before_cd() {
+        let args = vec![
+            "mise".to_string(),
+            "run".to_string(),
+            "--allow-read".to_string(),
+            "src".to_string(),
+            "--timeout".to_string(),
+            "5s".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+            "mytask".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+    }
+
+    #[test]
+    fn test_early_cd_arg_handles_subcommand_aliases() {
+        let args = vec![
+            "mise".to_string(),
+            "x".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+            "--".to_string(),
+            "true".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+
+        let args = vec![
+            "mise".to_string(),
+            "r".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+            "mytask".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+
+        let args = vec![
+            "mise".to_string(),
+            "r".to_string(),
             "mytask".to_string(),
             "-C".to_string(),
             "project".to_string(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -813,6 +813,7 @@ fn apply_early_cd(args: &[String]) -> Result<bool> {
 
 fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
     let cmd = Cli::command();
+    let (flags_with_values, _) = get_global_flags(&cmd);
     let mut subcommand = None;
     let mut iter = args.iter().skip(1).peekable();
     while let Some(arg) = iter.next() {
@@ -827,6 +828,21 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
                     && !cd.is_empty()
                 {
                     return Some(PathBuf::from(cd));
+                }
+                if let Some(flag) = arg.split_once('=').map(|(flag, _)| flag)
+                    && flags_with_values.iter().any(|f| f == flag)
+                {
+                    continue;
+                }
+                if flags_with_values.iter().any(|f| f == arg) {
+                    iter.next();
+                    continue;
+                }
+                if arg.len() > 2
+                    && let Some(flag) = arg.get(..2)
+                    && flags_with_values.iter().any(|f| f == flag)
+                {
+                    continue;
                 }
                 if subcommand.is_none() && !arg.starts_with('-') {
                     let sc = cmd.find_subcommand(arg)?;
@@ -990,6 +1006,31 @@ mod tests {
             "dummy@1.0.0".to_string(),
             "--".to_string(),
             "dummy".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+    }
+
+    #[test]
+    fn test_early_cd_arg_skips_global_flag_values_before_cd() {
+        let args = vec![
+            "mise".to_string(),
+            "--env".to_string(),
+            "production".to_string(),
+            "--jobs=4".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+            "settings".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+
+        let args = vec![
+            "mise".to_string(),
+            "-Eproduction".to_string(),
+            "-j4".to_string(),
+            "--cd=project".to_string(),
+            "settings".to_string(),
         ];
 
         assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -342,53 +342,105 @@ impl Commands {
     }
 }
 
-fn get_global_flags(cmd: &clap::Command) -> (Vec<String>, Vec<String>) {
-    let mut flags_with_values = Vec::new();
-    let mut boolean_flags = Vec::new();
+#[derive(Clone, Default)]
+struct CliArgFlags {
+    required_value: Vec<String>,
+    optional_value: Vec<String>,
+    boolean: Vec<String>,
+}
+
+impl CliArgFlags {
+    fn extend(&mut self, other: Self) {
+        self.required_value.extend(other.required_value);
+        self.optional_value.extend(other.optional_value);
+        self.boolean.extend(other.boolean);
+    }
+
+    fn flags_with_values(&self) -> Vec<String> {
+        self.required_value
+            .iter()
+            .chain(self.optional_value.iter())
+            .cloned()
+            .collect()
+    }
+
+    fn has_required_value(&self, flag: &str) -> bool {
+        self.required_value.iter().any(|f| f == flag)
+    }
+
+    fn has_optional_value(&self, flag: &str) -> bool {
+        self.optional_value.iter().any(|f| f == flag)
+    }
+
+    fn has_value(&self, flag: &str) -> bool {
+        self.has_required_value(flag) || self.has_optional_value(flag)
+    }
+
+    fn has_boolean(&self, flag: &str) -> bool {
+        self.boolean.iter().any(|f| f == flag)
+    }
+}
+
+fn push_arg_names(arg: &clap::Arg, flags: &mut Vec<String>) {
+    if let Some(long) = arg.get_long() {
+        flags.push(format!("--{}", long));
+    }
+    if let Some(aliases) = arg.get_all_aliases() {
+        flags.extend(aliases.into_iter().map(|alias| format!("--{}", alias)));
+    }
+    if let Some(short) = arg.get_short() {
+        flags.push(format!("-{}", short));
+    }
+}
+
+fn get_arg_flags(cmd: &clap::Command) -> CliArgFlags {
+    let mut flags = CliArgFlags::default();
 
     for arg in cmd.get_arguments() {
         let takes_value = matches!(
             arg.get_action(),
             clap::ArgAction::Set | clap::ArgAction::Append
         );
+        let optional_value = takes_value
+            && arg
+                .get_num_args()
+                .is_some_and(|range| range.min_values() == 0 && range.max_values() > 0);
         let is_bool = matches!(
             arg.get_action(),
-            clap::ArgAction::SetTrue | clap::ArgAction::SetFalse
+            clap::ArgAction::SetTrue | clap::ArgAction::SetFalse | clap::ArgAction::Count
         );
 
         if takes_value {
-            if let Some(long) = arg.get_long() {
-                flags_with_values.push(format!("--{}", long));
-            }
-            if let Some(short) = arg.get_short() {
-                flags_with_values.push(format!("-{}", short));
+            if optional_value {
+                push_arg_names(arg, &mut flags.optional_value);
+            } else {
+                push_arg_names(arg, &mut flags.required_value);
             }
         } else if is_bool {
-            if let Some(long) = arg.get_long() {
-                boolean_flags.push(format!("--{}", long));
-            }
-            if let Some(short) = arg.get_short() {
-                boolean_flags.push(format!("-{}", short));
-            }
+            push_arg_names(arg, &mut flags.boolean);
         }
     }
 
-    (flags_with_values, boolean_flags)
+    flags
+}
+
+fn get_global_flags(cmd: &clap::Command) -> (Vec<String>, Vec<String>) {
+    let flags = get_arg_flags(cmd);
+    (flags.flags_with_values(), flags.boolean)
+}
+
+fn get_flags_for_subcommand(cmd: &clap::Command, subcommand: &str) -> CliArgFlags {
+    let mut flags = get_arg_flags(cmd);
+    if let Some(sc) = cmd.get_subcommands().find(|s| s.get_name() == subcommand) {
+        flags.extend(get_arg_flags(sc));
+    }
+    flags
 }
 
 /// Get all flags (with values and boolean) from both global Cli and Run subcommand
 fn get_all_run_flags(cmd: &clap::Command) -> (Vec<String>, Vec<String>) {
-    // Get global flags from Cli
-    let (mut flags_with_values, mut boolean_flags) = get_global_flags(cmd);
-
-    // Get run-specific flags from Run subcommand
-    if let Some(run_cmd) = cmd.get_subcommands().find(|s| s.get_name() == "run") {
-        let (run_vals, run_bools) = get_global_flags(run_cmd);
-        flags_with_values.extend(run_vals);
-        boolean_flags.extend(run_bools);
-    }
-
-    (flags_with_values, boolean_flags)
+    let flags = get_flags_for_subcommand(cmd, "run");
+    (flags.flags_with_values(), flags.boolean)
 }
 
 /// Prefix used to escape flags that should be passed to tasks, not mise
@@ -823,8 +875,7 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
         return None;
     }
     let cmd = Cli::command();
-    let (global_flags_with_values, _) = get_global_flags(&cmd);
-    let (run_flags_with_values, _) = get_all_run_flags(&cmd);
+    let mut current_flags = get_arg_flags(&cmd);
     let mut subcommand = None;
     let mut iter = args.iter().skip(1).peekable();
     while let Some(arg) = iter.next() {
@@ -840,38 +891,73 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
                 {
                     return Some(PathBuf::from(cd));
                 }
-                let flags_with_values = if subcommand.as_deref() == Some("run") {
-                    &run_flags_with_values
-                } else {
-                    &global_flags_with_values
-                };
-                if let Some(flag) = arg.split_once('=').map(|(flag, _)| flag)
-                    && flags_with_values.iter().any(|f| f == flag)
-                {
-                    continue;
-                }
-                if flags_with_values.iter().any(|f| f == arg) {
-                    iter.next();
-                    continue;
-                }
-                if arg.len() > 2
-                    && let Some(flag) = arg.get(..2)
-                    && flags_with_values.iter().any(|f| f == flag)
-                {
+                if skip_known_flag(arg, &mut iter, &current_flags) {
                     continue;
                 }
                 if subcommand.is_none() && !arg.starts_with('-') {
                     let sc = find_subcommand_name(&cmd, arg)?;
+                    current_flags = get_flags_for_subcommand(&cmd, sc);
                     subcommand = Some(sc.to_string());
                     continue;
                 }
-                if subcommand.as_deref() == Some("run") && !arg.starts_with('-') {
+                if subcommand
+                    .as_deref()
+                    .is_some_and(subcommand_stops_cd_scan_after_positional)
+                {
                     return None;
                 }
             }
         }
     }
     None
+}
+
+fn subcommand_stops_cd_scan_after_positional(subcommand: &str) -> bool {
+    matches!(subcommand, "asdf" | "run" | "watch")
+}
+
+fn skip_known_flag<'a, I>(arg: &str, iter: &mut std::iter::Peekable<I>, flags: &CliArgFlags) -> bool
+where
+    I: Iterator<Item = &'a String>,
+{
+    if let Some(flag) = arg.split_once('=').map(|(flag, _)| flag)
+        && (flags.has_value(flag) || flags.has_boolean(flag))
+    {
+        return true;
+    }
+    if flags.has_required_value(arg) {
+        iter.next();
+        return true;
+    }
+    if flags.has_optional_value(arg) {
+        if iter
+            .peek()
+            .is_some_and(|next| !next.starts_with('-') && !is_cd_arg(next))
+        {
+            iter.next();
+        }
+        return true;
+    }
+    if flags.has_boolean(arg) || is_known_short_boolean_cluster(arg, flags) {
+        return true;
+    }
+    if arg.len() > 2
+        && !arg.starts_with("--")
+        && let Some(flag) = arg.get(..2)
+        && flags.has_value(flag)
+    {
+        return true;
+    }
+    false
+}
+
+fn is_known_short_boolean_cluster(arg: &str, flags: &CliArgFlags) -> bool {
+    if arg.len() <= 2 || !arg.starts_with('-') || arg.starts_with("--") {
+        return false;
+    }
+    arg[1..]
+        .chars()
+        .all(|short| flags.has_boolean(&format!("-{short}")))
 }
 
 fn has_cd_arg(args: &[String]) -> bool {
@@ -1093,6 +1179,76 @@ mod tests {
         ];
 
         assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+    }
+
+    #[test]
+    fn test_early_cd_arg_ignores_run_task_args() {
+        let args = vec![
+            "mise".to_string(),
+            "run".to_string(),
+            "mytask".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), None);
+
+        let args = vec![
+            "mise".to_string(),
+            "run".to_string(),
+            "-mytask".to_string(),
+            "--cd=project".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), None);
+    }
+
+    #[test]
+    fn test_early_cd_arg_handles_watch_args() {
+        let args = vec![
+            "mise".to_string(),
+            "watch".to_string(),
+            "--glob".to_string(),
+            "src/**/*.rs".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+            "mytask".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+
+        let args = vec![
+            "mise".to_string(),
+            "watch".to_string(),
+            "-e".to_string(),
+            ".rs".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+            "mytask".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+
+        let args = vec![
+            "mise".to_string(),
+            "w".to_string(),
+            "--clear".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+            "mytask".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+
+        let args = vec![
+            "mise".to_string(),
+            "watch".to_string(),
+            "mytask".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), None);
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -630,7 +630,6 @@ impl Cli {
         measure!("handle_shim", { shims::handle_shim().await })?;
         ctrlc::init();
         let print_version = version::print_version_if_requested(args)?;
-        let _ = measure!("backend::load_tools", { backend::load_tools().await });
 
         // Pre-process args to handle naked runs before clap parsing
         let cmd = Cli::command();
@@ -646,6 +645,7 @@ impl Cli {
         measure!("add_cli_matches", { Settings::add_cli_matches(&cli) });
         let _ = measure!("settings", { Settings::try_get() });
         measure!("logger", { logger::init() });
+        let _ = measure!("backend::load_tools", { backend::load_tools().await });
         warn_deprecated_backends_alias(&cmd, args);
         measure!("migrate", { migrate::run().await });
         if let Err(err) = crate::cache::auto_prune() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -625,11 +625,13 @@ impl Cli {
         if hook_env_module::should_exit_early_fast() {
             return Ok(());
         }
+        let early_cd = apply_early_cd(args)?;
         measure!("logger", { logger::init() });
         check_working_directory();
         measure!("handle_shim", { shims::handle_shim().await })?;
         ctrlc::init();
         let print_version = version::print_version_if_requested(args)?;
+        let _ = measure!("backend::load_tools", { backend::load_tools().await });
 
         // Pre-process args to handle naked runs before clap parsing
         let cmd = Cli::command();
@@ -641,11 +643,12 @@ impl Cli {
             Cli::parse_from(processed_args.iter())
         });
         // Validate --cd path BEFORE Settings processes it and changes the directory
-        validate_cd_path(&cli.cd)?;
+        if !early_cd {
+            validate_cd_path(&cli.cd)?;
+        }
         measure!("add_cli_matches", { Settings::add_cli_matches(&cli) });
         let _ = measure!("settings", { Settings::try_get() });
         measure!("logger", { logger::init() });
-        let _ = measure!("backend::load_tools", { backend::load_tools().await });
         warn_deprecated_backends_alias(&cmd, args);
         measure!("migrate", { migrate::run().await });
         if let Err(err) = crate::cache::auto_prune() {
@@ -794,6 +797,53 @@ fn check_working_directory() {
     }
 }
 
+fn apply_early_cd(args: &[String]) -> Result<bool> {
+    if *crate::env::IS_RUNNING_AS_SHIM {
+        return Ok(false);
+    }
+    let Some(cd) = early_cd_arg(args) else {
+        return Ok(false);
+    };
+    validate_cd_path(&Some(cd.clone()))?;
+    Settings::override_with(|s| {
+        s.cd = Some(cd);
+    });
+    Ok(true)
+}
+
+fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
+    let cmd = Cli::command();
+    let mut subcommand = None;
+    let mut iter = args.iter().skip(1).peekable();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--" => return None,
+            "-C" | "--cd" => return iter.next().map(PathBuf::from),
+            _ => {
+                if let Some(cd) = arg.strip_prefix("--cd=") {
+                    return Some(PathBuf::from(cd));
+                }
+                if let Some(cd) = arg.strip_prefix("-C")
+                    && !cd.is_empty()
+                {
+                    return Some(PathBuf::from(cd));
+                }
+                if subcommand.is_none() && !arg.starts_with('-') {
+                    let Some(sc) = cmd.find_subcommand(arg) else {
+                        return None;
+                    };
+                    subcommand = Some(sc.get_name().to_string());
+                    continue;
+                }
+                if subcommand.as_deref() == Some("run") && !arg.starts_with('-') {
+                    return None;
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Validate the --cd path if provided and return an error if it doesn't exist
 fn validate_cd_path(cd: &Option<PathBuf>) -> Result<()> {
     if let Some(path) = cd {
@@ -930,6 +980,33 @@ mod tests {
         let args = vec!["mise".to_string(), "run".to_string(), "b".to_string()];
 
         assert!(!uses_deprecated_backends_alias(&cmd, &args));
+    }
+
+    #[test]
+    fn test_early_cd_arg_finds_global_cd_before_tool_args() {
+        let args = vec![
+            "mise".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+            "exec".to_string(),
+            "dummy@1.0.0".to_string(),
+            "--".to_string(),
+            "dummy".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("project")));
+    }
+
+    #[test]
+    fn test_early_cd_arg_ignores_naked_task_args() {
+        let args = vec![
+            "mise".to_string(),
+            "mytask".to_string(),
+            "-C".to_string(),
+            "project".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), None);
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -904,7 +904,7 @@ fn normalize_cli_cd_paths(cli: &mut Cli, original_cwd: &Path, early_cd: &Path) {
 
 fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
     if !has_cd_arg(args) {
-        return None;
+        return std::env::var_os("MISE_CD").map(PathBuf::from);
     }
     let cmd = Cli::command();
     let mut current_flags = get_arg_flags(&cmd);
@@ -949,7 +949,7 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
             }
         }
     }
-    cd
+    cd.or_else(|| std::env::var_os("MISE_CD").map(PathBuf::from))
 }
 
 fn subcommand_stops_cd_scan_after_positional(subcommand: &str) -> bool {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,7 @@ use crate::{cli::args::ToolArg, path::PathExt};
 use crate::{hook_env as hook_env_module, logger, migrate, shims};
 use clap::{ArgAction, CommandFactory, Parser, Subcommand};
 use eyre::bail;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 mod activate;
 pub mod args;
@@ -695,11 +695,14 @@ impl Cli {
         // Escape flags after task names so they go to tasks, not mise
         let processed_args = escape_task_args(&cmd, &processed_args);
 
-        let cli = measure!("get_matches_from", {
+        let mut cli = measure!("get_matches_from", {
             Cli::parse_from(processed_args.iter())
         });
+        if let Some(early_cd) = &early_cd {
+            normalize_cli_cd_paths(&mut cli, &early_cd.original_cwd, &early_cd.cd);
+        }
         // Validate --cd path BEFORE Settings processes it and changes the directory
-        if !early_cd {
+        if early_cd.is_none() {
             validate_cd_path(&cli.cd)?;
         }
         measure!("add_cli_matches", { Settings::add_cli_matches(&cli) });
@@ -853,21 +856,50 @@ fn check_working_directory() {
     }
 }
 
-fn apply_early_cd(args: &[String]) -> Result<bool> {
+struct EarlyCd {
+    original_cwd: PathBuf,
+    cd: PathBuf,
+}
+
+fn apply_early_cd(args: &[String]) -> Result<Option<EarlyCd>> {
     if *crate::env::IS_RUNNING_AS_SHIM {
-        return Ok(false);
+        return Ok(None);
     }
     let Some(cd) = early_cd_arg(args) else {
-        return Ok(false);
+        return Ok(None);
     };
+    let original_cwd = crate::env::current_dir()?;
+    let cd = normalize_cd_path(cd, &original_cwd);
     if let Err(err) = validate_cd_path(&Some(cd.clone())) {
         logger::init();
         return Err(err);
     }
     Settings::override_with(|s| {
-        s.cd = Some(cd);
+        s.cd = Some(cd.clone());
     });
-    Ok(true)
+    Ok(Some(EarlyCd { original_cwd, cd }))
+}
+
+fn normalize_cd_path(cd: PathBuf, original_cwd: &Path) -> PathBuf {
+    if cd.is_relative() {
+        original_cwd.join(cd)
+    } else {
+        cd
+    }
+}
+
+fn normalize_cli_cd_paths(cli: &mut Cli, original_cwd: &Path, early_cd: &Path) {
+    if let Some(cd) = &mut cli.cd {
+        *cd = normalize_cd_path(cd.clone(), original_cwd);
+    }
+    if let Some(Commands::Run(run)) = &mut cli.command
+        && let Some(cd) = &mut run.cd
+    {
+        *cd = normalize_cd_path(cd.clone(), original_cwd);
+    }
+    if cli.cd.is_none() {
+        cli.cd = Some(early_cd.to_path_buf());
+    }
 }
 
 fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
@@ -876,26 +908,34 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
     }
     let cmd = Cli::command();
     let mut current_flags = get_arg_flags(&cmd);
+    let mut cd = None;
     let mut subcommand = None;
     let mut iter = args.iter().skip(1).peekable();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
-            "--" => return None,
-            "-C" | "--cd" => return iter.next().map(PathBuf::from),
+            "--" => return cd,
+            "-C" | "--cd" => {
+                cd = iter.next().map(PathBuf::from);
+                continue;
+            }
             _ => {
-                if let Some(cd) = arg.strip_prefix("--cd=") {
-                    return Some(PathBuf::from(cd));
+                if let Some(path) = arg.strip_prefix("--cd=") {
+                    cd = Some(PathBuf::from(path));
+                    continue;
                 }
-                if let Some(cd) = arg.strip_prefix("-C")
-                    && !cd.is_empty()
+                if let Some(path) = arg.strip_prefix("-C")
+                    && !path.is_empty()
                 {
-                    return Some(PathBuf::from(cd));
+                    cd = Some(PathBuf::from(path));
+                    continue;
                 }
                 if skip_known_flag(arg, &mut iter, &current_flags) {
                     continue;
                 }
                 if subcommand.is_none() && !arg.starts_with('-') {
-                    let sc = find_subcommand_name(&cmd, arg)?;
+                    let Some(sc) = find_subcommand_name(&cmd, arg) else {
+                        return cd;
+                    };
                     current_flags = get_flags_for_subcommand(&cmd, sc);
                     subcommand = Some(sc.to_string());
                     continue;
@@ -904,12 +944,12 @@ fn early_cd_arg(args: &[String]) -> Option<PathBuf> {
                     .as_deref()
                     .is_some_and(subcommand_stops_cd_scan_after_positional)
                 {
-                    return None;
+                    return cd;
                 }
             }
         }
     }
-    None
+    cd
 }
 
 fn subcommand_stops_cd_scan_after_positional(subcommand: &str) -> bool {
@@ -1153,6 +1193,31 @@ mod tests {
     }
 
     #[test]
+    fn test_early_cd_arg_uses_last_effective_cd() {
+        let args = vec![
+            "mise".to_string(),
+            "-C".to_string(),
+            "first".to_string(),
+            "--cd=second".to_string(),
+            "settings".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("second")));
+
+        let args = vec![
+            "mise".to_string(),
+            "-C".to_string(),
+            "first".to_string(),
+            "run".to_string(),
+            "-C".to_string(),
+            "taskdir".to_string(),
+            "build".to_string(),
+        ];
+
+        assert_eq!(early_cd_arg(&args), Some(PathBuf::from("taskdir")));
+    }
+
+    #[test]
     fn test_early_cd_arg_ignores_naked_task_args() {
         let args = vec![
             "mise".to_string(),
@@ -1283,6 +1348,36 @@ mod tests {
         ];
 
         assert_eq!(early_cd_arg(&args), None);
+    }
+
+    #[test]
+    fn test_normalize_cli_cd_paths_absolutizes_run_cd() {
+        let original_cwd = PathBuf::from("/tmp/mise-original");
+        let early_cd = original_cwd.join("project");
+        let mut cli = Cli::parse_from(["mise", "run", "-C", "project", "build"]);
+
+        normalize_cli_cd_paths(&mut cli, &original_cwd, &early_cd);
+
+        assert_eq!(cli.cd, Some(early_cd.clone()));
+        match &cli.command {
+            Some(Commands::Run(run)) => assert_eq!(run.cd, Some(early_cd)),
+            _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn test_normalize_cli_cd_paths_matches_repeated_cd() {
+        let original_cwd = PathBuf::from("/tmp/mise-original");
+        let early_cd = original_cwd.join("taskdir");
+        let mut cli = Cli::parse_from(["mise", "-C", "project", "run", "-C", "taskdir", "build"]);
+
+        normalize_cli_cd_paths(&mut cli, &original_cwd, &early_cd);
+
+        assert_eq!(cli.cd, Some(early_cd));
+        match &cli.command {
+            Some(Commands::Run(run)) => assert_eq!(run.cd, Some(original_cwd.join("taskdir"))),
+            _ => panic!("expected run command"),
+        }
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -804,7 +804,10 @@ fn apply_early_cd(args: &[String]) -> Result<bool> {
     let Some(cd) = early_cd_arg(args) else {
         return Ok(false);
     };
-    validate_cd_path(&Some(cd.clone()))?;
+    if let Err(err) = validate_cd_path(&Some(cd.clone())) {
+        logger::init();
+        return Err(err);
+    }
     Settings::override_with(|s| {
         s.cd = Some(cd);
     });

--- a/src/cli/settings/ls.rs
+++ b/src/cli/settings/ls.rs
@@ -1,6 +1,6 @@
 use crate::config;
+use crate::config::Settings;
 use crate::config::settings::{SETTINGS_META, SettingsPartial, SettingsType};
-use crate::config::{ALL_TOML_CONFIG_FILES, Settings};
 use crate::file::display_path;
 use crate::ui::table;
 use eyre::Result;
@@ -76,21 +76,24 @@ impl SettingsLs {
                     rows.extend(Row::from_toml(k.to_string(), v, None));
                 }
             }
-            rows.extend(ALL_TOML_CONFIG_FILES.iter().rev().flat_map(|source| {
-                match Settings::parse_settings_file(source) {
-                    Ok(partial) => match Row::from_partial(&partial, source) {
-                        Ok(rows) => rows,
+            rows.extend(
+                config::all_toml_config_files()
+                    .iter()
+                    .rev()
+                    .flat_map(|source| match Settings::parse_settings_file(source) {
+                        Ok(partial) => match Row::from_partial(&partial, source) {
+                            Ok(rows) => rows,
+                            Err(e) => {
+                                warn!("Error parsing {}: {}", display_path(source), e);
+                                vec![]
+                            }
+                        },
                         Err(e) => {
                             warn!("Error parsing {}: {}", display_path(source), e);
                             vec![]
                         }
-                    },
-                    Err(e) => {
-                        warn!("Error parsing {}: {}", display_path(source), e);
-                        vec![]
-                    }
-                }
-            }));
+                    }),
+            );
             rows
         };
         if let Some(key) = &self.setting {

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -2,8 +2,7 @@ use std::path::PathBuf;
 
 use crate::config::config_file::config_trust_root;
 use crate::config::{
-    ALL_CONFIG_FILES, DEFAULT_CONFIG_FILENAMES, Settings, config_file, config_files_in_dir,
-    is_global_config,
+    DEFAULT_CONFIG_FILENAMES, Settings, config_file, config_files_in_dir, is_global_config,
 };
 use crate::file::{display_path, remove_file};
 use crate::{config, dirs, env, file};
@@ -86,7 +85,7 @@ impl Trust {
 pub(super) fn untrust_config_file(config_file: Option<PathBuf>) -> Result<()> {
     let path = match config_file {
         Some(filename) => filename,
-        None => match ALL_CONFIG_FILES.first().cloned() {
+        None => match config::all_config_files().first().cloned() {
             Some(path) => path,
             None => {
                 warn!("No trusted config files found.");
@@ -169,7 +168,7 @@ impl Trust {
     }
 
     fn get_next(&self) -> Option<PathBuf> {
-        ALL_CONFIG_FILES.first().cloned()
+        config::all_config_files().first().cloned()
     }
     fn get_next_untrusted(&self) -> Option<PathBuf> {
         config::load_config_paths(&DEFAULT_CONFIG_FILENAMES, true)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -110,9 +110,7 @@ impl Config {
         timeout::run_with_timeout_async(
             async || {
                 _CONFIG.write().unwrap().take();
-                *GLOBAL_CONFIG_FILES.lock().unwrap() = None;
-                *SYSTEM_CONFIG_FILES.lock().unwrap() = None;
-                GLOB_RESULTS.lock().unwrap().clear();
+                reset_config_path_caches();
                 crate::task::reset();
                 Ok(())
             },
@@ -1071,17 +1069,8 @@ static TOML_CONFIG_FILENAMES: Lazy<Vec<String>> = Lazy::new(|| {
         .map(|s| s.to_string())
         .collect()
 });
-pub static ALL_CONFIG_FILES: Lazy<IndexSet<PathBuf>> = Lazy::new(|| {
-    load_config_paths(&DEFAULT_CONFIG_FILENAMES, false)
-        .into_iter()
-        .collect()
-});
-pub static IGNORED_CONFIG_FILES: Lazy<IndexSet<PathBuf>> = Lazy::new(|| {
-    load_config_paths(&DEFAULT_CONFIG_FILENAMES, true)
-        .into_iter()
-        .filter(|p| config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(p))
-        .collect()
-});
+static ALL_CONFIG_FILES: Lazy<Mutex<Option<IndexSet<PathBuf>>>> = Lazy::new(Default::default);
+static IGNORED_CONFIG_FILES: Lazy<Mutex<Option<IndexSet<PathBuf>>>> = Lazy::new(Default::default);
 // pub static LOCAL_CONFIG_FILES: Lazy<Vec<PathBuf>> = Lazy::new(|| {
 //     ALL_CONFIG_FILES
 //         .iter()
@@ -1092,6 +1081,40 @@ pub static IGNORED_CONFIG_FILES: Lazy<IndexSet<PathBuf>> = Lazy::new(|| {
 
 type GlobResults = HashMap<(PathBuf, String), Vec<PathBuf>>;
 static GLOB_RESULTS: Lazy<Mutex<GlobResults>> = Lazy::new(Default::default);
+
+pub fn reset_config_path_caches() {
+    *ALL_CONFIG_FILES.lock().unwrap() = None;
+    *IGNORED_CONFIG_FILES.lock().unwrap() = None;
+    *ALL_TOML_CONFIG_FILES.lock().unwrap() = None;
+    *GLOBAL_CONFIG_FILES.lock().unwrap() = None;
+    *SYSTEM_CONFIG_FILES.lock().unwrap() = None;
+    GLOB_RESULTS.lock().unwrap().clear();
+}
+
+pub fn all_config_files() -> IndexSet<PathBuf> {
+    let mut files = ALL_CONFIG_FILES.lock().unwrap();
+    if let Some(files) = &*files {
+        return files.clone();
+    }
+    let loaded = load_config_paths(&DEFAULT_CONFIG_FILENAMES, false)
+        .into_iter()
+        .collect();
+    *files = Some(loaded);
+    files.as_ref().unwrap().clone()
+}
+
+pub fn ignored_config_files() -> IndexSet<PathBuf> {
+    let mut files = IGNORED_CONFIG_FILES.lock().unwrap();
+    if let Some(files) = &*files {
+        return files.clone();
+    }
+    let loaded = load_config_paths(&DEFAULT_CONFIG_FILENAMES, true)
+        .into_iter()
+        .filter(|p| config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(p))
+        .collect();
+    *files = Some(loaded);
+    files.as_ref().unwrap().clone()
+}
 
 pub fn glob(dir: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
     let mut results = GLOB_RESULTS.lock().unwrap();
@@ -1359,16 +1382,24 @@ pub fn top_toml_config() -> Option<PathBuf> {
         .map(|p| p.to_path_buf())
 }
 
-pub static ALL_TOML_CONFIG_FILES: Lazy<IndexSet<PathBuf>> = Lazy::new(|| {
-    load_config_paths(&TOML_CONFIG_FILENAMES, false)
+static ALL_TOML_CONFIG_FILES: Lazy<Mutex<Option<IndexSet<PathBuf>>>> = Lazy::new(Default::default);
+
+pub fn all_toml_config_files() -> IndexSet<PathBuf> {
+    let mut files = ALL_TOML_CONFIG_FILES.lock().unwrap();
+    if let Some(files) = &*files {
+        return files.clone();
+    }
+    let loaded = load_config_paths(&TOML_CONFIG_FILENAMES, false)
         .into_iter()
-        .collect()
-});
+        .collect();
+    *files = Some(loaded);
+    files.as_ref().unwrap().clone()
+}
 
 /// list of all non-global mise.tomls
-pub fn local_toml_config_paths() -> Vec<&'static PathBuf> {
-    ALL_TOML_CONFIG_FILES
-        .iter()
+pub fn local_toml_config_paths() -> Vec<PathBuf> {
+    all_toml_config_files()
+        .into_iter()
         .filter(|p| !is_global_config(p))
         .collect()
 }
@@ -1382,7 +1413,6 @@ pub fn local_toml_config_path() -> PathBuf {
     local_toml_config_paths()
         .into_iter()
         .last()
-        .cloned()
         .unwrap_or_else(|| {
             dirs::CWD
                 .as_ref()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1092,28 +1092,38 @@ pub fn reset_config_path_caches() {
 }
 
 pub fn all_config_files() -> IndexSet<PathBuf> {
-    let mut files = ALL_CONFIG_FILES.lock().unwrap();
-    if let Some(files) = &*files {
-        return files.clone();
-    }
-    let loaded = load_config_paths(&DEFAULT_CONFIG_FILENAMES, false)
-        .into_iter()
-        .collect();
-    *files = Some(loaded);
-    files.as_ref().unwrap().clone()
+    cached_config_paths(&ALL_CONFIG_FILES, || {
+        load_config_paths(&DEFAULT_CONFIG_FILENAMES, false)
+            .into_iter()
+            .collect()
+    })
 }
 
 pub fn ignored_config_files() -> IndexSet<PathBuf> {
-    let mut files = IGNORED_CONFIG_FILES.lock().unwrap();
+    cached_config_paths(&IGNORED_CONFIG_FILES, || {
+        load_config_paths(&DEFAULT_CONFIG_FILENAMES, true)
+            .into_iter()
+            .filter(|p| {
+                config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(p)
+            })
+            .collect()
+    })
+}
+
+fn cached_config_paths(
+    cache: &Mutex<Option<IndexSet<PathBuf>>>,
+    load: impl FnOnce() -> IndexSet<PathBuf>,
+) -> IndexSet<PathBuf> {
+    if let Some(files) = cache.lock().unwrap().as_ref().cloned() {
+        return files;
+    }
+    let loaded = load();
+    let mut files = cache.lock().unwrap();
     if let Some(files) = &*files {
         return files.clone();
     }
-    let loaded = load_config_paths(&DEFAULT_CONFIG_FILENAMES, true)
-        .into_iter()
-        .filter(|p| config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(p))
-        .collect();
-    *files = Some(loaded);
-    files.as_ref().unwrap().clone()
+    *files = Some(loaded.clone());
+    loaded
 }
 
 pub fn glob(dir: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
@@ -1385,15 +1395,11 @@ pub fn top_toml_config() -> Option<PathBuf> {
 static ALL_TOML_CONFIG_FILES: Lazy<Mutex<Option<IndexSet<PathBuf>>>> = Lazy::new(Default::default);
 
 pub fn all_toml_config_files() -> IndexSet<PathBuf> {
-    let mut files = ALL_TOML_CONFIG_FILES.lock().unwrap();
-    if let Some(files) = &*files {
-        return files.clone();
-    }
-    let loaded = load_config_paths(&TOML_CONFIG_FILENAMES, false)
-        .into_iter()
-        .collect();
-    *files = Some(loaded);
-    files.as_ref().unwrap().clone()
+    cached_config_paths(&ALL_TOML_CONFIG_FILES, || {
+        load_config_paths(&TOML_CONFIG_FILENAMES, false)
+            .into_iter()
+            .collect()
+    })
 }
 
 /// list of all non-global mise.tomls

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -554,6 +554,8 @@ impl Settings {
         updater(partial);
         drop(lock);
         *BASE_SETTINGS.write().unwrap() = None;
+        crate::config::reset_config_path_caches();
+        crate::config::config_file::config_root::reset();
     }
 
     pub fn lockfile_enabled(&self) -> bool {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,5 +1,4 @@
 use crate::cli::Cli;
-use crate::config::ALL_TOML_CONFIG_FILES;
 use crate::duration;
 use crate::file::FindUp;
 use crate::platform::Platform;
@@ -504,9 +503,9 @@ impl Settings {
     }
 
     fn all_settings_files() -> Vec<SettingsPartial> {
-        ALL_TOML_CONFIG_FILES
-            .iter()
-            .map(|p| Self::parse_settings_file(p))
+        crate::config::all_toml_config_files()
+            .into_iter()
+            .map(|p| Self::parse_settings_file(&p))
             .filter_map(|cfg| match cfg {
                 Ok(cfg) => Some(cfg),
                 Err(e) => {
@@ -537,6 +536,7 @@ impl Settings {
         *CLI_SETTINGS.lock().unwrap() = cli_settings;
         *BASE_SETTINGS.write().unwrap() = None;
         // Clear caches that depend on settings and environment
+        crate::config::reset_config_path_caches();
         crate::config::config_file::config_root::reset();
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -449,7 +449,7 @@ impl Settings {
 
         // Don't process mise-specific flags when running as a shim
         if *crate::env::IS_RUNNING_AS_SHIM {
-            Self::reset(Some(s));
+            Self::reset_preserving_config_paths(Some(s));
             return;
         }
 
@@ -492,7 +492,11 @@ impl Settings {
         if cli.verbose > 1 {
             s.log_level = Some("trace".to_string());
         }
-        Self::reset(Some(s));
+        if cli.cd.is_some() {
+            Self::reset(Some(s));
+        } else {
+            Self::reset_preserving_config_paths(Some(s));
+        }
     }
 
     pub fn parse_settings_file(path: &Path) -> Result<SettingsPartial> {
@@ -533,11 +537,22 @@ impl Settings {
     }
 
     pub fn reset(cli_settings: Option<SettingsPartial>) {
+        Self::reset_inner(cli_settings, true);
+    }
+
+    // CLI flags like --quiet rebuild Settings but do not change config discovery.
+    // Keep path caches populated from the earlier startup pass unless --cd needs a new root.
+    fn reset_preserving_config_paths(cli_settings: Option<SettingsPartial>) {
+        Self::reset_inner(cli_settings, false);
+    }
+
+    fn reset_inner(cli_settings: Option<SettingsPartial>, reset_config_paths: bool) {
         *CLI_SETTINGS.lock().unwrap() = cli_settings;
         *BASE_SETTINGS.write().unwrap() = None;
-        // Clear caches that depend on settings and environment
-        crate::config::reset_config_path_caches();
-        crate::config::config_file::config_root::reset();
+        if reset_config_paths {
+            crate::config::reset_config_path_caches();
+            crate::config::config_file::config_root::reset();
+        }
     }
 
     /// Merge an override into the CLI-level settings partial.

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -111,15 +111,17 @@ pub fn should_exit_early_fast() -> bool {
     if args.len() < 2 || args[1] != "hook-env" {
         return false;
     }
-    // --cd changes the effective config/search root for this process, but
+    // --cd/MISE_CD changes the effective config/search root for this process, but
     // the fast path runs before full clap processing. Fall through so Settings
-    // can apply --cd and rebuild path-dependent caches first.
-    if args.iter().take_while(|a| a.as_str() != "--").any(|a| {
-        a == "-C"
-            || a == "--cd"
-            || a.starts_with("--cd=")
-            || a.strip_prefix("-C").is_some_and(|rest| !rest.is_empty())
-    }) {
+    // can apply the cd override and rebuild path-dependent caches first.
+    if std::env::var_os("MISE_CD").is_some()
+        || args.iter().take_while(|a| a.as_str() != "--").any(|a| {
+            a == "-C"
+                || a == "--cd"
+                || a.starts_with("--cd=")
+                || a.strip_prefix("-C").is_some_and(|rest| !rest.is_empty())
+        })
+    {
         return false;
     }
     // Can't exit early if no previous session

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -111,6 +111,17 @@ pub fn should_exit_early_fast() -> bool {
     if args.len() < 2 || args[1] != "hook-env" {
         return false;
     }
+    // --cd changes the effective config/search root for this process, but
+    // the fast path runs before full clap processing. Fall through so Settings
+    // can apply --cd and rebuild path-dependent caches first.
+    if args.iter().take_while(|a| a.as_str() != "--").any(|a| {
+        a == "-C"
+            || a == "--cd"
+            || a.starts_with("--cd=")
+            || a.strip_prefix("-C").is_some_and(|rest| !rest.is_empty())
+    }) {
+        return false;
+    }
     // Can't exit early if no previous session
     // Check for dir being set as a proxy for "has valid session"
     // (loaded_configs can be empty if there are no config files)

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -11,7 +11,9 @@ use crate::task::task_list::split_task_spec;
 use crate::task::task_output::{TaskOutput, trunc};
 use crate::task::task_output_handler::OutputHandler;
 use crate::task::task_script_parser::subcommand_name_from_parse;
-use crate::task::task_source_checker::{save_checksum, sources_are_fresh, task_cwd};
+use crate::task::task_source_checker::{
+    save_checksum_with_cd, sources_are_fresh_with_cd, task_cwd_with_cd,
+};
 use crate::task::{Deps, FailedTasks, GetMatchingExt, Task};
 use crate::toolset::env_cache::CachedEnv;
 use crate::ui::{style, time};
@@ -217,7 +219,10 @@ impl TaskExecutor {
         }
         // If any dependency actually ran, skip the source freshness check
         // so that downstream tasks are invalidated by upstream changes
-        if !self.force && !dep_ran && sources_are_fresh(task, config).await? {
+        if !self.force
+            && !dep_ran
+            && sources_are_fresh_with_cd(task, config, self.cd.as_deref()).await?
+        {
             if !self.quiet(Some(task)) {
                 self.eprint(task, &prefix, "sources up-to-date, skipping");
             }
@@ -409,7 +414,7 @@ impl TaskExecutor {
             );
         }
 
-        save_checksum(task, config).await?;
+        save_checksum_with_cd(task, config, self.cd.as_deref()).await?;
 
         Ok(true)
     }
@@ -1052,7 +1057,7 @@ impl TaskExecutor {
                 }
             }
         }
-        let dir = task_cwd(task, &config).await?;
+        let dir = task_cwd_with_cd(task, &config, self.cd.as_deref()).await?;
         if !dir.exists() {
             self.eprint(
                 task,

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -179,6 +179,21 @@ pub(crate) fn last_modified_file(
 
 /// Get the working directory for a task
 pub async fn task_cwd(task: &Task, config: &Arc<Config>) -> Result<PathBuf> {
+    task_cwd_with_cd(task, config, None).await
+}
+
+pub async fn task_cwd_with_cd(
+    task: &Task,
+    config: &Arc<Config>,
+    cd: Option<&Path>,
+) -> Result<PathBuf> {
+    // `mise run -C <dir>` changes the command cwd, but explicit task dirs still
+    // define where an individual task should run.
+    if let Some(cd) = cd
+        && !task_has_configured_dir(task, config)
+    {
+        return Ok(cd.to_path_buf());
+    }
     if let Some(d) = task.dir(config).await? {
         Ok(d)
     } else {
@@ -190,8 +205,18 @@ pub async fn task_cwd(task: &Task, config: &Arc<Config>) -> Result<PathBuf> {
     }
 }
 
-/// Check if task sources are up to date (fresher than outputs)
-pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool> {
+fn task_has_configured_dir(task: &Task, config: &Arc<Config>) -> bool {
+    task.dir.is_some()
+        || task
+            .cf(config)
+            .is_some_and(|cf| cf.task_config().dir.is_some())
+}
+
+pub async fn sources_are_fresh_with_cd(
+    task: &Task,
+    config: &Arc<Config>,
+    cd: Option<&Path>,
+) -> Result<bool> {
     if task.sources.is_empty() {
         return Ok(false);
     }
@@ -200,7 +225,7 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
     let equal_mtime_is_fresh = settings.task.source_freshness_equal_mtime_is_fresh;
 
     let run = async || -> Result<bool> {
-        let root = task_cwd(task, config).await?;
+        let root = task_cwd_with_cd(task, config, cd).await?;
         let matcher = build_source_matcher(&root, &task.sources);
         let glob_patterns = source_glob_patterns(&task.sources);
         let mut source_metadatas = get_file_metadatas(&root, &glob_patterns, &matcher)?;
@@ -290,13 +315,16 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
     }))
 }
 
-/// Save a checksum file after a task completes successfully
-pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
+pub async fn save_checksum_with_cd(
+    task: &Task,
+    config: &Arc<Config>,
+    cd: Option<&Path>,
+) -> Result<()> {
     if task.sources.is_empty() {
         return Ok(());
     }
     if task.outputs.is_auto() {
-        let root = task_cwd(task, config).await?;
+        let root = task_cwd_with_cd(task, config, cd).await?;
         for p in task.outputs.paths(task, &root) {
             debug!("touching auto output file: {p}");
             file::touch_file(&PathBuf::from(&p))?;
@@ -304,7 +332,7 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
     } else {
         // Check if explicitly defined outputs were generated
         // Use task_cwd to respect the task's dir setting, matching sources_are_fresh behavior
-        let root = task_cwd(task, config).await?;
+        let root = task_cwd_with_cd(task, config, cd).await?;
         for output in task.outputs.paths(task, &root) {
             let output_exists = if is_glob_pattern(&output) {
                 // For glob patterns, check if any files match


### PR DESCRIPTION
## Summary
Stacked on #9835. Do not merge this independently before #9835.

Fix `mise run -C/--cd <dir> <task>` so the requested directory is also the task execution cwd when the task does not define its own `dir` or inherit `task_config.dir`.

This covers the remaining behavior from discussion #4044. #9835 fixes the early config/task discovery side of `--cd`, including #5213, but it still left parent-config tasks executing from their config root instead of the run-level `--cd` target.

## Why This Is Separate
The base PR had to normalize early `--cd`/`MISE_CD` paths before config loading. This change is narrower and task-executor-specific: after clap parsing has produced the normalized run-level cd, task execution, source freshness, and checksum/output checks need to use that same cwd for tasks without an explicit configured directory.

Explicit task directories still win over the CLI cd, preserving existing task configuration behavior.

## Tests
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/mise-m3-cd-target mise run test:e2e e2e/cli/test_cd_settings`

Refs #9835
Refs #4044
