### PR TITLE
fix(tasks): show non-string task run entries in json output

### DIFF
--- a/e2e/tasks/test_task_ls_json_run_entries
+++ b/e2e/tasks/test_task_ls_json_run_entries
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# `mise tasks ls --json` should preserve non-script run entries.
+# Previously `run` was serialized via `run_script_strings()`, which
+# dropped object entries like `{ task = "..." }` and emitted `[]`.
+
+cat <<EOF >mise.toml
+[tasks.test]
+run = 'echo "ok"'
+
+[tasks.multiple]
+run = [{ task = 'tasks.test' }]
+EOF
+
+assert_contains "mise tasks ls --json" '"name": "multiple"'
+assert_contains "mise tasks ls --json" '"task": "tasks.test"'

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -326,7 +326,7 @@ impl ServerHandler for MiseServer {
                         "quiet": task.quiet,
                         "silent": task.silent,
                         "tools": task.tools.clone(),
-                        "run": task.run_script_strings(),
+                        "run": task.run(),
                         "usage": task.usage.clone(),
                     })
                 }).collect();

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -264,7 +264,7 @@ impl TasksLs {
                 "tools": task.tools,
                 "usage": task.usage,
                 "timeout": task.timeout,
-                "run": task.run_script_strings(),
+                "run": task.run(),
                 "args": task.args,
                 "file": task.file,
             }));


### PR DESCRIPTION
Fixes a bug mentioned in #10013 