### PR TITLE
fix: verify provenance during lock

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -480,55 +480,46 @@ backend = "github:crate-ci/cargo-release"
 checksum = "sha256:ee60ed5ad9c7c73e68ead7ccbc56fc2bf367eaa7f188b722a00cf15a71f08c6a"
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380569253"
-github_attestations = "unavailable"
 
 [tools."github:crate-ci/cargo-release"."platforms.linux-arm64-musl"]
 checksum = "sha256:ee60ed5ad9c7c73e68ead7ccbc56fc2bf367eaa7f188b722a00cf15a71f08c6a"
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380569253"
-github_attestations = "unavailable"
 
 [tools."github:crate-ci/cargo-release"."platforms.linux-x64"]
 checksum = "sha256:24e641b88c90411aaacba613f40d5c8f2b686b2721dfb61afd25b67e16956089"
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380569398"
-github_attestations = "unavailable"
 
 [tools."github:crate-ci/cargo-release"."platforms.linux-x64-baseline"]
 checksum = "sha256:24e641b88c90411aaacba613f40d5c8f2b686b2721dfb61afd25b67e16956089"
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380569398"
-github_attestations = "unavailable"
 
 [tools."github:crate-ci/cargo-release"."platforms.linux-x64-musl"]
 checksum = "sha256:24e641b88c90411aaacba613f40d5c8f2b686b2721dfb61afd25b67e16956089"
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380569398"
-github_attestations = "unavailable"
 
 [tools."github:crate-ci/cargo-release"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:24e641b88c90411aaacba613f40d5c8f2b686b2721dfb61afd25b67e16956089"
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380569398"
-github_attestations = "unavailable"
 
 [tools."github:crate-ci/cargo-release"."platforms.macos-arm64"]
 checksum = "sha256:135e1152c39b1a5ab4d3d370d0b95b0ce20a8e5a937465fcd9c6421d7c489a5b"
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380569463"
-github_attestations = "unavailable"
 
 [tools."github:crate-ci/cargo-release"."platforms.windows-x64"]
 checksum = "sha256:b36c0d3b8bd64ff78bfe6904525c5f7d8eafe56a5cd45b0d94793d8072500074"
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380570010"
-github_attestations = "unavailable"
 
 [tools."github:crate-ci/cargo-release"."platforms.windows-x64-baseline"]
 checksum = "sha256:b36c0d3b8bd64ff78bfe6904525c5f7d8eafe56a5cd45b0d94793d8072500074"
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380570010"
-github_attestations = "unavailable"
 
 [[tools.hk]]
 version = "1.45.0"
@@ -1059,37 +1050,31 @@ backend = "github:jdx/wait-for-gh-rate-limit"
 checksum = "sha256:156016c123e3a979c1e648b9c482338ba7cc0552028ba241eda1bcf9cf7e69e8"
 url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-aarch64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337588000"
-github_attestations = "unavailable"
 
 [tools.wait-for-gh-rate-limit."platforms.linux-arm64-musl"]
 checksum = "sha256:156016c123e3a979c1e648b9c482338ba7cc0552028ba241eda1bcf9cf7e69e8"
 url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-aarch64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337588000"
-github_attestations = "unavailable"
 
 [tools.wait-for-gh-rate-limit."platforms.linux-x64"]
 checksum = "sha256:90668d96b9f0485050c281d72797aa1c09e3d75196aca330a1b9fd4426778641"
 url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337587818"
-github_attestations = "unavailable"
 
 [tools.wait-for-gh-rate-limit."platforms.linux-x64-baseline"]
 checksum = "sha256:90668d96b9f0485050c281d72797aa1c09e3d75196aca330a1b9fd4426778641"
 url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337587818"
-github_attestations = "unavailable"
 
 [tools.wait-for-gh-rate-limit."platforms.linux-x64-musl"]
 checksum = "sha256:90668d96b9f0485050c281d72797aa1c09e3d75196aca330a1b9fd4426778641"
 url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337587818"
-github_attestations = "unavailable"
 
 [tools.wait-for-gh-rate-limit."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:90668d96b9f0485050c281d72797aa1c09e3d75196aca330a1b9fd4426778641"
 url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337587818"
-github_attestations = "unavailable"
 
 [tools.wait-for-gh-rate-limit."platforms.linux-x64-wait-for-gh-rate-limit"]
 checksum = "blake3:35c2fa30b45ee4a1437624f21c36b3a0b03f57c286429f45f7a4f31d83a15ee9"
@@ -1098,16 +1083,13 @@ checksum = "blake3:35c2fa30b45ee4a1437624f21c36b3a0b03f57c286429f45f7a4f31d83a15
 checksum = "sha256:266bb0edf065994b5a4b75c91adbae3e94c042ded1de03c00a1673c68409b77e"
 url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337588442"
-github_attestations = "unavailable"
 
 [tools.wait-for-gh-rate-limit."platforms.windows-x64"]
 checksum = "sha256:1e52ba1857d3918b54c336de32028abf5f03b8e16745413e573e4153ab9a92e2"
 url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337588993"
-github_attestations = "unavailable"
 
 [tools.wait-for-gh-rate-limit."platforms.windows-x64-baseline"]
 checksum = "sha256:1e52ba1857d3918b54c336de32028abf5f03b8e16745413e573e4153ab9a92e2"
 url = "https://github.com/jdx/wait-for-gh-rate-limit/releases/download/v1.1.1/wait-for-gh-rate-limit-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/wait-for-gh-rate-limit/releases/assets/337588993"
-github_attestations = "unavailable"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1265,6 +1265,11 @@
           "type": "string",
           "deprecated": true
         },
+        "provenance_api_failures_fatal": {
+          "default": true,
+          "description": "Fail when provenance API checks cannot be completed.",
+          "type": "boolean"
+        },
         "python": {
           "type": "object",
           "unevaluatedProperties": false,

--- a/settings.toml
+++ b/settings.toml
@@ -1740,6 +1740,22 @@ hide = true
 optional = true
 type = "String"
 
+[provenance_api_failures_fatal]
+default = true
+description = "Fail when provenance API checks cannot be completed."
+docs = """
+When enabled, mise treats provenance API failures as install errors. This keeps
+provenance strict by default: if a remote attestation or release-provenance API
+cannot be reached or queried, mise will fail instead of silently installing
+without provenance.
+
+Set this to `false` to warn and continue when provenance API checks fail. This
+does not ignore checksum failures, provenance verification mismatches, or
+lockfiles that already require provenance for the tool being installed.
+"""
+env = "MISE_PROVENANCE_API_FAILURES_FATAL"
+type = "Bool"
+
 [python.compile]
 description = "If true, compile python from source. If false, use precompiled binaries. If not set, use precompiled binaries if available."
 docs = """

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -10,7 +10,7 @@ use crate::config::Settings;
 use crate::file::{TarFormat, TarOptions};
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
-use crate::lockfile::{GithubAttestationsStatus, PlatformInfo, ProvenanceType};
+use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::path::{Path, PathBuf, PathExt};
 use crate::plugins::VERSION_REGEX;
 use crate::registry::REGISTRY;
@@ -781,23 +781,33 @@ impl Backend for AquaBackend {
 
         // Detect provenance from aqua registry config
         let mut provenance = self.detect_provenance_type(&pkg);
-        let mut github_attestations = None;
-
         if matches!(provenance, Some(ProvenanceType::GithubAttestations))
             && let Some(digest) = checksum.as_deref().filter(|d| d.starts_with("sha256:"))
         {
             match self.detect_github_attestations(&pkg, digest).await {
                 Ok(true) => {}
                 Ok(false) => {
-                    github_attestations = Some(GithubAttestationsStatus::Unavailable);
                     provenance = self.detect_non_github_provenance_type(&pkg);
                 }
                 Err(e) => {
+                    if Settings::get().provenance_api_failures_fatal
+                        || !crate::github::sigstore::is_api_failure(match &e {
+                            crate::github::sigstore::DetectError::SourceCreation(e)
+                            | crate::github::sigstore::DetectError::Fetch(e) => e,
+                        })
+                    {
+                        return Err(eyre!("{e}")).wrap_err_with(|| {
+                            format!(
+                                "GitHub attestation API query failed for {}/{}",
+                                pkg.repo_owner, pkg.repo_name
+                            )
+                        });
+                    }
                     warn!(
-                        "GitHub attestation API query failed for {}/{}: {e}. \
-                         Lockfile may not record github-attestations provenance.",
+                        "GitHub attestation API query failed for {}/{}, skipping attestation provenance: {e}",
                         pkg.repo_owner, pkg.repo_name
                     );
+                    provenance = self.detect_non_github_provenance_type(&pkg);
                 }
             }
         }
@@ -840,9 +850,8 @@ impl Backend for AquaBackend {
                 )
                 .await
             {
-                Ok((verified, gh_status)) => {
+                Ok(verified) => {
                     provenance = verified;
-                    github_attestations = gh_status;
                 }
                 Err(e) => {
                     // Clear provenance so install-time verification will run.
@@ -857,15 +866,11 @@ impl Backend for AquaBackend {
                 }
             }
         }
-        if provenance.is_some() {
-            github_attestations = None;
-        }
-
         Ok(PlatformInfo {
             url,
             checksum,
             provenance,
-            github_attestations,
+            github_attestations: None,
             ..Default::default()
         })
     }
@@ -1051,7 +1056,11 @@ impl AquaBackend {
         None
     }
 
-    async fn detect_github_attestations(&self, pkg: &AquaPackage, digest: &str) -> Result<bool> {
+    async fn detect_github_attestations(
+        &self,
+        pkg: &AquaPackage,
+        digest: &str,
+    ) -> std::result::Result<bool, crate::github::sigstore::DetectError> {
         crate::github::sigstore::detect_attestations(
             &pkg.repo_owner,
             &pkg.repo_name,
@@ -1059,7 +1068,6 @@ impl AquaBackend {
             digest,
         )
         .await
-        .map_err(|e| eyre!("{e}"))
     }
 
     /// Verify provenance at lock time by downloading the artifact to a temp directory
@@ -1071,7 +1079,7 @@ impl AquaBackend {
         v: &str,
         artifact_url: &str,
         detected: &ProvenanceType,
-    ) -> Result<(Option<ProvenanceType>, Option<GithubAttestationsStatus>)> {
+    ) -> Result<Option<ProvenanceType>> {
         let tmp_dir = tempfile::tempdir()?;
         let filename = get_filename_from_url(artifact_url);
         let artifact_path = tmp_dir.path().join(&filename);
@@ -1090,28 +1098,23 @@ impl AquaBackend {
                     .await?
                 {
                     GithubAttestationStatus::Verified => {
-                        Ok((Some(ProvenanceType::GithubAttestations), None))
+                        Ok(Some(ProvenanceType::GithubAttestations))
                     }
-                    GithubAttestationStatus::Unavailable => {
-                        Ok((None, Some(GithubAttestationsStatus::Unavailable)))
-                    }
+                    GithubAttestationStatus::Unavailable => Ok(None),
                 }
             }
             ProvenanceType::Slsa { .. } => {
                 let provenance_url = self
                     .run_slsa_check(&artifact_path, pkg, v, tmp_dir.path(), None)
                     .await?;
-                Ok((
-                    Some(ProvenanceType::Slsa {
-                        url: Some(provenance_url),
-                    }),
-                    None,
-                ))
+                Ok(Some(ProvenanceType::Slsa {
+                    url: Some(provenance_url),
+                }))
             }
             ProvenanceType::Minisign => {
                 self.run_minisign_check(&artifact_path, &filename, pkg, v, tmp_dir.path(), None)
                     .await?;
-                Ok((Some(ProvenanceType::Minisign), None))
+                Ok(Some(ProvenanceType::Minisign))
             }
             ProvenanceType::Cosign => {
                 if let Some(cosign) = Self::binary_cosign_config(pkg) {
@@ -1127,7 +1130,7 @@ impl AquaBackend {
                     self.run_cosign_check(&checksum_path, cosign, pkg, v, tmp_dir.path(), None)
                         .await?;
                 }
-                Ok((Some(ProvenanceType::Cosign), None))
+                Ok(Some(ProvenanceType::Cosign))
             }
         }
     }
@@ -1168,6 +1171,16 @@ impl AquaBackend {
                 "GitHub artifact attestations verification returned false"
             )),
             Err(crate::github::sigstore::AttestationError::NoAttestations) => {
+                Ok(GithubAttestationStatus::Unavailable)
+            }
+            Err(e)
+                if !Settings::get().provenance_api_failures_fatal
+                    && crate::github::sigstore::is_api_failure(&e) =>
+            {
+                warn!(
+                    "GitHub artifact attestations API failed for {}/{}; skipping attestation provenance: {e}",
+                    pkg.repo_owner, pkg.repo_name
+                );
                 Ok(GithubAttestationStatus::Unavailable)
             }
             Err(e) => Err(eyre!(
@@ -1847,23 +1860,16 @@ impl AquaBackend {
         // Check if the lockfile expects provenance for this platform, then clear it
         // so we can detect whether verification actually re-set it
         let platform_key = self.get_platform_key();
-        let skip_cached_absent_attestations = !Settings::get().force_provenance_verify()
-            && tv
-                .lock_platforms
-                .get(&platform_key)
-                .is_some_and(PlatformInfo::has_checksum_and_github_attestations_unavailable);
         let locked_provenance = tv
             .lock_platforms
             .get_mut(&platform_key)
             .and_then(|pi| pi.provenance.take());
         let expected_provenance = locked_provenance.as_ref();
-        let mut github_attestations_unavailable = skip_cached_absent_attestations;
 
         // When the lockfile specifies a provenance type, only run that specific mechanism.
         // This prevents false-positive downgrade errors when a tool supports multiple mechanisms
         // (e.g., both minisign and cosign) that would otherwise compete for the provenance slot.
-        let skip_attestations = skip_cached_absent_attestations
-            || expected_provenance.is_some_and(|l| !l.is_github_attestations());
+        let skip_attestations = expected_provenance.is_some_and(|l| !l.is_github_attestations());
         let skip_slsa = expected_provenance.is_some_and(|l| !l.is_slsa());
         let skip_minisign = expected_provenance.is_some_and(|l| !l.is_minisign());
         let skip_cosign = expected_provenance.is_some_and(|l| !l.is_cosign());
@@ -1880,9 +1886,7 @@ impl AquaBackend {
                         pi.provenance = Some(ProvenanceType::GithubAttestations);
                     }
                 }
-                GithubAttestationStatus::Unavailable => {
-                    github_attestations_unavailable = true;
-                }
+                GithubAttestationStatus::Unavailable => {}
             }
         }
         if !skip_slsa {
@@ -1974,15 +1978,6 @@ impl AquaBackend {
                 let platform_key = self.get_platform_key();
                 let platform_info = tv.lock_platforms.entry(platform_key).or_default();
                 platform_info.checksum = Some(checksum_val);
-            }
-        }
-        if github_attestations_unavailable {
-            let platform_key = self.get_platform_key();
-            if let Some(pi) = tv.lock_platforms.get_mut(&platform_key)
-                && pi.checksum.is_some()
-                && pi.provenance.is_none()
-            {
-                pi.github_attestations = Some(GithubAttestationsStatus::Unavailable);
             }
         }
         if let Some(pi) = tv.lock_platforms.get_mut(&platform_key)

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -13,7 +13,7 @@ use crate::config::{Config, Settings};
 use crate::file;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
-use crate::lockfile::{GithubAttestationsStatus, PlatformInfo, ProvenanceType};
+use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::toolset::ToolVersionOptions;
 use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{backend::Backend, forgejo, github, gitlab};
@@ -127,6 +127,8 @@ fn attestations_supported(api_url: &str) -> bool {
 enum VerificationStatus {
     /// No attestations or provenance found (not an error, tool may not have them)
     NoAttestations,
+    /// A remote API or download failed while checking provenance.
+    ApiError(String),
     /// An error occurred during verification
     Error(String),
 }
@@ -486,20 +488,19 @@ impl Backend for UnifiedGitBackend {
         match asset {
             Ok(asset) => {
                 // Detect provenance availability from release assets and attestation API
-                let (mut provenance, mut github_attestations) =
-                    if !self.is_gitlab() && !self.is_forgejo() {
-                        self.detect_provenance_type(
-                            tv,
-                            &opts,
-                            &repo,
-                            &api_url,
-                            asset.digest.as_deref(),
-                            target,
-                        )
-                        .await
-                    } else {
-                        (None, None)
-                    };
+                let mut provenance = if !self.is_gitlab() && !self.is_forgejo() {
+                    self.detect_provenance_type(
+                        tv,
+                        &opts,
+                        &repo,
+                        &api_url,
+                        asset.digest.as_deref(),
+                        target,
+                    )
+                    .await?
+                } else {
+                    None
+                };
 
                 // For the current platform, verify provenance cryptographically at lock time.
                 // This ensures the lockfile's provenance entry is backed by actual verification,
@@ -509,9 +510,8 @@ impl Backend for UnifiedGitBackend {
                         .verify_provenance_at_lock_time(tv, &opts, &repo, &api_url, &asset)
                         .await
                     {
-                        Ok((verified, gh_status)) => {
+                        Ok(verified) => {
                             provenance = verified;
-                            github_attestations = gh_status;
                         }
                         Err(e) => {
                             // Clear provenance so install-time verification will run.
@@ -524,16 +524,12 @@ impl Backend for UnifiedGitBackend {
                         }
                     }
                 }
-                if provenance.is_some() {
-                    github_attestations = None;
-                }
-
                 Ok(PlatformInfo {
                     url: Some(asset.url),
                     url_api: Some(asset.url_api),
                     checksum: asset.digest,
                     provenance,
-                    github_attestations,
+                    github_attestations: None,
                     ..Default::default()
                 })
             }
@@ -579,11 +575,10 @@ impl UnifiedGitBackend {
         api_url: &str,
         asset_digest: Option<&str>,
         target: &PlatformTarget,
-    ) -> (Option<ProvenanceType>, Option<GithubAttestationsStatus>) {
+    ) -> Result<Option<ProvenanceType>> {
         let settings = Settings::get();
         let version = &tv.version;
         let version_prefix = opts.version_prefix();
-        let mut github_attestations = None;
 
         let release =
             try_with_v_prefix_and_repo(version, version_prefix, Some(repo), |candidate| {
@@ -594,7 +589,7 @@ impl UnifiedGitBackend {
             .await
             .ok();
         let Some(release) = release else {
-            return (None, None);
+            return Ok(None);
         };
 
         // Check github-attestations first (higher priority, matching install verification order)
@@ -612,21 +607,33 @@ impl UnifiedGitBackend {
                 )
                 .await
                 {
-                    Ok(true) => return (Some(ProvenanceType::GithubAttestations), None),
-                    Ok(false) => {
-                        github_attestations = Some(GithubAttestationsStatus::Unavailable);
-                    }
+                    Ok(true) => return Ok(Some(ProvenanceType::GithubAttestations)),
+                    Ok(false) => {}
                     Err(crate::github::sigstore::DetectError::SourceCreation(e)) => {
-                        warn!(
-                            "Failed to create GitHub attestation source for {owner}/{repo_name}: {e}. \
-                             Lockfile may not record github-attestations provenance."
-                        );
+                        if !settings.provenance_api_failures_fatal
+                            && crate::github::sigstore::is_api_failure(&e)
+                        {
+                            warn!(
+                                "failed to create GitHub attestation source for {owner}/{repo_name}, skipping attestation provenance: {e}"
+                            );
+                        } else {
+                            return Err(eyre::eyre!(
+                                "failed to create GitHub attestation source for {owner}/{repo_name}: {e}"
+                            ));
+                        }
                     }
                     Err(crate::github::sigstore::DetectError::Fetch(e)) => {
-                        warn!(
-                            "GitHub attestation API query failed for {owner}/{repo_name}: {e}. \
-                             Lockfile may not record github-attestations provenance."
-                        );
+                        if !settings.provenance_api_failures_fatal
+                            && crate::github::sigstore::is_api_failure(&e)
+                        {
+                            warn!(
+                                "GitHub attestation API query failed for {owner}/{repo_name}, skipping attestation provenance: {e}"
+                            );
+                        } else {
+                            return Err(eyre::eyre!(
+                                "GitHub attestation API query failed for {owner}/{repo_name}: {e}"
+                            ));
+                        }
                     }
                 }
             }
@@ -648,11 +655,11 @@ impl UnifiedGitBackend {
                     .iter()
                     .find(|a| a.name == provenance_name)
                     .map(|a| a.browser_download_url.clone());
-                return (Some(ProvenanceType::Slsa { url }), None);
+                return Ok(Some(ProvenanceType::Slsa { url }));
             }
         }
 
-        (None, github_attestations)
+        Ok(None)
     }
 
     /// Verify provenance at lock time by downloading the artifact to a temp directory
@@ -665,7 +672,7 @@ impl UnifiedGitBackend {
         repo: &str,
         api_url: &str,
         asset: &ReleaseAsset,
-    ) -> Result<(Option<ProvenanceType>, Option<GithubAttestationsStatus>)> {
+    ) -> Result<Option<ProvenanceType>> {
         let tmp_dir = tempfile::tempdir()?;
         let filename = get_filename_from_url(&asset.url);
         let artifact_path = tmp_dir.path().join(&filename);
@@ -692,7 +699,6 @@ impl UnifiedGitBackend {
             .await?;
 
         let settings = Settings::get();
-        let mut github_attestations = None;
 
         // Try GitHub artifact attestations first (highest priority)
         if settings.github_attestations
@@ -713,7 +719,7 @@ impl UnifiedGitBackend {
                 {
                     Ok(true) => {
                         debug!("lock-time GitHub attestations verified for {}", repo);
-                        return Ok((Some(ProvenanceType::GithubAttestations), None));
+                        return Ok(Some(ProvenanceType::GithubAttestations));
                     }
                     Ok(false) => {
                         return Err(eyre::eyre!(
@@ -721,7 +727,6 @@ impl UnifiedGitBackend {
                         ));
                     }
                     Err(crate::github::sigstore::AttestationError::NoAttestations) => {
-                        github_attestations = Some(GithubAttestationsStatus::Unavailable);
                         debug!("no GitHub attestations found at lock time, trying SLSA");
                     }
                     Err(e) => {
@@ -778,12 +783,9 @@ impl UnifiedGitBackend {
                 {
                     Ok(true) => {
                         debug!("lock-time SLSA provenance verified for {}", repo);
-                        return Ok((
-                            Some(ProvenanceType::Slsa {
-                                url: Some(provenance_url),
-                            }),
-                            None,
-                        ));
+                        return Ok(Some(ProvenanceType::Slsa {
+                            url: Some(provenance_url),
+                        }));
                     }
                     Ok(false) => {
                         return Err(eyre::eyre!("SLSA provenance verification failed"));
@@ -807,12 +809,9 @@ impl UnifiedGitBackend {
                                         "lock-time SLSA provenance verified archive contents for {}",
                                         repo
                                     );
-                                    return Ok((
-                                        Some(ProvenanceType::Slsa {
-                                            url: Some(provenance_url),
-                                        }),
-                                        None,
-                                    ));
+                                    return Ok(Some(ProvenanceType::Slsa {
+                                        url: Some(provenance_url),
+                                    }));
                                 }
                                 Ok(false) => {
                                     return Err(eyre::eyre!(
@@ -835,13 +834,9 @@ impl UnifiedGitBackend {
             }
         }
 
-        if github_attestations.is_some() {
-            Ok((None, github_attestations))
-        } else {
-            Err(eyre::eyre!(
-                "provenance was detected but could not be verified at lock time"
-            ))
-        }
+        Err(eyre::eyre!(
+            "provenance was detected but could not be verified at lock time"
+        ))
     }
 
     fn is_gitlab(&self) -> bool {
@@ -964,15 +959,15 @@ impl UnifiedGitBackend {
             // disabling a verification setting with a provenance-bearing lockfile is a downgrade.
             self.ensure_provenance_setting_enabled(tv, &platform_key)?;
         } else {
-            let (provenance_result, github_attestations) = self
+            let provenance_result = self
                 .verify_attestations_or_slsa(ctx, tv, &file_path)
                 .await?;
 
             // Record provenance verification result in lock_platforms
-            if provenance_result.is_some() || github_attestations.is_some() {
+            if provenance_result.is_some() {
                 let platform_info = tv.lock_platforms.entry(platform_key).or_default();
                 platform_info.provenance = provenance_result;
-                platform_info.github_attestations = github_attestations;
+                platform_info.github_attestations = None;
             }
         }
 
@@ -1556,7 +1551,7 @@ impl UnifiedGitBackend {
         ctx: &InstallContext,
         tv: &ToolVersion,
         file_path: &std::path::Path,
-    ) -> Result<(Option<ProvenanceType>, Option<GithubAttestationsStatus>)> {
+    ) -> Result<Option<ProvenanceType>> {
         let settings = Settings::get();
 
         // Read the expected provenance from the lockfile. We use .clone() because tv is
@@ -1569,13 +1564,6 @@ impl UnifiedGitBackend {
             .get(&platform_key)
             .and_then(|pi| pi.provenance.clone());
         let expected_provenance = locked_provenance.as_ref();
-        let skip_cached_absent_attestations = !settings.force_provenance_verify()
-            && tv
-                .lock_platforms
-                .get(&platform_key)
-                .is_some_and(PlatformInfo::has_checksum_and_github_attestations_unavailable);
-        let mut github_attestations_unavailable = skip_cached_absent_attestations;
-
         // Only verify for GitHub repos (not GitLab/Forgejo)
         if self.is_gitlab() || self.is_forgejo() {
             if let Some(expected) = expected_provenance {
@@ -1584,12 +1572,11 @@ impl UnifiedGitBackend {
                      for GitLab/Forgejo backends. This may indicate a downgrade attack."
                 ));
             }
-            return Ok((None, None));
+            return Ok(None);
         }
 
         // When the lockfile specifies a provenance type, only run that specific mechanism
-        let skip_attestations = skip_cached_absent_attestations
-            || expected_provenance.is_some_and(|l| !l.is_github_attestations());
+        let skip_attestations = expected_provenance.is_some_and(|l| !l.is_github_attestations());
         let skip_slsa = expected_provenance.is_some_and(|l| !l.is_slsa());
 
         // If the lockfile expects github-attestations but the configured api_url
@@ -1630,7 +1617,7 @@ impl UnifiedGitBackend {
                              This may indicate a provenance type mismatch."
                         ));
                     }
-                    return Ok((Some(ProvenanceType::GithubAttestations), None));
+                    return Ok(Some(ProvenanceType::GithubAttestations));
                 }
                 Ok(false) => {
                     // Attestations exist but verification failed - hard error
@@ -1640,8 +1627,15 @@ impl UnifiedGitBackend {
                 }
                 Err(VerificationStatus::NoAttestations) => {
                     // No attestations - fall through to try SLSA
-                    github_attestations_unavailable = true;
                     debug!("No GitHub artifact attestations found for {tv}, trying SLSA");
+                }
+                Err(VerificationStatus::ApiError(e)) => {
+                    if expected_provenance.is_some() || settings.provenance_api_failures_fatal {
+                        return Err(eyre::eyre!(
+                            "GitHub artifact attestations verification error for {tv}: {e}"
+                        ));
+                    }
+                    warn!("GitHub artifact attestations API failed for {tv}, trying SLSA: {e}");
                 }
                 Err(VerificationStatus::Error(e)) => {
                     // Error during verification - hard error
@@ -1665,12 +1659,9 @@ impl UnifiedGitBackend {
                              This may indicate a provenance type mismatch."
                         ));
                     }
-                    return Ok((
-                        Some(ProvenanceType::Slsa {
-                            url: provenance_url,
-                        }),
-                        None,
-                    ));
+                    return Ok(Some(ProvenanceType::Slsa {
+                        url: provenance_url,
+                    }));
                 }
                 Ok((false, _)) => {
                     // Provenance exists but verification failed - hard error
@@ -1679,6 +1670,12 @@ impl UnifiedGitBackend {
                 Err(VerificationStatus::NoAttestations) => {
                     // No provenance found - this is fine
                     debug!("No SLSA provenance found for {tv}");
+                }
+                Err(VerificationStatus::ApiError(e)) => {
+                    if expected_provenance.is_some() || settings.provenance_api_failures_fatal {
+                        return Err(eyre::eyre!("SLSA verification error for {tv}: {e}"));
+                    }
+                    warn!("SLSA provenance API failed for {tv}, skipping SLSA provenance: {e}");
                 }
                 Err(VerificationStatus::Error(e)) => {
                     // Error during verification - hard error
@@ -1696,16 +1693,7 @@ impl UnifiedGitBackend {
             ));
         }
 
-        if github_attestations_unavailable
-            && tv
-                .lock_platforms
-                .get(&platform_key)
-                .is_some_and(|pi| pi.checksum.is_some())
-        {
-            Ok((None, Some(GithubAttestationsStatus::Unavailable)))
-        } else {
-            Ok((None, None))
-        }
+        Ok(None)
     }
 
     /// Try to verify GitHub artifact attestations. Returns:
@@ -1752,6 +1740,9 @@ impl UnifiedGitBackend {
             }
             Err(crate::github::sigstore::AttestationError::NoAttestations) => {
                 Err(VerificationStatus::NoAttestations)
+            }
+            Err(e) if crate::github::sigstore::is_api_failure(&e) => {
+                Err(VerificationStatus::ApiError(e.to_string()))
             }
             Err(e) => Err(VerificationStatus::Error(e.to_string())),
         }
@@ -1839,7 +1830,7 @@ impl UnifiedGitBackend {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    return Err(VerificationStatus::Error(format!(
+                    return Err(VerificationStatus::ApiError(format!(
                         "Failed to get release: {e}"
                     )));
                 }
@@ -1879,7 +1870,7 @@ impl UnifiedGitBackend {
             )
             .await
         {
-            return Err(VerificationStatus::Error(format!(
+            return Err(VerificationStatus::ApiError(format!(
                 "Failed to download provenance: {e}"
             )));
         }

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -5,7 +5,7 @@ use heck::ToKebabCase;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, mpsc};
 use std::thread;
 use tokio::sync::RwLock;
 
@@ -140,12 +140,7 @@ impl Backend for VfoxBackend {
         let mut tv = tv;
         self.ensure_plugin_installed(&ctx.config).await?;
         let (mut vfox, log_rx) = self.plugin.vfox()?;
-        thread::spawn(|| {
-            for line in log_rx {
-                // TODO: put this in ctx.pr.set_message()
-                info!("{}", line);
-            }
-        });
+        Self::forward_plugin_logs(log_rx);
         if let Ok(dep_env) = self.dependency_env(&ctx.config).await {
             vfox.cmd_env = Some(dep_env.into_iter().collect());
         }
@@ -288,11 +283,7 @@ impl Backend for VfoxBackend {
         }
 
         let (mut vfox, log_rx) = self.plugin.vfox()?;
-        thread::spawn(|| {
-            for line in log_rx {
-                info!("{}", line);
-            }
-        });
+        Self::forward_plugin_logs(log_rx);
         if let Ok(dep_env) = self.dependency_env(config).await {
             vfox.cmd_env = Some(dep_env.into_iter().collect());
         }
@@ -367,6 +358,15 @@ impl Backend for VfoxBackend {
 }
 
 impl VfoxBackend {
+    fn forward_plugin_logs(log_rx: mpsc::Receiver<String>) {
+        thread::spawn(move || {
+            for line in log_rx {
+                // TODO: put this in ctx.pr.set_message()
+                info!("{}", line);
+            }
+        });
+    }
+
     fn is_backend_plugin(&self) -> bool {
         matches!(&self.plugin_enum, PluginEnum::VfoxBackend(_))
     }

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -154,6 +154,10 @@ pub fn is_slsa_subject_mismatch(error: &AttestationError) -> bool {
     mise_sigstore::is_slsa_subject_mismatch(error)
 }
 
+pub fn is_api_failure(error: &AttestationError) -> bool {
+    matches!(error, AttestationError::Api(_) | AttestationError::Http(_))
+}
+
 /// Verify a keyless Cosign signature or bundle. Passthrough — no token needed.
 pub async fn verify_cosign_signature(
     artifact_path: &Path,
@@ -310,5 +314,15 @@ mod tests {
             Some("ghp_from_tokens_file"),
             "wrapper should resolve tokens from github_tokens.toml when env vars are empty"
         );
+    }
+
+    #[test]
+    fn test_is_api_failure_excludes_malformed_payloads() {
+        assert!(is_api_failure(&AttestationError::Api(
+            "rate limited".into()
+        )));
+        assert!(!is_api_failure(&AttestationError::Json(
+            serde_json::from_str::<serde_json::Value>("{").unwrap_err()
+        )));
     }
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -263,19 +263,11 @@ impl PlatformInfo {
             && self.url_api.is_none()
             && self.conda_deps.is_none()
             && self.provenance.is_none()
-            && self.github_attestations.is_none()
     }
 
     /// True when the lockfile has checksum-backed, successfully verified provenance.
     pub fn has_checksum_and_verified_provenance(&self) -> bool {
         self.checksum.is_some() && self.provenance.is_some()
-    }
-
-    /// True when the lockfile records that GitHub attestations were checked and absent.
-    pub fn has_checksum_and_github_attestations_unavailable(&self) -> bool {
-        self.checksum.is_some()
-            && self.provenance.is_none()
-            && self.github_attestations == Some(GithubAttestationsStatus::Unavailable)
     }
 
     /// Merge this PlatformInfo with another, preserving important data.
@@ -325,14 +317,6 @@ impl PlatformInfo {
             (Some(a), Some(b)) => Some(a.merge(b)),
             (a, b) => a.or(b),
         };
-        let github_attestations = if provenance.is_some() {
-            None
-        } else if url_changed {
-            self.github_attestations
-        } else {
-            self.github_attestations.or(other.github_attestations)
-        };
-
         PlatformInfo {
             checksum,
             size,
@@ -340,7 +324,7 @@ impl PlatformInfo {
             url_api,
             conda_deps: self.conda_deps.clone().or_else(|| other.conda_deps.clone()),
             provenance,
-            github_attestations,
+            github_attestations: None,
         }
     }
 }
@@ -479,14 +463,6 @@ impl From<PlatformInfo> for toml::Value {
                     table.insert("provenance".to_string(), provenance.to_string().into());
                 }
             }
-        }
-        if platform_info.provenance.is_none()
-            && let Some(github_attestations) = platform_info.github_attestations
-        {
-            table.insert(
-                "github_attestations".to_string(),
-                github_attestations.to_string().into(),
-            );
         }
         toml::Value::Table(table)
     }
@@ -829,17 +805,6 @@ impl Lockfile {
                     (Some(a), Some(b)) => Some(a.merge(b)),
                     (a, b) => a.or(b),
                 };
-                let github_attestations = if provenance.is_some() {
-                    None
-                } else {
-                    platform_info.github_attestations.or({
-                        if preserve_artifact_fields {
-                            existing.github_attestations
-                        } else {
-                            None
-                        }
-                    })
-                };
                 PlatformInfo {
                     checksum: platform_info.checksum.or_else(|| {
                         if preserve_artifact_fields {
@@ -865,7 +830,7 @@ impl Lockfile {
                     // rather than "not computed", so we shouldn't preserve stale deps
                     conda_deps: platform_info.conda_deps,
                     provenance,
-                    github_attestations,
+                    github_attestations: None,
                 }
             } else {
                 platform_info
@@ -2816,7 +2781,7 @@ backend = "conda:jq"
     }
 
     #[test]
-    fn test_github_attestations_unavailable_roundtrip() {
+    fn test_github_attestations_unavailable_legacy_parse_only() {
         let info = PlatformInfo {
             checksum: Some("sha256:abc123".to_string()),
             url: Some("https://example.com/tool.tar.gz".to_string()),
@@ -2826,19 +2791,17 @@ backend = "conda:jq"
 
         let toml_val: toml::Value = info.clone().into();
         let table = toml_val.as_table().unwrap();
-        assert_eq!(
-            table.get("github_attestations").unwrap().as_str().unwrap(),
-            "unavailable"
-        );
+        assert!(table.get("github_attestations").is_none());
         assert!(table.get("provenance").is_none());
 
-        let parsed: PlatformInfo = toml_val.try_into().unwrap();
+        let mut legacy = table.clone();
+        legacy.insert("github_attestations".to_string(), "unavailable".into());
+        let parsed: PlatformInfo = toml::Value::Table(legacy).try_into().unwrap();
         assert_eq!(
             parsed.github_attestations,
             Some(GithubAttestationsStatus::Unavailable)
         );
         assert!(parsed.provenance.is_none());
-        assert!(parsed.has_checksum_and_github_attestations_unavailable());
         assert!(!parsed.has_checksum_and_verified_provenance());
     }
 
@@ -2852,7 +2815,6 @@ backend = "conda:jq"
         let parsed: PlatformInfo = toml::Value::Table(table).try_into().unwrap();
         assert!(parsed.provenance.as_ref().unwrap().is_slsa());
         assert!(parsed.github_attestations.is_none());
-        assert!(!parsed.has_checksum_and_github_attestations_unavailable());
         assert!(parsed.has_checksum_and_verified_provenance());
 
         let serialized: toml::Value = PlatformInfo {
@@ -2929,12 +2891,9 @@ backend = "conda:jq"
         assert!(merged.provenance.as_ref().unwrap().is_slsa());
         assert!(merged.github_attestations.is_none());
 
-        // Merging with empty preserves the negative GitHub attestation cache.
+        // Merging with empty drops the legacy negative GitHub attestation cache.
         let merged = github_unavailable.merge_with(&PlatformInfo::default());
-        assert_eq!(
-            merged.github_attestations,
-            Some(GithubAttestationsStatus::Unavailable)
-        );
+        assert!(merged.github_attestations.is_none());
     }
 
     #[test]
@@ -2949,7 +2908,7 @@ backend = "conda:jq"
             github_attestations: Some(GithubAttestationsStatus::Unavailable),
             ..Default::default()
         };
-        assert!(!info.is_empty());
+        assert!(info.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Verify and record missing provenance while running `mise lock`, instead of forcing already-installed tools through the install path.
- Stop writing or preserving `github_attestations = "unavailable"` as lockfile state. Legacy entries still parse, but are dropped on write.
- Add `provenance_api_failures_fatal` so GitHub attestation API failures are blocking by default and can be made warn-only when needed.
- Keep malformed attestation JSON fatal even when API provenance failures are configured as non-blocking.

## Root Cause
Restored or older lockfiles could contain checksum-only entries or the old
`github_attestations = "unavailable"` sentinel. Reusing that sentinel meant
GitHub attestation availability could stay stale after cache restore or API
failure.

`mise lock` is the right place to refresh that metadata: it can query release
assets, download artifacts when needed for lock-time provenance verification,
and update the lockfile without deleting or reinstalling a working tool.

## Validation
- `target/debug/mise lock`
- `cargo test -p mise github::sigstore::tests::test_is_api_failure_excludes_malformed_payloads`
- `cargo test -p mise backend::vfox::test`
- `cargo fmt --check`
- `cargo clippy -p mise --all-targets -- -D warnings`
- commit hook: schema, format, cargo-check, shell/lua/markdown/prettier lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provenance detection/verification paths for `mise lock` and installs, which can affect whether tool installs fail vs. proceed when remote provenance services are unavailable. Also modifies lockfile serialization semantics, so existing lockfiles may be rewritten differently and alter caching/downgrade behavior.
> 
> **Overview**
> **`mise lock` now actively verifies and records provenance** (GitHub attestations and SLSA) at lock time for the current platform, rather than relying on install-time verification or persisting negative attestation cache state.
> 
> Adds a new setting `provenance_api_failures_fatal` (default `true`, env `MISE_PROVENANCE_API_FAILURES_FATAL`) to control whether remote provenance API failures abort; when disabled, *API* failures warn and fall back/skip, while malformed/verification errors remain fatal.
> 
> Removes writing/preserving `github_attestations = "unavailable"` in lockfiles (legacy values still parse but are dropped on write), simplifying `PlatformInfo` merging/serialization and updating `mise.lock` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258e64e7cc191c6967ff5410f18a3beda778ad32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->