### PR TITLE
fix(github): warn on versions host metadata fallback

### DIFF
--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -166,7 +166,8 @@ pub async fn github_release(repo: &str, tag: &str) -> eyre::Result<Option<Github
         encode_path_segment(tag)
     );
 
-    let Some(release) = fetch_optional_json(&url, "GitHub release metadata").await? else {
+    let label = format!("GitHub release metadata for {repo}@{tag}");
+    let Some(release) = fetch_optional_json(&url, &label).await? else {
         return Ok(None);
     };
     if !valid_github_release_asset_urls(&release, owner, repo_name) {
@@ -205,8 +206,8 @@ pub async fn github_attestations(
         encode_digest_path_segment(digest)
     );
 
-    let response: Option<AttestationsResponse> =
-        fetch_optional_json(&url, "GitHub attestations").await?;
+    let label = format!("GitHub attestations for {repo}@{digest}");
+    let response: Option<AttestationsResponse> = fetch_optional_json(&url, &label).await?;
     Ok(response.map(|r| r.attestations))
 }
 
@@ -222,11 +223,11 @@ where
         Err(err) => match http::error_code(&err).unwrap_or(0) {
             404 => Ok(None),
             429 => {
-                debug!("mise-versions rate limited while fetching {label}");
+                warn!("mise-versions rate limited while fetching {label}; falling back");
                 Ok(None)
             }
             _ => {
-                debug!("mise-versions {label} lookup failed: {err:#}");
+                warn!("mise-versions {label} lookup failed, falling back: {err:#}");
                 Ok(None)
             }
         },


### PR DESCRIPTION
## Summary
- warn when mise-versions GitHub metadata lookups hit rate limits or other non-404 failures
- include the release/attestation lookup context before falling back to the GitHub API
- keep 404 cache misses silent

## Why
When mise-versions release metadata fails transiently, mise falls back to the GitHub API. If CI has lost or lacks a GitHub token, the visible failure is a GitHub 403 with no indication that the versions-host lookup failed first. These warnings make that fallback path visible.

## Test plan
- cargo fmt
- cargo test versions_host

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in optional metadata fetch paths; 404 handling and fallback semantics are unchanged.
> 
> **Overview**
> Improves **visibility when mise-versions GitHub metadata lookups fail** and mise silently falls back to the GitHub API.
> 
> `github_release` and `github_attestations` now pass **context-specific labels** (e.g. `GitHub release metadata for {repo}@{tag}`) into shared `fetch_optional_json` handling. **429 rate limits** and **other non-404 errors** are logged at **`warn`** with explicit “falling back” wording instead of **`debug`**. **404** responses remain **silent** (treated as a cache miss).
> 
> No change to fallback behavior—only logging and error-message context so CI failures (e.g. GitHub 403 without a token) are easier to trace back to a prior versions-host failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77fd1d2ce12ee966e7886f3c26d004d58efcf494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for rate-limit and lookup failures with more explicit fallback indicators for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->