### PR TITLE
registry: use npm backend for npm on Windows

### DIFF
--- a/registry/npm.toml
+++ b/registry/npm.toml
@@ -1,4 +1,10 @@
-backends = ["aqua:npm/cli", "npm:npm"]
+backends = [
+  { full = "aqua:npm/cli", platforms = [
+    "linux",
+    "macos",
+  ] },
+  "npm:npm",
+]
 description = "the package manager for JavaScript"
 idiomatic_files = ["package.json"]
 overrides = ["node"]

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -774,8 +774,16 @@ mod tests {
         let _config = Config::get().await.unwrap();
 
         let fa: BackendArg = "npm".into();
-        assert_str_eq!("aqua:npm/cli", fa.full());
-        assert_eq!(BackendType::Aqua, fa.backend_type());
+        #[cfg(windows)]
+        {
+            assert_str_eq!("npm:npm", fa.full());
+            assert_eq!(BackendType::Npm, fa.backend_type());
+        }
+        #[cfg(not(windows))]
+        {
+            assert_str_eq!("aqua:npm/cli", fa.full());
+            assert_eq!(BackendType::Aqua, fa.backend_type());
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Keep `aqua:npm/cli` as the first `npm` shorthand backend on Linux and macOS.
- Let Windows fall through to the existing `npm:npm` backend.
- Pair with aquaproj/aqua-registry#54474, which stops advertising standalone `npm/cli` Windows support.

## Context

The standalone npm package tarballs include `package/bin/npm.cmd` and `package/bin/npx.cmd`, but those wrappers assume the Node/global npm layout and look for `node_modules/npm/bin/npm-cli.js` relative to the wrapper directory. That layout exists for Node-bundled npm and for npm installed through `npm install -g`, but not for the direct aqua extraction of `npm/cli`.

This fixes the Windows shorthand case from https://github.com/jdx/mise/discussions/10089 by selecting `npm:npm` on Windows instead of the broken standalone aqua tarball layout.

## Popularity

This is an existing registry entry. `npm/cli` is the upstream npm CLI, currently with 9,787 GitHub stars and 4,368 forks, and latest release `v11.15.0` published on 2026-05-20.

## Verification

```console
$ cargo build --all-features
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 40s

$ cargo test test_bare_npm_uses_registry_tool
running 1 test
test cli::args::backend_arg::tests::test_bare_npm_uses_registry_tool ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 988 filtered out; finished in 0.06s

$ cargo fmt -- --check
# passed

$ taplo fmt --check registry/npm.toml
# passed

$ MISE_OS=windows MISE_ARCH=x64 /home/risu/.cache/cargo-target/mise-409845c58888dcc6/debug/mise registry npm
npm:npm

$ MISE_OS=linux MISE_ARCH=x64 /home/risu/.cache/cargo-target/mise-409845c58888dcc6/debug/mise registry npm
aqua:npm/cli npm:npm

$ MISE_OS=macos MISE_ARCH=arm64 /home/risu/.cache/cargo-target/mise-409845c58888dcc6/debug/mise registry npm
aqua:npm/cli npm:npm
```

Windows smoke using upgraded mise `2026.5.15`, temp-only `MISE_DATA_DIR`/`MISE_CACHE_DIR`/`MISE_CONFIG_DIR`/`MISE_STATE_DIR`, and `MISE_BACKENDS_NPM=npm:npm` to mirror the registry fallback:

```console
$ mise --version
2026.5.15 windows-x64 (2026-05-23)

$ mise which -C $project npm
C:\Users\risu\AppData\Local\Temp\mise-npm-win-fallback-...\data\installs\npm\10.9.2\npm.cmd

$ mise exec -C $project -- npm --version
10.9.2
```

AI assistance: Codex was used for investigation and drafting; I reviewed the changes and verification results.
