### PR TITLE
registry: add hz (github:phongndo/hz)

### DIFF
--- a/registry/hz.toml
+++ b/registry/hz.toml
@@ -1,0 +1,4 @@
+backends = ["github:phongndo/hz"]
+description = "Fast terminal workflow for parallel development with agents"
+os = ["linux", "macos"]
+test = { cmd = "hz --version", expected = "hz {{version}}" }


### PR DESCRIPTION
Add `hz` as a registry shorthand backed by `github:phongndo/hz`.

`hz` is a fast terminal workflow for parallel development with agents.

Validation:
- `cargo run --locked --quiet -- test-tool hz`
- `taplo check registry/hz.toml`

Popularity / maintenance summary, checked 2026-06-06:
- GitHub repo: https://github.com/phongndo/hz
- Stars: 0
- Forks: 0
- Watchers: 0
- Latest release: v0.1.9, published 2026-06-06
- Release asset downloads at time of check: 4 total across v0.1.9 assets (3 binary archive downloads, 1 checksum download)
- Ships prebuilt macOS and Linux release archives for x86_64 and aarch64 through GitHub releases
- Third-party usage examples: none known yet
- Community channels / case studies: none yet
- Maintenance: project is new, actively maintained, has CI for quality and release workflows, and has release checks that verify the tag matches the package version
