### PR TITLE
fix(bun): use native windows-arm64 build for Bun >= 1.3.10

### DIFF
--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -25,6 +25,11 @@ use crate::{
 };
 use crate::{file, github, plugins};
 
+/// Bun started publishing native Windows ARM64 archives (`bun-windows-aarch64.zip`)
+/// in this release. Older releases only ship x64 Windows builds, so Windows ARM64
+/// falls back to `x64-baseline` under emulation for versions below this cutoff.
+const WINDOWS_ARM64_NATIVE_ARCHIVE_VERSION: &str = "1.3.10";
+
 #[derive(Debug)]
 pub struct BunPlugin {
     ba: Arc<BackendArg>,
@@ -55,7 +60,7 @@ impl BunPlugin {
             "https://github.com/oven-sh/bun/releases/download/bun-v{}/bun-{}-{}.zip",
             tv.version,
             os(),
-            arch()
+            arch(&tv.version)
         );
         let filename = url.split('/').next_back().unwrap();
         let tarball_path = tv.download_path().join(filename);
@@ -74,7 +79,7 @@ impl BunPlugin {
         file::unzip(tarball_path, &tv.download_path(), &Default::default())?;
         file::move_file(
             tv.download_path()
-                .join(format!("bun-{}-{}", os(), arch()))
+                .join(format!("bun-{}-{}", os(), arch(&tv.version)))
                 .join(bun_bin_name()),
             self.bun_bin(tv),
         )?;
@@ -222,9 +227,7 @@ impl Backend for BunPlugin {
 
         // Build the asset pattern for Bun's GitHub releases
         // Pattern: bun-{os}-{arch}.zip (where arch may include variants like -musl, -baseline)
-        let os_name = Self::map_os_to_bun(target.os_name());
-        let arch_name = Self::get_bun_arch_for_target(target);
-        let asset_pattern = format!("bun-{os_name}-{arch_name}.zip");
+        let asset_pattern = Self::bun_asset_filename(target, version);
 
         Ok(Some(GitHubReleaseInfo {
             repo: "oven-sh/bun".to_string(),
@@ -244,9 +247,7 @@ impl Backend for BunPlugin {
         let version = &tv.version;
 
         // Build platform-specific filename
-        let os_name = Self::map_os_to_bun(target.os_name());
-        let arch_name = Self::get_bun_arch_for_target(target);
-        let filename = format!("bun-{os_name}-{arch_name}.zip");
+        let filename = Self::bun_asset_filename(target, version);
 
         // Build download URL
         let url =
@@ -280,6 +281,7 @@ impl Backend for BunPlugin {
         // - macos-x64: x64, x64-baseline
         // - macos-arm64: aarch64
         // - windows-x64: x64, x64-baseline
+        // - windows-arm64: aarch64 (native, since Bun v1.3.10)
 
         // If the platform already has a qualifier, it's already a specific variant
         // Don't expand it to avoid duplicates
@@ -353,22 +355,59 @@ impl BunPlugin {
         }
     }
 
-    /// Get the full Bun arch string for a target platform
-    /// This handles musl, baseline, and other variants based on platform qualifiers
-    fn get_bun_arch_for_target(target: &PlatformTarget) -> String {
-        let base_arch = Self::map_arch_to_bun(target.arch_name());
+    /// Build the Bun release asset filename (`bun-{os}-{arch}.zip`) for a target platform.
+    fn bun_asset_filename(target: &PlatformTarget, version: &str) -> String {
+        let os_name = Self::map_os_to_bun(target.os_name());
+        let arch_name = Self::get_bun_arch_for_target(target, version);
+        format!("bun-{os_name}-{arch_name}.zip")
+    }
 
-        // Handle qualifiers like musl, baseline, etc.
-        if let Some(qualifier) = target.qualifier() {
-            match qualifier {
-                "musl" => format!("{}-musl", base_arch),
-                "musl-baseline" => format!("{}-musl-baseline", base_arch),
-                "baseline" => format!("{}-baseline", base_arch),
-                other => format!("{}-{}", base_arch, other),
+    /// Get the full Bun arch string for a target platform.
+    ///
+    /// This handles Bun's platform qualifiers (musl, baseline, etc.) and the
+    /// Windows ARM64 release cutover: native `bun-windows-aarch64.zip` archives
+    /// only exist from v1.3.10 onward, so older Windows ARM64 versions fall back
+    /// to `x64-baseline` under emulation.
+    fn get_bun_arch_for_target(target: &PlatformTarget, version: &str) -> String {
+        match (target.os_name(), target.arch_name()) {
+            ("windows", "arm64") if !Self::has_native_windows_arm64_archive(version) => {
+                "x64-baseline".to_string()
             }
-        } else {
-            base_arch.to_string()
+            (_, arch) => {
+                Self::bun_arch_with_qualifier(Self::map_arch_to_bun(arch), target.qualifier())
+            }
         }
+    }
+
+    /// Compose a base arch with Bun's variant qualifier suffix (musl, baseline, etc.).
+    fn bun_arch_with_qualifier(base_arch: &str, qualifier: Option<&str>) -> String {
+        match qualifier {
+            Some("musl") => format!("{base_arch}-musl"),
+            Some("musl-baseline") => format!("{base_arch}-musl-baseline"),
+            Some("baseline") => format!("{base_arch}-baseline"),
+            Some(other) => format!("{base_arch}-{other}"),
+            None => base_arch.to_string(),
+        }
+    }
+
+    /// Whether Bun publishes a native Windows ARM64 archive for the given version.
+    fn has_native_windows_arm64_archive(version: &str) -> bool {
+        let version = version
+            .strip_prefix("bun-v")
+            .or_else(|| version.strip_prefix('v'))
+            .unwrap_or(version);
+
+        // The historical x64-baseline fallback only applies to concrete semver
+        // releases before the cutoff. Anything that isn't a clean `x.y.z` release
+        // (a channel/tag like `canary`, or an unparseable ref) prefers the native
+        // Windows ARM64 archive instead of silently forcing x64 emulation.
+        let Some(version) = Versioning::new(version).filter(Versioning::is_ideal) else {
+            return true;
+        };
+
+        version
+            >= Versioning::new(WINDOWS_ARM64_NATIVE_ARCHIVE_VERSION)
+                .expect("Windows ARM64 native archive cutoff must be a valid version")
     }
 
     /// Check if the current system has AVX2 support (runtime detection)
@@ -423,38 +462,26 @@ impl BunPlugin {
         }
     }
 
-    /// Get the full Bun arch string with variants (musl, baseline, etc.)
-    /// Uses Settings::get().arch() to respect MISE_ARCH overrides and runtime AVX2 detection
-    fn get_bun_arch_with_variants() -> String {
+    /// Get the full Bun arch string with variants (musl, baseline, etc.) for the
+    /// current system and the given Bun version.
+    ///
+    /// Uses Settings::get().arch() to respect MISE_ARCH overrides and runtime AVX2
+    /// detection (both encapsulated in `current_platform_target`), then delegates to
+    /// the shared `get_bun_arch_for_target` so the Windows ARM64 cutover logic lives
+    /// in a single place.
+    fn get_bun_arch_with_variants(version: &str) -> String {
+        Self::get_bun_arch_for_target(&Self::current_platform_target(), version)
+    }
+
+    /// Build a `PlatformTarget` for the current system, mapping runtime AVX2/musl
+    /// detection (via `get_platform_variant`) onto the platform qualifier.
+    fn current_platform_target() -> PlatformTarget {
         let settings = Settings::get();
-        let arch = settings.arch();
-        let os = settings.os();
-        match arch {
-            "x64" => {
-                if Self::is_musl() {
-                    if Self::has_avx2() {
-                        "x64-musl".to_string()
-                    } else {
-                        "x64-musl-baseline".to_string()
-                    }
-                } else if Self::has_avx2() {
-                    "x64".to_string()
-                } else {
-                    "x64-baseline".to_string()
-                }
-            }
-            "arm64" => {
-                if Self::is_musl() {
-                    "aarch64-musl".to_string()
-                } else if os == "windows" {
-                    // Bun has no native windows-arm64 build; fall back to x64 under emulation
-                    "x64-baseline".to_string()
-                } else {
-                    "aarch64".to_string()
-                }
-            }
-            other => other.to_string(),
-        }
+        PlatformTarget::new(Platform {
+            os: settings.os().to_string(),
+            arch: settings.arch().to_string(),
+            qualifier: Self::get_platform_variant().map(str::to_string),
+        })
     }
 }
 
@@ -463,10 +490,64 @@ fn os() -> String {
     BunPlugin::map_os_to_bun(settings.os()).to_string()
 }
 
-fn arch() -> String {
-    BunPlugin::get_bun_arch_with_variants()
+fn arch(version: &str) -> String {
+    BunPlugin::get_bun_arch_with_variants(version)
 }
 
 fn bun_bin_name() -> &'static str {
     if cfg!(windows) { "bun.exe" } else { "bun" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(platform: &str) -> PlatformTarget {
+        PlatformTarget::new(Platform::parse(platform).unwrap())
+    }
+
+    #[test]
+    fn windows_arm64_asset_filename_matches_bun_release_cutover() {
+        // Native `bun-windows-aarch64.zip` archives first shipped in Bun 1.3.10.
+        // Older releases must keep using x64-baseline under emulation.
+        for (version, expected) in [
+            ("1.3.9", "bun-windows-x64-baseline.zip"),
+            ("1.3.10", "bun-windows-aarch64.zip"),
+            ("v1.3.10", "bun-windows-aarch64.zip"),
+            ("bun-v1.3.10", "bun-windows-aarch64.zip"),
+            ("1.3.14", "bun-windows-aarch64.zip"),
+            // Non-semver refs (channels/tags) prefer the native archive.
+            ("canary", "bun-windows-aarch64.zip"),
+        ] {
+            assert_eq!(
+                BunPlugin::bun_asset_filename(&target("windows-arm64"), version),
+                expected,
+                "unexpected Windows ARM64 asset for Bun {version}"
+            );
+        }
+    }
+
+    #[test]
+    fn bun_asset_filename_preserves_platform_variants() {
+        // Regression: every other platform/variant must keep its existing asset name.
+        for (platform, expected) in [
+            ("linux-x64", "bun-linux-x64.zip"),
+            ("linux-x64-baseline", "bun-linux-x64-baseline.zip"),
+            ("linux-x64-musl", "bun-linux-x64-musl.zip"),
+            ("linux-x64-musl-baseline", "bun-linux-x64-musl-baseline.zip"),
+            ("linux-arm64", "bun-linux-aarch64.zip"),
+            ("linux-arm64-musl", "bun-linux-aarch64-musl.zip"),
+            ("macos-x64", "bun-darwin-x64.zip"),
+            ("macos-x64-baseline", "bun-darwin-x64-baseline.zip"),
+            ("macos-arm64", "bun-darwin-aarch64.zip"),
+            ("windows-x64", "bun-windows-x64.zip"),
+            ("windows-x64-baseline", "bun-windows-x64-baseline.zip"),
+        ] {
+            assert_eq!(
+                BunPlugin::bun_asset_filename(&target(platform), "1.3.14"),
+                expected,
+                "unexpected asset for {platform}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The Bun plugin always downloads the `x64-baseline` build on Windows ARM64, running Bun under x64 emulation. Bun has shipped **native Windows ARM64 archives** (`bun-windows-aarch64.zip`) since **v1.3.10**, but mise never selected them.

Closes the request in discussion [#10044](https://github.com/jdx/mise/discussions/10044).

Verified against the upstream Bun releases:
- `bun-v1.3.9` → only `bun-windows-x64*` assets (no aarch64)
- `bun-v1.3.10` → first release with `bun-windows-aarch64.zip`
- `bun-v1.3.14` (latest) → `bun-windows-aarch64.zip` present

## Change

- For Windows ARM64, select `bun-windows-aarch64.zip` when the Bun version is **>= 1.3.10**, and keep the `x64-baseline` fallback for older releases.
- Unify the arch-resolution logic for the current system (`get_bun_arch_with_variants`) and for lockfile/platform targets (`get_bun_arch_for_target`) so the Windows ARM64 cutover lives in **a single place**. The download URL, the extracted directory name, and the lockfile asset/checksum all derive from the same `bun-{os}-{arch}.zip` helper, keeping them in sync.
- Runtime AVX2 / musl detection is preserved (now routed through `current_platform_target` → `get_platform_variant`).
- Non-semver refs (e.g. `canary`) prefer the native aarch64 archive rather than forcing x64 emulation.

All other platforms/variants (linux & macos x64/arm64, musl/baseline, windows x64) are unchanged.

This supersedes the earlier closed PRs #10045 and #10063, which took the same approach but stalled on unrelated Windows ARM64 CI runner issues.

## Tests

Added unit tests in `src/plugins/core/bun.rs`:
- `windows_arm64_asset_filename_matches_bun_release_cutover` — `1.3.9` → `x64-baseline`; `1.3.10` / `v1.3.10` / `bun-v1.3.10` / `canary` → `aarch64`.
- `bun_asset_filename_preserves_platform_variants` — regression guard that every other platform/variant keeps its existing asset name.

```
cargo test --bin mise plugins::core::bun::   # 2 passed
cargo clippy --bin mise                      # no new warnings
```