### PR TITLE
fix(ui): honor color settings in interactive prompt themes (#9999)

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -587,9 +587,16 @@
         },
         "color_theme": {
           "default": "default",
-          "description": "Theme for interactive prompts (default/charm, base16, catppuccin, dracula)",
+          "description": "Theme for interactive prompts (auto/default, charm, base16, catppuccin, dracula)",
           "type": "string",
-          "enum": ["default", "charm", "base16", "catppuccin", "dracula"]
+          "enum": [
+            "auto",
+            "default",
+            "charm",
+            "base16",
+            "catppuccin",
+            "dracula"
+          ]
         },
         "conda": {
           "type": "object",

--- a/settings.toml
+++ b/settings.toml
@@ -291,20 +291,26 @@ type = "Bool"
 
 [color_theme]
 default = "default"
-description = "Theme for interactive prompts (default/charm, base16, catppuccin, dracula)"
+description = "Theme for interactive prompts (auto/default, charm, base16, catppuccin, dracula)"
 docs = """
 Sets the color theme for interactive prompts like `mise run` task selection.
 Available themes:
 
-- `default` or `charm` - Default theme, works well on dark terminals
+- `auto` (or `default`) - Auto-detect the terminal background (via `COLORFGBG`) and
+  use a light-friendly theme (`base16`) on light terminals, otherwise `charm`
+- `charm` - The charm theme, works well on dark terminals (no auto-detection)
 - `base16` - Base16 theme, works well on light terminals
 - `catppuccin` - Catppuccin theme
 - `dracula` - Dracula theme
 
-If you're using a light terminal and the default theme is hard to read,
-try setting this to `base16`.
+`default` is an alias for `auto`: when left unset (or set to `auto`/`default`), mise
+auto-detects a light terminal background via `COLORFGBG` and switches to `base16` for
+readability. Set an explicit theme (e.g. `charm`) to disable auto-detection.
+
+When colors are disabled (`color=false`, `NO_COLOR`, or `CLICOLOR=0`), interactive
+prompts are rendered without any styling regardless of this setting.
 """
-enum = ["default", "charm", "base16", "catppuccin", "dracula"]
+enum = ["auto", "default", "charm", "base16", "catppuccin", "dracula"]
 env = "MISE_COLOR_THEME"
 type = "String"
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -2,23 +2,169 @@ use demand::Theme;
 
 use crate::config::Settings;
 
-/// Returns the demand theme based on the `color_theme` setting.
+/// Returns the demand theme based on the `color_theme` setting and the current
+/// terminal color state.
 ///
 /// Available themes:
-/// - "default" or "charm" - Default charm theme (good for dark terminals)
+/// - "auto" (or "default") - Auto-detect: use a light-friendly theme (base16) on
+///   light terminals, otherwise charm
+/// - "charm" - The charm theme (good for dark terminals, no auto-detection)
 /// - "base16" - Base16 theme (good for light terminals)
 /// - "catppuccin" - Catppuccin theme
 /// - "dracula" - Dracula theme
+///
+/// When colors are disabled (e.g. `color=false`, `NO_COLOR`, `CLICOLOR=0`) an
+/// unstyled theme is returned, mirroring `demand::Theme::default()`'s own
+/// behavior so that interactive prompts honor the color settings.
 pub fn get_theme() -> Theme {
     let settings = Settings::get();
-    match settings.color_theme.to_lowercase().as_str() {
+    select_theme(
+        console::colors_enabled_stderr(),
+        &settings.color_theme,
+        detect_light_background(),
+    )
+}
+
+/// Pure theme-selection logic, separated from global state so it can be tested
+/// deterministically (the test harness forces colors off globally, so the
+/// branches cannot be exercised through `get_theme()` directly).
+fn select_theme(colors_enabled: bool, color_theme: &str, light_background: bool) -> Theme {
+    // Honor disabled colors regardless of the requested theme. This matches
+    // `demand::Theme::default()`, which returns `Theme::new()` (no colors) when
+    // `console::colors_enabled_stderr()` is false.
+    if !colors_enabled {
+        return Theme::new();
+    }
+    let auto = || {
+        if light_background {
+            Theme::base16()
+        } else {
+            Theme::charm()
+        }
+    };
+    match color_theme.to_lowercase().as_str() {
+        "auto" | "default" | "" => auto(),
+        "charm" => Theme::charm(),
         "base16" => Theme::base16(),
         "catppuccin" => Theme::catppuccin(),
         "dracula" => Theme::dracula(),
-        "charm" | "default" | "" => Theme::charm(),
         other => {
             warn!("Unknown color theme '{}', using default", other);
-            Theme::charm()
+            auto()
         }
+    }
+}
+
+/// Best-effort detection of a light terminal background via the `COLORFGBG`
+/// environment variable (set by many terminals, e.g. iTerm2, konsole, rxvt).
+/// We intentionally avoid OSC 11 terminal queries, which can hang or corrupt
+/// output. Returns false (assume dark) when detection is not possible.
+fn detect_light_background() -> bool {
+    std::env::var("COLORFGBG")
+        .ok()
+        .as_deref()
+        .map(colorfgbg_is_light)
+        .unwrap_or(false)
+}
+
+/// Parse a `COLORFGBG` value ("foreground;background", sometimes with a middle
+/// field) and decide whether the background indicates a light terminal.
+/// The background is the last `;`-separated field; ANSI codes 7 (white) and
+/// 10..=15 (bright colors / bright white) are treated as light.
+fn colorfgbg_is_light(value: &str) -> bool {
+    value
+        .rsplit(';')
+        .next()
+        .and_then(|bg| bg.trim().parse::<u8>().ok())
+        .map(|bg| bg == 7 || (10..=15).contains(&bg))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn colors_disabled_returns_unstyled_theme() {
+        // Regardless of the requested theme, disabled colors -> no styling.
+        for theme in [
+            "default",
+            "charm",
+            "base16",
+            "catppuccin",
+            "dracula",
+            "auto",
+            "bogus",
+        ] {
+            let t = select_theme(false, theme, false);
+            let plain = Theme::new();
+            assert_eq!(t.title.fg(), plain.title.fg(), "theme={theme}");
+            assert_eq!(
+                t.selected_option.fg(),
+                plain.selected_option.fg(),
+                "theme={theme}"
+            );
+            assert_eq!(
+                t.unselected_option.fg(),
+                plain.unselected_option.fg(),
+                "theme={theme}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_theme_is_applied_when_colors_enabled() {
+        // base16's title color differs from charm's; confirm the explicit
+        // request wins and is actually colored.
+        let base16 = select_theme(true, "base16", false);
+        assert_eq!(base16.title.fg(), Theme::base16().title.fg());
+        assert!(base16.title.fg().is_some());
+
+        let charm = select_theme(true, "charm", true /* ignored for explicit */);
+        assert_eq!(charm.title.fg(), Theme::charm().title.fg());
+    }
+
+    #[test]
+    fn auto_picks_base16_on_light_and_charm_on_dark() {
+        for theme in ["auto", "default", ""] {
+            let light = select_theme(true, theme, true);
+            assert_eq!(
+                light.title.fg(),
+                Theme::base16().title.fg(),
+                "theme={theme}"
+            );
+
+            let dark = select_theme(true, theme, false);
+            assert_eq!(dark.title.fg(), Theme::charm().title.fg(), "theme={theme}");
+        }
+    }
+
+    #[test]
+    fn unknown_theme_falls_back_to_auto() {
+        assert_eq!(
+            select_theme(true, "bogus", true).title.fg(),
+            Theme::base16().title.fg()
+        );
+        assert_eq!(
+            select_theme(true, "bogus", false).title.fg(),
+            Theme::charm().title.fg()
+        );
+    }
+
+    #[test]
+    fn colorfgbg_light_detection() {
+        // Light backgrounds (white / bright)
+        assert!(colorfgbg_is_light("0;15"));
+        assert!(colorfgbg_is_light("0;7"));
+        assert!(colorfgbg_is_light("0;default;15"));
+        assert!(colorfgbg_is_light(" 0 ; 15 "));
+        // Dark backgrounds
+        assert!(!colorfgbg_is_light("15;0"));
+        assert!(!colorfgbg_is_light("7;0"));
+        assert!(!colorfgbg_is_light("15;8"));
+        // Unparseable -> assume dark
+        assert!(!colorfgbg_is_light(""));
+        assert!(!colorfgbg_is_light("foo"));
+        assert!(!colorfgbg_is_light("0;default"));
     }
 }


### PR DESCRIPTION
## Problem

Reported in discussion [#9999](https://github.com/jdx/mise/discussions/9999): the interactive `mise use` tool picker (and other `demand`-based prompts) ignores color settings. On light terminals the default theme is unreadable, and `color=false` / `NO_COLOR` have no effect on the prompt styling.

## Root cause

Interactive prompts use the `demand` crate. Its own `Theme::default()` already checks `console::colors_enabled_stderr()` and returns an unstyled `Theme::new()` when colors are disabled:

```rust
// demand-2.0.2/src/theme.rs
impl Default for Theme {
    fn default() -> Self {
        if console::colors_enabled_stderr() { Theme::charm() } else { Theme::new() }
    }
}
```

But mise's `src/ui/theme.rs::get_theme()` skipped that check and constructed a colored theme (`charm()` / `base16()` / …) directly, so the raw `ColorSpec` values were always emitted regardless of `color=false` / `NO_COLOR` / `CLICOLOR=0` (all of which already set `colors_enabled_stderr(false)` in `src/config/settings.rs`).

## Changes

- **Honor disabled colors**: `get_theme()` now returns `Theme::new()` (the same unstyled theme demand uses for its default) when `colors_enabled_stderr()` is false. This fixes every `get_theme()` call site (`mise use`, `mise run` task selection, `mise search`, `mise set`, `mise upgrade`, prompts) at once.
- **Light-terminal auto-detection**: added a `color_theme = "auto"` option, which is also the new behavior of the default `"default"`. It detects a light background via the `COLORFGBG` env var and picks `base16` for readability, otherwise `charm`. Explicit `charm` keeps the previous fixed dark theme (no auto-detection). OSC 11 terminal queries are intentionally **not** used (they can hang / corrupt output).
- **Tests**: selection logic is split into pure helpers (`select_theme`, `colorfgbg_is_light`) so both the colored and unstyled branches can be unit-tested without depending on the global color state (the test harness forces colors off globally).
- **Docs / schema**: updated `settings.toml` (enum + docs) and regenerated `schema/mise.json` via `mise run render:schema`.

## Behavior change note

When `color_theme` is left at its default, mise now auto-detects a light terminal via `COLORFGBG` and switches to `base16`. Terminals without `COLORFGBG`, and any explicit theme value, behave as before. `default` is documented as an alias for `auto`; set `charm` to force the previous dark theme.

## Testing

- `cargo test --bin mise ui::theme::` → 5 passed.
- `cargo build` → clean (pre-existing warnings only).
- Manual: `MISE_COLOR=0 mise use` / `NO_COLOR=1 mise use` produce no ANSI styling; `COLORFGBG="0;15" MISE_COLOR_THEME=auto mise use` renders the readable light theme.

Relates to the earlier abandoned draft #10009 (closed by its author without landing); this takes a simpler approach by reusing demand's own `Theme::new()` instead of manually clearing fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
