### PR TITLE
chore(npm): publish mise package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -112,6 +112,7 @@ jobs:
             export MISE_VERSION
             export RELEASE_DIR="releases"
             NPM_PREFIX=@jdxcode/mise mise x aube -- ./scripts/release-npm.sh
+            NPM_PREFIX=mise NPM_PLATFORM_PREFIX=@jdxcode/mise PUBLISH_PLATFORM_PACKAGES=0 mise x aube -- ./scripts/release-npm.sh
           else
             echo "DRY RUN: Would publish npm packages"
           fi

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -236,16 +236,18 @@ mise is available on npm as a precompiled binary. This isn't a Node.js packageâ€
 via npm. This is useful for JS projects that want to setup mise via `package.json` or `npx`.
 
 ```sh
-npm install -g @jdxcode/mise
+npm install -g mise
 ```
 
 Use npx if you just want to test it out for a single command without fully installing:
 
 ```sh
-npx @jdxcode/mise exec python@3.11 -- python some_script.py
+npx mise exec python@3.11 -- python some_script.py
 ```
 
-[npm package](https://www.npmjs.com/package/@jdxcode/mise)
+[npm package](https://www.npmjs.com/package/mise)
+
+The legacy [`@jdxcode/mise`](https://www.npmjs.com/package/@jdxcode/mise) package is still published.
 
 ### GitHub Releases
 

--- a/scripts/release-npm.sh
+++ b/scripts/release-npm.sh
@@ -8,6 +8,9 @@ error() {
 
 mkdir -p "$RELEASE_DIR/npm"
 
+NPM_PLATFORM_PREFIX="${NPM_PLATFORM_PREFIX:-$NPM_PREFIX}"
+PUBLISH_PLATFORM_PACKAGES="${PUBLISH_PLATFORM_PACKAGES:-1}"
+
 dist_tag_from_version() {
 	IFS="-" read -r -a version_split <<<"$1"
 	IFS="." read -r -a version_split <<<"${version_split[1]:-latest}"
@@ -15,29 +18,30 @@ dist_tag_from_version() {
 }
 dist_tag="$(dist_tag_from_version "$MISE_VERSION")"
 
-platforms=(
-	linux-x64
-	linux-arm64
-	linux-armv7
-	macos-x64
-	macos-arm64
-)
-for platform in "${platforms[@]}"; do
-	# shellcheck disable=SC2206
-	platform_split=(${platform//-/ })
-	os="${platform_split[0]}"
-	arch="${platform_split[1]}"
+if [ "$PUBLISH_PLATFORM_PACKAGES" != "0" ]; then
+	platforms=(
+		linux-x64
+		linux-arm64
+		linux-armv7
+		macos-x64
+		macos-arm64
+	)
+	for platform in "${platforms[@]}"; do
+		# shellcheck disable=SC2206
+		platform_split=(${platform//-/ })
+		os="${platform_split[0]}"
+		arch="${platform_split[1]}"
 
-	if [[ $os == "macos" ]]; then
-		os="darwin"
-	fi
+		if [[ $os == "macos" ]]; then
+			os="darwin"
+		fi
 
-	cp "$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.tar.gz" "$RELEASE_DIR/mise-latest-$platform.tar.gz"
-	cp "$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.tar.xz" "$RELEASE_DIR/mise-latest-$platform.tar.xz"
-	tar -xzvf "$RELEASE_DIR/mise-latest-$platform.tar.gz" -C "$RELEASE_DIR"
-	rm -rf "$RELEASE_DIR/npm"
-	mv "$RELEASE_DIR/mise" "$RELEASE_DIR/npm"
-	cat <<EOF >"$RELEASE_DIR/npm/package.json"
+		cp "$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.tar.gz" "$RELEASE_DIR/mise-latest-$platform.tar.gz"
+		cp "$RELEASE_DIR/$MISE_VERSION/mise-$MISE_VERSION-$platform.tar.xz" "$RELEASE_DIR/mise-latest-$platform.tar.xz"
+		tar -xzvf "$RELEASE_DIR/mise-latest-$platform.tar.gz" -C "$RELEASE_DIR"
+		rm -rf "$RELEASE_DIR/npm"
+		mv "$RELEASE_DIR/mise" "$RELEASE_DIR/npm"
+		cat <<EOF >"$RELEASE_DIR/npm/package.json"
 {
   "name": "$NPM_PREFIX-$os-$arch",
   "version": "$MISE_VERSION",
@@ -58,25 +62,29 @@ for platform in "${platforms[@]}"; do
   "cpu": "$arch"
 }
 EOF
-	pushd "$RELEASE_DIR/npm"
-	tree || true
-	aube_publish_args=(--access public --tag "$dist_tag" --provenance --no-git-checks)
-	if [ "${DRY_RUN:-1}" != "0" ]; then
-		echo DRY_RUN
-		echo aube publish "${aube_publish_args[@]}"
-		echo DRY_RUN
-	else
-		if ! aube publish "${aube_publish_args[@]}" 2>&1 | tee /tmp/npm-publish.log; then
-			if grep -qE "already (on|published)|previously published" /tmp/npm-publish.log; then
-				echo "Version already published, skipping..."
-			else
-				cat /tmp/npm-publish.log
-				exit 1
+		pushd "$RELEASE_DIR/npm"
+		tree || true
+		aube_publish_args=(--access public --tag "$dist_tag" --provenance --no-git-checks)
+		if [ "${DRY_RUN:-1}" != "0" ]; then
+			echo DRY_RUN
+			echo aube publish "${aube_publish_args[@]}"
+			echo DRY_RUN
+		else
+			if ! aube publish "${aube_publish_args[@]}" 2>&1 | tee /tmp/npm-publish.log; then
+				if grep -qE "already (on|published)|previously published" /tmp/npm-publish.log; then
+					echo "Version already published, skipping..."
+				else
+					cat /tmp/npm-publish.log
+					exit 1
+				fi
 			fi
 		fi
-	fi
-	popd
-done
+		popd
+	done
+else
+	rm -rf "$RELEASE_DIR/npm"
+	mkdir -p "$RELEASE_DIR/npm"
+fi
 
 cat <<EOF >"$RELEASE_DIR/npm/installArchSpecificPackage.js"
 var spawn = require('child_process').spawn;
@@ -90,13 +98,13 @@ function installArchSpecificPackage(version) {
     var platform = process.platform == 'win32' ? 'windows' : process.platform;
     var arch = platform == 'windows' && process.arch == 'ia32' ? 'x86' : process.arch;
 
-    var cp = spawn(platform == 'windows' ? 'npm.cmd' : 'npm', ['install', '--no-save', ['$NPM_PREFIX', platform, arch].join('-') + '@' + version], {
+    var cp = spawn(platform == 'windows' ? 'npm.cmd' : 'npm', ['install', '--no-save', ['$NPM_PLATFORM_PREFIX', platform, arch].join('-') + '@' + version], {
         stdio: 'inherit',
         shell: true
     });
 
     cp.on('close', function(code) {
-        var pkgJson = require.resolve(['$NPM_PREFIX', platform, arch].join('-') + '/package.json');
+        var pkgJson = require.resolve(['$NPM_PLATFORM_PREFIX', platform, arch].join('-') + '/package.json');
         var subpkg = JSON.parse(fs.readFileSync(pkgJson, 'utf8'));
         var executable = subpkg.bin.mise;
         var bin = path.resolve(path.dirname(pkgJson), executable);

--- a/scripts/release-npm.sh
+++ b/scripts/release-npm.sh
@@ -43,7 +43,7 @@ if [ "$PUBLISH_PLATFORM_PACKAGES" != "0" ]; then
 		mv "$RELEASE_DIR/mise" "$RELEASE_DIR/npm"
 		cat <<EOF >"$RELEASE_DIR/npm/package.json"
 {
-  "name": "$NPM_PREFIX-$os-$arch",
+  "name": "$NPM_PLATFORM_PREFIX-$os-$arch",
   "version": "$MISE_VERSION",
   "description": "Dev tools, env vars, and tasks in one CLI",
   "bin": {
@@ -85,6 +85,8 @@ else
 	rm -rf "$RELEASE_DIR/npm"
 	mkdir -p "$RELEASE_DIR/npm"
 fi
+
+cp README.md "$RELEASE_DIR/npm/README.md"
 
 cat <<EOF >"$RELEASE_DIR/npm/installArchSpecificPackage.js"
 var spawn = require('child_process').spawn;


### PR DESCRIPTION
## Summary
- document `mise` as the default npm install/npx package while keeping `@jdxcode/mise` noted as legacy
- publish the scoped `@jdxcode/mise` package set first, then publish the unscoped `mise` wrapper
- allow the unscoped wrapper to reuse the existing `@jdxcode/mise-<os>-<arch>` platform packages

## Trusted publishing settings
For the new `mise` npm package, configure npm trusted publishing with:
- Publisher: GitHub Actions
- Organization/user: jdx
- Repository: mise
- Workflow filename: npm-publish.yml
- Environment name: blank, unless an environment is added to the GitHub job

## Tests
- `git diff --check`
- `bash -n scripts/release-npm.sh`
- `shellcheck scripts/release-npm.sh`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release workflow and install-time npm dependency wiring change; misconfiguration could break installs or publish the wrong package names until trusted publishing is set up for `mise`.
> 
> **Overview**
> Adds a **second npm publish** in CI: first the existing **`@jdxcode/mise`** scoped platform packages, then an unscoped **`mise`** meta-package that skips re-publishing per-OS/arch tarballs and installs via the existing **`@jdxcode/mise-<os>-<arch>`** packages.
> 
> **`scripts/release-npm.sh`** gains **`NPM_PLATFORM_PREFIX`** (defaults to **`NPM_PREFIX`**) and **`PUBLISH_PLATFORM_PACKAGES`** (default on). When platform publish is off, only the wrapper **`package.json`** and **`installArchSpecificPackage.js`** are built, with the installer resolving **`$NPM_PLATFORM_PREFIX`** instead of **`$NPM_PREFIX`**.
> 
> **`docs/installing-mise.md`** documents **`npm install -g mise`**, **`npx mise`**, and the **`mise`** npm page, while noting **`@jdxcode/mise`** remains published as legacy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fdfe601f693ce19548ef5e55ee2f68642c9b460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated npm install instructions to reference the new mise package (legacy `@jdxcode/mise` still available).
  * Updated examples and links to use mise.

* **Chores**
  * Publishing workflow updated to support separate per-platform package names and an option to skip platform-specific publishes, and to adjust installer behavior to target the new package naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->