### PR TITLE
fix(github): explain attestation ip allow list errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5486,6 +5486,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "hex",
+ "mockito",
  "reqwest 0.13.3",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",

--- a/crates/mise-sigstore/Cargo.toml
+++ b/crates/mise-sigstore/Cargo.toml
@@ -42,3 +42,7 @@ native-tls = [
   "sigstore-verify/tuf",
 ]
 rustls = ["reqwest/rustls", "sigstore-verify/rustls", "sigstore-verify/tuf"]
+
+[dev-dependencies]
+mockito = "1"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use async_trait::async_trait;
 use base64::Engine;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::{Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sigstore_verify::VerificationPolicy;
@@ -243,6 +244,34 @@ impl AttestationClient {
         Ok(headers)
     }
 
+    async fn github_get(&self, url: reqwest::Url) -> Result<Response> {
+        let headers = self.github_headers(url.as_str())?;
+        let response = self.client.get(url).headers(headers.clone()).send().await?;
+
+        if response.status() == StatusCode::FORBIDDEN && headers.contains_key(AUTHORIZATION) {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+
+            if body.contains("IP allow list") {
+                return Err(AttestationError::Api(format!(
+                    "GitHub rejected the configured token because the organization has an IP allow list enabled. \
+                     Use a token permitted by the organization, or unset MISE_GITHUB_TOKEN/GITHUB_API_TOKEN/GITHUB_TOKEN \
+                     for this command if the resource is public and anonymous access is acceptable. \
+                     GitHub API returned {status}: {body}"
+                )));
+            }
+
+            return Err(AttestationError::Api(format!(
+                "GitHub API returned {status}: {body}"
+            )));
+        }
+
+        Ok(response)
+    }
+
     pub async fn fetch_attestations(&self, params: FetchParams) -> Result<Vec<Attestation>> {
         let url = if let Some(repo) = &params.repo {
             format!(
@@ -263,12 +292,7 @@ impl AttestationClient {
         let url = reqwest::Url::parse_with_params(&url, query_params)
             .map_err(|e| AttestationError::Api(format!("Invalid GitHub attestations URL: {e}")))?;
 
-        let response = self
-            .client
-            .get(url.clone())
-            .headers(self.github_headers(url.as_str())?)
-            .send()
-            .await?;
+        let response = self.github_get(url).await?;
 
         if response.status() == reqwest::StatusCode::NOT_FOUND {
             return Ok(vec![]);
@@ -301,12 +325,9 @@ impl AttestationClient {
     }
 
     async fn fetch_bundle_url(&self, bundle_url: &str) -> Result<serde_json::Value> {
-        let response = self
-            .client
-            .get(bundle_url)
-            .headers(self.github_headers(bundle_url)?)
-            .send()
-            .await?;
+        let url = reqwest::Url::parse(bundle_url)
+            .map_err(|e| AttestationError::Api(format!("Invalid GitHub bundle URL: {e}")))?;
+        let response = self.github_get(url).await?;
         if !response.status().is_success() {
             return Err(AttestationError::Api(format!(
                 "bundle URL returned {}",
@@ -1277,6 +1298,9 @@ async fn calculate_file_digest_async(path: &Path) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mockito::Matcher;
+
+    const IP_ALLOW_LIST_BODY: &str = r#"{"message":"Although you appear to have the correct authorization credentials, the `databricks` organization has an IP allow list enabled, and your IP address is not permitted to access this resource.","status":"403"}"#;
 
     #[test]
     fn signer_workflow_requires_identity() {
@@ -1318,6 +1342,78 @@ mod tests {
         .to_string();
 
         assert!(err.contains("Workflow verification failed"));
+    }
+
+    #[tokio::test]
+    async fn github_attestations_explain_ip_allow_list_403_without_retrying() {
+        let mut server = mockito::Server::new_async().await;
+        let path = "/repos/databricks/cli/attestations/sha256:abc123";
+        let authenticated = server
+            .mock("GET", path)
+            .match_query(Matcher::UrlEncoded("per_page".into(), "30".into()))
+            .match_header("authorization", "Bearer ghs_blocked")
+            .with_status(403)
+            .with_body(IP_ALLOW_LIST_BODY)
+            .expect(1)
+            .create_async()
+            .await;
+        let client = AttestationClient::builder()
+            .base_url(&server.url())
+            .github_token("ghs_blocked")
+            .build()
+            .unwrap();
+
+        let err = client
+            .fetch_attestations(FetchParams {
+                owner: "databricks".to_string(),
+                repo: Some("databricks/cli".to_string()),
+                digest: "sha256:abc123".to_string(),
+                limit: 30,
+                predicate_type: None,
+            })
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("organization has an IP allow list enabled"));
+        assert!(err.contains("configured token"));
+        assert!(err.contains("unset MISE_GITHUB_TOKEN/GITHUB_API_TOKEN/GITHUB_TOKEN"));
+        authenticated.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn github_attestations_do_not_retry_non_ip_allow_list_403() {
+        let mut server = mockito::Server::new_async().await;
+        let path = "/repos/owner/repo/attestations/sha256:def456";
+        let authenticated = server
+            .mock("GET", path)
+            .match_query(Matcher::UrlEncoded("per_page".into(), "30".into()))
+            .match_header("authorization", "Bearer ghs_forbidden")
+            .with_status(403)
+            .with_body(r#"{"message":"rate limit exceeded","status":"403"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let client = AttestationClient::builder()
+            .base_url(&server.url())
+            .github_token("ghs_forbidden")
+            .build()
+            .unwrap();
+
+        let err = client
+            .fetch_attestations(FetchParams {
+                owner: "owner".to_string(),
+                repo: Some("owner/repo".to_string()),
+                digest: "sha256:def456".to_string(),
+                limit: 30,
+                predicate_type: None,
+            })
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("rate limit exceeded"));
+        authenticated.assert_async().await;
     }
 
     /// A genuine `*.intoto.jsonl` produced by slsa-github-generator (sops


### PR DESCRIPTION
## Summary
- detect GitHub attestation API 403 responses caused by organization IP allow lists
- return a clear, actionable error instead of a generic API failure
- preserve configured authentication; this does not retry requests anonymously
- add regression tests for IP allow-list diagnostics and ordinary 403 handling

Discussed in https://github.com/jdx/mise/discussions/10085.

## Test
- `/home/coder/.cargo/bin/cargo test -p mise-sigstore --features rustls`

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to GitHub API client error handling and tests in mise-sigstore; no changes to signature verification or trust roots.
> 
> **Overview**
> GitHub attestation and bundle fetches now go through a shared **`github_get`** helper instead of duplicating authenticated `reqwest` calls.
> 
> When an authenticated request returns **403**, the client reads the response body once: if it mentions an **IP allow list**, it fails with a targeted message (use an allowed token or unset `MISE_GITHUB_TOKEN` / `GITHUB_API_TOKEN` / `GITHUB_TOKEN` for public resources); other authenticated 403s surface the API body without a second request. Bundle URLs are parsed to `reqwest::Url` before the same path.
> 
> **`mockito`** + async **`tokio`** dev-deps back new tests that assert a single GET on IP-allow-list and generic 403 errors (no follow-up unauthenticated retry in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f333102f7563371a4134073842df5ad3a96148d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->