### PR TITLE
fix(github): skip versions host for non-registry tools

### DIFF
--- a/e2e/backend/test_github_versions_host_no_api
+++ b/e2e/backend/test_github_versions_host_no_api
@@ -19,18 +19,18 @@ wait_for_file "$SERVER_PORT_FILE" "GitHub API blocker port file" 30 "$SERVER_PID
 SERVER_PORT=$(cat "$SERVER_PORT_FILE")
 
 rm -rf "$MISE_CACHE_DIR/github"
-mise uninstall github:jdx/mise-test-fixtures 2>/dev/null || true
+mise uninstall communique 2>/dev/null || true
 
 cat <<EOF >mise.toml
 [settings]
 url_replacements = { "https://api.github.com" = "http://127.0.0.1:$SERVER_PORT" }
 
 [tools]
-"github:jdx/mise-test-fixtures" = { version = "1.0.0", asset_pattern = "hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world" }
+communique = "1.1.3"
 EOF
 
 assert_succeed "mise install"
-assert_contains "mise x -- hello-world" "hello world"
+assert_contains "mise x -- communique --version" "communique 1.1.3"
 
 if compgen -G "$HEADERS_LOG_DIR/request_*.json" >/dev/null; then
   cat "$HEADERS_LOG_DIR"/request_*.json

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -7,14 +7,16 @@ use crate::backend::static_helpers::{
     get_filename_from_url, install_artifact, lookup_platform_key, lookup_with_fallback,
     template_string, try_with_v_prefix, try_with_v_prefix_and_repo, verify_artifact,
 };
-use crate::backend::{MISE_BINS_DIR, SecurityFeature, runtime_path_for_install_path};
+use crate::backend::{
+    MISE_BINS_DIR, SecurityFeature, backend_arg_matches_registry_backend,
+    runtime_path_for_install_path,
+};
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::config::{Config, Settings};
 use crate::file;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
-use crate::registry::REGISTRY;
 use crate::toolset::ToolVersionOptions;
 use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{backend::Backend, forgejo, github, gitlab};
@@ -619,10 +621,7 @@ impl UnifiedGitBackend {
     }
 
     fn use_versions_host_for_github_metadata(&self) -> bool {
-        let full = self.ba.full();
-        REGISTRY
-            .get(self.ba.short.as_str())
-            .is_some_and(|rt| rt.backends().iter().any(|b| *b == full))
+        backend_arg_matches_registry_backend(&self.ba)
     }
 
     async fn get_github_release_for_url(

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -14,6 +14,7 @@ use crate::file;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
+use crate::registry::REGISTRY;
 use crate::toolset::ToolVersionOptions;
 use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{backend::Backend, forgejo, github, gitlab};
@@ -392,7 +393,10 @@ impl Backend for UnifiedGitBackend {
                 }
             }
         } else {
-            match github::get_release_for_url(&api_url, &repo, "latest").await {
+            match self
+                .get_github_release_for_url(&api_url, &repo, "latest")
+                .await
+            {
                 Ok(r) => Some(r.tag_name),
                 Err(e) => {
                     debug!("Failed to fetch latest GitHub release for {repo}: {e}");
@@ -426,10 +430,19 @@ impl Backend for UnifiedGitBackend {
         let api_url = opts.api_url();
         let version_prefix = opts.version_prefix();
 
+        let use_versions_host = self.use_versions_host_for_github_metadata();
         match try_with_v_prefix_and_repo(version, version_prefix, Some(&repo), |candidate| {
             let api_url = api_url.clone();
             let repo = repo.clone();
-            async move { github::get_release_for_url(&api_url, &repo, &candidate).await }
+            async move {
+                github::get_release_for_url_with_versions_host(
+                    &api_url,
+                    &repo,
+                    &candidate,
+                    use_versions_host,
+                )
+                .await
+            }
         })
         .await
         {
@@ -605,6 +618,28 @@ impl UnifiedGitBackend {
         }
     }
 
+    fn use_versions_host_for_github_metadata(&self) -> bool {
+        let full = self.ba.full();
+        REGISTRY
+            .get(self.ba.short.as_str())
+            .is_some_and(|rt| rt.backends().iter().any(|b| *b == full))
+    }
+
+    async fn get_github_release_for_url(
+        &self,
+        api_url: &str,
+        repo: &str,
+        tag: &str,
+    ) -> Result<github::GithubRelease> {
+        github::get_release_for_url_with_versions_host(
+            api_url,
+            repo,
+            tag,
+            self.use_versions_host_for_github_metadata(),
+        )
+        .await
+    }
+
     /// Detect what provenance type is available for a release by checking its assets
     /// and querying the GitHub attestation API.
     async fn detect_provenance_type(
@@ -620,11 +655,20 @@ impl UnifiedGitBackend {
         let version = &tv.version;
         let version_prefix = opts.version_prefix();
 
+        let use_versions_host = self.use_versions_host_for_github_metadata();
         let release =
             try_with_v_prefix_and_repo(version, version_prefix, Some(repo), |candidate| {
                 let api_url = api_url.to_string();
                 let repo = repo.to_string();
-                async move { github::get_release_for_url(&api_url, &repo, &candidate).await }
+                async move {
+                    github::get_release_for_url_with_versions_host(
+                        &api_url,
+                        &repo,
+                        &candidate,
+                        use_versions_host,
+                    )
+                    .await
+                }
             })
             .await
             .ok();
@@ -782,11 +826,20 @@ impl UnifiedGitBackend {
         if settings.slsa && settings.github.slsa {
             let version = &tv.version;
             let version_prefix = opts.version_prefix();
+            let use_versions_host = self.use_versions_host_for_github_metadata();
             let release =
                 try_with_v_prefix_and_repo(version, version_prefix, Some(repo), |candidate| {
                     let api_url = api_url.to_string();
                     let repo = repo.to_string();
-                    async move { github::get_release_for_url(&api_url, &repo, &candidate).await }
+                    async move {
+                        github::get_release_for_url_with_versions_host(
+                            &api_url,
+                            &repo,
+                            &candidate,
+                            use_versions_host,
+                        )
+                        .await
+                    }
                 })
                 .await?;
 
@@ -1181,7 +1234,9 @@ impl UnifiedGitBackend {
         version: &str,
         target: &PlatformTarget,
     ) -> Result<ReleaseAsset> {
-        let release = github::get_release_for_url(api_url, repo, version).await?;
+        let release = self
+            .get_github_release_for_url(api_url, repo, version)
+            .await?;
         let available_assets: Vec<String> = release.assets.iter().map(|a| a.name.clone()).collect();
 
         // Build asset list with URLs for checksum fetching
@@ -1884,11 +1939,20 @@ impl UnifiedGitBackend {
 
         // Try to get the release (with version prefix support)
         let version_prefix = opts.version_prefix();
+        let use_versions_host = self.use_versions_host_for_github_metadata();
         let release =
             match try_with_v_prefix_and_repo(version, version_prefix, Some(&repo), |candidate| {
                 let api_url = api_url.to_string();
                 let repo = repo.clone();
-                async move { github::get_release_for_url(&api_url, &repo, &candidate).await }
+                async move {
+                    github::get_release_for_url_with_versions_host(
+                        &api_url,
+                        &repo,
+                        &candidate,
+                        use_versions_host,
+                    )
+                    .await
+                }
             })
             .await
             {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -85,7 +85,7 @@ pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 pub(crate) const MISE_BINS_DIR: &str = ".mise-bins";
 
 pub(crate) fn backend_arg_matches_registry_backend(ba: &BackendArg) -> bool {
-    let full = ba.full();
+    let full = ba.full_without_opts();
     REGISTRY
         .get(ba.short.as_str())
         .is_some_and(|rt| rt.backends().iter().any(|b| *b == full))
@@ -540,6 +540,16 @@ mod tests {
             &resolved,
             &["api_url", "version_prefix"],
         ));
+    }
+
+    #[test]
+    fn test_backend_arg_matches_registry_backend_ignores_inline_opts() {
+        let ba = BackendArg::new(
+            "communique".to_string(),
+            Some("github:jdx/communique[asset_pattern=communique-*]".to_string()),
+        );
+
+        assert!(backend_arg_matches_registry_backend(&ba));
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1151,7 +1151,11 @@ pub trait Backend: Debug + Send + Sync {
                 }
                 is_registry_backend
             } else {
-                true // Not in registry, safe to use versions host
+                trace!(
+                    "Skipping versions host for {} because it is not in the registry",
+                    ba.short
+                );
+                false
             }
         };
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -84,6 +84,13 @@ pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 
 pub(crate) const MISE_BINS_DIR: &str = ".mise-bins";
 
+pub(crate) fn backend_arg_matches_registry_backend(ba: &BackendArg) -> bool {
+    let full = ba.full();
+    REGISTRY
+        .get(ba.short.as_str())
+        .is_some_and(|rt| rt.backends().iter().any(|b| *b == full))
+}
+
 const VERSIONS_HOST_LOCAL_OPT_SOURCES: &[ToolOptionSource] = &[
     ToolOptionSource::InstallManifest,
     ToolOptionSource::BackendAlias,
@@ -1140,16 +1147,15 @@ pub trait Backend: Debug + Send + Sync {
             // the registry's default. When a user aliases a tool to a different backend
             // (e.g. `php = "github:verzly/php"`), the versions host would return versions
             // from the registry's default backend which may not match the aliased backend.
-            let full = ba.full();
-            if let Some(rt) = REGISTRY.get(ba.short.as_str()) {
-                let is_registry_backend = rt.backends().iter().any(|b| *b == full);
-                if !is_registry_backend {
+            if REGISTRY.contains_key(ba.short.as_str()) {
+                if !backend_arg_matches_registry_backend(&ba) {
                     trace!(
                         "Skipping versions host for {} because backend {} is not the registry default",
-                        ba.short, full
+                        ba.short,
+                        ba.full()
                     );
                 }
-                is_registry_backend
+                backend_arg_matches_registry_backend(&ba)
             } else {
                 trace!(
                     "Skipping versions host for {} because it is not in the registry",

--- a/src/github.rs
+++ b/src/github.rs
@@ -295,17 +295,13 @@ pub async fn get_release(repo: &str, tag: &str) -> Result<GithubRelease> {
         .await
 }
 
-pub async fn get_release_for_url(api_url: &str, repo: &str, tag: &str) -> Result<GithubRelease> {
-    get_release_for_url_with_versions_host(api_url, repo, tag, true).await
-}
-
 pub async fn get_release_for_url_with_versions_host(
     api_url: &str,
     repo: &str,
     tag: &str,
     use_versions_host: bool,
 ) -> Result<GithubRelease> {
-    let key = format!("{api_url}-{repo}-{tag}").to_kebab_case();
+    let key = format!("{api_url}-{repo}-{tag}-versions-host-{use_versions_host}").to_kebab_case();
     let cache = get_release_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     cache
@@ -933,7 +929,7 @@ something_else = "value"
         let repo = "owner/empty-assets-cache-test";
         let tag = "v1.0.0";
         let path = format!("/repos/{repo}/releases/tags/{tag}");
-        let key = format!("{}-{repo}-{tag}", server.url()).to_kebab_case();
+        let key = format!("{}-{repo}-{tag}-versions-host-true", server.url()).to_kebab_case();
 
         let cached_empty_release = make_release(tag);
         {
@@ -951,7 +947,9 @@ something_else = "value"
             .create_async()
             .await;
 
-        let release = get_release_for_url(&server.url(), repo, tag).await.unwrap();
+        let release = get_release_for_url_with_versions_host(&server.url(), repo, tag, true)
+            .await
+            .unwrap();
         assert!(release.assets.is_empty());
         empty_mock.assert_async().await;
         empty_mock.remove_async().await;
@@ -969,11 +967,15 @@ something_else = "value"
             .create_async()
             .await;
 
-        let release = get_release_for_url(&server.url(), repo, tag).await.unwrap();
+        let release = get_release_for_url_with_versions_host(&server.url(), repo, tag, true)
+            .await
+            .unwrap();
         assert_eq!(release.assets.len(), 1);
         assert_eq!(release.assets[0].name, "tool-v1.0.0-linux-x86_64.tar.gz");
 
-        let release = get_release_for_url(&server.url(), repo, tag).await.unwrap();
+        let release = get_release_for_url_with_versions_host(&server.url(), repo, tag, true)
+            .await
+            .unwrap();
         assert_eq!(release.assets.len(), 1);
         mock.assert_async().await;
     }

--- a/src/github.rs
+++ b/src/github.rs
@@ -296,12 +296,21 @@ pub async fn get_release(repo: &str, tag: &str) -> Result<GithubRelease> {
 }
 
 pub async fn get_release_for_url(api_url: &str, repo: &str, tag: &str) -> Result<GithubRelease> {
+    get_release_for_url_with_versions_host(api_url, repo, tag, true).await
+}
+
+pub async fn get_release_for_url_with_versions_host(
+    api_url: &str,
+    repo: &str,
+    tag: &str,
+    use_versions_host: bool,
+) -> Result<GithubRelease> {
     let key = format!("{api_url}-{repo}-{tag}").to_kebab_case();
     let cache = get_release_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     cache
         .get_or_try_init_async_if(
-            async || get_release_(api_url, repo, tag).await,
+            async || get_release_with_options(api_url, repo, tag, use_versions_host).await,
             should_cache_release,
         )
         .await
@@ -357,7 +366,17 @@ fn pick_best_build_revision(releases: Vec<GithubRelease>, version: &str) -> Opti
 }
 
 async fn get_release_(api_url: &str, repo: &str, tag: &str) -> Result<GithubRelease> {
-    if is_public_github_api_base(api_url)
+    get_release_with_options(api_url, repo, tag, true).await
+}
+
+async fn get_release_with_options(
+    api_url: &str,
+    repo: &str,
+    tag: &str,
+    use_versions_host: bool,
+) -> Result<GithubRelease> {
+    if use_versions_host
+        && is_public_github_api_base(api_url)
         && let Ok(Some(release)) = crate::versions_host::github_release(repo, tag).await
     {
         trace!("got GitHub release {repo}@{tag} from mise-versions");


### PR DESCRIPTION
## Summary
- skip the versions host for non-registry tools in remote version listing
- pass the same registry/backend gate into GitHub release metadata lookups
- keep registry-backed GitHub tools using mise-versions when their backend matches the registry entry

## Why
Non-registry tools can be private, internal, or ad hoc `github:owner/repo` references. Sending those release/version probes to mise-versions adds noise and can leak/internalize failures that should go directly to the configured upstream GitHub API instead.

## Test plan
- cargo fmt
- cargo test versions_host

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when GitHub installs and version resolution hit mise-versions vs api.github.com; wrong gating could break registry installs or send private repos to the wrong endpoint.
> 
> **Overview**
> **GitHub release metadata** now consults mise-versions only when the tool is in the registry and its backend matches the registry entry (inline `[...]` options are ignored for that check via `full_without_opts`). Install, version resolution, asset lookup, and provenance paths all pass this gate into `get_release_for_url_with_versions_host`.
> 
> **Remote version listing** for non-plugin `github:` tools no longer defaults to the versions host for tools absent from the registry; previously those lookups could still hit mise-versions.
> 
> The e2e test installs registry tool **communique** with `api.github.com` blocked and asserts no requests reach the public GitHub API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3acc31b4f45938f04b5ea7b17ccbeb2d23670b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * GitHub release resolution and caching were centralized to respect registry backend settings, reducing unnecessary external lookups and improving release resolution consistency.
* **Tests**
  * End-to-end tests updated to validate GitHub-backed installs can succeed without contacting the public GitHub API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->