### PR TITLE
test(aqua): allow commit metadata refs

### DIFF
--- a/src/aqua/standard_registry.rs
+++ b/src/aqua/standard_registry.rs
@@ -72,7 +72,14 @@ mod tests {
             "aquaproj/aqua-registry"
         );
         assert!(!AQUA_STANDARD_REGISTRY_METADATA.tag.is_empty());
-        assert!(AQUA_STANDARD_REGISTRY_METADATA.tag.starts_with('v'));
+        assert!(
+            AQUA_STANDARD_REGISTRY_METADATA.tag.starts_with('v')
+                || AQUA_STANDARD_REGISTRY_METADATA.tag.len() == 40
+                    && AQUA_STANDARD_REGISTRY_METADATA
+                        .tag
+                        .chars()
+                        .all(|c| c.is_ascii_hexdigit())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow baked aqua registry metadata to use either an upstream release tag or a pinned commit SHA
- fixes unit tests after release-plz started vendoring aqua-registry from upstream `main`

## Validation
- `cargo test --all-features aqua::standard_registry::tests::test_baked_registry_metadata`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion change with no runtime or security impact.
> 
> **Overview**
> Updates **`test_baked_registry_metadata`** so the baked aqua registry snapshot is valid when **`AQUA_STANDARD_REGISTRY_METADATA.tag`** is either a **`v…` release tag** or a **40-character hex commit SHA**, not only release tags.
> 
> This keeps unit tests passing when the vendored registry is pinned to an upstream **`main`** commit (e.g. via release-plz) instead of a tagged release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15b7eb34e76f237e7106dc020244e05a01f07d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced registry tag validation in tests to support additional acceptable formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->