### PR TITLE
registry: update entry for vale

### DIFF
--- a/registry/vale.toml
+++ b/registry/vale.toml
@@ -1,2 +1,2 @@
-backends = ["aqua:errata-ai/vale", "asdf:pdemagny/asdf-vale"]
+backends = ["aqua:vale-cli/vale", "asdf:pdemagny/asdf-vale"]
 description = ":pencil: A markup-aware linter for prose built with speed and extensibility in mind"


### PR DESCRIPTION
Now that the aqua registry reflects the new location of `vale` (https://github.com/aquaproj/aqua-registry/pull/50517), we can update the `mise` registry to match.