### PR TITLE
docs(config): remove outdated terraform main.tf reference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -409,7 +409,7 @@ in mise and nvm. Here are some of the supported idiomatic version files:
 | python     | `.python-version`, `.python-versions`     |
 | ruby       | `.ruby-version`, `Gemfile`                |
 | rust       | `rust-toolchain.toml`                     |
-| terraform  | `.terraform-version`, `main.tf`           |
+| terraform  | `.terraform-version`                      |
 | terragrunt | `.terragrunt-version`                     |
 | terramate  | `.terramate-version`                      |
 | yarn       | `.yvmrc`, `package.json`                  |


### PR DESCRIPTION
## Summary
- remove the outdated `main.tf` idiomatic version file reference for Terraform
- keep `.terraform-version` as the documented Terraform idiomatic version file

Reported in https://github.com/jdx/mise/discussions/3543.

## Verification
- `git grep -n "main\.tf\|main.tf" -- docs`
- `git diff --check`