### PR TITLE
fix(installer): add missing warn helper

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -22,6 +22,10 @@ else
   }
 fi
 
+warn() {
+  printf '%s\n' "$*" >&2
+}
+
 error() {
   echo "$@" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Recreates #9993 by @olfway with the original author preserved on the commit.
- Add the missing warn helper used by standalone installer checksum fallback paths.
- Use printf for the helper, matching the review suggestion from the original PR.

## Verification
- git diff --check
- sh -n packaging/standalone/install.envsubst
- Reproduced current upstream/main failure with get_checksum and verified this branch emits the warning instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the installation script's logging capabilities with improved warning messages for missing checksums during the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->