### PR TITLE
Add missing `warn` function to bootstrap script

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -22,6 +22,10 @@ else
   }
 fi
 
+warn() {
+  echo "$@" >&2
+}
+
 error() {
   echo "$@" >&2
   exit 1


### PR DESCRIPTION
   ## Summary
   - Add the missing `warn` helper to `packaging/standalone/install.envsubst`
   - Fix standalone installer paths that call `warn`, such as missing checksum messages

   ## Verification
   - Not run; shell helper-only change
