### PR TITLE
fix(install): skip inactive unknown tools

### DIFF
--- a/e2e/tools/test_os_arch_filter
+++ b/e2e/tools/test_os_arch_filter
@@ -2,6 +2,65 @@
 
 # Test that os field supports os/arch compound syntax for filtering tools.
 
+case "$(uname -s)" in
+  Darwin) _os="macos" ;;
+  Linux) _os="linux" ;;
+  *) _os="windows" ;;
+esac
+case "$(uname -m)" in
+  x86_64) _arch="x64" ;;
+  aarch64 | arm64) _arch="arm64" ;;
+  *) _arch="$(uname -m)" ;;
+esac
+case "$_arch" in
+  x64) _inactive_arch="arm64" ;;
+  *) _inactive_arch="x64" ;;
+esac
+case "$_os" in
+  linux) _inactive_os="macos" ;;
+  *) _inactive_os="linux" ;;
+esac
+
+# Unknown tools scoped away from the current OS should be skipped before
+# registry resolution.
+cat >mise.toml <<EOF
+[tools]
+nonexistent-os-filtered = { version = "latest", os = ["$_inactive_os"] }
+EOF
+mise i
+
+# Active unknown tools should still fail clearly.
+cat >mise.toml <<EOF
+[tools]
+nonexistent-os-filtered = { version = "latest", os = ["$_os"] }
+EOF
+assert_fail "mise i" "nonexistent-os-filtered not found in mise tool registry"
+
+# Unknown tools scoped away from the current OS/arch pair should also be
+# skipped before registry resolution.
+cat >mise.toml <<EOF
+[tools]
+nonexistent-os-arch-filtered = { version = "latest", os = ["${_os}/${_inactive_arch}"] }
+EOF
+mise i
+
+# Unknown tools scoped to the current OS/arch pair should still fail clearly.
+cat >mise.toml <<EOF
+[tools]
+nonexistent-os-arch-filtered = { version = "latest", os = ["${_os}/${_arch}"] }
+EOF
+assert_fail "mise i" "nonexistent-os-arch-filtered not found in mise tool registry"
+
+# Globally disabled unknown tools should be skipped before registry resolution.
+cat >mise.toml <<'EOF'
+[tools]
+nonexistent-disabled = "latest"
+
+[settings]
+disable_tools = ["nonexistent-disabled"]
+EOF
+mise i
+
 # Tool with a non-matching os/arch should be skipped (not installed).
 # "windows/arm64" won't match any CI runner or dev machine running this test.
 cat >mise.toml <<'EOF'
@@ -21,18 +80,6 @@ assert_contains "mise ls --installed tiny" "tiny"
 mise uninstall --all tiny
 
 # Tool with matching os/arch should install on this platform.
-# Detect current platform to construct a matching entry.
-case "$(uname -s)" in
-  Darwin) _os="macos" ;;
-  Linux) _os="linux" ;;
-  *) _os="windows" ;;
-esac
-case "$(uname -m)" in
-  x86_64) _arch="x64" ;;
-  aarch64 | arm64) _arch="arm64" ;;
-  *) _arch="$(uname -m)" ;;
-esac
-
 cat >mise.toml <<EOF
 [tools]
 tiny = { version = "latest", os = ["${_os}/${_arch}"] }

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -171,8 +171,11 @@ impl ToolRequestSetBuilder {
 
         for ba in trs.tools.keys().cloned().collect_vec() {
             if self.is_disabled(&ba) {
-                // Track tools that don't exist in the registry
-                if ba.backend_type() == BackendType::Unknown {
+                if trs
+                    .tools
+                    .get(&ba)
+                    .is_some_and(|requests| self.should_report_unknown_tool(&ba, requests))
+                {
                     trs.unknown_tools.push(ba.clone());
                 }
                 trs.tools.shift_remove(&ba);
@@ -190,6 +193,12 @@ impl ToolRequestSetBuilder {
             || (cfg!(windows) && backend_type == BackendType::Asdf)
             || !ba.is_os_supported()
             || !tool_enabled(self.enable_tools.as_ref(), &self.disable_tools, ba)
+    }
+
+    fn should_report_unknown_tool(&self, ba: &BackendArg, requests: &[ToolRequest]) -> bool {
+        ba.backend_type() == BackendType::Unknown
+            && tool_enabled(self.enable_tools.as_ref(), &self.disable_tools, ba)
+            && requests.iter().any(ToolRequest::is_os_supported)
     }
 
     async fn load_config_files(
@@ -299,6 +308,7 @@ pub fn tool_env_vars() -> impl Iterator<Item = (String, String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::toolset::{CoreToolOptions, ToolVersionOptions};
 
     #[test]
     fn test_load_runtime_env_with_valid_utf8() {
@@ -392,5 +402,67 @@ mod tests {
             std::env::remove_var("HOMEBREW_INSTALL_BADGE");
             std::env::remove_var("SOME_OTHER_VAR");
         }
+    }
+
+    fn unknown_tool_request(os: Option<Vec<String>>) -> (Arc<BackendArg>, Vec<ToolRequest>) {
+        let ba = Arc::new(BackendArg::from("unknown-os-filtered-tool"));
+        let options = ToolVersionOptions {
+            core: CoreToolOptions {
+                os,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let request =
+            ToolRequest::new_opts(ba.clone(), "latest", options, ToolSource::Unknown).unwrap();
+        (ba, vec![request])
+    }
+
+    fn inactive_os() -> String {
+        match crate::cli::version::OS.as_str() {
+            "linux" => "macos",
+            _ => "linux",
+        }
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn test_should_not_report_unknown_tool_when_all_requests_are_os_inactive() {
+        crate::toolset::install_state::init().await.unwrap();
+        let builder = ToolRequestSetBuilder::default();
+        let (ba, requests) = unknown_tool_request(Some(vec![inactive_os()]));
+
+        assert!(!builder.should_report_unknown_tool(&ba, &requests));
+    }
+
+    #[tokio::test]
+    async fn test_should_report_unknown_tool_when_any_request_is_os_active() {
+        crate::toolset::install_state::init().await.unwrap();
+        let builder = ToolRequestSetBuilder::default();
+        let (ba, mut requests) = unknown_tool_request(Some(vec![inactive_os()]));
+        let options = ToolVersionOptions {
+            core: CoreToolOptions {
+                os: Some(vec![crate::cli::version::OS.to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        requests.push(
+            ToolRequest::new_opts(ba.clone(), "latest", options, ToolSource::Unknown).unwrap(),
+        );
+
+        assert!(builder.should_report_unknown_tool(&ba, &requests));
+    }
+
+    #[tokio::test]
+    async fn test_should_not_report_unknown_tool_when_tool_is_disabled() {
+        crate::toolset::install_state::init().await.unwrap();
+        let (ba, requests) = unknown_tool_request(None);
+        let builder = ToolRequestSetBuilder {
+            disable_tools: BTreeSet::from([BackendArg::from("unknown-os-filtered-tool")]),
+            ..Default::default()
+        };
+
+        assert!(!builder.should_report_unknown_tool(&ba, &requests));
     }
 }


### PR DESCRIPTION
## Summary
- only record unknown tools for install errors when at least one request is active on the current OS
- honor `disable_tools`/`enable_tools` before emitting unknown-tool registry errors
- add regression coverage for OS-scoped unknown tools and disabled unknown tools

## Discussion
Refs https://github.com/jdx/mise/discussions/6896.

## Tests
- `cargo fmt --all -- --check`
- `cargo test tool_request_set::tests::test_should_ -- --nocapture`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/mise-409845c58888dcc6 mise run test:e2e e2e/tools/test_os_arch_filter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OS and OS/architecture filtering for tool installation and registry resolution.
  * Unknown tools are now properly skipped when filtered to non-matching operating system configurations.
  * Enhanced tool discovery logic to provide clearer handling of unavailable tools.

* **Tests**
  * Extended end-to-end testing for OS/architecture filtering and installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->