### PR TITLE
fix(conda): include channel in lock identity

### DIFF
--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -75,6 +75,10 @@ impl<'a> CondaOptions<'a> {
         Channel::from_str(&name, &config)
             .map_err(|e| eyre::eyre!("invalid conda channel '{}': {}", name, e))
     }
+
+    fn lockfile_options(&self) -> BTreeMap<String, String> {
+        BTreeMap::from([("channel".to_string(), self.channel_name())])
+    }
 }
 
 impl CondaBackend {
@@ -653,6 +657,15 @@ impl Backend for CondaBackend {
         &["channel"]
     }
 
+    fn resolve_lockfile_options(
+        &self,
+        request: &crate::toolset::ToolRequest,
+        _target: &PlatformTarget,
+    ) -> BTreeMap<String, String> {
+        let raw_opts = request.options();
+        CondaOptions::new(&raw_opts).lockfile_options()
+    }
+
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
         let raw_opts = config.get_tool_opts_with_overrides(&self.ba).await?;
         let opts = CondaOptions::new(&raw_opts);
@@ -831,6 +844,7 @@ mod tests {
     use rattler_conda_types::{
         PackageName, PackageRecord, RepoDataRecord, Version, package::DistArchiveIdentifier,
     };
+    use std::collections::BTreeMap;
     use std::str::FromStr;
     use url::Url;
 
@@ -866,6 +880,20 @@ mod tests {
         );
 
         assert_eq!(CondaOptions::new(&opts).channel_name(), "conda-forge");
+    }
+
+    #[test]
+    fn conda_lockfile_options_include_channel() {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "channel".to_string(),
+            toml::Value::String("bioconda".to_string()),
+        );
+
+        assert_eq!(
+            CondaOptions::new(&opts).lockfile_options(),
+            BTreeMap::from([("channel".to_string(), "bioconda".to_string())])
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- include Conda channel values in lockfile option identity
- reuse typed channel parsing for lock options
- add regression coverage for custom channel lock options

## Why this belongs in lock identity
The Conda channel is part of the package universe being solved. The same tool name and version can resolve to different package builds, dependency URLs, and checksums on `conda-forge`, `bioconda`, or a private channel. If the channel is not part of the lock identity, `mise lock` can reuse solve metadata from one channel while the config asks for another, which breaks reproducibility and can install the wrong artifact set.

## Verification
- `cargo fmt --check`
- `cargo test conda_lockfile_options_include_channel`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conda channel handling: Channel configurations specified in tool requests are now properly resolved and included in lockfile options during generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->