### PR TITLE
chore: release 2026.5.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2026.5.14](https://github.com/jdx/mise/compare/v2026.5.13..v2026.5.14) - 2026-05-22
+
+### 🐛 Bug Fixes
+
+- reject wrong-arch release assets by @jdx in [#10018](https://github.com/jdx/mise/pull/10018)
+
+### 📦️ Dependency Updates
+
+- update ghcr.io/jdx/mise:deb docker digest to fcb3768 by @renovate[bot] in [#10027](https://github.com/jdx/mise/pull/10027)
+- update docker/build-push-action digest to f9f3042 by @renovate[bot] in [#10024](https://github.com/jdx/mise/pull/10024)
+- update ghcr.io/jdx/mise:rpm docker digest to 5b2e369 by @renovate[bot] in [#10028](https://github.com/jdx/mise/pull/10028)
+- update docker/dockerfile:1 docker digest to 87999aa by @renovate[bot] in [#10025](https://github.com/jdx/mise/pull/10025)
+- update ghcr.io/jdx/mise:alpine docker digest to d2b3b40 by @renovate[bot] in [#10026](https://github.com/jdx/mise/pull/10026)
+- update zizmorcore/zizmor-action action to v0.5.4 by @renovate[bot] in [#10032](https://github.com/jdx/mise/pull/10032)
+- update rust docker digest to 0861191 by @renovate[bot] in [#10029](https://github.com/jdx/mise/pull/10029)
+- update docker/login-action digest to 650006c by @renovate[bot] in [#10040](https://github.com/jdx/mise/pull/10040)
+- update docker/metadata-action digest to 80c7e94 by @renovate[bot] in [#10041](https://github.com/jdx/mise/pull/10041)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (2)
+
+- [`Staffbase/gq`](https://github.com/Staffbase/gq)
+- [`openclaw/wacli`](https://github.com/openclaw/wacli)
+
 ## [2026.5.13](https://github.com/jdx/mise/compare/v2026.5.12..v2026.5.13) - 2026-05-21
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.5.13"
+version = "2026.5.14"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.5.13"
+version = "2026.5.14"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.5.13 macos-arm64 (2026-05-21)
+2026.5.14 macos-arm64 (2026-05-22)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_13.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_14.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_13.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_14.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_13.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_14.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_13.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_14.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.5.13";
+  version = "2026.5.14";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "28.4k",
+      stars: "28.5k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.5.13
+Version: 2026.5.14
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.5.13"
+version: "2026.5.14"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "v4.514.0"
+  "tag": "v4.515.0"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -7639,6 +7639,26 @@ packages:
       - name: go-timeout
         src: timeout_{{.Version}}_{{.OS}}_{{.Arch}}/go-timeout
   - type: github_release
+    repo_owner: Staffbase
+    repo_name: gq
+    description: CLI and MCP server for querying logs and metrics via Grafana datasource proxy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: Stranger6667
     repo_name: jsonschema
     description: A high-performance JSON Schema validator for Rust
@@ -68917,6 +68937,25 @@ packages:
         format: tar.gz
         files:
           - name: gog
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: openclaw
+    repo_name: wacli
+    description: WhatsApp in your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 0.10.0")
+        error_message: Please upgrade to version 0.10.0 or higher
+      - version_constraint: "true"
+        asset: wacli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         checksum:
           type: github_release
           asset: checksums.txt


### PR DESCRIPTION
### 🐛 Bug Fixes

- reject wrong-arch release assets by @jdx in [#10018](https://github.com/jdx/mise/pull/10018)

### 📦️ Dependency Updates

- update ghcr.io/jdx/mise:deb docker digest to fcb3768 by @renovate[bot] in [#10027](https://github.com/jdx/mise/pull/10027)
- update docker/build-push-action digest to f9f3042 by @renovate[bot] in [#10024](https://github.com/jdx/mise/pull/10024)
- update ghcr.io/jdx/mise:rpm docker digest to 5b2e369 by @renovate[bot] in [#10028](https://github.com/jdx/mise/pull/10028)
- update docker/dockerfile:1 docker digest to 87999aa by @renovate[bot] in [#10025](https://github.com/jdx/mise/pull/10025)
- update ghcr.io/jdx/mise:alpine docker digest to d2b3b40 by @renovate[bot] in [#10026](https://github.com/jdx/mise/pull/10026)
- update zizmorcore/zizmor-action action to v0.5.4 by @renovate[bot] in [#10032](https://github.com/jdx/mise/pull/10032)
- update rust docker digest to 0861191 by @renovate[bot] in [#10029](https://github.com/jdx/mise/pull/10029)
- update docker/login-action digest to 650006c by @renovate[bot] in [#10040](https://github.com/jdx/mise/pull/10040)
- update docker/metadata-action digest to 80c7e94 by @renovate[bot] in [#10041](https://github.com/jdx/mise/pull/10041)

## 📦 Aqua Registry Updates

### New Packages (2)

- [`Staffbase/gq`](https://github.com/Staffbase/gq)
- [`openclaw/wacli`](https://github.com/openclaw/wacli)