### PR TITLE
fix(github): accept canonical versions host repo casing

### DIFF
--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -286,8 +286,14 @@ fn valid_github_browser_download_url(url: &str, owner: &str, repo: &str, tag: &s
             segments.next()
         ),
         (Some(o), Some(r), Some("releases"), Some("download"), Some(t), Some(_asset), None)
-            if o == owner && r == repo && path_segment_matches(t, tag)
+            if github_repo_segment_matches(o, owner)
+                && github_repo_segment_matches(r, repo)
+                && path_segment_matches(t, tag)
     )
+}
+
+fn github_repo_segment_matches(segment: &str, expected: &str) -> bool {
+    segment.eq_ignore_ascii_case(expected)
 }
 
 fn path_segment_matches(segment: &str, expected: &str) -> bool {
@@ -313,7 +319,7 @@ fn valid_github_asset_api_url(url: &str, owner: &str, repo: &str) -> bool {
             segments.next()
         ),
         (Some("repos"), Some(o), Some(r), Some("releases"), Some("assets"), Some(_), None)
-            if o == owner && r == repo
+            if github_repo_segment_matches(o, owner) && github_repo_segment_matches(r, repo)
     )
 }
 
@@ -432,6 +438,12 @@ mod tests {
             "mise-test-fixtures",
             "release/2026"
         ));
+        assert!(valid_github_browser_download_url(
+            "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v0.5.6/dcg-aarch64-apple-darwin.tar.xz",
+            "Dicklesworthstone",
+            "Destructive_command_guard",
+            "v0.5.6"
+        ));
         assert!(!valid_github_browser_download_url(
             "https://github.com/jdx/mise-test-fixtures/releases/download/v0.9.0/hello-world.tar.gz",
             "jdx",
@@ -464,6 +476,11 @@ mod tests {
             "https://api.github.com/repos/jdx/mise-test-fixtures/releases/assets/1",
             "jdx",
             "mise-test-fixtures"
+        ));
+        assert!(valid_github_asset_api_url(
+            "https://api.github.com/repos/Dicklesworthstone/destructive_command_guard/releases/assets/430632958",
+            "Dicklesworthstone",
+            "Destructive_command_guard"
         ));
         assert!(!valid_github_asset_api_url(
             "https://api.github.com/repos/other/mise-test-fixtures/releases/assets/1",


### PR DESCRIPTION
## Summary
- accept GitHub owner/repo casing canonicalized by GitHub when validating `mise-versions` release asset URLs
- keep the strict host, path shape, asset kind, and release-tag checks unchanged
- add regression coverage for the reported mixed-case `Dicklesworthstone/Destructive_command_guard` release asset URLs

## How This Fixes It
`mise` asks `mise-versions` for cached GitHub release metadata using the backend slug the user requested, for example `github:Dicklesworthstone/Destructive_command_guard@v0.5.6`. Before using that metadata, `mise` validates every returned asset URL so a bad mirror response cannot make the GitHub backend silently select assets from an unrelated location.

The previous validation compared the `owner` and `repo` URL path segments byte-for-byte. GitHub owner and repository names are case-insensitive, and the GitHub API may return the canonical repository casing in `browser_download_url` and asset API URLs even when the request used different casing. That made valid mirror responses fail validation, emit `mise-versions returned invalid GitHub release asset URLs`, and fall back to the live GitHub API.

This PR adds `github_repo_segment_matches`, which uses ASCII case-insensitive comparison only for the GitHub owner and repository path segments in these two validated URL forms:

- `https://github.com/{owner}/{repo}/releases/download/{tag}/{asset}`
- `https://api.github.com/repos/{owner}/{repo}/releases/assets/{id}`

Everything else stays strict. The scheme and host must still be exactly `https://github.com` or `https://api.github.com`, the path must still have the expected shape, and the release tag comparison remains case-sensitive because Git tags are case-sensitive.

This deliberately does not make the client accept arbitrary renamed or transferred repositories with a different owner/repo. Without trusted canonical-repository metadata in the response, the client cannot distinguish a legitimate GitHub redirect from a bad mirror response that points at a different repository. The companion proxy-side PR, https://github.com/jdx/mise-versions/pull/214, handles renamed/transferred repositories by following safe GitHub API redirects and preserving compatibility for current released `mise` clients.

## Testing
- `cargo fmt --check`
- `cargo test valid_github_`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub URLs with mixed-case owner and repository names are now properly recognized and accepted for both browser downloads and GitHub asset API requests, improving URL handling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->