### PR TITLE
registry: add Confluent CLI

### DIFF
--- a/registry/confluent-cli.toml
+++ b/registry/confluent-cli.toml
@@ -1,4 +1,6 @@
 aliases = ["confluent"]
-backends = ["github:confluentinc/cli"]
+backends = [
+  { full = "github:confluentinc/cli", options = { bin = "confluent" } }
+]
 description = "CLI for Confluent Cloud and Confluent Platform"
 test = { cmd = "confluent --version", expected = "confluent version v{{version}}" }

--- a/registry/confluent-cli.toml
+++ b/registry/confluent-cli.toml
@@ -1,0 +1,4 @@
+aliases = ["confluent"]
+backends = ["github:confluentinc/cli"]
+description = "CLI for Confluent Cloud and Confluent Platform"
+test = { cmd = "confluent --version", expected = "confluent version v{{version}}" }


### PR DESCRIPTION
Add `confluent-cli` to registry.

Related links:
- https://github.com/confluentinc/cli
- https://docs.confluent.io/confluent-cli/current/overview.html