### PR TITLE
registry: add github backend and test for Liquibase

### DIFF
--- a/registry/liquibase.toml
+++ b/registry/liquibase.toml
@@ -1,3 +1,5 @@
 backends = ["github:liquibase/liquibase", "asdf:mise-plugins/mise-liquibase"]
 description = "Liquibase helps millions of developers track, version, and deploy database schema changes"
-test = { cmd = "liquibase --version", expected = "Liquibase Version: {{version}}" }
+test = { cmd = "liquibase --version", expected = "Liquibase Version: {{version}}", tools = [
+  "java",
+] }

--- a/registry/liquibase.toml
+++ b/registry/liquibase.toml
@@ -1,2 +1,3 @@
-backends = ["asdf:mise-plugins/mise-liquibase"]
+backends = ["github:liquibase/liquibase", "asdf:mise-plugins/mise-liquibase"]
 description = "Liquibase helps millions of developers track, version, and deploy database schema changes"
+test = { cmd = "liquibase --version", expected = "Liquibase Version: {{version}}" }


### PR DESCRIPTION
- Add the GitHub backend for Liquibase (`github:liquibase/liquibase`) to the registry
- Add a test to the registry for Liquibase (including Java as a dependency in `test.tools`)