### PR TITLE
registry: add mdsmith (github:jeduden/mdsmith)

### DIFF
--- a/registry/mdsmith.toml
+++ b/registry/mdsmith.toml
@@ -1,0 +1,3 @@
+backends = ["github:jeduden/mdsmith"]
+description = "fast, auto-fixing Markdown linter and formatter. Checks style, readability, structure, and cross-file integrity."
+test = { cmd = "mdsmith version", expected = "mdsmith v{{version}}" }


### PR DESCRIPTION
Adds registry/mdsmith.toml on the github:jeduden/mdsmith backend. mise use github:jeduden/mdsmith@VER already resolves; a registry entry allows to use the shorter, prefix-less mdsmith@VER form.

Description is the GitHub repo description: 
> fast, auto-fixing Markdown linter and formatter. Checks style, readability, structure, and cross-file integrity.

The test expectation matches the CLI output (mdsmith version prints `mdsmith vX.Y.Z`; the github backend strips the tag's v).

Popularity
GitHub: 7 stars, 1 fork
last release `v0.42.0` (2026-06-11)
min release aged `v0.40.0` (2026-06-10)

Testing:
Ran `target/debug/mise test-tool mdsmith`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mdsmith backend configuration for automated Markdown linting and formatting with style, readability, and structural validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->