### PR TITLE
feat: add stacker to registry

### DIFF
--- a/registry/gh-dash.toml
+++ b/registry/gh-dash.toml
@@ -1,0 +1,2 @@
+backends = ["github:dlvhdr/gh-dash"]
+description = "A rich terminal UI for GitHub that doesn't break your flow."

--- a/registry/pangolin-cli.toml
+++ b/registry/pangolin-cli.toml
@@ -1,0 +1,3 @@
+backends = ["github:fosrl/cli"]
+description = "Pangolin CLI tool and VPN client"
+test = { cmd = "pangolin-cli version", expected = "{{version}}" }

--- a/registry/stacker.toml
+++ b/registry/stacker.toml
@@ -1,2 +1,3 @@
 backends = ["github:project-stacker/stacker"]
+os = ["linux"]
 description = "A vendor-neutral OCI-native container image (tgz, squashfs, erofs) builder (purely based on OCI Image Specification)"

--- a/registry/stacker.toml
+++ b/registry/stacker.toml
@@ -1,0 +1,2 @@
+backends = ["github:project-stacker/stacker"]
+description = "A vendor-neutral OCI-native container image (tgz, squashfs, erofs) builder (purely based on OCI Image Specification)"


### PR DESCRIPTION
https://github.com/project-stacker/stacker

A vendor-neutral OCI-native container image (tgz, squashfs, erofs) builder (purely based on OCI Image Specification)