### PR TITLE
registry: add herdr (github:ogulcancelik/herdr)

### DIFF
--- a/registry/herdr.toml
+++ b/registry/herdr.toml
@@ -1,0 +1,3 @@
+backends = ["github:ogulcancelik/herdr"]
+description = "Agent multiplexer that lives in your terminal"
+test = { cmd = "herdr --version", expected = "herdr {{version}}" }


### PR DESCRIPTION
## Summary

Add Herdr to the registry via the GitHub releases backend.

Herdr is an agent multiplexer that lives in your terminal. It is a terminal workspace manager for running and coordinating AI coding agents, similar in spirit to a tmux-style workflow. It publishes Linux and macOS binaries for x86_64 and aarch64.

Mise support has been requested by Herdr users, and the GitHub backend already installs Herdr correctly with the full backend name.

## Validation

Tested the GitHub backend install locally:

```sh
mise x github:ogulcancelik/herdr@0.6.5 -- herdr --version
```

```text
herdr 0.6.5
```

## Popularity

Herdr has about 3.2k GitHub stars, 210 forks, active releases, and recent release binaries are being downloaded regularly.