### PR TITLE
fix(task): set config_root for global config tasks

### DIFF
--- a/e2e/tasks/test_task_global_config_root
+++ b/e2e/tasks/test_task_global_config_root
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[tasks.check-config-root]
+run = 'echo "config_root={{config_root}}"'
+TOML
+
+assert "mise run check-config-root" "config_root=$HOME"
+
+custom_root="$PWD/custom-global-root"
+mkdir -p "$custom_root"
+assert "MISE_GLOBAL_CONFIG_ROOT='$custom_root' mise run check-config-root" "config_root=$custom_root"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2267,6 +2267,9 @@ async fn load_config_tasks(
         if is_global {
             t.global = true;
         }
+        if t.config_root.is_none() {
+            t.config_root = Some(config_root.to_path_buf());
+        }
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
         match t.render(&config, &config_root).await {


### PR DESCRIPTION
## Summary
- set `task.config_root` for inline tasks loaded from config files before rendering
- add regression coverage for global config tasks using the documented `$HOME` default
- verify explicit `MISE_GLOBAL_CONFIG_ROOT` still overrides the default

Fixes the behavior reported in https://github.com/jdx/mise/discussions/10084.

## Test
- `PATH="$HOME/.cargo/bin:$PATH" MISE_TRUSTED_CONFIG_PATHS="$PWD" mise run test:e2e e2e/tasks/test_task_global_config_root`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change in task loading plus regression tests; no auth or security surface.
> 
> **Overview**
> Fixes **global config** inline tasks so the `{{config_root}}` template resolves correctly during task load.
> 
> When tasks are parsed from config files, **`config_root` is now set** on each task (if unset) from the config file’s root **before** `render()` runs—matching file-based tasks and fixing incorrect or missing values for tasks defined in `~/.config/mise` and similar paths.
> 
> Adds an **e2e** check that the default global root is **`$HOME`** and that **`MISE_GLOBAL_CONFIG_ROOT`** still overrides it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1fdccf24c6b04bc3c19334bca2d675b183f995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->