### PR TITLE
chore: release 2026.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,85 @@
 # Changelog
 
+## [2026.6.1](https://github.com/jdx/mise/compare/v2026.6.0..v2026.6.1) - 2026-06-06
+
+### 🚀 Features
+
+- **(aqua)** support multiple custom registries by @risu729 in [#10179](https://github.com/jdx/mise/pull/10179)
+- **(env)** support sops toml env files by @risu729 in [#10201](https://github.com/jdx/mise/pull/10201)
+- **(hooks)** add run_windows support by @risu729 in [#10202](https://github.com/jdx/mise/pull/10202)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** extract 7z archives by @risu729 in [#10224](https://github.com/jdx/mise/pull/10224)
+- **(elixir)** resolve lockfile urls from builds index by @risu729 in [#10226](https://github.com/jdx/mise/pull/10226)
+- **(env)** uv venv in env_cache key to prevent cross directory leak by @Nagato-Yuzuru in [#10217](https://github.com/jdx/mise/pull/10217)
+- **(github)** accept canonical versions host repo casing by @risu729 in [#10240](https://github.com/jdx/mise/pull/10240)
+- **(github)** refresh oauth token after 401 by @jdx in [#10246](https://github.com/jdx/mise/pull/10246)
+- **(github)** warn on versions host metadata fallback by @jdx in [#10254](https://github.com/jdx/mise/pull/10254)
+- **(github)** skip versions host for non-registry tools by @jdx in [#10255](https://github.com/jdx/mise/pull/10255)
+- **(github)** add structured versions host logs by @jdx in [#10256](https://github.com/jdx/mise/pull/10256)
+- **(ruby)** lock resolved install options by @risu729 in [#9992](https://github.com/jdx/mise/pull/9992)
+- **(task)** render task config includes by @risu729 in [#10225](https://github.com/jdx/mise/pull/10225)
+- watch cwds of dependencies by @43081j in [#10054](https://github.com/jdx/mise/pull/10054)
+- nix flake build test failure by @okuuva in [#10243](https://github.com/jdx/mise/pull/10243)
+- Make directory task include also support toml files by @davidolrik in [#10219](https://github.com/jdx/mise/pull/10219)
+
+### 🚜 Refactor
+
+- remove stale dead code by @risu729 in [#10238](https://github.com/jdx/mise/pull/10238)
+
+### 📚 Documentation
+
+- update snap installation by @salim-b in [#10250](https://github.com/jdx/mise/pull/10250)
+
+### 📦️ Dependency Updates
+
+- update ghcr.io/jdx/mise:rpm docker digest to 06492ad by @renovate[bot] in [#10231](https://github.com/jdx/mise/pull/10231)
+- update jdx/mise-action digest to dba1968 by @renovate[bot] in [#10232](https://github.com/jdx/mise/pull/10232)
+- update ghcr.io/jdx/mise:alpine docker digest to 2c22b32 by @renovate[bot] in [#10229](https://github.com/jdx/mise/pull/10229)
+- update rust crate toml_edit to v0.25.12 by @renovate[bot] in [#10236](https://github.com/jdx/mise/pull/10236)
+- update rust crate jiff to v0.2.28 by @renovate[bot] in [#10234](https://github.com/jdx/mise/pull/10234)
+- update rust crate ctor to v1.0.7 by @renovate[bot] in [#10233](https://github.com/jdx/mise/pull/10233)
+- update ghcr.io/jdx/mise:deb docker digest to fa244a8 by @renovate[bot] in [#10230](https://github.com/jdx/mise/pull/10230)
+- update rust crate reqwest to v0.13.4 by @renovate[bot] in [#10235](https://github.com/jdx/mise/pull/10235)
+- update actions/checkout digest to df4cb1c by @renovate[bot] in [#10228](https://github.com/jdx/mise/pull/10228)
+
+### 📦 Registry
+
+- use aqua for aube by @jdx in [#10171](https://github.com/jdx/mise/pull/10171)
+- add pgroll by @diegoholiveira in [#10252](https://github.com/jdx/mise/pull/10252)
+
+### Chore
+
+- **(ci)** use pr-closer action by @jdx in [#10222](https://github.com/jdx/mise/pull/10222)
+- **(ci)** separate e2e retry summaries by @risu729 in [#10223](https://github.com/jdx/mise/pull/10223)
+- fix spelling by @jsoref in [#10180](https://github.com/jdx/mise/pull/10180)
+
+### Security
+
+- prevent http install path escape by @jdx in [#10245](https://github.com/jdx/mise/pull/10245)
+
+### New Contributors
+
+- @davidolrik made their first contribution in [#10219](https://github.com/jdx/mise/pull/10219)
+- @diegoholiveira made their first contribution in [#10252](https://github.com/jdx/mise/pull/10252)
+- @Nagato-Yuzuru made their first contribution in [#10217](https://github.com/jdx/mise/pull/10217)
+- @jsoref made their first contribution in [#10180](https://github.com/jdx/mise/pull/10180)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (3)
+
+- [`dahlia/seonbi`](https://github.com/dahlia/seonbi)
+- [`dahlia/submark`](https://github.com/dahlia/submark)
+- [`oxc-project/oxc/oxfmt`](https://github.com/oxc-project/oxc)
+
+#### Updated Packages (3)
+
+- [`dahlia/gukhanmun`](https://github.com/dahlia/gukhanmun)
+- [`dahlia/hongdown`](https://github.com/dahlia/hongdown)
+- [`sayanarijit/jf`](https://github.com/sayanarijit/jf)
+
 ## [2026.6.0](https://github.com/jdx/mise/compare/v2026.5.18..v2026.6.0) - 2026-06-03
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.6.0"
+version = "2026.6.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.6.0"
+version = "2026.6.1"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.6.0 macos-arm64 (2026-06-03)
+2026.6.1 macos-arm64 (2026-06-06)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_0.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_1.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_0.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_1.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_0.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_1.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_0.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_1.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.6.0";
+  version = "2026.6.1";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "28.9k",
+      stars: "29.2k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.6.0
+Version: 2026.6.1
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.6.0"
+version: "2026.6.1"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "v4.520.1"
+  "tag": "v4.521.0"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -30027,7 +30027,7 @@ packages:
     description: Convert mixed-script Korean text into hangul-only text
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.1.1")
         asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
         files:
@@ -30044,13 +30044,28 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: "true"
+        asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        files:
+          - name: gukhanmun
+          - name: gukhanmun-mkdict
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: dahlia
     repo_name: hongdown
     description: A Markdown formatter that enforces Hong Minhee's Markdown style conventions
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.4.2")
         asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
         files:
@@ -30065,6 +30080,119 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: "true"
+        asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        files:
+          - name: hongdown
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: dahlia
+    repo_name: seonbi
+    description: SmartyPants for Korean language
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.3")
+        asset: seonbi-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: seonbi-{{.Version}}.{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: seonbi-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: seonbi-{{.Version}}.{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: seonbi-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: seonbi-{{.Version}}.{{.OS}}.{{.Format}}
+  - type: github_release
+    repo_owner: dahlia
+    repo_name: submark
+    description: Extract a part from CommonMark/Markdown docs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.1.0"
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "0.2.0"
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          windows: win64
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            asset: submark-{{.OS}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 0.3.1")
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          windows: win64
+        overrides:
+          - goos: windows
+            asset: submark-{{.OS}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          windows: win64
+        overrides:
+          - goos: windows
+            asset: submark-{{.OS}}
   - type: github_release
     repo_owner: daichirata
     repo_name: hammer
@@ -71184,6 +71312,58 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+  - name: oxc-project/oxc/oxfmt
+    type: github_release
+    repo_owner: oxc-project
+    repo_name: oxc
+    description: A collection of high-performance JavaScript tools
+    version_filter: Version matches "^apps_v"
+    version_prefix: apps_v
+    files:
+      - name: oxfmt
+        src: "{{.AssetWithoutExt}}"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.43.0")
+        asset: oxfmt-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: darwin
+            asset: oxfmt-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: oxfmt-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: semver("= 1.47.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.51.0")
+        asset: oxfmt-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.53.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: oxfmt-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     name: oxc-project/oxc/oxlint
     repo_owner: oxc-project
@@ -79394,7 +79574,7 @@ packages:
     version_overrides:
       - version_constraint: Version in ["v0.1.1", "v0.2.3"]
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.6.2")
         asset: jf-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
@@ -79411,6 +79591,25 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: jf-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
   - type: github_release
     repo_owner: sayanarijit
     repo_name: xplr


### PR DESCRIPTION
### 🚀 Features

- **(aqua)** support multiple custom registries by @risu729 in [#10179](https://github.com/jdx/mise/pull/10179)
- **(env)** support sops toml env files by @risu729 in [#10201](https://github.com/jdx/mise/pull/10201)
- **(hooks)** add run_windows support by @risu729 in [#10202](https://github.com/jdx/mise/pull/10202)

### 🐛 Bug Fixes

- **(aqua)** extract 7z archives by @risu729 in [#10224](https://github.com/jdx/mise/pull/10224)
- **(elixir)** resolve lockfile urls from builds index by @risu729 in [#10226](https://github.com/jdx/mise/pull/10226)
- **(env)** uv venv in env_cache key to prevent cross directory leak by @Nagato-Yuzuru in [#10217](https://github.com/jdx/mise/pull/10217)
- **(github)** accept canonical versions host repo casing by @risu729 in [#10240](https://github.com/jdx/mise/pull/10240)
- **(github)** refresh oauth token after 401 by @jdx in [#10246](https://github.com/jdx/mise/pull/10246)
- **(github)** warn on versions host metadata fallback by @jdx in [#10254](https://github.com/jdx/mise/pull/10254)
- **(github)** skip versions host for non-registry tools by @jdx in [#10255](https://github.com/jdx/mise/pull/10255)
- **(github)** add structured versions host logs by @jdx in [#10256](https://github.com/jdx/mise/pull/10256)
- **(ruby)** lock resolved install options by @risu729 in [#9992](https://github.com/jdx/mise/pull/9992)
- **(task)** render task config includes by @risu729 in [#10225](https://github.com/jdx/mise/pull/10225)
- watch cwds of dependencies by @43081j in [#10054](https://github.com/jdx/mise/pull/10054)
- nix flake build test failure by @okuuva in [#10243](https://github.com/jdx/mise/pull/10243)
- Make directory task include also support toml files by @davidolrik in [#10219](https://github.com/jdx/mise/pull/10219)

### 🚜 Refactor

- remove stale dead code by @risu729 in [#10238](https://github.com/jdx/mise/pull/10238)

### 📚 Documentation

- update snap installation by @salim-b in [#10250](https://github.com/jdx/mise/pull/10250)

### 📦️ Dependency Updates

- update ghcr.io/jdx/mise:rpm docker digest to 06492ad by @renovate[bot] in [#10231](https://github.com/jdx/mise/pull/10231)
- update jdx/mise-action digest to dba1968 by @renovate[bot] in [#10232](https://github.com/jdx/mise/pull/10232)
- update ghcr.io/jdx/mise:alpine docker digest to 2c22b32 by @renovate[bot] in [#10229](https://github.com/jdx/mise/pull/10229)
- update rust crate toml_edit to v0.25.12 by @renovate[bot] in [#10236](https://github.com/jdx/mise/pull/10236)
- update rust crate jiff to v0.2.28 by @renovate[bot] in [#10234](https://github.com/jdx/mise/pull/10234)
- update rust crate ctor to v1.0.7 by @renovate[bot] in [#10233](https://github.com/jdx/mise/pull/10233)
- update ghcr.io/jdx/mise:deb docker digest to fa244a8 by @renovate[bot] in [#10230](https://github.com/jdx/mise/pull/10230)
- update rust crate reqwest to v0.13.4 by @renovate[bot] in [#10235](https://github.com/jdx/mise/pull/10235)
- update actions/checkout digest to df4cb1c by @renovate[bot] in [#10228](https://github.com/jdx/mise/pull/10228)

### 📦 Registry

- use aqua for aube by @jdx in [#10171](https://github.com/jdx/mise/pull/10171)
- add pgroll by @diegoholiveira in [#10252](https://github.com/jdx/mise/pull/10252)

### Chore

- **(ci)** use pr-closer action by @jdx in [#10222](https://github.com/jdx/mise/pull/10222)
- **(ci)** separate e2e retry summaries by @risu729 in [#10223](https://github.com/jdx/mise/pull/10223)
- fix spelling by @jsoref in [#10180](https://github.com/jdx/mise/pull/10180)

### Security

- prevent http install path escape by @jdx in [#10245](https://github.com/jdx/mise/pull/10245)

### New Contributors

- @davidolrik made their first contribution in [#10219](https://github.com/jdx/mise/pull/10219)
- @diegoholiveira made their first contribution in [#10252](https://github.com/jdx/mise/pull/10252)
- @Nagato-Yuzuru made their first contribution in [#10217](https://github.com/jdx/mise/pull/10217)
- @jsoref made their first contribution in [#10180](https://github.com/jdx/mise/pull/10180)

## 📦 Aqua Registry Updates

### New Packages (3)

- [`dahlia/seonbi`](https://github.com/dahlia/seonbi)
- [`dahlia/submark`](https://github.com/dahlia/submark)
- [`oxc-project/oxc/oxfmt`](https://github.com/oxc-project/oxc)

### Updated Packages (3)

- [`dahlia/gukhanmun`](https://github.com/dahlia/gukhanmun)
- [`dahlia/hongdown`](https://github.com/dahlia/hongdown)
- [`sayanarijit/jf`](https://github.com/sayanarijit/jf)