### PR TITLE
fix(backend): apply install_env to install commands

### DIFF
--- a/docs/dev-tools/backends/asdf.md
+++ b/docs/dev-tools/backends/asdf.md
@@ -52,3 +52,17 @@ need to set env vars other than `PATH`.
 ## Writing asdf (legacy) plugins for mise
 
 See the asdf documentation for more information on [writing plugins](https://asdf-vm.com/plugins/create.html).
+
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `asdf` backend—these
+go in `[tools]` in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for asdf plugin install scripts:
+
+```toml
+[tools]
+"asdf:owner/plugin" = { version = "latest", install_env = { MAKEFLAGS = "-j8" } }
+```

--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -95,6 +95,15 @@ For options that do not skip `cargo-binstall`, any source-build fallback is hand
 | `crate`                    | Does not skip `cargo-binstall` when applicable. Git installs always use `cargo install`. |
 | `locked`                   | Passed through to `cargo-binstall`; does not skip it.                                    |
 
+### `install_env`
+
+Set environment variables for the `cargo install` or `cargo-binstall` command:
+
+```toml
+[tools]
+"cargo:eza" = { version = "latest", install_env = { CARGO_NET_GIT_FETCH_WITH_CLI = "true" } }
+```
+
 ### `features`
 
 Install additional components (passed as `cargo install --features`):

--- a/docs/dev-tools/backends/dotnet.md
+++ b/docs/dev-tools/backends/dotnet.md
@@ -69,6 +69,15 @@ import Settings from '/components/settings.vue';
 The following [tool-options](/dev-tools/#tool-options) are available for the `dotnet` backend—these
 go in `[tools]` in `mise.toml`.
 
+### `install_env`
+
+Set environment variables for the `dotnet tool install` command:
+
+```toml
+[tools]
+"dotnet:GitVersion.Tool" = { version = "latest", install_env = { DOTNET_CLI_TELEMETRY_OPTOUT = "1" } }
+```
+
 ### `prerelease`
 
 By default, NuGet pre-release versions are excluded from `mise ls-remote` and from `latest` resolution. Set `prerelease = true` to include them:

--- a/docs/dev-tools/backends/gem.md
+++ b/docs/dev-tools/backends/gem.md
@@ -50,3 +50,17 @@ Set these with `mise settings set [VARIABLE] [VALUE]` or by setting the environm
 import Settings from '/components/settings.vue';
 </script>
 <Settings child="gem" :level="3" />
+
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `gem` backend—these
+go in `[tools]` in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for the `gem install` command:
+
+```toml
+[tools]
+"gem:rubocop" = { version = "latest", install_env = { GEM_HOST_API_KEY = "..." } }
+```

--- a/docs/dev-tools/backends/go.md
+++ b/docs/dev-tools/backends/go.md
@@ -34,6 +34,16 @@ Hivemind version 1.1.0
 The following [tool-options](/dev-tools/#tool-options) are available for the `go` backend—these
 go in `[tools]` in `mise.toml`.
 
+### `install_env`
+
+Set environment variables for the `go install` command. mise still sets `GOBIN`
+to the tool install directory after applying `install_env`.
+
+```toml
+[tools]
+"go:github.com/DarthSim/hivemind" = { version = "latest", install_env = { GOPRIVATE = "github.com/acme/*" } }
+```
+
 ### `tags`
 
 Specify go build tags (passed as `go install -tags`):

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -74,6 +74,17 @@ import Settings from '/components/settings.vue';
 The following [tool-options](/dev-tools/#tool-options) are available for the `npm` backend—these
 go in `[tools]` in `mise.toml`.
 
+### `install_env`
+
+Set environment variables for the configured package manager install command.
+mise still controls install destination variables such as `BUN_INSTALL_GLOBAL_DIR`
+and `BUN_INSTALL_BIN` after applying `install_env`.
+
+```toml
+[tools]
+"npm:prettier" = { version = "latest", install_env = { NPM_CONFIG_REGISTRY = "https://registry.npmjs.org/" } }
+```
+
 ### `npm_args`
 
 Additional arguments to pass to `npm` installs when `settings.npm.package_manager = "npm"`.

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -104,6 +104,17 @@ import Settings from '/components/settings.vue';
 The following [tool-options](/dev-tools/#tool-options) are available for the `pipx` backend—these
 go in `[tools]` in `mise.toml`.
 
+### `install_env`
+
+Set environment variables for `uv tool install` or `pipx install`. mise still
+sets the tool directory, bin directory, and configured Python package index
+variables after applying `install_env`.
+
+```toml
+[tools]
+"pipx:black" = { version = "latest", install_env = { PIP_TRUSTED_HOST = "pypi.org" } }
+```
+
 ### `extras`
 
 Install additional components.

--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -68,12 +68,8 @@ go in `[tools]` in `mise.toml`.
 
 Set environment variables for Swift Package Manager commands such as
 `swift package dump-package`, `swift -print-target-info`, and `swift build`.
-This applies when the selected backend is `spm`.
-
-If you use a registry shorthand whose registry entry prefers another backend
-before `spm`, that other backend's behavior applies instead. For example, a
-tool whose registry entry lists `github:` before `spm:` will not run Swift
-Package Manager commands unless you explicitly use `spm:owner/repo`.
+For artifact bundle installs, this only applies to `swift -print-target-info`;
+the download, extract, and symlink steps are handled by mise directly.
 
 ```toml
 [tools]

--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -64,6 +64,22 @@ Other syntax may work but is unsupported and untested.
 The following [tool-options](/dev-tools/#tool-options) are available for the backend — these
 go in `[tools]` in `mise.toml`.
 
+### `install_env`
+
+Set environment variables for Swift Package Manager commands such as
+`swift package dump-package`, `swift -print-target-info`, and `swift build`.
+This applies when the selected backend is `spm`.
+
+If you use a registry shorthand whose registry entry prefers another backend
+before `spm`, that other backend's behavior applies instead. For example, a
+tool whose registry entry lists `github:` before `spm:` will not run Swift
+Package Manager commands unless you explicitly use `spm:owner/repo`.
+
+```toml
+[tools]
+"spm:tuist/tuist" = { version = "latest", install_env = { SWIFTPM_ENABLE_PLUGINS = "1" } }
+```
+
 ### `provider`
 
 Set the provider type to use for fetching assets and release information. Either `github` or `gitlab` (default is `github`).

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -102,3 +102,19 @@ For more information, see:
 - [Using Plugins](../../plugin-usage.md) - End-user guide
 - [Plugin Development](../../tool-plugin-development.md) - Developer guide
 - [Plugin Template](https://github.com/jdx/mise-tool-plugin-template) - Quick start template for creating plugins
+
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `vfox` backend—these
+go in `[tools]` in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for commands that a vfox plugin starts with `cmd.exec`
+during install hooks. vfox's built-in Lua HTTP, archive, and JSON helpers do not
+use these variables directly.
+
+```toml
+[tools]
+"vfox:version-fox/vfox-cmake" = { version = "latest", install_env = { HTTPS_PROXY = "http://proxy.example" } }
+```

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -183,7 +183,7 @@ ripgrep = { version = "latest", os = ["linux", "macos"] }
 "cargo:usage-cli" = {
     version = "latest",
     os = ["linux", "macos"],
-    depends = ["rust"]
+    locked = false
 }
 ```
 

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -151,6 +151,17 @@ port = 6379
 
 Internally, nested options are flattened to dot notation (e.g., `platforms.macos-x64.url`, `database.host`, `cache.redis.port`) for backend access.
 
+### Install environment
+
+Use `install_env` to set environment variables for the backend commands that run while a tool is installed.
+
+```toml
+[tools]
+"cargo:usage-cli" = { version = "latest", install_env = { RUST_BACKTRACE = "1" } }
+```
+
+`install_env` applies to install/build/package-manager commands such as `cargo install`, `npm install`, `go install`, `gem install`, `dotnet tool install`, Swift Package Manager builds, asdf install scripts, vfox commands started with `cmd.exec`, and install-time commands run by core language backends. It does not affect downloads or API requests that mise performs internally.
+
 ### Tool postinstall commands
 
 Run a command immediately after a tool finishes installing by adding a `postinstall` field to that tool's configuration. This is separate from `[hooks].postinstall` and applies only to when a specific tool is installed.

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -151,17 +151,6 @@ port = 6379
 
 Internally, nested options are flattened to dot notation (e.g., `platforms.macos-x64.url`, `database.host`, `cache.redis.port`) for backend access.
 
-### Install environment
-
-Use `install_env` to set environment variables for the backend commands that run while a tool is installed.
-
-```toml
-[tools]
-"cargo:usage-cli" = { version = "latest", install_env = { RUST_BACKTRACE = "1" } }
-```
-
-`install_env` applies to install/build/package-manager commands such as `cargo install`, `npm install`, `go install`, `gem install`, `dotnet tool install`, Swift Package Manager builds, asdf install scripts, vfox commands started with `cmd.exec`, and install-time commands run by core language backends. It does not affect downloads or API requests that mise performs internally.
-
 ### Tool postinstall commands
 
 Run a command immediately after a tool finishes installing by adding a `postinstall` field to that tool's configuration. This is separate from `[hooks].postinstall` and applies only to when a specific tool is installed.
@@ -194,7 +183,7 @@ ripgrep = { version = "latest", os = ["linux", "macos"] }
 "cargo:usage-cli" = {
     version = "latest",
     os = ["linux", "macos"],
-    install_env = { RUST_BACKTRACE = "1" }
+    depends = ["rust"]
 }
 ```
 

--- a/docs/lang/bun.md
+++ b/docs/lang/bun.md
@@ -21,3 +21,17 @@ See available versions with `mise ls-remote bun`.
 
 > [!NOTE]
 > Avoid using `bun upgrade` to upgrade bun as `mise` will not be aware of the change.
+
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `bun` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for install-time commands run by the core `bun` backend:
+
+```toml
+[tools]
+bun = { version = "latest", install_env = { HTTPS_PROXY = "http://proxy.example" } }
+```

--- a/docs/lang/deno.md
+++ b/docs/lang/deno.md
@@ -22,3 +22,17 @@ See available versions with `mise ls-remote deno`.
 
 > [!NOTE]
 > Avoid using `deno upgrade` to upgrade `deno` as `mise` will not be aware of the change.
+
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `deno` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for install-time commands run by the core `deno` backend:
+
+```toml
+[tools]
+deno = { version = "latest", install_env = { HTTPS_PROXY = "http://proxy.example" } }
+```

--- a/docs/lang/dotnet.md
+++ b/docs/lang/dotnet.md
@@ -115,6 +115,20 @@ dotnet = ["9", { version = "8.0.14", runtime = "dotnet" }]
 Only exact runtime versions are supported (e.g., `dotnet[runtime=dotnet]@8.0.14`). Channel syntax like `@8` is not currently supported for runtime installs, as it resolves against SDK versions rather than runtime versions.
 :::
 
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `dotnet` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for the .NET install script and install-time verification commands:
+
+```toml
+[tools]
+dotnet = { version = "latest", install_env = { DOTNET_CLI_TELEMETRY_OPTOUT = "1" } }
+```
+
 ## Environment Variables
 
 The plugin sets the following environment variables:

--- a/docs/lang/elixir.md
+++ b/docs/lang/elixir.md
@@ -16,3 +16,17 @@ mise use -g erlang elixir
 ```
 
 Note that [`erlang`](/lang/erlang.html) is required to install `elixir`.
+
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `elixir` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for install-time commands run by the core `elixir` backend:
+
+```toml
+[tools]
+elixir = { version = "latest", install_env = { MIX_HOME = "~/.mix" } }
+```

--- a/docs/lang/erlang.md
+++ b/docs/lang/erlang.md
@@ -23,6 +23,21 @@ See available versions with `mise ls-remote erlang`.
 The plugin uses [kerl](https://github.com/kerl/kerl) under the hood to build erlang.
 See kerl's docs for information on configuring kerl.
 
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `erlang` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for kerl build/install commands and other install-time commands run by
+the core `erlang` backend:
+
+```toml
+[tools]
+erlang = { version = "latest", install_env = { KERL_CONFIGURE_OPTIONS = "--without-javac" } }
+```
+
 ## Settings
 
 <script setup>

--- a/docs/lang/go.md
+++ b/docs/lang/go.md
@@ -43,6 +43,21 @@ github.com/daixiang0/gci # allows comments
 github.com/jesseduffield/lazygit
 ```
 
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `go` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for default package installation and install-time verification commands
+run by the core `go` backend:
+
+```toml
+[tools]
+go = { version = "latest", install_env = { GOPRIVATE = "github.com/acme/*" } }
+```
+
 ## Settings
 
 <script setup>

--- a/docs/lang/java.md
+++ b/docs/lang/java.md
@@ -111,6 +111,15 @@ mise/java/21.0.1-open:
 The following [tool-options](/dev-tools/#tool-options) are available for the `java` backend.
 These options go in the `[tools]` section in `mise.toml`.
 
+### `install_env`
+
+Set environment variables for install-time commands run by the core `java` backend:
+
+```toml
+[tools]
+java = { version = "latest", install_env = { JAVA_TOOL_OPTIONS = "-Djava.net.useSystemProxies=true" } }
+```
+
 ### `release_type`
 
 The `release_type` option allows you to specify the type of release to install. The following values

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -20,6 +20,21 @@ mise use -g node@26
 
 See the [Node.JS Cookbook](/mise-cookbook/nodejs.html) for common tasks and examples.
 
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `node` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for source builds, default package installation, Corepack setup, and
+install-time verification commands run by the core `node` backend:
+
+```toml
+[tools]
+node = { version = "latest", install_env = { CFLAGS = "-O2" } }
+```
+
 ## Pinning npm version
 
 By default, Node.js ships with a bundled version of npm. If you need a specific npm version

--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -37,6 +37,21 @@ mise use -g python@anaconda         # latest version of anaconda
 
 See the [Python Cookbook](/mise-cookbook/python.html) for common tasks and examples.
 
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `python` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for python-build, default package installation, and install-time
+verification commands run by the core `python` backend:
+
+```toml
+[tools]
+python = { version = "latest", install_env = { CONFIGURE_OPTS = "--enable-optimizations" } }
+```
+
 ## `.python-version` support
 
 `.python-version`/`.python-versions` files are supported by mise. See [idiomatic version files](/configuration.html#idiomatic-version-files).

--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -75,6 +75,20 @@ bcat ~> 0.6.0 # supports version constraints
 rubocop --pre # install prerelease version
 ```
 
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `ruby` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for ruby-build or ruby-install and default gem installation:
+
+```toml
+[tools]
+ruby = { version = "latest", install_env = { RUBY_CONFIGURE_OPTS = "--disable-install-doc" } }
+```
+
 ## `.ruby-version` and `Gemfile` support
 
 mise uses a `mise.toml` or `.tool-versions` file for auto-switching between software versions.

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -38,6 +38,15 @@ cargo build
 The following [tool-options](/dev-tools/#tool-options) are available for the `rust` backend—these
 go in `[tools]` in `mise.toml`.
 
+### `install_env`
+
+Set environment variables for rustup install commands:
+
+```toml
+[tools]
+rust = { version = "latest", install_env = { RUSTUP_DIST_SERVER = "https://static.rust-lang.org" } }
+```
+
 ### `components`
 
 The `components` option allows you to specify which components to install. Multiple components can be

--- a/docs/lang/swift.md
+++ b/docs/lang/swift.md
@@ -13,6 +13,20 @@ swift --version
 
 See [a mise guide for Swift developers](https://tuist.dev/blog/2025/02/04/mise) on how to use `mise` with `swift`.
 
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `swift` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for install-time commands run by the core `swift` backend:
+
+```toml
+[tools]
+swift = { version = "latest", install_env = { HTTPS_PROXY = "http://proxy.example" } }
+```
+
 ## Settings
 
 <script setup>

--- a/docs/lang/zig.md
+++ b/docs/lang/zig.md
@@ -45,6 +45,20 @@ mise use -g zls@latest # install latest zls release
 Note that a tagged release of `zig` should be used with
 the same tagged release of `zls`. Currently there is no Mach version of `zls`.
 
+## Tool Options
+
+The following [tool-options](/dev-tools/#tool-options) are available for the `zig` backend.
+These options go in the `[tools]` section in `mise.toml`.
+
+### `install_env`
+
+Set environment variables for install-time commands run by the core `zig` backend:
+
+```toml
+[tools]
+zig = { version = "latest", install_env = { HTTPS_PROXY = "http://proxy.example" } }
+```
+
 ## Settings
 
 <script setup>

--- a/e2e/backend/test_vfox_install_env
+++ b/e2e/backend/test_vfox_install_env
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+PLUGIN_DIR="$PWD/vfox-install-env"
+MARKER="$PWD/install-env-marker"
+
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
+PLUGIN = {}
+PLUGIN.name = "install-env"
+PLUGIN.version = "0.1.0"
+PLUGIN.homepage = "https://example.com/install-env"
+PLUGIN.license = "MIT"
+PLUGIN.description = "install env test plugin"
+LUA
+
+cat >"$PLUGIN_DIR/hooks/available.lua" <<'LUA'
+function PLUGIN:Available(ctx)
+	return {
+		{ version = "1.0.0" },
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/pre_install.lua" <<'LUA'
+function PLUGIN:PreInstall(ctx)
+	return {
+		version = ctx.version,
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/post_install.lua" <<LUA
+function PLUGIN:PostInstall(ctx)
+	local cmd = require("cmd")
+	cmd.exec("printf '%s' \"\$MISE_TEST_INSTALL_ENV_VALUE\" > \"$MARKER\"")
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/env_keys.lua" <<'LUA'
+function PLUGIN:EnvKeys(ctx)
+	return {}
+end
+LUA
+
+git -C "$PLUGIN_DIR" init
+git -C "$PLUGIN_DIR" add .
+git -C "$PLUGIN_DIR" -c user.name="mise" -c user.email="mise@example.com" commit -m "initial plugin"
+
+cat >mise.toml <<EOF
+[settings]
+unix_default_inline_shell_args = "sh -c"
+
+[tools]
+"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", install_env = { MISE_TEST_INSTALL_ENV_VALUE = "available" } }
+EOF
+
+mise install
+assert "cat '$MARKER'" "available"

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -176,7 +176,7 @@ impl AsdfBackend {
             let k = format!("MISE_TOOL_OPTS__{}", key.to_uppercase());
             sm = sm.with_env(k, value);
         }
-        for (key, value) in tv.request.options().core.install_env {
+        for (key, value) in tv.install_env() {
             sm = sm.with_env(key, value.clone());
         }
         if let Some(project_root) = &config.project_root {

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -247,7 +247,7 @@ impl Backend for CargoBackend {
             .arg(tv.install_path())
             .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-            .envs(opts.install_env().clone())
+            .envs(ctx.install_env(&tv))
             .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
             .prepend_path(
                 self.dependency_toolset(&ctx.config)

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -4,7 +4,6 @@ use std::{fmt::Debug, sync::Arc};
 use async_trait::async_trait;
 use color_eyre::Section;
 use eyre::{bail, eyre};
-use indexmap::IndexMap;
 use url::Url;
 
 use crate::Result;
@@ -69,8 +68,9 @@ impl<'a> CargoOptions<'a> {
         self.values.raw().get_string("crate")
     }
 
-    fn install_env(&self) -> &'a IndexMap<String, String> {
-        &self.values.raw().install_env
+    fn has_features_options(&self) -> bool {
+        self.values.raw().contains_key("features")
+            || self.values.raw().contains_key("default-features")
     }
 
     fn lockfile_options(&self, target: &PlatformTarget) -> BTreeMap<String, String> {

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -68,11 +68,6 @@ impl<'a> CargoOptions<'a> {
         self.values.raw().get_string("crate")
     }
 
-    fn has_features_options(&self) -> bool {
-        self.values.raw().contains_key("features")
-            || self.values.raw().contains_key("default-features")
-    }
-
     fn lockfile_options(&self, target: &PlatformTarget) -> BTreeMap<String, String> {
         let mut result = BTreeMap::new();
         for key in ["features", "default-features", "crate", "locked"] {

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -247,7 +247,7 @@ impl Backend for CargoBackend {
             .arg(tv.install_path())
             .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-            .envs(ctx.install_env(&tv))
+            .envs(tv.install_env())
             .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
             .prepend_path(
                 self.dependency_toolset(&ctx.config)

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -101,7 +101,7 @@ impl Backend for DotnetBackend {
 
         cli.with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
-            .envs(ctx.install_env(&tv))
+            .envs(tv.install_env())
             .execute()?;
 
         Ok(tv)

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -101,6 +101,7 @@ impl Backend for DotnetBackend {
 
         cli.with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
+            .envs(ctx.install_env(&tv))
             .execute()?;
 
         Ok(tv)

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -85,7 +85,7 @@ impl Backend for GemBackend {
             .arg(tv.install_path().join("libexec"))
             .with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
-            .envs(ctx.install_env(&tv))
+            .envs(tv.install_env())
             .execute()?;
 
         // We install the gem to {install_path}/libexec and create a wrapper script for each executable

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -85,6 +85,7 @@ impl Backend for GemBackend {
             .arg(tv.install_path().join("libexec"))
             .with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
+            .envs(ctx.install_env(&tv))
             .execute()?;
 
         // We install the gem to {install_path}/libexec and create a wrapper script for each executable

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -144,6 +144,7 @@ impl Backend for GoBackend {
             cmd.arg(format!("{}@{v}", self.tool_name()))
                 .with_pr(ctx.pr.as_ref())
                 .envs(self.dependency_env(&ctx.config).await?)
+                .envs(ctx.install_env(&tv))
                 .env("GOBIN", tv.install_path().join("bin"))
                 .execute()
         };

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -144,7 +144,7 @@ impl Backend for GoBackend {
             cmd.arg(format!("{}@{v}", self.tool_name()))
                 .with_pr(ctx.pr.as_ref())
                 .envs(self.dependency_env(&ctx.config).await?)
-                .envs(ctx.install_env(&tv))
+                .envs(tv.install_env())
                 .env("GOBIN", tv.install_path().join("bin"))
                 .execute()
         };

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -267,7 +267,7 @@ impl Backend for NPMBackend {
                     .arg(format!("{}@{}", self.tool_name(), tv.version))
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .envs(ctx.install_env(&tv))
+                    .envs(tv.install_env())
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                     .prepend_path(
                         self.dependency_toolset(&ctx.config)
@@ -294,7 +294,7 @@ impl Backend for NPMBackend {
                     .args(install_before_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .envs(ctx.install_env(&tv))
+                    .envs(tv.install_env())
                     .env("BUN_INSTALL_GLOBAL_DIR", tv.install_path())
                     .env("BUN_INSTALL_BIN", tv.install_path().join("bin"))
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
@@ -324,7 +324,7 @@ impl Backend for NPMBackend {
                     .args(install_before_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .envs(ctx.install_env(&tv))
+                    .envs(tv.install_env())
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                     .prepend_path(
                         self.dependency_toolset(&ctx.config)
@@ -350,7 +350,7 @@ impl Backend for NPMBackend {
                     .args(install_before_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .envs(ctx.install_env(&tv))
+                    .envs(tv.install_env())
                     .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                     .prepend_path(

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -267,6 +267,7 @@ impl Backend for NPMBackend {
                     .arg(format!("{}@{}", self.tool_name(), tv.version))
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+                    .envs(ctx.install_env(&tv))
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                     .prepend_path(
                         self.dependency_toolset(&ctx.config)
@@ -293,6 +294,7 @@ impl Backend for NPMBackend {
                     .args(install_before_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+                    .envs(ctx.install_env(&tv))
                     .env("BUN_INSTALL_GLOBAL_DIR", tv.install_path())
                     .env("BUN_INSTALL_BIN", tv.install_path().join("bin"))
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
@@ -322,6 +324,7 @@ impl Backend for NPMBackend {
                     .args(install_before_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+                    .envs(ctx.install_env(&tv))
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                     .prepend_path(
                         self.dependency_toolset(&ctx.config)
@@ -347,6 +350,7 @@ impl Backend for NPMBackend {
                     .args(install_before_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+                    .envs(ctx.install_env(&tv))
                     .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                     .prepend_path(

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -494,10 +494,11 @@ impl PIPXBackend {
             cmd = cmd.arg(arg);
         }
         cmd.with_pr(pr)
+            .envs(ts.env_with_path_without_tools(config).await?)
+            .envs(tv.request.options().core.install_env)
             .env("UV_TOOL_DIR", tv.install_path())
             .env("UV_TOOL_BIN_DIR", tv.install_path().join("bin"))
             .env("UV_INDEX", Self::get_index_url()?)
-            .envs(ts.env_with_path_without_tools(config).await?)
             .prepend_path(ts.list_paths(config).await)?
             .prepend_path(vec![tv.install_path().join("bin")])?
             .prepend_path(b.dependency_toolset(config).await?.list_paths(config).await)
@@ -516,8 +517,9 @@ impl PIPXBackend {
             cmd = cmd.arg(arg);
         }
         cmd.with_pr(pr)
-            .env("PIP_INDEX_URL", Self::get_index_url()?)
             .envs(ts.env_with_path_without_tools(config).await?)
+            .envs(tv.request.options().core.install_env)
+            .env("PIP_INDEX_URL", Self::get_index_url()?)
             .env_remove("PIPX_SHARED_LIBS")
             .env("PIPX_HOME", tv.install_path())
             .env("PIPX_BIN_DIR", tv.install_path().join("bin"))

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -495,7 +495,7 @@ impl PIPXBackend {
         }
         cmd.with_pr(pr)
             .envs(ts.env_with_path_without_tools(config).await?)
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .env("UV_TOOL_DIR", tv.install_path())
             .env("UV_TOOL_BIN_DIR", tv.install_path().join("bin"))
             .env("UV_INDEX", Self::get_index_url()?)
@@ -518,7 +518,7 @@ impl PIPXBackend {
         }
         cmd.with_pr(pr)
             .envs(ts.env_with_path_without_tools(config).await?)
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .env("PIP_INDEX_URL", Self::get_index_url()?)
             .env_remove("PIPX_SHARED_LIBS")
             .env("PIPX_HOME", tv.install_path())

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -10,6 +10,7 @@ use crate::install_context::InstallContext;
 use crate::toolset::{ToolVersion, ToolVersionOptions};
 use crate::{dirs, file, github, gitlab};
 use async_trait::async_trait;
+use duct::Expression;
 use eyre::{WrapErr, bail};
 use serde::Deserialize;
 use serde::Deserializer;
@@ -235,18 +236,21 @@ impl SPMBackend {
         repo_dir: &PathBuf,
         tv: &ToolVersion,
     ) -> Result<Vec<String>, eyre::Error> {
-        let package_json = cmd!(
-            "swift",
-            "package",
-            "dump-package",
-            "--package-path",
-            &repo_dir,
-            "--scratch-path",
-            tv.install_path(),
-            "--cache-path",
-            dirs::CACHE.join("spm"),
+        let package_json = with_install_env(
+            cmd!(
+                "swift",
+                "package",
+                "dump-package",
+                "--package-path",
+                &repo_dir,
+                "--scratch-path",
+                tv.install_path(),
+                "--cache-path",
+                dirs::CACHE.join("spm"),
+            )
+            .full_env(self.dependency_env(&ctx.config).await?),
+            tv,
         )
-        .full_env(self.dependency_env(&ctx.config).await?)
         .read()?;
         let executables = serde_json::from_str::<PackageDescription>(&package_json)
             .wrap_err("Failed to parse package description")?
@@ -280,6 +284,7 @@ impl SPMBackend {
             .arg("--cache-path")
             .arg(dirs::CACHE.join("spm"))
             .with_pr(ctx.pr.as_ref())
+            .envs(ctx.install_env(tv))
             .prepend_path(
                 self.dependency_toolset(&ctx.config)
                     .await?
@@ -288,22 +293,25 @@ impl SPMBackend {
             )?
             .execute()?;
 
-        let bin_path = cmd!(
-            "swift",
-            "build",
-            "--configuration",
-            "release",
-            "--product",
-            &executable,
-            "--package-path",
-            &repo_dir,
-            "--scratch-path",
-            tv.install_path(),
-            "--cache-path",
-            dirs::CACHE.join("spm"),
-            "--show-bin-path"
+        let bin_path = with_install_env(
+            cmd!(
+                "swift",
+                "build",
+                "--configuration",
+                "release",
+                "--product",
+                &executable,
+                "--package-path",
+                &repo_dir,
+                "--scratch-path",
+                tv.install_path(),
+                "--cache-path",
+                dirs::CACHE.join("spm"),
+                "--show-bin-path"
+            )
+            .full_env(self.dependency_env(&ctx.config).await?),
+            tv,
         )
-        .full_env(self.dependency_env(&ctx.config).await?)
         .read()?;
         Ok(PathBuf::from(bin_path.trim().to_string()).join(executable))
     }
@@ -355,7 +363,7 @@ impl SPMBackend {
             &file::TarOptions::new(file::TarFormat::Zip),
         )?;
 
-        let triples = swift_target_triples(ctx, self).await?;
+        let triples = swift_target_triples(ctx, self, tv).await?;
         let binaries = artifactbundle_binaries(&bundle_dir, &triples)?;
         if binaries.is_empty() {
             file::remove_all(tv.cache_path())?;
@@ -380,6 +388,13 @@ impl SPMBackend {
         file::remove_all(tv.cache_path())?;
         Ok(true)
     }
+}
+
+fn with_install_env(mut command: Expression, tv: &ToolVersion) -> Expression {
+    for (key, value) in tv.request.options().core.install_env {
+        command = command.env(key, value);
+    }
+    command
 }
 
 /// Parses the `filter_bins` tool option if set.
@@ -558,10 +573,13 @@ impl SwiftPackageRepo {
 async fn swift_target_triples(
     ctx: &InstallContext,
     backend: &SPMBackend,
+    tv: &ToolVersion,
 ) -> eyre::Result<Vec<String>> {
-    let target_info = cmd!("swift", "-print-target-info")
-        .full_env(backend.dependency_env(&ctx.config).await?)
-        .read()?;
+    let target_info = with_install_env(
+        cmd!("swift", "-print-target-info").full_env(backend.dependency_env(&ctx.config).await?),
+        tv,
+    )
+    .read()?;
     parse_swift_target_triples(&target_info)
 }
 

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -284,7 +284,7 @@ impl SPMBackend {
             .arg("--cache-path")
             .arg(dirs::CACHE.join("spm"))
             .with_pr(ctx.pr.as_ref())
-            .envs(ctx.install_env(tv))
+            .envs(tv.install_env())
             .prepend_path(
                 self.dependency_toolset(&ctx.config)
                     .await?
@@ -391,7 +391,7 @@ impl SPMBackend {
 }
 
 fn with_install_env(mut command: Expression, tv: &ToolVersion) -> Expression {
-    for (key, value) in tv.request.options().core.install_env {
+    for (key, value) in tv.install_env() {
         command = command.env(key, value);
     }
     command

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -147,7 +147,7 @@ impl Backend for VfoxBackend {
             .unwrap_or_default()
             .into_iter()
             .collect();
-        cmd_env.extend(ctx.install_env(&tv));
+        cmd_env.extend(tv.install_env());
         if !cmd_env.is_empty() {
             vfox.cmd_env = Some(cmd_env);
         }

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -141,8 +141,15 @@ impl Backend for VfoxBackend {
         self.ensure_plugin_installed(&ctx.config).await?;
         let (mut vfox, log_rx) = self.plugin.vfox()?;
         Self::forward_plugin_logs(log_rx);
-        if let Ok(dep_env) = self.dependency_env(&ctx.config).await {
-            vfox.cmd_env = Some(dep_env.into_iter().collect());
+        let mut cmd_env: indexmap::IndexMap<String, String> = self
+            .dependency_env(&ctx.config)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        cmd_env.extend(ctx.install_env(&tv));
+        if !cmd_env.is_empty() {
+            vfox.cmd_env = Some(cmd_env);
         }
 
         // Use backend methods if the plugin supports them

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
-use indexmap::IndexMap;
 use jiff::Timestamp;
 
-use crate::toolset::ToolVersion;
 use crate::ui::progress_report::SingleReport;
 use crate::{config::Config, toolset::Toolset};
 
@@ -16,10 +14,4 @@ pub struct InstallContext {
     /// require lockfile URLs to be present; fail if not
     pub locked: bool,
     pub before_date: Option<Timestamp>,
-}
-
-impl InstallContext {
-    pub fn install_env(&self, tv: &ToolVersion) -> IndexMap<String, String> {
-        tv.request.options().core.install_env
-    }
 }

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
+use indexmap::IndexMap;
 use jiff::Timestamp;
 
+use crate::toolset::ToolVersion;
 use crate::ui::progress_report::SingleReport;
 use crate::{config::Config, toolset::Toolset};
 
@@ -14,4 +16,10 @@ pub struct InstallContext {
     /// require lockfile URLs to be present; fail if not
     pub locked: bool,
     pub before_date: Option<Timestamp>,
+}
+
+impl InstallContext {
+    pub fn install_env(&self, tv: &ToolVersion) -> IndexMap<String, String> {
+        tv.request.options().core.install_env
+    }
 }

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -46,6 +46,7 @@ impl BunPlugin {
         CmdLineRunner::new(self.bun_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .arg("-v")
+            .envs(ctx.install_env(tv))
             .execute()
     }
 

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -46,7 +46,7 @@ impl BunPlugin {
         CmdLineRunner::new(self.bun_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .arg("-v")
-            .envs(ctx.install_env(tv))
+            .envs(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -49,6 +49,7 @@ impl DenoPlugin {
         CmdLineRunner::new(self.deno_bin(tv))
             .with_pr(pr)
             .arg("-V")
+            .envs(tv.request.options().core.install_env)
             .execute()
     }
 

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -49,7 +49,7 @@ impl DenoPlugin {
         CmdLineRunner::new(self.deno_bin(tv))
             .with_pr(pr)
             .arg("-V")
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -45,6 +45,7 @@ impl DotnetPlugin {
             .with_pr(ctx.pr.as_ref())
             .arg("--version")
             .envs(self.exec_env(&ctx.config, &ctx.ts, tv).await?)
+            .envs(ctx.install_env(tv))
             .prepend_path(self.list_bin_paths(&ctx.config, tv).await?)?
             .execute()
     }
@@ -152,6 +153,7 @@ impl Backend for DotnetPlugin {
         install_cmd(&script_path, &install_dir, &tv.version, runtime.as_deref())
             .with_pr(ctx.pr.as_ref())
             .envs(self.exec_env(&ctx.config, &ctx.ts, &tv).await?)
+            .envs(ctx.install_env(&tv))
             .execute()?;
 
         if !isolated {

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -44,8 +44,8 @@ impl DotnetPlugin {
         CmdLineRunner::new(DOTNET_BIN)
             .with_pr(ctx.pr.as_ref())
             .arg("--version")
+            .envs(tv.install_env())
             .envs(self.exec_env(&ctx.config, &ctx.ts, tv).await?)
-            .envs(ctx.install_env(tv))
             .prepend_path(self.list_bin_paths(&ctx.config, tv).await?)?
             .execute()
     }
@@ -152,8 +152,8 @@ impl Backend for DotnetPlugin {
             .set_message(format!("Installing .NET {} {}", install_type, tv.version));
         install_cmd(&script_path, &install_dir, &tv.version, runtime.as_deref())
             .with_pr(ctx.pr.as_ref())
+            .envs(tv.install_env())
             .envs(self.exec_env(&ctx.config, &ctx.ts, &tv).await?)
-            .envs(ctx.install_env(&tv))
             .execute()?;
 
         if !isolated {

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -40,7 +40,7 @@ impl ElixirPlugin {
         CmdLineRunner::new(self.elixir_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
-            .envs(ctx.install_env(tv))
+            .envs(tv.install_env())
             .arg("--version")
             .execute()
     }

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -40,6 +40,7 @@ impl ElixirPlugin {
         CmdLineRunner::new(self.elixir_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
+            .envs(ctx.install_env(tv))
             .arg("--version")
             .execute()
     }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -159,7 +159,7 @@ impl ErlangPlugin {
             .with_pr(ctx.pr.as_ref())
             .arg("-minimal")
             .arg(tv.install_path())
-            .envs(ctx.install_env(&tv))
+            .envs(tv.install_env())
             .execute()?;
 
         Ok(Some(tv))
@@ -300,7 +300,11 @@ impl ErlangPlugin {
         }
     }
 
-    async fn install_via_kerl(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
+    async fn install_via_kerl(
+        &self,
+        _ctx: &InstallContext,
+        tv: ToolVersion,
+    ) -> Result<ToolVersion> {
         self.update_kerl().await?;
 
         file::remove_all(tv.install_path())?;
@@ -315,12 +319,12 @@ impl ErlangPlugin {
                     &tv.version,
                     &tv.version,
                     tv.install_path()
-                );
-                for (key, value) in ctx.install_env(&tv) {
+                )
+                .env("MAKEFLAGS", format!("-j{}", num_cpus::get()));
+                for (key, value) in tv.install_env() {
                     cmd = cmd.env(key, value);
                 }
                 cmd.env("KERL_BASE_DIR", self.ba.cache_path.join("kerl"))
-                    .env("MAKEFLAGS", format!("-j{}", num_cpus::get()))
                     .run()?;
             }
         }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -159,6 +159,7 @@ impl ErlangPlugin {
             .with_pr(ctx.pr.as_ref())
             .arg("-minimal")
             .arg(tv.install_path())
+            .envs(ctx.install_env(&tv))
             .execute()?;
 
         Ok(Some(tv))
@@ -299,11 +300,7 @@ impl ErlangPlugin {
         }
     }
 
-    async fn install_via_kerl(
-        &self,
-        _ctx: &InstallContext,
-        tv: ToolVersion,
-    ) -> Result<ToolVersion> {
+    async fn install_via_kerl(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         self.update_kerl().await?;
 
         file::remove_all(tv.install_path())?;
@@ -312,16 +309,19 @@ impl ErlangPlugin {
                 unimplemented!("erlang does not yet support refs");
             }
             _ => {
-                cmd!(
+                let mut cmd = cmd!(
                     self.kerl_path(),
                     "build-install",
                     &tv.version,
                     &tv.version,
                     tv.install_path()
-                )
-                .env("KERL_BASE_DIR", self.ba.cache_path.join("kerl"))
-                .env("MAKEFLAGS", format!("-j{}", num_cpus::get()))
-                .run()?;
+                );
+                for (key, value) in ctx.install_env(&tv) {
+                    cmd = cmd.env(key, value);
+                }
+                cmd.env("KERL_BASE_DIR", self.ba.cache_path.join("kerl"))
+                    .env("MAKEFLAGS", format!("-j{}", num_cpus::get()))
+                    .run()?;
             }
         }
 

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -88,6 +88,7 @@ impl GoPlugin {
                 .arg("install")
                 .arg(package)
                 .envs(self._exec_env(tv)?)
+                .envs(tv.request.options().core.install_env)
                 .execute()?;
         }
         Ok(())
@@ -100,6 +101,7 @@ impl GoPlugin {
             .current_dir(tv.install_path())
             .with_pr(pr)
             .arg("version")
+            .envs(tv.request.options().core.install_env)
             .execute()
     }
 

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -88,7 +88,7 @@ impl GoPlugin {
                 .arg("install")
                 .arg(package)
                 .envs(self._exec_env(tv)?)
-                .envs(tv.request.options().core.install_env)
+                .envs(tv.install_env())
                 .execute()?;
         }
         Ok(())
@@ -101,7 +101,7 @@ impl GoPlugin {
             .current_dir(tv.install_path())
             .with_pr(pr)
             .arg("version")
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -151,7 +151,7 @@ impl JavaPlugin {
         CmdLineRunner::new(self.java_bin(tv))
             .with_pr(pr)
             .env("JAVA_HOME", tv.install_path())
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .arg("-version")
             .execute()
     }

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -151,6 +151,7 @@ impl JavaPlugin {
         CmdLineRunner::new(self.java_bin(tv))
             .with_pr(pr)
             .env("JAVA_HOME", tv.install_path())
+            .envs(tv.request.options().core.install_env)
             .arg("-version")
             .execute()
     }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -192,9 +192,9 @@ impl NodePlugin {
                 ..TarOptions::new(TarFormat::TarGz)
             },
         )?;
-        self.exec_configure(ctx, opts)?;
-        self.exec_make(ctx, opts)?;
-        self.exec_make_install(ctx, opts)?;
+        self.exec_configure(ctx, opts, tv)?;
+        self.exec_make(ctx, opts, tv)?;
+        self.exec_make_install(ctx, opts, tv)?;
         Ok(())
     }
 
@@ -216,44 +216,72 @@ impl NodePlugin {
             HTTP.download_file(url.clone(), local, Some(pr)).await?;
         }
         ctx.pr.next_operation();
-        let platform_info = tv
-            .lock_platforms
-            .entry(self.get_platform_key())
-            .or_default();
+        let platform_key = self.get_platform_key();
+        let needs_checksum = settings.node.verify
+            && tv
+                .lock_platforms
+                .get(&platform_key)
+                .map(|platform_info| platform_info.checksum.is_none())
+                .unwrap_or(true);
+        let checksum = if needs_checksum {
+            Some(self.get_checksum(ctx, tv, local, version).await?)
+        } else {
+            None
+        };
+        let platform_info = tv.lock_platforms.entry(platform_key).or_default();
         platform_info.url = Some(url.to_string());
-        if settings.node.verify && platform_info.checksum.is_none() {
-            platform_info.checksum = Some(self.get_checksum(ctx, local, version).await?);
+        if let Some(checksum) = checksum {
+            platform_info.checksum.get_or_insert(checksum);
         }
         self.verify_checksum(ctx, tv, local)?;
         Ok(())
     }
 
-    fn sh<'a>(&self, ctx: &'a InstallContext, opts: &BuildOpts) -> eyre::Result<CmdLineRunner<'a>> {
+    fn sh<'a>(
+        &self,
+        ctx: &'a InstallContext,
+        opts: &BuildOpts,
+        tv: &ToolVersion,
+    ) -> eyre::Result<CmdLineRunner<'a>> {
         let settings = Settings::get();
         let mut cmd = CmdLineRunner::new("sh")
             .prepend_path(opts.path.clone())?
             .with_pr(ctx.pr.as_ref())
             .current_dir(&opts.build_dir)
-            .arg("-c");
+            .arg("-c")
+            .envs(ctx.install_env(tv));
         if let Some(cflags) = settings.node.cflags() {
             cmd = cmd.env("CFLAGS", cflags);
         }
         Ok(cmd)
     }
 
-    fn exec_configure(&self, ctx: &InstallContext, opts: &BuildOpts) -> Result<()> {
-        self.sh(ctx, opts)?.arg(&opts.configure_cmd).execute()
+    fn exec_configure(
+        &self,
+        ctx: &InstallContext,
+        opts: &BuildOpts,
+        tv: &ToolVersion,
+    ) -> Result<()> {
+        self.sh(ctx, opts, tv)?.arg(&opts.configure_cmd).execute()
     }
-    fn exec_make(&self, ctx: &InstallContext, opts: &BuildOpts) -> Result<()> {
-        self.sh(ctx, opts)?.arg(&opts.make_cmd).execute()
+    fn exec_make(&self, ctx: &InstallContext, opts: &BuildOpts, tv: &ToolVersion) -> Result<()> {
+        self.sh(ctx, opts, tv)?.arg(&opts.make_cmd).execute()
     }
-    fn exec_make_install(&self, ctx: &InstallContext, opts: &BuildOpts) -> Result<()> {
-        self.sh(ctx, opts)?.arg(&opts.make_install_cmd).execute()
+    fn exec_make_install(
+        &self,
+        ctx: &InstallContext,
+        opts: &BuildOpts,
+        tv: &ToolVersion,
+    ) -> Result<()> {
+        self.sh(ctx, opts, tv)?
+            .arg(&opts.make_install_cmd)
+            .execute()
     }
 
     async fn get_checksum(
         &self,
         ctx: &InstallContext,
+        tv: &ToolVersion,
         tarball: &Path,
         version: &str,
     ) -> Result<String> {
@@ -266,7 +294,7 @@ impl NodePlugin {
         )
         .await?;
         if Settings::get().node.gpg_verify != Some(false) && version.starts_with("2") {
-            self.verify_with_gpg(ctx, &shasums_file, version, &tarball_name)
+            self.verify_with_gpg(ctx, tv, &shasums_file, version, &tarball_name)
                 .await?;
         }
         let shasums = file::read_to_string(&shasums_file)?;
@@ -278,6 +306,7 @@ impl NodePlugin {
     async fn verify_with_gpg(
         &self,
         ctx: &InstallContext,
+        tv: &ToolVersion,
         shasums_file: &Path,
         v: &str,
         tarball_name: &str,
@@ -307,6 +336,7 @@ impl NodePlugin {
             .arg(sig_file)
             .arg(shasums_file)
             .with_pr(ctx.pr.as_ref())
+            .envs(ctx.install_env(tv))
             .execute()?;
         Ok(())
     }
@@ -357,6 +387,7 @@ impl NodePlugin {
                 .arg("--global")
                 .arg(package)
                 .envs(config.env().await?)
+                .envs(tv.request.options().core.install_env)
                 .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
                 .execute()?;
         }
@@ -376,6 +407,7 @@ impl NodePlugin {
         CmdLineRunner::new(corepack)
             .with_pr(pr)
             .arg("enable")
+            .envs(tv.request.options().core.install_env)
             .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .execute()?;
         Ok(())
@@ -392,6 +424,7 @@ impl NodePlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
+            .envs(tv.request.options().core.install_env)
             .execute()
     }
 
@@ -406,6 +439,7 @@ impl NodePlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
+            .envs(tv.request.options().core.install_env)
             .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .execute()
     }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -248,11 +248,11 @@ impl NodePlugin {
             .prepend_path(opts.path.clone())?
             .with_pr(ctx.pr.as_ref())
             .current_dir(&opts.build_dir)
-            .arg("-c")
-            .envs(ctx.install_env(tv));
+            .arg("-c");
         if let Some(cflags) = settings.node.cflags() {
             cmd = cmd.env("CFLAGS", cflags);
         }
+        cmd = cmd.envs(tv.install_env());
         Ok(cmd)
     }
 
@@ -336,7 +336,7 @@ impl NodePlugin {
             .arg(sig_file)
             .arg(shasums_file)
             .with_pr(ctx.pr.as_ref())
-            .envs(ctx.install_env(tv))
+            .envs(tv.install_env())
             .execute()?;
         Ok(())
     }
@@ -387,7 +387,7 @@ impl NodePlugin {
                 .arg("--global")
                 .arg(package)
                 .envs(config.env().await?)
-                .envs(tv.request.options().core.install_env)
+                .envs(tv.install_env())
                 .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
                 .execute()?;
         }
@@ -407,7 +407,7 @@ impl NodePlugin {
         CmdLineRunner::new(corepack)
             .with_pr(pr)
             .arg("enable")
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .execute()?;
         Ok(())
@@ -424,7 +424,7 @@ impl NodePlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .execute()
     }
 
@@ -439,7 +439,7 @@ impl NodePlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .execute()
     }

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -380,9 +380,9 @@ impl PythonPlugin {
             .with_pr(ctx.pr.as_ref())
             .arg(tv.version.as_str())
             .arg(tv.install_path())
-            .env("PIP_REQUIRE_VIRTUALENV", "false")
             .envs(ctx.config.env().await?)
-            .envs(ctx.install_env(tv));
+            .envs(tv.install_env())
+            .env("PIP_REQUIRE_VIRTUALENV", "false");
         if Settings::get().verbose {
             cmd = cmd.arg("--verbose");
         }
@@ -426,9 +426,9 @@ impl PythonPlugin {
             .arg("--upgrade")
             .arg("-r")
             .arg(packages_file)
-            .env("PIP_REQUIRE_VIRTUALENV", "false")
             .envs(config.env().await?)
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
+            .env("PIP_REQUIRE_VIRTUALENV", "false")
             .execute()
     }
 
@@ -493,7 +493,7 @@ impl PythonPlugin {
             .with_pr(pr)
             .arg("--version")
             .envs(config.env().await?)
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -381,7 +381,8 @@ impl PythonPlugin {
             .arg(tv.version.as_str())
             .arg(tv.install_path())
             .env("PIP_REQUIRE_VIRTUALENV", "false")
-            .envs(ctx.config.env().await?);
+            .envs(ctx.config.env().await?)
+            .envs(ctx.install_env(tv));
         if Settings::get().verbose {
             cmd = cmd.arg("--verbose");
         }
@@ -427,6 +428,7 @@ impl PythonPlugin {
             .arg(packages_file)
             .env("PIP_REQUIRE_VIRTUALENV", "false")
             .envs(config.env().await?)
+            .envs(tv.request.options().core.install_env)
             .execute()
     }
 
@@ -491,6 +493,7 @@ impl PythonPlugin {
             .with_pr(pr)
             .arg("--version")
             .envs(config.env().await?)
+            .envs(tv.request.options().core.install_env)
             .execute()
     }
 

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -249,7 +249,7 @@ impl RubyPlugin {
                 .with_pr(pr)
                 .arg("install")
                 .envs(config.env().await?)
-                .envs(tv.request.options().core.install_env);
+                .envs(tv.install_env());
             match package.split_once(' ') {
                 Some((name, "--pre")) => cmd = cmd.arg(name).arg("--pre"),
                 Some((name, version)) => cmd = cmd.arg(name).arg("--version").arg(version),
@@ -300,7 +300,7 @@ impl RubyPlugin {
         Ok(cmd
             .with_pr(pr)
             .envs(config.env().await?)
-            .envs(tv.request.options().core.install_env))
+            .envs(tv.install_env()))
     }
     fn install_args_ruby_build(&self, tv: &ToolVersion) -> Result<Vec<String>> {
         let settings = Settings::get();

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -248,7 +248,8 @@ impl RubyPlugin {
             let mut cmd = CmdLineRunner::new(gem)
                 .with_pr(pr)
                 .arg("install")
-                .envs(config.env().await?);
+                .envs(config.env().await?)
+                .envs(tv.request.options().core.install_env);
             match package.split_once(' ') {
                 Some((name, "--pre")) => cmd = cmd.arg(name).arg("--pre"),
                 Some((name, version)) => cmd = cmd.arg(name).arg("--version").arg(version),
@@ -296,7 +297,10 @@ impl RubyPlugin {
                 .args(self.install_args_ruby_build(tv)?)
                 .stdin_string(self.fetch_patches().await?)
         };
-        Ok(cmd.with_pr(pr).envs(config.env().await?))
+        Ok(cmd
+            .with_pr(pr)
+            .envs(config.env().await?)
+            .envs(tv.request.options().core.install_env))
     }
     fn install_args_ruby_build(&self, tv: &ToolVersion) -> Result<Vec<String>> {
         let settings = Settings::get();

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -62,7 +62,8 @@ impl RubyPlugin {
             let mut cmd = CmdLineRunner::new(gem)
                 .with_pr(pr)
                 .arg("install")
-                .envs(config.env().await?);
+                .envs(config.env().await?)
+                .envs(tv.request.options().core.install_env);
             match package.split_once(' ') {
                 Some((name, "--pre")) => cmd = cmd.arg(name).arg("--pre"),
                 Some((name, version)) => cmd = cmd.arg(name).arg("--version").arg(version),
@@ -85,6 +86,7 @@ impl RubyPlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
+            .envs(tv.request.options().core.install_env)
             .execute()
     }
 
@@ -99,6 +101,7 @@ impl RubyPlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
+            .envs(tv.request.options().core.install_env)
             .env(&*PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .execute()
     }

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -63,7 +63,7 @@ impl RubyPlugin {
                 .with_pr(pr)
                 .arg("install")
                 .envs(config.env().await?)
-                .envs(tv.request.options().core.install_env);
+                .envs(tv.install_env());
             match package.split_once(' ') {
                 Some((name, "--pre")) => cmd = cmd.arg(name).arg("--pre"),
                 Some((name, version)) => cmd = cmd.arg(name).arg("--version").arg(version),
@@ -86,7 +86,7 @@ impl RubyPlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .execute()
     }
 
@@ -101,7 +101,7 @@ impl RubyPlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
-            .envs(tv.request.options().core.install_env)
+            .envs(tv.install_env())
             .env(&*PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .execute()
     }

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -47,7 +47,8 @@ impl RustPlugin {
             .arg("--default-toolchain")
             .arg("none")
             .arg("-y")
-            .envs(self.exec_env(&ctx.config, ts, tv).await?);
+            .envs(self.exec_env(&ctx.config, ts, tv).await?)
+            .envs(ctx.install_env(tv));
         if let Some(host) = settings.rust.default_host.as_ref() {
             cmd = cmd.arg("--default-host").arg(host);
         }
@@ -62,6 +63,7 @@ impl RustPlugin {
             .with_pr(ctx.pr.as_ref())
             .arg("-V")
             .envs(self.exec_env(&ctx.config, ts, tv).await?)
+            .envs(ctx.install_env(tv))
             .prepend_path(self.list_bin_paths(&ctx.config, tv).await?)?
             .execute()
     }
@@ -142,7 +144,8 @@ impl Backend for RustPlugin {
             .opt_args("--component", components)
             .opt_args("--target", targets)
             .prepend_path(self.list_bin_paths(&ctx.config, &tv).await?)?
-            .envs(self.exec_env(&ctx.config, ts, &tv).await?);
+            .envs(self.exec_env(&ctx.config, ts, &tv).await?)
+            .envs(ctx.install_env(&tv));
         if let Some(profile) = profile.as_ref() {
             cmd = cmd.arg("--profile").arg(profile);
         }

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -47,8 +47,8 @@ impl RustPlugin {
             .arg("--default-toolchain")
             .arg("none")
             .arg("-y")
-            .envs(self.exec_env(&ctx.config, ts, tv).await?)
-            .envs(ctx.install_env(tv));
+            .envs(tv.install_env())
+            .envs(self.exec_env(&ctx.config, ts, tv).await?);
         if let Some(host) = settings.rust.default_host.as_ref() {
             cmd = cmd.arg("--default-host").arg(host);
         }
@@ -62,8 +62,8 @@ impl RustPlugin {
         CmdLineRunner::new(RUSTC_BIN)
             .with_pr(ctx.pr.as_ref())
             .arg("-V")
+            .envs(tv.install_env())
             .envs(self.exec_env(&ctx.config, ts, tv).await?)
-            .envs(ctx.install_env(tv))
             .prepend_path(self.list_bin_paths(&ctx.config, tv).await?)?
             .execute()
     }
@@ -144,8 +144,8 @@ impl Backend for RustPlugin {
             .opt_args("--component", components)
             .opt_args("--target", targets)
             .prepend_path(self.list_bin_paths(&ctx.config, &tv).await?)?
-            .envs(self.exec_env(&ctx.config, ts, &tv).await?)
-            .envs(ctx.install_env(&tv));
+            .envs(tv.install_env())
+            .envs(self.exec_env(&ctx.config, ts, &tv).await?);
         if let Some(profile) = profile.as_ref() {
             cmd = cmd.arg("--profile").arg(profile);
         }

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -36,7 +36,7 @@ impl SwiftPlugin {
         CmdLineRunner::new(self.swift_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .arg("--version")
-            .envs(ctx.install_env(tv))
+            .envs(tv.install_env())
             .execute()
     }
 
@@ -79,7 +79,7 @@ impl SwiftPlugin {
                 .arg(tarball_path)
                 .arg(&tmp)
                 .with_pr(ctx.pr.as_ref())
-                .envs(ctx.install_env(tv))
+                .envs(tv.install_env())
                 .execute()?;
             file::remove_all(tv.install_path())?;
             file::rename(
@@ -141,7 +141,7 @@ impl SwiftPlugin {
             .arg("--verify")
             .arg(&sig_path)
             .arg(tarball_path)
-            .envs(ctx.install_env(tv))
+            .envs(tv.install_env())
             .execute()?;
         Ok(())
     }

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -36,6 +36,7 @@ impl SwiftPlugin {
         CmdLineRunner::new(self.swift_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .arg("--version")
+            .envs(ctx.install_env(tv))
             .execute()
     }
 
@@ -78,6 +79,7 @@ impl SwiftPlugin {
                 .arg(tarball_path)
                 .arg(&tmp)
                 .with_pr(ctx.pr.as_ref())
+                .envs(ctx.install_env(tv))
                 .execute()?;
             file::remove_all(tv.install_path())?;
             file::rename(
@@ -139,6 +141,7 @@ impl SwiftPlugin {
             .arg("--verify")
             .arg(&sig_path)
             .arg(tarball_path)
+            .envs(ctx.install_env(tv))
             .execute()?;
         Ok(())
     }

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -54,6 +54,7 @@ impl ZigPlugin {
         CmdLineRunner::new(self.zig_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .arg("version")
+            .envs(ctx.install_env(tv))
             .execute()
     }
 

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -54,7 +54,7 @@ impl ZigPlugin {
         CmdLineRunner::new(self.zig_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .arg("version")
-            .envs(ctx.install_env(tv))
+            .envs(tv.install_env())
             .execute()
     }
 

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -19,6 +19,7 @@ use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, tool_request};
 use console::style;
 use dashmap::DashMap;
 use eyre::{Result, bail};
+use indexmap::IndexMap;
 use jiff::Timestamp;
 #[cfg(windows)]
 use path_absolutize::Absolutize;
@@ -182,6 +183,11 @@ impl ToolVersion {
         }
         path
     }
+
+    pub fn install_env(&self) -> IndexMap<String, String> {
+        self.request.options().core.install_env
+    }
+
     pub fn runtime_path(&self) -> PathBuf {
         if self.locked {
             return self.install_path();


### PR DESCRIPTION
## Summary
- applies per-tool install_env to command-backed install paths across package-manager backends, vfox cmd.exec hooks, SPM build/probe commands, and core language install-time commands
- adds install_env docs for affected backend and language pages, including SPM shorthand and vfox helper caveats
- adds a vfox e2e covering install_env propagation into cmd.exec during install

Project item: https://github.com/users/risu729/projects/3/views/1?filterQuery=install_env&pane=issue&itemId=188373493

## Tests
- cargo fmt --all -- --check
- git diff --check && git diff --cached --check
- CARGO_TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)" mise run test:e2e -- test_vfox_install_env