### PR TITLE
test(use): cover quiet global use output

### DIFF
--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -100,6 +100,14 @@ assert "cat ~/.config/mise/config.toml" '[tools]
 dummy = "1"'
 rm -f ~/.config/mise/config.toml
 
+assert_empty "mise use --quiet -g dummy@1 2>&1"
+assert "cat ~/.config/mise/config.toml" '[tools]
+dummy = "1"'
+assert_empty "mise use --silent -g dummy@1 2>&1"
+assert "cat ~/.config/mise/config.toml" '[tools]
+dummy = "1"'
+rm -f ~/.config/mise/config.toml
+
 mise use -g "ubi:cli/cli[exe=gh]"
 assert "cat ~/.config/mise/config.toml" '[tools]
 "ubi:cli/cli" = { version = "latest", exe = "gh" }'


### PR DESCRIPTION
## Summary
- add e2e regression coverage for `mise use --quiet -g` suppressing success output while writing global config
- add the same coverage for `mise use --silent -g` on the idempotent global path reported in Discussion #9152

## Context
- Discussion: https://github.com/jdx/mise/discussions/9152
- The behavior fix is already merged in #9251; this PR adds the missing regression coverage.

## Test plan
- [x] `git diff --check`
- [x] isolated manual dummy-plugin check matching the new e2e assertions
- [ ] `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run test:e2e e2e/cli/test_use` (not run locally because the shared Cargo queue remained busy with unrelated jobs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for `mise use` command with `--quiet` and `--silent` global configuration flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->