### PR TITLE
fix(aqua): support GitHub attestation predicate fields

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -228,6 +228,7 @@ pub struct AquaMinisign {
 #[derive(Debug, Deserialize, Archive, RkyvDeserialize, RkyvSerialize, Clone)]
 pub struct AquaGithubArtifactAttestations {
     pub enabled: Option<bool>,
+    pub predicate_type: Option<String>,
     pub signer_workflow: Option<String>,
 }
 
@@ -1316,6 +1317,9 @@ impl AquaGithubArtifactAttestations {
         if let Some(enabled) = other.enabled {
             self.enabled = Some(enabled);
         }
+        if let Some(predicate_type) = other.predicate_type {
+            self.predicate_type = Some(predicate_type);
+        }
         if let Some(signer_workflow) = other.signer_workflow {
             self.signer_workflow = Some(signer_workflow);
         }
@@ -1376,6 +1380,30 @@ packages:
 
         assert_eq!(pkg.replacements.get("386"), Some(&"i686".to_string()));
         assert_eq!(pkg.vars[0].default.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_github_artifact_attestations_predicate_type() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - github_artifact_attestations:
+      enabled: true
+      predicate_type: https://slsa.dev/provenance/v1
+      signer_workflow: canonical-workflow.yml
+"#,
+        );
+
+        let attestations = pkg.github_artifact_attestations.unwrap();
+        assert_eq!(attestations.enabled, Some(true));
+        assert_eq!(
+            attestations.predicate_type.as_deref(),
+            Some("https://slsa.dev/provenance/v1")
+        );
+        assert_eq!(
+            attestations.signer_workflow.as_deref(),
+            Some("canonical-workflow.yml")
+        );
     }
 
     #[test]

--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -249,7 +249,7 @@ impl AttestationClient {
         Ok(headers)
     }
 
-    pub async fn fetch_attestations(&self, params: FetchParams) -> Result<Vec<Attestation>> {
+    fn attestations_url(&self, params: &FetchParams) -> Result<reqwest::Url> {
         let url = if let Some(repo) = &params.repo {
             format!(
                 "{}/repos/{repo}/attestations/{}",
@@ -266,8 +266,12 @@ impl AttestationClient {
         if let Some(predicate_type) = &params.predicate_type {
             query_params.push(("predicate_type", predicate_type.clone()));
         }
-        let url = reqwest::Url::parse_with_params(&url, query_params)
-            .map_err(|e| AttestationError::Api(format!("Invalid GitHub attestations URL: {e}")))?;
+        reqwest::Url::parse_with_params(&url, query_params)
+            .map_err(|e| AttestationError::Api(format!("Invalid GitHub attestations URL: {e}")))
+    }
+
+    pub async fn fetch_attestations(&self, params: FetchParams) -> Result<Vec<Attestation>> {
+        let url = self.attestations_url(&params)?;
 
         let response = self
             .client
@@ -1332,6 +1336,31 @@ pub async fn calculate_file_digest(path: &Path) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn attestations_url_includes_predicate_type() {
+        let client = AttestationClient::builder()
+            .base_url("https://api.github.com")
+            .build()
+            .unwrap();
+        let url = client
+            .attestations_url(&FetchParams {
+                owner: "owner".to_string(),
+                repo: Some("owner/repo".to_string()),
+                digest: "sha256:abc".to_string(),
+                limit: 30,
+                predicate_type: Some("https://slsa.dev/provenance/v1".to_string()),
+            })
+            .unwrap();
+        let query: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+
+        assert_eq!(url.path(), "/repos/owner/repo/attestations/sha256:abc");
+        assert_eq!(query.get("per_page").map(String::as_str), Some("30"));
+        assert_eq!(
+            query.get("predicate_type").map(String::as_str),
+            Some("https://slsa.dev/provenance/v1")
+        );
+    }
 
     #[test]
     fn signer_workflow_requires_identity() {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1012,7 +1012,7 @@ impl AquaBackend {
         let settings = Settings::get();
 
         // Check for GitHub artifact attestations (highest priority)
-        // The registry metadata (enabled flag, signer_workflow) is sufficient for
+        // The registry metadata (enabled flag, predicate_type, signer_workflow) is sufficient for
         // detection at lock-time. Actual cryptographic verification happens at
         // install time (always when locked_verify_provenance/paranoid is enabled,
         // or on first install when the lockfile doesn't yet have provenance).
@@ -1067,11 +1067,14 @@ impl AquaBackend {
         digest: &str,
     ) -> std::result::Result<bool, crate::github::sigstore::DetectError> {
         let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
-        crate::github::sigstore::detect_attestations(
+        crate::github::sigstore::detect_attestations_with_predicate_type(
             &pkg.repo_owner,
             &pkg.repo_name,
             github::API_URL,
             digest,
+            pkg.github_artifact_attestations
+                .as_ref()
+                .and_then(|att| att.predicate_type.as_deref()),
             self.use_versions_host_for_github_metadata(&repo),
         )
         .await
@@ -1158,12 +1161,17 @@ impl AquaBackend {
             .as_ref()
             .and_then(|att| att.signer_workflow.as_deref().map(unescape_regex_literal));
         let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
+        let predicate_type = pkg
+            .github_artifact_attestations
+            .as_ref()
+            .and_then(|att| att.predicate_type.as_deref());
 
-        match crate::github::sigstore::verify_attestation(
+        match crate::github::sigstore::verify_attestation_with_predicate_type(
             artifact_path,
             &pkg.repo_owner,
             &pkg.repo_name,
             signer_workflow.as_deref(),
+            predicate_type,
             None,
             self.use_versions_host_for_github_metadata(&repo),
         )

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -29,7 +29,7 @@
 use std::path::Path;
 
 use mise_sigstore::sources::github::GitHubSource;
-use mise_sigstore::{ArtifactRef, AttestationSource};
+use mise_sigstore::{ArtifactRef, AttestationClient, AttestationSource, FetchParams};
 
 pub use mise_sigstore::{AttestationError, SlsaArtifact};
 
@@ -54,6 +54,16 @@ fn routed_api_url(api_url: &str) -> String {
     } else {
         url.to_string()
     }
+}
+
+fn attestation_client(api_url: &str) -> AttestationResult<AttestationClient> {
+    let token = resolve_token_for_wrapper(Some(api_url));
+    let base_url = routed_api_url(api_url);
+    let mut builder = AttestationClient::builder().base_url(&base_url);
+    if let Some(token) = token.as_deref() {
+        builder = builder.github_token(token);
+    }
+    builder.build()
 }
 
 /// Verify a GitHub artifact attestation for a file on disk.
@@ -129,6 +139,50 @@ pub async fn verify_attestation(
     }
 }
 
+/// Verify a GitHub artifact attestation filtered by predicate type.
+///
+/// The versions-host cache is keyed by digest only, so predicate-filtered
+/// requests go directly to the GitHub attestations API.
+pub async fn verify_attestation_with_predicate_type(
+    artifact_path: &Path,
+    owner: &str,
+    repo: &str,
+    expected_workflow: Option<&str>,
+    predicate_type: Option<&str>,
+    api_url: Option<&str>,
+    use_versions_host: bool,
+) -> AttestationResult<bool> {
+    let Some(predicate_type) = predicate_type else {
+        return verify_attestation(
+            artifact_path,
+            owner,
+            repo,
+            expected_workflow,
+            api_url,
+            use_versions_host,
+        )
+        .await;
+    };
+
+    let artifact_digest = mise_sigstore::calculate_file_digest(artifact_path).await?;
+    let client = attestation_client(api_url.unwrap_or(crate::github::API_URL))?;
+    let attestations = client
+        .fetch_attestations(FetchParams {
+            owner: owner.to_string(),
+            repo: Some(format!("{owner}/{repo}")),
+            digest: format!("sha256:{artifact_digest}"),
+            limit: 30,
+            predicate_type: Some(predicate_type.to_string()),
+        })
+        .await?;
+    mise_sigstore::verify_github_attestation_with_attestations(
+        artifact_path,
+        &attestations,
+        expected_workflow,
+    )
+    .await
+}
+
 /// Reason the pre-download attestation probe could not complete.
 ///
 /// Preserved as two variants so callers can log distinct warnings for a misconfigured
@@ -137,8 +191,7 @@ pub async fn verify_attestation(
 /// wrapper keeps that signal instead of flattening both into one error string.
 #[derive(Debug)]
 pub enum DetectError {
-    /// `GitHubSource::with_base_url` rejected the (owner, repo, api_url) tuple — usually a
-    /// malformed base URL.
+    /// Attestation source/client construction rejected the base URL.
     SourceCreation(AttestationError),
     /// The attestations endpoint returned an error (403 rate-limit, 5xx, network failure).
     Fetch(AttestationError),
@@ -195,6 +248,41 @@ pub async fn detect_attestations(
     let artifact_ref = ArtifactRef::from_digest(digest);
     let attestations = source
         .fetch_attestations(&artifact_ref)
+        .await
+        .map_err(DetectError::Fetch)?;
+    Ok(!attestations.is_empty())
+}
+
+/// Probe the GitHub attestation API for the given digest and predicate type.
+///
+/// The versions-host cache is keyed by digest only, so predicate-filtered
+/// requests go directly to the GitHub attestations API.
+pub async fn detect_attestations_with_predicate_type(
+    owner: &str,
+    repo: &str,
+    api_url: &str,
+    digest: &str,
+    predicate_type: Option<&str>,
+    use_versions_host: bool,
+) -> Result<bool, DetectError> {
+    let Some(predicate_type) = predicate_type else {
+        return detect_attestations(owner, repo, api_url, digest, use_versions_host).await;
+    };
+
+    let client = attestation_client(api_url).map_err(DetectError::SourceCreation)?;
+    let digest = if digest.contains(':') {
+        digest.to_string()
+    } else {
+        format!("sha256:{digest}")
+    };
+    let attestations = client
+        .fetch_attestations(FetchParams {
+            owner: owner.to_string(),
+            repo: Some(format!("{owner}/{repo}")),
+            digest,
+            limit: 30,
+            predicate_type: Some(predicate_type.to_string()),
+        })
         .await
         .map_err(DetectError::Fetch)?;
     Ok(!attestations.is_empty())


### PR DESCRIPTION
## Summary
- model aqua `github_artifact_attestations.predicate_type`
- pass predicate filters into GitHub attestation detection and verification for aqua packages
- bypass the digest-only versions-host attestation cache when a predicate filter is configured

## Field References
- aqua `github_artifact_attestations` docs: https://aquaproj.github.io/docs/reference/registry-config/github-artifact-attestations/
- aqua Go config type for `predicate_type`: https://pkg.go.dev/github.com/aquaproj/aqua/v2/pkg/config/registry#GitHubArtifactAttestations
- GitHub REST attestation `predicate_type` query filter: https://docs.github.com/en/rest/orgs/attestations?apiVersion=2022-11-28#list-attestations
- GitHub CLI `gh attestation verify --predicate-type`: https://cli.github.com/manual/gh_attestation_verify
- SPDX specification index: https://spdx.dev/specifications/

## Packages Using This Field
Current aqua-registry entries using `github_artifact_attestations.predicate_type`:

- `foundry-rs/foundry`: https://github.com/aquaproj/aqua-registry/blob/main/pkgs/foundry-rs/foundry/registry.yaml#L41-L43
  - configured predicate: `https://spdx.dev/Document/v2.3`
  - Foundry generates an SPDX SBOM with Syft and then creates an SBOM attestation for the release archive: https://github.com/foundry-rs/foundry/blob/master/.github/workflows/release.yml#L291-L345
- `gleam-lang/gleam`: https://github.com/aquaproj/aqua-registry/blob/main/pkgs/gleam-lang/gleam/registry.yaml#L143-L145 and https://github.com/aquaproj/aqua-registry/blob/main/pkgs/gleam-lang/gleam/registry.yaml#L162-L164
  - configured predicate: `https://spdx.dev/Document/v2.3`
  - Gleam generates SPDX and CycloneDX build SBOMs, then attests the release archive using the SPDX SBOM path: https://github.com/gleam-lang/gleam/blob/main/.github/actions/build-release/action.yml#L215-L270

## SPDX SBOM vs SLSA Provenance
SPDX is a standard Software Bill of Materials format. An SPDX SBOM answers "what is in this artifact?" It lists package/component metadata such as dependencies, versions, relationships, licenses, and related identifiers. The predicate value `https://spdx.dev/Document/v2.3` identifies an in-toto/GitHub attestation whose predicate payload is an SPDX 2.3 document.

SLSA provenance answers "where and how did this artifact come from?" It describes the source, builder, workflow, build inputs, and build parameters for an artifact. The common GitHub provenance predicate is `https://slsa.dev/provenance/v1`.

Short version: SPDX SBOM is inventory; SLSA provenance is build origin.

## Why Foundry and Gleam Use SPDX Here
Both package entries point at release workflows that generate SBOMs and create GitHub artifact attestations with an SBOM payload. That means the attestation the registry is asking aqua/mise to verify is specifically an SPDX SBOM attestation, not the default SLSA provenance attestation.

This does not mean SLSA is unimportant or unavailable. It means this particular aqua registry field is being used to select the SBOM attestation for the release archive. Foundry also has a separate generic/provenance-style attestation step, but the aqua registry entry explicitly configures the SPDX predicate for the archive SBOM attestation.

## Why aqua Supports This
GitHub artifact attestations are not limited to SLSA provenance. GitHub's API and `gh attestation verify` both accept a predicate type filter so callers can select provenance, SBOM, release, or custom predicate attestations. aqua exposes `predicate_type` so registry entries can preserve that upstream verification policy instead of hard-coding one attestation kind.

## Why mise Needs This
mise consumes aqua-registry metadata. If mise ignores `predicate_type`, it cannot faithfully implement the registry's requested verification policy for packages like Foundry and Gleam.

Before this PR, `predicate_type` was not parsed or sent to GitHub. For these packages, mise treated GitHub artifact attestation verification as "find any valid attestation for this artifact and signer workflow." That could pass by verifying a different predicate type when multiple attestations exist, or pass an SPDX attestation only accidentally because the unfiltered API result happened to include it. It did not enforce "verify the SPDX SBOM attestation" as requested by aqua-registry.

This PR changes that behavior by sending `predicate_type` to GitHub during detection and verification. Because mise's versions-host attestation cache is keyed by digest only, predicate-filtered requests bypass that cache and query GitHub directly.

## Tests
- `mise run format` (includes `cargo check --all-features`)
- `cargo test -p aqua-registry test_github_artifact_attestations_predicate_type -- --nocapture`
- `cargo test -p mise-sigstore attestations_url_includes_predicate_type -- --nocapture`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub artifact attestations now support an optional predicate-type filter sourced from registry metadata and applied during provenance detection and cryptographic verification, and attestation fetches include predicate-type when present.

* **Tests**
  * Added unit tests covering predicate-type deserialization, URL construction including predicate-type, and predicate-filtered attestation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->