### PR TITLE
fix(task): include task refs in json run output

### DIFF
--- a/e2e/tasks/test_task_json_run_entries
+++ b/e2e/tasks/test_task_json_run_entries
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks.example1]
+run = "echo example1"
+
+[tasks.example2]
+run = "echo example2"
+
+[tasks.example3]
+run = "echo example3"
+
+[tasks.one_by_one]
+run = [
+  "echo start",
+  { task = "example1", args = ["--flag"], env = { FOO = "bar" } },
+  { tasks = ["example2", "example3"] },
+]
+EOF
+
+expected_run='[
+  "echo start",
+  {
+    "task": "example1",
+    "args": [
+      "--flag"
+    ],
+    "env": {
+      "FOO": "bar"
+    }
+  },
+  {
+    "tasks": [
+      "example2",
+      "example3"
+    ]
+  }
+]'
+
+assert_json "mise tasks ls --json | jq '.[] | select(.name == \"one_by_one\") | .run'" "$expected_run"
+assert_json "mise tasks info one_by_one --json | jq '.run'" "$expected_run"

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -326,7 +326,7 @@ impl ServerHandler for MiseServer {
                         "quiet": task.quiet,
                         "silent": task.silent,
                         "tools": task.tools.clone(),
-                        "run": task.run_script_strings(),
+                        "run": task.run(),
                         "usage": task.usage.clone(),
                     })
                 }).collect();

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -264,7 +264,7 @@ impl TasksLs {
                 "tools": task.tools,
                 "usage": task.usage,
                 "timeout": task.timeout,
-                "run": task.run_script_strings(),
+                "run": task.run(),
                 "args": task.args,
                 "file": task.file,
             }));


### PR DESCRIPTION
## Summary
- serialize full task `run` entries in `tasks ls --json` instead of script-only entries
- do the same for the MCP tasks resource
- add e2e coverage for mixed script, single-task, and task-group run entries in `tasks ls --json` and `tasks info --json`

Addresses https://github.com/jdx/mise/discussions/10013.

## Tests
- `mise run format`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 mise run test:e2e e2e/tasks/test_task_json_run_entries`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added end-to-end test for task JSON output validation, verifying support for array-based commands and nested task references.

* **Bug Fixes**
  * Updated task data representation in JSON output for `tasks ls` command and MCP resource endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->