### PR TITLE
registry: add moon (aqua:moonrepo/moon)

### DIFF
--- a/registry/moon.toml
+++ b/registry/moon.toml
@@ -4,4 +4,4 @@ idiomatic_files = [".moon/*"]
 
 [test]
 cmd = "moon --version"
-expected = "moon"
+expected = "moon {{ version }}"

--- a/registry/moon.toml
+++ b/registry/moon.toml
@@ -1,2 +1,6 @@
-description = "moonrepo: A build system and monorepo management tool for the web ecosystem, written in Rust"
+description = "A build system and monorepo management tool for the web ecosystem, written in Rust"
 backends = ["github:moonrepo/moon"]
+
+[test]
+cmd = "moon --version"
+expected = "moon"

--- a/registry/moon.toml
+++ b/registry/moon.toml
@@ -1,5 +1,5 @@
 description = "A build system and monorepo management tool for the web ecosystem, written in Rust"
-backends = ["github:moonrepo/moon"]
+backends = ["aqua:moonrepo/moon"]
 idiomatic_files = [".moon/*"]
 
 [test]

--- a/registry/moon.toml
+++ b/registry/moon.toml
@@ -1,0 +1,2 @@
+description = "moonrepo: A build system and monorepo management tool for the web ecosystem, written in Rust"
+backends = ["github:moonrepo/moon"]

--- a/registry/moon.toml
+++ b/registry/moon.toml
@@ -1,5 +1,6 @@
 description = "A build system and monorepo management tool for the web ecosystem, written in Rust"
 backends = ["github:moonrepo/moon"]
+idiomatic_files = [".moon/*"]
 
 [test]
 cmd = "moon --version"


### PR DESCRIPTION
moon is a monorepo build system which my organization uses via Mise. Installing it via the Aqua backend works perfectly, so this file just aliases that for convenience.