### PR TITLE
chore: release 2026.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [2026.6.0](https://github.com/jdx/mise/compare/v2026.5.18..v2026.6.0) - 2026-06-03
+
+### 🚀 Features
+
+- **(npm)** ensure npm is managed by corepack when node.corepack=true and node.npm_shim=false by @roele in [#10196](https://github.com/jdx/mise/pull/10196)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** mirror aqua windows extension semantics by @risu729 in [#10167](https://github.com/jdx/mise/pull/10167)
+- **(bun)** improve musl detection logic using runtime detection by @roele in [#10195](https://github.com/jdx/mise/pull/10195)
+- **(completion)** rely on usage#649 for global flags, keep -r/-S promotion by @JamBalaya56562 in [#10176](https://github.com/jdx/mise/pull/10176)
+- **(spm)** track artifact bundle options in lock identity by @risu729 in [#10160](https://github.com/jdx/mise/pull/10160)
+- **(task)** honor task_config.includes order so a local task can override a git::include by @vmaleze in [#10191](https://github.com/jdx/mise/pull/10191)
+- **(task)** honor MISE_CYGDRIVE_PREFIX for Git Bash, not only Cygwin by @JamBalaya56562 in [#10190](https://github.com/jdx/mise/pull/10190)
+
+### 📚 Documentation
+
+- Fix example syntax for choice function in templates by @joekrill in [#10197](https://github.com/jdx/mise/pull/10197)
+- add sponsor footer by @jdx in [#10182](https://github.com/jdx/mise/pull/10182)
+
+### New Contributors
+
+- @joekrill made their first contribution in [#10197](https://github.com/jdx/mise/pull/10197)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (3)
+
+- [`cliwright/whoiam`](https://github.com/cliwright/whoiam)
+- [`google-antigravity/antigravity-cli`](https://github.com/google-antigravity/antigravity-cli)
+- [`tidewave-ai/tidewave_app`](https://github.com/tidewave-ai/tidewave_app)
+
+#### Updated Packages (1)
+
+- [`endevco/aube`](https://github.com/endevco/aube)
+
 ## [2026.5.18](https://github.com/jdx/mise/compare/v2026.5.17..v2026.5.18) - 2026-05-31
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.5.18"
+version = "2026.6.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.5.18"
+version = "2026.6.0"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.5.18 macos-arm64 (2026-05-31)
+2026.6.0 macos-arm64 (2026-06-03)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_18.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_0.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_5_18.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_0.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_5_18.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_0.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_5_18.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_0.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.5.18";
+  version = "2026.6.0";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.5.18
+Version: 2026.6.0
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.5.18"
+version: "2026.6.0"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "v4.519.0"
+  "tag": "v4.520.1"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -25070,6 +25070,27 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: cliwright
+    repo_name: whoiam
+    description: CLI tool for checking and validating your current AWS IAM identity
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: whoiam_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: clog-tool
     repo_name: clog-cli
     description: Generate beautiful changelogs from your Git commit history
@@ -35305,9 +35326,19 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: darwin
             replacements:
               amd64: amd64
@@ -43528,46 +43559,30 @@ packages:
         supported_envs:
           - linux
           - darwin
-  - type: http
-    name: google.com/antigravity-cli
-    description: Google's agentic development platform CLI companion
-    link: https://antigravity.google/download
-    format: tar.gz
+  - type: github_release
+    repo_owner: google-antigravity
+    repo_name: antigravity-cli
+    aliases:
+      - name: google.com/antigravity-cli
+    description: Google Antigravity CLI companion
     files:
       - name: agy
-        src: antigravity
-    checksum:
-      type: http
-      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/{{.OS}}_{{.Arch}}.json
-      file_format: regexp
-      algorithm: sha512
-      pattern:
-        checksum: '"sha512": "([0-9a-f]{128})"'
-    overrides:
-      - goos: linux
-        goarch: amd64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
-      - goos: linux
-        goarch: arm64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-arm/cli_linux_arm64.tar.gz
-      - goos: darwin
-        goarch: amd64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-x64/cli_mac_x64.tar.gz
-      - goos: darwin
-        goarch: arm64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-arm/cli_mac_arm64.tar.gz
-      - goos: windows
-        goarch: amd64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-x64/cli_windows_x64.exe
-        format: raw
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 1.0.4")
+        error_message: The version is old. Please upgrade to 1.0.4 or later.
+      - version_constraint: "true"
+        asset: agy_cli_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         files:
           - name: agy
-      - goos: windows
-        goarch: arm64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-arm/cli_windows_arm64.exe
-        format: raw
-        files:
-          - name: agy
+            src: antigravity
+        replacements:
+          amd64: x64
+          darwin: mac
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: google
     repo_name: addlicense
@@ -90468,6 +90483,24 @@ packages:
       type: github_release
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
+  - type: github_release
+    repo_owner: tidewave-ai
+    repo_name: tidewave_app
+    description: Tidewave is the coding agent for full-stack web app development
+    files:
+      - name: tidewave
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tidewave-cli-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
   - type: github_release
     repo_owner: tilt-dev
     repo_name: ctlptl


### PR DESCRIPTION
### 🚀 Features

- **(npm)** ensure npm is managed by corepack when node.corepack=true and node.npm_shim=false by @roele in [#10196](https://github.com/jdx/mise/pull/10196)

### 🐛 Bug Fixes

- **(aqua)** mirror aqua windows extension semantics by @risu729 in [#10167](https://github.com/jdx/mise/pull/10167)
- **(bun)** improve musl detection logic using runtime detection by @roele in [#10195](https://github.com/jdx/mise/pull/10195)
- **(completion)** rely on usage#649 for global flags, keep -r/-S promotion by @JamBalaya56562 in [#10176](https://github.com/jdx/mise/pull/10176)
- **(spm)** track artifact bundle options in lock identity by @risu729 in [#10160](https://github.com/jdx/mise/pull/10160)
- **(task)** honor task_config.includes order so a local task can override a git::include by @vmaleze in [#10191](https://github.com/jdx/mise/pull/10191)
- **(task)** honor MISE_CYGDRIVE_PREFIX for Git Bash, not only Cygwin by @JamBalaya56562 in [#10190](https://github.com/jdx/mise/pull/10190)

### 📚 Documentation

- Fix example syntax for choice function in templates by @joekrill in [#10197](https://github.com/jdx/mise/pull/10197)
- add sponsor footer by @jdx in [#10182](https://github.com/jdx/mise/pull/10182)

### New Contributors

- @joekrill made their first contribution in [#10197](https://github.com/jdx/mise/pull/10197)

## 📦 Aqua Registry Updates

### New Packages (3)

- [`cliwright/whoiam`](https://github.com/cliwright/whoiam)
- [`google-antigravity/antigravity-cli`](https://github.com/google-antigravity/antigravity-cli)
- [`tidewave-ai/tidewave_app`](https://github.com/tidewave-ai/tidewave_app)

### Updated Packages (1)

- [`endevco/aube`](https://github.com/endevco/aube)