### PR TITLE
fix(pipx): combine --pip-args value to avoid argparse error

### DIFF
--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -387,10 +387,9 @@ impl PIPXBackend {
 
     fn pip_uploaded_prior_to_args(before_date: Option<Timestamp>) -> Vec<OsString> {
         match before_date {
-            Some(before_date) => vec![
-                "--pip-args".into(),
-                format!("--uploaded-prior-to={before_date}").into(),
-            ],
+            Some(before_date) => {
+                vec![format!("--pip-args=--uploaded-prior-to={before_date}").into()]
+            }
             None => vec![],
         }
     }
@@ -898,12 +897,14 @@ mod tests {
         let before_date = "2024-01-02T03:04:05Z".parse().unwrap();
         let args = PIPXBackend::pip_uploaded_prior_to_args(Some(before_date));
 
+        // Combined into a single `--pip-args=VALUE` argv element so pipx's
+        // argparse doesn't treat the leading `--` of the value as a new flag
+        // (see discussion #9976).
         assert_eq!(
             args,
-            vec![
-                OsString::from("--pip-args"),
-                OsString::from("--uploaded-prior-to=2024-01-02T03:04:05Z"),
-            ]
+            vec![OsString::from(
+                "--pip-args=--uploaded-prior-to=2024-01-02T03:04:05Z"
+            )]
         );
     }
 


### PR DESCRIPTION
## Summary

Reopening #9982

pipx's argparse rejected `--pip-args --uploaded-prior-to=...` because the value starts with `--`. Pack into a single `--pip-args=VALUE` element. Regression from #9190.

Closes #9976

## Context

I'm seeing this across a bunch of failures on railpack. [Here's an example](https://github.com/railwayapp/railpack/actions/runs/26365713405/job/77609431920?pr=564).

This occurs [because `install_before` is set](https://github.com/railwayapp/railpack/blob/ffdb0331677897577eafe61edc600aafdec387be/core/generate/mise_step_builder.go#L293-L294) and the `pipx` backend is used. [Here's the project](https://github.com/railwayapp/railpack/tree/main/examples/python-poetry) to reproduce the failure (although the mise config which triggers it is _not_ shown there, it's injected into the project when it's built by railpack).