### PR TITLE
registry: add cargo-msrv

### DIFF
--- a/registry/cargo-msrv.toml
+++ b/registry/cargo-msrv.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:foresterre/cargo-msrv", "cargo:cargo-msrv"]
+description = "Find the minimum supported Rust version for your project"
+test = { cmd = "cargo msrv --version", expected = "cargo-msrv {{version}}" }


### PR DESCRIPTION
## Summary
- add `cargo-msrv` to the registry using the aqua backend
- keep `cargo:cargo-msrv` as a fallback backend
- add a version check for `cargo msrv --version`

## Popularity
- GitHub: 1,198 stars, 45 forks, latest release `v0.19.3` published 2026-03-25, last pushed 2026-06-08
- crates.io: 480,687 total downloads, 21,298 recent downloads
- Distribution: present in the aqua registry as `foresterre/cargo-msrv`

## Verification
- `cargo fmt --check`
- `cargo run --quiet -- registry cargo-msrv`
- `cargo run --quiet -- test-tool cargo-msrv --jobs 1`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only addition with no changes to install logic or runtime behavior beyond listing a new tool.
> 
> **Overview**
> Adds **cargo-msrv** to the mise tool registry so users can install the MSRV finder via `mise install cargo-msrv`.
> 
> The new `registry/cargo-msrv.toml` entry uses **aqua** (`foresterre/cargo-msrv`) as the primary install backend with **cargo** (`cargo-msrv`) as fallback, and defines a smoke test that runs `cargo msrv --version` and expects `cargo-msrv {{version}}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa9ef2148bed153ba6c2d7065e5d3ec8d61be3c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration support for cargo-msrv tool integration, enabling version testing and backend entry setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->