### PR TITLE
registry: add longbridge-terminal (github:longbridge/longbridge-terminal)

### DIFF
--- a/registry/longbridge-terminal.toml
+++ b/registry/longbridge-terminal.toml
@@ -1,0 +1,2 @@
+backends = ["cargo:longbridge-terminal"]
+description = "AI-native CLI for Longbridge Securities — real-time market data, portfolio, and trading"

--- a/registry/longbridge-terminal.toml
+++ b/registry/longbridge-terminal.toml
@@ -1,2 +1,7 @@
-backends = ["cargo:longbridge-terminal"]
+backends = [
+  "github:longbridge/longbridge-terminal",
+  "cargo:longbridge-terminal",
+]
+bin = "longbridge"
 description = "AI-native CLI for Longbridge Securities — real-time market data, portfolio, and trading"
+test = { cmd = "longbridge --version", expected = "longbridge {{version}}" }


### PR DESCRIPTION
## Summary

Adds [longbridge-terminal](https://github.com/longbridge/longbridge-terminal) to the mise registry.

- **Tool name**: `longbridge-terminal`
- **Binary**: `longbridge`
- **Primary backend**: `github:longbridge/longbridge-terminal` (pre-built binaries for macOS/Linux/Windows)
- **Fallback backend**: `cargo:longbridge-terminal`
- **Language**: Rust
- **Latest release**: v0.22.1
- **Description**: AI-native CLI for Longbridge Securities — real-time market data, portfolio, and trading for HK/US/A-share/SG markets

## Install

```sh
mise use -g longbridge-terminal
```

## Registry entry

```toml
backends = [
  "github:longbridge/longbridge-terminal",
  "cargo:longbridge-terminal",
]
bin = "longbridge"
description = "AI-native CLI for Longbridge Securities — real-time market data, portfolio, and trading"
test = { cmd = "longbridge --version", expected = "longbridge {{version}}" }
```

## Popularity

- GitHub: 837 stars, 68 forks
- 30 releases, actively maintained (latest v0.22.1)
- Pre-built binaries available for darwin-amd64, darwin-arm64, linux-amd64, linux-arm64, linux-musl-amd64, linux-musl-arm64, windows-amd64