### PR TITLE
fix(cache): honor plugin filter when pruning cache

### DIFF
--- a/docs/cli/cache/prune.md
+++ b/docs/cli/cache/prune.md
@@ -14,7 +14,7 @@ Change this with the MISE_CACHE_PRUNE_AGE environment variable.
 
 ### `[PLUGIN]…`
 
-Plugin(s) to clear cache for e.g.: node, python
+Plugin(s) to prune cache for e.g.: node, python
 
 ## Flags
 

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -147,7 +147,7 @@ Run `mise cache` with no args to view the current cache directory."
     cmd "clear" help="Deletes all cache files in mise" {
         alias "c"
         alias "clean" hide=true
-        arg "[PLUGIN]..." help="Plugin(s) to clear cache for e.g.: node, python" var=true
+        arg "[PLUGIN]..." help="Plugin(s) to prune cache for e.g.: node, python" var=true
     }
 }
 cmd "completion" help="Generate shell completions" {

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -147,7 +147,7 @@ Run `mise cache` with no args to view the current cache directory."
     cmd "clear" help="Deletes all cache files in mise" {
         alias "c"
         alias "clean" hide=true
-        arg "[PLUGIN]..." help="Plugin(s) to prune cache for e.g.: node, python" var=true
+        arg "[PLUGIN]..." help="Plugin(s) to clear cache for e.g.: node, python" var=true
     }
 }
 cmd "completion" help="Generate shell completions" {

--- a/e2e/cli/test_cache_prune_plugin
+++ b/e2e/cli/test_cache_prune_plugin
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+mkdir -p "$MISE_CACHE_DIR/node" "$MISE_CACHE_DIR/python"
+printf node >"$MISE_CACHE_DIR/node/old"
+printf python >"$MISE_CACHE_DIR/python/old"
+touch -t 202001010000 "$MISE_CACHE_DIR/node/old" "$MISE_CACHE_DIR/python/old"
+
+MISE_CACHE_PRUNE_AGE=1s mise cache prune node
+
+if [[ -e $MISE_CACHE_DIR/node/old ]]; then
+  fail "node cache was not pruned"
+fi
+
+if [[ ! -e $MISE_CACHE_DIR/python/old ]]; then
+  fail "python cache was pruned"
+fi
+
+ok "cache prune only pruned the requested plugin"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -718,7 +718,7 @@ Mark all cache files as old
 .PP
 .TP
 \fB<PLUGIN>\fR
-Plugin(s) to clear cache for e.g.: node, python
+Plugin(s) to prune cache for e.g.: node, python
 .SH "MISE CACHE PRUNE"
 Removes stale mise cache files
 
@@ -739,7 +739,7 @@ Just show what would be pruned
 .PP
 .TP
 \fB<PLUGIN>\fR
-Plugin(s) to clear cache for e.g.: node, python
+Plugin(s) to prune cache for e.g.: node, python
 .SH "MISE COMPLETION"
 Generate shell completions
 .PP

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -718,7 +718,7 @@ Mark all cache files as old
 .PP
 .TP
 \fB<PLUGIN>\fR
-Plugin(s) to prune cache for e.g.: node, python
+Plugin(s) to clear cache for e.g.: node, python
 .SH "MISE CACHE PRUNE"
 Removes stale mise cache files
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -140,7 +140,7 @@ cmd cache help="Manage the mise cache" {
         alias c
         alias clean hide=#true
         flag --outdate help="Mark all cache files as old" hide=#true
-        arg "[PLUGIN]…" help="Plugin(s) to prune cache for e.g.: node, python" required=#false var=#true
+        arg "[PLUGIN]…" help="Plugin(s) to clear cache for e.g.: node, python" required=#false var=#true
     }
     cmd path help="Show the cache directory path" {
         alias dir

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -140,7 +140,7 @@ cmd cache help="Manage the mise cache" {
         alias c
         alias clean hide=#true
         flag --outdate help="Mark all cache files as old" hide=#true
-        arg "[PLUGIN]…" help="Plugin(s) to clear cache for e.g.: node, python" required=#false var=#true
+        arg "[PLUGIN]…" help="Plugin(s) to prune cache for e.g.: node, python" required=#false var=#true
     }
     cmd path help="Show the cache directory path" {
         alias dir
@@ -150,7 +150,7 @@ cmd cache help="Manage the mise cache" {
         long_help "Removes stale mise cache files\n\nBy default, this command will remove files that have not been accessed in 30 days.\nChange this with the MISE_CACHE_PRUNE_AGE environment variable."
         flag "-v --verbose" help="Show pruned files" var=#true count=#true
         flag --dry-run help="Just show what would be pruned"
-        arg "[PLUGIN]…" help="Plugin(s) to clear cache for e.g.: node, python" required=#false var=#true
+        arg "[PLUGIN]…" help="Plugin(s) to prune cache for e.g.: node, python" required=#false var=#true
     }
 }
 cmd completion help="Generate shell completions" {

--- a/src/cli/cache/prune.rs
+++ b/src/cli/cache/prune.rs
@@ -4,6 +4,7 @@ use crate::config::Settings;
 use crate::dirs::CACHE;
 use crate::toolset::env_cache::CachedEnv;
 use eyre::Result;
+use heck::ToKebabCase;
 use number_prefix::NumberPrefix;
 use std::time::Duration;
 
@@ -14,7 +15,7 @@ use std::time::Duration;
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, visible_alias = "p")]
 pub struct CachePrune {
-    /// Plugin(s) to clear cache for
+    /// Plugin(s) to prune cache for
     /// e.g.: node, python
     plugin: Option<Vec<String>>,
 
@@ -39,14 +40,33 @@ impl CachePrune {
         };
         let mut results = PruneResults { size: 0, count: 0 };
 
-        // Prune main cache
-        let r = cache::prune(&CACHE.to_path_buf(), &opts)?;
-        results.size += r.size;
-        results.count += r.count;
+        let cache_dirs = match &self.plugin {
+            Some(plugins) => plugins
+                .iter()
+                .filter_map(|plugin| {
+                    let kebab = plugin.to_kebab_case();
+                    if kebab.is_empty() {
+                        warn!("invalid plugin name: {plugin}");
+                        None
+                    } else {
+                        Some(CACHE.join(kebab))
+                    }
+                })
+                .collect(),
+            None => vec![CACHE.to_path_buf()],
+        };
+
+        for p in cache_dirs {
+            if p.exists() {
+                let r = cache::prune(&p, &opts)?;
+                results.size += r.size;
+                results.count += r.count;
+            }
+        }
 
         // Prune env cache using env_cache_ttl
         let env_cache_dir = CachedEnv::cache_dir();
-        if env_cache_dir.exists() {
+        if self.plugin.is_none() && env_cache_dir.exists() {
             let env_opts = PruneOptions {
                 dry_run: self.dry_run,
                 verbose: self.verbose > 0,
@@ -59,7 +79,13 @@ impl CachePrune {
 
         let count = results.count;
         let size = bytes_str(results.size);
-        info!("cache pruned {count} files, {size}");
+        match &self.plugin {
+            Some(plugins) => info!(
+                "cache pruned for {}: {count} files, {size}",
+                plugins.join(", ")
+            ),
+            None => info!("cache pruned {count} files, {size}"),
+        }
         Ok(())
     }
 }

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -697,7 +697,7 @@ const completionSpec: Fig.Spec = {
           description: "Deletes all cache files in mise",
           args: {
             name: "plugin",
-            description: "Plugin(s) to clear cache for e.g.: node, python",
+            description: "Plugin(s) to prune cache for e.g.: node, python",
             isOptional: true,
             isVariadic: true,
             generators: pluginGenerator,
@@ -725,7 +725,7 @@ const completionSpec: Fig.Spec = {
           ],
           args: {
             name: "plugin",
-            description: "Plugin(s) to clear cache for e.g.: node, python",
+            description: "Plugin(s) to prune cache for e.g.: node, python",
             isOptional: true,
             isVariadic: true,
             generators: pluginGenerator,

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -697,7 +697,7 @@ const completionSpec: Fig.Spec = {
           description: "Deletes all cache files in mise",
           args: {
             name: "plugin",
-            description: "Plugin(s) to prune cache for e.g.: node, python",
+            description: "Plugin(s) to clear cache for e.g.: node, python",
             isOptional: true,
             isVariadic: true,
             generators: pluginGenerator,


### PR DESCRIPTION
## Summary
- Honor the optional `mise cache prune [PLUGIN]...` argument instead of always pruning the whole cache.
- Mirror `mise cache clear` by mapping each requested plugin name to its cache subdirectory before pruning stale files.
- Leave env-cache pruning on the unscoped `mise cache prune` path only, because the env cache is not scoped to a single plugin directory.
- Reword the prune argument help from "clear cache" to "prune cache" while leaving `cache clear` wording unchanged.

## Behavior
Before this change, `mise cache prune node` accepted `node` but ignored it and pruned all cache directories, plus the env cache. With this change, `mise cache prune node` only prunes stale files under the node cache directory. Running `mise cache prune` with no arguments keeps the existing all-cache behavior.

## Testing
- `cargo fmt --all -- --check`
- `git diff --check`
- `mise run test:e2e e2e/cli/test_cache_prune_plugin`
