### PR TITLE
fix(config): report invalid miserc files

### DIFF
--- a/e2e/config/test_miserc
+++ b/e2e/config/test_miserc
@@ -15,6 +15,16 @@ MISE_ENV=ci assert "mise ls dummy" "dummy  1.1.0 (missing)  ~/workdir/mise.toml 
 
 # Test ceiling_paths in .miserc.toml - subdirectory should pick up parent miserc
 rm -f .miserc.toml
+
+# Invalid global miserc TOML should be reported instead of silently ignored.
+cat >"$MISE_CONFIG_DIR/miserc.toml" <<'EOF'
+ceiling_paths = ["{{ env.HOME }}"]
+fdsfads
+EOF
+assert_fail "mise config ls" "Invalid TOML in config file:"
+assert_fail "mise config ls" "~/.config/mise/miserc.toml:2:8"
+assert_fail "mise config ls" "key with no value, expected"
+rm -f "$MISE_CONFIG_DIR/miserc.toml"
 echo 'env = ["test"]' >.miserc.toml
 mkdir -p subdir
 cd subdir || exit 1

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -617,9 +617,7 @@ impl Cli {
         crate::env::ARGS.write().unwrap().clone_from(args);
         // Load .miserc.toml early, before MISE_ENV and other early settings are accessed.
         // This allows setting MISE_ENV in a config file instead of only via env vars.
-        if let Err(err) = crate::config::miserc::init() {
-            warn!("Failed to load .miserc.toml: {err}");
-        }
+        crate::config::miserc::init()?;
         if *crate::env::MISE_TOOL_STUB && args.len() >= 2 {
             tool_stub::short_circuit_stub(&args[2..]).await?;
         }

--- a/src/config/miserc.rs
+++ b/src/config/miserc.rs
@@ -12,6 +12,7 @@ use std::sync::OnceLock;
 use eyre::Result;
 use tera::Context;
 
+use crate::config::config_file::diagnostic::toml_parse_error;
 use crate::config::settings::MisercSettings;
 use crate::dirs;
 use crate::env;
@@ -133,14 +134,9 @@ fn load_miserc_settings() -> Result<MisercSettings> {
         if let Ok(content) = file::read_to_string(&path) {
             let config_root = path.parent().unwrap_or(Path::new("."));
             let content = render_miserc_template(&mut tera, &content, config_root);
-            match toml::from_str::<MisercSettings>(&content) {
-                Ok(settings) => {
-                    merge_settings(&mut merged, settings);
-                }
-                Err(e) => {
-                    warn!("Failed to parse {}: {}", path.display(), e);
-                }
-            }
+            let settings = toml::from_str::<MisercSettings>(&content)
+                .map_err(|e| toml_parse_error(&e, &content, &path))?;
+            merge_settings(&mut merged, settings);
         }
     }
 


### PR DESCRIPTION
## Summary
- propagate `.miserc.toml` TOML parse errors during CLI startup instead of logging and continuing
- reuse the existing rich config-file TOML diagnostic for miserc parse failures
- add e2e coverage for invalid global `miserc.toml`

## Root Cause
Invalid miserc TOML was converted to a warning inside `load_miserc_settings`, and CLI startup swallowed `miserc::init()` errors. Since this runs before logger initialization, users saw a successful command with no diagnostic.

## Validation
- `cargo fmt --check`
- `mise run test:e2e test_miserc`
- pre-commit hooks on `git commit`

Fixes #9933

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI startup to fail fast on invalid `miserc.toml`, which could newly break users with previously-ignored malformed config files but is limited to early config parsing behavior.
> 
> **Overview**
> **Invalid `miserc.toml` files are no longer silently ignored.** CLI startup now propagates `miserc::init()` failures instead of logging a warning and continuing.
> 
> `miserc` TOML parsing now uses the shared rich `toml_parse_error` diagnostic and returns an error on parse failure rather than warning and merging defaults. An e2e test was added to assert that an invalid global `~/.config/mise/miserc.toml` produces a clear failure message with file/line context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4685b2db6a363c10e9c04a7b0da618ecde91d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->