### PR TITLE
chore(ci): quiet passing e2e logs

### DIFF
--- a/e2e/run_all_tests
+++ b/e2e/run_all_tests
@@ -31,7 +31,7 @@ if [[ -f $RELEASE_SKIP_FILE ]]; then
   fi
 fi
 
-pushd e2e
+pushd e2e >/dev/null
 # List test files with a portable fallback chain.
 list_test_files() {
   local pattern="$1"
@@ -53,7 +53,7 @@ FAST_FILES=()
 while IFS= read -r line; do
   FAST_FILES+=("$line")
 done < <(list_test_files "test_*" | grep -v "_slow$")
-popd
+popd >/dev/null
 FILES=("${FAST_FILES[@]}" "${SLOW_FILES[@]}")
 MISE_BIN="$(resolve_mise_bin)"
 test_count=0
@@ -120,6 +120,15 @@ STATUS_FILES=()
 FINISHED=()
 FAILED_TESTS=()
 ORIGINAL_GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-}"
+
+SHOW_PASSING_LOGS="${E2E_SHOW_PASSING_LOGS:-}"
+if [[ -z $SHOW_PASSING_LOGS ]]; then
+  if [[ -n ${GITHUB_ACTIONS:-} ]]; then
+    SHOW_PASSING_LOGS=0
+  else
+    SHOW_PASSING_LOGS=1
+  fi
+fi
 
 LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mise-e2e-logs.XXXXXX")"
 # shellcheck disable=SC2329
@@ -193,12 +202,16 @@ while [[ $completed -lt $total ]]; do
   done
 
   while [[ $printed -lt $total && ${FINISHED[$printed]:-0} == 1 ]]; do
-    cat "${LOG_FILES[$printed]}"
     test_status="$(cat "${STATUS_FILES[$printed]}")"
     test_status="${test_status:-1}"
     if [[ $test_status != 0 ]]; then
       status=1
       FAILED_TESTS+=("${RUN_FILES[$printed]}")
+      cat "${LOG_FILES[$printed]}"
+    elif [[ $SHOW_PASSING_LOGS == 1 ]]; then
+      cat "${LOG_FILES[$printed]}"
+    else
+      echo "PASS: ${RUN_FILES[$printed]}" >&2
     fi
     test_count=$((test_count + 1))
     printed=$((printed + 1))


### PR DESCRIPTION
## Summary
- hide full logs for passing e2e tests in GitHub Actions by default
- keep full logs for failures and allow opting back in with `E2E_SHOW_PASSING_LOGS=1`
- silence runner `pushd`/`popd` directory echoes

## Tests
- `bash -n e2e/run_all_tests`
- `GITHUB_ACTIONS=1 TEST_TRANCHE_COUNT=10000 TEST_TRANCHE=222 E2E_JOBS=1 ./e2e/run_all_tests`
- `E2E_SHOW_PASSING_LOGS=1 GITHUB_ACTIONS=1 TEST_TRANCHE_COUNT=10000 TEST_TRANCHE=222 E2E_JOBS=1 ./e2e/run_all_tests`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only logging behavior in the e2e orchestration script; no product runtime or security impact.
> 
> **Overview**
> The e2e runner **reduces CI log noise** by not dumping full output for passing tests when `GITHUB_ACTIONS` is set; failures still print complete logs, and **`E2E_SHOW_PASSING_LOGS=1`** restores verbose passing output.
> 
> On pass (when logs are suppressed), it prints a one-line **`PASS: <test>`** to stderr instead of `cat`ing the log file. **`pushd`/`popd`** now redirect to `/dev/null` so directory changes are not echoed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb58b272bd92e1812f49b80bfde3477d3eabdcc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->