### PR TITLE
fix(lock): allow lock and upgrade in locked mode

### DIFF
--- a/e2e/lockfile/test_lockfile_locked_mode
+++ b/e2e/lockfile/test_lockfile_locked_mode
@@ -80,7 +80,7 @@ EOF
 
 assert_contains "mise install --dry-run 2>&1" "would install"
 
-# --- Test 7: mise lock refuses to run in --locked mode ---
+# --- Test 7: mise lock can refresh lockfiles in locked mode ---
 export MISE_LOCKFILE=1
 
 cat <<'EOF' >mise.toml
@@ -95,8 +95,10 @@ backend = "aqua:jqlang/jq"
 "platforms.$PLATFORM" = { url = "https://example.com/jq-1.7.1.tar.gz" }
 EOF
 
-assert_fail_contains "mise lock --locked 2>&1" "mise lock is disabled in --locked mode"
-MISE_LOCKED=1 assert_fail_contains "mise lock 2>&1" "mise lock is disabled in --locked mode"
+mise lock --locked --platform "$PLATFORM"
+assert_contains "cat mise.lock" "1.7.1"
+MISE_LOCKED=1 mise lock --platform "$PLATFORM"
+assert_contains "cat mise.lock" "1.7.1"
 
 # Restore for any subsequent tests
 export MISE_LOCKFILE=1

--- a/e2e/lockfile/test_lockfile_upgrade_prune
+++ b/e2e/lockfile/test_lockfile_upgrade_prune
@@ -31,6 +31,16 @@ assert_not_contains "mise ls --installed dummy" "1.1.0"
 # The lockfile should now have 1.0.0 locked
 assert_contains "cat mise.lock" "1.0.0"
 
+# Enable strict mode after the lockfile has been populated. `mise upgrade`
+# still needs to install the new version and refresh mise.lock.
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "1"
+
+[settings]
+locked = true
+EOF
+
 # Now upgrade - this should:
 # 1. Install 1.1.0 (the latest matching version)
 # 2. Uninstall 1.0.0 (no longer needed)

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -204,7 +204,13 @@ impl Install {
         // ensure that only current versions are sent to lockfile rebuild
         versions.retain(|tv| current_versions.iter().any(|(_, cv)| tv == cv));
 
-        config::rebuild_shims_and_runtime_symlinks(&config, ts, &versions).await?;
+        config::rebuild_shims_and_runtime_symlinks(
+            &config,
+            ts,
+            &versions,
+            crate::lockfile::LockfileUpdateMode::Normal,
+        )
+        .await?;
 
         // Warn about tools that were installed but not in any config file
         if !inactive_tools.is_empty() {
@@ -349,7 +355,13 @@ impl Install {
         }
         measure!("rebuild_shims_and_runtime_symlinks", {
             let ts = config.get_toolset().await?;
-            config::rebuild_shims_and_runtime_symlinks(&config, ts, &versions).await?;
+            config::rebuild_shims_and_runtime_symlinks(
+                &config,
+                ts,
+                &versions,
+                crate::lockfile::LockfileUpdateMode::Normal,
+            )
+            .await?;
         });
         Ok(())
     }

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -60,7 +60,13 @@ impl Link {
 
         let config = Config::reset().await?;
         let ts = config.get_toolset().await?;
-        config::rebuild_shims_and_runtime_symlinks(&config, ts, &[]).await?;
+        config::rebuild_shims_and_runtime_symlinks(
+            &config,
+            ts,
+            &[],
+            crate::lockfile::LockfileUpdateMode::Normal,
+        )
+        .await?;
         Ok(())
     }
 }

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -11,7 +11,7 @@ use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, Toolset, ToolsetBu
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{cli::args::ToolArg, config::Settings};
 use console::style;
-use eyre::{Result, bail};
+use eyre::Result;
 use jiff::Timestamp;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
@@ -76,11 +76,6 @@ pub struct Lock {
 impl Lock {
     pub async fn run(self) -> Result<()> {
         let settings = Settings::get();
-        if settings.locked {
-            bail!(
-                "mise lock is disabled in --locked mode\nhint: Remove --locked or unset MISE_LOCKED=1"
-            );
-        }
         let config = Config::get().await?;
         let before_date = self.get_before_date()?;
         let lock_resolve_options = ResolveOptions {

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -75,7 +75,13 @@ impl Prune {
             }
             config = Config::reset().await?;
             let ts = config.get_toolset().await?;
-            config::rebuild_shims_and_runtime_symlinks(&config, ts, &[]).await?;
+            config::rebuild_shims_and_runtime_symlinks(
+                &config,
+                ts,
+                &[],
+                crate::lockfile::LockfileUpdateMode::Normal,
+            )
+            .await?;
         }
         Ok(())
     }

--- a/src/cli/sync/node.rs
+++ b/src/cli/sync/node.rs
@@ -47,7 +47,13 @@ impl SyncNode {
         }
         let config = Config::reset().await?;
         let ts = config.get_toolset().await?;
-        config::rebuild_shims_and_runtime_symlinks(&config, ts, &[]).await?;
+        config::rebuild_shims_and_runtime_symlinks(
+            &config,
+            ts,
+            &[],
+            crate::lockfile::LockfileUpdateMode::Normal,
+        )
+        .await?;
         Ok(())
     }
 

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -32,7 +32,13 @@ impl SyncPython {
         }
         let config = Config::get().await?;
         let ts = config.get_toolset().await?;
-        config::rebuild_shims_and_runtime_symlinks(&config, ts, &[]).await?;
+        config::rebuild_shims_and_runtime_symlinks(
+            &config,
+            ts,
+            &[],
+            crate::lockfile::LockfileUpdateMode::Normal,
+        )
+        .await?;
         Ok(())
     }
 

--- a/src/cli/sync/ruby.rs
+++ b/src/cli/sync/ruby.rs
@@ -32,7 +32,13 @@ impl SyncRuby {
         }
         let config = Config::reset().await?;
         let ts = config.get_toolset().await?;
-        config::rebuild_shims_and_runtime_symlinks(&config, ts, &[]).await?;
+        config::rebuild_shims_and_runtime_symlinks(
+            &config,
+            ts,
+            &[],
+            crate::lockfile::LockfileUpdateMode::Normal,
+        )
+        .await?;
         Ok(())
     }
 

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -90,7 +90,13 @@ impl Uninstall {
         file::touch_dir(&dirs::DATA)?;
         let config = Config::reset().await?;
         let ts = config.get_toolset().await?;
-        config::rebuild_shims_and_runtime_symlinks(&config, ts, &[]).await?;
+        config::rebuild_shims_and_runtime_symlinks(
+            &config,
+            ts,
+            &[],
+            crate::lockfile::LockfileUpdateMode::Normal,
+        )
+        .await?;
 
         Ok(())
     }

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -93,7 +93,13 @@ impl Unuse {
             .await?;
             let config = Config::reset().await?;
             let ts = config.get_toolset().await?;
-            config::rebuild_shims_and_runtime_symlinks(&config, ts, &[]).await?;
+            config::rebuild_shims_and_runtime_symlinks(
+                &config,
+                ts,
+                &[],
+                crate::lockfile::LockfileUpdateMode::Normal,
+            )
+            .await?;
         }
 
         Ok(())

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -271,6 +271,7 @@ impl Upgrade {
                 refresh_remote_versions: false,
                 inactive: self.inactive,
             },
+            locked: false,
             ..Default::default()
         };
 
@@ -402,7 +403,13 @@ impl Upgrade {
             }
         }
 
-        config::rebuild_shims_and_runtime_symlinks(config, ts, &successful_versions).await?;
+        config::rebuild_shims_and_runtime_symlinks(
+            config,
+            ts,
+            &successful_versions,
+            crate::lockfile::LockfileUpdateMode::AllowLocked,
+        )
+        .await?;
 
         if successful_versions.iter().any(|v| v.short() == "python") {
             PIPXBackend::reinstall_all(config)

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -229,7 +229,13 @@ impl Use {
 
             let config = Config::reset().await?;
             let ts = config.get_toolset().await?;
-            config::rebuild_shims_and_runtime_symlinks(&config, ts, &versions).await?;
+            config::rebuild_shims_and_runtime_symlinks(
+                &config,
+                ts,
+                &versions,
+                crate::lockfile::LockfileUpdateMode::Normal,
+            )
+            .await?;
         }
 
         self.render_success_message(cf.as_ref(), &versions, &self.remove)?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1747,6 +1747,7 @@ pub async fn rebuild_shims_and_runtime_symlinks(
     config: &Arc<Config>,
     ts: &Toolset,
     new_versions: &[ToolVersion],
+    lockfile_update_mode: lockfile::LockfileUpdateMode,
 ) -> Result<()> {
     measure!("rebuilding runtime symlinks", {
         runtime_symlinks::rebuild_for_toolset(config, ts)
@@ -1767,14 +1768,18 @@ pub async fn rebuild_shims_and_runtime_symlinks(
         lockfile::snapshot_pre_install_platforms(new_versions)
     };
     measure!("updating lockfiles", {
-        lockfile::update_lockfiles(config, ts, new_versions)
+        lockfile::update_lockfiles(config, ts, new_versions, lockfile_update_mode)
             .wrap_err("failed to update lockfiles")?;
     });
     if !new_versions.is_empty() {
         measure!("auto-locking platforms", {
-            lockfile::auto_lock_new_versions(config, new_versions, &pre_install_platforms)
-                .await
-                .wrap_err("failed to auto-lock platforms for new versions")?;
+            lockfile::auto_lock_new_versions(
+                new_versions,
+                &pre_install_platforms,
+                lockfile_update_mode,
+            )
+            .await
+            .wrap_err("failed to auto-lock platforms for new versions")?;
         });
     }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -926,8 +926,25 @@ pub fn extract_env_from_config_path(path: &Path) -> Option<String> {
         .filter(|s| s != "local")
 }
 
-pub fn update_lockfiles(config: &Config, ts: &Toolset, new_versions: &[ToolVersion]) -> Result<()> {
-    if !Settings::get().lockfile_enabled() || Settings::get().locked {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockfileUpdateMode {
+    Normal,
+    AllowLocked,
+}
+
+impl LockfileUpdateMode {
+    fn allow_locked(self) -> bool {
+        matches!(self, Self::AllowLocked)
+    }
+}
+
+pub fn update_lockfiles(
+    config: &Config,
+    ts: &Toolset,
+    new_versions: &[ToolVersion],
+    mode: LockfileUpdateMode,
+) -> Result<()> {
+    if !Settings::get().lockfile_enabled() || (Settings::get().locked && !mode.allow_locked()) {
         return Ok(());
     }
 
@@ -1314,11 +1331,14 @@ pub fn determine_existing_platforms(lockfile_path: &Path) -> Result<Vec<Platform
 /// so the lockfile is complete and doesn't change when other developers on different
 /// platforms run `mise install`.
 pub async fn auto_lock_new_versions(
-    _config: &Config,
     new_versions: &[ToolVersion],
     pre_install_platforms: &HashMap<PathBuf, BTreeSet<String>>,
+    mode: LockfileUpdateMode,
 ) -> Result<()> {
-    if !Settings::get().lockfile_enabled() || Settings::get().locked || new_versions.is_empty() {
+    if !Settings::get().lockfile_enabled()
+        || (Settings::get().locked && !mode.allow_locked())
+        || new_versions.is_empty()
+    {
         return Ok(());
     }
 

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -59,7 +59,13 @@ impl Toolset {
         let installed = self.install_all_versions(config, versions, opts).await?;
         if !installed.is_empty() {
             let ts = config.get_toolset().await?;
-            config::rebuild_shims_and_runtime_symlinks(config, ts, &installed).await?;
+            config::rebuild_shims_and_runtime_symlinks(
+                config,
+                ts,
+                &installed,
+                crate::lockfile::LockfileUpdateMode::Normal,
+            )
+            .await?;
             // Re-check what's still missing after installation
             let still_missing = self.list_missing_versions(config).await;
             return Ok((installed, still_missing));
@@ -546,7 +552,13 @@ impl Toolset {
                     .await?;
                 if !versions.is_empty() {
                     let ts = config.get_toolset().await?;
-                    config::rebuild_shims_and_runtime_symlinks(config, ts, &versions).await?;
+                    config::rebuild_shims_and_runtime_symlinks(
+                        config,
+                        ts,
+                        &versions,
+                        crate::lockfile::LockfileUpdateMode::Normal,
+                    )
+                    .await?;
                 }
                 return Ok(Some(versions));
             }


### PR DESCRIPTION
## Summary
- allow `mise lock` to refresh/generate lockfile entries even when `locked = true` or `--locked` is active
- allow `mise upgrade` to install the newly resolved version and refresh `mise.lock` under locked mode
- keep install-time locked validation intact for normal `mise install` flows
- extend focused lockfile e2e coverage for both commands

Fixes discussion: https://github.com/jdx/mise/discussions/10016

## Tests
- `mise exec rust -- cargo fmt --all`
- `mise exec rust -- cargo check --all-features`
- `PATH=/home/coder/.rustup/toolchains/1.95.0-x86_64-unknown-linux-gnu/bin:$PATH mise run test:e2e e2e/lockfile/test_lockfile_upgrade_prune e2e/lockfile/test_lockfile_locked_mode`

Note: plain `mise run format` and plain `mise run test:e2e ...` hit a local missing `cargo` shim, so I used the explicit Rust toolchain path for the task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when lockfiles mutate under `locked`, which affects reproducibility guarantees; scope is narrow (lock/upgrade paths only) but touches core install/lock behavior.
> 
> **Overview**
> **Locked mode** no longer blocks every lockfile write. A new `LockfileUpdateMode` (`Normal` vs `AllowLocked`) gates `update_lockfiles` and `auto_lock_new_versions`: when `settings.locked` is set, updates are skipped unless the caller opts in with `AllowLocked`.
> 
> **`mise lock`** drops the hard error in locked mode; e2e now expects `mise lock` (with `--locked` / `MISE_LOCKED`) to refresh `mise.lock`.
> 
> **`mise upgrade`** passes `locked: false` on install and uses `AllowLocked` when rebuilding shims/lockfiles so new versions can install and `mise.lock` can move forward under `locked = true`. Other commands (`install`, `use`, `prune`, etc.) still pass `Normal`, so ordinary installs stay strict.
> 
> E2e adds locked-mode coverage for lock refresh and upgrade-with-prune after enabling `locked` in config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3837b00c29d15c04000d75f3130a9874d2435f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->