### PR TITLE
registry: add flux9s (github:dgunzy/flux9s)

### DIFF
--- a/registry/flux9s.toml
+++ b/registry/flux9s.toml
@@ -1,0 +1,3 @@
+backends = ["github:dgunzy/flux9s"]
+description = "A K9s-inspired terminal UI for monitoring Flux resources in real-time"
+test = { cmd = "flux9s version", expected = "flux9s {{version}}" }


### PR DESCRIPTION
## Popularity

- Star count: 203 (but rising)
- Most recent push: May 18th, 2026 (active development)
- Latest release: 0.9.0 on April 28th, 2026

## Tests

- `cargo test registry::tests`
- `cargo run -- registry flux9s`
- `./target/debug/mise test-tool flux9s`