### PR TITLE
fix: nix flake build test failure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,9 @@ rustPlatform.buildRustPackage {
     pkg-config
     rustPlatform.bindgenHook
   ];
+  nativeCheckInputs = with pkgs; [
+    git
+  ];
   buildInputs = with pkgs; [
     bash
     coreutils


### PR DESCRIPTION
Adding the `git::tests::clone_by_sha_does_not_panic` broke nix flake builds as `git` was not available during tests. Adding it to `nativeCheckInputs` fixes the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include Git in the test environment to support validation during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->