### PR TITLE
docs: On Debian/Ubuntu, use extrepo for installing

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,11 +51,9 @@ choco install mise
 == Debian/Ubuntu (apt)
 
 ```sh
-sudo apt update -y && sudo apt install -y curl
-sudo install -dm 755 /etc/apt/keyrings
-curl -fSs https://mise.en.dev/gpg-key.pub | sudo tee /etc/apt/keyrings/mise-archive-keyring.asc 1> /dev/null
-echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.asc] https://mise.en.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
-sudo apt update -y
+sudo apt install -y extrepo
+sudo extrepo enable mise
+sudo apt update
 sudo apt install -y mise
 ```
 

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -125,13 +125,11 @@ sudo apt update -y
 sudo apt install -y mise
 ```
 
-For older Ubuntu/Debian versions:
+On Debian 11+ and Ubuntu 22.04+, mise repository can be enabled with extrepo:
 
 ```sh
-sudo apt update -y && sudo apt install -y curl
-sudo install -dm 755 /etc/apt/keyrings
-curl -fSs https://mise.en.dev/gpg-key.pub | sudo tee /etc/apt/keyrings/mise-archive-keyring.asc 1> /dev/null
-echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.asc] https://mise.en.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
+sudo apt install -y extrepo
+sudo extrepo enable mise
 sudo apt update -y
 sudo apt install -y mise
 ```

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -121,7 +121,7 @@ On Ubuntu 26.04+, mise is available via a PPA:
 
 ```sh
 sudo add-apt-repository -y ppa:jdxcode/mise
-sudo apt update -y
+sudo apt update
 sudo apt install -y mise
 ```
 
@@ -130,7 +130,7 @@ On Debian 11+ and Ubuntu 22.04+, mise repository can be enabled with extrepo:
 ```sh
 sudo apt install -y extrepo
 sudo extrepo enable mise
-sudo apt update -y
+sudo apt update
 sudo apt install -y mise
 ```
 

--- a/docs/mise-cookbook/docker.md
+++ b/docs/mise-cookbook/docker.md
@@ -43,6 +43,7 @@ The following example also shows installing using `extrepo` on Debian/Ubuntu ima
 With this approach you cannot specify `MISE_VERSION` or `MISE_INSTALL_PATH`.
 
 ```Dockerfile [Dockerfile]
+# syntax=docker/dockerfile:1
 FROM debian:13-slim
 
 RUN <<EOF

--- a/docs/mise-cookbook/docker.md
+++ b/docs/mise-cookbook/docker.md
@@ -39,19 +39,22 @@ For toolbox containers or bastion hosts where tools should be pre-installed for 
 use `mise install --system` to install tools into `/usr/local/share/mise/installs`.
 Each user's mise will automatically find these system-level tools without any configuration.
 
+The following example also shows installing using `extrepo` on Debian/Ubuntu image.
+With this approach you cannot specify `MISE_VERSION` or `MISE_INSTALL_PATH`.
+
 ```Dockerfile [Dockerfile]
 FROM debian:13-slim
 
-RUN apt-get update  \
-    && apt-get -y --no-install-recommends install  \
-        sudo curl git ca-certificates build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
-
-# Install mise
-RUN curl https://mise.run | sh
+RUN <<EOF
+  set -ex
+  apt-get update
+  apt-get install -y extrepo
+  extrepo enable mise
+  apt-get remove -y --auto-remove extrepo # extrepo and its deps are not needed after extrepo enable
+  apt-get update
+  apt-get install -y mise build-essential
+  rm -fr /var/lib/apt/lists/*
+EOF
 
 # Pre-install tools to the system-wide shared directory
 RUN mise install --system node@26 python@3.15


### PR DESCRIPTION
Recently [mise deb repository was added to Debian extrepo](https://salsa.debian.org/extrepo-team/extrepo-data/-/merge_requests/475). This follow-up to https://github.com/jdx/mise/discussions/10248 proposes the following documentation changes:
* For Debian and Ubuntu, show only installation with `extrepo` on Getting Started and Installing Mise pages.
* Mise + Docker Cookbook starts with universal `curl | sh` installing but in the second example (for multi-user containers) shows alternative installing with `extrepo`.
  * Note that example `python@3.15` cannot be found by mise. It's also in https://github.com/jdx/mise/blob/main/docs/lang/python.md so I didn't change it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified Debian/Ubuntu install flow to use an extrepo-based workflow.
  * Added an alternative install path for Debian 11+ and Ubuntu 22.04+, and adjusted PPA ordering for newer Ubuntu.
  * Updated Docker cookbook with an extrepo-based installation example and clarified limitations around version/path customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->