### PR TITLE
registry: add weave-cli and weave-driver (github:Ataraxy-Labs/weave)

### DIFF
--- a/registry/weave-cli.toml
+++ b/registry/weave-cli.toml
@@ -21,3 +21,4 @@ asset_pattern = "weave-cli-x86_64-apple-darwin.tar.gz"
 
 [backends.options.platforms.windows-x64]
 asset_pattern = "weave-cli-x86_64-pc-windows-msvc.zip"
+bin = "weave.exe"

--- a/registry/weave-cli.toml
+++ b/registry/weave-cli.toml
@@ -1,0 +1,23 @@
+description = "Semantic merge tool for code — CLI"
+test = { cmd = "weave --version", expected = "{{version}}" }
+
+[[backends]]
+full = "github:Ataraxy-Labs/weave"
+
+[backends.options]
+bin = "weave"
+
+[backends.options.platforms.linux-x64]
+asset_pattern = "weave-cli-x86_64-unknown-linux-gnu.tar.gz"
+
+[backends.options.platforms.linux-arm64]
+asset_pattern = "weave-cli-aarch64-unknown-linux-gnu.tar.gz"
+
+[backends.options.platforms.macos-arm64]
+asset_pattern = "weave-cli-aarch64-apple-darwin.tar.gz"
+
+[backends.options.platforms.macos-x64]
+asset_pattern = "weave-cli-x86_64-apple-darwin.tar.gz"
+
+[backends.options.platforms.windows-x64]
+asset_pattern = "weave-cli-x86_64-pc-windows-msvc.zip"

--- a/registry/weave-driver.toml
+++ b/registry/weave-driver.toml
@@ -1,0 +1,23 @@
+description = "Semantic merge tool for code — git merge driver"
+test = { cmd = "weave-driver --version", expected = "{{version}}" }
+
+[[backends]]
+full = "github:Ataraxy-Labs/weave"
+
+[backends.options]
+bin = "weave-driver"
+
+[backends.options.platforms.linux-x64]
+asset_pattern = "weave-driver-x86_64-unknown-linux-gnu.tar.gz"
+
+[backends.options.platforms.linux-arm64]
+asset_pattern = "weave-driver-aarch64-unknown-linux-gnu.tar.gz"
+
+[backends.options.platforms.macos-arm64]
+asset_pattern = "weave-driver-aarch64-apple-darwin.tar.gz"
+
+[backends.options.platforms.macos-x64]
+asset_pattern = "weave-driver-x86_64-apple-darwin.tar.gz"
+
+[backends.options.platforms.windows-x64]
+asset_pattern = "weave-driver-x86_64-pc-windows-msvc.zip"

--- a/registry/weave-driver.toml
+++ b/registry/weave-driver.toml
@@ -21,3 +21,4 @@ asset_pattern = "weave-driver-x86_64-apple-darwin.tar.gz"
 
 [backends.options.platforms.windows-x64]
 asset_pattern = "weave-driver-x86_64-pc-windows-msvc.zip"
+bin = "weave-driver.exe"


### PR DESCRIPTION
Add `weave-cli` and `weave-driver` to the mise registry for [Weave](https://github.com/Ataraxy-Labs/weave), an entity-level semantic git merge driver that helps to resolve false conflicts via tree-sitter.

The two binaries ship as separate assets in the same GitHub release, so I believe they need separate registry entries. Please advise if this is not the case. `weave-driver` is the git merge driver binary (registered via `git config merge.weave.driver`); `weave-cli` is the user-facing CLI.

## Popularity

- GitHub: 1,079 stars, 30 forks
- Created: February 2026; latest release: v0.3.3, May 2026
- Actively maintained: last push May 18 2026

## Test

```
$ target/debug/mise test-tool weave-cli
target/debug/mise test-tool weave-cli                                                                 
mise Removing installs directory: /home/<user>/.local/share/mise/installs/weave-cli
mise Removing cache directory: /home/<user>/.cache/mise/weave-cli
mise Removing downloads directory: /home/<user>/.local/share/mise/downloads/weave-cli
cleaning weave-cli                                                                                                                             ✔
weave-cli@0.3.3                     extract weave-cli-aarch64-unknown-linux-gnu.tar.gz                                                         ✔
mise $ /home/<user>/.local/share/mise/installs/weave-cli/latest/weave --version
weave 0.3.3
mise weave-cli: OK

$ target/debug/mise test-tool weave-driver
target/debug/mise test-tool weave-driver                                                             
mise Removing installs directory: /home/<user>/.local/share/mise/installs/weave-driver
mise Removing cache directory: /home/<user>/.cache/mise/weave-driver
mise Removing downloads directory: /home/<user>/.local/share/mise/downloads/weave-driver
cleaning weave-driver                                                                                                                          ✔
weave-driver@0.3.3                  extract weave-driver-aarch64-unknown-linux-gnu.tar.gz                                                      ✔
mise $ /home/<user>/.local/share/mise/installs/weave-driver/latest/weave-driver --version
weave-driver 0.3.3
mise weave-driver: OK
```

Note: does not exist on aqua registry.