### PR TITLE
fix(copr): increase build timeout

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,11 @@ name: docker
 
 on:
   push:
+    branches: ["main"]
     tags: ["v[0-9]*"]
+    paths:
+      - ".github/workflows/docker.yml"
+      - "packaging/*/Dockerfile"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@ name: docker
 
 on:
   push:
-    branches: ["main"]
     tags: ["v[0-9]*"]
   workflow_dispatch:
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: ["main"]
     tags: ["v[0-9]*"]
-    paths:
-      - ".github/workflows/docker.yml"
-      - "packaging/*/Dockerfile"
   workflow_dispatch:
 
 concurrency:

--- a/packaging/copr/Dockerfile
+++ b/packaging/copr/Dockerfile
@@ -16,8 +16,9 @@ RUN dnf update -y && \
     dnf clean all
 
 # Install copr-cli via dnf to ensure dependencies are properly managed and to avoid potential issues with manual installation
-RUN dnf install -y copr-cli python3-rich && \
+RUN dnf install -y copr-cli && \
     dnf clean all && \
+    test "$(command -v copr-cli)" = "/usr/bin/copr-cli" && \
     copr-cli --help >/dev/null
 
 # Add mise to PATH

--- a/packaging/copr/Dockerfile
+++ b/packaging/copr/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf update -y && \
         rust \
         cargo \
         gcc \
+        openssl-devel \
         tar \
         gzip && \
     dnf clean all
@@ -20,13 +21,6 @@ RUN dnf install -y copr-cli && \
     dnf clean all && \
     test "$(readlink -f "$(command -v copr-cli)")" = "/usr/bin/copr-cli" && \
     copr-cli --help >/dev/null
-
-# Add mise to PATH
-ENV PATH="/root/.local/bin:${PATH}"
-
-# Install mise and use it to install cargo-vendor
-RUN curl https://mise.run | sh
-RUN mise use -g cargo-binstall cargo:cargo-vendor
 
 # Set up RPM build environment
 RUN rpmdev-setuptree

--- a/packaging/copr/Dockerfile
+++ b/packaging/copr/Dockerfile
@@ -16,8 +16,9 @@ RUN dnf update -y && \
     dnf clean all
 
 # Install copr-cli via dnf to ensure dependencies are properly managed and to avoid potential issues with manual installation
-RUN dnf install -y copr-cli && \
-    dnf clean all
+RUN dnf install -y copr-cli python3-rich && \
+    dnf clean all && \
+    copr-cli --help >/dev/null
 
 # Add mise to PATH
 ENV PATH="/root/.local/bin:${PATH}"

--- a/packaging/copr/Dockerfile
+++ b/packaging/copr/Dockerfile
@@ -18,7 +18,7 @@ RUN dnf update -y && \
 # Install copr-cli via dnf to ensure dependencies are properly managed and to avoid potential issues with manual installation
 RUN dnf install -y copr-cli && \
     dnf clean all && \
-    test "$(command -v copr-cli)" = "/usr/bin/copr-cli" && \
+    test "$(readlink -f "$(command -v copr-cli)")" = "/usr/bin/copr-cli" && \
     copr-cli --help >/dev/null
 
 # Add mise to PATH

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -288,7 +288,7 @@ if [ "$DRY_RUN" != "true" ]; then
 	# be interpreted as shell syntax, and validate each value against a
 	# conservative chroot pattern before forwarding to copr-cli.
 	IFS=' ' read -ra chroot_array <<<"$CHROOTS"
-	copr_args=("build")
+	copr_args=("build" "--nowait")
 	for chroot in "${chroot_array[@]}"; do
 		[ -z "$chroot" ] && continue
 		if ! [[ "$chroot" =~ ^[A-Za-z0-9._+-]+$ ]]; then

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -12,6 +12,7 @@ MAINTAINER_NAME="${MAINTAINER_NAME:-mise Release Bot}"
 MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-noreply@mise.jdx.dev}"
 COPR_OWNER="${COPR_OWNER:-jdxcode}"
 COPR_PROJECT="${COPR_PROJECT:-mise}"
+COPR_BUILD_TIMEOUT="${COPR_BUILD_TIMEOUT:-180000}"
 DRY_RUN="${DRY_RUN:-false}"
 
 # Store the repository root directory
@@ -105,6 +106,7 @@ echo "Build Profile: $BUILD_PROFILE"
 echo "Chroots: $CHROOTS"
 echo "COPR Owner: $COPR_OWNER"
 echo "COPR Project: $COPR_PROJECT"
+echo "COPR Build Timeout: $COPR_BUILD_TIMEOUT"
 echo "Maintainer: $MAINTAINER_NAME <$MAINTAINER_EMAIL>"
 echo "Dry Run: $DRY_RUN"
 echo ""
@@ -288,7 +290,7 @@ if [ "$DRY_RUN" != "true" ]; then
 	# be interpreted as shell syntax, and validate each value against a
 	# conservative chroot pattern before forwarding to copr-cli.
 	IFS=' ' read -ra chroot_array <<<"$CHROOTS"
-	copr_args=("build" "--nowait")
+	copr_args=("build" "--timeout" "$COPR_BUILD_TIMEOUT")
 	for chroot in "${chroot_array[@]}"; do
 		[ -z "$chroot" ] && continue
 		if ! [[ "$chroot" =~ ^[A-Za-z0-9._+-]+$ ]]; then


### PR DESCRIPTION
## Summary
- Increase the COPR build timeout via `COPR_BUILD_TIMEOUT`, defaulting to `180000`, and pass it through to `copr-cli build`.
- Keep the COPR image smoke test for the distro-managed `copr-cli` path and `copr-cli --help`.
- Stop installing mise just to install the obsolete `cargo-vendor` crate; Fedora's `cargo` already provides `cargo vendor`.
- Add `openssl-devel` to the COPR image build dependencies so the packaging environment matches the RPM spec and supports OpenSSL-linked Rust crates.

## Context
The old `ModuleNotFoundError: rich` failure came from a stale COPR image using `/usr/local/sbin/copr-cli`. Current Fedora 45 `copr-cli` from dnf does not require `rich`.

The current COPR failure is build timeout: COPR build `10503441` had 11 successful chroots and `fedora-rawhide-aarch64` failed with `!! Copr timeout => sending INT`. This PR fixes that by increasing the actual COPR builder timeout instead of using `--nowait`.

## Validation
- `git diff --check`
- `docker build --no-cache -t mise-copr-pr10071 -f packaging/copr/Dockerfile .` on local Docker/OrbStack native arm64
- Container smoke check: `copr-cli` resolves to `/usr/bin/copr-cli`, `copr-cli --help >/dev/null`, `cargo --version`, `cargo vendor --help >/dev/null`, `rpmdev-setuptree`
- Full dry-run pipeline in the PR image: `VERSION=2026.5.15 ./packaging/copr/build-copr.sh --dry-run`, producing `mise-2026.5.15-1.fc45.src.rpm`

Note: an attempted `linux/amd64` build under local OrbStack emulation failed in `curl https://mise.run | sh` with tar `Function not implemented`; the Dockerfile no longer runs that installer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and CI infrastructure only; no runtime application, auth, or data-path changes.
> 
> **Overview**
> Addresses COPR builds timing out (e.g. `fedora-rawhide-aarch64`) by introducing **`COPR_BUILD_TIMEOUT`** (default **180000**) and forwarding it to **`copr-cli build --timeout`**, with the value echoed in the build configuration log.
> 
> The **COPR packaging image** drops the **mise** installer path used only to install **`cargo-vendor`** (Fedora **`cargo`** already provides **`cargo vendor`**), adds **`openssl-devel`** to align with the RPM spec for OpenSSL-linked Rust builds, and **smoke-tests** that **`copr-cli`** resolves to **`/usr/bin/copr-cli`** and runs **`--help`** successfully after install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8eea237bf7bf6407243c20e1590fe2b22afa5af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->