### PR TITLE
docs(settings): prefer assignment form for set examples

### DIFF
--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -60,7 +60,7 @@ This will execute a `cargo install` command with the corresponding Git options.
 
 ## Settings
 
-Set these with `mise settings set [VARIABLE] [VALUE]` or by setting the environment variable listed.
+Set these with `mise settings set [VARIABLE]=[VALUE]` or by setting the environment variable listed.
 
 Some Cargo settings are only meaningful when mise runs `cargo install`. If `cargo-binstall`
 installs a prebuilt binary, Cargo build settings and `cargo install` behavior do not affect that

--- a/docs/dev-tools/backends/conda.md
+++ b/docs/dev-tools/backends/conda.md
@@ -68,7 +68,7 @@ If a platform-specific package is not available, the backend will fall back to `
 
 ## Settings
 
-Set these with `mise settings set [VARIABLE] [VALUE]` or by setting the environment variable listed.
+Set these with `mise settings set [VARIABLE]=[VALUE]` or by setting the environment variable listed.
 
 <script setup>
 import Settings from '/components/settings.vue';

--- a/docs/dev-tools/backends/dotnet.md
+++ b/docs/dev-tools/backends/dotnet.md
@@ -57,7 +57,7 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 
 ## Settings
 
-Set these with `mise settings set [VARIABLE] [VALUE]` or by setting the environment variable listed.
+Set these with `mise settings set [VARIABLE]=[VALUE]` or by setting the environment variable listed.
 
 <script setup>
 import Settings from '/components/settings.vue';

--- a/docs/dev-tools/backends/gem.md
+++ b/docs/dev-tools/backends/gem.md
@@ -44,7 +44,7 @@ mise install -f "gem:*"
 
 ## Settings
 
-Set these with `mise settings set [VARIABLE] [VALUE]` or by setting the environment variable listed.
+Set these with `mise settings set [VARIABLE]=[VALUE]` or by setting the environment variable listed.
 
 <script setup>
 import Settings from '/components/settings.vue';

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -62,7 +62,7 @@ The version will be set in `~/.config/mise/config.toml` with the following forma
 
 ## Settings
 
-Set these with `mise settings set [VARIABLE] [VALUE]` or by setting the environment variable listed.
+Set these with `mise settings set [VARIABLE]=[VALUE]` or by setting the environment variable listed.
 
 <script setup>
 import Settings from '/components/settings.vue';

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -93,7 +93,7 @@ Other syntax may work but is unsupported and untested.
 
 ## Settings
 
-Set these with `mise settings set [VARIABLE] [VALUE]` or by setting the environment variable listed.
+Set these with `mise settings set [VARIABLE]=[VALUE]` or by setting the environment variable listed.
 
 <script setup>
 import Settings from '/components/settings.vue';

--- a/docs/dev-tools/github-tokens.md
+++ b/docs/dev-tools/github-tokens.md
@@ -126,7 +126,7 @@ Run `ghtkn get` once manually before relying on it from mise so any browser-base
 The credential command runs with mise shims removed from `PATH` to avoid recursive mise invocations. If you install `ghtkn` with mise, use `mise which` to find the real executable path and store that in `credential_command` instead of relying on the shim:
 
 ```sh
-mise settings set github.credential_command "$(mise which ghtkn) get -m 1h"
+mise settings set github.credential_command="$(mise which ghtkn) get -m 1h"
 ```
 
 Do not make the credential command run `mise x`, `mise exec`, or another command that may need GitHub access to resolve or install `ghtkn`, since that can loop while mise is trying to obtain the GitHub token.
@@ -157,8 +157,8 @@ This feature is experimental. Enable it with `mise settings experimental=true` (
 Create a GitHub App with device flow enabled, then configure its client ID:
 
 ```sh
-mise settings set experimental true
-mise settings set github.oauth_client_id Iv1.yourgithubappclientid
+mise settings set experimental=true
+mise settings set github.oauth_client_id=Iv1.yourgithubappclientid
 ```
 
 Authorize once:

--- a/docs/environments/secrets/age.md
+++ b/docs/environments/secrets/age.md
@@ -13,7 +13,7 @@ This is a simple method of storing encrypted environment variables directly in `
 1. Enable experimental features:
 
 ```bash
-mise settings set experimental true
+mise settings set experimental=true
 ```
 
 2. [optional] Generate an age key (if you want to create a new age key and don't want to use your ssh key):
@@ -82,7 +82,7 @@ Age decryption is strict by default. If no identities are found, no available id
 To allow commands and tasks to continue when an age value cannot be decrypted, disable strict mode:
 
 ```bash
-mise settings set age.strict false
+mise settings set age.strict=false
 ```
 
 In non-strict mode, mise skips values that cannot be decrypted and continues resolving the rest of the environment.

--- a/docs/lang/dotnet.md
+++ b/docs/lang/dotnet.md
@@ -53,7 +53,7 @@ with an SDK version, mise will automatically use it:
 Enable idiomatic version file support:
 
 ```sh
-mise settings set idiomatic_version_file_enable_tools dotnet
+mise settings set idiomatic_version_file_enable_tools=dotnet
 ```
 
 ## Isolated Mode
@@ -65,7 +65,7 @@ If you prefer the traditional mise approach where each version gets its own dire
 isolated mode:
 
 ```sh
-mise settings set dotnet.isolated true
+mise settings set dotnet.isolated=true
 ```
 
 In isolated mode each SDK version is installed under `~/.local/share/mise/installs/dotnet/<version>/`,

--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -287,7 +287,7 @@ brew link pkg-config
 a [handful of settings](https://github.com/pyenv/pyenv/tree/master/plugins/python-build), in
 additional to that python in mise has a few extra configuration variables.
 
-Set these with `mise settings set [VARIABLE] [VALUE]` or by setting the environment variable.
+Set these with `mise settings set [VARIABLE]=[VALUE]` or by setting the environment variable.
 
 <script setup>
 import Settings from '/components/settings.vue';

--- a/e2e/cli/test_settings_add
+++ b/e2e/cli/test_settings_add
@@ -7,10 +7,10 @@ assert "mise settings get disable_hints" '["a", "b"]'
 assert "mise settings add disable_hints a" ""
 assert "grep disable_hints ~/.config/mise/config.toml" 'disable_hints = ["a", "b"]'
 
-assert "mise settings add idiomatic_version_file_enable_tools python" ""
+assert "mise settings add idiomatic_version_file_enable_tools=python" ""
 assert "mise settings add idiomatic_version_file_enable_tools rust" ""
 assert "mise settings get idiomatic_version_file_enable_tools" '["python", "rust"]'
-assert "mise settings add idiomatic_version_file_enable_tools python,rust,zig" ""
+assert "mise settings add idiomatic_version_file_enable_tools=python,rust,zig" ""
 assert "grep idiomatic_version_file_enable_tools ~/.config/mise/config.toml" 'idiomatic_version_file_enable_tools = ["python", "rust", "zig"]'
 
 # test "settings add key=value" format

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -515,7 +515,7 @@ impl NodePlugin {
                     }
                 }
                 msg.push_str("\nYou can try setting the flavor using:\n");
-                msg.push_str("  mise settings set node.flavor <flavor>\n");
+                msg.push_str("  mise settings set node.flavor=<flavor>\n");
                 return Ok(Some(msg));
             } else {
                 // Fallback: list all files for that version if no arch match

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -297,7 +297,7 @@ impl PythonPlugin {
                         debug!("no precompiled python found for {}", tv.version);
                     } else {
                         warn!(
-                            "no precompiled python found for {}, force mise to use a precompiled version with `mise settings set python.compile false`",
+                            "no precompiled python found for {}, force mise to use a precompiled version with `mise settings set python.compile=false`",
                             tv.version
                         );
                     }


### PR DESCRIPTION
## Summary
- use `mise settings set key=value` in docs and CLI hints where it shortens examples
- keep `settings add` user-facing examples in the clearer append-style form
- exercise `settings add key=value` for `idiomatic_version_file_enable_tools` in e2e coverage

## Tests
- `mise run test:e2e e2e/cli/test_settings_set e2e/cli/test_settings_add`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only and documentation changes with no settings CLI logic modified in this diff.
> 
> **Overview**
> Documentation and in-app hints now show **`mise settings set key=value`** instead of space-separated `key value`, including the shared “Settings” boilerplate on backend/lang pages, GitHub token and age encryption guides, and dotnet/python examples.
> 
> Runtime messages in the **node** and **python** core plugins were updated to match (e.g. `node.flavor=<flavor>`, `python.compile=false`). E2e **`test_settings_add`** now exercises `settings add idiomatic_version_file_enable_tools=python` (and comma lists) alongside the existing append-style `add` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e3f71d9a663d711470eb875b7a9663e1dce849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command examples across backend and language documentation to use `key=value` syntax format for settings configuration.

* **Tests**
  * Updated tests to align with settings command syntax changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->