### PR TITLE
fix(aqua): lock github_content raw URLs

### DIFF
--- a/e2e/cli/test_lock
+++ b/e2e/cli/test_lock
@@ -77,6 +77,17 @@ assert_contains "echo '$output'" "Processing 1 tool(s)"
 assert_contains "cat mise.lock" "jqlang/jq"
 assert_not_contains "cat mise.lock" "mikefarah/yq"
 
+echo "=== Testing aqua github_content lock URLs ==="
+rm -f mise.lock
+cat <<EOF >mise.toml
+[tools]
+"aqua:awslabs/git-secrets" = "1.3.0"
+EOF
+
+mise lock --platform macos-arm64
+assert_contains "cat mise.lock" 'url = "https://raw.githubusercontent.com/awslabs/git-secrets/1.3.0/git-secrets"'
+assert_not_contains "cat mise.lock" "archive/refs/tags/1.3.0.tar.gz"
+
 echo "=== Testing minimum release age filtering ==="
 rm -f mise.lock
 cat <<EOF >mise.toml

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -760,8 +760,13 @@ impl Backend for AquaBackend {
                 }
                 result
             }
-            AquaPackageType::GithubArchive | AquaPackageType::GithubContent => {
-                (Some(self.github_archive_url(&pkg, &v)), None)
+            AquaPackageType::GithubArchive => (Some(self.github_archive_url(&pkg, &v)), None),
+            AquaPackageType::GithubContent => {
+                if pkg.path.is_some() {
+                    (Some(self.github_content_url(&pkg, &v)), None)
+                } else {
+                    bail!("github_content package requires `path`")
+                }
             }
             AquaPackageType::Http => (pkg.url(&v, target_os, target_arch).ok(), None),
             _ => (None, None),


### PR DESCRIPTION
## Summary
- lock aqua `github_content` packages with raw GitHub content URLs instead of archive URLs
- return the same missing-`path` error in lock resolution that install resolution already uses
- add e2e coverage for `aqua:awslabs/git-secrets@1.3.0` lock output

## Discussion
Addresses https://github.com/jdx/mise/discussions/10003.

## Tests
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 MISE_TRUSTED_CONFIG_PATHS="$PWD" mise run test:e2e e2e/cli/test_lock`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise run format`