### PR TITLE
fix(backend): pass install_env to postinstall

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,7 +178,7 @@ See [Tools](/dev-tools/). In addition to specifying versions, each tool entry ca
 
 - `os`: Restrict installation to certain operating systems
 - `depends`: Install order relative to other tools in this config only; vfox plugin hook dependencies belong in plugin `metadata.lua` (see [Tool Dependencies](/dev-tools/#tool-dependencies))
-- `install_env`: Environment vars used during install
+- `install_env`: Environment vars used during install and tool-level `postinstall`
 - `postinstall`: Command to run after installation completes for that specific tool
 
 Examples:

--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -164,7 +164,7 @@ Behavior:
 
 - The command runs once the install completes successfully for that tool/version.
 - The tool's bin path is on PATH during the command, so you can invoke the installed tool directly.
-- Environment variables include `MISE_TOOL_INSTALL_PATH` pointing to the tool's install directory.
+- Environment variables include `MISE_TOOL_INSTALL_PATH` pointing to the tool's install directory and any variables from that tool's `install_env` option.
 - If the install fails, the `postinstall` command is not run.
 
 ## OS-Specific Tools

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -75,6 +75,7 @@ Tool-level postinstall scripts receive the following environment variables:
 - `MISE_TOOL_NAME`: The short name of the tool (e.g., "node", "python")
 - `MISE_TOOL_VERSION`: The version that was installed (e.g., "20.10.0", "3.12.0")
 - `MISE_TOOL_INSTALL_PATH`: The path where the tool was installed
+- Variables from that tool's `install_env` option
 
 ## Task hooks
 

--- a/e2e/config/test_hooks_postinstall_env
+++ b/e2e/config/test_hooks_postinstall_env
@@ -15,7 +15,7 @@ EXPLICIT_PRE_TOOLS = {value = "explicitly_pre_tools", tools = false}
 POST_TOOLS_VAR = {value = "available_after_tools", tools = true}
 
 [tools]
-dummy = { version = "latest", postinstall = "echo PRE_TOOLS_VAR=\$PRE_TOOLS_VAR; echo EXPLICIT_PRE_TOOLS=\$EXPLICIT_PRE_TOOLS; echo POST_TOOLS_VAR=\$POST_TOOLS_VAR" }
+dummy = { version = "latest", install_env = { INSTALL_ENV_VAR = "available_during_install" }, postinstall = "echo PRE_TOOLS_VAR=\$PRE_TOOLS_VAR; echo EXPLICIT_PRE_TOOLS=\$EXPLICIT_PRE_TOOLS; echo POST_TOOLS_VAR=\$POST_TOOLS_VAR; echo INSTALL_ENV_VAR=\$INSTALL_ENV_VAR" }
 EOF
 
 # Remove any existing dummy installation to force reinstall
@@ -37,6 +37,14 @@ if [[ $output == *"EXPLICIT_PRE_TOOLS=explicitly_pre_tools"* ]]; then
   echo "✓ EXPLICIT_PRE_TOOLS is available in postinstall"
 else
   echo "✗ EXPLICIT_PRE_TOOLS is NOT available in postinstall"
+  echo "Output: $output"
+  exit 1
+fi
+
+if [[ $output == *"INSTALL_ENV_VAR=available_during_install"* ]]; then
+  echo "✓ INSTALL_ENV_VAR is available in postinstall"
+else
+  echo "✗ INSTALL_ENV_VAR is NOT available in postinstall"
   echo "Output: $output"
   exit 1
 fi

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1818,6 +1818,7 @@ pub trait Backend: Debug + Send + Sync {
                 env_vars.entry(k).or_insert(v);
             }
         }
+        env_vars.extend(tv.request.options().core.install_env);
 
         // Use the backend's list_bin_paths to get the correct binary directories
         // instead of hardcoding install_path/bin, which may not match the actual


### PR DESCRIPTION
## Summary
- passes per-tool install_env into tool-level postinstall hook commands
- documents that tool-level postinstall receives install_env variables
- extends the postinstall environment e2e to cover install_env

Project item: https://github.com/users/risu729/projects/3/views/1?filterQuery=install_env&pane=issue&itemId=188373493

## Tests
- cargo fmt --all -- --check
- git diff --check
- CARGO_TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)" mise run test:e2e -- test_hooks_postinstall_env