### PR TITLE
registry: add ghtkn

### DIFF
--- a/registry/ghtkn.toml
+++ b/registry/ghtkn.toml
@@ -1,0 +1,7 @@
+backends = [
+  "aqua:suzuki-shunsuke/ghtkn",
+  "github:suzuki-shunsuke/ghtkn",
+  "go:github.com/suzuki-shunsuke/ghtkn/cmd/ghtkn",
+]
+description = "Create short-lived GitHub App User Access Tokens for secure local development"
+test = { cmd = "ghtkn --version", expected = "ghtkn version {{version}}" }

--- a/registry/ghtkn.toml
+++ b/registry/ghtkn.toml
@@ -1,7 +1,3 @@
-backends = [
-  "aqua:suzuki-shunsuke/ghtkn",
-  "github:suzuki-shunsuke/ghtkn",
-  "go:github.com/suzuki-shunsuke/ghtkn/cmd/ghtkn",
-]
+backends = ["aqua:suzuki-shunsuke/ghtkn", "github:suzuki-shunsuke/ghtkn"]
 description = "Create short-lived GitHub App User Access Tokens for secure local development"
 test = { cmd = "ghtkn --version", expected = "ghtkn version {{version}}" }


### PR DESCRIPTION
Add `ghtkn` as a registry shorthand for `suzuki-shunsuke/ghtkn`.

## Reason

`ghtkn` is now used as one of the methods for GitHub token management in mise.

## Popularity

- GitHub: 149 stars, 1 fork
- Latest release: `v0.2.4`, published 2025-12-09
- Recent upstream activity: pushed in May 2026

## Caveat

Public popularity is below the usual mise registry bar. This PR is still proposed because `ghtkn` is now used by mise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new registry configuration entry with support for multiple source backends (Aqua and GitHub) for obtaining releases and integrated version validation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->