### PR TITLE
fix(en): preserve env profile in activated subshells

### DIFF
--- a/e2e/cli/test_en_mise_env
+++ b/e2e/cli/test_en_mise_env
@@ -72,3 +72,12 @@ assert_contains "mise en -s 'bash -c \"mise env | grep TTT_BASE_VAR\"'" "TTT_BAS
 
 # Test 16: Without -E flag, env-specific variable is not set
 assert_not_contains "mise en -s 'bash -c \"mise env\"'" "TTT_ENV_NAME"
+
+# Test 17: -E should survive when the spawned interactive shell activates mise
+zsh_bin=$(command -v zsh)
+mkdir -p zsh-home
+cat >zsh-home/.zshrc <<EOF
+eval "\$(mise activate zsh)"
+EOF
+assert_contains "ZDOTDIR=$(pwd)/zsh-home HOME=$(pwd)/zsh-home SHELL=$zsh_bin mise -E dev en -s 'zsh -i -c \"echo \$MISE_ENV\"'" "dev"
+assert_contains "ZDOTDIR=$(pwd)/zsh-home HOME=$(pwd)/zsh-home SHELL=$zsh_bin mise -E dev en -s 'zsh -i -c \"mise env | grep TTT_ENV_NAME\"'" "TTT_ENV_NAME=dev"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -198,7 +198,18 @@ impl Exec {
         // would outrank the inner toolset's resolved tool. See discussion #9754.
         // Computed after all env modifications so the diff fully describes what
         // mise added (matches task_executor.rs).
-        if let Ok(serialized) = EnvDiff::from_final_env(&env::PRISTINE_ENV, &env).serialize() {
+        let removed_mise_env = if !env::MISE_ENV.is_empty() {
+            // Keep explicit -E profiles active if the child shell sources `mise activate`.
+            env.remove("MISE_ENV")
+        } else {
+            None
+        };
+        env.remove("__MISE_DIFF");
+        let serialized = EnvDiff::from_final_env(&env::PRISTINE_ENV, &env).serialize();
+        if let Some(mise_env) = removed_mise_env {
+            env.insert("MISE_ENV".to_string(), mise_env);
+        }
+        if let Ok(serialized) = serialized {
             env.insert("__MISE_DIFF".to_string(), serialized);
         }
 


### PR DESCRIPTION
## Summary
- keep explicit `-E`/`MISE_ENV` profiles out of the `__MISE_DIFF` that activated child shells reverse
- add an e2e regression covering `mise -E dev en` spawning interactive zsh that sources `mise activate zsh`

## Test
- `mise run test:e2e e2e/cli/test_en_mise_env`
- `cargo fmt --all -- --check`

Fixes discussion #10007.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to exec env serialization plus an e2e regression; no auth or data-path changes.
> 
> **Overview**
> Fixes **`mise -E` / `MISE_ENV` profiles being dropped** when a child from `mise en` (or exec) runs an interactive shell that sources **`mise activate`**.
> 
> When building **`__MISE_DIFF`** for the spawned process, **`MISE_ENV` is temporarily removed** (and any stale **`__MISE_DIFF`** cleared) so the serialized diff only captures tool/path changes—not the explicit env profile, which would otherwise be undone on activation. **`MISE_ENV` is restored** in the child environment after serialization.
> 
> Adds **e2e test 17**: interactive **zsh** with `mise activate` still sees `MISE_ENV=dev` and dev-specific config after `mise -E dev en`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22f82fcbab17d092dda91ca626ee6abd0c30e4d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->