### PR TITLE
fix(toolset): reject dash-prefixed version strings

### DIFF
--- a/e2e/cli/test_use_invalid_version
+++ b/e2e/cli/test_use_invalid_version
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Regression test for https://github.com/jdx/mise/discussions/9975
+# `mise use dummy@--version` (or any dash-prefixed identifier) must fail and
+# leave mise.toml untouched, instead of silently writing the bad value because
+# the underlying tool happened to exit 0.
+
+cat >mise.toml <<'EOF'
+[tools]
+dummy = "1.0.0"
+EOF
+
+assert_fail "mise use dummy@--version"
+assert_fail "mise use dummy@--list"
+assert_fail "mise use dummy@-"
+
+assert "cat mise.toml" '[tools]
+dummy = "1.0.0"'

--- a/src/cli/args/tool_arg.rs
+++ b/src/cli/args/tool_arg.rs
@@ -299,4 +299,13 @@ mod tests {
         t("@biomejs/biome@1.0.0", "@biomejs/biome", Some("1.0.0"));
         t("@biomejs/biome@", "@biomejs/biome", None);
     }
+
+    #[tokio::test]
+    async fn test_tool_arg_rejects_dash_prefixed_version() {
+        let _config = Config::get().await.unwrap();
+        assert!(ToolArg::from_str("ruby@--version").is_err());
+        assert!(ToolArg::from_str("ruby@--list").is_err());
+        assert!(ToolArg::from_str("node@-").is_err());
+        assert!(ToolArg::from_str("node@-rc1").is_err());
+    }
 }

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -418,6 +418,9 @@ fn validate_version_string(s: &str) -> Result<()> {
     if s.is_empty() {
         return Ok(());
     }
+    if s.starts_with('-') {
+        bail!("invalid tool version {s:?}: cannot start with '-'");
+    }
     if s.contains("..") {
         bail!("invalid tool version {s:?}: contains path-traversal sequence");
     }
@@ -620,6 +623,13 @@ mod tests {
             // path traversal
             "../etc/passwd",
             "1.0/../etc",
+            // leading dash — would be parsed as a flag by the backend's
+            // underlying CLI (e.g. `ruby-build --version` exits 0) and silently
+            // written to mise.toml. See discussion #9975.
+            "--version",
+            "--list",
+            "-rc1",
+            "-",
         ] {
             assert!(
                 validate_version_string(v).is_err(),


### PR DESCRIPTION
## Summary

`mise use ruby@--version` parses `--version` as a version and reaches the backend; `ruby-build --version` exits 0, so mise writes `ruby = "--version"` into mise.toml. Reject any version starting with `-` in `validate_version_string` (alongside the existing guards from #9814).

Closes #9975