### PR TITLE
fix(github): refresh oauth token after 401

### DIFF
--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -145,27 +145,37 @@ pub async fn refresh_cached_token_for_host(
     let canonical_host =
         api_host(&settings.github.oauth_api_url).unwrap_or_else(|| host.to_string());
     let cache_key = cache_key(&canonical_host, client_id, scopes);
+    refresh_cached_token(&cache_key, Some(stale_access_token)).await
+}
 
+async fn refresh_cached_token(
+    cache_key: &str,
+    stale_access_token: Option<&str>,
+) -> Result<Option<String>> {
     let _lock = REFRESH_TOKEN_LOCK.lock().await;
     let mut cache = read_cache();
-    let Some(mut cached) = cache.tokens.get(&cache_key).cloned() else {
+    let Some(mut cached) = cache.tokens.get(cache_key).cloned() else {
         return Ok(None);
     };
-    if cached.access_token != stale_access_token {
-        return Ok(Some(cached.access_token));
-    }
 
-    cached.expires_at = chrono::Utc::now();
-    cache.tokens.insert(cache_key.clone(), cached.clone());
-    if let Err(err) = write_cache(&cache) {
-        warn!("failed to invalidate GitHub OAuth token cache: {err:#}");
+    if let Some(stale_access_token) = stale_access_token {
+        if cached.access_token != stale_access_token {
+            return Ok(Some(cached.access_token));
+        }
+        cached.expires_at = chrono::Utc::now();
+        cache.tokens.insert(cache_key.to_string(), cached.clone());
+        if let Err(err) = write_cache(&cache) {
+            warn!("failed to invalidate GitHub OAuth token cache: {err:#}");
+        }
+    } else if reusable(&cached) {
+        return Ok(Some(cached.access_token));
     }
 
     let Some(refreshed) = refresh_token(&cached).await? else {
         return Ok(None);
     };
     let access_token = refreshed.access_token.clone();
-    cache.tokens.insert(cache_key, refreshed);
+    cache.tokens.insert(cache_key.to_string(), refreshed);
     if let Err(err) = write_cache(&cache) {
         warn!("failed to cache refreshed GitHub OAuth token: {err:#}");
     }
@@ -198,15 +208,8 @@ async fn token_async(req: TokenRequest) -> Result<String> {
         return Ok(cached.access_token.clone());
     }
     if let Some(cached) = cache.tokens.get(&cache_key).cloned() {
-        match refresh_token(&cached).await {
-            Ok(Some(refreshed)) => {
-                let token = refreshed.access_token.clone();
-                cache.tokens.insert(cache_key, refreshed);
-                if let Err(err) = write_cache(&cache) {
-                    warn!("failed to cache GitHub OAuth token: {err:#}");
-                }
-                return Ok(token);
-            }
+        match refresh_cached_token(&cache_key, None).await {
+            Ok(Some(token)) => return Ok(token),
             Ok(None) => {}
             Err(err) => {
                 debug!("failed to refresh GitHub OAuth token: {err:#}");

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -11,6 +11,8 @@ const GRANT_DEVICE_CODE: &str = "urn:ietf:params:oauth:grant-type:device_code";
 const DEFAULT_TOKEN_SECS: i64 = 8 * 60 * 60;
 const REUSE_BUFFER_SECS: i64 = 300;
 
+static REFRESH_TOKEN_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 #[derive(Debug, Clone)]
 pub struct TokenRequest {
     pub host: String,
@@ -127,7 +129,10 @@ pub fn token(req: TokenRequest) -> Result<String> {
     block_on(token_async(req))
 }
 
-pub async fn refresh_cached_token_for_host(host: &str) -> Result<Option<String>> {
+pub async fn refresh_cached_token_for_host(
+    host: &str,
+    stale_access_token: &str,
+) -> Result<Option<String>> {
     let settings = Settings::get();
     if settings.github.oauth_client_id.trim().is_empty()
         || !host_matches_settings(host, &settings.github.oauth_api_url)
@@ -140,10 +145,15 @@ pub async fn refresh_cached_token_for_host(host: &str) -> Result<Option<String>>
     let canonical_host =
         api_host(&settings.github.oauth_api_url).unwrap_or_else(|| host.to_string());
     let cache_key = cache_key(&canonical_host, client_id, scopes);
+
+    let _lock = REFRESH_TOKEN_LOCK.lock().await;
     let mut cache = read_cache();
     let Some(mut cached) = cache.tokens.get(&cache_key).cloned() else {
         return Ok(None);
     };
+    if cached.access_token != stale_access_token {
+        return Ok(Some(cached.access_token));
+    }
 
     cached.expires_at = chrono::Utc::now();
     cache.tokens.insert(cache_key.clone(), cached.clone());

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -65,6 +65,9 @@ struct TokenCache {
     tokens: HashMap<String, CachedToken>,
 }
 
+#[cfg(test)]
+static TEST_CACHE_PATH: std::sync::RwLock<Option<PathBuf>> = std::sync::RwLock::new(None);
+
 pub fn resolve_token(host: &str) -> Option<String> {
     let settings = Settings::get();
     if settings.github.oauth_client_id.trim().is_empty()
@@ -78,6 +81,25 @@ pub fn resolve_token(host: &str) -> Option<String> {
         allow_device_flow: false,
     })
     .ok()
+}
+
+pub fn cached_access_token_for_host(host: &str) -> Option<String> {
+    let settings = Settings::get();
+    let client_id = settings.github.oauth_client_id.trim();
+    if client_id.is_empty() || !host_matches_settings(host, &settings.github.oauth_api_url) {
+        return None;
+    }
+    let canonical_host =
+        api_host(&settings.github.oauth_api_url).unwrap_or_else(|| host.to_string());
+    let cache_key = cache_key(
+        &canonical_host,
+        client_id,
+        settings.github.oauth_scopes.trim(),
+    );
+    read_cache()
+        .tokens
+        .get(&cache_key)
+        .map(|cached| cached.access_token.clone())
 }
 
 /// If OAuth is configured and a cached or refreshable token is available,
@@ -103,6 +125,41 @@ pub fn inject_token_env(env: &mut EnvMap) {
 
 pub fn token(req: TokenRequest) -> Result<String> {
     block_on(token_async(req))
+}
+
+pub async fn refresh_cached_token_for_host(host: &str) -> Result<Option<String>> {
+    let settings = Settings::get();
+    if settings.github.oauth_client_id.trim().is_empty()
+        || !host_matches_settings(host, &settings.github.oauth_api_url)
+    {
+        return Ok(None);
+    }
+
+    let client_id = settings.github.oauth_client_id.trim();
+    let scopes = settings.github.oauth_scopes.trim();
+    let canonical_host =
+        api_host(&settings.github.oauth_api_url).unwrap_or_else(|| host.to_string());
+    let cache_key = cache_key(&canonical_host, client_id, scopes);
+    let mut cache = read_cache();
+    let Some(mut cached) = cache.tokens.get(&cache_key).cloned() else {
+        return Ok(None);
+    };
+
+    cached.expires_at = chrono::Utc::now();
+    cache.tokens.insert(cache_key.clone(), cached.clone());
+    if let Err(err) = write_cache(&cache) {
+        warn!("failed to invalidate GitHub OAuth token cache: {err:#}");
+    }
+
+    let Some(refreshed) = refresh_token(&cached).await? else {
+        return Ok(None);
+    };
+    let access_token = refreshed.access_token.clone();
+    cache.tokens.insert(cache_key, refreshed);
+    if let Err(err) = write_cache(&cache) {
+        warn!("failed to cache refreshed GitHub OAuth token: {err:#}");
+    }
+    Ok(Some(access_token))
 }
 
 async fn token_async(req: TokenRequest) -> Result<String> {
@@ -346,6 +403,10 @@ fn cache_key(host: &str, client_id: &str, scopes: &str) -> String {
 }
 
 fn cache_path() -> PathBuf {
+    #[cfg(test)]
+    if let Some(path) = TEST_CACHE_PATH.read().unwrap().clone() {
+        return path;
+    }
     env::MISE_STATE_DIR.join("github-oauth-tokens.toml")
 }
 
@@ -409,5 +470,22 @@ fn block_on<F: std::future::Future>(future: F) -> F::Output {
             .build()
             .expect("failed to build tokio runtime")
             .block_on(future)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    pub(crate) fn cache_key(host: &str, client_id: &str, scopes: &str) -> String {
+        super::cache_key(host, client_id, scopes)
+    }
+
+    pub(crate) fn set_cache_path(path: PathBuf) {
+        *TEST_CACHE_PATH.write().unwrap() = Some(path);
+    }
+
+    pub(crate) fn clear_cache_path() {
+        *TEST_CACHE_PATH.write().unwrap() = None;
     }
 }

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -158,20 +158,25 @@ async fn refresh_cached_token(
         return Ok(None);
     };
 
-    if let Some(stale_access_token) = stale_access_token {
+    let invalidate_on_none = if let Some(stale_access_token) = stale_access_token {
         if cached.access_token != stale_access_token {
             return Ok(Some(cached.access_token));
         }
-        cached.expires_at = chrono::Utc::now();
-        cache.tokens.insert(cache_key.to_string(), cached.clone());
-        if let Err(err) = write_cache(&cache) {
-            warn!("failed to invalidate GitHub OAuth token cache: {err:#}");
-        }
+        true
     } else if reusable(&cached) {
         return Ok(Some(cached.access_token));
-    }
+    } else {
+        false
+    };
 
     let Some(refreshed) = refresh_token(&cached).await? else {
+        if invalidate_on_none {
+            cached.expires_at = chrono::Utc::now();
+            cache.tokens.insert(cache_key.to_string(), cached);
+            if let Err(err) = write_cache(&cache) {
+                warn!("failed to invalidate GitHub OAuth token cache: {err:#}");
+            }
+        }
         return Ok(None);
     };
     let access_token = refreshed.access_token.clone();
@@ -512,5 +517,100 @@ pub(crate) mod test_support {
 
     pub(crate) fn clear_cache_path() {
         *TEST_CACHE_PATH.write().unwrap() = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct OAuthEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        vars: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl OAuthEnvGuard {
+        fn new(auth_url: String, cache_path: PathBuf) -> Self {
+            let lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+            let vars = vec![
+                (
+                    "MISE_GITHUB_OAUTH_CLIENT_ID",
+                    std::env::var("MISE_GITHUB_OAUTH_CLIENT_ID").ok(),
+                ),
+                (
+                    "MISE_GITHUB_OAUTH_AUTH_URL",
+                    std::env::var("MISE_GITHUB_OAUTH_AUTH_URL").ok(),
+                ),
+                (
+                    "MISE_GITHUB_OAUTH_API_URL",
+                    std::env::var("MISE_GITHUB_OAUTH_API_URL").ok(),
+                ),
+                (
+                    "MISE_GITHUB_OAUTH_SCOPES",
+                    std::env::var("MISE_GITHUB_OAUTH_SCOPES").ok(),
+                ),
+            ];
+            crate::env::set_var("MISE_GITHUB_OAUTH_CLIENT_ID", "Iv1.mock");
+            crate::env::set_var("MISE_GITHUB_OAUTH_AUTH_URL", auth_url);
+            crate::env::set_var("MISE_GITHUB_OAUTH_API_URL", "https://api.github.com");
+            crate::env::remove_var("MISE_GITHUB_OAUTH_SCOPES");
+            test_support::set_cache_path(cache_path);
+            Settings::reset(None);
+            Self { _lock: lock, vars }
+        }
+    }
+
+    impl Drop for OAuthEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.vars {
+                if let Some(value) = value {
+                    crate::env::set_var(key, value);
+                } else {
+                    crate::env::remove_var(key);
+                }
+            }
+            test_support::clear_cache_path();
+            Settings::reset(None);
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_error_preserves_cached_token() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            if let Ok((sock, _)) = listener.accept().await {
+                drop(sock);
+            }
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("github-oauth-tokens.toml");
+        let _guard =
+            OAuthEnvGuard::new(format!("http://127.0.0.1:{port}/login"), cache_path.clone());
+
+        let expires_at = chrono::DateTime::parse_from_rfc3339("2099-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let cache_key = cache_key("api.github.com", "Iv1.mock", "");
+        std::fs::write(
+            &cache_path,
+            format!(
+                r#"[tokens.{cache_key}]
+access_token = "ghu-stale"
+expires_at = "2099-01-01T00:00:00Z"
+refresh_token = "ghr-refresh"
+refresh_expires_at = "2099-01-01T00:00:00Z"
+"#
+            ),
+        )
+        .unwrap();
+
+        let result = refresh_cached_token(&cache_key, Some("ghu-stale")).await;
+
+        assert!(result.is_err());
+        let cache = read_cache();
+        let cached = cache.tokens.get(&cache_key).unwrap();
+        assert_eq!(cached.access_token, "ghu-stale");
+        assert_eq!(cached.expires_at, expires_at);
     }
 }

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -474,9 +474,21 @@ fn default_poll_interval() -> u64 {
     5
 }
 
-fn block_on<F: std::future::Future>(future: F) -> F::Output {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        tokio::task::block_in_place(|| handle.block_on(future))
+fn block_on<F>(future: F) -> F::Output
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    if tokio::runtime::Handle::try_current().is_ok() {
+        std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build tokio runtime")
+                .block_on(future)
+        })
+        .join()
+        .expect("tokio runtime thread panicked")
     } else {
         tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/src/http.rs
+++ b/src/http.rs
@@ -43,6 +43,31 @@ static HTTP_CACHE: Lazy<Mutex<HashMap<String, CachedResult>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 type RetryHeaders = Arc<Mutex<HeaderMap>>;
 
+#[derive(Clone)]
+struct SendOnceOptions {
+    use_netrc: bool,
+    retry_github_oauth_401: bool,
+    retry_headers: Option<RetryHeaders>,
+}
+
+impl SendOnceOptions {
+    fn new(retry_headers: Option<RetryHeaders>) -> Self {
+        Self {
+            use_netrc: true,
+            retry_github_oauth_401: true,
+            retry_headers,
+        }
+    }
+
+    fn recursive_retry(&self) -> Self {
+        Self {
+            use_netrc: false,
+            retry_github_oauth_401: false,
+            retry_headers: self.retry_headers.clone(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Client {
     reqwest: reqwest::Client,
@@ -454,8 +479,14 @@ impl Client {
         verb_label: &str,
         retry_headers: Option<RetryHeaders>,
     ) -> Result<Response> {
-        self.send_once_inner(method, url, headers, verb_label, true, true, retry_headers)
-            .await
+        self.send_once_inner(
+            method,
+            url,
+            headers,
+            verb_label,
+            SendOnceOptions::new(retry_headers),
+        )
+        .await
     }
 
     async fn send_once_inner(
@@ -464,9 +495,7 @@ impl Client {
         mut url: Url,
         headers: &HeaderMap,
         verb_label: &str,
-        use_netrc: bool,
-        retry_github_oauth_401: bool,
-        retry_headers: Option<RetryHeaders>,
+        options: SendOnceOptions,
     ) -> Result<Response> {
         let original_url = url.clone();
         apply_url_replacements(&mut url);
@@ -474,7 +503,7 @@ impl Client {
 
         // Apply netrc credentials after URL replacement
         let mut final_headers = headers.clone();
-        if use_netrc {
+        if options.use_netrc && !final_headers.contains_key(AUTHORIZATION) {
             final_headers.extend(netrc_headers(&url));
         }
 
@@ -510,7 +539,7 @@ impl Client {
         }
         debug!("{} {url} {}", verb_label, resp.status());
         display_github_rate_limit(&resp);
-        if retry_github_oauth_401
+        if options.retry_github_oauth_401
             && let Some(stale_access_token) =
                 stale_github_oauth_unauthorized_token(&original_url, &final_headers, &resp)
             && let Some(host) = original_url.host_str()
@@ -519,10 +548,10 @@ impl Client {
                 .await
             {
                 Ok(Some(token)) => {
-                    let mut headers = final_headers.clone();
+                    let mut headers = headers.clone();
                     if let Ok(value) = HeaderValue::from_str(format!("Bearer {token}").as_str()) {
                         headers.insert(AUTHORIZATION, value);
-                        if let Some(retry_headers) = &retry_headers {
+                        if let Some(retry_headers) = &options.retry_headers {
                             *retry_headers.lock().unwrap() = headers.clone();
                         }
                         debug!(
@@ -534,9 +563,7 @@ impl Client {
                             original_url,
                             &headers,
                             verb_label,
-                            false,
-                            false,
-                            retry_headers,
+                            options.recursive_retry(),
                         ))
                         .await;
                     } else {
@@ -574,9 +601,7 @@ impl Client {
                     original_url,
                     &headers,
                     verb_label,
-                    false,
-                    false,
-                    retry_headers,
+                    options.recursive_retry(),
                 ))
                 .await;
             }
@@ -648,9 +673,7 @@ fn stale_github_oauth_unauthorized_token(
         return None;
     }
     let host = url.host_str()?;
-    let Some(token) = crate::github::oauth::cached_access_token_for_host(host) else {
-        return None;
-    };
+    let token = crate::github::oauth::cached_access_token_for_host(host)?;
     let header_token = headers
         .get(AUTHORIZATION)
         .and_then(|header| header.to_str().ok())

--- a/src/http.rs
+++ b/src/http.rs
@@ -41,21 +41,26 @@ pub static HTTP_FETCH: Lazy<Client> = Lazy::new(|| {
 type CachedResult = Arc<OnceCell<Result<String, String>>>;
 static HTTP_CACHE: Lazy<Mutex<HashMap<String, CachedResult>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
-type RetryHeaders = Arc<Mutex<HeaderMap>>;
+type RetryStateHandle = Arc<Mutex<RetryState>>;
+
+struct RetryState {
+    headers: HeaderMap,
+    use_netrc: bool,
+}
 
 #[derive(Clone)]
 struct SendOnceOptions {
     use_netrc: bool,
     retry_github_oauth_401: bool,
-    retry_headers: Option<RetryHeaders>,
+    retry_state: Option<RetryStateHandle>,
 }
 
 impl SendOnceOptions {
-    fn new(retry_headers: Option<RetryHeaders>) -> Self {
+    fn new(retry_state: Option<RetryStateHandle>, use_netrc: bool) -> Self {
         Self {
-            use_netrc: true,
+            use_netrc,
             retry_github_oauth_401: true,
-            retry_headers,
+            retry_state,
         }
     }
 
@@ -63,7 +68,7 @@ impl SendOnceOptions {
         Self {
             use_netrc: false,
             retry_github_oauth_401: false,
-            retry_headers: self.retry_headers.clone(),
+            retry_state: self.retry_state.clone(),
         }
     }
 }
@@ -407,15 +412,22 @@ impl Client {
         verb_label: &str,
         retries: i64,
     ) -> Result<Response> {
-        let retry_headers = Arc::new(Mutex::new(headers.clone()));
+        let retry_state = Arc::new(Mutex::new(RetryState {
+            headers: headers.clone(),
+            use_netrc: true,
+        }));
         retry_async_with_retries(verb_label, &url, retries, || async {
-            let headers = retry_headers.lock().unwrap().clone();
+            let (headers, use_netrc) = {
+                let state = retry_state.lock().unwrap();
+                (state.headers.clone(), state.use_netrc)
+            };
             self.send_once_with_https_fallback_with_retry_headers(
                 method.clone(),
                 url.clone(),
                 &headers,
                 verb_label,
-                Some(retry_headers.clone()),
+                Some(retry_state.clone()),
+                use_netrc,
             )
             .await
         })
@@ -437,7 +449,7 @@ impl Client {
         verb_label: &str,
     ) -> Result<Response> {
         self.send_once_with_https_fallback_with_retry_headers(
-            method, url, headers, verb_label, None,
+            method, url, headers, verb_label, None, true,
         )
         .await
     }
@@ -448,7 +460,8 @@ impl Client {
         url: Url,
         headers: &HeaderMap,
         verb_label: &str,
-        retry_headers: Option<RetryHeaders>,
+        retry_state: Option<RetryStateHandle>,
+        use_netrc: bool,
     ) -> Result<Response> {
         match self
             .send_once_with_retry_headers(
@@ -456,7 +469,8 @@ impl Client {
                 url.clone(),
                 headers,
                 verb_label,
-                retry_headers.clone(),
+                retry_state.clone(),
+                use_netrc,
             )
             .await
         {
@@ -464,8 +478,15 @@ impl Client {
             Err(err) if url.scheme() == "http" && is_connection_error(&err) => {
                 let mut url = url;
                 url.set_scheme("https").unwrap();
-                self.send_once_with_retry_headers(method, url, headers, verb_label, retry_headers)
-                    .await
+                self.send_once_with_retry_headers(
+                    method,
+                    url,
+                    headers,
+                    verb_label,
+                    retry_state,
+                    use_netrc,
+                )
+                .await
             }
             Err(err) => Err(err),
         }
@@ -477,14 +498,15 @@ impl Client {
         url: Url,
         headers: &HeaderMap,
         verb_label: &str,
-        retry_headers: Option<RetryHeaders>,
+        retry_state: Option<RetryStateHandle>,
+        use_netrc: bool,
     ) -> Result<Response> {
         self.send_once_inner(
             method,
             url,
             headers,
             verb_label,
-            SendOnceOptions::new(retry_headers),
+            SendOnceOptions::new(retry_state, use_netrc),
         )
         .await
     }
@@ -503,7 +525,7 @@ impl Client {
 
         // Apply netrc credentials after URL replacement
         let mut final_headers = headers.clone();
-        if options.use_netrc && !final_headers.contains_key(AUTHORIZATION) {
+        if options.use_netrc {
             final_headers.extend(netrc_headers(&url));
         }
 
@@ -551,8 +573,11 @@ impl Client {
                     let mut headers = headers.clone();
                     if let Ok(value) = HeaderValue::from_str(format!("Bearer {token}").as_str()) {
                         headers.insert(AUTHORIZATION, value);
-                        if let Some(retry_headers) = &options.retry_headers {
-                            *retry_headers.lock().unwrap() = headers.clone();
+                        if let Some(retry_state) = &options.retry_state {
+                            *retry_state.lock().unwrap() = RetryState {
+                                headers: headers.clone(),
+                                use_netrc: false,
+                            };
                         }
                         debug!(
                             "{} {} retrying with refreshed GitHub OAuth token after 401",
@@ -1069,6 +1094,10 @@ mod tests {
                 "MISE_GITHUB_OAUTH_API_URL",
                 std::env::var("MISE_GITHUB_OAUTH_API_URL").ok(),
             ),
+            (
+                "MISE_GITHUB_OAUTH_SCOPES",
+                std::env::var("MISE_GITHUB_OAUTH_SCOPES").ok(),
+            ),
             ("MISE_GITHUB_TOKEN", std::env::var("MISE_GITHUB_TOKEN").ok()),
             ("GITHUB_API_TOKEN", std::env::var("GITHUB_API_TOKEN").ok()),
             ("GITHUB_TOKEN", std::env::var("GITHUB_TOKEN").ok()),
@@ -1078,6 +1107,7 @@ mod tests {
         crate::env::set_var("MISE_GITHUB_OAUTH_CLIENT_ID", "Iv1.mock");
         crate::env::set_var("MISE_GITHUB_OAUTH_AUTH_URL", format!("{server_url}/login"));
         crate::env::set_var("MISE_GITHUB_OAUTH_API_URL", format!("{server_url}/api/v3"));
+        crate::env::remove_var("MISE_GITHUB_OAUTH_SCOPES");
         crate::env::remove_var("MISE_GITHUB_TOKEN");
         crate::env::remove_var("GITHUB_API_TOKEN");
         crate::env::remove_var("GITHUB_TOKEN");
@@ -1152,7 +1182,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cache_path = dir.path().join("github-oauth-tokens.toml");
         let _guard = set_test_github_oauth(&server.url(), cache_path.clone());
-        let cache_key = crate::github::oauth::test_support::cache_key("127.0.0.1", "Iv1.mock", "");
+        let settings = crate::config::Settings::get();
+        let cache_key = crate::github::oauth::test_support::cache_key(
+            "127.0.0.1",
+            "Iv1.mock",
+            settings.github.oauth_scopes.trim(),
+        );
         std::fs::write(
             &cache_path,
             format!(

--- a/src/http.rs
+++ b/src/http.rs
@@ -1233,20 +1233,33 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         )
         .unwrap();
 
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer ghu-stale"));
         let client = Client::new(Duration::from_secs(3), ClientKind::Http).unwrap();
         let text = client
-            .get_text(format!("{server_url}/api/v3/repos/owner/repo/releases"))
+            .get_text_request(format!("{server_url}/api/v3/repos/owner/repo/releases"))
+            .headers(&headers)
+            .send()
             .await
-            .unwrap();
+            .unwrap_or_else(|err| {
+                let requests = requests.lock().unwrap();
+                panic!(
+                    "request failed: {err:#}\nrequests:\n{}",
+                    requests.join("\n---\n")
+                );
+            });
 
         assert_eq!(text, "[]");
         assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
         let requests = requests.lock().unwrap();
-        assert!(requests[0].contains("GET /api/v3/repos/owner/repo/releases"));
-        assert!(requests[0].contains("authorization: Bearer ghu-stale"));
-        assert!(requests[1].contains("POST /login/oauth/access_token"));
-        assert!(requests[2].contains("GET /api/v3/repos/owner/repo/releases"));
-        assert!(requests[2].contains("authorization: Bearer ghu-refreshed"));
+        let first_request = requests[0].to_ascii_lowercase();
+        let refresh_request = requests[1].to_ascii_lowercase();
+        let retry_request = requests[2].to_ascii_lowercase();
+        assert!(first_request.contains("get /api/v3/repos/owner/repo/releases"));
+        assert!(first_request.contains("authorization: bearer ghu-stale"));
+        assert!(refresh_request.contains("post /login/oauth/access_token"));
+        assert!(retry_request.contains("get /api/v3/repos/owner/repo/releases"));
+        assert!(retry_request.contains("authorization: bearer ghu-refreshed"));
         let cache = std::fs::read_to_string(cache_path).unwrap();
         assert!(cache.contains("ghu-refreshed"));
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1127,6 +1127,17 @@ mod tests {
     async fn spawn_canned_server(
         responses: Vec<&'static str>,
     ) -> (u16, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        let (port, count, _) = spawn_recording_server(responses).await;
+        (port, count)
+    }
+
+    async fn spawn_recording_server(
+        responses: Vec<&'static str>,
+    ) -> (
+        u16,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    ) {
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -1134,7 +1145,9 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let count = Arc::new(AtomicUsize::new(0));
+        let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
         let count_inner = count.clone();
+        let requests_inner = requests.clone();
         tokio::spawn(async move {
             for resp in responses {
                 let Ok((mut sock, _)) = listener.accept().await else {
@@ -1156,11 +1169,15 @@ mod tests {
                         Err(_) => break,
                     }
                 }
+                requests_inner
+                    .lock()
+                    .unwrap()
+                    .push(String::from_utf8_lossy(&total).to_string());
                 let _ = sock.write_all(resp.as_bytes()).await;
                 let _ = sock.shutdown().await;
             }
         });
-        (port, count)
+        (port, count, requests)
     }
 
     fn ok_response() -> &'static str {
@@ -1175,13 +1192,28 @@ mod tests {
     fn server_error_response() -> &'static str {
         "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
     }
+    fn unauthorized_response() -> &'static str {
+        "HTTP/1.1 401 Unauthorized\r\nContent-Length: 15\r\nConnection: close\r\n\r\nBad credentials"
+    }
+    fn github_oauth_token_response() -> &'static str {
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 51\r\nConnection: close\r\n\r\n{\"access_token\":\"ghu-refreshed\",\"expires_in\":28800}"
+    }
+    fn json_empty_array_response() -> &'static str {
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n[]"
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_github_oauth_401_refreshes_and_retries_once() {
-        let mut server = mockito::Server::new_async().await;
+        let (port, count, requests) = spawn_recording_server(vec![
+            unauthorized_response(),
+            github_oauth_token_response(),
+            json_empty_array_response(),
+        ])
+        .await;
+        let server_url = format!("http://127.0.0.1:{port}");
         let dir = tempfile::tempdir().unwrap();
         let cache_path = dir.path().join("github-oauth-tokens.toml");
-        let _guard = set_test_github_oauth(&server.url(), cache_path.clone());
+        let _guard = set_test_github_oauth(&server_url, cache_path.clone());
         let settings = crate::config::Settings::get();
         let cache_key = crate::github::oauth::test_support::cache_key(
             "127.0.0.1",
@@ -1201,44 +1233,20 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         )
         .unwrap();
 
-        let stale = server
-            .mock("GET", "/api/v3/repos/owner/repo/releases")
-            .match_header("authorization", "Bearer ghu-stale")
-            .with_status(401)
-            .with_body("Bad credentials")
-            .expect(1)
-            .create_async()
-            .await;
-        let refresh = server
-            .mock("POST", "/login/oauth/access_token")
-            .match_body(mockito::Matcher::Regex(
-                "grant_type=refresh_token".to_string(),
-            ))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(r#"{"access_token":"ghu-refreshed","expires_in":28800}"#)
-            .expect(1)
-            .create_async()
-            .await;
-        let refreshed = server
-            .mock("GET", "/api/v3/repos/owner/repo/releases")
-            .match_header("authorization", "Bearer ghu-refreshed")
-            .with_status(200)
-            .with_body("[]")
-            .expect(1)
-            .create_async()
-            .await;
-
         let client = Client::new(Duration::from_secs(3), ClientKind::Http).unwrap();
         let text = client
-            .get_text(format!("{}/api/v3/repos/owner/repo/releases", server.url()))
+            .get_text(format!("{server_url}/api/v3/repos/owner/repo/releases"))
             .await
             .unwrap();
 
         assert_eq!(text, "[]");
-        stale.assert_async().await;
-        refresh.assert_async().await;
-        refreshed.assert_async().await;
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
+        let requests = requests.lock().unwrap();
+        assert!(requests[0].contains("GET /api/v3/repos/owner/repo/releases"));
+        assert!(requests[0].contains("authorization: Bearer ghu-stale"));
+        assert!(requests[1].contains("POST /login/oauth/access_token"));
+        assert!(requests[2].contains("GET /api/v3/repos/owner/repo/releases"));
+        assert!(requests[2].contains("authorization: Bearer ghu-refreshed"));
         let cache = std::fs::read_to_string(cache_path).unwrap();
         assert!(cache.contains("ghu-refreshed"));
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -423,7 +423,7 @@ impl Client {
         headers: &HeaderMap,
         verb_label: &str,
     ) -> Result<Response> {
-        self.send_once_inner(method, url, headers, verb_label, true)
+        self.send_once_inner(method, url, headers, verb_label, true, true)
             .await
     }
 
@@ -434,6 +434,7 @@ impl Client {
         headers: &HeaderMap,
         verb_label: &str,
         use_netrc: bool,
+        retry_github_oauth_401: bool,
     ) -> Result<Response> {
         apply_url_replacements(&mut url);
         debug!("{} {}", verb_label, &url);
@@ -476,6 +477,32 @@ impl Client {
         }
         debug!("{} {url} {}", verb_label, resp.status());
         display_github_rate_limit(&resp);
+        if retry_github_oauth_401
+            && is_stale_github_oauth_unauthorized(&url, &final_headers, &resp)
+            && let Some(host) = url.host_str()
+        {
+            match crate::github::oauth::refresh_cached_token_for_host(host).await {
+                Ok(Some(token)) => {
+                    let mut headers = final_headers;
+                    headers.insert(
+                        AUTHORIZATION,
+                        HeaderValue::from_str(format!("Bearer {token}").as_str()).unwrap(),
+                    );
+                    debug!(
+                        "{} {} retrying with refreshed GitHub OAuth token after 401",
+                        verb_label, &url
+                    );
+                    return Box::pin(
+                        self.send_once_inner(method, url, &headers, verb_label, false, false),
+                    )
+                    .await;
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    debug!("failed to refresh GitHub OAuth token after 401: {err:#}");
+                }
+            }
+        }
         if is_authenticated_github_forbidden(&url, &final_headers, &resp) {
             let status = resp.status();
             let status_error = resp
@@ -494,8 +521,10 @@ impl Client {
                     "{} {} retrying without GitHub auth after {}",
                     verb_label, &url, status
                 );
-                return Box::pin(self.send_once_inner(method, url, &headers, verb_label, false))
-                    .await;
+                return Box::pin(
+                    self.send_once_inner(method, url, &headers, verb_label, false, false),
+                )
+                .await;
             }
             return Err(status_error.into());
         }
@@ -554,6 +583,23 @@ fn is_authenticated_github_forbidden(url: &Url, headers: &HeaderMap, resp: &Resp
     resp.status() == StatusCode::FORBIDDEN
         && url.host_str() == Some("api.github.com")
         && headers.contains_key(AUTHORIZATION)
+}
+
+fn is_stale_github_oauth_unauthorized(url: &Url, headers: &HeaderMap, resp: &Response) -> bool {
+    if resp.status() != StatusCode::UNAUTHORIZED || !crate::github::is_github_api_url(url) {
+        return false;
+    }
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let Some(token) = crate::github::oauth::cached_access_token_for_host(host) else {
+        return false;
+    };
+    headers
+        .get(AUTHORIZATION)
+        .and_then(|header| header.to_str().ok())
+        .and_then(|header| header.strip_prefix("Bearer "))
+        .is_some_and(|header_token| header_token == token)
 }
 
 pub fn error_code(e: &Report) -> Option<u16> {
@@ -802,6 +848,7 @@ mod tests {
     use super::*;
     use confique::Layer;
     use indexmap::IndexMap;
+    use std::path::PathBuf;
     use url::Url;
 
     // Mutex to ensure tests don't interfere with each other when modifying global settings
@@ -902,6 +949,65 @@ mod tests {
         SettingsGuard { _lock: lock }
     }
 
+    struct GithubOauthSettingsGuard {
+        _settings_lock: std::sync::MutexGuard<'static, ()>,
+        _github_env_lock: std::sync::MutexGuard<'static, ()>,
+        vars: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl Drop for GithubOauthSettingsGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.vars {
+                if let Some(value) = value {
+                    crate::env::set_var(key, value);
+                } else {
+                    crate::env::remove_var(key);
+                }
+            }
+            crate::github::oauth::test_support::clear_cache_path();
+            crate::config::Settings::reset(None);
+        }
+    }
+
+    fn set_test_github_oauth(server_url: &str, cache_path: PathBuf) -> GithubOauthSettingsGuard {
+        let settings_lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let github_env_lock = crate::github::TEST_ENV_LOCK.lock().unwrap();
+        let vars = vec![
+            ("MISE_EXPERIMENTAL", std::env::var("MISE_EXPERIMENTAL").ok()),
+            (
+                "MISE_GITHUB_OAUTH_CLIENT_ID",
+                std::env::var("MISE_GITHUB_OAUTH_CLIENT_ID").ok(),
+            ),
+            (
+                "MISE_GITHUB_OAUTH_AUTH_URL",
+                std::env::var("MISE_GITHUB_OAUTH_AUTH_URL").ok(),
+            ),
+            (
+                "MISE_GITHUB_OAUTH_API_URL",
+                std::env::var("MISE_GITHUB_OAUTH_API_URL").ok(),
+            ),
+            ("MISE_GITHUB_TOKEN", std::env::var("MISE_GITHUB_TOKEN").ok()),
+            ("GITHUB_API_TOKEN", std::env::var("GITHUB_API_TOKEN").ok()),
+            ("GITHUB_TOKEN", std::env::var("GITHUB_TOKEN").ok()),
+        ];
+
+        crate::env::set_var("MISE_EXPERIMENTAL", "1");
+        crate::env::set_var("MISE_GITHUB_OAUTH_CLIENT_ID", "Iv1.mock");
+        crate::env::set_var("MISE_GITHUB_OAUTH_AUTH_URL", format!("{server_url}/login"));
+        crate::env::set_var("MISE_GITHUB_OAUTH_API_URL", format!("{server_url}/api/v3"));
+        crate::env::remove_var("MISE_GITHUB_TOKEN");
+        crate::env::remove_var("GITHUB_API_TOKEN");
+        crate::env::remove_var("GITHUB_TOKEN");
+        crate::github::oauth::test_support::set_cache_path(cache_path);
+        crate::config::Settings::reset(None);
+
+        GithubOauthSettingsGuard {
+            _settings_lock: settings_lock,
+            _github_env_lock: github_env_lock,
+            vars,
+        }
+    }
+
     // A tiny in-process HTTP/1.1 responder. Each accepted connection consumes
     // the next response from `responses` and writes it back. Returns the bound
     // port and an Arc counter of connections actually served.
@@ -955,6 +1061,68 @@ mod tests {
     }
     fn server_error_response() -> &'static str {
         "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_github_oauth_401_refreshes_and_retries_once() {
+        let mut server = mockito::Server::new_async().await;
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("github-oauth-tokens.toml");
+        let _guard = set_test_github_oauth(&server.url(), cache_path.clone());
+        let cache_key = crate::github::oauth::test_support::cache_key("127.0.0.1", "Iv1.mock", "");
+        std::fs::write(
+            &cache_path,
+            format!(
+                r#"[tokens.{cache_key}]
+access_token = "ghu-stale"
+expires_at = "2099-01-01T00:00:00Z"
+refresh_token = "ghr-refresh"
+refresh_expires_at = "2099-01-01T00:00:00Z"
+"#
+            ),
+        )
+        .unwrap();
+
+        let stale = server
+            .mock("GET", "/api/v3/repos/owner/repo/releases")
+            .match_header("authorization", "Bearer ghu-stale")
+            .with_status(401)
+            .with_body("Bad credentials")
+            .expect(1)
+            .create_async()
+            .await;
+        let refresh = server
+            .mock("POST", "/login/oauth/access_token")
+            .match_body(mockito::Matcher::Regex(
+                "grant_type=refresh_token".to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"access_token":"ghu-refreshed","expires_in":28800}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let refreshed = server
+            .mock("GET", "/api/v3/repos/owner/repo/releases")
+            .match_header("authorization", "Bearer ghu-refreshed")
+            .with_status(200)
+            .with_body("[]")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = Client::new(Duration::from_secs(3), ClientKind::Http).unwrap();
+        let text = client
+            .get_text(format!("{}/api/v3/repos/owner/repo/releases", server.url()))
+            .await
+            .unwrap();
+
+        assert_eq!(text, "[]");
+        stale.assert_async().await;
+        refresh.assert_async().await;
+        refreshed.assert_async().await;
+        let cache = std::fs::read_to_string(cache_path).unwrap();
+        assert!(cache.contains("ghu-refreshed"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -41,6 +41,7 @@ pub static HTTP_FETCH: Lazy<Client> = Lazy::new(|| {
 type CachedResult = Arc<OnceCell<Result<String, String>>>;
 static HTTP_CACHE: Lazy<Mutex<HashMap<String, CachedResult>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
+type RetryHeaders = Arc<Mutex<HeaderMap>>;
 
 #[derive(Debug)]
 pub struct Client {
@@ -381,9 +382,17 @@ impl Client {
         verb_label: &str,
         retries: i64,
     ) -> Result<Response> {
+        let retry_headers = Arc::new(Mutex::new(headers.clone()));
         retry_async_with_retries(verb_label, &url, retries, || async {
-            self.send_once_with_https_fallback(method.clone(), url.clone(), headers, verb_label)
-                .await
+            let headers = retry_headers.lock().unwrap().clone();
+            self.send_once_with_https_fallback_with_retry_headers(
+                method.clone(),
+                url.clone(),
+                &headers,
+                verb_label,
+                Some(retry_headers.clone()),
+            )
+            .await
         })
         .await
     }
@@ -402,28 +411,50 @@ impl Client {
         headers: &HeaderMap,
         verb_label: &str,
     ) -> Result<Response> {
+        self.send_once_with_https_fallback_with_retry_headers(
+            method, url, headers, verb_label, None,
+        )
+        .await
+    }
+
+    async fn send_once_with_https_fallback_with_retry_headers(
+        &self,
+        method: Method,
+        url: Url,
+        headers: &HeaderMap,
+        verb_label: &str,
+        retry_headers: Option<RetryHeaders>,
+    ) -> Result<Response> {
         match self
-            .send_once(method.clone(), url.clone(), headers, verb_label)
+            .send_once_with_retry_headers(
+                method.clone(),
+                url.clone(),
+                headers,
+                verb_label,
+                retry_headers.clone(),
+            )
             .await
         {
             Ok(resp) => Ok(resp),
             Err(err) if url.scheme() == "http" && is_connection_error(&err) => {
                 let mut url = url;
                 url.set_scheme("https").unwrap();
-                self.send_once(method, url, headers, verb_label).await
+                self.send_once_with_retry_headers(method, url, headers, verb_label, retry_headers)
+                    .await
             }
             Err(err) => Err(err),
         }
     }
 
-    async fn send_once(
+    async fn send_once_with_retry_headers(
         &self,
         method: Method,
         url: Url,
         headers: &HeaderMap,
         verb_label: &str,
+        retry_headers: Option<RetryHeaders>,
     ) -> Result<Response> {
-        self.send_once_inner(method, url, headers, verb_label, true, true)
+        self.send_once_inner(method, url, headers, verb_label, true, true, retry_headers)
             .await
     }
 
@@ -435,7 +466,9 @@ impl Client {
         verb_label: &str,
         use_netrc: bool,
         retry_github_oauth_401: bool,
+        retry_headers: Option<RetryHeaders>,
     ) -> Result<Response> {
+        let original_url = url.clone();
         apply_url_replacements(&mut url);
         debug!("{} {}", verb_label, &url);
 
@@ -479,8 +512,8 @@ impl Client {
         display_github_rate_limit(&resp);
         if retry_github_oauth_401
             && let Some(stale_access_token) =
-                stale_github_oauth_unauthorized_token(&url, &final_headers, &resp)
-            && let Some(host) = url.host_str()
+                stale_github_oauth_unauthorized_token(&original_url, &final_headers, &resp)
+            && let Some(host) = original_url.host_str()
         {
             match crate::github::oauth::refresh_cached_token_for_host(host, &stale_access_token)
                 .await
@@ -489,13 +522,22 @@ impl Client {
                     let mut headers = final_headers.clone();
                     if let Ok(value) = HeaderValue::from_str(format!("Bearer {token}").as_str()) {
                         headers.insert(AUTHORIZATION, value);
+                        if let Some(retry_headers) = &retry_headers {
+                            *retry_headers.lock().unwrap() = headers.clone();
+                        }
                         debug!(
                             "{} {} retrying with refreshed GitHub OAuth token after 401",
                             verb_label, &url
                         );
-                        return Box::pin(
-                            self.send_once_inner(method, url, &headers, verb_label, false, false),
-                        )
+                        return Box::pin(self.send_once_inner(
+                            method,
+                            original_url,
+                            &headers,
+                            verb_label,
+                            false,
+                            false,
+                            retry_headers,
+                        ))
                         .await;
                     } else {
                         debug!(
@@ -527,9 +569,15 @@ impl Client {
                     "{} {} retrying without GitHub auth after {}",
                     verb_label, &url, status
                 );
-                return Box::pin(
-                    self.send_once_inner(method, url, &headers, verb_label, false, false),
-                )
+                return Box::pin(self.send_once_inner(
+                    method,
+                    original_url,
+                    &headers,
+                    verb_label,
+                    false,
+                    false,
+                    retry_headers,
+                ))
                 .await;
             }
             return Err(status_error.into());

--- a/src/http.rs
+++ b/src/http.rs
@@ -478,24 +478,30 @@ impl Client {
         debug!("{} {url} {}", verb_label, resp.status());
         display_github_rate_limit(&resp);
         if retry_github_oauth_401
-            && is_stale_github_oauth_unauthorized(&url, &final_headers, &resp)
+            && let Some(stale_access_token) =
+                stale_github_oauth_unauthorized_token(&url, &final_headers, &resp)
             && let Some(host) = url.host_str()
         {
-            match crate::github::oauth::refresh_cached_token_for_host(host).await {
+            match crate::github::oauth::refresh_cached_token_for_host(host, &stale_access_token)
+                .await
+            {
                 Ok(Some(token)) => {
-                    let mut headers = final_headers;
-                    headers.insert(
-                        AUTHORIZATION,
-                        HeaderValue::from_str(format!("Bearer {token}").as_str()).unwrap(),
-                    );
-                    debug!(
-                        "{} {} retrying with refreshed GitHub OAuth token after 401",
-                        verb_label, &url
-                    );
-                    return Box::pin(
-                        self.send_once_inner(method, url, &headers, verb_label, false, false),
-                    )
-                    .await;
+                    let mut headers = final_headers.clone();
+                    if let Ok(value) = HeaderValue::from_str(format!("Bearer {token}").as_str()) {
+                        headers.insert(AUTHORIZATION, value);
+                        debug!(
+                            "{} {} retrying with refreshed GitHub OAuth token after 401",
+                            verb_label, &url
+                        );
+                        return Box::pin(
+                            self.send_once_inner(method, url, &headers, verb_label, false, false),
+                        )
+                        .await;
+                    } else {
+                        debug!(
+                            "refreshed GitHub OAuth token contains invalid header bytes; skipping retry"
+                        );
+                    }
                 }
                 Ok(None) => {}
                 Err(err) => {
@@ -585,21 +591,27 @@ fn is_authenticated_github_forbidden(url: &Url, headers: &HeaderMap, resp: &Resp
         && headers.contains_key(AUTHORIZATION)
 }
 
-fn is_stale_github_oauth_unauthorized(url: &Url, headers: &HeaderMap, resp: &Response) -> bool {
+fn stale_github_oauth_unauthorized_token(
+    url: &Url,
+    headers: &HeaderMap,
+    resp: &Response,
+) -> Option<String> {
     if resp.status() != StatusCode::UNAUTHORIZED || !crate::github::is_github_api_url(url) {
-        return false;
+        return None;
     }
-    let Some(host) = url.host_str() else {
-        return false;
-    };
+    let host = url.host_str()?;
     let Some(token) = crate::github::oauth::cached_access_token_for_host(host) else {
-        return false;
+        return None;
     };
-    headers
+    let header_token = headers
         .get(AUTHORIZATION)
         .and_then(|header| header.to_str().ok())
-        .and_then(|header| header.strip_prefix("Bearer "))
-        .is_some_and(|header_token| header_token == token)
+        .and_then(|header| header.strip_prefix("Bearer "))?;
+    if header_token == token {
+        Some(header_token.to_string())
+    } else {
+        None
+    }
 }
 
 pub fn error_code(e: &Report) -> Option<u16> {


### PR DESCRIPTION
## Summary
- detect 401 responses from GitHub API calls that used the cached native GitHub OAuth token
- invalidate and refresh the cached OAuth access token, then retry the request once
- keep surfacing the original 401 behavior if the refresh/retry path cannot recover

Fixes the stale-token scenario reported in https://github.com/jdx/mise/discussions/10244.

## Tests
- cargo test http::tests::test_github_oauth_401_refreshes_and_retries_once
- mise run test:e2e e2e/cli/test_token_github

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared HTTP send/retry logic and OAuth token cache persistence; scope is limited to GitHub API 401s that match the native OAuth cache, with a single retry and mutex-guarded refresh.
> 
> **Overview**
> **GitHub API calls that fail with 401 while using the cached native OAuth access token are now recovered automatically** instead of surfacing a hard auth failure when the token is stale but still present in cache.
> 
> The HTTP client detects that case (401 on a GitHub API URL where `Authorization: Bearer` matches the on-disk OAuth cache), calls a new host-scoped refresh path, **persists the new token**, updates retry headers for the outer retry loop, and **reissues the request once**. If refresh cannot recover, behavior stays the same as before (the original 401 path).
> 
> OAuth refresh is **centralized and serialized**: a global async mutex, shared `refresh_cached_token` used from normal token resolution and from the 401 path, optional invalidation when refresh fails after a known-stale token, and a safer `block_on` when already inside a Tokio runtime. Tests cover refresh-on-401 end-to-end and preserving the cache when refresh errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2fa130803cc18b8914142ec11b34e985b25c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Automatic GitHub OAuth token refresh that transparently retries a failed request once when a cached token is stale.
  - Host-scoped access to read and refresh the token cache for testing and diagnostics.

* **Bug Fixes**
  - Avoids failed API calls from expired/stale GitHub tokens by detecting, refreshing, persisting, and retrying requests.

* **Refactor**
  - HTTP retry/fallback flow updated so authorization header updates propagate through retries.

* **Tests**
  - Added tests and helpers to validate refresh-and-retry behavior and cache persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->