### PR TITLE
chore(deps): update astral-tokio-tar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",


### PR DESCRIPTION
## Summary
- update `astral-tokio-tar` from 0.6.1 to 0.6.2 in `Cargo.lock`
- resolves the `RUSTSEC-2026-0145` cargo-deny vulnerability failure

## Validation
- `cargo deny check`

Note: `cargo deny check` still prints the existing stale advisory ignore warning for `RUSTSEC-2024-0370`, but exits successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only dependency bump; main impact is updated transitive code pulled from crates.io, which could affect build/runtime behavior if the crate is exercised.
> 
> **Overview**
> Updates the pinned dependency `astral-tokio-tar` from **0.6.1 → 0.6.2** (checksum change) in `Cargo.lock`, primarily to resolve the `cargo-deny` advisory failure (`RUSTSEC-2026-0145`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34911e0dbee098a5bceb2b7e028a5efbe598a9c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->