### PR TITLE
fix(use): reject leading-dash tool versions

### DIFF
--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -34,6 +34,10 @@ mise use --pin dummy@1
 assert "cat mise.toml" '[tools]
 dummy = "1.0.0"'
 
+assert_fail "mise use dummy@--version" "must not start with '-'"
+assert "cat mise.toml" '[tools]
+dummy = "1.0.0"'
+
 MISE_PIN=1 mise use --fuzzy dummy@1
 assert "cat mise.toml" '[tools]
 dummy = "1"'

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -433,11 +433,15 @@ fn validate_version_string(s: &str) -> Result<()> {
 
 /// Validate `ref:`/`branch:`/`tag:`/`rev:` values. Same character rules as
 /// version strings: branch/tag names already use the same broad vocabulary
-/// (`/`, `+`, `-`, etc.), and only the shell-quote-breaking characters need
-/// rejection. Kept as a separate function for distinct error messages.
+/// (`/`, `+`, `-`, etc.), so only shell-quote-breaking characters and leading
+/// dashes need rejection. Kept as a separate function for distinct error
+/// messages.
 fn validate_ref_string(s: &str) -> Result<()> {
     if s.is_empty() {
         return Ok(());
+    }
+    if s.starts_with('-') {
+        bail!("invalid tool ref {s:?}: must not start with '-'");
     }
     if s.contains("..") {
         bail!("invalid tool ref {s:?}: contains path-traversal sequence");
@@ -644,7 +648,16 @@ mod tests {
 
     #[test]
     fn test_validate_ref_string_rejects_metacharacters() {
-        for v in ["a$(id)", "a..b", "a`b`", "a\"b", "a'b", "a\\b"] {
+        for v in [
+            "a$(id)",
+            "a..b",
+            "a`b`",
+            "a\"b",
+            "a'b",
+            "a\\b",
+            "--version",
+            "-v",
+        ] {
             assert!(
                 validate_ref_string(v).is_err(),
                 "expected ref {v:?} to be rejected"

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -413,10 +413,14 @@ impl ToolRequest {
 /// semver ranges like `>=20 <21 || >=22` or `^1.0.0`, dates, channel names,
 /// `lts/hydrogen`, etc.) continues to work — those characters are only
 /// dangerous in *unquoted* shell context, which cannot occur without one of
-/// the rejected expansion characters appearing first.
+/// the rejected expansion characters appearing first. Leading dashes are also
+/// rejected so backend install tools cannot mistake a version for a CLI flag.
 fn validate_version_string(s: &str) -> Result<()> {
     if s.is_empty() {
         return Ok(());
+    }
+    if s.starts_with('-') {
+        bail!("invalid tool version {s:?}: must not start with '-'");
     }
     if s.contains("..") {
         bail!("invalid tool version {s:?}: contains path-traversal sequence");
@@ -612,6 +616,9 @@ mod tests {
             "1.0\"x",
             "1.0'x",
             "1.0\\x",
+            // backend commands could parse leading dashes as flags
+            "--version",
+            "-v",
             // control characters / newline splitting
             "1.0\nrm",
             "1.0\rrm",


### PR DESCRIPTION
## Summary
- reject tool version strings that start with `-` before backend installation runs
- add coverage so `mise use dummy@--version` fails and leaves `mise.toml` unchanged

## Tests
- `cargo fmt --check`
- `RUSTFLAGS="-C linker=/usr/bin/gcc -C link-arg=-fuse-ld=bfd -C link-self-contained=no" /home/coder/.cargo/bin/cargo test -q toolset::tool_request::tests::test_validate_version_string_rejects_metacharacters`
- `PATH=/home/coder/.cargo/bin:$PATH RUSTFLAGS="-C linker=/usr/bin/gcc -C link-arg=-fuse-ld=bfd -C link-self-contained=no" mise run test:e2e e2e/cli/test_use`

Addresses discussion #9975.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation guard at parse time with no auth or data-path changes; versions like `1.2.3-beta` remain valid.
> 
> **Overview**
> **`mise use` and other tool-version parsing** now reject version and ref strings that **start with `-`**, with a clear error (`must not start with '-'`), so values like `--version` cannot be passed through to backends that might treat them as CLI flags.
> 
> The same rule applies to **`ref:` / `branch:` / `tag:` / `rev:`** values. Unit tests cover `--version` and `-v`; an e2e case asserts **`mise use dummy@--version`** fails and **`mise.toml`** stays unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b65680fa74b86d2f1a14cd9e55363f7557876cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->