### PR TITLE
feat(backend): allow version_expr to post-process version_regex results

### DIFF
--- a/registry/oc.toml
+++ b/registry/oc.toml
@@ -9,6 +9,7 @@ full = "http:oc"
 bin = "oc"
 version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
 version_regex = 'href="(\d+\.\d+\.\d+)/"'
+version_expr = 'sortVersions(versions)'
 
 [backends.options.platforms.linux-x64]
 url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-linux-{{ version }}.tar.gz"

--- a/registry/oc.toml
+++ b/registry/oc.toml
@@ -7,9 +7,9 @@ full = "http:oc"
 
 [backends.options]
 bin = "oc"
+version_expr = 'sortVersions(versions)'
 version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
 version_regex = 'href="(\d+\.\d+\.\d+)/"'
-version_expr = 'sortVersions(versions)'
 
 [backends.options.platforms.linux-x64]
 url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-client-linux-{{ version }}.tar.gz"

--- a/registry/openshift-install.toml
+++ b/registry/openshift-install.toml
@@ -7,9 +7,9 @@ full = "http:openshift-install"
 
 [backends.options]
 bin = "openshift-install"
+version_expr = 'sortVersions(versions)'
 version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
 version_regex = 'href="(\d+\.\d+\.\d+)/"'
-version_expr = 'sortVersions(versions)'
 
 [backends.options.platforms.linux-x64]
 url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-install-linux-{{ version }}.tar.gz"

--- a/registry/openshift-install.toml
+++ b/registry/openshift-install.toml
@@ -9,6 +9,7 @@ full = "http:openshift-install"
 bin = "openshift-install"
 version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
 version_regex = 'href="(\d+\.\d+\.\d+)/"'
+version_expr = 'sortVersions(versions)'
 
 [backends.options.platforms.linux-x64]
 url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/openshift-install-linux-{{ version }}.tar.gz"

--- a/src/backend/version_list.rs
+++ b/src/backend/version_list.rs
@@ -114,9 +114,10 @@ pub fn parse_version_list(
 
     // DO NOT sort versions here - the backend/upstream determines version order.
     // Sorting is handled elsewhere (e.g., versions host, resolve logic).
-    // If a version_expr is provided, use it to post-process the extracted versions
-    // (e.g. sortVersions). When no other extraction method produced results,
-    // the expr operates on `body` alone (the original behavior).
+    // When a registry entry needs explicit sorting, it can use version_expr
+    // (e.g. sortVersions) to post-process the extracted versions.
+    // When no other extraction method produced results, the expr operates on
+    // `body` alone (the original behavior).
     if let Some(expr_str) = version_expr {
         versions = eval_version_expr(expr_str, trimmed, &versions)?;
     }
@@ -125,19 +126,17 @@ pub fn parse_version_list(
 }
 
 /// Evaluate a version expression using expr-lang.
-/// When `versions` is non-empty, it is injected as a `versions` variable
-/// so the expression can post-process previously extracted version lists.
+/// The previously extracted version list is always injected as a `versions`
+/// variable so the expression can post-process it (e.g. sortVersions).
 fn eval_version_expr(expr_str: &str, body: &str, versions: &[String]) -> Result<Vec<String>> {
     use versions::Versioning;
 
     let mut ctx = Context::default();
     ctx.insert("body".to_string(), Value::String(body.to_string()));
-    if !versions.is_empty() {
-        ctx.insert(
-            "versions".to_string(),
-            Value::Array(versions.iter().map(|v| Value::String(v.clone())).collect()),
-        );
-    }
+    ctx.insert(
+        "versions".to_string(),
+        Value::Array(versions.iter().map(|v| Value::String(v.clone())).collect()),
+    );
 
     // expr-lang 1.0+ has built-in fromJSON, keys, values, len, toJSON functions
     let mut env = Environment::new();

--- a/src/backend/version_list.rs
+++ b/src/backend/version_list.rs
@@ -52,14 +52,9 @@ pub fn parse_version_list(
     let mut versions = Vec::new();
     let trimmed = content.trim();
 
-    // If an expr is provided, use it to evaluate and extract versions
-    // Fail hard if the expression is invalid - don't silently fall through
-    if let Some(expr_str) = version_expr {
-        versions = eval_version_expr(expr_str, trimmed)?;
-    }
     // If a JSON path is provided (like ".[].version" or ".versions"), try to use it
     // but fall back to text parsing if JSON parsing fails
-    else if let Some(json_path) = version_json_path {
+    if let Some(json_path) = version_json_path {
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed)
             && let Ok(extracted) = jq::extract(&json, json_path)
         {
@@ -119,16 +114,30 @@ pub fn parse_version_list(
 
     // DO NOT sort versions here - the backend/upstream determines version order.
     // Sorting is handled elsewhere (e.g., versions host, resolve logic).
+    // If a version_expr is provided, use it to post-process the extracted versions
+    // (e.g. sortVersions). When no other extraction method produced results,
+    // the expr operates on `body` alone (the original behavior).
+    if let Some(expr_str) = version_expr {
+        versions = eval_version_expr(expr_str, trimmed, &versions)?;
+    }
 
     Ok(versions)
 }
 
-/// Evaluate a version expression using expr-lang
-fn eval_version_expr(expr_str: &str, body: &str) -> Result<Vec<String>> {
+/// Evaluate a version expression using expr-lang.
+/// When `versions` is non-empty, it is injected as a `versions` variable
+/// so the expression can post-process previously extracted version lists.
+fn eval_version_expr(expr_str: &str, body: &str, versions: &[String]) -> Result<Vec<String>> {
     use versions::Versioning;
 
     let mut ctx = Context::default();
     ctx.insert("body".to_string(), Value::String(body.to_string()));
+    if !versions.is_empty() {
+        ctx.insert(
+            "versions".to_string(),
+            Value::Array(versions.iter().map(|v| Value::String(v.clone())).collect()),
+        );
+    }
 
     // expr-lang 1.0+ has built-in fromJSON, keys, values, len, toJSON functions
     let mut env = Environment::new();
@@ -409,5 +418,19 @@ mod tests {
         )
         .unwrap();
         assert_eq!(versions, vec!["1.0.0", "1.1.0", "1.2.0-rc1"]);
+    }
+
+    #[test]
+    fn test_parse_with_regex_and_version_expr_pipeline() {
+        let content =
+            r#"<a href="4.9.9/">4.9.9</a><a href="4.21.3/">4.21.3</a><a href="4.10.1/">4.10.1</a>"#;
+        let versions = parse_version_list(
+            content,
+            Some(r#"href="(\d+\.\d+\.\d+)/""#),
+            None,
+            Some("sortVersions(versions)"),
+        )
+        .unwrap();
+        assert_eq!(versions, vec!["4.9.9", "4.10.1", "4.21.3"]);
     }
 }


### PR DESCRIPTION
  ## Summary

  - Allow `version_expr` and `version_regex` to work together as a pipeline: regex extracts versions, then expr post-processes them (e.g. sorting)
  - Previously these were mutually exclusive in an `if/else if` chain (#7723). This PR allows combining them, but if there was a reason for keeping them separate, happy to take a different approach.
  - Fix `oc` and `openshift-install` version sorting by adding `sortVersions(versions)` to their registry entries

  ## Motivation

  The upstream HTML directory at `mirror.openshift.com` lists versions lexicographically. `find_match_in_list` returns the last element assuming ascending order, so `latest` resolves to `4.9.9` instead of `4.22.0`.

  A registry-side fix was the only option because:
  - These tools are distributed via `mirror.openshift.com`, not GitHub Releases, so switching to `aqua:` or `github:` is not possible
  - `version_expr` alone can't extract from HTML — expr-lang has no regex capture function, and `version_regex` / `version_expr` were mutually exclusive

  ## Changes

  - `src/backend/version_list.rs`: Move `version_expr` evaluation to run after extraction. When both `version_regex` and `version_expr` are specified, the regex results are passed as a `versions` variable into the expr context. When
  `version_expr` is used alone, it operates on `body` as before. No existing registry entries combine the two, so this is a no-op for all current tools.
  - `registry/oc.toml`, `registry/openshift-install.toml`: Add `version_expr = 'sortVersions(versions)'`

  ## Test plan

  - [x] `cargo test backend::version_list` — 24 tests pass (including new pipeline test)
  - [x] `mise ls-remote oc` returns versions in ascending semantic order
  - [x] `mise latest oc` resolves to `4.22.0` (not `4.9.9`)

  ### Before (current release)
```
  $ mise ls-remote oc | tail -5
  4.9.59
  4.9.6
  4.9.7
  4.9.8
  4.9.9

  $ mise latest oc
  4.9.9
```

  ### After (this PR)
```
  $ target/debug/mise ls-remote oc | tail -5
  4.21.16
  4.21.17
  4.21.18
  4.21.19
  4.22.0

  $ target/debug/mise latest oc
  4.22.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * oc client now applies explicit sorting when selecting available versions.
  * OpenShift installer now applies explicit sorting when selecting installer versions.
  * Version-processing pipeline can apply configurable post-processing expressions to extracted version lists.
* **Tests**
  * Added unit coverage for version extraction plus post-processing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->