### PR TITLE
feat(npm): ensure npm is managed by corepack when node.corepack=true and node.npm_shim=false

### DIFF
--- a/e2e/core/test_node_npm_shim_slow
+++ b/e2e/core/test_node_npm_shim_slow
@@ -21,3 +21,14 @@ node_path="$(mise where "node@$node_version")"
 assert_fail "grep -q 'mise reshim' '$node_path/bin/npm'"
 assert_succeed "test -L '$node_path/bin/npm'"
 assert_contains "mise x node@$node_version -- npm --version" "."
+
+# Corepack: ensure npm is managed by corepack, when node.corepack=true and node.npm_shim=false.
+export MISE_NODE_NPM_SHIM=0
+export MISE_NODE_COREPACK=1
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+mise i -y -f "node@$node_version"
+node_path="$(mise where "node@$node_version")"
+assert_fail "grep -q 'mise reshim' '$node_path/bin/npm'"
+assert_succeed "test -L '$node_path/bin/npm'"
+assert_contains "realpath '$node_path/bin/npm'" "/corepack/"
+assert_contains "mise x node@$node_version -- npm --version" "."

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -419,6 +419,20 @@ impl NodePlugin {
         Ok(())
     }
 
+    fn enable_npm_corepack_shim(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<()> {
+        pr.set_message("enable corepack npm shim".into());
+        let corepack = self.corepack_path(tv);
+        CmdLineRunner::new(corepack)
+            .with_pr(pr)
+            .arg("enable")
+            .arg("npm")
+            .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
+            .envs(tv.install_env())
+            .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
+            .execute()?;
+        Ok(())
+    }
+
     async fn test_node(
         &self,
         config: &Arc<Config>,
@@ -660,6 +674,9 @@ impl Backend for NodePlugin {
         }
         if settings.node.corepack && self.corepack_path(&tv).exists() {
             self.enable_default_corepack_shims(&tv, ctx.pr.as_ref())?;
+            if !settings.node.npm_shim {
+                self.enable_npm_corepack_shim(&tv, ctx.pr.as_ref())?;
+            }
         }
 
         Ok(tv)


### PR DESCRIPTION
Ensures `npm` is managed by corepack if `node.corepack=true` and `node.npm_shim=false` as mentioned in #10194 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage verifying npm remains node-managed when Corepack is enabled, shows Corepack-managed npm behavior, suppresses interactive download prompts, and that `npm --version` still runs.

* **New Features**
  * Node installation now selectively enables Corepack shims and will enable the npm-specific Corepack shim when appropriate, improving npm/Corepack integration during installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->