### PR TITLE
feat(github): use versions host for release metadata

### DIFF
--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -219,6 +219,12 @@ pub struct Attestation {
     bundle_url: Option<String>,
 }
 
+impl Attestation {
+    pub fn has_inline_bundle(&self) -> bool {
+        self.bundle.is_some()
+    }
+}
+
 impl AttestationClient {
     pub fn builder() -> AttestationClientBuilder {
         AttestationClientBuilder::default()
@@ -332,7 +338,16 @@ pub async fn verify_github_attestation(
     token: Option<&str>,
     signer_workflow: Option<&str>,
 ) -> Result<bool> {
-    verify_github_attestation_inner(artifact_path, owner, repo, token, signer_workflow, None).await
+    verify_github_attestation_inner(
+        artifact_path,
+        owner,
+        repo,
+        token,
+        signer_workflow,
+        None,
+        None,
+    )
+    .await
 }
 
 pub async fn verify_github_attestation_with_base_url(
@@ -350,8 +365,44 @@ pub async fn verify_github_attestation_with_base_url(
         token,
         signer_workflow,
         Some(base_url),
+        None,
     )
     .await
+}
+
+pub async fn verify_github_attestation_with_base_url_and_digest(
+    artifact_path: &Path,
+    owner: &str,
+    repo: &str,
+    token: Option<&str>,
+    signer_workflow: Option<&str>,
+    base_url: &str,
+    digest: &str,
+) -> Result<bool> {
+    verify_github_attestation_inner(
+        artifact_path,
+        owner,
+        repo,
+        token,
+        signer_workflow,
+        Some(base_url),
+        Some(digest),
+    )
+    .await
+}
+
+pub async fn verify_github_attestation_with_attestations(
+    artifact_path: &Path,
+    attestations: &[Attestation],
+    signer_workflow: Option<&str>,
+) -> Result<bool> {
+    if attestations.is_empty() {
+        return Err(AttestationError::NoAttestations);
+    }
+
+    let artifact = tokio::fs::read(artifact_path).await?;
+    let mut trust_roots = TrustRoots::default();
+    verify_attestation_bundles(attestations, &artifact, signer_workflow, &mut trust_roots).await
 }
 
 async fn verify_github_attestation_inner(
@@ -361,6 +412,7 @@ async fn verify_github_attestation_inner(
     token: Option<&str>,
     signer_workflow: Option<&str>,
     base_url: Option<&str>,
+    digest: Option<&str>,
 ) -> Result<bool> {
     let mut builder = AttestationClient::builder();
     if let Some(token) = token {
@@ -370,7 +422,10 @@ async fn verify_github_attestation_inner(
         builder = builder.base_url(base_url);
     }
     let client = builder.build()?;
-    let digest = calculate_file_digest_async(artifact_path).await?;
+    let digest = match digest {
+        Some(digest) => digest.to_string(),
+        None => calculate_file_digest(artifact_path).await?,
+    };
     let attestations = client
         .fetch_attestations(FetchParams {
             owner: owner.to_string(),
@@ -1261,7 +1316,7 @@ fn verify_raw_signature(
         .map_err(|e| AttestationError::Verification(format!("signature verification failed: {e}")))
 }
 
-async fn calculate_file_digest_async(path: &Path) -> Result<String> {
+pub async fn calculate_file_digest(path: &Path) -> Result<String> {
     let mut file = tokio::fs::File::open(path).await?;
     let mut hasher = Sha256::new();
     let mut buffer = [0; 8192];

--- a/docs/dev-tools/github-tokens.md
+++ b/docs/dev-tools/github-tokens.md
@@ -1,6 +1,8 @@
 # GitHub Tokens
 
-Many tools in mise are hosted on GitHub, and mise uses the GitHub API to list versions and download releases. Unauthenticated requests are subject to low [rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api), which can cause `403 Forbidden` errors — especially in CI. This page explains how to configure GitHub authentication in mise.
+Many tools in mise are hosted on GitHub. For public releases, mise uses [mise-versions](https://mise-versions.jdx.dev) by default as a shared cache for version lists, release metadata, and GitHub artifact attestations. This avoids most unauthenticated GitHub API calls during normal installs, including CI and Docker builds.
+
+GitHub tokens are still useful when mise has to fall back to GitHub's API, when `MISE_USE_VERSIONS_HOST=0` is set, or when installing tools from private repositories, GitHub Enterprise, or custom GitHub API hosts. Unauthenticated requests are subject to low [rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api), which can cause `403 Forbidden` errors. This page explains how to configure GitHub authentication in mise.
 
 ## Token Priority
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,6 +108,12 @@ get around GitHub rate limits when querying for new versions. Check that repo fo
 see if it has an updated version. This service can be disabled by
 setting `MISE_USE_VERSIONS_HOST=0`.
 
+mise also uses the versions host as a shared cache for public GitHub release metadata and
+GitHub artifact attestations. This means normal installs of public `github:` and many
+`aqua:` tools can avoid unauthenticated GitHub API calls even in Docker builds or CI jobs
+that do not have a token configured. If the versions host does not have the requested
+metadata yet, mise falls back to GitHub's API.
+
 mise-versions itself also struggles with rate limits but you can help it to fetch more frequently by authenticating
 with its [GitHub app](https://github.com/apps/mise-versions). It does not require any permissions since it simply
 fetches public repository information. The more people do this, the quicker
@@ -209,6 +215,12 @@ HTTP status client error (403 Forbidden) for url
 
 This can happen if the tool is hosted on GitHub, and you've hit the API rate limit. This is especially
 common running mise in a CI environment like GitHub Actions.
+
+By default, mise uses <https://mise-versions.jdx.dev> to avoid most public GitHub API calls
+for release metadata and artifact attestation checks. If you still see this error, it usually
+means the metadata was not available from the versions host yet, `MISE_USE_VERSIONS_HOST=0`
+is set, the tool uses a private repository, or the tool uses GitHub Enterprise/custom API
+settings.
 
 See [GitHub Tokens](/dev-tools/github-tokens.html) for how to configure authentication and avoid rate limits.
 

--- a/e2e/backend/test_github_versions_host_no_api
+++ b/e2e/backend/test_github_versions_host_no_api
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Verify the github backend can install from real mise-versions release and
+# attestation metadata without contacting api.github.com.
+
+SERVER_PORT_FILE="$TMPDIR/github_api_blocker_port"
+HEADERS_LOG_DIR="$TMPDIR/github_api_blocker_logs"
+mkdir -p "$HEADERS_LOG_DIR"
+
+MISE_HTTP_TEST_PORT_FILE="$SERVER_PORT_FILE" python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" 0 "$HEADERS_LOG_DIR" &
+SERVER_PID=$!
+
+cleanup() {
+  kill "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_file "$SERVER_PORT_FILE" "GitHub API blocker port file" 30 "$SERVER_PID"
+SERVER_PORT=$(cat "$SERVER_PORT_FILE")
+
+rm -rf "$MISE_CACHE_DIR/github"
+mise uninstall github:jdx/mise-test-fixtures 2>/dev/null || true
+
+cat <<EOF >mise.toml
+[settings]
+url_replacements = { "https://api.github.com" = "http://127.0.0.1:$SERVER_PORT" }
+
+[tools]
+"github:jdx/mise-test-fixtures" = { version = "1.0.0", asset_pattern = "hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world" }
+EOF
+
+assert_succeed "mise install"
+assert_contains "mise x -- hello-world" "hello world"
+
+if compgen -G "$HEADERS_LOG_DIR/request_*.json" >/dev/null; then
+  cat "$HEADERS_LOG_DIR"/request_*.json
+  fail "api.github.com was contacted; install should use mise-versions metadata"
+fi

--- a/e2e/cli/test_ls_cache
+++ b/e2e/cli/test_ls_cache
@@ -4,12 +4,15 @@ export MISE_USE_VERSIONS_HOST=1
 # verify that cache is reused for `mise ls`
 # see https://github.com/jdx/mise/discussions/6736
 
-assert_contains "mise -v use bat 2>&1" "GET https://api.github.com/repos/sharkdp/bat/releases/latest 200 OK"
+assert_contains "mise -v use bat 2>&1" "GET https://mise-versions.jdx.dev/api/github/repos/sharkdp/bat/releases/latest 200 OK"
 find "$MISE_CACHE_DIR" -type f -exec touch -t 202001010000 {} +
 
 output="$(mise -v ls bat 2>&1)"
 if [[ $output == *"GET https://api.github.com/repos/sharkdp/bat/releases/latest"* ]]; then
   fail "[mise -v ls bat] unexpectedly fetched the GitHub latest release"
+fi
+if [[ $output == *"GET https://mise-versions.jdx.dev/api/github/repos/sharkdp/bat/releases/latest"* ]]; then
+  fail "[mise -v ls bat] unexpectedly fetched the GitHub latest release from mise-versions"
 fi
 if [[ $output == *"GET https://mise-versions.jdx.dev/tools/bat.toml"* ]]; then
   fail "[mise -v ls bat] unexpectedly fetched the versions host"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1727,7 +1727,7 @@
         },
         "use_versions_host": {
           "default": true,
-          "description": "Set to false to disable using the mise-versions API as a quick way for mise to query for new versions.",
+          "description": "Set to false to disable using the mise-versions API for version lists, public GitHub release metadata, and GitHub artifact attestations.",
           "type": "boolean"
         },
         "use_versions_host_track": {

--- a/settings.toml
+++ b/settings.toml
@@ -2507,12 +2507,24 @@ type = "Bool"
 
 [use_versions_host]
 default = true
-description = "Set to false to disable using the mise-versions API as a quick way for mise to query for new versions."
+description = "Set to false to disable using the mise-versions API for version lists, public GitHub release metadata, and GitHub artifact attestations."
 docs = """
 Set to "false" to disable using [mise-versions](https://mise-versions.jdx.dev) as
-a quick way for mise to query for new versions. This host regularly grabs all the
-latest versions of core and community plugins. It's faster than running a plugin's
-`list-all` command and gets around GitHub rate limiting problems when using it.
+a shared cache for version lists, public GitHub release metadata, and GitHub artifact
+attestations.
+
+This host regularly grabs all the latest versions of core and community plugins.
+It's faster than running a plugin's `list-all` command and gets around GitHub
+rate limiting problems when using it. For tools distributed through public GitHub
+releases, mise also uses this host before calling GitHub's releases and artifact
+attestation APIs directly. This avoids the anonymous GitHub API rate limit in
+normal installs, including Docker builds and CI jobs that do not have a GitHub
+token configured.
+
+If the versions host does not have the requested metadata yet, mise falls back to
+GitHub's API. Private repositories, GitHub Enterprise, custom GitHub API URLs, and
+users who disable this setting still need normal GitHub authentication when they
+would otherwise exceed GitHub's rate limits.
 
 mise-versions itself also struggles with rate limits but you can help it to fetch more frequently by authenticating
 with its [GitHub app](https://github.com/apps/mise-versions). It does not require any permissions since it simply

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -401,6 +401,36 @@ impl Backend for UnifiedGitBackend {
         }
     }
 
+    async fn resolve_exact_version(
+        &self,
+        config: &Arc<Config>,
+        version: &str,
+    ) -> eyre::Result<Option<String>> {
+        if Settings::get().offline() || self.is_gitlab() || self.is_forgejo() {
+            return Ok(None);
+        }
+
+        let repo = self.repo();
+        let raw_opts = config.get_tool_opts_with_overrides(&self.ba).await?;
+        let opts = self.options(&raw_opts);
+        let api_url = opts.api_url();
+        let version_prefix = opts.version_prefix();
+
+        match try_with_v_prefix_and_repo(version, version_prefix, Some(&repo), |candidate| {
+            let api_url = api_url.clone();
+            let repo = repo.clone();
+            async move { github::get_release_for_url(&api_url, &repo, &candidate).await }
+        })
+        .await
+        {
+            Ok(release) => Ok(Some(self.strip_version_prefix(&release.tag_name, &opts))),
+            Err(e) => {
+                debug!("Failed to resolve exact GitHub release for {repo}@{version}: {e}");
+                Ok(None)
+            }
+        }
+    }
+
     async fn install_version_(
         &self,
         ctx: &InstallContext,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1259,6 +1259,19 @@ pub trait Backend: Debug + Send + Sync {
         Ok(None)
     }
 
+    /// Backend-specific fast path for exact version requests.
+    ///
+    /// Return `Ok(None)` when the backend cannot cheaply prove that `version`
+    /// is an exact upstream version. Callers must still fall back to normal
+    /// prefix/latest resolution in that case.
+    async fn resolve_exact_version(
+        &self,
+        _config: &Arc<Config>,
+        _version: &str,
+    ) -> eyre::Result<Option<String>> {
+        Ok(None)
+    }
+
     /// Backend opt-in for installing an unresolved `latest` request.
     ///
     /// Most backends must resolve `latest` to a concrete version before install.

--- a/src/github.rs
+++ b/src/github.rs
@@ -355,6 +355,13 @@ fn pick_best_build_revision(releases: Vec<GithubRelease>, version: &str) -> Opti
 }
 
 async fn get_release_(api_url: &str, repo: &str, tag: &str) -> Result<GithubRelease> {
+    if is_public_github_api_base(api_url)
+        && let Ok(Some(release)) = crate::versions_host::github_release(repo, tag).await
+    {
+        trace!("got GitHub release {repo}@{tag} from mise-versions");
+        return Ok(release);
+    }
+
     let url = if tag == "latest" {
         format!("{api_url}/repos/{repo}/releases/latest")
     } else {
@@ -364,6 +371,10 @@ async fn get_release_(api_url: &str, repo: &str, tag: &str) -> Result<GithubRele
     crate::http::HTTP_FETCH
         .json_with_headers(url, &headers)
         .await
+}
+
+fn is_public_github_api_base(api_url: &str) -> bool {
+    api_url.trim_end_matches('/') == API_URL
 }
 
 fn next_page(headers: &HeaderMap) -> Option<String> {

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -67,17 +67,63 @@ pub async fn verify_attestation(
     expected_workflow: Option<&str>,
     api_url: Option<&str>,
 ) -> AttestationResult<bool> {
+    let mut digest = None;
+    if use_versions_host_for_attestations(api_url) {
+        let artifact_digest = mise_sigstore::calculate_file_digest(artifact_path).await?;
+        match crate::versions_host::github_attestations(
+            &format!("{owner}/{repo}"),
+            &format!("sha256:{artifact_digest}"),
+        )
+        .await
+        {
+            Ok(Some(attestations)) => {
+                trace!(
+                    "got {} GitHub attestations for {owner}/{repo}@sha256:{artifact_digest} from mise-versions",
+                    attestations.len()
+                );
+                if attestations.iter().any(|a| !a.has_inline_bundle()) {
+                    debug!(
+                        "mise-versions returned GitHub attestations without inline bundles; falling back to GitHub API"
+                    );
+                } else {
+                    return mise_sigstore::verify_github_attestation_with_attestations(
+                        artifact_path,
+                        &attestations,
+                        expected_workflow,
+                    )
+                    .await;
+                }
+            }
+            Ok(None) => {}
+            Err(err) => debug!("mise-versions GitHub attestations lookup failed: {err:#}"),
+        }
+        digest = Some(artifact_digest);
+    }
+
     let token = resolve_token_for_wrapper(api_url);
     let base_url = routed_api_url(api_url.unwrap_or(crate::github::API_URL));
-    mise_sigstore::verify_github_attestation_with_base_url(
-        artifact_path,
-        owner,
-        repo,
-        token.as_deref(),
-        expected_workflow,
-        &base_url,
-    )
-    .await
+    if let Some(digest) = digest {
+        mise_sigstore::verify_github_attestation_with_base_url_and_digest(
+            artifact_path,
+            owner,
+            repo,
+            token.as_deref(),
+            expected_workflow,
+            &base_url,
+            &digest,
+        )
+        .await
+    } else {
+        mise_sigstore::verify_github_attestation_with_base_url(
+            artifact_path,
+            owner,
+            repo,
+            token.as_deref(),
+            expected_workflow,
+            &base_url,
+        )
+        .await
+    }
 }
 
 /// Reason the pre-download attestation probe could not complete.
@@ -124,6 +170,20 @@ pub async fn detect_attestations(
     api_url: &str,
     digest: &str,
 ) -> Result<bool, DetectError> {
+    if use_versions_host_for_attestations(Some(api_url)) {
+        match crate::versions_host::github_attestations(&format!("{owner}/{repo}"), digest).await {
+            Ok(Some(attestations)) => {
+                trace!(
+                    "got {} GitHub attestation probes for {owner}/{repo}@{digest} from mise-versions",
+                    attestations.len()
+                );
+                return Ok(!attestations.is_empty());
+            }
+            Ok(None) => {}
+            Err(err) => debug!("mise-versions GitHub attestation probe failed: {err:#}"),
+        }
+    }
+
     let token = resolve_token_for_wrapper(Some(api_url));
     let base_url = routed_api_url(api_url);
     let source = GitHubSource::with_base_url(owner, repo, token.as_deref(), &base_url)
@@ -134,6 +194,18 @@ pub async fn detect_attestations(
         .await
         .map_err(DetectError::Fetch)?;
     Ok(!attestations.is_empty())
+}
+
+fn use_versions_host_for_attestations(api_url: Option<&str>) -> bool {
+    let settings = crate::config::Settings::get();
+    if settings.prefer_offline() || !settings.use_versions_host {
+        return false;
+    }
+
+    api_url
+        .unwrap_or(crate::github::API_URL)
+        .trim_end_matches('/')
+        == crate::github::API_URL
 }
 
 /// Verify SLSA provenance for an already-downloaded artifact. Passthrough — no token needed.
@@ -204,9 +276,17 @@ mod tests {
 
     impl SettingsGuard {
         fn new(replacements: Option<indexmap::IndexMap<String, String>>) -> Self {
+            Self::with_versions_host(replacements, None)
+        }
+
+        fn with_versions_host(
+            replacements: Option<indexmap::IndexMap<String, String>>,
+            use_versions_host: Option<bool>,
+        ) -> Self {
             let lock = TEST_SETTINGS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             let mut settings = crate::config::settings::SettingsPartial::empty();
             settings.url_replacements = replacements;
+            settings.use_versions_host = use_versions_host;
             crate::config::Settings::reset(Some(settings));
             Self { _lock: lock }
         }
@@ -381,5 +461,14 @@ mod tests {
         let routed = routed_api_url(crate::github::API_URL);
 
         assert_eq!(routed, crate::github::API_URL);
+    }
+
+    #[test]
+    fn test_use_versions_host_for_attestations_respects_setting() {
+        let _settings = SettingsGuard::with_versions_host(None, Some(false));
+
+        assert!(!use_versions_host_for_attestations(Some(
+            crate::github::API_URL
+        )));
     }
 }

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -81,7 +81,9 @@ pub async fn verify_attestation(
                     "got {} GitHub attestations for {owner}/{repo}@sha256:{artifact_digest} from mise-versions",
                     attestations.len()
                 );
-                if attestations.iter().any(|a| !a.has_inline_bundle()) {
+                if attestations.is_empty() {
+                    return Err(AttestationError::NoAttestations);
+                } else if attestations.iter().any(|a| !a.has_inline_bundle()) {
                     debug!(
                         "mise-versions returned GitHub attestations without inline bundles; falling back to GitHub API"
                     );

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::{cmp::Ordering, sync::LazyLock};
 use std::{collections::BTreeMap, sync::Arc};
 
+use crate::backend::backend_type::BackendType;
 use crate::backend::{ABackend, VersionInfo};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
@@ -458,6 +459,14 @@ impl ToolVersion {
         // Prefix versions like "2" still need remote resolution to find e.g. "2.1.0".
         // "latest" also needs remote resolution but is handled in the block above.
         if prefer_offline && !opts.latest_versions && v.matches('.').count() >= 2 {
+            return build(v);
+        }
+        // Exact pinned github: versions do not need the full releases list.
+        // Asset resolution will fetch the specific release later, and public
+        // GitHub release metadata can come from mise-versions there. Keeping
+        // this path exact avoids an unnecessary GitHub `/releases` API call in
+        // normal installs without changing prefix/latest resolution.
+        if backend.get_type() == BackendType::Github && v.matches('.').count() >= 2 {
             return build(v);
         }
         // First try with date filter (common case)

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use std::{cmp::Ordering, sync::LazyLock};
 use std::{collections::BTreeMap, sync::Arc};
 
-use crate::backend::backend_type::BackendType;
 use crate::backend::{ABackend, VersionInfo};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
@@ -461,12 +460,13 @@ impl ToolVersion {
         if prefer_offline && !opts.latest_versions && v.matches('.').count() >= 2 {
             return build(v);
         }
-        // Exact pinned github: versions do not need the full releases list.
-        // Asset resolution will fetch the specific release later, and public
-        // GitHub release metadata can come from mise-versions there. Keeping
-        // this path exact avoids an unnecessary GitHub `/releases` API call in
-        // normal installs without changing prefix/latest resolution.
-        if backend.get_type() == BackendType::Github && v.matches('.').count() >= 2 {
+        // Exact pinned GitHub versions do not need the full releases list when
+        // the backend can cheaply prove the tag exists. If it cannot, fall
+        // through to normal prefix resolution so requests like "1.2.3" can
+        // still resolve to "1.2.3.4" when that is the latest matching version.
+        if v.matches('.').count() >= 2
+            && let Some(v) = backend.resolve_exact_version(config, &v).await?
+        {
             return build(v);
         }
         // First try with date filter (common case)

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -197,7 +197,7 @@ pub async fn github_attestations(
         "https://mise-versions.jdx.dev/api/github/repos/{}/{}/attestations/{}",
         encode_path_segment(owner),
         encode_path_segment(repo_name),
-        encode_path_segment(digest)
+        encode_digest_path_segment(digest)
     );
 
     let response: Option<AttestationsResponse> =
@@ -240,6 +240,10 @@ fn split_github_repo(repo: &str) -> Option<(&str, &str)> {
 
 fn encode_path_segment(segment: &str) -> String {
     urlencoding::encode(segment).into_owned()
+}
+
+fn encode_digest_path_segment(digest: &str) -> String {
+    encode_path_segment(digest).replace("%3A", ":")
 }
 
 fn valid_github_release_asset_urls(release: &GithubRelease, owner: &str, repo: &str) -> bool {
@@ -391,6 +395,14 @@ mod tests {
     #[test]
     fn test_encode_path_segment_encodes_digest() {
         assert_eq!(encode_path_segment("sha256:abc/def"), "sha256%3Aabc%2Fdef");
+    }
+
+    #[test]
+    fn test_encode_digest_path_segment_preserves_algorithm_separator() {
+        assert_eq!(
+            encode_digest_path_segment("sha256:abc/def"),
+            "sha256:abc%2Fdef"
+        );
     }
 
     #[test]

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -1,9 +1,11 @@
 use crate::backend::VersionInfo;
 use crate::config::Settings;
+use crate::github::GithubRelease;
 use crate::http;
 use crate::http::HTTP_FETCH;
 use crate::plugins::core::CORE_PLUGINS;
 use crate::registry::REGISTRY;
+use mise_sigstore::Attestation;
 use reqwest::header::{HeaderMap, HeaderValue};
 use std::{
     collections::{HashMap, HashSet},
@@ -62,6 +64,12 @@ struct VersionEntry {
     /// fields by default), so populating it in mise-versions is forward-compatible.
     #[serde(default)]
     prerelease: bool,
+}
+
+#[derive(serde::Deserialize)]
+struct AttestationsResponse {
+    #[serde(default)]
+    attestations: Vec<Attestation>,
 }
 
 /// List versions from the versions host (mise-versions.jdx.dev).
@@ -133,6 +141,164 @@ pub async fn list_versions(tool: &str) -> eyre::Result<Option<Vec<VersionInfo>>>
         .await
         .insert(tool.to_string(), versions.clone());
     Ok(Some(versions))
+}
+
+/// Fetch cached public GitHub release metadata from the versions host.
+///
+/// This endpoint is intentionally shaped like GitHub's release object so the
+/// normal backend asset-selection code remains authoritative on the client.
+pub async fn github_release(repo: &str, tag: &str) -> eyre::Result<Option<GithubRelease>> {
+    if !enabled_for_github_metadata() {
+        return Ok(None);
+    }
+
+    let Some((owner, repo_name)) = split_github_repo(repo) else {
+        return Ok(None);
+    };
+    let url = format!(
+        "https://mise-versions.jdx.dev/api/github/repos/{}/{}/releases/{}",
+        encode_path_segment(owner),
+        encode_path_segment(repo_name),
+        encode_path_segment(tag)
+    );
+
+    let Some(release) = fetch_optional_json(&url, "GitHub release metadata").await? else {
+        return Ok(None);
+    };
+    if !valid_github_release_asset_urls(&release, owner, repo_name) {
+        warn!("mise-versions returned invalid GitHub release asset URLs for {repo}@{tag}");
+        return Ok(None);
+    }
+    if !valid_github_release_tag(&release, tag) {
+        warn!(
+            "mise-versions returned GitHub release tag {} for requested {repo}@{tag}",
+            release.tag_name
+        );
+        return Ok(None);
+    }
+    Ok(Some(release))
+}
+
+/// Fetch cached GitHub Artifact Attestation payloads by artifact digest.
+///
+/// The returned bundles are not trusted by virtue of coming from mise-versions;
+/// callers still verify them cryptographically against the downloaded artifact.
+pub async fn github_attestations(
+    repo: &str,
+    digest: &str,
+) -> eyre::Result<Option<Vec<Attestation>>> {
+    if !enabled_for_github_metadata() {
+        return Ok(None);
+    }
+
+    let Some((owner, repo_name)) = split_github_repo(repo) else {
+        return Ok(None);
+    };
+    let url = format!(
+        "https://mise-versions.jdx.dev/api/github/repos/{}/{}/attestations/{}",
+        encode_path_segment(owner),
+        encode_path_segment(repo_name),
+        encode_path_segment(digest)
+    );
+
+    let response: Option<AttestationsResponse> =
+        fetch_optional_json(&url, "GitHub attestations").await?;
+    Ok(response.map(|r| r.attestations))
+}
+
+async fn fetch_optional_json<T>(url: &str, label: &str) -> eyre::Result<Option<T>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    match HTTP_FETCH
+        .json_with_headers(url, &VERSIONS_HOST_HEADERS)
+        .await
+    {
+        Ok(value) => Ok(Some(value)),
+        Err(err) => match http::error_code(&err).unwrap_or(0) {
+            404 => Ok(None),
+            429 => {
+                warn!("mise-versions rate limited while fetching {label}");
+                Ok(None)
+            }
+            _ => {
+                debug!("mise-versions {label} lookup failed: {err:#}");
+                Ok(None)
+            }
+        },
+    }
+}
+
+fn enabled_for_github_metadata() -> bool {
+    let settings = Settings::get();
+    !settings.prefer_offline() && settings.use_versions_host
+}
+
+fn split_github_repo(repo: &str) -> Option<(&str, &str)> {
+    let (owner, name) = repo.split_once('/')?;
+    (!owner.is_empty() && !name.is_empty() && !name.contains('/')).then_some((owner, name))
+}
+
+fn encode_path_segment(segment: &str) -> String {
+    urlencoding::encode(segment).into_owned()
+}
+
+fn valid_github_release_asset_urls(release: &GithubRelease, owner: &str, repo: &str) -> bool {
+    !release.assets.is_empty()
+        && release.assets.iter().all(|asset| {
+            valid_github_browser_download_url(&asset.browser_download_url, owner, repo)
+                && valid_github_asset_api_url(&asset.url, owner, repo)
+        })
+}
+
+fn valid_github_release_tag(release: &GithubRelease, tag: &str) -> bool {
+    tag == "latest" || release.tag_name == tag
+}
+
+fn valid_github_browser_download_url(url: &str, owner: &str, repo: &str) -> bool {
+    let Ok(url) = url::Url::parse(url) else {
+        return false;
+    };
+    if url.scheme() != "https" || url.host_str() != Some("github.com") {
+        return false;
+    }
+    let mut segments = url.path_segments().into_iter().flatten();
+    matches!(
+        (
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next()
+        ),
+        (Some(o), Some(r), Some("releases"), Some("download"), Some(_tag), Some(_asset), None)
+            if o == owner && r == repo
+    )
+}
+
+fn valid_github_asset_api_url(url: &str, owner: &str, repo: &str) -> bool {
+    let Ok(url) = url::Url::parse(url) else {
+        return false;
+    };
+    if url.scheme() != "https" || url.host_str() != Some("api.github.com") {
+        return false;
+    }
+    let mut segments = url.path_segments().into_iter().flatten();
+    matches!(
+        (
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next()
+        ),
+        (Some("repos"), Some(o), Some(r), Some("releases"), Some("assets"), Some(_), None)
+            if o == owner && r == repo
+    )
 }
 
 /// Tracks a tool installation asynchronously (fire-and-forget)
@@ -214,5 +380,97 @@ mod tests {
             track_install_url("node"),
             "https://mise-versions.jdx.dev/api/tools/node"
         );
+    }
+
+    #[test]
+    fn test_split_github_repo() {
+        assert_eq!(split_github_repo("cli/cli"), Some(("cli", "cli")));
+        assert_eq!(split_github_repo("cli"), None);
+        assert_eq!(split_github_repo("cli/cli/extra"), None);
+    }
+
+    #[test]
+    fn test_encode_path_segment_encodes_digest() {
+        assert_eq!(encode_path_segment("sha256:abc/def"), "sha256%3Aabc%2Fdef");
+    }
+
+    #[test]
+    fn test_valid_github_browser_download_url() {
+        assert!(valid_github_browser_download_url(
+            "https://github.com/jdx/mise-test-fixtures/releases/download/v1.0.0/hello-world.tar.gz",
+            "jdx",
+            "mise-test-fixtures"
+        ));
+        assert!(!valid_github_browser_download_url(
+            "https://evil.example.com/jdx/mise-test-fixtures/releases/download/v1.0.0/hello-world.tar.gz",
+            "jdx",
+            "mise-test-fixtures"
+        ));
+        assert!(!valid_github_browser_download_url(
+            "https://github.com/other/mise-test-fixtures/releases/download/v1.0.0/hello-world.tar.gz",
+            "jdx",
+            "mise-test-fixtures"
+        ));
+        assert!(!valid_github_browser_download_url(
+            "https://github.com/jdx/mise-test-fixtures/releases/download",
+            "jdx",
+            "mise-test-fixtures"
+        ));
+    }
+
+    #[test]
+    fn test_valid_github_asset_api_url() {
+        assert!(valid_github_asset_api_url(
+            "https://api.github.com/repos/jdx/mise-test-fixtures/releases/assets/1",
+            "jdx",
+            "mise-test-fixtures"
+        ));
+        assert!(!valid_github_asset_api_url(
+            "https://api.github.com/repos/other/mise-test-fixtures/releases/assets/1",
+            "jdx",
+            "mise-test-fixtures"
+        ));
+        assert!(!valid_github_asset_api_url(
+            "https://github.com/jdx/mise-test-fixtures/releases/assets/1",
+            "jdx",
+            "mise-test-fixtures"
+        ));
+        assert!(!valid_github_asset_api_url(
+            "https://api.github.com/repos/jdx/mise-test-fixtures/releases/assets/1/extra",
+            "jdx",
+            "mise-test-fixtures"
+        ));
+    }
+
+    #[test]
+    fn test_valid_github_release_asset_urls_rejects_empty_assets() {
+        let release = GithubRelease {
+            tag_name: "v1.0.0".into(),
+            draft: false,
+            prerelease: false,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            assets: vec![],
+        };
+
+        assert!(!valid_github_release_asset_urls(
+            &release,
+            "jdx",
+            "mise-test-fixtures"
+        ));
+    }
+
+    #[test]
+    fn test_valid_github_release_tag() {
+        let release = GithubRelease {
+            tag_name: "v1.0.0".into(),
+            draft: false,
+            prerelease: false,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            assets: vec![],
+        };
+
+        assert!(valid_github_release_tag(&release, "v1.0.0"));
+        assert!(valid_github_release_tag(&release, "latest"));
+        assert!(!valid_github_release_tag(&release, "v2.0.0"));
     }
 }

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -249,8 +249,12 @@ fn encode_digest_path_segment(digest: &str) -> String {
 fn valid_github_release_asset_urls(release: &GithubRelease, owner: &str, repo: &str) -> bool {
     !release.assets.is_empty()
         && release.assets.iter().all(|asset| {
-            valid_github_browser_download_url(&asset.browser_download_url, owner, repo)
-                && valid_github_asset_api_url(&asset.url, owner, repo)
+            valid_github_browser_download_url(
+                &asset.browser_download_url,
+                owner,
+                repo,
+                &release.tag_name,
+            ) && valid_github_asset_api_url(&asset.url, owner, repo)
         })
 }
 
@@ -258,7 +262,7 @@ fn valid_github_release_tag(release: &GithubRelease, tag: &str) -> bool {
     tag == "latest" || release.tag_name == tag
 }
 
-fn valid_github_browser_download_url(url: &str, owner: &str, repo: &str) -> bool {
+fn valid_github_browser_download_url(url: &str, owner: &str, repo: &str, tag: &str) -> bool {
     let Ok(url) = url::Url::parse(url) else {
         return false;
     };
@@ -276,9 +280,13 @@ fn valid_github_browser_download_url(url: &str, owner: &str, repo: &str) -> bool
             segments.next(),
             segments.next()
         ),
-        (Some(o), Some(r), Some("releases"), Some("download"), Some(_tag), Some(_asset), None)
-            if o == owner && r == repo
+        (Some(o), Some(r), Some("releases"), Some("download"), Some(t), Some(_asset), None)
+            if o == owner && r == repo && path_segment_matches(t, tag)
     )
+}
+
+fn path_segment_matches(segment: &str, expected: &str) -> bool {
+    segment == expected || urlencoding::decode(segment).is_ok_and(|decoded| decoded == expected)
 }
 
 fn valid_github_asset_api_url(url: &str, owner: &str, repo: &str) -> bool {
@@ -410,22 +418,38 @@ mod tests {
         assert!(valid_github_browser_download_url(
             "https://github.com/jdx/mise-test-fixtures/releases/download/v1.0.0/hello-world.tar.gz",
             "jdx",
-            "mise-test-fixtures"
+            "mise-test-fixtures",
+            "v1.0.0"
+        ));
+        assert!(valid_github_browser_download_url(
+            "https://github.com/jdx/mise-test-fixtures/releases/download/release%2F2026/hello-world.tar.gz",
+            "jdx",
+            "mise-test-fixtures",
+            "release/2026"
+        ));
+        assert!(!valid_github_browser_download_url(
+            "https://github.com/jdx/mise-test-fixtures/releases/download/v0.9.0/hello-world.tar.gz",
+            "jdx",
+            "mise-test-fixtures",
+            "v1.0.0"
         ));
         assert!(!valid_github_browser_download_url(
             "https://evil.example.com/jdx/mise-test-fixtures/releases/download/v1.0.0/hello-world.tar.gz",
             "jdx",
-            "mise-test-fixtures"
+            "mise-test-fixtures",
+            "v1.0.0"
         ));
         assert!(!valid_github_browser_download_url(
             "https://github.com/other/mise-test-fixtures/releases/download/v1.0.0/hello-world.tar.gz",
             "jdx",
-            "mise-test-fixtures"
+            "mise-test-fixtures",
+            "v1.0.0"
         ));
         assert!(!valid_github_browser_download_url(
             "https://github.com/jdx/mise-test-fixtures/releases/download",
             "jdx",
-            "mise-test-fixtures"
+            "mise-test-fixtures",
+            "v1.0.0"
         ));
     }
 

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -218,7 +218,7 @@ where
         Err(err) => match http::error_code(&err).unwrap_or(0) {
             404 => Ok(None),
             429 => {
-                warn!("mise-versions rate limited while fetching {label}");
+                debug!("mise-versions rate limited while fetching {label}");
                 Ok(None)
             }
             _ => {

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -68,7 +68,6 @@ struct VersionEntry {
 
 #[derive(serde::Deserialize)]
 struct AttestationsResponse {
-    #[serde(default)]
     attestations: Vec<Attestation>,
 }
 
@@ -472,5 +471,16 @@ mod tests {
         assert!(valid_github_release_tag(&release, "v1.0.0"));
         assert!(valid_github_release_tag(&release, "latest"));
         assert!(!valid_github_release_tag(&release, "v2.0.0"));
+    }
+
+    #[test]
+    fn test_attestations_response_requires_attestations_field() {
+        assert!(serde_json::from_str::<AttestationsResponse>("{}").is_err());
+        assert!(
+            serde_json::from_str::<AttestationsResponse>(r#"{"attestations":[]}"#)
+                .unwrap()
+                .attestations
+                .is_empty()
+        );
     }
 }


### PR DESCRIPTION
## Why this matters

This tackles one of mise's oldest and most painful operational problems: public GitHub API rate limits during installs. A huge amount of the registry ultimately resolves through GitHub releases, especially via `aqua:` and `github:` tools. In CI and Docker builds there is often no GitHub token, so many independent installs all compete for GitHub's low anonymous API limit just to discover release assets or check provenance.

With this PR, normal public GitHub-backed installs can use mise's shared versions host for release metadata and GitHub artifact attestations before falling back to `api.github.com`. That means common installs like `gh`, `gum`, `eza`, `starship`, `lazygit`, `lazydocker`, and many aqua-backed tools no longer need to hit GitHub directly just to resolve release assets. This should remove a long-running source of flaky Docker builds, CI failures, and confusing "403 API rate limit exceeded" reports for users who are not doing anything unusual.

## Summary

- try `mise-versions` before `api.github.com` for public GitHub release metadata
- fetch cached GitHub attestation payloads from `mise-versions` before using GitHub's attestation API
- keep verification local: cached attestation bundles are still verified against the downloaded artifact
- validate mirrored release asset URLs before using them, requiring same-repo GitHub release download URLs and same-repo GitHub release asset API URLs
- fall back to GitHub's API when the versions host misses, fails, is disabled, or when a non-public GitHub API host is configured
- keep versions-host metadata fallback quiet, so private GitHub repos that the shared cache cannot access still work out of the box with normal GitHub authentication and no spurious warning
- add an e2e test using real `mise-versions` that fails if `api.github.com` is contacted
- update docs for `use_versions_host`, GitHub token guidance, and rate-limit troubleshooting

## Security / correctness notes

- `mise-versions` is a metadata cache, not a trust root. Release asset URLs are validated before use, and artifact attestations are verified locally by mise.
- The versions host is only used for public `api.github.com` flows. GitHub Enterprise/custom API hosts continue to use their configured API path.
- Private github.com repositories naturally miss the shared cache and fall back to GitHub's API without warning.
- Empty release asset lists are not cached as usable release metadata, so transient GitHub/API weirdness does not poison installs.
- If the shared cache does not have data yet, existing authenticated/unauthenticated GitHub fallback behavior remains in place.

## Testing

- `cargo fmt`
- `cargo check -q`
- `cargo test -q versions_host::tests`
- `cargo test -q -p mise-sigstore`
- `bash -n e2e/backend/test_github_versions_host_no_api`

Note: the new e2e depends on the production `mise-versions` mirror endpoints from `jdx/mise-versions#201`. Production currently needs the follow-up Worker fix in `jdx/mise-versions#202` to stop returning 502 for mirrored GitHub release metadata; after that deploy, this e2e should be run against the live service.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install and provenance paths for many public GitHub tools; mitigations include strict URL validation, local attestation verification, and unchanged GitHub API fallback when the cache misses or is disabled.
> 
> **Overview**
> Public GitHub installs can now use **mise-versions** for release metadata and artifact attestations before calling `api.github.com`, cutting anonymous API use in CI and Docker when `use_versions_host` is on.
> 
> **Release resolution:** `get_release_` tries `versions_host::github_release` for public `api.github.com` URLs, with URL/tag validation on mirrored assets. The GitHub backend adds `resolve_exact_version` so pinned semver-like versions can be proven via a single release lookup instead of listing all releases. `ToolVersion` resolution calls that hook before full remote version lists.
> 
> **Attestations:** `verify_attestation` and `detect_attestations` fetch cached bundles from mise-versions when enabled; inline bundles are verified locally via new `mise-sigstore` entry points (`verify_github_attestation_with_attestations`, optional precomputed digest). Missing or bundle-URL-only cache entries fall back to GitHub’s API without treating cache miss as failure for private repos.
> 
> **Docs/tests:** `use_versions_host` descriptions and troubleshooting/GitHub token docs reflect the broader cache role. E2e blocks `api.github.com` while installing from real mise-versions metadata; `mise ls` cache test expects versions-host GitHub release URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34bae18a2ac2cb6e9382aa77f5d54e4bc954a2ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->