### PR TITLE
refactor(core): parse plugin tool options locally

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -765,8 +765,20 @@ mod tests {
 
         opts.opts.insert(
             "prerelease".to_string(),
-            toml::Value::String("false".into()),
+            toml::Value::String("FALSE".into()),
         );
+        assert!(!backend.include_prereleases(&opts));
+
+        opts.opts
+            .insert("prerelease".to_string(), toml::Value::String("1".into()));
+        assert!(backend.include_prereleases(&opts));
+
+        opts.opts
+            .insert("prerelease".to_string(), toml::Value::String("0".into()));
+        assert!(!backend.include_prereleases(&opts));
+
+        opts.opts
+            .insert("prerelease".to_string(), toml::Value::String("00".into()));
         assert!(!backend.include_prereleases(&opts));
 
         // Defense-in-depth: also accept a native TOML boolean, in case a future
@@ -2881,11 +2893,7 @@ pub(crate) fn mark_prerelease(mut version: VersionInfo) -> VersionInfo {
 }
 
 fn tool_option_bool(value: &toml::Value) -> bool {
-    match value {
-        toml::Value::Boolean(b) => *b,
-        toml::Value::String(s) => s.parse::<bool>().unwrap_or(false),
-        _ => false,
-    }
+    crate::backend::options::bool_value_or_default("prerelease", value, false)
 }
 
 /// Fuzzy-match `versions` against `query` with PEP 440 prerelease detection

--- a/src/backend/options.rs
+++ b/src/backend/options.rs
@@ -75,17 +75,28 @@ pub(crate) fn is_falsey(value: &str) -> bool {
 }
 
 pub(crate) fn bool_value_or_default(key: &str, value: &toml::Value, default: bool) -> bool {
-    match value {
-        toml::Value::Boolean(value) => *value,
-        toml::Value::String(value) => bool_str_or_default(key, value, default),
-        toml::Value::Integer(0) => false,
-        toml::Value::Integer(1) => true,
-        _ => invalid_bool_value(key, value, default),
+    bool_value(key, value).unwrap_or(default)
+}
+
+pub(crate) fn bool_value(key: &str, value: &toml::Value) -> Option<bool> {
+    let parsed = match value {
+        toml::Value::Boolean(value) => Some(*value),
+        toml::Value::String(value) => parse_bool_str(value),
+        toml::Value::Integer(0) => Some(false),
+        toml::Value::Integer(1) => Some(true),
+        _ => None,
+    };
+    if parsed.is_none() {
+        warn_invalid_bool_value(key, value);
     }
+    parsed
 }
 
 fn bool_str_or_default(key: &str, value: &str, default: bool) -> bool {
-    parse_bool_str(value).unwrap_or_else(|| invalid_bool_value(key, value, default))
+    parse_bool_str(value).unwrap_or_else(|| {
+        warn_invalid_bool_value(key, value);
+        default
+    })
 }
 
 fn parse_bool_str(value: &str) -> Option<bool> {
@@ -98,11 +109,10 @@ fn parse_bool_str(value: &str) -> Option<bool> {
     }
 }
 
-fn invalid_bool_value(key: &str, value: impl std::fmt::Display, default: bool) -> bool {
+fn warn_invalid_bool_value(key: &str, value: impl std::fmt::Display) {
     warn!(
-        "invalid boolean value for tool option `{key}`: {value}; expected true, false, 1, or 0; using {default}"
+        "invalid boolean value for tool option `{key}`: {value}; expected true, false, 1, or 0; using default"
     );
-    default
 }
 
 #[cfg(test)]
@@ -167,6 +177,7 @@ mod tests {
             BackendOptions::new(&opts_with_value("flag", toml::Value::Integer(2)))
                 .bool_with_default("flag", true)
         );
+        assert_eq!(bool_value("flag", &toml::Value::String("00".into())), None);
     }
 
     #[test]

--- a/src/backend/options.rs
+++ b/src/backend/options.rs
@@ -47,11 +47,18 @@ impl<'a> BackendOptions<'a> {
 
     pub(crate) fn platform_bool_for_target(&self, key: &str, target: &PlatformTarget) -> bool {
         self.platform_string_for_target(key, target)
-            .is_some_and(|v| is_truthy(&v))
+            .is_some_and(|v| bool_str_or_default(key, &v, false))
     }
 
     pub(crate) fn bool(&self, key: &str) -> bool {
-        self.raw.get_string(key).is_some_and(|v| is_truthy(&v))
+        self.bool_with_default(key, false)
+    }
+
+    pub(crate) fn bool_with_default(&self, key: &str, default: bool) -> bool {
+        self.raw
+            .opts
+            .get(key)
+            .map_or(default, |value| bool_value_or_default(key, value, default))
     }
 
     pub(crate) fn available_platforms_with_key(&self, key: &str) -> Vec<String> {
@@ -60,13 +67,107 @@ impl<'a> BackendOptions<'a> {
 }
 
 pub(crate) fn is_truthy(value: &str) -> bool {
-    matches!(value.trim(), "true" | "1")
+    matches!(value.trim().to_ascii_lowercase().as_str(), "true" | "1")
+}
+
+pub(crate) fn is_falsey(value: &str) -> bool {
+    matches!(value.trim().to_ascii_lowercase().as_str(), "false" | "0")
+}
+
+pub(crate) fn bool_value_or_default(key: &str, value: &toml::Value, default: bool) -> bool {
+    match value {
+        toml::Value::Boolean(value) => *value,
+        toml::Value::String(value) => bool_str_or_default(key, value, default),
+        toml::Value::Integer(0) => false,
+        toml::Value::Integer(1) => true,
+        _ => invalid_bool_value(key, value, default),
+    }
+}
+
+fn bool_str_or_default(key: &str, value: &str, default: bool) -> bool {
+    parse_bool_str(value).unwrap_or_else(|| invalid_bool_value(key, value, default))
+}
+
+fn parse_bool_str(value: &str) -> Option<bool> {
+    if is_truthy(value) {
+        Some(true)
+    } else if is_falsey(value) {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+fn invalid_bool_value(key: &str, value: impl std::fmt::Display, default: bool) -> bool {
+    warn!(
+        "invalid boolean value for tool option `{key}`: {value}; expected true, false, 1, or 0; using {default}"
+    );
+    default
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::platform::Platform;
+
+    fn opts_with_value(key: &str, value: toml::Value) -> ToolVersionOptions {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(key.to_string(), value);
+        opts
+    }
+
+    #[test]
+    fn test_bool_parses_consistent_formats() {
+        assert!(
+            BackendOptions::new(&opts_with_value("flag", toml::Value::Boolean(true))).bool("flag")
+        );
+        assert!(
+            !BackendOptions::new(&opts_with_value("flag", toml::Value::Boolean(false)))
+                .bool("flag")
+        );
+        assert!(
+            BackendOptions::new(&opts_with_value("flag", toml::Value::String("TRUE".into())))
+                .bool("flag")
+        );
+        assert!(
+            !BackendOptions::new(&opts_with_value(
+                "flag",
+                toml::Value::String("FALSE".into())
+            ))
+            .bool("flag")
+        );
+        assert!(
+            BackendOptions::new(&opts_with_value("flag", toml::Value::String("1".into())))
+                .bool("flag")
+        );
+        assert!(
+            !BackendOptions::new(&opts_with_value("flag", toml::Value::String("0".into())))
+                .bool("flag")
+        );
+        assert!(
+            BackendOptions::new(&opts_with_value("flag", toml::Value::Integer(1))).bool("flag")
+        );
+        assert!(
+            !BackendOptions::new(&opts_with_value("flag", toml::Value::Integer(0))).bool("flag")
+        );
+    }
+
+    #[test]
+    fn test_bool_invalid_values_fall_back_to_default() {
+        assert!(!BackendOptions::new(&ToolVersionOptions::default()).bool("missing"));
+        assert!(
+            !BackendOptions::new(&opts_with_value("flag", toml::Value::String("00".into())))
+                .bool("flag")
+        );
+        assert!(
+            BackendOptions::new(&opts_with_value("flag", toml::Value::String("00".into())))
+                .bool_with_default("flag", true)
+        );
+        assert!(
+            BackendOptions::new(&opts_with_value("flag", toml::Value::Integer(2)))
+                .bool_with_default("flag", true)
+        );
+    }
 
     #[test]
     fn test_platform_bool_for_target_uses_requested_target() {

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -9,19 +9,41 @@ use versions::Versioning;
 
 use crate::backend::Backend;
 use crate::backend::VersionInfo;
+use crate::backend::options::BackendOptions;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::parallel;
-use crate::toolset::{ToolVersion, Toolset};
+use crate::toolset::{ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{dirs, env, file, plugins};
 
 #[derive(Debug)]
 pub struct DotnetPlugin {
     ba: Arc<BackendArg>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DotnetOptions<'a> {
+    values: BackendOptions<'a>,
+}
+
+impl<'a> DotnetOptions<'a> {
+    fn new(raw: &'a ToolVersionOptions) -> Self {
+        Self {
+            values: BackendOptions::new(raw),
+        }
+    }
+
+    fn runtime(&self) -> Option<&'a str> {
+        self.values.str("runtime")
+    }
+
+    fn runtime_framework_name(&self) -> Option<&'static str> {
+        self.runtime().and_then(runtime_framework_name)
+    }
 }
 
 impl DotnetPlugin {
@@ -36,7 +58,9 @@ impl DotnetPlugin {
     }
 
     async fn test_dotnet(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
-        if tv.request.options().get("runtime").is_some() {
+        let raw_opts = tv.request.options();
+        let opts = DotnetOptions::new(&raw_opts);
+        if opts.runtime().is_some() {
             // Skip version check for runtime-only installs — `dotnet --version` exits non-zero without an SDK
             return Ok(());
         }
@@ -126,7 +150,9 @@ impl Backend for DotnetPlugin {
         file::create_dir_all(&install_dir)?;
 
         // Read and validate runtime options
-        let runtime = tv.request.options().get("runtime").map(|s| s.to_string());
+        let raw_opts = tv.request.options();
+        let opts = DotnetOptions::new(&raw_opts);
+        let runtime = opts.runtime().map(str::to_string);
         if let Some(ref rt) = runtime
             && runtime_framework_name(rt).is_none()
         {
@@ -176,10 +202,11 @@ impl Backend for DotnetPlugin {
         if Self::is_isolated() {
             // Isolated: mise handles removal of install_path by default
         } else {
-            let runtime = tv.request.options().get("runtime").map(|s| s.to_string());
-            if let Some(rt) = runtime {
+            let raw_opts = tv.request.options();
+            let opts = DotnetOptions::new(&raw_opts);
+            if let Some(rt) = opts.runtime() {
                 // Runtime: remove the shared runtime directory for this version
-                let Some(framework) = runtime_framework_name(&rt) else {
+                let Some(framework) = runtime_framework_name(rt) else {
                     return Ok(());
                 };
                 let runtime_dir = dotnet_root()
@@ -384,5 +411,31 @@ impl Ord for SortedVersion {
 impl PartialOrd for SortedVersion {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts_with_runtime(runtime: &str) -> ToolVersionOptions {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "runtime".to_string(),
+            toml::Value::String(runtime.to_string()),
+        );
+        opts
+    }
+
+    #[test]
+    fn dotnet_options_reads_runtime() {
+        let opts = opts_with_runtime("aspnetcore");
+        let parsed = DotnetOptions::new(&opts);
+
+        assert_eq!(parsed.runtime(), Some("aspnetcore"));
+        assert_eq!(
+            parsed.runtime_framework_name(),
+            Some("Microsoft.AspNetCore.App")
+        );
     }
 }

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -154,7 +154,7 @@ impl Backend for DotnetPlugin {
         let opts = DotnetOptions::new(&raw_opts);
         let runtime = opts.runtime().map(str::to_string);
         if let Some(ref rt) = runtime
-            && runtime_framework_name(rt).is_none()
+            && opts.runtime_framework_name().is_none()
         {
             return Err(eyre::eyre!(
                 "Invalid runtime option '{}'. Valid options: dotnet, aspnetcore, windowsdesktop",
@@ -204,9 +204,9 @@ impl Backend for DotnetPlugin {
         } else {
             let raw_opts = tv.request.options();
             let opts = DotnetOptions::new(&raw_opts);
-            if let Some(rt) = opts.runtime() {
+            if opts.runtime().is_some() {
                 // Runtime: remove the shared runtime directory for this version
-                let Some(framework) = runtime_framework_name(rt) else {
+                let Some(framework) = opts.runtime_framework_name() else {
                     return Ok(());
                 };
                 let runtime_dir = dotnet_root()

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -774,6 +774,11 @@ impl JavaMetadata {
     }
 }
 
+// only care about these features
+static JAVA_FEATURES: Lazy<HashSet<String>> = Lazy::new(|| {
+    HashSet::from(["crac", "javafx", "jcef", "leyden", "lite", "musl"].map(|s| s.to_string()))
+});
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -805,8 +810,3 @@ mod tests {
         );
     }
 }
-
-// only care about these features
-static JAVA_FEATURES: Lazy<HashSet<String>> = Lazy::new(|| {
-    HashSet::from(["crac", "javafx", "jcef", "leyden", "lite", "musl"].map(|s| s.to_string()))
-});

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -4,6 +4,7 @@ use std::fs::{self};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::backend::options::BackendOptions;
 use crate::backend::{
     Backend, VersionInfo, normalize_idiomatic_contents, platform_target::PlatformTarget,
 };
@@ -17,7 +18,7 @@ use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lockfile::PlatformInfo;
 use crate::platform::Platform;
-use crate::toolset::{ToolRequest, ToolVersion, Toolset};
+use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{file, plugins};
 use async_trait::async_trait;
@@ -45,6 +46,32 @@ pub struct JavaPlugin {
     java_metadata_ga_cache: CacheManager<HashMap<String, JavaMetadata>>,
     java_metadata_target_cache:
         tokio::sync::Mutex<HashMap<(String, String), HashMap<String, JavaMetadata>>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct JavaOptions<'a> {
+    values: BackendOptions<'a>,
+}
+
+impl<'a> JavaOptions<'a> {
+    fn new(raw: &'a ToolVersionOptions) -> Self {
+        Self {
+            values: BackendOptions::new(raw),
+        }
+    }
+
+    fn release_type(&self) -> &'a str {
+        self.values.str("release_type").unwrap_or("ga")
+    }
+
+    fn lockfile_options(&self) -> BTreeMap<String, String> {
+        let mut opts = BTreeMap::new();
+        let release_type = self.release_type();
+        if release_type != "ga" {
+            opts.insert("release_type".to_string(), release_type.to_string());
+        }
+        opts
+    }
 }
 
 impl JavaPlugin {
@@ -297,11 +324,8 @@ impl JavaPlugin {
     }
 
     fn tv_release_type(&self, tv: &ToolVersion) -> String {
-        tv.request
-            .options()
-            .get("release_type")
-            .map(|s| s.to_string())
-            .unwrap_or(String::from("ga"))
+        let raw_opts = tv.request.options();
+        JavaOptions::new(&raw_opts).release_type().to_string()
     }
 
     fn tv_to_java_version(&self, tv: &ToolVersion) -> String {
@@ -361,11 +385,8 @@ impl Backend for JavaPlugin {
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-        let opts = config.get_tool_opts_with_overrides(&self.ba).await?;
-        let release_type = opts
-            .get("release_type")
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "ga".to_string());
+        let raw_opts = config.get_tool_opts_with_overrides(&self.ba).await?;
+        let release_type = JavaOptions::new(&raw_opts).release_type().to_string();
 
         let versions = self
             .fetch_java_metadata(&release_type)
@@ -458,14 +479,8 @@ impl Backend for JavaPlugin {
         request: &ToolRequest,
         _target: &PlatformTarget,
     ) -> BTreeMap<String, String> {
-        let mut opts = BTreeMap::new();
-        if let Some(release_type) = request.options().get("release_type") {
-            let release_type = release_type.to_string();
-            if release_type != "ga" {
-                opts.insert("release_type".to_string(), release_type);
-            }
-        }
-        opts
+        let raw_opts = request.options();
+        JavaOptions::new(&raw_opts).lockfile_options()
     }
 
     async fn resolve_lock_info(
@@ -756,6 +771,38 @@ impl JavaMetadata {
         }
         v.push(self.version.clone());
         v.join("-")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts_with_release_type(release_type: &str) -> ToolVersionOptions {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "release_type".to_string(),
+            toml::Value::String(release_type.to_string()),
+        );
+        opts
+    }
+
+    #[test]
+    fn java_options_reads_release_type() {
+        let default_opts = ToolVersionOptions::default();
+        assert_eq!(JavaOptions::new(&default_opts).release_type(), "ga");
+        assert!(
+            JavaOptions::new(&default_opts)
+                .lockfile_options()
+                .is_empty()
+        );
+
+        let opts = opts_with_release_type("ea");
+        assert_eq!(JavaOptions::new(&opts).release_type(), "ea");
+        assert_eq!(
+            JavaOptions::new(&opts).lockfile_options(),
+            BTreeMap::from([("release_type".to_string(), "ea".to_string())])
+        );
     }
 }
 

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -51,9 +51,7 @@ impl<'a> PythonOptions<'a> {
     }
 
     fn patch_sysconfig(&self) -> bool {
-        // Preserve the existing option semantics: only the string "false"
-        // disables sysconfig patching.
-        self.values.str("patch_sysconfig") != Some("false")
+        self.values.bool_with_default("patch_sysconfig", true)
     }
 
     fn virtualenv(&self) -> Option<&'a str> {
@@ -1072,9 +1070,12 @@ mod tests {
     use super::*;
 
     fn opts_with(key: &str, value: &str) -> ToolVersionOptions {
+        opts_with_value(key, toml::Value::String(value.to_string()))
+    }
+
+    fn opts_with_value(key: &str, value: toml::Value) -> ToolVersionOptions {
         let mut opts = ToolVersionOptions::default();
-        opts.opts
-            .insert(key.to_string(), toml::Value::String(value.to_string()));
+        opts.opts.insert(key.to_string(), value);
         opts
     }
 
@@ -1082,6 +1083,17 @@ mod tests {
     fn python_options_reads_patch_sysconfig() {
         assert!(PythonOptions::new(&ToolVersionOptions::default()).patch_sysconfig());
         assert!(!PythonOptions::new(&opts_with("patch_sysconfig", "false")).patch_sysconfig());
+        assert!(!PythonOptions::new(&opts_with("patch_sysconfig", "FALSE")).patch_sysconfig());
+        assert!(!PythonOptions::new(&opts_with("patch_sysconfig", "0")).patch_sysconfig());
+        assert!(
+            !PythonOptions::new(&opts_with_value(
+                "patch_sysconfig",
+                toml::Value::Boolean(false)
+            ))
+            .patch_sysconfig()
+        );
+        assert!(PythonOptions::new(&opts_with("patch_sysconfig", "1")).patch_sysconfig());
+        assert!(PythonOptions::new(&opts_with("patch_sysconfig", "00")).patch_sysconfig());
     }
 
     #[test]

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -51,6 +51,8 @@ impl<'a> PythonOptions<'a> {
     }
 
     fn patch_sysconfig(&self) -> bool {
+        // Preserve the existing option semantics: only the string "false"
+        // disables sysconfig patching.
         self.values.str("patch_sysconfig") != Some("false")
     }
 

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -1,3 +1,4 @@
+use crate::backend::options::BackendOptions;
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::static_helpers::fetch_checksum_from_shasums;
 use crate::backend::{Backend, VersionCacheManager, VersionInfo};
@@ -12,7 +13,7 @@ use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::platform::Platform;
-use crate::toolset::{ToolRequest, ToolVersion, Toolset};
+use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{Result, lock_file::LockFile};
 use crate::{dirs, file, plugins, sysconfig};
@@ -35,6 +36,27 @@ const ATTESTATION_HELP: &str = "To disable attestation verification, set MISE_PY
 #[derive(Debug)]
 pub struct PythonPlugin {
     ba: Arc<BackendArg>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PythonOptions<'a> {
+    values: BackendOptions<'a>,
+}
+
+impl<'a> PythonOptions<'a> {
+    fn new(raw: &'a ToolVersionOptions) -> Self {
+        Self {
+            values: BackendOptions::new(raw),
+        }
+    }
+
+    fn patch_sysconfig(&self) -> bool {
+        self.values.str("patch_sysconfig") != Some("false")
+    }
+
+    fn virtualenv(&self) -> Option<&'a str> {
+        self.values.str("virtualenv")
+    }
 }
 
 pub fn python_path(tv: &ToolVersion) -> PathBuf {
@@ -354,7 +376,9 @@ impl PythonPlugin {
             .map(|s| re_digits.replace(s, "").to_string());
         if cfg!(unix) {
             if let (Some(major), Some(minor), Some(suffix)) = (major, minor, suffix) {
-                if tv.request.options().get("patch_sysconfig") != Some("false") {
+                let raw_opts = tv.request.options();
+                let opts = PythonOptions::new(&raw_opts);
+                if opts.patch_sysconfig() {
                     sysconfig::update_sysconfig(&install, major, minor, &suffix)?;
                 }
             } else {
@@ -447,7 +471,9 @@ impl PythonPlugin {
         config: &Arc<Config>,
         tv: &ToolVersion,
     ) -> eyre::Result<Option<PathBuf>> {
-        if let Some(virtualenv) = tv.request.options().get("virtualenv") {
+        let raw_opts = tv.request.options();
+        let opts = PythonOptions::new(&raw_opts);
+        if let Some(virtualenv) = opts.virtualenv() {
             if !Settings::get().experimental {
                 warn!(
                     "please enable experimental mode with `mise settings experimental=true` \
@@ -1042,6 +1068,25 @@ fn filter_freethreaded(v: &str, flavor: &Option<String>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn opts_with(key: &str, value: &str) -> ToolVersionOptions {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts
+            .insert(key.to_string(), toml::Value::String(value.to_string()));
+        opts
+    }
+
+    #[test]
+    fn python_options_reads_patch_sysconfig() {
+        assert!(PythonOptions::new(&ToolVersionOptions::default()).patch_sysconfig());
+        assert!(!PythonOptions::new(&opts_with("patch_sysconfig", "false")).patch_sysconfig());
+    }
+
+    #[test]
+    fn python_options_reads_virtualenv() {
+        let opts = opts_with("virtualenv", ".venv");
+        assert_eq!(PythonOptions::new(&opts).virtualenv(), Some(".venv"));
+    }
 
     #[test]
     fn test_resolve_python_arch_windows_x64() {

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::backend::Backend;
 use crate::backend::VersionInfo;
+use crate::backend::options::BackendOptions;
 use crate::build_time::TARGET;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
@@ -11,7 +12,7 @@ use crate::http::HTTP;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolSource::IdiomaticVersionFile;
 use crate::toolset::outdated_info::OutdatedInfo;
-use crate::toolset::{ResolveOptions, ToolVersion, Toolset};
+use crate::toolset::{ResolveOptions, ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{dirs, env, file, github, plugins};
 use async_trait::async_trait;
@@ -21,6 +22,46 @@ use xx::regex;
 #[derive(Debug)]
 pub struct RustPlugin {
     ba: Arc<BackendArg>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RustOptions<'a> {
+    values: BackendOptions<'a>,
+}
+
+impl<'a> RustOptions<'a> {
+    fn new(raw: &'a ToolVersionOptions) -> Self {
+        Self {
+            values: BackendOptions::new(raw),
+        }
+    }
+
+    fn profile(&self) -> Option<&'a str> {
+        self.values.str("profile")
+    }
+
+    fn comma_list(&self, name: &str) -> Option<Vec<String>> {
+        self.values
+            .str(name)
+            .map(|c| c.split(',').map(|s| s.to_string()).collect())
+    }
+
+    fn install_args(
+        &self,
+        rt: Option<&RustToolchain>,
+    ) -> (Option<String>, Option<Vec<String>>, Option<Vec<String>>) {
+        let profile = rt
+            .and_then(|rt| rt.profile.clone())
+            .or_else(|| self.profile().map(str::to_string));
+        let components = rt
+            .and_then(|rt| rt.components.clone())
+            .or_else(|| self.comma_list("components"));
+        let targets = rt
+            .and_then(|rt| rt.targets.clone())
+            .or_else(|| self.comma_list("targets"));
+
+        (profile, components, targets)
+    }
 }
 
 impl RustPlugin {
@@ -271,26 +312,8 @@ fn get_args(tv: &ToolVersion) -> (Option<String>, Option<Vec<String>>, Option<Ve
         None
     };
 
-    let get_tooloption = |name: &str| {
-        tv.request
-            .options()
-            .get(name)
-            .map(|c| c.split(',').map(|s| s.to_string()).collect())
-    };
-    let profile = rt
-        .as_ref()
-        .and_then(|rt| rt.profile.clone())
-        .or_else(|| tv.request.options().get("profile").map(|s| s.to_string()));
-    let components = rt
-        .as_ref()
-        .and_then(|rt| rt.components.clone())
-        .or_else(|| get_tooloption("components"));
-    let targets = rt
-        .as_ref()
-        .and_then(|rt| rt.targets.clone())
-        .or_else(|| get_tooloption("targets"));
-
-    (profile, components, targets)
+    let raw_opts = tv.request.options();
+    RustOptions::new(&raw_opts).install_args(rt.as_ref())
 }
 
 fn parse_idiomatic_file(path: &Path) -> Result<RustToolchain> {
@@ -410,4 +433,51 @@ fn cargo_bin() -> PathBuf {
 }
 fn cargo_bindir() -> PathBuf {
     cargo_home().join("bin")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts_with(key: &str, value: &str) -> ToolVersionOptions {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts
+            .insert(key.to_string(), toml::Value::String(value.to_string()));
+        opts
+    }
+
+    #[test]
+    fn rust_options_reads_install_args() {
+        let mut opts = opts_with("profile", "minimal");
+        opts.opts.insert(
+            "components".to_string(),
+            toml::Value::String("clippy,rustfmt".to_string()),
+        );
+        opts.opts.insert(
+            "targets".to_string(),
+            toml::Value::String("wasm32-wasip1".to_string()),
+        );
+
+        let (profile, components, targets) = RustOptions::new(&opts).install_args(None);
+
+        assert_eq!(profile, Some("minimal".to_string()));
+        assert_eq!(
+            components,
+            Some(vec!["clippy".to_string(), "rustfmt".to_string()])
+        );
+        assert_eq!(targets, Some(vec!["wasm32-wasip1".to_string()]));
+    }
+
+    #[test]
+    fn rust_idiomatic_options_override_tool_options() {
+        let opts = opts_with("profile", "minimal");
+        let rt = RustToolchain {
+            profile: Some("default".to_string()),
+            ..Default::default()
+        };
+
+        let (profile, _, _) = RustOptions::new(&opts).install_args(Some(&rt));
+
+        assert_eq!(profile, Some("default".to_string()));
+    }
 }

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -43,7 +43,7 @@ impl<'a> RustOptions<'a> {
     fn comma_list(&self, name: &str) -> Option<Vec<String>> {
         self.values
             .str(name)
-            .map(|c| c.split(',').map(|s| s.to_string()).collect())
+            .map(|c| c.split(',').map(|s| s.trim().to_string()).collect())
     }
 
     fn install_args(
@@ -451,7 +451,7 @@ mod tests {
         let mut opts = opts_with("profile", "minimal");
         opts.opts.insert(
             "components".to_string(),
-            toml::Value::String("clippy,rustfmt".to_string()),
+            toml::Value::String("clippy, rustfmt".to_string()),
         );
         opts.opts.insert(
             "targets".to_string(),


### PR DESCRIPTION
## Summary
- add local typed option readers for core .NET runtime, Java release_type, Rust profile/components/targets, and Python patch_sysconfig/virtualenv options
- route install, listing, activation, and lockfile option reads through those local readers
- parse boolean tool options consistently via the shared backend option helper
- add focused parser tests for each touched core plugin and shared boolean parsing

## Verification
- cargo fmt --check
- git diff --check
- cargo test backend::options::tests
- cargo test python_options_reads_patch_sysconfig
- cargo test test_include_prereleases_accepts_bool_and_string_values

Notes:
- Node, Erlang, Ruby, and core Go do not currently read raw per-tool option keys in this PR C parser phase; their remaining work is setting-derived identity classification for PR D.

Project: https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=185472417