### PR TITLE
registry: use aqua for aube

### DIFF
--- a/registry/aube.toml
+++ b/registry/aube.toml
@@ -1,3 +1,3 @@
-backends = ["github:endevco/aube", "cargo:aube"]
+backends = ["aqua:endevco/aube", "github:endevco/aube", "cargo:aube"]
 description = "A fast Node.js package manager"
 test = { cmd = "aube --version", expected = "{{version}}" }


### PR DESCRIPTION
## Summary
- Prefer `aqua:endevco/aube` for the `aube` registry shorthand.
- Keep the existing `github:` and `cargo:` entries as fallbacks.

This should land after the aqua-registry aube libc variant update so glibc hosts get the optimized glibc asset via aqua and musl hosts keep the musl asset.

Upstream aqua-registry branch: https://github.com/jdx/aqua-registry/tree/feat/aube-libc-variants
Related discussion: https://github.com/aquaproj/aqua-registry/issues/54615

## Tests
- `cargo test registry::`
- `cargo run --quiet -- registry aube --json | jq -r '.backends | join(" ")'`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry backend ordering change with no runtime or security logic in mise itself.
> 
> **Overview**
> The `aube` registry entry now tries **`aqua:endevco/aube` first**, with **`github:endevco/aube`** and **`cargo:aube`** unchanged as fallbacks.
> 
> That ordering lets installs use aqua’s libc-specific release assets (glibc vs musl) once the upstream aqua-registry update is available, instead of defaulting to GitHub/Cargo first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f6b71ee72c6843451f03bf1d6043d5d02316bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->