### PR TITLE
fix(env): drop stale install paths during reactivation

### DIFF
--- a/e2e/env/test_zsh_reactivate_drops_stale_install_path
+++ b/e2e/env/test_zsh_reactivate_drops_stale_install_path
@@ -1,0 +1,70 @@
+#!/usr/bin/env zsh
+# shellcheck disable=SC1071
+set -euo pipefail
+
+# Reproduces https://github.com/jdx/mise/discussions/10095:
+# a non-interactive zsh inherits an inactive mise install path before the active
+# project tool path, then re-runs `mise activate zsh`.
+
+export MISE_NODE_COMPILE=0
+export MISE_OFFLINE=1
+
+mkdir -p "$MISE_DATA_DIR/installs/node/24/bin"
+mkdir -p "$MISE_DATA_DIR/installs/node/22.17.1/bin"
+
+cat >"$MISE_DATA_DIR/installs/node/24/bin/node" <<'EOF'
+#!/usr/bin/env bash
+echo v24.16.0
+EOF
+
+cat >"$MISE_DATA_DIR/installs/node/22.17.1/bin/node" <<'EOF'
+#!/usr/bin/env bash
+echo v22.17.1
+EOF
+
+chmod +x "$MISE_DATA_DIR/installs/node/24/bin/node"
+chmod +x "$MISE_DATA_DIR/installs/node/22.17.1/bin/node"
+
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[settings]
+idiomatic_version_file_enable_tools = ["node"]
+
+[tools]
+node = "24"
+EOF
+
+cat >package.json <<'EOF'
+{
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "22.x",
+      "onFail": "error"
+    }
+  }
+}
+EOF
+
+eval "$(mise activate zsh)"
+[[ $(node -v) == "v22.17.1" ]] || {
+  echo "initial activation should use node 22 from package.json"
+  exit 1
+}
+
+# Simulate a parent shell or editor extension that injected the global Node
+# install path ahead of the active project path before spawning a child shell.
+export PATH="$MISE_DATA_DIR/installs/node/24/bin:$PATH"
+
+output=$(zsh -f -c 'eval "$(mise activate zsh)" && node -v && print -r -- "$PATH" | tr : "\n" | grep "/installs/node/"')
+
+[[ $output == v22.17.1* ]] || {
+  echo "expected reactivation to keep node 22 first, got:"
+  echo "$output"
+  exit 1
+}
+
+first_node_path=$(echo "$output" | sed -n '2p')
+[[ $first_node_path == "$MISE_DATA_DIR/installs/node/22.17.1/bin" ]] || {
+  echo "expected first node path to be node 22, got: $first_node_path"
+  exit 1
+}

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -7,14 +7,14 @@ use crate::file::{canonicalize_cached, display_rel_path};
 use crate::hook_env::{PREV_SESSION, WatchFilePattern};
 use crate::shell::{ShellType, get_shell};
 use crate::toolset::Toolset;
-use crate::{env, hook_env, hooks, watch_files};
+use crate::{dirs, env, hook_env, hooks, watch_files};
 use console::truncate_str;
 use eyre::Result;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use std::collections::{BTreeSet, HashSet};
 use std::ops::Deref;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{borrow::Cow, sync::Arc};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -287,6 +287,14 @@ impl HookEnv {
                         continue;
                     }
 
+                    // Paths under mise's installs dir are mise-managed even if
+                    // the previous session diff did not claim them. Preserving a
+                    // stale install path as a user prefix can shadow the active
+                    // version selected by the current toolset.
+                    if is_mise_install_path(path) {
+                        continue;
+                    }
+
                     // Place in pre or post_user based on position relative to original PATH
                     if seen_orig {
                         post_user.push(path.clone());
@@ -495,6 +503,17 @@ impl HookEnv {
             hook_env::serialize(&session)?,
         ))
     }
+}
+
+fn is_mise_install_path(path: &Path) -> bool {
+    if path.starts_with(*dirs::INSTALLS) {
+        return true;
+    }
+
+    let Some(path) = canonicalize_cached(path) else {
+        return false;
+    };
+    canonicalize_cached(*dirs::INSTALLS).is_some_and(|installs| path.starts_with(installs))
 }
 
 fn patch_to_status(patch: EnvDiffOperation) -> String {


### PR DESCRIPTION
## Summary
- Treat PATH entries under mise's installs directory as mise-managed during `hook-env` reactivation, even when the inherited session diff did not claim them.
- Prevent an inactive install path like `installs/node/24/bin` from being preserved as a user prefix ahead of the active project version.
- Add a zsh e2e regression for the non-interactive reactivation case from discussion #10095.

## Reproduction
The new `e2e/env/test_zsh_reactivate_drops_stale_install_path` test sets global `node = "24"`, enables `package.json` idiomatic versions, creates a project with `devEngines.runtime.version = "22.x"`, activates zsh, then simulates a parent/editor environment that prepends the inactive global Node install path before spawning a non-interactive zsh child.

Before this change, the test fails with:

```text
v24.16.0
.../installs/node/24/bin
.../installs/node/22.17.1/bin
```

After this change, reactivation keeps `node@22.17.1` first.

Discussion context: https://github.com/jdx/mise/discussions/10095#discussioncomment-17084030

## Tests
- `mise run build`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 e2e/run_test env/test_zsh_reactivate_drops_stale_install_path`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 e2e/run_test env/test_path_reorder_after_activate`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 e2e/run_test env/test_path_interleaved_regression`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 e2e/run_test cli/test_activate_multiple_zsh`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stale tool installation paths could remain in the PATH after shell reactivation, potentially causing the wrong tool version to be executed.

* **Tests**
  * Added regression test to verify PATH is correctly ordered after shell reactivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->