### PR TITLE
chore: fix spelling

### DIFF
--- a/crates/vfox/lua/htmlparser.lua
+++ b/crates/vfox/lua/htmlparser.lua
@@ -112,7 +112,7 @@ local function parse(text,limit) -- {{{
 		-- tpl-placeholders and attributes {{{
 		text=text
 			:gsub(
-				"(=[%s]-)".. -- only match attr.values, and not random strings between two random apostrophs
+				"(=[%s]-)".. -- only match attr.values, and not random strings between two random apostrophes
 				"(%b'')",
 				function(...)return g(2,...)end
 			)

--- a/crates/vfox/lua/htmlparser.lua
+++ b/crates/vfox/lua/htmlparser.lua
@@ -135,7 +135,7 @@ local function parse(text,limit) -- {{{
 				(opts.tpl_marker_pattern or "[^%w%s]").. -- Capture templating symbol
 				")([%g%s]-)".. -- match placeholder's content
 				"(%2)(>)".. -- placeholder's tail
-				"([^>]*>)", -- remainings
+				"([^>]*>)", -- remaining
 				function(...)return g(5,...)end
 			)
 		-- }}}

--- a/crates/vfox/lua/htmlparser/ElementNode.lua
+++ b/crates/vfox/lua/htmlparser/ElementNode.lua
@@ -150,7 +150,7 @@ function ElementNode:close(closestart, closeend)
 	if closestart and closeend then
 		self._closestart, self._closeend = closestart, closeend
 	end
-	-- inform hihger level nodes about this element's existence in their branches
+	-- inform higher level nodes about this element's existence in their branches
 	local node = self
 	while true do
 		node = node.parent

--- a/crates/vfox/lua/htmlparser/ElementNode.lua
+++ b/crates/vfox/lua/htmlparser/ElementNode.lua
@@ -237,7 +237,7 @@ local function select(self, s)
 			start, pos, switch, stype, name, eq, quote = string.find(part,
 				"(%(?%)?)" ..         -- switch = a possible ( or ) switching the filter on or off
 				"([:%[#.]?)" ..       -- stype = a possible :, [, #, or .
-				"([%w-_\\]+)" ..      -- name = 1 or more alphanumeric chars (+ hyphen, reverse slash and uderscore)
+				"([%w-_\\]+)" ..      -- name = 1 or more alphanumeric chars (+ hyphen, reverse slash and underscore)
 				"([|%*~%$!%^]?=?)" .. -- eq = a possible |=, *=, ~=, $=, !=, ^=, or =
 				"(['\"]?)",           -- quote = a ' or " delimiting a possible attribute value
 				pos + 1

--- a/crates/vfox/lua/htmlparser/ElementNode.lua
+++ b/crates/vfox/lua/htmlparser/ElementNode.lua
@@ -237,7 +237,7 @@ local function select(self, s)
 			start, pos, switch, stype, name, eq, quote = string.find(part,
 				"(%(?%)?)" ..         -- switch = a possible ( or ) switching the filter on or off
 				"([:%[#.]?)" ..       -- stype = a possible :, [, #, or .
-				"([%w-_\\]+)" ..      -- name = 1 or more alfanumeric chars (+ hyphen, reverse slash and uderscore)
+				"([%w-_\\]+)" ..      -- name = 1 or more alphanumeric chars (+ hyphen, reverse slash and uderscore)
 				"([|%*~%$!%^]?=?)" .. -- eq = a possible |=, *=, ~=, $=, !=, ^=, or =
 				"(['\"]?)",           -- quote = a ' or " delimiting a possible attribute value
 				pos + 1

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -373,7 +373,7 @@ export default withMermaid(
       gtag('js', new Date());
       gtag('config', 'G-B69G389C8T');`,
       ],
-      // OpenGraph
+      // Open Graph
       ["meta", { property: "og:site_name", content: "mise-en-place" }],
       ["meta", { property: "og:type", content: "website" }],
       [

--- a/docs/cli/plugins/install.md
+++ b/docs/cli/plugins/install.md
@@ -7,7 +7,7 @@
 
 Install a plugin
 
-note that mise automatically can install plugins when you install a tool
+note that mise can automatically install plugins when you install a tool
 e.g.: `mise install cmake@3.30` will autoinstall the cmake plugin
 
 This behavior can be modified in ~/.config/mise/config.toml

--- a/docs/cli/prune.md
+++ b/docs/cli/prune.md
@@ -27,7 +27,7 @@ Do not actually delete anything
 
 ### `--configs`
 
-Prune only tracked and trusted configuration links that point to non-existent configurations
+Prune only tracked and trusted configuration links that point to nonexistent configurations
 
 ### `--dry-run-code`
 

--- a/docs/cli/reshim.md
+++ b/docs/cli/reshim.md
@@ -12,7 +12,7 @@ other ways to install things (like using yarn or pnpm for node) that mise does
 not know about and so it will be necessary to call this explicitly.
 
 If you think mise should automatically call this for a particular command, please
-open an issue on the mise repo. You can also setup a shell function to reshim
+open an issue on the mise repo. You can also set up a shell function to reshim
 automatically (it's really fast so you don't need to worry about overhead):
 
 ```

--- a/docs/cli/tasks/validate.md
+++ b/docs/cli/tasks/validate.md
@@ -44,7 +44,7 @@ Validation Checks:
 The validate command performs the following checks:
 
   • Circular Dependencies: Detects dependency cycles
-  • Missing References: Finds references to non-existent tasks
+  • Missing References: Finds references to nonexistent tasks
   • Usage Spec Parsing: Validates #USAGE directives and specs
   • Timeout Format: Checks timeout values are valid durations
   • Alias Conflicts: Detects duplicate aliases across tasks

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -200,14 +200,14 @@ repository will be discarded.
 Don't load global ignores
 
 This disables loading of global or user ignore files, like '~/.gitignore',
-'~/.config/watchexec/ignore', or '%APPDATA%\Bazzar\2.0\ignore'. Contrast with
+'~/.config/watchexec/ignore', or '%APPDATA%\Bazaar\2.0\ignore'. Contrast with
 '--no-vcs-ignore' and '--no-project-ignore'.
 
 Supported global ignore files
 
   - Git (if core.excludesFile is set): the file at that path
   - Git (otherwise): the first found of $XDG_CONFIG_HOME/git/ignore, %APPDATA%/.gitignore, %USERPROFILE%/.gitignore, $HOME/.config/git/ignore, $HOME/.gitignore.
-  - Bazaar: the first found of %APPDATA%/Bazzar/2.0/ignore, $HOME/.bazaar/ignore.
+  - Bazaar: the first found of %APPDATA%/Bazaar/2.0/ignore, $HOME/.bazaar/ignore.
   - Watchexec: the first found of $XDG_CONFIG_HOME/watchexec/ignore, %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore, $HOME/.watchexec/ignore.
 
 Like for project files, Git and Bazaar global files will only be used for the corresponding

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -6,7 +6,7 @@ The configuration goes into `mise.toml`.
 
 ## CD hook
 
-This hook is run anytimes the directory is changed.
+This hook is run anytime the directory is changed.
 
 ```toml
 [hooks]

--- a/docs/mise-cookbook/shell-tricks.md
+++ b/docs/mise-cookbook/shell-tricks.md
@@ -1,6 +1,6 @@
 # Shell tricks
 
-A collection of shell utities leveraging mise.
+A collection of shell utilities leveraging mise.
 
 ## Prompt colouring
 

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -746,7 +746,7 @@ other ways to install things (like using yarn or pnpm for node) that mise does
 not know about and so it will be necessary to call this explicitly.
 
 If you think mise should automatically call this for a particular command, please
-open an issue on the mise repo. You can also setup a shell function to reshim
+open an issue on the mise repo. You can also set up a shell function to reshim
 automatically (it's really fast so you don't need to worry about overhead):
 
 npm() {

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -724,7 +724,7 @@ as will versions only referenced on the command line (`mise exec <TOOL>@<VERSION
     rm -rf ~/.local/share/mise/versions/node/20.0.1
 "
     flag "-n --dry-run" help="Do not actually delete anything"
-    flag "--configs" help="Prune only tracked and trusted configuration links that point to non-existent configurations"
+    flag "--configs" help="Prune only tracked and trusted configuration links that point to nonexistent configurations"
     flag "--tools" help="Prune only unused versions of tools"
     arg "[PLUGIN]..." help="Prune only versions from this plugin(s)" var=true
 }

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -537,7 +537,7 @@ It's a useful command to get the current state of your tools."#
         arg "<PLUGIN_FLAG>"
     }
     flag "-c --current" help="Only show tool versions currently specified in a .tool-versions/.mise.toml"
-    flag "-g --global" help="Only show tool versions currently specified in a the global .tool-versions/.mise.toml"
+    flag "-g --global" help="Only show tool versions currently specified in the global .tool-versions/.mise.toml"
     flag "-i --installed" help="Only show tool versions that are installed (Hides tools defined in .tool-versions/.mise.toml but not installed)"
     flag "--parseable" help="Output in an easily parseable format" hide=true
     flag "-J --json" help="Output in JSON format"

--- a/docs/mise.usage.kdl
+++ b/docs/mise.usage.kdl
@@ -606,7 +606,7 @@ cmd "plugins" help="Manage plugins" {
         alias "i" "a" "add"
         long_help r"Install a plugin
 
-note that mise automatically can install plugins when you install a tool
+note that mise can automatically install plugins when you install a tool
 e.g.: `mise install node@20` will autoinstall the node plugin
 
 This behavior can be modified in ~/.config/mise/config.toml"

--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -40,7 +40,7 @@ Note that global and system config files (e.g., `~/.config/mise/config.toml`) ar
 
 ## Community plugins
 
-Community plugins can not be directly installed via short-name under paranoid.
+Community plugins cannot be directly installed via short-name under paranoid.
 You can install plugins that are either core, maintained by the mise team,
 or plugins that mise has marked as "first-party"—meaning plugins developed by
 the same team that builds the tool the plugin installs.

--- a/docs/plugin-lua-modules.md
+++ b/docs/plugin-lua-modules.md
@@ -94,7 +94,7 @@ local resp, err = http.try_get({
     url = "https://primary.example.com/index"
 })
 if err ~= nil then
-    -- fallback to another source
+    -- fall back to another source
     resp, err = http.try_get({ url = "https://fallback.example.com/index" })
 end
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -637,7 +637,7 @@ I don't want to turn all file tasks into tera templates just for this feature.
 ## `[task_config]` options
 
 Options available in the top-level `mise.toml` `[task_config]` section. These apply to all tasks which
-are included by that config file or use the same root directory, e.g.: `~/src/myprojec/mise.toml`'s `[task_config]`
+are included by that config file or use the same root directory, e.g.: `~/src/myproject/mise.toml`'s `[task_config]`
 applies to file tasks like `~/src/myproject/mise-tasks/mytask` but not to tasks in `~/src/myproject/subproj/mise.toml`.
 
 ### `task_config.dir`

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -91,8 +91,8 @@ Tera also supports powerful [expressions](https://keats.github.io/tera/docs/#exp
 - concatenation `~`, e.g. <code v-pre>{{ "hello " ~ 'world' ~ \`!\` }}</code>
 - in checking, e.g. <span v-pre>`{{ some_var in [1, 2, 3] }}`</span>
 
-Tera also supports control structures such as <span v-pre>`if`</span> and
-<span v-pre>`for`</span>. [Read more](https://keats.github.io/tera/docs/#control-structures).
+Tera also supports [control structures such as <span v-pre>`if`</span> and
+<span v-pre>`for`</span>](https://keats.github.io/tera/docs/#control-structures).
 
 ### Tera Filters
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@ For non-interactive setups, consider using shims instead which will route calls 
 directory by looking at `PWD` every time they're executed. You can also call `mise exec` instead of
 expecting things to be directly on PATH. You can also run `mise env` in a non-interactive shell,
 however that
-will only setup the global tools. It won't modify the environment variables when entering into a
+will only set up the global tools. It won't modify the environment variables when entering into a
 different project.
 
 ::: warning

--- a/e2e-win/config_ceiling_paths.Tests.ps1
+++ b/e2e-win/config_ceiling_paths.Tests.ps1
@@ -75,7 +75,7 @@ GRANDCHILD = "true"
         $output | Should -Not -Match "export PARENT=true"
     }
 
-    It 'handles non-existent ceiling path' {
+    It 'handles nonexistent ceiling path' {
         $env:MISE_CEILING_PATHS = Join-Path $TestRoot "nonexistent"
         $output = mise env | Out-String
         $output | Should -Match "export GRANDCHILD=true"

--- a/e2e-win/tasks_ceiling_paths.Tests.ps1
+++ b/e2e-win/tasks_ceiling_paths.Tests.ps1
@@ -84,7 +84,7 @@ Write-Output "grandchild"
         $output | Should -Not -Match "task-parent"
     }
 
-    It 'handles non-existent ceiling path' {
+    It 'handles nonexistent ceiling path' {
         $env:MISE_CEILING_PATHS = Join-Path $TestRoot "nonexistent"
         $output = mise tasks | Out-String
         $output | Should -Match "task-grandchild"

--- a/e2e/backend/test_aqua_failed_install_cleanup
+++ b/e2e/backend/test_aqua_failed_install_cleanup
@@ -5,7 +5,7 @@
 # subdirectory (e.g. installs/tilt/9999.9999.9999) but left the parent
 # (installs/tilt/) as an empty directory behind.
 
-# Trigger a failed install using a non-existent version number.
+# Trigger a failed install using a nonexistent version number.
 # This causes the GitHub API to return 404 after create_install_dirs() has
 # already created installs/tilt/9999.9999.9999.
 assert_fail "mise x tilt@9999.9999.9999 -- tilt version"

--- a/e2e/backend/test_npm_shim_recursion_system_dir
+++ b/e2e/backend/test_npm_shim_recursion_system_dir
@@ -33,7 +33,7 @@ export PATH="$MISE_SYSTEM_DATA_DIR/shims:$PATH"
 # _list_remote_versions runs `npm view ... --json` and the only `npm` on
 # PATH is the system shim we just planted. Use a real-but-uninstalled node
 # version (matches the pattern in test_go_shim_recursion using
-# `go = "1.23.3"`) — picking a non-existent version like `99.0.0` would risk
+# `go = "1.23.3"`) — picking a nonexistent version like `99.0.0` would risk
 # `mise ls` failing on version resolution and masking a fork-bomb regression.
 cat >>mise.toml <<'EOF'
 [tools]

--- a/e2e/cli/test_cd_nonexistent
+++ b/e2e/cli/test_cd_nonexistent
@@ -2,18 +2,18 @@
 
 set -euo pipefail
 
-# Test that mise shows a friendly error when --cd is set to a non-existent path
+# Test that mise shows a friendly error when --cd is set to a nonexistent path
 # This validates that the error message is clear and helpful to users
 
-echo "Testing --cd with non-existent directory..."
+echo "Testing --cd with nonexistent directory..."
 
-# Test 1: --cd with non-existent absolute path
-echo "Test 1: --cd with non-existent absolute path"
+# Test 1: --cd with nonexistent absolute path
+echo "Test 1: --cd with nonexistent absolute path"
 assert_fail "mise --cd /nonexistent/path/that/does/not/exist config ls" \
   "Directory specified with --cd does not exist"
 
-# Test 2: --cd with non-existent relative path
-echo "Test 2: --cd with non-existent relative path"
+# Test 2: --cd with nonexistent relative path
+echo "Test 2: --cd with nonexistent relative path"
 assert_fail "mise --cd ./nonexistent config ls" \
   "Directory specified with --cd does not exist"
 
@@ -45,15 +45,15 @@ else
   fail "Error message missing expected text: ${output:0:200}..."
 fi
 
-# Test 6: Test with run command and non-existent --cd path
-echo "Test 6: --cd with run command and non-existent path"
+# Test 6: Test with run command and nonexistent --cd path
+echo "Test 6: --cd with run command and nonexistent path"
 assert_fail "mise run --cd /nonexistent/path hello" \
   "Directory specified with --cd does not exist"
 
-# Test 7: Test with other commands and non-existent --cd path
-echo "Test 7: --cd with various commands and non-existent path"
+# Test 7: Test with other commands and nonexistent --cd path
+echo "Test 7: --cd with various commands and nonexistent path"
 assert_fail "mise --cd /nonexistent ls" \
   "Directory specified with --cd does not exist"
 
 echo ""
-echo "All --cd non-existent directory tests passed!"
+echo "All --cd nonexistent directory tests passed!"

--- a/e2e/cli/test_install_parallel_failure
+++ b/e2e/cli/test_install_parallel_failure
@@ -33,7 +33,7 @@ assert_not_contains "mise ls --installed dummy" "other-dummy"
 # Test 2: Install with missing plugin that would cause early return
 # This tests the plugin installation error handling
 
-# Try to install a non-existent plugin
+# Try to install a nonexistent plugin
 assert_fail "mise install nonexistent@latest" "nonexistent not found in mise tool registry"
 
 # Test 3: Install multiple tools with mixed success/failure

--- a/e2e/cli/test_nonexistent_cwd
+++ b/e2e/cli/test_nonexistent_cwd
@@ -2,11 +2,11 @@
 
 set -euo pipefail
 
-# Test that mise handles commands from non-existent directories gracefully
+# Test that mise handles commands from nonexistent directories gracefully
 # This test validates that when a directory is deleted while mise is running from it,
 # mise shows a warning but continues execution
 
-# Test helper function to run commands from a non-existent directory
+# Test helper function to run commands from a nonexistent directory
 run_from_nonexistent() {
   local cmd="$1"
   local should_succeed="${2:-true}" # Whether the command should succeed despite the warning
@@ -21,14 +21,14 @@ run_from_nonexistent() {
   # Remove the directory while we're still in it
   rmdir "$temp_dir"
 
-  # Now we're in a non-existent directory - run the mise command
+  # Now we're in a nonexistent directory - run the mise command
   local status=0
   local output
   output=$(MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 bash -c "$cmd 2>&1") || status=$?
 
-  # Check for the warning about non-existent directory
+  # Check for the warning about nonexistent directory
   if [[ $output == *"Current directory does not exist"* ]] || [[ $output == *"WARNING"* ]]; then
-    ok "[$cmd] showed warning about non-existent directory"
+    ok "[$cmd] showed warning about nonexistent directory"
   else
     # Some commands might not trigger the warning if they exit early
     debug "[$cmd] may not have shown warning, output: ${output:0:100}..."
@@ -36,7 +36,7 @@ run_from_nonexistent() {
 
   if [[ $should_succeed == "true" ]]; then
     if [[ $status -eq 0 ]]; then
-      ok "[$cmd] succeeded despite non-existent directory"
+      ok "[$cmd] succeeded despite nonexistent directory"
     else
       # Command might fail for other reasons (e.g., missing tools)
       debug "[$cmd] failed (status $status), which might be expected"
@@ -53,32 +53,32 @@ run_from_nonexistent() {
   cd "$HOME" || cd / || true
 }
 
-echo "Testing mise commands from non-existent directories..."
+echo "Testing mise commands from nonexistent directories..."
 
 # Test various commands - they should all show a warning but may still work
-echo "Test 1: mise --version from non-existent directory"
+echo "Test 1: mise --version from nonexistent directory"
 run_from_nonexistent "mise --version" "true"
 
-echo "Test 2: mise ls from non-existent directory"
+echo "Test 2: mise ls from nonexistent directory"
 run_from_nonexistent "mise ls" "true"
 
-echo "Test 3: mise current from non-existent directory"
+echo "Test 3: mise current from nonexistent directory"
 run_from_nonexistent "mise current" "true"
 
-echo "Test 4: mise env from non-existent directory"
+echo "Test 4: mise env from nonexistent directory"
 run_from_nonexistent "mise env" "true"
 
-echo "Test 5: mise doctor from non-existent directory"
+echo "Test 5: mise doctor from nonexistent directory"
 run_from_nonexistent "mise doctor" "true"
 
-echo "Test 6: mise plugins from non-existent directory"
+echo "Test 6: mise plugins from nonexistent directory"
 run_from_nonexistent "mise plugins" "true"
 
 # Commands that need to write to cwd might fail
-echo "Test 7: mise use from non-existent directory"
+echo "Test 7: mise use from nonexistent directory"
 run_from_nonexistent "mise use node@20" "false"
 
-echo "Test 8: mise install from non-existent directory"
+echo "Test 8: mise install from nonexistent directory"
 run_from_nonexistent "mise install" "true" # Should work for global tools
 
 # Test that the warning appears consistently
@@ -99,4 +99,4 @@ fi
 cd "$HOME" || cd / || true
 
 echo ""
-echo "All non-existent directory tests passed!"
+echo "All nonexistent directory tests passed!"

--- a/e2e/cli/test_nonexistent_tool
+++ b/e2e/cli/test_nonexistent_tool
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Test behavior with non-existent tools in config
+# Test behavior with nonexistent tools in config
 
 set -euo pipefail
 
@@ -7,40 +7,40 @@ set -euo pipefail
 export RUST_BACKTRACE=0
 export MISE_FRIENDLY_ERROR=1
 
-# Create mise.toml with a non-existent tool
+# Create mise.toml with a nonexistent tool
 cat >mise.toml <<EOF
 [tools]
 nonexistent-tool-xyz = "1.0.0"
 EOF
 
-echo "Test 1: mise install should error for non-existent tool in mise.toml"
+echo "Test 1: mise install should error for nonexistent tool in mise.toml"
 status=0
 output=$(mise install 2>&1) || status=$?
 if [[ $status -ne 0 ]] && [[ $output == *"nonexistent-tool-xyz not found in mise tool registry"* ]]; then
-  echo "✓ Test 1 passed: mise install errors for non-existent tool"
+  echo "✓ Test 1 passed: mise install errors for nonexistent tool"
 else
-  echo "✗ Test 1 failed: Expected error for non-existent tool"
+  echo "✗ Test 1 failed: Expected error for nonexistent tool"
   echo "  Status: $status"
   echo "  Output: $output"
   exit 1
 fi
 
-echo "Test 2: mise use should error for non-existent tool"
+echo "Test 2: mise use should error for nonexistent tool"
 status=0
 output=$(mise use nonexistent-tool-abc@1.0.0 2>&1) || status=$?
 if [[ $status -ne 0 ]] && [[ $output == *"nonexistent-tool-abc not found in mise tool registry"* ]]; then
-  echo "✓ Test 2 passed: mise use errors for non-existent tool"
+  echo "✓ Test 2 passed: mise use errors for nonexistent tool"
 else
-  echo "✗ Test 2 failed: Expected error for non-existent tool"
+  echo "✗ Test 2 failed: Expected error for nonexistent tool"
   echo "  Status: $status"
   echo "  Output: $output"
   exit 1
 fi
 
-echo "Test 3: mise env should warn but not error for non-existent tool"
+echo "Test 3: mise env should warn but not error for nonexistent tool"
 status=0
 output=$(mise env 2>&1) || status=$?
-# mise env should warn about the non-existent tool but still exit successfully
+# mise env should warn about the nonexistent tool but still exit successfully
 if [[ $status -eq 0 ]]; then
   if [[ $output == *"WARN"* ]] && [[ $output == *"nonexistent-tool-xyz"* ]]; then
     echo "✓ Test 3 passed: mise env warns but does not error"
@@ -56,10 +56,10 @@ else
   exit 1
 fi
 
-echo "Test 4: mise hook-env should not error for non-existent tool"
+echo "Test 4: mise hook-env should not error for nonexistent tool"
 status=0
 output=$(mise hook-env 2>&1) || status=$?
-# mise hook-env is designed for shell integration, so it should silently skip non-existent tools
+# mise hook-env is designed for shell integration, so it should silently skip nonexistent tools
 if [[ $status -eq 0 ]]; then
   echo "✓ Test 4 passed: mise hook-env does not error"
 else
@@ -69,26 +69,26 @@ else
   exit 1
 fi
 
-echo "Test 5: mise install with explicit non-existent tool should error"
+echo "Test 5: mise install with explicit nonexistent tool should error"
 status=0
 output=$(mise install nonexistent-explicit-tool@1.0.0 2>&1) || status=$?
 if [[ $status -ne 0 ]] && [[ $output == *"nonexistent-explicit-tool not found in mise tool registry"* ]]; then
-  echo "✓ Test 5 passed: explicit mise install errors for non-existent tool"
+  echo "✓ Test 5 passed: explicit mise install errors for nonexistent tool"
 else
-  echo "✗ Test 5 failed: Expected error for non-existent tool"
+  echo "✗ Test 5 failed: Expected error for nonexistent tool"
   echo "  Status: $status"
   echo "  Output: $output"
   exit 1
 fi
 
-echo "Test 6: mise ls should not list non-existent tool"
+echo "Test 6: mise ls should not list nonexistent tool"
 status=0
 output=$(mise ls nonexistent-tool-xyz 2>&1) || status=$?
-# mise ls should either error or show nothing for a non-existent tool
+# mise ls should either error or show nothing for a nonexistent tool
 if [[ $output != *"nonexistent-tool-xyz"*"1.0.0"* ]]; then
-  echo "✓ Test 6 passed: mise ls does not list non-existent tool as installed"
+  echo "✓ Test 6 passed: mise ls does not list nonexistent tool as installed"
 else
-  echo "✗ Test 6 failed: mise ls should not show non-existent tool"
+  echo "✗ Test 6 failed: mise ls should not show nonexistent tool"
   echo "  Output: $output"
   exit 1
 fi

--- a/e2e/cli/test_shared_install_dirs
+++ b/e2e/cli/test_shared_install_dirs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Test that MISE_SHARED_INSTALL_DIRS allows fallback to shared directories
+# Test that MISE_SHARED_INSTALL_DIRS allows falling back to shared directories
 
 # Install tiny into the primary directory
 mise install tiny@1.0.1

--- a/e2e/cli/test_tool_stub_errors
+++ b/e2e/cli/test_tool_stub_errors
@@ -78,7 +78,7 @@ fi
 # Clean up
 rm test_bin_path
 
-# Test 4: Actual tool not found (non-existent tool)
+# Test 4: Actual tool not found (nonexistent tool)
 cat >test_tool_notfound <<'EOF'
 #!/usr/bin/env -S mise tool-stub
 tool = "nonexistent-tool-that-doesnt-exist"
@@ -86,7 +86,7 @@ EOF
 chmod +x test_tool_notfound
 
 output=$(mise tool-stub ./test_tool_notfound 2>&1 || true)
-# The error for non-existent tools shows up as a toolset resolution error
+# The error for nonexistent tools shows up as a toolset resolution error
 if [[ $output == *"No current versions found after resolving toolset"* ]]; then
   echo "✓ Test 4 passed: Non-existent tool error handled correctly"
 else

--- a/e2e/config/test_config_ceiling_paths
+++ b/e2e/config/test_config_ceiling_paths
@@ -59,8 +59,8 @@ assert_not_contains "mise env" "export CHILD=true"
 assert_not_contains "mise env" "export PARENT=true"
 echo "Test 4: Passed"
 
-# Test 5: Ceiling path with non-existent directory
-echo "Test 5: With non-existent ceiling path, should find all configs"
+# Test 5: Ceiling path with nonexistent directory
+echo "Test 5: With nonexistent ceiling path, should find all configs"
 export MISE_CEILING_PATHS="$TEST_ROOT/nonexistent"
 assert_contains "mise env" "export GRANDCHILD=true"
 assert_contains "mise env" "export CHILD=true"

--- a/e2e/generate/test_generate_bootstrap
+++ b/e2e/generate/test_generate_bootstrap
@@ -13,7 +13,7 @@ assert "mise generate bootstrap -l -w"
 # shellcheck disable=SC2016
 assert_contains "cat ./bin/mise" 'exec -a "$0" "$MISE_INSTALL_PATH" "$@"'
 
-# ensure that that the commands don't rely on the global mise bin
+# ensure that the commands don't rely on the global mise bin
 original_mise="$(which mise)"
 mise_dir="$(dirname "$original_mise")"
 OLD_PATH="$PATH"

--- a/e2e/generate/test_generate_tool_stub_lock
+++ b/e2e/generate/test_generate_tool_stub_lock
@@ -55,7 +55,7 @@ assert_succeed "mise generate tool-stub bin/tiny --lock"
 # Version should be the same after re-locking
 assert_contains "cat bin/tiny" "version = \"$locked_version\""
 
-# Test 4: Lock fails on non-existent file
+# Test 4: Lock fails on nonexistent file
 assert_fail "mise generate tool-stub bin/nonexistent --lock"
 
 # Test 5: Execute the locked stub to verify it works

--- a/e2e/shell/fish_shims_reorder_script.fish
+++ b/e2e/shell/fish_shims_reorder_script.fish
@@ -6,7 +6,7 @@
 # Get the mise binary path from argv (passed by the wrapper)
 set -l mise_dir $argv[1]
 
-# Ensure shims directory exists (fish_add_path skips non-existent dirs)
+# Ensure shims directory exists (fish_add_path skips nonexistent dirs)
 mkdir -p $HOME/.local/share/mise/shims
 
 # Clear any pre-existing __MISE_BIN so the debug binary uses current_exe()

--- a/e2e/tasks/test_task_info_monorepo
+++ b/e2e/tasks/test_task_info_monorepo
@@ -22,15 +22,15 @@ echo Hello, World!
 """
 EOF
 
-# Test non-existent task
+# Test nonexistent task
 assert_fail "mise tasks info nonexistent"
 assert_contains "mise tasks info nonexistent 2>&1 || true" "Task not found: nonexistent"
 
-# Test non-existent monorepo task
+# Test nonexistent monorepo task
 assert_fail "mise tasks info //lib:nonexistent"
 assert_contains "mise tasks info //lib:nonexistent 2>&1 || true" "Task not found: //lib:nonexistent"
 
-# Test non-existent alias
+# Test nonexistent alias
 assert_fail "mise tasks info //lib:fake_alias"
 assert_contains "mise tasks info //lib:fake_alias 2>&1 || true" "Task not found: //lib:fake_alias"
 

--- a/e2e/tasks/test_task_remote_git_https
+++ b/e2e/tasks/test_task_remote_git_https
@@ -90,7 +90,7 @@ assert_directory_not_exists "${MISE_LOCAL_CACHE_DIR}"
 mise cache clear # Clear cache to force redownload
 
 #################################################################################
-# Test remote tasks with with ref
+# Test remote tasks with ref
 #################################################################################
 
 cat <<EOF >mise.toml

--- a/e2e/tasks/test_task_remote_git_ssh
+++ b/e2e/tasks/test_task_remote_git_ssh
@@ -47,7 +47,7 @@ assert_directory_not_empty "${REMOTE_TASKS_DIR}"
 mise cache clear # Clear cache to force redownload
 
 # #################################################################################
-# # Test remote tasks with with ref
+# # Test remote tasks with ref
 # #################################################################################
 
 cat <<EOF >mise.toml

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -33,10 +33,10 @@ run = "echo valid"
 
 [tasks.invalid]
 run = "echo invalid"
-depends = ["non-existent"]
+depends = ["nonexistent"]
 EOF
 
-assert_contains "mise tasks validate 2>&1 || true" "Dependency 'non-existent' not found"
+assert_contains "mise tasks validate 2>&1 || true" "Dependency 'nonexistent' not found"
 assert_contains "mise tasks validate 2>&1 || true" "missing-dependency"
 
 # Test invalid timeout

--- a/e2e/tasks/test_tasks_ceiling_paths
+++ b/e2e/tasks/test_tasks_ceiling_paths
@@ -66,8 +66,8 @@ assert_not_contains "mise tasks" "task-child"
 assert_not_contains "mise tasks" "task-parent"
 echo "Test 4: Passed"
 
-# Test 5: Ceiling path with non-existent directory
-echo "Test 5: With non-existent ceiling path, should find all tasks"
+# Test 5: Ceiling path with nonexistent directory
+echo "Test 5: With nonexistent ceiling path, should find all tasks"
 export MISE_CEILING_PATHS="$TEST_ROOT/nonexistent"
 assert_contains "mise tasks" "task-grandchild"
 assert_contains "mise tasks" "task-child"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1807,7 +1807,7 @@ to show core and user plugins
 .SH "MISE PLUGINS INSTALL"
 Install a plugin
 
-note that mise automatically can install plugins when you install a tool
+note that mise can automatically install plugins when you install a tool
 e.g.: `mise install cmake@3.30` will autoinstall the cmake plugin
 
 This behavior can be modified in ~/.config/mise/config.toml

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2072,7 +2072,7 @@ You can list prunable tools with `mise ls \-\-prunable`
 Do not actually delete anything
 .TP
 \fB\-\-configs\fR
-Prune only tracked and trusted configuration links that point to non\-existent configurations
+Prune only tracked and trusted configuration links that point to nonexistent configurations
 .TP
 \fB\-\-dry\-run\-code\fR
 Like \-\-dry\-run but exits with code 1 if there are tools to prune

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2128,7 +2128,7 @@ other ways to install things (like using yarn or pnpm for node) that mise does
 not know about and so it will be necessary to call this explicitly.
 
 If you think mise should automatically call this for a particular command, please
-open an issue on the mise repo. You can also setup a shell function to reshim
+open an issue on the mise repo. You can also set up a shell function to reshim
 automatically (it's really fast so you don't need to worry about overhead):
 
     npm() {

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3708,14 +3708,14 @@ repository will be discarded.
 Don't load global ignores
 
 This disables loading of global or user ignore files, like '~/.gitignore',
-\&'~/.config/watchexec/ignore', or '%APPDATA%\\Bazzar\\2.0\\ignore'. Contrast with
+\&'~/.config/watchexec/ignore', or '%APPDATA%\\Bazaar\\2.0\\ignore'. Contrast with
 \&'\-\-no\-vcs\-ignore' and '\-\-no\-project\-ignore'.
 
 Supported global ignore files
 
   \- Git (if core.excludesFile is set): the file at that path
   \- Git (otherwise): the first found of $XDG_CONFIG_HOME/git/ignore, %APPDATA%/.gitignore, %USERPROFILE%/.gitignore, $HOME/.config/git/ignore, $HOME/.gitignore.
-  \- Bazaar: the first found of %APPDATA%/Bazzar/2.0/ignore, $HOME/.bazaar/ignore.
+  \- Bazaar: the first found of %APPDATA%/Bazaar/2.0/ignore, $HOME/.bazaar/ignore.
   \- Watchexec: the first found of $XDG_CONFIG_HOME/watchexec/ignore, %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore, $HOME/.watchexec/ignore.
 
 Like for project files, Git and Bazaar global files will only be used for the corresponding

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2148,7 +2148,7 @@ Examples:
 
 """#
     flag "-n --dry-run" help="Do not actually delete anything"
-    flag --configs help="Prune only tracked and trusted configuration links that point to non-existent configurations"
+    flag --configs help="Prune only tracked and trusted configuration links that point to nonexistent configurations"
     flag --dry-run-code help="Like --dry-run but exits with code 1 if there are tools to prune" {
         long_help #"""
 Like --dry-run but exits with code 1 if there are tools to prune
@@ -3202,7 +3202,7 @@ Validation Checks:
 The validate command performs the following checks:
 
   • Circular Dependencies: Detects dependency cycles
-  • Missing References: Finds references to non-existent tasks
+  • Missing References: Finds references to nonexistent tasks
   • Usage Spec Parsing: Validates #USAGE directives and specs
   • Timeout Format: Checks timeout values are valid durations
   • Alias Conflicts: Detects duplicate aliases across tasks

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2205,7 +2205,7 @@ other ways to install things (like using yarn or pnpm for node) that mise does
 not know about and so it will be necessary to call this explicitly.
 
 If you think mise should automatically call this for a particular command, please
-open an issue on the mise repo. You can also setup a shell function to reshim
+open an issue on the mise repo. You can also set up a shell function to reshim
 automatically (it's really fast so you don't need to worry about overhead):
 
     npm() {

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1874,7 +1874,7 @@ to show core and user plugins
         long_help #"""
 Install a plugin
 
-note that mise automatically can install plugins when you install a tool
+note that mise can automatically install plugins when you install a tool
 e.g.: `mise install cmake@3.30` will autoinstall the cmake plugin
 
 This behavior can be modified in ~/.config/mise/config.toml

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3953,14 +3953,14 @@ repository will be discarded.
 Don't load global ignores
 
 This disables loading of global or user ignore files, like '~/.gitignore',
-'~/.config/watchexec/ignore', or '%APPDATA%\Bazzar\2.0\ignore'. Contrast with
+'~/.config/watchexec/ignore', or '%APPDATA%\Bazaar\2.0\ignore'. Contrast with
 '--no-vcs-ignore' and '--no-project-ignore'.
 
 Supported global ignore files
 
   - Git (if core.excludesFile is set): the file at that path
   - Git (otherwise): the first found of $XDG_CONFIG_HOME/git/ignore, %APPDATA%/.gitignore, %USERPROFILE%/.gitignore, $HOME/.config/git/ignore, $HOME/.gitignore.
-  - Bazaar: the first found of %APPDATA%/Bazzar/2.0/ignore, $HOME/.bazaar/ignore.
+  - Bazaar: the first found of %APPDATA%/Bazaar/2.0/ignore, $HOME/.bazaar/ignore.
   - Watchexec: the first found of $XDG_CONFIG_HOME/watchexec/ignore, %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore, $HOME/.watchexec/ignore.
 
 Like for project files, Git and Bazaar global files will only be used for the corresponding

--- a/registry/auto-doc.toml
+++ b/registry/auto-doc.toml
@@ -1,3 +1,3 @@
 backends = ["github:tj-actions/auto-doc", "asdf:mise-plugins/mise-auto-doc"]
-description = "Github action that turns your reusable workflows and custom actions into easy to read markdown tables"
+description = "GitHub action that turns your reusable workflows and custom actions into easy to read markdown tables"
 test = { cmd = "auto-doc --help", expected = "auto-doc [flags]" }

--- a/registry/terramate.toml
+++ b/registry/terramate.toml
@@ -1,3 +1,3 @@
 backends = ["aqua:terramate-io/terramate", "asdf:martinlindner/asdf-terramate"]
-description = "Open-source Infrastructure as Code (IaC) orchestration platform: GitOps workflows, orchestration, code generation, observability, drift detection, asset management, policies, Slack notifications, and more. Integrates with Terraform, OpenTofu, Terragrunt, Kubernetes, GitHub Actions, GitLab CI/CD, BitBucket Pipelines, and any other CI/CD platform"
+description = "Open-source Infrastructure as Code (IaC) orchestration platform: GitOps workflows, orchestration, code generation, observability, drift detection, asset management, policies, Slack notifications, and more. Integrates with Terraform, OpenTofu, Terragrunt, Kubernetes, GitHub Actions, GitLab CI/CD, Bitbucket Pipelines, and any other CI/CD platform"
 idiomatic_files = [".terramate-version"]

--- a/src/assets/bash_zsh_support/chpwd/README.md
+++ b/src/assets/bash_zsh_support/chpwd/README.md
@@ -12,6 +12,6 @@ Implemented based on the description from
 
 2. add the hook - replace `_hook_name` with your function name:
 
-        export -a chpwd_functions                              # define hooks as an shell array
+        export -a chpwd_functions                              # define hooks as a shell array
         [[ " ${chpwd_functions[*]} " == *" _hook_name "* ]] || # prevent double addition
         chpwd_functions+=(_hook_name)                          # finally add it to the list

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -139,7 +139,7 @@ impl Backend for AquaBackend {
     async fn install_operation_count(&self, tv: &ToolVersion, _ctx: &InstallContext) -> usize {
         let pkg = match self.package_with_options(tv, &[&tv.version]).await {
             Ok(pkg) => pkg,
-            Err(_) => return 3, // fallback to default
+            Err(_) => return 3, // fall back to default
         };
         let format = pkg.format(&tv.version, os(), arch()).unwrap_or_default();
 

--- a/src/cli/config/set.rs
+++ b/src/cli/config/set.rs
@@ -78,7 +78,7 @@ impl ConfigSet {
                     t.set_implicit(true);
                     toml_edit::Item::Table(t)
                 });
-            // if the key is a tool with a simple value, we want to convert it to a inline table preserving the version
+            // if the key is a tool with a simple value, we want to convert it to an inline table preserving the version
             let is_simple_tool_version =
                 full_key.starts_with("tools.") && idx == 1 && !container.is_table_like();
             if is_simple_tool_version {

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -18,7 +18,7 @@ use crate::{backend::unalias_backend, config::Settings};
 
 /// Install a plugin
 ///
-/// note that mise automatically can install plugins when you install a tool
+/// note that mise can automatically install plugins when you install a tool
 /// e.g.: `mise install cmake@3.30` will autoinstall the cmake plugin
 ///
 /// This behavior can be modified in ~/.config/mise/config.toml

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -33,7 +33,7 @@ pub struct Prune {
     #[clap(long, short = 'n')]
     pub dry_run: bool,
 
-    /// Prune only tracked and trusted configuration links that point to non-existent configurations
+    /// Prune only tracked and trusted configuration links that point to nonexistent configurations
     #[clap(long)]
     pub configs: bool,
 

--- a/src/cli/reshim.rs
+++ b/src/cli/reshim.rs
@@ -12,7 +12,7 @@ use crate::toolset::ToolsetBuilder;
 /// not know about and so it will be necessary to call this explicitly.
 ///
 /// If you think mise should automatically call this for a particular command, please
-/// open an issue on the mise repo. You can also setup a shell function to reshim
+/// open an issue on the mise repo. You can also set up a shell function to reshim
 /// automatically (it's really fast so you don't need to worry about overhead):
 ///
 ///     npm() {

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -722,7 +722,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 The validate command performs the following checks:
 
   • <bold>Circular Dependencies</bold>: Detects dependency cycles
-  • <bold>Missing References</bold>: Finds references to non-existent tasks
+  • <bold>Missing References</bold>: Finds references to nonexistent tasks
   • <bold>Usage Spec Parsing</bold>: Validates #USAGE directives and specs
   • <bold>Timeout Format</bold>: Checks timeout values are valid durations
   • <bold>Alias Conflicts</bold>: Detects duplicate aliases across tasks

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -569,14 +569,14 @@ pub struct WatchexecArgs {
     /// Don't load global ignores
     ///
     /// This disables loading of global or user ignore files, like '~/.gitignore',
-    /// '~/.config/watchexec/ignore', or '%APPDATA%\Bazzar\2.0\ignore'. Contrast with
+    /// '~/.config/watchexec/ignore', or '%APPDATA%\Bazaar\2.0\ignore'. Contrast with
     /// '--no-vcs-ignore' and '--no-project-ignore'.
     ///
     /// Supported global ignore files
     ///
     ///   - Git (if core.excludesFile is set): the file at that path
     ///   - Git (otherwise): the first found of $XDG_CONFIG_HOME/git/ignore, %APPDATA%/.gitignore, %USERPROFILE%/.gitignore, $HOME/.config/git/ignore, $HOME/.gitignore.
-    ///   - Bazaar: the first found of %APPDATA%/Bazzar/2.0/ignore, $HOME/.bazaar/ignore.
+    ///   - Bazaar: the first found of %APPDATA%/Bazaar/2.0/ignore, $HOME/.bazaar/ignore.
     ///   - Watchexec: the first found of $XDG_CONFIG_HOME/watchexec/ignore, %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore, $HOME/.watchexec/ignore.
     ///
     /// Like for project files, Git and Bazaar global files will only be used for the corresponding

--- a/src/file.rs
+++ b/src/file.rs
@@ -1711,11 +1711,11 @@ mod tests {
         // Test that the function correctly identifies when to strip components
         // This is a basic test to ensure the logic works correctly
 
-        // For now, we'll test with a non-existent file to ensure the function
+        // For now, we'll test with a nonexistent file to ensure the function
         // returns false when it can't read the archive
         let non_existent_path = Path::new("/non/existent/archive.tar.gz");
         let result = should_strip_components(non_existent_path, TarFormat::TarGz);
-        assert!(result.is_err()); // Should fail to open non-existent file
+        assert!(result.is_err()); // Should fail to open nonexistent file
 
         // Note: To properly test this function, we would need actual tar archives
         // with different structures (single file, single directory, multiple entries)

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -584,7 +584,7 @@ impl Backend for JavaPlugin {
                     let metadata = self.tv_to_metadata(&tv).await?;
                     (metadata, tarball_path)
                 } else {
-                    // No URL in lockfile, fallback to metadata
+                    // No URL in lockfile, fall back to metadata
                     let metadata = self.tv_to_metadata(&tv).await?;
                     let tarball_path = self
                         .download(ctx, &mut tv, ctx.pr.as_ref(), metadata)

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -1065,7 +1065,7 @@ fn python_arch_for_target(target: &PlatformTarget) -> &'static str {
 fn ensure_not_windows() -> eyre::Result<()> {
     if cfg!(windows) {
         bail!(
-            "python can not currently be compiled on windows with core:python, use vfox:python instead"
+            "python cannot currently be compiled on windows with core:python, use vfox:python instead"
         );
     }
     Ok(())

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -561,7 +561,7 @@ async fn get_desired_shims(
                 }
             }));
         } else if cfg!(macos) {
-            // some bins might be uppercased but on mac APFS is case insensitive
+            // some bins might be uppercased but on mac APFS is case-insensitive
             shims.extend(bins.into_iter().map(|b| b.to_lowercase()));
         } else {
             shims.extend(bins);

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -19,7 +19,7 @@ pub type TaskKey = (String, Vec<String>, Vec<(String, String)>);
 pub struct Deps {
     pub graph: DiGraph<Task, ()>,
     sent: HashSet<TaskKey>, // tasks that have already started so should not run again
-    removed: HashSet<TaskKey>, // tasks that have already finished to track if we are in an infinitve loop
+    removed: HashSet<TaskKey>, // tasks that have already finished to track if we are in an infinite loop
     executed: HashSet<TaskKey>, // tasks that actually began executing (not just scheduled)
     ran: HashSet<TaskKey>, // tasks that actually ran their commands (not skipped due to fresh sources)
     dep_edges: HashMap<TaskKey, HashSet<TaskKey>>, // maps each task to its direct dependency task keys

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -415,7 +415,7 @@ pub async fn get_task_lists(
 
         // A path starting with "//" on Windows will be treated as a UNC path by
         // PathBuf, but "//" in UNIX will be collapsed to "/" by PathBuf.
-        // Checking a non-existent UNC path for Windows will incur a large
+        // Checking a nonexistent UNC path for Windows will incur a large
         // hiccup (~2.8s) due to Windows trying to resolve the UNC path.
         let t_for_path_check = t
             .strip_prefix("//")

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -146,7 +146,7 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
                                 (0..n).map(|_| alphabet.choose(&mut rng).unwrap()).collect();
                             Ok(Value::String(result))
                         }
-                        _ => Err("choice alphabet must be an string".into()),
+                        _ => Err("choice alphabet must be a string".into()),
                     }
                 }
                 _ => Err("choice n must be an integer".into()),

--- a/src/test.rs
+++ b/src/test.rs
@@ -25,7 +25,7 @@ fn init() {
     env::set_var("MISE_ENV", "");
     env::set_var("MISE_DATA_DIR", env::HOME.join("data"));
     env::set_var("MISE_GLOBAL_CONFIG_FILE", "~/config/config.toml");
-    env::set_var("MISE_SYSTEM_CONFIG_FILE", "doesntexist");
+    env::set_var("MISE_SYSTEM_CONFIG_FILE", "nonexistent");
     env::set_var(
         "MISE_OVERRIDE_CONFIG_FILENAMES",
         ".test.mise.toml:test.config.toml",

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -2447,7 +2447,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--configs",
           description:
-            "Prune only tracked and trusted configuration links that point to non-existent configurations",
+            "Prune only tracked and trusted configuration links that point to nonexistent configurations",
           isRepeatable: false,
         },
         {


### PR DESCRIPTION
A couple of items fail CI.

One appears to be a rate limit (I think this is discussed in a private discussion repository).

```
2026-05-31T16:24:49.1841348Z mise WARN  GitHub API returned a 403 Forbidden error. This is most commonly caused by exceeding the rate limit, though other causes (e.g. insufficient token permissions) are possible.
2026-05-31T16:24:49.1842577Z Error: 
2026-05-31T16:24:49.1844001Z    0: [91mFailed to install ubi:databricks/cli@0.233.0: HTTP request to https://api.github.com/repos/databricks/cli/releases/tags/v0.233.0 returned an error status: HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/databricks/cli/releases/tags/v0.233.0)[0m
```

I'd hope that the CI / code would be sufficiently tolerant that this wouldn't happen (retry w/ backoff).

---

Another is something to do with completion, an older version of my changes didn't seem to result in this failure, but when I looked at the diff between the current version and the previous version, I couldn't see why my later changes would cause the failure.

```
2026-05-31T17:30:07.2882025Z ##[error][mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run build -- -c ''] expected 'mise.toml
2026-05-31T17:30:07.2892452Z mise.usage.kdl' but got 'mise.toml	mise.toml
2026-05-31T17:30:07.2893269Z mise.usage.kdl	mise.usage.kdl'
2026-05-31T17:30:07.2893834Z tasks/test_task_completion: 3s
```

Note that testing this is painful in forks because a bunch of things require paid runners. I tested using 07fc35c1c733e4c1127566ae58973e01200893b5 as main and making a PR into that. It's possible to do some magic so that preferrer runners are used if known to be available and github runners are used as a fallback, I could make a PR for that if there's interest.

I can, of course, split the changes/drop changes as requested. AI was not used to develop these changes...