### PR TITLE
fix(upgrade): preserve versions pinned by tracked locks

### DIFF
--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -206,6 +206,34 @@ assert_contains "cat mise.lock" "3.0.1"
 assert_not_contains "cat mise.lock" "2.0.0"
 rm -f mise.toml mise.lock
 
+# Test: upgrading one tracked project should preserve versions pinned by another tracked lockfile
+rm -rf tracked-upgrade
+mkdir -p tracked-upgrade/foo tracked-upgrade/bar
+mise uninstall dummy --all || true
+for project in tracked-upgrade/foo tracked-upgrade/bar; do
+  cat <<'EOF' >"$project/mise.toml"
+[tools]
+dummy = "latest"
+EOF
+  cat <<'EOF' >"$project/mise.lock"
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+EOF
+done
+mise install dummy@1.0.0
+(cd tracked-upgrade/foo && mise ls dummy >/dev/null)
+(cd tracked-upgrade/bar && mise ls dummy >/dev/null)
+(cd tracked-upgrade/bar && mise upgrade dummy@2.0.0)
+assert_contains "mise ls --installed dummy" "1.0.0"
+assert_contains "mise ls --installed dummy" "2.0.0"
+assert_contains "cd tracked-upgrade/foo && mise ls dummy" "1.0.0"
+assert_not_contains "cd tracked-upgrade/foo && mise ls dummy" "missing"
+assert_contains "cat tracked-upgrade/foo/mise.lock" "1.0.0"
+assert_contains "cat tracked-upgrade/bar/mise.lock" "2.0.0"
+assert_not_contains "cat tracked-upgrade/bar/mise.lock" "1.0.0"
+rm -rf tracked-upgrade
+
 # Test: upgrading a global fuzzy version should update the global lockfile
 cat <<'EOF' >"$MISE_CONFIG_DIR/config.toml"
 [tools]

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1,14 +1,15 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::backend::pipx::PIPXBackend;
-use crate::cli::args::ToolArg;
+use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, config_file};
 use crate::duration::parse_into_timestamp;
 use crate::file::display_path;
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{
     ConfigScope, InstallOptions, ResolveOptions, ToolSource, ToolVersion, ToolsetBuilder,
-    get_versions_needed_by_tracked_configs,
+    get_versions_needed_by_tracked_configs_excluding_locks,
 };
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
@@ -346,10 +347,51 @@ impl Upgrade {
             .await
             .wrap_err("failed to rebuild runtime symlinks")?;
 
-        // Get versions needed by tracked configs AFTER upgrade
-        // This ensures we don't uninstall versions still needed by other projects
-        let versions_needed_by_tracked =
-            get_versions_needed_by_tracked_configs(config, false, false).await?;
+        // Get versions needed by tracked configs AFTER upgrade. Preserve lockfile pins
+        // from other projects, but ignore stale pre-upgrade locks for configs we just
+        // upgraded so their old versions can still be removed.
+        let successful_backends: HashSet<_> = successful_versions
+            .iter()
+            .flat_map(|v| {
+                [
+                    v.ba().short.clone(),
+                    v.ba().tool_name.clone(),
+                    v.ba().full(),
+                    v.ba().full_without_opts(),
+                ]
+            })
+            .collect();
+        let mut upgraded_config_paths: HashSet<_> = outdated
+            .iter()
+            .filter(|o| backend_matches(&successful_backends, o.tool_version.ba()))
+            .filter_map(|o| o.source.path().map(|path| path.to_path_buf()))
+            .collect();
+        for tvl in ts.versions.values() {
+            if backend_matches(&successful_backends, &tvl.backend)
+                && let Some(path) = tvl.source.path()
+            {
+                upgraded_config_paths.insert(path.to_path_buf());
+            }
+        }
+        for (path, cf) in config.config_files.iter() {
+            let Ok(trs) = cf.to_tool_request_set() else {
+                continue;
+            };
+            if trs
+                .tools
+                .keys()
+                .any(|ba| backend_matches(&successful_backends, ba))
+            {
+                upgraded_config_paths.insert(path.clone());
+            }
+        }
+        let versions_needed_by_tracked = get_versions_needed_by_tracked_configs_excluding_locks(
+            config,
+            true,
+            false,
+            &upgraded_config_paths,
+        )
+        .await?;
 
         // Only uninstall old versions of tools that were successfully upgraded
         // and are not needed by any tracked config
@@ -479,6 +521,13 @@ impl Upgrade {
         }
         Ok(None)
     }
+}
+
+fn backend_matches(backends: &HashSet<String>, ba: &BackendArg) -> bool {
+    backends.contains(&ba.short)
+        || backends.contains(&ba.tool_name)
+        || backends.contains(&ba.full())
+        || backends.contains(&ba.full_without_opts())
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -664,21 +664,36 @@ pub async fn get_versions_needed_by_tracked_configs(
     use_locked_version: bool,
     offline: bool,
 ) -> Result<std::collections::HashSet<(String, String)>> {
-    let mut needed = std::collections::HashSet::new();
-    // `mise prune` should keep versions pinned by lockfiles. `mise upgrade`
-    // passes false because it checks what tracked configs resolve to after an
-    // upgrade, before their lockfiles have been updated.
-    // Prune also passes offline=true: it only protects installed versions, so
-    // remote resolution can never affect the outcome and just adds latency.
-    let opts = ResolveOptions {
+    get_versions_needed_by_tracked_configs_excluding_locks(
+        config,
         use_locked_version,
         offline,
-        ..Default::default()
-    };
+        &HashSet::new(),
+    )
+    .await
+}
+
+/// Like [`get_versions_needed_by_tracked_configs`], but ignores lockfile pins
+/// for the provided config paths.
+pub async fn get_versions_needed_by_tracked_configs_excluding_locks(
+    config: &Arc<Config>,
+    use_locked_version: bool,
+    offline: bool,
+    exclude_locked_config_paths: &HashSet<PathBuf>,
+) -> Result<std::collections::HashSet<(String, String)>> {
+    let mut needed = std::collections::HashSet::new();
+    // `mise prune` should keep versions pinned by lockfiles. `mise upgrade`
+    // also protects lockfiles for other tracked projects, but excludes configs
+    // it just upgraded so stale locks there do not keep the old version alive.
+    // Prune also passes offline=true: it only protects installed versions, so
+    // remote resolution can never affect the outcome and just adds latency.
     for (path, cf) in config.get_tracked_config_files().await? {
-        // Prune should protect versions pinned by other tracked projects'
-        // lockfiles. Upgrade passes use_locked_version=false because it must
-        // decide whether old versions are still needed after upgrading.
+        let use_locked_version = use_locked_version && !exclude_locked_config_paths.contains(&path);
+        let opts = ResolveOptions {
+            use_locked_version,
+            offline,
+            ..Default::default()
+        };
         if use_locked_version && Settings::get().lockfile_enabled() {
             let (lockfile_path, _) = lockfile_path_for_config(&path);
             match Lockfile::read(&lockfile_path) {


### PR DESCRIPTION
## Summary
- protect versions pinned by other tracked project lockfiles during `mise upgrade` cleanup
- ignore stale lockfile pins only for config files that were just upgraded
- add an e2e regression for two tracked projects sharing `dummy = "latest"` with separate locks

Fixes discussion #9978.

## Tests
- `cargo fmt --check`
- `git diff --check`
- `mise run test:e2e e2e/cli/test_upgrade`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-upgrade uninstall and tracked lockfile resolution; incorrect exclusion logic could prune versions other projects still need, though behavior is covered by a new e2e test.
> 
> **Overview**
> **`mise upgrade` cleanup** now treats **other tracked projects’ lockfile pins** as versions that must stay installed, while **not** treating stale lock entries on configs that were just upgraded as a reason to keep the old build.
> 
> The upgrade path switches from ignoring lockfiles entirely during post-upgrade uninstall decisions to **`get_versions_needed_by_tracked_configs_excluding_locks`**, which honors lockfiles globally but skips lockfile protection for config paths tied to the successful upgrade (outdated sources, active toolset entries, and any tracked config that references the upgraded backend). A small **`backend_matches`** helper aligns backend aliases when building that exclusion set.
> 
> **`get_versions_needed_by_tracked_configs`** is refactored to delegate to the new API with an empty exclusion set, so **`mise prune`** behavior is unchanged.
> 
> An **e2e scenario** adds two tracked dirs (`foo` / `bar`) both on `dummy = "latest"` with separate locks at `1.0.0`; upgrading only `bar` to `2.0.0` must leave `foo` on `1.0.0` and both lockfiles correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4af7ce43e455eb8cb4139a11f2c4b4ffe5abb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->