### PR TITLE
chore(ci): disable setup-node cache for npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Install mise
         run: |


### PR DESCRIPTION
## Summary
- Disable `actions/setup-node` automatic package manager caching in the npm publish workflow
- Keeps setup-node registry/auth configuration while avoiding zizmor's cache-poisoning finding

## Verification
- `zizmor --persona=regular --min-severity=high --color=never .`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only tweak; publish path and auth wiring are unchanged aside from skipping automatic npm cache restore/save.
> 
> **Overview**
> The **npm publish** workflow still uses `actions/setup-node` for Node 24 and registry auth in `~/.npmrc` (used by **aube**), but turns off its built-in package manager cache with `package-manager-cache: false`.
> 
> That avoids **zizmor** cache-poisoning findings on this release job without changing how packages are published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9683f3802da562d22964ebe0d6a4dc757d934fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->