### PR TITLE
chore: release 2026.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [2026.6.3](https://github.com/jdx/mise/compare/v2026.6.2..v2026.6.3) - 2026-06-11
+
+### 🚀 Features
+
+- **(backend)** allow version_expr to post-process version_regex results by @konono in [#10302](https://github.com/jdx/mise/pull/10302)
+- **(config)** automatically define platform environments (auto_env) by @jdx in [#10316](https://github.com/jdx/mise/pull/10316)
+- **(deps)** add support for Deno by @felipecrs in [#10291](https://github.com/jdx/mise/pull/10291)
+- **(github)** add --refresh flag to mint a fresh OAuth token by @jdx in [#10317](https://github.com/jdx/mise/pull/10317)
+
+### 🐛 Bug Fixes
+
+- **(backend)** respect permissive minimum release age by @jdx in [#10310](https://github.com/jdx/mise/pull/10310)
+- **(completions)** require usage 3.5 by @jdx in [#10313](https://github.com/jdx/mise/pull/10313)
+- **(config)** default release age cutoff should not disable installed-version resolution by @jdx in [#10315](https://github.com/jdx/mise/pull/10315)
+- **(lock)** lock idiomatic version file tools by @jdx in [#10309](https://github.com/jdx/mise/pull/10309)
+- **(lock)** disambiguate idiomatic lock target by @jdx in [#10319](https://github.com/jdx/mise/pull/10319)
+- **(python)** honor minimum release age for core versions by @jdx in [#10311](https://github.com/jdx/mise/pull/10311)
+- **(registry)** rename podman gh organization by @TyceHerrman in [#10288](https://github.com/jdx/mise/pull/10288)
+- **(task)** preserve inner quotes for cmd /c tasks and hooks on windows by @JamBalaya56562 in [#10301](https://github.com/jdx/mise/pull/10301)
+- **(task)** resolve templates in included task files by @jdx in [#10312](https://github.com/jdx/mise/pull/10312)
+- retry rename on Windows transient file locks during install by @jhult in [#10300](https://github.com/jdx/mise/pull/10300)
+
+### 📦 Registry
+
+- add imagemagick ([aqua:ImageMagick/ImageMagick](https://github.com/ImageMagick/ImageMagick)) by @thernstig in [#10118](https://github.com/jdx/mise/pull/10118)
+- add vscode-cli (backend:aqua:microsoft/vscode/code) by @felipecrs in [#10314](https://github.com/jdx/mise/pull/10314)
+
+### New Contributors
+
+- @felipecrs made their first contribution in [#10314](https://github.com/jdx/mise/pull/10314)
+- @jhult made their first contribution in [#10300](https://github.com/jdx/mise/pull/10300)
+
+### 📦 Aqua Registry Updates
+
+#### Updated Packages (2)
+
+- [`SonarSource/sonarqube-cli`](https://github.com/SonarSource/sonarqube-cli)
+- [`ubugeeei-prod/vize`](https://github.com/ubugeeei-prod/vize)
+
 ## [2026.6.2](https://github.com/jdx/mise/compare/v2026.6.1..v2026.6.2) - 2026-06-09
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.6.2"
+version = "2026.6.3"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.6.2"
+version = "2026.6.3"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.6.2 macos-arm64 (2026-06-09)
+2026.6.3 macos-arm64 (2026-06-11)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_2.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_3.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_2.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_3.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_2.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_3.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_2.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_3.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.6.2";
+  version = "2026.6.3";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "29.3k",
+      stars: "29.4k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.6.2
+Version: 2026.6.3
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.6.2"
+version: "2026.6.3"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "b2116015b48a040543836bbd35f8ca3a3313698e"
+  "tag": "44a0433752f5dca6bf0fb2fe6c6f6bea58621072"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -7375,12 +7375,22 @@ packages:
           - darwin/arm64
           - linux/amd64
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.14.0.2224")
         url: https://binaries.sonarsource.com/Distribution/sonarqube-cli/{{.Version}}/{{.OS}}/sonarqube-cli-{{.Version}}-{{.OS}}-{{.Arch}}.exe
         format: raw
         replacements:
           darwin: macos
           amd64: x86-64
+      - version_constraint: "true"
+        url: https://binaries.sonarsource.com/Distribution/sonarqube-cli/{{.Version}}/{{.OS}}/sonarqube-cli-{{.Version}}-{{.OS}}-{{.Arch}}.bin
+        format: raw
+        complete_windows_ext: false
+        replacements:
+          darwin: macos
+          amd64: x86-64
+        overrides:
+          - goos: windows
+            url: https://binaries.sonarsource.com/Distribution/sonarqube-cli/{{.Version}}/{{.OS}}/sonarqube-cli-{{.Version}}-{{.OS}}-{{.Arch}}.exe
   - type: github_release
     repo_owner: Songmu
     repo_name: ecschedule
@@ -93621,6 +93631,18 @@ packages:
       - vue
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.106.0")
+        asset: vize-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: vize-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -93633,6 +93655,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.cosign.bundle"
+          opts:
+            - --certificate-identity
+            - https://github.com/ubugeeei-prod/vize/.github/workflows/release.yml@refs/tags/{{.Version}}
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
   - type: github_release
     repo_owner: umlx5h
     repo_name: gtrash


### PR DESCRIPTION
### 🚀 Features

- **(backend)** allow version_expr to post-process version_regex results by @konono in [#10302](https://github.com/jdx/mise/pull/10302)
- **(config)** automatically define platform environments (auto_env) by @jdx in [#10316](https://github.com/jdx/mise/pull/10316)
- **(deps)** add support for Deno by @felipecrs in [#10291](https://github.com/jdx/mise/pull/10291)
- **(github)** add --refresh flag to mint a fresh OAuth token by @jdx in [#10317](https://github.com/jdx/mise/pull/10317)

### 🐛 Bug Fixes

- **(backend)** respect permissive minimum release age by @jdx in [#10310](https://github.com/jdx/mise/pull/10310)
- **(completions)** require usage 3.5 by @jdx in [#10313](https://github.com/jdx/mise/pull/10313)
- **(config)** default release age cutoff should not disable installed-version resolution by @jdx in [#10315](https://github.com/jdx/mise/pull/10315)
- **(lock)** lock idiomatic version file tools by @jdx in [#10309](https://github.com/jdx/mise/pull/10309)
- **(lock)** disambiguate idiomatic lock target by @jdx in [#10319](https://github.com/jdx/mise/pull/10319)
- **(python)** honor minimum release age for core versions by @jdx in [#10311](https://github.com/jdx/mise/pull/10311)
- **(registry)** rename podman gh organization by @TyceHerrman in [#10288](https://github.com/jdx/mise/pull/10288)
- **(task)** preserve inner quotes for cmd /c tasks and hooks on windows by @JamBalaya56562 in [#10301](https://github.com/jdx/mise/pull/10301)
- **(task)** resolve templates in included task files by @jdx in [#10312](https://github.com/jdx/mise/pull/10312)
- retry rename on Windows transient file locks during install by @jhult in [#10300](https://github.com/jdx/mise/pull/10300)

### 📦 Registry

- add imagemagick ([aqua:ImageMagick/ImageMagick](https://github.com/ImageMagick/ImageMagick)) by @thernstig in [#10118](https://github.com/jdx/mise/pull/10118)
- add vscode-cli (backend:aqua:microsoft/vscode/code) by @felipecrs in [#10314](https://github.com/jdx/mise/pull/10314)

### New Contributors

- @felipecrs made their first contribution in [#10314](https://github.com/jdx/mise/pull/10314)
- @jhult made their first contribution in [#10300](https://github.com/jdx/mise/pull/10300)

## 📦 Aqua Registry Updates

### Updated Packages (2)

- [`SonarSource/sonarqube-cli`](https://github.com/SonarSource/sonarqube-cli)
- [`ubugeeei-prod/vize`](https://github.com/ubugeeei-prod/vize)