### PR TITLE
chore(ci): switch back to github-hosted runners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   docs:
     if: github.repository == 'jdx/mise'
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -21,19 +21,15 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   check-changes:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       registry-changed: ${{ steps.check.outputs.registry-changed }}
@@ -51,20 +51,16 @@ jobs:
 
   build:
     timeout-minutes: 20
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     needs: check-changes
     if: needs.check-changes.outputs.registry-changed == 'true'
     env:
       GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache
@@ -88,7 +84,7 @@ jobs:
 
   list-changed-tools:
     timeout-minutes: 10
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     needs: check-changes
     if: github.event_name == 'pull_request' && needs.check-changes.outputs.registry-changed == 'true'
     outputs:
@@ -142,7 +138,7 @@ jobs:
           fi
 
   validate-new-tools:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: list-changed-tools
     if: |
@@ -171,7 +167,7 @@ jobs:
   test-tool:
     name: test-tool-${{ matrix.tranche }}
     timeout-minutes: 30
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     needs:
       - build
       - list-changed-tools
@@ -356,7 +352,7 @@ jobs:
         run: mise run test-tool-retry --check-only --grace-period ${{ steps.retry.outputs.failed_tools }}
 
   registry-ci:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     needs:
       - check-changes

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,7 +22,7 @@ jobs:
   release-plz:
     if: github.repository == 'jdx/mise'
     timeout-minutes: 20
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-release-plz-rust-linux
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   build-tarball-linux:
     if: github.event_name != 'pull_request' || github.head_ref == 'release'
     name: build-tarball-${{matrix.name}}
-    runs-on: namespace-profile-endev-linux-amd64-large
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
       MINIO_AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_AWS_ACCESS_KEY_ID }}
@@ -71,7 +71,7 @@ jobs:
   build-tarball-macos:
     if: github.event_name != 'pull_request' || github.head_ref == 'release'
     name: build-tarball-${{matrix.name}}
-    runs-on: namespace-profile-endev-macos-arm64
+    runs-on: macos-latest
     timeout-minutes: 90
     env:
       MINIO_AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "crates/vfox/**"
   push:
-    branches: [release]
+    branches: [main, release]
 
 concurrency:
   group: test-vfox-${{ github.ref }}
@@ -21,16 +21,12 @@ env:
 
 jobs:
   "test-vfox":
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on:
   push:
     tags: ["v*"]
-    branches: ["main", "mise"]
+    branches: ["main", "mise", "release"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:
@@ -27,17 +27,13 @@ permissions:
 
 jobs:
   build-ubuntu:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache
@@ -71,10 +67,10 @@ jobs:
       MISE_CACHE_DIR: ~/.cache/mise
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
         with:
           shared-key: build
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - shell: pwsh
         run: |
           cargo build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update
@@ -91,20 +87,16 @@ jobs:
 
   unit:
     name: unit-macos
-    runs-on: namespace-profile-endev-macos-arm64;overrides.cache-tag=mise-pr-rust-macos
+    runs-on: macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache
@@ -129,7 +121,7 @@ jobs:
         if: always()
 
   nightly:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux-nightly
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -137,13 +129,9 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
       - run: rustup default nightly
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache
@@ -166,7 +154,7 @@ jobs:
         if: always()
 
   lint:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [build-ubuntu]
     steps:
@@ -175,16 +163,12 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with:
           tool: cargo-deny,cargo-msrv,cargo-machete
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache
@@ -226,7 +210,7 @@ jobs:
 
   e2e:
     name: e2e-${{matrix.tranche}}
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     needs: [build-ubuntu]
     timeout-minutes: 30
     strategy:
@@ -263,7 +247,7 @@ jobs:
           MISE_E2E_DOCKER: "1"
           TEST_TRANCHE: ${{matrix.tranche}}
           TEST_TRANCHE_COUNT: 8
-          TEST_ALL: ${{github.head_ref == 'release' && '1' || '0'}}
+          TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
         with:
           timeout_minutes: 30
           retry_wait_seconds: 30
@@ -278,10 +262,10 @@ jobs:
       MISE_CACHE_DIR: ~/.cache/mise
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] save-if already gates writes to main/release
         with:
           shared-key: build
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - name: cargo test
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
@@ -314,7 +298,7 @@ jobs:
           command: pwsh e2e-win\run.ps1
 
   test-ci:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     needs:
       - build-ubuntu

--- a/.github/workflows/vendored-file-warning.yml
+++ b/.github/workflows/vendored-file-warning.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   warn:
     if: github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev'
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     steps:
       - name: Fail on vendored file changes
         run: |

--- a/registry/amp.toml
+++ b/registry/amp.toml
@@ -1,3 +1,6 @@
-backends = ["npm:@sourcegraph/amp"]
+backends = [
+  { full = "npm:@ampcode/cli", options = { allow_builds = [
+    "@ampcode/cli",
+  ] } },
+]
 description = "An agentic coding tool built by Sourcegraph"
-test = { cmd = "amp --version", expected = "{{version}}" }

--- a/registry/ghcup.toml
+++ b/registry/ghcup.toml
@@ -1,4 +1,4 @@
 backends = ["aqua:haskell/ghcup-hs", "asdf:mise-plugins/mise-ghcup"]
 description = "GHCup is an installer for the general purpose language Haskell"
 os = ["linux", "macos"]
-test = { cmd = "ghcup --version", expected = "The GHCup Haskell installer, version {{version}}" }
+test = { cmd = "ghcup --version", expected = "The GHCup Haskell installer, version v{{version}}" }

--- a/registry/infisical.toml
+++ b/registry/infisical.toml
@@ -1,3 +1,5 @@
-backends = ["github:Infisical/cli"]
+backends = [
+  { full = "github:Infisical/cli", options = { asset_pattern = "cli_{{ version }}_{{ os(macos='darwin') }}_{{ arch(x64='amd64') }}.tar.gz" } },
+]
 description = "The open source secret management platform: Sync secrets across your team/infrastructure and prevent secret leaks"
 test = { cmd = "infisical --version", expected = "infisical version {{version}}" }

--- a/registry/wash.toml
+++ b/registry/wash.toml
@@ -1,3 +1,3 @@
 backends = ["aqua:wasmCloud/wasmCloud/wash"]
 description = "wasmCloud Shell (wash)"
-test = { cmd = "wash --version | head -n1 | awk '{print $2}'", expected = "v{{version}}" }
+test = { cmd = "wash --version | head -n1 | awk '{print $2}'", expected = "{{version}}" }


### PR DESCRIPTION
## Summary
- replace Namespace runner labels with GitHub-hosted `ubuntu-latest`/`macos-latest`
- replace remaining `namespacelabs/nscloud-cache-action` steps with the repo's existing pinned `Swatinem/rust-cache` pattern outside `release.yml`
- keep `.github/workflows/release.yml` cache-free; its jobs only switch runner labels
- allow Rust cache writes from trusted `main` and `release` branch refs while keeping PR refs read-only
- run `test-vfox` on `main` and `release` so its Rust cache can be saved
- run the main `test` workflow on release-branch pushes and set `TEST_ALL=1` there
- fix stale registry tests for `wash`, `ghcup`, `infisical`, and `amp` exposed by the full registry matrix

## Test
- `mise run build`
- `MISE_EXPERIMENTAL=1 MISE_LOCKFILE=1 MISE_USE_VERSIONS_HOST_TRACK=0 RUST_BACKTRACE=1 target/debug/mise test-tool --jobs=1 wash ghcup infisical`
- `npm_config_yes=true npx @sourcegraph/amp@0.0.1780100432-ge69f4e --help`
- `rg -n "namespace-profile|namespacelabs/nscloud-cache-action" .github/workflows .github/actions || true`
- `rg -n "cache|Swatinem/rust-cache|actions/cache|nscloud-cache|sccache|RUSTC_WRAPPER|SCCACHE" .github/workflows/release.yml || true`
- `git diff --check`
- `actionlint -ignore 'SC2129'`

Note: plain `actionlint` still reports the existing `SC2129` style warning in `registry.yml`; ignored here to validate this runner/cache change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad CI runner and caching changes can slow builds or break PR workflows; registry backend/test edits affect tool installs in production registry paths.
> 
> **Overview**
> Moves CI off **Namespace** self-hosted runners to GitHub-hosted **`ubuntu-latest`** / **`macos-latest`** across docs, test, registry, hyperfine, release-plz, and related workflows. **`release.yml`** only changes runner labels; it stays without the new Rust cache steps.
> 
> Replaces **`namespacelabs/nscloud-cache-action`** with pinned **`Swatinem/rust-cache`** (still paired with **sccache** where used). Cache **writes** are limited to **`main`** and **`release`** refs; PRs stay restore-only. **`test`** and **`test-vfox`** now run on **`release`** pushes so caches can be saved; **`test`** e2e sets **`TEST_ALL=1`** on the release branch.
> 
> Registry fixes for stale **`test-tool`** expectations: **`wash`** / **`ghcup`** version strings, **`infisical`** GitHub asset pattern, and **`amp`** npm backend (`@ampcode/cli` with **`allow_builds`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4c960253d23a4860bad49321d90a0403e1d770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->