### PR TITLE
fix(install): reconcile manifest for cached installs

### DIFF
--- a/e2e/backend/test_install_manifest_reconcile
+++ b/e2e/backend/test_install_manifest_reconcile
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+MANIFEST="$MISE_DATA_DIR/installs/.mise-installs.toml"
+INSTALL_DIR="$MISE_DATA_DIR/installs/http-manifest-reconcile/1.0.0"
+SHIM="$MISE_DATA_DIR/shims/hello-world"
+
+mkdir -p "$INSTALL_DIR/bin"
+cat <<'EOF' >"$INSTALL_DIR/bin/hello-world"
+#!/usr/bin/env bash
+echo "hello world"
+EOF
+chmod +x "$INSTALL_DIR/bin/hello-world"
+
+cat <<'EOF' >mise.toml
+[tools]
+"http:manifest-reconcile" = { version = "1.0.0", url = "https://example.invalid/tool.tar.gz", bin_path = "bin" }
+EOF
+
+rm -f "$MANIFEST" "$SHIM"
+
+mise install
+assert_contains "cat $MANIFEST" 'short = "http:manifest-reconcile"'
+assert_contains "cat $MANIFEST" 'full = "http:manifest-reconcile"'
+
+mise reshim
+assert_succeed "test -e $SHIM"

--- a/e2e/backend/test_install_manifest_reconcile
+++ b/e2e/backend/test_install_manifest_reconcile
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 MANIFEST="$MISE_DATA_DIR/installs/.mise-installs.toml"
+TOOL_MANIFEST="$MISE_DATA_DIR/installs/http-manifest-reconcile/.mise.backend.toml"
 INSTALL_DIR="$MISE_DATA_DIR/installs/http-manifest-reconcile/1.0.0"
 SHIM="$MISE_DATA_DIR/shims/hello-world"
 
@@ -16,11 +17,14 @@ cat <<'EOF' >mise.toml
 "http:manifest-reconcile" = { version = "1.0.0", url = "https://example.invalid/tool.tar.gz", bin_path = "bin" }
 EOF
 
-rm -f "$MANIFEST" "$SHIM"
+rm -f "$MANIFEST" "$TOOL_MANIFEST" "$SHIM"
 
 mise install
 assert_contains "cat $MANIFEST" 'short = "http:manifest-reconcile"'
 assert_contains "cat $MANIFEST" 'full = "http:manifest-reconcile"'
+assert_contains "cat $TOOL_MANIFEST" 'short = "http:manifest-reconcile"'
+assert_contains "cat $TOOL_MANIFEST" 'full = "http:manifest-reconcile"'
 
+rm -f "$MANIFEST"
 mise reshim
 assert_succeed "test -e $SHIM"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1729,9 +1729,7 @@ pub trait Backend: Debug + Send + Sync {
                 .await?;
             ctx.pr.next_operation();
         } else if self.is_version_installed(&ctx.config, &tv, true) {
-            if tv.install_path().starts_with(*dirs::INSTALLS) {
-                install_state::write_backend_meta(self.ba())?;
-            }
+            install_state::write_backend_meta_for_install_path(self.ba(), &tv.install_path())?;
             return Ok(tv);
         }
 
@@ -1744,9 +1742,7 @@ pub trait Backend: Debug + Send + Sync {
 
         // Double-checked (locking) that it wasn't installed while we were waiting for the lock
         if self.is_version_installed(&ctx.config, &tv, true) && !ctx.force {
-            if tv.install_path().starts_with(*dirs::INSTALLS) {
-                install_state::write_backend_meta(self.ba())?;
-            }
+            install_state::write_backend_meta_for_install_path(self.ba(), &tv.install_path())?;
             return Ok(tv);
         }
 
@@ -1763,19 +1759,10 @@ pub trait Backend: Debug + Send + Sync {
         };
 
         let install_path = tv.install_path();
-        let mut update_install_state = false;
-        if install_path.starts_with(*dirs::INSTALLS) {
-            install_state::write_backend_meta(self.ba())?;
-            update_install_state = true;
-        } else if env::install_path_category(&install_path) != env::InstallPathCategory::Local {
-            // For --system/--shared installs, write manifest to the target installs dir
-            if let Some(installs_dir) = install_path.parent().and_then(|p| p.parent()) {
-                let manifest = installs_dir.join(".mise-installs.toml");
-                install_state::write_backend_meta_to(self.ba(), &manifest)?;
-                update_install_state = true;
-            }
-        }
-        if update_install_state {
+        install_state::write_backend_meta_for_install_path(self.ba(), &install_path)?;
+        if install_path.starts_with(*dirs::INSTALLS)
+            || env::install_path_category(&install_path) != env::InstallPathCategory::Local
+        {
             install_state::add_tool_version(self.ba(), &install_path, &tv.tv_pathname());
         }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1729,6 +1729,9 @@ pub trait Backend: Debug + Send + Sync {
                 .await?;
             ctx.pr.next_operation();
         } else if self.is_version_installed(&ctx.config, &tv, true) {
+            if tv.install_path().starts_with(*dirs::INSTALLS) {
+                install_state::write_backend_meta(self.ba())?;
+            }
             return Ok(tv);
         }
 
@@ -1741,6 +1744,9 @@ pub trait Backend: Debug + Send + Sync {
 
         // Double-checked (locking) that it wasn't installed while we were waiting for the lock
         if self.is_version_installed(&ctx.config, &tv, true) && !ctx.force {
+            if tv.install_path().starts_with(*dirs::INSTALLS) {
+                install_state::write_backend_meta(self.ba())?;
+            }
             return Ok(tv);
         }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -8,9 +8,10 @@ use crate::config::Settings;
 use crate::duration::parse_into_timestamp;
 use crate::hooks::Hooks;
 use crate::toolset::{
-    InstallOptions, ResolveOptions, ToolRequest, ToolSource, Toolset, tool_env_vars,
+    InstallOptions, ResolveOptions, ToolRequest, ToolRequestSet, ToolSource, Toolset,
+    install_state, tool_env_vars,
 };
-use crate::{config, env, exit, hooks};
+use crate::{config, dirs, env, exit, hooks};
 use clap::ValueHint;
 use eyre::Result;
 use itertools::Itertools;
@@ -322,6 +323,10 @@ impl Install {
                 .collect_vec()
         });
         let has_missing = !missing.is_empty();
+        if !self.is_dry_run() {
+            self.reconcile_installed_manifest_entries(&config, &trs)
+                .await?;
+        }
         let versions = if missing.is_empty() {
             measure!("run_postinstall_hook", {
                 info!("all tools are installed");
@@ -351,6 +356,26 @@ impl Install {
             let ts = config.get_toolset().await?;
             config::rebuild_shims_and_runtime_symlinks(&config, ts, &versions).await?;
         });
+        Ok(())
+    }
+
+    async fn reconcile_installed_manifest_entries(
+        &self,
+        config: &Arc<Config>,
+        trs: &ToolRequestSet,
+    ) -> Result<()> {
+        for (_, requests, _) in trs.iter() {
+            for tr in requests {
+                if matches!(tr, ToolRequest::System { .. }) || !tr.is_os_supported() {
+                    continue;
+                }
+                let tv = tr.resolve(config, &ResolveOptions::default()).await?;
+                let install_path = tv.install_path();
+                if install_path.starts_with(*dirs::INSTALLS) && install_path.exists() {
+                    install_state::write_backend_meta(tv.ba())?;
+                }
+            }
+        }
         Ok(())
     }
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -324,7 +324,7 @@ impl Install {
         });
         let has_missing = !missing.is_empty();
         if !self.is_dry_run() {
-            self.reconcile_installed_manifest_entries(&config, &trs)
+            self.reconcile_installed_manifest_entries(&config, trs)
                 .await?;
         }
         let versions = if missing.is_empty() {

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -8,13 +8,12 @@ use crate::config::Settings;
 use crate::duration::parse_into_timestamp;
 use crate::hooks::Hooks;
 use crate::toolset::{
-    InstallOptions, ResolveOptions, ToolRequest, ToolRequestSet, ToolSource, Toolset,
-    install_state, tool_env_vars,
+    InstallOptions, ResolveOptions, ToolRequest, ToolSource, ToolVersion, Toolset, install_state,
+    tool_env_vars,
 };
-use crate::{config, dirs, env, exit, hooks};
+use crate::{config, env, exit, hooks};
 use clap::ValueHint;
 use eyre::Result;
-use itertools::Itertools;
 use jiff::Timestamp;
 use std::path::PathBuf;
 
@@ -304,6 +303,7 @@ impl Install {
         let trs = measure!("get_tool_request_set", {
             config.get_tool_request_set().await?
         });
+        let install_opts = self.install_opts()?;
 
         // Install plugins from [plugins] config section first
         // This must happen before checking for missing tools so env-only plugins get installed
@@ -315,17 +315,13 @@ impl Install {
             // This will error with a proper message like "tool not found in mise tool registry"
             ba.backend()?;
         }
-        let missing = measure!("fetching missing runtimes", {
-            trs.missing_tools(&config)
+        let (installed, missing) = measure!("fetching missing runtimes", {
+            trs.partition_installed_tools(&config, &install_opts.resolve_options)
                 .await
-                .into_iter()
-                .cloned()
-                .collect_vec()
         });
         let has_missing = !missing.is_empty();
         if !self.is_dry_run() {
-            self.reconcile_installed_manifest_entries(&config, trs)
-                .await?;
+            self.reconcile_installed_manifest_entries(&installed)?;
         }
         let versions = if missing.is_empty() {
             measure!("run_postinstall_hook", {
@@ -342,7 +338,7 @@ impl Install {
         } else {
             let mut ts = Toolset::from(trs.clone());
             measure!("install_all_versions", {
-                ts.install_all_versions(&mut config, missing, &self.install_opts()?)
+                ts.install_all_versions(&mut config, missing, &install_opts)
                     .await?
             })
         };
@@ -359,22 +355,12 @@ impl Install {
         Ok(())
     }
 
-    async fn reconcile_installed_manifest_entries(
-        &self,
-        config: &Arc<Config>,
-        trs: &ToolRequestSet,
-    ) -> Result<()> {
-        for (_, requests, _) in trs.iter() {
-            for tr in requests {
-                if matches!(tr, ToolRequest::System { .. }) || !tr.is_os_supported() {
-                    continue;
-                }
-                let tv = tr.resolve(config, &ResolveOptions::default()).await?;
-                let install_path = tv.install_path();
-                if install_path.starts_with(*dirs::INSTALLS) && install_path.exists() {
-                    install_state::write_backend_meta(tv.ba())?;
-                }
+    fn reconcile_installed_manifest_entries(&self, versions: &[ToolVersion]) -> Result<()> {
+        for tv in versions {
+            if matches!(tv.request, ToolRequest::System { .. }) {
+                continue;
             }
+            install_state::write_backend_meta_for_install_path(tv.ba(), &tv.install_path())?;
         }
         Ok(())
     }

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -39,7 +39,7 @@ pub struct InstallStateTool {
 
 /// Entry in the consolidated manifest file (.mise-installs.toml).
 /// Versions are NOT stored here — they come from the filesystem.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct ManifestTool {
     /// Original short name (e.g. "github:jdx/mise-test-fixtures").
     /// May differ from the manifest key (which is the kebab-cased dir name).
@@ -128,6 +128,28 @@ fn write_tool_manifest_to(path: &Path, tool: &ManifestTool) -> Result<()> {
     let body = toml::to_string_pretty(tool)?;
     file::write(path, body.trim())?;
     Ok(())
+}
+
+fn manifest_path_for_install_path(install_path: &Path) -> Option<PathBuf> {
+    if install_path.starts_with(*dirs::INSTALLS) {
+        Some(manifest_path())
+    } else if env::install_path_category(install_path) != env::InstallPathCategory::Local {
+        install_path
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|installs_dir| installs_dir.join(".mise-installs.toml"))
+    } else {
+        None
+    }
+}
+
+fn manifest_tool_for_backend(ba: &BackendArg) -> ManifestTool {
+    ManifestTool {
+        short: ba.short.clone(),
+        full: Some(ba.full_without_opts()),
+        explicit_backend: ba.has_explicit_backend(),
+        opts: persistent_opts(ba),
+    }
 }
 
 /// Read a legacy `.mise.backend` file for migration purposes.
@@ -550,31 +572,27 @@ pub async fn add_plugin(short: &str, plugin_type: PluginType) -> Result<()> {
     Ok(())
 }
 
-/// Writes backend metadata to the consolidated manifest file.
-/// Uses the primary installs dir manifest by default.
-pub fn write_backend_meta(ba: &BackendArg) -> Result<()> {
-    write_backend_meta_to(ba, &manifest_path())
+pub fn write_backend_meta_for_install_path(ba: &BackendArg, install_path: &Path) -> Result<()> {
+    if let Some(path) = manifest_path_for_install_path(install_path) {
+        write_backend_meta_to_if_missing(ba, &path)?;
+    }
+    Ok(())
 }
 
-/// Writes backend metadata to a manifest at a specific install path.
-pub fn write_backend_meta_to(ba: &BackendArg, path: &Path) -> Result<()> {
-    let full = ba.full_without_opts();
-    let explicit = ba.has_explicit_backend();
-    let opts_map = persistent_opts(ba);
-
+fn write_backend_meta_to_if_missing(ba: &BackendArg, path: &Path) -> Result<()> {
     let _lock = MANIFEST_LOCK.lock().expect("MANIFEST_LOCK lock failed");
     let mut manifest = read_manifest_from(path);
-    let manifest_tool = ManifestTool {
-        short: ba.short.clone(),
-        full: Some(full),
-        explicit_backend: explicit,
-        opts: opts_map,
-    };
-    manifest.insert(ba.short.to_kebab_case(), manifest_tool.clone());
-    write_manifest_to(path, &manifest)?;
+    let key = ba.short.to_kebab_case();
+    let manifest_tool = manifest_tool_for_backend(ba);
+    if manifest.get(&key) != Some(&manifest_tool) {
+        manifest.insert(key, manifest_tool.clone());
+        write_manifest_to(path, &manifest)?;
+    }
     if let Some(installs_dir) = path.parent() {
         let tool_manifest = tool_manifest_path(installs_dir, &ba.short);
-        if tool_manifest.parent().is_some_and(|p| p.exists()) {
+        if tool_manifest.parent().is_some_and(|p| p.exists())
+            && read_tool_manifest_from(&tool_manifest) != Some(manifest_tool.clone())
+        {
             write_tool_manifest_to(&tool_manifest, &manifest_tool)?;
         }
     }

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -7,9 +7,10 @@ use std::{
 use crate::backend::backend_type::BackendType;
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, Settings};
-use crate::env;
 use crate::registry::{REGISTRY, tool_enabled};
-use crate::toolset::{ToolRequest, ToolSource, Toolset};
+use crate::toolset::tool_version::ResolveOptions;
+use crate::toolset::{ToolRequest, ToolSource, ToolVersion, Toolset};
+use crate::{backend, env};
 use indexmap::IndexMap;
 use itertools::Itertools;
 
@@ -53,6 +54,35 @@ impl ToolRequestSet {
             }
         }
         tools
+    }
+
+    pub async fn partition_installed_tools(
+        &self,
+        config: &Arc<Config>,
+        opts: &ResolveOptions,
+    ) -> (Vec<ToolVersion>, Vec<ToolRequest>) {
+        let mut installed = vec![];
+        let mut missing = vec![];
+        for tr in self.tools.values().flatten() {
+            if !tr.is_os_supported() {
+                continue;
+            }
+            if let Some(backend) = backend::get(tr.ba()) {
+                match tr.resolve(config, opts).await {
+                    Ok(tv) if backend.is_version_installed(config, &tv, false) => {
+                        installed.push(tv)
+                    }
+                    Ok(_) => missing.push(tr.clone()),
+                    Err(e) => {
+                        debug!("ToolRequestSet.partition_installed_tools: {e:#}");
+                        missing.push(tr.clone());
+                    }
+                }
+            } else {
+                missing.push(tr.clone());
+            }
+        }
+        (installed, missing)
     }
 
     pub fn list_tools(&self) -> Vec<&Arc<BackendArg>> {


### PR DESCRIPTION
This should work, but it seems like a not good fix, so I'll come back to this after tool opts refactor and other fixes complete.

## Summary
- write backend manifest metadata when `mise install` finds configured tools already installed
- keep backend install skip paths reconciling metadata before returning
- add an e2e regression for a restored explicit-backend install directory with a missing `.mise-installs.toml` entry

Fixes discussion #8478.

## Tests
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 mise run test:e2e e2e/backend/test_install_manifest_reconcile`
- `mise run format`
- `shfmt -d --apply-ignore e2e/backend/test_install_manifest_reconcile`
- `shellcheck -x e2e/backend/test_install_manifest_reconcile`
- `git diff --check`