### PR TITLE
chore: release 2026.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [2026.6.4](https://github.com/jdx/mise/compare/v2026.6.3..v2026.6.4) - 2026-06-12
+
+### 🚀 Features
+
+- **(github)** add `matching` and `matching_regex` asset options by @devnulled in [#10325](https://github.com/jdx/mise/pull/10325)
+- **(oci)** add configurable layer owner by @ThomasK33 in [#10075](https://github.com/jdx/mise/pull/10075)
+- **(system)** declarative system packages (apt, dnf, pacman, and brew without brew) by @jdx in [#10326](https://github.com/jdx/mise/pull/10326)
+- **(system)** add mise system use and mise system upgrade by @jdx in [#10346](https://github.com/jdx/mise/pull/10346)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** support override env selectors by @risu729 in [#10200](https://github.com/jdx/mise/pull/10200)
+- **(aqua)** route versions host by registry repo by @jdx in [#10341](https://github.com/jdx/mise/pull/10341)
+- **(backend)** honor zero minimum release age flag by @jdx in [#10344](https://github.com/jdx/mise/pull/10344)
+- **(core)** preserve inner quotes for remaining cmd /c call sites on windows by @JamBalaya56562 in [#10323](https://github.com/jdx/mise/pull/10323)
+- **(dotnet)** include runtime in lock identity by @risu729 in [#10175](https://github.com/jdx/mise/pull/10175)
+- **(install)** skip inactive unknown tools by @risu729 in [#10206](https://github.com/jdx/mise/pull/10206)
+- **(java)** include shorthand vendor in lock identity by @risu729 in [#9989](https://github.com/jdx/mise/pull/9989)
+- **(task)** append forwarded args to inline bash -c tasks on windows by @JamBalaya56562 in [#10321](https://github.com/jdx/mise/pull/10321)
+- **(task)** validate monorepo-relative task refs by @jdx in [#10342](https://github.com/jdx/mise/pull/10342)
+- **(task)** show multiline descriptions in usage help by @risu729 in [#10204](https://github.com/jdx/mise/pull/10204)
+- **(tasks)** refactor editor command handling and improve error reporting by @roele in [#9752](https://github.com/jdx/mise/pull/9752)
+
+### 🧪 Testing
+
+- **(completions)** update usage 3.5 expectations by @jdx in [#10340](https://github.com/jdx/mise/pull/10340)
+- **(use)** cover quiet global use output by @risu729 in [#10199](https://github.com/jdx/mise/pull/10199)
+
+### 📦️ Dependency Updates
+
+- update ghcr.io/jdx/mise:alpine docker digest to 1248f2a by @renovate[bot] in [#10331](https://github.com/jdx/mise/pull/10331)
+- update rust crate tabled to 0.21 by @renovate[bot] in [#10337](https://github.com/jdx/mise/pull/10337)
+- update rattler by @renovate[bot] in [#10336](https://github.com/jdx/mise/pull/10336)
+- update actions/checkout action to v6.0.3 by @renovate[bot] in [#10335](https://github.com/jdx/mise/pull/10335)
+- update ghcr.io/jdx/mise:deb docker digest to 50edf9f by @renovate[bot] in [#10332](https://github.com/jdx/mise/pull/10332)
+- update rust docker digest to 4fd8406 by @renovate[bot] in [#10334](https://github.com/jdx/mise/pull/10334)
+- update ghcr.io/jdx/mise:rpm docker digest to 57866e0 by @renovate[bot] in [#10333](https://github.com/jdx/mise/pull/10333)
+
+### 📦 Registry
+
+- add ghtkn by @TyceHerrman in [#9967](https://github.com/jdx/mise/pull/9967)
+- add antigravity-cli by @rhanneken in [#10324](https://github.com/jdx/mise/pull/10324)
+
+### New Contributors
+
+- @ThomasK33 made their first contribution in [#10075](https://github.com/jdx/mise/pull/10075)
+- @devnulled made their first contribution in [#10325](https://github.com/jdx/mise/pull/10325)
+
 ## [2026.6.3](https://github.com/jdx/mise/compare/v2026.6.2..v2026.6.3) - 2026-06-11
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.6.3"
+version = "2026.6.4"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.6.3"
+version = "2026.6.4"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.6.3 macos-arm64 (2026-06-11)
+2026.6.4 macos-arm64 (2026-06-12)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_3.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_4.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_3.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_4.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_3.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_4.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_3.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_4.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.6.3";
+  version = "2026.6.4";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.6.3
+Version: 2026.6.4
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.6.3"
+version: "2026.6.4"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "44a0433752f5dca6bf0fb2fe6c6f6bea58621072"
+  "tag": "65a9b1fd22924a0a075067605725031175c121df"
 }


### PR DESCRIPTION
### 🚀 Features

- **(github)** add `matching` and `matching_regex` asset options by @devnulled in [#10325](https://github.com/jdx/mise/pull/10325)
- **(oci)** add configurable layer owner by @ThomasK33 in [#10075](https://github.com/jdx/mise/pull/10075)
- **(system)** declarative system packages (apt, dnf, pacman, and brew without brew) by @jdx in [#10326](https://github.com/jdx/mise/pull/10326)
- **(system)** add mise system use and mise system upgrade by @jdx in [#10346](https://github.com/jdx/mise/pull/10346)

### 🐛 Bug Fixes

- **(aqua)** support override env selectors by @risu729 in [#10200](https://github.com/jdx/mise/pull/10200)
- **(aqua)** route versions host by registry repo by @jdx in [#10341](https://github.com/jdx/mise/pull/10341)
- **(backend)** honor zero minimum release age flag by @jdx in [#10344](https://github.com/jdx/mise/pull/10344)
- **(core)** preserve inner quotes for remaining cmd /c call sites on windows by @JamBalaya56562 in [#10323](https://github.com/jdx/mise/pull/10323)
- **(dotnet)** include runtime in lock identity by @risu729 in [#10175](https://github.com/jdx/mise/pull/10175)
- **(install)** skip inactive unknown tools by @risu729 in [#10206](https://github.com/jdx/mise/pull/10206)
- **(java)** include shorthand vendor in lock identity by @risu729 in [#9989](https://github.com/jdx/mise/pull/9989)
- **(task)** append forwarded args to inline bash -c tasks on windows by @JamBalaya56562 in [#10321](https://github.com/jdx/mise/pull/10321)
- **(task)** validate monorepo-relative task refs by @jdx in [#10342](https://github.com/jdx/mise/pull/10342)
- **(task)** show multiline descriptions in usage help by @risu729 in [#10204](https://github.com/jdx/mise/pull/10204)
- **(tasks)** refactor editor command handling and improve error reporting by @roele in [#9752](https://github.com/jdx/mise/pull/9752)

### 🧪 Testing

- **(completions)** update usage 3.5 expectations by @jdx in [#10340](https://github.com/jdx/mise/pull/10340)
- **(use)** cover quiet global use output by @risu729 in [#10199](https://github.com/jdx/mise/pull/10199)

### 📦️ Dependency Updates

- update ghcr.io/jdx/mise:alpine docker digest to 1248f2a by @renovate[bot] in [#10331](https://github.com/jdx/mise/pull/10331)
- update rust crate tabled to 0.21 by @renovate[bot] in [#10337](https://github.com/jdx/mise/pull/10337)
- update rattler by @renovate[bot] in [#10336](https://github.com/jdx/mise/pull/10336)
- update actions/checkout action to v6.0.3 by @renovate[bot] in [#10335](https://github.com/jdx/mise/pull/10335)
- update ghcr.io/jdx/mise:deb docker digest to 50edf9f by @renovate[bot] in [#10332](https://github.com/jdx/mise/pull/10332)
- update rust docker digest to 4fd8406 by @renovate[bot] in [#10334](https://github.com/jdx/mise/pull/10334)
- update ghcr.io/jdx/mise:rpm docker digest to 57866e0 by @renovate[bot] in [#10333](https://github.com/jdx/mise/pull/10333)

### 📦 Registry

- add ghtkn by @TyceHerrman in [#9967](https://github.com/jdx/mise/pull/9967)
- add antigravity-cli by @rhanneken in [#10324](https://github.com/jdx/mise/pull/10324)

### New Contributors

- @ThomasK33 made their first contribution in [#10075](https://github.com/jdx/mise/pull/10075)
- @devnulled made their first contribution in [#10325](https://github.com/jdx/mise/pull/10325)