### PR TITLE
feat(npm): add allow_builds option

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -79,9 +79,9 @@ installation.
 With the default `npm.package_manager = "auto"` setting, mise installs through `aube` when `aube` is
 installed. If `aube` is not installed, mise installs through `npm`. Setting
 `npm.package_manager = "aube"`, `"pnpm"`, `"bun"`, or `"npm"` chooses that package manager
-explicitly. The `aube_args`, `pnpm_args`, `bun_args`, and `npm_args` options only affect the package
-manager that is actually used; an approval option for one package manager does not change the
-behavior of another.
+explicitly. The `allow_builds`, `aube_args`, `pnpm_args`, `bun_args`, and `npm_args` options only
+affect the package manager that is actually used; an approval option for one package manager does
+not change the behavior of another.
 
 For tools that need reviewed dependency build scripts, consider using `aube` or `pnpm` because they
 support package-level build approvals.
@@ -89,33 +89,38 @@ support package-level build approvals.
 ### `aube`
 
 [`aube`](https://aube.en.dev/package-manager/lifecycle-scripts) follows the pnpm v11 build approval
-model: dependency lifecycle scripts are denied unless explicitly allowlisted. Use `aube_args` to pass
-CLI flags to `aube add --global`:
+model: dependency lifecycle scripts are denied unless explicitly allowlisted. Use `allow_builds` for
+reviewed dependency builds:
 
 ```toml
 [tools]
-"npm:some-tool" = { version = "latest", aube_args = "--allow-build=esbuild" }
+"npm:some-tool" = { version = "latest", allow_builds = ["esbuild"] }
 ```
 
-Repeat `--allow-build=<pkg>` for each reviewed dependency build.
+`allow_builds` is passed to `aube add --global` as one `--allow-build=<pkg>` flag per package.
+Use `aube_args` for other raw aube flags.
+Set `allow_builds = true` to pass `--dangerously-allow-all-builds` when you explicitly accept that
+every dependency build script may run.
 
 ### `pnpm`
 
 [`pnpm`](https://pnpm.io/cli/add#--allow-build) uses build approval settings for dependency
-lifecycle scripts. Use `pnpm_args` to pass CLI flags to `pnpm add --global`:
+lifecycle scripts. Use `allow_builds` for reviewed dependency builds:
 
 ```toml
 [tools]
-"npm:some-tool" = { version = "latest", pnpm_args = "--allow-build=esbuild" }
+"npm:some-tool" = { version = "latest", allow_builds = ["esbuild"] }
 ```
 
-Repeat `--allow-build=<pkg>` for each reviewed dependency build. `--allow-build` was added in pnpm
-v10.4.0 and is supported by pnpm v10.4.0+ and v11.x.
+`allow_builds` is passed to `pnpm add --global` as one `--allow-build=<pkg>` flag per package.
+`--allow-build` was added in pnpm v10.4.0 and is supported by pnpm v10.4.0+ and v11.x.
+Set `allow_builds = true` to pass `--dangerously-allow-all-builds` when you explicitly accept that
+every dependency build script may run.
 
 [`pnpm approve-builds`](https://pnpm.io/cli/approve-builds) was added in v10.1.0, but it is not
 recommended to run `approve-builds` from postinstall. `pnpm approve-builds -g` worked for global
 packages in pnpm v10.4.0 through v10.x and was removed in v11.0.0; use
-`pnpm_args = "--allow-build=<pkg>"` for global installs with pnpm v10.4.0+ or v11.x.
+`allow_builds = ["<pkg>"]` for global installs with pnpm v10.4.0+ or v11.x.
 
 ### `bun`
 
@@ -153,20 +158,43 @@ the install graph can run lifecycle scripts:
 The following [tool-options](/dev-tools/#tool-options) are available for the `npm` backend. These
 go in `[tools]` in `mise.toml`.
 
+### `allow_builds`
+
+Packages whose dependency lifecycle build scripts should be approved when
+`settings.npm.package_manager = "aube"` or `"pnpm"`. Use this instead of spelling out
+`--allow-build` in both `aube_args` and `pnpm_args`.
+
+For example, to allow one verified dependency build script:
+
+```toml
+[tools]
+"npm:some-tool" = { version = "latest", allow_builds = ["esbuild"] }
+```
+
+For multiple reviewed dependency builds:
+
+```toml
+[tools]
+"npm:some-tool" = { version = "latest", allow_builds = ["esbuild", "sharp"] }
+```
+
+To allow all dependency build scripts for the install:
+
+```toml
+[tools]
+"npm:some-tool" = { version = "latest", allow_builds = true }
+```
+
+`allow_builds` does not affect `npm` or `bun` installs because those package managers do not expose
+the same package-level build approval model for this global install path.
+
 ### `aube_args`
 
 Additional arguments to pass to `aube add --global` when
 `settings.npm.package_manager = "aube"`.
 These are raw user-supplied arguments.
 
-For example, to allow one verified dependency build script:
-
-```toml
-[tools]
-"npm:some-tool" = { version = "latest", aube_args = "--allow-build=esbuild" }
-```
-
-Or to install `npm` with aube's append-only reporter mode:
+For example, to install `npm` with aube's append-only reporter mode:
 
 ```toml
 [tools]
@@ -181,11 +209,11 @@ Or to install `npm` with aube's append-only reporter mode:
 Additional arguments to pass to `pnpm` installs when `settings.npm.package_manager = "pnpm"`.
 These are raw user-supplied arguments.
 
-For example, to allow one verified dependency build script:
+For example, to set pnpm's log level:
 
 ```toml
 [tools]
-"npm:some-tool" = { version = "latest", pnpm_args = "--allow-build=esbuild" }
+"npm:some-tool" = { version = "latest", pnpm_args = "--loglevel=warn" }
 ```
 
 ### `bun_args`

--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -83,7 +83,7 @@ export MISE_NPM_PACKAGE_MANAGER=pnpm
 
 cat >.mise.toml <<EOF
 [tools]
-"npm:tiny" = { version = "latest", pnpm_args = "--loglevel=warn" }
+"npm:tiny" = { version = "latest", pnpm_args = "--loglevel=warn", allow_builds = ["tiny"] }
 EOF
 PNPM_DEBUG_LOG="$TMPDIR/pnpm_debug.log"
 if ! MISE_DEBUG=1 mise install >"$PNPM_DEBUG_LOG" 2>&1; then
@@ -93,6 +93,7 @@ if ! MISE_DEBUG=1 mise install >"$PNPM_DEBUG_LOG" 2>&1; then
 fi
 assert_contains "cat '$PNPM_DEBUG_LOG'" "--config.minimumReleaseAge="
 assert_contains "cat '$PNPM_DEBUG_LOG'" "--loglevel=warn"
+assert_contains "cat '$PNPM_DEBUG_LOG'" "--allow-build=tiny"
 echo "✓ npm backend successfully installs package using pnpm (package_manager=pnpm)"
 mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
 
@@ -113,7 +114,7 @@ fi
 
 cat >.mise.toml <<EOF
 [tools]
-"npm:tiny" = { version = "latest", aube_args = "--reporter append-only" }
+"npm:tiny" = { version = "latest", aube_args = "--reporter append-only", allow_builds = "tiny" }
 EOF
 AUBE_DEBUG_LOG="$TMPDIR/aube_debug.log"
 if ! MISE_DEBUG=1 mise install >"$AUBE_DEBUG_LOG" 2>&1; then
@@ -123,6 +124,7 @@ if ! MISE_DEBUG=1 mise install >"$AUBE_DEBUG_LOG" 2>&1; then
 fi
 assert_contains "cat '$AUBE_DEBUG_LOG'" "--reporter"
 assert_contains "cat '$AUBE_DEBUG_LOG'" "append-only"
+assert_contains "cat '$AUBE_DEBUG_LOG'" "--allow-build=tiny"
 echo "✓ npm backend successfully installs package using aube (package_manager=aube)"
 mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
 

--- a/registry/codebuff.toml
+++ b/registry/codebuff.toml
@@ -4,5 +4,4 @@ description = "Codebuff is a CLI tool that writes code for you"
 full = "npm:codebuff"
 
 [backends.options]
-aube_args = "--allow-build=codebuff"
-pnpm_args = "--allow-build=codebuff"
+allow_builds = ["codebuff"]

--- a/registry/gemini-cli.toml
+++ b/registry/gemini-cli.toml
@@ -6,5 +6,4 @@ test = { cmd = "gemini --version", expected = "{{version}}", tools = ["aube"] }
 full = "npm:@google/gemini-cli"
 
 [backends.options]
-aube_args = "--allow-build=@github/keytar --allow-build=node-pty"
-pnpm_args = "--allow-build=@github/keytar --allow-build=node-pty"
+allow_builds = ["@github/keytar", "node-pty"]

--- a/registry/jules.toml
+++ b/registry/jules.toml
@@ -7,5 +7,4 @@ test = { cmd = "jules version", expected = "Version: v{{version}}", tools = [
 full = "npm:@google/jules"
 
 [backends.options]
-aube_args = "--allow-build=@google/jules"
-pnpm_args = "--allow-build=@google/jules"
+allow_builds = ["@google/jules"]

--- a/registry/orval.toml
+++ b/registry/orval.toml
@@ -5,5 +5,4 @@ test = { cmd = "orval --version", expected = "{{version}}", tools = ["aube"] }
 full = "npm:orval"
 
 [backends.options]
-aube_args = "--allow-build=esbuild"
-pnpm_args = "--allow-build=esbuild"
+allow_builds = ["esbuild"]

--- a/registry/serverless.toml
+++ b/registry/serverless.toml
@@ -4,8 +4,7 @@ description = "Serverless Framework"
 full = "npm:serverless"
 
 [backends.options]
-aube_args = "--allow-build=serverless"
-pnpm_args = "--allow-build=serverless"
+allow_builds = ["serverless"]
 
 [[backends]]
 full = "asdf:mise-plugins/mise-serverless"

--- a/registry/vercel.toml
+++ b/registry/vercel.toml
@@ -5,5 +5,4 @@ test = { cmd = "vc --version", expected = "{{version}}", tools = ["aube"] }
 full = "npm:vercel"
 
 [backends.options]
-aube_args = "--allow-build=esbuild"
-pnpm_args = "--allow-build=esbuild"
+allow_builds = ["esbuild"]

--- a/registry/wrangler.toml
+++ b/registry/wrangler.toml
@@ -7,5 +7,4 @@ test = { cmd = "wrangler --version", expected = "{{version}}", tools = [
 full = "npm:wrangler"
 
 [backends.options]
-aube_args = "--allow-build=esbuild --allow-build=sharp --allow-build=workerd"
-pnpm_args = "--allow-build=esbuild --allow-build=sharp --allow-build=workerd"
+allow_builds = ["esbuild", "sharp", "workerd"]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -49,6 +49,13 @@ struct NpmOptions<'a> {
     values: BackendOptions<'a>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AllowBuilds {
+    None,
+    All,
+    Packages(Vec<String>),
+}
+
 impl<'a> NpmOptions<'a> {
     fn new(raw: &'a ToolVersionOptions) -> Self {
         Self {
@@ -72,10 +79,76 @@ impl<'a> NpmOptions<'a> {
         self.values.str("aube_args")
     }
 
+    fn allow_builds(&self) -> eyre::Result<AllowBuilds> {
+        let Some(value) = self.values.raw().opts.get("allow_builds") else {
+            return Ok(AllowBuilds::None);
+        };
+        match value {
+            toml::Value::Boolean(true) => Ok(AllowBuilds::All),
+            toml::Value::Boolean(false) => Ok(AllowBuilds::None),
+            toml::Value::String(value) => {
+                Ok(Self::canonical_allow_build_packages(vec![value.clone()]))
+            }
+            toml::Value::Array(values) => {
+                let packages = values
+                    .iter()
+                    .map(|value| {
+                        value.as_str().map(str::to_string).ok_or_else(|| {
+                            eyre::eyre!("allow_builds array must contain only strings")
+                        })
+                    })
+                    .collect::<eyre::Result<Vec<_>>>()?;
+                Ok(Self::canonical_allow_build_packages(packages))
+            }
+            _ => Err(eyre::eyre!(
+                "allow_builds must be true, false, a string, or array"
+            )),
+        }
+    }
+
+    fn allow_build_args(&self) -> eyre::Result<Vec<OsString>> {
+        Ok(match self.allow_builds()? {
+            AllowBuilds::None => vec![],
+            AllowBuilds::All => vec![OsString::from("--dangerously-allow-all-builds")],
+            AllowBuilds::Packages(packages) => packages
+                .into_iter()
+                .map(|package| OsString::from(format!("--allow-build={package}")))
+                .collect(),
+        })
+    }
+
+    fn canonical_allow_build_packages(mut packages: Vec<String>) -> AllowBuilds {
+        packages.sort();
+        packages.dedup();
+        if packages.is_empty() {
+            AllowBuilds::None
+        } else {
+            AllowBuilds::Packages(packages)
+        }
+    }
+
+    fn canonical_allow_builds_lockfile_value(&self) -> eyre::Result<Option<String>> {
+        Ok(match self.allow_builds()? {
+            AllowBuilds::None => None,
+            AllowBuilds::All => Some("true".into()),
+            AllowBuilds::Packages(packages) => Some(format!("{packages:?}")),
+        })
+    }
+
     fn lockfile_options(&self) -> BTreeMap<String, String> {
         install_time_option_keys()
             .into_iter()
-            .filter_map(|key| self.values.str(&key).map(|value| (key, value.to_string())))
+            .filter_map(|key| {
+                let value = if key == "allow_builds" {
+                    self.canonical_allow_builds_lockfile_value().ok().flatten()
+                } else {
+                    self.values.raw().opts.get(&key).map(|value| match value {
+                        toml::Value::String(value) => value.clone(),
+                        _ => value.to_string(),
+                    })
+                };
+                value.map(|value| (key, value))
+            })
             .collect()
     }
 }
@@ -280,6 +353,7 @@ impl Backend for NPMBackend {
                 if let Some(args) = options.aube_args() {
                     cmd = cmd.args(shell_words::split(args)?);
                 }
+                cmd = cmd.args(options.allow_build_args()?);
                 cmd.execute()?;
             }
             NpmPackageManager::Bun => {
@@ -338,6 +412,7 @@ impl Backend for NPMBackend {
                 if let Some(args) = options.pnpm_args() {
                     cmd = cmd.args(shell_words::split(args)?);
                 }
+                cmd = cmd.args(options.allow_build_args()?);
                 cmd.execute()?;
             }
             _ => {
@@ -747,6 +822,7 @@ pub fn install_time_option_keys() -> Vec<String> {
         "pnpm_args".into(),
         "bun_args".into(),
         "aube_args".into(),
+        "allow_builds".into(),
     ]
 }
 
@@ -1028,6 +1104,14 @@ mod tests {
             "aube_args".to_string(),
             toml::Value::String("--loglevel=warn".into()),
         );
+        options.opts.insert(
+            "allow_builds".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("sharp".into()),
+                toml::Value::String("esbuild".into()),
+                toml::Value::String("sharp".into()),
+            ]),
+        );
         options.install_env.insert(
             "NPM_CONFIG_REGISTRY".to_string(),
             "https://registry.example.com".to_string(),
@@ -1049,7 +1133,91 @@ mod tests {
             resolved.get("aube_args"),
             Some(&"--loglevel=warn".to_string())
         );
+        assert_eq!(
+            resolved.get("allow_builds"),
+            Some(&"[\"esbuild\", \"sharp\"]".to_string())
+        );
         assert!(!resolved.contains_key("install_env.NPM_CONFIG_REGISTRY"));
+    }
+
+    #[test]
+    fn test_allow_build_args_accepts_string_array_or_true() {
+        let mut string_options = ToolVersionOptions::default();
+        string_options.opts.insert(
+            "allow_builds".to_string(),
+            toml::Value::String("esbuild".into()),
+        );
+        assert_eq!(
+            NpmOptions::new(&string_options).allow_build_args().unwrap(),
+            vec![OsString::from("--allow-build=esbuild")]
+        );
+
+        let mut array_options = ToolVersionOptions::default();
+        array_options.opts.insert(
+            "allow_builds".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("esbuild".into()),
+                toml::Value::String("sharp".into()),
+            ]),
+        );
+        assert_eq!(
+            NpmOptions::new(&array_options).allow_build_args().unwrap(),
+            vec![
+                OsString::from("--allow-build=esbuild"),
+                OsString::from("--allow-build=sharp"),
+            ]
+        );
+
+        let mut true_options = ToolVersionOptions::default();
+        true_options
+            .opts
+            .insert("allow_builds".to_string(), toml::Value::Boolean(true));
+        assert_eq!(
+            NpmOptions::new(&true_options).allow_build_args().unwrap(),
+            vec![OsString::from("--dangerously-allow-all-builds")]
+        );
+    }
+
+    #[test]
+    fn test_allow_build_lockfile_value_is_canonical() {
+        let mut string_options = ToolVersionOptions::default();
+        string_options.opts.insert(
+            "allow_builds".to_string(),
+            toml::Value::String("esbuild".into()),
+        );
+        assert_eq!(
+            NpmOptions::new(&string_options)
+                .canonical_allow_builds_lockfile_value()
+                .unwrap(),
+            Some("[\"esbuild\"]".into())
+        );
+
+        let mut array_options = ToolVersionOptions::default();
+        array_options.opts.insert(
+            "allow_builds".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("sharp".into()),
+                toml::Value::String("esbuild".into()),
+                toml::Value::String("sharp".into()),
+            ]),
+        );
+        assert_eq!(
+            NpmOptions::new(&array_options)
+                .canonical_allow_builds_lockfile_value()
+                .unwrap(),
+            Some("[\"esbuild\", \"sharp\"]".into())
+        );
+
+        let mut true_options = ToolVersionOptions::default();
+        true_options
+            .opts
+            .insert("allow_builds".to_string(), toml::Value::Boolean(true));
+        assert_eq!(
+            NpmOptions::new(&true_options)
+                .canonical_allow_builds_lockfile_value()
+                .unwrap(),
+            Some("true".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add an npm backend `allow_builds` tool option that expands to `--allow-build=<pkg>` for aube and pnpm installs.
- Keep `aube_args` and `pnpm_args` as raw escape hatches, while replacing duplicated registry build approvals from #9916 with `allow_builds`.
- Document the friendlier option and cover string/array parsing plus e2e command flag plumbing.

## Testing
- `cargo fmt --check`
- `bash -n e2e/backend/test_npm_package_manager`
- `git diff --check`
- `cargo test backend::npm`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time dependency build-script approval plumbing; `allow_builds = true` enables all builds, though behavior matches existing explicit flags.
> 
> **Overview**
> Adds a unified **`allow_builds`** npm backend tool option so **aube** and **pnpm** global installs get dependency build approvals without duplicating `--allow-build` in both `aube_args` and `pnpm_args`. Values can be a **string**, **array** of package names (sorted/deduped for lockfiles), or **`true`** for `--dangerously-allow-all-builds`; **`false`/omit** adds no flags. **`aube_args` / `pnpm_args`** stay raw passthrough for other flags.
> 
> Registry entries for tools like **wrangler**, **gemini-cli**, and **vercel** switch to `allow_builds`. Docs and e2e assert `--allow-build=…` on pnpm/aube install paths. Unit tests cover CLI arg expansion and canonical lockfile serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d4bbadd5ae14c6e1e0f03d5e55e92a9045d5c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->