### PR TITLE
fix: show version in friendly errors

### DIFF
--- a/e2e/cli/test_error_display
+++ b/e2e/cli/test_error_display
@@ -61,6 +61,11 @@ echo "Test 4: Plugin not found"
 local_assert_fail "mise install nonexistent-tool@1.0.0" \
   "mise ERROR Failed to install nonexistent-tool@1.0.0: nonexistent-tool not found in mise tool registry"
 
+# Test 4b: Friendly errors include mise version
+echo "Test 4b: Friendly errors include mise version"
+local_assert_fail "mise install nonexistent-tool@1.0.0" \
+  "mise ERROR Version:"
+
 # Test 5: Multiple tool failures (could be single or multiple depending on timing)
 echo "Test 5: Multiple tool failures"
 local_assert_fail "mise install tiny@999.999.999 jq@999.999.999" \

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,7 @@ fn display_friendly_err(err: &Report) {
     for err in err.chain() {
         error!("{err}");
     }
+    error!("Version: {}", *VERSION);
     let msg = ui::style::edim("Run with --verbose or MISE_VERBOSE=1 for more information");
     error!("{msg}");
 }


### PR DESCRIPTION
## Summary
- show the formatted mise version in friendly error output
- add e2e coverage for the new friendly error version line

## Test
- cargo fmt --check
- cargo check -q
- mise run test:e2e e2e/cli/test_error_display

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error display only; no auth, install logic, or data handling.
> 
> **Overview**
> Friendly error output (when `MISE_FRIENDLY_ERROR=1`) now prints the running **mise** version after the error chain, before the verbose-mode hint—matching the version already shown in non-friendly error sections.
> 
> E2E coverage in `test_error_display` asserts that line appears (`mise ERROR Version:`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43afbc052d1022674e12c44e565625ccb0e38c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->