### PR TITLE
registry: add github: fallback backends for locally-verified tools

### DIFF
--- a/e2e/backend/test_disable_backends
+++ b/e2e/backend/test_disable_backends
@@ -5,13 +5,13 @@ assert_fail "MISE_DISABLE_BACKENDS=ubi mise install ubi:example/example@1.0.0" "
 assert_fail "MISE_DISABLE_BACKENDS=ubi mise use -g ubi:example/example@1.0.0" "backend ubi is disabled by disable_backends"
 assert_fail "MISE_DISABLE_BACKENDS=asdf mise install asdf:dummy@1.0.0" "backend asdf is disabled by disable_backends"
 
-assert "mise registry age" "aqua:FiloSottile/age asdf:threkk/asdf-age"
+assert "mise registry age" "aqua:FiloSottile/age github:FiloSottile/age asdf:threkk/asdf-age"
 
 mise install age
 assert_fail "ls $MISE_DATA_DIR/plugins/age"
 mise uninstall age
 
-MISE_DISABLE_BACKENDS=aqua mise install age
+MISE_DISABLE_BACKENDS=aqua,github mise install age
 ls "$MISE_DATA_DIR/plugins/age"
 assert "MISE_DISABLE_BACKENDS=asdf mise tool age --backend" "asdf:age"
 eval "$(mise activate bash)" && _mise_hook

--- a/e2e/cli/test_registry
+++ b/e2e/cli/test_registry
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-assert "mise registry gh" "aqua:cli/cli asdf:bartlomiejdanek/asdf-github-cli"
-assert_contains "mise registry" "gh                            aqua:cli/cli asdf:bartlomiejdanek/asdf-github-cli"
+assert "mise registry gh" "aqua:cli/cli github:cli/cli asdf:bartlomiejdanek/asdf-github-cli"
+assert_contains "mise registry" "gh                            aqua:cli/cli github:cli/cli asdf:bartlomiejdanek/asdf-github-cli"
 
 # --json flag tests
 assert "mise registry gh --json | jq -r '.short'" "gh"

--- a/registry/act.toml
+++ b/registry/act.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:nektos/act", "asdf:gr1m0h/asdf-act"]
+backends = ["aqua:nektos/act", "github:nektos/act", "asdf:gr1m0h/asdf-act"]
 description = "Run your GitHub Actions locally"
 test = { cmd = "act --version", expected = "act version {{version}}" }

--- a/registry/actionlint.toml
+++ b/registry/actionlint.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:rhysd/actionlint",
+  "github:rhysd/actionlint",
   "asdf:crazy-matt/asdf-actionlint",
   "go:github.com/rhysd/actionlint/cmd/actionlint",
 ]

--- a/registry/age.toml
+++ b/registry/age.toml
@@ -1,3 +1,7 @@
-backends = ["aqua:FiloSottile/age", "asdf:threkk/asdf-age"]
+backends = [
+  "aqua:FiloSottile/age",
+  "github:FiloSottile/age",
+  "asdf:threkk/asdf-age",
+]
 description = "A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability"
 test = { cmd = "age --version", expected = "v{{version}}" }

--- a/registry/bat.toml
+++ b/registry/bat.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:sharkdp/bat",
+  "github:sharkdp/bat",
   "cargo:bat",
   "asdf:https://gitlab.com/wt0f/asdf-bat",
 ]

--- a/registry/cargo-binstall.toml
+++ b/registry/cargo-binstall.toml
@@ -1,3 +1,7 @@
-backends = ["aqua:cargo-bins/cargo-binstall", "cargo:cargo-binstall"]
+backends = [
+  "aqua:cargo-bins/cargo-binstall",
+  "github:cargo-bins/cargo-binstall",
+  "cargo:cargo-binstall",
+]
 description = "Binary installation for rust projects"
 test = { cmd = "cargo binstall -V", expected = "{{version}}" }

--- a/registry/cargo-insta.toml
+++ b/registry/cargo-insta.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:mitsuhiko/insta", "cargo:insta"]
+backends = ["aqua:mitsuhiko/insta", "github:mitsuhiko/insta", "cargo:insta"]
 description = "A snapshot testing library for rust"
 test = { cmd = "cargo insta --version", expected = "cargo-insta {{version}}" }

--- a/registry/cmake.toml
+++ b/registry/cmake.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:Kitware/CMake",
+  "github:Kitware/CMake",
   "asdf:mise-plugins/mise-cmake",
   "vfox:mise-plugins/vfox-cmake",
 ]

--- a/registry/cmdx.toml
+++ b/registry/cmdx.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:suzuki-shunsuke/cmdx"]
+backends = ["aqua:suzuki-shunsuke/cmdx", "github:suzuki-shunsuke/cmdx"]
 description = "Task runner. It provides useful help messages and supports interactive prompts and validation of arguments"
 test = { cmd = "cmdx version", expected = "cmdx version {{version}}" }

--- a/registry/coreutils.toml
+++ b/registry/coreutils.toml
@@ -1,2 +1,2 @@
-backends = ["aqua:uutils/coreutils"]
+backends = ["aqua:uutils/coreutils", "github:uutils/coreutils"]
 description = "Cross-platform Rust rewrite of the GNU coreutils"

--- a/registry/delta.toml
+++ b/registry/delta.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:dandavison/delta",
+  "github:dandavison/delta",
   "asdf:andweeb/asdf-delta",
   "cargo:git-delta",
 ]

--- a/registry/fd.toml
+++ b/registry/fd.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:sharkdp/fd",
+  "github:sharkdp/fd",
   "asdf:https://gitlab.com/wt0f/asdf-fd",
   "cargo:fd-find",
 ]

--- a/registry/fzf.toml
+++ b/registry/fzf.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:junegunn/fzf", "asdf:kompiro/asdf-fzf"]
+backends = ["aqua:junegunn/fzf", "github:junegunn/fzf", "asdf:kompiro/asdf-fzf"]
 description = ":cherry_blossom: A command-line fuzzy finder"
 test = { cmd = "fzf --version", expected = "{{version}}" }

--- a/registry/git-cliff.toml
+++ b/registry/git-cliff.toml
@@ -1,3 +1,7 @@
-backends = ["aqua:orhun/git-cliff", "asdf:jylenhof/asdf-git-cliff"]
+backends = [
+  "aqua:orhun/git-cliff",
+  "github:orhun/git-cliff",
+  "asdf:jylenhof/asdf-git-cliff",
+]
 description = "A highly customizable Changelog Generator that follows Conventional Commit specifications"
 test = { cmd = "git-cliff --version", expected = "git-cliff {{version}}" }

--- a/registry/github-cli.toml
+++ b/registry/github-cli.toml
@@ -1,4 +1,8 @@
 aliases = ["gh"]
-backends = ["aqua:cli/cli", "asdf:bartlomiejdanek/asdf-github-cli"]
+backends = [
+  "aqua:cli/cli",
+  "github:cli/cli",
+  "asdf:bartlomiejdanek/asdf-github-cli",
+]
 description = "GitHub’s official command line tool"
 test = { cmd = "gh --version", expected = "gh version {{version}}" }

--- a/registry/hk.toml
+++ b/registry/hk.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:jdx/hk"]
+backends = ["aqua:jdx/hk", "github:jdx/hk"]
 description = "git hook and pre-commit lint manager"
 test = { cmd = "hk --version", expected = "hk {{version}}" }

--- a/registry/htmlq.toml
+++ b/registry/htmlq.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:mgdm/htmlq", "cargo:htmlq"]
+backends = ["aqua:mgdm/htmlq", "github:mgdm/htmlq", "cargo:htmlq"]
 description = "Like jq, but for HTML"
 test = { cmd = "htmlq --version", expected = "htmlq {{version}}" }

--- a/registry/jq.toml
+++ b/registry/jq.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:jqlang/jq", "asdf:mise-plugins/asdf-jq"]
+backends = ["aqua:jqlang/jq", "github:jqlang/jq", "asdf:mise-plugins/asdf-jq"]
 description = "Command-line JSON processor"
 test = { cmd = "jq --version", expected = "jq-{{version}}" }

--- a/registry/lua-language-server.toml
+++ b/registry/lua-language-server.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:LuaLS/lua-language-server",
+  "github:LuaLS/lua-language-server",
   "asdf:bellini666/asdf-lua-language-server",
 ]
 description = "A language server that offers Lua language support - programmed in Lua"

--- a/registry/ninja.toml
+++ b/registry/ninja.toml
@@ -1,2 +1,6 @@
-backends = ["aqua:ninja-build/ninja", "asdf:asdf-community/asdf-ninja"]
+backends = [
+  "aqua:ninja-build/ninja",
+  "github:ninja-build/ninja",
+  "asdf:asdf-community/asdf-ninja",
+]
 description = "a small build system with a focus on speed"

--- a/registry/pkl.toml
+++ b/registry/pkl.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:apple/pkl", "asdf:mise-plugins/asdf-pkl"]
+backends = ["aqua:apple/pkl", "github:apple/pkl", "asdf:mise-plugins/asdf-pkl"]
 description = "A configuration as code language with rich validation and tooling"
 test = { cmd = "pkl --version", expected = "Pkl {{version}}" }

--- a/registry/pnpm.toml
+++ b/registry/pnpm.toml
@@ -1,4 +1,4 @@
-backends = ["aqua:pnpm/pnpm", "npm:pnpm"]
+backends = ["aqua:pnpm/pnpm", "github:pnpm/pnpm", "npm:pnpm"]
 description = "Fast, disk space efficient package manager"
 detect = ["pnpm-lock.yaml", "pnpm-workspace.yaml"]
 idiomatic_files = ["package.json"]

--- a/registry/pre-commit.toml
+++ b/registry/pre-commit.toml
@@ -1,7 +1,17 @@
-backends = [
-  "aqua:pre-commit/pre-commit",
-  "asdf:jonathanmorley/asdf-pre-commit",
-  "pipx:pre-commit",
-]
 description = "A framework for managing and maintaining multi-language pre-commit hooks"
 test = { cmd = "pre-commit --version", expected = "pre-commit {{version}}" }
+
+[[backends]]
+full = "aqua:pre-commit/pre-commit"
+
+[[backends]]
+full = "github:pre-commit/pre-commit"
+
+[backends.options]
+bin = "pre-commit"
+
+[[backends]]
+full = "asdf:jonathanmorley/asdf-pre-commit"
+
+[[backends]]
+full = "pipx:pre-commit"

--- a/registry/rclone.toml
+++ b/registry/rclone.toml
@@ -1,3 +1,7 @@
-backends = ["aqua:rclone/rclone", "asdf:johnlayton/asdf-rclone"]
+backends = [
+  "aqua:rclone/rclone",
+  "github:rclone/rclone",
+  "asdf:johnlayton/asdf-rclone",
+]
 description = '"rsync for cloud storage" - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Yandex Files'
 test = { cmd = "rclone version", expected = "rclone v{{version}}" }

--- a/registry/ripgrep.toml
+++ b/registry/ripgrep.toml
@@ -1,6 +1,7 @@
 aliases = ["rg"]
 backends = [
   "aqua:BurntSushi/ripgrep",
+  "github:BurntSushi/ripgrep",
   "asdf:https://gitlab.com/wt0f/asdf-ripgrep",
   "cargo:ripgrep",
 ]

--- a/registry/rust-analyzer.toml
+++ b/registry/rust-analyzer.toml
@@ -1,2 +1,6 @@
-backends = ["aqua:rust-lang/rust-analyzer", "asdf:Xyven1/asdf-rust-analyzer"]
+backends = [
+  "aqua:rust-lang/rust-analyzer",
+  "github:rust-lang/rust-analyzer",
+  "asdf:Xyven1/asdf-rust-analyzer",
+]
 description = "A Rust compiler front-end for IDEs"

--- a/registry/shellcheck.toml
+++ b/registry/shellcheck.toml
@@ -1,3 +1,7 @@
-backends = ["aqua:koalaman/shellcheck", "asdf:luizm/asdf-shellcheck"]
+backends = [
+  "aqua:koalaman/shellcheck",
+  "github:koalaman/shellcheck",
+  "asdf:luizm/asdf-shellcheck",
+]
 description = "ShellCheck, a static analysis tool for shell scripts"
 test = { cmd = "shellcheck --version", expected = "version: {{version}}" }

--- a/registry/shfmt.toml
+++ b/registry/shfmt.toml
@@ -1,7 +1,17 @@
-backends = [
-  "aqua:mvdan/sh",
-  "asdf:luizm/asdf-shfmt",
-  "go:mvdan.cc/sh/v3/cmd/shfmt",
-]
 description = "A shell parser, formatter, and interpreter with bash support; includes shfmt"
 test = { cmd = "shfmt --version", expected = "v{{version}}" }
+
+[[backends]]
+full = "aqua:mvdan/sh"
+
+[[backends]]
+full = "github:mvdan/sh"
+
+[backends.options]
+bin = "shfmt"
+
+[[backends]]
+full = "asdf:luizm/asdf-shfmt"
+
+[[backends]]
+full = "go:mvdan.cc/sh/v3/cmd/shfmt"

--- a/registry/sops.toml
+++ b/registry/sops.toml
@@ -1,2 +1,6 @@
-backends = ["aqua:getsops/sops", "asdf:mise-plugins/mise-sops"]
+backends = [
+  "aqua:getsops/sops",
+  "github:getsops/sops",
+  "asdf:mise-plugins/mise-sops",
+]
 description = "Simple and flexible tool for managing secrets"

--- a/registry/stylua.toml
+++ b/registry/stylua.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:JohnnyMorganz/StyLua",
+  "github:JohnnyMorganz/StyLua",
   "asdf:jc00ke/asdf-stylua",
   "cargo:stylua",
 ]

--- a/registry/taplo.toml
+++ b/registry/taplo.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:tamasfe/taplo", "cargo:taplo-cli"]
+backends = ["aqua:tamasfe/taplo", "github:tamasfe/taplo", "cargo:taplo-cli"]
 description = "A TOML toolkit written in Rust"
 test = { cmd = "taplo --version", expected = "taplo {{version}}" }

--- a/registry/usage.toml
+++ b/registry/usage.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:jdx/usage",
+  "github:jdx/usage",
   { full = "asdf:mise-plugins/mise-usage", platforms = [
     "linux",
     "macos",

--- a/registry/uv.toml
+++ b/registry/uv.toml
@@ -1,4 +1,9 @@
-backends = ["aqua:astral-sh/uv", "asdf:asdf-community/asdf-uv", "pipx:uv"]
+backends = [
+  "aqua:astral-sh/uv",
+  "github:astral-sh/uv",
+  "asdf:asdf-community/asdf-uv",
+  "pipx:uv",
+]
 description = "An extremely fast Python package installer and resolver, written in Rust"
 detect = ["uv.lock"]
 test = { cmd = "uv --version", expected = "uv {{version}}" }

--- a/registry/yamlfmt.toml
+++ b/registry/yamlfmt.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:google/yamlfmt",
+  "github:google/yamlfmt",
   "asdf:mise-plugins/asdf-yamlfmt",
   "go:github.com/google/yamlfmt/cmd/yamlfmt",
 ]

--- a/registry/yq.toml
+++ b/registry/yq.toml
@@ -1,5 +1,6 @@
 backends = [
   "aqua:mikefarah/yq",
+  "github:mikefarah/yq",
   "asdf:sudermanjr/asdf-yq",
   "go:github.com/mikefarah/yq/v4",
 ]


### PR DESCRIPTION
Follow-up to #10000. I didn't get a chance to address the bot review comments there before the branch became stale.

## Summary

Add `github:` fallback backend entries to 34 registry files for tools that are already in the registry. Each new entry is inserted immediately after the existing `aqua:` entry, providing a Tier 1 GitHub releases fallback for users who have `aqua` disabled (e.g. via `MISE_DISABLE_BACKENDS=aqua`) or unavailable, before falling through to lower-tier backends (`asdf:`, `vfox:`, `cargo:`, etc.).

Per the [AGENTS.md backend-tier guidance](https://github.com/jdx/mise/blob/main/AGENTS.md#L41-L48), `aqua:` is the preferred Tier 1 backend and `github:` is the recommended fallback. Many existing registry entries currently fall through from `aqua:` directly to `asdf:` plugins (which AGENTS.md discourages for new entries on supply-chain grounds) or to runtime-backed backends (`cargo:`, `go:`, `pipx:`). This PR fills the gap.

For tools where the `github:` backend downloads binaries with platform-specific or versioned filenames (shfmt, pre-commit), the entries use the `[[backends]]` table form to set `bin` to ensure the binary is callable by its expected short name.

## Popularity

No popularity-check section is needed because this PR does not add any new tools to the registry. It only adds a `github:` backend for tools that are already accepted registry entries.

## Verification

All `github:owner/repo@latest` installs were verified on **Windows 11 x86_64** via:

```powershell
$env:MISE_DATA_DIR = "<temp-dir>"
mise install "github:<owner>/<repo>@latest"
# Then: mise exec "github:<owner>/<repo>@latest" -- <tool> --version
```

Each install was verified for both successful installation (exit 0) AND binary callability by the tool's expected short name. Tools where the binary was not callable were either fixed with `bin` or removed from the PR.

**Caveat:** Verification was performed on a single host platform (Windows x86_64). Cross-platform asset availability was not exhaustively checked.

## Candidate set and results

### Modified — inline `backends` array (32 tools, `github:` inserted after `aqua:`)

| Installed tool | Registry file | `github:` backend added |
|---|---|---|
| `act` | `act.toml` | `github:nektos/act` |
| `actionlint` | `actionlint.toml` | `github:rhysd/actionlint` |
| `age` | `age.toml` | `github:FiloSottile/age` |
| `bat` | `bat.toml` | `github:sharkdp/bat` |
| `cargo-binstall` | `cargo-binstall.toml` | `github:cargo-bins/cargo-binstall` |
| `cargo-insta` | `cargo-insta.toml` | `github:mitsuhiko/insta` |
| `cmake` | `cmake.toml` | `github:Kitware/CMake` |
| `cmdx` | `cmdx.toml` | `github:suzuki-shunsuke/cmdx` |
| `coreutils` | `coreutils.toml` | `github:uutils/coreutils` |
| `delta` | `delta.toml` | `github:dandavison/delta` |
| `fd` | `fd.toml` | `github:sharkdp/fd` |
| `fzf` | `fzf.toml` | `github:junegunn/fzf` |
| `git-cliff` | `git-cliff.toml` | `github:orhun/git-cliff` |
| `github-cli` / `gh` | `github-cli.toml` | `github:cli/cli` |
| `hk` | `hk.toml` | `github:jdx/hk` |
| `htmlq` | `htmlq.toml` | `github:mgdm/htmlq` |
| `jq` | `jq.toml` | `github:jqlang/jq` |
| `lua-language-server` | `lua-language-server.toml` | `github:LuaLS/lua-language-server` |
| `ninja` | `ninja.toml` | `github:ninja-build/ninja` |
| `pkl` | `pkl.toml` | `github:apple/pkl` |
| `pnpm` | `pnpm.toml` | `github:pnpm/pnpm` |
| `rclone` | `rclone.toml` | `github:rclone/rclone` |
| `ripgrep` / `rg` | `ripgrep.toml` | `github:BurntSushi/ripgrep` |
| `rust-analyzer` | `rust-analyzer.toml` | `github:rust-lang/rust-analyzer` |
| `shellcheck` | `shellcheck.toml` | `github:koalaman/shellcheck` |
| `sops` | `sops.toml` | `github:getsops/sops` |
| `stylua` | `stylua.toml` | `github:JohnnyMorganz/StyLua` |
| `taplo` | `taplo.toml` | `github:tamasfe/taplo` |
| `usage` | `usage.toml` | `github:jdx/usage` |
| `uv` | `uv.toml` | `github:astral-sh/uv` |
| `yamlfmt` | `yamlfmt.toml` | `github:google/yamlfmt` |
| `yq` | `yq.toml` | `github:mikefarah/yq` |

### Modified — converted to `[[backends]]` table form to set `bin` (2 tools)

These tools ship binaries with platform-specific or versioned filenames that the `github:` backend doesn't automatically rename. The `bin` option ensures the binary is callable by its expected short name.

| Installed tool | Registry file | `github:` backend | `bin` |
|---|---|---|---|
| `shfmt` | `shfmt.toml` | `github:mvdan/sh` | `"shfmt"` |
| `pre-commit` | `pre-commit.toml` | `github:pre-commit/pre-commit` | `"pre-commit"` |
