### PR TITLE
chore(release): vendor aqua registry from main

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -283,12 +283,12 @@ AQUA_REGISTRY_METADATA="$AQUA_REGISTRY_DIR/metadata.json"
 AQUA_REGISTRY_FILE="$AQUA_REGISTRY_DIR/registry.yml"
 AQUA_REGISTRY_REPO="aquaproj/aqua-registry"
 
-# Capture current aqua-registry tag before updating
+# Capture current aqua-registry ref before updating
 OLD_AQUA_REGISTRY_TAG=""
 if [[ -f $AQUA_REGISTRY_METADATA ]]; then
 	OLD_AQUA_REGISTRY_TAG="$(jq -r '.tag // empty' "$AQUA_REGISTRY_METADATA")"
 fi
-NEW_AQUA_REGISTRY_TAG="$(gh release view --repo "$AQUA_REGISTRY_REPO" --json tagName --jq .tagName)"
+NEW_AQUA_REGISTRY_TAG="$(gh api "repos/$AQUA_REGISTRY_REPO/commits/main" --jq .sha)"
 
 rm -rf "$AQUA_REGISTRY_DIR"
 mkdir -p "$AQUA_REGISTRY_DIR"


### PR DESCRIPTION
## Summary
- vendor aqua-registry from the current upstream `main` commit instead of the latest tagged release
- keep writing the resolved commit SHA into `vendor/aqua-registry/metadata.json` as `tag`, so the vendored snapshot remains reproducible and existing build metadata keeps working

## Validation
- `bash -n xtasks/release-plz`
- resolved `aquaproj/aqua-registry` main to `b2116015b48a040543836bbd35f8ca3a3313698e` and confirmed that fetched registry contains `repo_owner: jdx` / `repo_name: aube` with the `endevco/aube` alias

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script-only change; vendoring still pins a specific commit SHA in metadata with no runtime auth or data-path changes.
> 
> **Overview**
> Updates **`xtasks/release-plz`** so the vendored **`aquaproj/aqua-registry`** snapshot tracks upstream **`main`** instead of the latest GitHub release.
> 
> **`NEW_AQUA_REGISTRY_TAG`** is now resolved via **`gh api …/commits/main`** (commit SHA) rather than **`gh release view`**. The same variable still drives **`raw.githubusercontent.com`** fetches and is written to **`vendor/aqua-registry/metadata.json`** as **`tag`**, so prep/release behavior and aqua changelog diffs stay keyed to a fixed ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42eaa6ce0ba5890d02b84f5c24cc46483730af44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->