### PR TITLE
docs(configuration): trim global settings example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,9 +305,11 @@ See [Monorepo Tasks](/tasks/monorepo) for detailed usage and examples.
 
 ## Global config: `~/.config/mise/config.toml`
 
-mise can be configured in `~/.config/mise/config.toml`. It's like local `mise.toml` files except
-that
-it is used for all directories.
+mise can be configured in `~/.config/mise/config.toml`. It works like a local `mise.toml`, but
+applies to every directory.
+
+Only a few common settings are shown here. See [Settings](/configuration/settings) for the full
+list and descriptions.
 
 ```toml [~/.config/mise/config.toml]
 [tools]
@@ -317,46 +319,16 @@ node = 'lts'
 python = ['3.10', '3.11']
 
 [settings]
-# tools can read the versions files used by other version managers
-# for example, .nvmrc in the case of node's nvm
+# read version files used by other version managers, such as .nvmrc
 idiomatic_version_file_enable_tools = ['node']
 
-# keep downloaded archive/source files for debugging
-always_keep_download = false        # deleted after install; not a cache
-always_keep_install = false         # deleted on failure by default
-
-# configure how frequently (in minutes) to fetch updated plugin repository changes
-# this is updated whenever a new runtime is installed
-# (note: this isn't currently implemented but there are plans to add it: https://github.com/jdx/mise/discussions/6735)
-plugin_autoupdate_last_check_duration = '1 week' # set to 0 to disable updates
-
-# config files with these prefixes will be trusted by default
 trusted_config_paths = [
     '~/work/my-trusted-projects',
 ]
 
-verbose = false       # set to true to see full installation output, see `MISE_VERBOSE`
-http_timeout = "30s"  # set the timeout for http requests as duration string, see `MISE_HTTP_TIMEOUT`
-jobs = 4              # number of plugins or runtimes to install in parallel. The default is `4`.
-raw = false           # set to true to directly pipe plugins to stdin/stdout/stderr
-yes = false           # set to true to automatically answer yes to all prompts
-
-not_found_auto_install = true # see MISE_NOT_FOUND_AUTO_INSTALL
-task.output = "prefix" # see Tasks Runner for more information
-paranoid = false       # see MISE_PARANOID
-
-# shorthands_file is deprecated - use [plugins] in this file (see "plugins" above)
-disable_default_registry = false   # disable the default registry, see `MISE_DISABLE_DEFAULT_REGISTRY`
-disable_tools = ['node']           # disable specific tools, generally used to turn off core tools
-
-experimental = true # enable experimental features
-
-# configure messages displayed when entering directories with config files
-status = {
-  missing_tools = "if_other_versions_installed",
-  show_env = false,
-  show_tools = false,
-}
+[settings.status]
+show_env = false
+show_tools = false
 
 [env]
 _.file = '.env'


### PR DESCRIPTION
## Summary
- shorten the global config section intro
- trim the sample `[settings]` block to a few common global preferences
- remove duplicated per-setting explanations and plugin-centric examples from this page

## Testing
- `mise run docs:build`

*This PR was generated by an AI coding assistant.*