### PR TITLE
docs: update snap installation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,10 +68,10 @@ sudo dnf install mise
 
 See the [copr page](https://copr.fedorainfracloud.org/coprs/jdxcode/mise/) for more information.
 
-== Snap (beta)
+== Snap
 
 ```sh
-sudo snap install mise --classic --beta
+sudo snap install mise --classic
 ```
 
 See the [snapcraft.io page](https://snapcraft.io/mise) for more information.

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -189,10 +189,10 @@ dnf install mise
 
 [COPR package page](https://copr.fedorainfracloud.org/coprs/jdxcode/mise/)
 
-### Snap (Linux, currently in beta)
+### Snap (Linux)
 
 ```sh
-sudo snap install mise --classic --beta
+sudo snap install mise --classic
 ```
 
 [snapcraft.io page](https://snapcraft.io/mise)


### PR DESCRIPTION
Snap package has a stable channel meanwhile (and the release in the beta channel is outdated OTOH).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Snap (Linux) installation guidance across the docs: removed the beta designation and now recommends the stable Snap install.
  * Example install command and headings updated to reflect the current recommended stable installation method for Linux users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->