### PR TITLE
chore: release 2026.5.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Changelog
 
+## [2026.5.17](https://github.com/jdx/mise/compare/v2026.5.16..v2026.5.17) - 2026-05-31
+
+### 🚀 Features
+
+- **(aqua)** add compiled custom registry cache by @risu729 in [#9583](https://github.com/jdx/mise/pull/9583)
+
+### 🐛 Bug Fixes
+
+- **(bun)** use native windows-arm64 build for Bun >= 1.3.10 by @JamBalaya56562 in [#10150](https://github.com/jdx/mise/pull/10150)
+- **(completion)** keep global -C/--cd usable in task argument completion by @JamBalaya56562 in [#10153](https://github.com/jdx/mise/pull/10153)
+- **(env)** force uppercase PATH key on unix by @risu729 in [#9927](https://github.com/jdx/mise/pull/9927)
+- **(http)** limit versions host fallback retries by @jdx in [#10142](https://github.com/jdx/mise/pull/10142)
+- **(pipx)** upgrade shared pip environment when using version constraints by @iloveitaly in [#10138](https://github.com/jdx/mise/pull/10138)
+- **(shim)** refresh stale Windows shims after a mise version update by @JamBalaya56562 in [#10152](https://github.com/jdx/mise/pull/10152)
+- **(task)** honor explicit and quoted shell paths on Windows by @JamBalaya56562 in [#10148](https://github.com/jdx/mise/pull/10148)
+- **(task)** convert PATH to /cygdrive form for Cygwin bash tasks by @JamBalaya56562 in [#10147](https://github.com/jdx/mise/pull/10147)
+- **(ui)** honor color settings in interactive prompt themes by @JamBalaya56562 in [#10151](https://github.com/jdx/mise/pull/10151)
+- **(upgrade)** handle lone v prefix in --bump latest queries by @zeitlinger in [#10130](https://github.com/jdx/mise/pull/10130)
+
+### 🚜 Refactor
+
+- **(spm)** parse tool options locally by @risu729 in [#9959](https://github.com/jdx/mise/pull/9959)
+
+### 📚 Documentation
+
+- **(glossary)** split Aliases into Tool Aliases and Shell Aliases by @thernstig in [#9983](https://github.com/jdx/mise/pull/9983)
+
+### 🧪 Testing
+
+- deflake python venv go backend e2e by @jdx in [#10156](https://github.com/jdx/mise/pull/10156)
+
+### 📦️ Dependency Updates
+
+- update rust docker digest to fb328f0 by @renovate[bot] in [#10135](https://github.com/jdx/mise/pull/10135)
+- update zizmorcore/zizmor-action action to v0.5.6 by @renovate[bot] in [#10136](https://github.com/jdx/mise/pull/10136)
+- update ghcr.io/jdx/mise:deb docker digest to b0291a9 by @renovate[bot] in [#10133](https://github.com/jdx/mise/pull/10133)
+- update fedora:45 docker digest to 0c1f63e by @renovate[bot] in [#10131](https://github.com/jdx/mise/pull/10131)
+- update ghcr.io/jdx/mise:rpm docker digest to 9e5e851 by @renovate[bot] in [#10134](https://github.com/jdx/mise/pull/10134)
+- update ghcr.io/jdx/mise:alpine docker digest to 736b665 by @renovate[bot] in [#10132](https://github.com/jdx/mise/pull/10132)
+- update rust crate sigstore-verify to 0.8.0 by @renovate[bot] in [#10137](https://github.com/jdx/mise/pull/10137)
+- bump aube to 1.16.1 by @jdx in [#10143](https://github.com/jdx/mise/pull/10143)
+
+### 📦 Registry
+
+- add herdr ([github:ogulcancelik/herdr](https://github.com/ogulcancelik/herdr)) by @ogulcancelik in [#10154](https://github.com/jdx/mise/pull/10154)
+- add databricks-cli ([aqua:databricks/cli](https://github.com/databricks/cli)) by @yigal100 in [#10072](https://github.com/jdx/mise/pull/10072)
+
+### Webpage
+
+- Use most modern tools by @cclauss in [#10170](https://github.com/jdx/mise/pull/10170)
+
+### Chore
+
+- **(ci)** switch back to github-hosted runners by @jdx in [#10144](https://github.com/jdx/mise/pull/10144)
+- **(clippy)** clean up accumulated Windows-only clippy warnings by @JamBalaya56562 in [#10149](https://github.com/jdx/mise/pull/10149)
+
+### New Contributors
+
+- @cclauss made their first contribution in [#10170](https://github.com/jdx/mise/pull/10170)
+- @yigal100 made their first contribution in [#10072](https://github.com/jdx/mise/pull/10072)
+- @ogulcancelik made their first contribution in [#10154](https://github.com/jdx/mise/pull/10154)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (7)
+
+- [`Bearer/bearer`](https://github.com/Bearer/bearer)
+- [`ImageMagick/ImageMagick`](https://github.com/ImageMagick/ImageMagick)
+- [`dahlia/gukhanmun`](https://github.com/dahlia/gukhanmun)
+- [`dahlia/hongdown`](https://github.com/dahlia/hongdown)
+- [`grafana/oats`](https://github.com/grafana/oats)
+- [`s0undt3ch/ToolR`](https://github.com/s0undt3ch/ToolR)
+- [`ubugeeei-prod/vize`](https://github.com/ubugeeei-prod/vize)
+
+#### Updated Packages (2)
+
+- [`Boeing/config-file-validator`](https://github.com/Boeing/config-file-validator)
+- [`npm/cli`](https://github.com/npm/cli)
+
 ## [2026.5.16](https://github.com/jdx/mise/compare/v2026.5.15..v2026.5.16) - 2026-05-28
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.5.16"
+version = "2026.5.17"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.5.16"
+version = "2026.5.17"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.5.16 macos-arm64 (2026-05-28)
+2026.5.17 macos-arm64 (2026-05-31)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_16.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_17.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_16.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_17.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_16.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_17.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_16.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_17.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.5.16";
+  version = "2026.5.17";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "28.8k",
+      stars: "28.9k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.5.16
+Version: 2026.5.17
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.5.16"
+version: "2026.5.17"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "v4.517.0"
+  "tag": "v4.519.0"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -987,6 +987,48 @@ packages:
           - windows
   - type: github_release
     repo_owner: Bearer
+    repo_name: bearer
+    description: Code security scanning tool (SAST) to discover, filter and prioritize security and privacy risks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.24.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.43.4")
+        asset: bearer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+            files:
+              - name: bearer
+                src: usr/bin/bearer
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: bearer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+            files:
+              - name: bearer
+                src: usr/bin/bearer
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: Bearer
     repo_name: gon
     description: Sign, notarize, and package macOS CLI tools and applications written in any language. Available as both a CLI and a Go library
     version_constraint: "false"
@@ -1082,107 +1124,93 @@ packages:
   - type: github_release
     repo_owner: Boeing
     repo_name: config-file-validator
-    description: Cross Platform tool to validate configuration files
-    asset: validator-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        goarch: amd64
-        format: zip
-      - goos: windows
-        goarch: arm64
-        type: go_install
-        path: github.com/Boeing/config-file-validator/cmd/validator
+    description: Cross-platform CLI tool to validate configuration files across 17 formats. Syntax and schema validation with JSON Schema, XSD, and SchemaStore integration. Written in Go
     files:
       - name: validator
-    checksum:
-      type: github_release
-      asset: "{{.Asset}}.md5"
-      algorithm: md5
-    version_constraint: semver(">= 1.5.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v1.4.0"
-        asset: validator-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-        format: raw
-        checksum:
-          enabled: false
-        overrides:
-          - goos: windows
-            goarch: amd64
-            asset: validator-{{trimV .Version}}
-          - goos: linux
-            goarch: arm64
-            type: go_install
-            path: github.com/Boeing/config-file-validator/cmd/validator
-          - goos: windows
-            goarch: arm64
-            type: go_install
-            path: github.com/Boeing/config-file-validator/cmd/validator
-        files:
-          - name: validator
-        replacements:
-          darwin: macos
-        rosetta2: true
       - version_constraint: Version == "v1.3.0"
         asset: validator.{{.OS}}-{{.Arch}}
         format: raw
+        rosetta2: true
         replacements:
           darwin: macos
-        rosetta2: true
-        checksum:
-          enabled: false
         overrides:
           - goos: windows
-            goarch: amd64
             asset: validator
-          - goos: linux
-            goarch: arm64
-            type: go_install
-            path: github.com/Boeing/config-file-validator/cmd/validator
-          - goos: windows
-            goarch: arm64
-            type: go_install
-            path: github.com/Boeing/config-file-validator/cmd/validator
-      - version_constraint: semver(">= 1.0.1")
-        asset: validator.{{.OS}}-{{.Arch}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.4.0"
+        asset: validator-{{trimV .Version}}-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
-        replacements: {}
-        checksum:
-          enabled: false
+        replacements:
+          darwin: macos
         overrides:
           - goos: windows
-            goarch: amd64
-            asset: validator
-          - goarch: arm64
-            type: go_install
-            path: github.com/Boeing/config-file-validator/cmd/validator
-          - goos: darwin
-            type: go_install
-            path: github.com/Boeing/config-file-validator/cmd/validator
-      - version_constraint: Version == "v1.0.0"
+            asset: validator-{{trimV .Version}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.2.0")
         asset: validator.{{.OS}}-{{.Arch}}
         format: raw
-        replacements: {}
-        rosetta2: true
-        checksum:
-          enabled: false
         overrides:
           - goos: windows
-            goarch: amd64
             asset: validator
-          - goarch: arm64
-            type: go_build
-            files:
-              - name: validator
-                src: ./cmd/validator
-                dir: config-file-validator-{{trimV .Version}}
-          - goos: darwin
-            type: go_build
-            files:
-              - name: validator
-                src: ./cmd/validator
-                dir: config-file-validator-{{trimV .Version}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 2.1.0")
+        asset: validator-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v2.2.0"
+        asset: validator-v2.2-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v2.2.1"
+        asset: validator-v2.2-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: validator-v{{(semver .Version).Major}}.{{(semver .Version).Minor}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: Builditluc
     repo_name: wiki-tui
@@ -4120,6 +4148,75 @@ packages:
             files:
               - name: redli
                 src: redli_{{.Arch}}.exe
+  - type: github_release
+    repo_owner: ImageMagick
+    repo_name: ImageMagick
+    description: ImageMagick is a free and open-source software suite for displaying, creating, converting, modifying, and editing raster images
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 7.1.2-18")
+        supported_envs:
+          - windows/amd64
+        overrides:
+          - goos: linux
+            format: raw
+            asset: ImageMagick-{{.Version}}-gcc-x86_64.AppImage
+            files:
+              - name: magick
+          - goos: windows
+            asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
+            format: 7z
+            files:
+              - name: compare
+              - name: composite
+              - name: conjure
+              - name: identify
+              - name: magick
+              - name: mogrify
+              - name: montage
+              - name: stream
+      - version_constraint: Version == "7.1.2-19"
+        github_artifact_attestations:
+          signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
+        supported_envs:
+          - windows/amd64
+        overrides:
+          - goos: windows
+            asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
+            format: 7z
+            files:
+              - name: compare
+              - name: composite
+              - name: conjure
+              - name: identify
+              - name: magick
+              - name: mogrify
+              - name: montage
+              - name: stream
+      - version_constraint: "true"
+        github_artifact_attestations:
+          signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
+        supported_envs:
+          - windows/amd64
+          - linux/amd64
+        overrides:
+          - goos: linux
+            format: raw
+            asset: ImageMagick-{{.Version}}-gcc-x86_64.AppImage
+            files:
+              - name: magick
+          - goos: windows
+            asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
+            format: 7z
+            files:
+              - name: compare
+              - name: composite
+              - name: conjure
+              - name: identify
+              - name: magick
+              - name: mogrify
+              - name: montage
+              - name: stream
   - type: github_release
     repo_owner: IohannRabeson
     repo_name: tmignore-rs
@@ -29904,6 +30001,50 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: dahlia
+    repo_name: gukhanmun
+    description: Convert mixed-script Korean text into hangul-only text
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        files:
+          - name: gukhanmun
+            src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun
+          - name: gukhanmun-mkdict
+            src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun-mkdict
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: dahlia
+    repo_name: hongdown
+    description: A Markdown formatter that enforces Hong Minhee's Markdown style conventions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        files:
+          - name: hongdown
+            src: hongdown-{{.Arch}}-{{.OS}}/hongdown
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: daichirata
     repo_name: hammer
     description: hammer is a command-line tool to schema management for Google Cloud Spanner
@@ -44840,6 +44981,26 @@ packages:
       - linux
       - darwin
     version_prefix: mimir-
+  - type: github_release
+    repo_owner: grafana
+    repo_name: oats
+    description: OpenTelemetry Acceptance Tests (OATs), or OATs for short, is a test framework for OpenTelemetry
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: oats_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        github_artifact_attestations:
+          signer_workflow: grafana/oats/.github/workflows/release.yml
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: grafana
     repo_name: tanka
@@ -67682,6 +67843,9 @@ packages:
     repo_name: cli
     description: the package manager for JavaScript
     version_filter: Version matches "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    supported_envs:
+      - darwin
+      - linux
     url: https://registry.npmjs.org/npm/-/npm-{{trimV .Version}}.tgz
     format: tar.gz
     files:
@@ -67689,13 +67853,6 @@ packages:
         src: package/bin/npm-cli.js
       - name: npx
         src: package/bin/npx-cli.js
-    overrides:
-      - goos: windows
-        files:
-          - name: npm
-            src: package/bin/npm.cmd
-          - name: npx
-            src: package/bin/npx.cmd
   - type: github_archive
     repo_owner: npryce
     repo_name: adr-tools
@@ -78086,6 +78243,36 @@ packages:
       type: github_release
       asset: smap_{{.Version}}--sha256_checksums.txt
       algorithm: sha256
+  - type: github_release
+    repo_owner: s0undt3ch
+    repo_name: ToolR
+    description: In-project CLI tooling support
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 0.20.0")
+        error_message: Standalone binaries are available from v0.20.0; please use v0.20.0 or later
+      - version_constraint: "true"
+        asset: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: toolr
+            src: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}/toolr
+        windows_arm_emulation: true
+        github_artifact_attestations:
+          enabled: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: sachaos
     repo_name: go-life
@@ -92993,8 +93180,10 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
-    repo_owner: ubugeeei
+    repo_owner: ubugeeei-prod
     repo_name: vize
+    aliases:
+      - name: ubugeeei/vize
     description: Unofficial High-Performance Vue.js Toolchain in Rust
     search_words:
       - vue


### PR DESCRIPTION
### 🚀 Features

- **(aqua)** add compiled custom registry cache by @risu729 in [#9583](https://github.com/jdx/mise/pull/9583)

### 🐛 Bug Fixes

- **(bun)** use native windows-arm64 build for Bun >= 1.3.10 by @JamBalaya56562 in [#10150](https://github.com/jdx/mise/pull/10150)
- **(completion)** keep global -C/--cd usable in task argument completion by @JamBalaya56562 in [#10153](https://github.com/jdx/mise/pull/10153)
- **(env)** force uppercase PATH key on unix by @risu729 in [#9927](https://github.com/jdx/mise/pull/9927)
- **(http)** limit versions host fallback retries by @jdx in [#10142](https://github.com/jdx/mise/pull/10142)
- **(pipx)** upgrade shared pip environment when using version constraints by @iloveitaly in [#10138](https://github.com/jdx/mise/pull/10138)
- **(shim)** refresh stale Windows shims after a mise version update by @JamBalaya56562 in [#10152](https://github.com/jdx/mise/pull/10152)
- **(task)** honor explicit and quoted shell paths on Windows by @JamBalaya56562 in [#10148](https://github.com/jdx/mise/pull/10148)
- **(task)** convert PATH to /cygdrive form for Cygwin bash tasks by @JamBalaya56562 in [#10147](https://github.com/jdx/mise/pull/10147)
- **(ui)** honor color settings in interactive prompt themes by @JamBalaya56562 in [#10151](https://github.com/jdx/mise/pull/10151)
- **(upgrade)** handle lone v prefix in --bump latest queries by @zeitlinger in [#10130](https://github.com/jdx/mise/pull/10130)

### 🚜 Refactor

- **(spm)** parse tool options locally by @risu729 in [#9959](https://github.com/jdx/mise/pull/9959)

### 📚 Documentation

- **(glossary)** split Aliases into Tool Aliases and Shell Aliases by @thernstig in [#9983](https://github.com/jdx/mise/pull/9983)

### 🧪 Testing

- deflake python venv go backend e2e by @jdx in [#10156](https://github.com/jdx/mise/pull/10156)

### 📦️ Dependency Updates

- update rust docker digest to fb328f0 by @renovate[bot] in [#10135](https://github.com/jdx/mise/pull/10135)
- update zizmorcore/zizmor-action action to v0.5.6 by @renovate[bot] in [#10136](https://github.com/jdx/mise/pull/10136)
- update ghcr.io/jdx/mise:deb docker digest to b0291a9 by @renovate[bot] in [#10133](https://github.com/jdx/mise/pull/10133)
- update fedora:45 docker digest to 0c1f63e by @renovate[bot] in [#10131](https://github.com/jdx/mise/pull/10131)
- update ghcr.io/jdx/mise:rpm docker digest to 9e5e851 by @renovate[bot] in [#10134](https://github.com/jdx/mise/pull/10134)
- update ghcr.io/jdx/mise:alpine docker digest to 736b665 by @renovate[bot] in [#10132](https://github.com/jdx/mise/pull/10132)
- update rust crate sigstore-verify to 0.8.0 by @renovate[bot] in [#10137](https://github.com/jdx/mise/pull/10137)
- bump aube to 1.16.1 by @jdx in [#10143](https://github.com/jdx/mise/pull/10143)

### 📦 Registry

- add herdr ([github:ogulcancelik/herdr](https://github.com/ogulcancelik/herdr)) by @ogulcancelik in [#10154](https://github.com/jdx/mise/pull/10154)
- add databricks-cli ([aqua:databricks/cli](https://github.com/databricks/cli)) by @yigal100 in [#10072](https://github.com/jdx/mise/pull/10072)

### Webpage

- Use most modern tools by @cclauss in [#10170](https://github.com/jdx/mise/pull/10170)

### Chore

- **(ci)** switch back to github-hosted runners by @jdx in [#10144](https://github.com/jdx/mise/pull/10144)
- **(clippy)** clean up accumulated Windows-only clippy warnings by @JamBalaya56562 in [#10149](https://github.com/jdx/mise/pull/10149)

### New Contributors

- @cclauss made their first contribution in [#10170](https://github.com/jdx/mise/pull/10170)
- @yigal100 made their first contribution in [#10072](https://github.com/jdx/mise/pull/10072)
- @ogulcancelik made their first contribution in [#10154](https://github.com/jdx/mise/pull/10154)

## 📦 Aqua Registry Updates

### New Packages (7)

- [`Bearer/bearer`](https://github.com/Bearer/bearer)
- [`ImageMagick/ImageMagick`](https://github.com/ImageMagick/ImageMagick)
- [`dahlia/gukhanmun`](https://github.com/dahlia/gukhanmun)
- [`dahlia/hongdown`](https://github.com/dahlia/hongdown)
- [`grafana/oats`](https://github.com/grafana/oats)
- [`s0undt3ch/ToolR`](https://github.com/s0undt3ch/ToolR)
- [`ubugeeei-prod/vize`](https://github.com/ubugeeei-prod/vize)

### Updated Packages (2)

- [`Boeing/config-file-validator`](https://github.com/Boeing/config-file-validator)
- [`npm/cli`](https://github.com/npm/cli)