### PR TITLE
fix(pipx): upgrade shared pip environment when using version constraints

### DIFF
--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -30,6 +30,7 @@ If you have `uv` installed, mise will use `uv tool install` under the hood and y
 When [`minimum_release_age`](/configuration/settings.html#minimum_release_age) is set, mise forwards the cutoff
 to transitive Python dependency resolution during install. The uv install path uses uv's
 `--exclude-newer` flag, and the `pipx` fallback passes pip's `--uploaded-prior-to` flag.
+When using `minimum_release_age` with the `pipx` install path, `pip >= 26.0` is required for pip's `--uploaded-prior-to` support, and you are responsible for ensuring that compatible Python/pip environment is installed.
 
 In case you need `pipx` for other reasons, you can install it with or without mise.
 Here is how to install `pipx` with mise:


### PR DESCRIPTION
- Trigger an upgrade of the shared pip environment to meet minimum requirements (pip>=26.0) when `before_date` constraints are applied.
- Add an e2e regression test to verify installation flows for packages with `minimum_release_age`.
