### PR TITLE
fix(install): store metadata alongside install dirs

### DIFF
--- a/e2e/backend/test_install_manifest
+++ b/e2e/backend/test_install_manifest
@@ -41,3 +41,26 @@ rm -f "$MANIFEST"
 assert_succeed "mise ls"
 assert_contains "cat $MANIFEST" "legacy-test"
 assert_contains "cat $MANIFEST" "asdf:legacy-test"
+
+# Per-tool manifests should allow install dirs copied from different roots to merge
+rm -f "$MANIFEST"
+mkdir -p "$MISE_DATA_DIR/installs/source-a/1.0.0"
+mkdir -p "$MISE_DATA_DIR/installs/source-b/2.0.0"
+cat >"$MISE_DATA_DIR/installs/source-a/.mise.backend.toml" <<'TOML'
+short = "source-a"
+full = "asdf:source-a"
+explicit_backend = false
+TOML
+cat >"$MISE_DATA_DIR/installs/source-b/.mise.backend.toml" <<'TOML'
+short = "source-b"
+full = "asdf:source-b"
+explicit_backend = false
+TOML
+
+assert_contains "mise ls --installed" "source-a"
+assert_contains "mise ls --installed" "source-b"
+
+# New installs should write sidecar metadata so the directory is self-describing
+rm -f "$MISE_DATA_DIR/installs/tiny/.mise.backend.toml"
+mise install --force tiny@3.1.0
+assert_contains "cat $MISE_DATA_DIR/installs/tiny/.mise.backend.toml" 'short = "tiny"'

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1757,14 +1757,20 @@ pub trait Backend: Debug + Send + Sync {
         };
 
         let install_path = tv.install_path();
+        let mut update_install_state = false;
         if install_path.starts_with(*dirs::INSTALLS) {
             install_state::write_backend_meta(self.ba())?;
+            update_install_state = true;
         } else if env::install_path_category(&install_path) != env::InstallPathCategory::Local {
             // For --system/--shared installs, write manifest to the target installs dir
             if let Some(installs_dir) = install_path.parent().and_then(|p| p.parent()) {
                 let manifest = installs_dir.join(".mise-installs.toml");
                 install_state::write_backend_meta_to(self.ba(), &manifest)?;
+                update_install_state = true;
             }
+        }
+        if update_install_state {
+            install_state::add_tool_version(self.ba(), &install_path, &tv.tv_pathname());
         }
 
         self.cleanup_install_dirs(&tv);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1896,6 +1896,9 @@ pub trait Backend: Debug + Send + Sync {
             rmdir(&tv.download_path())?;
         }
         rmdir(&tv.cache_path())?;
+        if !dryrun {
+            self.cleanup_empty_installs_dir();
+        }
         Ok(())
     }
     async fn uninstall_version_impl(
@@ -1990,6 +1993,18 @@ pub trait Backend: Debug + Send + Sync {
     fn cleanup_install_dirs(&self, tv: &ToolVersion) {
         if !Settings::get().always_keep_download {
             let _ = remove_all_with_warning(tv.download_path());
+        }
+    }
+    fn cleanup_empty_installs_dir(&self) {
+        let installs_path = &self.ba().installs_path;
+        if file::dir_subdirs(installs_path).is_ok_and(|entries| entries.is_empty()) {
+            let _ = file::remove_file(installs_path.join(".mise.backend.toml"));
+            if installs_path
+                .read_dir()
+                .is_ok_and(|mut entries| entries.next().is_none())
+            {
+                let _ = remove_all_with_warning(installs_path);
+            }
         }
     }
     fn incomplete_file_path(&self, tv: &ToolVersion) -> PathBuf {

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -496,6 +496,51 @@ pub fn list_versions(short: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+pub fn add_tool_version(ba: &BackendArg, install_path: &Path, version: &str) {
+    let tool_dir = install_path.parent().map(Path::to_path_buf);
+    let full = ba.full_without_opts();
+    let explicit_backend = ba.has_explicit_backend();
+    let opts = persistent_opts(ba);
+
+    let mut tools = INSTALL_STATE_TOOLS
+        .lock()
+        .expect("INSTALL_STATE_TOOLS lock failed");
+    let Some(existing_tools) = tools.as_ref() else {
+        return;
+    };
+
+    let mut next_tools = existing_tools.deref().clone();
+    let tool = next_tools
+        .entry(ba.short.clone())
+        .or_insert_with(|| InstallStateTool {
+            short: ba.short.clone(),
+            full: Some(full.clone()),
+            versions: Vec::new(),
+            explicit_backend,
+            opts: opts.clone(),
+            installs_path: tool_dir.clone(),
+        });
+
+    if tool.full.is_none() {
+        tool.full = Some(full);
+    }
+    tool.explicit_backend = explicit_backend;
+    if tool.opts.is_empty() {
+        tool.opts = opts;
+    }
+    if tool.installs_path.is_none() {
+        tool.installs_path = tool_dir;
+    }
+    if !tool.versions.iter().any(|v| v == version) {
+        // Do not sort here: this version has just been resolved by the backend
+        // for this install run, and offline dependency env resolution should
+        // see that concrete result without adding another ordering rule.
+        tool.versions.push(version.to_string());
+    }
+
+    *tools = Some(Arc::new(next_tools));
+}
+
 pub async fn add_plugin(short: &str, plugin_type: PluginType) -> Result<()> {
     let mut plugins = init_plugins().await?.deref().clone();
     plugins.insert(short.to_string(), plugin_type);
@@ -515,16 +560,7 @@ pub fn write_backend_meta(ba: &BackendArg) -> Result<()> {
 pub fn write_backend_meta_to(ba: &BackendArg, path: &Path) -> Result<()> {
     let full = ba.full_without_opts();
     let explicit = ba.has_explicit_backend();
-
-    // Store opts as native TOML values, filtering out ephemeral keys.
-    let mut opts_map: BTreeMap<String, toml::Value> = BTreeMap::new();
-    if let Some(o) = ba.opts.as_ref() {
-        for (k, v) in &o.opts {
-            if !EPHEMERAL_OPT_KEYS.contains(&k.as_str()) {
-                opts_map.insert(k.clone(), v.clone());
-            }
-        }
-    }
+    let opts_map = persistent_opts(ba);
 
     let _lock = MANIFEST_LOCK.lock().expect("MANIFEST_LOCK lock failed");
     let mut manifest = read_manifest_from(path);
@@ -543,6 +579,19 @@ pub fn write_backend_meta_to(ba: &BackendArg, path: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn persistent_opts(ba: &BackendArg) -> BTreeMap<String, toml::Value> {
+    // Store opts as native TOML values, filtering out ephemeral keys.
+    let mut opts_map: BTreeMap<String, toml::Value> = BTreeMap::new();
+    if let Some(o) = ba.opts.as_ref() {
+        for (k, v) in &o.opts {
+            if !EPHEMERAL_OPT_KEYS.contains(&k.as_str()) {
+                opts_map.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    opts_map
 }
 
 pub fn incomplete_file_path(short: &str, v: &str) -> PathBuf {

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -67,6 +67,12 @@ fn manifest_path() -> PathBuf {
     dirs::INSTALLS.join(".mise-installs.toml")
 }
 
+fn tool_manifest_path(installs_dir: &Path, short: &str) -> PathBuf {
+    installs_dir
+        .join(short.to_kebab_case())
+        .join(".mise.backend.toml")
+}
+
 /// Read the consolidated manifest file. Returns empty map if it doesn't exist.
 fn read_manifest() -> Manifest {
     read_manifest_from(&manifest_path())
@@ -95,6 +101,31 @@ fn write_manifest(manifest: &Manifest) -> Result<()> {
 
 fn write_manifest_to(path: &Path, manifest: &Manifest) -> Result<()> {
     let body = toml::to_string_pretty(manifest)?;
+    file::write(path, body.trim())?;
+    Ok(())
+}
+
+fn read_tool_manifest_from(path: &Path) -> Option<ManifestTool> {
+    if !path.exists() {
+        return None;
+    }
+    match file::read_to_string(path) {
+        std::result::Result::Ok(body) => match toml::from_str(&body) {
+            std::result::Result::Ok(m) => Some(m),
+            Err(err) => {
+                warn!(
+                    "failed to parse tool manifest at {}: {err:#}",
+                    display_path(path)
+                );
+                None
+            }
+        },
+        Err(_) => None,
+    }
+}
+
+fn write_tool_manifest_to(path: &Path, tool: &ManifestTool) -> Result<()> {
+    let body = toml::to_string_pretty(tool)?;
     file::write(path, body.trim())?;
     Ok(())
 }
@@ -203,7 +234,8 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
     let mut tools = BTreeMap::new();
     for dir_name in subdirs {
         let dir = dirs::INSTALLS.join(&dir_name);
-        let manifest_tool = manifest.get(&dir_name);
+        let tool_manifest = read_tool_manifest_from(&dir.join(".mise.backend.toml"));
+        let manifest_tool = tool_manifest.as_ref().or_else(|| manifest.get(&dir_name));
         let legacy_meta = if manifest_tool.is_none() {
             read_legacy_backend_meta(&dir_name)
         } else {
@@ -316,7 +348,10 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
         };
         for dir_name in shared_subdirs {
             let dir = shared_dir.join(&dir_name);
-            let manifest_tool = shared_manifest.get(&dir_name);
+            let tool_manifest = read_tool_manifest_from(&dir.join(".mise.backend.toml"));
+            let manifest_tool = tool_manifest
+                .as_ref()
+                .or_else(|| shared_manifest.get(&dir_name));
             let versions: Vec<String> = file::dir_subdirs(&dir)
                 .unwrap_or_else(|err| {
                     warn!("reading versions in {} failed: {err:?}", display_path(&dir));
@@ -493,16 +528,20 @@ pub fn write_backend_meta_to(ba: &BackendArg, path: &Path) -> Result<()> {
 
     let _lock = MANIFEST_LOCK.lock().expect("MANIFEST_LOCK lock failed");
     let mut manifest = read_manifest_from(path);
-    manifest.insert(
-        ba.short.to_kebab_case(),
-        ManifestTool {
-            short: ba.short.clone(),
-            full: Some(full),
-            explicit_backend: explicit,
-            opts: opts_map,
-        },
-    );
+    let manifest_tool = ManifestTool {
+        short: ba.short.clone(),
+        full: Some(full),
+        explicit_backend: explicit,
+        opts: opts_map,
+    };
+    manifest.insert(ba.short.to_kebab_case(), manifest_tool.clone());
     write_manifest_to(path, &manifest)?;
+    if let Some(installs_dir) = path.parent() {
+        let tool_manifest = tool_manifest_path(installs_dir, &ba.short);
+        if tool_manifest.parent().is_some_and(|p| p.exists()) {
+            write_tool_manifest_to(&tool_manifest, &manifest_tool)?;
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- write per-tool `.mise.backend.toml` metadata next to install directories
- prefer per-tool metadata over the consolidated `.mise-installs.toml` manifest when initializing install state
- refresh the in-memory install-state cache after successful installs so same-run dependency env resolution sees freshly installed tools
- cover merged install directories and sidecar creation in the install manifest e2e test

## Why
A single root `.mise-installs.toml` does not travel with install subdirectories, so merging install directories from different sources can lose backend identity. Keeping sidecar metadata in each tool directory makes copied installs self-describing while preserving the consolidated manifest for compatibility.

The install-state refresh also fixes same-run `--system` dependency installs: when a backend dependency like `go = "prefix:1.24"` is installed earlier in the same `mise install --system --jobs 1` run, later backend installs can resolve their offline dependency env from the concrete version the backend already selected, without adding filesystem or semver ordering assumptions.

## Validation
- `cargo fmt --all`
- `cargo check --all-features`
- `git diff --check`
- `mise run test:e2e e2e/cli/test_install_system_go_backend_slow`
- `mise run test:e2e backend/test_install_manifest`
- pre-commit hook: `hk` lint suite via `git commit`

*This pull request was generated by an AI coding assistant.*
