### PR TITLE
fix(backend): respect permissive minimum release age

### DIFF
--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -362,7 +362,10 @@ impl Backend for UnifiedGitBackend {
         Ok(versions)
     }
 
-    async fn latest_stable_version(&self, config: &Arc<Config>) -> eyre::Result<Option<String>> {
+    async fn latest_stable_version_info(
+        &self,
+        config: &Arc<Config>,
+    ) -> eyre::Result<Option<VersionInfo>> {
         if Settings::get().offline() {
             trace!("Skipping latest stable version due to offline mode");
             return Ok(None);
@@ -383,12 +386,12 @@ impl Backend for UnifiedGitBackend {
             return Ok(None);
         }
 
-        let latest_tag = if self.is_gitlab() {
+        let latest_release = if self.is_gitlab() {
             // GitLab doesn't have a "latest" endpoint
             return Ok(None);
         } else if self.is_forgejo() {
             match forgejo::get_release_for_url(&api_url, &repo, "latest").await {
-                Ok(r) => Some(r.tag_name),
+                Ok(r) => Some((r.tag_name, r.created_at, r.prerelease)),
                 Err(e) => {
                     debug!("Failed to fetch latest Forgejo release for {repo}: {e}");
                     None
@@ -399,7 +402,7 @@ impl Backend for UnifiedGitBackend {
                 .get_github_release_for_url(&api_url, &repo, "latest")
                 .await
             {
-                Ok(r) => Some(r.tag_name),
+                Ok(r) => Some((r.tag_name, r.created_at, r.prerelease)),
                 Err(e) => {
                     debug!("Failed to fetch latest GitHub release for {repo}: {e}");
                     None
@@ -407,14 +410,14 @@ impl Backend for UnifiedGitBackend {
             }
         };
 
-        let latest_version = latest_tag
-            .filter(|tag| version_prefix.is_none_or(|p| tag.starts_with(p)))
-            .map(|tag| self.strip_version_prefix(&tag, &opts));
-
-        match latest_version {
-            Some(version) => Ok(Some(version)),
-            None => Ok(None),
-        }
+        Ok(latest_release
+            .filter(|(tag, _, _)| version_prefix.is_none_or(|p| tag.starts_with(p)))
+            .map(|(tag, created_at, prerelease)| VersionInfo {
+                version: self.strip_version_prefix(&tag, &opts),
+                created_at: Some(created_at),
+                prerelease,
+                ..Default::default()
+            }))
     }
 
     async fn resolve_exact_version(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1281,6 +1281,20 @@ pub trait Backend: Debug + Send + Sync {
         Ok(None)
     }
 
+    /// Backend-specific fast path for the absolute latest stable version with
+    /// metadata when the upstream endpoint already provides it.
+    ///
+    /// Backends may keep overriding `latest_stable_version` when they only have
+    /// a version string. This metadata variant lets release-age filtering
+    /// verify fast-path candidates even when the cached full version list is
+    /// stale.
+    async fn latest_stable_version_info(
+        &self,
+        _config: &Arc<Config>,
+    ) -> eyre::Result<Option<VersionInfo>> {
+        Ok(None)
+    }
+
     /// Backend-specific fast path for exact version requests.
     ///
     /// Return `Ok(None)` when the backend cannot cheaply prove that `version`
@@ -1566,16 +1580,33 @@ pub trait Backend: Debug + Send + Sync {
         let before_date = effective_latest_before_date(self, config, before_date).await?;
         let resolved_query = query.as_deref().unwrap_or("latest");
         let mut fallback_refresh = refresh;
-        if resolved_query == "latest"
-            && let Some(version) = self.latest_stable_version(config).await?
-        {
+        let latest = if resolved_query == "latest" {
+            match self.latest_stable_version_info(config).await? {
+                Some(info) => Some(info),
+                None => self
+                    .latest_stable_version(config)
+                    .await?
+                    .map(|version| VersionInfo {
+                        version,
+                        ..Default::default()
+                    }),
+            }
+        } else {
+            None
+        };
+        if let Some(latest) = latest {
+            let version = latest.version.clone();
             match before_date {
                 Some(before) => {
                     let versions = self
                         .list_remote_versions_with_info_with_refresh(config, refresh)
                         .await?;
                     fallback_refresh = false;
-                    let info = versions.iter().find(|v| v.version == version);
+                    let info = latest
+                        .created_at
+                        .as_ref()
+                        .map(|_| &latest)
+                        .or_else(|| versions.iter().find(|v| v.version == version));
                     if latest_stable_candidate_allowed_by_before_date(&version, info, before) {
                         return Ok(Some(version));
                     }
@@ -2481,12 +2512,24 @@ fn latest_stable_candidate_allowed_by_before_date(
     before: Timestamp,
 ) -> bool {
     let Some(info) = info else {
+        if before > crate::duration::process_now() {
+            debug!(
+                "Latest stable version {version} is missing from remote version metadata, but the cutoff is in the future"
+            );
+            return true;
+        }
         debug!(
             "Latest stable version {version} is missing from remote version metadata; falling back to full version list"
         );
         return false;
     };
     let Some(created_at) = info.created_at.as_deref() else {
+        if before > crate::duration::process_now() {
+            debug!(
+                "Latest stable version {version} has no release date metadata, but the cutoff is in the future"
+            );
+            return true;
+        }
         debug!(
             "Latest stable version {version} has no release date metadata; falling back to full version list"
         );
@@ -2517,8 +2560,10 @@ mod latest_version_tests {
     struct LatestBackend {
         ba: Arc<BackendArg>,
         stable_result: Option<String>,
+        stable_info: Option<VersionInfo>,
         remote_versions: Vec<VersionInfo>,
         stable_calls: AtomicUsize,
+        stable_info_calls: AtomicUsize,
         list_calls: AtomicUsize,
     }
 
@@ -2527,6 +2572,7 @@ mod latest_version_tests {
             Self {
                 ba: Arc::new(name.into()),
                 stable_result: Some("9.9.9".to_string()),
+                stable_info: None,
                 remote_versions: vec![
                     VersionInfo {
                         version: "1.0.0".to_string(),
@@ -2540,12 +2586,18 @@ mod latest_version_tests {
                     },
                 ],
                 stable_calls: AtomicUsize::new(0),
+                stable_info_calls: AtomicUsize::new(0),
                 list_calls: AtomicUsize::new(0),
             }
         }
 
         fn with_stable_result(mut self, stable_result: Option<&str>) -> Self {
             self.stable_result = stable_result.map(str::to_string);
+            self
+        }
+
+        fn with_stable_info(mut self, stable_info: VersionInfo) -> Self {
+            self.stable_info = Some(stable_info);
             self
         }
 
@@ -2578,6 +2630,14 @@ mod latest_version_tests {
         ) -> eyre::Result<Option<String>> {
             self.stable_calls.fetch_add(1, Ordering::SeqCst);
             Ok(self.stable_result.clone())
+        }
+
+        async fn latest_stable_version_info(
+            &self,
+            _config: &Arc<Config>,
+        ) -> eyre::Result<Option<VersionInfo>> {
+            self.stable_info_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.stable_info.clone())
         }
 
         async fn install_version_(
@@ -2687,6 +2747,60 @@ mod latest_version_tests {
                 .unwrap()
                 .as_deref(),
             Some("1.0.0")
+        );
+        assert_eq!(backend.stable_calls(), 1);
+        assert_eq!(backend.list_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_date_filtered_latest_uses_stable_info_when_version_list_is_stale() {
+        let config = Config::get().await.unwrap();
+        let backend = LatestBackend::new("test-latest-before-date-stale-metadata")
+            .with_stable_info(VersionInfo {
+                version: "3.0.0".to_string(),
+                created_at: Some("2026-01-01".to_string()),
+                ..Default::default()
+            });
+        backend
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .clear()
+            .unwrap();
+        let before = crate::duration::parse_into_timestamp("2099-01-01").unwrap();
+
+        assert_eq!(
+            backend
+                .latest_version(&config, Some("latest".to_string()), Some(before))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("3.0.0")
+        );
+        assert_eq!(backend.stable_calls(), 0);
+        assert_eq!(backend.list_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_permissive_cutoff_keeps_canonical_latest_missing_from_metadata() {
+        let config = Config::get().await.unwrap();
+        let backend = LatestBackend::new("test-latest-before-date-permissive")
+            .with_stable_result(Some("3.0.0"));
+        backend
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .clear()
+            .unwrap();
+        let before = crate::duration::parse_into_timestamp("2099-01-01").unwrap();
+
+        assert_eq!(
+            backend
+                .latest_version(&config, Some("latest".to_string()), Some(before))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("3.0.0")
         );
         assert_eq!(backend.stable_calls(), 1);
         assert_eq!(backend.list_calls(), 1);
@@ -2845,8 +2959,10 @@ mod latest_version_tests {
         let backend = LatestBackend {
             ba: Arc::new(ba),
             stable_result: Some("9.9.9".to_string()),
+            stable_info: None,
             remote_versions: vec![],
             stable_calls: AtomicUsize::new(0),
+            stable_info_calls: AtomicUsize::new(0),
             list_calls: AtomicUsize::new(0),
         };
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1553,10 +1553,13 @@ pub trait Backend: Debug + Send + Sync {
         query: Option<String>,
     ) -> eyre::Result<Option<String>> {
         let resolved_query = query.as_deref().unwrap_or("latest");
-        if resolved_query == "latest"
-            && let Some(version) = self.latest_stable_version(config).await?
-        {
-            return Ok(Some(version));
+        if resolved_query == "latest" {
+            if let Some(info) = self.latest_stable_version_info(config).await? {
+                return Ok(Some(info.version));
+            }
+            if let Some(version) = self.latest_stable_version(config).await? {
+                return Ok(Some(version));
+            }
         }
         self.latest_version_for_query(config, resolved_query, None, false)
             .await
@@ -2605,6 +2608,10 @@ mod latest_version_tests {
             self.stable_calls.load(Ordering::SeqCst)
         }
 
+        fn stable_info_calls(&self) -> usize {
+            self.stable_info_calls.load(Ordering::SeqCst)
+        }
+
         fn list_calls(&self) -> usize {
             self.list_calls.load(Ordering::SeqCst)
         }
@@ -2779,6 +2786,36 @@ mod latest_version_tests {
         );
         assert_eq!(backend.stable_calls(), 0);
         assert_eq!(backend.list_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_unfiltered_latest_uses_stable_info_when_version_list_is_stale() {
+        let config = Config::get().await.unwrap();
+        let backend = LatestBackend::new("test-unfiltered-latest-stale-metadata").with_stable_info(
+            VersionInfo {
+                version: "3.0.0".to_string(),
+                created_at: Some("2026-01-01".to_string()),
+                ..Default::default()
+            },
+        );
+        backend
+            .get_remote_version_cache()
+            .lock()
+            .await
+            .clear()
+            .unwrap();
+
+        assert_eq!(
+            backend
+                .latest_version_unfiltered(&config, Some("latest".to_string()))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("3.0.0")
+        );
+        assert_eq!(backend.stable_info_calls(), 1);
+        assert_eq!(backend.stable_calls(), 0);
+        assert_eq!(backend.list_calls(), 0);
     }
 
     #[tokio::test]

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -7,7 +7,7 @@ use crate::backend::Backend;
 use crate::backend::backend_type::BackendType;
 use crate::cli::args::{BackendArg, split_bracketed_opts};
 use crate::config::{Config, Settings};
-use crate::duration::parse_into_timestamp;
+use crate::duration::{parse_duration, parse_into_timestamp};
 
 const DEFAULT_MINIMUM_RELEASE_AGE: &str = "24h";
 
@@ -55,9 +55,15 @@ fn resolve_before_date_with_excludes(
         return Ok(Some(before_date));
     }
     if let Some(before) = minimum_release_age {
+        if parse_duration(before).is_ok_and(|duration| duration.is_zero()) {
+            return Ok(None);
+        }
         return Ok(Some(parse_into_timestamp(before)?));
     }
     if !excluded && let Some(before) = &Settings::get().minimum_release_age {
+        if parse_duration(before).is_ok_and(|duration| duration.is_zero()) {
+            return Ok(None);
+        }
         return Ok(Some(parse_into_timestamp(before)?));
     }
     if !excluded && backend_arg.is_some_and(default_minimum_release_age_applies) {
@@ -174,6 +180,18 @@ mod tests {
             resolved_timestamp(None, Some("2024-01-02")),
             Some(crate::duration::parse_into_timestamp("2024-01-02").unwrap())
         );
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_zero_minimum_release_age_disables_cutoff() {
+        Settings::reset(None);
+        assert_eq!(resolved_timestamp(None, Some("0s")), None);
+
+        let mut partial = SettingsPartial::empty();
+        partial.minimum_release_age = Some("0s".to_string());
+        Settings::reset(Some(partial));
+        assert_eq!(resolved_tool_timestamp("github:cli/cli", None, None), None);
         Settings::reset(None);
     }
 


### PR DESCRIPTION
## Summary

Fixes `minimum_release_age` handling when resolving `latest` through backend fast paths.

- Treat `minimum_release_age = "0s"` as disabling the cutoff, matching the documented behavior.
- Let backends expose fast-path latest release metadata so release-age filtering can validate the canonical latest release even when cached remote-version metadata is stale.
- Populate GitHub/Forgejo latest fast-path results with `created_at` metadata from the release endpoint.
- Add regression coverage for stale metadata, permissive future cutoffs, and `0s` cutoff disabling.

## Root Cause

`latest_stable_version()` returned only a version string. When `minimum_release_age` was active, mise checked that version against the cached full version metadata. If the canonical latest release had not yet appeared in the cached metadata list, mise treated it like an unverified/too-new release and fell back to an older cached version, producing warnings such as `ignored by minimum_release_age` even for permissive cutoffs.

Separately, `"0s"` was parsed as a timestamp at process start instead of `None`, so it still enabled the metadata filtering path despite the docs saying it disables the delay.

## Validation

- `cargo test latest_version_tests`
- `cargo test install_before::tests::test_zero_minimum_release_age_disables_cutoff`
- `cargo fmt --all -- --check`

Refs https://github.com/jdx/mise/discussions/10303#discussioncomment-17261848

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core latest-version resolution and release-age filtering used across installs; behavior is narrowed with tests but affects many backends' latest queries.
> 
> **Overview**
> Fixes **`minimum_release_age`** so `latest` resolution through backend fast paths behaves as documented.
> 
> **`0s` disables the cutoff:** `install_before` now treats zero-duration `minimum_release_age` (e.g. `"0s"`) as **no** release-age filter instead of a timestamp at process start.
> 
> **Rich fast-path metadata:** A new **`latest_stable_version_info`** hook returns **`VersionInfo`** (including **`created_at`**) from canonical upstream “latest” endpoints. GitHub/Forgejo populate it from `/releases/latest`. **`latest_version`** / **`latest_version_unfiltered`** prefer this hook, then fall back to the string-only fast path.
> 
> **Stale cache + age filtering:** When a cutoff is active, release-age checks use fast-path metadata when present, so the canonical latest can pass even if it is missing from a stale cached version list. **`latest_stable_candidate_allowed_by_before_date`** accepts fast-path candidates when the cutoff is in the **future** and metadata is missing or lacks a date (permissive case).
> 
> Regression tests cover stale metadata, unfiltered latest, permissive future cutoffs, and `0s` disabling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39f9e63c8db8cc0ba27c798312cca87c1f52452a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable release resolution now returns release date and prerelease metadata.
  * Option to disable the minimum-release-age cutoff by setting duration to zero.

* **Improvements**
  * Version resolution uses stable-release metadata to improve cutoff and freshness decisions.
  * Backends can provide richer stable-version information to improve accuracy.

* **Tests**
  * Added and updated tests covering stable-metadata use and zero-duration cutoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->