### PR TITLE
feat(config): default release age and warn on hidden versions

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -14,8 +14,8 @@ similar to how the pipx backend uses `uv` when available.
 If you use `aube`, `pnpm`, or `bun` as the package manager, that package manager
 must also be installed.
 
-When [`minimum_release_age`](/configuration/settings.html#minimum_release_age) is set, the npm backend
-forwards that cutoff to transitive dependency resolution during install. This relies on the
+The npm backend forwards [`minimum_release_age`](/configuration/settings.html#minimum_release_age)
+to transitive dependency resolution during install. This relies on the
 configured package manager supporting its native release-age flag:
 
 - `aube` using its `minimumReleaseAge` setting

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -27,7 +27,7 @@ This relies on having `uv` (recommended) or `pipx` installed.
 
 If you have `uv` installed, mise will use `uv tool install` under the hood and you don't need to install `pipx` to run the commands containing "pipx:".
 
-When [`minimum_release_age`](/configuration/settings.html#minimum_release_age) is set, mise forwards the cutoff
+mise forwards [`minimum_release_age`](/configuration/settings.html#minimum_release_age)
 to transitive Python dependency resolution during install. The uv install path uses uv's
 `--exclude-newer` flag, and the `pipx` fallback passes pip's `--uploaded-prior-to` flag.
 When using `minimum_release_age` with the `pipx` install path, `pip >= 26.0` is required for pip's `--uploaded-prior-to` support, and you are responsible for ensuring that compatible Python/pip environment is installed.

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -355,11 +355,11 @@ When enabled, every `mise install` will cryptographically verify provenance rega
 
 ## Minimum Release Age
 
-In addition to lockfiles, mise supports the [`minimum_release_age`](/configuration/settings.html#minimum_release_age) setting to limit supply chain risk by only installing versions that have been available for a minimum amount of time:
+In addition to lockfiles, mise uses the [`minimum_release_age`](/configuration/settings.html#minimum_release_age) setting to limit supply chain risk by only installing versions that have been available for a minimum amount of time. It defaults to `24h`:
 
 ```toml
 [settings]
-minimum_release_age = "7d"  # only resolve to versions released more than 7 days ago
+minimum_release_age = "7d"  # override the default 24h delay
 ```
 
 This pairs well with lockfiles — use `minimum_release_age` to avoid picking up brand-new releases, and lockfiles to pin the exact versions you've vetted.

--- a/docs/security.md
+++ b/docs/security.md
@@ -75,7 +75,7 @@ minimum_release_age = "1d"  # trivy updates are time-sensitive, use a shorter wi
 Precedence: `--minimum-release-age` CLI flag > per-tool `minimum_release_age` > global
 `minimum_release_age` setting.
 
-Use `minimum_release_age_excludes` to exclude tools or backends from the global setting:
+Use `minimum_release_age_excludes` to exclude tools or backends from the global/default setting:
 
 ```toml
 [settings]
@@ -84,8 +84,9 @@ minimum_release_age_excludes = ["trivy", "npm:*"]
 ```
 
 Exclusions can match backend wildcards like `npm:*`, tool shorthands like `trivy`, or full backend
-IDs like `npm:prettier`. Per-tool `minimum_release_age` options and the CLI flag still apply even
-when a tool matches the exclusion list.
+IDs like `npm:prettier`. Matching tools skip the global setting and built-in default. Per-tool
+`minimum_release_age` options and the CLI flag still apply even when a tool matches the exclusion
+list.
 
 See [`minimum_release_age`](/configuration/settings.html#minimum_release_age) for the setting
 reference.

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -17,7 +17,9 @@ unset MISE_MINIMUM_RELEASE_AGE
 
 # Test: minimum_release_age=0s effectively disables the delay and returns the absolute latest.
 export MISE_MINIMUM_RELEASE_AGE="0s"
-assert_not_contains "mise latest npm:prettier" "2.8.8"
+latest_prettier="$(mise latest npm:prettier)"
+assert_matches "echo \"$latest_prettier\"" '^[0-9]+\.[0-9]+\.[0-9]+$'
+assert_not_contains_text "$latest_prettier" "2.8.8"
 unset MISE_MINIMUM_RELEASE_AGE
 
 # Test: `mise latest --minimum-release-age` CLI flag should filter by date

--- a/e2e/backend/test_npm_install_before
+++ b/e2e/backend/test_npm_install_before
@@ -15,8 +15,10 @@ export MISE_MINIMUM_RELEASE_AGE="2023-06-01"
 assert_contains "mise latest npm:prettier" "2.8.8"
 unset MISE_MINIMUM_RELEASE_AGE
 
-# Test: without minimum_release_age, latest is the absolute latest (newer than 2.8.8)
+# Test: minimum_release_age=0s effectively disables the delay and returns the absolute latest.
+export MISE_MINIMUM_RELEASE_AGE="0s"
 assert_not_contains "mise latest npm:prettier" "2.8.8"
+unset MISE_MINIMUM_RELEASE_AGE
 
 # Test: `mise latest --minimum-release-age` CLI flag should filter by date
 assert_contains "mise latest npm:prettier --minimum-release-age 2023-06-01" "2.8.8"

--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -103,9 +103,9 @@ export MISE_NPM_PACKAGE_MANAGER=aube
 
 # Ensure aube is available after the default package manager test, since
 # npm.package_manager=auto uses aube when it is already installed.
-# Pin to the current aube release checked for this test. Bypass
-# MISE_MINIMUM_RELEASE_AGE because the global filter is set to test the
-# package-manager flag plumbing below.
+# Pin to the current aube release checked for this test. Remove this test's
+# MISE_MINIMUM_RELEASE_AGE override; the explicit version bypasses the default
+# release-age filter.
 AUBE_TEST_VERSION="1.16.0"
 if ! command -v aube >/dev/null 2>&1; then
   echo "aube not available in test environment, installing..."

--- a/e2e/cli/test_install_before
+++ b/e2e/cli/test_install_before
@@ -43,6 +43,8 @@ cat <<EOF >mise.toml
 [tools]
 jq = "latest"
 EOF
+mise uninstall jq --all 2>/dev/null || true
+mise install jq@1.6
 output=$(mise upgrade jq --minimum-release-age 2019-01-01 --dry-run 2>&1)
 assert_contains "echo '$output'" "newer jq release"
 

--- a/e2e/cli/test_install_before
+++ b/e2e/cli/test_install_before
@@ -38,6 +38,14 @@ mise install tiny@1.0.0
 output=$(mise upgrade --minimum-release-age 2025-01-01 --dry-run 2>&1)
 assert_contains "echo '$output'" "tiny"
 
+rm -f mise.toml
+cat <<EOF >mise.toml
+[tools]
+jq = "latest"
+EOF
+output=$(mise upgrade jq --minimum-release-age 2019-01-01 --dry-run 2>&1)
+assert_contains "echo '$output'" "newer jq release"
+
 # Test: install --minimum-release-age with relative duration "90d"
 mise uninstall tiny --all 2>/dev/null || true
 output=$(mise install tiny@latest --minimum-release-age 90d --dry-run 2>&1)

--- a/e2e/cli/test_ls_remote
+++ b/e2e/cli/test_ls_remote
@@ -17,6 +17,7 @@ assert "mise ls-remote dummy@sub-1:2" "1.0.0
 # result is cached and reused for the second query.
 assert_contains "mise ls-remote jq --minimum-release-age 2019-01-01" "1.6"
 assert_not_contains "mise ls-remote jq --minimum-release-age 2019-01-01" "1.7.1"
+assert_contains "mise ls-remote jq --minimum-release-age 2019-01-01 2>&1" "newer jq release"
 assert_contains "mise ls-remote jq --minimum-release-age 2024-01-01" "1.7.1"
 assert_not_empty "mise ls-remote jq --minimum-release-age 1d"
 assert_contains "mise ls-remote jq --before 2019-01-01" "1.6"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1088,6 +1088,7 @@
           "enum": ["trace", "debug", "info", "warn", "error"]
         },
         "minimum_release_age": {
+          "default": "24h",
           "description": "Minimum release age / supply chain protection — only install versions older than this threshold",
           "type": "string"
         },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1088,7 +1088,6 @@
           "enum": ["trace", "debug", "info", "warn", "error"]
         },
         "minimum_release_age": {
-          "default": "24h",
           "description": "Minimum release age / supply chain protection — only install versions older than this threshold",
           "type": "string"
         },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1093,7 +1093,7 @@
         },
         "minimum_release_age_excludes": {
           "default": [],
-          "description": "Tools and backends to exclude from the global minimum_release_age setting",
+          "description": "Tools and backends to exclude from the global/default minimum_release_age setting",
           "type": "array",
           "items": {
             "type": "string"

--- a/settings.toml
+++ b/settings.toml
@@ -1358,7 +1358,6 @@ hide = true
 type = "String"
 
 [minimum_release_age]
-default = "24h"
 description = "Minimum release age / supply chain protection — only install versions older than this threshold"
 docs = """
 Filter tool versions by release date to limit supply chain risk. Similar to Renovate's
@@ -1407,6 +1406,7 @@ minimum_release_age = "7d"  # override for this tool only
 ```
 """
 env = "MISE_MINIMUM_RELEASE_AGE"
+optional = true
 type = "String"
 
 [minimum_release_age_excludes]

--- a/settings.toml
+++ b/settings.toml
@@ -1358,6 +1358,7 @@ hide = true
 type = "String"
 
 [minimum_release_age]
+default = "24h"
 description = "Minimum release age / supply chain protection — only install versions older than this threshold"
 docs = """
 Filter tool versions by release date to limit supply chain risk. Similar to Renovate's
@@ -1376,7 +1377,7 @@ Example:
 
 ```toml
 [settings]
-minimum_release_age = "7d"  # only install versions released more than 7 days ago
+minimum_release_age = "7d"  # default is 24h
 ```
 
 Capability depends on what each backend can report or pass through:
@@ -1395,6 +1396,8 @@ cutoff date.
 
 For `npm:` and `pipx:` package-manager support details, see the backend docs.
 
+Defaults to `24h`. Set `minimum_release_age = "0s"` to effectively disable the delay.
+
 Can be overridden with the `--minimum-release-age` CLI flag or per-tool with the `minimum_release_age` tool option.
 
 ```toml
@@ -1404,7 +1407,6 @@ minimum_release_age = "7d"  # override for this tool only
 ```
 """
 env = "MISE_MINIMUM_RELEASE_AGE"
-optional = true
 type = "String"
 
 [minimum_release_age_excludes]

--- a/settings.toml
+++ b/settings.toml
@@ -1411,9 +1411,9 @@ type = "String"
 
 [minimum_release_age_excludes]
 default = []
-description = "Tools and backends to exclude from the global minimum_release_age setting"
+description = "Tools and backends to exclude from the global/default minimum_release_age setting"
 docs = """
-Exclude tools or backends from the global [`minimum_release_age`](#minimum_release_age) setting.
+Exclude tools or backends from the global/default [`minimum_release_age`](#minimum_release_age) setting.
 This is useful for tools where newly published releases are time-sensitive.
 
 Exclusions match any of:
@@ -1430,7 +1430,7 @@ minimum_release_age = "7d"
 minimum_release_age_excludes = ["trivy", "npm:*"]
 ```
 
-This only excludes tools from the global setting. A per-tool `minimum_release_age` option
+This excludes matching tools from the global setting and built-in default. A per-tool `minimum_release_age` option
 or the `--minimum-release-age` CLI flag still applies to matching tools.
 """
 env = "MISE_MINIMUM_RELEASE_AGE_EXCLUDES"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -172,7 +172,6 @@ fn is_false(v: &bool) -> bool {
 
 impl VersionInfo {
     fn created_at_timestamp(&self) -> Option<Timestamp> {
-        use crate::duration::parse_into_timestamp;
         match &self.created_at {
             Some(ts) => {
                 let created = parse_into_timestamp(ts);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -189,19 +189,18 @@ impl VersionInfo {
     /// Filter versions to only include those released before the given timestamp.
     /// Versions without a created_at timestamp are included by default.
     pub fn filter_by_date(versions: Vec<Self>, before: Timestamp) -> Vec<Self> {
+        use crate::duration::parse_into_timestamp;
+
         versions
             .into_iter()
             .filter(|v| match &v.created_at {
-                Some(ts) => {
-                    if v.hidden_by_date(before) {
-                        false
-                    } else {
-                        if crate::duration::parse_into_timestamp(ts).is_err() {
-                            trace!("Failed to parse timestamp: {}", ts);
-                        }
+                Some(ts) => match parse_into_timestamp(ts) {
+                    Ok(created) => created < before,
+                    Err(_) => {
+                        trace!("Failed to parse timestamp: {}", ts);
                         true
                     }
-                }
+                },
                 None => true,
             })
             .collect()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1527,6 +1527,27 @@ pub trait Backend: Debug + Send + Sync {
             .await
     }
 
+    /// Get the latest version without applying release-date cutoffs.
+    ///
+    /// This is intended for diagnostics that compare a date-filtered result
+    /// with the absolute latest result. Normal resolution should use
+    /// `latest_version` so global, per-tool, and default release-age cutoffs are
+    /// honored.
+    async fn latest_version_unfiltered(
+        &self,
+        config: &Arc<Config>,
+        query: Option<String>,
+    ) -> eyre::Result<Option<String>> {
+        let resolved_query = query.as_deref().unwrap_or("latest");
+        if resolved_query == "latest"
+            && let Some(version) = self.latest_stable_version(config).await?
+        {
+            return Ok(Some(version));
+        }
+        self.latest_version_for_query(config, resolved_query, None, false)
+            .await
+    }
+
     /// Like `latest_version` but with explicit refresh control. Pass
     /// `refresh = true` to bypass the cached remote-versions list when falling
     /// back to the full version-list path. The `latest_stable_version` fast

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -171,29 +171,38 @@ fn is_false(v: &bool) -> bool {
 }
 
 impl VersionInfo {
+    pub fn hidden_by_date(&self, before: Timestamp) -> bool {
+        use crate::duration::parse_into_timestamp;
+        match &self.created_at {
+            Some(ts) => match parse_into_timestamp(ts) {
+                Ok(created) => created >= before,
+                Err(_) => false,
+            },
+            None => false,
+        }
+    }
+
+    pub fn count_hidden_by_date(versions: &[Self], before: Timestamp) -> usize {
+        versions.iter().filter(|v| v.hidden_by_date(before)).count()
+    }
+
     /// Filter versions to only include those released before the given timestamp.
     /// Versions without a created_at timestamp are included by default.
     pub fn filter_by_date(versions: Vec<Self>, before: Timestamp) -> Vec<Self> {
-        use crate::duration::parse_into_timestamp;
         versions
             .into_iter()
-            .filter(|v| {
-                match &v.created_at {
-                    Some(ts) => {
-                        // Parse the timestamp using parse_into_timestamp which handles
-                        // RFC3339, date-only (YYYY-MM-DD), and other formats
-                        match parse_into_timestamp(ts) {
-                            Ok(created) => created < before,
-                            Err(_) => {
-                                // If we can't parse the timestamp, include the version
-                                trace!("Failed to parse timestamp: {}", ts);
-                                true
-                            }
+            .filter(|v| match &v.created_at {
+                Some(ts) => {
+                    if v.hidden_by_date(before) {
+                        false
+                    } else {
+                        if crate::duration::parse_into_timestamp(ts).is_err() {
+                            trace!("Failed to parse timestamp: {}", ts);
                         }
+                        true
                     }
-                    // Include versions without timestamps
-                    None => true,
                 }
+                None => true,
             })
             .collect()
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -171,15 +171,23 @@ fn is_false(v: &bool) -> bool {
 }
 
 impl VersionInfo {
-    pub fn hidden_by_date(&self, before: Timestamp) -> bool {
+    fn created_at_timestamp(&self) -> Option<Timestamp> {
         use crate::duration::parse_into_timestamp;
         match &self.created_at {
-            Some(ts) => match parse_into_timestamp(ts) {
-                Ok(created) => created >= before,
-                Err(_) => false,
-            },
-            None => false,
+            Some(ts) => {
+                let created = parse_into_timestamp(ts);
+                if created.is_err() {
+                    trace!("Failed to parse timestamp: {}", ts);
+                }
+                created.ok()
+            }
+            None => None,
         }
+    }
+
+    pub fn hidden_by_date(&self, before: Timestamp) -> bool {
+        self.created_at_timestamp()
+            .is_some_and(|created| created >= before)
     }
 
     pub fn count_hidden_by_date(versions: &[Self], before: Timestamp) -> usize {
@@ -189,19 +197,11 @@ impl VersionInfo {
     /// Filter versions to only include those released before the given timestamp.
     /// Versions without a created_at timestamp are included by default.
     pub fn filter_by_date(versions: Vec<Self>, before: Timestamp) -> Vec<Self> {
-        use crate::duration::parse_into_timestamp;
-
         versions
             .into_iter()
-            .filter(|v| match &v.created_at {
-                Some(ts) => match parse_into_timestamp(ts) {
-                    Ok(created) => created < before,
-                    Err(_) => {
-                        trace!("Failed to parse timestamp: {}", ts);
-                        true
-                    }
-                },
-                None => true,
+            .filter(|v| {
+                v.created_at_timestamp()
+                    .is_none_or(|created| created < before)
             })
             .collect()
     }

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -123,23 +123,16 @@ impl LsRemote {
         };
         let matches_prefix = |v: &str| prefix.as_ref().is_none_or(|p| v.starts_with(p));
 
-        let all_versions = plugin.list_remote_versions_with_info(config).await?;
-        let hidden_versions = before_date
-            .map(|before| {
-                VersionInfo::count_hidden_by_date(
-                    &all_versions
-                        .iter()
-                        .filter(|v| matches_prefix(&v.version))
-                        .cloned()
-                        .collect::<Vec<_>>(),
-                    before,
-                )
-            })
-            .unwrap_or_default();
-        let versions = filter_versions_by_date(all_versions, before_date)
+        let versions_matching_prefix = plugin
+            .list_remote_versions_with_info(config)
+            .await?
             .into_iter()
             .filter(|v| matches_prefix(&v.version))
             .collect::<Vec<_>>();
+        let hidden_versions = before_date
+            .map(|before| VersionInfo::count_hidden_by_date(&versions_matching_prefix, before))
+            .unwrap_or_default();
+        let versions = filter_versions_by_date(versions_matching_prefix, before_date);
 
         if self.json {
             miseprintln!("{}", serde_json::to_string(&versions)?);

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -123,13 +123,23 @@ impl LsRemote {
         };
         let matches_prefix = |v: &str| prefix.as_ref().is_none_or(|p| v.starts_with(p));
 
-        let versions = filter_versions_by_date(
-            plugin.list_remote_versions_with_info(config).await?,
-            before_date,
-        )
-        .into_iter()
-        .filter(|v| matches_prefix(&v.version))
-        .collect::<Vec<_>>();
+        let all_versions = plugin.list_remote_versions_with_info(config).await?;
+        let hidden_versions = before_date
+            .map(|before| {
+                VersionInfo::count_hidden_by_date(
+                    &all_versions
+                        .iter()
+                        .filter(|v| matches_prefix(&v.version))
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    before,
+                )
+            })
+            .unwrap_or_default();
+        let versions = filter_versions_by_date(all_versions, before_date)
+            .into_iter()
+            .filter(|v| matches_prefix(&v.version))
+            .collect::<Vec<_>>();
 
         if self.json {
             miseprintln!("{}", serde_json::to_string(&versions)?);
@@ -137,20 +147,23 @@ impl LsRemote {
             for v in versions {
                 miseprintln!("{}", v.version);
             }
+            warn_if_versions_hidden_by_minimum_release_age(plugin.id(), hidden_versions);
         }
         Ok(())
     }
 
     async fn run_all(self, config: &Arc<Config>, before_date: Option<Timestamp>) -> Result<()> {
         let mut versions = vec![];
+        let mut hidden_versions = 0;
         for b in backend::list() {
             let tool = b.id().to_string();
             let before_date =
                 resolve_before_date_for_backend(config, b.as_ref(), before_date).await?;
-            for v in filter_versions_by_date(
-                b.list_remote_versions_with_info(config).await?,
-                before_date,
-            ) {
+            let all_versions = b.list_remote_versions_with_info(config).await?;
+            if let Some(before) = before_date {
+                hidden_versions += VersionInfo::count_hidden_by_date(&all_versions, before);
+            }
+            for v in filter_versions_by_date(all_versions, before_date) {
                 versions.push(VersionOutputAll {
                     tool: tool.clone(),
                     version: v.version,
@@ -167,6 +180,7 @@ impl LsRemote {
             for v in versions {
                 miseprintln!("{}@{}", v.tool, v.version);
             }
+            warn_if_versions_hidden_by_minimum_release_age("tools", hidden_versions);
         }
         Ok(())
     }
@@ -185,6 +199,14 @@ impl LsRemote {
             None => Ok(None),
         }
     }
+}
+
+fn warn_if_versions_hidden_by_minimum_release_age(tool: &str, hidden_versions: usize) {
+    if hidden_versions == 0 {
+        return;
+    }
+    let s = if hidden_versions == 1 { "" } else { "s" };
+    warn!("{hidden_versions} newer {tool} release{s} hidden by minimum_release_age");
 }
 
 fn filter_versions_by_date(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -6,7 +6,10 @@ use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, config_file};
 use crate::duration::parse_into_timestamp;
 use crate::file::display_path;
+use crate::semver::split_version_prefix;
+use crate::toolset::is_outdated_version;
 use crate::toolset::outdated_info::OutdatedInfo;
+use crate::toolset::outdated_info::prefixed_latest_query;
 use crate::toolset::{
     ConfigScope, InstallOptions, ResolveOptions, ToolSource, ToolVersion, ToolsetBuilder,
     get_versions_needed_by_tracked_configs_excluding_locks,
@@ -140,6 +143,14 @@ impl Upgrade {
         let mut outdated = ts
             .list_outdated_versions_filtered(&config, self.bump, &opts, filter_tools, exclude_tools)
             .await;
+        self.warn_if_newer_versions_hidden_by_minimum_release_age(
+            &config,
+            &ts,
+            &opts,
+            filter_tools,
+            exclude_tools,
+        )
+        .await;
         if self.interactive && !outdated.is_empty() {
             outdated = self.get_interactive_tool_set(&outdated)?;
         }
@@ -527,6 +538,136 @@ impl Upgrade {
             return Ok(Some(parse_into_timestamp(minimum_release_age)?));
         }
         Ok(None)
+    }
+
+    async fn warn_if_newer_versions_hidden_by_minimum_release_age(
+        &self,
+        config: &Arc<Config>,
+        ts: &crate::toolset::Toolset,
+        opts: &ResolveOptions,
+        filter_tools: Option<&[ToolArg]>,
+        exclude_tools: Option<&[ToolArg]>,
+    ) {
+        let list_versions = if opts.inactive {
+            match ts.list_all_versions(config).await {
+                Ok(v) => v,
+                Err(err) => {
+                    warn!("Failed to list all versions: {err:#}");
+                    vec![]
+                }
+            }
+        } else {
+            ts.list_current_versions()
+        };
+        let mut warned = HashSet::new();
+        for (_, tv) in list_versions {
+            if let Some(exclude) = exclude_tools
+                && exclude.iter().any(|t| t.ba.as_ref() == tv.ba())
+            {
+                continue;
+            }
+            if let Some(tools) = filter_tools
+                && !tools.iter().any(|t| t.ba.as_ref() == tv.ba())
+            {
+                continue;
+            }
+            let warning_key = format!("{}@{}", tv.ba().short, tv.request.version());
+            if !warned.insert(warning_key) {
+                continue;
+            }
+            let eligible_latest = self.latest_for_upgrade(config, &tv, opts).await;
+            let unfiltered_latest = self.unfiltered_latest_for_upgrade(config, &tv, opts).await;
+            match (eligible_latest, unfiltered_latest) {
+                (Some(eligible), Some(unfiltered))
+                    if is_outdated_version(&eligible, &unfiltered) =>
+                {
+                    warn!(
+                        "newer {} release {unfiltered} ignored by minimum_release_age; latest eligible release is {eligible}",
+                        tv.ba().short
+                    );
+                }
+                (None, Some(unfiltered)) => {
+                    warn!(
+                        "newer {} release {unfiltered} ignored by minimum_release_age; no eligible release found",
+                        tv.ba().short
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    async fn latest_for_upgrade(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        opts: &ResolveOptions,
+    ) -> Option<String> {
+        let backend = match tv.backend() {
+            Ok(backend) => backend,
+            Err(err) => {
+                warn!("Error getting backend for {tv}: {err:#}");
+                return None;
+            }
+        };
+        let latest = if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown)
+        {
+            let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
+            backend
+                .latest_version(
+                    config,
+                    prefixed_latest_query(&prefix, &prefix_version),
+                    opts.before_date,
+                )
+                .await
+                .ok()
+                .flatten()
+        } else {
+            tv.latest_version_with_opts(config, opts).await.ok()
+        };
+        latest
+    }
+
+    async fn unfiltered_latest_for_upgrade(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        opts: &ResolveOptions,
+    ) -> Option<String> {
+        let backend = match tv.backend() {
+            Ok(backend) => backend,
+            Err(err) => {
+                warn!("Error getting backend for {tv}: {err:#}");
+                return None;
+            }
+        };
+        let query = if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown) {
+            let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
+            prefixed_latest_query(&prefix, &prefix_version).unwrap_or_else(|| "latest".to_string())
+        } else {
+            tv.request.version()
+        };
+        let mut matches = match backend.list_versions_matching(config, &query).await {
+            Ok(matches) => matches,
+            Err(err) => {
+                warn!("Error getting latest version for {}: {err:#}", tv.ba());
+                return None;
+            }
+        };
+        if matches.is_empty() && query == "latest" {
+            matches = match backend.list_remote_versions(config).await {
+                Ok(versions) => versions,
+                Err(err) => {
+                    warn!("Error getting latest version for {}: {err:#}", tv.ba());
+                    return None;
+                }
+            };
+        }
+        if matches.contains(&query) {
+            Some(query)
+        } else {
+            matches.last().cloned()
+        }
     }
 }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -598,7 +598,20 @@ impl Upgrade {
             let eligible_latest = self
                 .latest_for_upgrade(config, &tv, &opts_with_effective_before_date)
                 .await;
-            let baseline_latest = self.baseline_latest_for_upgrade(config, &tv, opts).await;
+            let eligible_latest = match eligible_latest {
+                Ok(latest) => latest,
+                Err(err) => {
+                    warn!("Error getting latest version for {}: {err:#}", tv.ba());
+                    continue;
+                }
+            };
+            let baseline_latest = match self.baseline_latest_for_upgrade(config, &tv, opts).await {
+                Ok(latest) => latest,
+                Err(err) => {
+                    warn!("Error getting latest version for {}: {err:#}", tv.ba());
+                    continue;
+                }
+            };
             match (eligible_latest, baseline_latest) {
                 (Some(eligible), Some(baseline)) if is_outdated_version(&eligible, &baseline) => {
                     warn!(
@@ -622,16 +635,9 @@ impl Upgrade {
         config: &Arc<Config>,
         tv: &ToolVersion,
         opts: &ResolveOptions,
-    ) -> Option<String> {
-        let backend = match tv.backend() {
-            Ok(backend) => backend,
-            Err(err) => {
-                warn!("Error getting backend for {tv}: {err:#}");
-                return None;
-            }
-        };
-        let latest = if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown)
-        {
+    ) -> Result<Option<String>> {
+        let backend = tv.backend()?;
+        if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown) {
             let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
             backend
                 .latest_version(
@@ -640,12 +646,9 @@ impl Upgrade {
                     opts.before_date,
                 )
                 .await
-                .ok()
-                .flatten()
         } else {
-            tv.latest_version_with_opts(config, opts).await.ok()
-        };
-        latest
+            tv.latest_version_with_opts(config, opts).await.map(Some)
+        }
     }
 
     async fn baseline_latest_for_upgrade(
@@ -653,41 +656,15 @@ impl Upgrade {
         config: &Arc<Config>,
         tv: &ToolVersion,
         opts: &ResolveOptions,
-    ) -> Option<String> {
-        let backend = match tv.backend() {
-            Ok(backend) => backend,
-            Err(err) => {
-                warn!("Error getting backend for {tv}: {err:#}");
-                return None;
-            }
-        };
+    ) -> Result<Option<String>> {
+        let backend = tv.backend()?;
         let query = if self.bump || (opts.inactive && tv.request.source() == &ToolSource::Unknown) {
             let (prefix, prefix_version) = split_version_prefix(&tv.request.version());
-            prefixed_latest_query(&prefix, &prefix_version).unwrap_or_else(|| "latest".to_string())
+            prefixed_latest_query(&prefix, &prefix_version)
         } else {
-            tv.request.version()
+            Some(tv.request.version())
         };
-        let mut matches = match backend.list_versions_matching(config, &query).await {
-            Ok(matches) => matches,
-            Err(err) => {
-                warn!("Error getting latest version for {}: {err:#}", tv.ba());
-                return None;
-            }
-        };
-        if matches.is_empty() && query == "latest" {
-            matches = match backend.list_remote_versions(config).await {
-                Ok(versions) => versions,
-                Err(err) => {
-                    warn!("Error getting latest version for {}: {err:#}", tv.ba());
-                    return None;
-                }
-            };
-        }
-        if matches.contains(&query) {
-            Some(query)
-        } else {
-            matches.last().cloned()
-        }
+        backend.latest_version_unfiltered(config, query).await
     }
 }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -598,19 +598,17 @@ impl Upgrade {
             let eligible_latest = self
                 .latest_for_upgrade(config, &tv, &opts_with_effective_before_date)
                 .await;
-            let unfiltered_latest = self.unfiltered_latest_for_upgrade(config, &tv, opts).await;
-            match (eligible_latest, unfiltered_latest) {
-                (Some(eligible), Some(unfiltered))
-                    if is_outdated_version(&eligible, &unfiltered) =>
-                {
+            let baseline_latest = self.baseline_latest_for_upgrade(config, &tv, opts).await;
+            match (eligible_latest, baseline_latest) {
+                (Some(eligible), Some(baseline)) if is_outdated_version(&eligible, &baseline) => {
                     warn!(
-                        "newer {} release {unfiltered} ignored by minimum_release_age; latest eligible release is {eligible}",
+                        "newer {} release {baseline} ignored by minimum_release_age; latest eligible release is {eligible}",
                         tv.ba().short
                     );
                 }
-                (None, Some(unfiltered)) => {
+                (None, Some(baseline)) => {
                     warn!(
-                        "newer {} release {unfiltered} ignored by minimum_release_age; no eligible release found",
+                        "newer {} release {baseline} ignored by minimum_release_age; no eligible release found",
                         tv.ba().short
                     );
                 }
@@ -650,7 +648,7 @@ impl Upgrade {
         latest
     }
 
-    async fn unfiltered_latest_for_upgrade(
+    async fn baseline_latest_for_upgrade(
         &self,
         config: &Arc<Config>,
         tv: &ToolVersion,

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -6,6 +6,7 @@ use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, config_file};
 use crate::duration::parse_into_timestamp;
 use crate::file::display_path;
+use crate::install_before::resolve_before_date_for_tool;
 use crate::semver::split_version_prefix;
 use crate::toolset::is_outdated_version;
 use crate::toolset::outdated_info::OutdatedInfo;
@@ -575,7 +576,28 @@ impl Upgrade {
             if !warned.insert(warning_key) {
                 continue;
             }
-            let eligible_latest = self.latest_for_upgrade(config, &tv, opts).await;
+            let before_date = match resolve_before_date_for_tool(
+                tv.ba(),
+                opts.before_date,
+                tv.request.options().minimum_release_age(),
+            ) {
+                Ok(Some(before_date)) => before_date,
+                Ok(None) => continue,
+                Err(err) => {
+                    warn!(
+                        "Error resolving minimum_release_age for {}: {err:#}",
+                        tv.ba()
+                    );
+                    continue;
+                }
+            };
+            let opts_with_effective_before_date = ResolveOptions {
+                before_date: Some(before_date),
+                ..opts.clone()
+            };
+            let eligible_latest = self
+                .latest_for_upgrade(config, &tv, &opts_with_effective_before_date)
+                .await;
             let unfiltered_latest = self.unfiltered_latest_for_upgrade(config, &tv, opts).await;
             match (eligible_latest, unfiltered_latest) {
                 (Some(eligible), Some(unfiltered))

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -380,9 +380,7 @@ impl Settings {
     fn set_hidden_configs(&mut self) {
         if let Some(v) = self.install_before.take() {
             warn_deprecated("install_before");
-            if self.minimum_release_age.is_none() {
-                self.minimum_release_age = Some(v);
-            }
+            self.minimum_release_age = v;
         }
         // Migrate task_* settings to task.* (must run before auto_install override below)
         if let Some(v) = self.task_disable_paths.take()
@@ -1108,7 +1106,7 @@ mod tests {
         partial.install_before = Some("7d".to_string());
         Settings::reset(Some(partial));
         let settings = Settings::get();
-        assert_eq!(settings.minimum_release_age.as_deref(), Some("7d"));
+        assert_eq!(settings.minimum_release_age, "7d");
         Settings::reset(None);
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -380,7 +380,9 @@ impl Settings {
     fn set_hidden_configs(&mut self) {
         if let Some(v) = self.install_before.take() {
             warn_deprecated("install_before");
-            self.minimum_release_age = v;
+            if self.minimum_release_age.is_none() {
+                self.minimum_release_age = Some(v);
+            }
         }
         // Migrate task_* settings to task.* (must run before auto_install override below)
         if let Some(v) = self.task_disable_paths.take()
@@ -1106,7 +1108,18 @@ mod tests {
         partial.install_before = Some("7d".to_string());
         Settings::reset(Some(partial));
         let settings = Settings::get();
-        assert_eq!(settings.minimum_release_age, "7d");
+        assert_eq!(settings.minimum_release_age.as_deref(), Some("7d"));
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_minimum_release_age_hidden_alias_wins_over_install_before() {
+        let mut partial = SettingsPartial::empty();
+        partial.install_before = Some("7d".to_string());
+        partial.minimum_release_age = Some("3d".to_string());
+        Settings::reset(Some(partial));
+        let settings = Settings::get();
+        assert_eq!(settings.minimum_release_age.as_deref(), Some("3d"));
         Settings::reset(None);
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -250,6 +250,16 @@ fn warn_deprecated(key: &str) {
     }
 }
 
+fn normalize_hidden_config_aliases(mut partial: SettingsPartial) -> SettingsPartial {
+    if let Some(v) = partial.install_before.take() {
+        warn_deprecated("install_before");
+        if partial.minimum_release_age.is_none() {
+            partial.minimum_release_age = Some(v);
+        }
+    }
+    partial
+}
+
 impl Settings {
     pub fn parse_default_package_line(package: &str) -> Option<String> {
         let package = package.split('#').next().unwrap_or_default().trim();
@@ -276,7 +286,9 @@ impl Settings {
 
         // Initial pass to obtain cd option
         let mut sb = Self::builder()
-            .preloaded(CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default())
+            .preloaded(normalize_hidden_config_aliases(
+                CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
+            ))
             .env();
 
         let mut settings = sb.load()?;
@@ -290,7 +302,9 @@ impl Settings {
 
         // Reload settings after current directory option processed
         sb = Self::builder()
-            .preloaded(CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default())
+            .preloaded(normalize_hidden_config_aliases(
+                CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
+            ))
             .env();
         for file in Self::all_settings_files() {
             sb = sb.preloaded(file);
@@ -520,7 +534,7 @@ impl Settings {
         let raw = file::read_to_string(path)?;
         let settings_file: SettingsFile = toml::from_str(&raw)?;
 
-        Ok(settings_file.settings)
+        Ok(normalize_hidden_config_aliases(settings_file.settings))
     }
 
     fn all_settings_files() -> Vec<SettingsPartial> {

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -60,7 +60,7 @@ fn resolve_before_date_with_excludes(
     if !excluded && let Some(before) = &Settings::get().minimum_release_age {
         return Ok(Some(parse_into_timestamp(before)?));
     }
-    if backend_arg.is_some_and(default_minimum_release_age_applies) {
+    if !excluded && backend_arg.is_some_and(default_minimum_release_age_applies) {
         return Ok(Some(parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE)?));
     }
     Ok(None)
@@ -195,10 +195,7 @@ mod tests {
         partial.minimum_release_age = Some("2024-01-03".to_string());
         partial.minimum_release_age_excludes = Some(vec!["npm:prettier".to_string()]);
         Settings::reset(Some(partial));
-        assert_eq!(
-            resolved_tool_timestamp("npm:prettier", None, None),
-            Some(crate::duration::parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE).unwrap())
-        );
+        assert_eq!(resolved_tool_timestamp("npm:prettier", None, None), None);
         Settings::reset(None);
     }
 
@@ -221,10 +218,7 @@ mod tests {
         partial.minimum_release_age = Some("2024-01-03".to_string());
         partial.minimum_release_age_excludes = Some(vec!["npm:*".to_string()]);
         Settings::reset(Some(partial));
-        assert_eq!(
-            resolved_tool_timestamp("npm:prettier", None, None),
-            Some(crate::duration::parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE).unwrap())
-        );
+        assert_eq!(resolved_tool_timestamp("npm:prettier", None, None), None);
         Settings::reset(None);
     }
 

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -57,10 +57,7 @@ fn resolve_before_date_with_excludes(
     if let Some(before) = minimum_release_age {
         return Ok(Some(parse_into_timestamp(before)?));
     }
-    if excluded {
-        return Ok(None);
-    }
-    if let Some(before) = &Settings::get().minimum_release_age {
+    if !excluded && let Some(before) = &Settings::get().minimum_release_age {
         return Ok(Some(parse_into_timestamp(before)?));
     }
     if backend_arg.is_some_and(default_minimum_release_age_applies) {
@@ -193,12 +190,15 @@ mod tests {
     }
 
     #[test]
-    fn test_effective_before_date_excludes_global_by_tool() {
+    fn test_effective_before_date_excludes_global_by_backend_id() {
         let mut partial = SettingsPartial::empty();
         partial.minimum_release_age = Some("2024-01-03".to_string());
-        partial.minimum_release_age_excludes = Some(vec!["node".to_string()]);
+        partial.minimum_release_age_excludes = Some(vec!["npm:prettier".to_string()]);
         Settings::reset(Some(partial));
-        assert_eq!(resolved_tool_timestamp("node", None, None), None);
+        assert_eq!(
+            resolved_tool_timestamp("npm:prettier", None, None),
+            Some(crate::duration::parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE).unwrap())
+        );
         Settings::reset(None);
     }
 
@@ -221,17 +221,10 @@ mod tests {
         partial.minimum_release_age = Some("2024-01-03".to_string());
         partial.minimum_release_age_excludes = Some(vec!["npm:*".to_string()]);
         Settings::reset(Some(partial));
-        assert_eq!(resolved_tool_timestamp("npm:prettier", None, None), None);
-        Settings::reset(None);
-    }
-
-    #[test]
-    fn test_effective_before_date_excludes_global_by_full_backend_id() {
-        let mut partial = SettingsPartial::empty();
-        partial.minimum_release_age = Some("2024-01-03".to_string());
-        partial.minimum_release_age_excludes = Some(vec!["npm:prettier".to_string()]);
-        Settings::reset(Some(partial));
-        assert_eq!(resolved_tool_timestamp("npm:prettier", None, None), None);
+        assert_eq!(
+            resolved_tool_timestamp("npm:prettier", None, None),
+            Some(crate::duration::parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE).unwrap())
+        );
         Settings::reset(None);
     }
 

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -4,16 +4,20 @@ use eyre::Result;
 use jiff::Timestamp;
 
 use crate::backend::Backend;
+use crate::backend::backend_type::BackendType;
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
 use crate::duration::parse_into_timestamp;
+
+const DEFAULT_MINIMUM_RELEASE_AGE: &str = "24h";
 
 /// Resolve the effective `minimum_release_age` cutoff.
 ///
 /// Precedence (highest to lowest):
 /// 1. `before_date` - a pre-resolved `ResolveOptions` cutoff.
 /// 2. A per-tool, backend, or config `minimum_release_age` option.
-/// 3. The global `minimum_release_age` setting.
+/// 3. The global `minimum_release_age` setting, or the built-in default for
+///    backends that provide release timestamps.
 ///
 /// All string-based durations (e.g. `"3d"`) are resolved against
 /// [`crate::duration::process_now`] so that every call within a single mise
@@ -25,7 +29,7 @@ pub fn resolve_before_date(
     before_date: Option<Timestamp>,
     minimum_release_age: Option<&str>,
 ) -> Result<Option<Timestamp>> {
-    resolve_before_date_with_excludes(before_date, minimum_release_age, false)
+    resolve_before_date_with_excludes(None, before_date, minimum_release_age, false)
 }
 
 pub fn resolve_before_date_for_tool(
@@ -34,6 +38,7 @@ pub fn resolve_before_date_for_tool(
     minimum_release_age: Option<&str>,
 ) -> Result<Option<Timestamp>> {
     resolve_before_date_with_excludes(
+        Some(backend_arg),
         before_date,
         minimum_release_age,
         is_minimum_release_age_excluded(backend_arg),
@@ -41,6 +46,7 @@ pub fn resolve_before_date_for_tool(
 }
 
 fn resolve_before_date_with_excludes(
+    backend_arg: Option<&BackendArg>,
     before_date: Option<Timestamp>,
     minimum_release_age: Option<&str>,
     excluded: bool,
@@ -54,9 +60,30 @@ fn resolve_before_date_with_excludes(
     if excluded {
         return Ok(None);
     }
-    Ok(Some(parse_into_timestamp(
-        &Settings::get().minimum_release_age,
-    )?))
+    if let Some(before) = &Settings::get().minimum_release_age {
+        return Ok(Some(parse_into_timestamp(before)?));
+    }
+    if backend_arg.is_some_and(default_minimum_release_age_applies) {
+        return Ok(Some(parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE)?));
+    }
+    Ok(None)
+}
+
+fn default_minimum_release_age_applies(backend_arg: &BackendArg) -> bool {
+    matches!(
+        backend_arg.backend_type(),
+        BackendType::Aqua
+            | BackendType::Cargo
+            | BackendType::Core
+            | BackendType::Gem
+            | BackendType::Github
+            | BackendType::Gitlab
+            | BackendType::Go
+            | BackendType::Npm
+            | BackendType::Pipx
+            | BackendType::Spm
+            | BackendType::Ubi
+    )
 }
 
 fn is_minimum_release_age_excluded(backend_arg: &BackendArg) -> bool {
@@ -91,7 +118,7 @@ pub(crate) async fn resolve_before_date_for_backend<B: Backend + ?Sized>(
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_before_date, resolve_before_date_for_tool};
+    use super::{DEFAULT_MINIMUM_RELEASE_AGE, resolve_before_date, resolve_before_date_for_tool};
     use crate::cli::args::BackendArg;
     use crate::config::settings::{Settings, SettingsPartial};
     use confique::Layer;
@@ -217,12 +244,26 @@ mod tests {
     }
 
     #[test]
-    fn test_effective_before_date_falls_back_to_default_setting() {
+    fn test_effective_before_date_without_backend_has_no_default() {
+        Settings::reset(None);
+        assert_eq!(resolved_timestamp(None, None), None);
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_before_date_falls_back_to_default_for_supported_backend() {
         Settings::reset(None);
         assert_eq!(
-            resolved_timestamp(None, None),
-            Some(crate::duration::parse_into_timestamp("24h").unwrap())
+            resolved_tool_timestamp("npm:prettier", None, None),
+            Some(crate::duration::parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE).unwrap())
         );
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_before_date_skips_default_for_unsupported_backend() {
+        Settings::reset(None);
+        assert_eq!(resolved_tool_timestamp("asdf:tiny", None, None), None);
         Settings::reset(None);
     }
 

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -54,10 +54,9 @@ fn resolve_before_date_with_excludes(
     if excluded {
         return Ok(None);
     }
-    if let Some(before) = &Settings::get().minimum_release_age {
-        return Ok(Some(parse_into_timestamp(before)?));
-    }
-    Ok(None)
+    Ok(Some(parse_into_timestamp(
+        &Settings::get().minimum_release_age,
+    )?))
 }
 
 fn is_minimum_release_age_excluded(backend_arg: &BackendArg) -> bool {
@@ -218,9 +217,12 @@ mod tests {
     }
 
     #[test]
-    fn test_effective_before_date_none_when_unset() {
+    fn test_effective_before_date_falls_back_to_default_setting() {
         Settings::reset(None);
-        assert_eq!(resolved_timestamp(None, None), None);
+        assert_eq!(
+            resolved_timestamp(None, None),
+            Some(crate::duration::parse_into_timestamp("24h").unwrap())
+        );
         Settings::reset(None);
     }
 

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -5,7 +5,7 @@ use jiff::Timestamp;
 
 use crate::backend::Backend;
 use crate::backend::backend_type::BackendType;
-use crate::cli::args::BackendArg;
+use crate::cli::args::{BackendArg, split_bracketed_opts};
 use crate::config::{Config, Settings};
 use crate::duration::parse_into_timestamp;
 
@@ -75,6 +75,7 @@ fn default_minimum_release_age_applies(backend_arg: &BackendArg) -> bool {
         BackendType::Aqua
             | BackendType::Cargo
             | BackendType::Core
+            | BackendType::Forgejo
             | BackendType::Gem
             | BackendType::Github
             | BackendType::Gitlab
@@ -92,14 +93,31 @@ fn is_minimum_release_age_excluded(backend_arg: &BackendArg) -> bool {
         return false;
     }
 
-    let full = backend_arg.full_without_opts();
-    let backend_type = backend_arg.backend_type().to_string();
-    let backend_wildcard = format!("{backend_type}:*");
-
+    let mut full = None;
+    let mut backend_wildcard = None;
     excludes.iter().any(|exclude| {
         let exclude = exclude.trim();
-        !exclude.is_empty()
-            && (exclude == backend_arg.short || exclude == full || exclude == backend_wildcard)
+        if exclude.is_empty() {
+            return false;
+        }
+        if exclude == backend_arg.short {
+            return true;
+        }
+        let full = full.get_or_insert_with(|| {
+            if backend_arg.short.contains(':') {
+                split_bracketed_opts(&backend_arg.short)
+                    .map(|(name, _)| name.to_string())
+                    .unwrap_or_else(|| backend_arg.short.clone())
+            } else {
+                backend_arg.full_without_opts()
+            }
+        });
+        if exclude == full {
+            return true;
+        }
+        let backend_wildcard =
+            backend_wildcard.get_or_insert_with(|| format!("{}:*", backend_arg.backend_type()));
+        exclude == backend_wildcard
     })
 }
 
@@ -255,6 +273,16 @@ mod tests {
         Settings::reset(None);
         assert_eq!(
             resolved_tool_timestamp("npm:prettier", None, None),
+            Some(crate::duration::parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE).unwrap())
+        );
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_before_date_falls_back_to_default_for_forgejo_backend() {
+        Settings::reset(None);
+        assert_eq!(
+            resolved_tool_timestamp("forgejo:codeberg.org/forgejo/forgejo", None, None),
             Some(crate::duration::parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE).unwrap())
         );
         Settings::reset(None);

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -214,7 +214,7 @@ impl Display for OutdatedInfo {
     }
 }
 
-fn prefixed_latest_query(prefix: &str, prefix_version: &str) -> Option<String> {
+pub(crate) fn prefixed_latest_query(prefix: &str, prefix_version: &str) -> Option<String> {
     let prefix = prefix.trim();
     if prefix.is_empty()
         || prefix_version.is_empty()

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -477,7 +477,7 @@ impl Toolset {
             let tool_dir_name = tv.ba().tool_dir_name();
             tv.install_path = Some(dir.join(tool_dir_name).join(tv.tv_pathname()));
         }
-        let before_date = tv.before_date;
+        let before_date = transitive_dependency_before_date(tr, &tv);
 
         let ctx = InstallContext {
             config: config.clone(),
@@ -633,5 +633,16 @@ fn should_refresh_remote_versions(
         }
         ToolRequest::Sub { orig_version, .. } => orig_version == "latest",
         ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => false,
+    }
+}
+
+fn transitive_dependency_before_date(
+    tr: &ToolRequest,
+    tv: &ToolVersion,
+) -> Option<jiff::Timestamp> {
+    match tr {
+        ToolRequest::Version { version, .. } if version == &tv.version => None,
+        ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => None,
+        _ => tv.before_date,
     }
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -641,7 +641,9 @@ fn transitive_dependency_before_date(
     tv: &ToolVersion,
 ) -> Option<jiff::Timestamp> {
     match tr {
-        ToolRequest::Version { version, .. } if version == &tv.version => None,
+        ToolRequest::Version { version, .. } if version != "latest" && version == &tv.version => {
+            None
+        }
         ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => None,
         _ => tv.before_date,
     }


### PR DESCRIPTION
## Summary
- default `minimum_release_age` to `24h` at runtime for backends that can use release timestamps
- keep `minimum_release_age` optional internally so explicit values keep precedence over deprecated `install_before`
- avoid applying the built-in default to asdf/vfox/plugin-style tools without release timestamps
- warn when newer releases are hidden by the release-age cutoff
- strengthen release-age e2e coverage so opt-out and warning assertions require concrete setup/output

## Tests
- `mise run render:schema`
- `cargo fmt --all -- --check`
- `cargo test install_before`
- `cargo test latest_version_tests`
- `cargo test test_settings_toml_is_sorted`
- `mise run test:e2e e2e/cli/test_lock_env e2e/cli/test_lock_version`
- `MISE_GPG_VERIFY=false mise run test:e2e e2e/cli/test_install_before`
- `MISE_GPG_VERIFY=false mise run test:e2e e2e/backend/test_npm_install_before`
- `mise run lint`

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default version resolution for many backends without explicit config, which can surprise upgrades and CI; behavior is mitigated by `0s`, exclusions, and pinned versions bypassing the filter.
> 
> **Overview**
> **Supply-chain default:** Fuzzy version resolution on timestamp-capable backends (core, aqua, github, npm, pipx, etc.) now applies a built-in **24h** `minimum_release_age` when no global or per-tool value is set. **`minimum_release_age = "0s"`** turns that off. **`minimum_release_age_excludes`** skips both the global setting and this default. Plugin-style backends without release metadata (e.g. asdf) are unchanged.
> 
> **Visibility:** `mise ls-remote` warns how many releases were hidden; **`mise upgrade`** compares date-filtered vs unfiltered latest and warns when a newer release is ignored (e.g. `newer jq release … ignored by minimum_release_age`).
> 
> **Resolution plumbing:** `install_before` is normalized into `minimum_release_age` (explicit `minimum_release_age` wins). `Backend::latest_version_unfiltered` supports upgrade diagnostics. Pinned exact versions no longer forward release-age cutoffs into npm/pipx transitive installs. `VersionInfo` gains shared date-filter helpers.
> 
> **Docs/schema:** Settings and security docs document the 24h default, exclusions, and opt-out; e2e tests cover `0s`, upgrade warnings, and ls-remote warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a10b96ed3a33339eeb8d2ccab3f453b2949aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default 24-hour minimum-release-age: versions released less than 24h are skipped by default.
  * Commands now warn when newer releases are ignored due to the release-age filter and report how many versions are hidden.

* **Documentation**
  * Clarified default = "24h", how to override per-tool/global, that pinned versions bypass the delay, and that "0s" disables it.

* **Tests**
  * Added/updated unit and e2e tests covering release-age behavior and regressions.

* **Refactor**
  * Normalized legacy/alias settings and added backend-specific fallback behavior for the release-age cutoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->