### PR TITLE
fix(aqua): canonicalize and reject duplicate vars

### DIFF
--- a/e2e/backend/test_aqua_vars
+++ b/e2e/backend/test_aqua_vars
@@ -63,6 +63,27 @@ EOF_MISE
 MISE_TIMINGS=1 mise lock --platform "$MISE_PLATFORM"
 assert_succeed "cmp mise.lock nested-vars.lock"
 
+rm -f mise.toml mise.lock
+mkdir -p .config/mise/conf.d
+
+cat <<'EOF_MISE' >.config/mise/conf.d/01-base.toml
+[tools."aqua:example/vars-tool"]
+version = "1.0.0"
+vars.fixture_version = "1.0.0"
+EOF_MISE
+
+cat <<'EOF_MISE' >.config/mise/conf.d/02-override.toml
+[tools."aqua:example/vars-tool"]
+version = "1.0.0"
+fixture_version = "2.0.0"
+EOF_MISE
+
+MISE_TIMINGS=1 mise lock --platform "$MISE_PLATFORM"
+assert_contains "cat .config/mise/mise.lock" '"vars.fixture_version" = "2.0.0"'
+assert_contains "cat .config/mise/mise.lock" 'url = "https://mise.en.dev/test-fixtures/hello-world-2.0.0.tar.gz"'
+assert_not_contains "cat .config/mise/mise.lock" '"vars.fixture_version" = "1.0.0"'
+rm -rf .config/mise
+
 cat <<'EOF_MISE' >mise.toml
 [tools]
 "aqua:example/vars-tool" = { version = "1.0.0", vars = { fixture_version = ["2.0.0"] } }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -65,46 +65,66 @@ impl<'a> AquaOptions<'a> {
     }
 
     fn var(&self, name: &str) -> Result<Option<String>> {
-        let opts = self.values.raw();
-        if let Some(toml::Value::Table(vars)) = opts.opts.get("vars")
-            && let Some(value) = vars.get(name)
-        {
-            return toml_string_var(&format!("vars.{name}"), value).map(Some);
-        }
-        opts.opts
+        self.canonical_var_options()?
             .get(name)
-            .map(|value| toml_string_var(name, value).map(Some))
+            .map(|value| toml_string_var(&format!("vars.{name}"), value).map(Some))
             .unwrap_or(Ok(None))
     }
 
-    fn lockfile_options(&self) -> BTreeMap<String, String> {
-        let mut result = BTreeMap::new();
+    fn lockfile_options(&self) -> Result<BTreeMap<String, String>> {
+        Ok(self
+            .canonical_var_options()?
+            .into_iter()
+            .filter_map(|(key, value)| {
+                toml_value_to_string(value).map(|value| (format!("vars.{key}"), value))
+            })
+            .collect())
+    }
+
+    fn canonical_var_options(&self) -> Result<BTreeMap<String, &toml::Value>> {
+        let mut vars = BTreeMap::new();
         for (key, value) in self.values.raw().iter() {
             if key == "symlink_bins" || EPHEMERAL_OPT_KEYS.contains(&key.as_str()) {
                 continue;
             }
+
             if key == "vars" {
                 if let toml::Value::Table(table) = value {
-                    Self::insert_vars_lockfile_options(&mut result, table);
+                    Self::insert_nested_var_options(&mut vars, table)?;
                 }
-            } else if let Some(value) = toml_value_to_string(value) {
-                let key = if key.starts_with("vars.") {
-                    key.clone()
-                } else {
-                    format!("vars.{key}")
-                };
-                result.entry(key).or_insert(value);
+                continue;
             }
+
+            let key = if let Some(key) = key.strip_prefix("vars.") {
+                key.to_string()
+            } else {
+                key.clone()
+            };
+            Self::insert_var_option(&mut vars, key, value)?;
         }
-        result
+        Ok(vars)
     }
 
-    fn insert_vars_lockfile_options(result: &mut BTreeMap<String, String>, table: &toml::Table) {
-        for (key, value) in table {
-            if let Some(value) = toml_value_to_string(value) {
-                result.insert(format!("vars.{key}"), value);
-            }
+    fn insert_var_option<'b>(
+        result: &mut BTreeMap<String, &'b toml::Value>,
+        key: String,
+        value: &'b toml::Value,
+    ) -> Result<()> {
+        if result.contains_key(&key) {
+            bail!("conflicting aqua var `{key}`: use only one spelling");
         }
+        result.insert(key, value);
+        Ok(())
+    }
+
+    fn insert_nested_var_options<'b>(
+        result: &mut BTreeMap<String, &'b toml::Value>,
+        table: &'b toml::Table,
+    ) -> Result<()> {
+        for (key, value) in table {
+            Self::insert_var_option(result, key.clone(), value)?;
+        }
+        Ok(())
     }
 }
 
@@ -584,7 +604,7 @@ impl Backend for AquaBackend {
             });
         }
 
-        let cache_key = opts.lockfile_options();
+        let cache_key = opts.lockfile_options()?;
         let cache: CacheManager<Vec<PathBuf>> =
             CacheManagerBuilder::new(tv.cache_path().join("bin_paths.msgpack.z"))
                 .with_fresh_file(install_path.clone())
@@ -622,7 +642,7 @@ impl Backend for AquaBackend {
         &self,
         request: &ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let request_options = request.options();
         AquaOptions::new(&request_options).lockfile_options()
     }
@@ -2934,7 +2954,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_var_options_prefers_nested_vars() {
+    fn test_apply_var_options_errors_for_duplicate_nested_vars() {
         let mut pkg = AquaPackage::default();
         pkg.asset = "tool-{{.Vars.channel}}-{{.Version}}.tar.gz".to_string();
         pkg.vars = vec![aqua_var("channel", true)];
@@ -2952,11 +2972,83 @@ mod tests {
             .insert("vars".to_string(), toml::Value::Table(vars));
 
         let opts = AquaOptions::new(&opts);
+        let err = AquaBackend::apply_var_options(pkg, &opts).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("conflicting aqua var `channel`: use only one spelling"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_apply_var_options_reads_prefixed_vars() {
+        let mut pkg = AquaPackage::default();
+        pkg.asset = "tool-{{.Vars.channel}}-{{.Version}}.tar.gz".to_string();
+        pkg.vars = vec![aqua_var("channel", true)];
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "vars.channel".to_string(),
+            toml::Value::String("stable".to_string()),
+        );
+
+        let opts = AquaOptions::new(&opts);
         let pkg = AquaBackend::apply_var_options(pkg, &opts).unwrap();
 
         assert_eq!(
             pkg.asset("1.0.0", "linux", "amd64").unwrap(),
-            "tool-beta-1.0.0.tar.gz"
+            "tool-stable-1.0.0.tar.gz"
+        );
+    }
+
+    #[test]
+    fn test_apply_var_options_errors_for_duplicate_prefixed_vars() {
+        let mut pkg = AquaPackage::default();
+        pkg.asset = "tool-{{.Vars.channel}}-{{.Version}}.tar.gz".to_string();
+        pkg.vars = vec![aqua_var("channel", true)];
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "vars.channel".to_string(),
+            toml::Value::String("manifest".to_string()),
+        );
+        opts.opts.insert(
+            "channel".to_string(),
+            toml::Value::String("stable".to_string()),
+        );
+
+        let opts = AquaOptions::new(&opts);
+        let err = AquaBackend::apply_var_options(pkg, &opts).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("conflicting aqua var `channel`: use only one spelling"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_apply_var_options_allows_same_spelling_overrides() {
+        let mut pkg = AquaPackage::default();
+        pkg.asset = "tool-{{.Vars.channel}}-{{.Version}}.tar.gz".to_string();
+        pkg.vars = vec![aqua_var("channel", true)];
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "channel".to_string(),
+            toml::Value::String("manifest".to_string()),
+        );
+        let mut overrides = ToolVersionOptions::default();
+        overrides.opts.insert(
+            "channel".to_string(),
+            toml::Value::String("stable".to_string()),
+        );
+        opts.apply_overrides(&overrides);
+
+        let opts = AquaOptions::new(&opts);
+        let pkg = AquaBackend::apply_var_options(pkg, &opts).unwrap();
+
+        assert_eq!(
+            pkg.asset("1.0.0", "linux", "amd64").unwrap(),
+            "tool-stable-1.0.0.tar.gz"
         );
     }
 
@@ -3018,7 +3110,7 @@ mod tests {
         opts.opts
             .insert("vars".to_string(), toml::Value::Table(vars));
 
-        let lock_opts = AquaOptions::new(&opts).lockfile_options();
+        let lock_opts = AquaOptions::new(&opts).lockfile_options().unwrap();
 
         assert_eq!(lock_opts.get("vars.channel"), Some(&"stable".to_string()));
         assert_eq!(lock_opts.get("vars.go_version"), Some(&"1.24".to_string()));
@@ -3044,19 +3136,25 @@ mod tests {
             .opts
             .insert("vars".to_string(), toml::Value::Table(vars));
 
+        let mut prefixed = ToolVersionOptions::default();
+        prefixed.opts.insert(
+            "vars.channel".to_string(),
+            toml::Value::String("stable".to_string()),
+        );
+
         assert_eq!(
-            AquaOptions::new(&top_level).lockfile_options(),
-            AquaOptions::new(&nested).lockfile_options()
+            AquaOptions::new(&top_level).lockfile_options().unwrap(),
+            AquaOptions::new(&nested).lockfile_options().unwrap()
+        );
+        assert_eq!(
+            AquaOptions::new(&prefixed).lockfile_options().unwrap(),
+            AquaOptions::new(&nested).lockfile_options().unwrap()
         );
     }
 
     #[test]
-    fn test_lockfile_options_nested_aqua_vars_take_precedence() {
+    fn test_lockfile_options_errors_for_duplicate_nested_vars() {
         let mut opts = ToolVersionOptions::default();
-        opts.opts.insert(
-            "channel".to_string(),
-            toml::Value::String("stable".to_string()),
-        );
         let mut vars = toml::Table::new();
         vars.insert(
             "channel".to_string(),
@@ -3064,10 +3162,39 @@ mod tests {
         );
         opts.opts
             .insert("vars".to_string(), toml::Value::Table(vars));
+        opts.opts.insert(
+            "channel".to_string(),
+            toml::Value::String("stable".to_string()),
+        );
 
-        let lock_opts = AquaOptions::new(&opts).lockfile_options();
+        let err = AquaOptions::new(&opts).lockfile_options().unwrap_err();
 
-        assert_eq!(lock_opts.get("vars.channel"), Some(&"beta".to_string()));
+        assert!(
+            err.to_string()
+                .contains("conflicting aqua var `channel`: use only one spelling"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_lockfile_options_errors_for_duplicate_prefixed_vars() {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "channel".to_string(),
+            toml::Value::String("stable".to_string()),
+        );
+        opts.opts.insert(
+            "vars.channel".to_string(),
+            toml::Value::String("manifest".to_string()),
+        );
+
+        let err = AquaOptions::new(&opts).lockfile_options().unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("conflicting aqua var `channel`: use only one spelling"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -259,9 +259,9 @@ impl Backend for CargoBackend {
         &self,
         request: &ToolRequest,
         target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let opts = request.options();
-        CargoOptions::new(&opts).lockfile_options(target)
+        Ok(CargoOptions::new(&opts).lockfile_options(target))
     }
 }
 

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -661,9 +661,9 @@ impl Backend for CondaBackend {
         &self,
         request: &crate::toolset::ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let raw_opts = request.options();
-        CondaOptions::new(&raw_opts).lockfile_options()
+        Ok(CondaOptions::new(&raw_opts).lockfile_options())
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -587,9 +587,9 @@ impl Backend for UnifiedGitBackend {
         &self,
         request: &ToolRequest,
         target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let raw_opts = request.options();
-        self.options(&raw_opts).lockfile_options(target)
+        Ok(self.options(&raw_opts).lockfile_options(target))
     }
 
     /// Resolve platform-specific lock information for cross-platform lockfile generation.

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -15,7 +15,7 @@ use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions};
 use async_trait::async_trait;
 use dashmap::DashMap;
-use eyre::WrapErr;
+use eyre::{Result, WrapErr};
 use serde_json::Deserializer;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
@@ -169,9 +169,9 @@ impl Backend for GoBackend {
         &self,
         request: &ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let raw_opts = request.options();
-        GoOptions::new(&raw_opts).lockfile_options()
+        Ok(GoOptions::new(&raw_opts).lockfile_options())
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -937,8 +937,8 @@ pub trait Backend: Debug + Send + Sync {
         &self,
         _request: &ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
-        BTreeMap::new() // Default: no options affect artifact identity
+    ) -> Result<BTreeMap<String, String>> {
+        Ok(BTreeMap::new()) // Default: no options affect artifact identity
     }
 
     /// Returns all platform variants that should be locked for a given base platform.

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -224,9 +224,9 @@ impl Backend for NPMBackend {
         &self,
         request: &ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let opts = request.options();
-        NpmOptions::new(&opts).lockfile_options()
+        Ok(NpmOptions::new(&opts).lockfile_options())
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
@@ -1278,7 +1278,9 @@ mod tests {
         let request =
             ToolRequest::new_opts(backend.ba().clone(), "latest", options, ToolSource::Unknown)
                 .unwrap();
-        let resolved = backend.resolve_lockfile_options(&request, &PlatformTarget::from_current());
+        let resolved = backend
+            .resolve_lockfile_options(&request, &PlatformTarget::from_current())
+            .unwrap();
         assert_eq!(
             resolved.get("npm_args"),
             Some(&"--ignore-scripts=false".to_string())

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -322,9 +322,9 @@ impl Backend for PIPXBackend {
         &self,
         request: &ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let opts = request.options();
-        PipxOptions::new(&opts).lockfile_options()
+        Ok(PipxOptions::new(&opts).lockfile_options())
     }
 }
 

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -13,7 +13,7 @@ use crate::toolset::{ToolVersion, ToolVersionOptions};
 use crate::{dirs, file, github, gitlab};
 use async_trait::async_trait;
 use duct::Expression;
-use eyre::{WrapErr, bail};
+use eyre::{Result, WrapErr, bail};
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::de::{MapAccess, Visitor};
@@ -162,9 +162,9 @@ impl Backend for SPMBackend {
         &self,
         request: &crate::toolset::ToolRequest,
         target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let raw_opts = request.options();
-        SpmOptions::new(&raw_opts).lockfile_options(target)
+        Ok(SpmOptions::new(&raw_opts).lockfile_options(target))
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -15,7 +15,7 @@ use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{backend::Backend, toolset::ToolVersionOptions};
 use crate::{file, github, gitlab, hash};
 use async_trait::async_trait;
-use eyre::bail;
+use eyre::{Result, bail};
 use regex::Regex;
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -452,9 +452,9 @@ impl Backend for UbiBackend {
         &self,
         request: &ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let raw_opts = request.options();
-        UbiOptions::new(&raw_opts).lockfile_options()
+        Ok(UbiOptions::new(&raw_opts).lockfile_options())
     }
 }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2135,6 +2135,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_tool_options_preserve_quoted_literal_dotted_keys() {
+        crate::toolset::install_state::init().await.unwrap();
+        let cf = MiseToml::from_str(
+            r#"
+            [tools."aqua:example/vars-tool"]
+            version = "1.0.0"
+            fixture_version = "2.0.0"
+            "vars.fixture_version" = "1.0.0"
+            "#,
+            std::path::Path::new("mise.toml"),
+        )
+        .unwrap();
+        let trs = cf.to_tool_request_set().unwrap();
+        let (_, requests, _) = trs.iter().next().unwrap();
+        let opts = requests[0].options();
+
+        assert_eq!(opts.get("fixture_version"), Some("2.0.0"));
+        assert_eq!(opts.get("vars.fixture_version"), Some("1.0.0"));
+    }
+
+    #[tokio::test]
     async fn test_env_source_var_in_tool() {
         let cwd = CWD.as_ref().unwrap();
         let script = cwd.join("set-go-version.sh");

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1134,15 +1134,15 @@ pub fn update_lockfiles(
         let tools_by_short: HashMap<String, Vec<LockfileTool>> = tool_versions_by_short
             .into_iter()
             .map(|(short, versions)| {
-                (
+                Ok((
                     short,
                     versions
                         .iter()
                         .map(lockfile_tool_from_tool_version)
-                        .collect(),
-                )
+                        .collect::<Result<Vec<_>>>()?,
+                ))
             })
-            .collect();
+            .collect::<Result<_>>()?;
 
         // Check for provenance regression before merging (which drops old version entries).
         // For github backend tools, error if the highest prior version had provenance but
@@ -1516,7 +1516,20 @@ pub async fn resolve_tool_lock_info(
     let target = PlatformTarget::new(platform.clone());
 
     let (info, options, conda_packages) = if let Some(backend) = backend {
-        let options = backend.resolve_lockfile_options(&tv.request, &target);
+        let options = match backend.resolve_lockfile_options(&tv.request, &target) {
+            Ok(options) => options,
+            Err(e) => {
+                return (
+                    ba.short.clone(),
+                    tv.version.clone(),
+                    ba.stored_full(),
+                    platform,
+                    Err(e.to_string()),
+                    BTreeMap::new(),
+                    BTreeMap::new(),
+                );
+            }
+        };
         match backend.resolve_lock_info(&tv, &target).await {
             Ok(info) => {
                 let conda_packages = if backend.get_type() == BackendType::Conda {
@@ -1980,16 +1993,7 @@ impl LockfileTool {
     }
 }
 
-impl From<ToolVersionList> for Vec<LockfileTool> {
-    fn from(tvl: ToolVersionList) -> Self {
-        tvl.versions
-            .iter()
-            .map(lockfile_tool_from_tool_version)
-            .collect()
-    }
-}
-
-fn lockfile_tool_from_tool_version(tv: &ToolVersion) -> LockfileTool {
+fn lockfile_tool_from_tool_version(tv: &ToolVersion) -> Result<LockfileTool> {
     let mut platforms = BTreeMap::new();
 
     // Convert tool version lock_platforms to lockfile platforms
@@ -2000,17 +2004,17 @@ fn lockfile_tool_from_tool_version(tv: &ToolVersion) -> LockfileTool {
     // Resolve lockfile options from the backend
     let options = if let Ok(backend) = tv.request.backend() {
         let target = PlatformTarget::from_current();
-        backend.resolve_lockfile_options(&tv.request, &target)
+        backend.resolve_lockfile_options(&tv.request, &target)?
     } else {
         BTreeMap::new()
     };
 
-    LockfileTool {
+    Ok(LockfileTool {
         version: tv.version.clone(),
         backend: Some(tv.ba().stored_full()),
         options,
         platforms,
-    }
+    })
 }
 
 fn format(mut doc: DocumentMut) -> String {

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -97,9 +97,9 @@ impl Backend for DotnetPlugin {
         &self,
         request: &ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let raw_opts = request.options();
-        DotnetOptions::new(&raw_opts).lockfile_options()
+        Ok(DotnetOptions::new(&raw_opts).lockfile_options())
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
@@ -483,7 +483,9 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            backend.resolve_lockfile_options(&request, &PlatformTarget::from_current()),
+            backend
+                .resolve_lockfile_options(&request, &PlatformTarget::from_current())
+                .unwrap(),
             BTreeMap::from([("runtime".to_string(), "aspnetcore".to_string())])
         );
 
@@ -497,6 +499,7 @@ mod tests {
         assert!(
             backend
                 .resolve_lockfile_options(&request_no_runtime, &PlatformTarget::from_current())
+                .unwrap()
                 .is_empty()
         );
     }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -392,7 +392,7 @@ impl Backend for ErlangPlugin {
         &self,
         _request: &ToolRequest,
         target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let mut opts = BTreeMap::new();
         let settings = Settings::get();
         let is_current_platform = target.is_current();
@@ -407,6 +407,6 @@ impl Backend for ErlangPlugin {
             opts.insert("compile".to_string(), "true".to_string());
         }
 
-        opts
+        Ok(opts)
     }
 }

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -489,10 +489,10 @@ impl Backend for JavaPlugin {
         &self,
         request: &ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let raw_opts = request.options();
-        JavaOptions::new(&raw_opts)
-            .lockfile_options(&request.version(), &Settings::get().java.shorthand_vendor)
+        Ok(JavaOptions::new(&raw_opts)
+            .lockfile_options(&request.version(), &Settings::get().java.shorthand_vendor))
     }
 
     async fn resolve_lock_info(

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -741,7 +741,7 @@ impl Backend for NodePlugin {
         &self,
         _request: &ToolRequest,
         target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let mut opts = BTreeMap::new();
         let settings = Settings::get();
         let is_current_platform = target.is_current();
@@ -762,7 +762,7 @@ impl Backend for NodePlugin {
             opts.insert("flavor".to_string(), flavor);
         }
 
-        opts
+        Ok(opts)
     }
 
     async fn resolve_lock_info(

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -930,7 +930,7 @@ impl Backend for PythonPlugin {
         &self,
         request: &ToolRequest,
         target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let mut opts = BTreeMap::new();
         let settings = Settings::get();
         let is_current_platform = target.is_current();
@@ -961,7 +961,7 @@ impl Backend for PythonPlugin {
 
         let raw_opts = request.options();
         opts.extend(PythonOptions::new(&raw_opts).lockfile_options());
-        opts
+        Ok(opts)
     }
 
     async fn resolve_lock_info(

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -1036,10 +1036,10 @@ impl Backend for RubyPlugin {
         &self,
         _request: &ToolRequest,
         target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         if target.os_name() == "windows" {
             // Windows uses RubyInstaller2, so ruby-build/precompiled settings do not affect it.
-            return BTreeMap::new();
+            return Ok(BTreeMap::new());
         }
 
         let mut opts = BTreeMap::new();
@@ -1082,7 +1082,7 @@ impl Backend for RubyPlugin {
             }
         }
 
-        opts
+        Ok(opts)
     }
 
     async fn resolve_lock_info(
@@ -1206,7 +1206,7 @@ mod tests {
 
         let backend = RubyPlugin::new();
         let request = ToolRequest::new(backend.ba().clone(), "3.3.0", ToolSource::Unknown).unwrap();
-        backend.resolve_lockfile_options(&request, &target)
+        backend.resolve_lockfile_options(&request, &target).unwrap()
     }
 
     fn non_current_platform_target() -> PlatformTarget {
@@ -1337,7 +1337,7 @@ mod tests {
         let backend = RubyPlugin::new();
         let request = ToolRequest::new(backend.ba().clone(), "3.3.0", ToolSource::Unknown).unwrap();
         let target = PlatformTarget::new(Platform::parse("macos-arm64").unwrap());
-        let opts = backend.resolve_lockfile_options(&request, &target);
+        let opts = backend.resolve_lockfile_options(&request, &target).unwrap();
         let tv = ToolVersion::new(request, "3.3.0".to_string());
         let info = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -155,14 +155,14 @@ impl Backend for RustPlugin {
         &self,
         request: &ToolRequest,
         _target: &PlatformTarget,
-    ) -> BTreeMap<String, String> {
+    ) -> Result<BTreeMap<String, String>> {
         let rt = match request.source() {
             IdiomaticVersionFile(path) => parse_idiomatic_file(path).ok(),
             _ => None,
         };
 
         let raw_opts = request.options();
-        RustOptions::new(&raw_opts).lockfile_options(rt.as_ref())
+        Ok(RustOptions::new(&raw_opts).lockfile_options(rt.as_ref()))
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -331,7 +331,7 @@ impl ToolRequest {
     ) -> Result<Option<LockfileTool>> {
         let request_options = if let Ok(backend) = self.backend() {
             let target = PlatformTarget::from_current();
-            backend.resolve_lockfile_options(self, &target)
+            backend.resolve_lockfile_options(self, &target)?
         } else {
             BTreeMap::new()
         };

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -16,6 +16,7 @@ use crate::{backend, ui};
 pub enum ProgressIcon {
     Success,
     Skipped,
+    #[allow(dead_code)]
     Warning,
     Error,
 }


### PR DESCRIPTION
## Summary

- canonicalize Aqua var options from plain keys, nested `vars`, and literal `vars.<name>` backend-option keys into one lock/cache identity
- reject duplicate final Aqua vars with a source-neutral `conflicting aqua var` error instead of picking one spelling
- add unit/e2e coverage for literal dotted-key parsing, duplicate detection, and normal higher-precedence config overrides

## Details

TOML already treats unquoted dotted keys and tables as the same structure: `vars.channel = "stable"` and `[vars] channel = "stable"` both parse as a nested `vars` table. This PR does not distinguish those TOML forms.

The extra spelling mise has to normalize is the literal backend-option key `"vars.channel"`, which can come from backend arg/manual option parsing or persisted raw option maps rather than TOML dotted-key parsing. Aqua now canonicalizes that literal key to the same `vars.channel` lock/cache identity as nested TOML `vars.channel` and the documented plain `channel` var option.

If two entries in the final flattened options map collapse to the same Aqua var, Aqua stops with `conflicting aqua var`. If a higher-precedence config layer overrides a lower-precedence layer before Aqua sees the options, only the winning value reaches the backend, so normal config precedence still applies silently.

## Note

`mise lock` still has existing best-effort behavior that can ignore invalid config/tool request conversion or skip failed per-platform lock resolution while writing successful entries. This PR does not change that broader policy; making invalid in-scope config fatal for `mise lock` should be handled separately.

## Test plan

- [ ] CI (lint, unit, e2e)
- [ ] `mise run test:e2e e2e/backend/test_aqua_vars`