### PR TITLE
fix(aqua): support cosign public-key bundles

### DIFF
--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -7,8 +7,10 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sigstore_verify::VerificationPolicy;
 use sigstore_verify::trust_root::{SigstoreInstance, TrustedRoot};
+use sigstore_verify::types::bundle::VerificationMaterialContent;
 use sigstore_verify::types::{
-    Artifact, Bundle, DerCertificate, DerPublicKey, Sha256Hash, SignatureBytes,
+    Artifact, Bundle, DerCertificate, DerPublicKey, HashAlgorithm, Sha256Hash, SignatureBytes,
+    SignatureContent,
 };
 use thiserror::Error;
 use tokio::io::AsyncReadExt;
@@ -424,6 +426,15 @@ pub async fn verify_cosign_signature_with_key(
         .ok()
         .and_then(|content| Bundle::from_json(content).ok());
     if let Some(bundle) = bundle {
+        if matches!(
+            &bundle.verification_material.content,
+            VerificationMaterialContent::PublicKey { .. }
+        ) {
+            let artifact = tokio::fs::read(artifact_path).await?;
+            verify_public_key_bundle(&artifact, &bundle, &public_key)?;
+            return Ok(true);
+        }
+
         // Bundle path: needs the trust root for tlog (Rekor) verification.
         let trusted_root = production_trusted_root().await?;
         let artifact = tokio::fs::read(artifact_path).await?;
@@ -446,6 +457,79 @@ pub async fn verify_cosign_signature_with_key(
     let signature = decode_cosign_signature(&raw_bytes);
     verify_raw_signature(&artifact, &signature, &public_key)?;
     Ok(true)
+}
+
+fn verify_public_key_bundle(
+    artifact: &[u8],
+    bundle: &Bundle,
+    public_key: &DerPublicKey,
+) -> Result<()> {
+    use sigstore_verify::bundle::{ValidationOptions, validate_bundle_with_options};
+    use sigstore_verify::crypto::{
+        KeyType, SigningScheme, detect_key_type, verify_signature, verify_signature_prehashed,
+    };
+
+    validate_bundle_with_options(
+        bundle,
+        &ValidationOptions {
+            require_inclusion_proof: true,
+            require_timestamp: false,
+        },
+    )
+    .map_err(|e| AttestationError::Verification(format!("bundle validation failed: {e}")))?;
+
+    let scheme = match detect_key_type(public_key) {
+        KeyType::Ed25519 => SigningScheme::Ed25519,
+        KeyType::EcdsaP256 => SigningScheme::EcdsaP256Sha256,
+        KeyType::Unknown => {
+            return Err(AttestationError::Verification(
+                "unsupported or unrecognized public key type".to_string(),
+            ));
+        }
+    };
+
+    match &bundle.content {
+        SignatureContent::MessageSignature(msg_sig) => {
+            let artifact_hash = Sha256Hash::try_from_slice(&Sha256::digest(artifact))?;
+            if let Some(digest) = &msg_sig.message_digest {
+                if digest.algorithm != HashAlgorithm::Sha2256 {
+                    return Err(AttestationError::Verification(format!(
+                        "unsupported message digest algorithm {}",
+                        digest.algorithm
+                    )));
+                }
+                if digest.digest != artifact_hash {
+                    return Err(AttestationError::Verification(
+                        "message digest in bundle does not match artifact hash".to_string(),
+                    ));
+                }
+            }
+
+            if scheme.uses_sha256() && scheme.supports_prehashed() {
+                verify_signature_prehashed(public_key, &artifact_hash, &msg_sig.signature, scheme)
+            } else {
+                verify_signature(public_key, artifact, &msg_sig.signature, scheme)
+            }
+            .map_err(|e| {
+                AttestationError::Verification(format!("signature verification failed: {e}"))
+            })?;
+        }
+        SignatureContent::DsseEnvelope(envelope) => {
+            let payload = envelope.decode_payload();
+            let pae = sigstore_verify::types::pae(&envelope.payload_type, &payload);
+            if !envelope
+                .signatures
+                .iter()
+                .any(|sig| verify_signature(public_key, &pae, &sig.sig, scheme).is_ok())
+            {
+                return Err(AttestationError::Verification(
+                    "DSSE signature verification failed: no valid signatures found".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub async fn verify_slsa_provenance(

--- a/e2e/backend/test_aqua_cosign
+++ b/e2e/backend/test_aqua_cosign
@@ -50,5 +50,23 @@ fi
 assert_contains "mise x aqua:technicalpickles/envsense@0.3.4 -- which envsense" "envsense"
 echo "✓ envsense installed and working correctly"
 
+echo "=== Testing Native Cosign Verification (public key bundle config) ==="
+echo "Installing kube-linter with native public-key bundle verification..."
+
+output=$(mise install aqua:stackrox/kube-linter@0.8.3 2>&1)
+echo "$output"
+
+if echo "$output" | grep -q "Cosign verified"; then
+  echo "✅ Native public-key bundle Cosign verification was used"
+else
+  echo "❌ ERROR: public-key bundle Cosign verification was not detected in output"
+  echo "Output was:"
+  echo "$output"
+  exit 1
+fi
+
+assert_contains "mise x aqua:stackrox/kube-linter@0.8.3 -- kube-linter version" "0.8.3"
+echo "✓ kube-linter installed and working correctly"
+
 echo ""
 echo "=== Native Cosign Verification Test Passed ✓ ==="

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1418,8 +1418,21 @@ impl AquaBackend {
             let bundle_path = download_dir.join(get_filename_from_url(&bundle_url));
             HTTP.download_file(&bundle_url, &bundle_path, pr).await?;
 
-            match crate::github::sigstore::verify_cosign_signature(target_path, &bundle_path).await
-            {
+            let opts = cosign.opts(pkg, v, os(), arch())?;
+            let result = if let Some(key_url) = cosign_opt_value(&opts, "--key") {
+                let key_path = download_dir.join(get_filename_from_url(key_url));
+                HTTP.download_file(key_url, &key_path, pr).await?;
+                crate::github::sigstore::verify_cosign_signature_with_key(
+                    target_path,
+                    &bundle_path,
+                    &key_path,
+                )
+                .await
+            } else {
+                crate::github::sigstore::verify_cosign_signature(target_path, &bundle_path).await
+            };
+
+            match result {
                 Ok(true) => {
                     debug!("cosign (bundle) verified");
                     Ok(())
@@ -2567,6 +2580,12 @@ fn toml_value_kind(value: &toml::Value) -> &'static str {
         toml::Value::Table(_) => "object",
         toml::Value::Datetime(_) => "datetime",
     }
+}
+
+fn cosign_opt_value<'a>(opts: &'a [String], flag: &str) -> Option<&'a str> {
+    opts.windows(2)
+        .find(|pair| pair[0] == flag)
+        .map(|pair| pair[1].as_str())
 }
 
 fn version_with_prefix<'a>(version: &'a str, version_prefix: Option<&str>) -> Cow<'a, str> {


### PR DESCRIPTION
## Summary
- honor aqua cosign bundle configs that provide a public key through `cosign.opts`
- verify Sigstore public-key bundles locally instead of routing them through the unsupported `sigstore-verify` public-key path
- add `aqua:stackrox/kube-linter@0.8.3` to the aqua cosign e2e coverage

## Root Cause
`stackrox/kube-linter@0.8.3` declares a Sigstore bundle plus a long-lived cosign public key. mise downloaded the bundle but treated it as keyless because the key lives in aqua `opts`, then `sigstore-verify 0.7.0` rejected `verificationMaterial.publicKey` with `public key verification not yet supported`.

## Validation
- `cargo check -p mise-sigstore`
- `cargo build`
- `./target/debug/mise install aqua:stackrox/kube-linter@0.8.3` with clean temp `MISE_*` dirs
- `./target/debug/mise run test:e2e e2e/backend/test_aqua_cosign`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signature verification paths for Aqua cosign bundles by adding a new local verification flow for `verificationMaterial.publicKey`, which could cause false accept/reject if bundle parsing or signature checks are incorrect.
> 
> **Overview**
> Adds support for Aqua cosign bundle configurations that supply a public key via `cosign.opts --key`, downloading that key and using `verify_cosign_signature_with_key` when verifying bundles.
> 
> Updates `mise-sigstore` to **locally verify Sigstore bundles whose `verificationMaterial` is a public key** (including message-signature and DSSE forms) instead of routing them through `sigstore-verify`’s unsupported public-key bundle path.
> 
> Extends the Aqua cosign E2E test to cover a real public-key bundle case (`aqua:stackrox/kube-linter@0.8.3`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9aefc44495428702216abbed578b5cb996c03d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->