### PR TITLE
chore(deps): bump ctor to 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.12.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f"
+checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -5037,9 +5037,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.12.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40"
+checksum = "76b87baf24dab54aad743d8e009b90a09e34f4e4457d6f92a375e901453e56c3"
 
 [[package]]
 name = "linktime-proc-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,7 @@ toml = "1.0"
 
 [dev-dependencies]
 clap-sort = "1"
-ctor = "0.12"
+ctor = "1"
 insta = { version = "1", features = ["filters", "json"] }
 mockito = "1"
 pretty_assertions = "1"

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,7 +5,7 @@ use indoc::indoc;
 
 use crate::{env, file};
 
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
     if env::var("RUST_LOG").is_err() {
         env::set_var("RUST_LOG", "debug")


### PR DESCRIPTION
## Summary
- bump the ctor dev-dependency requirement to 1
- refresh Cargo.lock to ctor 1.0.6 and link-section 0.17.0
- update the test initializer attribute for ctor 1.x

## Validation
- cargo test --workspace --no-run
- git commit hook lint suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to dev/test tooling; the main risk is unexpected test initialization behavior changes from `ctor` 1.x.
> 
> **Overview**
> Bumps the dev-dependency on `ctor` from `0.12` to `1` and refreshes `Cargo.lock` accordingly (including pulling in newer `link-section`).
> 
> Updates the test bootstrap in `src/test.rs` to use the `ctor` 1.x attribute form (`#[ctor::ctor(unsafe)]`) so tests continue to run with the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 970ec190b518fd5b4c67456151f73d2a82e02a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->