### PR TITLE
fix(task): resolve templates in included task files

### DIFF
--- a/e2e/tasks/test_task_templates
+++ b/e2e/tasks/test_task_templates
@@ -181,4 +181,23 @@ EOF
 
 assert "mise run build" "cargo build"
 
+# Test templates apply to tasks defined in included tasks.toml files
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_templates."template:failing-task"]
+run = "echo from template && exit 1"
+
+[task_config]
+includes = ["tasks.toml"]
+EOF
+
+cat <<'EOF' >tasks.toml
+[failing-task]
+extends = "template:failing-task"
+EOF
+
+assert_fail "mise run failing-task" "from template"
+
 echo '' >mise.toml

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1907,8 +1907,10 @@ async fn load_local_tasks_with_context(
                     if !found_config {
                         let includes = task_includes_for_dir(&subdir, &config.config_files)?;
                         for include in includes {
-                            let mut subdir_tasks =
-                                load_tasks_includes(&config, &include, &subdir, &None).await?;
+                            let mut subdir_tasks = load_tasks_includes(
+                                &config, &include, &subdir, &None, &templates,
+                            )
+                            .await?;
                             if is_global_task_include_path(&include) {
                                 mark_tasks_as_global(&mut subdir_tasks);
                             }
@@ -2209,7 +2211,7 @@ async fn load_config_and_file_tasks(
 ) -> Result<Vec<Task>> {
     let config_root = cf.config_root();
     let config_tasks = load_config_tasks(config, cf.clone(), &config_root, templates).await?;
-    let file_tasks = load_file_tasks(config, cf.clone(), &config_root).await?;
+    let file_tasks = load_file_tasks(config, cf.clone(), &config_root, templates).await?;
     Ok(merge_file_and_config_tasks(file_tasks, config_tasks))
 }
 
@@ -2277,9 +2279,10 @@ async fn load_tasks_includes(
     root: &Path,
     config_root: &Path,
     task_config_dir: &Option<String>,
+    templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     if root.is_file() && root.extension().map(|e| e == "toml").unwrap_or(false) {
-        load_task_file(config, root, config_root, task_config_dir).await
+        load_task_file(config, root, config_root, task_config_dir, templates).await
     } else if root.is_dir() {
         let all_files = WalkDir::new(root)
             .follow_links(true)
@@ -2305,7 +2308,9 @@ async fn load_tasks_includes(
             .partition(|p| is_toml(p));
         let mut tasks = vec![];
         for path in toml_files {
-            tasks.extend(load_task_file(config, &path, config_root, task_config_dir).await?);
+            tasks.extend(
+                load_task_file(config, &path, config_root, task_config_dir, templates).await?,
+            );
         }
         let root = Arc::new(root.to_path_buf());
         let config_root = Arc::new(config_root.to_path_buf());
@@ -2395,6 +2400,7 @@ async fn load_file_tasks(
     config: &Arc<Config>,
     cf: Arc<dyn ConfigFile>,
     config_root: &Path,
+    templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let includes = cf
         .task_config_includes()?
@@ -2413,7 +2419,8 @@ async fn load_file_tasks(
         };
         for path in paths {
             let mut loaded =
-                load_tasks_includes(config, &path, &config_root, &task_config_dir).await?;
+                load_tasks_includes(config, &path, &config_root, &task_config_dir, templates)
+                    .await?;
             if is_global_task_include_path(&path) {
                 mark_tasks_as_global(&mut loaded);
             }
@@ -2492,7 +2499,8 @@ pub async fn load_tasks_in_dir(
             expand_task_include(&resolve_dir, include)
         };
         for p in paths {
-            let mut loaded = load_tasks_includes(config, &p, dir, &task_config_dir).await?;
+            let mut loaded =
+                load_tasks_includes(config, &p, dir, &task_config_dir, templates).await?;
             if is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);
             }
@@ -2520,6 +2528,7 @@ async fn load_task_file(
     path: &Path,
     config_root: &Path,
     task_config_dir: &Option<String>,
+    templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let raw = file::read_to_string_async(path).await?;
     let mut tasks = toml::from_str::<Tasks>(&raw)
@@ -2536,6 +2545,7 @@ async fn load_task_file(
     let mut out = vec![];
     for (_, mut task) in tasks {
         let config_root = config_root.to_path_buf();
+        resolve_task_template(&mut task, templates)?;
         if let Err(err) = task.render(config, &config_root).await {
             warn!("rendering task: {err:?}");
         }
@@ -2999,7 +3009,14 @@ vars = { target = "linux" }
 "#,
         )?;
 
-        let tasks = load_task_file(&config, &tasks_toml, temp_dir.path(), &None).await?;
+        let tasks = load_task_file(
+            &config,
+            &tasks_toml,
+            temp_dir.path(),
+            &None,
+            &IndexMap::new(),
+        )
+        .await?;
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].name, "build");
         assert_eq!(tasks[0].description, "linux");


### PR DESCRIPTION
## Summary

Fixes task template resolution for tasks defined in TOML files loaded through `task_config.includes`.

Tasks loaded from included `tasks.toml` files were parsed and rendered without receiving the collected `task_templates` map, so a task that only had `extends = "template:..."` could be loaded without the template's `run` entries and then exit successfully without doing anything.

## Changes

- Thread collected task templates through included task-file loading.
- Resolve `extends` for included TOML tasks before rendering them.
- Add an e2e regression for the repro from discussion #8779.

## Validation

- `mise run test:e2e e2e/tasks/test_task_templates`

Fixes https://github.com/jdx/mise/discussions/8779

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to task-loading plumbing with a regression e2e; fixes incorrect silent no-op runs, no auth or data-path impact.
> 
> **Overview**
> **Fixes `extends` for tasks loaded from `task_config.includes` TOML files** (e.g. `tasks.toml`), where templates were never applied so tasks could run with no `run` and succeed silently.
> 
> The collected `task_templates` map is now passed through `load_file_tasks` → `load_tasks_includes` → `load_task_file`, and **`resolve_task_template` runs on included TOML tasks** before rendering—the same path inline `[tasks.*]` entries already used. Monorepo subdirectory include loading gets the same threading.
> 
> An e2e case covers a template in `mise.toml` with a task in an included `tasks.toml` that `extends` it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56da5b2a5a32477119ddae5b7d938aa1388eb19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation for task template definitions applied to tasks in included task configuration files.

* **Chores**
  * Enhanced task template support in the configuration and file task loading pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->