### PR TITLE
fix(aqua): extract 7z archives

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -464,8 +464,8 @@ impl AquaPackage {
     fn detect_format(&self, asset_name: &str) -> &'static str {
         let formats = [
             "tar.br", "tar.bz2", "tar.gz", "tar.lz4", "tar.sz", "tar.xz", "tbr", "tbz", "tbz2",
-            "tgz", "tlz4", "tsz", "txz", "tar.zst", "zip", "gz", "bz2", "lz4", "sz", "xz", "zst",
-            "dmg", "pkg", "rar", "tar",
+            "tgz", "tlz4", "tsz", "txz", "tar.zst", "zip", "7z", "gz", "bz2", "lz4", "sz", "xz",
+            "zst", "dmg", "pkg", "rar", "tar",
         ];
 
         for format in formats {
@@ -1566,6 +1566,18 @@ packages:
         let asset = pkg.asset("1.0.0", "windows", "amd64").unwrap();
 
         assert_eq!(asset, "tool-1.0.0.ps1");
+    }
+
+    #[test]
+    fn test_format_detects_7z_asset() {
+        let pkg = AquaPackage {
+            asset: "tool-{{.Version}}-{{.OS}}-{{.Arch}}.7z".to_string(),
+            ..Default::default()
+        };
+
+        let format = pkg.format("1.0.0", "windows", "amd64").unwrap();
+
+        assert_eq!(format, "7z");
     }
 
     #[test]

--- a/e2e-win/7z.Tests.ps1
+++ b/e2e-win/7z.Tests.ps1
@@ -39,3 +39,48 @@ Describe '7z-strip-components' {
         mise x http:ip7z/7zip -- 7za | Out-String | Should -Match "7-Zip \(a\) 25\.00"
     }
 }
+
+Describe 'aqua-7z' {
+    BeforeAll {
+        $cfg = ".\mise.local.toml"
+        $registryDir = ".\aqua-registry-local"
+        New-Item -ItemType Directory -Force $registryDir | Out-Null
+        $registryContent = @"
+packages:
+  - type: http
+    name: example/7zip
+    supported_envs:
+      - windows
+    url: https://mise.en.dev/test-fixtures/7z2500-extra.7z
+    files:
+      - name: 7za
+        src: 7za/bin/7za.exe
+"@
+        $registryContent | Out-File (Join-Path $registryDir "registry.yml")
+
+        $content = @"
+[tools]
+"aqua:example/7zip" = "25.00"
+"@
+        $content | Out-File $cfg
+        Get-Content $cfg
+
+        $script:oldAquaBakedRegistry = $env:MISE_AQUA_BAKED_REGISTRY
+        $script:oldAquaRegistryUrl = $env:MISE_AQUA_REGISTRY_URL
+        $env:MISE_AQUA_BAKED_REGISTRY = "0"
+        $registryPath = (Resolve-Path $registryDir).Path
+        $env:MISE_AQUA_REGISTRY_URL = ([System.Uri]$registryPath).AbsoluteUri
+    }
+
+    AfterAll {
+        Remove-Item $cfg -ErrorAction Ignore
+        Remove-Item $registryDir -Recurse -Force -ErrorAction Ignore
+        $env:MISE_AQUA_BAKED_REGISTRY = $script:oldAquaBakedRegistry
+        $env:MISE_AQUA_REGISTRY_URL = $script:oldAquaRegistryUrl
+    }
+
+    It 'executes 7za 25.00 via aqua' {
+        mise install
+        mise x aqua:example/7zip -- 7za | Out-String | Should -Match "7-Zip \(a\) 25\.00"
+    }
+}

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -2295,7 +2295,7 @@ impl AquaBackend {
             file::create_dir_all(&install_path)?;
             file::copy(&tarball_path, first_bin_path)?;
             make_executable = true;
-        } else if uses_untar_extractor(format) {
+        } else if format.starts_with("tar") || (format == "7z" && cfg!(windows)) {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
             make_executable = true;
         } else if format == "zip" {
@@ -3013,15 +3013,6 @@ mod tests {
     }
 
     #[test]
-    fn test_uses_untar_extractor_supports_7z() {
-        assert!(uses_untar_extractor("tar.gz"));
-        assert!(uses_untar_extractor("tar.xz"));
-        assert!(uses_untar_extractor("7z"));
-        assert!(!uses_untar_extractor("zip"));
-        assert!(!uses_untar_extractor("raw"));
-    }
-
-    #[test]
     fn test_srcs_support_file_link_with_default_src() {
         let mut pkg = AquaPackage::default();
         pkg.files = vec![AquaFile {
@@ -3415,10 +3406,6 @@ fn needs_extraction(format: &str, pkg_type: &AquaPackageType) -> bool {
             pkg_type,
             AquaPackageType::GithubArchive | AquaPackageType::GithubContent
         )
-}
-
-fn uses_untar_extractor(format: &str) -> bool {
-    format.starts_with("tar") || format == "7z"
 }
 
 /// Check if a platform is supported by the package's supported_envs.

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -2295,7 +2295,7 @@ impl AquaBackend {
             file::create_dir_all(&install_path)?;
             file::copy(&tarball_path, first_bin_path)?;
             make_executable = true;
-        } else if format.starts_with("tar") {
+        } else if uses_untar_extractor(format) {
             file::untar(&tarball_path, &install_path, &tar_opts)?;
             make_executable = true;
         } else if format == "zip" {
@@ -3013,6 +3013,15 @@ mod tests {
     }
 
     #[test]
+    fn test_uses_untar_extractor_supports_7z() {
+        assert!(uses_untar_extractor("tar.gz"));
+        assert!(uses_untar_extractor("tar.xz"));
+        assert!(uses_untar_extractor("7z"));
+        assert!(!uses_untar_extractor("zip"));
+        assert!(!uses_untar_extractor("raw"));
+    }
+
+    #[test]
     fn test_srcs_support_file_link_with_default_src() {
         let mut pkg = AquaPackage::default();
         pkg.files = vec![AquaFile {
@@ -3406,6 +3415,10 @@ fn needs_extraction(format: &str, pkg_type: &AquaPackageType) -> bool {
             pkg_type,
             AquaPackageType::GithubArchive | AquaPackageType::GithubContent
         )
+}
+
+fn uses_untar_extractor(format: &str) -> bool {
+    format.starts_with("tar") || format == "7z"
 }
 
 /// Check if a platform is supported by the package's supported_envs.


### PR DESCRIPTION
## Summary
- route aqua `format: 7z` archives through the existing archive extractor
- detect `.7z` assets in the aqua registry mirror when `format` is omitted
- add Windows e2e coverage using a small local aqua registry and the existing 7z fixture

## References
- Addresses https://github.com/jdx/mise/discussions/10215 (`aqua:ImageMagick/ImageMagick` failed with `unsupported format: 7z`)
- Unblocks https://github.com/jdx/mise/pull/10214, the mise registry PR adding `aqua:ImageMagick/ImageMagick` for Windows support; that PR exposed that mise's aqua backend did not support 7z extraction
- Aqua registry reference: https://github.com/aquaproj/aqua-registry/pull/50281 added `ImageMagick/ImageMagick` to aqua, where aqua can install the Windows `.7z` release assets

## Testing
- `cargo fmt --all -- --check`
- `git diff --check`
- Attempted `cargo test -p aqua-registry test_format_detects_7z_asset`, but local execution was blocked for an extended period by the shared Cargo build-directory lock from other worktrees; CI should cover this path
- Windows Pester e2e not run locally on Linux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 7z archive format detection to recognize and handle 7z compressed archives
  * Implemented Windows-optimized extraction handling for 7z packages ensuring proper decompression and installation

* **Tests**
  * Added end-to-end test suite validating 7z package installation workflow on Windows
  * Test coverage includes local registry configuration, tool installation, and execution verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->