### PR TITLE
chore(ci): separate e2e retry summaries

### DIFF
--- a/e2e/run_all_tests
+++ b/e2e/run_all_tests
@@ -262,6 +262,7 @@ if ((${#FAILED_TESTS[@]} > 0)); then
         for failed in "${FAILED_TESTS[@]}"; do
           echo "- \`$failed\`"
         done
+        echo
       } >>"$ORIGINAL_GITHUB_STEP_SUMMARY"
     fi
   fi


### PR DESCRIPTION
## Summary
- Add a trailing blank line after the failed e2e test list in `GITHUB_STEP_SUMMARY`.
- Prevent retry attempts from appending the next summary table directly after the previous failed-test list item.

Discussion: https://github.com/jdx/mise/discussions/10177

## Verification
- `bash -n e2e/run_all_tests`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise x shellcheck -- shellcheck -x e2e/run_all_tests`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise x shfmt -- shfmt -d e2e/run_all_tests`
- GitHub Markdown API regression check: old snippet rendered 0 tables; fixed snippet rendered 1 table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown formatting in end-to-end test failure summaries for enhanced readability in CI logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->