### PR TITLE
registry: add vscode-cli (backend:aqua:microsoft/vscode/code)

### DIFF
--- a/registry/vscode-cli.toml
+++ b/registry/vscode-cli.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:microsoft/vscode/code"]
+description = "The standalone CLI for Visual Studio Code"
+test = { cmd = "code --version", expected = "code {{version}}" }


### PR DESCRIPTION
## New package

The Visual Studio Code CLI.

Name: vscode-cli
Source code: https://github.com/microsoft/vscode/tree/main/cli
Stars: 186.1K

## Remarks

I personally think `mise x code` should invoke VS Code CLI, but unfortunately there's already a [package named code](https://github.com/jdx/mise/blob/94c76ea3e2a53399371ae3bcb4840c190007c374/registry/code.toml) which points to [just-every/code](https://github.com/just-every/code) instead.

Discussion about repurposing that package happened [here](https://github.com/jdx/mise/discussions/10290#discussioncomment-17257103).

Closes https://github.com/jdx/mise/discussions/10290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for Visual Studio Code CLI registry support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->