### PR TITLE
registry: use aqua backend for qsv

### DIFF
--- a/registry/qsv.toml
+++ b/registry/qsv.toml
@@ -1,3 +1,3 @@
-backends = ["github:dathere/qsv", "asdf:vjda/asdf-qsv"]
+backends = ["aqua:dathere/qsv", "github:dathere/qsv", "asdf:vjda/asdf-qsv"]
 description = "Blazing-fast Data-Wrangling toolkit"
 test = { cmd = "qsv --version", expected = "qsv {{version}}" }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -30252,8 +30252,157 @@ packages:
     version_overrides:
       - version_constraint: Version in ["0.15.0", "0.24.0", "0.48.0", "0.61.3", "0.68.0", "0.93.0", "0.102.0"]
         no_asset: true
-      - version_constraint: Version in ["publish-testing"]
+      - version_constraint: Version in ["publish-testing", "0.26.0", "0.131.1"]
         error_message: This version isn't supported.
+      - version_constraint: Version == "0.13.1"
+        asset: xsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: xsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.14.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "0.14.1"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.zip.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "0.16.0"
+        asset: qsv-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.16.1"
+        asset: qsv-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: target/release/qsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: windows
+            files:
+              - name: qsv
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.16.2"
+        asset: qsv-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: target/release/qsv
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version in ["0.22.0", "0.22.1", "0.22.2"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: Version in ["0.23.0", "0.24.1", "0.25.2-beta"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version == "0.30.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.90.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              amd64: x86_64
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - windows/amd64
       - version_constraint: Version == "0.108.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30272,6 +30421,25 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
+      - version_constraint: Version == "0.109.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
       - version_constraint: Version == "0.113.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30363,6 +30531,76 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
+      - version_constraint: semver("<= 0.21.0")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: target/{{.Arch}}-{{.OS}}/release/qsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.40.3")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version in ["0.65.0", "0.66.0", "0.67.0", "0.70.0", "0.72.0"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            goarch: arm64
+            files:
+              - name: qsv
+                src: qsv-{{.Version}}-{{.Arch}}-{{.OS}}/qsv
+      - version_constraint: semver("<= 0.75.0")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+      - version_constraint: semver("<= 0.76.2")
+        no_asset: true
       - version_constraint: semver("<= 7.0.1")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30406,7 +30644,7 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 16.1.0")
+      - version_constraint: "true"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         replacements:
@@ -30430,24 +30668,6 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: "true"
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}-testing.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
   - type: github_release
     repo_owner: datreeio
     repo_name: datree

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -30252,157 +30252,8 @@ packages:
     version_overrides:
       - version_constraint: Version in ["0.15.0", "0.24.0", "0.48.0", "0.61.3", "0.68.0", "0.93.0", "0.102.0"]
         no_asset: true
-      - version_constraint: Version in ["publish-testing", "0.26.0", "0.131.1"]
+      - version_constraint: Version in ["publish-testing"]
         error_message: This version isn't supported.
-      - version_constraint: Version == "0.13.1"
-        asset: xsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        files:
-          - name: qsv
-            src: xsv
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "0.14.0"
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        supported_envs:
-          - linux/amd64
-          - windows/amd64
-      - version_constraint: Version == "0.14.1"
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.zip.{{.Format}}
-        supported_envs:
-          - linux/amd64
-          - windows/amd64
-      - version_constraint: Version == "0.16.0"
-        asset: qsv-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        complete_windows_ext: false
-        replacements:
-          darwin: macos
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "0.16.1"
-        asset: qsv-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        files:
-          - name: qsv
-            src: target/release/qsv
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          darwin: macos
-        overrides:
-          - goos: windows
-            files:
-              - name: qsv
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "0.16.2"
-        asset: qsv-{{.OS}}.{{.Format}}
-        format: zip
-        files:
-          - name: qsv
-            src: target/release/qsv
-        replacements:
-          darwin: macos
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version in ["0.22.0", "0.22.1", "0.22.2"]
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        files:
-          - name: qsv
-            src: qsv-{{.Version}}/qsv
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
-      - version_constraint: Version in ["0.23.0", "0.24.1", "0.25.2-beta"]
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        files:
-          - name: qsv
-            src: qsv-{{.Version}}/qsv
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-      - version_constraint: Version == "0.30.0"
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "0.90.0"
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        replacements:
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              amd64: x86_64
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
-        supported_envs:
-          - linux
-          - windows/amd64
       - version_constraint: Version == "0.108.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30421,25 +30272,6 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
-      - version_constraint: Version == "0.109.0"
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
-          - goos: windows
-            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
       - version_constraint: Version == "0.113.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30531,76 +30363,6 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 0.21.0")
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        files:
-          - name: qsv
-            src: target/{{.Arch}}-{{.OS}}/release/qsv
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.40.3")
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-      - version_constraint: Version in ["0.65.0", "0.66.0", "0.67.0", "0.70.0", "0.72.0"]
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
-          - goos: darwin
-            goarch: arm64
-            files:
-              - name: qsv
-                src: qsv-{{.Version}}-{{.Arch}}-{{.OS}}/qsv
-      - version_constraint: semver("<= 0.75.0")
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
-      - version_constraint: semver("<= 0.76.2")
-        no_asset: true
       - version_constraint: semver("<= 7.0.1")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30644,7 +30406,7 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 16.1.0")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         replacements:
@@ -30668,6 +30430,24 @@ packages:
           - linux
           - darwin/arm64
           - windows
+      - version_constraint: "true"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}-testing.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
   - type: github_release
     repo_owner: datreeio
     repo_name: datree


### PR DESCRIPTION
## Summary
- Prefer `aqua:dathere/qsv` for the `qsv` registry shorthand.
- Keep the existing `github:dathere/qsv` and `asdf:vjda/asdf-qsv` fallbacks.
- Leave `vendor/aqua-registry/` unchanged; validation uses a local `file://` aqua registry override with the updated qsv package definition.

## Popularity
- GitHub: 3,644 stars, 105 forks, latest release `20.0.0` published 2026-05-03, pushed 2026-05-16.
- crates.io: 241,840 total downloads, 1,030 recent downloads, newest crate version `16.1.0`, updated 2026-02-15.

## Testing
```console
$ cargo build --bin mise
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 44s
```

```console
$ MISE_AQUA_REGISTRY_URL=file://$AQUA_REGISTRY_DIR mise ls-remote --no-versions-host qsv
3.0.0
3.1.1
3.2.0
3.3.0
4.0.0
...
17.0.0
18.0.0
19.0.0
19.1.0
20.0.0
```

```console
$ MISE_AQUA_REGISTRY_URL=file://$AQUA_REGISTRY_DIR mise x qsv@latest -- qsv --version
qsv 20.0.0-... (x86_64-unknown-linux-musl compiled with Rust 1.95; ...) prebuilt
```
