### PR TITLE
fix: allow loongarch64 and riscv64 as valid platform arches

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -84,9 +84,9 @@ impl Platform {
 
         // Validate architecture
         match self.arch.as_str() {
-            "x64" | "arm64" | "x86" => {}
+            "x64" | "arm64" | "x86" | "loongarch64" | "riscv64" => {}
             _ => bail!(
-                "Unsupported architecture '{}'. Supported: x64, arm64, x86",
+                "Unsupported architecture '{}'. Supported: x64, arm64, x86, loongarch64, riscv64",
                 self.arch
             ),
         }


### PR DESCRIPTION
## Summary

- add loongarch64 and riscv64 to the list of valid arches inside `Platform::validate()`

## Reasoning

1. `test_determine_target_platforms_one_platform_lockfile_is_authoritative` is broken on loongarch64 and riscv64 machines.
2. breakage is caused by `determine_target_platforms_from_lockfile({"linux-riscv64"})` (or same for loongarch64) returning common platform set instead of one platform which is expected in the above mentioned test.
3. Setting `MISE_LOCKFILE_PLATFORMS` to `linux-riscv64` (or `linux-loongarch64`) fixes this test, but breaks several others which rely on the `Platform::validate()`.
4. Thus I suggest adding those arches to the validate function to solve all these problems at once.

## Sidenote

I acknowledge that this might the problem with the test or not considered a problem at all. However it is a small fix which seems right to me so I jumped to opening PR. Feel free to reject or request changes.