### PR TITLE
fix(aqua): skip in-place link when src and dst alias same inode

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -2458,6 +2458,13 @@ impl AquaBackend {
             file::create_dir_all(parent)?;
         }
 
+        // On case-insensitive filesystems src and dst can be different
+        // strings but the same on-disk file; without this guard the branches
+        // below would overwrite src with a self-referential link.
+        if link.dst.exists() && same_disk_entry(&link.src, &link.dst) {
+            return Ok(());
+        }
+
         if link.hard || (cfg!(windows) && link.explicit_link) {
             trace!("ln {} {}", link.src.display(), link.dst.display());
             if link.dst.is_dir() {
@@ -2490,6 +2497,24 @@ impl AquaBackend {
             file::make_symlink(&target, &link.dst)?;
         }
         Ok(())
+    }
+}
+
+fn same_disk_entry(a: &Path, b: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        match (fs::metadata(a), fs::metadata(b)) {
+            (Ok(am), Ok(bm)) => am.dev() == bm.dev() && am.ino() == bm.ino(),
+            _ => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        match (fs::canonicalize(a), fs::canonicalize(b)) {
+            (Ok(ac), Ok(bc)) => ac == bc,
+            _ => false,
+        }
     }
 }
 
@@ -3044,6 +3069,30 @@ mod tests {
         .to_string();
 
         assert!(err.contains("destination is a directory"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_create_file_link_skips_when_dst_aliases_src_inode() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let src = tmp.path().join("Godot");
+        fs::write(&src, b"binary contents")?;
+        // hard_link gives portable same-inode src/dst without needing a
+        // case-insensitive filesystem
+        let dst = tmp.path().join("Godot-alias");
+        fs::hard_link(&src, &dst)?;
+
+        AquaBackend::create_file_link(&AquaFileLink {
+            src: src.clone(),
+            dst: dst.clone(),
+            hard: false,
+            explicit_link: false,
+        })?;
+
+        assert!(dst.exists(), "dst must still exist after the early return");
+        assert!(!dst.is_symlink(), "dst must not be replaced with a symlink");
+        assert_eq!(fs::read(&src)?, b"binary contents");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- On case-insensitive filesystems (macOS APFS, NTFS) an aqua package whose registry entry names a file link where `src` and `dst` differ only in case — like godot's `Godot.app/Contents/MacOS/Godot` → `godot` — resolves both paths to the same on-disk file. `AquaBackend::create_file_link` then removed the source binary and replaced it with a self-referential symlink, leaving the install broken.
- Added a guard at the top of `create_file_link`: when `dst` exists and resolves to the same on-disk entry as `src`, return early. The check uses `dev`+`ino` on unix and `canonicalize` on other platforms.
- Affects all three branches (`hard:true` hardlink, Windows copy, unix symlink), since each previously called `remove_file(dst)` before recreating the link.

## Reproducer

```
mise install godot@4.6.3-stable
ls -la ~/.local/share/mise/installs/godot/4.6.3-stable/Godot.app/Contents/MacOS/
```

Before this PR: `godot -> Godot` (broken symlink), no `Godot` binary.
After this PR: `Godot` binary present, sibling `godot` symlink works.

## Approach

The `!dst.exists()` precondition at the call site was removed earlier to support `hard:true` overwrite semantics, which exposed the case-insensitive aliasing case. Rather than restore that precondition (which would re-break overwrite), the guard lives inside `create_file_link` and only short-circuits when the two paths demonstrably refer to the same inode/canonical path — a no-op situation either way.

`fs::canonicalize`-based comparison alone isn't enough: it correctly identifies APFS/NTFS case-insensitive aliases but not hardlinked siblings. Using `dev`+`ino` on unix covers both, which keeps the regression test portable on case-sensitive Linux CI.

Other backends that create similar links (`conda`, `github`, etc.) retain their own `!dst.exists()` guards, so they aren't affected by this pattern.

## Note for affected users

This fix prevents *new* installs from being corrupted. Existing installs that already have a self-referential symlink (godot, plus any other aqua packages with case-only link renames on macOS) still need a manual repair:

```
mise uninstall godot
mise install godot
```

*This code was generated with help from Opus 4.7 in Claude Code*