### PR TITLE
chore(clippy): clean up accumulated Windows-only clippy warnings

### DIFF
--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -3,11 +3,13 @@ use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
+#[cfg(unix)]
+use crate::env;
 use crate::file;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolVersion;
-use crate::{Result, config::Config, env};
+use crate::{Result, config::Config};
 use async_trait::async_trait;
 use indoc::formatdoc;
 use serde::Deserialize;

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -6,7 +6,9 @@ use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
+#[cfg(unix)]
 use crate::env;
+#[cfg(unix)]
 use crate::file;
 use crate::github::{self, GithubRelease};
 use crate::http::HTTP_FETCH;
@@ -26,7 +28,9 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::{fmt::Debug, sync::Arc};
 use versions::Versioning;

--- a/src/env.rs
+++ b/src/env.rs
@@ -414,6 +414,7 @@ pub static __MISE_ZSH_PRECMD_RUN: Lazy<bool> = Lazy::new(|| !var_is_false("__MIS
 pub static LINUX_DISTRO: Lazy<Option<String>> = Lazy::new(linux_distro);
 /// Detected glibc version on Linux as (major, minor), e.g. (2, 17).
 /// Returns None on non-Linux or if detection fails.
+#[cfg_attr(windows, allow(dead_code))]
 pub static LINUX_GLIBC_VERSION: Lazy<Option<(u32, u32)>> = Lazy::new(linux_glibc_version);
 pub static PREFER_OFFLINE: Lazy<AtomicBool> =
     Lazy::new(|| prefer_offline(&ARGS.read().unwrap()).into());
@@ -761,6 +762,7 @@ fn linux_glibc_version() -> Option<(u32, u32)> {
 }
 
 #[cfg(not(target_os = "linux"))]
+#[cfg_attr(windows, allow(dead_code))]
 fn linux_glibc_version() -> Option<(u32, u32)> {
     None
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -323,6 +323,7 @@ fn should_cache_release(release: &GithubRelease) -> bool {
 /// Note: this relies on `list_releases` which may only return the first page of results
 /// when `MISE_LIST_ALL_VERSIONS` is not set. For repos with many releases, older versions
 /// may not be found, falling back to the exact version tag via `get_release`.
+#[cfg_attr(windows, allow(dead_code))]
 pub async fn get_release_with_build_revision(repo: &str, version: &str) -> Result<GithubRelease> {
     let releases = list_releases(repo).await?;
     match pick_best_build_revision(releases, version) {
@@ -336,6 +337,7 @@ pub async fn get_release_with_build_revision(repo: &str, version: &str) -> Resul
 /// Given releases with tags like "3.3.11", "3.3.11-1", "3.3.11-2", picks the one
 /// with the highest numeric `-N` suffix. The base version (no suffix) is treated as
 /// revision 0.
+#[cfg_attr(windows, allow(dead_code))]
 fn pick_best_build_revision(releases: Vec<GithubRelease>, version: &str) -> Option<GithubRelease> {
     let prefix = format!("{version}-");
     releases

--- a/src/plugins/core/ruby_common.rs
+++ b/src/plugins/core/ruby_common.rs
@@ -31,6 +31,7 @@ pub fn rubyinstaller_url(version: &str) -> String {
 /// Resolve RubyInstaller2 binary URL and checksum from GitHub releases.
 /// Returns `Ok(PlatformInfo::default())` for non-MRI versions since
 /// RubyInstaller2 only distributes standard MRI Ruby.
+#[cfg_attr(windows, allow(dead_code))]
 pub async fn resolve_rubyinstaller_lock_info(version: &str) -> Result<PlatformInfo> {
     if !is_mri_version(version) {
         return Ok(PlatformInfo::default());

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -84,14 +84,17 @@ impl SandboxConfig {
     }
 
     /// Compute effective deny flags, accounting for allow_* implying deny_*.
+    #[cfg_attr(windows, allow(dead_code))]
     pub fn effective_deny_read(&self) -> bool {
         self.deny_read || !self.allow_read.is_empty()
     }
 
+    #[cfg_attr(windows, allow(dead_code))]
     pub fn effective_deny_write(&self) -> bool {
         self.deny_write || !self.allow_write.is_empty()
     }
 
+    #[cfg_attr(windows, allow(dead_code))]
     pub fn effective_deny_net(&self) -> bool {
         self.deny_net || !self.allow_net.is_empty()
     }
@@ -150,6 +153,7 @@ impl SandboxConfig {
     /// On Linux: applies Landlock rules and seccomp filters in-process (inherited across exec).
     /// On macOS: returns a modified command that wraps through sandbox-exec.
     #[cfg(not(test))]
+    #[cfg_attr(windows, allow(dead_code))]
     #[allow(unused_variables)]
     pub async fn apply(
         &self,
@@ -218,6 +222,7 @@ impl SandboxConfig {
 
 /// A command rewritten to run through a sandbox wrapper (macOS sandbox-exec).
 #[cfg(not(test))]
+#[cfg_attr(windows, allow(dead_code))]
 #[derive(Debug)]
 pub struct SandboxedCommand {
     pub program: String,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2255,7 +2255,9 @@ mod tests {
     use crate::{config::Config, dirs};
     use pretty_assertions::assert_eq;
 
-    use super::{TaskConfirm, name_from_path, tera_tag_has_usage_ref, tera_template_has_usage_ref};
+    #[cfg(unix)]
+    use super::TaskConfirm;
+    use super::{name_from_path, tera_tag_has_usage_ref, tera_template_has_usage_ref};
 
     // Thread-local storage to capture parser state during tests
     thread_local! {
@@ -2268,6 +2270,7 @@ mod tests {
         });
     }
 
+    #[cfg(unix)]
     fn take_captured_fields() -> Option<Vec<String>> {
         CAPTURED_PARSER_FIELDS.with(|captured| captured.lock().unwrap().take())
     }

--- a/src/task/task_confirm.rs
+++ b/src/task/task_confirm.rs
@@ -28,7 +28,9 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
+    #[cfg(unix)]
     use crate::config::Config;
+    #[cfg(unix)]
     use crate::task::{Task, TaskConfirm};
 
     #[tokio::test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -3,7 +3,9 @@ use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings, env_directive::EnvDirective};
 use crate::duration;
 use crate::env_diff::EnvDiff;
-use crate::file::{display_path, is_executable, replace_path};
+#[cfg(not(windows))]
+use crate::file::is_executable;
+use crate::file::{display_path, replace_path};
 use crate::sandbox::SandboxConfig;
 use crate::task::TaskKey;
 use crate::task::task_context_builder::TaskContextBuilder;

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -154,15 +154,15 @@ impl ToolVersion {
         // handle non-symlinks on windows
         // TODO: make this a utility function in xx
         #[cfg(windows)]
-        if path.is_file() {
-            if let Ok(p) = file::read_to_string(&path).map(PathBuf::from) {
-                let path = self.ba().installs_path.join(p);
-                if path.exists() {
-                    return path
-                        .absolutize()
-                        .expect("failed to absolutize path")
-                        .to_path_buf();
-                }
+        if path.is_file()
+            && let Ok(p) = file::read_to_string(&path).map(PathBuf::from)
+        {
+            let path = self.ba().installs_path.join(p);
+            if path.exists() {
+                return path
+                    .absolutize()
+                    .expect("failed to absolutize path")
+                    .to_path_buf();
             }
         }
 


### PR DESCRIPTION
## What

Cleans up the pre-existing `cargo clippy --all-targets` warnings that fire only on the **Windows** build (`x86_64-pc-windows-msvc`). They are unrelated to feature work and were burying genuinely new warnings under noise.

After this change, `cargo clippy --all-targets` is **warning-free on Windows** and `cargo test --bin mise` still passes (943 tests). No behavior change.

## Why these aren't simple deletions

Most of the "unused" symbols are **actually used on Linux/macOS** (or under `#[cfg(unix)]` tests) and are only dead on Windows, where the relevant code paths are `#[cfg]`-compiled out. Deleting them would break the Unix builds, so:

- **Imports only used under `#[cfg(unix)]` / `#[cfg(not(windows))]`** are guarded with the matching `#[cfg(...)]` (same style as the existing `#[cfg(unix)] use ...PermissionsExt`), not removed:
  - `gem`: `crate::env`
  - `pipx`: `crate::env`, `crate::file`, `std::path::PathBuf`
  - `task_executor`: `file::is_executable`
  - `task_confirm` / `task` tests: `Config`, `Task`, `TaskConfirm`, `take_captured_fields`

- **Dead-code items whose callers are unconditional** (so the definitions can't be `#[cfg]`-gated without a compile error) get `#[cfg_attr(windows, allow(dead_code))]`, mirroring the existing `#[cfg_attr(not(windows), allow(dead_code))]` in `src/path.rs`:
  - `env`: `LINUX_GLIBC_VERSION` + the non-Linux `linux_glibc_version` stub
  - `github`: `get_release_with_build_revision`, `pick_best_build_revision`
  - `ruby_common`: `resolve_rubyinstaller_lock_info`
  - `sandbox`: `effective_deny_{read,write,net}`, `apply`, `SandboxedCommand`

- Collapsed a nested `if` (`clippy::collapsible_if`) in `tool_version.rs` (inside the existing `#[cfg(windows)]` block).

## Verification (Windows, `x86_64-pc-windows-msvc`)

- `cargo clippy --all-targets` → 0 warnings
- `cargo test --bin mise` → 943 passed; 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
