### PR TITLE
chore(ci): use pr-closer action

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -14,4 +14,4 @@ jobs:
       checks: read
       statuses: read
     steps:
-      - uses: jdx/pr-closer@v1
+      - uses: jdx/pr-closer@44b9e7859d29e01b4b38e50e2ad6b5c5d00a6973 # v1.0.1

--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -6,34 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  close-stale-prs:
+  pr-closer:
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
+      checks: read
+      statuses: read
     steps:
-      - name: Close stale PRs
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          CUTOFF=$(date -u -d '7 days ago' +%Y-%m-%d)
-          gh pr list -R "$REPO" --state open --search "updated:<$CUTOFF -author:jdx -label:keep-open sort:updated-asc" --json number,mergeStateStatus,statusCheckRollup --limit 500 | \
-          jq -r '
-            def failed_check:
-              (.statusCheckRollup | length > 0) and
-              ([.statusCheckRollup[].conclusion // "" | ascii_upcase] | any(. == "FAILURE" or . == "TIMED_OUT" or . == "ACTION_REQUIRED" or . == "STARTUP_FAILURE"));
-
-            .[]
-            | failed_check as $failed
-            | (.mergeStateStatus == "DIRTY") as $conflicted
-            | if $failed and $conflicted then [.number, "failing checks and merge conflicts"]
-              elif $failed then [.number, "failing checks"]
-              elif $conflicted then [.number, "merge conflicts"]
-              else empty
-              end
-            | @tsv
-          ' | \
-          while IFS=$'\t' read -r pr reason; do
-            echo "Closing PR #$pr ($reason)"
-            gh pr close "$pr" -R "$REPO" -c "This PR has had $reason for more than 7 days. Feel free to reopen or create a new PR if you'd like to continue working on this."
-          done
+      - uses: jdx/pr-closer@v1


### PR DESCRIPTION
## Summary
- replace the inline pr-closer workflow script with the shared jdx/pr-closer action
- keep the existing daily schedule and manual dispatch trigger
- grant issue/comment and status permissions needed by the shared action

## Tests
- actionlint .github/workflows/pr-closer.yml

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only refactor to a pinned third-party action; stale-PR behavior depends on action parity with the removed script.
> 
> **Overview**
> **Replaces** the hand-rolled `pr-closer` job (shell, `gh`, and `jq` filtering stale PRs with failing checks or merge conflicts) with the pinned reusable action **`jdx/pr-closer@v1.0.1`**. The **daily midnight** schedule and **`workflow_dispatch`** trigger are unchanged.
> 
> The job is renamed to **`pr-closer`**, and workflow **`permissions`** are expanded with **`issues: write`**, **`checks: read`**, and **`statuses: read`** so the shared action can comment/close and read check status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5b80c00d0a915db78415fb7e0c6ea4cc4808e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow for pull request automation: replaced custom close logic with a maintained action, adjusted job permissions to include issues write and read access for checks/statuses, and simplified the workflow implementation. This is an infrastructure change with no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->