### PR TITLE
fix(task): respect --cd for task cwd

### DIFF
--- a/e2e/cli/test_chdir
+++ b/e2e/cli/test_chdir
@@ -23,9 +23,18 @@ run = '''echo "{{ exec(command='pwd') | trim }}"'''
 [tasks.explicit_dir]
 run = 'pwd'
 dir = "test"
+
+[tasks.dep_pwd]
+run = 'pwd'
+
+[tasks.parent_pwd]
+depends = ["dep_pwd"]
+run = 'pwd'
 EOF
 
 assert "mise run --cd subdir pwd" "$PWD/subdir"
 assert "mise -C subdir run pwd" "$PWD/subdir"
 assert "mise run --cd subdir exec_pwd" "$PWD/subdir"
 assert "mise run --cd subdir explicit_dir" "$PWD/test"
+assert "mise run --cd subdir parent_pwd" "$PWD/subdir
+$PWD/subdir"

--- a/e2e/cli/test_chdir
+++ b/e2e/cli/test_chdir
@@ -11,3 +11,21 @@ assert_contains "mise config --cd $PWD/test ls" "test/mise.toml"
 assert_contains "mise run --cd $PWD/test hello" "Hello, World!"
 assert_contains "mise run --cd ./test hello" "Hello, World!"
 assert_contains "mise run --cd test hello" "Hello, World!"
+
+mkdir -p ./subdir
+cat <<EOF >./mise.toml
+[tasks.pwd]
+run = 'pwd'
+
+[tasks.exec_pwd]
+run = '''echo "{{ exec(command='pwd') | trim }}"'''
+
+[tasks.explicit_dir]
+run = 'pwd'
+dir = "test"
+EOF
+
+assert "mise run --cd subdir pwd" "$PWD/subdir"
+assert "mise -C subdir run pwd" "$PWD/subdir"
+assert "mise run --cd subdir exec_pwd" "$PWD/subdir"
+assert "mise run --cd subdir explicit_dir" "$PWD/test"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -239,7 +239,6 @@ impl Run {
         // Unescape task args early so we can check for help flags
         self.args = unescape_task_args(&self.args);
         self.args_last = unescape_task_args(&self.args_last);
-        self.normalize_cd()?;
 
         // Temporarily unset cache key to force fresh env computation
         if self.fresh_env {
@@ -253,6 +252,7 @@ impl Run {
             self.args.contains(&"--help".to_string()) || self.args.contains(&"-h".to_string());
 
         let mut config = Config::get().await?;
+        self.normalize_cd()?;
 
         // Handle task help early to avoid unnecessary toolset/deps work
         if has_help_in_task_args {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -239,6 +239,7 @@ impl Run {
         // Unescape task args early so we can check for help flags
         self.args = unescape_task_args(&self.args);
         self.args_last = unescape_task_args(&self.args_last);
+        self.normalize_cd()?;
 
         // Temporarily unset cache key to force fresh env computation
         if self.fresh_env {
@@ -345,7 +346,8 @@ impl Run {
         // 1. Discover deps providers from monorepo subdirectory configs
         // 2. Include monorepo subdirectory tools in the toolset before installing
         // 3. Reuse the resolved list for execution (avoiding duplicate work)
-        let resolved_tasks = resolve_depends(&config, task_list).await?;
+        let mut resolved_tasks = resolve_depends(&config, task_list).await?;
+        self.apply_cd_to_default_task_dirs(&config, &mut resolved_tasks);
 
         // Collect subdirectory config files from all resolved tasks. In
         // monorepos these come from sub mise.toml files referenced via the
@@ -429,6 +431,36 @@ impl Run {
             .find(|s| s.get_name() == "run")
             .unwrap()
             .clone()
+    }
+
+    fn normalize_cd(&mut self) -> Result<()> {
+        if self.cd.is_some() {
+            // Settings has already applied --cd by this point. Store the
+            // effective absolute cwd so task templating does not apply a
+            // relative --cd path a second time.
+            self.cd = Some(env::current_dir()?);
+        }
+        Ok(())
+    }
+
+    fn apply_cd_to_default_task_dirs(&self, config: &Arc<Config>, tasks: &mut [Task]) {
+        let Some(cd) = &self.cd else {
+            return;
+        };
+        let cd = cd.to_string_lossy().to_string();
+        for task in tasks {
+            if Self::uses_default_task_dir(config, task) {
+                task.dir = Some(cd.clone());
+            }
+        }
+    }
+
+    fn uses_default_task_dir(config: &Arc<Config>, task: &Task) -> bool {
+        let has_task_config_dir = task
+            .cf(config)
+            .and_then(|cf| cf.task_config().dir.as_ref())
+            .is_some();
+        task.dir.is_none() && !has_task_config_dir
     }
 
     async fn parallelize_tasks(mut self, mut config: Arc<Config>, tasks: Vec<Task>) -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes the remaining `mise run --cd` task-resolution inconsistency from discussions https://github.com/jdx/mise/discussions/5213 and https://github.com/jdx/mise/discussions/4044.

`Settings` applies `--cd` before `Run::run()` executes, but `Run` still retained the original parsed `cd` argument. For a relative path such as `--cd subdir`, task script templating passed that relative path into Tera helpers after the process was already in `subdir`. That made helpers such as `exec(command='pwd')` resolve from `subdir/subdir`, matching the double-application failure described in #4044.

This PR normalizes `Run.cd` to the effective absolute current directory after settings have applied `--cd`. That gives task Tera helpers a stable base directory instead of re-applying the raw relative argument.

It also applies the same effective directory to resolved tasks that are using the implicit default task directory. This makes `mise run --cd subdir task` and `mise -C subdir run task` execute no-dir tasks from the requested directory, while still preserving explicit task directory choices:

- `dir = ...` on the task is not overwritten
- `[task_config].dir` is not overwritten
- task config/project root metadata remains available through `MISE_PROJECT_ROOT`, `MISE_CONFIG_ROOT`, and `{{config_root}}`

## Risk

The user-visible behavior change is limited to tasks invoked with `--cd`/`-C` that do not configure `dir` themselves. Those tasks now run from the effective `--cd` directory instead of falling back to the directory of the `mise.toml` that defined them. That matches the CLI flag text ("change directory before executing the command") and the reported discussions, but it can affect tasks that intentionally used `--cd` only for config lookup while relying on the old implicit project-root execution directory. Those tasks can keep the old behavior by setting `dir = "{{config_root}}"` or `[task_config].dir` explicitly.

The regression test includes an underscore task name (`exec_pwd`) so this path continues to cover task names that are not simple kebab-case. I did not change tool-name parsing or registry/backend resolution, so tools with underscores should not be affected by this patch.

## Tests

- `CARGO_TARGET_DIR=/tmp/mise-m7-cd-target /home/risu/.rustup/toolchains/1.95.0-x86_64-unknown-linux-gnu/bin/cargo build --bin mise --all-features`
- `CARGO_TARGET_DIR=/tmp/mise-m7-cd-target PATH=/tmp/mise-m7-cd-target/debug:$PATH mise run test:e2e test_chdir`
- `/home/risu/.rustup/toolchains/1.95.0-x86_64-unknown-linux-gnu/bin/cargo fmt --all -- --check`
- `git diff --check`

*This PR was generated by an AI coding assistant.*