### PR TITLE
fix(github): handle x86 release assets as x64 fallback

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -315,6 +315,13 @@ impl AssetPicker {
             if pattern.is_match(asset) {
                 return if arch.matches_target(&self.target_arch) {
                     50
+                } else if *arch == AssetArch::X86
+                    && AssetArch::X64.matches_target(&self.target_arch)
+                {
+                    // Some projects use "x86" for their x86-64 artifacts. Keep
+                    // this below a real x64/amd64 match so correctly named
+                    // assets win when both are present.
+                    5
                 } else {
                     // Architecture mismatch should be disqualifying - don't silently
                     // fall back to incompatible architectures (e.g., x86_64 when arm64
@@ -417,6 +424,7 @@ impl AssetPicker {
             || asset.ends_with(".intoto")
             || asset.ends_with(".attestation")
             || asset.ends_with(".pem")
+            || asset.ends_with(".cert")
             || asset.ends_with(".crt")
             || asset.ends_with(".key")
             || asset.ends_with(".pub")
@@ -1339,6 +1347,32 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
         .with_preferred_name("opengrep");
         let picked = picker.pick_best_asset(&assets).unwrap();
         assert_eq!(picked, "opengrep_musllinux_aarch64");
+    }
+
+    #[test]
+    fn test_x86_asset_is_x64_fallback() {
+        let assets = vec![
+            "opengrep-core_linux_x86.tar.gz".to_string(),
+            "opengrep_manylinux_x86".to_string(),
+            "opengrep_manylinux_x86.cert".to_string(),
+            "opengrep_manylinux_x86.sig".to_string(),
+            "opengrep_musllinux_x86".to_string(),
+        ];
+
+        let picker = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("opengrep");
+        let picked = picker.pick_best_asset(&assets).unwrap();
+        assert_eq!(picked, "opengrep_manylinux_x86");
+
+        let exact_assets = vec![
+            "opengrep_manylinux_x86".to_string(),
+            "opengrep_manylinux_x86_64".to_string(),
+        ];
+        let picked = picker.pick_best_asset(&exact_assets).unwrap();
+        assert_eq!(picked, "opengrep_manylinux_x86_64");
+
+        let arm_picker = AssetPicker::with_libc("linux".to_string(), "aarch64".to_string(), None);
+        assert_eq!(arm_picker.pick_best_asset(&exact_assets), None);
     }
 
     #[test]

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -424,7 +424,6 @@ impl AssetPicker {
             || asset.ends_with(".intoto")
             || asset.ends_with(".attestation")
             || asset.ends_with(".pem")
-            || asset.ends_with(".cert")
             || asset.ends_with(".crt")
             || asset.ends_with(".key")
             || asset.ends_with(".pub")
@@ -1354,7 +1353,6 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
         let assets = vec![
             "opengrep-core_linux_x86.tar.gz".to_string(),
             "opengrep_manylinux_x86".to_string(),
-            "opengrep_manylinux_x86.cert".to_string(),
             "opengrep_manylinux_x86.sig".to_string(),
             "opengrep_musllinux_x86".to_string(),
         ];

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -71,7 +71,18 @@ pub async fn fetch_checksum_from_file(checksum_url: &str, algo: &str) -> Option<
 
 // Shared OS/arch patterns used across helpers
 const OS_PATTERNS: &[&str] = &[
-    "linux", "darwin", "macos", "windows", "win", "freebsd", "openbsd", "netbsd", "android",
+    "linux",
+    "manylinux",
+    "musllinux",
+    "darwin",
+    "macos",
+    "osx",
+    "windows",
+    "win",
+    "freebsd",
+    "openbsd",
+    "netbsd",
+    "android",
     "unknown",
 ];
 // Longer arch patterns first to avoid partial matches
@@ -1080,6 +1091,18 @@ mod tests {
         assert_eq!(
             clean_binary_name("app-linux.AppImage", None),
             "app.AppImage"
+        );
+        assert_eq!(
+            clean_binary_name("opengrep_osx_arm64", Some("opengrep/opengrep")),
+            "opengrep"
+        );
+        assert_eq!(
+            clean_binary_name("opengrep_manylinux_x86", Some("opengrep/opengrep")),
+            "opengrep"
+        );
+        assert_eq!(
+            clean_binary_name("opengrep_musllinux_x86", Some("opengrep/opengrep")),
+            "opengrep"
         );
 
         // Test edge cases

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -71,18 +71,7 @@ pub async fn fetch_checksum_from_file(checksum_url: &str, algo: &str) -> Option<
 
 // Shared OS/arch patterns used across helpers
 const OS_PATTERNS: &[&str] = &[
-    "linux",
-    "manylinux",
-    "musllinux",
-    "darwin",
-    "macos",
-    "osx",
-    "windows",
-    "win",
-    "freebsd",
-    "openbsd",
-    "netbsd",
-    "android",
+    "linux", "darwin", "macos", "windows", "win", "freebsd", "openbsd", "netbsd", "android",
     "unknown",
 ];
 // Longer arch patterns first to avoid partial matches
@@ -1091,18 +1080,6 @@ mod tests {
         assert_eq!(
             clean_binary_name("app-linux.AppImage", None),
             "app.AppImage"
-        );
-        assert_eq!(
-            clean_binary_name("opengrep_osx_arm64", Some("opengrep/opengrep")),
-            "opengrep"
-        );
-        assert_eq!(
-            clean_binary_name("opengrep_manylinux_x86", Some("opengrep/opengrep")),
-            "opengrep"
-        );
-        assert_eq!(
-            clean_binary_name("opengrep_musllinux_x86", Some("opengrep/opengrep")),
-            "opengrep"
         );
 
         // Test edge cases


### PR DESCRIPTION
## Summary
- allow GitHub release assets tagged only as `x86` to serve as a low-priority fallback on x64 targets
- preserve explicit x64/amd64 preference when correctly named assets exist
- keep the fallback scoped so non-x64 targets still reject mismatched x86 assets

## Split scope
- Certificate metadata handling was extracted to #10158.
- OpenGrep platform suffix cleanup was extracted to #10166.

## Discussion
Part of https://github.com/jdx/mise/discussions/10033.

## Tests
- `git diff --check upstream/main...HEAD`
- Attempted `cargo test test_x86_asset_is_x64_fallback`; local test build stops before this test in untouched `src/backend/aqua.rs` test code with the existing `Option<bool>`/`bool` mismatch around `complete_windows_ext`.
- GitHub CI passed on the rebased and narrowed branch.