### PR TITLE
fix(ui): honor color settings in prompt themes

### DIFF
--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -28,7 +28,20 @@ pub fn get_theme() -> Theme {
 
 fn no_color_theme() -> Theme {
     let mut theme = Theme::new();
+    theme.title = Default::default();
+    theme.description = Default::default();
+    theme.cursor = Default::default();
+    theme.selected_option = Default::default();
+    theme.selected_prefix_fg = Default::default();
+    theme.unselected_option = Default::default();
+    theme.unselected_prefix_fg = Default::default();
+    theme.error_indicator = Default::default();
+    theme.input_cursor = Default::default();
     theme.input_placeholder = Default::default();
+    theme.input_prompt = Default::default();
+    theme.help_key = Default::default();
+    theme.help_desc = Default::default();
+    theme.help_sep = Default::default();
     theme.focused_button = Default::default();
     theme.blurred_button = Default::default();
     theme.cursor_style = Default::default();
@@ -49,7 +62,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn get_theme_returns_no_color_theme_when_color_is_disabled() {
+    fn get_theme_returns_no_color_theme_when_stderr_colors_are_disabled() {
         let mut partial = SettingsPartial::empty();
         partial.color = Some(false);
         partial.color_theme = Some("base16".to_string());
@@ -58,10 +71,31 @@ mod tests {
         let theme = get_theme();
         let cursor_color = theme.real_cursor_color(None);
 
-        assert!(theme.title.fg().is_none());
-        assert!(theme.description.fg().is_none());
-        assert!(theme.selected_option.fg().is_none());
-        assert!(theme.unselected_option.fg().is_none());
+        for color in [
+            &theme.title,
+            &theme.description,
+            &theme.cursor,
+            &theme.selected_option,
+            &theme.selected_prefix_fg,
+            &theme.unselected_option,
+            &theme.unselected_prefix_fg,
+            &theme.error_indicator,
+            &theme.input_cursor,
+            &theme.input_placeholder,
+            &theme.input_prompt,
+            &theme.help_key,
+            &theme.help_desc,
+            &theme.help_sep,
+            &theme.focused_button,
+            &theme.blurred_button,
+            &theme.cursor_style,
+            &theme.breadcrumb_active,
+            &theme.breadcrumb_clickable,
+            &theme.breadcrumb_future,
+        ] {
+            assert!(color.fg().is_none());
+            assert!(color.bg().is_none());
+        }
         assert!(cursor_color.fg().is_none());
         assert!(cursor_color.bg().is_none());
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -11,6 +11,9 @@ use crate::config::Settings;
 /// - "dracula" - Dracula theme
 pub fn get_theme() -> Theme {
     let settings = Settings::get();
+    if !console::colors_enabled_stderr() {
+        return no_color_theme();
+    }
     match settings.color_theme.to_lowercase().as_str() {
         "base16" => Theme::base16(),
         "catppuccin" => Theme::catppuccin(),
@@ -20,5 +23,48 @@ pub fn get_theme() -> Theme {
             warn!("Unknown color theme '{}', using default", other);
             Theme::charm()
         }
+    }
+}
+
+fn no_color_theme() -> Theme {
+    let mut theme = Theme::new();
+    theme.input_placeholder = Default::default();
+    theme.focused_button = Default::default();
+    theme.blurred_button = Default::default();
+    theme.cursor_style = Default::default();
+    theme.force_style = false;
+    theme.breadcrumb_active = Default::default();
+    theme.breadcrumb_clickable = Default::default();
+    theme.breadcrumb_future = Default::default();
+    theme
+}
+
+#[cfg(test)]
+mod tests {
+    use confique::Layer;
+
+    use crate::config::Settings;
+    use crate::config::settings::SettingsPartial;
+
+    use super::*;
+
+    #[test]
+    fn get_theme_returns_no_color_theme_when_color_is_disabled() {
+        let mut partial = SettingsPartial::empty();
+        partial.color = Some(false);
+        partial.color_theme = Some("base16".to_string());
+        Settings::reset(Some(partial));
+
+        let theme = get_theme();
+        let cursor_color = theme.real_cursor_color(None);
+
+        assert!(theme.title.fg().is_none());
+        assert!(theme.description.fg().is_none());
+        assert!(theme.selected_option.fg().is_none());
+        assert!(theme.unselected_option.fg().is_none());
+        assert!(cursor_color.fg().is_none());
+        assert!(cursor_color.bg().is_none());
+
+        Settings::reset(None);
     }
 }


### PR DESCRIPTION
## Summary
- make demand prompt themes fall back to an unstyled theme when stderr colors are disabled
- clear the remaining color specs from demand's nominal no-color theme so filter cursors/buttons do not emit ANSI styling
- add a regression test for `color=false` with `color_theme=base16`

## Discussion
Addresses https://github.com/jdx/mise/discussions/9999.

## Tests
- `mise run format`
- `cargo fmt --all -- --check`
- `cargo test --all-features ui::theme::tests::get_theme_returns_no_color_theme_when_color_is_disabled -- --exact`