### PR TITLE
feat(task): add os/arch-specific task overrides via [tasks.name.<platform>]

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -37,17 +37,52 @@ run = "echo hello"
 run = ["echo hello"]
 ```
 
-### `run_windows`
+### Platform-specific overrides
 
-- **Type**: `string | (string | { task: string, args?: string[], env?: { [key]: string } } | { tasks: string[] })[]`
+You can define OS-specific or platform-specific variants of `run` and `shell` using
+dot-syntax sub-tables. If a matching platform override exists it takes precedence;
+the base `run` value is the fallback for all unmatched platforms.
 
-Windows-specific variant of `run` supporting the same structured syntax:
+**Platform keys**: `linux`, `macos`, `windows`, or `<os>/<arch>` (e.g. `linux/x64`,
+`linux/arm64`, `macos/x64`, `macos/arm64`, `windows/x64`, `windows/arm64`).
+Task platform matching uses the host OS/architecture, not `MISE_OS`/`MISE_ARCH`
+overrides used for tool binary selection.
+
+**Matching order** (most specific wins, evaluated independently for `run` and
+`shell`):
+
+1. `<os>/<arch>` — exact platform (e.g. `linux/x64`)
+2. `<os>` — all architectures on that OS (e.g. `linux`, `macos`)
+3. Base `run` — everything else
 
 ```mise-toml
 [tasks.build]
 run = "cargo build"
-run_windows = "cargo build --features windows"
+
+[tasks.build.linux]
+run = "cargo build --release"
+
+[tasks.build."linux/x64"]
+run = "cargo build --target x86_64-unknown-linux-gnu"
+
+[tasks.build.windows]
+run = "cargo build --features windows"
+shell = "pwsh -Command"
 ```
+
+All other task fields (`description`, `depends`, `env`, `dir`, etc.) are inherited
+from the base task definition. Platform subtables only support `run` and `shell`;
+put run entries under the subtable's `run` key.
+
+If `shell` is omitted, inline tasks use [`unix_default_inline_shell_args`](/configuration/settings.html#unix_default_inline_shell_args)
+by default. Windows-specific tasks use [`windows_default_inline_shell_args`](/configuration/settings.html#windows_default_inline_shell_args)
+when selected.
+
+For file-backed tasks, a selected platform-specific `run` overrides the `file`
+execution on that platform.
+
+> **Deprecated**: `run_windows` is still supported for backward compatibility
+> but is equivalent to `[tasks.<name>.windows]`. Prefer the new platform-specific syntax.
 
 ### `description`
 

--- a/docs/tasks/templates.md
+++ b/docs/tasks/templates.md
@@ -53,18 +53,20 @@ Templates use colon (`:`) separators for namespacing, similar to task naming con
 
 When a task extends a template, fields are merged according to these rules:
 
-| Field                                   | Behavior                                                    |
-| --------------------------------------- | ----------------------------------------------------------- |
-| `run`, `run_windows`                    | Local overrides completely                                  |
-| `tools`                                 | Deep merge (local tools added/override template)            |
-| `env`                                   | Deep merge (local env added/override template)              |
-| `depends`, `depends_post`, `wait_for`   | Local overrides completely (not merged)                     |
-| `dir`                                   | Local overrides; defaults to config_root if not in template |
-| `sources`, `outputs`                    | Local overrides completely                                  |
-| Sandbox deny fields                     | Compose with task-local settings                            |
-| Sandbox allow fields                    | Template and task-local values are combined                 |
-| `description`, `shell`, `timeout`, etc. | Local overrides template (if set)                           |
-| `quiet`, `hide`, `raw`                  | Not carried over (must be set explicitly in task)           |
+| Field                                   | Behavior                                                         |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| `run`                                   | Local overrides completely                                       |
+| Platform overrides                      | Merged per `run`/`shell` field; local platform fields take precedence |
+| `tools`                                 | Deep merge (local tools added/override template)                 |
+| `env`                                   | Deep merge (local env added/override template)                   |
+| `depends`, `depends_post`, `wait_for`   | Local overrides completely (not merged)                          |
+| `dir`                                   | Local overrides; defaults to config_root if not in template      |
+| `sources`, `outputs`                    | Local overrides completely                                       |
+| Sandbox deny fields                     | Compose with task-local settings                                 |
+| Sandbox allow fields                    | Template and task-local values are combined                      |
+| `description`, `shell`, `timeout`, etc. | Local overrides template (if set)                                |
+| `raw_args`, `interactive`               | Template `true` carries over                                     |
+| `quiet`, `hide`, `raw`                  | Not carried over (must be set explicitly in task)                |
 
 ### Example: Deep Merge for Tools
 

--- a/docs/tasks/toml-tasks.md
+++ b/docs/tasks/toml-tasks.md
@@ -108,13 +108,21 @@ run = [
 ]
 ```
 
-You can specify an alternate command to run on Windows by using the `run_windows` key:
+You can define platform-specific run commands using dot-syntax sub-tables:
 
 ```mise-toml
 [tasks.test]
 run = 'cargo test'
-run_windows = 'cargo test --features windows'
+
+[tasks.test.linux]
+run = 'cargo test --target x86_64-unknown-linux-gnu'
+
+[tasks.test.windows]
+run = 'cargo test --features windows'
 ```
+
+For each platform-specific field, the most specific match wins: `<os>/<arch>` → `<os>` → base.
+See [Platform-specific overrides](/tasks/task-configuration.html#platform-specific-overrides) for details.
 
 ### Specifying which directory to use
 

--- a/e2e/tasks/test_task_platform
+++ b/e2e/tasks/test_task_platform
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+
+# Default task (all platforms)
+cat <<EOF >mise.toml
+[tasks.hello]
+run = "echo default"
+[tasks.hello.linux]
+run = "echo linux"
+[tasks.hello."linux/x64"]
+run = "echo linux-x64"
+[tasks.hello.macos]
+run = "echo macos"
+[tasks.hello.windows]
+run = "echo windows"
+EOF
+
+# On linux/x64, the most specific match should win
+if [[ "$(uname -s)" == "Linux" ]]; then
+  if [[ "$(uname -m)" == "x86_64" ]]; then
+    assert "mise run hello" "linux-x64"
+  elif [[ "$(uname -m)" == "aarch64" ]]; then
+    assert "mise run hello" "linux"
+  fi
+elif [[ "$(uname -s)" == "Darwin" ]]; then
+  if [[ "$(uname -m)" == "x86_64" ]]; then
+    assert "mise run hello" "macos"
+  elif [[ "$(uname -m)" == "arm64" ]]; then
+    assert "mise run hello" "macos"
+  fi
+fi
+
+# Test that unknown platform keys cause a helpful error
+cat <<EOF >mise.toml
+[tasks.test]
+run = "echo default"
+[tasks.test.notaplatform]
+run = "echo bad"
+EOF
+
+assert_fail "mise run test" "unknown field"
+
+# Test that unsupported extra keys in a platform table are rejected
+cat <<EOF >mise.toml
+[tasks.extra]
+run = "echo default"
+[tasks.extra.linux]
+run = "echo linux"
+env.FOO = "bar"
+EOF
+
+assert_fail "mise run extra" "unknown field"
+
+# Test run_windows backward compat still works (on non-windows, uses run)
+cat <<EOF >mise.toml
+[tasks.legacy]
+run = "echo default"
+run_windows = "echo windows-legacy"
+EOF
+
+# On non-windows, should use the default run
+if [[ "$(uname -s)" != "MINGW"* ]] && [[ "$(uname -s)" != "MSYS"* ]] && [[ "$(uname -s)" != "CYGWIN"* ]]; then
+  assert "mise run legacy" "default"
+fi
+
+# Test that platform task only overrides run, not other fields like description
+cat <<EOF >mise.toml
+[tasks.partial]
+run = "echo default"
+description = "A task"
+[tasks.partial.linux]
+run = "echo linux-only"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert "mise run partial" "linux-only"
+fi
+assert_contains "mise tasks ls --json" "A task"
+
+# Test platform-specific shell override
+cat <<'EOF' >mise.toml
+[tasks.shell-default]
+run = 'echo default shell'
+
+[tasks.shell-default.linux]
+shell = "bash -c"
+run = 'echo $0'
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise run shell-default" "bash"
+fi
+
+# Test platform-specific shell supports templates
+cat <<'EOF' >mise.toml
+[tasks.templated-platform-shell]
+run = "echo default"
+
+[tasks.templated-platform-shell.linux]
+shell = "bash {{ '-c' }}"
+run = 'echo $0'
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise run templated-platform-shell" "bash"
+fi
+
+# Test MISE_OS is for tool binary selection, not task runtime platform selection
+cat <<EOF >mise.toml
+[tasks.mise_os_ignored]
+run = "echo default"
+
+[tasks.mise_os_ignored.windows]
+run = "echo windows"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert "MISE_OS=windows mise run mise_os_ignored" "default"
+fi
+
+# Test platform run/shell fallback is field-specific
+if [[ "$(uname -s)" == "Linux" ]]; then
+  case "$(uname -m)" in
+  x86_64) platform_key="linux/x64" ;;
+  aarch64 | arm64) platform_key="linux/arm64" ;;
+  *) platform_key="" ;;
+  esac
+
+  if [[ -n "$platform_key" ]]; then
+    cat <<EOF >mise.toml
+[tasks.field_run_fallback]
+run = "echo base"
+
+[tasks.field_run_fallback.linux]
+run = "echo linux-run"
+
+[tasks.field_run_fallback."$platform_key"]
+shell = "bash -c"
+
+[tasks.field_shell_fallback]
+run = "echo base"
+
+[tasks.field_shell_fallback.linux]
+shell = "bash -c"
+
+[tasks.field_shell_fallback."$platform_key"]
+run = 'echo \$0'
+EOF
+
+    assert "mise run field_run_fallback" "linux-run"
+    assert_contains "mise run field_shell_fallback" "bash"
+  fi
+fi
+
+# Test platform run overrides file-backed execution
+cat <<'SCRIPT' >file-task.sh
+echo file-task
+SCRIPT
+cat <<EOF >mise.toml
+[tasks.file_platform]
+file = "file-task.sh"
+
+[tasks.file_platform.linux]
+run = "echo platform-run"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert "mise run file_platform" "platform-run"
+fi
+
+# Test platform overrides with array and structured run entries
+cat <<EOF >mise.toml
+[tasks.child]
+run = "echo child"
+
+[tasks.platform_array]
+run = "echo default"
+[tasks.platform_array.linux]
+run = ["echo a", "echo b"]
+
+[tasks.platform_structured]
+run = "echo default"
+[tasks.platform_structured.linux]
+run = { task = "child" }
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise run platform_array" "a"
+  assert_contains "mise run platform_array" "b"
+  assert "mise run platform_structured" "child"
+fi
+
+# Test structured platform run tables reject unsupported fields
+cat <<EOF >mise.toml
+[tasks.child]
+run = "echo child"
+
+[tasks.parent]
+run = "echo default"
+[tasks.parent.linux]
+task = "child"
+dir = "subdir"
+EOF
+
+assert_fail "mise run parent" "unknown field"
+
+# Test direct platform values are rejected; platform subtables only support run/shell
+cat <<EOF >mise.toml
+[tasks.direct_platform]
+run = "echo default"
+linux = "echo direct"
+EOF
+
+assert_fail "mise run direct_platform" "platform override must be a table"
+
+# Test that an explicit empty platform run array overrides the base task
+cat <<EOF >mise.toml
+[tasks.empty]
+run = "echo default"
+[tasks.empty.linux]
+run = []
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_empty "mise run empty"
+fi
+
+# Test that tasks without platform overrides still work as before
+cat <<EOF >mise.toml
+tasks.simple = "echo simple"
+EOF
+
+assert "mise run simple" "simple"

--- a/e2e/tasks/test_task_templates
+++ b/e2e/tasks/test_task_templates
@@ -31,6 +31,47 @@ EOF
 # Basic template extension should work
 assert "mise run build" "building python"
 
+# Test platform-specific template run override is inherited
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."python:build"]
+run = "echo template build"
+
+[task_templates."python:build".linux]
+run = "echo linux template build"
+
+[tasks.build]
+extends = "python:build"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert "mise run build" "linux template build"
+else
+  assert "mise run build" "template build"
+fi
+
+# Test platform-specific template fields merge independently
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."python:build".linux]
+run = 'echo $0'
+shell = "sh -c"
+
+[tasks.build]
+extends = "python:build"
+
+[tasks.build.linux]
+shell = "bash -c"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise run build" "bash"
+fi
+
 # Test local override of run command
 cat <<'EOF' >mise.toml
 [settings]
@@ -46,6 +87,103 @@ run = "echo local build"
 EOF
 
 assert "mise run build" "local build"
+
+# Test local platform override wins over template run_windows on Linux
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."python:build"]
+run = "echo template build"
+run_windows = "echo template windows build"
+
+[tasks.build]
+extends = "python:build"
+
+[tasks.build.linux]
+run = "echo local-linux"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert "mise run build" "local-linux"
+fi
+
+# Test task-local run_windows wins over template Windows platform override
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."python:build"]
+run = "echo template build"
+
+[task_templates."python:build".windows]
+run = "echo template windows build"
+
+[tasks.build]
+extends = "python:build"
+run_windows = "echo local windows build"
+EOF
+
+if [[ "$(uname -s)" == "MINGW"* ]] || [[ "$(uname -s)" == "MSYS"* ]] || [[ "$(uname -s)" == "CYGWIN"* ]]; then
+  assert "mise run build" "local windows build"
+fi
+
+# Test task-local base run suppresses template platform run but preserves platform shell
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."python:build".linux]
+run = "echo template platform build"
+shell = "bash -c"
+
+[tasks.build]
+extends = "python:build"
+run = 'echo $0'
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise run build" "bash"
+  assert_not_contains "mise run build" "template platform build"
+fi
+
+# Test task-local base shell overrides template platform shell
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."python:build".linux]
+shell = "sh -c"
+
+[tasks.build]
+extends = "python:build"
+run = 'echo $0'
+shell = "bash -c"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise run build" "bash"
+fi
+
+# Test task-local run overrides a platform-specific template run on Linux
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."python:build"]
+run = "echo template build"
+
+[task_templates."python:build".linux]
+run = "echo linux template build"
+
+[tasks.build]
+extends = "python:build"
+run = "echo local build"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert "mise run build" "local build"
+fi
 
 # Test tools deep merge
 cat <<'EOF' >mise.toml
@@ -180,5 +318,19 @@ extends = "rust:cargo:build"
 EOF
 
 assert "mise run build" "cargo build"
+
+# Test invalid platform key in a task template fails with unknown field
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."python:build"]
+run = "echo build"
+
+[task_templates."python:build".linxu]
+run = "echo bad"
+EOF
+
+assert_fail "mise run build" "unknown field"
 
 echo '' >mise.toml

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -11,6 +11,19 @@ EOF
 
 assert_contains "mise tasks validate" "✓ All 2 task(s) validated successfully"
 
+# Test that a platform override with empty run does not trigger no-execution on Linux
+cat <<EOF >mise.toml
+[tasks.default]
+run = "echo default"
+
+[tasks.default.linux]
+run = []
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_not_contains "mise tasks validate 2>&1 || true" "no-execution"
+fi
+
 # Test circular dependency detection
 cat <<EOF >mise.toml
 [tasks.a]
@@ -136,6 +149,58 @@ assert_contains "mise tasks validate --json 2>&1 || true" '"tasks_validated": 2'
 assert_contains "mise tasks validate --json 2>&1 || true" '"errors": 1'
 assert_contains "mise tasks validate --json 2>&1 || true" '"category": "missing-dependency"'
 
+# Test non-current platform run references are validated
+cat <<EOF >mise.toml
+[tasks.helper]
+run = "echo helper"
+
+[tasks.foo]
+run = "echo foo"
+
+[tasks.foo.windows]
+run = { task = "missing-task" }
+EOF
+
+assert_contains "mise tasks validate 2>&1 || true" "missing-task"
+assert_contains "mise tasks validate 2>&1 || true" "missing-task-reference"
+
+# Test current shell absolute paths are validated
+cat <<EOF >mise.toml
+[tasks.bad-shell]
+run = "echo bad"
+shell = "/definitely/not/mise-shell -c"
+EOF
+
+assert_contains "mise tasks validate 2>&1 || true" "invalid-shell"
+assert_contains "mise tasks validate 2>&1 || true" "Shell command not found"
+
+# Test non-current platform shell paths are syntax-checked but not required locally
+cat <<EOF >mise.toml
+[tasks.platform-shell]
+run = "echo ok"
+
+[tasks.platform-shell.macos]
+shell = "/definitely/not/macos-shell -c"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise tasks validate" "✓ All 1 task(s) validated successfully"
+fi
+
+# Test a selected platform shell suppresses base-shell path validation
+cat <<EOF >mise.toml
+[tasks.platform-shell-override]
+run = "echo ok"
+shell = "/definitely/not/base-shell -c"
+
+[tasks.platform-shell-override.linux]
+shell = "bash -c"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise tasks validate" "✓ All 1 task(s) validated successfully"
+fi
+
 # Test errors-only flag
 cat <<EOF >mise.toml
 [tasks.error-task]
@@ -178,6 +243,8 @@ EOF
 
 assert_contains "mise tasks validate filetask" "✓ All 1 task(s) validated successfully"
 
+rm -rf mise-tasks
+
 # Test missing file
 cat <<EOF >mise.toml
 [tasks.missing-file]
@@ -187,8 +254,21 @@ EOF
 assert_contains "mise tasks validate 2>&1 || true" "Task file not found"
 assert_contains "mise tasks validate 2>&1 || true" "missing-file"
 
+# Test selected platform run suppresses file validation on that platform
+cat <<EOF >mise.toml
+[tasks.file-platform-override]
+file = "./does-not-exist.sh"
+
+[tasks.file-platform-override.linux]
+run = "echo platform"
+EOF
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise tasks validate" "✓ All 1 task(s) validated successfully"
+fi
+
 # Clean up before next test
-rm -rf mise-tasks non-executable.sh
+rm -f non-executable.sh
 
 # Test that run entries can reference tasks by alias (not just by name)
 cat <<'EOF' >mise.toml

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -36,6 +36,11 @@
               }
             }
           ],
+          "patternProperties": {
+            "^(linux|macos|windows)(/(x64|arm64))?$": {
+              "$ref": "#/$defs/task_platform_override"
+            }
+          },
           "unevaluatedProperties": false,
           "type": "object"
         }
@@ -239,30 +244,10 @@
           "type": "boolean"
         },
         "run": {
-          "oneOf": [
-            {
-              "$ref": "#/$defs/task_run_entry"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/task_run_entry"
-              }
-            }
-          ]
+          "$ref": "#/$defs/task_run"
         },
         "run_windows": {
-          "oneOf": [
-            {
-              "$ref": "#/$defs/task_run_entry"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/task_run_entry"
-              }
-            }
-          ]
+          "$ref": "#/$defs/task_run"
         },
         "file": {
           "description": "Execute an external script",
@@ -351,6 +336,20 @@
         }
       },
       "type": "object"
+    },
+    "task_platform_override": {
+      "description": "platform-specific task run and shell override",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "run": {
+          "$ref": "#/$defs/task_run"
+        },
+        "shell": {
+          "description": "platform-specific shell command to run the script with",
+          "type": "string"
+        }
+      }
     },
     "env": {
       "additionalProperties": {
@@ -661,6 +660,55 @@
         "type": "string"
       }
     },
+    "task_run": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/task_run_entry"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/task_run_entry"
+          }
+        }
+      ]
+    },
+    "task_dependency_item": {
+      "description": "task name and args",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "task": {
+              "type": "string"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["task"],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
     "task_run_entry": {
       "oneOf": [
         {
@@ -706,42 +754,6 @@
             }
           },
           "required": ["tasks"]
-        }
-      ]
-    },
-    "task_dependency_item": {
-      "description": "task name and args",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "task": {
-              "type": "string"
-            },
-            "args": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "env": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          },
-          "required": ["task"],
-          "unevaluatedProperties": false
         }
       ]
     },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1859,6 +1859,33 @@
         }
       ]
     },
+    "task_run": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/task_run_entry"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/task_run_entry"
+          }
+        }
+      ]
+    },
+    "task_platform_override": {
+      "description": "platform-specific task run and shell override",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "run": {
+          "$ref": "#/$defs/task_run"
+        },
+        "shell": {
+          "description": "platform-specific shell command to run the script with",
+          "type": "string"
+        }
+      }
+    },
     "task": {
       "oneOf": [
         {
@@ -1887,6 +1914,11 @@
               }
             }
           ],
+          "patternProperties": {
+            "^(linux|macos|windows)(/(x64|arm64))?$": {
+              "$ref": "#/$defs/task_platform_override"
+            }
+          },
           "unevaluatedProperties": false,
           "type": "object"
         }
@@ -2513,30 +2545,10 @@
           "type": "boolean"
         },
         "run": {
-          "oneOf": [
-            {
-              "$ref": "#/$defs/task_run_entry"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/task_run_entry"
-              }
-            }
-          ]
+          "$ref": "#/$defs/task_run"
         },
         "run_windows": {
-          "oneOf": [
-            {
-              "$ref": "#/$defs/task_run_entry"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/task_run_entry"
-              }
-            }
-          ]
+          "$ref": "#/$defs/task_run"
         },
         "file": {
           "description": "Execute an external script",
@@ -2633,6 +2645,11 @@
           "$ref": "#/$defs/task_props"
         }
       ],
+      "patternProperties": {
+        "^(linux|macos|windows)(/(x64|arm64))?$": {
+          "$ref": "#/$defs/task_platform_override"
+        }
+      },
       "unevaluatedProperties": false,
       "type": "object"
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -791,7 +791,8 @@ impl Run {
     fn validate_task(&self, task: &Task) -> Result<()> {
         use crate::file;
         use crate::ui;
-        if let Some(path) = &task.file
+        if task.selected_platform_run().is_none()
+            && let Some(path) = &task.file
             && path.exists()
             && !file::is_executable(path)
         {

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -387,6 +387,12 @@ impl TasksValidate {
     fn validate_file_existence(&self, task: &Task) -> Vec<ValidationIssue> {
         let mut issues = Vec::new();
 
+        // A current-platform `run` override replaces file-backed execution, so
+        // the file is not required for this platform.
+        if task.selected_platform_run().is_some() {
+            return issues;
+        }
+
         if let Some(ref file) = task.file {
             if !file.exists() {
                 issues.push(ValidationIssue {
@@ -465,11 +471,55 @@ impl TasksValidate {
     fn validate_shell(&self, task: &Task) -> Vec<ValidationIssue> {
         let mut issues = Vec::new();
 
-        if let Some(ref shell) = task.shell {
-            // Parse shell command (could be "bash -c" or just "bash")
-            let shell_parts: Vec<&str> = shell.split_whitespace().collect();
-            if let Some(shell_cmd) = shell_parts.first() {
-                // Check if it's an absolute path
+        let settings = crate::config::settings::Settings::get();
+        let os = settings.host_os();
+        let arch = settings.host_arch();
+        let platform_key = format!("{}/{}", os, arch);
+        let selected_platform_shell = if task
+            .platform_tasks
+            .get(&platform_key)
+            .and_then(|platform| platform.shell.as_ref())
+            .is_some()
+        {
+            Some(platform_key.as_str())
+        } else if task
+            .platform_tasks
+            .get(os)
+            .and_then(|platform| platform.shell.as_ref())
+            .is_some()
+        {
+            Some(os)
+        } else {
+            None
+        };
+
+        let mut validate = |shell: &str, details: Option<String>, check_exists: bool| {
+            let shell_parts = match crate::path::split_shell_command(shell) {
+                Ok(shell_parts) => shell_parts,
+                Err(err) => {
+                    issues.push(ValidationIssue {
+                        task: task.name.clone(),
+                        severity: Severity::Error,
+                        category: "invalid-shell".to_string(),
+                        message: format!("Invalid shell command: {}", shell),
+                        details: details.or_else(|| Some(err.to_string())),
+                    });
+                    return;
+                }
+            };
+
+            let Some(shell_cmd) = shell_parts.first().filter(|cmd| !cmd.trim().is_empty()) else {
+                issues.push(ValidationIssue {
+                    task: task.name.clone(),
+                    severity: Severity::Error,
+                    category: "invalid-shell".to_string(),
+                    message: format!("Invalid shell command: {}", shell),
+                    details,
+                });
+                return;
+            };
+
+            if check_exists {
                 let shell_path = PathBuf::from(shell_cmd);
                 if shell_path.is_absolute() && !shell_path.exists() {
                     issues.push(ValidationIssue {
@@ -477,9 +527,22 @@ impl TasksValidate {
                         severity: Severity::Error,
                         category: "invalid-shell".to_string(),
                         message: format!("Shell command not found: {}", shell_cmd),
-                        details: Some(format!("Full shell: {}", shell)),
+                        details: details.or_else(|| Some(format!("Full shell: {}", shell))),
                     });
                 }
+            }
+        };
+
+        if let Some(ref shell) = task.shell {
+            validate(shell, None, selected_platform_shell.is_none());
+        }
+        for (platform, platform_override) in &task.platform_tasks {
+            if let Some(shell) = &platform_override.shell {
+                validate(
+                    shell,
+                    Some(format!("Platform: {platform}, full shell: {shell}")),
+                    selected_platform_shell == Some(platform.as_str()),
+                );
             }
         }
 
@@ -541,57 +604,83 @@ impl TasksValidate {
     ) -> Vec<ValidationIssue> {
         let mut issues = Vec::new();
 
-        // Validate run entries
-        for entry in task.run() {
-            match entry {
-                crate::task::RunEntry::Script(script) => {
-                    // Check if script is empty
-                    if script.trim().is_empty() {
-                        issues.push(ValidationIssue {
-                            task: task.name.clone(),
-                            severity: Severity::Warning,
-                            category: "empty-script".to_string(),
-                            message: "Task contains empty script entry".to_string(),
-                            details: None,
-                        });
+        let mut validate_entries = |entries: &[crate::task::RunEntry], details: Option<&str>| {
+            for entry in entries {
+                match entry {
+                    crate::task::RunEntry::Script(script) => {
+                        // Check if script is empty
+                        if script.trim().is_empty() {
+                            issues.push(ValidationIssue {
+                                task: task.name.clone(),
+                                severity: Severity::Warning,
+                                category: "empty-script".to_string(),
+                                message: "Task contains empty script entry".to_string(),
+                                details: details.map(str::to_string),
+                            });
+                        }
                     }
-                }
-                crate::task::RunEntry::SingleTask {
-                    task: task_name, ..
-                } => {
-                    // Strip inline arguments before checking existence, matching runtime behavior
-                    let (name, _) = crate::task::task_list::split_task_spec(task_name);
-                    if !Self::task_exists(all_tasks, name) {
-                        issues.push(ValidationIssue {
-                            task: task.name.clone(),
-                            severity: Severity::Error,
-                            category: "missing-task-reference".to_string(),
-                            message: format!("Task '{}' referenced in run entry not found", name),
-                            details: None,
-                        });
-                    }
-                }
-                crate::task::RunEntry::TaskGroup { tasks } => {
-                    // Strip inline arguments before checking existence, matching runtime behavior
-                    for task_name in tasks {
+                    crate::task::RunEntry::SingleTask {
+                        task: task_name, ..
+                    } => {
+                        // Strip inline arguments before checking existence, matching runtime behavior
                         let (name, _) = crate::task::task_list::split_task_spec(task_name);
                         if !Self::task_exists(all_tasks, name) {
                             issues.push(ValidationIssue {
                                 task: task.name.clone(),
                                 severity: Severity::Error,
                                 category: "missing-task-reference".to_string(),
-                                message: format!("Task '{}' in task group not found", name),
-                                details: Some("Referenced in parallel task group".to_string()),
+                                message: format!(
+                                    "Task '{}' referenced in run entry not found",
+                                    name
+                                ),
+                                details: details.map(str::to_string),
                             });
                         }
                     }
+                    crate::task::RunEntry::TaskGroup { tasks } => {
+                        // Strip inline arguments before checking existence, matching runtime behavior
+                        for task_name in tasks {
+                            let (name, _) = crate::task::task_list::split_task_spec(task_name);
+                            if !Self::task_exists(all_tasks, name) {
+                                issues.push(ValidationIssue {
+                                    task: task.name.clone(),
+                                    severity: Severity::Error,
+                                    category: "missing-task-reference".to_string(),
+                                    message: format!("Task '{}' in task group not found", name),
+                                    details: Some(
+                                        details
+                                            .map(|d| {
+                                                format!("{d}; referenced in parallel task group")
+                                            })
+                                            .unwrap_or_else(|| {
+                                                "Referenced in parallel task group".to_string()
+                                            }),
+                                    ),
+                                });
+                            }
+                        }
+                    }
                 }
+            }
+        };
+
+        validate_entries(&task.run, None);
+        validate_entries(&task.run_windows, Some("run_windows"));
+        for (platform, platform_override) in &task.platform_tasks {
+            if let Some(run) = &platform_override.run {
+                validate_entries(run, Some(&format!("platform {platform}")));
             }
         }
 
         // Check if task has no run entries and no file
         // Allow tasks with dependencies but no run entries (meta/group tasks)
-        if task.run().is_empty()
+        let has_declared_run = !task.run.is_empty()
+            || !task.run_windows.is_empty()
+            || task
+                .platform_tasks
+                .values()
+                .any(|platform| platform.run.is_some());
+        if !has_declared_run
             && task.file.is_none()
             && task.depends.is_empty()
             && task.depends_post.is_empty()

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -30,7 +30,7 @@ use crate::hooks::{Hook, HookDef, Hooks};
 use crate::oci::OciConfig;
 use crate::redactions::Redactions;
 use crate::registry::REGISTRY;
-use crate::task::{Task, TaskTemplate};
+use crate::task::{RunEntry, Task, TaskPlatformOverride, TaskTemplate};
 use crate::tera::{BASE_CONTEXT, contains_template_syntax, get_tera, render_str};
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource, ToolVersionOptions};
 use crate::watch_files::WatchFile;
@@ -1722,6 +1722,94 @@ impl<'de> de::Deserialize<'de> for MiseTomlTool {
     }
 }
 
+/// Parse a platform subtable with `run`/`shell` keys into a platform override.
+fn parse_platform_override(val: &toml::Value) -> eyre::Result<TaskPlatformOverride> {
+    #[derive(Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct PlatformOverride {
+        #[serde(default, deserialize_with = "deserialize_arr")]
+        run: Vec<RunEntry>,
+        #[serde(default)]
+        shell: Option<String>,
+    }
+
+    if let toml::Value::Table(t) = val {
+        if let Some(extra) = t
+            .keys()
+            .find(|key| !matches!(key.as_str(), "run" | "shell"))
+        {
+            return Err(eyre!("unknown field `{extra}`, expected `run` or `shell`"));
+        }
+        let platform: PlatformOverride = val
+            .clone()
+            .try_into()
+            .wrap_err("failed to deserialize platform override")?;
+        return Ok(TaskPlatformOverride {
+            run: t.contains_key("run").then_some(platform.run),
+            shell: platform.shell,
+        });
+    }
+
+    Err(eyre!(
+        "platform override must be a table with `run` and/or `shell`"
+    ))
+}
+
+fn split_platform_tasks(
+    table: toml::Table,
+) -> eyre::Result<(toml::Table, BTreeMap<String, TaskPlatformOverride>)> {
+    let mut platform_tasks = BTreeMap::new();
+    let mut task_table = toml::Table::new();
+    for (key, value) in table {
+        if crate::task::is_platform_key(&key) {
+            let platform = parse_platform_override(&value)?;
+            platform_tasks.insert(key, platform);
+        } else {
+            task_table.insert(key, value);
+        }
+    }
+    Ok((task_table, platform_tasks))
+}
+
+fn is_task_template_key(key: &str) -> bool {
+    matches!(
+        key,
+        "allow_env"
+            | "allow_net"
+            | "allow_read"
+            | "allow_write"
+            | "alias"
+            | "confirm"
+            | "deny_all"
+            | "deny_env"
+            | "deny_net"
+            | "deny_read"
+            | "deny_write"
+            | "depends"
+            | "depends_post"
+            | "description"
+            | "dir"
+            | "env"
+            | "file"
+            | "hide"
+            | "interactive"
+            | "outputs"
+            | "quiet"
+            | "raw"
+            | "raw_args"
+            | "run"
+            | "run_windows"
+            | "shell"
+            | "silent"
+            | "sources"
+            | "timeout"
+            | "tools"
+            | "usage"
+            | "vars"
+            | "wait_for"
+    )
+}
+
 impl<'de> de::Deserialize<'de> for Tasks {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
@@ -1776,14 +1864,26 @@ impl<'de> de::Deserialize<'de> for Tasks {
                                 }))
                             }
 
-                            fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+                            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
                             where
                                 M: de::MapAccess<'de>,
                             {
-                                let t = de::Deserialize::deserialize(
-                                    de::value::MapAccessDeserializer::new(map),
-                                )?;
-                                Ok(TaskDef(t))
+                                let mut table = toml::Table::new();
+                                while let Some(key) = map.next_key::<String>()? {
+                                    let value = map.next_value::<toml::Value>()?;
+                                    table.insert(key, value);
+                                }
+
+                                let (task_table, platform_tasks) =
+                                    split_platform_tasks(table).map_err(de::Error::custom)?;
+
+                                let task_str =
+                                    toml::to_string(&task_table).map_err(de::Error::custom)?;
+                                let mut task: Task =
+                                    toml::from_str(&task_str).map_err(de::Error::custom)?;
+                                task.platform_tasks = platform_tasks;
+
+                                Ok(TaskDef(task))
                             }
                         }
                         deserializer.deserialize_any(TaskDefVisitor)
@@ -1822,7 +1922,27 @@ impl<'de> de::Deserialize<'de> for TaskTemplates {
             {
                 let mut templates = IndexMap::new();
                 while let Some(name) = map.next_key::<String>()? {
-                    let template: TaskTemplate = map.next_value()?;
+                    let value = map.next_value::<toml::Value>()?;
+                    let template: TaskTemplate = match value {
+                        toml::Value::Table(table) => {
+                            let (template_table, platform_tasks) =
+                                split_platform_tasks(table).map_err(de::Error::custom)?;
+                            if let Some(unknown) =
+                                template_table.keys().find(|key| !is_task_template_key(key))
+                            {
+                                return Err(de::Error::custom(format!(
+                                    "unknown field `{unknown}`"
+                                )));
+                            }
+                            let template_str =
+                                toml::to_string(&template_table).map_err(de::Error::custom)?;
+                            let mut template: TaskTemplate =
+                                toml::from_str(&template_str).map_err(de::Error::custom)?;
+                            template.platform_tasks = platform_tasks;
+                            template
+                        }
+                        value => value.try_into().map_err(de::Error::custom)?,
+                    };
                     templates.insert(name, template);
                 }
                 Ok(TaskTemplates(templates))

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -733,7 +733,11 @@ impl Settings {
     }
 
     pub fn default_inline_shell(&self) -> Result<Vec<String>> {
-        let sa = if cfg!(windows) {
+        self.default_inline_shell_for_os(self.host_os())
+    }
+
+    pub fn default_inline_shell_for_os(&self, os: &str) -> Result<Vec<String>> {
+        let sa = if os == "windows" {
             &self.windows_default_inline_shell_args
         } else {
             &self.unix_default_inline_shell_args
@@ -742,7 +746,11 @@ impl Settings {
     }
 
     pub fn default_file_shell(&self) -> Result<Vec<String>> {
-        let sa = if cfg!(windows) {
+        self.default_file_shell_for_os(self.host_os())
+    }
+
+    pub fn default_file_shell_for_os(&self, os: &str) -> Result<Vec<String>> {
+        let sa = if os == "windows" {
             &self.windows_default_file_shell_args
         } else {
             &self.unix_default_file_shell_args
@@ -751,20 +759,19 @@ impl Settings {
     }
 
     pub fn os(&self) -> &str {
-        match self.os.as_deref().unwrap_or(OS) {
-            "darwin" | "macos" => "macos",
-            "linux" => "linux",
-            "windows" => "windows",
-            other => other,
-        }
+        normalize_os(self.os.as_deref().unwrap_or(OS))
     }
 
     pub fn arch(&self) -> &str {
-        match self.arch.as_deref().unwrap_or(ARCH) {
-            "x86_64" | "amd64" => "x64",
-            "aarch64" | "arm64" => "arm64",
-            other => other,
-        }
+        normalize_arch(self.arch.as_deref().unwrap_or(ARCH))
+    }
+
+    pub fn host_os(&self) -> &'static str {
+        normalize_os(OS)
+    }
+
+    pub fn host_arch(&self) -> &'static str {
+        normalize_arch(ARCH)
     }
 
     pub fn libc(&self) -> Option<&str> {
@@ -806,6 +813,23 @@ impl Settings {
                     .iter()
                     .take_while(|a| *a != "--")
                     .any(|a| a == "--no-hooks")
+    }
+}
+
+fn normalize_os(os: &str) -> &str {
+    match os {
+        "darwin" | "macos" => "macos",
+        "linux" => "linux",
+        "windows" => "windows",
+        other => other,
+    }
+}
+
+fn normalize_arch(arch: &str) -> &str {
+    match arch {
+        "x86_64" | "amd64" => "x64",
+        "aarch64" | "arm64" => "arm64",
+        other => other,
     }
 }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -112,7 +112,7 @@ impl TaskToolValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum RunEntry {
     /// Shell script entry
     Script(String),
@@ -126,6 +126,12 @@ pub enum RunEntry {
     },
     /// Run multiple tasks in parallel
     TaskGroup { tasks: Vec<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TaskPlatformOverride {
+    pub run: Option<Vec<RunEntry>>,
+    pub shell: Option<String>,
 }
 
 impl std::hash::Hash for RunEntry {
@@ -347,6 +353,19 @@ impl Display for RunEntry {
     }
 }
 
+/// Valid platform spec patterns: `linux`, `macos`, `windows`, `linux/x64`, etc.
+pub fn is_platform_key(key: &str) -> bool {
+    let valid_os = ["linux", "macos", "windows"];
+    if valid_os.contains(&key) {
+        return true;
+    }
+    if let Some((os, arch)) = key.split_once('/') {
+        let valid_arch = ["x64", "arm64"];
+        return valid_os.contains(&os) && valid_arch.contains(&arch);
+    }
+    false
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Task {
@@ -432,6 +451,11 @@ pub struct Task {
 
     #[serde(default, deserialize_with = "deserialize_arr")]
     pub run_windows: Vec<RunEntry>,
+
+    /// Resolved platform-specific task overrides, populated post-deserialization.
+    /// Key: platform spec ("linux", "macos", "windows", "linux/x64", etc.)
+    #[serde(skip)]
+    pub platform_tasks: BTreeMap<String, TaskPlatformOverride>,
 
     // command type
     // pub command: Option<String>,
@@ -773,12 +797,46 @@ impl Task {
         format!("[{}]", console::truncate_str(&inner, max_width, "…"))
     }
 
-    pub fn run(&self) -> &Vec<RunEntry> {
-        if cfg!(windows) && !self.run_windows.is_empty() {
-            &self.run_windows
-        } else {
-            &self.run
+    fn selected_platform_value<'a, T>(
+        &'a self,
+        get: impl Fn(&'a TaskPlatformOverride) -> Option<&'a T>,
+    ) -> Option<&'a T> {
+        let settings = crate::config::settings::Settings::get();
+        let os = settings.host_os();
+        let arch = settings.host_arch();
+
+        // 1. Platform-specific: <os>/<arch> (most specific)
+        let key = format!("{}/{}", os, arch);
+        if let Some(value) = self.platform_tasks.get(&key).and_then(&get) {
+            return Some(value);
         }
+
+        // 2. OS-level: <os> (applies to all arches)
+        self.platform_tasks.get(os).and_then(get)
+    }
+
+    pub fn selected_platform_run(&self) -> Option<&Vec<RunEntry>> {
+        self.selected_platform_value(|platform| platform.run.as_ref())
+    }
+
+    fn selected_platform_shell(&self) -> Option<&String> {
+        self.selected_platform_value(|platform| platform.shell.as_ref())
+    }
+
+    pub fn run(&self) -> &Vec<RunEntry> {
+        if let Some(run_entries) = self.selected_platform_run() {
+            return run_entries;
+        }
+
+        // Legacy run_windows (backward compat)
+        if crate::config::settings::Settings::get().host_os() == "windows"
+            && !self.run_windows.is_empty()
+        {
+            return &self.run_windows;
+        }
+
+        // Default
+        &self.run
     }
 
     /// Returns only the script strings from the run entries (without rendering)
@@ -959,7 +1017,9 @@ impl Task {
         env: &EnvMap,
         extra_vars: Option<IndexMap<String, String>>,
     ) -> Result<(usage::Spec, Vec<String>)> {
-        let (mut spec, scripts) = if let Some(file) = self.file_path(config).await? {
+        let (mut spec, scripts) = if self.selected_platform_run().is_none()
+            && let Some(file) = self.file_path(config).await?
+        {
             let spec = usage::Spec::parse_script(&file)
                 .inspect_err(|e| {
                     warn!(
@@ -994,7 +1054,9 @@ impl Task {
     /// Parse usage spec for display purposes without expensive environment rendering
     pub async fn parse_usage_spec_for_display(&self, config: &Arc<Config>) -> Result<usage::Spec> {
         let dir = self.dir(config).await?;
-        let mut spec = if let Some(file) = self.file_path(config).await? {
+        let mut spec = if self.selected_platform_run().is_none()
+            && let Some(file) = self.file_path(config).await?
+        {
             usage::Spec::parse_script(&file)
                 .inspect_err(|e| {
                     warn!(
@@ -1239,7 +1301,8 @@ impl Task {
     }
 
     pub fn shell(&self) -> eyre::Result<Option<Vec<String>>> {
-        let Some(shell) = self.shell.as_ref() else {
+        let shell = self.selected_platform_shell().or(self.shell.as_ref());
+        let Some(shell) = shell else {
             return Ok(None);
         };
         // A malformed explicit shell (e.g. an unbalanced quote in a path with
@@ -1317,6 +1380,7 @@ impl Task {
         self.depends.extend(other.depends);
         self.depends_post.extend(other.depends_post);
         self.wait_for.extend(other.wait_for);
+        self.platform_tasks.extend(other.platform_tasks);
         if other.dir.is_some() {
             self.dir = other.dir;
         }
@@ -1413,6 +1477,12 @@ impl Task {
                 .shell
                 .as_ref()
                 .is_some_and(|s| contains_template_syntax(s))
+            || self.platform_tasks.values().any(|platform| {
+                platform
+                    .shell
+                    .as_ref()
+                    .is_some_and(|s| contains_template_syntax(s))
+            })
             || self.allow_read.iter().any(|p| path_contains_template(p))
             || self.allow_write.iter().any(|p| path_contains_template(p))
             || tools_have_template
@@ -1495,6 +1565,13 @@ impl Task {
             && contains_template_syntax(shell)
         {
             *shell = render_str(&mut tera, shell, &tera_ctx)?;
+        }
+        for platform in self.platform_tasks.values_mut() {
+            if let Some(shell) = &mut platform.shell
+                && contains_template_syntax(shell)
+            {
+                *shell = render_str(&mut tera, shell, &tera_ctx)?;
+            }
         }
         let mut render_sandbox_paths = |paths: &mut Vec<PathBuf>| -> Result<()> {
             let mut rendered = Vec::with_capacity(paths.len());
@@ -1891,6 +1968,7 @@ impl Default for Task {
             depends_raw: None,
             depends_post_raw: None,
             wait_for_raw: None,
+            platform_tasks: BTreeMap::new(),
         }
     }
 }
@@ -2254,12 +2332,13 @@ pub async fn parse_usage_values_from_task(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
     use std::sync::Mutex;
 
-    use crate::task::Task;
+    use crate::task::{Task, TaskPlatformOverride};
     use crate::{config::Config, dirs};
     use pretty_assertions::assert_eq;
 
@@ -2333,6 +2412,29 @@ mod tests {
 
         assert_eq!(task.allow_read, vec![crate::env::HOME.join("read")]);
         assert_eq!(task.allow_write, vec![crate::env::HOME.join("write")]);
+    }
+
+    #[tokio::test]
+    async fn test_render_platform_shell() {
+        let config = Config::get().await.unwrap();
+        let mut task = Task {
+            platform_tasks: BTreeMap::from([(
+                "linux".to_string(),
+                TaskPlatformOverride {
+                    run: None,
+                    shell: Some("{{ env.HOME }}/bin/bash -c".to_string()),
+                },
+            )]),
+            ..Default::default()
+        };
+
+        task.render(&config, Path::new(".")).await.unwrap();
+
+        let expected = format!("{}/bin/bash -c", crate::env::HOME.display());
+        assert_eq!(
+            task.platform_tasks["linux"].shell.as_deref(),
+            Some(expected.as_str())
+        );
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -400,7 +400,9 @@ impl TaskExecutor {
 
         let timer = std::time::Instant::now();
 
-        if let Some(file) = task.file_path(config).await? {
+        if task.selected_platform_run().is_none()
+            && let Some(file) = task.file_path(config).await?
+        {
             let exec_start = std::time::Instant::now();
             self.exec_file(config, &file, task, &env, &prefix, extra_vars)
                 .await?;
@@ -857,11 +859,14 @@ impl TaskExecutor {
         args: &[String],
     ) -> Result<(String, Vec<String>)> {
         let display = file.display().to_string();
-        if !Settings::get().use_file_shell_for_executable_tasks && can_execute_directly(file) {
+        let explicit_shell = task.shell()?;
+        if explicit_shell.is_none()
+            && !Settings::get().use_file_shell_for_executable_tasks
+            && can_execute_directly(file)
+        {
             return Ok((display, args.to_vec()));
         }
-        let shell = task
-            .shell()?
+        let shell = explicit_shell
             .or_else(|| shell_from_shebang(file))
             .or_else(|| shell_from_extension(file))
             .unwrap_or(Settings::get().default_file_shell()?);

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -1,9 +1,12 @@
 use crate::config::config_file::mise_toml::EnvList;
 use crate::config::config_file::toml::deserialize_arr;
 use crate::task::task_sources::TaskOutputs;
-use crate::task::{RunEntry, Silent, Task, TaskConfirm, TaskDep, TaskToolValue};
+use crate::task::{
+    RunEntry, Silent, Task, TaskConfirm, TaskDep, TaskPlatformOverride, TaskToolValue,
+};
 use indexmap::IndexMap;
 use serde::Deserialize;
+use std::collections::BTreeMap;
 
 /// A task template definition that can be extended by tasks via `extends`
 /// Templates are defined in [task_templates.*] sections of mise.toml
@@ -32,6 +35,10 @@ pub struct TaskTemplate {
     #[serde(default)]
     pub raw: Option<bool>,
     #[serde(default)]
+    pub raw_args: Option<bool>,
+    #[serde(default)]
+    pub interactive: Option<bool>,
+    #[serde(default)]
     pub sources: Vec<String>,
     #[serde(default)]
     pub outputs: TaskOutputs,
@@ -51,6 +58,8 @@ pub struct TaskTemplate {
     pub run: Vec<RunEntry>,
     #[serde(default, deserialize_with = "deserialize_arr")]
     pub run_windows: Vec<RunEntry>,
+    #[serde(skip)]
+    pub platform_tasks: BTreeMap<String, TaskPlatformOverride>,
     #[serde(default)]
     pub file: Option<String>,
     /// Block reads, writes, network, and env vars
@@ -82,12 +91,24 @@ pub struct TaskTemplate {
     pub allow_env: Vec<String>,
 }
 
+fn platform_key_covers(local_key: &str, template_key: &str) -> bool {
+    if local_key == template_key {
+        return true;
+    }
+    if !local_key.contains('/') {
+        return template_key
+            .strip_prefix(local_key)
+            .is_some_and(|rest| rest.starts_with('/'));
+    }
+    false
+}
+
 impl Task {
     /// Merge a template into this task, using template values only where the task
     /// doesn't already have values set. This allows tasks to override template values.
     ///
     /// Merge semantics:
-    /// - run, run_windows: Local overrides completely (if non-empty)
+    /// - run, run_windows, platform override fields: Local overrides where set
     /// - tools: Deep merge (local tools added/override template)
     /// - env: Deep merge (template first, then local overrides)
     /// - vars: Deep merge (template first, then local overrides)
@@ -96,15 +117,80 @@ impl Task {
     /// - sources, outputs: Local overrides completely (if non-empty)
     /// - Other fields: Local overrides template (if set)
     pub fn merge_template(&mut self, template: &TaskTemplate) {
+        let has_local_run = !self.run.is_empty();
+        let has_local_shell = self.shell.is_some();
+
         // run: only use template if local is empty
-        if self.run.is_empty() {
+        if !has_local_run {
             self.run = template.run.clone();
         }
 
-        // run_windows: only use template if local is empty
-        if self.run_windows.is_empty() {
+        let local_run_windows = !self.run_windows.is_empty();
+        let local_platform_tasks = self.platform_tasks.clone();
+
+        // run_windows: only use template if local run/run_windows/windows platform run overrides are empty
+        if !has_local_run
+            && !local_run_windows
+            && !local_platform_tasks.iter().any(|(key, platform)| {
+                platform.run.is_some() && platform_key_covers(key, "windows")
+            })
+        {
             self.run_windows = template.run_windows.clone();
         }
+
+        // platform_tasks: merge per field. A local base `run` suppresses all
+        // template platform runs, but not template platform shells. A local
+        // platform `run` only overrides covered template `run` fields; a local
+        // `shell` only overrides covered template `shell` fields. Legacy local
+        // run_windows also overrides template Windows platform runs, but not
+        // template Windows shells.
+        let mut platform_tasks = BTreeMap::new();
+
+        for (template_key, template_platform) in &template.platform_tasks {
+            let local_run_covers =
+                local_platform_tasks
+                    .iter()
+                    .any(|(local_key, local_platform)| {
+                        local_platform.run.is_some() && platform_key_covers(local_key, template_key)
+                    });
+            let local_shell_covers =
+                local_platform_tasks
+                    .iter()
+                    .any(|(local_key, local_platform)| {
+                        local_platform.shell.is_some()
+                            && platform_key_covers(local_key, template_key)
+                    });
+
+            let run = if has_local_run
+                || local_run_covers
+                || (local_run_windows && platform_key_covers("windows", template_key))
+            {
+                None
+            } else {
+                template_platform.run.clone()
+            };
+            let shell = if has_local_shell || local_shell_covers {
+                None
+            } else {
+                template_platform.shell.clone()
+            };
+
+            if run.is_some() || shell.is_some() {
+                platform_tasks.insert(template_key.clone(), TaskPlatformOverride { run, shell });
+            }
+        }
+
+        for (local_key, local_platform) in local_platform_tasks {
+            let platform = platform_tasks.entry(local_key).or_default();
+            if local_platform.run.is_some() {
+                platform.run = local_platform.run;
+            }
+            if local_platform.shell.is_some() {
+                platform.shell = local_platform.shell;
+            }
+        }
+
+        self.platform_tasks = platform_tasks;
 
         // tools: deep merge (template first, then local overrides)
         let mut merged_tools = template.tools.clone();
@@ -178,6 +264,13 @@ impl Task {
         // Therefore, we do NOT merge these boolean fields from templates to avoid the case
         // where a task explicitly sets `quiet = false` but gets overridden by a template's
         // `quiet = true`. Users must explicitly set these in their task if needed.
+
+        if template.raw_args == Some(true) {
+            self.raw_args = true;
+        }
+        if template.interactive == Some(true) {
+            self.interactive = true;
+        }
 
         // silent: use template only if local is Off (Silent is an enum, so we can distinguish)
         if matches!(self.silent, Silent::Off)
@@ -253,6 +346,194 @@ mod tests {
         // Template run should be used when local is empty
         assert_eq!(task.run.len(), 1);
         assert!(matches!(&task.run[0], RunEntry::Script(s) if s == "template command"));
+    }
+
+    #[test]
+    fn test_merge_template_platform_overrides_per_key() {
+        let mut task = Task {
+            platform_tasks: BTreeMap::from([(
+                "linux".to_string(),
+                TaskPlatformOverride {
+                    run: Some(vec![RunEntry::Script("local linux".to_string())]),
+                    shell: None,
+                },
+            )]),
+            ..Default::default()
+        };
+        let template = TaskTemplate {
+            platform_tasks: BTreeMap::from([
+                (
+                    "linux".to_string(),
+                    TaskPlatformOverride {
+                        run: Some(vec![RunEntry::Script("template linux".to_string())]),
+                        shell: None,
+                    },
+                ),
+                (
+                    "windows".to_string(),
+                    TaskPlatformOverride {
+                        run: Some(vec![RunEntry::Script("template windows".to_string())]),
+                        shell: None,
+                    },
+                ),
+            ]),
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert!(matches!(
+            &task.platform_tasks["linux"].run.as_ref().unwrap()[0],
+            RunEntry::Script(s) if s == "local linux"
+        ));
+        assert!(matches!(
+            &task.platform_tasks["windows"].run.as_ref().unwrap()[0],
+            RunEntry::Script(s) if s == "template windows"
+        ));
+    }
+
+    #[test]
+    fn test_merge_template_platform_overrides_per_field() {
+        let mut task = Task {
+            platform_tasks: BTreeMap::from([(
+                "linux".to_string(),
+                TaskPlatformOverride {
+                    run: None,
+                    shell: Some("bash -c".to_string()),
+                },
+            )]),
+            ..Default::default()
+        };
+        let template = TaskTemplate {
+            platform_tasks: BTreeMap::from([(
+                "linux".to_string(),
+                TaskPlatformOverride {
+                    run: Some(vec![RunEntry::Script("template linux".to_string())]),
+                    shell: Some("sh -c".to_string()),
+                },
+            )]),
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        let linux = &task.platform_tasks["linux"];
+        assert!(matches!(
+            &linux.run.as_ref().unwrap()[0],
+            RunEntry::Script(s) if s == "template linux"
+        ));
+        assert_eq!(linux.shell.as_deref(), Some("bash -c"));
+    }
+
+    #[test]
+    fn test_merge_template_run_windows_keeps_template_windows_platform_shell() {
+        let mut task = Task {
+            run_windows: vec![RunEntry::Script("local windows".to_string())],
+            ..Default::default()
+        };
+        let template = TaskTemplate {
+            platform_tasks: BTreeMap::from([(
+                "windows".to_string(),
+                TaskPlatformOverride {
+                    run: Some(vec![RunEntry::Script("template windows".to_string())]),
+                    shell: Some("pwsh -Command".to_string()),
+                },
+            )]),
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert_eq!(task.run_windows.len(), 1);
+        let windows = &task.platform_tasks["windows"];
+        assert!(windows.run.is_none());
+        assert_eq!(windows.shell.as_deref(), Some("pwsh -Command"));
+    }
+
+    #[test]
+    fn test_merge_template_local_run_keeps_template_platform_shell() {
+        let mut task = Task {
+            run: vec![RunEntry::Script("local run".to_string())],
+            ..Default::default()
+        };
+        let template = TaskTemplate {
+            platform_tasks: BTreeMap::from([(
+                "windows".to_string(),
+                TaskPlatformOverride {
+                    run: Some(vec![RunEntry::Script("template windows".to_string())]),
+                    shell: Some("pwsh -Command".to_string()),
+                },
+            )]),
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert_eq!(task.run.len(), 1);
+        let windows = &task.platform_tasks["windows"];
+        assert!(windows.run.is_none());
+        assert_eq!(windows.shell.as_deref(), Some("pwsh -Command"));
+    }
+
+    #[test]
+    fn test_merge_template_local_shell_overrides_template_platform_shell() {
+        let mut task = Task {
+            shell: Some("bash -c".to_string()),
+            ..Default::default()
+        };
+        let template = TaskTemplate {
+            platform_tasks: BTreeMap::from([(
+                "windows".to_string(),
+                TaskPlatformOverride {
+                    run: None,
+                    shell: Some("pwsh -Command".to_string()),
+                },
+            )]),
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert_eq!(task.shell.as_deref(), Some("bash -c"));
+        assert!(!task.platform_tasks.contains_key("windows"));
+    }
+
+    #[test]
+    fn test_merge_template_run_windows_overrides_template_windows_platform() {
+        let mut task = Task {
+            run_windows: vec![RunEntry::Script("local windows".to_string())],
+            ..Default::default()
+        };
+        let template = TaskTemplate {
+            platform_tasks: BTreeMap::from([(
+                "windows".to_string(),
+                TaskPlatformOverride {
+                    run: Some(vec![RunEntry::Script("template windows".to_string())]),
+                    shell: None,
+                },
+            )]),
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert_eq!(task.run_windows.len(), 1);
+        assert!(!task.platform_tasks.contains_key("windows"));
+    }
+
+    #[test]
+    fn test_merge_template_raw_args_and_interactive() {
+        let mut task = Task::default();
+        let template = TaskTemplate {
+            raw_args: Some(true),
+            interactive: Some(true),
+            ..Default::default()
+        };
+
+        task.merge_template(&template);
+
+        assert!(task.raw_args);
+        assert!(task.interactive);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds support for specifying platform-specific tasks and deprecates:

```toml
[tasks.my_task]
run_windows = '<my command>'
```

` in favor of:

```toml
[tasks.my_task.windows]
run = '<my command>'
```

os/arch combos can also be specified as tasks:

```toml
[task.my_task]
run = '<my general command>'

[tasks.my_task."linux/arm64"]
run = '<my arm64-specific command only for Linux>'
```

Windows-specific tasks use https://mise.jdx.dev/configuration/settings.html#windows_default_inline_shell_args by default, but it can be overridden as well. Only `run` and `shell` can be overridden in platform-specific tasks to keep them simple and functionally equivalent to the current task configuration system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for platform-specific task configuration using dot-syntax subtables (e.g., `[tasks.name.linux]`). Platform overrides follow a precedence order: most-specific match (`<os>/<arch>`) wins, followed by OS-level (`<os>`), then base configuration.

* **Documentation**
  * Updated task configuration documentation to reflect new platform-specific syntax and deprecation of `run_windows` in favor of platform subtables.

* **Deprecations**
  * `run_windows` is now deprecated; use `[tasks.<name>.windows]` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->