### PR TITLE
fix(aqua): support override env selectors

### DIFF
--- a/crates/aqua-registry/src/cache.rs
+++ b/crates/aqua-registry/src/cache.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-const COMPILED_REGISTRY_CACHE_VERSION: &str = "v2";
+const COMPILED_REGISTRY_CACHE_VERSION: &str = "v3";
 
 #[derive(Debug, Clone)]
 pub struct RegistryCache {

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -1965,6 +1965,7 @@ packages:
 packages:
   - url: https://example.com/tool-default
     format: raw
+    complete_windows_ext: false
     overrides:
       - envs:
           - darwin

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -826,6 +826,7 @@ impl AquaOverride {
 
 fn envs_match(envs: &[String], os: &str, arch: &str) -> bool {
     let os_arch = format!("{os}/{arch}");
+    // Aqua env selectors accept GOOS, GOARCH, GOOS/GOARCH, or the wildcard "all".
     envs.iter()
         .any(|env| env == "all" || env == os || env == arch || env == &os_arch)
 }
@@ -1990,6 +1991,29 @@ packages:
             windows_amd64.url("1.0.0", "windows", "amd64").unwrap(),
             "https://example.com/tool-default"
         );
+    }
+
+    #[test]
+    fn test_override_envs_all_matches_any_platform() {
+        let yml = r#"
+packages:
+  - url: https://example.com/tool-default
+    format: raw
+    overrides:
+      - envs:
+          - all
+        url: https://example.com/tool-all
+"#;
+        let pkg = first_registry_package(yml);
+
+        for (os, arch) in [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")] {
+            let resolved = pkg.clone().with_version(&["1.0.0"], os, arch);
+
+            assert_eq!(
+                resolved.url("1.0.0", os, arch).unwrap(),
+                "https://example.com/tool-all"
+            );
+        }
     }
 
     #[test]

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -827,7 +827,7 @@ impl AquaOverride {
 fn envs_match(envs: &[String], os: &str, arch: &str) -> bool {
     let os_arch = format!("{os}/{arch}");
     envs.iter()
-        .any(|env| matches!(env.as_str(), "all") || env == os || env == arch || env == &os_arch)
+        .any(|env| env == "all" || env == os || env == arch || env == &os_arch)
 }
 
 impl AquaVariant {

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -2006,7 +2006,11 @@ packages:
 "#;
         let pkg = first_registry_package(yml);
 
-        for (os, arch) in [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")] {
+        for (os, arch) in [
+            ("linux", "amd64"),
+            ("darwin", "arm64"),
+            ("windows", "amd64"),
+        ] {
             let resolved = pkg.clone().with_version(&["1.0.0"], os, arch);
 
             assert_eq!(

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -102,6 +102,8 @@ struct AquaOverride {
     goos: Option<String>,
     goarch: Option<String>,
     #[serde(default)]
+    envs: Vec<String>,
+    #[serde(default)]
     variants: Vec<AquaVariant>,
 }
 
@@ -812,22 +814,20 @@ impl AquaPackage {
 
 impl AquaOverride {
     fn matches(&self, os: &str, arch: &str, runtime: AquaRuntime<'_>) -> bool {
-        let platform_matches = if let (Some(goos), Some(goarch)) = (&self.goos, &self.goarch) {
-            goos == os && goarch == arch
-        } else if let Some(goos) = &self.goos {
-            goos == os
-        } else if let Some(goarch) = &self.goarch {
-            goarch == arch
-        } else {
-            false
-        };
-
-        platform_matches
+        self.goos.as_ref().is_none_or(|goos| goos == os)
+            && self.goarch.as_ref().is_none_or(|goarch| goarch == arch)
+            && (self.envs.is_empty() || envs_match(&self.envs, os, arch))
             && self
                 .variants
                 .iter()
                 .all(|variant| variant.matches(os, runtime))
     }
+}
+
+fn envs_match(envs: &[String], os: &str, arch: &str) -> bool {
+    let os_arch = format!("{os}/{arch}");
+    envs.iter()
+        .any(|env| matches!(env.as_str(), "all") || env == os || env == arch || env == &os_arch)
 }
 
 impl AquaVariant {
@@ -1933,6 +1933,93 @@ packages:
         assert_eq!(
             musl.url("1.0.0", "linux", "amd64").unwrap(),
             "https://example.com/tool-1.0.0-linux-amd64-musl"
+        );
+    }
+
+    #[test]
+    fn test_override_envs_match_os() {
+        let yml = r#"
+packages:
+  - files:
+      - name: catalina.sh
+        src: apache-tomcat-{{.SemVer}}/bin/catalina.sh
+    overrides:
+      - envs:
+          - windows
+        files:
+          - name: catalina.bat
+            src: apache-tomcat-{{.SemVer}}/bin/catalina.bat
+"#;
+        let pkg = first_registry_package(yml);
+
+        let linux = pkg.clone().with_version(&["10.1.0"], "linux", "amd64");
+        let windows = pkg.with_version(&["10.1.0"], "windows", "amd64");
+
+        assert_eq!(linux.files[0].name, "catalina.sh");
+        assert_eq!(windows.files[0].name, "catalina.bat");
+    }
+
+    #[test]
+    fn test_override_envs_match_os_arch() {
+        let yml = r#"
+packages:
+  - url: https://example.com/tool-default
+    format: raw
+    overrides:
+      - envs:
+          - darwin
+          - windows/arm64
+        url: https://example.com/tool-cargo
+"#;
+        let pkg = first_registry_package(yml);
+
+        let darwin = pkg.clone().with_version(&["1.0.0"], "darwin", "amd64");
+        let windows_arm64 = pkg.clone().with_version(&["1.0.0"], "windows", "arm64");
+        let windows_amd64 = pkg.with_version(&["1.0.0"], "windows", "amd64");
+
+        assert_eq!(
+            darwin.url("1.0.0", "darwin", "amd64").unwrap(),
+            "https://example.com/tool-cargo"
+        );
+        assert_eq!(
+            windows_arm64.url("1.0.0", "windows", "arm64").unwrap(),
+            "https://example.com/tool-cargo"
+        );
+        assert_eq!(
+            windows_amd64.url("1.0.0", "windows", "amd64").unwrap(),
+            "https://example.com/tool-default"
+        );
+    }
+
+    #[test]
+    fn test_override_envs_combine_with_goarch() {
+        let yml = r#"
+packages:
+  - url: https://example.com/tool-default
+    format: raw
+    overrides:
+      - goarch: arm64
+        envs:
+          - linux
+        url: https://example.com/tool-linux-arm64
+"#;
+        let pkg = first_registry_package(yml);
+
+        let linux_amd64 = pkg.clone().with_version(&["1.0.0"], "linux", "amd64");
+        let linux_arm64 = pkg.clone().with_version(&["1.0.0"], "linux", "arm64");
+        let darwin_arm64 = pkg.with_version(&["1.0.0"], "darwin", "arm64");
+
+        assert_eq!(
+            linux_amd64.url("1.0.0", "linux", "amd64").unwrap(),
+            "https://example.com/tool-default"
+        );
+        assert_eq!(
+            linux_arm64.url("1.0.0", "linux", "arm64").unwrap(),
+            "https://example.com/tool-linux-arm64"
+        );
+        assert_eq!(
+            darwin_arm64.url("1.0.0", "darwin", "arm64").unwrap(),
+            "https://example.com/tool-default"
         );
     }
 


### PR DESCRIPTION
## Summary
- parse `overrides[].envs` in Aqua registry package overrides
- apply `envs` as an additional override selector alongside `goos`, `goarch`, and supported `variants`
- bump the compiled Aqua registry cache version because the archived override layout changed

## What is `overrides[].envs`?
Aqua registry packages can define `overrides` to replace parts of a package definition for specific runtime targets. The `envs` field is one of Aqua's override selectors: each entry can match a GOOS value such as `windows`, a GOARCH value such as `arm64`, a combined `GOOS/GOARCH` value such as `windows/arm64`, or `all`.

Aqua treats `envs` as an optional selector alongside `goos`, `goarch`, and `variants`: if it is present, at least one listed environment must match the target runtime; if other selectors are also present, they must match too.

Relevant Aqua references:
- https://github.com/aquaproj/aqua/blob/main/pkg/config/registry/package_info.go
- https://github.com/aquaproj/aqua/blob/main/pkg/config/registry/override.go
- https://github.com/aquaproj/aqua/blob/main/pkg/config/registry/supported_envs.go

## Packages using this field
Two live aqua-registry entries show why this matters:

- `apache/tomcat` uses `overrides[].envs: [windows]` to switch the installed file from `catalina.sh` to `catalina.bat` on Windows.
  https://github.com/aquaproj/aqua-registry/blob/main/pkgs/apache/tomcat/registry.yaml
- `eza-community/eza` uses `overrides[].envs: [darwin, windows/arm64]` to route those targets through its `type: cargo` package configuration instead of the default release-asset path.
  https://github.com/aquaproj/aqua-registry/blob/main/pkgs/eza-community/eza/registry.yaml

## Why mise needs support
Before this change, mise parsed and applied Aqua overrides for `goos`, `goarch`, and supported `variants`, but ignored `overrides[].envs`. Env-only overrides therefore never applied. That could make mise choose the wrong file or package configuration for valid Aqua registry packages, especially on Windows and Darwin targets.

Supporting `envs` makes mise's native Aqua backend match Aqua's selector semantics for these registry entries and prevents platform-specific override data from being silently skipped.

## Tests
- `rustfmt --edition 2024 --check crates/aqua-registry/src/types.rs crates/aqua-registry/src/cache.rs`
- `git diff --check`
- `cargo test -p aqua-registry override_envs --no-default-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment selectors for overrides, allowing rules to target specific OS, architecture, or combined "os/arch" identifiers (including an "all" option) for more precise selection of files, URLs, and variants.

* **Chores**
  * Bumped the compiled registry cache layout version; previously compiled caches will be ignored and rebuilt automatically on next use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->