### PR TITLE
fix(registry): rename podman gh organization

### DIFF
--- a/registry/podman.toml
+++ b/registry/podman.toml
@@ -1,7 +1,7 @@
 description = "Podman: A tool for managing OCI containers and pods"
 
 [[backends]]
-full = "github:containers/podman"
+full = "github:podman-container-tools/podman"
 
 [[backends]]
 full = "asdf:tvon/asdf-podman"


### PR DESCRIPTION
podman gh org changed names 6/1/26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Podman container tools registry backend configuration to reference the current source repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->