### PR TITLE
registry: add claudeline

### DIFF
--- a/registry/claudeline.toml
+++ b/registry/claudeline.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:lexfrei/claudeline", "github:lexfrei/claudeline"]
+description = "Claude Code statusline with real usage limits from the Anthropic API"
+test = { cmd = "claudeline -v", expected = "claudeline {{version}}" }


### PR DESCRIPTION
Adds [claudeline](https://github.com/lexfrei/claudeline) — a Claude Code statusline that surfaces real usage limits from the Anthropic API.

```toml
backends = ["aqua:lexfrei/claudeline", "github:lexfrei/claudeline"]
```

- Primary backend `aqua:lexfrei/claudeline` is being added in aquaproj/aqua-registry#55083 (resolves once merged); `github:` backend works today as a fallback.
- Upstream ships darwin amd64/arm64 release assets only (Go project via GoReleaser), so installs are macOS-only for now.

Verified locally: `mise x github:lexfrei/claudeline -- claudeline -v` → `claudeline 1.5.0 (…)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Claudeline statusline backend tool.
  * Included configuration and a descriptive note about observed API usage limits.
  * Added a version-check test to verify the Claudeline installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->