### PR TITLE
add gq

### DIFF
--- a/registry/gq.toml
+++ b/registry/gq.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:Staffbase/gq"]
+description = "CLI and MCP server for querying logs and metrics via Grafana's datasource proxy"
+test = { cmd = "gq version", expected = "{{version}}" }

--- a/registry/gq.toml
+++ b/registry/gq.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:Staffbase/gq"]
+backends = ["aqua:Staffbase/gq", "github:Staffbase/gq"]
 description = "CLI and MCP server for querying logs and metrics via Grafana's datasource proxy"
 test = { cmd = "gq version", expected = "{{version}}" }


### PR DESCRIPTION
Resubmission of #10015 with the bot feedback addressed.

add [gq](https://github.com/Staffbase/gq) — CLI and MCP server for querying logs and metrics via Grafana's datasource proxy.

## Changes from the previous attempt

- `backends`: switched from `github:` to `aqua:` per CLAUDE.md preference for Tier 1. The package was added to aqua-registry in [aquaproj/aqua-registry#54148](https://github.com/aquaproj/aqua-registry/pull/54148) (merged 2026-05-21 by @suzuki-shunsuke).
- `test.expected`: switched to `{{version}}` (gemini-code-assist's suggestion).

## Popularity

- GitHub: 1 star, 0 forks
- Created public: 2026-05-21
- First release (v0.0.1): 2026-05-21
- Listed in aqua-registry standard registry: 2026-05-21

🤖 Drafted with [Claude Code](https://claude.com/claude-code)