### PR TITLE
fix(config): preserve user tool alias identities

### DIFF
--- a/e2e/config/test_config_alias
+++ b/e2e/config/test_config_alias
@@ -3,6 +3,7 @@
 cat <<EOF >mise.toml
 tools.erlang = "1.0.0-erlang"
 tools.node = "1.0.0-node"
+tools.nodejs = "1.0.0-nodejs"
 tools.corenode = "22.0.0"
 tools.python = "1.0.0-python"
 tools.mytool = "2"
@@ -11,6 +12,7 @@ tools.mytool-lts = "lts"
 [tool_alias]
 erlang = 'asdf:https://github.com/jdx/mise-tiny'
 node = "asdf:tiny"
+nodejs = "asdf:tiny"
 corenode = "core:node"
 python = 'asdf:jdx/mise-tiny'
 mytool = "asdf:tiny"
@@ -19,8 +21,11 @@ backend = "asdf:tiny"
 versions = {lts = "1.0.1"}
 EOF
 
+assert_contains "mise ls --json" '/installs/node/1.0.0-node"'
+assert_contains "mise ls --json" '/installs/nodejs/1.0.0-nodejs"'
 assert_contains "mise x erlang -- mise-tiny" "mise-tiny: v1.0.0-erlang"
 assert_contains "mise x node -- rtx-tiny" "rtx-tiny: v1.0.0-node"
+assert_contains "mise x nodejs -- rtx-tiny" "rtx-tiny: v1.0.0-nodejs"
 assert_contains "mise x corenode -- node -v" "v22.0.0"
 assert_contains "mise x python -- mise-tiny" "mise-tiny: v1.0.0-python"
 assert_contains "mise x mytool -- rtx-tiny" "rtx-tiny: v2.1.0"

--- a/e2e/config/test_config_alias
+++ b/e2e/config/test_config_alias
@@ -32,3 +32,15 @@ assert_contains "mise x mytool -- rtx-tiny" "rtx-tiny: v2.1.0"
 assert_contains "mise x mytool-lts -- rtx-tiny" "rtx-tiny: v1.0.1"
 
 assert_contains "mise x rg@14.0.0 -- rg --version" "ripgrep 14.0.0"
+
+mkdir -p ~/.config/mise
+cat <<EOF >~/.config/mise/config.toml
+[tool_alias]
+nodejs = "asdf:tiny"
+EOF
+cat <<EOF >mise.toml
+tools.nodejs = "1.0.0-nodejs"
+EOF
+
+assert_contains "mise ls --json" '/installs/nodejs/1.0.0-nodejs"'
+assert_contains "mise x nodejs -- rtx-tiny" "rtx-tiny: v1.0.0-nodejs"

--- a/registry/go.toml
+++ b/registry/go.toml
@@ -1,3 +1,4 @@
+aliases = ["golang"]
 backends = ["core:go"]
 description = "go lang (Builtin plugin)"
 detect = ["go.mod", "go.sum"]

--- a/registry/node.toml
+++ b/registry/node.toml
@@ -1,3 +1,4 @@
+aliases = ["nodejs"]
 backends = ["core:node"]
 description = "Node.js® is a free, open-source, cross-platform JavaScript runtime environment that lets developers create servers, web apps, command line tools and scripts (Builtin plugin)"
 detect = ["package.json", ".nvmrc", ".node-version"]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2978,7 +2978,7 @@ pub fn unalias_backend(backend: &str) -> &str {
         "dotnet-core" => "dotnet",
         "nodejs" => "node",
         "golang" => "go",
-        _ => REGISTRY.get(backend).map(|rt| rt.short).unwrap_or(backend),
+        _ => backend,
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -315,15 +315,15 @@ pub fn remove(short: &str) {
 pub fn arg_to_backend(ba: BackendArg) -> Option<ABackend> {
     match ba.backend_type() {
         BackendType::Core => {
-            CORE_PLUGINS
-                .get(&ba.short)
-                .or_else(|| {
-                    // this can happen if something like "corenode" is aliased to "core:node"
-                    ba.full()
-                        .strip_prefix("core:")
-                        .and_then(|short| CORE_PLUGINS.get(short))
-                })
-                .cloned()
+            let canonical = if CORE_PLUGINS.contains_key(&ba.short) {
+                ba.short.clone()
+            } else {
+                // this can happen for explicit core syntax like "core:node" or
+                // if something like "corenode" is aliased to "core:node"
+                let full = ba.full_without_opts();
+                full.strip_prefix("core:")?.to_string()
+            };
+            crate::plugins::core::backend_from_arg(&canonical, ba)
         }
         BackendType::Aqua => Some(Arc::new(aqua::AquaBackend::from_arg(ba))),
         BackendType::Asdf => Some(Arc::new(asdf::AsdfBackend::from_arg(ba))),
@@ -2973,11 +2973,12 @@ pub(crate) fn fuzzy_match_versions(
 }
 
 pub fn unalias_backend(backend: &str) -> &str {
+    let backend = backend.trim_start_matches("core:");
     match backend {
         "dotnet-core" => "dotnet",
         "nodejs" => "node",
         "golang" => "go",
-        _ => backend.trim_start_matches("core:"),
+        _ => REGISTRY.get(backend).map(|rt| rt.short).unwrap_or(backend),
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -318,8 +318,8 @@ pub fn arg_to_backend(ba: BackendArg) -> Option<ABackend> {
             let canonical = if CORE_PLUGINS.contains_key(&ba.short) {
                 ba.short.clone()
             } else {
-                // this can happen for explicit core syntax like "core:node" or
-                // if something like "corenode" is aliased to "core:node"
+                // this can happen if something like "corenode" is aliased to
+                // "core:node" while keeping "corenode" as the install identity
                 let full = ba.full_without_opts();
                 full.strip_prefix("core:")?.to_string()
             };

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -1,5 +1,5 @@
+use crate::backend::ABackend;
 use crate::backend::backend_type::BackendType;
-use crate::backend::{ABackend, unalias_backend};
 use crate::config::Config;
 use crate::plugins::PluginType;
 use crate::registry::REGISTRY;
@@ -58,14 +58,8 @@ pub struct BackendArg {
 
 impl<A: AsRef<str>> From<A> for BackendArg {
     fn from(s: A) -> Self {
-        let short = unalias_backend(s.as_ref()).to_string();
-        // Check if this is a full backend identifier (e.g., "aqua:oven-sh/bun")
-        // If so, treat it as explicit since the user specified the backend
-        let explicit = if let Some((prefix, _)) = short.split_once(':') {
-            BackendType::guess(prefix) != BackendType::Unknown
-        } else {
-            false
-        };
+        let short = resolve_constructor_short(s.as_ref(), None, false);
+        let explicit = is_explicit_backend_syntax(s.as_ref());
         let (short_parsed, tool_name, opts) = parse_backend_components(&short, None);
         Self::new_raw(
             short_parsed,
@@ -148,11 +142,10 @@ fn parse_backend_components(
     short: &str,
     full: Option<&String>,
 ) -> (String, String, Option<ToolVersionOptions>) {
-    let short = unalias_backend(short).to_string();
-    let source = full.unwrap_or(&short);
+    let source = full.map(String::as_str).unwrap_or(short);
     let (source, opts) = match split_bracketed_opts(source) {
         Some((name, opts_str)) => (name, Some(parse_tool_options(opts_str))),
-        None => (source.as_str(), None),
+        None => (source, None),
     };
     let (_backend, tool_name) = source.split_once(':').unwrap_or(("", source));
     let short = strip_opts(&short);
@@ -164,14 +157,13 @@ fn parse_backend_components_fallible(
     short: &str,
     full: Option<&String>,
 ) -> Result<(String, String, Option<ToolVersionOptions>)> {
-    let short = unalias_backend(short).to_string();
-    let source = full.unwrap_or(&short);
+    let source = full.map(String::as_str).unwrap_or(short);
     let (source, opts) = match split_bracketed_opts(source) {
         Some((name, opts_str)) => (
             name,
             Some(try_parse_tool_options(opts_str).map_err(|err| eyre::eyre!(err))?),
         ),
-        None => (source.as_str(), None),
+        None => (source, None),
     };
     let (_backend, tool_name) = source.split_once(':').unwrap_or(("", source));
     let short = strip_opts(&short);
@@ -179,10 +171,77 @@ fn parse_backend_components_fallible(
     Ok((short, tool_name.to_string(), opts))
 }
 
+fn is_explicit_backend_syntax(short: &str) -> bool {
+    let short = strip_opts(short);
+    short
+        .split_once(':')
+        .is_some_and(|(prefix, _)| BackendType::guess(prefix) != BackendType::Unknown)
+}
+
+fn user_alias_exists(short: &str) -> bool {
+    if !config::is_loaded() {
+        return false;
+    }
+
+    let short = strip_opts(short);
+    let config = Config::get_();
+    config.all_aliases.contains_key(&short) || config.repo_urls.contains_key(&short)
+}
+
+fn registry_canonical_short(short: &str) -> Option<&'static str> {
+    let short = strip_opts(short);
+    if short.contains(':') {
+        return None;
+    }
+
+    match short.as_str() {
+        "dotnet-core" => Some("dotnet"),
+        "nodejs" => Some("node"),
+        "golang" => Some("go"),
+        _ => REGISTRY
+            .get(&short)
+            .map(|rt| rt.short)
+            .filter(|canonical| *canonical != short),
+    }
+}
+
+fn canonicalize_registry_alias(short: &str) -> String {
+    let (name, opts) = split_bracketed_opts(short)
+        .map(|(name, opts)| (name, Some(opts)))
+        .unwrap_or((short, None));
+    let canonical = registry_canonical_short(name).unwrap_or(name);
+    match opts {
+        Some(opts) => format!("{canonical}[{opts}]"),
+        None => canonical.to_string(),
+    }
+}
+
+fn resolve_constructor_short(short: &str, full: Option<&String>, preserve_short: bool) -> String {
+    if preserve_short
+        || full.is_some()
+        || is_explicit_backend_syntax(short)
+        || user_alias_exists(short)
+    {
+        short.to_string()
+    } else {
+        canonicalize_registry_alias(short)
+    }
+}
+
 impl BackendArg {
     #[requires(!short.is_empty())]
     pub fn new(short: String, full: Option<String>) -> Self {
-        let resolution = BackendResolution::new(full.is_some());
+        let explicit = full.is_some() || is_explicit_backend_syntax(&short);
+        let short = resolve_constructor_short(&short, full.as_ref(), false);
+        let resolution = BackendResolution::new(explicit);
+        let (short, tool_name, opts) = parse_backend_components(&short, full.as_ref());
+        Self::new_raw(short, full, tool_name, opts, resolution)
+    }
+
+    pub(crate) fn new_preserve_short(short: String, full: Option<String>) -> Self {
+        let explicit = full.is_some() || is_explicit_backend_syntax(&short);
+        let short = resolve_constructor_short(&short, full.as_ref(), true);
+        let resolution = BackendResolution::new(explicit);
         let (short, tool_name, opts) = parse_backend_components(&short, full.as_ref());
         Self::new_raw(short, full, tool_name, opts, resolution)
     }
@@ -346,7 +405,7 @@ impl BackendArg {
     }
 
     pub fn full(&self) -> String {
-        let short = unalias_backend(&self.short);
+        let short = self.short.as_str();
 
         // Check for environment variable override first
         // e.g., MISE_BACKENDS_MYTOOLS='github:myorg/mytools'
@@ -516,8 +575,7 @@ impl BackendArg {
     }
 
     fn env_backend_override(&self) -> Option<String> {
-        let short = unalias_backend(&self.short);
-        let env_key = format!("MISE_BACKENDS_{}", short.to_shouty_snake_case());
+        let env_key = format!("MISE_BACKENDS_{}", self.short.to_shouty_snake_case());
         env::var(&env_key).ok()
     }
 
@@ -525,10 +583,9 @@ impl BackendArg {
         if !config::is_loaded() || self.has_env_backend_override() {
             return None;
         }
-        let short = unalias_backend(&self.short);
         Config::get_()
             .all_aliases
-            .get(short)
+            .get(&self.short)
             .and_then(|alias| alias.backend.as_deref())
             .and_then(|backend| split_bracketed_opts(backend).map(|(_, opts)| opts))
             .map(parse_tool_options)
@@ -567,7 +624,7 @@ impl BackendArg {
         let full = if let Some(full) = &self.full {
             full.clone()
         } else {
-            let short = unalias_backend(&self.short);
+            let short = self.short.as_str();
             if let Some(full) = install_state::get_tool_full(short) {
                 full
             } else if let Some(pt) = install_state::get_plugin_type(short) {
@@ -623,18 +680,41 @@ impl BackendArg {
     pub fn uses_plugin(&self) -> bool {
         install_state::get_plugin_type(&self.short).is_some()
     }
+
+    pub(crate) fn registry_alias_canonicalized(&self) -> Self {
+        if is_explicit_backend_syntax(&self.short) {
+            return self.clone();
+        }
+
+        let canonical = canonicalize_registry_alias(&self.short);
+        if canonical == self.short {
+            return self.clone();
+        }
+
+        let mut ba = self.clone();
+        ba.short = canonical;
+        if ba.full.is_none() {
+            ba.tool_name = ba
+                .short
+                .split_once(':')
+                .map(|(_, tool_name)| tool_name)
+                .unwrap_or(&ba.short)
+                .to_string();
+        }
+        let pathname = ba.short.to_kebab_case();
+        ba.cache_path = dirs::CACHE.join(&pathname);
+        ba.installs_path = dirs::INSTALLS.join(&pathname);
+        ba.downloads_path = dirs::DOWNLOADS.join(&pathname);
+        ba
+    }
 }
 
 impl FromStr for BackendArg {
     type Err = eyre::Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let short = unalias_backend(s).to_string();
-        let explicit = if let Some((prefix, _)) = short.split_once(':') {
-            BackendType::guess(prefix) != BackendType::Unknown
-        } else {
-            false
-        };
+        let short = resolve_constructor_short(s, None, false);
+        let explicit = is_explicit_backend_syntax(s);
         let (short_parsed, tool_name, opts) = parse_backend_components_fallible(&short, None)?;
         Ok(Self::new_raw(
             short_parsed,
@@ -716,7 +796,10 @@ mod tests {
             asdf("clojure", "asdf:mise-plugins/mise-clojure", "clojure");
         }
         cargo("cargo:eza", "cargo:eza", "eza");
+        t("nodejs", "core:node", "node", BackendType::Core);
+        t("golang", "core:go", "go", BackendType::Core);
         t("dotnet-core", "core:dotnet", "dotnet", BackendType::Core);
+        t("core:node", "core:node", "node", BackendType::Core);
         // core("node", "node", "node");
         npm("npm:@antfu/ni", "npm:@antfu/ni", "@antfu/ni");
         npm("npm:prettier", "npm:prettier", "prettier");
@@ -768,7 +851,10 @@ mod tests {
         };
         t("asdf:node", "asdf-node");
         t("node", "node");
+        t("nodejs", "node");
+        t("golang", "go");
         t("dotnet-core", "dotnet");
+        t("core:node", "core-node");
         t("cargo:eza", "cargo-eza");
         t("npm:@antfu/ni", "npm-antfu-ni");
         t("npm:prettier", "npm-prettier");
@@ -1029,5 +1115,40 @@ mod tests {
         assert_eq!(ba.registry_opts().get("bin"), Some("solc"));
         assert_eq!(opts.get("bin"), Some("solc"));
         assert_eq!(opts.get("foo"), Some("resolved"));
+    }
+
+    #[tokio::test]
+    async fn test_explicit_backend_alias_preserves_short() {
+        let _config = Config::get().await.unwrap();
+
+        let ba = BackendArg::new("nodejs".to_string(), Some("asdf:tiny".to_string()));
+
+        assert_eq!(ba.short, "nodejs");
+        assert_str_eq!("asdf:tiny", ba.full());
+        assert_eq!(BackendType::Asdf, ba.backend_type());
+        assert_str_eq!(
+            ba.installs_path.to_string_lossy(),
+            dirs::INSTALLS.join("nodejs").to_string_lossy()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_explicit_core_backend_preserves_identity() {
+        let _config = Config::get().await.unwrap();
+
+        let ba: BackendArg = "core:node".into();
+
+        assert_eq!(ba.short, "core:node");
+        assert_str_eq!("core:node", ba.full());
+        assert_eq!("node", ba.tool_name);
+        assert_eq!(BackendType::Core, ba.backend_type());
+        assert_str_eq!(
+            ba.installs_path.to_string_lossy(),
+            dirs::INSTALLS.join("core-node").to_string_lossy()
+        );
+
+        let backend = ba.backend().unwrap();
+        assert_eq!(backend.ba().short, "core:node");
+        assert_str_eq!("core:node", backend.ba().full());
     }
 }

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -198,10 +198,7 @@ fn registry_canonical_short(short: &str) -> Option<&'static str> {
         "dotnet-core" => Some("dotnet"),
         "nodejs" => Some("node"),
         "golang" => Some("go"),
-        _ => REGISTRY
-            .get(&short)
-            .map(|rt| rt.short)
-            .filter(|canonical| *canonical != short),
+        _ => None,
     }
 }
 
@@ -1129,6 +1126,20 @@ mod tests {
         assert_str_eq!(
             ba.installs_path.to_string_lossy(),
             dirs::INSTALLS.join("nodejs").to_string_lossy()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_registry_lookup_alias_preserves_identity() {
+        let _config = Config::get().await.unwrap();
+
+        let ba: BackendArg = "gh".into();
+
+        assert_eq!(ba.short, "gh");
+        assert_str_eq!("aqua:cli/cli", ba.full());
+        assert_str_eq!(
+            ba.installs_path.to_string_lossy(),
+            dirs::INSTALLS.join("gh").to_string_lossy()
         );
     }
 

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -188,32 +188,39 @@ fn user_alias_exists(short: &str) -> bool {
     config.all_aliases.contains_key(&short) || config.repo_urls.contains_key(&short)
 }
 
-fn registry_canonical_short(short: &str) -> Option<&'static str> {
-    let short = strip_opts(short);
-    if short.contains(':') {
-        return None;
-    }
-
-    match short.as_str() {
-        "dotnet-core" => Some("dotnet"),
-        "nodejs" => Some("node"),
-        "golang" => Some("go"),
-        _ => None,
-    }
-}
-
 fn canonicalize_registry_alias(short: &str) -> String {
     let (name, opts) = split_bracketed_opts(short)
         .map(|(name, opts)| (name, Some(opts)))
         .unwrap_or((short, None));
-    let canonical = registry_canonical_short(name).unwrap_or(name);
+    let canonical = if name.contains(':') {
+        name
+    } else {
+        backend::unalias_backend(name)
+    };
     match opts {
         Some(opts) => format!("{canonical}[{opts}]"),
         None => canonical.to_string(),
     }
 }
 
+fn core_backend_short(short: &str) -> Option<String> {
+    let (name, opts) = split_bracketed_opts(short)
+        .map(|(name, opts)| (name, Some(opts)))
+        .unwrap_or((short, None));
+    let core_short = name.strip_prefix("core:")?;
+    Some(match opts {
+        Some(opts) => format!("{core_short}[{opts}]"),
+        None => core_short.to_string(),
+    })
+}
+
 fn resolve_constructor_short(short: &str, full: Option<&String>, preserve_short: bool) -> String {
+    if full.is_none()
+        && let Some(core_short) = core_backend_short(short)
+    {
+        return core_short;
+    }
+
     if preserve_short
         || full.is_some()
         || is_explicit_backend_syntax(short)
@@ -580,9 +587,25 @@ impl BackendArg {
         self.env_backend_override().is_some()
     }
 
+    fn env_backend_override_keys(&self) -> Vec<String> {
+        let mut keys = vec![format!(
+            "MISE_BACKENDS_{}",
+            self.short.to_shouty_snake_case()
+        )];
+        let canonical_short = backend::unalias_backend(&self.short);
+        if canonical_short != self.short {
+            keys.push(format!(
+                "MISE_BACKENDS_{}",
+                canonical_short.to_shouty_snake_case()
+            ));
+        }
+        keys
+    }
+
     fn env_backend_override(&self) -> Option<String> {
-        let env_key = format!("MISE_BACKENDS_{}", self.short.to_shouty_snake_case());
-        env::var(&env_key).ok()
+        self.env_backend_override_keys()
+            .into_iter()
+            .find_map(|key| env::var(key).ok())
     }
 
     fn backend_alias_opts_from_loaded_config(&self) -> Option<ToolVersionOptions> {
@@ -857,7 +880,7 @@ mod tests {
         t("nodejs", "node");
         t("golang", "go");
         t("dotnet-core", "dotnet");
-        t("core:node", "core-node");
+        t("core:node", "node");
         t("cargo:eza", "cargo-eza");
         t("npm:@antfu/ni", "npm-antfu-ni");
         t("npm:prettier", "npm-prettier");
@@ -1150,22 +1173,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_explicit_core_backend_preserves_identity() {
+    async fn test_explicit_core_backend_uses_canonical_identity() {
         let _config = Config::get().await.unwrap();
 
         let ba: BackendArg = "core:node".into();
 
-        assert_eq!(ba.short, "core:node");
+        assert_eq!(ba.short, "node");
         assert_str_eq!("core:node", ba.full());
         assert_eq!("node", ba.tool_name);
         assert_eq!(BackendType::Core, ba.backend_type());
         assert_str_eq!(
             ba.installs_path.to_string_lossy(),
-            dirs::INSTALLS.join("core-node").to_string_lossy()
+            dirs::INSTALLS.join("node").to_string_lossy()
         );
 
         let backend = ba.backend().unwrap();
-        assert_eq!(backend.ba().short, "core:node");
+        assert_eq!(backend.ba().short, "node");
         assert_str_eq!("core:node", backend.ba().full());
+    }
+
+    #[tokio::test]
+    async fn test_core_backend_opts_use_canonical_identity() {
+        let _config = Config::get().await.unwrap();
+
+        let ba: BackendArg = "core:node[foo=bar]".into();
+
+        assert_eq!(ba.short, "node");
+        assert_str_eq!("core:node[foo=bar]", ba.full_with_opts());
+        assert_eq!(ba.opts().get("foo"), Some("bar"));
+        assert_str_eq!(
+            ba.installs_path.to_string_lossy(),
+            dirs::INSTALLS.join("node").to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn test_preserved_registry_alias_checks_alias_and_canonical_env_backend_override_keys() {
+        let ba = BackendArg::new_preserve_short("nodejs".to_string(), None);
+
+        assert_eq!(ba.short, "nodejs");
+        assert_eq!(
+            ba.env_backend_override_keys(),
+            vec!["MISE_BACKENDS_NODEJS", "MISE_BACKENDS_NODE"]
+        );
+        assert_str_eq!(
+            ba.installs_path.to_string_lossy(),
+            dirs::INSTALLS.join("nodejs").to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn test_canonical_registry_alias_checks_only_canonical_env_backend_override_key() {
+        let ba: BackendArg = "nodejs".into();
+
+        assert_eq!(ba.short, "node");
+        assert_eq!(ba.env_backend_override_keys(), vec!["MISE_BACKENDS_NODE"]);
     }
 }

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -225,6 +225,15 @@ fn resolve_constructor_short(short: &str, full: Option<&String>, preserve_short:
     }
 }
 
+fn paths_for_short(short: &str) -> (PathBuf, PathBuf, PathBuf) {
+    let pathname = short.to_kebab_case();
+    (
+        dirs::CACHE.join(&pathname),
+        dirs::INSTALLS.join(&pathname),
+        dirs::DOWNLOADS.join(&pathname),
+    )
+}
+
 impl BackendArg {
     #[requires(!short.is_empty())]
     pub fn new(short: String, full: Option<String>) -> Self {
@@ -250,14 +259,14 @@ impl BackendArg {
         opts: Option<ToolVersionOptions>,
         resolution: BackendResolution,
     ) -> Self {
-        let pathname = short.to_kebab_case();
+        let (cache_path, installs_path, downloads_path) = paths_for_short(&short);
         Self {
             tool_name,
             short,
             full,
-            cache_path: dirs::CACHE.join(&pathname),
-            installs_path: dirs::INSTALLS.join(&pathname),
-            downloads_path: dirs::DOWNLOADS.join(&pathname),
+            cache_path,
+            installs_path,
+            downloads_path,
             opts,
             resolution,
             // backend: Default::default(),
@@ -698,10 +707,7 @@ impl BackendArg {
                 .unwrap_or(&ba.short)
                 .to_string();
         }
-        let pathname = ba.short.to_kebab_case();
-        ba.cache_path = dirs::CACHE.join(&pathname);
-        ba.installs_path = dirs::INSTALLS.join(&pathname);
-        ba.downloads_path = dirs::DOWNLOADS.join(&pathname);
+        (ba.cache_path, ba.installs_path, ba.downloads_path) = paths_for_short(&ba.short);
         ba
     }
 }

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -148,7 +148,7 @@ fn parse_backend_components(
         None => (source, None),
     };
     let (_backend, tool_name) = source.split_once(':').unwrap_or(("", source));
-    let short = strip_opts(&short);
+    let short = strip_opts(short);
 
     (short, tool_name.to_string(), opts)
 }
@@ -166,7 +166,7 @@ fn parse_backend_components_fallible(
         None => (source, None),
     };
     let (_backend, tool_name) = source.split_once(':').unwrap_or(("", source));
-    let short = strip_opts(&short);
+    let short = strip_opts(short);
 
     Ok((short, tool_name.to_string(), opts))
 }

--- a/src/cli/args/tool_arg.rs
+++ b/src/cli/args/tool_arg.rs
@@ -11,6 +11,7 @@ use xx::regex;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ToolArg {
+    pub input: String,
     pub short: String,
     pub ba: Arc<BackendArg>,
     pub version: Option<String>,
@@ -44,6 +45,7 @@ impl FromStr for ToolArg {
             .map(|v| ToolRequest::new(ba.clone(), v, ToolSource::Argument))
             .transpose()?;
         Ok(Self {
+            input: backend_input.to_string(),
             short: ba.short.clone(),
             tvr,
             version: version.map(|v| v.to_string()),
@@ -89,6 +91,32 @@ impl Display for ToolVersionType {
 }
 
 impl ToolArg {
+    pub fn resolve_user_alias(&self) -> eyre::Result<Self> {
+        if crate::config::is_loaded() {
+            let config = crate::config::Config::get_();
+            if self.input != self.ba.short
+                && (config.all_aliases.contains_key(&self.input)
+                    || config.repo_urls.contains_key(&self.input))
+            {
+                let ba = Arc::new(BackendArg::new_preserve_short(self.input.clone(), None));
+                let tvr = self
+                    .version
+                    .as_ref()
+                    .map(|v| ToolRequest::new(ba.clone(), v, ToolSource::Argument))
+                    .transpose()?;
+                return Ok(Self {
+                    input: self.input.clone(),
+                    short: ba.short.clone(),
+                    ba,
+                    version: self.version.clone(),
+                    version_type: self.version_type.clone(),
+                    tvr,
+                });
+            }
+        }
+        Ok(self.clone())
+    }
+
     /// this handles the case where the user typed in:
     /// mise local node 20.0.0
     /// instead of
@@ -104,6 +132,7 @@ impl ToolArg {
             let b = tools[1].clone();
             if a.tvr.is_none() && b.tvr.is_none() && re.is_match(&b.ba.tool_name) {
                 tools[1].short = a.short.clone();
+                tools[1].input = a.input.clone();
                 tools[1].tvr = Some(ToolRequest::new(
                     a.ba.clone(),
                     &b.ba.tool_name,
@@ -210,6 +239,7 @@ mod tests {
         assert_eq!(
             tool,
             ToolArg {
+                input: "node".into(),
                 short: "node".into(),
                 ba: Arc::new("node".into()),
                 version: None,
@@ -226,6 +256,7 @@ mod tests {
         assert_eq!(
             tool,
             ToolArg {
+                input: "node".into(),
                 short: "node".into(),
                 ba: Arc::new("node".into()),
                 version: Some("20".into()),
@@ -244,6 +275,7 @@ mod tests {
         assert_eq!(
             tool,
             ToolArg {
+                input: "nodejs".into(),
                 short: "node".into(),
                 ba: Arc::new("node".into()),
                 version: Some("lts".into()),

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -9,7 +9,7 @@ use std::fmt::{Debug, Formatter};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     sync::{Mutex, MutexGuard},
 };
 use tera::Context as TeraContext;
@@ -295,28 +295,24 @@ impl MiseToml {
             task.config_source.clone_from(&rf.path);
             task.config_root = project_root.clone();
         }
-        rf.normalize_tool_registry_aliases();
         // trace!("{}", rf.dump()?);
         Ok(rf)
     }
 
-    fn normalize_tool_registry_aliases(&mut self) {
-        let user_aliases: HashSet<&str> = self
-            .alias
-            .keys()
-            .chain(self.tool_alias.keys())
-            .map(|s| s.as_str())
-            .collect::<HashSet<_>>();
-        let mut tools = self.tools.lock().unwrap();
-        let mut normalized = IndexMap::with_capacity(tools.len());
-        for (ba, tvp) in std::mem::take(&mut *tools) {
-            if user_aliases.contains(ba.short.as_str()) || ba.has_explicit_backend() {
-                normalized.insert(ba, tvp);
-            } else {
-                normalized.insert(ba.registry_alias_canonicalized(), tvp);
-            }
+    fn has_user_alias_for_tool(&self, short: &str) -> bool {
+        self.alias.contains_key(short)
+            || self.tool_alias.contains_key(short)
+            || Config::maybe_get().is_some_and(|config| {
+                config.all_aliases.contains_key(short) || config.repo_urls.contains_key(short)
+            })
+    }
+
+    fn tool_backend_arg(&self, ba: &BackendArg) -> BackendArg {
+        if ba.has_explicit_backend() || self.has_user_alias_for_tool(&ba.short) {
+            ba.clone()
+        } else {
+            ba.registry_alias_canonicalized()
         }
-        *tools = normalized;
     }
 
     fn doc(&self) -> eyre::Result<DocumentMut> {
@@ -822,6 +818,7 @@ impl ConfigFile for MiseToml {
             }
         }
         for (ba, tvp) in tools.iter() {
+            let ba = self.tool_backend_arg(ba);
             for tool in &tvp.0 {
                 let version = self.parse_template_with_context(&context, &tool.tt.to_string())?;
                 let tvr = if let Some(mut options) = tool.options.clone() {
@@ -2265,13 +2262,10 @@ mod tests {
         "#});
 
         let tools = cf.tools.lock().unwrap();
-        let keys = tools.keys().map(|ba| ba.short.as_str()).collect::<Vec<_>>();
+        let ba = cf.tool_backend_arg(tools.keys().next().unwrap());
 
-        assert_eq!(keys, vec!["node"]);
-        assert_eq!(
-            tools.keys().next().unwrap().installs_path,
-            dirs::INSTALLS.join("node")
-        );
+        assert_eq!(ba.short, "node");
+        assert_eq!(ba.installs_path, dirs::INSTALLS.join("node"));
     }
 
     #[test]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -9,7 +9,7 @@ use std::fmt::{Debug, Formatter};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::{Mutex, MutexGuard},
 };
 use tera::Context as TeraContext;
@@ -295,8 +295,28 @@ impl MiseToml {
             task.config_source.clone_from(&rf.path);
             task.config_root = project_root.clone();
         }
+        rf.normalize_tool_registry_aliases();
         // trace!("{}", rf.dump()?);
         Ok(rf)
+    }
+
+    fn normalize_tool_registry_aliases(&mut self) {
+        let user_aliases = self
+            .alias
+            .keys()
+            .chain(self.tool_alias.keys())
+            .cloned()
+            .collect::<HashSet<_>>();
+        let mut tools = self.tools.lock().unwrap();
+        let mut normalized = IndexMap::with_capacity(tools.len());
+        for (ba, tvp) in std::mem::take(&mut *tools) {
+            if user_aliases.contains(&ba.short) || ba.has_explicit_backend() {
+                normalized.insert(ba, tvp);
+            } else {
+                normalized.insert(ba.registry_alias_canonicalized(), tvp);
+            }
+        }
+        *tools = normalized;
     }
 
     fn doc(&self) -> eyre::Result<DocumentMut> {
@@ -1841,7 +1861,7 @@ impl<'de> de::Deserialize<'de> for BackendArg {
             where
                 E: de::Error,
             {
-                Ok(v.into())
+                Ok(BackendArg::new_preserve_short(v.to_string(), None))
             }
         }
 
@@ -2211,6 +2231,47 @@ mod tests {
         let cf: Box<dyn ConfigFile> = Box::new(cf);
         assert_snapshot!(cf);
         file::remove_file(&p).unwrap();
+    }
+
+    #[test]
+    fn test_tool_alias_preserves_registry_alias_identity() {
+        let cf = parse(formatdoc! {r#"
+            tools.node = "1.0.0-node"
+            tools.nodejs = "1.0.0-nodejs"
+
+            [tool_alias]
+            node = "asdf:tiny"
+            nodejs = "asdf:tiny"
+        "#});
+
+        let tools = cf.tools.lock().unwrap();
+        let keys = tools.keys().map(|ba| ba.short.as_str()).collect::<Vec<_>>();
+
+        assert_eq!(keys, vec!["node", "nodejs"]);
+        assert_eq!(
+            tools
+                .keys()
+                .find(|ba| ba.short == "nodejs")
+                .unwrap()
+                .installs_path,
+            dirs::INSTALLS.join("nodejs")
+        );
+    }
+
+    #[test]
+    fn test_bare_registry_alias_tool_key_canonicalizes() {
+        let cf = parse(formatdoc! {r#"
+            tools.nodejs = "22.0.0"
+        "#});
+
+        let tools = cf.tools.lock().unwrap();
+        let keys = tools.keys().map(|ba| ba.short.as_str()).collect::<Vec<_>>();
+
+        assert_eq!(keys, vec!["node"]);
+        assert_eq!(
+            tools.keys().next().unwrap().installs_path,
+            dirs::INSTALLS.join("node")
+        );
     }
 
     #[test]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2275,6 +2275,22 @@ mod tests {
     }
 
     #[test]
+    fn test_registry_lookup_alias_tool_key_preserves_identity() {
+        let cf = parse(formatdoc! {r#"
+            tools.gh = "2.92.0"
+        "#});
+
+        let tools = cf.tools.lock().unwrap();
+        let keys = tools.keys().map(|ba| ba.short.as_str()).collect::<Vec<_>>();
+
+        assert_eq!(keys, vec!["gh"]);
+        assert_eq!(
+            tools.keys().next().unwrap().installs_path,
+            dirs::INSTALLS.join("gh")
+        );
+    }
+
+    #[test]
     fn test_tasks_confirm_parses() {
         let body = r#"
 [tasks.deploy]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -301,16 +301,16 @@ impl MiseToml {
     }
 
     fn normalize_tool_registry_aliases(&mut self) {
-        let user_aliases = self
+        let user_aliases: HashSet<&str> = self
             .alias
             .keys()
             .chain(self.tool_alias.keys())
-            .cloned()
+            .map(|s| s.as_str())
             .collect::<HashSet<_>>();
         let mut tools = self.tools.lock().unwrap();
         let mut normalized = IndexMap::with_capacity(tools.len());
         for (ba, tvp) in std::mem::take(&mut *tools) {
-            if user_aliases.contains(&ba.short) || ba.has_explicit_backend() {
+            if user_aliases.contains(ba.short.as_str()) || ba.has_explicit_backend() {
                 normalized.insert(ba, tvp);
             } else {
                 normalized.insert(ba.registry_alias_canonicalized(), tvp);

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2269,6 +2269,19 @@ mod tests {
     }
 
     #[test]
+    fn test_explicit_core_tool_key_uses_canonical_identity() {
+        let cf = parse(formatdoc! {r#"
+            tools."core:node" = "22.0.0"
+        "#});
+
+        let tools = cf.tools.lock().unwrap();
+        let ba = tools.keys().next().unwrap();
+
+        assert_eq!(ba.short, "node");
+        assert_eq!(ba.installs_path, dirs::INSTALLS.join("node"));
+    }
+
+    #[test]
     fn test_registry_lookup_alias_tool_key_preserves_identity() {
         let cf = parse(formatdoc! {r#"
             tools.gh = "2.92.0"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -376,9 +376,8 @@ impl Config {
         if backend_arg.has_env_backend_override() {
             return None;
         }
-        let short = backend::unalias_backend(&backend_arg.short);
         self.all_aliases
-            .get(short)
+            .get(&backend_arg.short)
             .and_then(|alias| alias.backend.as_deref())
             .and_then(|backend| split_bracketed_opts(backend).map(|(_, opts)| opts))
             .map(crate::toolset::parse_tool_options)

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -32,9 +32,11 @@ pub struct BunPlugin {
 
 impl BunPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: Arc::new(plugins::core::new_backend_arg("bun")),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("bun"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
     }
 
     fn bun_bin(&self, tv: &ToolVersion) -> PathBuf {

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -31,9 +31,11 @@ pub struct DenoPlugin {
 
 impl DenoPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: Arc::new(plugins::core::new_backend_arg("deno")),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("deno"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
     }
 
     fn deno_bin(&self, tv: &ToolVersion) -> PathBuf {

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -26,9 +26,11 @@ pub struct DotnetPlugin {
 
 impl DotnetPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: plugins::core::new_backend_arg("dotnet").into(),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("dotnet"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: ba.into() }
     }
 
     fn is_isolated() -> bool {

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -26,9 +26,11 @@ pub struct ElixirPlugin {
 
 impl ElixirPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: Arc::new(plugins::core::new_backend_arg("elixir")),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("elixir"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
     }
 
     fn elixir_bin(&self, tv: &ToolVersion) -> PathBuf {

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -32,9 +32,11 @@ const KERL_VERSION: &str = "4.4.0";
 
 impl ErlangPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: Arc::new(plugins::core::new_backend_arg("erlang")),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("erlang"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
     }
 
     fn kerl_path(&self) -> PathBuf {

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -28,9 +28,11 @@ pub struct GoPlugin {
 
 impl GoPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: Arc::new(plugins::core::new_backend_arg("go")),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("go"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
     }
 
     /// Check if a Go version string is valid (not "1" and not beta/rc)

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -49,8 +49,12 @@ pub struct JavaPlugin {
 
 impl JavaPlugin {
     pub fn new() -> Self {
+        Self::from_arg(plugins::core::new_backend_arg("java"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
         let settings = Settings::get();
-        let ba = Arc::new(plugins::core::new_backend_arg("java"));
+        let ba = Arc::new(ba);
         Self {
             java_metadata_ea_cache: CacheManagerBuilder::new(
                 ba.cache_path.join("java_metadata_ea.msgpack.z"),

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -108,3 +108,22 @@ pub fn new_backend_arg(tool_name: &str) -> BackendArg {
         BackendResolution::new(true),
     )
 }
+
+pub fn backend_from_arg(canonical_short: &str, ba: BackendArg) -> Option<Arc<dyn Backend>> {
+    match canonical_short {
+        "bun" => Some(Arc::new(bun::BunPlugin::from_arg(ba))),
+        "deno" => Some(Arc::new(deno::DenoPlugin::from_arg(ba))),
+        "dotnet" => Some(Arc::new(dotnet::DotnetPlugin::from_arg(ba))),
+        "elixir" => Some(Arc::new(elixir::ElixirPlugin::from_arg(ba))),
+        "erlang" => Some(Arc::new(erlang::ErlangPlugin::from_arg(ba))),
+        "go" => Some(Arc::new(go::GoPlugin::from_arg(ba))),
+        "java" => Some(Arc::new(java::JavaPlugin::from_arg(ba))),
+        "node" => Some(Arc::new(node::NodePlugin::from_arg(ba))),
+        "python" => Some(Arc::new(python::PythonPlugin::from_arg(ba))),
+        "ruby" => Some(Arc::new(ruby::RubyPlugin::from_arg(ba))),
+        "rust" => Some(Arc::new(rust::RustPlugin::from_arg(ba))),
+        "swift" => Some(Arc::new(swift::SwiftPlugin::from_arg(ba))),
+        "zig" => Some(Arc::new(zig::ZigPlugin::from_arg(ba))),
+        _ => None,
+    }
+}

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -41,9 +41,11 @@ enum FetchOutcome {
 
 impl NodePlugin {
     pub fn new() -> Self {
-        Self {
-            ba: plugins::core::new_backend_arg("node").into(),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("node"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: ba.into() }
     }
 
     async fn fetch_binary(

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -92,7 +92,11 @@ fn python_version_sort_key(
 
 impl PythonPlugin {
     pub fn new() -> Self {
-        let ba = Arc::new(plugins::core::new_backend_arg("python"));
+        Self::from_arg(plugins::core::new_backend_arg("python"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        let ba = Arc::new(ba);
         Self { ba }
     }
 

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -37,9 +37,11 @@ pub struct RubyPlugin {
 
 impl RubyPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: Arc::new(plugins::core::new_backend_arg("ruby")),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("ruby"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
     }
 
     fn ruby_build_path(&self) -> PathBuf {

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -30,9 +30,11 @@ pub struct RubyPlugin {
 
 impl RubyPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: plugins::core::new_backend_arg("ruby").into(),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("ruby"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: ba.into() }
     }
 
     fn ruby_path(&self, tv: &ToolVersion) -> PathBuf {

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -25,9 +25,11 @@ pub struct RustPlugin {
 
 impl RustPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: plugins::core::new_backend_arg("rust").into(),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("rust"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: ba.into() }
     }
 
     async fn setup_rustup(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -22,9 +22,11 @@ pub struct SwiftPlugin {
 
 impl SwiftPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: Arc::new(plugins::core::new_backend_arg("swift")),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("swift"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
     }
 
     fn swift_bin(&self, tv: &ToolVersion) -> PathBuf {

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -36,9 +36,11 @@ const MIRRORS_FILENAME: &str = "community-mirrors.txt";
 
 impl ZigPlugin {
     pub fn new() -> Self {
-        Self {
-            ba: Arc::new(plugins::core::new_backend_arg("zig")),
-        }
+        Self::from_arg(plugins::core::new_backend_arg("zig"))
+    }
+
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
     }
 
     fn zig_bin(&self, tv: &ToolVersion) -> PathBuf {

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -134,7 +134,12 @@ impl ToolsetBuilder {
     }
 
     fn load_runtime_args(&self, ts: &mut Toolset) -> eyre::Result<()> {
-        for (_, args) in self.args.iter().into_group_map_by(|arg| arg.ba.clone()) {
+        let args = self
+            .args
+            .iter()
+            .map(ToolArg::resolve_user_alias)
+            .collect::<eyre::Result<Vec<_>>>()?;
+        for (_, args) in args.into_iter().into_group_map_by(|arg| arg.ba.clone()) {
             let mut arg_ts = Toolset::new(ToolSource::Argument);
             // carry over options (e.g. filter_bins) from config for this tool
             let config_options = ts

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -218,7 +218,12 @@ impl ToolRequestSetBuilder {
     }
 
     fn load_runtime_args(&self, mut trs: ToolRequestSet) -> eyre::Result<ToolRequestSet> {
-        for (_, args) in self.args.iter().into_group_map_by(|arg| arg.ba.clone()) {
+        let args = self
+            .args
+            .iter()
+            .map(ToolArg::resolve_user_alias)
+            .collect::<eyre::Result<Vec<_>>>()?;
+        for (_, args) in args.into_iter().into_group_map_by(|arg| arg.ba.clone()) {
             let mut arg_ts = ToolRequestSet::new();
             for arg in args {
                 if let Some(tvr) = &arg.tvr {
@@ -241,6 +246,7 @@ impl ToolRequestSetBuilder {
         let tool_args = env::TOOL_ARGS.read().unwrap();
         let mut arg_trs = ToolRequestSet::new();
         for arg in tool_args.iter() {
+            let arg = arg.resolve_user_alias()?;
             if let Some(tvr) = &arg.tvr {
                 let mut tvr = tvr.clone();
                 // When CLI specifies a version for a tool that's in config,


### PR DESCRIPTION
## Summary
- keep user-defined `[tool_alias]` names as distinct tool identities, even when they overlap registry compatibility aliases
- keep bare compatibility aliases like `nodejs`, `golang`, and `dotnet-core` canonical by default
- preserve ordinary registry lookup aliases like `gh` as requested identities instead of broad-canonicalizing every registry alias
- keep literal `core:<tool>` syntax on the canonical core install root while still allowing user aliases to point at `core:<tool>` with their own install identity
- keep `MISE_BACKENDS_<canonical>` working for preserved compatibility aliases, with alias-specific override keys taking precedence

## Why this shape
The original bug was caused by normalizing tool names too early. `BackendArg` used to collapse names like `nodejs` to `node` as soon as they were parsed. That is fine for a bare registry compatibility alias, but it is wrong after the user defines `[tool_alias] nodejs = ...`: at that point `nodejs` is no longer just a shorthand for `node`; it is the user-selected tool identity and should get its own config key, install root, and lockfile identity.

The fix keeps config-file tool keys uncollapsed while parsing, then decides later after aliases from the current file and already-loaded layers are known:
- if the key is a user alias, preserve the key as the tool identity, e.g. `nodejs` installs under `installs/nodejs`;
- if the key is only a built-in compatibility alias, canonicalize it, e.g. bare `tools.nodejs = ...` still behaves like `tools.node = ...`;
- if the key is an ordinary registry lookup alias such as `gh`, preserve it as `gh` instead of converting it to the registry short name `github-cli`.

The `core:<tool>` case is intentionally different. `core:node` is backend syntax for the built-in Node backend, not a user alias name, so it should keep using the existing `node` install root. A user alias that points at core still preserves the alias: `[tool_alias] corenode = "core:node"` with `tools.corenode = ...` installs as `corenode`, while literal `tools."core:node" = ...` canonicalizes to `node`.

For backend override env vars, preserved aliases now check both forms. For example a preserved `nodejs` alias checks `MISE_BACKENDS_NODEJS` first, then falls back to the historical `MISE_BACKENDS_NODE`, so existing override setups keep working.

## Tests
- `cargo test backend_arg`
- `cargo test tool_arg`
- `cargo test registry_alias`
- `cargo test explicit_core_tool_key`
- `cargo test unalias_backend`
- `mise run test:e2e e2e/config/test_config_alias`

Note: the e2e command also matched and ran `config/test_config_alias_github_edit`; both e2e tests passed.
