### PR TITLE
registry: add datahub

### DIFF
--- a/registry/datahub.toml
+++ b/registry/datahub.toml
@@ -1,0 +1,3 @@
+backends = ["pipx:acryl-datahub"]
+description = "DataHub CLI - open-source metadata platform for the modern data stack"
+test = { cmd = "datahub version", expected = "DataHub CLI version" }


### PR DESCRIPTION
## Summary

Adds a registry entry for `datahub`, the CLI for [DataHub](https://datahubproject.io) - an open-source metadata platform for the modern data stack. The OSS project is at [datahub-project/datahub](https://github.com/datahub-project/datahub) with 12k GitHub stars.

## Popularity

- GitHub: 12k stars, actively maintained ([datahub-project/datahub](https://github.com/datahub-project/datahub))
- PyPI: [acryl-datahub](https://pypi.org/project/acryl-datahub/) - approximately 4 million monthly downloads ([pypistats](https://pypistats.org/packages/acryl-datahub))

## Backend

`pipx:acryl-datahub` is the only viable backend. `acryl-datahub` is a Python-only package distributed exclusively via PyPI - there are no pre-built binaries, so `aqua:` and `github:` backends are not applicable.