### PR TITLE
[docs] Fix installation section for Scoop

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,7 +41,6 @@ winget install jdx.mise
 ```
 
 ```shell [scoop]
-# https://github.com/ScoopInstaller/Main/pull/6374
 scoop install mise
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,12 +36,12 @@ brew install mise
 == Windows
 ::: code-group
 
-```shell [winget]
-winget install jdx.mise
-```
-
 ```shell [scoop]
 scoop install mise
+```
+
+```shell [winget]
+winget install jdx.mise
 ```
 
 ```shell [chocolatey]


### PR DESCRIPTION
On https://mise.jdx.dev/getting-started.html the command to install via Scoop includes extra content, unlike the other mechanisms, which gets copied to the clipboard when clicking the button. I also moved Scoop to the front to match the recommendations on https://mise.jdx.dev/installing-mise.html#installation-methods (which I agree with as Scoop is definitely preferred for CLIs).

<img width="1144" height="726" alt="image" src="https://github.com/user-attachments/assets/f2b9c437-c8a0-4efd-8ec2-946309c09da3" />