### PR TITLE
fix: clarify GitHub attestation errors

### DIFF
--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1646,7 +1646,8 @@ impl UnifiedGitBackend {
                 Err(VerificationStatus::Error(e)) => {
                     // Error during verification - hard error
                     return Err(eyre::eyre!(
-                        "GitHub artifact attestations verification error for {tv}: {e}"
+                        "GitHub artifact attestations verification error for {tv}: {e}{}",
+                        Self::github_attestation_api_error_hint(&e)
                     ));
                 }
             }
@@ -1754,6 +1755,20 @@ impl UnifiedGitBackend {
                 Err(VerificationStatus::NoAttestations)
             }
             Err(e) => Err(VerificationStatus::Error(e.to_string())),
+        }
+    }
+
+    fn github_attestation_api_error_hint(err: &str) -> &'static str {
+        if err.contains("GitHub API returned")
+            || err.contains("HTTP error")
+            || err.contains("error sending request")
+        {
+            " Check that the GitHub token can read artifact attestations \
+             (for GitHub Actions, set `permissions: attestations: read`) \
+             and retry; transient GitHub API failures should not be treated \
+             as missing release provenance."
+        } else {
+            ""
         }
     }
 
@@ -2041,6 +2056,17 @@ mod tests {
         let backend = create_test_backend();
         assert!(backend.matches_pattern("test-v1.0.0.zip", "test-*"));
         assert!(!backend.matches_pattern("other-v1.0.0.zip", "test-*"));
+    }
+
+    #[test]
+    fn test_github_attestation_api_error_hint() {
+        let hint = UnifiedGitBackend::github_attestation_api_error_hint(
+            "API error: GitHub API returned 403: Resource not accessible by integration",
+        );
+        assert!(hint.contains("attestations: read"));
+
+        let hint = UnifiedGitBackend::github_attestation_api_error_hint("No attestations found");
+        assert!(hint.is_empty());
     }
 
     #[test]

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1759,12 +1759,13 @@ impl UnifiedGitBackend {
     }
 
     fn github_attestation_api_error_hint(err: &str) -> &'static str {
-        if err.contains("GitHub API returned") {
+        let err = err.to_ascii_lowercase();
+        if err.contains("github api returned") {
             " Check that the GitHub token can read artifact attestations \
              (for GitHub Actions, set `permissions: attestations: read`) \
              and retry; transient GitHub API failures should not be treated \
              as missing release provenance."
-        } else if err.contains("HTTP error") || err.contains("error sending request") {
+        } else if err.contains("http error") || err.contains("error sending request") {
             " This may be a transient network or TLS error; retry before \
              treating this as missing release provenance."
         } else {
@@ -2061,12 +2062,12 @@ mod tests {
     #[test]
     fn test_github_attestation_api_error_hint() {
         let hint = UnifiedGitBackend::github_attestation_api_error_hint(
-            "API error: GitHub API returned 403: Resource not accessible by integration",
+            "API error: github API returned 403: Resource not accessible by integration",
         );
         assert!(hint.contains("attestations: read"));
 
         let hint = UnifiedGitBackend::github_attestation_api_error_hint(
-            "HTTP error: error sending request for url (https://api.github.com/...)",
+            "HTTP ERROR: error sending request for url (https://api.github.com/...)",
         );
         assert!(hint.contains("transient network or TLS error"));
         assert!(!hint.contains("attestations: read"));

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1759,14 +1759,14 @@ impl UnifiedGitBackend {
     }
 
     fn github_attestation_api_error_hint(err: &str) -> &'static str {
-        if err.contains("GitHub API returned")
-            || err.contains("HTTP error")
-            || err.contains("error sending request")
-        {
+        if err.contains("GitHub API returned") {
             " Check that the GitHub token can read artifact attestations \
              (for GitHub Actions, set `permissions: attestations: read`) \
              and retry; transient GitHub API failures should not be treated \
              as missing release provenance."
+        } else if err.contains("HTTP error") || err.contains("error sending request") {
+            " This may be a transient network or TLS error; retry before \
+             treating this as missing release provenance."
         } else {
             ""
         }
@@ -2064,6 +2064,12 @@ mod tests {
             "API error: GitHub API returned 403: Resource not accessible by integration",
         );
         assert!(hint.contains("attestations: read"));
+
+        let hint = UnifiedGitBackend::github_attestation_api_error_hint(
+            "HTTP error: error sending request for url (https://api.github.com/...)",
+        );
+        assert!(hint.contains("transient network or TLS error"));
+        assert!(!hint.contains("attestations: read"));
 
         let hint = UnifiedGitBackend::github_attestation_api_error_hint("No attestations found");
         assert!(hint.is_empty());

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1167,8 +1167,9 @@ fn check_single_tool_provenance(
     version: &str,
     backend: &str,
     platform_key: &str,
-    new_provenance: Option<&ProvenanceType>,
+    new_platform_info: Option<&PlatformInfo>,
 ) -> Option<String> {
+    let new_provenance = new_platform_info.and_then(|pi| pi.provenance.as_ref());
     if new_provenance.is_some() || !backend.starts_with("github:") {
         return None;
     }
@@ -1195,10 +1196,23 @@ fn check_single_tool_provenance(
     }
 
     let prov = prior.platforms[platform_key].provenance.as_ref().unwrap();
+    let github_attestations_hint = new_platform_info
+        .and_then(|pi| pi.github_attestations.as_ref())
+        .and_then(|status| match status {
+            GithubAttestationsStatus::Unavailable => Some(
+                " The new lockfile entry recorded GitHub attestations as unavailable; \
+                 this can happen when the GitHub attestation API returns no attestations \
+                 for the artifact digest, or when a stale cached lock entry was reused. \
+                 Re-run with MISE_LOCKED_VERIFY_PROVENANCE=1 or clear the mise cache \
+                 before treating this as a release provenance regression."
+                    .to_string(),
+            ),
+        })
+        .unwrap_or_default();
     Some(format!(
         "{short}@{version} has no provenance verification on {platform_key}, \
          but {short}@{} had {prov}. This could indicate a supply chain \
-         attack. Verify the release is authentic before proceeding.",
+         attack. Verify the release is authentic before proceeding.{github_attestations_hint}",
         prior.version,
     ))
 }
@@ -1223,10 +1237,7 @@ fn check_provenance_regression(
     for (short, new_entries) in new_tools {
         for new_entry in new_entries {
             let backend = new_entry.backend.as_deref().unwrap_or("");
-            let new_provenance = new_entry
-                .platforms
-                .get(&current_platform)
-                .and_then(|pi| pi.provenance.as_ref());
+            let new_platform_info = new_entry.platforms.get(&current_platform);
 
             if let Some(err) = check_single_tool_provenance(
                 existing_lockfile.tools.get(short),
@@ -1234,7 +1245,7 @@ fn check_provenance_regression(
                 &new_entry.version,
                 backend,
                 &current_platform,
-                new_provenance,
+                new_platform_info,
             ) {
                 regressing.insert(short.clone());
                 errors.push(err);
@@ -1558,7 +1569,7 @@ pub fn apply_lock_result(lockfile: &mut Lockfile, result: LockResolutionResult) 
             &version,
             &backend,
             &platform_key,
-            info.provenance.as_ref(),
+            Some(info),
         ) {
             return Err(eyre!("{err}"));
         }
@@ -2975,6 +2986,22 @@ backend = "conda:jq"
         )
         .unwrap();
         assert!(err.contains("has no provenance verification"));
+
+        let unavailable_info = PlatformInfo {
+            github_attestations: Some(GithubAttestationsStatus::Unavailable),
+            ..Default::default()
+        };
+        let err = check_single_tool_provenance(
+            Some(&existing),
+            "tool",
+            "1.1.0",
+            "github:owner/repo",
+            &platform,
+            Some(&unavailable_info),
+        )
+        .unwrap();
+        assert!(err.contains("recorded GitHub attestations as unavailable"));
+        assert!(err.contains("MISE_LOCKED_VERIFY_PROVENANCE=1"));
 
         let mut prior = basic_tool("1.0.0", "github:owner/repo");
         prior.platforms.insert(


### PR DESCRIPTION
## Summary
- add a GitHub attestation API failure hint for token permission and transient API errors
- make provenance regression errors call out cached unavailable GitHub attestation state
- cover both messages with focused unit tests

## Validation
- cargo fmt --check
- cargo test -p mise lockfile::tests::test_github_attestations_unavailable_counts_as_missing_for_regression
- cargo test -p mise backend::github::tests::test_github_attestation_api_error_hint
- commit hook: hk lint suite including cargo check --all-features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily changes error-message formatting and threads existing `PlatformInfo.github_attestations` state into provenance-regression reporting, with added unit coverage.
> 
> **Overview**
> Improves install-time GitHub attestation verification errors by appending an actionable hint when failures look like missing token permissions (e.g. `attestations: read`) or transient HTTP/network issues.
> 
> Adjusts lockfile provenance regression detection to take the full `PlatformInfo` (not just `provenance`) so regression errors can call out when the new entry explicitly recorded GitHub attestations as *unavailable* (and suggest retrying with `MISE_LOCKED_VERIFY_PROVENANCE=1` / clearing cache). Adds focused unit tests for both hint paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30ee92c1e8464f1d333ca303a9c4d4d16feb9c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->