### PR TITLE
fix(upgrade): improve current version detection

### DIFF
--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -140,7 +140,8 @@ EOF
 # Verify the lockfile pins to 1.0.0
 assert "mise ls dummy" "dummy  1.0.0  ~/workdir/mise.toml  1"
 # Upgrade should install 1.1.0 and update the lockfile
-mise up
+output="$(mise up 2>&1)"
+assert_contains "echo '$output'" "  dummy 1.0.0 → 1.1.0"
 assert "mise ls dummy" "dummy  1.1.0  ~/workdir/mise.toml  1"
 # Verify the lockfile was updated to 1.1.0
 assert_contains "cat mise.lock" "1.1.0"

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -6,6 +6,7 @@ use crate::env::TERM_WIDTH;
 use crate::lockfile::{Lockfile, lockfile_path_for_config};
 use crate::registry::REGISTRY;
 use crate::registry::tool_enabled;
+use crate::runtime_symlinks::is_runtime_symlink;
 use crate::{backend, parallel};
 pub use builder::{ConfigScope, ToolsetBuilder};
 use console::truncate_str;
@@ -331,7 +332,9 @@ impl Toolset {
                     warn!("Error getting outdated info for {tv}: {e:#}");
                 }
             }
-            if t.symlink_path(&tv).is_some() {
+            if let Some(symlink_path) = t.symlink_path(&tv)
+                && !is_runtime_symlink(&symlink_path)
+            {
                 trace!("skipping symlinked version {tv}");
                 // do not consider symlinked versions to be outdated
                 return Ok(outdated);

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -1,7 +1,7 @@
 use crate::semver::{chunkify_version, split_version_prefix};
 use crate::toolset;
 use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, ToolVersion};
-use crate::{Result, config::Config};
+use crate::{Result, backend::ABackend, config::Config};
 use serde::Serialize;
 use std::{
     collections::BTreeSet,
@@ -33,11 +33,7 @@ pub struct OutdatedInfo {
 impl OutdatedInfo {
     pub fn new(config: &Arc<Config>, tv: ToolVersion, latest: String) -> Result<Self> {
         let t = tv.backend()?;
-        let current = if t.is_version_installed(config, &tv, true) {
-            Some(tv.version.clone())
-        } else {
-            None
-        };
+        let current = Self::current_version(config, &t, &tv)?;
         let oi = Self {
             source: tv.request.source().clone(),
             name: tv.ba().short.to_string(),
@@ -49,6 +45,24 @@ impl OutdatedInfo {
             latest,
         };
         Ok(oi)
+    }
+
+    fn current_version(
+        config: &Arc<Config>,
+        backend: &ABackend,
+        tv: &ToolVersion,
+    ) -> Result<Option<String>> {
+        if backend.is_version_installed(config, tv, true) {
+            return Ok(Some(tv.version.clone()));
+        }
+
+        let query = match &tv.request {
+            ToolRequest::Version { version, .. } if version == "latest" => None,
+            ToolRequest::Version { version, .. } => Some(version.clone()),
+            ToolRequest::Prefix { prefix, .. } => Some(prefix.clone()),
+            _ => return Ok(None),
+        };
+        Ok(backend.latest_installed_version(query)?)
     }
 
     pub async fn resolve(
@@ -380,9 +394,13 @@ pub fn is_outdated_version(current: &str, latest: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
+    use std::sync::Arc;
     use test_log::test;
 
-    use super::{check_semver_bump, is_outdated_version, prefixed_latest_query};
+    use super::{OutdatedInfo, check_semver_bump, is_outdated_version, prefixed_latest_query};
+    use crate::cli::args::{BackendArg, BackendResolution};
+    use crate::config::Config;
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions, install_state};
 
     #[test]
     fn test_is_outdated_version() {
@@ -478,5 +496,34 @@ mod tests {
         assert_eq!(prefixed_latest_query("prefix:1.", "24"), None);
         assert_eq!(prefixed_latest_query("", "17.0.7"), None);
         assert_eq!(prefixed_latest_query("temurin-", ""), None);
+    }
+
+    #[tokio::test]
+    async fn current_version_uses_installed_version_matching_request() {
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let short = "summary-current-test";
+        let mut backend = BackendArg::new_raw(
+            short.into(),
+            Some(format!("asdf:{short}")),
+            short.into(),
+            Some(ToolVersionOptions::default()),
+            BackendResolution::new(true),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join(short);
+        let install_path = backend.installs_path.join("1.25.9");
+        std::fs::create_dir_all(&install_path).unwrap();
+        install_state::add_tool_version(&backend, &install_path, "1.25.9");
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "1.25".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "1.25.10".into());
+        let info = OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap();
+
+        assert_eq!(info.current.as_deref(), Some("1.25.9"));
     }
 }

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -52,17 +52,27 @@ impl OutdatedInfo {
         backend: &ABackend,
         tv: &ToolVersion,
     ) -> Result<Option<String>> {
+        if matches!(&tv.request, ToolRequest::Version { version, .. } if version == "latest") {
+            return Ok(None);
+        }
         if backend.is_version_installed(config, tv, true) {
             return Ok(Some(tv.version.clone()));
         }
 
         let query = match &tv.request {
-            ToolRequest::Version { version, .. } if version == "latest" => None,
             ToolRequest::Version { version, .. } => Some(version.clone()),
             ToolRequest::Prefix { prefix, .. } => Some(prefix.clone()),
             _ => return Ok(None),
         };
-        Ok(backend.latest_installed_version(query)?)
+        let Some(current) = backend.latest_installed_version(query)? else {
+            return Ok(None);
+        };
+        let current_tv = ToolVersion::new(tv.request.clone(), current);
+        if backend.is_version_installed(config, &current_tv, true) {
+            Ok(Some(current_tv.version))
+        } else {
+            Ok(None)
+        }
     }
 
     pub async fn resolve(
@@ -525,5 +535,62 @@ mod tests {
         let info = OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap();
 
         assert_eq!(info.current.as_deref(), Some("1.25.9"));
+    }
+
+    #[tokio::test]
+    async fn current_version_ignores_stale_install_state_matches() {
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let short = "summary-current-stale-test";
+        let mut backend = BackendArg::new_raw(
+            short.into(),
+            Some(format!("asdf:{short}")),
+            short.into(),
+            Some(ToolVersionOptions::default()),
+            BackendResolution::new(true),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join(short);
+        let install_path = backend.installs_path.join("1.25.9");
+        install_state::add_tool_version(&backend, &install_path, "1.25.9");
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "1.25".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "1.25.10".into());
+        let info = OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap();
+
+        assert_eq!(info.current, None);
+    }
+
+    #[tokio::test]
+    async fn current_version_does_not_infer_latest_alias() {
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let short = "summary-current-latest-test";
+        let mut backend = BackendArg::new_raw(
+            short.into(),
+            Some(format!("asdf:{short}")),
+            short.into(),
+            Some(ToolVersionOptions::default()),
+            BackendResolution::new(true),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join(short);
+        let install_path = backend.installs_path.join("1.25.9");
+        std::fs::create_dir_all(&install_path).unwrap();
+        install_state::add_tool_version(&backend, &install_path, "1.25.9");
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "latest".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "1.25.10".into());
+        let info = OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap();
+
+        assert_eq!(info.current, None);
     }
 }

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -52,11 +52,11 @@ impl OutdatedInfo {
         backend: &ABackend,
         tv: &ToolVersion,
     ) -> Result<Option<String>> {
-        if matches!(&tv.request, ToolRequest::Version { version, .. } if version == "latest") {
-            return Ok(None);
-        }
         if backend.is_version_installed(config, tv, true) {
             return Ok(Some(tv.version.clone()));
+        }
+        if matches!(&tv.request, ToolRequest::Version { version, .. } if version == "latest") {
+            return Ok(None);
         }
 
         let query = match &tv.request {
@@ -538,6 +538,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn current_version_uses_installed_version_matching_prefix_request() {
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let short = "summary-current-prefix-test";
+        let mut backend = BackendArg::new_raw(
+            short.into(),
+            Some(format!("asdf:{short}")),
+            short.into(),
+            Some(ToolVersionOptions::default()),
+            BackendResolution::new(true),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join(short);
+        let install_path = backend.installs_path.join("1.25.9");
+        std::fs::create_dir_all(&install_path).unwrap();
+        install_state::add_tool_version(&backend, &install_path, "1.25.9");
+
+        let request = ToolRequest::Prefix {
+            backend: Arc::new(backend),
+            prefix: "1.25".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "1.25.10".into());
+        let info = OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap();
+
+        assert_eq!(info.current.as_deref(), Some("1.25.9"));
+    }
+
+    #[tokio::test]
     async fn current_version_ignores_stale_install_state_matches() {
         let config = Config::get().await.unwrap();
         let temp_dir = tempfile::tempdir().unwrap();
@@ -592,5 +621,34 @@ mod tests {
         let info = OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap();
 
         assert_eq!(info.current, None);
+    }
+
+    #[tokio::test]
+    async fn current_version_reports_installed_resolved_latest() {
+        let config = Config::get().await.unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let short = "summary-current-resolved-latest-test";
+        let mut backend = BackendArg::new_raw(
+            short.into(),
+            Some(format!("asdf:{short}")),
+            short.into(),
+            Some(ToolVersionOptions::default()),
+            BackendResolution::new(true),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join(short);
+        let install_path = backend.installs_path.join("1.25.10");
+        std::fs::create_dir_all(&install_path).unwrap();
+        install_state::add_tool_version(&backend, &install_path, "1.25.10");
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "latest".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "1.25.10".into());
+        let info = OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap();
+
+        assert_eq!(info.current.as_deref(), Some("1.25.10"));
     }
 }


### PR DESCRIPTION
## Summary
- show the installed matching version in upgrade summaries when the configured request is a prefix like `go = "1.25"`
- keep literal `latest` from borrowing an installed version unless the resolved concrete version is actually installed
- allow runtime symlinks such as `latest -> ./1.0.0` through outdated resolution while still skipping user-linked symlinks
- add regression tests for `ToolRequest::Version`, `ToolRequest::Prefix`, stale install-state entries, resolved `latest`, and the lockfile-backed plain `mise up` summary path

## Root Cause
Plain `mise up` can resolve a prefix request to the target version before building the summary. For `go = "1.25"`, the summary checked whether the resolved target like `1.25.10` was already installed and reported `(none)` when only the matching previous version like `1.25.9` existed.

The fix computes the displayed current version from the original request when the resolved target is not installed, so prefix requests can show the best matching installed version. Literal `latest` remains conservative: it only reports current when the resolved concrete version is actually installed.

## Follow-ups
CI and review exposed adjacent edge cases while validating the fix: runtime symlinks need to continue through the outdated resolver, and `ToolRequest::Prefix`/resolved-`latest` needed direct tests.

## Validation
- `cargo fmt --check`
- `cargo test toolset::outdated_info`
- `cargo clippy -- -D warnings`
- `mise run test:e2e e2e/cli/test_upgrade_parallel_failure`
- `mise run test:e2e e2e/cli/test_upgrade` reached and passed the new lockfile summary assertion, then later failed on an unrelated GitHub API 401 while installing `ubi:bazelbuild/buildtools`