### PR TITLE
registry: add modem-dev/hunk (aqua:modem-dev/hunk)

### DIFF
--- a/registry/hunk.toml
+++ b/registry/hunk.toml
@@ -1,0 +1,12 @@
+aliases = ["hunkdiff"]
+description = "Review-first terminal diff viewer for agentic coders"
+test = { cmd = "hunk --version", expected = "{{version}}" }
+
+[[backends]]
+full = "aqua:modem-dev/hunk"
+
+[[backends]]
+full = "github:modem-dev/hunk"
+
+[backends.options]
+bin = "hunk"


### PR DESCRIPTION
Same as #9849, which was closed by a bot.

---

This PR adds [modem-dev/hunk](https://github.com/modem-dev/hunk) to the registry. This tool has already been added to the aqua registry so uses that as the primary backend. The `github` backend did not work out of the box, because their release doesn’t mark the `hunk` binary as executable. `hunkdiff` alias is added because their npm package is named that.

## Popularity

- Star count: 3.9k with 82 forks (at the time of opening this PR)
- Most recent push: May 14th, 2026 (active development)
- Latest release: 0.12.0 on May 13th, 2026
- Available via `npm` and homebrew

## Tests

- `cargo test registry::tests`
- `cargo run -- registry hunk`
- `./target/debug/mise test-tool hunk` (also `hunkdiff`)
- `MISE_DISABLE_BACKENDS=aqua ./target/debug/mise test-tool hunk` (also `hunkdiff`)