### PR TITLE
fix(config): honor ceiling paths during miserc discovery

### DIFF
--- a/e2e/config/test_miserc
+++ b/e2e/config/test_miserc
@@ -34,6 +34,19 @@ assert "mise ls dummy" "dummy  2.0.0 (missing)  ~/workdir/mise.test.toml  2"
 
 cd .. || exit 1
 
+# MISE_CEILING_PATHS should also limit early .miserc.toml discovery.
+rm -f .miserc.toml
+mkdir -p ceiling-parent/child/grandchild
+echo 'env = ["test"]' >ceiling-parent/.miserc.toml
+echo "tools.dummy = '1'" >ceiling-parent/child/grandchild/mise.toml
+echo "tools.dummy = '2'" >ceiling-parent/child/grandchild/mise.test.toml
+cd ceiling-parent/child/grandchild || exit 1
+export MISE_CEILING_PATHS="$HOME/workdir/ceiling-parent/child"
+assert "mise ls dummy" "dummy  1.1.0 (missing)  ~/workdir/ceiling-parent/child/grandchild/mise.toml  1"
+unset MISE_CEILING_PATHS
+
+cd ../../.. || exit 1
+
 # Test Tera template support in .miserc.toml
 # ceiling_paths with {{ env.HOME }} should expand and stop config traversal
 rm -f .miserc.toml

--- a/src/config/miserc.rs
+++ b/src/config/miserc.rs
@@ -165,6 +165,7 @@ fn merge_settings(target: &mut MisercSettings, source: MisercSettings) {
 /// Find all miserc.toml files in order of precedence (highest first).
 fn find_miserc_files() -> Vec<PathBuf> {
     let mut files = Vec::new();
+    let ceiling_paths = env_ceiling_paths();
 
     // Local hierarchy: .miserc.toml and .config/miserc.toml in cwd and ancestors
     // Use raw std::env to avoid depending on our lazy statics
@@ -172,6 +173,9 @@ fn find_miserc_files() -> Vec<PathBuf> {
         // Walk up the directory tree, but stop at home or root
         let home: &Path = &dirs::HOME;
         for dir in cwd.ancestors() {
+            if ceiling_paths.contains(dir) {
+                break;
+            }
             let path = dir.join(".miserc.toml");
             if path.is_file() {
                 files.push(path);
@@ -201,6 +205,19 @@ fn find_miserc_files() -> Vec<PathBuf> {
     }
 
     files
+}
+
+fn env_ceiling_paths() -> BTreeSet<PathBuf> {
+    // Only the raw env var is available here; env::MISE_CEILING_PATHS also
+    // falls back to .miserc, which would recurse during .miserc discovery.
+    env::var_os("MISE_CEILING_PATHS")
+        .map(|v| {
+            std::env::split_paths(&v)
+                .filter(|p| !p.as_os_str().is_empty())
+                .map(file::replace_path)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- stop early .miserc.toml discovery at raw MISE_CEILING_PATHS entries
- avoid using the lazy MISE_CEILING_PATHS fallback during .miserc discovery to prevent recursion
- add a regression case where a parent .miserc.toml above the ceiling would otherwise inject MISE_ENV

## Related
- Project item: https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=183814890
- Discussion: https://github.com/jdx/mise/discussions/5743

## Tests
- cargo test --all-features config::miserc::tests -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 mise run test:e2e e2e/config/test_miserc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `MISE_CEILING_PATHS` environment variable now properly limits how far configuration file discovery traverses up the directory hierarchy.

* **Tests**
  * Added end-to-end tests verifying ceiling path constraints on configuration file discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->