### PR TITLE
fix(github): skip versions host for non-registry attestations

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -24,7 +24,7 @@ use crate::{
     cache::{CacheManager, CacheManagerBuilder},
 };
 use crate::{
-    backend::{Backend, MISE_BINS_DIR, strict_metadata},
+    backend::{Backend, MISE_BINS_DIR, backend_arg_matches_registry_backend, strict_metadata},
     config::Config,
 };
 use crate::{file, github, minisign};
@@ -1071,6 +1071,7 @@ impl AquaBackend {
             &pkg.repo_name,
             github::API_URL,
             digest,
+            backend_arg_matches_registry_backend(&self.ba),
         )
         .await
     }
@@ -1162,6 +1163,7 @@ impl AquaBackend {
             &pkg.repo_name,
             signer_workflow.as_deref(),
             None,
+            backend_arg_matches_registry_backend(&self.ba),
         )
         .await
         {

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -686,7 +686,11 @@ impl UnifiedGitBackend {
             if parts.len() == 2 {
                 let (owner, repo_name) = (parts[0], parts[1]);
                 match crate::github::sigstore::detect_attestations(
-                    owner, repo_name, api_url, digest,
+                    owner,
+                    repo_name,
+                    api_url,
+                    digest,
+                    self.use_versions_host_for_github_metadata(),
                 )
                 .await
                 {
@@ -797,6 +801,7 @@ impl UnifiedGitBackend {
                     repo_name,
                     None,
                     Some(api_url),
+                    self.use_versions_host_for_github_metadata(),
                 )
                 .await
                 {
@@ -1845,6 +1850,7 @@ impl UnifiedGitBackend {
             repo_name,
             None, // We don't know the expected workflow
             Some(api_url),
+            self.use_versions_host_for_github_metadata(),
         )
         .await
         {

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -66,9 +66,10 @@ pub async fn verify_attestation(
     repo: &str,
     expected_workflow: Option<&str>,
     api_url: Option<&str>,
+    use_versions_host: bool,
 ) -> AttestationResult<bool> {
     let mut digest = None;
-    if use_versions_host_for_attestations(api_url) {
+    if use_versions_host_for_attestations(api_url, use_versions_host) {
         let artifact_digest = mise_sigstore::calculate_file_digest(artifact_path).await?;
         match crate::versions_host::github_attestations(
             &format!("{owner}/{repo}"),
@@ -171,8 +172,9 @@ pub async fn detect_attestations(
     repo: &str,
     api_url: &str,
     digest: &str,
+    use_versions_host: bool,
 ) -> Result<bool, DetectError> {
-    if use_versions_host_for_attestations(Some(api_url)) {
+    if use_versions_host_for_attestations(Some(api_url), use_versions_host) {
         match crate::versions_host::github_attestations(&format!("{owner}/{repo}"), digest).await {
             Ok(Some(attestations)) => {
                 trace!(
@@ -198,9 +200,9 @@ pub async fn detect_attestations(
     Ok(!attestations.is_empty())
 }
 
-fn use_versions_host_for_attestations(api_url: Option<&str>) -> bool {
+fn use_versions_host_for_attestations(api_url: Option<&str>, use_versions_host: bool) -> bool {
     let settings = crate::config::Settings::get();
-    if settings.prefer_offline() || !settings.use_versions_host {
+    if !use_versions_host || settings.prefer_offline() || !settings.use_versions_host {
         return false;
     }
 
@@ -469,8 +471,23 @@ mod tests {
     fn test_use_versions_host_for_attestations_respects_setting() {
         let _settings = SettingsGuard::with_versions_host(None, Some(false));
 
-        assert!(!use_versions_host_for_attestations(Some(
-            crate::github::API_URL
-        )));
+        assert!(!use_versions_host_for_attestations(
+            Some(crate::github::API_URL),
+            true
+        ));
+    }
+
+    #[test]
+    fn test_use_versions_host_for_attestations_respects_registry_gate() {
+        let _settings = SettingsGuard::with_versions_host(None, Some(true));
+
+        assert!(!use_versions_host_for_attestations(
+            Some(crate::github::API_URL),
+            false
+        ));
+        assert!(use_versions_host_for_attestations(
+            Some(crate::github::API_URL),
+            true
+        ));
     }
 }

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -726,6 +726,7 @@ impl PythonPlugin {
             "python-build-standalone",
             None, // Accept any workflow from repo
             None,
+            true,
         )
         .await
         {

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -27,6 +27,7 @@ use crate::ui::progress_report::SingleReport;
 use crate::{file, hash, plugins, timeout};
 
 const RUBY_INDEX_URL: &str = "https://cache.ruby-lang.org/pub/ruby/index.txt";
+const DEFAULT_RUBY_PRECOMPILED_URL: &str = "jdx/ruby";
 const ATTESTATION_HELP: &str = "To disable attestation verification, set MISE_RUBY_GITHUB_ATTESTATIONS=false\n\
     or add `ruby.github_attestations = false` under [settings] in mise.toml";
 
@@ -433,6 +434,10 @@ impl RubyPlugin {
             return None;
         }
         Some(ProvenanceType::GithubAttestations)
+    }
+
+    fn use_versions_host_for_precompiled_attestations(source: &str) -> bool {
+        source == DEFAULT_RUBY_PRECOMPILED_URL
     }
 
     /// Check if precompiled binaries should be tried
@@ -845,6 +850,7 @@ impl RubyPlugin {
             repo,
             None, // Accept any workflow from repo
             None,
+            Self::use_versions_host_for_precompiled_attestations(source),
         )
         .await
         {
@@ -1169,7 +1175,6 @@ mod tests {
     static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     const DEFAULT_RUBY_BUILD_REPO: &str = "https://github.com/rbenv/ruby-build.git";
     const DEFAULT_RUBY_INSTALL_REPO: &str = "https://github.com/postmodern/ruby-install.git";
-    const DEFAULT_RUBY_PRECOMPILED_URL: &str = "jdx/ruby";
 
     struct SettingsResetGuard {
         _lock: std::sync::MutexGuard<'static, ()>,
@@ -1278,6 +1283,16 @@ mod tests {
         "#}),
             ""
         );
+    }
+
+    #[test]
+    fn test_ruby_precompiled_versions_host_only_for_default_source() {
+        assert!(RubyPlugin::use_versions_host_for_precompiled_attestations(
+            DEFAULT_RUBY_PRECOMPILED_URL
+        ));
+        assert!(!RubyPlugin::use_versions_host_for_precompiled_attestations(
+            "acme/ruby"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- pass the existing registry/default backend gate into GitHub attestation detection and verification
- apply the same gate to Aqua GitHub attestations so custom Aqua packages use GitHub directly
- keep known core precompiled repos eligible, while custom Ruby precompiled repos bypass mise-versions

## Tests
- cargo test test_use_versions_host_for_attestations --all-features
- cargo test test_ruby_precompiled_versions_host_only_for_default_source --all-features
- mise run test:unit
- cargo fmt --check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provenance/attestation fetch paths for installs and lock-time verification; mis-gating could skip cached attestations or hit the wrong API, but behavior is narrowed with tests and known core paths preserved.
> 
> **Overview**
> GitHub artifact attestation **detect** and **verify** now take an explicit **`use_versions_host`** flag instead of always routing public GitHub API traffic through **mise-versions** when global settings allow it.
> 
> **GitHub** and **Aqua** backends pass the existing **registry/default-backend** gate (`backend_arg_matches_registry_backend`), so custom `github:` repos and non-registry Aqua packages talk to GitHub directly. **Python** precompiled builds still use the versions host (`true`). **Ruby** precompiled attestations use mise-versions only for the default **`jdx/ruby`** source; other `owner/repo` precompiled URLs skip it.
> 
> `use_versions_host_for_attestations` now requires that flag **and** the usual offline / `use_versions_host` settings. Unit tests cover the new gate and Ruby source behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146c0dc0d89b61074880f55311e215c3412c6998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced GitHub package attestation verification to respect configured metadata host settings consistently across all verification flows, including aqua backend, Python/Ruby plugins, and lock-time verification.
  * Improved cryptographic signature validation by ensuring attestation host configuration is applied uniformly during attestation detection and validation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->