### PR TITLE
add gq

### DIFF
--- a/registry/gq.toml
+++ b/registry/gq.toml
@@ -1,0 +1,3 @@
+backends = ["github:Staffbase/gq"]
+description = "CLI and MCP server for querying logs and metrics via Grafana's datasource proxy"
+test = { cmd = "gq version", expected = "gq {{version}}" }


### PR DESCRIPTION
add [gq](https://github.com/Staffbase/gq) — CLI and MCP server for querying logs and metrics via Grafana's datasource proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)