### PR TITLE
fix: reject wrong-arch release assets

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -327,9 +327,7 @@ impl AssetPicker {
     }
 
     fn has_arch_mismatch(&self, asset: &str) -> bool {
-        ARCH_PATTERNS.iter().any(|(arch, pattern)| {
-            pattern.is_match(asset) && !arch.matches_target(&self.target_arch)
-        })
+        self.score_arch_match(asset) < 0
     }
 
     fn score_libc_match(&self, asset: &str) -> i32 {

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -226,7 +226,7 @@ impl AssetPicker {
         let scored_assets = self.score_all_assets(assets);
         scored_assets
             .into_iter()
-            .filter(|(score, _)| *score > 0)
+            .filter(|(score, asset)| *score > 0 && !self.has_arch_mismatch(asset))
             .min_by(|(score_a, name_a), (score_b, name_b)| {
                 score_b
                     .cmp(score_a)
@@ -324,6 +324,12 @@ impl AssetPicker {
             }
         }
         0
+    }
+
+    fn has_arch_mismatch(&self, asset: &str) -> bool {
+        ARCH_PATTERNS.iter().any(|(arch, pattern)| {
+            pattern.is_match(asset) && !arch.matches_target(&self.target_arch)
+        })
     }
 
     fn score_libc_match(&self, asset: &str) -> i32 {
@@ -1572,6 +1578,26 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-darwin.ta
             "Architecture mismatch should result in negative score, got {}",
             score
         );
+    }
+
+    #[test]
+    fn test_arch_mismatch_rejected_after_positive_bonuses() {
+        let picker = AssetPicker::with_libc("linux".to_string(), "aarch64".to_string(), None)
+            .with_preferred_name("cargo-msrv");
+        let assets = vec![
+            "cargo-msrv-aarch64-apple-darwin-v0.19.3.tgz".to_string(),
+            "cargo-msrv-x86_64-apple-darwin-v0.19.3.tgz".to_string(),
+            "cargo-msrv-x86_64-pc-windows-msvc-v0.19.3.zip".to_string(),
+            "cargo-msrv-x86_64-unknown-linux-gnu-v0.19.3.tgz".to_string(),
+            "cargo-msrv-x86_64-unknown-linux-musl-v0.19.3.tgz".to_string(),
+        ];
+
+        let score = picker.score_asset("cargo-msrv-x86_64-unknown-linux-gnu-v0.19.3.tgz");
+        assert!(
+            score > 0,
+            "regression setup should cover wrong-arch assets rescued by bonuses, got {score}"
+        );
+        assert_eq!(picker.pick_best_asset(&assets), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject release assets that explicitly declare a non-matching architecture during automatic asset selection
- add a cargo-msrv-style regression where preferred-name/archive/libc bonuses previously rescued x86_64 Linux assets for an arm64 Linux target

## Validation

- cargo test backend::asset_matcher::tests::test_arch_mismatch_rejected --manifest-path /home/jdx/src/mise/Cargo.toml
- cargo fmt --check --manifest-path /home/jdx/src/mise/Cargo.toml
- git diff --check
- pre-commit hook: cargo fmt --all -- --check, cargo check --all-features, and repo lint tasks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core asset auto-selection to hard-reject assets that explicitly declare a non-matching architecture, which may alter which release artifact is chosen (or cause no match) for some repos with unusual naming.
> 
> **Overview**
> **Prevents selecting incompatible release artifacts** by filtering out any asset whose filename indicates an explicit architecture mismatch, even if other scoring bonuses would otherwise make it the top pick.
> 
> Adds a regression test covering a `cargo-msrv`-style release where preferred-name/archive/libc bonuses previously allowed a wrong-arch Linux asset to be selected for an arm64 target, and introduces a small helper (`has_arch_mismatch`) to enforce this rule consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca51b0681baebf8f995ff3c0fcf0d73ad4364dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->