### PR TITLE
docs(security): clarify minimum release age support

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -85,6 +85,7 @@ export default withMermaid(
             { text: "Registry", link: "/registry" },
             { text: "GitHub Tokens", link: "/dev-tools/github-tokens" },
             { text: "mise.lock Lockfile", link: "/dev-tools/mise-lock" },
+            { text: "Security", link: "/security" },
             { text: "OCI Images (experimental)", link: "/dev-tools/mise-oci" },
             { text: "Deps", link: "/dev-tools/deps" },
             {

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -364,8 +364,12 @@ minimum_release_age = "7d"  # only resolve to versions released more than 7 days
 
 This pairs well with lockfiles — use `minimum_release_age` to avoid picking up brand-new releases, and lockfiles to pin the exact versions you've vetted.
 
-Some package-manager backends also forward this cutoff into transitive dependency resolution during
-install. This includes `npm:` and `pipx:` tools.
+This setting filters top-level fuzzy version resolution for backends that provide release timestamps.
+Versions without timestamps are included by default.
+
+Only `npm:` and `pipx:` currently forward the same cutoff into transitive dependency resolution during
+install. Other backends may select an older top-level tool version, but they do not constrain
+dependencies fetched by the tool's installer/compiler.
 
 ## See Also
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,91 @@
+# Security
+
+mise includes several supply-chain controls for installing and managing tools. These controls have
+different coverage depending on the backend and the metadata available from upstream.
+
+## Software verification
+
+mise provides native software verification for aqua tools without requiring external dependencies.
+For aqua tools, Cosign/Minisign signatures, SLSA provenance, and GitHub artifact attestations are
+verified automatically using mise's built-in implementation.
+
+For other verification needs, such as GPG, you can install additional tools:
+
+```sh
+brew install gpg
+```
+
+To configure aqua verification, which is enabled by default:
+
+```sh
+# Disable specific verification methods if needed
+export MISE_AQUA_COSIGN=false
+export MISE_AQUA_SLSA=false
+export MISE_AQUA_GITHUB_ATTESTATIONS=false
+export MISE_AQUA_MINISIGN=false
+```
+
+For lockfile checksum and provenance behavior, see [mise.lock](/dev-tools/mise-lock.html).
+
+## Minimum release age
+
+To limit supply-chain risk, you can restrict mise to only install versions released before a
+certain date or duration. This is similar to Renovate's
+[minimum release age](https://docs.renovatebot.com/key-concepts/minimum-release-age/) concept:
+newly published versions are ignored until they have been available for a configurable amount of
+time.
+
+```toml
+# mise.toml
+[settings]
+minimum_release_age = "7d"  # only install versions released more than 7 days ago
+```
+
+Supports relative durations (`7d`, `6m`, `1y`) and absolute dates (`2024-06-01`). For most
+backends, this only affects fuzzy version resolution, such as `node@20` or `latest`.
+Explicitly pinned versions like `node@22.5.0` bypass the filter.
+
+Capability depends on the backend:
+
+| Capability | Backends |
+| --- | --- |
+| Top-level version filtering | Backends that provide release timestamps, such as `aqua:`, `cargo:`, `github:`, `gitlab:`, `go:`, `npm:`, `pipx:`, and many core tools |
+| Transitive dependency filtering during install | `npm:` and `pipx:` |
+
+Versions without timestamps are included by default. Backends without transitive dependency support
+may still select an older top-level tool version, but they do not constrain dependencies fetched by
+the tool's installer/compiler.
+
+For `npm:` and `pipx:` transitive dependency support details, refer to the
+[npm backend docs](/dev-tools/backends/npm.html) and
+[pipx backend docs](/dev-tools/backends/pipx.html).
+
+You can also set `minimum_release_age` per-tool to override the global setting:
+
+```toml
+# mise.toml
+[settings]
+minimum_release_age = "7d"  # default for all tools
+
+[tools.trivy]
+version = "latest"
+minimum_release_age = "1d"  # trivy updates are time-sensitive, use a shorter window
+```
+
+Precedence: `--minimum-release-age` CLI flag > per-tool `minimum_release_age` > global
+`minimum_release_age` setting.
+
+Use `minimum_release_age_excludes` to exclude tools or backends from the global setting:
+
+```toml
+[settings]
+minimum_release_age = "7d"
+minimum_release_age_excludes = ["trivy", "npm:*"]
+```
+
+Exclusions can match backend wildcards like `npm:*`, tool shorthands like `trivy`, or full backend
+IDs like `npm:prettier`. Per-tool `minimum_release_age` options and the CLI flag still apply even
+when a tool matches the exclusion list.
+
+See [`minimum_release_age`](/configuration/settings.html#minimum_release_age) for the setting
+reference.

--- a/docs/security.md
+++ b/docs/security.md
@@ -47,10 +47,10 @@ Explicitly pinned versions like `node@22.5.0` bypass the filter.
 
 Capability depends on the backend:
 
-| Capability | Backends |
-| --- | --- |
-| Top-level version filtering | Backends that provide release timestamps, such as `aqua:`, `cargo:`, `github:`, `gitlab:`, `go:`, `npm:`, `pipx:`, and many core tools |
-| Transitive dependency filtering during install | `npm:` and `pipx:` |
+| Capability                                     | Backends                                                                                                                               |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Top-level version filtering                    | Backends that provide release timestamps, such as `aqua:`, `cargo:`, `github:`, `gitlab:`, `go:`, `npm:`, `pipx:`, and many core tools |
+| Transitive dependency filtering during install | `npm:` and `pipx:`                                                                                                                     |
 
 Versions without timestamps are included by default. Backends without transitive dependency support
 may still select an older top-level tool version, but they do not constrain dependencies fetched by

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -148,69 +148,13 @@ Don't do this inside of scripts because mise may add a command in a future versi
 
 ## Software verification
 
-mise provides **native software verification** for aqua tools without requiring external dependencies. For aqua tools, Cosign/Minisign signatures, SLSA provenance, and GitHub artifact attestations are verified automatically using mise's built-in implementation.
-
-For other verification needs (like GPG), you can install additional tools:
-
-```sh
-brew install gpg
-# Note: cosign and slsa-verifier are no longer needed for aqua tools
-# mise now handles verification natively
-```
-
-To configure aqua verification (all enabled by default):
-
-```sh
-# Disable specific verification methods if needed
-export MISE_AQUA_COSIGN=false
-export MISE_AQUA_SLSA=false
-export MISE_AQUA_GITHUB_ATTESTATIONS=false
-export MISE_AQUA_MINISIGN=false
-```
+See [Security](/security.html#software-verification) for mise's software verification controls,
+including aqua signatures, SLSA provenance, and GitHub artifact attestations.
 
 ## Minimum release age
 
-To limit supply chain risk, you can restrict mise to only install versions released before a certain date or duration. This is similar to Renovate's [minimum release age](https://docs.renovatebot.com/key-concepts/minimum-release-age/) concept — newly published versions are ignored until they've been available for a configurable amount of time.
-
-```toml
-# mise.toml
-[settings]
-minimum_release_age = "7d"  # only install versions released more than 7 days ago
-```
-
-Supports relative durations (`7d`, `6m`, `1y`) and absolute dates (`2024-06-01`). For most backends, this only affects fuzzy version resolution (e.g., `node@20` or `latest`) — explicitly pinned versions like `node@22.5.0` bypass the filter.
-
-For `npm:` and `pipx:` tools, the same cutoff is also forwarded to transitive dependency resolution
-during install. Refer to the
-[npm backend docs](/dev-tools/backends/npm.html) and [pipx backend docs](/dev-tools/backends/pipx.html)
-for package-manager support details.
-
-You can also set `minimum_release_age` per-tool to override the global setting:
-
-```toml
-# mise.toml
-[settings]
-minimum_release_age = "7d"  # default for all tools
-
-[tools.trivy]
-version = "latest"
-minimum_release_age = "1d"  # trivy updates are time-sensitive, use a shorter window
-```
-
-Precedence: `--minimum-release-age` CLI flag > per-tool `minimum_release_age` > global `minimum_release_age` setting.
-
-Use `minimum_release_age_excludes` to exclude tools or backends from the global setting:
-
-```toml
-[settings]
-minimum_release_age = "7d"
-minimum_release_age_excludes = ["trivy", "npm:*"]
-```
-
-Exclusions can match backend wildcards like `npm:*`, tool shorthands like `trivy`, or full backend IDs like `npm:prettier`.
-Per-tool `minimum_release_age` options and the CLI flag still apply even when a tool matches the exclusion list.
-
-See [`minimum_release_age`](/configuration/settings.html#minimum_release_age) for more details.
+See [Security](/security.html#minimum-release-age) for supply-chain delay controls, backend support,
+and transitive dependency filtering behavior.
 
 ## [`mise up --bump`](/cli/upgrade.html)
 

--- a/settings.toml
+++ b/settings.toml
@@ -1379,16 +1379,21 @@ Example:
 minimum_release_age = "7d"  # only install versions released more than 7 days ago
 ```
 
-Only affects backends that provide release timestamps (aqua, cargo, npm, pipx, and some core plugins).
-Versions without timestamps are included by default.
+Capability depends on what each backend can report or pass through:
+
+- Top-level version filtering: applies to fuzzy version requests when the backend provides release
+  timestamps, such as `aqua:`, `cargo:`, `github:`, `gitlab:`, `go:`, `npm:`, `pipx:`, and many
+  core tools. Versions without timestamps are included by default.
+- Transitive dependency filtering during install: only `npm:` and `pipx:` currently forward the
+  cutoff to the package manager. Other backends may still select an older top-level tool version,
+  but they do not constrain dependencies fetched by the tool's installer/compiler.
 
 **Behavior**: For most backends, this filter only applies when resolving fuzzy version requests
 like `node@20` or `latest`. Explicitly pinned versions like `node@22.5.0` are not filtered,
 allowing you to selectively use newer versions for specific tools while keeping others behind the
 cutoff date.
 
-Some package-manager backends also forward the cutoff to transitive dependency resolution during
-install. This includes `npm:` and `pipx:` tools.
+For `npm:` and `pipx:` package-manager support details, see the backend docs.
 
 Can be overridden with the `--minimum-release-age` CLI flag or per-tool with the `minimum_release_age` tool option.
 


### PR DESCRIPTION
## Summary
- add a Security page for supply-chain controls
- move software verification and minimum release age guidance out of Tips & Tricks into Security
- clarify that `minimum_release_age` has two capability levels: top-level fuzzy version filtering and transitive dependency filtering
- document that only `npm:` and `pipx:` currently forward the cutoff to package-manager dependency resolution
- keep Tips & Tricks as short pointers to the Security page

## Tests
- `cargo test test_settings_toml_is_sorted`
- `mise run docs:build`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior changes.
> 
> **Overview**
> Adds a dedicated **Security** docs page and links it from the Dev Tools sidebar. **Software verification** (aqua Cosign/SLSA/attestations, env toggles) and **minimum release age** guidance move out of Tips & Tricks into that page, with Tips & Tricks reduced to links.
> 
> **`minimum_release_age`** is documented as two separate capabilities: **top-level fuzzy version filtering** (backends with release timestamps) versus **transitive dependency filtering during install**, which only **`npm:`** and **`pipx:`** currently forward to the package manager. Other backends may pick an older tool version but do not age-filter installer-fetched dependencies. The same wording is aligned in `mise-lock.md` and the generated `settings.toml` docs for `minimum_release_age`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41599227fe2825ca69f028d2135dd19d66fed1a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->