### PR TITLE
registry: add cargo-release

### DIFF
--- a/registry/cargo-release.toml
+++ b/registry/cargo-release.toml
@@ -1,0 +1,3 @@
+backends = ["github:crate-ci/cargo-release"]
+description = "Cargo subcommand for releasing crates"
+test = { cmd = "cargo release --version", expected = "cargo-release {{version}}" }


### PR DESCRIPTION
## Summary
- add `cargo-release` registry shorthand backed by `github:crate-ci/cargo-release`
- include a `cargo release --version` smoke test

## Popularity
- GitHub: 1,564 stars, 132 forks
- Latest release: v1.1.2 published 2026-03-24
- Recent activity: pushed 2026-06-04

## Test
- `cargo build --all-features`
- `target/debug/mise test-tool cargo-release`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 49fb0718f95615e1d7ea5241dbdeed376ed4e3eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded registry with new cargo-release entry, including automated test validation to ensure proper version reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->