### PR TITLE
feat(oci): add configurable layer owner

### DIFF
--- a/docs/cli/oci/build.md
+++ b/docs/cli/oci/build.md
@@ -44,6 +44,12 @@ Where to place tool installs inside the image (default: /mise)
 
 Do not embed the currently-running mise binary at /usr/local/bin/mise
 
+### `--owner <UID[:GID]>`
+
+UID[:GID] to assign to every tar entry in generated layers
+
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+
 Examples:
 
 ```

--- a/docs/cli/oci/push.md
+++ b/docs/cli/oci/push.md
@@ -47,7 +47,9 @@ Don't embed the mise binary (ignored with --image-dir)
 
 ### `--owner <UID[:GID]>`
 
-UID[:GID] to assign to every tar entry when building (ignored with --image-dir)
+UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
+
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
 
 ### `--tool <TOOL>`
 

--- a/docs/cli/oci/push.md
+++ b/docs/cli/oci/push.md
@@ -45,6 +45,10 @@ Override in-image mount point (ignored with --image-dir)
 
 Don't embed the mise binary (ignored with --image-dir)
 
+### `--owner <UID[:GID]>`
+
+UID[:GID] to assign to every tar entry when building (ignored with --image-dir)
+
 ### `--tool <TOOL>`
 
 Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`

--- a/docs/cli/oci/run.md
+++ b/docs/cli/oci/run.md
@@ -62,6 +62,10 @@ Override in-image mount point (ignored with --image-dir)
 
 Don't embed the mise binary (ignored with --image-dir)
 
+### `--owner <UID[:GID]>`
+
+UID[:GID] to assign to every tar entry when building (ignored with --image-dir)
+
 ### `--volume… <HOST:CONTAINER>`
 
 Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)

--- a/docs/cli/oci/run.md
+++ b/docs/cli/oci/run.md
@@ -64,7 +64,9 @@ Don't embed the mise binary (ignored with --image-dir)
 
 ### `--owner <UID[:GID]>`
 
-UID[:GID] to assign to every tar entry when building (ignored with --image-dir)
+UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
+
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
 
 ### `--volume… <HOST:CONTAINER>`
 

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -115,7 +115,7 @@ mise oci run [--engine ENGINE] [--image-dir DIR]
 - `--engine` — `auto` (default, prefers podman), `podman`, or `docker`.
 - `--image-dir` — skip the build and use an existing OCI layout.
 - `--owner UID[:GID]` — numeric owner for generated layer entries when
-  building fresh. Conflicts with `--image-dir`.
+  building fresh; it cannot be combined with `--image-dir`.
 - `-i`, `-t`, `-e`, `--volume`, `-w`, `--keep` — pass through to the
   underlying engine the same way `docker run` uses them. (There's no
   `-v` short flag for `--volume` because mise reserves `-v` for
@@ -158,7 +158,7 @@ mise oci push [--tool TOOL] [--image-dir DIR]
 - `--image-dir` — push an existing OCI layout instead of building.
 
 - `--owner UID[:GID]` — numeric owner for generated layer entries when
-  building fresh. Conflicts with `--image-dir`.
+  building fresh; it cannot be combined with `--image-dir`.
 
 Examples:
 

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -80,7 +80,8 @@ the previous build (or from the registry, on pull).
 ## `mise oci build`
 
 ```sh
-mise oci build [-o PATH] [--from REF] [--tag REF] [--mount-point PATH] [--no-mise]
+mise oci build [-o PATH] [--from REF] [--tag REF] [--mount-point PATH]
+               [--no-mise] [--owner UID[:GID]]
 ```
 
 - `-o, --output PATH` — output directory (default `./mise-oci`)
@@ -92,6 +93,10 @@ mise oci build [-o PATH] [--from REF] [--tag REF] [--mount-point PATH] [--no-mis
   (default `/mise`). Must be absolute.
 - `--no-mise` — don't embed the running mise binary at
   `/usr/local/bin/mise`
+- `--owner UID[:GID]` — numeric owner for every generated layer entry.
+  Defaults to `[oci].user_id` / `[oci].group_id`, then `0:0`. If GID is
+  omitted, it defaults to UID. This affects file ownership only, not the
+  image `USER` directive.
 
 ## `mise oci run`
 
@@ -101,6 +106,7 @@ Build (or reuse) an image and run a command inside it, like
 ```sh
 mise oci run [--engine ENGINE] [--image-dir DIR]
              [--from REF] [--mount-point PATH] [--no-mise]
+             [--owner UID[:GID]]
              [-i] [-t] [-e KEY=VAL]... [--volume HOST:CONTAINER]...
              [-w DIR] [--keep]
              -- <cmd> [args...]
@@ -108,6 +114,8 @@ mise oci run [--engine ENGINE] [--image-dir DIR]
 
 - `--engine` — `auto` (default, prefers podman), `podman`, or `docker`.
 - `--image-dir` — skip the build and use an existing OCI layout.
+- `--owner UID[:GID]` — numeric owner for generated layer entries when
+  building fresh. Conflicts with `--image-dir`.
 - `-i`, `-t`, `-e`, `--volume`, `-w`, `--keep` — pass through to the
   underlying engine the same way `docker run` uses them. (There's no
   `-v` short flag for `--volume` because mise reserves `-v` for
@@ -140,6 +148,7 @@ login`, etc.).
 ```sh
 mise oci push [--tool TOOL] [--image-dir DIR]
               [--from REF] [--mount-point PATH] [--no-mise]
+              [--owner UID[:GID]]
               <REGISTRY_REF>
 ```
 
@@ -147,6 +156,9 @@ mise oci push [--tool TOOL] [--image-dir DIR]
   `ghcr.io/me/devenv:latest`). Must include a registry host.
 - `--tool` — `auto` (default, prefers skopeo), `skopeo`, or `crane`.
 - `--image-dir` — push an existing OCI layout instead of building.
+
+- `--owner UID[:GID]` — numeric owner for generated layer entries when
+  building fresh. Conflicts with `--image-dir`.
 
 Examples:
 
@@ -163,13 +175,15 @@ mise oci push --image-dir ./img ghcr.io/me/devenv:v1
 
 ```toml
 [oci]
-from       = "debian:bookworm-slim"  # base image ref
-tag        = "ghcr.io/me/devenv:v1"  # default tag for the built image
-workdir    = "/workspace"             # WORKDIR
-entrypoint = ["bash", "-l"]           # ENTRYPOINT
-cmd        = []                        # CMD
-user       = "nonroot"                # USER
-mount_point = "/mise"                 # where tools install in the image
+from        = "debian:bookworm-slim"  # base image ref
+tag         = "ghcr.io/me/devenv:v1"  # default tag for the built image
+workdir     = "/workspace"             # WORKDIR
+entrypoint  = ["bash", "-l"]           # ENTRYPOINT
+cmd         = []                        # CMD
+user        = "nonroot"                # USER
+user_id     = 1000                      # tar layer entry UID (file ownership)
+group_id    = 1000                      # tar layer entry GID (defaults to user_id)
+mount_point = "/mise"                  # where tools install in the image
 
 # Extra env baked into the image config (image-only — won't shadow MISE_*).
 [oci.env]
@@ -179,6 +193,10 @@ NODE_ENV = "production"
 [oci.labels]
 "org.opencontainers.image.source" = "https://github.com/me/my-app"
 ```
+
+`[oci].user` sets the image `USER` directive. `[oci].user_id` and
+`[oci].group_id` set layer file ownership; if no `group_id` is configured,
+it defaults to the resolved `user_id`.
 
 CLI flags override the `[oci]` section. The `[oci]` section overrides the
 `oci.default_from` / `oci.default_mount_point` settings.

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1605,6 +1605,11 @@ Where to place tool installs inside the image (default: /mise)
 .TP
 \fB\-\-no\-mise\fR
 Do not embed the currently\-running mise binary at /usr/local/bin/mise
+.TP
+\fB\-\-owner\fR \fI<UID[:GID]>\fR
+UID[:GID] to assign to every tar entry in generated layers
+
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
 .SH "MISE OCI PUSH"
 [experimental] Build an OCI image and push it to a registry
 
@@ -1638,6 +1643,9 @@ Override in\-image mount point (ignored with \-\-image\-dir)
 .TP
 \fB\-\-no\-mise\fR
 Don't embed the mise binary (ignored with \-\-image\-dir)
+.TP
+\fB\-\-owner\fR \fI<UID[:GID]>\fR
+UID[:GID] to assign to every tar entry when building (ignored with \-\-image\-dir)
 .TP
 \fB\-\-tool\fR \fI<TOOL>\fR
 Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`
@@ -1692,6 +1700,9 @@ Override in\-image mount point (ignored with \-\-image\-dir)
 .TP
 \fB\-\-no\-mise\fR
 Don't embed the mise binary (ignored with \-\-image\-dir)
+.TP
+\fB\-\-owner\fR \fI<UID[:GID]>\fR
+UID[:GID] to assign to every tar entry when building (ignored with \-\-image\-dir)
 .TP
 \fB\-\-volume\fR \fI<HOST:CONTAINER>\fR
 Bind\-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1645,7 +1645,9 @@ Override in\-image mount point (ignored with \-\-image\-dir)
 Don't embed the mise binary (ignored with \-\-image\-dir)
 .TP
 \fB\-\-owner\fR \fI<UID[:GID]>\fR
-UID[:GID] to assign to every tar entry when building (ignored with \-\-image\-dir)
+UID[:GID] to assign to every tar entry when building (conflicts with \-\-image\-dir)
+
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
 .TP
 \fB\-\-tool\fR \fI<TOOL>\fR
 Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`
@@ -1702,7 +1704,9 @@ Override in\-image mount point (ignored with \-\-image\-dir)
 Don't embed the mise binary (ignored with \-\-image\-dir)
 .TP
 \fB\-\-owner\fR \fI<UID[:GID]>\fR
-UID[:GID] to assign to every tar entry when building (ignored with \-\-image\-dir)
+UID[:GID] to assign to every tar entry when building (conflicts with \-\-image\-dir)
+
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
 .TP
 \fB\-\-volume\fR \fI<HOST:CONTAINER>\fR
 Bind\-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1682,7 +1682,12 @@ See `mise oci build --help` for details.
             arg <MOUNT_POINT>
         }
         flag --no-mise help="Don't embed the mise binary (ignored with --image-dir)"
-        flag --owner help="UID[:GID] to assign to every tar entry when building (ignored with --image-dir)" {
+        flag --owner help="UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)" {
+            long_help #"""
+UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
+
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+"""#
             arg "<UID[:GID]>"
         }
         flag --tool help="Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`" default=auto {
@@ -1752,7 +1757,12 @@ By default, both the container (`--rm`) and the loaded image are removed when th
             arg <MOUNT_POINT>
         }
         flag --no-mise help="Don't embed the mise binary (ignored with --image-dir)"
-        flag --owner help="UID[:GID] to assign to every tar entry when building (ignored with --image-dir)" {
+        flag --owner help="UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)" {
+            long_help #"""
+UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
+
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+"""#
             arg "<UID[:GID]>"
         }
         flag --volume help="Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)" var=#true {

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1622,6 +1622,10 @@ By default `mise oci build` only packages tools declared in the project's mise c
             arg <MOUNT_POINT>
         }
         flag --no-mise help="Do not embed the currently-running mise binary at /usr/local/bin/mise"
+        flag --owner help="UID[:GID] to assign to every tar entry in generated layers" {
+            long_help "UID[:GID] to assign to every tar entry in generated layers\n\nOverrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive."
+            arg "<UID[:GID]>"
+        }
     }
     cmd push help="[experimental] Build an OCI image and push it to a registry" {
         long_help #"""
@@ -1674,6 +1678,9 @@ See `mise oci build --help` for details.
             arg <MOUNT_POINT>
         }
         flag --no-mise help="Don't embed the mise binary (ignored with --image-dir)"
+        flag --owner help="UID[:GID] to assign to every tar entry when building (ignored with --image-dir)" {
+            arg "<UID[:GID]>"
+        }
         flag --tool help="Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`" default=auto {
             arg <TOOL> {
                 choices auto skopeo crane
@@ -1741,6 +1748,9 @@ By default, both the container (`--rm`) and the loaded image are removed when th
             arg <MOUNT_POINT>
         }
         flag --no-mise help="Don't embed the mise binary (ignored with --image-dir)"
+        flag --owner help="UID[:GID] to assign to every tar entry when building (ignored with --image-dir)" {
+            arg "<UID[:GID]>"
+        }
         flag --volume help="Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)" var=#true {
             long_help #"""
 Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1623,7 +1623,11 @@ By default `mise oci build` only packages tools declared in the project's mise c
         }
         flag --no-mise help="Do not embed the currently-running mise binary at /usr/local/bin/mise"
         flag --owner help="UID[:GID] to assign to every tar entry in generated layers" {
-            long_help "UID[:GID] to assign to every tar entry in generated layers\n\nOverrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive."
+            long_help #"""
+UID[:GID] to assign to every tar entry in generated layers
+
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+"""#
             arg "<UID[:GID]>"
         }
     }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2862,6 +2862,18 @@
           "type": "string",
           "description": "User baked into the image config"
         },
+        "user_id": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Numeric UID assigned to tar layer entries"
+        },
+        "group_id": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Numeric GID assigned to tar layer entries. Defaults to user_id when unset"
+        },
         "mount_point": {
           "type": "string",
           "description": "Override where mise installs go in the image (default /mise)"

--- a/src/cli/oci/build.rs
+++ b/src/cli/oci/build.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 use crate::cli::oci::common::{perform_build, short_digest};
 use crate::config::Settings;
 use crate::file::display_path;
-use crate::oci::BuildOptions;
+use crate::oci::{BuildOptions, LayerOwner};
 
 /// [experimental] Build an OCI image from the current mise.toml
 ///
@@ -50,6 +50,14 @@ pub struct Build {
     /// Do not embed the currently-running mise binary at /usr/local/bin/mise
     #[clap(long)]
     no_mise: bool,
+
+    /// UID[:GID] to assign to every tar entry in generated layers
+    ///
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
+    #[clap(long, value_name = "UID[:GID]")]
+    owner: Option<LayerOwner>,
 }
 
 impl Build {
@@ -61,6 +69,7 @@ impl Build {
             from: self.from.clone(),
             tag: self.tag.clone(),
             mount_point: self.mount_point.clone(),
+            owner: self.owner,
             include_mise: !self.no_mise,
         };
         let out = perform_build(opts, self.include_global).await?;

--- a/src/cli/oci/push.rs
+++ b/src/cli/oci/push.rs
@@ -49,7 +49,11 @@ pub struct Push {
     #[clap(long)]
     no_mise: bool,
 
-    /// UID[:GID] to assign to every tar entry when building (ignored with --image-dir)
+    /// UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
+    ///
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[clap(long, value_name = "UID[:GID]")]
     owner: Option<LayerOwner>,
 

--- a/src/cli/oci/push.rs
+++ b/src/cli/oci/push.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 use crate::cli::oci::common::perform_build;
 use crate::config::Settings;
 use crate::file;
-use crate::oci::BuildOptions;
+use crate::oci::{BuildOptions, LayerOwner};
 
 /// [experimental] Build an OCI image and push it to a registry
 ///
@@ -32,7 +32,7 @@ pub struct Push {
     from: Option<String>,
 
     /// Push an already-built OCI image layout (skip the build step)
-    #[clap(long, value_hint = ValueHint::DirPath, conflicts_with_all = &["from", "mount_point", "no_mise", "include_global"])]
+    #[clap(long, value_hint = ValueHint::DirPath, conflicts_with_all = &["from", "mount_point", "no_mise", "owner", "include_global"])]
     image_dir: Option<PathBuf>,
 
     /// Also include tools from the global / system config (default: project-only)
@@ -48,6 +48,10 @@ pub struct Push {
     /// Don't embed the mise binary (ignored with --image-dir)
     #[clap(long)]
     no_mise: bool,
+
+    /// UID[:GID] to assign to every tar entry when building (ignored with --image-dir)
+    #[clap(long, value_name = "UID[:GID]")]
+    owner: Option<LayerOwner>,
 
     /// Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`.
     #[clap(long, default_value = "auto")]
@@ -95,6 +99,7 @@ impl Push {
                     from: self.from.clone(),
                     tag: Some(self.reference.clone()),
                     mount_point: self.mount_point.clone(),
+                    owner: self.owner,
                     include_mise: !self.no_mise,
                 };
                 let built = perform_build(opts, self.include_global).await?;

--- a/src/cli/oci/run.rs
+++ b/src/cli/oci/run.rs
@@ -60,7 +60,11 @@ pub struct Run {
     #[clap(long)]
     no_mise: bool,
 
-    /// UID[:GID] to assign to every tar entry when building (ignored with --image-dir)
+    /// UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
+    ///
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[clap(long, value_name = "UID[:GID]")]
     owner: Option<LayerOwner>,
 

--- a/src/cli/oci/run.rs
+++ b/src/cli/oci/run.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 use crate::cli::oci::common::perform_build;
 use crate::config::Settings;
 use crate::file;
-use crate::oci::BuildOptions;
+use crate::oci::{BuildOptions, LayerOwner};
 
 /// [experimental] Build an OCI image from the current mise.toml and run a command in it
 ///
@@ -33,7 +33,7 @@ pub struct Run {
     from: Option<String>,
 
     /// Use an already-built OCI image layout instead of building fresh
-    #[clap(long, value_hint = ValueHint::DirPath, conflicts_with_all = &["from", "mount_point", "no_mise", "include_global"])]
+    #[clap(long, value_hint = ValueHint::DirPath, conflicts_with_all = &["from", "mount_point", "no_mise", "owner", "include_global"])]
     image_dir: Option<PathBuf>,
 
     /// Also include tools from the global / system config (default: project-only)
@@ -59,6 +59,10 @@ pub struct Run {
     /// Don't embed the mise binary (ignored with --image-dir)
     #[clap(long)]
     no_mise: bool,
+
+    /// UID[:GID] to assign to every tar entry when building (ignored with --image-dir)
+    #[clap(long, value_name = "UID[:GID]")]
+    owner: Option<LayerOwner>,
 
     /// Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)
     ///
@@ -129,6 +133,7 @@ impl Run {
                     from: self.from.clone(),
                     tag: Some("mise-oci:run".to_string()),
                     mount_point: self.mount_point.clone(),
+                    owner: self.owner,
                     include_mise: !self.no_mise,
                 };
                 let built = perform_build(opts, self.include_global).await?;

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -762,6 +762,32 @@ mod tests {
     }
 
     #[test]
+    fn resolve_layer_owner_uses_merged_config_group_id_from_same_layer() {
+        let mut oci = OciConfig::default();
+        oci.fill_defaults_from(OciConfig {
+            user_id: Some(1000),
+            group_id: Some(1001),
+            ..Default::default()
+        });
+
+        assert_eq!(resolve_layer_owner(None, &oci), LayerOwner::new(1000, 1001));
+    }
+
+    #[test]
+    fn resolve_layer_owner_does_not_inherit_less_specific_group_after_user_override() {
+        let mut oci = OciConfig {
+            user_id: Some(1000),
+            ..Default::default()
+        };
+        oci.fill_defaults_from(OciConfig {
+            group_id: Some(2000),
+            ..Default::default()
+        });
+
+        assert_eq!(resolve_layer_owner(None, &oci), LayerOwner::new(1000, 1000));
+    }
+
+    #[test]
     fn resolve_layer_owner_cli_value_wins_over_config() {
         let oci = OciConfig {
             user_id: Some(1000),

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -14,7 +14,7 @@ use crate::backend::backend_type::BackendType;
 use crate::config::{Config, Settings};
 use crate::file;
 use crate::oci::OciConfig;
-use crate::oci::layer::{self, LayerBlob};
+use crate::oci::layer::{self, LayerBlob, LayerOwner};
 use crate::oci::layout::ImageLayout;
 use crate::oci::manifest::{self, Descriptor, ImageConfig, ImageManifest, Platform, RootFs};
 use crate::oci::registry;
@@ -31,6 +31,8 @@ pub struct BuildOptions {
     pub tag: Option<String>,
     /// Where mise tools get installed inside the image.
     pub mount_point: Option<String>,
+    /// Numeric owner assigned to every tar entry in generated layers.
+    pub owner: Option<LayerOwner>,
     /// Embed the current mise binary at /usr/local/bin/mise.
     pub include_mise: bool,
 }
@@ -89,6 +91,8 @@ impl Builder {
                  depend on the working directory and mis-resolve tools."
             );
         }
+
+        let owner = resolve_layer_owner(self.opts.owner, &self.oci);
 
         // --- 1. Base image (optional) ---
         let from_ref = self
@@ -191,7 +195,7 @@ impl Builder {
                 );
             }
             let tv_prefix = tool_tar_prefix(&mount_point, tv);
-            let blob = layer::build_layer_from_dir(&install_path, &tv_prefix)
+            let blob = layer::build_layer_from_dir(&install_path, &tv_prefix, owner)
                 .wrap_err_with(|| format!("building layer for {}", tv.style()))?;
             tool_layers.push((tv.ba().short.clone(), tv.version.clone(), blob));
         }
@@ -215,7 +219,7 @@ impl Builder {
                     let bytes = std::fs::read(&exe)
                         .wrap_err_with(|| format!("reading mise binary at {}", exe.display()))?;
                     let files = vec![("usr/local/bin/mise".to_string(), bytes, 0o755u32)];
-                    mise_layer = Some(layer::build_layer_from_files(&files)?);
+                    mise_layer = Some(layer::build_layer_from_files(&files, owner)?);
                 }
                 Err(e) => {
                     warn!("could not locate mise binary to embed in image: {e}");
@@ -231,7 +235,7 @@ impl Builder {
                 config_toml.into_bytes(),
                 0o644u32,
             )];
-            layer::build_layer_from_files(&files)?
+            layer::build_layer_from_files(&files, owner)?
         };
 
         // --- 5. Write all layer blobs into the layout ---
@@ -567,6 +571,14 @@ impl Builder {
     }
 }
 
+fn resolve_layer_owner(opts_owner: Option<LayerOwner>, oci: &OciConfig) -> LayerOwner {
+    opts_owner.unwrap_or_else(|| {
+        let uid = oci.user_id.unwrap_or(0);
+        let gid = oci.group_id.unwrap_or(uid);
+        LayerOwner::new(uid, gid)
+    })
+}
+
 fn reject_unsupported_backends(
     versions: &[(Arc<dyn crate::backend::Backend>, ToolVersion)],
 ) -> Result<()> {
@@ -714,4 +726,52 @@ fn days_to_ymd(days: i64) -> (i64, u32, u32) {
 
 fn sanitize_label(s: &str) -> String {
     s.replace([':', '/'], ".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_layer_owner_defaults_to_root() {
+        assert_eq!(
+            resolve_layer_owner(None, &OciConfig::default()),
+            LayerOwner::new(0, 0)
+        );
+    }
+
+    #[test]
+    fn resolve_layer_owner_uses_config_with_uid_as_gid_default() {
+        let oci = OciConfig {
+            user_id: Some(1000),
+            ..Default::default()
+        };
+
+        assert_eq!(resolve_layer_owner(None, &oci), LayerOwner::new(1000, 1000));
+    }
+
+    #[test]
+    fn resolve_layer_owner_uses_config_group_id_when_present() {
+        let oci = OciConfig {
+            user_id: Some(1000),
+            group_id: Some(1001),
+            ..Default::default()
+        };
+
+        assert_eq!(resolve_layer_owner(None, &oci), LayerOwner::new(1000, 1001));
+    }
+
+    #[test]
+    fn resolve_layer_owner_cli_value_wins_over_config() {
+        let oci = OciConfig {
+            user_id: Some(1000),
+            group_id: Some(1001),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            resolve_layer_owner(Some(LayerOwner::new(2000, 2001)), &oci),
+            LayerOwner::new(2000, 2001)
+        );
+    }
 }

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -2,7 +2,7 @@
 //!
 //! Produces a gzipped tar where:
 //! - All mtimes are zeroed (or set from SOURCE_DATE_EPOCH).
-//! - All uid/gid are 0 with empty uname/gname.
+//! - All uid/gid are set from a fixed owner (default 0:0) with empty uname/gname.
 //! - Entries are sorted by path before writing.
 //! - Permissions are normalized (dirs 0755, exec files 0755, others 0644).
 //! - Gzip header mtime is zero'd (fixed compression level).
@@ -15,6 +15,7 @@ use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use eyre::{Context, Result};
 use flate2::Compression;
@@ -38,25 +39,77 @@ pub struct LayerBlob {
     pub bytes: Vec<u8>,
 }
 
+/// Numeric owner to write into every tar header in a generated OCI layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LayerOwner {
+    pub uid: u32,
+    pub gid: u32,
+}
+
+impl LayerOwner {
+    pub const fn new(uid: u32, gid: u32) -> Self {
+        Self { uid, gid }
+    }
+}
+
+impl Default for LayerOwner {
+    fn default() -> Self {
+        Self::new(0, 0)
+    }
+}
+
+impl FromStr for LayerOwner {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let mut parts = s.split(':');
+        let uid = parse_owner_id(parts.next().unwrap_or_default(), "uid")?;
+        let gid = match parts.next() {
+            Some(gid) => parse_owner_id(gid, "gid")?,
+            None => uid,
+        };
+        if parts.next().is_some() {
+            return Err("owner must be UID or UID:GID".to_string());
+        }
+        Ok(Self::new(uid, gid))
+    }
+}
+
+fn parse_owner_id(value: &str, name: &str) -> std::result::Result<u32, String> {
+    if value.is_empty() {
+        return Err(format!("{name} must not be empty"));
+    }
+    value
+        .parse::<u32>()
+        .map_err(|_| format!("{name} must be a non-negative integer <= {}", u32::MAX))
+}
+
 /// Build a reproducible gzipped tar layer from files in `src_dir`, placing them
 /// under `target_prefix` inside the tar (e.g. `/mise/installs/node/20.0.0`).
 ///
 /// `src_dir` must exist and be a directory. Symlinks are preserved; their
-/// targets are NOT followed.
-pub fn build_layer_from_dir(src_dir: &Path, target_prefix: &str) -> Result<LayerBlob> {
+/// targets are NOT followed. `owner` is applied to every emitted tar entry.
+pub fn build_layer_from_dir(
+    src_dir: &Path,
+    target_prefix: &str,
+    owner: LayerOwner,
+) -> Result<LayerBlob> {
     if !src_dir.is_dir() {
         eyre::bail!("not a directory: {}", src_dir.display());
     }
 
     let entries = collect_sorted_entries(src_dir)?;
-    build_layer_from_entries(&entries, target_prefix)
+    build_layer_from_entries(&entries, target_prefix, owner)
 }
 
 /// Build a layer from an in-memory list of (path_in_tar, content) pairs.
 /// Useful for layers that don't correspond to a real directory (e.g. the
-/// synthesized config layer).
-pub fn build_layer_from_files(files: &[(String, Vec<u8>, u32)]) -> Result<LayerBlob> {
-    let mut sorted = files.to_vec();
+/// synthesized config layer). `owner` is applied to every emitted tar entry.
+pub fn build_layer_from_files(
+    files: &[(String, Vec<u8>, u32)],
+    owner: LayerOwner,
+) -> Result<LayerBlob> {
+    let mut sorted: Vec<&(String, Vec<u8>, u32)> = files.iter().collect();
     sorted.sort_by(|a, b| a.0.cmp(&b.0));
 
     let mut tar_bytes = Vec::new();
@@ -67,27 +120,16 @@ pub fn build_layer_from_files(files: &[(String, Vec<u8>, u32)]) -> Result<LayerB
         // Track which parent directories we've emitted so we don't repeat them.
         let mut emitted_dirs: std::collections::BTreeSet<String> = Default::default();
 
-        for (path, contents, mode) in &sorted {
+        for (path, contents, mode) in sorted {
             for dir in parent_dirs(path) {
                 if emitted_dirs.insert(dir.clone()) {
-                    let mut header = Header::new_gnu();
-                    header.set_entry_type(EntryType::Directory);
-                    header.set_mode(0o755);
-                    header.set_uid(0);
-                    header.set_gid(0);
-                    header.set_size(0);
-                    header.set_mtime(0);
-                    header.set_cksum();
-                    builder
-                        .append_data(&mut header, format!("{dir}/"), std::io::empty())
-                        .wrap_err_with(|| format!("writing dir entry {dir}"))?;
+                    emit_dir(&mut builder, &dir, owner)?;
                 }
             }
             let mut header = Header::new_gnu();
             header.set_entry_type(EntryType::Regular);
             header.set_mode(*mode);
-            header.set_uid(0);
-            header.set_gid(0);
+            apply_owner(&mut header, owner);
             header.set_size(contents.len() as u64);
             header.set_mtime(0);
             header.set_cksum();
@@ -160,7 +202,11 @@ fn collect_sorted_entries(src_dir: &Path) -> Result<Vec<Entry>> {
     Ok(entries)
 }
 
-fn build_layer_from_entries(entries: &[Entry], target_prefix: &str) -> Result<LayerBlob> {
+fn build_layer_from_entries(
+    entries: &[Entry],
+    target_prefix: &str,
+    owner: LayerOwner,
+) -> Result<LayerBlob> {
     let prefix = target_prefix.trim_matches('/');
 
     let mut tar_bytes = Vec::new();
@@ -175,7 +221,7 @@ fn build_layer_from_entries(entries: &[Entry], target_prefix: &str) -> Result<La
         let mut emitted_dirs: std::collections::BTreeSet<String> = Default::default();
         for dir in prefix_parents(prefix) {
             if emitted_dirs.insert(dir.clone()) {
-                emit_dir(&mut builder, &dir)?;
+                emit_dir(&mut builder, &dir, owner)?;
             }
         }
 
@@ -192,15 +238,14 @@ fn build_layer_from_entries(entries: &[Entry], target_prefix: &str) -> Result<La
             match &e.kind {
                 EntryKind::Dir => {
                     if emitted_dirs.insert(path_in_tar.clone()) {
-                        emit_dir(&mut builder, &path_in_tar)?;
+                        emit_dir(&mut builder, &path_in_tar, owner)?;
                     }
                 }
                 EntryKind::File => {
                     let mut header = Header::new_gnu();
                     header.set_entry_type(EntryType::Regular);
                     header.set_mode(e.mode);
-                    header.set_uid(0);
-                    header.set_gid(0);
+                    apply_owner(&mut header, owner);
                     header.set_size(e.size);
                     header.set_mtime(0);
                     header.set_cksum();
@@ -214,8 +259,7 @@ fn build_layer_from_entries(entries: &[Entry], target_prefix: &str) -> Result<La
                     let mut header = Header::new_gnu();
                     header.set_entry_type(EntryType::Symlink);
                     header.set_mode(e.mode);
-                    header.set_uid(0);
-                    header.set_gid(0);
+                    apply_owner(&mut header, owner);
                     header.set_size(0);
                     header.set_mtime(0);
                     header
@@ -234,12 +278,16 @@ fn build_layer_from_entries(entries: &[Entry], target_prefix: &str) -> Result<La
     finalize_layer(tar_bytes)
 }
 
-fn emit_dir<W: Write>(builder: &mut tar::Builder<W>, path: &str) -> Result<()> {
+fn apply_owner(header: &mut Header, owner: LayerOwner) {
+    header.set_uid(owner.uid as u64);
+    header.set_gid(owner.gid as u64);
+}
+
+fn emit_dir<W: Write>(builder: &mut tar::Builder<W>, path: &str, owner: LayerOwner) -> Result<()> {
     let mut header = Header::new_gnu();
     header.set_entry_type(EntryType::Directory);
     header.set_mode(0o755);
-    header.set_uid(0);
-    header.set_gid(0);
+    apply_owner(&mut header, owner);
     header.set_size(0);
     header.set_mtime(0);
     header.set_cksum();
@@ -431,8 +479,10 @@ mod tests {
         fs::write(dir.path().join("bin/hello"), b"#!/bin/sh\necho hi\n").unwrap();
         fs::write(dir.path().join("README"), b"hello\n").unwrap();
 
-        let a = build_layer_from_dir(dir.path(), "mise/installs/test/1.0").unwrap();
-        let b = build_layer_from_dir(dir.path(), "mise/installs/test/1.0").unwrap();
+        let a = build_layer_from_dir(dir.path(), "mise/installs/test/1.0", LayerOwner::default())
+            .unwrap();
+        let b = build_layer_from_dir(dir.path(), "mise/installs/test/1.0", LayerOwner::default())
+            .unwrap();
         assert_eq!(a.digest, b.digest, "digests should match across runs");
         assert_eq!(a.diff_id, b.diff_id, "diff_ids should match across runs");
         assert_eq!(a.bytes, b.bytes, "bytes should match across runs");
@@ -442,8 +492,8 @@ mod tests {
     fn different_prefix_different_digest() {
         let dir = tempdir().unwrap();
         fs::write(dir.path().join("x"), b"x").unwrap();
-        let a = build_layer_from_dir(dir.path(), "a").unwrap();
-        let b = build_layer_from_dir(dir.path(), "b").unwrap();
+        let a = build_layer_from_dir(dir.path(), "a", LayerOwner::default()).unwrap();
+        let b = build_layer_from_dir(dir.path(), "b", LayerOwner::default()).unwrap();
         assert_ne!(a.digest, b.digest);
     }
 
@@ -457,9 +507,87 @@ mod tests {
                 0o755,
             ),
         ];
-        let a = build_layer_from_files(&files).unwrap();
-        let b = build_layer_from_files(&files).unwrap();
+        let a = build_layer_from_files(&files, LayerOwner::default()).unwrap();
+        let b = build_layer_from_files(&files, LayerOwner::default()).unwrap();
         assert_eq!(a.bytes, b.bytes);
+    }
+
+    #[test]
+    fn default_files_layer_owner_is_root() {
+        let files = vec![("etc/mise/config.toml".to_string(), b"foo\n".to_vec(), 0o644)];
+        let blob = build_layer_from_files(&files, LayerOwner::default()).unwrap();
+
+        assert_layer_owner(&blob, 0, 0);
+    }
+
+    #[test]
+    fn configured_files_layer_owner_applies_to_every_entry_and_is_reproducible() {
+        let files = vec![
+            ("etc/mise/config.toml".to_string(), b"foo\n".to_vec(), 0o644),
+            (
+                "usr/local/bin/mise".to_string(),
+                b"#!/bin/sh\nexec true\n".to_vec(),
+                0o755,
+            ),
+        ];
+        let owner = LayerOwner::new(1000, 1001);
+
+        let a = build_layer_from_files(&files, owner).unwrap();
+        let b = build_layer_from_files(&files, owner).unwrap();
+
+        assert_layer_owner(&a, 1000, 1001);
+        assert_eq!(a.bytes, b.bytes);
+    }
+
+    #[test]
+    fn configured_dir_layer_owner_applies_to_every_entry() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("bin")).unwrap();
+        fs::write(dir.path().join("bin/hello"), b"#!/bin/sh\necho hi\n").unwrap();
+
+        let blob = build_layer_from_dir(
+            dir.path(),
+            "opt/mise/installs/test/1.0",
+            LayerOwner::new(1000, 1000),
+        )
+        .unwrap();
+
+        assert_layer_owner(&blob, 1000, 1000);
+    }
+
+    #[test]
+    fn layer_owner_parses_uid_and_optional_gid() {
+        assert_eq!(
+            "1000".parse::<LayerOwner>().unwrap(),
+            LayerOwner::new(1000, 1000)
+        );
+        assert_eq!(
+            "1000:1001".parse::<LayerOwner>().unwrap(),
+            LayerOwner::new(1000, 1001)
+        );
+
+        for invalid in ["", ":", "1000:", ":1000", "1:2:3", "abc", "-1"] {
+            assert!(
+                invalid.parse::<LayerOwner>().is_err(),
+                "{invalid:?} should be rejected"
+            );
+        }
+    }
+
+    fn assert_layer_owner(blob: &LayerBlob, uid: u64, gid: u64) {
+        let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
+        let mut archive = tar::Archive::new(decoder);
+        let mut entries_seen = 0;
+
+        for entry in archive.entries().unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            assert_eq!(entry.header().uid().unwrap(), uid, "uid for {path}");
+            assert_eq!(entry.header().gid().unwrap(), gid, "gid for {path}");
+            entries_seen += 1;
+        }
+
+        assert!(entries_seen > 0, "expected at least one tar entry");
     }
 
     #[cfg(unix)]

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -16,6 +16,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 pub use builder::{BuildOptions, BuildOutput, Builder};
+pub use layer::LayerOwner;
 
 /// Normalize a Rust-style arch name (`x86_64`, `aarch64`) to the OCI-spec
 /// value (`amd64`, `arm64`).
@@ -62,6 +63,12 @@ pub struct OciConfig {
     /// User baked into the image config.
     #[serde(default)]
     pub user: Option<String>,
+    /// Numeric UID assigned to tar layer entries.
+    #[serde(default)]
+    pub user_id: Option<u32>,
+    /// Numeric GID assigned to tar layer entries. Defaults to `user_id` when unset.
+    #[serde(default)]
+    pub group_id: Option<u32>,
     /// Override where mise installs go in the image. Defaults to the value of
     /// the `oci.default_mount_point` setting (`/mise`).
     #[serde(default)]
@@ -101,6 +108,12 @@ impl OciConfig {
         }
         if self.user.is_none() {
             self.user = other.user;
+        }
+        if self.user_id.is_none() {
+            self.user_id = other.user_id;
+        }
+        if self.group_id.is_none() {
+            self.group_id = other.group_id;
         }
         if self.mount_point.is_none() {
             self.mount_point = other.mount_point;

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -109,10 +109,13 @@ impl OciConfig {
         if self.user.is_none() {
             self.user = other.user;
         }
+        let had_user_id = self.user_id.is_some();
         if self.user_id.is_none() {
             self.user_id = other.user_id;
         }
-        if self.group_id.is_none() {
+        // If a more-specific layer selected a UID but omitted GID, leave GID
+        // unset so owner resolution can apply the documented gid = uid fallback.
+        if self.group_id.is_none() && !had_user_id {
             self.group_id = other.group_id;
         }
         if self.mount_point.is_none() {

--- a/xtasks/fig/addCustomGenerators.ts
+++ b/xtasks/fig/addCustomGenerators.ts
@@ -194,11 +194,11 @@ const main = async (fileName: string, outFile?: string) => {
     const transformedSourceFile = result.transformed[0];
 
     const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
-    const output = printer.printNode(
-      ts.EmitHint.Unspecified,
-      transformedSourceFile,
-      sourceFile
-    );
+    const output = printer
+      .printNode(ts.EmitHint.Unspecified, transformedSourceFile, sourceFile)
+      // usage-cli drops brackets from Fig arg names; keep GID visibly optional.
+      .replaceAll('"name": "uid:gid"', '"name": "uid[:gid]"')
+      .replaceAll('name: "uid:gid"', 'name: "uid[:gid]"');
 
     fsAsync.writeFile(
       outFile ?? `${fileName.replace(".ts", "")}.out.ts`,

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1895,6 +1895,15 @@ const completionSpec: Fig.Spec = {
                 "Do not embed the currently-running mise binary at /usr/local/bin/mise",
               isRepeatable: false,
             },
+            {
+              name: "--owner",
+              description:
+                "UID[:GID] to assign to every tar entry in generated layers",
+              isRepeatable: false,
+              args: {
+                name: "uid:gid",
+              },
+            },
           ],
         },
         {
@@ -1941,6 +1950,15 @@ const completionSpec: Fig.Spec = {
               description:
                 "Don't embed the mise binary (ignored with --image-dir)",
               isRepeatable: false,
+            },
+            {
+              name: "--owner",
+              description:
+                "UID[:GID] to assign to every tar entry when building (ignored with --image-dir)",
+              isRepeatable: false,
+              args: {
+                name: "uid:gid",
+              },
             },
             {
               name: "--tool",
@@ -2023,6 +2041,15 @@ const completionSpec: Fig.Spec = {
               description:
                 "Don't embed the mise binary (ignored with --image-dir)",
               isRepeatable: false,
+            },
+            {
+              name: "--owner",
+              description:
+                "UID[:GID] to assign to every tar entry when building (ignored with --image-dir)",
+              isRepeatable: false,
+              args: {
+                name: "uid:gid",
+              },
             },
             {
               name: "--volume",

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1901,7 +1901,7 @@ const completionSpec: Fig.Spec = {
                 "UID[:GID] to assign to every tar entry in generated layers",
               isRepeatable: false,
               args: {
-                name: "uid:gid",
+                name: "uid[:gid]",
               },
             },
           ],
@@ -1954,10 +1954,10 @@ const completionSpec: Fig.Spec = {
             {
               name: "--owner",
               description:
-                "UID[:GID] to assign to every tar entry when building (ignored with --image-dir)",
+                "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)",
               isRepeatable: false,
               args: {
-                name: "uid:gid",
+                name: "uid[:gid]",
               },
             },
             {
@@ -2045,10 +2045,10 @@ const completionSpec: Fig.Spec = {
             {
               name: "--owner",
               description:
-                "UID[:GID] to assign to every tar entry when building (ignored with --image-dir)",
+                "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)",
               isRepeatable: false,
               args: {
-                name: "uid:gid",
+                name: "uid[:gid]",
               },
             },
             {


### PR DESCRIPTION
## Summary
- add `mise oci build --owner UID[:GID]`
- add `[oci].user_id` / `[oci].group_id` for layer file ownership
- keep the default at `0:0` so existing layer digests are unchanged unless opted in

## Why
This lets OCI images run as a non-root user without needing a runtime `chown -R` of the mise install tree. The selected owner is applied to generated tool layers, `/etc/mise`, and the embedded mise layer.

## Validation
- `cargo fmt --check`
- `cargo test --bin mise oci:: -- --nocapture`
- `cargo test --bin mise cli::tests::test_subcommands_are_sorted -- --nocapture`
- `cargo build --bin mise`
- built an OCI image and verified ownership via `crane export` + `tar --numeric-owner`

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --owner <UID[:GID]> to OCI commands (build, push, run) to set numeric ownership for generated layer files; defaults to 0:0, GID defaults to UID when omitted, and conflicts/ignored when --image-dir is used. This only affects tar-entry ownership; image USER remains separate.
  * Added user_id and group_id OCI config options for defaults.

* **Documentation**
  * Updated CLI help, man pages, usage spec, completion, and config docs for the new flag and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->