### PR TITLE
fix(rust): store toolchain options on idiomatic requests

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -33,8 +33,8 @@ use crate::runtime_symlinks::is_runtime_symlink;
 use crate::tera::{contains_template_syntax, get_tera, render_str};
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{
-    ResolveOptions, ToolOptionSource, ToolRequest, ToolVersion, Toolset, install_state,
-    is_outdated_version,
+    ResolveOptions, ToolOptionSource, ToolRequest, ToolVersion, ToolVersionOptions, Toolset,
+    install_state, is_outdated_version,
 };
 use crate::ui::progress_report::SingleReport;
 use crate::{
@@ -81,6 +81,7 @@ pub mod vfox;
 pub type ABackend = Arc<dyn Backend>;
 pub type BackendMap = BTreeMap<String, ABackend>;
 pub type BackendList = Vec<ABackend>;
+pub type IdiomaticVersion = (String, Option<ToolVersionOptions>);
 pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 
 pub(crate) const MISE_BINS_DIR: &str = ".mise-bins";
@@ -1786,6 +1787,52 @@ pub trait Backend: Debug + Send + Sync {
             );
         }
         self._parse_idiomatic_file(path).await
+    }
+
+    /// Parses an idiomatic version file to extract versions plus backend options
+    /// implied by that file.
+    async fn parse_idiomatic_file_with_options(
+        &self,
+        path: &Path,
+    ) -> eyre::Result<Vec<(String, ToolVersionOptions)>> {
+        let versions =
+            if crate::config::config_file::idiomatic_version::package_json::is_package_json(path) {
+                crate::config::config_file::idiomatic_version::package_json::parse(path, self.id())?
+                    .into_iter()
+                    .map(|version| (version, None))
+                    .collect()
+            } else {
+                self._parse_idiomatic_file_with_options(path).await?
+            };
+        let options = self.ba().opts();
+        Ok(versions
+            .into_iter()
+            .map(|(version, file_options)| {
+                let mut options = options.clone();
+                if let Some(file_options) = file_options {
+                    options.apply_overrides(&file_options);
+                }
+                (version, options)
+            })
+            .collect())
+    }
+
+    /// Backend-specific implementation for `parse_idiomatic_file_with_options`.
+    /// Backends overriding this should only parse the file and return options
+    /// implied by the file itself. Return `None` when a parsed version has no
+    /// file-specific options. The public wrapper merges any returned options
+    /// with `self.ba().opts()` so registry, alias, and backend defaults are
+    /// preserved centrally.
+    async fn _parse_idiomatic_file_with_options(
+        &self,
+        path: &Path,
+    ) -> eyre::Result<Vec<IdiomaticVersion>> {
+        Ok(self
+            .parse_idiomatic_file(path)
+            .await?
+            .into_iter()
+            .map(|version| (version, None))
+            .collect())
     }
 
     /// Backend-specific implementation for `parse_idiomatic_file`.

--- a/src/config/config_file/idiomatic_version/mod.rs
+++ b/src/config/config_file/idiomatic_version/mod.rs
@@ -7,8 +7,6 @@ use crate::cli::args::BackendArg;
 use crate::config::config_file::ConfigFile;
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource};
 
-use super::ConfigFileType;
-
 pub mod package_json;
 
 #[derive(Debug, Clone)]
@@ -53,10 +51,6 @@ impl IdiomaticVersionFile {
 }
 
 impl ConfigFile for IdiomaticVersionFile {
-    fn config_type(&self) -> ConfigFileType {
-        ConfigFileType::IdiomaticVersion(vec![])
-    }
-
     fn get_path(&self) -> &Path {
         self.path.as_path()
     }

--- a/src/config/config_file/idiomatic_version/mod.rs
+++ b/src/config/config_file/idiomatic_version/mod.rs
@@ -7,6 +7,8 @@ use crate::cli::args::BackendArg;
 use crate::config::config_file::ConfigFile;
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource};
 
+use super::ConfigFileType;
+
 pub mod package_json;
 
 #[derive(Debug, Clone)]
@@ -16,15 +18,26 @@ pub struct IdiomaticVersionFile {
 }
 
 impl IdiomaticVersionFile {
+    #[allow(dead_code)]
+    #[cfg(test)]
+    pub fn init(path: PathBuf) -> Self {
+        Self {
+            path,
+            tools: ToolRequestSet::new(),
+        }
+    }
+
     pub async fn parse(path: PathBuf, plugins: BackendList) -> Result<Self> {
         let source = ToolSource::IdiomaticVersionFile(path.clone());
         let mut tools = ToolRequestSet::new();
 
         for plugin in plugins {
-            match plugin.parse_idiomatic_file(&path).await {
+            match plugin.parse_idiomatic_file_with_options(&path).await {
                 Ok(versions) => {
-                    for v in versions {
-                        let tr = ToolRequest::new(plugin.ba().clone(), &v, source.clone())?;
+                    for (version, options) in versions {
+                        let mut tr =
+                            ToolRequest::new(plugin.ba().clone(), &version, source.clone())?;
+                        tr.set_options(options);
                         tools.add_version(tr, &source);
                     }
                 }
@@ -40,6 +53,10 @@ impl IdiomaticVersionFile {
 }
 
 impl ConfigFile for IdiomaticVersionFile {
+    fn config_type(&self) -> ConfigFileType {
+        ConfigFileType::IdiomaticVersion(vec![])
+    }
+
     fn get_path(&self) -> &Path {
         self.path.as_path()
     }

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -3,14 +3,13 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::backend::VersionInfo;
 use crate::backend::options::BackendOptions;
-use crate::backend::{Backend, platform_target::PlatformTarget};
+use crate::backend::{Backend, IdiomaticVersion, platform_target::PlatformTarget};
 use crate::build_time::TARGET;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
-use crate::toolset::ToolSource::IdiomaticVersionFile;
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{ResolveOptions, ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
@@ -41,33 +40,38 @@ impl<'a> RustOptions<'a> {
     }
 
     fn comma_list(&self, name: &str) -> Option<Vec<String>> {
-        self.values
-            .str(name)
-            .map(|c| c.split(',').map(|s| s.trim().to_string()).collect())
+        match self.values.raw().opts.get(name) {
+            Some(toml::Value::String(value)) => Some(
+                value
+                    .split(',')
+                    .map(|value| value.trim().to_string())
+                    .collect(),
+            ),
+            Some(toml::Value::Array(values)) => Some(
+                values
+                    .iter()
+                    .filter_map(|value| value.as_str().map(|value| value.trim().to_string()))
+                    .collect(),
+            ),
+            _ => None,
+        }
     }
 
-    fn install_args(
-        &self,
-        rt: Option<&RustToolchain>,
-    ) -> (Option<String>, Option<Vec<String>>, Option<Vec<String>>) {
-        let profile = rt
-            .and_then(|rt| rt.profile.clone())
-            .or_else(|| self.profile().map(str::to_string));
-        let components = rt
-            .and_then(|rt| rt.components.clone())
-            .or_else(|| self.comma_list("components"));
-        let targets = rt
-            .and_then(|rt| rt.targets.clone())
-            .or_else(|| self.comma_list("targets"));
+    fn install_args(&self) -> (Option<String>, Option<Vec<String>>, Option<Vec<String>>) {
+        let profile = self.profile().map(str::to_string);
+        let components = self.comma_list("components");
+        let targets = self.comma_list("targets");
 
         (profile, components, targets)
     }
 
-    fn lockfile_options(&self, rt: Option<&RustToolchain>) -> BTreeMap<String, String> {
-        let (profile, components, targets) = self.install_args(rt);
+    fn lockfile_options(&self) -> BTreeMap<String, String> {
+        let (profile, components, targets) = self.install_args();
         let mut opts = BTreeMap::new();
 
-        if let Some(profile) = profile {
+        if let Some(profile) = profile
+            && !profile.is_empty()
+        {
             opts.insert("profile".into(), profile);
         }
         if let Some(components) = components
@@ -75,6 +79,7 @@ impl<'a> RustOptions<'a> {
         {
             let mut components = components;
             components.sort();
+            components.dedup();
             opts.insert("components".into(), components.join(","));
         }
         if let Some(targets) = targets
@@ -82,6 +87,7 @@ impl<'a> RustOptions<'a> {
         {
             let mut targets = targets;
             targets.sort();
+            targets.dedup();
             opts.insert("targets".into(), targets.join(","));
         }
 
@@ -156,13 +162,8 @@ impl Backend for RustPlugin {
         request: &ToolRequest,
         _target: &PlatformTarget,
     ) -> Result<BTreeMap<String, String>> {
-        let rt = match request.source() {
-            IdiomaticVersionFile(path) => parse_idiomatic_file(path).ok(),
-            _ => None,
-        };
-
         let raw_opts = request.options();
-        Ok(RustOptions::new(&raw_opts).lockfile_options(rt.as_ref()))
+        Ok(RustOptions::new(&raw_opts).lockfile_options())
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
@@ -203,18 +204,35 @@ impl Backend for RustPlugin {
     }
 
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
+        Ok(self
+            ._parse_idiomatic_file_with_options(path)
+            .await?
+            .into_iter()
+            .map(|(version, _)| version)
+            .collect())
+    }
+
+    async fn _parse_idiomatic_file_with_options(
+        &self,
+        path: &Path,
+    ) -> Result<Vec<IdiomaticVersion>> {
         let rt = parse_idiomatic_file(path)?;
         if rt.channel.is_empty() {
             return Ok(vec![]);
         }
-        Ok(vec![rt.channel])
+        let options = rt.apply_to_options(ToolVersionOptions::default());
+        Ok(vec![(
+            rt.channel.clone(),
+            (!options.is_empty()).then_some(options),
+        )])
     }
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         self.setup_rustup(ctx, &tv).await?;
         let ts = ctx.config.get_toolset().await?;
 
-        let (profile, components, targets) = get_args(&tv);
+        let raw_opts = tv.request.options();
+        let (profile, components, targets) = RustOptions::new(&raw_opts).install_args();
 
         let mut cmd = CmdLineRunner::new(RUSTUP_BIN)
             .with_pr(ctx.pr.as_ref())
@@ -341,18 +359,31 @@ struct RustToolchain {
     targets: Option<Vec<String>>,
 }
 
-fn get_args(tv: &ToolVersion) -> (Option<String>, Option<Vec<String>>, Option<Vec<String>>) {
-    let rt = if tv.request.source().is_idiomatic_version_file() {
-        match tv.request.source() {
-            IdiomaticVersionFile(path) => parse_idiomatic_file(path).ok(),
-            _ => None,
+impl RustToolchain {
+    fn apply_to_options(&self, options: ToolVersionOptions) -> ToolVersionOptions {
+        let mut opts = options;
+        if let Some(profile) = &self.profile {
+            opts.opts
+                .insert("profile".into(), toml::Value::String(profile.clone()));
         }
-    } else {
-        None
-    };
+        if let Some(components) = &self.components {
+            opts.opts
+                .insert("components".into(), string_array(components));
+        }
+        if let Some(targets) = &self.targets {
+            opts.opts.insert("targets".into(), string_array(targets));
+        }
+        opts
+    }
+}
 
-    let raw_opts = tv.request.options();
-    RustOptions::new(&raw_opts).install_args(rt.as_ref())
+fn string_array(values: &[String]) -> toml::Value {
+    toml::Value::Array(
+        values
+            .iter()
+            .map(|value| toml::Value::String(value.clone()))
+            .collect(),
+    )
 }
 
 fn parse_idiomatic_file(path: &Path) -> Result<RustToolchain> {
@@ -497,7 +528,7 @@ mod tests {
             toml::Value::String("wasm32-wasip1".to_string()),
         );
 
-        let (profile, components, targets) = RustOptions::new(&opts).install_args(None);
+        let (profile, components, targets) = RustOptions::new(&opts).install_args();
 
         assert_eq!(profile, Some("minimal".to_string()));
         assert_eq!(
@@ -514,10 +545,42 @@ mod tests {
             profile: Some("default".to_string()),
             ..Default::default()
         };
+        let opts = rt.apply_to_options(opts);
 
-        let (profile, _, _) = RustOptions::new(&opts).install_args(Some(&rt));
+        let (profile, _, _) = RustOptions::new(&opts).install_args();
 
         assert_eq!(profile, Some("default".to_string()));
+    }
+
+    #[tokio::test]
+    async fn rust_idiomatic_options_are_tool_options() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("rust-toolchain.toml");
+        std::fs::write(
+            &path,
+            r#"
+[toolchain]
+channel = "1.85.0"
+profile = "minimal"
+components = [" rustfmt ", "clippy", "clippy"]
+targets = ["wasm32-wasip1", " wasm32-wasip1 "]
+"#,
+        )?;
+
+        let plugin = RustPlugin::new();
+        let versions = plugin.parse_idiomatic_file_with_options(&path).await?;
+        let (version, options) = versions.into_iter().next().unwrap();
+
+        assert_eq!(version, "1.85.0");
+        assert_eq!(
+            RustOptions::new(&options).lockfile_options(),
+            BTreeMap::from([
+                ("components".to_string(), "clippy,rustfmt".to_string()),
+                ("profile".to_string(), "minimal".to_string()),
+                ("targets".to_string(), "wasm32-wasip1".to_string()),
+            ])
+        );
+        Ok(())
     }
 
     #[test]
@@ -533,7 +596,7 @@ mod tests {
         );
 
         assert_eq!(
-            RustOptions::new(&opts).lockfile_options(None),
+            RustOptions::new(&opts).lockfile_options(),
             BTreeMap::from([
                 ("components".to_string(), "clippy,rustfmt".to_string()),
                 ("profile".to_string(), "minimal".to_string()),
@@ -543,20 +606,28 @@ mod tests {
     }
 
     #[test]
-    fn rust_lockfile_options_use_idiomatic_options() {
+    fn rust_idiomatic_options_override_inline_options() {
         let opts = opts_with("profile", "minimal");
         let rt = RustToolchain {
             profile: Some("default".to_string()),
             components: Some(vec!["rustfmt".to_string()]),
             ..Default::default()
         };
+        let opts = rt.apply_to_options(opts);
 
         assert_eq!(
-            RustOptions::new(&opts).lockfile_options(Some(&rt)),
+            RustOptions::new(&opts).lockfile_options(),
             BTreeMap::from([
                 ("components".to_string(), "rustfmt".to_string()),
                 ("profile".to_string(), "default".to_string()),
             ])
         );
+    }
+
+    #[test]
+    fn rust_lockfile_options_skip_empty_profile() {
+        let opts = opts_with("profile", "");
+
+        assert_eq!(RustOptions::new(&opts).lockfile_options(), BTreeMap::new());
     }
 }


### PR DESCRIPTION
This is required to include options from idiomatic files in the lockfile.

## Summary
- add an option-aware idiomatic-file parsing path while keeping the existing plain `parse_idiomatic_file` hook for backends that only return versions
- store `rust-toolchain.toml` `profile`, `components`, and `targets` on the generated Rust `ToolRequest` when parsing idiomatic files
- make Rust install and lockfile option resolution read the same `request.options()` instead of reparsing `rust-toolchain.toml`
- remove the now-unneeded Rust `get_args` helper and call `RustOptions::install_args()` directly at install time

## Behavior

### Previous behavior
- `IdiomaticVersionFile::parse` only asked backends for version strings, then created `ToolRequest`s without any file-derived Rust tool options stored on the request.
- Rust compensated with backend-specific reparsing:
  - install time used `get_args()` to re-read `rust-toolchain.toml` for idiomatic requests
  - lockfile option resolution also re-read `rust-toolchain.toml` for idiomatic requests
- When a `rust-toolchain.toml` field and existing Rust tool options both provided the same setting, the file value won. Missing file fields fell back to the existing request/backend options.
- Non-Rust backends only returned plain version strings from idiomatic files.

### Changed behavior
- `Backend::parse_idiomatic_file` and `_parse_idiomatic_file` still exist for plain version parsing. This keeps non-option backends on the old hook shape.
- `Backend::parse_idiomatic_file_with_options` is now a wrapper: by default it calls `parse_idiomatic_file`, wraps each version as `(version, None)`, then merges backend/default options.
- Rust overrides the option-aware hook to return only file-derived options from `rust-toolchain.toml`. The shared wrapper starts with backend/default options and applies the file-derived options over them before the idiomatic `ToolRequest` is stored.
- Rust install and lockfile code now both read `request.options()`. The generated request is the source of truth, so the backend no longer repeats disk reads during install or lockfile generation.
- `get_args` became a thin wrapper around `tv.request.options()` plus `RustOptions::install_args()`, so it was removed.

### Option precedence
- The intended Rust idiomatic-file merge behavior is unchanged: `rust-toolchain.toml` values still override existing Rust tool options for the same keys, and omitted file fields still fall back to existing request/backend options.
- The meaningful behavior changes are canonicalization fixes for Rust lockfile options: array values are normalized consistently with comma-separated strings, `components`/`targets` are deduplicated after sorting, and an empty `profile` no longer emits a spurious lockfile key.

## Tests
- `cargo fmt --all`
- `cargo test --bin mise rust_`
- `cargo test --bin mise test_idiomatic_parse_error_propagation` was attempted locally but waited on an unrelated Cargo build-directory lock; GitHub Actions covers this path on the pushed branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Version files can now include tool-specific options that are parsed and applied per project version, enabling more granular configuration control.

* **Improvements**
  * Rust toolchain options are handled more consistently, including normalized and deduplicated component/target lists and unified install-time argument behavior.
  * Enhanced `rust-toolchain.toml` parsing to accept both comma-separated values and TOML arrays.

* **Tests**
  * Updated and expanded coverage to match the new options-merging and normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->