### PR TITLE
registry: add antigravity-cli

### DIFF
--- a/registry/antigravity-cli.toml
+++ b/registry/antigravity-cli.toml
@@ -1,0 +1,4 @@
+aliases = ["agy"]
+backends = ["aqua:google.com/antigravity-cli"]
+description = "Google's agentic development platform CLI companion"
+test = { cmd = "agy --version", expected = "{{version}}" }


### PR DESCRIPTION
Adds a registry entry for the Antigravity CLI, Google's agentic development platform CLI companion, backed by the existing `aqua:google.com/antigravity-cli` package.

> [!NOTE]
> Antigravity CLI is the official successor to [Gemini CLI](https://github.com/google-gemini/gemini-cli) (already in the registry as `gemini-cli.toml`), which Google is shutting down on June 18, 2026 per their [official transition announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/). The aqua registry has already accepted it.
>
> - GitHub [`google-antigravity/antigravity-cli`](https://github.com/google-antigravity/antigravity-cli), 702 stars, repo created 2026-05-13
> - aqua entry [`google.com/antigravity-cli`](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/google.com/antigravity-cli/registry.yaml)