### PR TITLE
feat(core): deprecate default package files

### DIFF
--- a/docs/lang/go.md
+++ b/docs/lang/go.md
@@ -34,8 +34,29 @@ See [idiomatic version files](/configuration.html#idiomatic-version-files)
 
 ## Default packages
 
+::: warning Planned deprecation
+Default package files are deprecated. They are still supported for now, but mise will start warning
+in `2026.11.0` and support will be removed in `2027.11.0`.
+
+For Go CLIs, install the tool directly with the `go:` backend:
+
+```toml
+[tools]
+"go:github.com/jesseduffield/lazygit" = "latest"
+```
+
+For packages that really should be installed into every Go version, use a tool-level `postinstall`
+hook:
+
+```toml
+[tools]
+go = { version = "1.25", postinstall = "go install github.com/daixiang0/gci@latest" }
+```
+
+:::
+
 mise can automatically install a default set of packages right after installing a new go version.
-To enable this feature, provide a `$HOME/.default-go-packages` file that lists one packages per
+To use this legacy feature, provide a `$HOME/.default-go-packages` file that lists one package per
 line, for example:
 
 ```text

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -75,7 +75,30 @@ idiomatic_version_file_enable_tools = ["node"]
 
 ## Default node packages
 
-mise-node can automatically install a default set of npm packages right after installing a node version. To enable this feature, provide a `$HOME/.default-npm-packages` file that lists one package per line, for example:
+::: warning Planned deprecation
+Default package files are deprecated. They are still supported for now, but mise will start warning
+in `2026.11.0` and support will be removed in `2027.11.0`.
+
+For npm CLIs, install the tool directly with the [npm backend](/dev-tools/backends/npm.html):
+
+```toml
+[tools]
+"npm:typescript" = "latest"
+```
+
+For packages that really should be installed into every Node.js version, use a tool-level
+`postinstall` hook:
+
+```toml
+[tools]
+node = { version = "22", postinstall = "npm install -g typescript" }
+```
+
+:::
+
+mise-node can automatically install a default set of npm packages right after installing a node
+version. To use this legacy feature, provide a `$HOME/.default-npm-packages` file that lists one
+package per line, for example:
 
 ```text
 lodash

--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -135,9 +135,30 @@ See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for more exampl
 
 ## Default Python packages
 
+::: warning Planned deprecation
+Default package files are deprecated. They are still supported for now, but mise will start warning
+in `2026.11.0` and support will be removed in `2027.11.0`.
+
+For Python CLIs, install the tool directly with the [pipx backend](/dev-tools/backends/pipx.html):
+
+```toml
+[tools]
+"pipx:black" = "latest"
+```
+
+For packages that really should be installed into every Python version, use a tool-level
+`postinstall` hook:
+
+```toml
+[tools]
+python = { version = "3.13", postinstall = "python -m pip install --upgrade ansible" }
+```
+
+:::
+
 mise can automatically install a default set of Python packages with pip right after installing a
-Python version. To enable this feature, provide a `$HOME/.default-python-packages` file that lists
-one package per line, for example:
+Python version. To use this legacy feature, provide a `$HOME/.default-python-packages` file that
+lists one package per line, for example:
 
 ```text
 ansible

--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -64,8 +64,29 @@ mise use -g ruby@truffleruby            # latest version of truffleruby
 
 ## Default gems
 
+::: warning Planned deprecation
+Default package files are deprecated. They are still supported for now, but mise will start warning
+in `2026.11.0` and support will be removed in `2027.11.0`.
+
+For Ruby CLIs, install the tool directly with the [gem backend](/dev-tools/backends/gem.html):
+
+```toml
+[tools]
+"gem:rubocop" = "latest"
+```
+
+For gems that really should be installed into every Ruby version, use a tool-level `postinstall`
+hook:
+
+```toml
+[tools]
+ruby = { version = "3.4", postinstall = "gem install rubocop" }
+```
+
+:::
+
 mise can automatically install a default set of gems right after installing a new ruby version.
-To enable this feature, provide a `$HOME/.default-gems` file that lists one gem per line, for
+To use this legacy feature, provide a `$HOME/.default-gems` file that lists one gem per line, for
 example:
 
 ```text

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -867,7 +867,8 @@
             "default_packages_file": {
               "default": "~/.default-go-packages",
               "description": "Path to a file containing default go packages to install when installing go.",
-              "type": "string"
+              "type": "string",
+              "deprecated": true
             },
             "download_mirror": {
               "default": "https://dl.google.com/go",
@@ -1114,7 +1115,8 @@
             },
             "default_packages_file": {
               "description": "Path to a file containing default npm packages to install.",
-              "type": "string"
+              "type": "string",
+              "deprecated": true
             },
             "flavor": {
               "description": "Install a specific node flavor like glibc-217 or musl. Use with unofficial node build repo.",
@@ -1279,7 +1281,8 @@
             },
             "default_packages_file": {
               "description": "Path to a file containing default python packages to install when installing a python version.",
-              "type": "string"
+              "type": "string",
+              "deprecated": true
             },
             "github_attestations": {
               "description": "Enable GitHub Artifact Attestations verification for precompiled Python binaries.",
@@ -1366,7 +1369,8 @@
             "default_packages_file": {
               "default": "~/.default-gems",
               "description": "Path to a file containing default ruby gems to install when installing ruby.",
-              "type": "string"
+              "type": "string",
+              "deprecated": true
             },
             "github_attestations": {
               "description": "Enable GitHub Artifact Attestations verification for precompiled Ruby binaries.",

--- a/settings.toml
+++ b/settings.toml
@@ -902,6 +902,9 @@ type = "Path"
 
 [go.default_packages_file]
 default = "~/.default-go-packages"
+deprecated = "Default go package files are deprecated. Use tool-level postinstall hooks for packages that should be installed into every go version, or use the go: backend for CLI tools."
+deprecated_remove_at = "2027.11.0"
+deprecated_warn_at = "2026.11.0"
 description = "Path to a file containing default go packages to install when installing go."
 env = "MISE_GO_DEFAULT_PACKAGES_FILE"
 type = "Path"
@@ -1433,6 +1436,9 @@ type = "Bool"
 
 [node.default_packages_file]
 default_docs = "~/.default-npm-packages"
+deprecated = "Default npm package files are deprecated. Use tool-level postinstall hooks for packages that should be installed into every node version, or use the npm: backend for CLI tools."
+deprecated_remove_at = "2027.11.0"
+deprecated_warn_at = "2026.11.0"
 description = "Path to a file containing default npm packages to install."
 docs = """
 Path to a file containing packages to install with npm after installing a new Node.js version.
@@ -1774,6 +1780,9 @@ optional = true
 type = "Bool"
 
 [python.default_packages_file]
+deprecated = "Default python package files are deprecated. Use tool-level postinstall hooks for packages that should be installed into every python version, or use the pipx: backend for CLI tools."
+deprecated_remove_at = "2027.11.0"
+deprecated_warn_at = "2026.11.0"
 description = "Path to a file containing default python packages to install when installing a python version."
 env = "MISE_PYTHON_DEFAULT_PACKAGES_FILE"
 optional = true
@@ -1909,6 +1918,9 @@ type = "Bool"
 
 [ruby.default_packages_file]
 default = "~/.default-gems"
+deprecated = "Default ruby gem files are deprecated. Use tool-level postinstall hooks for gems that should be installed into every ruby version, or use the gem: backend for CLI tools."
+deprecated_remove_at = "2027.11.0"
+deprecated_warn_at = "2026.11.0"
 description = "Path to a file containing default ruby gems to install when installing ruby."
 env = "MISE_RUBY_DEFAULT_PACKAGES_FILE"
 type = "String"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -251,6 +251,20 @@ fn warn_deprecated(key: &str) {
 }
 
 impl Settings {
+    pub fn parse_default_package_line(package: &str) -> Option<String> {
+        let package = package.split('#').next().unwrap_or_default().trim();
+        (!package.is_empty()).then(|| package.to_string())
+    }
+
+    pub fn warn_default_package_file_deprecated(id: &'static str, package_type: &str) {
+        deprecated_at!(
+            "2026.11.0",
+            "2027.11.0",
+            id,
+            "Default {package_type} files are deprecated. Use tool-level postinstall hooks for packages that should be installed into every runtime version, or use package manager backends such as npm:, pipx:, gem:, or go: for CLI tools."
+        );
+    }
+
     pub fn get() -> Arc<Self> {
         Self::try_get().unwrap()
     }

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -72,11 +72,17 @@ impl GoPlugin {
         let settings = Settings::get();
         let default_packages_file = file::replace_path(&settings.go.default_packages_file);
         let body = file::read_to_string(default_packages_file).unwrap_or_default();
-        for package in body.lines() {
-            let package = package.split('#').next().unwrap_or_default().trim();
-            if package.is_empty() {
-                continue;
-            }
+        let mut packages = body
+            .lines()
+            .filter_map(Settings::parse_default_package_line)
+            .peekable();
+        if packages.peek().is_some() {
+            Settings::warn_default_package_file_deprecated(
+                "go.default_packages_file",
+                "go package",
+            );
+        }
+        for package in packages {
             pr.set_message(format!("install default package: {package}"));
             let package = if package.contains('@') {
                 package.to_string()

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -344,11 +344,17 @@ impl NodePlugin {
         let settings = Settings::get();
         let default_packages_file = file::replace_path(settings.node.default_packages_file());
         let body = file::read_to_string(&default_packages_file).unwrap_or_default();
-        for package in body.lines() {
-            let package = package.split('#').next().unwrap_or_default().trim();
-            if package.is_empty() {
-                continue;
-            }
+        let mut packages = body
+            .lines()
+            .filter_map(Settings::parse_default_package_line)
+            .peekable();
+        if packages.peek().is_some() {
+            Settings::warn_default_package_file_deprecated(
+                "node.default_packages_file",
+                "npm package",
+            );
+        }
+        for package in packages {
             pr.set_message(format!("install default package: {package}"));
             let npm = self.npm_path(tv);
             CmdLineRunner::new(npm)

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -416,6 +416,16 @@ impl PythonPlugin {
         if !packages_file.exists() {
             return Ok(());
         }
+        if file::read_to_string(packages_file)
+            .unwrap_or_default()
+            .lines()
+            .any(|package| Settings::parse_default_package_line(package).is_some())
+        {
+            Settings::warn_default_package_file_deprecated(
+                "python.default_packages_file",
+                "python package",
+            );
+        }
         pr.set_message("install default packages".into());
         CmdLineRunner::new(tv.install_path().join("bin/python"))
             .with_pr(pr)

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -238,11 +238,17 @@ impl RubyPlugin {
         let settings = Settings::get();
         let default_gems_file = file::replace_path(&settings.ruby.default_packages_file);
         let body = file::read_to_string(&default_gems_file).unwrap_or_default();
-        for package in body.lines() {
-            let package = package.split('#').next().unwrap_or_default().trim();
-            if package.is_empty() {
-                continue;
-            }
+        let mut packages = body
+            .lines()
+            .filter_map(Settings::parse_default_package_line)
+            .peekable();
+        if packages.peek().is_some() {
+            Settings::warn_default_package_file_deprecated(
+                "ruby.default_packages_file",
+                "ruby gem",
+            );
+        }
+        for package in packages {
             pr.set_message(format!("install default gem: {package}"));
             let gem = self.gem_path(tv);
             let mut cmd = CmdLineRunner::new(gem)

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -52,11 +52,17 @@ impl RubyPlugin {
         let settings = Settings::get();
         let default_gems_file = file::replace_path(&settings.ruby.default_packages_file);
         let body = file::read_to_string(&default_gems_file).unwrap_or_default();
-        for package in body.lines() {
-            let package = package.split('#').next().unwrap_or_default().trim();
-            if package.is_empty() {
-                continue;
-            }
+        let mut packages = body
+            .lines()
+            .filter_map(Settings::parse_default_package_line)
+            .peekable();
+        if packages.peek().is_some() {
+            Settings::warn_default_package_file_deprecated(
+                "ruby.default_packages_file",
+                "ruby gem",
+            );
+        }
+        for package in packages {
             pr.set_message(format!("install default gem: {}", package));
             let gem = self.gem_path(tv);
             let mut cmd = CmdLineRunner::new(gem)


### PR DESCRIPTION
## Summary
- deprecate node/python/ruby/go default package file settings with 2026.11.0 warning and 2027.11.0 removal metadata
- warn when non-empty default package files are consumed during installs
- document replacements with package-manager backends for CLIs and tool-level postinstall hooks for per-runtime installs

## Context
- Recent discussion: https://github.com/jdx/mise/discussions/9951

## Validation
- mise run render:schema
- cargo fmt --check
- cargo check
- mise run docs:build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core runtime install flows to emit new deprecation warnings when legacy default package files are present, which could affect user output/automation. Otherwise it is mostly documentation and schema/setting metadata updates.
> 
> **Overview**
> Adds a *planned deprecation* for Go/Node/Python/Ruby default package files, including new docs guidance to use package-manager backends (e.g. `npm:`, `pipx:`, `gem:`, `go:`) or per-tool `postinstall` hooks instead.
> 
> Marks the related settings/schema fields as deprecated with `2026.11.0` warn and `2027.11.0` removal metadata, and updates the core plugins to detect non-empty default package files and emit a single deprecation warning when they are consumed during installs (with shared parsing/helpers in `Settings`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca479b2eddcef37109998d1ca1e38be3adebbf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->