### PR TITLE
fix(config): resolve registry shorthands in tool aliases

### DIFF
--- a/e2e/cli/test_tool_alias
+++ b/e2e/cli/test_tool_alias
@@ -32,3 +32,12 @@ EOF
 mise i tiny@both
 # tool_alias should take precedence - should install 1.1.0
 assert_contains "mise ls tiny" "1.1.0"
+
+# Test 4: backend aliases can point at registry shorthands and keep registry options
+cat >mise.toml <<'EOF'
+[tool_alias]
+llama = "llama.cpp"
+EOF
+
+assert "mise tool llama --backend" "github:ggml-org/llama.cpp[version_prefix=b]"
+assert "mise tool llama --tool-options --json | jq -r .version_prefix" "b"

--- a/e2e/cli/test_tool_alias
+++ b/e2e/cli/test_tool_alias
@@ -37,7 +37,11 @@ assert_contains "mise ls tiny" "1.1.0"
 cat >mise.toml <<'EOF'
 [tool_alias]
 llama = "llama.cpp"
+llama-custom = "llama.cpp[asset_pattern=llama-b{{version}}]"
 EOF
 
 assert "mise tool llama --backend" "github:ggml-org/llama.cpp[version_prefix=b]"
 assert "mise tool llama --tool-options --json | jq -r .version_prefix" "b"
+assert "mise tool llama-custom --backend" "github:ggml-org/llama.cpp[version_prefix=b,asset_pattern=llama-b{{version}}]"
+assert "mise tool llama-custom --tool-options --json | jq -r .version_prefix" "b"
+assert "mise tool llama-custom --tool-options --json | jq -r .asset_pattern" "llama-b{{version}}"

--- a/e2e/cli/test_tool_alias
+++ b/e2e/cli/test_tool_alias
@@ -40,8 +40,8 @@ llama = "llama.cpp"
 llama-custom = "llama.cpp[asset_pattern=llama-b{{version}}]"
 EOF
 
-assert "mise tool llama --backend" "github:ggml-org/llama.cpp[version_prefix=b]"
+assert "mise tool llama --backend" "github:ggml-org/llama.cpp"
 assert "mise tool llama --tool-options --json | jq -r .version_prefix" "b"
-assert "mise tool llama-custom --backend" "github:ggml-org/llama.cpp[version_prefix=b,asset_pattern=llama-b{{version}}]"
+assert "mise tool llama-custom --backend" "github:ggml-org/llama.cpp"
 assert "mise tool llama-custom --tool-options --json | jq -r .version_prefix" "b"
 assert "mise tool llama-custom --tool-options --json | jq -r .asset_pattern" "llama-b{{version}}"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -183,6 +183,33 @@ fn parse_backend_components_fallible(
     Ok((short, tool_name.to_string(), opts))
 }
 
+fn resolve_registry_backend_alias(alias: &str) -> Option<String> {
+    let alias_name = split_bracketed_opts(alias)
+        .map(|(name, _)| name)
+        .unwrap_or(alias);
+
+    if let Some((prefix, _)) = alias_name.split_once(':')
+        && BackendType::guess(prefix) != BackendType::Unknown
+    {
+        return None;
+    }
+
+    let registry_tool = REGISTRY.get(alias_name)?;
+    let full = registry_tool.backends().first()?.to_string();
+    let registry_opts = registry_tool.backend_options(&full);
+    let opts = serialize_tool_options(
+        registry_opts
+            .opts
+            .iter()
+            .filter(|(key, _)| !EPHEMERAL_OPT_KEYS.contains(&key.as_str())),
+    );
+
+    Some(match opts {
+        Some(opts) => format!("{full}[{opts}]"),
+        None => full,
+    })
+}
+
 impl BackendArg {
     #[requires(!short.is_empty())]
     pub fn new(short: String, full: Option<String>) -> Self {
@@ -366,7 +393,7 @@ impl BackendArg {
                 .get(short)
                 .and_then(|a| a.backend.clone())
             {
-                return full;
+                return resolve_registry_backend_alias(&full).unwrap_or(full);
             }
             if let Some(url) = Config::get_().repo_urls.get(short) {
                 return match install_state::get_plugin_type(short).unwrap_or(PluginType::Asdf) {

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -183,37 +183,6 @@ fn parse_backend_components_fallible(
     Ok((short, tool_name.to_string(), opts))
 }
 
-fn resolve_registry_backend_alias(alias: &str) -> Option<String> {
-    let (alias_name, alias_opts) = match split_bracketed_opts(alias) {
-        Some((name, opts)) => (name, Some(parse_tool_options(opts))),
-        None => (alias, None),
-    };
-
-    if let Some((prefix, _)) = alias_name.split_once(':')
-        && BackendType::guess(prefix) != BackendType::Unknown
-    {
-        return None;
-    }
-
-    let registry_tool = REGISTRY.get(alias_name)?;
-    let full = registry_tool.backends().first()?.to_string();
-    let mut registry_opts = registry_tool.backend_options(&full);
-    if let Some(alias_opts) = alias_opts {
-        registry_opts.apply_overrides(&alias_opts);
-    }
-    let opts = serialize_tool_options(
-        registry_opts
-            .opts
-            .iter()
-            .filter(|(key, _)| !EPHEMERAL_OPT_KEYS.contains(&key.as_str())),
-    );
-
-    Some(match opts {
-        Some(opts) => format!("{full}[{opts}]"),
-        None => full,
-    })
-}
-
 impl BackendArg {
     #[requires(!short.is_empty())]
     pub fn new(short: String, full: Option<String>) -> Self {
@@ -392,12 +361,8 @@ impl BackendArg {
         }
 
         if config::is_loaded() {
-            if let Some(full) = Config::get_()
-                .all_aliases
-                .get(short)
-                .and_then(|a| a.backend.clone())
-            {
-                return resolve_registry_backend_alias(&full).unwrap_or(full);
+            if let Some(alias) = Config::get_().resolve_backend_alias(short) {
+                return alias.full;
             }
             if let Some(url) = Config::get_().repo_urls.get(short) {
                 return match install_state::get_plugin_type(short).unwrap_or(PluginType::Asdf) {
@@ -505,6 +470,12 @@ impl BackendArg {
     }
 
     pub fn registry_opts(&self) -> ToolVersionOptions {
+        if config::is_loaded()
+            && !self.has_env_backend_override()
+            && let Some(alias) = Config::get_().resolve_backend_alias(&self.short)
+        {
+            return alias.registry_opts;
+        }
         let full = self.full_without_opts();
         REGISTRY
             .get(self.short.as_str())
@@ -525,7 +496,9 @@ impl BackendArg {
         if let Some(manifest_opts) = self.install_manifest_opts() {
             opts.apply_overrides(manifest_opts);
         }
-        if let Some(full_opts) = self.resolved_full_opts() {
+        if alias_opts.is_none()
+            && let Some(full_opts) = self.resolved_full_opts()
+        {
             opts.apply_overrides(&full_opts);
         }
         if let Some(alias_opts) = alias_opts {
@@ -573,11 +546,9 @@ impl BackendArg {
         }
         let short = unalias_backend(&self.short);
         Config::get_()
-            .all_aliases
-            .get(short)
-            .and_then(|alias| alias.backend.as_deref())
-            .and_then(|backend| split_bracketed_opts(backend).map(|(_, opts)| opts))
-            .map(parse_tool_options)
+            .resolve_backend_alias(short)
+            .map(|alias| alias.alias_opts)
+            .filter(|opts| !opts.is_empty())
     }
 
     pub fn set_opts(&mut self, opts: Option<ToolVersionOptions>) {

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -184,9 +184,10 @@ fn parse_backend_components_fallible(
 }
 
 fn resolve_registry_backend_alias(alias: &str) -> Option<String> {
-    let alias_name = split_bracketed_opts(alias)
-        .map(|(name, _)| name)
-        .unwrap_or(alias);
+    let (alias_name, alias_opts) = match split_bracketed_opts(alias) {
+        Some((name, opts)) => (name, Some(parse_tool_options(opts))),
+        None => (alias, None),
+    };
 
     if let Some((prefix, _)) = alias_name.split_once(':')
         && BackendType::guess(prefix) != BackendType::Unknown
@@ -196,7 +197,10 @@ fn resolve_registry_backend_alias(alias: &str) -> Option<String> {
 
     let registry_tool = REGISTRY.get(alias_name)?;
     let full = registry_tool.backends().first()?.to_string();
-    let registry_opts = registry_tool.backend_options(&full);
+    let mut registry_opts = registry_tool.backend_options(&full);
+    if let Some(alias_opts) = alias_opts {
+        registry_opts.apply_overrides(&alias_opts);
+    }
     let opts = serialize_tool_options(
         registry_opts
             .opts
@@ -521,9 +525,7 @@ impl BackendArg {
         if let Some(manifest_opts) = self.install_manifest_opts() {
             opts.apply_overrides(manifest_opts);
         }
-        if alias_opts.is_none()
-            && let Some(full_opts) = self.resolved_full_opts()
-        {
+        if let Some(full_opts) = self.resolved_full_opts() {
             opts.apply_overrides(&full_opts);
         }
         if let Some(alias_opts) = alias_opts {

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -819,31 +819,18 @@ impl ConfigFile for MiseToml {
                     // when config provides its own options. This allows:
                     // - Changing url/asset_pattern/checksum without reinstall issues
                     // - Preserving post-install options like bin_path for binary discovery
-                    let mut ba_opts = ba.opts().clone();
+                    let default_opts = ba.opts().clone();
+                    let mut ba_opts = default_opts.clone();
                     let backend_type = ba.backend_type();
                     ba_opts.opts.retain(|k, _| {
                         !crate::backend::is_install_time_option_key_for_type(&backend_type, k)
                     });
                     ba_opts.merge(&options.opts);
-                    // Re-apply registry defaults for install-time keys not overridden by user.
-                    // The filtering above strips both stale install-state cache AND registry
-                    // defaults. We want to keep registry defaults while discarding stale cache.
-                    if let Some(rt) = crate::registry::REGISTRY.get(ba.short.as_str()) {
-                        let full = ba.full();
-                        // Get structured options from registry (table-format backends)
-                        let mut registry_opts = rt.backend_options(&full);
-                        // Also parse inline options from [key=val,...] in the full string
-                        if let Some(start) = full.rfind('[')
-                            && full.ends_with(']')
-                        {
-                            let inline = crate::toolset::parse_tool_options(
-                                &full[start + 1..full.len() - 1],
-                            );
-                            for (k, v) in inline.opts {
-                                registry_opts.opts.entry(k).or_insert(v);
-                            }
-                        }
-                        for (k, v) in registry_opts.opts {
+                    // Re-apply backend defaults for install-time keys not overridden by user.
+                    // The filtering above strips install-time registry and alias defaults
+                    // together with stale install-state cache; only restore the defaults.
+                    for (k, v) in default_opts.opts {
+                        if crate::backend::is_install_time_option_key_for_type(&backend_type, &k) {
                             ba_opts.opts.entry(k).or_insert(v);
                         }
                     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,7 @@ use tokio::{sync::OnceCell, task::JoinSet};
 use walkdir::WalkDir;
 
 use crate::backend::ABackend;
+use crate::backend::backend_type::BackendType;
 use crate::cli::args::{BackendArg, split_bracketed_opts};
 use crate::cli::version;
 use crate::config::config_file::idiomatic_version::IdiomaticVersionFile;
@@ -83,6 +84,46 @@ pub struct Config {
 pub struct Alias {
     pub backend: Option<String>,
     pub versions: IndexMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BackendAliasResolution {
+    pub full: String,
+    pub registry_opts: ToolVersionOptions,
+    pub alias_opts: ToolVersionOptions,
+}
+
+fn resolve_backend_alias(alias: &str) -> BackendAliasResolution {
+    let (alias, alias_opts) = match split_bracketed_opts(alias) {
+        Some((alias, opts)) => (alias, crate::toolset::parse_tool_options(opts)),
+        None => (alias, ToolVersionOptions::default()),
+    };
+
+    if let Some((prefix, _)) = alias.split_once(':')
+        && BackendType::guess(prefix) != BackendType::Unknown
+    {
+        return BackendAliasResolution {
+            full: alias.to_string(),
+            registry_opts: ToolVersionOptions::default(),
+            alias_opts,
+        };
+    }
+
+    if let Some(registry_tool) = registry::REGISTRY.get(alias)
+        && let Some(full) = registry_tool.backends().first()
+    {
+        return BackendAliasResolution {
+            full: full.to_string(),
+            registry_opts: registry_tool.backend_options(full),
+            alias_opts,
+        };
+    }
+
+    BackendAliasResolution {
+        full: alias.to_string(),
+        registry_opts: ToolVersionOptions::default(),
+        alias_opts,
+    }
 }
 
 static _CONFIG: RwLock<Option<Arc<Config>>> = RwLock::new(None);
@@ -352,17 +393,23 @@ impl Config {
         backend_arg: &Arc<BackendArg>,
     ) -> Result<ResolvedToolOptions> {
         let config_opts = self.get_tool_opts(backend_arg).await?;
-        let alias_opts = self.get_backend_alias_opts(backend_arg);
+        let backend_alias = if backend_arg.has_env_backend_override() {
+            None
+        } else {
+            self.resolve_backend_alias(&backend_arg.short)
+        };
         let mut resolved = ResolvedToolOptions::default();
         resolved.apply_overrides(&backend_arg.registry_opts(), ToolOptionSource::Registry);
         if let Some(manifest_opts) = backend_arg.install_manifest_opts() {
             resolved.apply_overrides(manifest_opts, ToolOptionSource::InstallManifest);
         }
-        if let Some(full_opts) = backend_arg.resolved_full_opts() {
+        if backend_alias.is_none()
+            && let Some(full_opts) = backend_arg.resolved_full_opts()
+        {
             resolved.apply_overrides(&full_opts, ToolOptionSource::BackendAlias);
         }
-        if let Some(alias_opts) = alias_opts {
-            resolved.apply_overrides(&alias_opts, ToolOptionSource::BackendAlias);
+        if let Some(backend_alias) = backend_alias {
+            resolved.apply_overrides(&backend_alias.alias_opts, ToolOptionSource::BackendAlias);
         }
         if let Some(config_opts) = config_opts {
             resolved.apply_overrides(&config_opts, ToolOptionSource::Config);
@@ -373,16 +420,10 @@ impl Config {
         Ok(resolved)
     }
 
-    fn get_backend_alias_opts(&self, backend_arg: &BackendArg) -> Option<ToolVersionOptions> {
-        if backend_arg.has_env_backend_override() {
-            return None;
-        }
-        let short = backend::unalias_backend(&backend_arg.short);
-        self.all_aliases
-            .get(short)
-            .and_then(|alias| alias.backend.as_deref())
-            .and_then(|backend| split_bracketed_opts(backend).map(|(_, opts)| opts))
-            .map(crate::toolset::parse_tool_options)
+    pub(crate) fn resolve_backend_alias(&self, short: &str) -> Option<BackendAliasResolution> {
+        let short = backend::unalias_backend(short);
+        let alias = self.all_aliases.get(short)?.backend.as_deref()?;
+        Some(resolve_backend_alias(alias))
     }
 
     pub fn get_repo_url(&self, plugin_name: &str) -> Option<String> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -358,9 +358,7 @@ impl Config {
         if let Some(manifest_opts) = backend_arg.install_manifest_opts() {
             resolved.apply_overrides(manifest_opts, ToolOptionSource::InstallManifest);
         }
-        if alias_opts.is_none()
-            && let Some(full_opts) = backend_arg.resolved_full_opts()
-        {
+        if let Some(full_opts) = backend_arg.resolved_full_opts() {
             resolved.apply_overrides(&full_opts, ToolOptionSource::BackendAlias);
         }
         if let Some(alias_opts) = alias_opts {


### PR DESCRIPTION
## Summary

- resolve `[tool_alias]` backend targets through the registry when they name a registry shorthand
- keep registry/default/alias options in structured option layers instead of serializing them into the backend string
- add an e2e regression for registry shorthand backend aliases

## Behavior

This lets aliases like this work:

```toml
[tool_alias]
llama = "llama.cpp"
llama-custom = "llama.cpp[asset_pattern=llama-b{{version}}]"
```

`llama.cpp` is resolved through the registry to `github:ggml-org/llama.cpp`, while the registry option `version_prefix = "b"` remains available through normal tool option resolution. Alias-specific bracket options are applied as backend-alias options on top of the registry defaults.

## Implementation notes

`Config::resolve_backend_alias` parses a backend alias target into three pieces: the resolved backend string, registry options from the target if it is a registry shorthand, and inline options from the alias value. If the alias target already has a known backend prefix, such as `github:owner/repo`, it is treated as an explicit backend. Otherwise, a registry hit like `llama.cpp` is resolved to the registry backend and the registry options for that backend are kept separately.

`BackendArg::full()` now uses only the resolved backend string. Option merging stays in the existing option pipeline: registry options first, install manifest options, backend-alias options, config options, and finally inline CLI options. This keeps `mise tool llama --backend` consistent with normal registry tools while `mise tool llama --tool-options --json` shows the effective options.

The config tool-request path also reuses the already-resolved default options when config supplies its own tool options, so install-time defaults such as `version_prefix` are not accidentally dropped when a tool has local config overrides.

## Safety

The change is scoped to `[tool_alias]` entries with a `backend` value. Existing aliases that already point at full backend identifiers continue to resolve as explicit backends. Environment backend overrides still take precedence and bypass config alias resolution. Unknown bare alias targets continue to fall back to the previous bare backend string behavior.

Keeping options structured avoids the earlier fragile behavior where registry options were serialized into `BackendArg::full()` and then reparsed. It also preserves the established precedence order, so alias defaults do not override config or CLI options.

## Discussion

Addresses the behavior reported in https://github.com/jdx/mise/discussions/9316.

## Tests

- Added the e2e reproduction first and confirmed it failed at `mise tool llama --backend` before the fix.
- `CARGO_TARGET_DIR=$(cargo metadata --no-deps --format-version 1 | jq -r .target_directory) mise run test:e2e e2e/cli/test_tool_alias`
- `CARGO_TARGET_DIR=$(cargo metadata --no-deps --format-version 1 | jq -r .target_directory) mise run test:e2e e2e/backend/test_github_tool_alias_asset_pattern`
- `cargo fmt --all -- --check`
- `git diff --check`
