### PR TITLE
fix(backend): scope cache-only latest resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,7 +1655,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2297,7 +2297,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2517,7 +2517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4778,7 +4778,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4907,7 +4907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4927,7 +4927,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5705,7 +5705,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5932,7 +5932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6559,7 +6559,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7562,7 +7562,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7621,7 +7621,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8869,7 +8869,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8910,7 +8910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10021,7 +10021,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -70,7 +70,6 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  { id = "RUSTSEC-2024-0370", reason = "proc-macro-error dependency from sigstore crate - no safe upgrade available" },
   { id = "RUSTSEC-2023-0071", reason = "rsa crate Marvin attack vulnerability from sigstore crate - no safe upgrade available" },
   { id = "RUSTSEC-2025-0119", reason = "number_prefix crate is unmaintained - used by indicatif/self_update, no safe upgrade available" },
   # rustls-webpki 0.102.8 advisories — pulled in transitively by sigstore-tsa

--- a/e2e/cli/test_hook_env_latest_cache_only
+++ b/e2e/cli/test_hook_env_latest_cache_only
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+cat >mise.toml <<EOF
+[tools]
+dummy = "latest"
+EOF
+
+mise cache clear dummy
+
+output="$TMPDIR/hook_env_latest_cache_only.txt"
+MISE_DEBUG=1 MISE_FAILURE=1 RTX_FAILURE=1 mise hook-env --shell bash --force 2>&1 |
+  tee "$output"
+
+if grep -q "latest-stable" "$output"; then
+  fail "hook-env should not call latest-stable in cache-only mode"
+fi
+
+if grep -q "bin/list-all" "$output"; then
+  fail "hook-env should not fetch remote versions in cache-only mode"
+fi

--- a/e2e/cli/test_hook_env_latest_cache_only
+++ b/e2e/cli/test_hook_env_latest_cache_only
@@ -18,3 +18,21 @@ fi
 if grep -q "bin/list-all" "$output"; then
   fail "hook-env should not fetch remote versions in cache-only mode"
 fi
+
+mise ls-remote dummy >/dev/null
+
+output="$TMPDIR/hook_env_latest_cache_hit.txt"
+MISE_DEBUG=1 MISE_FAILURE=1 RTX_FAILURE=1 mise hook-env --shell bash --force 2>&1 |
+  tee "$output"
+
+if grep -q "latest-stable" "$output"; then
+  fail "hook-env should not call latest-stable on a cache hit"
+fi
+
+if grep -q "bin/list-all" "$output"; then
+  fail "hook-env should not fetch remote versions on a cache hit"
+fi
+
+if grep -q "No cached remote versions" "$output"; then
+  fail "hook-env should use cached remote versions after cache warmup"
+fi

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1461,6 +1461,40 @@ pub trait Backend: Debug + Send + Sync {
         Ok(find_match_in_list(&matches, query))
     }
 
+    /// Resolve latest from the existing remote-version cache without fetching.
+    /// Used by prefer-offline config resolution so activation-style paths avoid
+    /// backend latest endpoints and remote listings.
+    async fn latest_version_from_cache(
+        &self,
+        config: &Arc<Config>,
+        query: &str,
+        before_date: Option<Timestamp>,
+    ) -> eyre::Result<Option<String>> {
+        let opts = config.get_tool_opts_with_overrides(self.ba()).await?;
+        let want_prereleases = self.include_prereleases(&opts);
+        let remote_versions = self.get_remote_version_cache();
+        let remote_versions = remote_versions.lock().await;
+        let versions = match remote_versions.get_cached() {
+            Ok(versions) => filter_cached_prereleases(versions, want_prereleases),
+            Err(err) => {
+                debug!(
+                    "No cached remote versions available for {} while resolving latest in prefer-offline mode: {:#}",
+                    self.ba(),
+                    err
+                );
+                vec![]
+            }
+        };
+        let versions: Vec<String> = match before_date {
+            Some(before) => VersionInfo::filter_by_date(versions, before)
+                .into_iter()
+                .map(|v| v.version)
+                .collect(),
+            None => versions.into_iter().map(|v| v.version).collect(),
+        };
+        Ok(find_match_in_list(&versions, query))
+    }
+
     /// Get the latest version, optionally filtered by release date.
     ///
     /// `latest_stable_version` may use backend-specific fast paths (dist tags,
@@ -2745,6 +2779,59 @@ mod latest_version_tests {
 
         assert_eq!(latest.as_deref(), Some("2.0.0"));
         assert_eq!(backend.stable_calls(), 1);
+        assert_eq!(backend.list_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_cached_latest_uses_cached_versions_without_fetching() {
+        let config = Config::get().await.unwrap();
+        let backend = LatestBackend::new("test-cached-latest-cache");
+        let cache = backend.get_remote_version_cache();
+        {
+            let mut cache = cache.lock().await;
+            cache.clear().unwrap();
+            cache
+                .write(&vec![
+                    VersionInfo {
+                        version: "1.0.0".to_string(),
+                        ..Default::default()
+                    },
+                    VersionInfo {
+                        version: "2.0.0".to_string(),
+                        ..Default::default()
+                    },
+                ])
+                .unwrap();
+        }
+
+        let latest = backend
+            .latest_version_from_cache(&config, "latest", None)
+            .await
+            .unwrap();
+
+        assert_eq!(latest.as_deref(), Some("2.0.0"));
+        assert_eq!(backend.stable_calls(), 0);
+        assert_eq!(backend.list_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_cached_latest_without_cache_does_not_fetch() {
+        let config = Config::get().await.unwrap();
+        let backend = LatestBackend::new("test-cached-latest-no-cache");
+        backend
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .clear()
+            .unwrap();
+
+        let latest = backend
+            .latest_version_from_cache(&config, "latest", None)
+            .await
+            .unwrap();
+
+        assert_eq!(latest, None);
+        assert_eq!(backend.stable_calls(), 0);
         assert_eq!(backend.list_calls(), 0);
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -673,6 +673,12 @@ impl Settings {
         self.offline() || self.prefer_offline || env::PREFER_OFFLINE.load(Ordering::Relaxed)
     }
 
+    /// Returns true when resolving symbolic latest should only use installed
+    /// versions or the on-disk remote-version cache.
+    pub fn cache_only_remote_latest(&self) -> bool {
+        self.prefer_offline || env::cache_only_remote_latest()
+    }
+
     pub fn env_cache_ttl(&self) -> Duration {
         duration::parse_duration(&self.env_cache_ttl).unwrap()
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -18,7 +18,10 @@ use std::{
 };
 use std::{path, process};
 use std::{path::Path, string::ToString};
-use std::{path::PathBuf, sync::atomic::AtomicBool};
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 pub static ARGS: RwLock<Vec<String>> = RwLock::new(vec![]);
 pub static TOOL_ARGS: RwLock<Vec<ToolArg>> = RwLock::new(vec![]);
@@ -417,6 +420,7 @@ pub static LINUX_DISTRO: Lazy<Option<String>> = Lazy::new(linux_distro);
 pub static LINUX_GLIBC_VERSION: Lazy<Option<(u32, u32)>> = Lazy::new(linux_glibc_version);
 pub static PREFER_OFFLINE: Lazy<AtomicBool> =
     Lazy::new(|| prefer_offline(&ARGS.read().unwrap()).into());
+pub static CACHE_ONLY_REMOTE_LATEST: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 pub static OFFLINE: Lazy<bool> = Lazy::new(|| offline(&ARGS.read().unwrap()));
 pub static WARN_ON_MISSING_REQUIRED_ENV: Lazy<bool> =
     Lazy::new(|| warn_on_missing_required_env(&ARGS.read().unwrap()));
@@ -606,25 +610,55 @@ fn prefer_offline(args: &[String]) -> bool {
     }
 
     // Otherwise fall back to the original command-based logic
+    command_matches(
+        args,
+        &[
+            "--prefer-offline",
+            "activate",
+            "current",
+            "direnv",
+            "env",
+            "exec",
+            "hook-env",
+            "ls",
+            "where",
+            "x",
+        ],
+    )
+}
+
+/// returns true if symbolic latest resolution should avoid both latest-stable
+/// endpoints and remote version listings unless a caller explicitly requested
+/// latest-version semantics.
+pub fn cache_only_remote_latest() -> bool {
+    CACHE_ONLY_REMOTE_LATEST.load(Ordering::Relaxed)
+        || cache_only_remote_latest_args(&ARGS.read().unwrap())
+}
+
+fn cache_only_remote_latest_args(args: &[String]) -> bool {
+    if var_is_true("MISE_PREFER_OFFLINE") {
+        return true;
+    }
+
+    command_matches(
+        args,
+        &[
+            "--prefer-offline",
+            "activate",
+            "completion",
+            "direnv",
+            "doctor",
+            "hook-env",
+        ],
+    )
+}
+
+fn command_matches(args: &[String], commands: &[&str]) -> bool {
     args.iter()
         .take_while(|a| *a != "--")
         .filter(|a| !a.starts_with('-') || *a == "--prefer-offline")
         .nth(1)
-        .map(|a| {
-            [
-                "--prefer-offline",
-                "activate",
-                "current",
-                "direnv",
-                "env",
-                "exec",
-                "hook-env",
-                "ls",
-                "where",
-                "x",
-            ]
-            .contains(&a.as_str())
-        })
+        .map(|a| commands.contains(&a.as_str()))
         .unwrap_or_default()
 }
 
@@ -882,6 +916,32 @@ mod tests {
             let expected: IndexSet<String> = expected.into_iter().map(|s| s.to_string()).collect();
             assert_eq!(result, expected, "input: {input:?}");
         }
+    }
+
+    #[test]
+    fn test_cache_only_remote_latest_command_scope() {
+        assert!(cache_only_remote_latest_args(&[
+            "mise".into(),
+            "hook-env".into()
+        ]));
+        assert!(cache_only_remote_latest_args(&[
+            "mise".into(),
+            "completion".into()
+        ]));
+        assert!(cache_only_remote_latest_args(&[
+            "mise".into(),
+            "--prefer-offline".into(),
+            "current".into()
+        ]));
+        assert!(!cache_only_remote_latest_args(&[
+            "mise".into(),
+            "current".into()
+        ]));
+        assert!(!cache_only_remote_latest_args(&[
+            "mise".into(),
+            "ls".into()
+        ]));
+        assert!(!cache_only_remote_latest_args(&["mise".into(), "x".into()]));
     }
 
     #[test]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -31,6 +31,7 @@ pub async fn handle_shim() -> Result<()> {
     let mut config = Config::get().await?;
     let mut args = env::ARGS.read().unwrap().clone();
     env::PREFER_OFFLINE.store(true, Ordering::Relaxed);
+    env::CACHE_ONLY_REMOTE_LATEST.store(true, Ordering::Relaxed);
     trace!("shim[{bin_name}] args: {}", args.join(" "));
     args[0] = which_shim(&mut config, &env::MISE_BIN_NAME)
         .await?

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -367,12 +367,15 @@ impl ToolVersion {
             {
                 return build(v);
             }
-            let prefer_offline_latest = prefer_offline && !opts.latest_versions;
-            if prefer_offline_latest
-                && let Some(v) = backend
+            let cache_only_remote_latest =
+                settings.cache_only_remote_latest() && !opts.latest_versions;
+            if cache_only_remote_latest {
+                if let Some(v) = backend
                     .latest_version_from_cache(config, "latest", opts.before_date)
                     .await?
-            {
+                {
+                    return build(v);
+                }
                 return build(v);
             }
             if !is_offline
@@ -504,7 +507,9 @@ impl ToolVersion {
         opts: &ResolveOptions,
     ) -> Result<Self> {
         let backend = request.backend()?;
-        if v == "latest" && opts.offline {
+        let cache_only_remote_latest =
+            Settings::get().cache_only_remote_latest() && !opts.latest_versions;
+        if v == "latest" && (opts.offline || cache_only_remote_latest) {
             // Can't resolve sub-N:latest offline (no remote latest, and
             // applying version_sub to latest_installed_version would shift
             // one step too low). Return the raw spec; callers that care

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -368,12 +368,15 @@ impl ToolVersion {
                 return build(v);
             }
             let prefer_offline_latest = prefer_offline && !opts.latest_versions;
-            let latest_version = if prefer_offline_latest {
-                backend
+            if prefer_offline_latest
+                && let Some(v) = backend
                     .latest_version_from_cache(config, "latest", opts.before_date)
                     .await?
-            } else if !is_offline {
-                backend
+            {
+                return build(v);
+            }
+            if !is_offline
+                && let Some(v) = backend
                     .latest_version_with_refresh(
                         config,
                         None,
@@ -381,13 +384,7 @@ impl ToolVersion {
                         opts.refresh_remote_versions,
                     )
                     .await?
-            } else {
-                None
-            };
-            if let Some(v) = latest_version {
-                return build(v);
-            }
-            if prefer_offline_latest {
+            {
                 return build(v);
             }
             if !is_offline {
@@ -467,7 +464,7 @@ impl ToolVersion {
         // In prefer-offline mode (hook-env, activate, exec), skip remote version
         // fetching for fully-qualified versions (e.g. "2.3.2") that aren't installed.
         // Prefix versions like "2" still need remote resolution to find e.g. "2.1.0".
-        // "latest" uses installed/cache-only resolution in the block above.
+        // "latest" checks installed/cached versions first in the block above.
         if settings.prefer_offline() && v.matches('.').count() >= 2 {
             return build(v);
         }
@@ -507,8 +504,7 @@ impl ToolVersion {
         opts: &ResolveOptions,
     ) -> Result<Self> {
         let backend = request.backend()?;
-        let prefer_offline_latest = Settings::get().prefer_offline() && !opts.latest_versions;
-        if v == "latest" && (opts.offline || prefer_offline_latest) {
+        if v == "latest" && opts.offline {
             // Can't resolve sub-N:latest offline (no remote latest, and
             // applying version_sub to latest_installed_version would shift
             // one step too low). Return the raw spec; callers that care

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -367,8 +367,13 @@ impl ToolVersion {
             {
                 return build(v);
             }
-            if !is_offline
-                && let Some(v) = backend
+            let prefer_offline_latest = prefer_offline && !opts.latest_versions;
+            let latest_version = if prefer_offline_latest {
+                backend
+                    .latest_version_from_cache(config, "latest", opts.before_date)
+                    .await?
+            } else if !is_offline {
+                backend
                     .latest_version_with_refresh(
                         config,
                         None,
@@ -376,7 +381,13 @@ impl ToolVersion {
                         opts.refresh_remote_versions,
                     )
                     .await?
-            {
+            } else {
+                None
+            };
+            if let Some(v) = latest_version {
+                return build(v);
+            }
+            if prefer_offline_latest {
                 return build(v);
             }
             if !is_offline {
@@ -456,7 +467,7 @@ impl ToolVersion {
         // In prefer-offline mode (hook-env, activate, exec), skip remote version
         // fetching for fully-qualified versions (e.g. "2.3.2") that aren't installed.
         // Prefix versions like "2" still need remote resolution to find e.g. "2.1.0".
-        // "latest" also needs remote resolution but is handled in the block above.
+        // "latest" uses installed/cache-only resolution in the block above.
         if settings.prefer_offline() && v.matches('.').count() >= 2 {
             return build(v);
         }
@@ -496,7 +507,8 @@ impl ToolVersion {
         opts: &ResolveOptions,
     ) -> Result<Self> {
         let backend = request.backend()?;
-        if v == "latest" && opts.offline {
+        let prefer_offline_latest = Settings::get().prefer_offline() && !opts.latest_versions;
+        if v == "latest" && (opts.offline || prefer_offline_latest) {
             // Can't resolve sub-N:latest offline (no remote latest, and
             // applying version_sub to latest_installed_version would shift
             // one step too low). Return the raw spec; callers that care


### PR DESCRIPTION
## Summary
- add a narrower cache-only latest mode for activation/background paths (`activate`, `hook-env`, `direnv`, `doctor`, `completion`) and shims
- in that mode, resolve config `latest` from installed versions first, then from the on-disk remote-version cache only; on cache miss, keep the symbolic `latest` instead of calling latest-stable or remote version listing
- preserve normal latest resolution for `mise current`, `mise ls`, `mise x`, and explicit `@latest` requests, so interactive commands still refresh when they need the true latest
- keep prefer-offline install/prefix cache behavior and include the dependency advisory update already on this branch
- add regression coverage for cache-only `hook-env` latest lookup on cache miss and cache hit

## How this fixes it
`ToolVersion::resolve_version()` already preferred an installed version for config `latest`, but on a miss it went through `Backend::latest_version_with_refresh()` whenever the command was not strict offline. That shared backend path tries `latest_stable_version()` first, then falls back to the normal remote-version listing path. For fast shell paths, that means a config entry like `dummy = "latest"` can still execute `bin/latest-stable`, GitHub `/releases/latest`, npm dist tags, PyPI metadata, or a backend list operation before the prompt can render.

This PR keeps the installed-version fast path, then adds a separate `cache_only_remote_latest` gate for shell/background contexts. When that gate is active and the request is not an explicit latest lookup (`!opts.latest_versions`), the resolver calls `Backend::latest_version_from_cache()` instead of `latest_version_with_refresh()`. That method reads only the existing `remote_versions.msgpack.z` cache, applies the same prerelease filtering and release-date cutoff filtering, and returns the best cached match. If there is no cache, it deliberately returns the unresolved symbolic request so `hook-env`/activation can continue without reaching the network.

The scope is intentionally narrower than `prefer_offline()`. Commands that users run specifically to inspect or execute the current latest version still use the normal resolver, and explicit `tool@latest` keeps `latest_versions = true`, which bypasses this cache-only path. Shims set the cache-only flag directly because shim startup must stay prompt-safe regardless of argv shape.

`sub-N:latest` gets the same cache-only/offline treatment as before: in these modes it keeps the raw request rather than doing a remote latest lookup and then subtracting, because applying `sub-N` to an installed latest would select the wrong version.

## Investigation
This was not introduced only by the Aqua `/latest` work. The Aqua change made the problem much more visible for Aqua-backed tools, but the prefer-offline/latest gap already existed for other backends.

Relevant history:
- `4300c4839` / #8500 (2026-03-07) added a prefer-offline guard for `latest` after `env`, `hook-env`, `activate`, and `exec` could make remote calls for `latest` configs.
- `b71c870e6` / #8532 (2026-03-09) intentionally removed that guard to fix GitHub `@latest` resolving to the literal string `latest`; after that, prefer-offline `latest` could again call backend latest/list paths.
- Before Aqua gained its fast path, this could already affect backends with their own latest lookup or fallback listing behavior, including `github`/`forgejo` (`/releases/latest`), `asdf` (`bin/latest-stable`), `npm` (dist tags), and `pipx` (package index metadata), plus generic remote-version listing on fallback.
- `5ac735212` / #9277 (2026-05-07) added Aqua's GitHub latest-release fast path, so Aqua tools started hitting the same existing resolver behavior through `/releases/latest`.

So the recent Aqua work exposed the issue for Aqua, but the underlying bug is broader: shell/background prefer-offline paths need a resolver mode that can use installed/cache data without treating `latest` like an interactive request for the canonical upstream latest.

## Other ideas
- Add an explicit resolver intent enum to `ResolveOptions`, e.g. `InteractiveLatest`, `ShellActivation`, `Install`, `Offline`, instead of inferring behavior from command names and atomics.
- Split `prefer_offline` into two settings: one for cache TTL/fallback preference and one for strict no-network latest resolution in shell paths.
- Move cache-only latest lookup into the backend latest resolver as a first-class refresh mode, rather than branching in `ToolVersion::resolve_version()`.
- Revisit strict `offline` latest semantics separately. This PR keeps existing strict-offline behavior rather than folding that behavior change into the activation fix.

## Tests
- `git diff --check upstream/main...HEAD`
- `mise x -- cargo test latest_version_tests --bin mise`
- `mise x -- cargo test test_cache_only_remote_latest_command_scope --bin mise`
- `mise x -- shellcheck -x e2e/cli/test_hook_env_latest_cache_only`
- `mise x -- shfmt -d --apply-ignore e2e/cli/test_hook_env_latest_cache_only`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 mise run test:e2e e2e/cli/test_hook_env_latest_cache_only`
