### PR TITLE
docs(site): add vitepress-plugin-llms for llms.txt generation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,6 +10,7 @@ import {
 import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 import { withMermaid } from "vitepress-plugin-mermaid";
 import kdlGrammar from "./grammars/kdl.tmLanguage.json";
+import llmstxt from "vitepress-plugin-llms";
 import miseTomlGrammar from "./grammars/mise-toml.tmLanguage.json";
 
 const configDir = dirname(fileURLToPath(import.meta.url));
@@ -304,6 +305,7 @@ export default withMermaid(
             ruby: "logos:ruby",
           },
         }),
+        llmstxt(),
       ],
     },
     head: [

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,7 +10,9 @@ import {
 import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 import { withMermaid } from "vitepress-plugin-mermaid";
 import kdlGrammar from "./grammars/kdl.tmLanguage.json";
-import llmstxt from "vitepress-plugin-llms";
+import llmstxt, {
+  copyOrDownloadAsMarkdownButtons,
+} from "vitepress-plugin-llms";
 import miseTomlGrammar from "./grammars/mise-toml.tmLanguage.json";
 
 const configDir = dirname(fileURLToPath(import.meta.url));
@@ -289,6 +291,7 @@ export default withMermaid(
       config(md) {
         md.use(groupIconMdPlugin);
         md.use(tabsMarkdownPlugin);
+        md.use(copyOrDownloadAsMarkdownButtons);
       },
     },
     vite: {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import type { Theme } from "vitepress";
 import DefaultTheme from "vitepress/theme";
 import { enhanceAppWithTabs } from "vitepress-plugin-tabs/client";
+import CopyOrDownloadAsMarkdownButtons from "vitepress-plugin-llms/vitepress-components/CopyOrDownloadAsMarkdownButtons.vue";
 import { initBanner } from "./banner";
 import "virtual:group-icons.css";
 import "./custom.css";
@@ -13,6 +14,10 @@ export default {
   Layout,
   enhanceApp({ app }) {
     enhanceAppWithTabs(app);
+    app.component(
+      "CopyOrDownloadAsMarkdownButtons",
+      CopyOrDownloadAsMarkdownButtons,
+    );
     initBanner();
   },
   setup() {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "typescript-eslint": "^8.58.2",
     "vitepress": "1.6.4",
     "vitepress-plugin-group-icons": "^1.6.5",
+    "vitepress-plugin-llms": "1.13.0",
     "vitepress-plugin-mermaid": "2.0.17",
     "vitepress-plugin-tabs": "^0.9.0"
   }


### PR DESCRIPTION
I want to make it easier for agents to read the Mise docs. This PR uses [vitepress-plugin-llms](https://github.com/okineadev/vitepress-plugin-llms) to add an `/llms.txt` (overview + sitemap), `.md` variants of the docs, and a copy widget:

<img width="359" height="291" alt="image" src="https://github.com/user-attachments/assets/cdfee42b-efbb-4d27-9e42-fdbcaed5dadc" />

> [!NOTE]
> `<Settings />` and `<Registry />` components don't actually render anything — `/configuration/settings.md` is a paragraph then… nothing. Could use some feedback before I fix that.

## Rendering settings/registries

There's a few options but the cleanest seems to be rendering a partial and including it. One for settings, one for registries (to be honest, I didn't look much at registries).

For settings, we'd render a `docs/_partials/settings.md` from `docs/settings.data.ts` and update `docs/configuration/settings.md` with something like:

```markdown
<llm-only>
  <!--@include: ../_partials/settings.md-->
</llm-only>
```

We might have to update the docs that reference the `<Settings />` component to have something like:

```markdown
<llm-only>
  Read /configuration/settings.md for details on available settings.
</llm-only>
```

I had ideas for some "smarter" ways, but the most reasonable alternative seemed awful (parsing `<Settings />` and its attributes with regex to search/replace with constructed Markdown 🥴).

## Why vitepress-plugin-llms

- Used for [Vite's own docs](https://github.com/vitejs/vite/blob/b089c2bab9a92543678e07af6997435542d738c5/docs/.vitepress/config.ts#L11) and a bunch of other major projects.
- Roughly 171k monthly npm downloads, MIT-licensed, no install scripts or telemetry.

**Other notes:**
- Was proposed as an official plugin in https://github.com/vuejs/vitepress/pull/4692 but didn't get any traction.
- [Patches](https://github.com/okineadev/vitepress-plugin-llms/tree/main/patches) a couple packages but it looks benign. No idea if those changes are upstreamed.
