### PR TITLE
chore(ci): ignore RUSTSEC-2026-0173 proc-macro-error2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,7 @@ feature-depth = 1
 # output a note when they are encountered.
 ignore = [
   { id = "RUSTSEC-2024-0370", reason = "proc-macro-error dependency from sigstore crate - no safe upgrade available" },
+  { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained - transitive via age/mlua/tabled/rops, no safe upgrade available" },
   { id = "RUSTSEC-2023-0071", reason = "rsa crate Marvin attack vulnerability from sigstore crate - no safe upgrade available" },
   { id = "RUSTSEC-2025-0119", reason = "number_prefix crate is unmaintained - used by indicatif/self_update, no safe upgrade available" },
   # rustls-webpki 0.102.8 advisories — pulled in transitively by sigstore-tsa


### PR DESCRIPTION
## Summary
- Ignore new `RUSTSEC-2026-0173` advisory for unmaintained `proc-macro-error2`
- Fixes `cargo deny check` failures in CI (`lint` job)

`proc-macro-error2` is a transitive dependency via `age`, `mlua` (vfox), `tabled`, and `rops`. There is no safe upgrade path yet; this mirrors the existing ignore for the original `proc-macro-error` advisory (`RUSTSEC-2024-0370`).

## Test plan
- [ ] CI `lint` job passes (`cargo deny check`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency security configuration to acknowledge an unmaintained transitive dependency without available upgrade options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->