### PR TITLE
feat(config): automatically define platform environments (auto_env)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ a lot easier than figuring out mise's rules.
 Notes:
 
 - Paths which start with `mise` can be dotfiles, e.g.: `.mise.toml` or `.mise/config.toml`.
-- This list doesn't include [Configuration Environments](/configuration/environments) which allow for environment-specific config files like `mise.development.toml`—set with `MISE_ENV=development`.
+- This list doesn't include [Configuration Environments](/configuration/environments) which allow for environment-specific config files like `mise.development.toml`—set with `MISE_ENV=development`. Platform-specific environments like `mise.windows.toml` or `mise.macos-arm64.toml` can be enabled automatically with the [`auto_env` setting](/configuration/environments.html#platform-environments).
 - See [`LOCAL_CONFIG_FILENAMES` in `src/config/mod.rs`](https://github.com/jdx/mise/blob/main/src/config/mod.rs) for the actual code for these paths and their precedence. Some legacy paths are not listed here for brevity.
 
 ## Configuration Hierarchy

--- a/docs/configuration/environments.md
+++ b/docs/configuration/environments.md
@@ -76,3 +76,45 @@ The rules around which file is written are different because we ultimately need 
 the docs for [`mise use`](/cli/use.html) for more information.
 
 Multiple environments can be specified, e.g. `MISE_ENV=ci,test` with the last one taking precedence.
+
+## Platform environments
+
+With the [`auto_env` setting](/configuration/settings.html#auto_env) enabled, mise automatically
+treats the following as active config environments, based on the current platform:
+
+| Environment   | Values                                         |
+| ------------- | ---------------------------------------------- |
+| `{os_family}` | `unix` (not defined on Windows—use `windows`)  |
+| `{os}`        | `linux`, `macos`, `windows`                    |
+| `{os}-{arch}` | e.g. `linux-x64`, `macos-arm64`, `windows-x64` |
+
+Architectures use mise's remapped names: `x86_64` → `x64` and `aarch64` → `arm64`.
+
+This makes config files like `mise.windows.toml`, `mise.macos-arm64.toml`, or `mise.unix.toml`
+load automatically, and matching lockfiles like `mise.windows.lock` get selected. All of the
+usual config file locations and `.local.toml` variants work.
+
+Platform environments have lower precedence than explicit `MISE_ENV` entries. The full order is
+(later overrides earlier): `unix` < `{os}` < `{os}-{arch}` < explicit `MISE_ENV` entries.
+
+Platform environments only affect config file discovery and lockfile selection. They are not
+added to `MISE_ENV` itself: the `{{ mise_env }}` template variable and the `MISE_ENV` variable
+passed to subprocesses and tasks only reflect explicit environments.
+
+### Rollout
+
+`auto_env` is currently **disabled by default**. Starting with mise `2027.6.0` it will default
+to enabled; from `2026.12.0` until then, mise warns if it finds a platform-specific config file
+that would be newly loaded. To control the behavior explicitly:
+
+```toml
+# .miserc.toml
+auto_env = true # adopt the new behavior now
+# or
+auto_env = false # keep the old behavior and silence the warning
+```
+
+or set `MISE_AUTO_ENV=true` / `MISE_AUTO_ENV=false`. Like `MISE_ENV`, this is an early-init
+setting: it must be set in `.miserc.toml` or via the environment variable — setting it in
+`mise.toml` has no effect because config file discovery has already happened by the time
+`mise.toml` is read.

--- a/e2e/config/test_config_auto_env
+++ b/e2e/config/test_config_auto_env
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Test auto_env: platform environments (unix, {os}, {os}-{arch}) are
+# automatically active for config file discovery when enabled
+
+os="$(uname -s)"
+case "$os" in
+  Darwin) os=macos ;;
+  Linux) os=linux ;;
+esac
+arch="$(uname -m)"
+case "$arch" in
+  x86_64) arch=x64 ;;
+  aarch64 | arm64) arch=arm64 ;;
+esac
+
+echo 'env.AAA = "base"
+env.BBB = "base"' >mise.toml
+echo 'env.AAA = "unix"
+env.UNIX_LOADED = "1"' >mise.unix.toml
+echo "env.AAA = \"$os\"" >"mise.$os.toml"
+echo "env.AAA = \"$os-$arch\"" >"mise.$os-$arch.toml"
+echo 'env.AAA = "prod"' >mise.prod.toml
+
+# default: off, platform configs are not loaded
+assert "mise env --json | jq -r .AAA" "base"
+
+# no rollout warning at the current version (this assertion flips when the
+# phase-2 warning activates in 2026.12.0 — see warn_if_auto_env_files_exist)
+assert_not_contains "mise env 2>&1" "load automatically"
+
+# opt in: all platform configs load, most specific wins (unix < os < os-arch)
+MISE_AUTO_ENV=true assert "mise env --json | jq -r .AAA" "$os-$arch"
+MISE_AUTO_ENV=true assert "mise env --json | jq -r .UNIX_LOADED" "1"
+MISE_AUTO_ENV=true assert "mise env --json | jq -r .BBB" "base"
+
+# explicit MISE_ENV entries take precedence over auto platform envs
+MISE_AUTO_ENV=true MISE_ENV=prod assert "mise env --json | jq -r .AAA" "prod"
+
+# explicit MISE_ENV listing a platform env dedupes (file loaded once) and
+# keeps its user-specified (higher) precedence
+MISE_AUTO_ENV=true MISE_ENV=$os assert "mise env --json | jq -r .AAA" "$os"
+MISE_AUTO_ENV=true MISE_ENV=$os assert "mise config ls | grep -c \"mise.$os.toml\"" "1"
+
+# explicit opt-out
+MISE_AUTO_ENV=false assert "mise env --json | jq -r .AAA" "base"
+
+# auto envs are not added to MISE_ENV itself: {{ mise_env }} and MISE_ENV
+# propagation to subprocesses only reflect explicit environments
+cat <<'EOF' >>mise.toml
+[tasks.print]
+run = '{% if mise_env %}echo {{mise_env}}{% endif %}'
+EOF
+MISE_AUTO_ENV=true assert "mise run print" ""
+MISE_AUTO_ENV=true MISE_ENV=prod assert "mise run print" "[prod]"
+
+# auto_env can be enabled via .miserc.toml
+echo 'auto_env = true' >.miserc.toml
+assert "mise env --json | jq -r .AAA" "$os-$arch"
+# env var overrides .miserc.toml
+MISE_AUTO_ENV=false assert "mise env --json | jq -r .AAA" "base"
+rm -f .miserc.toml
+
+# global config dir platform configs load too
+mkdir -p "$MISE_CONFIG_DIR"
+echo "env.GLOBAL_AUTO = \"$os\"" >"$MISE_CONFIG_DIR/config.$os.toml"
+MISE_AUTO_ENV=true assert "mise env --json | jq -r .GLOBAL_AUTO" "$os"
+assert "mise env --json | jq -r .GLOBAL_AUTO" "null"
+rm -f "$MISE_CONFIG_DIR/config.$os.toml"

--- a/e2e/config/test_config_auto_env
+++ b/e2e/config/test_config_auto_env
@@ -25,9 +25,11 @@ echo 'env.AAA = "prod"' >mise.prod.toml
 # default: off, platform configs are not loaded
 assert "mise env --json | jq -r .AAA" "base"
 
-# no rollout warning at the current version (this assertion flips when the
-# phase-2 warning activates in 2026.12.0 — see warn_if_auto_env_files_exist)
-assert_not_contains "mise env 2>&1" "load automatically"
+# the rollout warning never fires once the user has set auto_env explicitly,
+# regardless of the phase the current version is in (the version-gated unset
+# case is covered by the should_warn_auto_env unit tests)
+assert_not_contains "MISE_AUTO_ENV=false mise env 2>&1" "load automatically"
+assert_not_contains "MISE_AUTO_ENV=true mise env 2>&1" "load automatically"
 
 # opt in: all platform configs load, most specific wins (unix < os < os-arch)
 MISE_AUTO_ENV=true assert "mise env --json | jq -r .AAA" "$os-$arch"

--- a/e2e/lockfile/test_lockfile_auto_env
+++ b/e2e/lockfile/test_lockfile_auto_env
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Test that auto platform environments (auto_env) select matching
+# mise.<env>.lock lockfiles, and explicit MISE_ENV lockfiles still win
+
+export MISE_LOCKFILE=1
+
+os="$(uname -s)"
+case "$os" in
+  Darwin) os=macos ;;
+  Linux) os=linux ;;
+esac
+
+cat >"mise.$os.toml" <<'EOF'
+[tools]
+tiny = "2"
+EOF
+
+touch "mise.$os.lock"
+
+assert "mise install tiny@2.1.0"
+
+# with auto_env enabled, mise.$os.toml is active and its lockfile is written
+assert "MISE_AUTO_ENV=true mise use tiny@2"
+assert_contains "cat mise.$os.lock" '[[tools.tiny]]'
+assert_contains "cat mise.$os.lock" 'version = "2.1.0"'
+
+# the locked version is honored when resolving with auto_env enabled
+assert "MISE_AUTO_ENV=true mise ls tiny --json | jq -r '.[0].version'" "2.1.0"
+
+# explicit env lockfile takes precedence over the auto platform one
+cat >mise.prod.toml <<'EOF'
+[tools]
+tiny = "1"
+EOF
+touch mise.prod.lock
+assert "mise install tiny@1.0.1"
+assert "MISE_ENV=prod mise use tiny@1"
+assert_contains "cat mise.prod.lock" 'version = "1.0.1"'
+assert "MISE_AUTO_ENV=true MISE_ENV=prod mise ls tiny --json | jq -r '.[0].version'" "1.0.1"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -538,6 +538,10 @@
           "type": "boolean",
           "deprecated": true
         },
+        "auto_env": {
+          "description": "Automatically enable platform config environments (unix, {os}, {os}-{arch}).",
+          "type": "boolean"
+        },
         "auto_install": {
           "default": true,
           "description": "Automatically install missing tools when running `mise x`, `mise run`, or as part of the 'not found' handler.",

--- a/schema/miserc.json
+++ b/schema/miserc.json
@@ -5,6 +5,10 @@
   "type": "object",
   "unevaluatedProperties": false,
   "properties": {
+    "auto_env": {
+      "description": "Automatically enable platform config environments (unix, {os}, {os}-{arch}).",
+      "type": "boolean"
+    },
     "ceiling_paths": {
       "default": [],
       "description": "Directories where mise stops searching for config files.",

--- a/settings.toml
+++ b/settings.toml
@@ -211,6 +211,36 @@ env = "MISE_ASDF_COMPAT"
 hide = true
 type = "Bool"
 
+[auto_env]
+description = "Automatically enable platform config environments (unix, {os}, {os}-{arch})."
+docs = """
+When enabled, mise treats the following as active config environments (in addition
+to any explicit `MISE_ENV`): `unix` (on unix-family platforms), the OS name
+(`linux`/`macos`/`windows`), and `{os}-{arch}` (e.g. `macos-arm64`, `windows-x64`,
+using mise's remapped arch names: `x86_64` -> `x64`, `aarch64` -> `arm64`).
+
+This causes config files such as `mise.windows.toml`, `mise/config.macos-arm64.toml`,
+or `mise.unix.toml` to be loaded automatically, and matching `mise.<env>.lock`
+lockfiles to be selected. Platform environments have lower precedence than explicit
+`MISE_ENV` entries; the full precedence order is `unix` < `{os}` < `{os}-{arch}` <
+explicit `MISE_ENV` entries. Platform environments do not affect the
+`{{ mise_env }}` template variable or the `MISE_ENV` variable passed to subprocesses.
+
+When unset, this currently defaults to `false`. Starting with mise 2027.6.0 it will
+default to `true`; set it to `false` to keep the old behavior, or `true` to adopt
+the new behavior early.
+
+This is an early-init setting: it must be set in `.miserc.toml` or via the
+`MISE_AUTO_ENV` environment variable. Setting it in `mise.toml` will have no effect
+because config file discovery has already occurred by the time `mise.toml` is read.
+
+See [Configuration Environments](/configuration/environments.html) for more details.
+"""
+env = "MISE_AUTO_ENV"
+optional = true
+rc = true
+type = "Bool"
+
 [auto_install]
 default = true
 description = "Automatically install missing tools when running `mise x`, `mise run`, or as part of the 'not found' handler."

--- a/src/config/miserc.rs
+++ b/src/config/miserc.rs
@@ -51,6 +51,11 @@ pub fn get_env() -> Option<&'static Vec<String>> {
     get().env.as_ref()
 }
 
+/// Get the auto_env value from miserc, if set.
+pub fn get_auto_env() -> Option<bool> {
+    get().auto_env
+}
+
 /// Get the ceiling_paths value from miserc, if set.
 pub fn get_ceiling_paths() -> Option<&'static BTreeSet<PathBuf>> {
     get().ceiling_paths.as_ref()
@@ -147,6 +152,9 @@ fn load_miserc_settings() -> Result<MisercSettings> {
 fn merge_settings(target: &mut MisercSettings, source: MisercSettings) {
     if source.env.is_some() {
         target.env = source.env;
+    }
+    if source.auto_env.is_some() {
+        target.auto_env = source.auto_env;
     }
     if source.ceiling_paths.is_some() {
         target.ceiling_paths = source.ceiling_paths;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1260,6 +1260,12 @@ fn detect_auto_env_candidate_files() -> Vec<PathBuf> {
     // same file (e.g. ~/.config/mise/config.{env}.toml when cwd is under $HOME)
     let mut found = IndexSet::new();
     for dir in all_dirs().unwrap_or_default() {
+        if env::MISE_IGNORED_CONFIG_PATHS
+            .iter()
+            .any(|p| dir.starts_with(p))
+        {
+            continue;
+        }
         for env_name in &candidate_envs {
             for pattern in env_config_patterns(env_name) {
                 found.extend(glob(&dir, &pattern).unwrap_or_default());
@@ -1281,7 +1287,15 @@ fn detect_auto_env_candidate_files() -> Vec<PathBuf> {
             }
         }
     }
-    found.into_iter().collect()
+    // apply the same filters as load_config_paths so we don't warn about files
+    // that wouldn't be loaded even with auto_env enabled
+    found
+        .into_iter()
+        .filter(|p| {
+            !is_default_config_dir_override_filtered(p)
+                && !(config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(p))
+        })
+        .collect()
 }
 
 /// Load config hierarchy from a specific directory (for monorepo tasks)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1256,7 +1256,9 @@ fn detect_auto_env_candidate_files() -> Vec<PathBuf> {
         .into_iter()
         .filter(|name| !env::MISE_ENV.contains(name))
         .collect_vec();
-    let mut found = vec![];
+    // IndexSet: the all_dirs() walk and the global/system dir checks can find the
+    // same file (e.g. ~/.config/mise/config.{env}.toml when cwd is under $HOME)
+    let mut found = IndexSet::new();
     for dir in all_dirs().unwrap_or_default() {
         for env_name in &candidate_envs {
             for pattern in env_config_patterns(env_name) {
@@ -1274,12 +1276,12 @@ fn detect_auto_env_candidate_files() -> Vec<PathBuf> {
             ] {
                 let p = dir.join(filename);
                 if p.is_file() {
-                    found.push(p);
+                    found.insert(p);
                 }
             }
         }
     }
-    found
+    found.into_iter().collect()
 }
 
 /// Load config hierarchy from a specific directory (for monorepo tasks)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1294,8 +1294,9 @@ fn detect_auto_env_candidate_files() -> Vec<PathBuf> {
     found
         .into_iter()
         .filter(|p| {
-            !is_default_config_dir_override_filtered(p)
-                && !(config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(p))
+            !(is_default_config_dir_override_filtered(p)
+                || config_file::is_ignored(&config_trust_root(p))
+                || config_file::is_ignored(p))
         })
         .collect()
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -219,6 +219,8 @@ impl Config {
             }
         }
 
+        warn_if_auto_env_files_exist();
+
         time!("load done");
 
         measure!("config::load install_state", {
@@ -1023,24 +1025,32 @@ static LOCAL_CONFIG_FILENAMES: Lazy<IndexSet<&'static str>> = Lazy::new(|| {
 
     paths
 });
+/// Config filename patterns for a single MISE_ENV environment, in precedence order
+/// (later wins, matching LOCAL_CONFIG_FILENAMES ordering)
+fn env_config_patterns(env: &str) -> Vec<String> {
+    vec![
+        format!(".config/mise/config.{env}.toml"),
+        format!(".config/mise.{env}.toml"),
+        format!("mise/config.{env}.toml"),
+        format!("mise.{env}.toml"),
+        format!(".mise/config.{env}.toml"),
+        format!(".mise.{env}.toml"),
+        format!(".config/mise/config.{env}.local.toml"),
+        format!(".config/mise.{env}.local.toml"),
+        format!("mise/config.{env}.local.toml"),
+        format!("mise.{env}.local.toml"),
+        format!(".mise/config.{env}.local.toml"),
+        format!(".mise.{env}.local.toml"),
+    ]
+}
+
 pub static DEFAULT_CONFIG_FILENAMES: Lazy<Vec<String>> = Lazy::new(|| {
     let mut filenames = LOCAL_CONFIG_FILENAMES
         .iter()
         .map(|f| f.to_string())
         .collect_vec();
-    for env in &*env::MISE_ENV {
-        filenames.push(format!(".config/mise/config.{env}.toml"));
-        filenames.push(format!(".config/mise.{env}.toml"));
-        filenames.push(format!("mise/config.{env}.toml"));
-        filenames.push(format!("mise.{env}.toml"));
-        filenames.push(format!(".mise/config.{env}.toml"));
-        filenames.push(format!(".mise.{env}.toml"));
-        filenames.push(format!(".config/mise/config.{env}.local.toml"));
-        filenames.push(format!(".config/mise.{env}.local.toml"));
-        filenames.push(format!("mise/config.{env}.local.toml"));
-        filenames.push(format!("mise.{env}.local.toml"));
-        filenames.push(format!(".mise/config.{env}.local.toml"));
-        filenames.push(format!(".mise.{env}.local.toml"));
+    for env in &*env::MISE_ENV_WITH_AUTO {
+        filenames.extend(env_config_patterns(env));
     }
     filenames
 });
@@ -1183,6 +1193,95 @@ pub fn load_config_paths(config_filenames: &[String], include_ignored: bool) -> 
         .collect()
 }
 
+/// Whether to emit the phase-2 auto_env rollout warning. Pure for unit testing.
+/// Warns only when the user hasn't decided (setting unset), auto envs aren't
+/// already active, and the mise version is in the warning window that precedes
+/// the 2027.6.0 default flip.
+fn should_warn_auto_env(
+    version: &versions::Versioning,
+    setting: Option<bool>,
+    auto_envs_active: bool,
+) -> bool {
+    setting.is_none()
+        && !auto_envs_active
+        && *version >= versions::Versioning::new("2026.12.0").unwrap()
+        && !env::auto_env_default_for_version(version)
+}
+
+/// Phase-2 rollout warning for auto_env: starting with 2026.12.0, tell users about
+/// platform-specific config files (e.g. mise.windows.toml) that mise will begin
+/// loading automatically when auto_env defaults to true in 2027.6.0.
+fn warn_if_auto_env_files_exist() {
+    // dead code once the default flips on: the files load, so there is nothing to warn about
+    debug_assert!(
+        !env::auto_env_default_for_version(&version::V),
+        "auto_env is now default-on; remove warn_if_auto_env_files_exist() and should_warn_auto_env()"
+    );
+    if !should_warn_auto_env(
+        &version::V,
+        env::auto_env_setting(),
+        !env::AUTO_ENV_NAMES.is_empty(),
+    ) || *env::IS_RUNNING_AS_SHIM
+    {
+        return;
+    }
+    // skip hook-env to keep the every-prompt path free of extra filesystem checks
+    let args = env::ARGS.read().unwrap();
+    if args
+        .iter()
+        .take_while(|a| *a != "--")
+        .filter(|a| !a.starts_with('-'))
+        .nth(1)
+        .is_some_and(|a| a == "hook-env")
+    {
+        return;
+    }
+    drop(args);
+    let found = detect_auto_env_candidate_files();
+    if !found.is_empty() {
+        warn_once!(
+            "Found platform-specific config file(s) that mise will load automatically starting in 2027.6.0: {}. \
+            Set MISE_AUTO_ENV=true (or `auto_env = true` in .miserc.toml) to enable this now, \
+            or auto_env=false to keep the current behavior and silence this warning. \
+            See https://mise.jdx.dev/configuration/environments.html#platform-environments",
+            found.iter().map(display_path).join(", ")
+        );
+    }
+}
+
+/// Config files that exist on disk and would be loaded if auto_env were enabled,
+/// but are not loaded today because their platform env is not in MISE_ENV.
+fn detect_auto_env_candidate_files() -> Vec<PathBuf> {
+    let candidate_envs = env::platform_env_names()
+        .into_iter()
+        .filter(|name| !env::MISE_ENV.contains(name))
+        .collect_vec();
+    let mut found = vec![];
+    for dir in all_dirs().unwrap_or_default() {
+        for env_name in &candidate_envs {
+            for pattern in env_config_patterns(env_name) {
+                found.extend(glob(&dir, &pattern).unwrap_or_default());
+            }
+        }
+    }
+    for dir in [*dirs::CONFIG, *dirs::SYSTEM_CONFIG] {
+        for env_name in &candidate_envs {
+            for filename in [
+                format!("config.{env_name}.toml"),
+                format!("mise.{env_name}.toml"),
+                format!("config.{env_name}.local.toml"),
+                format!("mise.{env_name}.local.toml"),
+            ] {
+                let p = dir.join(filename);
+                if p.is_file() {
+                    found.push(p);
+                }
+            }
+        }
+    }
+    found
+}
+
 /// Load config hierarchy from a specific directory (for monorepo tasks)
 /// This loads all config files from start_dir up through parent directories,
 /// including MISE_ENV-specific configs and idiomatic version files.
@@ -1296,13 +1395,13 @@ pub fn system_config_files() -> IndexSet<PathBuf> {
 
 static CONFIG_FILENAMES: Lazy<Vec<String>> = Lazy::new(|| {
     let mut filenames = vec!["config.toml".to_string(), "mise.toml".to_string()];
-    for env in &*env::MISE_ENV {
+    for env in &*env::MISE_ENV_WITH_AUTO {
         filenames.push(format!("config.{env}.toml"));
         filenames.push(format!("mise.{env}.toml"));
     }
     filenames.push("config.local.toml".to_string());
     filenames.push("mise.local.toml".to_string());
-    for env in &*env::MISE_ENV {
+    for env in &*env::MISE_ENV_WITH_AUTO {
         filenames.push(format!("config.{env}.local.toml"));
         filenames.push(format!("mise.{env}.local.toml"));
     }
@@ -2562,6 +2661,44 @@ mod tests {
     async fn test_load() {
         let config = Config::reset().await.unwrap();
         assert_debug_snapshot!(config);
+    }
+
+    #[test]
+    fn test_env_config_patterns() {
+        assert_eq!(
+            env_config_patterns("linux"),
+            vec![
+                ".config/mise/config.linux.toml",
+                ".config/mise.linux.toml",
+                "mise/config.linux.toml",
+                "mise.linux.toml",
+                ".mise/config.linux.toml",
+                ".mise.linux.toml",
+                ".config/mise/config.linux.local.toml",
+                ".config/mise.linux.local.toml",
+                "mise/config.linux.local.toml",
+                "mise.linux.local.toml",
+                ".mise/config.linux.local.toml",
+                ".mise.linux.local.toml",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_should_warn_auto_env() {
+        let v = |s: &str| versions::Versioning::new(s).unwrap();
+        // before the warning window: never warn
+        assert!(!should_warn_auto_env(&v("2026.6.2"), None, false));
+        // inside the warning window: warn only when the user hasn't decided
+        assert!(should_warn_auto_env(&v("2026.12.0"), None, false));
+        assert!(should_warn_auto_env(&v("2027.5.9"), None, false));
+        assert!(!should_warn_auto_env(&v("2026.12.0"), Some(false), false));
+        assert!(!should_warn_auto_env(&v("2026.12.0"), Some(true), true));
+        // auto envs already active (e.g. opted in): nothing to warn about
+        assert!(!should_warn_auto_env(&v("2026.12.0"), None, true));
+        // default flipped on: warning is obsolete
+        assert!(!should_warn_auto_env(&v("2027.6.0"), None, true));
+        assert!(!should_warn_auto_env(&v("2027.6.0"), Some(false), false));
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1244,7 +1244,7 @@ fn warn_if_auto_env_files_exist() {
         warn_once!(
             "Found platform-specific config file(s) that mise will load automatically starting in 2027.6.0: {}. \
             Set MISE_AUTO_ENV=true (or `auto_env = true` in .miserc.toml) to enable this now, \
-            or auto_env=false to keep the current behavior and silence this warning. \
+            or `auto_env = false` to keep the current behavior and silence this warning. \
             See https://mise.jdx.dev/configuration/environments.html#platform-environments",
             found.iter().map(display_path).join(", ")
         );

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1225,18 +1225,20 @@ fn warn_if_auto_env_files_exist() {
     {
         return;
     }
-    // skip hook-env to keep the every-prompt path free of extra filesystem checks
-    let args = env::ARGS.read().unwrap();
-    if args
+    // Skip hook-env to keep the every-prompt path free of extra filesystem checks.
+    // Match the subcommand anywhere before `--` rather than guessing its positional
+    // slot (flags with separate values like `--cd /path` would shift it); the warning
+    // is advisory, so erring toward skipping it is the safe direction.
+    if env::ARGS
+        .read()
+        .unwrap()
         .iter()
+        .skip(1)
         .take_while(|a| *a != "--")
-        .filter(|a| !a.starts_with('-'))
-        .nth(1)
-        .is_some_and(|a| a == "hook-env")
+        .any(|a| a == "hook-env")
     {
         return;
     }
-    drop(args);
     let found = detect_auto_env_candidate_files();
     if !found.is_empty() {
         warn_once!(

--- a/src/env.rs
+++ b/src/env.rs
@@ -257,6 +257,71 @@ pub static MISE_OVERRIDE_CONFIG_FILENAMES: Lazy<IndexSet<String>> =
             .unwrap_or_default(),
     });
 pub static MISE_ENV: Lazy<Vec<String>> = Lazy::new(|| environment(&ARGS.read().unwrap()));
+
+/// The tri-state auto_env setting: MISE_AUTO_ENV env var > .miserc.toml > unset
+pub fn auto_env_setting() -> Option<bool> {
+    if var_is_true("MISE_AUTO_ENV") {
+        Some(true)
+    } else if var_is_false("MISE_AUTO_ENV") {
+        Some(false)
+    } else {
+        miserc::get_auto_env()
+    }
+}
+
+/// Default for auto_env when the setting is unset: off until mise 2027.6.0
+pub(crate) fn auto_env_default_for_version(v: &versions::Versioning) -> bool {
+    *v >= versions::Versioning::new("2027.6.0").unwrap()
+}
+
+/// Platform-derived environment names, regardless of whether auto_env is enabled.
+/// Ordered least to most specific: os family ("unix"), os, "{os}-{arch}".
+/// On Windows the family equals the os so it dedupes to ["windows", "windows-{arch}"].
+pub fn platform_env_names() -> Vec<String> {
+    let mut names: Vec<String> = vec![];
+    for name in [
+        consts::FAMILY.to_string(),
+        crate::cli::version::OS.to_string(),
+        format!(
+            "{}-{}",
+            *crate::cli::version::OS,
+            *crate::cli::version::ARCH
+        ),
+    ] {
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    names
+}
+
+/// Platform environments active for config file discovery and lockfile selection.
+/// Empty unless auto_env is enabled. Names already in MISE_ENV are excluded so
+/// explicit environments keep their user-specified (higher) precedence.
+/// These are deliberately not part of MISE_ENV: they do not affect the
+/// `{{ mise_env }}` template variable or MISE_ENV propagation to subprocesses.
+pub static AUTO_ENV_NAMES: Lazy<Vec<String>> = Lazy::new(|| {
+    let enabled =
+        auto_env_setting().unwrap_or_else(|| auto_env_default_for_version(&crate::cli::version::V));
+    if !enabled {
+        return vec![];
+    }
+    platform_env_names()
+        .into_iter()
+        .filter(|name| !MISE_ENV.contains(name))
+        .collect()
+});
+
+/// Auto platform envs followed by explicit MISE_ENV entries, for "later wins"
+/// consumers like config filename enumeration.
+pub static MISE_ENV_WITH_AUTO: Lazy<Vec<String>> = Lazy::new(|| {
+    AUTO_ENV_NAMES
+        .iter()
+        .chain(MISE_ENV.iter())
+        .cloned()
+        .collect()
+});
+
 pub static MISE_GLOBAL_CONFIG_FILE: Lazy<Option<PathBuf>> =
     Lazy::new(|| var_path("MISE_GLOBAL_CONFIG_FILE").or_else(|| var_path("MISE_CONFIG_FILE")));
 pub static MISE_GLOBAL_CONFIG_ROOT: Lazy<PathBuf> =
@@ -873,6 +938,47 @@ mod tests {
             PathBuf::from("/foo/bar")
         );
         remove_var("MISE_TEST_PATH");
+    }
+
+    #[test]
+    fn test_auto_env_default_for_version() {
+        let v = |s: &str| versions::Versioning::new(s).unwrap();
+        assert!(!auto_env_default_for_version(&v("2026.6.2")));
+        assert!(!auto_env_default_for_version(&v("2026.12.0")));
+        assert!(!auto_env_default_for_version(&v("2027.5.9")));
+        assert!(auto_env_default_for_version(&v("2027.6.0")));
+        assert!(auto_env_default_for_version(&v("2028.1.0")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_platform_env_names_unix() {
+        let names = platform_env_names();
+        assert_eq!(names.len(), 3);
+        assert_eq!(names[0], "unix");
+        assert_eq!(names[1], *crate::cli::version::OS);
+        assert_eq!(
+            names[2],
+            format!(
+                "{}-{}",
+                *crate::cli::version::OS,
+                *crate::cli::version::ARCH
+            )
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_platform_env_names_windows() {
+        // os family == os on windows, so the list dedupes to two entries
+        let names = platform_env_names();
+        assert_eq!(
+            names,
+            vec![
+                "windows".to_string(),
+                format!("windows-{}", *crate::cli::version::ARCH)
+            ]
+        );
     }
 
     #[cfg(unix)]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1638,11 +1638,13 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
         seen_roots.insert(root.clone());
 
         // Read lockfiles in priority order (highest first):
-        // 1. mise.<env>.local.lock (if MISE_ENV is set)
+        // 1. mise.<env>.local.lock (explicit MISE_ENV, then auto platform envs)
         // 2. mise.local.lock
-        // 3. mise.<env>.lock (if MISE_ENV is set)
+        // 3. mise.<env>.lock (explicit MISE_ENV, then auto platform envs)
         // 4. mise.lock
-        for env_name in env::MISE_ENV.iter() {
+        // AUTO_ENV_NAMES is ordered least to most specific, so reverse it here
+        // to read the most specific (e.g. macos-arm64) first.
+        for env_name in env::MISE_ENV.iter().chain(env::AUTO_ENV_NAMES.iter().rev()) {
             let p = root.join(format!("mise.{env_name}.local.lock"));
             if let Ok(l) = Lockfile::read(&p) {
                 all.push(l);
@@ -1652,7 +1654,7 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
         if let Ok(local) = Lockfile::read(&local_path) {
             all.push(local);
         }
-        for env_name in env::MISE_ENV.iter() {
+        for env_name in env::MISE_ENV.iter().chain(env::AUTO_ENV_NAMES.iter().rev()) {
             let p = root.join(format!("mise.{env_name}.lock"));
             if let Ok(l) = Lockfile::read(&p) {
                 all.push(l);


### PR DESCRIPTION
## What

Adds a new tri-state `auto_env` early-init setting (`MISE_AUTO_ENV` env var or `auto_env` in `.miserc.toml`). When enabled, mise automatically treats platform-derived names as active config environments:

- `unix` (os family, unix platforms only)
- `{os}` — `linux` / `macos` / `windows`
- `{os}-{arch}` — e.g. `windows-x64`, `macos-arm64` (using mise's remapped arch names)

so config files like `mise.windows.toml`, `mise/config.macos-arm64.toml`, or `mise.unix.toml` (and their `.local.toml` variants, plus global/system `config.{env}.toml`) load automatically, and matching `mise.<env>.lock` lockfiles are selected.

Precedence is `unix` < `{os}` < `{os}-{arch}` < explicit `MISE_ENV` entries, with dedupe when a user explicitly lists a platform name. The platform envs are deliberately **not** added to `MISE_ENV` itself: the `{{ mise_env }}` template variable and `MISE_ENV` propagation to subprocesses/tasks only reflect explicit environments.

## Phased rollout

- **Now:** off by default, no warning. Opt in with `auto_env = true`.
- **2026.12.0:** still off by default, but if a config file exists that *would* be newly loaded, warn once per process (names the files; silenced by setting `auto_env` either way). The check is skipped for shims and `hook-env` so the per-prompt path pays nothing.
- **2027.6.0:** default flips on via compile-time version comparison — no code change needed at release time; the warning disappears naturally because the files now load. `auto_env = false` still opts out. A `debug_assert` (same pattern as `deprecated_at!`) reminds us to delete the transitional warning code then.

## Reviewer notes

- The enable decision must be early-init (`rc = true`) because settings loading itself depends on config discovery (`Settings::try_get()` → `ALL_TOML_CONFIG_FILES` → `DEFAULT_CONFIG_FILENAMES` → `MISE_ENV`) — same constraint and docs caveat as the existing `env`/`ceiling_paths` rc settings.
- Single source of truth lives in `src/env.rs` (`AUTO_ENV_NAMES` / `MISE_ENV_WITH_AUTO`); consumers are `DEFAULT_CONFIG_FILENAMES`, the global/system `CONFIG_FILENAMES`, and lockfile read order in `src/lockfile.rs` (explicit env locks still beat auto ones).
- Tests: unit tests cover the version-gated logic (compile-time version can't be faked in e2e); new e2e tests cover opt-in/out, precedence, dedupe, `.miserc.toml`, global config dir, and lockfile selection.
- Docs: new "Platform environments" section in `docs/configuration/environments.md` (the phase-2 warning links to its anchor), pointer in `docs/configuration.md`, and the settings reference renders from `settings.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which config and lockfiles load for projects that already have platform-named files; rollout is gated and opt-out exists, but mistaken enablement could shift tool versions and env vars.
> 
> **Overview**
> Adds **`auto_env`**, an early-init setting (`MISE_AUTO_ENV` or `.miserc.toml`) that, when enabled, automatically loads platform-specific config environments (`unix`, `{os}`, `{os}-{arch}`) so files like `mise.windows.toml` and matching `mise.<env>.lock` files participate in discovery without setting `MISE_ENV`. Precedence is platform envs first (least → most specific), then explicit `MISE_ENV`; auto envs are **not** reflected in `MISE_ENV` or `{{ mise_env }}`.
> 
> Config filename enumeration is centralized via `env_config_patterns` and `MISE_ENV_WITH_AUTO`; lockfile reads include auto platform locks after explicit env locks. **Phased rollout:** off by default now; version-gated one-time warning (2026.12.0–2027.5.x) when unset platform configs exist; default-on at 2027.6.0.
> 
> Docs, JSON schemas, `settings.toml`, e2e tests for config/lockfile behavior, and unit tests for warning/version logic accompany the Rust changes in `env.rs`, `miserc.rs`, `config/mod.rs`, and `lockfile.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da8ce12ac3ceb334901a8cac7456ca43c7721c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auto_env to automatically detect and apply platform-specific environments with explicit env precedence and opt-in/opt-out controls.

* **Documentation**
  * Expanded docs detailing platform environment discovery, precedence rules, rollout/warning behavior, and how to control auto-loading.

* **Tests**
  * Added end-to-end tests covering discovery, precedence, lockfile selection, opt-in/opt-out, and config-dir behavior.

* **Chores**
  * Added settings/schema entries and a rollout warning to surface newly detected platform-specific config files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->