### PR TITLE
chore: release 2026.5.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## [2026.5.13](https://github.com/jdx/mise/compare/v2026.5.12..v2026.5.13) - 2026-05-21
+
+### 🚀 Features
+
+- **(npm)** disable npm lifecycle scripts by default by @risu729 in [#9913](https://github.com/jdx/mise/pull/9913)
+
+### 🐛 Bug Fixes
+
+- **(completion)** avoid network calls when generating completions by @sargunv-headway in [#10010](https://github.com/jdx/mise/pull/10010)
+- **(config)** track install manifest option source by @risu729 in [#9958](https://github.com/jdx/mise/pull/9958)
+- **(doctor)** honor http timeout for version checks by @risu729 in [#9977](https://github.com/jdx/mise/pull/9977)
+- **(github)** prefer primary binary assets by @risu729 in [#10008](https://github.com/jdx/mise/pull/10008)
+- **(release)** bake secondary mise-plugins vfox plugins by @risu729 in [#9832](https://github.com/jdx/mise/pull/9832)
+- **(shim)** preserve optioned aliases during rebuilds by @risu729 in [#9848](https://github.com/jdx/mise/pull/9848)
+
+### 🚜 Refactor
+
+- **(dotnet)** parse backend tool options locally by @risu729 in [#9962](https://github.com/jdx/mise/pull/9962)
+
+### 📚 Documentation
+
+- remove how i use mise article by @jdx in [#9996](https://github.com/jdx/mise/pull/9996)
+
+### 🧪 Testing
+
+- **(s3)** cover current config over install manifest opts by @risu729 in [#9917](https://github.com/jdx/mise/pull/9917)
+
+### 📦️ Dependency Updates
+
+- update astral-tokio-tar by @jdx in [#9997](https://github.com/jdx/mise/pull/9997)
+
+### 📦 Registry
+
+- update entry for vale by @eread in [#10002](https://github.com/jdx/mise/pull/10002)
+- use aqua backend for vector by @jdx in [#10011](https://github.com/jdx/mise/pull/10011)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (2)
+
+- `google.com/antigravity-cli`
+- [`sholdee/crd-schema-publisher`](https://github.com/sholdee/crd-schema-publisher)
+
+#### Updated Packages (4)
+
+- [`FairwindsOps/pluto`](https://github.com/FairwindsOps/pluto)
+- [`goccy/bigquery-emulator`](https://github.com/goccy/bigquery-emulator)
+- [`sourcemeta/jsonschema`](https://github.com/sourcemeta/jsonschema)
+- [`wasmCloud/wasmCloud/wash`](https://github.com/wasmCloud/wasmCloud)
+
 ## [2026.5.12](https://github.com/jdx/mise/compare/v2026.5.11..v2026.5.12) - 2026-05-19
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.5.12"
+version = "2026.5.13"
 dependencies = [
  "age",
  "aho-corasick",
@@ -9738,7 +9738,7 @@ dependencies = [
 
 [[package]]
 name = "vfox"
-version = "2026.3.0"
+version = "2026.5.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.5.12"
+version = "2026.5.13"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.5.12 macos-arm64 (2026-05-19)
+2026.5.13 macos-arm64 (2026-05-21)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_12.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_13.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_12.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_13.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_12.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_13.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_12.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_13.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/crates/vfox/Cargo.toml
+++ b/crates/vfox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfox"
-version = "2026.3.0"
+version = "2026.5.0"
 edition = "2024"
 license = "MIT"
 description = "Interface to vfox plugins"

--- a/crates/vfox/embedded-plugins/vfox-groovy/hooks/available.lua
+++ b/crates/vfox/embedded-plugins/vfox-groovy/hooks/available.lua
@@ -9,7 +9,7 @@ function PLUGIN:Available(ctx)
         url = util.GROOVY_URL
     })
     if err ~= nil or resp.status_code ~= 200 then
-        error("parsing release info failed: " .. (err or ("HTTP " .. resp.status_code)))
+        error("paring release info failed." .. err)
     end
     local result = {}
     html.parse(resp.body):find("a"):each(function(i, selection)

--- a/crates/vfox/embedded-plugins/vfox-scala/hooks/available.lua
+++ b/crates/vfox/embedded-plugins/vfox-scala/hooks/available.lua
@@ -7,6 +7,7 @@ function PLUGIN:Available(ctx)
     local resp, err = http.get({
         url = util.SEARCH_URL,
     })
+    print(err)
     if err ~= nil or resp.status_code ~= 200 then
         return {}
     end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.5.12";
+  version = "2026.5.13";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "28.3k",
+      stars: "28.4k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.5.12
+Version: 2026.5.13
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.5.12"
+version: "2026.5.13"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "v4.513.0"
+  "tag": "v4.514.0"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -3301,7 +3301,7 @@ packages:
               - https://artifacts.fairwinds.com/cosign.pub
               - --signature
               - https://github.com/FairwindsOps/pluto/releases/download/{{.Version}}/checksums.txt.sig
-      - version_constraint: "true"
+      - version_constraint: semver("<=5.23.5")
         asset: pluto_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -3314,6 +3314,20 @@ packages:
               - https://artifacts.fairwinds.com/cosign-p256.pub
               - --signature
               - https://github.com/FairwindsOps/pluto/releases/download/{{.Version}}/checksums.txt.sig
+      - version_constraint: "true"
+        asset: pluto_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --key
+              - https://artifacts.fairwinds.com/cosign-p256.pub
   - type: github_release
     repo_owner: FairwindsOps
     repo_name: polaris
@@ -41933,13 +41947,22 @@ packages:
         rosetta2: true
         supported_envs:
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.7.0")
         asset: bigquery-emulator-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: "true"
+        asset: bigquery-emulator_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: goccy/bigquery-emulator/\.github/workflows/release\.yml
   - name: goccy/go-yaml/ycat
     type: go_build
     repo_owner: goccy
@@ -43255,6 +43278,46 @@ packages:
         supported_envs:
           - linux
           - darwin
+  - type: http
+    name: google.com/antigravity-cli
+    description: Google's agentic development platform CLI companion
+    link: https://antigravity.google/download
+    format: tar.gz
+    files:
+      - name: agy
+        src: antigravity
+    checksum:
+      type: http
+      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/{{.OS}}_{{.Arch}}.json
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: '"sha512": "([0-9a-f]{128})"'
+    overrides:
+      - goos: linux
+        goarch: amd64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
+      - goos: linux
+        goarch: arm64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-arm/cli_linux_arm64.tar.gz
+      - goos: darwin
+        goarch: amd64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-x64/cli_mac_x64.tar.gz
+      - goos: darwin
+        goarch: arm64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-arm/cli_mac_arm64.tar.gz
+      - goos: windows
+        goarch: amd64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-x64/cli_windows_x64.exe
+        format: raw
+        files:
+          - name: agy
+      - goos: windows
+        goarch: arm64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-arm/cli_windows_arm64.exe
+        format: raw
+        files:
+          - name: agy
   - type: github_release
     repo_owner: google
     repo_name: addlicense
@@ -80447,6 +80510,35 @@ packages:
           asset: tparagen_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: sholdee
+    repo_name: crd-schema-publisher
+    description: Browsable CRD docs and IDE validation schemas, straight from your Kubernetes cluster
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2026.424.75813")
+        no_asset: true
+      - version_constraint: "true"
+        asset: crd-schema-publisher-{{.OS}}-{{.Arch}}
+        format: raw
+        github_artifact_attestations:
+          signer_workflow: sholdee/crd-schema-publisher/.github/workflows/release.yaml
+        checksum:
+          type: github_release
+          asset: checksums-sha256.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - https://github.com/sholdee/crd-schema-publisher/.github/workflows/release.yaml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums-sha256.txt.sigstore.json
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: showwin
     repo_name: speedtest-go
     asset: speedtest-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
@@ -82841,6 +82933,15 @@ packages:
           - goos: linux
             replacements:
               arm64: aarch64
+      - version_constraint: semver("<= 15.6.2")
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: jsonschema
+            src: "{{.AssetWithoutExt}}/bin/jsonschema"
+        replacements:
+          amd64: x86_64
       - version_constraint: "true"
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
@@ -82850,6 +82951,16 @@ packages:
             src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
   - type: github_release
     repo_owner: spacelift-io
     repo_name: spacectl
@@ -95314,9 +95425,64 @@ packages:
     repo_owner: wasmCloud
     repo_name: wasmCloud
     description: wasmCloud is an open source Cloud Native Computing Foundation (CNCF) project that enables teams to build, manage, and scale polyglot apps across any cloud, K8s, or edge
-    version_prefix: wash-v
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("< 2.0.0")
+        version_prefix: wash-v
+        asset: wash-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 2.0.1")
+        asset: wash-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        github_artifact_attestations:
+          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/wash\.yml
+      - version_constraint: semver("<= 2.0.5")
+        asset: wash-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: wash-{{.Arch}}-{{.OS}}.{{.Format}}
+        github_artifact_attestations:
+          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/wash\.yml
+      - version_constraint: semver("< 2.1.0")
+        asset: wash-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: wash-{{.Arch}}-{{.OS}}.{{.Format}}
+        github_artifact_attestations:
+          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/release-tag\.yml
       - version_constraint: "true"
         asset: wash-{{.Arch}}-{{.OS}}
         format: raw
@@ -95327,6 +95493,21 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: wash-{{.Arch}}-{{.OS}}.{{.Format}}
+        cosign:
+          bundle:
+            type: github_release
+            asset: wash.sigstore.json
+          opts:
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
+            - --certificate-identity
+            - https://github.com/wasmCloud/wasmCloud/.github/workflows/release-tag.yml@refs/heads/main
+        github_artifact_attestations:
+          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/release-tag\.yml
   - type: github_release
     repo_owner: wasmerio
     repo_name: wapm-cli


### PR DESCRIPTION
### 🚀 Features

- **(npm)** disable npm lifecycle scripts by default by @risu729 in [#9913](https://github.com/jdx/mise/pull/9913)

### 🐛 Bug Fixes

- **(completion)** avoid network calls when generating completions by @sargunv-headway in [#10010](https://github.com/jdx/mise/pull/10010)
- **(config)** track install manifest option source by @risu729 in [#9958](https://github.com/jdx/mise/pull/9958)
- **(doctor)** honor http timeout for version checks by @risu729 in [#9977](https://github.com/jdx/mise/pull/9977)
- **(github)** prefer primary binary assets by @risu729 in [#10008](https://github.com/jdx/mise/pull/10008)
- **(release)** bake secondary mise-plugins vfox plugins by @risu729 in [#9832](https://github.com/jdx/mise/pull/9832)
- **(shim)** preserve optioned aliases during rebuilds by @risu729 in [#9848](https://github.com/jdx/mise/pull/9848)

### 🚜 Refactor

- **(dotnet)** parse backend tool options locally by @risu729 in [#9962](https://github.com/jdx/mise/pull/9962)

### 📚 Documentation

- remove how i use mise article by @jdx in [#9996](https://github.com/jdx/mise/pull/9996)

### 🧪 Testing

- **(s3)** cover current config over install manifest opts by @risu729 in [#9917](https://github.com/jdx/mise/pull/9917)

### 📦️ Dependency Updates

- update astral-tokio-tar by @jdx in [#9997](https://github.com/jdx/mise/pull/9997)

### 📦 Registry

- update entry for vale by @eread in [#10002](https://github.com/jdx/mise/pull/10002)
- use aqua backend for vector by @jdx in [#10011](https://github.com/jdx/mise/pull/10011)

## 📦 Aqua Registry Updates

### New Packages (2)

- `google.com/antigravity-cli`
- [`sholdee/crd-schema-publisher`](https://github.com/sholdee/crd-schema-publisher)

### Updated Packages (4)

- [`FairwindsOps/pluto`](https://github.com/FairwindsOps/pluto)
- [`goccy/bigquery-emulator`](https://github.com/goccy/bigquery-emulator)
- [`sourcemeta/jsonschema`](https://github.com/sourcemeta/jsonschema)
- [`wasmCloud/wasmCloud/wash`](https://github.com/wasmCloud/wasmCloud)