### PR TITLE
fix(github): add structured versions host logs

### DIFF
--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -148,7 +148,10 @@ impl<'a> VersionsHostLogContext<'a> {
             fields.push_str(&format!(" digest={}", log_value(digest)));
         }
         if let Some(full) = self.full {
-            fields.push_str(&format!(" full={}", log_value(full)));
+            fields.push_str(&format!(
+                " full={}",
+                log_value(&sanitize_full_for_log(full))
+            ));
         }
         if let Some(version) = self.version {
             fields.push_str(&format!(" version={}", log_value(version)));
@@ -166,6 +169,20 @@ fn log_value(value: &str) -> String {
     } else {
         format!("{:?}", value)
     }
+}
+
+fn sanitize_full_for_log(full: &str) -> String {
+    let Some((backend, value)) = full.split_once(':') else {
+        return full.to_string();
+    };
+    if let Ok(mut url) = url::Url::parse(value) {
+        let _ = url.set_username("");
+        let _ = url.set_password(None);
+        url.set_query(None);
+        url.set_fragment(None);
+        return format!("{backend}:{url}");
+    }
+    full.to_string()
 }
 
 fn log_versions_host_trace(ctx: VersionsHostLogContext<'_>, outcome: &str, extra: &str) {
@@ -257,12 +274,12 @@ pub async fn list_versions(tool: &str) -> eyre::Result<Option<Vec<VersionInfo>>>
         },
     };
 
-    log_versions_host_trace(ctx, "success", &format!("versions={}", versions.len()));
-
     if versions.is_empty() {
         log_versions_host_trace(ctx, "empty", "fallback=true");
         return Ok(None);
     }
+
+    log_versions_host_trace(ctx, "success", &format!("versions={}", versions.len()));
 
     CACHE
         .lock()
@@ -577,6 +594,20 @@ mod tests {
         assert_eq!(
             fields,
             r#"endpoint=install_track tool="some tool" full=github:jdx/mise version=1.2.3"#
+        );
+    }
+
+    #[test]
+    fn test_versions_host_log_context_redacts_full_url_credentials() {
+        let fields = VersionsHostLogContext::install_track(
+            "private",
+            "github:https://user:token@example.com/org/repo?token=secret#frag",
+            "1.2.3",
+        )
+        .fields();
+        assert_eq!(
+            fields,
+            r#"endpoint=install_track tool=private full=github:https://example.com/org/repo version=1.2.3"#
         );
     }
 

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -73,14 +73,127 @@ struct AttestationsResponse {
     attestations: Vec<Attestation>,
 }
 
+#[derive(Clone, Copy)]
+struct VersionsHostLogContext<'a> {
+    endpoint: &'static str,
+    tool: Option<&'a str>,
+    repo: Option<&'a str>,
+    tag: Option<&'a str>,
+    digest: Option<&'a str>,
+    full: Option<&'a str>,
+    version: Option<&'a str>,
+}
+
+impl<'a> VersionsHostLogContext<'a> {
+    fn version_list(tool: &'a str) -> Self {
+        Self {
+            endpoint: "version_list",
+            tool: Some(tool),
+            repo: None,
+            tag: None,
+            digest: None,
+            full: None,
+            version: None,
+        }
+    }
+
+    fn github_release(repo: &'a str, tag: &'a str) -> Self {
+        Self {
+            endpoint: "github_release",
+            tool: None,
+            repo: Some(repo),
+            tag: Some(tag),
+            digest: None,
+            full: None,
+            version: None,
+        }
+    }
+
+    fn github_attestations(repo: &'a str, digest: &'a str) -> Self {
+        Self {
+            endpoint: "github_attestations",
+            tool: None,
+            repo: Some(repo),
+            tag: None,
+            digest: Some(digest),
+            full: None,
+            version: None,
+        }
+    }
+
+    fn install_track(tool: &'a str, full: &'a str, version: &'a str) -> Self {
+        Self {
+            endpoint: "install_track",
+            tool: Some(tool),
+            repo: None,
+            tag: None,
+            digest: None,
+            full: Some(full),
+            version: Some(version),
+        }
+    }
+
+    fn fields(&self) -> String {
+        let mut fields = format!("endpoint={}", self.endpoint);
+        if let Some(tool) = self.tool {
+            fields.push_str(&format!(" tool={}", log_value(tool)));
+        }
+        if let Some(repo) = self.repo {
+            fields.push_str(&format!(" repo={}", log_value(repo)));
+        }
+        if let Some(tag) = self.tag {
+            fields.push_str(&format!(" tag={}", log_value(tag)));
+        }
+        if let Some(digest) = self.digest {
+            fields.push_str(&format!(" digest={}", log_value(digest)));
+        }
+        if let Some(full) = self.full {
+            fields.push_str(&format!(" full={}", log_value(full)));
+        }
+        if let Some(version) = self.version {
+            fields.push_str(&format!(" version={}", log_value(version)));
+        }
+        fields
+    }
+}
+
+fn log_value(value: &str) -> String {
+    if value
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-' | b'/' | b':' | b'@'))
+    {
+        value.to_string()
+    } else {
+        format!("{:?}", value)
+    }
+}
+
+fn log_versions_host_trace(ctx: VersionsHostLogContext<'_>, outcome: &str, extra: &str) {
+    if extra.is_empty() {
+        trace!("mise-versions {} outcome={outcome}", ctx.fields());
+    } else {
+        trace!("mise-versions {} outcome={outcome} {extra}", ctx.fields());
+    }
+}
+
+fn log_versions_host_warn(ctx: VersionsHostLogContext<'_>, outcome: &str, extra: &str) {
+    if extra.is_empty() {
+        warn!("mise-versions {} outcome={outcome}", ctx.fields());
+    } else {
+        warn!("mise-versions {} outcome={outcome} {extra}", ctx.fields());
+    }
+}
+
 /// List versions from the versions host (mise-versions.jdx.dev).
 /// Returns Vec<VersionInfo> with created_at timestamps from the TOML endpoint.
 pub async fn list_versions(tool: &str) -> eyre::Result<Option<Vec<VersionInfo>>> {
+    let ctx = VersionsHostLogContext::version_list(tool);
     let settings = Settings::get();
     if settings.prefer_offline()
         || !settings.use_versions_host
         || !PLUGINS_USE_VERSION_HOST.contains(tool)
     {
+        log_versions_host_trace(ctx, "disabled", "fallback=true");
         return Ok(None);
     }
 
@@ -89,10 +202,11 @@ pub async fn list_versions(tool: &str) -> eyre::Result<Option<Vec<VersionInfo>>>
     static RATE_LIMITED: AtomicBool = AtomicBool::new(false);
 
     if let Some(versions) = CACHE.lock().await.get(tool) {
+        log_versions_host_trace(ctx, "cache_hit", &format!("versions={}", versions.len()));
         return Ok(Some(versions.clone()));
     }
     if RATE_LIMITED.load(Ordering::Relaxed) {
-        warn!("{tool}: skipping versions host check due to rate limit");
+        log_versions_host_warn(ctx, "skipped_rate_limited", "fallback=true");
         return Ok(None);
     }
 
@@ -120,23 +234,33 @@ pub async fn list_versions(tool: &str) -> eyre::Result<Option<Vec<VersionInfo>>>
                 .collect()
         }
         Err(err) => match http::error_code(&err).unwrap_or(0) {
-            404 => return Ok(None),
-            429 => {
-                RATE_LIMITED.store(true, Ordering::Relaxed);
-                warn!("{tool}: mise-versions rate limited");
+            404 => {
+                log_versions_host_trace(ctx, "not_found", "status=404 fallback=true");
                 return Ok(None);
             }
-            _ => return Err(err),
+            429 => {
+                RATE_LIMITED.store(true, Ordering::Relaxed);
+                log_versions_host_warn(ctx, "rate_limited", "status=429 fallback=true");
+                return Ok(None);
+            }
+            status => {
+                log_versions_host_warn(
+                    ctx,
+                    "failed",
+                    &format!(
+                        "status={status} fallback=false error={}",
+                        log_value(&err.to_string())
+                    ),
+                );
+                return Err(err);
+            }
         },
     };
 
-    trace!(
-        "got {} {} versions from versions host",
-        versions.len(),
-        tool
-    );
+    log_versions_host_trace(ctx, "success", &format!("versions={}", versions.len()));
 
     if versions.is_empty() {
+        log_versions_host_trace(ctx, "empty", "fallback=true");
         return Ok(None);
     }
 
@@ -166,21 +290,26 @@ pub async fn github_release(repo: &str, tag: &str) -> eyre::Result<Option<Github
         encode_path_segment(tag)
     );
 
-    let label = format!("GitHub release metadata for {repo}@{tag}");
-    let Some(release) = fetch_optional_json(&url, &label).await? else {
+    let ctx = VersionsHostLogContext::github_release(repo, tag);
+    let Some(release) = fetch_optional_json(&url, ctx).await? else {
         return Ok(None);
     };
     if !valid_github_release_asset_urls(&release, owner, repo_name) {
-        warn!("mise-versions returned invalid GitHub release asset URLs for {repo}@{tag}");
+        log_versions_host_warn(ctx, "invalid_asset_urls", "fallback=true");
         return Ok(None);
     }
     if !valid_github_release_tag(&release, tag) {
-        warn!(
-            "mise-versions returned GitHub release tag {} for requested {repo}@{tag}",
-            release.tag_name
+        log_versions_host_warn(
+            ctx,
+            "tag_mismatch",
+            &format!(
+                "returned_tag={} fallback=true",
+                log_value(&release.tag_name)
+            ),
         );
         return Ok(None);
     }
+    log_versions_host_trace(ctx, "success", "");
     Ok(Some(release))
 }
 
@@ -206,12 +335,22 @@ pub async fn github_attestations(
         encode_digest_path_segment(digest)
     );
 
-    let label = format!("GitHub attestations for {repo}@{digest}");
-    let response: Option<AttestationsResponse> = fetch_optional_json(&url, &label).await?;
+    let ctx = VersionsHostLogContext::github_attestations(repo, digest);
+    let response: Option<AttestationsResponse> = fetch_optional_json(&url, ctx).await?;
+    if let Some(response) = &response {
+        log_versions_host_trace(
+            ctx,
+            "success",
+            &format!("attestations={}", response.attestations.len()),
+        );
+    }
     Ok(response.map(|r| r.attestations))
 }
 
-async fn fetch_optional_json<T>(url: &str, label: &str) -> eyre::Result<Option<T>>
+async fn fetch_optional_json<T>(
+    url: &str,
+    ctx: VersionsHostLogContext<'_>,
+) -> eyre::Result<Option<T>>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -221,13 +360,23 @@ where
     {
         Ok(value) => Ok(Some(value)),
         Err(err) => match http::error_code(&err).unwrap_or(0) {
-            404 => Ok(None),
-            429 => {
-                warn!("mise-versions rate limited while fetching {label}; falling back");
+            404 => {
+                log_versions_host_trace(ctx, "not_found", "status=404 fallback=true");
                 Ok(None)
             }
-            _ => {
-                warn!("mise-versions {label} lookup failed, falling back: {err:#}");
+            429 => {
+                log_versions_host_warn(ctx, "rate_limited", "status=429 fallback=true");
+                Ok(None)
+            }
+            status => {
+                log_versions_host_warn(
+                    ctx,
+                    "failed",
+                    &format!(
+                        "status={status} fallback=true error={}",
+                        log_value(&err.to_string())
+                    ),
+                );
                 Ok(None)
             }
         },
@@ -370,9 +519,25 @@ async fn track_install_async(tool: &str, full: &str, version: &str) -> eyre::Res
         .post_json_with_headers(url, &body, &VERSIONS_HOST_HEADERS)
         .await
     {
-        Ok(true) => trace!("Tracked install: {full}@{version}"),
-        Ok(false) => trace!("Track request failed"),
-        Err(e) => trace!("Track request error: {e}"),
+        Ok(true) => log_versions_host_trace(
+            VersionsHostLogContext::install_track(tool, full, version),
+            "success",
+            "",
+        ),
+        Ok(false) => log_versions_host_trace(
+            VersionsHostLogContext::install_track(tool, full, version),
+            "failed",
+            "status=unknown",
+        ),
+        Err(err) => log_versions_host_trace(
+            VersionsHostLogContext::install_track(tool, full, version),
+            "failed",
+            &format!(
+                "status={} error={}",
+                http::error_code(&err).unwrap_or(0),
+                log_value(&err.to_string())
+            ),
+        ),
     }
 
     Ok(())
@@ -402,6 +567,16 @@ mod tests {
         assert_eq!(
             track_install_url("node"),
             "https://mise-versions.jdx.dev/api/tools/node"
+        );
+    }
+
+    #[test]
+    fn test_versions_host_log_context_fields_quotes_spaces() {
+        let fields =
+            VersionsHostLogContext::install_track("some tool", "github:jdx/mise", "1.2.3").fields();
+        assert_eq!(
+            fields,
+            r#"endpoint=install_track tool="some tool" full=github:jdx/mise version=1.2.3"#
         );
     }
 


### PR DESCRIPTION
## Summary
- add logfmt-style structured fields for mise-versions version-list, GitHub release, GitHub attestation, and install-tracking calls
- log stable `endpoint`, `tool`/`repo`/`tag`/`digest`, `outcome`, `status`, and `fallback` fields for successes and fallback paths
- preserve existing fallback behavior while making non-404 failures easier to inspect from debug/warn logs

## Tests
- `cargo test -q versions_host`
- `cargo clippy --all-features --all-targets -- -D warnings`

Note: This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes in versions-host HTTP paths; fallbacks and error handling are preserved, with safer logging for credentials in `full` URLs.
> 
> **Overview**
> Adds **structured, logfmt-style tracing** for all mise-versions (`versions_host`) traffic so debug/warn logs are easier to filter and correlate.
> 
> A shared `VersionsHostLogContext` now drives logs for **version list**, **GitHub release**, **GitHub attestations**, and **install tracking**, emitting stable fields (`endpoint`, `tool`/`repo`/`tag`/`digest`/`full`/`version`, `outcome`, `status`, `fallback`, counts where relevant). Values with spaces are quoted; **`full` URLs are sanitized** (credentials, query, fragment stripped) before logging.
> 
> Ad-hoc `warn!`/`trace!` strings are replaced on success and fallback paths (disabled, cache hit, 404, 429, empty, validation failures, etc.). **Runtime behavior is unchanged**: same fallbacks and error propagation (e.g. version-list still **returns `Err`** on non-404 failures; optional JSON fetches still **return `None`**).
> 
> Unit tests cover log field formatting and URL redaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3fb9fa884768ff77d23445f2ec867233e3a06ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved structured logging and tracing for versions-host interactions, install tracking, and release/attestation fetches for clearer diagnostics.
  * More consistent handling of missing or rate-limited release/attestation data with graceful fallbacks and clearer warnings for invalid or mismatched release metadata.

* **Tests**
  * Added unit tests for log field rendering and redaction of sensitive URL information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->