### PR TITLE
fix(aqua): resolve prefixed vars with manifest opts

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -71,33 +71,43 @@ impl<'a> AquaOptions<'a> {
         {
             return toml_string_var(&format!("vars.{name}"), value).map(Some);
         }
+        if let Some(value) = opts.opts.get(name) {
+            return toml_string_var(name, value).map(Some);
+        }
         let prefixed = format!("vars.{name}");
         if let Some(value) = opts.opts.get(&prefixed) {
             return toml_string_var(&prefixed, value).map(Some);
         }
-        opts.opts
-            .get(name)
-            .map(|value| toml_string_var(name, value).map(Some))
-            .unwrap_or(Ok(None))
+        Ok(None)
     }
 
     fn lockfile_options(&self) -> BTreeMap<String, String> {
         let mut result = BTreeMap::new();
         for (key, value) in self.values.raw().iter() {
-            if key == "symlink_bins" || EPHEMERAL_OPT_KEYS.contains(&key.as_str()) {
+            if key.starts_with("vars.")
+                && !EPHEMERAL_OPT_KEYS.contains(&key.as_str())
+                && let Some(value) = toml_value_to_string(value)
+            {
+                result.insert(key.clone(), value);
+            }
+        }
+        for (key, value) in self.values.raw().iter() {
+            if key == "vars"
+                || key == "symlink_bins"
+                || key.starts_with("vars.")
+                || EPHEMERAL_OPT_KEYS.contains(&key.as_str())
+            {
                 continue;
             }
+            if let Some(value) = toml_value_to_string(value) {
+                result.insert(format!("vars.{key}"), value);
+            }
+        }
+        for (key, value) in self.values.raw().iter() {
             if key == "vars" {
                 if let toml::Value::Table(table) = value {
                     Self::insert_vars_lockfile_options(&mut result, table);
                 }
-            } else if let Some(value) = toml_value_to_string(value) {
-                let key = if key.starts_with("vars.") {
-                    key.clone()
-                } else {
-                    format!("vars.{key}")
-                };
-                result.entry(key).or_insert(value);
             }
         }
         result
@@ -2789,6 +2799,30 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_var_options_prefers_plain_vars_over_prefixed_vars() {
+        let mut pkg = AquaPackage::default();
+        pkg.asset = "tool-{{.Vars.channel}}-{{.Version}}.tar.gz".to_string();
+        pkg.vars = vec![aqua_var("channel", true)];
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "vars.channel".to_string(),
+            toml::Value::String("manifest".to_string()),
+        );
+        opts.opts.insert(
+            "channel".to_string(),
+            toml::Value::String("stable".to_string()),
+        );
+
+        let opts = AquaOptions::new(&opts);
+        let pkg = AquaBackend::apply_var_options(pkg, &opts).unwrap();
+
+        assert_eq!(
+            pkg.asset("1.0.0", "linux", "amd64").unwrap(),
+            "tool-stable-1.0.0.tar.gz"
+        );
+    }
+
+    #[test]
     fn test_apply_var_options_errors_for_array_vars() {
         let mut pkg = AquaPackage::default();
         pkg.vars = vec![aqua_var("channels", true)];
@@ -2896,6 +2930,23 @@ mod tests {
         let lock_opts = AquaOptions::new(&opts).lockfile_options();
 
         assert_eq!(lock_opts.get("vars.channel"), Some(&"beta".to_string()));
+    }
+
+    #[test]
+    fn test_lockfile_options_plain_aqua_vars_take_precedence_over_prefixed_vars() {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "vars.channel".to_string(),
+            toml::Value::String("manifest".to_string()),
+        );
+        opts.opts.insert(
+            "channel".to_string(),
+            toml::Value::String("stable".to_string()),
+        );
+
+        let lock_opts = AquaOptions::new(&opts).lockfile_options();
+
+        assert_eq!(lock_opts.get("vars.channel"), Some(&"stable".to_string()));
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -71,6 +71,10 @@ impl<'a> AquaOptions<'a> {
         {
             return toml_string_var(&format!("vars.{name}"), value).map(Some);
         }
+        let prefixed = format!("vars.{name}");
+        if let Some(value) = opts.opts.get(&prefixed) {
+            return toml_string_var(&prefixed, value).map(Some);
+        }
         opts.opts
             .get(name)
             .map(|value| toml_string_var(name, value).map(Some))
@@ -2761,6 +2765,26 @@ mod tests {
         assert_eq!(
             pkg.asset("1.0.0", "linux", "amd64").unwrap(),
             "tool-beta-1.0.0.tar.gz"
+        );
+    }
+
+    #[test]
+    fn test_apply_var_options_reads_prefixed_vars() {
+        let mut pkg = AquaPackage::default();
+        pkg.asset = "tool-{{.Vars.channel}}-{{.Version}}.tar.gz".to_string();
+        pkg.vars = vec![aqua_var("channel", true)];
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "vars.channel".to_string(),
+            toml::Value::String("stable".to_string()),
+        );
+
+        let opts = AquaOptions::new(&opts);
+        let pkg = AquaBackend::apply_var_options(pkg, &opts).unwrap();
+
+        assert_eq!(
+            pkg.asset("1.0.0", "linux", "amd64").unwrap(),
+            "tool-stable-1.0.0.tar.gz"
         );
     }
 

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -90,16 +90,16 @@ impl From<InstallStateTool> for BackendArg {
             }
         }
 
+        let opts_source = opts.as_ref().map(|_| ToolOptionSource::InstallManifest);
         let mut tool = Self::new_raw(
             short,
             ist.full,
             tool_name,
-            opts,
+            None,
             BackendResolution::new(ist.explicit_backend),
         );
-        if tool.opts.is_some() {
-            tool.opts_source = Some(ToolOptionSource::InstallManifest);
-        }
+        tool.opts = opts;
+        tool.opts_source = opts_source;
         if let Some(installs_path) = ist.installs_path {
             tool.installs_path = installs_path;
         }
@@ -199,6 +199,7 @@ impl BackendArg {
         resolution: BackendResolution,
     ) -> Self {
         let pathname = short.to_kebab_case();
+        let opts_source = opts.as_ref().map(|_| ToolOptionSource::InlineBackendArg);
         Self {
             tool_name,
             short,
@@ -207,7 +208,7 @@ impl BackendArg {
             installs_path: dirs::INSTALLS.join(&pathname),
             downloads_path: dirs::DOWNLOADS.join(&pathname),
             opts,
-            opts_source: opts.as_ref().map(|_| ToolOptionSource::InlineBackendArg),
+            opts_source,
             resolution,
             // backend: Default::default(),
         }
@@ -448,7 +449,7 @@ impl BackendArg {
         if split_bracketed_opts(&full).is_some() {
             return full;
         }
-        if let Some(opts) = &self.opts
+        if let Some(opts) = self.explicit_opts()
             && let Some(opts_str) = serialize_tool_options(
                 opts.opts
                     .iter()
@@ -959,6 +960,27 @@ mod tests {
             "gitlab:jdxcode/mise-test-fixtures[asset_pattern=hello-world-1.0.0.tar.gz,bin_path=hello-world-1.0.0/bin]",
             fa.full_with_opts()
         );
+    }
+
+    #[tokio::test]
+    async fn test_full_with_opts_omits_install_manifest_opts() {
+        let _config = Config::get().await.unwrap();
+
+        let mut opts = std::collections::BTreeMap::new();
+        opts.insert(
+            "version_json_path".to_string(),
+            toml::Value::String(".manifest".to_string()),
+        );
+        let fa = BackendArg::from(crate::toolset::install_state::InstallStateTool {
+            short: "http:hello".to_string(),
+            full: Some("http:hello".to_string()),
+            versions: vec!["1.0.0".to_string()],
+            explicit_backend: true,
+            opts,
+            installs_path: None,
+        });
+
+        assert_str_eq!("http:hello", fa.full_with_opts());
     }
 
     #[tokio::test]

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -5,7 +5,7 @@ use crate::plugins::PluginType;
 use crate::registry::REGISTRY;
 use crate::toolset::install_state::InstallStateTool;
 use crate::toolset::{
-    EPHEMERAL_OPT_KEYS, ToolVersionOptions, install_state, parse_tool_options,
+    EPHEMERAL_OPT_KEYS, ToolOptionSource, ToolVersionOptions, install_state, parse_tool_options,
     serialize_tool_options, try_parse_tool_options,
 };
 use crate::{backend, config, dirs, lockfile, registry};
@@ -51,6 +51,7 @@ pub struct BackendArg {
     /// ~/.local/share/mise/downloads/<THIS>
     pub downloads_path: PathBuf,
     pub opts: Option<ToolVersionOptions>,
+    opts_source: Option<ToolOptionSource>,
     resolution: BackendResolution,
     // TODO: make this not a hash key anymore to use this
     // backend: OnceCell<ABackend>,
@@ -96,6 +97,9 @@ impl From<InstallStateTool> for BackendArg {
             opts,
             BackendResolution::new(ist.explicit_backend),
         );
+        if tool.opts.is_some() {
+            tool.opts_source = Some(ToolOptionSource::InstallManifest);
+        }
         if let Some(installs_path) = ist.installs_path {
             tool.installs_path = installs_path;
         }
@@ -203,6 +207,7 @@ impl BackendArg {
             installs_path: dirs::INSTALLS.join(&pathname),
             downloads_path: dirs::DOWNLOADS.join(&pathname),
             opts,
+            opts_source: opts.as_ref().map(|_| ToolOptionSource::InlineBackendArg),
             resolution,
             // backend: Default::default(),
         }
@@ -485,6 +490,9 @@ impl BackendArg {
         config_opts: Option<ToolVersionOptions>,
     ) -> ToolVersionOptions {
         let mut opts = self.registry_opts();
+        if let Some(manifest_opts) = self.install_manifest_opts() {
+            opts.apply_overrides(manifest_opts);
+        }
         if alias_opts.is_none()
             && let Some(full_opts) = self.resolved_full_opts()
         {
@@ -503,7 +511,15 @@ impl BackendArg {
     }
 
     pub fn explicit_opts(&self) -> Option<&ToolVersionOptions> {
-        self.opts.as_ref()
+        self.opts
+            .as_ref()
+            .filter(|_| self.opts_source == Some(ToolOptionSource::InlineBackendArg))
+    }
+
+    pub fn install_manifest_opts(&self) -> Option<&ToolVersionOptions> {
+        self.opts
+            .as_ref()
+            .filter(|_| self.opts_source == Some(ToolOptionSource::InstallManifest))
     }
 
     pub(crate) fn resolved_full_opts(&self) -> Option<ToolVersionOptions> {
@@ -536,6 +552,10 @@ impl BackendArg {
 
     pub fn set_opts(&mut self, opts: Option<ToolVersionOptions>) {
         self.opts = opts;
+        self.opts_source = self
+            .opts
+            .as_ref()
+            .map(|_| ToolOptionSource::InlineBackendArg);
     }
 
     /// Returns true if the user explicitly specified the full backend identifier.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2780,6 +2780,11 @@ mod tests {
             resolved.source_for_key("manifest_only"),
             Some(crate::toolset::ToolOptionSource::InstallManifest)
         );
+        assert_eq!(opts.get("config_only"), Some("true"));
+        assert_eq!(
+            resolved.source_for_key("config_only"),
+            Some(crate::toolset::ToolOptionSource::Config)
+        );
         Ok(())
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2789,6 +2789,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_resolve_tool_opts_preserves_aqua_symlink_bins_from_install_manifest() -> Result<()>
+    {
+        crate::toolset::install_state::init().await?;
+
+        let source = crate::toolset::ToolSource::MiseToml(PathBuf::from("mise.toml"));
+        let config_ba = Arc::new(BackendArg::from("aqua:manifest-opts"));
+        let config_opts = crate::toolset::parse_tool_options("channel=stable");
+        let mut trs = ToolRequestSet::new();
+        trs.add_version(
+            crate::toolset::ToolRequest::new_opts(config_ba, "1.0.0", config_opts, source.clone())?,
+            &source,
+        );
+
+        let mut manifest_opts = BTreeMap::new();
+        manifest_opts.insert(
+            "channel".to_string(),
+            toml::Value::String("manifest".to_string()),
+        );
+        manifest_opts.insert(
+            "symlink_bins".to_string(),
+            toml::Value::String("true".to_string()),
+        );
+        let ba = Arc::new(BackendArg::from(
+            crate::toolset::install_state::InstallStateTool {
+                short: "aqua:manifest-opts".to_string(),
+                full: Some("aqua:manifest-opts".to_string()),
+                versions: vec!["1.0.0".to_string()],
+                explicit_backend: true,
+                opts: manifest_opts,
+                installs_path: None,
+            },
+        ));
+
+        let config = Config {
+            tera_ctx: BASE_CONTEXT.clone(),
+            config_files: Default::default(),
+            env: OnceCell::new(),
+            env_with_sources: OnceCell::new(),
+            shorthands: get_shorthands(&Settings::get()),
+            hooks: OnceCell::new(),
+            tasks_cache: Arc::new(DashMap::new()),
+            tool_request_set: OnceCell::new(),
+            toolset: OnceCell::new(),
+            all_aliases: Default::default(),
+            aliases: Default::default(),
+            project_root: Default::default(),
+            repo_urls: Default::default(),
+            shell_aliases: Default::default(),
+            tera_files: Default::default(),
+            vars: Default::default(),
+            vars_loader: None,
+            vars_results: OnceCell::new(),
+        };
+        config.tool_request_set.set(trs).ok();
+        let config = Arc::new(config);
+
+        let resolved = config.resolve_tool_opts_with_overrides(&ba).await?;
+        let opts = resolved.options();
+
+        assert_eq!(opts.get("channel"), Some("stable"));
+        assert_eq!(
+            resolved.source_for_key("channel"),
+            Some(crate::toolset::ToolOptionSource::Config)
+        );
+        assert_eq!(opts.get("symlink_bins"), Some("true"));
+        assert_eq!(
+            resolved.source_for_key("symlink_bins"),
+            Some(crate::toolset::ToolOptionSource::InstallManifest)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_resolve_tool_opts_prefers_env_backend_override_over_alias_opts() -> Result<()> {
         unsafe {
             std::env::set_var("MISE_BACKENDS_ENV_OPTS_TEST", "github:env/repo[foo=env]");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -355,6 +355,9 @@ impl Config {
         let alias_opts = self.get_backend_alias_opts(backend_arg);
         let mut resolved = ResolvedToolOptions::default();
         resolved.apply_overrides(&backend_arg.registry_opts(), ToolOptionSource::Registry);
+        if let Some(manifest_opts) = backend_arg.install_manifest_opts() {
+            resolved.apply_overrides(manifest_opts, ToolOptionSource::InstallManifest);
+        }
         if alias_opts.is_none()
             && let Some(full_opts) = backend_arg.resolved_full_opts()
         {
@@ -2703,6 +2706,79 @@ mod tests {
         assert_eq!(
             resolved.source_for_key("foo"),
             Some(crate::toolset::ToolOptionSource::BackendAlias)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_resolve_tool_opts_prefers_config_over_install_manifest_opts() -> Result<()> {
+        crate::toolset::install_state::init().await?;
+
+        let source = crate::toolset::ToolSource::MiseToml(PathBuf::from("mise.toml"));
+        let config_ba = Arc::new(BackendArg::from("http:manifest-opts"));
+        let config_opts =
+            crate::toolset::parse_tool_options("version_json_path=.current,config_only=true");
+        let mut trs = ToolRequestSet::new();
+        trs.add_version(
+            crate::toolset::ToolRequest::new_opts(config_ba, "1.0.0", config_opts, source.clone())?,
+            &source,
+        );
+
+        let mut manifest_opts = BTreeMap::new();
+        manifest_opts.insert(
+            "version_json_path".to_string(),
+            toml::Value::String(".manifest".to_string()),
+        );
+        manifest_opts.insert(
+            "manifest_only".to_string(),
+            toml::Value::String("true".to_string()),
+        );
+        let ba = Arc::new(BackendArg::from(
+            crate::toolset::install_state::InstallStateTool {
+                short: "http:manifest-opts".to_string(),
+                full: Some("http:manifest-opts".to_string()),
+                versions: vec!["1.0.0".to_string()],
+                explicit_backend: true,
+                opts: manifest_opts,
+                installs_path: None,
+            },
+        ));
+
+        let config = Config {
+            tera_ctx: BASE_CONTEXT.clone(),
+            config_files: Default::default(),
+            env: OnceCell::new(),
+            env_with_sources: OnceCell::new(),
+            shorthands: get_shorthands(&Settings::get()),
+            hooks: OnceCell::new(),
+            tasks_cache: Arc::new(DashMap::new()),
+            tool_request_set: OnceCell::new(),
+            toolset: OnceCell::new(),
+            all_aliases: Default::default(),
+            aliases: Default::default(),
+            project_root: Default::default(),
+            repo_urls: Default::default(),
+            shell_aliases: Default::default(),
+            tera_files: Default::default(),
+            vars: Default::default(),
+            vars_loader: None,
+            vars_results: OnceCell::new(),
+        };
+        config.tool_request_set.set(trs).ok();
+        let config = Arc::new(config);
+
+        let resolved = config.resolve_tool_opts_with_overrides(&ba).await?;
+        let opts = resolved.options();
+
+        assert_eq!(opts.get("version_json_path"), Some(".current"));
+        assert_eq!(
+            resolved.source_for_key("version_json_path"),
+            Some(crate::toolset::ToolOptionSource::Config)
+        );
+        assert_eq!(opts.get("manifest_only"), Some("true"));
+        assert_eq!(
+            resolved.source_for_key("manifest_only"),
+            Some(crate::toolset::ToolOptionSource::InstallManifest)
         );
         Ok(())
     }

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -130,6 +130,7 @@ impl DerefMut for ToolOptions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolOptionSource {
     Registry,
+    InstallManifest,
     BackendAlias,
     Config,
     InlineBackendArg,


### PR DESCRIPTION
Stacked on #9958. Target branch remains `main`.

## Summary
- preserve Aqua `symlink_bins` from the install manifest while current config overrides ordinary options
- resolve flat `vars.<name>` option keys in `AquaOptions::var`, matching bracket and TOML dotted-key syntax
- add regression coverage for both manifest-only `symlink_bins` and prefixed Aqua vars

## Verification
- `git diff --check fix/install-manifest-option-source...fix/aqua-symlink-bins-manifest-only`