### PR TITLE
fix(task): show multiline descriptions in usage help

### DIFF
--- a/e2e/tasks/test_task_multiline_description
+++ b/e2e/tasks/test_task_multiline_description
@@ -16,5 +16,7 @@ EOF
 assert_contains "mise tasks ls --local" "format  Format the changed files..."
 assert_not_contains "mise tasks ls --local" "If you just want to check the files"
 
+assert_contains "mise format --help 2>&1 || true" "Format the changed files"
+assert_contains "mise format --help 2>&1 || true" "If you just want to check the files without automatically fixing them, use the check task."
 assert_contains "mise run format --help 2>&1 || true" "Format the changed files"
 assert_contains "mise run format --help 2>&1 || true" "If you just want to check the files without automatically fixing them, use the check task."

--- a/e2e/tasks/test_task_multiline_description
+++ b/e2e/tasks/test_task_multiline_description
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks.format]
+description = """Format the changed files
+
+If you just want to check the files without automatically fixing them, use the check task."""
+usage = 'arg "<file>"'
+run = 'echo "$usage_file"'
+
+[tasks.check]
+description = "Check the files are formatted"
+run = "echo check"
+EOF
+
+assert_contains "mise tasks ls --local" "format  Format the changed files..."
+assert_not_contains "mise tasks ls --local" "If you just want to check the files"
+
+assert_contains "mise run format --help 2>&1 || true" "Format the changed files"
+assert_contains "mise run format --help 2>&1 || true" "If you just want to check the files without automatically fixing them, use the check task."

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -928,8 +928,23 @@ impl Task {
     }
 
     fn populate_spec_metadata(&self, spec: &mut usage::Spec) {
+        let has_usage_spec = has_any_usage_spec(spec);
         spec.name = self.display_name.clone();
         spec.bin = self.display_name.clone();
+        if has_usage_spec && !self.description.is_empty() {
+            if spec.about.is_none() {
+                spec.about = Some(
+                    self.description
+                        .lines()
+                        .next()
+                        .unwrap_or_default()
+                        .to_string(),
+                );
+            }
+            if spec.about_long.is_none() && self.description.contains('\n') {
+                spec.about_long = Some(self.description.clone());
+            }
+        }
         if spec.cmd.help.is_none() {
             spec.cmd.help = Some(self.description.clone());
         }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -945,7 +945,7 @@ impl Task {
         spec.cmd.usage = spec.cmd.usage();
     }
 
-    fn promote_description_to_usage_about(&self, spec: &mut usage::Spec) {
+    fn populate_usage_about(&self, spec: &mut usage::Spec) {
         let has_usage_spec = has_any_args_defined(spec)
             || has_any_usage_spec(spec)
             || !self.usage.trim().is_empty()
@@ -966,7 +966,6 @@ impl Task {
             if spec.about_long.is_none() && self.description.contains('\n') {
                 spec.about_long = Some(self.description.clone());
             }
-            spec.cmd.help = None;
         }
     }
     pub async fn parse_usage_spec_with_vars(
@@ -994,7 +993,7 @@ impl Task {
             (spec, scripts)
         };
         self.populate_spec_metadata(&mut spec);
-        self.promote_description_to_usage_about(&mut spec);
+        self.populate_usage_about(&mut spec);
         Ok((spec, scripts))
     }
 
@@ -1028,7 +1027,7 @@ impl Task {
                 .await?
         };
         self.populate_spec_metadata(&mut spec);
-        self.promote_description_to_usage_about(&mut spec);
+        self.populate_usage_about(&mut spec);
         Ok(spec)
     }
 
@@ -1071,7 +1070,10 @@ impl Task {
     }
 
     pub async fn render_markdown(&self, config: &Arc<Config>) -> Result<String> {
-        let spec = self.parse_usage_spec_for_display(config).await?;
+        let mut spec = self.parse_usage_spec_for_display(config).await?;
+        if spec.about.is_some() && spec.cmd.help.as_deref() == Some(self.description.as_str()) {
+            spec.cmd.help = None;
+        }
         let ctx = usage::docs::markdown::MarkdownRenderer::new(spec)
             .with_replace_pre_with_code_fences(true)
             .with_header_level(2);
@@ -2377,7 +2379,7 @@ mod tests {
 
         assert_eq!(spec.about.as_deref(), Some("Format the changed files"));
         assert_eq!(spec.about_long.as_deref(), Some(description.as_str()));
-        assert_eq!(spec.cmd.help, None);
+        assert_eq!(spec.cmd.help.as_deref(), Some(description.as_str()));
 
         let help = usage::docs::cli::render_help(&spec, &spec.cmd, true);
         assert!(help.contains("Format the changed files"));

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -928,23 +928,8 @@ impl Task {
     }
 
     fn populate_spec_metadata(&self, spec: &mut usage::Spec) {
-        let has_usage_spec = has_any_usage_spec(spec);
         spec.name = self.display_name.clone();
         spec.bin = self.display_name.clone();
-        if has_usage_spec && !self.description.is_empty() {
-            if spec.about.is_none() {
-                spec.about = Some(
-                    self.description
-                        .lines()
-                        .next()
-                        .unwrap_or_default()
-                        .to_string(),
-                );
-            }
-            if spec.about_long.is_none() && self.description.contains('\n') {
-                spec.about_long = Some(self.description.clone());
-            }
-        }
         if spec.cmd.help.is_none() {
             spec.cmd.help = Some(self.description.clone());
         }
@@ -958,6 +943,31 @@ impl Task {
                 Some(format!("- Depends: {}", self.depends.iter().join(", ")));
         }
         spec.cmd.usage = spec.cmd.usage();
+    }
+
+    fn promote_description_to_usage_about(&self, spec: &mut usage::Spec) {
+        let has_usage_spec = has_any_args_defined(spec)
+            || has_any_usage_spec(spec)
+            || !self.usage.trim().is_empty()
+            || !spec.cmd.usage.is_empty();
+        if has_usage_spec
+            && !self.description.is_empty()
+            && spec.cmd.help.as_deref() == Some(self.description.as_str())
+        {
+            if spec.about.is_none() {
+                spec.about = Some(
+                    self.description
+                        .lines()
+                        .next()
+                        .unwrap_or_default()
+                        .to_string(),
+                );
+            }
+            if spec.about_long.is_none() && self.description.contains('\n') {
+                spec.about_long = Some(self.description.clone());
+            }
+            spec.cmd.help = None;
+        }
     }
     pub async fn parse_usage_spec_with_vars(
         &self,
@@ -984,6 +994,7 @@ impl Task {
             (spec, scripts)
         };
         self.populate_spec_metadata(&mut spec);
+        self.promote_description_to_usage_about(&mut spec);
         Ok((spec, scripts))
     }
 
@@ -1017,6 +1028,7 @@ impl Task {
                 .await?
         };
         self.populate_spec_metadata(&mut spec);
+        self.promote_description_to_usage_about(&mut spec);
         Ok(spec)
     }
 
@@ -2266,7 +2278,7 @@ mod tests {
     use std::path::Path;
     use std::sync::Mutex;
 
-    use crate::task::Task;
+    use crate::task::{RunEntry, Task};
     use crate::{config::Config, dirs};
     use pretty_assertions::assert_eq;
 
@@ -2340,6 +2352,36 @@ mod tests {
 
         assert_eq!(task.allow_read, vec![crate::env::HOME.join("read")]);
         assert_eq!(task.allow_write, vec![crate::env::HOME.join("write")]);
+    }
+
+    #[tokio::test]
+    async fn test_usage_task_description_populates_help_metadata() {
+        let config = Config::get().await.unwrap();
+        let description = indoc::indoc! {"
+            Format the changed files
+
+            If you just want to check the files without automatically fixing them, use the check task.
+        "}
+        .trim()
+        .to_string();
+        let task = Task {
+            name: "format".to_string(),
+            display_name: "format".to_string(),
+            description: description.clone(),
+            usage: r#"arg "<file>""#.to_string(),
+            run: vec![RunEntry::Script("echo {{ usage.file }}".to_string())],
+            ..Default::default()
+        };
+
+        let spec = task.parse_usage_spec_for_display(&config).await.unwrap();
+
+        assert_eq!(spec.about.as_deref(), Some("Format the changed files"));
+        assert_eq!(spec.about_long.as_deref(), Some(description.as_str()));
+        assert_eq!(spec.cmd.help, None);
+
+        let help = usage::docs::cli::render_help(&spec, &spec.cmd, true);
+        assert!(help.contains("Format the changed files"));
+        assert!(help.contains("If you just want to check the files"));
     }
 
     #[test]

--- a/tasks.md
+++ b/tasks.md
@@ -77,10 +77,11 @@ Fetch GPG keys for signing or verification
 
 ## `filetask`
 
+This is a test build script
+
+
 - **Usage**: `filetask [-f --force] [-u --user <user>] [file] [arg_with_default]`
 - **Aliases**: `ft`
-
-This is a test build script
 
 ### Arguments
 
@@ -244,9 +245,10 @@ run all tests
 
 ## `test-tool-retry`
 
-- **Usage**: `test-tool-retry [--grace-period] [--check-only] <tools>…`
-
 Retry failed test-tools with grace period for recent upstream releases
+
+
+- **Usage**: `test-tool-retry [--grace-period] [--check-only] <tools>…`
 
 ### Arguments
 


### PR DESCRIPTION
## Summary
- Promote a task `description` into usage's root `about`/`long_about` fields when the task has a usage spec, so `mise <task> --help` and `mise run <task> --help` can show multiline task descriptions.
- Keep task lists compact: `mise tasks ls` still renders a single-line, truncated description.
- Keep `cmd.help` populated for `mise tasks ls --usage`, while suppressing that duplicate only when generating task markdown.
- Add e2e coverage for multiline task descriptions.

Addresses discussion #4772.

## History Checked
This was partly already fixed, but at a different layer:

- `2eafaf511` / #8824 fixed usage-based help when a task script explicitly defines usage metadata such as `#USAGE long_about` without args or flags. That means usage's own `long_about` path already worked.
- `6069e605d` / #8623 improved `usage.*` template value parsing for args, flags, defaults, and subcommands. That is about runtime/template values, not task help text.
- This PR handles the missing mise integration: a TOML/file task `description` was only copied to `cmd.help`, which is useful for command listings, but usage's CLI help renderer expects root `about`/`long_about` for the top description shown by `--help`.

## What Changes
Given:

```toml
[tasks.format]
description = """Format the changed files

If you just want to check the files without automatically fixing them, use the check task."""
usage = 'arg "<file>"'
run = 'echo "$usage_file"'
```

Task lists remain intentionally short:

```text
$ mise tasks ls --local
format  Format the changed files...
```

Task help now shows the full multiline description:

```text
$ mise format --help
Format the changed files

If you just want to check the files without automatically fixing them, use the check task.

Usage: format <file>
```

The same applies through `mise run format --help`.

`mise tasks ls --usage` still gets command-level help metadata because this PR keeps `spec.cmd.help` populated. The markdown renderer clears that generated `cmd.help` only for docs output when the same description has already been promoted to `about`, avoiding duplicate description text in `tasks.md`.

## Usage Help Field Mapping
The relevant `usage` fields are separate and used in different places:

- `Spec.about`: short root command description. This is the first paragraph shown by normal CLI help.
- `Spec.about_long` / KDL `long_about`: longer root command description. Long help (`--help`) prefers this when present.
- `SpecCommand.help` / KDL `cmd ... help`: command or subcommand summary. mise uses this for task command metadata, especially `mise tasks ls --usage`.
- `SpecCommand.help_long` / KDL `cmd ... long_help`: long command/subcommand summary when declared in a usage spec.
- `SpecArg.help` / `SpecFlag.help`: per-argument and per-flag descriptions in the Arguments/Flags sections.
- `SpecArg.help_long` / `SpecFlag.help_long`: longer per-argument and per-flag descriptions for long help.
- `before_help` / `after_help`: extra text placed around generated help content; this PR does not use these for task descriptions.

This PR maps mise task `description` to:

- `Spec.about`: first line of the task description
- `Spec.about_long`: full task description only when it is multiline
- `SpecCommand.help`: still the task description, for usage export/listing compatibility

## Tests
- `cargo test test_usage_task_description_populates_help_metadata --all-features`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 mise run test:e2e test_task_multiline_description`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 mise run test:e2e test_task_ls_usage`
- `mise run render`
- `cargo fmt --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test verifying multiline task descriptions display correctly in task listings and help output.

* **Bug Fixes**
  * Improved multiline task description handling in help text and help output rendering.
  * Prevented duplicate content when task descriptions are included in generated documentation.

* **Documentation**
  * Updated task documentation with improved formatting and task descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->