### PR TITLE
fix(task): convert PATH to /cygdrive form for Cygwin bash tasks

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -195,7 +195,7 @@ shell = '"C:\Program Files\Git\bin\bash.exe" -c'
 
 #### Cygwin
 
-mise also detects Cygwin bash (by a `cygwin` / `cygwin64` segment in its path) and
+mise also detects Cygwin bash (by a `cygwin` / `cygwin64` / `cygwin32` segment in its path) and
 converts PATH using Cygwin's `/cygdrive/c/...` form instead of Git Bash's `/c/...`,
 so binaries on PATH resolve correctly. Point `MISE_BASH_PATH` at your Cygwin bash so
 the intended one is used:
@@ -211,6 +211,9 @@ set `MISE_CYGDRIVE_PREFIX` to match — mise does not read `/etc/fstab`:
 # e.g. for an fstab that mounts drives under /mnt
 $env:MISE_CYGDRIVE_PREFIX = "/mnt"
 ```
+
+The prefix must be absolute (start with `/`); a relative value like `mnt` is rejected
+with a warning and the default `/cygdrive` is used instead.
 
 ## mise isn't working when calling from tmux or another shell initialization script
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -193,6 +193,25 @@ shell = '"C:\Program Files\Git\bin\bash.exe" -c'
 
 (On macOS/Linux, `shell` follows POSIX quoting rules instead.)
 
+#### Cygwin
+
+mise also detects Cygwin bash (by a `cygwin` / `cygwin64` segment in its path) and
+converts PATH using Cygwin's `/cygdrive/c/...` form instead of Git Bash's `/c/...`,
+so binaries on PATH resolve correctly. Point `MISE_BASH_PATH` at your Cygwin bash so
+the intended one is used:
+
+```powershell
+$env:MISE_BASH_PATH = "C:\cygwin64\bin\bash.exe"
+```
+
+If you changed the `cygdrive` prefix in `/etc/fstab` (the default is `/cygdrive`),
+set `MISE_CYGDRIVE_PREFIX` to match — mise does not read `/etc/fstab`:
+
+```powershell
+# e.g. for an fstab that mounts drives under /mnt
+$env:MISE_CYGDRIVE_PREFIX = "/mnt"
+```
+
 ## mise isn't working when calling from tmux or another shell initialization script
 
 `mise activate` will not update PATH until the shell prompt is displayed. So if you need to access a

--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -108,4 +108,66 @@ esac
             Remove-Item -Path "$TestDrive\mise.path_repro.toml" -ErrorAction SilentlyContinue
         }
     }
+
+    It 'converts PATH to /cygdrive form for a Cygwin bash subshell task' {
+        # Cygwin resolves drives via `/cygdrive/c/...`, not Git Bash's `/c/...`.
+        # When mise detects a Cygwin bash (here pinned via MISE_BASH_PATH), the
+        # task's PATH must use the `/cygdrive/` form or commands won't resolve.
+        # Skipped unless Cygwin is actually installed, since CI runners lack it.
+
+        $cygwinBash = "C:\cygwin64\bin\bash.exe"
+        if (-not (Test-Path $cygwinBash)) {
+            Set-ItResult -Skipped -Because "Cygwin bash not installed at $cygwinBash"
+            return
+        }
+
+        @'
+[tasks.cygdrive_repro]
+shell = "bash -c"
+run = '''
+case "$PATH" in
+  */cygdrive/*)
+    echo "PATH-cygdrive-style"
+    ;;
+  *)
+    echo "PATH-not-cygdrive"
+    ;;
+esac
+'''
+'@ | Out-File -FilePath "mise.cygdrive_repro.toml" -Encoding utf8NoBOM
+
+        # Save and restore the env vars we override so a dev machine's real
+        # settings (a developer may export MISE_BASH_PATH / MISE_CYGDRIVE_PREFIX)
+        # and later tests are not disturbed. Pin MISE_CYGDRIVE_PREFIX to the
+        # default so the `/cygdrive` assertion holds even when the caller has
+        # exported a custom prefix such as `/mnt` (which the feature honors).
+        $oldConfig = $env:MISE_CONFIG_FILE
+        $oldBashPath = $env:MISE_BASH_PATH
+        $oldCygPrefix = $env:MISE_CYGDRIVE_PREFIX
+        $env:MISE_CONFIG_FILE = "$TestDrive\mise.cygdrive_repro.toml"
+        $env:MISE_BASH_PATH = $cygwinBash
+        $env:MISE_CYGDRIVE_PREFIX = "/cygdrive"
+        try {
+            $output = mise run cygdrive_repro 2>&1 | Select -Last 1
+            $output | Should -Be 'PATH-cygdrive-style'
+        }
+        finally {
+            if ($null -eq $oldConfig) {
+                Remove-Item -Path Env:\MISE_CONFIG_FILE -ErrorAction SilentlyContinue
+            } else {
+                $env:MISE_CONFIG_FILE = $oldConfig
+            }
+            if ($null -eq $oldBashPath) {
+                Remove-Item -Path Env:\MISE_BASH_PATH -ErrorAction SilentlyContinue
+            } else {
+                $env:MISE_BASH_PATH = $oldBashPath
+            }
+            if ($null -eq $oldCygPrefix) {
+                Remove-Item -Path Env:\MISE_CYGDRIVE_PREFIX -ErrorAction SilentlyContinue
+            } else {
+                $env:MISE_CYGDRIVE_PREFIX = $oldCygPrefix
+            }
+            Remove-Item -Path "$TestDrive\mise.cygdrive_repro.toml" -ErrorAction SilentlyContinue
+        }
+    }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -33,8 +33,16 @@ impl PathExt for Path {
 }
 
 /// Convert a Windows-style path list (`;`-separated, drive-letter prefix, `\` or `/`
-/// separator) into a Git Bash / MSYS Unix-style path list (`:`-separated, `/c/...`
-/// prefix, `/` separator).
+/// separator) into a POSIX Unix-style path list (`:`-separated, `/` separator) for a
+/// shell that resolves commands from PATH itself.
+///
+/// `drive_prefix` selects the cygdrive mount style inserted before the drive letter
+/// (no trailing slash):
+///
+/// - `""` → `/c/foo` — MSYS2 / Git Bash (the dominant case, and the default).
+/// - `"/cygdrive"` → `/cygdrive/c/foo` — Cygwin's default mount.
+/// - any other value (e.g. from `MISE_CYGDRIVE_PREFIX`) → a custom Cygwin `cygdrive`
+///   prefix configured via `/etc/fstab`.
 ///
 /// Pure Rust, no subprocess. Designed for the case where mise on Windows spawns a
 /// POSIX shell (`bash -c`, `sh -c`, ...) for a task — that shell uses PATH itself to
@@ -42,7 +50,7 @@ impl PathExt for Path {
 ///
 /// Conversion rules per entry, applied independently:
 ///
-/// - `<drive>:[\\/]...` (canonical Windows drive path) → `/<drive lowercase>/<rest with `/` separator>`
+/// - `<drive>:[\\/]...` (canonical Windows drive path) → `<drive_prefix>/<drive lowercase>/<rest with `/` separator>`
 /// - already-Unix entries (start with `/`) → pass through unchanged
 /// - empty entries (e.g. trailing `;`) → preserved as empty
 /// - UNC (`\\?\...`, `\\server\share\...`) → pass through unchanged. bash will fail
@@ -51,22 +59,26 @@ impl PathExt for Path {
 ///   `\` is replaced with `/` so that bash can resolve entries like
 ///   `node_modules\.bin` or `.\bin` injected by tools that emit Windows separators.
 ///
-/// Out of scope (kept narrow per maintainer guidance — see PR description / `_context/`):
+/// `drive_prefix` only affects canonical drive entries; every other shape above is
+/// prefix-independent.
 ///
-/// - Cygwin's `/etc/fstab` mount table
-/// - Cygwin's `/cygdrive/c/` prefix (Git Bash uses `/c/`, which is the dominant case)
+/// Out of scope (kept narrow per maintainer guidance):
+///
+/// - Cygwin's `/etc/fstab` mount table is not parsed. A non-default `cygdrive` prefix
+///   is supplied explicitly via `MISE_CYGDRIVE_PREFIX` (resolved by the caller) rather
+///   than discovered from fstab.
 /// - Git Bash's "magic" mount of `/usr` to its install dir — `/c/Program Files/Git/usr/bin`
 ///   is resolved by bash to the same executable as `/usr/bin`, so no remapping is needed
 ///   for PATH-resolution to succeed.
 #[cfg_attr(not(windows), allow(dead_code))]
-pub fn windows_path_list_to_unix(path_list: &str) -> String {
+pub fn windows_path_list_to_unix(path_list: &str, drive_prefix: &str) -> String {
     let mut out = String::with_capacity(path_list.len());
     let mut first = true;
     for entry in path_list.split(WINDOWS_PATH_SEP) {
         if !first {
             out.push(':');
         }
-        append_single_windows_path_to_unix(&mut out, entry);
+        append_single_windows_path_to_unix(&mut out, entry, drive_prefix);
         first = false;
     }
     out
@@ -76,7 +88,7 @@ pub fn windows_path_list_to_unix(path_list: &str) -> String {
 const WINDOWS_PATH_SEP: char = ';';
 
 #[cfg_attr(not(windows), allow(dead_code))]
-fn append_single_windows_path_to_unix(out: &mut String, entry: &str) {
+fn append_single_windows_path_to_unix(out: &mut String, entry: &str, drive_prefix: &str) {
     if entry.is_empty() {
         return;
     }
@@ -93,7 +105,10 @@ fn append_single_windows_path_to_unix(out: &mut String, entry: &str) {
         && (bytes[2] == b'\\' || bytes[2] == b'/');
 
     let rest = if is_canonical_drive {
-        // C:\foo → /c/foo : emit `/<drive lowercase>` then the tail with `\` → `/`.
+        // C:\foo → <prefix>/c/foo : emit the cygdrive prefix (empty for MSYS/Git
+        // Bash, `/cygdrive` for Cygwin), then `/<drive lowercase>`, then the tail
+        // with `\` → `/`.
+        out.push_str(drive_prefix);
         out.push('/');
         out.push((bytes[0] as char).to_ascii_lowercase());
         &entry[2..]
@@ -208,6 +223,27 @@ fn split_shell_command_windows(s: &str) -> eyre::Result<Vec<String>> {
     Ok(args)
 }
 
+/// Returns true if `program` (typically a resolved absolute bash path) is a Cygwin
+/// shell, detected by a `cygwin` / `cygwin64` / `cygwin32` path segment — Cygwin's
+/// default install dirs are `C:\cygwin64` and `C:\cygwin`. Used on Windows to pick
+/// the `/cygdrive/c/` PATH form instead of MSYS2 / Git Bash's `/c/`.
+///
+/// Normalizes `\` → `/` first so it works for both backslash paths (`MISE_BASH_PATH`,
+/// `bash_candidates`) and forward-slash paths (`which::which_in`). Matches whole path
+/// segments so a directory that merely contains "cygwin" as a substring (e.g.
+/// `my-cygwinish-tools`) does not trip it. `MSYSTEM` is deliberately not consulted —
+/// PowerShell-launched mise inherits none, so it is not a reliable signal.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub fn is_cygwin_shell(program: &Path) -> bool {
+    let Some(s) = program.to_str() else {
+        return false;
+    };
+    s.to_ascii_lowercase()
+        .replace('\\', "/")
+        .split('/')
+        .any(|seg| seg == "cygwin" || seg == "cygwin64" || seg == "cygwin32")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,30 +252,34 @@ mod tests {
         parts.iter().map(|s| s.to_string()).collect()
     }
 
+    /// MSYS2 / Git Bash style (`/c/...`) — the empty cygdrive prefix (the default).
+    fn msys(s: &str) -> String {
+        windows_path_list_to_unix(s, "")
+    }
+
+    /// Cygwin default style (`/cygdrive/c/...`).
+    fn cygwin(s: &str) -> String {
+        windows_path_list_to_unix(s, "/cygdrive")
+    }
+
     #[test]
     fn test_windows_path_list_to_unix_basic() {
-        assert_eq!(windows_path_list_to_unix(r"C:\foo;D:\bar"), "/c/foo:/d/bar");
+        assert_eq!(msys(r"C:\foo;D:\bar"), "/c/foo:/d/bar");
     }
 
     #[test]
     fn test_windows_path_list_to_unix_forward_slash() {
-        assert_eq!(windows_path_list_to_unix("C:/foo;D:/bar"), "/c/foo:/d/bar");
+        assert_eq!(msys("C:/foo;D:/bar"), "/c/foo:/d/bar");
     }
 
     #[test]
     fn test_windows_path_list_to_unix_mixed_separators() {
-        assert_eq!(
-            windows_path_list_to_unix(r"C:\foo\bar;D:/baz/qux"),
-            "/c/foo/bar:/d/baz/qux"
-        );
+        assert_eq!(msys(r"C:\foo\bar;D:/baz/qux"), "/c/foo/bar:/d/baz/qux");
     }
 
     #[test]
     fn test_windows_path_list_to_unix_passthrough_unix_entries() {
-        assert_eq!(
-            windows_path_list_to_unix("/usr/bin;C:\\foo;/c/bar"),
-            "/usr/bin:/c/foo:/c/bar"
-        );
+        assert_eq!(msys("/usr/bin;C:\\foo;/c/bar"), "/usr/bin:/c/foo:/c/bar");
     }
 
     #[test]
@@ -248,38 +288,32 @@ mod tests {
         // so we cannot split the result on `:` to inspect entries — bash receives
         // the whole string and will fail to use the UNC entry, which matches what
         // would happen without conversion).
-        assert_eq!(
-            windows_path_list_to_unix(r"\\?\C:\foo;C:\bar"),
-            r"\\?\C:\foo:/c/bar"
-        );
+        assert_eq!(msys(r"\\?\C:\foo;C:\bar"), r"\\?\C:\foo:/c/bar");
     }
 
     #[test]
     fn test_windows_path_list_to_unix_empty_entries() {
-        assert_eq!(windows_path_list_to_unix("C:\\foo;"), "/c/foo:");
-        assert_eq!(windows_path_list_to_unix(";C:\\foo"), ":/c/foo");
-        assert_eq!(windows_path_list_to_unix(""), "");
+        assert_eq!(msys("C:\\foo;"), "/c/foo:");
+        assert_eq!(msys(";C:\\foo"), ":/c/foo");
+        assert_eq!(msys(""), "");
     }
 
     #[test]
     fn test_windows_path_list_to_unix_drive_letter_case() {
-        assert_eq!(windows_path_list_to_unix(r"C:\foo"), "/c/foo");
-        assert_eq!(windows_path_list_to_unix(r"c:\foo"), "/c/foo");
+        assert_eq!(msys(r"C:\foo"), "/c/foo");
+        assert_eq!(msys(r"c:\foo"), "/c/foo");
     }
 
     #[test]
     fn test_windows_path_list_to_unix_program_files_with_spaces() {
-        assert_eq!(
-            windows_path_list_to_unix(r"C:\Program Files\Git\bin"),
-            "/c/Program Files/Git/bin"
-        );
+        assert_eq!(msys(r"C:\Program Files\Git\bin"), "/c/Program Files/Git/bin");
     }
 
     #[test]
     fn test_windows_path_list_to_unix_bare_drive_letter_passthrough() {
         // Bare "C:" or "C:foo" (relative-to-drive) is unrecognized — pass through.
-        assert_eq!(windows_path_list_to_unix("C:"), "C:");
-        assert_eq!(windows_path_list_to_unix("C:foo"), "C:foo");
+        assert_eq!(msys("C:"), "C:");
+        assert_eq!(msys("C:foo"), "C:foo");
     }
 
     #[test]
@@ -288,20 +322,70 @@ mod tests {
         // and tools that emit Windows separators may produce backslash forms. bash
         // does not treat `\` as a separator, so we translate `\` → `/` for non-UNC,
         // non-canonical-drive entries too.
+        assert_eq!(msys(r"node_modules\.bin"), "node_modules/.bin");
+        assert_eq!(msys(r".\bin"), "./bin");
         assert_eq!(
-            windows_path_list_to_unix(r"node_modules\.bin"),
-            "node_modules/.bin"
-        );
-        assert_eq!(windows_path_list_to_unix(r".\bin"), "./bin");
-        assert_eq!(
-            windows_path_list_to_unix(r"node_modules\.bin;C:\tools\bin"),
+            msys(r"node_modules\.bin;C:\tools\bin"),
             "node_modules/.bin:/c/tools/bin"
         );
     }
 
     #[test]
     fn test_windows_path_list_to_unix_single_entry() {
-        assert_eq!(windows_path_list_to_unix(r"C:\foo"), "/c/foo");
+        assert_eq!(msys(r"C:\foo"), "/c/foo");
+    }
+
+    #[test]
+    fn test_windows_path_list_to_unix_cygwin_basic() {
+        assert_eq!(cygwin(r"C:\foo;D:\bar"), "/cygdrive/c/foo:/cygdrive/d/bar");
+    }
+
+    #[test]
+    fn test_windows_path_list_to_unix_cygwin_forward_slash() {
+        assert_eq!(cygwin("C:/foo;D:/bar"), "/cygdrive/c/foo:/cygdrive/d/bar");
+    }
+
+    #[test]
+    fn test_windows_path_list_to_unix_cygwin_drive_letter_case() {
+        assert_eq!(cygwin(r"c:\foo"), "/cygdrive/c/foo");
+    }
+
+    #[test]
+    fn test_windows_path_list_to_unix_cygwin_program_files_with_spaces() {
+        assert_eq!(
+            cygwin(r"C:\Program Files\Git\bin"),
+            "/cygdrive/c/Program Files/Git/bin"
+        );
+    }
+
+    #[test]
+    fn test_windows_path_list_to_unix_cygwin_passthrough_unix_and_unc() {
+        // The cygdrive prefix only affects canonical drive entries; already-Unix
+        // and UNC entries are still passed through verbatim.
+        assert_eq!(
+            cygwin(r"/usr/bin;\\?\C:\x;C:\y"),
+            r"/usr/bin:\\?\C:\x:/cygdrive/c/y"
+        );
+    }
+
+    #[test]
+    fn test_windows_path_list_to_unix_cygwin_empty_entries() {
+        assert_eq!(cygwin("C:\\foo;"), "/cygdrive/c/foo:");
+    }
+
+    #[test]
+    fn test_windows_path_list_to_unix_cygwin_relative_paths_unprefixed() {
+        // Non-drive entries get no cygdrive prefix — only `\` → `/`.
+        assert_eq!(cygwin(r"node_modules\.bin"), "node_modules/.bin");
+    }
+
+    #[test]
+    fn test_windows_path_list_to_unix_custom_cygdrive_prefix() {
+        // A custom prefix such as `MISE_CYGDRIVE_PREFIX=/mnt` (fstab-configured).
+        assert_eq!(
+            windows_path_list_to_unix(r"C:\foo;D:\bar", "/mnt"),
+            "/mnt/c/foo:/mnt/d/bar"
+        );
     }
 
     #[test]
@@ -399,5 +483,31 @@ mod tests {
             sv(&["bash script", "-c"])
         );
         assert_eq!(split_shell_command("'a b' c").unwrap(), sv(&["a b", "c"]));
+    }
+
+    #[test]
+    fn test_is_cygwin_shell_detects_cygwin_paths() {
+        assert!(is_cygwin_shell(Path::new(r"C:\cygwin64\bin\bash.exe")));
+        assert!(is_cygwin_shell(Path::new(r"C:\cygwin\bin\bash.exe")));
+        assert!(is_cygwin_shell(Path::new(r"D:\tools\cygwin64\bin\bash.exe")));
+        assert!(is_cygwin_shell(Path::new("C:/cygwin64/bin/bash.exe")));
+        // Case-insensitive in both the drive and the `cygwin` segment.
+        assert!(is_cygwin_shell(Path::new(r"C:\CygWin64\bin\BASH.EXE")));
+    }
+
+    #[test]
+    fn test_is_cygwin_shell_rejects_non_cygwin() {
+        assert!(!is_cygwin_shell(Path::new(
+            r"C:\Program Files\Git\bin\bash.exe"
+        )));
+        assert!(!is_cygwin_shell(Path::new(r"C:\msys64\usr\bin\bash.exe")));
+        assert!(!is_cygwin_shell(Path::new("bash")));
+        assert!(!is_cygwin_shell(Path::new(
+            r"C:\Users\me\scoop\apps\git\current\bin\bash.exe"
+        )));
+        // A substring that is not a whole path segment must not match.
+        assert!(!is_cygwin_shell(Path::new(
+            r"C:\my-cygwinish-tools\bash.exe"
+        )));
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -228,9 +228,10 @@ fn split_shell_command_windows(s: &str) -> eyre::Result<Vec<String>> {
 /// default install dirs are `C:\cygwin64` and `C:\cygwin`. Used on Windows to pick
 /// the `/cygdrive/c/` PATH form instead of MSYS2 / Git Bash's `/c/`.
 ///
-/// Normalizes `\` → `/` first so it works for both backslash paths (`MISE_BASH_PATH`,
-/// `bash_candidates`) and forward-slash paths (`which::which_in`). Matches whole path
-/// segments so a directory that merely contains "cygwin" as a substring (e.g.
+/// Splits on both `/` and `\` and compares segments case-insensitively, so it works
+/// for backslash paths (`MISE_BASH_PATH`, `bash_candidates`) and forward-slash paths
+/// (`which::which_in`) without allocating any temporaries. Matches whole path segments
+/// so a directory that merely contains "cygwin" as a substring (e.g.
 /// `my-cygwinish-tools`) does not trip it. `MSYSTEM` is deliberately not consulted —
 /// PowerShell-launched mise inherits none, so it is not a reliable signal.
 #[cfg_attr(not(windows), allow(dead_code))]
@@ -238,10 +239,11 @@ pub fn is_cygwin_shell(program: &Path) -> bool {
     let Some(s) = program.to_str() else {
         return false;
     };
-    s.to_ascii_lowercase()
-        .replace('\\', "/")
-        .split('/')
-        .any(|seg| seg == "cygwin" || seg == "cygwin64" || seg == "cygwin32")
+    s.split(['/', '\\']).any(|seg| {
+        seg.eq_ignore_ascii_case("cygwin")
+            || seg.eq_ignore_ascii_case("cygwin64")
+            || seg.eq_ignore_ascii_case("cygwin32")
+    })
 }
 
 #[cfg(test)]
@@ -306,7 +308,10 @@ mod tests {
 
     #[test]
     fn test_windows_path_list_to_unix_program_files_with_spaces() {
-        assert_eq!(msys(r"C:\Program Files\Git\bin"), "/c/Program Files/Git/bin");
+        assert_eq!(
+            msys(r"C:\Program Files\Git\bin"),
+            "/c/Program Files/Git/bin"
+        );
     }
 
     #[test]
@@ -489,7 +494,9 @@ mod tests {
     fn test_is_cygwin_shell_detects_cygwin_paths() {
         assert!(is_cygwin_shell(Path::new(r"C:\cygwin64\bin\bash.exe")));
         assert!(is_cygwin_shell(Path::new(r"C:\cygwin\bin\bash.exe")));
-        assert!(is_cygwin_shell(Path::new(r"D:\tools\cygwin64\bin\bash.exe")));
+        assert!(is_cygwin_shell(Path::new(
+            r"D:\tools\cygwin64\bin\bash.exe"
+        )));
         assert!(is_cygwin_shell(Path::new("C:/cygwin64/bin/bash.exe")));
         // Case-insensitive in both the drive and the `cygwin` segment.
         assert!(is_cygwin_shell(Path::new(r"C:\CygWin64\bin\BASH.EXE")));

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1512,7 +1512,8 @@ fn maybe_convert_env_for_msys_shell<'a>(
             // mise itself runs inside Git Bash and spawns another bash subshell.
             && (path_val.contains(';') || path_val.contains('\\'))
         {
-            let converted = crate::path::windows_path_list_to_unix(path_val);
+            let drive_prefix = msys_drive_prefix_for(program, env);
+            let converted = crate::path::windows_path_list_to_unix(path_val, &drive_prefix);
             let mut new_env = env.clone();
             new_env.insert((*crate::env::PATH_KEY).to_string(), converted);
             return std::borrow::Cow::Owned(new_env);
@@ -1523,6 +1524,25 @@ fn maybe_convert_env_for_msys_shell<'a>(
         let _ = program;
     }
     std::borrow::Cow::Borrowed(env)
+}
+
+/// The cygdrive prefix inserted before drive letters when converting PATH for a
+/// POSIX shell: empty for MSYS2 / Git Bash (`/c/...`), `/cygdrive` for Cygwin
+/// (`/cygdrive/c/...`). A Cygwin user with a non-default `cygdrive` mount (configured
+/// in `/etc/fstab`) can override it via `MISE_CYGDRIVE_PREFIX` — mise does not parse
+/// fstab. A trailing `/` is trimmed since the converter emits its own separator after
+/// the prefix, so `MISE_CYGDRIVE_PREFIX=/` collapses to the MSYS `/c/...` form.
+#[cfg(windows)]
+fn msys_drive_prefix_for(program: &Path, env: &BTreeMap<String, String>) -> String {
+    if !crate::path::is_cygwin_shell(program) {
+        return String::new();
+    }
+    env.get("MISE_CYGDRIVE_PREFIX")
+        .cloned()
+        .or_else(|| std::env::var("MISE_CYGDRIVE_PREFIX").ok())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| "/cygdrive".to_string())
 }
 
 /// Read the shebang from a file and parse it into a shell command.
@@ -1613,6 +1633,33 @@ mod tests {
         let out =
             maybe_convert_env_for_msys_shell(Path::new(r"C:\Program Files\Git\bin\bash.exe"), &env);
         assert_eq!(out.get(&*crate::env::PATH_KEY).unwrap(), "/c/foo:/d/bar");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_maybe_convert_env_for_msys_shell_uses_cygdrive_for_cygwin_bash() {
+        // A Cygwin bash (detected by the `cygwin64` path segment) needs the
+        // `/cygdrive/c/...` form, not Git Bash's `/c/...`.
+        let env = env_with_path(r"C:\foo;D:\bar");
+        let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);
+        assert_eq!(
+            out.get(&*crate::env::PATH_KEY).unwrap(),
+            "/cygdrive/c/foo:/cygdrive/d/bar"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_maybe_convert_env_for_msys_shell_honors_cygdrive_prefix_override() {
+        // A non-default cygdrive mount (e.g. fstab `/mnt`) is supplied via
+        // MISE_CYGDRIVE_PREFIX in the task env rather than parsed from fstab.
+        let mut env = env_with_path(r"C:\foo;D:\bar");
+        env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "/mnt".to_string());
+        let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);
+        assert_eq!(
+            out.get(&*crate::env::PATH_KEY).unwrap(),
+            "/mnt/c/foo:/mnt/d/bar"
+        );
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1531,18 +1531,38 @@ fn maybe_convert_env_for_msys_shell<'a>(
 /// (`/cygdrive/c/...`). A Cygwin user with a non-default `cygdrive` mount (configured
 /// in `/etc/fstab`) can override it via `MISE_CYGDRIVE_PREFIX` — mise does not parse
 /// fstab. A trailing `/` is trimmed since the converter emits its own separator after
-/// the prefix, so `MISE_CYGDRIVE_PREFIX=/` collapses to the MSYS `/c/...` form.
+/// the prefix, so `MISE_CYGDRIVE_PREFIX=/` collapses to the MSYS `/c/...` form. A
+/// non-empty value that is not absolute (no leading `/`, e.g. `mnt`) would produce
+/// relative PATH entries that bash silently ignores, so it is rejected with a warning
+/// and the default `/cygdrive` is used instead.
 #[cfg(windows)]
 fn msys_drive_prefix_for(program: &Path, env: &BTreeMap<String, String>) -> String {
+    const DEFAULT: &str = "/cygdrive";
     if !crate::path::is_cygwin_shell(program) {
         return String::new();
     }
-    env.get("MISE_CYGDRIVE_PREFIX")
+    let raw = env
+        .get("MISE_CYGDRIVE_PREFIX")
         .cloned()
         .or_else(|| std::env::var("MISE_CYGDRIVE_PREFIX").ok())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.trim_end_matches('/').to_string())
-        .unwrap_or_else(|| "/cygdrive".to_string())
+        .filter(|s| !s.is_empty());
+    let Some(mut s) = raw else {
+        return DEFAULT.to_string();
+    };
+    // Trim trailing slashes in place — the converter appends its own separator.
+    s.truncate(s.trim_end_matches('/').len());
+    if s.is_empty() {
+        // `MISE_CYGDRIVE_PREFIX=/` → empty prefix → MSYS `/c/...` form.
+        String::new()
+    } else if s.starts_with('/') {
+        s
+    } else {
+        warn!(
+            "MISE_CYGDRIVE_PREFIX={s:?} is not absolute (must start with `/`); \
+             using the default `{DEFAULT}`"
+        );
+        DEFAULT.to_string()
+    }
 }
 
 /// Read the shebang from a file and parse it into a shell command.
@@ -1660,6 +1680,30 @@ mod tests {
             out.get(&*crate::env::PATH_KEY).unwrap(),
             "/mnt/c/foo:/mnt/d/bar"
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_maybe_convert_env_for_msys_shell_rejects_relative_cygdrive_prefix() {
+        // A prefix without a leading slash (e.g. `mnt`) would yield relative PATH
+        // entries bash ignores; fall back to the default `/cygdrive` instead.
+        let mut env = env_with_path(r"C:\foo;D:\bar");
+        env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "mnt".to_string());
+        let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);
+        assert_eq!(
+            out.get(&*crate::env::PATH_KEY).unwrap(),
+            "/cygdrive/c/foo:/cygdrive/d/bar"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_maybe_convert_env_for_msys_shell_cygdrive_prefix_slash_is_msys() {
+        // `MISE_CYGDRIVE_PREFIX=/` trims to empty → MSYS `/c/...` form.
+        let mut env = env_with_path(r"C:\foo;D:\bar");
+        env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "/".to_string());
+        let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);
+        assert_eq!(out.get(&*crate::env::PATH_KEY).unwrap(), "/c/foo:/d/bar");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

PR #9547 added Windows→Unix PATH conversion so `mise` launched from PowerShell can spawn a POSIX shell (`bash -c`) for a task with a usable PATH. It unconditionally emits the MSYS2 / Git Bash `/c/foo` form, but **Cygwin expects `/cygdrive/c/foo`** — so Cygwin users' PATH was corrupted and binaries like `cygpath` became `command not found`.

Reported in #9950. Cygwin was intentionally out of scope in #9547; this is the follow-up.

## Fix

- Detect Cygwin bash by a `cygwin` / `cygwin64` / `cygwin32` **path segment** in the resolved bash path. Detection runs *after* bash resolution, so it sees the real exe (`C:\cygwin64\bin\bash.exe`, or a `MISE_BASH_PATH` pointing there). Segment-matching avoids false positives like `my-cygwinish-tools`.
- Thread a `drive_prefix` through `windows_path_list_to_unix`: `""` for MSYS2 / Git Bash (`/c/...`, unchanged) and `/cygdrive` for Cygwin (`/cygdrive/c/...`).
- A non-default cygdrive mount (configured in `/etc/fstab`) can be supplied via **`MISE_CYGDRIVE_PREFIX`** (e.g. `/mnt`); mise does not parse fstab. A trailing `/` is trimmed, so `MISE_CYGDRIVE_PREFIX=/` collapses to the MSYS `/c/...` form.

Pure Rust, no subprocess (no `cygpath` fork). Windows-only and bash-path-based; `MSYSTEM` is not consulted since PowerShell-launched mise inherits none.

## Out of scope (intentional)

- **Parsing `/etc/fstab`** — replaced by the explicit `MISE_CYGDRIVE_PREFIX` escape hatch.
- **Auto-adding Cygwin to `bash_candidates()`** — would change bash auto-selection for users who have both Git Bash and Cygwin installed. Cygwin users pick their bash via `MISE_BASH_PATH` or PATH; this fix ensures PATH is formatted correctly for whichever bash is chosen.

## Tests

- `src/path.rs`: Cygwin conversion (basic, forward-slash, drive-letter case, spaces, UNC / already-unix passthrough, empty, relative), custom prefix, and `is_cygwin_shell` detection (true/false incl. the false-positive guard).
- `src/task/task_executor.rs`: `maybe_convert_env_for_msys_shell` routes Cygwin → `/cygdrive`, Git Bash → `/c/` (unchanged), and honors `MISE_CYGDRIVE_PREFIX`.
- `e2e-win/task.Tests.ps1`: skippable Cygwin e2e asserting the task PATH contains `/cygdrive/`.

28 unit tests pass locally on `x86_64-pc-windows-msvc`. `CHANGELOG.md` is git-cliff-generated, so left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
