### PR TITLE
registry: add wacli

### DIFF
--- a/registry/wacli.toml
+++ b/registry/wacli.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:openclaw/wacli", "github:openclaw/wacli"]
+description = "Send WhatsApp messages or search and sync WhatsApp history"
+test = { cmd = "wacli --help", expected = "Usage:" }


### PR DESCRIPTION
## Summary
- Add `wacli` as a mise registry alias backed by `aqua:openclaw/wacli`.

## Why
- `wacli` is already available in aqua-registry, so mise users can install it with the shorter `mise use wacli` form instead of the explicit backend form.

## Popularity
- GitHub: 2,446 stars, 287 forks
- Latest release: v0.10.0
- Recent activity: pushed 2026-05-22

## Test Plan
- `python3 - <<'PY' ... tomllib.load(open('registry/wacli.toml', 'rb')) ... PY`
- `git diff --check`

AI assistance was used to prepare this change.
