### PR TITLE
chore: release 2026.5.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [2026.5.18](https://github.com/jdx/mise/compare/v2026.5.17..v2026.5.18) - 2026-05-31
+
+### 🚀 Features
+
+- **(config)** add script arrays for hooks by @risu729 in [#9836](https://github.com/jdx/mise/pull/9836)
+
+### 🐛 Bug Fixes
+
+- **(conda)** include channel in lock identity by @risu729 in [#9984](https://github.com/jdx/mise/pull/9984)
+- **(config)** honor ceiling paths during miserc discovery by @risu729 in [#10165](https://github.com/jdx/mise/pull/10165)
+- **(env)** drop stale install paths during reactivation by @risu729 in [#10162](https://github.com/jdx/mise/pull/10162)
+- **(github)** include target artifact options in lock identity by @risu729 in [#9985](https://github.com/jdx/mise/pull/9985)
+- **(installer)** add missing warn helper by @risu729 in [#10157](https://github.com/jdx/mise/pull/10157)
+- **(python)** include sysconfig patch option in lock identity by @risu729 in [#10161](https://github.com/jdx/mise/pull/10161)
+- **(rust)** include toolchain install options in lock identity by @risu729 in [#9988](https://github.com/jdx/mise/pull/9988)
+- **(task)** include task refs in json run output by @risu729 in [#10163](https://github.com/jdx/mise/pull/10163)
+- **(task)** bump usage for completions by @jdx in [#10181](https://github.com/jdx/mise/pull/10181)
+
+### Chore
+
+- **(ci)** revert switch back to github-hosted runners by @jdx in [#10184](https://github.com/jdx/mise/pull/10184)
+- **(npm)** publish mise package by @jdx in [#10183](https://github.com/jdx/mise/pull/10183)
+
 ## [2026.5.17](https://github.com/jdx/mise/compare/v2026.5.16..v2026.5.17) - 2026-05-31
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.5.17"
+version = "2026.5.18"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.5.17"
+version = "2026.5.18"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.5.17 macos-arm64 (2026-05-31)
+2026.5.18 macos-arm64 (2026-05-31)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_17.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_18.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_17.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_18.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_17.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_18.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_17.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_18.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.5.17";
+  version = "2026.5.18";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.5.17
+Version: 2026.5.18
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.5.17"
+version: "2026.5.18"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.


### PR DESCRIPTION
### 🚀 Features

- **(config)** add script arrays for hooks by @risu729 in [#9836](https://github.com/jdx/mise/pull/9836)

### 🐛 Bug Fixes

- **(conda)** include channel in lock identity by @risu729 in [#9984](https://github.com/jdx/mise/pull/9984)
- **(config)** honor ceiling paths during miserc discovery by @risu729 in [#10165](https://github.com/jdx/mise/pull/10165)
- **(env)** drop stale install paths during reactivation by @risu729 in [#10162](https://github.com/jdx/mise/pull/10162)
- **(github)** include target artifact options in lock identity by @risu729 in [#9985](https://github.com/jdx/mise/pull/9985)
- **(installer)** add missing warn helper by @risu729 in [#10157](https://github.com/jdx/mise/pull/10157)
- **(python)** include sysconfig patch option in lock identity by @risu729 in [#10161](https://github.com/jdx/mise/pull/10161)
- **(rust)** include toolchain install options in lock identity by @risu729 in [#9988](https://github.com/jdx/mise/pull/9988)
- **(task)** include task refs in json run output by @risu729 in [#10163](https://github.com/jdx/mise/pull/10163)
- **(task)** bump usage for completions by @jdx in [#10181](https://github.com/jdx/mise/pull/10181)

### Chore

- **(ci)** revert switch back to github-hosted runners by @jdx in [#10184](https://github.com/jdx/mise/pull/10184)
- **(npm)** publish mise package by @jdx in [#10183](https://github.com/jdx/mise/pull/10183)