### PR TITLE
ci: build/publish snap package for arm64

### DIFF
--- a/.github/workflows/snapcraft-publish.yml
+++ b/.github/workflows/snapcraft-publish.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, ubuntu-24.04-arm]
+        runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 20
     steps:

--- a/.github/workflows/snapcraft-publish.yml
+++ b/.github/workflows/snapcraft-publish.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-snapcraft:
     strategy:

--- a/.github/workflows/snapcraft-publish.yml
+++ b/.github/workflows/snapcraft-publish.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   publish-snapcraft:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 20
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Hi there 🙂 

I recently tried to install `mise` using `snap` on and `arm64` desktop and found it wasn't supported. It looks like the `snapcraft.yaml` already states `arm64` as a target architecture, so this change adjusts the publication workflow to run on both `amd64` and `arm64` runners, in the hope that'll result in publication for `arm64`.
