### PR TITLE
fix(lock): disambiguate idiomatic lock target

### DIFF
--- a/e2e/lockfile/test_lockfile_idiomatic_version_file
+++ b/e2e/lockfile/test_lockfile_idiomatic_version_file
@@ -48,6 +48,8 @@ idiomatic_version_file_enable_tools = ["dummy"]
 lockfile = true
 EOF
 
+# Keep mise.toml and .mise/config.toml together to verify that an idiomatic
+# .dummy-version maps to .mise/mise.lock instead of the root mise.lock.
 mkdir -p .mise
 cat <<'EOF' >.mise/config.toml
 [settings]

--- a/e2e/lockfile/test_lockfile_idiomatic_version_file
+++ b/e2e/lockfile/test_lockfile_idiomatic_version_file
@@ -48,6 +48,27 @@ idiomatic_version_file_enable_tools = ["dummy"]
 lockfile = true
 EOF
 
+mkdir -p .mise
+cat <<'EOF' >.mise/config.toml
+[settings]
+idiomatic_version_file_enable_tools = ["dummy"]
+lockfile = true
+EOF
+
+echo "1" >.dummy-version
+
+output=$(mise lock --dry-run --platform "$PLATFORM" 2>&1)
+assert_contains "echo '$output'" ".mise/mise.lock"
+assert_not_contains "echo '$output'" "for ~/workdir/mise.lock"
+
+rm -rf mise.toml .mise .dummy-version
+
+cat <<'EOF' >mise.toml
+[settings]
+idiomatic_version_file_enable_tools = ["dummy"]
+lockfile = true
+EOF
+
 echo "1" >.dummy-version
 touch mise.lock
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -898,6 +898,7 @@ pub fn lockfile_path_for_config(config_path: &Path) -> (PathBuf, bool) {
 ///
 /// Idiomatic version files are not config files themselves, so their lock entries
 /// belong to the nearest active mise config root that contains the version file.
+/// If multiple configs share that root, the highest-precedence config wins.
 pub fn lockfile_path_for_tool_source(
     config: &Config,
     source: &ToolSource,
@@ -907,8 +908,9 @@ pub fn lockfile_path_for_tool_source(
         ToolSource::IdiomaticVersionFile(path) => config
             .config_files
             .iter()
-            .filter(|(_, cf)| cf.source().is_mise_toml())
-            .filter_map(|(config_path, cf)| {
+            .enumerate()
+            .filter(|(_, (_, cf))| cf.source().is_mise_toml())
+            .filter_map(|(idx, (config_path, cf))| {
                 let root = cf.project_root().unwrap_or_else(|| cf.config_root());
                 let is_base = !is_local_config(config_path)
                     && extract_env_from_config_path(config_path).is_none();
@@ -916,12 +918,13 @@ pub fn lockfile_path_for_tool_source(
                     (
                         root.components().count(),
                         is_base,
+                        idx,
                         lockfile_path_for_config(config_path),
                     )
                 })
             })
-            .max_by_key(|(root_depth, is_base, _)| (*root_depth, *is_base))
-            .map(|(_, _, lockfile)| lockfile),
+            .max_by_key(|(root_depth, is_base, idx, _)| (*root_depth, *is_base, *idx))
+            .map(|(_, _, _, lockfile)| lockfile),
         _ => None,
     }
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -898,7 +898,9 @@ pub fn lockfile_path_for_config(config_path: &Path) -> (PathBuf, bool) {
 ///
 /// Idiomatic version files are not config files themselves, so their lock entries
 /// belong to the nearest active mise config root that contains the version file.
-/// If multiple configs share that root, the highest-precedence config wins.
+/// If multiple base configs share that root, the later entry in config_files wins
+/// so colocated configs have a deterministic lockfile target, such as
+/// .mise/config.toml mapping .dummy-version to .mise/mise.lock instead of mise.lock.
 pub fn lockfile_path_for_tool_source(
     config: &Config,
     source: &ToolSource,
@@ -918,6 +920,7 @@ pub fn lockfile_path_for_tool_source(
                     (
                         root.components().count(),
                         is_base,
+                        // Tie-break same-root base configs by config_files order.
                         idx,
                         lockfile_path_for_config(config_path),
                     )


### PR DESCRIPTION
## Summary
- prefer the highest-precedence mise config when idiomatic version files map to multiple configs with the same project root
- add e2e coverage for root mise.toml vs .mise/config.toml lockfile targeting

## Validation
- cargo fmt --check
- mise run test:e2e e2e/lockfile/test_lockfile_idiomatic_version_file
- cargo clippy --all-features -- -D warnings

Follow-up to #10309.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which lockfile path is used for idiomatic version sources in multi-config repos; behavior is more deterministic but may differ from the previous ambiguous choice for edge cases.
> 
> **Overview**
> Fixes ambiguous lockfile targeting when an idiomatic version file (e.g. `.dummy-version`) is covered by more than one base `mise.toml` at the same project root.
> 
> **`lockfile_path_for_tool_source`** still picks the deepest matching config root and prefers base configs, but when several configs tie on those criteria it now breaks ties using **`config_files` order** (later entry wins). That makes colocated `mise.toml` and `.mise/config.toml` consistently map the idiomatic file to **`.mise/mise.lock`** instead of the root **`mise.lock`**.
> 
> E2e coverage runs `mise lock --dry-run` with both configs present and asserts the lock output targets `.mise/mise.lock`, not the root lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be58cafbb6ec5cc13be0e70483c8ce707ac084cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test covering an idiomatic version-file lockfile scenario and cleanup behavior.

* **Bug Fixes**
  * Made lockfile selection deterministic when multiple configurations coexist, and ensured dry-run output references the local lockfile path rather than a hardcoded location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->