### PR TITLE
test(e2e): assert captured output without shell eval

### DIFF
--- a/e2e/assert.sh
+++ b/e2e/assert.sh
@@ -250,6 +250,15 @@ assert_contains() {
   fi
 }
 
+assert_contains_text() {
+  local actual="$1"
+  if [[ $actual == *"$2"* ]]; then
+    ok "[text] '$2' is in output"
+  else
+    fail "[text] expected '$2' to be in output"
+  fi
+}
+
 assert_not_contains() {
   local actual
   actual="$(quiet_assert_succeed "$1")"
@@ -257,6 +266,15 @@ assert_not_contains() {
     ok "[$1] '$2' is not in output"
   else
     fail "[$1] expected '$2' not to be in '$actual'"
+  fi
+}
+
+assert_not_contains_text() {
+  local actual="$1"
+  if [[ $actual != *"$2"* ]]; then
+    ok "[text] '$2' is not in output"
+  else
+    fail "[text] expected '$2' not to be in output"
   fi
 }
 

--- a/e2e/core/test_python_github_attestations
+++ b/e2e/core/test_python_github_attestations
@@ -11,8 +11,8 @@ output=$(mise install python@3.13.5 2>&1) || true
 echo "$output"
 
 # Verify attestation verification was attempted and succeeded
-assert_contains "echo \"$output\"" "verify GitHub artifact attestations"
-assert_contains "echo \"$output\"" "✓ GitHub artifact attestations verified"
+assert_contains_text "$output" "verify GitHub artifact attestations"
+assert_contains_text "$output" "✓ GitHub artifact attestations verified"
 
 # Verify the installed Python works
 assert "mise x python@3.13.5 -- python --version" "Python 3.13.5"


### PR DESCRIPTION
## Summary
- add text-based e2e assertion helpers for already-captured output
- update the Python GitHub attestation e2e test to avoid re-evaluating captured output through `bash -c`

## Why
When `mise install` output contains warning text with shell-sensitive characters, e.g. `(403 Forbidden)` inside a quoted URL error, `assert_contains "echo "$output"" ...` can turn captured output back into shell syntax and fail with `bash: -c: line 5: syntax error near unexpected token `('`.

## Verification
- `bash -n e2e/assert.sh e2e/core/test_python_github_attestations`
- synthetic assertion check with `(403 Forbidden)` warning text
- `mise run test:e2e e2e/core/test_python_github_attestations`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion helpers and one e2e test update; no production or runtime behavior changes.
> 
> **Overview**
> Adds **`assert_contains_text`** and **`assert_not_contains_text`** in `e2e/assert.sh` so e2e tests can assert substrings on **already-captured** stdout/stderr without wrapping it in a command that runs under `bash -c`.
> 
> The Python GitHub attestations e2e test now passes `$output` directly to those helpers instead of `assert_contains "echo \"$output\"" ...`, avoiding shell parse errors when install logs include parenthesized text (e.g. `(403 Forbidden)` in URL errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6a86cb109168ff74c6b0179462c15423a8d055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added new assertion helpers for substring validation in test framework
  * Updated existing tests to use improved assertion methods
<!-- end of auto-generated comment: release notes by coderabbit.ai -->