### PR TITLE
feat(task): inherit interactive and raw_args from task templates

### DIFF
--- a/docs/tasks/templates.md
+++ b/docs/tasks/templates.md
@@ -53,18 +53,19 @@ Templates use colon (`:`) separators for namespacing, similar to task naming con
 
 When a task extends a template, fields are merged according to these rules:
 
-| Field                                   | Behavior                                                    |
-| --------------------------------------- | ----------------------------------------------------------- |
-| `run`, `run_windows`                    | Local overrides completely                                  |
-| `tools`                                 | Deep merge (local tools added/override template)            |
-| `env`                                   | Deep merge (local env added/override template)              |
-| `depends`, `depends_post`, `wait_for`   | Local overrides completely (not merged)                     |
-| `dir`                                   | Local overrides; defaults to config_root if not in template |
-| `sources`, `outputs`                    | Local overrides completely                                  |
-| Sandbox deny fields                     | Compose with task-local settings                            |
-| Sandbox allow fields                    | Template and task-local values are combined                 |
-| `description`, `shell`, `timeout`, etc. | Local overrides template (if set)                           |
-| `quiet`, `hide`, `raw`                  | Not carried over (must be set explicitly in task)           |
+| Field                                   | Behavior                                                      |
+| --------------------------------------- | ------------------------------------------------------------- |
+| `run`, `run_windows`                    | Local overrides completely                                    |
+| `tools`                                 | Deep merge (local tools added/override template)              |
+| `env`                                   | Deep merge (local env added/override template)                |
+| `depends`, `depends_post`, `wait_for`   | Local overrides completely (not merged)                       |
+| `dir`                                   | Local overrides; defaults to config_root if not in template   |
+| `sources`, `outputs`                    | Local overrides completely                                    |
+| Sandbox deny fields                     | Compose with task-local settings                              |
+| Sandbox allow fields                    | Template and task-local values are combined                   |
+| `description`, `shell`, `timeout`, etc. | Local overrides template (if set)                             |
+| `interactive`, `raw_args`               | Enabled when template sets `true` (sticky; task can also set) |
+| `quiet`, `hide`, `raw`                  | Not carried over (must be set explicitly in task)             |
 
 ### Example: Deep Merge for Tools
 

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -47,6 +47,8 @@ shell = "bash -c"
 [task_templates.base]
 quiet = true
 dir = "{{config_root}}"
+interactive = true
+raw_args = true
 deny_net = true
 allow_env = ["CI"]
 

--- a/e2e/tasks/test_task_templates
+++ b/e2e/tasks/test_task_templates
@@ -181,4 +181,19 @@ EOF
 
 assert "mise run build" "cargo build"
 
+# Test raw_args inherited from template
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."proxy:base"]
+raw_args = true
+run = 'echo "got:$@"'
+
+[tasks.proxy]
+extends = "proxy:base"
+EOF
+
+assert "mise run proxy --help" "got: --help"
+
 echo '' >mise.toml

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -53,6 +53,10 @@ pub struct TaskTemplate {
     pub run_windows: Vec<RunEntry>,
     #[serde(default)]
     pub file: Option<String>,
+    #[serde(default)]
+    pub interactive: bool,
+    #[serde(default)]
+    pub raw_args: bool,
     /// Block reads, writes, network, and env vars
     #[serde(default)]
     pub deny_all: bool,
@@ -178,6 +182,14 @@ impl Task {
         // Therefore, we do NOT merge these boolean fields from templates to avoid the case
         // where a task explicitly sets `quiet = false` but gets overridden by a template's
         // `quiet = true`. Users must explicitly set these in their task if needed.
+
+        // interactive/raw_args: sticky-true merge (matches task overlay merge in Task::merge)
+        if template.interactive {
+            self.interactive = true;
+        }
+        if template.raw_args {
+            self.raw_args = true;
+        }
 
         // silent: use template only if local is Off (Silent is an enum, so we can distinguish)
         if matches!(self.silent, Silent::Off)
@@ -401,6 +413,48 @@ mod tests {
             _ => None,
         });
         assert_eq!(shared_val, Some("task_value"));
+    }
+
+    #[test]
+    fn test_merge_template_interactive_from_template() {
+        let mut task = Task::default();
+        let template = TaskTemplate {
+            interactive: true,
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert!(task.interactive);
+    }
+
+    #[test]
+    fn test_merge_template_raw_args_from_template() {
+        let mut task = Task::default();
+        let template = TaskTemplate {
+            raw_args: true,
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert!(task.raw_args);
+    }
+
+    #[test]
+    fn test_merge_template_interactive_task_already_set() {
+        let mut task = Task {
+            interactive: true,
+            ..Default::default()
+        };
+        let template = TaskTemplate {
+            interactive: false,
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert!(task.interactive);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `interactive` and `raw_args` to `TaskTemplate` and merge them into extended tasks
- use sticky-true merge semantics (same as task overlay merge in `Task::merge`)
- document merge behavior in `docs/tasks/templates.md`
- cover runtime inheritance (`e2e/tasks/test_task_templates`) and schema acceptance (`e2e/config/test_schema_tombi`)

## Notes

- `Task` stores these as plain `bool`, so merge only propagates `true` from templates (cannot distinguish unset vs explicit `false` on tasks yet)
- complements #10242, which removes unused `hide`/`quiet`/`raw` from templates

## Test plan

- [x] `cargo test task_template`
- [ ] `mise run test:e2e test_task_templates`
- [ ] `mise run test:e2e test_schema_tombi`


Made with [Cursor](https://cursor.com)