### PR TITLE
fix(task): preserve inner quotes for cmd /c tasks and hooks on windows

### DIFF
--- a/e2e-win/task_quoting.Tests.ps1
+++ b/e2e-win/task_quoting.Tests.ps1
@@ -1,0 +1,62 @@
+
+Describe 'task inner-quote preservation (cmd /c)' {
+    # Regression tests for https://github.com/jdx/mise/discussions/9355:
+    # on Windows, inner double quotes in a task's `run` string were mangled when
+    # the default `cmd /c` shell was spawned, because the script was passed as an
+    # ordinary std::process::Command argument and re-quoted MSVCRT-style (inner
+    # `"` -> `\"`), which cmd.exe does not understand. The child then saw e.g.
+    # `\"hello world\"` instead of `"hello world"`, or `"import` instead of the
+    # whole `-c` argument. The fix passes the command to cmd verbatim.
+
+    BeforeAll {
+        $originalPath = Get-Location
+        $originalTrustedConfigPaths = $env:MISE_TRUSTED_CONFIG_PATHS
+        Set-Location TestDrive:
+        $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
+
+        @'
+[tasks.echo_quoted]
+run = 'echo "hello world"'
+
+[tasks.echo_doc]
+run = 'echo "My Great Document.typ"'
+
+[tasks.node_inner_quotes]
+run = 'node -e "console.log(2 + 2)"'
+'@ | Out-File -FilePath "mise.toml" -Encoding utf8NoBOM
+    }
+
+    AfterAll {
+        Set-Location $originalPath
+        if ($null -ne $originalTrustedConfigPaths) {
+            $env:MISE_TRUSTED_CONFIG_PATHS = $originalTrustedConfigPaths
+        } else {
+            Remove-Item -Path Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'does not backslash-escape inner double quotes' {
+        # The smoking gun of the bug was a stray backslash reaching the program.
+        $output = mise run echo_quoted | Select-Object -Last 1
+        $output | Should -Not -Match '\\'
+        $output | Should -Be '"hello world"'
+    }
+
+    It 'preserves a quoted filename with spaces (discussion #9355 repro)' {
+        $output = mise run echo_doc | Select-Object -Last 1
+        $output | Should -Not -Match '\\'
+        $output | Should -Be '"My Great Document.typ"'
+    }
+
+    It 'passes an inner-quoted -c argument through as a single argument' {
+        # Mirrors the `python -c "..."` / `node -e "..."` repro: without the fix
+        # the quoted script is split at the first space and the interpreter
+        # fails with a syntax error instead of printing the result.
+        if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because "node not on PATH"
+            return
+        }
+        $output = mise run node_inner_quotes | Select-Object -Last 1
+        $output | Should -Be '4'
+    }
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -474,6 +474,19 @@ impl<'a> CmdLineRunner<'a> {
         self
     }
 
+    /// Append a single argument to the command line *verbatim*, bypassing the
+    /// MSVCRT-style quoting std normally applies on Windows. Required when
+    /// spawning `cmd.exe /c <script>`: cmd does not understand the `\"`
+    /// escaping std would otherwise emit for inner double quotes, so the script
+    /// must reach cmd unquoted. See `TaskExecutor::get_cmd_program_and_args`
+    /// and discussion #9355.
+    #[cfg(windows)]
+    pub fn raw_arg<S: AsRef<OsStr>>(mut self, arg: S) -> Self {
+        use std::os::windows::process::CommandExt;
+        self.cmd.raw_arg(arg);
+        self
+    }
+
     pub fn with_pr(mut self, pr: &'a dyn SingleReport) -> Self {
         self.pr = Some(pr);
         self

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -583,6 +583,47 @@ async fn execute(
     // Prevent recursive hook execution (e.g. hook runs `mise run` which spawns
     // a shell that activates mise and re-triggers hooks)
     env.insert("MISE_NO_HOOKS".to_string(), "1".to_string());
+
+    // On Windows, when the hook shell is cmd.exe, the rendered command must be
+    // passed to cmd *verbatim*. Going through std/duct's MSVCRT-style quoting
+    // would escape inner `"` as `\"`, which cmd.exe does not understand, so a
+    // hook like `python -c "import x"` is mangled. Unlike tasks, hooks have no
+    // `usage`/shebang/file-based escape hatch, so this is the only fix. duct
+    // can't emit raw args, so spawn std Command directly with raw command-line
+    // args (wrapped in one outer quote pair + `/s`), forwarding stdout to stderr
+    // to match the duct path's `stdout_to_stderr()`. See discussion #9355.
+    #[cfg(windows)]
+    {
+        let runs_command = shell
+            .iter()
+            .skip(1)
+            .any(|f| f.eq_ignore_ascii_case("/c") || f.eq_ignore_ascii_case("/k"));
+        if crate::path::is_cmd_shell_program(Path::new(&shell[0])) && runs_command {
+            use std::os::windows::io::AsHandle;
+            use std::os::windows::process::CommandExt;
+            let cmd_args = crate::path::cmd_verbatim_args(&shell[1..], &rendered_script, &[]);
+            trace!("hook (cmd verbatim): {} {}", shell[0], cmd_args.join(" "));
+            let mut c = std::process::Command::new(&shell[0]);
+            for a in &cmd_args {
+                c.raw_arg(a);
+            }
+            c.env_clear();
+            c.envs(env.iter());
+            // Send the hook's stdout to mise's stderr (matching the duct
+            // `stdout_to_stderr()` the non-cmd path uses) by handing the child a
+            // clone of our stderr handle. Redirecting the descriptor directly —
+            // rather than piping through a reader thread — means a hook that
+            // spawns a background child holding the write end can't block us
+            // waiting for pipe EOF, and stdout/stderr ordering is preserved.
+            c.stdout(std::io::stderr().as_handle().try_clone_to_owned()?);
+            let status = c.status()?;
+            if !status.success() {
+                eyre::bail!("hook command failed: {status}");
+            }
+            return Ok(());
+        }
+    }
+
     cmd(&shell[0], args)
         .stdout_to_stderr()
         // .dir(root)

--- a/src/path.rs
+++ b/src/path.rs
@@ -152,6 +152,89 @@ pub fn is_posix_shell_program(program: &Path) -> bool {
     POSIX_SHELLS.iter().any(|name| *name == stem)
 }
 
+/// Returns true if `program` is `cmd` / `cmd.exe`, the Windows command
+/// interpreter. Used on Windows to decide whether an inline task/hook command
+/// must be passed to the shell *verbatim* (via raw command-line args) instead
+/// of through std's MSVCRT-style argument quoting. cmd.exe does not understand
+/// the `\"` escaping std emits for inner double quotes, so that quoting mangles
+/// commands like `python -c "import x"`. See discussion #9355.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub fn is_cmd_shell_program(program: &Path) -> bool {
+    program_stem(program).as_deref() == Some("cmd")
+}
+
+/// Assemble the args (everything after the `cmd.exe` program) for running
+/// `script` — plus any forwarded `args` — through cmd.exe *verbatim*.
+///
+/// Returns the cmd switches from `shell_flags` (with `/s` ensured at the front),
+/// followed by the whole command wrapped in a single outer double-quote pair.
+/// The caller must append these to the command line as *raw* args (e.g.
+/// [`crate::cmd::CmdLineRunner::raw_arg`] / `Command::raw_arg`) so std does not
+/// apply its MSVCRT-style quoting. cmd's `/s` then strips exactly that one outer
+/// pair and runs the remainder untouched, so any inner double quotes in the
+/// command (e.g. `python -c "import x"`) survive to the child. See discussion
+/// #9355.
+///
+/// `script` is emitted exactly as written (it carries the user's own quoting).
+/// Forwarded `args` are separate argv values, so each is MSVCRT-quoted *inside*
+/// the outer pair (cmd passes those inner quotes through untouched) — preserving
+/// the spaces-in-forwarded-args fix from #6744 instead of splitting them.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub fn cmd_verbatim_args(shell_flags: &[String], script: &str, args: &[String]) -> Vec<String> {
+    let mut body = script.to_string();
+    for arg in args {
+        body.push(' ');
+        body.push_str(&quote_arg_for_cmd_body(arg));
+    }
+    let mut out: Vec<String> = Vec::with_capacity(shell_flags.len() + 2);
+    if !shell_flags.iter().any(|f| f.eq_ignore_ascii_case("/s")) {
+        out.push("/s".to_string());
+    }
+    out.extend(shell_flags.iter().cloned());
+    out.push(format!("\"{body}\""));
+    out
+}
+
+/// MSVCRT/`CommandLineToArgvW`-style quoting for a single argument, matching the
+/// rules `std::process::Command` uses on Windows. Used for forwarded args placed
+/// inside [`cmd_verbatim_args`]' outer quote pair so the *child program* (parsed
+/// by the C runtime) sees each as one argument. Quotes when needed: empty, or
+/// containing whitespace, `"`, or a cmd.exe metacharacter (`& | < > ( ) ^`).
+/// The metacharacters matter because, after `cmd /s /c` strips the single outer
+/// quote pair, an unquoted `a&b` would be parsed by cmd as shell syntax rather
+/// than reaching the child as one argv value; double quotes suppress that. (`%`
+/// is intentionally omitted — cmd expands `%VAR%` even inside quotes, so quoting
+/// cannot protect it.) Backslashes are doubled only where they precede a `"`.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub(crate) fn quote_arg_for_cmd_body(arg: &str) -> String {
+    if !arg.is_empty() && !arg.contains([' ', '\t', '"', '&', '|', '<', '>', '(', ')', '^']) {
+        return arg.to_string();
+    }
+    let mut s = String::with_capacity(arg.len() + 2);
+    s.push('"');
+    let mut backslashes = 0usize;
+    for c in arg.chars() {
+        if c == '\\' {
+            backslashes += 1;
+        } else {
+            if c == '"' {
+                // Emit 2n+1 backslashes so the `"` is escaped, not a delimiter.
+                for _ in 0..=backslashes {
+                    s.push('\\');
+                }
+            }
+            backslashes = 0;
+        }
+        s.push(c);
+    }
+    // Double the trailing backslashes so they don't escape the closing quote.
+    for _ in 0..backslashes {
+        s.push('\\');
+    }
+    s.push('"');
+    s
+}
+
 /// Split a configured shell *command string* (program + args) into argv,
 /// honoring host conventions.
 ///
@@ -412,6 +495,88 @@ mod tests {
         assert!(!is_posix_shell_program(Path::new("pwsh.exe")));
         assert!(!is_posix_shell_program(Path::new("rustc")));
         assert!(!is_posix_shell_program(Path::new("")));
+    }
+
+    #[test]
+    fn test_is_cmd_shell_program() {
+        assert!(is_cmd_shell_program(Path::new("cmd")));
+        assert!(is_cmd_shell_program(Path::new("cmd.exe")));
+        assert!(is_cmd_shell_program(Path::new("CMD.EXE")));
+        assert!(is_cmd_shell_program(Path::new(
+            r"C:\Windows\System32\cmd.exe"
+        )));
+
+        assert!(!is_cmd_shell_program(Path::new("bash")));
+        assert!(!is_cmd_shell_program(Path::new("bash.exe")));
+        assert!(!is_cmd_shell_program(Path::new("powershell")));
+        assert!(!is_cmd_shell_program(Path::new("pwsh.exe")));
+        // `cmd.com` is not the modern interpreter we target.
+        assert!(!is_cmd_shell_program(Path::new("cmd.com")));
+        assert!(!is_cmd_shell_program(Path::new("")));
+    }
+
+    #[test]
+    fn test_cmd_verbatim_args() {
+        let c = || "/c".to_string();
+
+        // The reported case: inner double quotes must survive untouched inside
+        // the single outer quote pair, with `/s` ensured. The caller passes
+        // each element as a raw arg, so the resulting command line is
+        // `cmd /s /c "uv run python -c "import x""` — cmd strips only the outer
+        // pair. See discussion #9355.
+        assert_eq!(
+            cmd_verbatim_args(&[c()], r#"uv run python -c "import x""#, &[]),
+            sv(&["/s", "/c", r#""uv run python -c "import x"""#])
+        );
+
+        // No inner quotes — still wrapped, still gets `/s`.
+        assert_eq!(
+            cmd_verbatim_args(&[c()], "echo hi", &[]),
+            sv(&["/s", "/c", r#""echo hi""#])
+        );
+
+        // Forwarded args go inside the same outer quote pair, each MSVCRT-quoted
+        // when it contains spaces so the program still sees them as one argument
+        // (preserving the #6744 spaces-in-args fix). `c` stays bare.
+        assert_eq!(
+            cmd_verbatim_args(&[c()], "proxy", &["a b".to_string(), "c".to_string()]),
+            sv(&["/s", "/c", r#""proxy "a b" c""#])
+        );
+
+        // A forwarded path with a space (mirrors e2e-win/task_args.Tests.ps1):
+        // `type ".\test dir\file.txt"` must reach `type` as a single argument.
+        assert_eq!(
+            cmd_verbatim_args(&[c()], "type", &[r".\test dir\file.txt".to_string()]),
+            sv(&["/s", "/c", r#""type ".\test dir\file.txt"""#])
+        );
+
+        // An explicit `/s` in the shell flags is not duplicated.
+        assert_eq!(
+            cmd_verbatim_args(&["/s".to_string(), c()], "echo hi", &[]),
+            sv(&["/s", "/c", r#""echo hi""#])
+        );
+    }
+
+    #[test]
+    fn test_quote_arg_for_cmd_body() {
+        // No special chars -> returned as-is (no quotes added).
+        assert_eq!(quote_arg_for_cmd_body("plain"), "plain");
+        // Space/tab -> wrapped.
+        assert_eq!(quote_arg_for_cmd_body("a b"), r#""a b""#);
+        // Empty -> quoted empty string.
+        assert_eq!(quote_arg_for_cmd_body(""), r#""""#);
+        // Inner quote -> escaped as \".
+        assert_eq!(quote_arg_for_cmd_body(r#"a"b"#), r#""a\"b""#);
+        // Trailing backslashes are doubled before the closing quote (only when
+        // the arg is quoted because it also contains a space).
+        assert_eq!(quote_arg_for_cmd_body(r"a b\"), r#""a b\\""#);
+        // A backslash not adjacent to a quote is left alone.
+        assert_eq!(quote_arg_for_cmd_body(r"a\b c"), r#""a\b c""#);
+        // cmd metacharacters (no whitespace) are still quoted so cmd does not
+        // interpret them as shell syntax after stripping the outer quote pair.
+        assert_eq!(quote_arg_for_cmd_body("a&b"), r#""a&b""#);
+        assert_eq!(quote_arg_for_cmd_body("foo|bar"), r#""foo|bar""#);
+        assert_eq!(quote_arg_for_cmd_body("a>b"), r#""a>b""#);
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -845,8 +845,10 @@ impl TaskExecutor {
             self.exec_with_text_file_busy_retry(&file, args, task, env, prefix)
                 .await
         } else {
-            let (program, args) = self.get_cmd_program_and_args(script, task, args)?;
-            self.exec_program(&program, &args, task, env, prefix).await
+            let (program, args, cmd_verbatim) =
+                self.get_cmd_program_and_args(script, task, args)?;
+            self.exec_program(&program, &args, task, env, prefix, cmd_verbatim)
+                .await
         }
     }
 
@@ -874,18 +876,40 @@ impl TaskExecutor {
         Ok((shell[0].clone(), full_args[1..].to_vec()))
     }
 
+    /// Build the `(program, args, cmd_verbatim)` for an inline script. When
+    /// `cmd_verbatim` is true (Windows + a `cmd.exe` inline shell), `args` are
+    /// already wrapped for cmd and must be appended to the command line
+    /// verbatim (via `CmdLineRunner::raw_arg`) rather than through std's
+    /// MSVCRT-style quoting — see the windows branch below and discussion #9355.
     fn get_cmd_program_and_args(
         &self,
         script: &str,
         task: &Task,
         args: &[String],
-    ) -> Result<(String, Vec<String>)> {
+    ) -> Result<(String, Vec<String>, bool)> {
         let shell = task.shell()?.unwrap_or(self.clone_default_inline_shell()?);
         trace!("using shell: {}", shell.join(" "));
         let mut full_args = shell.clone();
 
         #[cfg(windows)]
         {
+            // When the inline shell is cmd.exe, hand the script to cmd verbatim
+            // instead of letting std::process::Command apply MSVCRT-style
+            // quoting. std would wrap the script in quotes and escape any inner
+            // `"` as `\"`, but cmd.exe does not understand that escaping, so
+            // commands like `python -c "import x"` get mangled (the child sees
+            // `\"import`). We assemble the whole command into one body, wrap it
+            // in a single outer quote pair, and use `/s` so cmd strips exactly
+            // that pair and runs the rest — inner quotes included — verbatim.
+            // See discussion #9355.
+            let runs_command = shell
+                .iter()
+                .skip(1)
+                .any(|f| f.eq_ignore_ascii_case("/c") || f.eq_ignore_ascii_case("/k"));
+            if crate::path::is_cmd_shell_program(Path::new(&shell[0])) && runs_command {
+                let cmd_args = crate::path::cmd_verbatim_args(&shell[1..], script, args);
+                return Ok((shell[0].clone(), cmd_args, true));
+            }
             full_args.push(script.to_string());
             full_args.extend(args.iter().cloned());
         }
@@ -898,7 +922,7 @@ impl TaskExecutor {
             }
             full_args.push(script);
         }
-        Ok((full_args[0].clone(), full_args[1..].to_vec()))
+        Ok((full_args[0].clone(), full_args[1..].to_vec(), false))
     }
 
     fn clone_default_inline_shell(&self) -> Result<Vec<String>> {
@@ -963,7 +987,8 @@ impl TaskExecutor {
         prefix: &str,
     ) -> Result<()> {
         let (program, args) = self.get_file_program_and_args(file, task, args)?;
-        self.exec_program(&program, &args, task, env, prefix).await
+        self.exec_program(&program, &args, task, env, prefix, false)
+            .await
     }
 
     async fn exec_with_text_file_busy_retry(
@@ -1005,7 +1030,10 @@ impl TaskExecutor {
         task: &Task,
         env: &BTreeMap<String, String>,
         prefix: &str,
+        cmd_verbatim: bool,
     ) -> Result<()> {
+        #[cfg(not(windows))]
+        let _ = cmd_verbatim;
         let config = Config::get().await?;
         let program = program.to_executable();
         let redactions = config.redactions();
@@ -1024,8 +1052,20 @@ impl TaskExecutor {
         #[cfg(windows)]
         let program = resolve_posix_shell_program_path(&program, env).unwrap_or(program);
         let env = maybe_convert_env_for_msys_shell(Path::new(&program), env);
-        let mut cmd = CmdLineRunner::new(program.clone())
-            .args(args)
+        let runner = CmdLineRunner::new(program.clone());
+        // On Windows, `cmd_verbatim` means `args` are already wrapped for cmd.exe
+        // and must be appended to the command line without std's MSVCRT-style
+        // quoting (which would escape inner `"` as `\"` and break the command).
+        // See `get_cmd_program_and_args` and discussion #9355.
+        #[cfg(windows)]
+        let runner = if cmd_verbatim {
+            args.iter().fold(runner, |r, a| r.raw_arg(a))
+        } else {
+            runner.args(args)
+        };
+        #[cfg(not(windows))]
+        let runner = runner.args(args);
+        let mut cmd = runner
             .envs(env.as_ref())
             .redact(redactions.deref().clone())
             .raw(raw)


### PR DESCRIPTION
## Problem

On Windows, inner double quotes in a task's `run` string — and in `[hooks]` commands — are mangled when spawned through the default `cmd /c` shell. Reported in #9355 (originally #6119).

```toml
[tasks.repro]
run = 'uv run --no-project python -c "import pathlib; print(pathlib.Path.home())"'
```

```
DEBUG $ cmd /c uv run --no-project python -c "import pathlib; print(pathlib.Path.home())"
  File "<string>", line 1
    "import
SyntaxError: unterminated string literal
```

The debug line looks correct, but Python receives just `"import`. Likewise `run = 'echo "x"'` prints `\"x\"`. `[hooks]` (`postinstall`, `enter`, `cd`, …) are hit identically, and unlike tasks they have **no** `usage`/shebang/file-based escape hatch.

## Root cause

mise builds the argv `["cmd", "/c", <script>, …]` and passes the script as an ordinary `std::process::Command` argument. On Windows, std serializes argv into `lpCommandLine` using MSVCRT/`CommandLineToArgvW`-style quoting (it wraps the script in quotes and escapes inner `"` as `\"`). `cmd.exe` does **not** parse that convention — it treats `\"` literally — so the child receives mangled arguments. No `raw_arg` was used anywhere in the tree.

## Fix

When the inline/hook shell is `cmd.exe`, build the command line **verbatim** via raw command-line args:

- The whole command is wrapped in a single outer quote pair and run as `cmd /s /c "<body>"`. `/s` strips exactly that one outer pair and leaves the remainder — including the user's inner quotes — untouched.
- Forwarded args are MSVCRT-quoted **inside** the outer pair so the program still sees them as separate arguments, preserving the spaces-in-args fix from #6744 (e.g. `mise run type ".\test dir\file.txt"`).
- `[hooks]` spawn through duct, which can't emit raw args, so the cmd case now spawns a `std::process::Command` directly and forwards stdout to stderr to match the previous `stdout_to_stderr()` behavior.
- Non-cmd shells (`pwsh -Command`, `bash -c`, …) are gated out via `is_cmd_shell_program` and keep the existing behavior.

New helpers live in `src/path.rs` (`is_cmd_shell_program`, `cmd_verbatim_args`, `quote_arg_for_cmd_body`) so the other call sites can reuse them later.

## Scope / follow-ups

- This PR fixes **inline tasks** and **`[hooks]`** (the two paths reported in #9355).
- The same root cause also affects `watch_files`, `deps`, `{{ exec() }}`, `mise exec -c`, and backend scripts. Those can reuse `cmd_verbatim_args` in a follow-up.
- The separate `shell = "bash -c"` `$0`-shift issue noted in the discussion is left for a follow-up.

## Testing

- Unit tests for `is_cmd_shell_program`, `cmd_verbatim_args`, and `quote_arg_for_cmd_body` (covering the MSVCRT quoting edge cases and the `type ".\test dir\file.txt"` case from `e2e-win/task_args.Tests.ps1`). I verified this pure string logic locally.
- New `e2e-win/task_quoting.Tests.ps1`: asserts inner quotes survive (no `\` mangling) and that an inner-quoted `-c` argument reaches the program as a single argument.
- Heads-up: my local environment couldn't compile the full crate (a C-dependency toolchain limitation) and can't compile the `#[cfg(windows)]` branches at all, so I'm **relying on CI** for the Windows build, clippy, and the `e2e-win` run.

Refs #9355, #6119.

---
*This pull request was prepared with the help of an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows task and hook execution so inline commands run via cmd preserve inner double quotes and don’t produce stray backslashes, improving reliability of quoted arguments.

* **Tests**
  * Added a Windows end-to-end test that validates quoted-string preservation across task runs (skips if Node is unavailable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->