### PR TITLE
fix(github): retry without auth on 401 Unauthorized

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -509,6 +509,15 @@ impl Client {
             }
             return Err(status_error.into());
         }
+        if is_authenticated_github_unauthorized(&url, &final_headers, &resp) {
+            let mut headers = final_headers;
+            headers.remove(AUTHORIZATION);
+            debug!(
+                "{} {} retrying without GitHub auth after 401",
+                verb_label, &url
+            );
+            return Box::pin(self.send_once_inner(method, url, &headers, verb_label, false)).await;
+        }
         resp.error_for_status_ref()?;
         Ok(resp)
     }
@@ -516,6 +525,12 @@ impl Client {
 
 fn is_authenticated_github_forbidden(url: &Url, headers: &HeaderMap, resp: &Response) -> bool {
     resp.status() == StatusCode::FORBIDDEN
+        && url.host_str() == Some("api.github.com")
+        && headers.contains_key(AUTHORIZATION)
+}
+
+fn is_authenticated_github_unauthorized(url: &Url, headers: &HeaderMap, resp: &Response) -> bool {
+    resp.status() == StatusCode::UNAUTHORIZED
         && url.host_str() == Some("api.github.com")
         && headers.contains_key(AUTHORIZATION)
 }


### PR DESCRIPTION
## Summary

When `GITHUB_TOKEN` is set to a token scoped to a private GitHub Enterprise instance (e.g. `github.example.com`), requests to `api.github.com` return **401 Unauthorized** because the token is not valid there.

This is common in enterprise environments where developers must have `GITHUB_TOKEN` set for internal tooling (`make lint`, CI scripts, etc.), but that same token is invalid for public GitHub. Since mise's token resolution chain (`MISE_GITHUB_TOKEN` > `GITHUB_API_TOKEN` > `GITHUB_TOKEN`) picks up the enterprise token, every `api.github.com` request fails with 401.

## Fix

Mirror the existing 403 retry-without-auth logic from #9506: when `api.github.com` returns 401 and an `Authorization` header was sent, strip the header and retry unauthenticated. Public API endpoints (release listings, tags) work fine without auth — they just have lower rate limits (60 req/hr vs 5000).

The 401 block is placed after the existing 403 block in `send_once_inner`, using the same pattern:
1. Check status + url + header presence
2. Remove `Authorization` header
3. Retry via `send_once_inner` with `auth=false`

## Alternatives considered

- **`MISE_GITHUB_TOKEN=""`** — empty strings are filtered out by `.filter(|t| !t.is_empty())` in `resolve_token`, so this doesn't suppress the fallback to `GITHUB_TOKEN`.
- **`use_versions_host=true`** — only covers version listing, not download URL resolution which still hits `api.github.com`.
- **Lockfiles** — works but requires central maintenance whenever any tool version changes across repositories, which doesn't scale.
- **Wrapper scripts / direnv** — fragile, breaks when developers forget to source them.

## Related

- Discussion #7218 (token priority and enterprise conflicts)
- Discussion #9119 (403 with IP allow lists — same class of problem)
- PR #9506 (the 403 retry pattern this mirrors)