### PR TITLE
fix(aqua): avoid double raw windows extensions

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -611,7 +611,7 @@ impl AquaPackage {
     }
 
     /// Apply Windows executable extension to an asset or URL string if appropriate.
-    /// Mirrors upstream aqua's `completeWindowsExtToAsset` decision tree.
+    /// Keeps already-extended raw assets unchanged to avoid doubling custom Windows extensions.
     fn complete_windows_ext_to_asset(&self, s: &str, v: &str, os: &str) -> Result<String> {
         if os != "windows" || s.ends_with(".exe") || s.ends_with(".jar") {
             return Ok(s.to_string());

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -617,7 +617,10 @@ impl AquaPackage {
             return Ok(s.to_string());
         }
         if self.format == "raw" {
-            return Ok(self.complete_windows_ext(s));
+            if self.os_file_ext_is_empty(s, v) {
+                return Ok(self.complete_windows_ext(s));
+            }
+            return Ok(s.to_string());
         }
         if !self.format.is_empty() {
             return Ok(s.to_string());
@@ -1502,6 +1505,20 @@ packages:
     }
 
     #[test]
+    fn test_url_raw_preserves_custom_windows_ext() {
+        let pkg = AquaPackage {
+            url: "https://example.com/tool/{{.Version}}/tool.bat".to_string(),
+            format: "raw".to_string(),
+            windows_ext: ".bat".to_string(),
+            ..Default::default()
+        };
+
+        let url = pkg.url("1.0.0", "windows", "amd64").unwrap();
+
+        assert_eq!(url, "https://example.com/tool/1.0.0/tool.bat");
+    }
+
+    #[test]
     fn test_asset_appends_format_ext_by_default() {
         let pkg = AquaPackage {
             asset: "tool-{{.Version}}-{{.OS}}-{{.Arch}}".to_string(),
@@ -1532,6 +1549,20 @@ packages:
     fn test_asset_uses_custom_windows_ext() {
         let pkg = AquaPackage {
             asset: "tool-{{.Version}}-{{.OS}}-{{.Arch}}".to_string(),
+            format: "raw".to_string(),
+            windows_ext: ".bat".to_string(),
+            ..Default::default()
+        };
+
+        let asset = pkg.asset("1.0.0", "windows", "amd64").unwrap();
+
+        assert_eq!(asset, "tool-1.0.0-windows-amd64.bat");
+    }
+
+    #[test]
+    fn test_asset_raw_preserves_custom_windows_ext() {
+        let pkg = AquaPackage {
+            asset: "tool-{{.Version}}-{{.OS}}-{{.Arch}}.bat".to_string(),
             format: "raw".to_string(),
             windows_ext: ".bat".to_string(),
             ..Default::default()


### PR DESCRIPTION
## Summary
- keep raw Windows aqua assets/URLs with an existing file extension unchanged before applying `windows_ext`
- continue completing extensionless raw Windows assets/URLs as before
- add regression coverage for raw `.bat` asset and direct URL rendering

## Review validation
Validated the remaining CodeRabbit comment from #10167 with a focused reproduction. Before the fix, this allowed registry shape rendered a double extension on Windows:

```yaml
asset: tool-{{.Version}}-{{.OS}}-{{.Arch}}.bat
format: raw
windows_ext: .bat
```

For `1.0.0` on `windows/amd64`, `pkg.asset(...)` produced `tool-1.0.0-windows-amd64.bat.bat` instead of `tool-1.0.0-windows-amd64.bat`. The same issue is observable for direct URLs such as `https://example.com/tool/{{.Version}}/tool.bat`, which would make mise request `tool.bat.bat`.

I also checked the current aqua registry: `sass/dart-sass` uses `windows_ext: .bat`, but it is archive-based rather than this `format: raw` shape. So this is not a current dart-sass regression; it is a valid edge case for raw assets/URLs that the registry schema permits.

## Upstream aqua comparison
Current `aquaproj/aqua` at `1e4b1cf0` does not avoid this edge case. Its `completeWindowsExtToAsset` returns `completeWindowsExt(asset)` unconditionally for `format: raw` after only skipping assets ending in `.exe` or `.jar`.

I verified that with a temporary local reproduction against aqua's `RenderAsset` path: the same `format: raw` / `windows_ext: .bat` asset rendered as `tool-1.0.0-windows-amd64.bat.bat`.


## Tests
- `cargo test -p aqua-registry raw_preserves_custom_windows_ext -- --nocapture`
- `cargo test -p aqua-registry`
- `cargo fmt -p aqua-registry --check`

## Current aqua-registry packages
None. I scanned current `aquaproj/aqua-registry` at `830124e62b` for packages matching the exact risky shape: `format: raw`, Windows extension completion enabled, a custom `windows_ext`, and an asset/URL that already carries that extension. No packages match.

The only current `windows_ext: .bat` package found is `sass/dart-sass`, and it uses archive formats (`zip`/`tar.gz`) rather than `format: raw`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows extension handling for raw-format assets to more conservatively preserve existing file extensions and prevent unintended modifications.

* **Tests**
  * Added test coverage for raw assets with custom extensions to verify they remain unmodified during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->