### PR TITLE
registry: update aube and pitchfork aqua entries

### DIFF
--- a/registry/aube.toml
+++ b/registry/aube.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:endevco/aube", "github:endevco/aube", "cargo:aube"]
+backends = ["aqua:jdx/aube", "github:jdx/aube", "cargo:aube"]
 description = "A fast Node.js package manager"
 test = { cmd = "aube --version", expected = "{{version}}" }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -35388,8 +35388,10 @@ packages:
       - linux
       - amd64
   - type: github_release
-    repo_owner: endevco
+    repo_owner: jdx
     repo_name: aube
+    aliases:
+      - name: endevco/aube
     description: A fast Node.js package manager
     version_constraint: "false"
     version_overrides:
@@ -35447,6 +35449,35 @@ packages:
           - linux
           - darwin/arm64
           - windows
+      - version_constraint: semver("<= 1.18.1")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
       - version_constraint: "true"
         asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -35477,12 +35508,12 @@ packages:
           - darwin/arm64
           - windows
         github_artifact_attestations:
-          signer_workflow: endevco/aube/\.github/workflows/release\.yml
+          signer_workflow: jdx/aube/\.github/workflows/release\.yml
   - type: github_release
-    repo_owner: endevco
+    repo_owner: jdx
     repo_name: pitchfork
     aliases:
-      - name: jdx/pitchfork
+      - name: endevco/pitchfork
     description: Daemons with DX
     version_constraint: "false"
     version_overrides:


### PR DESCRIPTION
## Summary
- update the aube shorthand to prefer `aqua:jdx/aube` and `github:jdx/aube`
- sync the vendored aqua registry entries for `jdx/aube` and `jdx/pitchfork`
- keep `endevco/aube` and `endevco/pitchfork` aliases for compatibility
- disable GitHub artifact attestations for aube versions `<= 1.18.1`, matching aquaproj/aqua-registry#55084

## Popularity
- aube: 1,381 GitHub stars, 30 forks, latest release v1.18.2 published 2026-06-09
- pitchfork: 497 GitHub stars, 25 forks, latest release v2.13.1 published 2026-06-08

## Testing
- `taplo fmt --check registry/aube.toml`
- `ruby -e 'require "yaml"; YAML.load_file("vendor/aqua-registry/registry.yml", aliases: true); puts "vendor yaml ok"'`\n- `ruby -e 'require "yaml"; data = YAML.load_file("vendor/aqua-registry/registry.yml", aliases: true); pkgs = data.fetch("packages"); %w[aube pitchfork].each { |name| p pkgs.find { |pkg| pkg["repo_owner"] == "jdx" && pkg["repo_name"] == name }.slice("repo_owner", "repo_name", "aliases") }'`\n- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and vendored install metadata only; no runtime or auth changes, with backward-compatible aliases.
> 
> **Overview**
> **Moves aube and pitchfork install metadata from `endevco` to `jdx` as the canonical GitHub owner**, while keeping `endevco/*` aqua aliases so old references still resolve.
> 
> In `registry/aube.toml`, aqua/github backends now point at `jdx/aube`. The vendored aqua registry mirrors upstream: both packages use `repo_owner: jdx`, aliases swap to `endevco/...`, and **aube** gains a `semver("<= 1.18.1")` override (glibc/musl Linux variants, no GitHub artifact attestations). Newer aube releases use attestation signer workflow `jdx/aube/...` instead of `endevco/aube/...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4839c0452bdb56922ce06185398b97ad1d80c504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package registry configuration to reflect backend source changes for the aube tool and related projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->