### PR TITLE
docs: improve sponsor logo contrast

### DIFF
--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -135,8 +135,10 @@ onMounted(async () => {
 
 .EndevSponsorsLogo {
   align-items: center;
+  background: #171717;
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(42, 31, 26, 0.08);
   display: inline-flex;
   height: 40px;
   justify-content: center;
@@ -147,7 +149,18 @@ onMounted(async () => {
 }
 
 .EndevSponsorsLogo:hover {
+  background: #242424;
+  border-color: var(--vp-c-brand-1);
+}
+
+.dark .EndevSponsorsLogo {
   background: var(--vp-c-bg-soft);
+  border-color: var(--vp-c-divider);
+  box-shadow: none;
+}
+
+.dark .EndevSponsorsLogo:hover {
+  background: var(--vp-c-bg-mute);
   border-color: var(--vp-c-brand-1);
 }
 


### PR DESCRIPTION
## Summary
- add a dark surface behind footer sponsor logos so white sponsor SVGs remain legible in light mode
- keep dark mode using the existing soft theme surface

Fixes discussion #10266.

## Tests
- mise run docs:build

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped VitePress theme CSS only; no data, auth, or runtime behavior changes.
> 
> **Overview**
> Footer sponsor logo chips in **light mode** now use a fixed dark surface (`#171717`) with a light shadow and a slightly lighter hover background, so **white/light SVG logos stay readable** on the docs footer.
> 
> **Dark mode** is split into explicit `.dark .EndevSponsorsLogo` rules: default uses the existing soft theme background (no shadow); hover uses the mute surface plus brand border—matching prior behavior without applying the light-mode dark chip styling globally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c8362fcb440aaeb16916c8ab7070d2bcd01002c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced sponsor logo styling with improved visual presentation through refined backgrounds, decorative borders, and subtle shadows
  * Improved dark mode compatibility with theme-aware styling adjustments for optimal visibility across light and dark themes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->