### PR TITLE
test: deflake python venv go backend e2e

### DIFF
--- a/e2e/core/test_python_venv_with_go_backend_deadlock_slow
+++ b/e2e/core/test_python_venv_with_go_backend_deadlock_slow
@@ -5,6 +5,15 @@
 # fixes https://github.com/jdx/mise/discussions/7059
 set -euo pipefail
 export MISE_PYTHON_GITHUB_ATTESTATIONS=0
+install_timeout="${MISE_E2E_INSTALL_TIMEOUT:-180}"
+
+cleanup_go_cache() {
+  # Required to properly cleanup as go installs read-only sources
+  if [ -d ~/go ]; then
+    chmod -R +w ~/go
+  fi
+}
+trap cleanup_go_cache EXIT
 
 cat >.mise.toml <<EOF
 [tools]
@@ -18,7 +27,7 @@ EOF
 
 # This should complete without timeout (previously would hang indefinitely)
 # The go backend tool resolution should not interfere with Python venv creation
-timeout 60 mise install
+timeout "$install_timeout" mise install
 
 # Verify Python venv was created
 assert "mise x -- python --version" "Python 3.12.3"
@@ -27,6 +36,3 @@ assert "mise x -- which python" "$HOME/my_venv/bin/python"
 
 # Verify Go backend tool was installed and can run
 assert_contains "mise x -- gum --version" "0.17.0"
-
-# Required to properly cleanup as go installs read-only sources
-chmod -R +w ~/go


### PR DESCRIPTION
## Summary
- increase the deadlock regression test watchdog from 60s to a configurable default of 180s
- run Go cache permission cleanup through an EXIT trap so timed-out runs do not leave read-only files behind

## Context
The failing CI run timed out in `core/test_python_venv_with_go_backend_deadlock_slow` while cold-installing `go:github.com/charmbracelet/gum@0.17.0`. The test still catches real hangs, but gives ordinary Go module downloads/builds more room.

## Verification
- `bash -n e2e/core/test_python_venv_with_go_backend_deadlock_slow`
- `shellcheck e2e/core/test_python_venv_with_go_backend_deadlock_slow`

Full targeted e2e was attempted locally but did not reach the test because the local build failed first: `aws-lc-sys`/bindgen could not find `libclang`.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes an e2e shell test timeout and cleanup; no production code paths.
> 
> **Overview**
> Deflakes the slow Python-venv + Go-backend deadlock e2e by giving `mise install` more time on cold CI (default **180s** via `MISE_E2E_INSTALL_TIMEOUT`, was a fixed **60s**).
> 
> Go module cache cleanup (`chmod -R +w ~/go`) now runs on **EXIT** so a `timeout` kill still leaves the cache writable for teardown instead of only running after a successful run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f2f4aaabc97931f91151f71c5ac414ab3a787f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->