### PR TITLE
fix(bun): improve musl detection logic using runtime detection

### DIFF
--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -8,7 +8,6 @@ use eyre::Result;
 use itertools::Itertools;
 use versions::Versioning;
 
-use crate::backend::static_helpers::fetch_checksum_from_shasums;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::http::HTTP;
@@ -16,6 +15,7 @@ use crate::install_context::InstallContext;
 use crate::lockfile::PlatformInfo;
 use crate::toolset::ToolVersion;
 use crate::ui::progress_report::SingleReport;
+use crate::{backend::static_helpers::fetch_checksum_from_shasums, platform::detect_libc};
 use crate::{
     backend::{
         Backend, GitHubReleaseInfo, ReleaseType, VersionInfo, platform_target::PlatformTarget,
@@ -423,12 +423,12 @@ impl BunPlugin {
 
     /// Check if we're running on a musl-based system
     /// Respects the global libc setting when configured, otherwise falls back
-    /// to the binary's compile-time target.
+    /// to runtime detection (e.g. via `detect_libc`) for best effort accuracy.
     fn is_musl() -> bool {
         match Settings::get().libc() {
             Some("musl") => true,
             Some("gnu") => false,
-            _ => cfg!(target_env = "musl"),
+            _ => detect_libc() == Some("musl"),
         }
     }
 


### PR DESCRIPTION
Fixes an issue with `glibc` fallback for bun as mentioned in #10185 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform detection in the Bun plugin: when system libc preference is unset, the tool now uses runtime detection and treats unknown results as non-musl. This reduces incorrect musl assumptions and improves compatibility across Linux environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->