### PR TITLE
chore: release 2026.5.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,104 @@
 # Changelog
 
+## [2026.5.16](https://github.com/jdx/mise/compare/v2026.5.15..v2026.5.16) - 2026-05-28
+
+### 🚀 Features
+
+- **(github)** use versions host for release metadata by @jdx in [#10127](https://github.com/jdx/mise/pull/10127)
+- **(node)** add node.npm_shim setting to opt out of npm wrapper by @jjb in [#10082](https://github.com/jdx/mise/pull/10082)
+- **(npm)** add allow_builds option by @jdx in [#10116](https://github.com/jdx/mise/pull/10116)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** skip in-place link when src and dst alias same inode by @tvararu in [#10012](https://github.com/jdx/mise/pull/10012)
+- **(aqua)** lock github_content raw URLs by @risu729 in [#10102](https://github.com/jdx/mise/pull/10102)
+- **(backend)** strip system shims dir from dependency_env PATH by @andrewjamesbrown in [#10019](https://github.com/jdx/mise/pull/10019)
+- **(backend)** adjust libc detection for musl distros by @thespags in [#10020](https://github.com/jdx/mise/pull/10020)
+- **(copr)** increase build timeout by @jdx in [#10071](https://github.com/jdx/mise/pull/10071)
+- **(en)** preserve env profile in activated subshells by @jdx in [#10124](https://github.com/jdx/mise/pull/10124)
+- **(install)** reject disabled backends by @risu729 in [#9905](https://github.com/jdx/mise/pull/9905)
+- **(lock)** allow lock and upgrade in locked mode by @jdx in [#10111](https://github.com/jdx/mise/pull/10111)
+- **(pipx)** combine --pip-args value to avoid argparse error by @iloveitaly in [#10120](https://github.com/jdx/mise/pull/10120)
+- **(shim)** skip hidden executables by @jdx in [#10123](https://github.com/jdx/mise/pull/10123)
+- **(task)** set config_root for global config tasks by @jdx in [#10106](https://github.com/jdx/mise/pull/10106)
+- **(task)** expand sandbox allow paths by @jdx in [#10112](https://github.com/jdx/mise/pull/10112)
+- **(toolset)** avoid remote version fetches in shell hooks by @jdx in [#10098](https://github.com/jdx/mise/pull/10098)
+- **(unset)** respect global config path from home by @jdx in [#10105](https://github.com/jdx/mise/pull/10105)
+- **(upgrade)** improve current version detection by @jdx in [#9973](https://github.com/jdx/mise/pull/9973)
+- **(upgrade)** preserve versions pinned by tracked locks by @jdx in [#10114](https://github.com/jdx/mise/pull/10114)
+- **(use)** reject leading-dash tool versions by @jdx in [#10113](https://github.com/jdx/mise/pull/10113)
+- show version in friendly errors by @jdx in [#10109](https://github.com/jdx/mise/pull/10109)
+
+### 📚 Documentation
+
+- **(config)** remove outdated terraform main.tf reference by @risu729 in [#10099](https://github.com/jdx/mise/pull/10099)
+- **(trust)** clarify untrusted config behavior by @jdx in [#10097](https://github.com/jdx/mise/pull/10097)
+
+### ⚡ Performance
+
+- cache repeated path canonicalization by @jdx in [#10068](https://github.com/jdx/mise/pull/10068)
+
+### 🧪 Testing
+
+- **(backend)** replace slow go install fixture by @jdx in [#10122](https://github.com/jdx/mise/pull/10122)
+- **(http)** cover current config over install manifest opts by @risu729 in [#9915](https://github.com/jdx/mise/pull/9915)
+
+### 🛡️ Security
+
+- **(security)** apply url replacements to GitHub attestations by @SlaterByte in [#9971](https://github.com/jdx/mise/pull/9971)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by @renovate[bot] in [#10060](https://github.com/jdx/mise/pull/10060)
+- lock file maintenance by @renovate[bot] in [#10062](https://github.com/jdx/mise/pull/10062)
+- bump aube to 1.16.0 by @jdx in [#10110](https://github.com/jdx/mise/pull/10110)
+
+### 📦 Registry
+
+- add modem-dev/hunk ([aqua:modem-dev/hunk](https://github.com/modem-dev/hunk)) by @naoki-mizuno in [#10051](https://github.com/jdx/mise/pull/10051)
+- add wacli by @dovocoder in [#10043](https://github.com/jdx/mise/pull/10043)
+- add github backend and test for Liquibase by @benberryallwood in [#10052](https://github.com/jdx/mise/pull/10052)
+- make aube more resilient (cargo:aube) by @bgeron in [#10092](https://github.com/jdx/mise/pull/10092)
+- use npm backend for npm on Windows by @risu729 in [#10101](https://github.com/jdx/mise/pull/10101)
+- allow npm dependency builds by @risu729 in [#9916](https://github.com/jdx/mise/pull/9916)
+- add longbridge-terminal ([github:longbridge/longbridge-terminal](https://github.com/longbridge/longbridge-terminal)) by @hogan-yuan in [#10073](https://github.com/jdx/mise/pull/10073)
+
+### Chore
+
+- **(ci)** disable setup-node cache for npm publish by @jdx in [#10070](https://github.com/jdx/mise/pull/10070)
+- **(ci)** quiet passing e2e logs by @jdx in [#10115](https://github.com/jdx/mise/pull/10115)
+
+### New Contributors
+
+- @jjb made their first contribution in [#10082](https://github.com/jdx/mise/pull/10082)
+- @hogan-yuan made their first contribution in [#10073](https://github.com/jdx/mise/pull/10073)
+- @thespags made their first contribution in [#10020](https://github.com/jdx/mise/pull/10020)
+- @HYP3R00T made their first contribution in [#10081](https://github.com/jdx/mise/pull/10081)
+- @SlaterByte made their first contribution in [#9971](https://github.com/jdx/mise/pull/9971)
+- @andrewjamesbrown made their first contribution in [#10019](https://github.com/jdx/mise/pull/10019)
+- @dovocoder made their first contribution in [#10043](https://github.com/jdx/mise/pull/10043)
+- @naoki-mizuno made their first contribution in [#10051](https://github.com/jdx/mise/pull/10051)
+- @ofek made their first contribution in [#10059](https://github.com/jdx/mise/pull/10059)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (5)
+
+- [`databricks/cli`](https://github.com/databricks/cli)
+- [`felixgwilliams/nbwipers`](https://github.com/felixgwilliams/nbwipers)
+- [`jgm/pandoc`](https://github.com/jgm/pandoc)
+- [`ktlint/ktlint`](https://github.com/ktlint/ktlint)
+- `x.ai/cli/grok`
+
+#### Updated Packages (6)
+
+- [`betterleaks/betterleaks`](https://github.com/betterleaks/betterleaks)
+- [`coder/coder`](https://github.com/coder/coder)
+- [`gittuf/gittuf`](https://github.com/gittuf/gittuf)
+- [`jdx/mise`](https://github.com/jdx/mise)
+- [`jedisct1/minisign`](https://github.com/jedisct1/minisign)
+- [`minio/mc`](https://github.com/minio/mc)
+
 ## [2026.5.15](https://github.com/jdx/mise/compare/v2026.5.14..v2026.5.15) - 2026-05-23
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.5.15"
+version = "2026.5.16"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.5.15"
+version = "2026.5.16"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.5.15 macos-arm64 (2026-05-23)
+2026.5.16 macos-arm64 (2026-05-28)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_15.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_16.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_15.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_16.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_15.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_16.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_15.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_16.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.5.15";
+  version = "2026.5.16";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "28.5k",
+      stars: "28.8k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.5.15
+Version: 2026.5.16
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.5.15"
+version: "2026.5.16"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "v4.515.0"
+  "tag": "v4.517.0"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -19160,6 +19160,18 @@ packages:
       - secrets
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("< 1.3.0")
+        asset: betterleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: betterleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -19169,6 +19181,15 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/betterleaks/betterleaks/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip
@@ -26493,6 +26514,16 @@ packages:
         overrides:
           - goos: linux
             format: tar
+      - version_constraint: semver("< 2.33.0")
+        asset: coder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: coder_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
       - version_constraint: "true"
         asset: coder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
@@ -26503,6 +26534,8 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
+        github_artifact_attestations:
+          signer_workflow: coder/coder/\.github/workflows/release\.yaml
   - type: github_release
     repo_owner: coder3101
     repo_name: protols
@@ -30229,6 +30262,21 @@ packages:
       type: github_release
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
+  - type: github_release
+    repo_owner: databricks
+    repo_name: cli
+    description: Databricks CLI
+    files:
+      - name: databricks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: databricks_cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: databricks_cli_{{trimV .Version}}_SHA256SUMS
+          algorithm: sha256
   - type: github_release
     repo_owner: databricks
     repo_name: click
@@ -36954,6 +37002,45 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: felixgwilliams
+    repo_name: nbwipers
+    description: nbwipers is a command line tool to wipe clean jupyter notebooks, written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.6")
+        asset: nbwipers-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: nbwipers-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: ffuf
     repo_name: ffuf
     description: Fast web fuzzer written in Go
@@ -40763,6 +40850,8 @@ packages:
               - https://token.actions.githubusercontent.com
               - --certificate-identity
               - "https://github.com/gittuf/gittuf/.github/workflows/release.yml@refs/tags/{{.Version}}"
+        github_artifact_attestations:
+          signer_workflow: gittuf/gittuf/\.github/workflows/release\.yml
   - type: github_release
     repo_owner: gitui-org
     repo_name: gitui
@@ -50272,6 +50361,10 @@ packages:
         supported_envs:
           - linux
           - darwin
+        checksum:
+          type: github_release
+          asset: SHASUMS512.txt
+          algorithm: sha512
       - version_constraint: semver("<= 2024.0.0")
         asset: rtx-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -50287,6 +50380,29 @@ packages:
         supported_envs:
           - linux
           - darwin
+        checksum:
+          type: github_release
+          asset: SHASUMS512.txt
+          algorithm: sha512
+      - version_constraint: semver("<= 2024.12.17")
+        asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        format: tar.gz
+        files:
+          - name: mise
+            src: mise/bin/mise
+        overrides:
+          - goos: darwin
+            asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: SHASUMS512.txt
+          algorithm: sha512
       - version_constraint: semver(">= 2025.7.13, <= 2025.7.15")
         no_asset: true
       - version_constraint: semver("<= 2025.8.21")
@@ -50304,6 +50420,15 @@ packages:
         supported_envs:
           - linux
           - darwin
+        checksum:
+          type: github_release
+          asset: SHASUMS512.txt
+          algorithm: sha512
+          minisign:
+            type: github_release
+            asset: SHASUMS512.txt.minisig
+            # https://github.com/jdx/mise/blob/main/minisign.pub
+            public_key: RWTC3g8W3z4RZK3V3qv7fa1QY4JEWyBtqIHW+85QlJpZc5yG+uNYNBSZ
       - version_constraint: "true"
         asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
         format: tar.gz
@@ -50321,6 +50446,15 @@ packages:
           - darwin
         github_immutable_release: true
         github_release_attestations: true
+        checksum:
+          type: github_release
+          asset: SHASUMS512.txt
+          algorithm: sha512
+          minisign:
+            type: github_release
+            asset: SHASUMS512.txt.minisig
+            # https://github.com/jdx/mise/blob/main/minisign.pub
+            public_key: RWTC3g8W3z4RZK3V3qv7fa1QY4JEWyBtqIHW+85QlJpZc5yG+uNYNBSZ
   - type: github_release
     repo_owner: jdx
     repo_name: usage
@@ -50410,6 +50544,10 @@ packages:
           darwin: osx
         supported_envs:
           - darwin
+        minisign:
+          type: github_release
+          asset: "{{.Asset}}.minisig"
+          public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
       - version_constraint: Version == "0.4"
         no_asset: true
       - version_constraint: semver("<= 0.8")
@@ -50420,6 +50558,10 @@ packages:
           darwin: osx
         supported_envs:
           - darwin
+        minisign:
+          type: github_release
+          asset: "{{.Asset}}.minisig"
+          public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
       - version_constraint: Version == "0.9"
         asset: minisign-{{.OS}}.{{.Format}}
         format: zip
@@ -50432,6 +50574,10 @@ packages:
         supported_envs:
           - darwin
           - windows/amd64
+        minisign:
+          type: github_release
+          asset: "{{.Asset}}.minisig"
+          public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
       - version_constraint: Version in ["0.10", "0.11"]
         asset: minisign-{{.Version}}-{{.OS}}.{{.Format}}
         format: zip
@@ -50451,11 +50597,15 @@ packages:
           - goos: windows
             files:
               - name: minisign
-                src: minisign-win64/minisign.exe
+                src: minisign-win64/minisign
         supported_envs:
           - darwin
           - windows
           - amd64
+        minisign:
+          type: github_release
+          asset: "{{.Asset}}.minisig"
+          public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
       - version_constraint: "true"
         asset: minisign-{{.Version}}-{{.OS}}.{{.Format}}
         format: zip
@@ -50478,6 +50628,10 @@ packages:
           - darwin/arm64
           - windows
           - linux/amd64
+        minisign:
+          type: github_release
+          asset: "{{.Asset}}.minisig"
+          public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
   - type: github_release
     repo_owner: jedisct1
     repo_name: piknik
@@ -51039,6 +51193,62 @@ packages:
         supported_envs:
           - linux/amd64
           - linux/arm64
+  - type: github_release
+    repo_owner: jgm
+    repo_name: pandoc
+    description: Universal markup converter
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 3.0.0")
+        error_message: This version is too old. Please upgrade to 3.0.0 or a newer version.
+      - version_constraint: semver("<= 3.1.1")
+        asset: pandoc-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macOS
+        overrides:
+          - goos: linux
+            files:
+              - name: pandoc
+                src: "pandoc-{{.Version}}/bin/pandoc"
+          - goos: darwin
+            format: zip
+            asset: pandoc-{{.Version}}-{{.OS}}.{{.Format}}
+            files:
+              - name: pandoc
+                src: "pandoc-{{.Version}}/bin/pandoc"
+          - goos: windows
+            format: zip
+            files:
+              - name: pandoc
+                src: "pandoc-{{.Version}}/pandoc"
+            replacements:
+              amd64: x86_64
+      - version_constraint: "true"
+        asset: pandoc-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macOS
+        overrides:
+          - goos: linux
+            format: tar.gz
+            files:
+              - name: pandoc
+                src: "pandoc-{{.Version}}/bin/pandoc"
+            replacements:
+              amd64: amd64
+          - goos: darwin
+            asset: pandoc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            files:
+              - name: pandoc
+                src: "pandoc-{{.Version}}-{{.Arch}}/bin/pandoc"
+          - goos: windows
+            files:
+              - name: pandoc
+                src: "pandoc-{{.Version}}/pandoc"
   - type: github_release
     repo_owner: jiro4989
     repo_name: ojosama
@@ -55939,6 +56149,23 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+  - type: github_release
+    repo_owner: ktlint
+    repo_name: ktlint
+    aliases:
+      - name: pinterest/ktlint
+    description: An anti-bikeshedding Kotlin linter with built-in formatter
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.49.0")
+        complete_windows_ext: false
+        asset: ktlint
+      - version_constraint: "true"
+        asset: "ktlint-{{.Version}}.{{.Format}}"
+        format: zip
+        files:
+          - name: ktlint
+            src: "{{.AssetWithoutExt}}/bin/ktlint"
   - type: github_release
     repo_owner: ktock
     repo_name: buildg
@@ -63285,6 +63512,10 @@ packages:
       type: http
       algorithm: sha256
       url: https://dl.min.io/client/mc/release/{{.OS}}-{{.Arch}}/archive/mc.{{.Version}}.sha256sum
+    minisign:
+      type: http
+      url: https://dl.min.io/client/mc/release/{{.OS}}-{{.Arch}}/archive/mc.{{.Version}}.minisig
+      public_key: RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav
   - type: github_release
     repo_owner: miniscruff
     repo_name: changie
@@ -72207,21 +72438,6 @@ packages:
         overrides:
           - goos: windows
             replacements: {}
-  - type: github_release
-    repo_owner: pinterest
-    repo_name: ktlint
-    description: An anti-bikeshedding Kotlin linter with built-in formatter
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.49.0")
-        complete_windows_ext: false
-        asset: ktlint
-      - version_constraint: "true"
-        asset: "ktlint-{{.Version}}.{{.Format}}"
-        format: zip
-        files:
-          - name: ktlint
-            src: "{{.AssetWithoutExt}}/bin/ktlint"
   - name: pipe-cd/pipecd/pipectl
     type: github_release
     repo_owner: pipe-cd
@@ -96738,6 +96954,19 @@ packages:
     files:
       - name: gobump
         src: gobump_{{.Version}}_{{.OS}}_{{.Arch}}/gobump
+  - type: http
+    name: x.ai/cli/grok
+    link: https://x.ai/cli
+    description: Grok Build TUI
+    format: raw
+    url: https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-{{.Version}}-{{.OS}}-{{.Arch}}
+    files:
+      - name: grok
+      - name: agent
+    replacements:
+      darwin: macos
+      amd64: x86_64
+      arm64: aarch64
   - type: github_release
     repo_owner: xataio
     repo_name: pgroll


### PR DESCRIPTION
### 🚀 Features

- **(github)** use versions host for release metadata by @jdx in [#10127](https://github.com/jdx/mise/pull/10127)
- **(node)** add node.npm_shim setting to opt out of npm wrapper by @jjb in [#10082](https://github.com/jdx/mise/pull/10082)
- **(npm)** add allow_builds option by @jdx in [#10116](https://github.com/jdx/mise/pull/10116)

### 🐛 Bug Fixes

- **(aqua)** skip in-place link when src and dst alias same inode by @tvararu in [#10012](https://github.com/jdx/mise/pull/10012)
- **(aqua)** lock github_content raw URLs by @risu729 in [#10102](https://github.com/jdx/mise/pull/10102)
- **(backend)** strip system shims dir from dependency_env PATH by @andrewjamesbrown in [#10019](https://github.com/jdx/mise/pull/10019)
- **(backend)** adjust libc detection for musl distros by @thespags in [#10020](https://github.com/jdx/mise/pull/10020)
- **(copr)** increase build timeout by @jdx in [#10071](https://github.com/jdx/mise/pull/10071)
- **(en)** preserve env profile in activated subshells by @jdx in [#10124](https://github.com/jdx/mise/pull/10124)
- **(install)** reject disabled backends by @risu729 in [#9905](https://github.com/jdx/mise/pull/9905)
- **(lock)** allow lock and upgrade in locked mode by @jdx in [#10111](https://github.com/jdx/mise/pull/10111)
- **(pipx)** combine --pip-args value to avoid argparse error by @iloveitaly in [#10120](https://github.com/jdx/mise/pull/10120)
- **(shim)** skip hidden executables by @jdx in [#10123](https://github.com/jdx/mise/pull/10123)
- **(task)** set config_root for global config tasks by @jdx in [#10106](https://github.com/jdx/mise/pull/10106)
- **(task)** expand sandbox allow paths by @jdx in [#10112](https://github.com/jdx/mise/pull/10112)
- **(toolset)** avoid remote version fetches in shell hooks by @jdx in [#10098](https://github.com/jdx/mise/pull/10098)
- **(unset)** respect global config path from home by @jdx in [#10105](https://github.com/jdx/mise/pull/10105)
- **(upgrade)** improve current version detection by @jdx in [#9973](https://github.com/jdx/mise/pull/9973)
- **(upgrade)** preserve versions pinned by tracked locks by @jdx in [#10114](https://github.com/jdx/mise/pull/10114)
- **(use)** reject leading-dash tool versions by @jdx in [#10113](https://github.com/jdx/mise/pull/10113)
- show version in friendly errors by @jdx in [#10109](https://github.com/jdx/mise/pull/10109)

### 📚 Documentation

- **(config)** remove outdated terraform main.tf reference by @risu729 in [#10099](https://github.com/jdx/mise/pull/10099)
- **(trust)** clarify untrusted config behavior by @jdx in [#10097](https://github.com/jdx/mise/pull/10097)

### ⚡ Performance

- cache repeated path canonicalization by @jdx in [#10068](https://github.com/jdx/mise/pull/10068)

### 🧪 Testing

- **(backend)** replace slow go install fixture by @jdx in [#10122](https://github.com/jdx/mise/pull/10122)
- **(http)** cover current config over install manifest opts by @risu729 in [#9915](https://github.com/jdx/mise/pull/9915)

### 🛡️ Security

- **(security)** apply url replacements to GitHub attestations by @SlaterByte in [#9971](https://github.com/jdx/mise/pull/9971)

### 📦️ Dependency Updates

- lock file maintenance by @renovate[bot] in [#10060](https://github.com/jdx/mise/pull/10060)
- lock file maintenance by @renovate[bot] in [#10062](https://github.com/jdx/mise/pull/10062)
- bump aube to 1.16.0 by @jdx in [#10110](https://github.com/jdx/mise/pull/10110)

### 📦 Registry

- add modem-dev/hunk ([aqua:modem-dev/hunk](https://github.com/modem-dev/hunk)) by @naoki-mizuno in [#10051](https://github.com/jdx/mise/pull/10051)
- add wacli by @dovocoder in [#10043](https://github.com/jdx/mise/pull/10043)
- add github backend and test for Liquibase by @benberryallwood in [#10052](https://github.com/jdx/mise/pull/10052)
- make aube more resilient (cargo:aube) by @bgeron in [#10092](https://github.com/jdx/mise/pull/10092)
- use npm backend for npm on Windows by @risu729 in [#10101](https://github.com/jdx/mise/pull/10101)
- allow npm dependency builds by @risu729 in [#9916](https://github.com/jdx/mise/pull/9916)
- add longbridge-terminal ([github:longbridge/longbridge-terminal](https://github.com/longbridge/longbridge-terminal)) by @hogan-yuan in [#10073](https://github.com/jdx/mise/pull/10073)

### Chore

- **(ci)** disable setup-node cache for npm publish by @jdx in [#10070](https://github.com/jdx/mise/pull/10070)
- **(ci)** quiet passing e2e logs by @jdx in [#10115](https://github.com/jdx/mise/pull/10115)

### New Contributors

- @jjb made their first contribution in [#10082](https://github.com/jdx/mise/pull/10082)
- @hogan-yuan made their first contribution in [#10073](https://github.com/jdx/mise/pull/10073)
- @thespags made their first contribution in [#10020](https://github.com/jdx/mise/pull/10020)
- @HYP3R00T made their first contribution in [#10081](https://github.com/jdx/mise/pull/10081)
- @SlaterByte made their first contribution in [#9971](https://github.com/jdx/mise/pull/9971)
- @andrewjamesbrown made their first contribution in [#10019](https://github.com/jdx/mise/pull/10019)
- @dovocoder made their first contribution in [#10043](https://github.com/jdx/mise/pull/10043)
- @naoki-mizuno made their first contribution in [#10051](https://github.com/jdx/mise/pull/10051)
- @ofek made their first contribution in [#10059](https://github.com/jdx/mise/pull/10059)

## 📦 Aqua Registry Updates

### New Packages (5)

- [`databricks/cli`](https://github.com/databricks/cli)
- [`felixgwilliams/nbwipers`](https://github.com/felixgwilliams/nbwipers)
- [`jgm/pandoc`](https://github.com/jgm/pandoc)
- [`ktlint/ktlint`](https://github.com/ktlint/ktlint)
- `x.ai/cli/grok`

### Updated Packages (6)

- [`betterleaks/betterleaks`](https://github.com/betterleaks/betterleaks)
- [`coder/coder`](https://github.com/coder/coder)
- [`gittuf/gittuf`](https://github.com/gittuf/gittuf)
- [`jdx/mise`](https://github.com/jdx/mise)
- [`jedisct1/minisign`](https://github.com/jedisct1/minisign)
- [`minio/mc`](https://github.com/minio/mc)