### PR TITLE
fix(dotnet): include runtime in lock identity

### DIFF
--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -8,15 +8,15 @@ use serde::Deserialize;
 use versions::Versioning;
 
 use crate::backend::Backend;
-use crate::backend::VersionInfo;
 use crate::backend::options::BackendOptions;
+use crate::backend::{VersionInfo, platform_target::PlatformTarget};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::parallel;
-use crate::toolset::{ToolVersion, ToolVersionOptions, Toolset};
+use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{dirs, env, file, plugins};
 
@@ -43,6 +43,14 @@ impl<'a> DotnetOptions<'a> {
 
     fn runtime_framework_name(&self) -> Option<&'static str> {
         self.runtime().and_then(runtime_framework_name)
+    }
+
+    fn lockfile_options(&self) -> BTreeMap<String, String> {
+        let mut opts = BTreeMap::new();
+        if let Some(runtime) = self.runtime() {
+            opts.insert("runtime".to_string(), runtime.to_string());
+        }
+        opts
     }
 }
 
@@ -83,6 +91,15 @@ impl Backend for DotnetPlugin {
 
     fn supports_lockfile_url(&self) -> bool {
         false
+    }
+
+    fn resolve_lockfile_options(
+        &self,
+        request: &ToolRequest,
+        _target: &PlatformTarget,
+    ) -> BTreeMap<String, String> {
+        let raw_opts = request.options();
+        DotnetOptions::new(&raw_opts).lockfile_options()
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
@@ -417,6 +434,7 @@ impl PartialOrd for SortedVersion {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::toolset::ToolSource;
 
     fn opts_with_runtime(runtime: &str) -> ToolVersionOptions {
         let mut opts = ToolVersionOptions::default();
@@ -436,6 +454,37 @@ mod tests {
         assert_eq!(
             parsed.runtime_framework_name(),
             Some("Microsoft.AspNetCore.App")
+        );
+    }
+
+    #[test]
+    fn dotnet_lockfile_options_include_runtime() {
+        let opts = opts_with_runtime("dotnet");
+        assert_eq!(
+            DotnetOptions::new(&opts).lockfile_options(),
+            BTreeMap::from([("runtime".to_string(), "dotnet".to_string())])
+        );
+        assert!(
+            DotnetOptions::new(&ToolVersionOptions::default())
+                .lockfile_options()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn resolve_lockfile_options_include_runtime() {
+        let backend = DotnetPlugin::new();
+        let request = ToolRequest::new_opts(
+            backend.ba().clone(),
+            "8.0.14",
+            opts_with_runtime("aspnetcore"),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+
+        assert_eq!(
+            backend.resolve_lockfile_options(&request, &PlatformTarget::from_current()),
+            BTreeMap::from([("runtime".to_string(), "aspnetcore".to_string())])
         );
     }
 }

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -486,5 +486,18 @@ mod tests {
             backend.resolve_lockfile_options(&request, &PlatformTarget::from_current()),
             BTreeMap::from([("runtime".to_string(), "aspnetcore".to_string())])
         );
+
+        let request_no_runtime = ToolRequest::new_opts(
+            backend.ba().clone(),
+            "8.0.14",
+            ToolVersionOptions::default(),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        assert!(
+            backend
+                .resolve_lockfile_options(&request_no_runtime, &PlatformTarget::from_current())
+                .is_empty()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add core dotnet lockfile option identity for the `runtime` tool option
- keep SDK installs using the default empty lock option set
- add unit coverage for the dotnet option mapper and backend hook, including SDK/no-runtime behavior

## Context
This implements the missing PR D follow-up from https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=185472417. The direct `dotnet:` backend was not the target; this change applies to the core .NET plugin in `src/plugins/core/dotnet.rs`.

## Why `runtime` belongs in the lock identity
The core .NET plugin installs an SDK by default, but `runtime = "..."` changes the artifact class passed to `dotnet-install` and installs a runtime-only shared framework instead. Those are different install results even when the requested .NET version string is the same.

Lockfile entries are looked up by resolved version plus backend lockfile options. Without including `runtime`, an SDK request and a runtime request for the same version can share a lock entry, leaving one install to reuse stale identity from the other. Keeping SDK installs as the empty option set preserves existing lock entries, while adding `runtime` only for runtime installs makes SDK and runtime lock entries distinct.

## Tests
- `cargo fmt --check`
- `cargo test dotnet_lockfile_options_include_runtime`
- `cargo test resolve_lockfile_options_include_runtime`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved .NET tool support for lockfile-specific options and runtime configuration.

* **Tests**
  * Added test coverage for .NET lockfile handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->