### PR TITLE
fix(completion): avoid network calls when generating completions

### DIFF
--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -54,7 +54,7 @@ impl Completion {
 
     async fn call_usage(&self, shell: Shell) -> Result<String> {
         let config = Config::get().await?;
-        // Completion generation only needs installed/cached tool paths to find `usage`;
+        // Completion generation only needs enough of the local tool environment to find `usage`;
         // offline resolution avoids shell-startup network fetches.
         let toolset = ToolsetBuilder::new()
             .with_resolve_options(ResolveOptions {

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -1,6 +1,6 @@
 use crate::cmd::cmd;
 use crate::config::Config;
-use crate::toolset::ToolsetBuilder;
+use crate::toolset::{ResolveOptions, ToolsetBuilder};
 use clap::ValueEnum;
 use clap::builder::PossibleValue;
 use eyre::Result;
@@ -54,7 +54,15 @@ impl Completion {
 
     async fn call_usage(&self, shell: Shell) -> Result<String> {
         let config = Config::get().await?;
-        let toolset = ToolsetBuilder::new().build(&config).await?;
+        // Completion generation only needs installed/cached tool paths to find `usage`;
+        // offline resolution avoids shell-startup network fetches.
+        let toolset = ToolsetBuilder::new()
+            .with_resolve_options(ResolveOptions {
+                offline: true,
+                ..Default::default()
+            })
+            .build(&config)
+            .await?;
         let mut args = vec![
             "generate".into(),
             "completion".into(),


### PR DESCRIPTION
## Summary

`mise completion` is often run on shell init, where network calls while resolving the toolset delay every shell startup. Here we avoid refreshing remote version metadata while generating shell completions.

`mise completion` builds the active toolset only to provide an environment for running `usage generate completion`. If `usage` is unavailable, completion generation already falls back to the prerendered completions.

## Verification

- `RUSTUP_TOOLCHAIN=stable target/debug/mise run lint-fix`
- `MISE_LOG_LEVEL=debug MISE_FETCH_REMOTE_VERSIONS_TIMEOUT=1 target/debug/mise completion zsh`
  - confirmed no remote GET/WARN output