### PR TITLE
fix(upgrade): handle lone v prefix in --bump latest queries

### DIFF
--- a/e2e/core/test_v_prefix_bump_query
+++ b/e2e/core/test_v_prefix_bump_query
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Regression test for aqua-backed tools pinned with a leading v prefix.
+# `mise upgrade --bump` used to derive the fuzzy latest query `v3` from
+# `v3.12.0`, but aqua normalizes shfmt releases to bare versions like 3.13.1.
+# That mismatch triggered: "no latest version found".
+cat <<'TOML' > mise.toml
+[tools]
+shfmt = "v3.12.0"
+TOML
+
+assert_not_contains "mise upgrade shfmt --bump --dry-run 2>&1" "no latest version found"

--- a/e2e/core/test_v_prefix_bump_query
+++ b/e2e/core/test_v_prefix_bump_query
@@ -4,9 +4,10 @@
 # `mise upgrade --bump` used to derive the fuzzy latest query `v3` from
 # `v3.12.0`, but aqua normalizes shfmt releases to bare versions like 3.13.1.
 # That mismatch triggered: "no latest version found".
-cat <<'TOML' > mise.toml
+cat <<'TOML' >mise.toml
 [tools]
 shfmt = "v3.12.0"
 TOML
 
 assert_not_contains "mise upgrade shfmt --bump --dry-run 2>&1" "no latest version found"
+assert_contains "mise upgrade shfmt --bump --dry-run 2>&1" "Would bump shfmt@v3.13.1 in ~/workdir/mise.toml"

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -216,7 +216,14 @@ impl Display for OutdatedInfo {
 
 fn prefixed_latest_query(prefix: &str, prefix_version: &str) -> Option<String> {
     let prefix = prefix.trim();
-    if prefix.is_empty() || prefix_version.is_empty() || prefix.contains(':') {
+    if prefix.is_empty()
+        || prefix_version.is_empty()
+        || prefix.contains(':')
+        // A lone leading v/V is version syntax, not a backend/vendor prefix.
+        // Treat it as unprefixed so backends with normalized bare versions like
+        // 3.13.1 still resolve their latest release during --bump.
+        || matches!(prefix, "v" | "V")
+    {
         return None;
     }
 
@@ -504,6 +511,8 @@ mod tests {
             Some("corretto-2024".to_string())
         );
         assert_eq!(prefixed_latest_query("prefix:1.", "24"), None);
+        assert_eq!(prefixed_latest_query("v", "3.13.1"), None);
+        assert_eq!(prefixed_latest_query("V", "3.13.1"), None);
         assert_eq!(prefixed_latest_query("", "17.0.7"), None);
         assert_eq!(prefixed_latest_query("temurin-", ""), None);
     }

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -137,8 +137,8 @@ impl OutdatedInfo {
         }
         if bump {
             let old = oi.tool_version.request.version();
-            let old = old.strip_prefix(&prefix).unwrap_or_default();
-            let new = oi.latest.strip_prefix(&prefix).unwrap_or_default();
+            let old = old.strip_prefix(&prefix).unwrap_or(old.as_str());
+            let new = oi.latest.strip_prefix(&prefix).unwrap_or(&oi.latest);
             if let Some(bumped_version) = check_semver_bump(old, new)
                 && bumped_version != oi.tool_version.request.version()
             {
@@ -515,6 +515,20 @@ mod tests {
         assert_eq!(prefixed_latest_query("V", "3.13.1"), None);
         assert_eq!(prefixed_latest_query("", "17.0.7"), None);
         assert_eq!(prefixed_latest_query("temurin-", ""), None);
+    }
+
+    #[test]
+    fn test_v_prefix_bump_preserves_bare_latest_version() {
+        let prefix = "v";
+        let old = "v3.12.0";
+        let latest = "3.13.1";
+
+        let old = old.strip_prefix(prefix).unwrap_or(old);
+        let new = latest.strip_prefix(prefix).unwrap_or(latest);
+        let bumped = check_semver_bump(old, new).unwrap();
+
+        assert_eq!(bumped, "3.13.1");
+        assert_eq!(format!("{prefix}{bumped}"), "v3.13.1");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- fix `mise upgrade --bump` / `mise outdated --bump` when a tool is pinned with a lone leading `v` prefix
- treat `v`/`V` as version syntax rather than a backend or vendor prefix when building the latest-version query
- add a regression e2e test covering `shfmt = "v3.12.0"`

## Root cause
`--bump` splits the configured version into a prefix and numeric portion before asking the backend for the latest matching version.
For a pin like `v3.13.1`, that produced the fuzzy query `v3`.

The aqua backend normalizes tags like `v3.13.1` to bare versions like `3.13.1`, so querying for `v3` returned no match and emitted `no latest version found` even though the tool was up to date.

## Validation
- `cargo test test_prefixed_latest_query`
- manual repro with a built binary before/after the fix using:
  - `[tools] shfmt = "v3.13.1"`
  - `mise up -lvn shfmt`

## Notes
I also added an e2e regression test, but I could not run the full `mise run test:e2e e2e/core/test_v_prefix_bump_query` task locally because the environment failed while installing `npm:prettier@3` through `aube` with a permission error under `~/.local/share/aube/...`.
