### PR TITLE
docs: fix relative duration example for months

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -41,7 +41,7 @@ time.
 minimum_release_age = "7d"  # only install versions released more than 7 days ago
 ```
 
-Supports relative durations (`7d`, `6m`, `1y`) and absolute dates (`2024-06-01`). For most
+Supports relative durations (`7d`, `6mo`, `1y`) and absolute dates (`2024-06-01`). For most
 backends, this only affects fuzzy version resolution, such as `node@20` or `latest`.
 Explicitly pinned versions like `node@22.5.0` bypass the filter.
 

--- a/settings.toml
+++ b/settings.toml
@@ -1414,7 +1414,7 @@ durations and absolute cutoff dates.
 
 Supports:
 
-- Relative durations: `7d` (7 days ago), `90d` (90 days ago), `6m` (6 months ago), `1y` (1 year ago)
+- Relative durations: `7d` (7 days ago), `90d` (90 days ago), `6mo` (6 months ago), `1y` (1 year ago)
 - Absolute dates: `2024-06-01`, `2024-06-01T12:00:00Z`
 
 Example:


### PR DESCRIPTION
Just a minor fix for the `minimum_release_age` settings docs where the relative duration example for "6 months" isn't `6m` but `6mo` according to [jiff's "friendly" format](https://docs.rs/jiff/latest/jiff/struct.Span.html).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify the correct relative duration format when configuring the minimum release age setting, specifically using `6mo` for 6-month durations instead of `6m`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->