### PR TITLE
fix(task): honor MISE_CYGDRIVE_PREFIX for Git Bash, not only Cygwin

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -204,8 +204,12 @@ the intended one is used:
 $env:MISE_BASH_PATH = "C:\cygwin64\bin\bash.exe"
 ```
 
-If you changed the `cygdrive` prefix in `/etc/fstab` (the default is `/cygdrive`),
-set `MISE_CYGDRIVE_PREFIX` to match — mise does not read `/etc/fstab`:
+#### Custom `cygdrive` mount root (Cygwin **and** Git Bash / MSYS2)
+
+The `cygdrive` automount mechanism is shared by Cygwin and MSYS2 / Git Bash — both let
+you change the mount root in `/etc/fstab` (Cygwin's default is `/cygdrive`, Git Bash /
+MSYS2's is `/`, i.e. `/c/...`). mise does not read `/etc/fstab`, so if you changed it,
+set `MISE_CYGDRIVE_PREFIX` to match — this works for **either** shell:
 
 ```powershell
 # e.g. for an fstab that mounts drives under /mnt
@@ -213,7 +217,8 @@ $env:MISE_CYGDRIVE_PREFIX = "/mnt"
 ```
 
 The prefix must be absolute (start with `/`); a relative value like `mnt` is rejected
-with a warning and the default `/cygdrive` is used instead.
+with a warning and the shell's default is used instead. `MISE_CYGDRIVE_PREFIX=/`
+collapses to the Git Bash `/c/...` form.
 
 ## mise isn't working when calling from tmux or another shell initialization script
 

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1529,27 +1529,33 @@ fn maybe_convert_env_for_msys_shell<'a>(
 }
 
 /// The cygdrive prefix inserted before drive letters when converting PATH for a
-/// POSIX shell: empty for MSYS2 / Git Bash (`/c/...`), `/cygdrive` for Cygwin
-/// (`/cygdrive/c/...`). A Cygwin user with a non-default `cygdrive` mount (configured
-/// in `/etc/fstab`) can override it via `MISE_CYGDRIVE_PREFIX` — mise does not parse
-/// fstab. A trailing `/` is trimmed since the converter emits its own separator after
-/// the prefix, so `MISE_CYGDRIVE_PREFIX=/` collapses to the MSYS `/c/...` form. A
-/// non-empty value that is not absolute (no leading `/`, e.g. `mnt`) would produce
-/// relative PATH entries that bash silently ignores, so it is rejected with a warning
-/// and the default `/cygdrive` is used instead.
+/// POSIX shell. `is_cygwin_shell` only selects the *default* when no override is set:
+/// empty for MSYS2 / Git Bash (`/c/...`), `/cygdrive` for Cygwin (`/cygdrive/c/...`).
+///
+/// The `cygdrive` automount mechanism is shared by Cygwin and MSYS2 / Git Bash — both
+/// let the user change the mount root in `/etc/fstab` (Cygwin's default is `/cygdrive`,
+/// MSYS2's is `/`). mise does not parse fstab, so `MISE_CYGDRIVE_PREFIX` is an explicit
+/// override honored for *both* shells. A trailing `/` is trimmed since the converter
+/// emits its own separator after the prefix, so `MISE_CYGDRIVE_PREFIX=/` collapses to
+/// the MSYS `/c/...` form. A non-empty value that is not absolute (no leading `/`, e.g.
+/// `mnt`) would produce relative PATH entries that bash silently ignores, so it is
+/// rejected with a warning and the shell's default is used instead.
 #[cfg(windows)]
 fn msys_drive_prefix_for(program: &Path, env: &BTreeMap<String, String>) -> String {
-    const DEFAULT: &str = "/cygdrive";
-    if !crate::path::is_cygwin_shell(program) {
-        return String::new();
-    }
+    // Default automount root when no override is set: empty for Git Bash / MSYS2
+    // (`/c/...`), `/cygdrive` for Cygwin (`/cygdrive/c/...`).
+    let default = if crate::path::is_cygwin_shell(program) {
+        "/cygdrive"
+    } else {
+        ""
+    };
     let raw = env
         .get("MISE_CYGDRIVE_PREFIX")
         .cloned()
         .or_else(|| std::env::var("MISE_CYGDRIVE_PREFIX").ok())
         .filter(|s| !s.is_empty());
     let Some(mut s) = raw else {
-        return DEFAULT.to_string();
+        return default.to_string();
     };
     // Trim trailing slashes in place — the converter appends its own separator.
     s.truncate(s.trim_end_matches('/').len());
@@ -1559,11 +1565,18 @@ fn msys_drive_prefix_for(program: &Path, env: &BTreeMap<String, String>) -> Stri
     } else if s.starts_with('/') {
         s
     } else {
+        // Describe the default clearly: an empty prefix is the Git Bash `/c/...` form,
+        // otherwise the Cygwin `/cygdrive` root.
+        let default_desc = if default.is_empty() {
+            "the Git Bash `/c/...` form".to_string()
+        } else {
+            format!("the default `{default}`")
+        };
         warn!(
             "MISE_CYGDRIVE_PREFIX={s:?} is not absolute (must start with `/`); \
-             using the default `{DEFAULT}`"
+             using {default_desc}"
         );
-        DEFAULT.to_string()
+        default.to_string()
     }
 }
 
@@ -1678,6 +1691,22 @@ mod tests {
         let mut env = env_with_path(r"C:\foo;D:\bar");
         env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "/mnt".to_string());
         let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);
+        assert_eq!(
+            out.get(&*crate::env::PATH_KEY).unwrap(),
+            "/mnt/c/foo:/mnt/d/bar"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_maybe_convert_env_for_msys_shell_honors_cygdrive_prefix_for_git_bash() {
+        // The cygdrive automount root is configurable in MSYS2 / Git Bash too (not just
+        // Cygwin). A Git Bash user with a non-default fstab mount supplies it via
+        // MISE_CYGDRIVE_PREFIX; without it the default would (wrongly) be `/c/...`.
+        let mut env = env_with_path(r"C:\foo;D:\bar");
+        env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "/mnt".to_string());
+        let out =
+            maybe_convert_env_for_msys_shell(Path::new(r"C:\Program Files\Git\bin\bash.exe"), &env);
         assert_eq!(
             out.get(&*crate::env::PATH_KEY).unwrap(),
             "/mnt/c/foo:/mnt/d/bar"

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1717,7 +1717,9 @@ mod tests {
     #[cfg(windows)]
     fn test_maybe_convert_env_for_msys_shell_rejects_relative_cygdrive_prefix() {
         // A prefix without a leading slash (e.g. `mnt`) would yield relative PATH
-        // entries bash ignores; fall back to the default `/cygdrive` instead.
+        // entries bash ignores; fall back to the shell's default instead. For the
+        // Cygwin binary used here that default is `/cygdrive` (Git Bash would fall
+        // back to an empty prefix, i.e. the `/c/...` form).
         let mut env = env_with_path(r"C:\foo;D:\bar");
         env.insert("MISE_CYGDRIVE_PREFIX".to_string(), "mnt".to_string());
         let out = maybe_convert_env_for_msys_shell(Path::new(r"C:\cygwin64\bin\bash.exe"), &env);


### PR DESCRIPTION
## Problem

PR #10147 added Cygwin support to the Windows→Unix PATH conversion, with `MISE_CYGDRIVE_PREFIX` as an escape hatch for a non-default `cygdrive` automount root configured in `/etc/fstab`.

As pointed out in [review feedback](https://github.com/jdx/mise/pull/10147#issuecomment-4589301205) (thanks @lewis-yeung), the `cygdrive` automount mechanism is **also** present in MSYS2 / Git Bash (a Cygwin derivative), where the mount root is likewise configurable in `/etc/fstab` (default `/`, i.e. `/c/...`).

`msys_drive_prefix_for` returned an empty prefix immediately for any non-Cygwin bash and **never read `MISE_CYGDRIVE_PREFIX`**, so a Git Bash user with a custom automount root got a corrupted `/c/...` PATH with no way to fix it — the same class of bug #10147 set out to address, still present for Git Bash.

## Fix

- `is_cygwin_shell` now only selects the **default** prefix when no override is set: empty for Git Bash / MSYS2 (`/c/...`), `/cygdrive` for Cygwin (`/cygdrive/c/...`).
- `MISE_CYGDRIVE_PREFIX` is now honored for **both** shells. The relative-value warning reports the shell-appropriate default.

No behavior change for existing users: Git Bash without an override still emits `/c/...`, Cygwin without an override still emits `/cygdrive/c/...`. The only new behavior is that a Git Bash user *can* now set a custom prefix.

## Tests

- Added `test_maybe_convert_env_for_msys_shell_honors_cygdrive_prefix_for_git_bash` (Git Bash + `MISE_CYGDRIVE_PREFIX=/mnt` → `/mnt/c/...`).
- Existing Git Bash (`/c/...`) and Cygwin (`/cygdrive/...`) tests still guard the defaults.
- Verified the full binary builds and all `path::` unit tests pass; the `#[cfg(windows)]` prefix logic was exercised standalone across all input combinations.

Follow-up to #10147.

---
*This PR was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Windows troubleshooting guide with clearer instructions for configuring cygdrive mount roots and using MISE_CYGDRIVE_PREFIX, including absolute-path requirements and behavior when set to "/".

* **Bug Fixes**
  * Improved Windows PATH conversion for POSIX shells (Cygwin, MSYS2/Git Bash) to honor custom cygdrive prefixes and produce correct converted paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->