### PR TITLE
Webpage: Use most modern tools

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -103,7 +103,7 @@ hero:
           <pre><code>$ curl https://mise.run | sh<br />✓ mise installed<br /><br />$ mise doctor<br />✓ mise is ready</code></pre>
         </div>
         <div class="recipe-panel recipe-panel-2">
-          <pre><code>$ mise use node@24 python@3.13 terraform@1<br />✓ wrote mise.toml<br /><br />$ mise install<br />✓ installed 3 tools</code></pre>
+          <pre><code>$ mise use node@26 python@3.14 terraform@1<br />✓ wrote mise.toml<br /><br />$ mise install<br />✓ installed 3 tools</code></pre>
         </div>
         <div class="recipe-panel recipe-panel-3">
           <pre><code>$ cat .env.local<br />DATABASE_URL=postgres://localhost/orders<br /><br />$ mise env -s bash<br />export DATABASE_URL=postgres://localhost/orders</code></pre>


### PR DESCRIPTION
At the top of https://mise.jdx.dev energize users with the most modern tools.
```diff
- <pre><code>$ mise use node@24 python@3.13 terraform@1<br />✓ wrote mise.toml<br /><br />$ mise install<br />✓ installed 3 tools</code></pre>
+ <pre><code>$ mise use node@26 python@3.14 terraform@1<br />✓ wrote mise.toml<br /><br />$ mise install<br />✓ installed 3 tools</code></pre>
```
https://nodejs.org/en/about/previous-releases -- Node.js v26 was released on May 05, 2026.
https://devguide.python.org/versions -- Python v3.14 was released on October 07, 2025.