### PR TITLE
chore: release 2026.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## [2026.5.11](https://github.com/jdx/mise/compare/v2026.5.10..v2026.5.11) - 2026-05-17
+
+### 🐛 Bug Fixes
+
+- **(backend)** avoid release age cutoff for dependency envs by @risu729 in [#9808](https://github.com/jdx/mise/pull/9808)
+- **(cache)** honor plugin filter when pruning cache by @risu729 in [#9914](https://github.com/jdx/mise/pull/9914)
+- **(config)** report invalid miserc files by @jdx in [#9937](https://github.com/jdx/mise/pull/9937)
+- **(doctor)** list installed plugins from install state by @risu729 in [#9863](https://github.com/jdx/mise/pull/9863)
+- **(erlang)** respect compile false for precompiled installs by @risu729 in [#9866](https://github.com/jdx/mise/pull/9866)
+- **(github)** asset picker handles ambiguous patterns and runtime archives by @jdx in [#9946](https://github.com/jdx/mise/pull/9946)
+- **(install)** respect default inline shell in postinstall by @risu729 in [#9812](https://github.com/jdx/mise/pull/9812)
+- **(install)** store metadata alongside install dirs by @jdx in [#9941](https://github.com/jdx/mise/pull/9941)
+- **(plugins)** support remote git subdirectory sources by @jdx in [#9893](https://github.com/jdx/mise/pull/9893)
+- **(task)** preserve task env across nested hook-env by @risu729 in [#9850](https://github.com/jdx/mise/pull/9850)
+- **(use)** ignore system config for global shadow warning by @risu729 in [#9900](https://github.com/jdx/mise/pull/9900)
+- **(vfox)** use selected install path for env keys by @risu729 in [#9907](https://github.com/jdx/mise/pull/9907)
+- verify provenance during lock by @jdx in [#9945](https://github.com/jdx/mise/pull/9945)
+
+### 🚜 Refactor
+
+- **(aqua)** parse tool options locally by @risu729 in [#9872](https://github.com/jdx/mise/pull/9872)
+- **(cargo)** parse tool options locally by @risu729 in [#9922](https://github.com/jdx/mise/pull/9922)
+- **(npm)** parse tool options locally by @risu729 in [#9920](https://github.com/jdx/mise/pull/9920)
+- **(pipx)** parse tool options locally by @risu729 in [#9921](https://github.com/jdx/mise/pull/9921)
+- **(s3)** parse tool options locally by @risu729 in [#9871](https://github.com/jdx/mise/pull/9871)
+- **(ubi)** parse tool options locally by @risu729 in [#9873](https://github.com/jdx/mise/pull/9873)
+
+### 📚 Documentation
+
+- **(configuration)** trim global settings example by @risu729 in [#9912](https://github.com/jdx/mise/pull/9912)
+
+### 🛡️ Security
+
+- **(security)** verify SLSA archive contents by @sargunv in [#9898](https://github.com/jdx/mise/pull/9898)
+
+### 📦️ Dependency Updates
+
+- bump ctor to 1 by @jdx in [#9938](https://github.com/jdx/mise/pull/9938)
+
+### 📦 Registry
+
+- fix sourcery platform archive format by @risu729 in [#9902](https://github.com/jdx/mise/pull/9902)
+- prefer aqua for tools also in aqua-registry by @risu729 in [#9789](https://github.com/jdx/mise/pull/9789)
+- add aqua backend for jbang by @risu729 in [#9811](https://github.com/jdx/mise/pull/9811)
+- alias dotnet-core to dotnet by @risu729 in [#9807](https://github.com/jdx/mise/pull/9807)
+- add lisette by @ivov in [#9944](https://github.com/jdx/mise/pull/9944)
+
+### Chore
+
+- **(ci)** require clear hyperfine regressions by @risu729 in [#9874](https://github.com/jdx/mise/pull/9874)
+- **(ci)** close failing or conflicted PRs sooner by @jdx in [#9939](https://github.com/jdx/mise/pull/9939)
+
+### New Contributors
+
+- @ivov made their first contribution in [#9944](https://github.com/jdx/mise/pull/9944)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (1)
+
+- [`glossia/cli`](https://github.com/glossia/cli)
+
+#### Updated Packages (1)
+
+- [`dathere/qsv`](https://github.com/dathere/qsv)
+
 ## [2026.5.10](https://github.com/jdx/mise/compare/v2026.5.9..v2026.5.10) - 2026-05-16
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.5.10"
+version = "2026.5.11"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.5.10"
+version = "2026.5.11"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.5.10 macos-arm64 (2026-05-16)
+2026.5.11 macos-arm64 (2026-05-17)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_10.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_11.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_10.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_11.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_10.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_11.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_10.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_11.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.5.10";
+  version = "2026.5.11";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "28.2k",
+      stars: "28.3k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.5.10
+Version: 2026.5.11
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.5.10"
+version: "2026.5.11"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "v4.512.0"
+  "tag": "v4.512.1"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -30252,8 +30252,157 @@ packages:
     version_overrides:
       - version_constraint: Version in ["0.15.0", "0.24.0", "0.48.0", "0.61.3", "0.68.0", "0.93.0", "0.102.0"]
         no_asset: true
-      - version_constraint: Version in ["publish-testing"]
+      - version_constraint: Version in ["publish-testing", "0.26.0", "0.131.1"]
         error_message: This version isn't supported.
+      - version_constraint: Version == "0.13.1"
+        asset: xsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: xsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.14.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "0.14.1"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.zip.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "0.16.0"
+        asset: qsv-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.16.1"
+        asset: qsv-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: target/release/qsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: windows
+            files:
+              - name: qsv
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.16.2"
+        asset: qsv-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: target/release/qsv
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version in ["0.22.0", "0.22.1", "0.22.2"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: Version in ["0.23.0", "0.24.1", "0.25.2-beta"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version == "0.30.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.90.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              amd64: x86_64
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - windows/amd64
       - version_constraint: Version == "0.108.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30272,6 +30421,25 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
+      - version_constraint: Version == "0.109.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
       - version_constraint: Version == "0.113.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30363,6 +30531,76 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
+      - version_constraint: semver("<= 0.21.0")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: target/{{.Arch}}-{{.OS}}/release/qsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.40.3")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version in ["0.65.0", "0.66.0", "0.67.0", "0.70.0", "0.72.0"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            goarch: arm64
+            files:
+              - name: qsv
+                src: qsv-{{.Version}}-{{.Arch}}-{{.OS}}/qsv
+      - version_constraint: semver("<= 0.75.0")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+      - version_constraint: semver("<= 0.76.2")
+        no_asset: true
       - version_constraint: semver("<= 7.0.1")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30406,7 +30644,7 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 16.1.0")
+      - version_constraint: "true"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         replacements:
@@ -30430,24 +30668,6 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: "true"
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}-testing.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
   - type: github_release
     repo_owner: datreeio
     repo_name: datree
@@ -40881,25 +41101,44 @@ packages:
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
           signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
-  - type: http
-    name: glossia.ai/cli
+  - type: github_release
+    repo_owner: glossia
+    repo_name: cli
+    aliases:
+      - name: glossia.ai/cli
     description: Localize like you ship software
-    link: https://glossia.ai/docs/reference/cli
-    version_prefix: cli-v
-    windows_arm_emulation: true
-    url: https://glossia-releases.t3.storage.dev/cli/{{.SemVer}}/glossia-{{.OS}}-{{.Arch}}.{{.Format}}
     files:
       - name: glossia
-    replacements:
-      amd64: x64
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: http
-      url: https://glossia-releases.t3.storage.dev/cli/{{.SemVer}}/SHA256SUMS
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 0.15.1")
+        version_prefix: cli-v
+        type: http
+        windows_arm_emulation: true
+        url: https://glossia-releases.t3.storage.dev/cli/{{.SemVer}}/glossia-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x64
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: http
+          url: https://glossia-releases.t3.storage.dev/cli/{{.SemVer}}/SHA256SUMS
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: glossia-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: go-acme
     repo_name: lego


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(backend)** avoid release age cutoff for dependency envs by @risu729 in [#9808](https://github.com/jdx/mise/pull/9808)
- **(cache)** honor plugin filter when pruning cache by @risu729 in [#9914](https://github.com/jdx/mise/pull/9914)
- **(config)** report invalid miserc files by @jdx in [#9937](https://github.com/jdx/mise/pull/9937)
- **(doctor)** list installed plugins from install state by @risu729 in [#9863](https://github.com/jdx/mise/pull/9863)
- **(erlang)** respect compile false for precompiled installs by @risu729 in [#9866](https://github.com/jdx/mise/pull/9866)
- **(github)** asset picker handles ambiguous patterns and runtime archives by @jdx in [#9946](https://github.com/jdx/mise/pull/9946)
- **(install)** respect default inline shell in postinstall by @risu729 in [#9812](https://github.com/jdx/mise/pull/9812)
- **(install)** store metadata alongside install dirs by @jdx in [#9941](https://github.com/jdx/mise/pull/9941)
- **(plugins)** support remote git subdirectory sources by @jdx in [#9893](https://github.com/jdx/mise/pull/9893)
- **(task)** preserve task env across nested hook-env by @risu729 in [#9850](https://github.com/jdx/mise/pull/9850)
- **(use)** ignore system config for global shadow warning by @risu729 in [#9900](https://github.com/jdx/mise/pull/9900)
- **(vfox)** use selected install path for env keys by @risu729 in [#9907](https://github.com/jdx/mise/pull/9907)
- verify provenance during lock by @jdx in [#9945](https://github.com/jdx/mise/pull/9945)

### 🚜 Refactor

- **(aqua)** parse tool options locally by @risu729 in [#9872](https://github.com/jdx/mise/pull/9872)
- **(cargo)** parse tool options locally by @risu729 in [#9922](https://github.com/jdx/mise/pull/9922)
- **(npm)** parse tool options locally by @risu729 in [#9920](https://github.com/jdx/mise/pull/9920)
- **(pipx)** parse tool options locally by @risu729 in [#9921](https://github.com/jdx/mise/pull/9921)
- **(s3)** parse tool options locally by @risu729 in [#9871](https://github.com/jdx/mise/pull/9871)
- **(ubi)** parse tool options locally by @risu729 in [#9873](https://github.com/jdx/mise/pull/9873)

### 📚 Documentation

- **(configuration)** trim global settings example by @risu729 in [#9912](https://github.com/jdx/mise/pull/9912)

### 🛡️ Security

- **(security)** verify SLSA archive contents by @sargunv in [#9898](https://github.com/jdx/mise/pull/9898)

### 📦️ Dependency Updates

- bump ctor to 1 by @jdx in [#9938](https://github.com/jdx/mise/pull/9938)

### 📦 Registry

- fix sourcery platform archive format by @risu729 in [#9902](https://github.com/jdx/mise/pull/9902)
- prefer aqua for tools also in aqua-registry by @risu729 in [#9789](https://github.com/jdx/mise/pull/9789)
- add aqua backend for jbang by @risu729 in [#9811](https://github.com/jdx/mise/pull/9811)
- alias dotnet-core to dotnet by @risu729 in [#9807](https://github.com/jdx/mise/pull/9807)
- add lisette by @ivov in [#9944](https://github.com/jdx/mise/pull/9944)

### Chore

- **(ci)** require clear hyperfine regressions by @risu729 in [#9874](https://github.com/jdx/mise/pull/9874)
- **(ci)** close failing or conflicted PRs sooner by @jdx in [#9939](https://github.com/jdx/mise/pull/9939)

### New Contributors

- @ivov made their first contribution in [#9944](https://github.com/jdx/mise/pull/9944)

## 📦 Aqua Registry Updates

### New Packages (1)

- [`glossia/cli`](https://github.com/glossia/cli)

### Updated Packages (1)

- [`dathere/qsv`](https://github.com/dathere/qsv)