### PR TITLE
fix(aqua): support deprecated signer-workflow field

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -223,7 +223,9 @@ pub struct AquaMinisign {
 #[derive(Debug, Deserialize, Archive, RkyvDeserialize, RkyvSerialize, Clone)]
 pub struct AquaGithubArtifactAttestations {
     pub enabled: Option<bool>,
-    pub signer_workflow: Option<String>,
+    signer_workflow: Option<String>,
+    #[serde(rename = "signer-workflow")]
+    signer_workflow_deprecated: Option<String>,
 }
 
 /// Checksum verification configuration
@@ -1194,12 +1196,19 @@ impl AquaMinisign {
 }
 
 impl AquaGithubArtifactAttestations {
+    pub fn signer_workflow(&self) -> Option<&str> {
+        self.signer_workflow
+            .as_deref()
+            .or(self.signer_workflow_deprecated.as_deref())
+    }
+
     fn merge(&mut self, other: Self) {
         if let Some(enabled) = other.enabled {
             self.enabled = Some(enabled);
         }
-        if let Some(signer_workflow) = other.signer_workflow {
+        if let Some(signer_workflow) = other.signer_workflow.or(other.signer_workflow_deprecated) {
             self.signer_workflow = Some(signer_workflow);
+            self.signer_workflow_deprecated = None;
         }
     }
 }
@@ -1258,6 +1267,41 @@ packages:
 
         assert_eq!(pkg.replacements.get("386"), Some(&"i686".to_string()));
         assert_eq!(pkg.vars[0].default.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_github_artifact_attestations_signer_workflow_fields() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - github_artifact_attestations:
+      signer_workflow: canonical-workflow.yml
+      signer-workflow: deprecated-workflow.yml
+"#,
+        );
+
+        let attestations = pkg.github_artifact_attestations.unwrap();
+        assert_eq!(
+            attestations.signer_workflow(),
+            Some("canonical-workflow.yml")
+        );
+    }
+
+    #[test]
+    fn test_github_artifact_attestations_deprecated_signer_workflow() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - github_artifact_attestations:
+      signer-workflow: deprecated-workflow.yml
+"#,
+        );
+
+        let attestations = pkg.github_artifact_attestations.unwrap();
+        assert_eq!(
+            attestations.signer_workflow(),
+            Some("deprecated-workflow.yml")
+        );
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -228,7 +228,7 @@ impl Backend for AquaBackend {
             let signer_workflow = all_pkgs
                 .iter()
                 .filter_map(|p| p.github_artifact_attestations.as_ref())
-                .find_map(|a| a.signer_workflow.clone());
+                .find_map(|a| a.signer_workflow().map(String::from));
             features.push(SecurityFeature::GithubAttestations { signer_workflow });
         }
 
@@ -1154,7 +1154,7 @@ impl AquaBackend {
         let signer_workflow = pkg
             .github_artifact_attestations
             .as_ref()
-            .and_then(|att| att.signer_workflow.as_deref().map(unescape_regex_literal));
+            .and_then(|att| att.signer_workflow().map(unescape_regex_literal));
 
         match crate::github::sigstore::verify_attestation(
             artifact_path,


### PR DESCRIPTION
## Summary
- parse deprecated aqua YAML field `github_artifact_attestations.signer-workflow`
- keep `signer_workflow` as the preferred canonical field
- route call sites through a `signer_workflow()` accessor so deprecated-field-only registry entries are honored

## Context
Aqua kept the old hyphenated YAML field for compatibility while moving to canonical `signer_workflow`. Its accessor prefers `signer_workflow` and falls back to deprecated `signer-workflow`.

This PR mirrors that behavior in mise's aqua-registry model. It intentionally does not include `predicate_type` support; that remains scoped to #10169.

## Tests
- `cargo check -p mise --all-features`
- `cargo test -p aqua-registry test_github_artifact_attestations -- --nocapture`
