### PR TITLE
registry: add imagemagick backend aqua:ImageMagick/ImageMagick for Windows support

### DIFF
--- a/registry/imagemagick.toml
+++ b/registry/imagemagick.toml
@@ -1,3 +1,3 @@
-backends = ["conda:imagemagick", "asdf:mise-plugins/mise-imagemagick"]
+backends = ["aqua:ImageMagick/ImageMagick", "conda:imagemagick", "asdf:mise-plugins/mise-imagemagick"]
 description = "ImageMagick is a free, open-source software suite for creating, editing, converting, and displaying images. It supports 200+ formats and offers powerful command-line tools and APIs for automation, scripting, and integration across platforms"
 # test = { cmd = "magick --version", expected = "ImageMagick" }


### PR DESCRIPTION
It is required to install `mise use -g imagemagick` on Windows. Current backends conda and asdf in [`registry/imagemagick.toml`](https://github.com/jdx/mise/blob/main/registry/imagemagick.toml) don't support Windows.

I followed @jdx suggestion in #8476 to add [ImageMagick](https://github.com/ImageMagick/ImageMagick) directly to aqua registry. That was completed in https://github.com/aquaproj/aqua-registry/pull/50281 and works OK `aqua g -i ImageMagick/ImageMagick && aqua i`.

⚠️ Blocked by #10215