### PR TITLE
registry: make aube more resilient (cargo:aube)

### DIFF
--- a/registry/aube.toml
+++ b/registry/aube.toml
@@ -1,3 +1,3 @@
-backends = ["github:endevco/aube"]
+backends = ["github:endevco/aube", "cargo:aube"]
 description = "A fast Node.js package manager"
 test = { cmd = "aube --version", expected = "{{version}}" }


### PR DESCRIPTION
Aube isn't mise-installable in docker on mac (linux arm). This fixes that.

`mise use cargo:aube` does fail on arm mac native, because there seems to be an issue with the binstall binaries for aube:

```
> mise use -g cargo:aube
error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.
help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
mise ERROR cargo-binstall failed
 INFO resolve: Resolving package: 'aube@=1.15.0'
ERROR resolve: When resolving aube bin aubr is not found. This binary is not optional so it must be included in the archive, please contact with upstream to fix this issue.
 WARN resolve: Error while downloading and extracting from fetcher github.com: failed to find or install binaries: bin file /Users/bram/.local/share/mise/installs/cargo-aube/1.15.0/cargo-binstallxysmDP/bin-aube-aarch64-apple-darwin-GhCrateMeta/aubr not found
 WARN The package aube v1.15.0 will be installed from source (with cargo)
ERROR Cargo errored! ExitStatus(unix_wait_status(256))
ERROR Fatal error:
  × For crate aube: subprocess cargo install aube --version 1.15.0 --locked
  │ --root /Users/bram/.local/share/mise/installs/cargo-aube/1.15.0 errored
  │ with exit status: 1
  ╰─▶ subprocess cargo install aube --version 1.15.0 --locked --root /Users/
      bram/.local/share/mise/installs/cargo-aube/1.15.0 errored with exit
      status: 1

cargo:aube@1.15.0            status: 1
```

However, presumably either the github download works, or mise will completely fall back to compiling from source. So I think this makes aube mise-installable in all cases.