### PR TITLE
Remove broken link to "How I Use mise" page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -226,7 +226,6 @@ export default withMermaid(
             { text: "Templates", link: "/templates" },
             { text: "URL Replacements", link: "/url-replacements" },
             { text: "Model Context Protocol", link: "/mcp" },
-            { text: "How I Use mise", link: "/how-i-use-mise" },
             { text: "Directory Structure", link: "/directories" },
             { text: "Cache Behavior", link: "/cache-behavior" },
           ],


### PR DESCRIPTION
Eliminate a broken link in the documentation that referred to the "How I Use mise" page.