### PR TITLE
fix(core): preserve inner quotes for remaining cmd /c call sites on windows

### DIFF
--- a/e2e-win/exec_inner_quotes.Tests.ps1
+++ b/e2e-win/exec_inner_quotes.Tests.ps1
@@ -1,0 +1,54 @@
+Describe 'exec / exec() inner-quote preservation (cmd /c)' {
+    # Regression tests for https://github.com/jdx/mise/discussions/9355, extended
+    # beyond inline tasks/hooks to `mise exec -c` and the tera `exec()` template
+    # function. On Windows these spawn the default `cmd /c` shell; the command
+    # must reach cmd verbatim so inner double quotes survive, instead of being
+    # MSVCRT-requoted (inner `"` -> `\"`), which cmd.exe does not understand.
+
+    BeforeAll {
+        $originalPath = Get-Location
+        $originalTrustedConfigPaths = $env:MISE_TRUSTED_CONFIG_PATHS
+        Set-Location TestDrive:
+        $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
+    }
+
+    AfterAll {
+        Set-Location $originalPath
+        if ($null -ne $originalTrustedConfigPaths) {
+            $env:MISE_TRUSTED_CONFIG_PATHS = $originalTrustedConfigPaths
+        } else {
+            Remove-Item -Path Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'preserves inner double quotes in mise exec -c' {
+        # cmd's echo prints the quotes literally; the bug produced `\"...\"`.
+        $output = mise exec -c 'echo "hello world"' | Select-Object -Last 1
+        $output | Should -Not -Match '\\'
+        $output | Should -Be '"hello world"'
+    }
+
+    It 'passes an inner-quoted -c argument through to a program (mise exec -c)' {
+        # Without the fix the quoted script is split at the first space and node
+        # fails with a syntax error instead of printing the result.
+        if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because "node not on PATH"
+            return
+        }
+        $output = mise exec -c 'node -e "console.log(2 + 2)"' | Select-Object -Last 1
+        $output | Should -Be '4'
+    }
+
+    It 'preserves inner double quotes in the exec() template function' {
+        @'
+[env]
+EXEC_QUOTED = "{{ exec(command='echo \"a b\"') }}"
+'@ | Out-File -FilePath "mise.toml" -Encoding utf8NoBOM
+        # Parse JSON so the assertion sees the real value, not shell-quoted text.
+        # cmd's echo keeps the quotes, so the preserved value is exactly `"a b"`;
+        # a dropped-quote regression would yield `a b` and fail this.
+        $value = (mise env --json | ConvertFrom-Json).EXEC_QUOTED
+        $value | Should -Be '"a b"'
+        $value | Should -Not -Match '\\'
+    }
+}

--- a/e2e/env/test_env_template
+++ b/e2e/env/test_env_template
@@ -7,6 +7,19 @@ ENV_TMPL_EXEC = "{{ exec(command='echo foo') }}"
 EOF
 assert_contains "mise env -s zsh | grep ENV_TMPL_EXEC" "export ENV_TMPL_EXEC=foo"
 
+# Inner double quotes in an exec() command must survive to the shell. This is
+# the same run_once path shared with the Windows cmd-verbatim fix; on Unix it
+# guards against a regression in the refactor. `echo "a b"` must resolve to
+# exactly `a b` (echo strips the quotes) — not `"a b"` or a backslash-escaped
+# variant, which a broken refactor could produce.
+cat <<EOF >mise.toml
+[env]
+ENV_TMPL_EXEC_QUOTED = "{{ exec(command='echo \"a b\"') }}"
+EOF
+assert_json_partial_object "mise env --json" "ENV_TMPL_EXEC_QUOTED" '{
+  "ENV_TMPL_EXEC_QUOTED": "a b"
+}'
+
 cat <<EOF >mise.toml
 [env]
 B = "{{ env.A }}"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1966,8 +1966,7 @@ pub trait Backend: Debug + Send + Sync {
             .env("MISE_TOOL_NAME", tv.ba().short.clone())
             .env("MISE_TOOL_VERSION", tv.version.clone())
             .with_pr(ctx.pr.as_ref())
-            .args(shell_args)
-            .arg(&rendered_script)
+            .cmd_body_args(shell_args, &rendered_script)
             .envs(env_vars);
 
         // Set MISE_CONFIG_ROOT and MISE_PROJECT_ROOT from the tool's source config file

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -254,7 +254,10 @@ impl Exec {
         }
 
         time!("exec");
-        exec_program(program, args, env, &sandbox).await
+        // shell_body_mode: true only for the `-c`/`--command` path, where
+        // parse_command synthesized `shell + [flags.., body]`. A positional
+        // command must not be reinterpreted as a shell body.
+        exec_program(program, args, env, &sandbox, self.c.is_some()).await
     }
 }
 
@@ -264,6 +267,7 @@ pub async fn exec_program<T, U>(
     args: U,
     env: BTreeMap<String, String>,
     sandbox: &SandboxConfig,
+    _shell_body_mode: bool,
 ) -> Result<()>
 where
     T: IntoExecutablePath,
@@ -349,6 +353,7 @@ pub async fn exec_program<T, U>(
     args: U,
     env: BTreeMap<String, String>,
     sandbox: &SandboxConfig,
+    shell_body_mode: bool,
 ) -> Result<()>
 where
     T: IntoExecutablePath,
@@ -408,13 +413,36 @@ where
         std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
     });
     let program = which::which_in(program, lookup_path, cwd)?;
-    let cmd = cmd::cmd(program, args);
+    let args: Vec<OsString> = args.into_iter().map(Into::into).collect();
 
     // Windows does not support exec in the same way as Unix,
     // so we emulate it instead by not handling Ctrl-C and letting
     // the child process deal with it instead.
     win_exec::set_ctrlc_handler()?;
 
+    // `mise exec -c "<cmd>"` spawns the configured shell as `cmd /c <cmd>`. For
+    // cmd, pass the command verbatim so inner double quotes survive (#9355).
+    // Gated on `shell_body_mode` (the `-c`/`--command` path) so a positional
+    // `mise exec -- cmd /c "echo one" two` is not reinterpreted as a shell body.
+    // cwd is intentionally inherited from the process here, matching the duct
+    // fallback below; the resolved `cwd` above governs program lookup only.
+    if shell_body_mode {
+        if let (Some(prog), [.., last]) = (program.to_str(), args.as_slice()) {
+            let flags: Vec<String> = args[..args.len() - 1]
+                .iter()
+                .map(|a| a.to_string_lossy().into_owned())
+                .collect();
+            let body = last.to_string_lossy();
+            if let Some(mut c) = crate::path::cmd_verbatim_command(prog, &flags, &body) {
+                match c.status()?.code() {
+                    Some(code) => std::process::exit(code),
+                    None => return Err(eyre!("command failed: terminated by signal")),
+                }
+            }
+        }
+    }
+
+    let cmd = cmd::cmd(program, args);
     let res = cmd.unchecked().run()?;
     match res.status.code() {
         Some(code) => {
@@ -430,6 +458,7 @@ pub async fn exec_program<T, U>(
     args: U,
     env: BTreeMap<String, String>,
     _sandbox: &SandboxConfig,
+    _shell_body_mode: bool,
 ) -> Result<()>
 where
     T: IntoExecutablePath,

--- a/src/cli/tool_stub.rs
+++ b/src/cli/tool_stub.rs
@@ -585,7 +585,7 @@ async fn execute_with_tool_request(
             }
             env.insert(crate::env::PATH_KEY.to_string(), path_env.to_string());
 
-            crate::cli::exec::exec_program(bin_path, args, env, &Default::default()).await
+            crate::cli::exec::exec_program(bin_path, args, env, &Default::default(), false).await
         }
         Err(e) => match e {
             BinPathError::ToolNotFound(tool_name) => {
@@ -707,6 +707,7 @@ pub(crate) async fn short_circuit_stub(args: &[String]) -> Result<()> {
             args,
             BTreeMap::new(),
             &Default::default(),
+            false,
         )
         .await;
     }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -474,6 +474,27 @@ impl<'a> CmdLineRunner<'a> {
         self
     }
 
+    /// Append a shell's `flags` followed by an inline command `body`. On Windows,
+    /// when this runner's program is `cmd[.exe]` and `flags` contain `/c`|`/k`,
+    /// the body is handed to cmd *verbatim* (raw args, one outer quote pair via
+    /// [`crate::path::cmd_verbatim_args`]) so inner double quotes survive — the
+    /// same fix the inline-task path uses. Otherwise (Unix, or a non-cmd Windows
+    /// shell) this is exactly `self.args(flags).arg(body)`. See #9355.
+    pub fn cmd_body_args(self, flags: &[String], body: &str) -> Self {
+        #[cfg(windows)]
+        {
+            let program = std::path::PathBuf::from(self.cmd.get_program());
+            let runs_command = flags
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case("/c") || f.eq_ignore_ascii_case("/k"));
+            if crate::path::is_cmd_shell_program(&program) && runs_command {
+                let cmd_args = crate::path::cmd_verbatim_args(flags, body, &[]);
+                return cmd_args.into_iter().fold(self, |r, a| r.raw_arg(a));
+            }
+        }
+        self.args(flags).arg(body)
+    }
+
     /// Append a single argument to the command line *verbatim*, bypassing the
     /// MSVCRT-style quoting std normally applies on Windows. Required when
     /// spawning `cmd.exe /c <script>`: cmd does not understand the `\"`
@@ -1069,5 +1090,45 @@ mod tests {
         let _config = Config::get().await.unwrap();
         let output = cmd!("echo", "foo", "bar").read().unwrap();
         assert_eq!("foo bar", output);
+    }
+
+    #[test]
+    fn test_cmd_body_args_unix_fallthrough() {
+        // On Unix `cmd_body_args` must be exactly `args(flags).arg(body)` — the
+        // non-regression contract shared by every CmdLineRunner call site.
+        let r = super::CmdLineRunner::new("bash").cmd_body_args(&["-c".to_string()], "echo hi");
+        assert_eq!(r.get_args(), vec!["-c".to_string(), "echo hi".to_string()]);
+    }
+}
+
+#[cfg(test)]
+#[cfg(windows)]
+mod windows_tests {
+    #[test]
+    fn test_cmd_body_args_cmd_verbatim() {
+        // cmd /c <body>: the verbatim branch produces the cmd_verbatim_args output
+        // (`/s /c "<body>"`) rather than the fall-through [/c, <body>] layout.
+        let r =
+            super::CmdLineRunner::new("cmd").cmd_body_args(&["/c".to_string()], r#"echo "a b""#);
+        assert!(r.get_program().to_lowercase().contains("cmd"));
+        assert_eq!(
+            r.get_args(),
+            vec![
+                "/s".to_string(),
+                "/c".to_string(),
+                r#""echo "a b"""#.to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_cmd_body_args_non_cmd_fallthrough() {
+        // A non-cmd Windows shell keeps the plain args(flags).arg(body) layout.
+        let r = super::CmdLineRunner::new("pwsh")
+            .cmd_body_args(&["-Command".to_string()], r#"echo "a b""#);
+        assert_eq!(
+            r.get_args(),
+            vec!["-Command".to_string(), r#"echo "a b""#.to_string()]
+        );
     }
 }

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -771,9 +771,15 @@ impl DepsEngine {
             None => std::env::current_dir()?,
         };
 
-        let mut runner = CmdLineRunner::new(&cmd.program)
-            .args(&cmd.args)
-            .current_dir(cwd);
+        // cmd.args is [shell flags.., run]; route the run body through
+        // cmd_body_args so an inner-quoted command survives `cmd /c` on Windows.
+        // On Unix / non-cmd shells this is byte-identical to .args(&cmd.args).
+        let mut runner = CmdLineRunner::new(&cmd.program);
+        runner = match cmd.args.split_last() {
+            Some((body, flags)) => runner.cmd_body_args(flags, body),
+            None => runner,
+        };
+        runner = runner.current_dir(cwd);
 
         // Apply timeout if configured
         if let Some(timeout) = timeout {

--- a/src/path.rs
+++ b/src/path.rs
@@ -235,6 +235,37 @@ pub(crate) fn quote_arg_for_cmd_body(arg: &str) -> String {
     s
 }
 
+/// Windows: if `program` is `cmd[.exe]` invoked with a `/c`|`/k` flag, build a
+/// configured-but-unspawned [`std::process::Command`] that hands `body` to cmd
+/// *verbatim* — raw args, a single outer quote pair, `/s` ensured (see
+/// [`cmd_verbatim_args`]) — so inner double quotes survive. Returns `None` for
+/// any non-cmd shell (or a cmd invocation that does not run a command string),
+/// so the caller falls through to its existing duct/std path unchanged.
+///
+/// Only the program and args are set; the caller owns env, cwd, stdio, and
+/// spawning. Mirrors the inline-task path in
+/// `TaskExecutor::get_cmd_program_and_args` and the hook path in
+/// `hooks::execute`, extended to the other `cmd /c` call sites. See #9355.
+#[cfg(windows)]
+pub fn cmd_verbatim_command(
+    program: &str,
+    flags: &[String],
+    body: &str,
+) -> Option<std::process::Command> {
+    use std::os::windows::process::CommandExt;
+    let runs_command = flags
+        .iter()
+        .any(|f| f.eq_ignore_ascii_case("/c") || f.eq_ignore_ascii_case("/k"));
+    if !is_cmd_shell_program(Path::new(program)) || !runs_command {
+        return None;
+    }
+    let mut c = std::process::Command::new(program);
+    for a in cmd_verbatim_args(flags, body, &[]) {
+        c.raw_arg(a);
+    }
+    Some(c)
+}
+
 /// Split a configured shell *command string* (program + args) into argv,
 /// honoring host conventions.
 ///
@@ -577,6 +608,32 @@ mod tests {
         assert_eq!(quote_arg_for_cmd_body("a&b"), r#""a&b""#);
         assert_eq!(quote_arg_for_cmd_body("foo|bar"), r#""foo|bar""#);
         assert_eq!(quote_arg_for_cmd_body("a>b"), r#""a>b""#);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_cmd_verbatim_command() {
+        // cmd + /c -> Some; the body is wrapped in one outer quote pair with `/s`
+        // ensured, passed via raw_arg (which appears verbatim in get_args()).
+        let c = cmd_verbatim_command("cmd", &["/c".to_string()], r#"echo "a b""#).unwrap();
+        assert_eq!(c.get_program().to_str(), Some("cmd"));
+        let args: Vec<String> = c
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            vec![
+                "/s".to_string(),
+                "/c".to_string(),
+                r#""echo "a b"""#.to_string()
+            ]
+        );
+        // /k also runs a command string.
+        assert!(cmd_verbatim_command("cmd", &["/k".to_string()], "echo hi").is_some());
+        // Non-cmd shell, or cmd without /c|/k -> None (caller falls through).
+        assert!(cmd_verbatim_command("bash", &["-c".to_string()], "echo hi").is_none());
+        assert!(cmd_verbatim_command("cmd", &[], "echo hi").is_none());
     }
 
     #[test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -452,10 +452,48 @@ pub fn tera_exec(
                     env_no_shims
                         .insert(env::PATH_KEY.to_string(), strip_shims_from_path(&path_val));
                 }
-                let mut cmd: duct::Expression = cmd(&shell[0], args).full_env(&env_no_shims);
-                if let Some(dir) = &dir {
-                    cmd = cmd.dir(dir);
-                }
+                // Run the command capturing stdout (duct `.read()` trims one
+                // trailing newline). On Windows a `cmd /c` command is passed
+                // verbatim so inner double quotes survive (#9355); non-cmd shells
+                // and Unix keep the duct path. Returns eyre::Result so it can feed
+                // the cache's get_or_try_init directly.
+                let run_once = || -> eyre::Result<String> {
+                    #[cfg(windows)]
+                    {
+                        if let Some(mut c) =
+                            crate::path::cmd_verbatim_command(&shell[0], &shell[1..], command)
+                        {
+                            c.env_clear();
+                            c.envs(env_no_shims.iter());
+                            if let Some(dir) = &dir {
+                                c.current_dir(dir);
+                            }
+                            let out = c.output()?;
+                            if !out.status.success() {
+                                eyre::bail!(
+                                    "exec command failed: {}",
+                                    String::from_utf8_lossy(&out.stderr)
+                                );
+                            }
+                            // Strict UTF-8 like duct's `.read()` (which uses
+                            // read_to_string and errors on invalid UTF-8 rather
+                            // than substituting U+FFFD replacement characters).
+                            let mut s = String::from_utf8(out.stdout)?;
+                            // Match duct's `.read()`: strip *all* trailing \r and
+                            // \n, so the cmd path returns byte-identical output to
+                            // the non-cmd (duct) path on the same machine.
+                            while s.ends_with('\n') || s.ends_with('\r') {
+                                s.pop();
+                            }
+                            return Ok(s);
+                        }
+                    }
+                    let mut expr: duct::Expression = cmd(&shell[0], args).full_env(&env_no_shims);
+                    if let Some(dir) = &dir {
+                        expr = expr.dir(dir);
+                    }
+                    Ok(expr.read()?)
+                };
                 let result = if cache.is_some() || cache_duration.is_some() {
                     let cachehash = hash::hash_blake3_to_str(
                         &(dir
@@ -474,12 +512,12 @@ pub fn tera_exec(
                         cacheman = cacheman.with_fresh_duration(Some(cache_duration));
                     }
                     let cache = cacheman.build();
-                    match cache.get_or_try_init(|| Ok(cmd.read()?)) {
+                    match cache.get_or_try_init(run_once) {
                         Ok(result) => result.clone(),
                         Err(e) => return Err(format!("exec command: {e}").into()),
                     }
                 } else {
-                    cmd.read()?
+                    run_once().map_err(|e| tera::Error::msg(format!("exec command: {e}")))?
                 };
                 Ok(Value::String(result))
             }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -91,8 +91,19 @@ pub fn get_credential_command_token(provider: &str, cmd: &str, host: &str) -> Op
             return None;
         }
     };
-    let result = std::process::Command::new(program)
-        .args(args)
+    let mut command = std::process::Command::new(&program);
+    command.args(&args);
+    // On Windows, route a `cmd /c <credential-command>` through the verbatim
+    // builder so inner double quotes survive (#9355). Other shells and Unix keep
+    // the plain Command::new(program).args(args). The command body is the last
+    // element of args (see credential_command_shell_from).
+    #[cfg(windows)]
+    if let Some((body, flags)) = args.split_last() {
+        if let Some(c) = crate::path::cmd_verbatim_command(&program, flags, body) {
+            command = c;
+        }
+    }
+    let result = command
         .env("PATH", &path_without_shims)
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("MISE_CREDENTIAL_HOST", host)

--- a/src/watch_files.rs
+++ b/src/watch_files.rs
@@ -111,6 +111,24 @@ async fn execute(
     );
     // TODO: this should be different but I don't have easy access to it
     // env.insert("MISE_CONFIG_ROOT".to_string(), root.to_string_lossy().to_string());
+    // On Windows, `cmd /c <run>` must receive the command verbatim so inner
+    // double quotes survive (#9355). Mirror the hook path: spawn a raw Command
+    // with stdout redirected to our stderr handle (duct's stdout_to_stderr) and
+    // the full env. Non-cmd shells / Unix fall through to the duct path below.
+    #[cfg(windows)]
+    {
+        if let Some(mut c) = crate::path::cmd_verbatim_command(program, shell_args, run) {
+            use std::os::windows::io::AsHandle;
+            c.env_clear();
+            c.envs(env.iter());
+            c.stdout(std::io::stderr().as_handle().try_clone_to_owned()?);
+            let status = c.status()?;
+            if !status.success() {
+                eyre::bail!("watch_files command failed: {status}");
+            }
+            return Ok(());
+        }
+    }
     cmd(program, args)
         .stdout_to_stderr()
         // .dir(root)


### PR DESCRIPTION
## Problem

#10301 fixed `cmd /c` inner-double-quote mangling for **inline tasks** and **`[hooks]`** on Windows by passing the command to cmd verbatim (`cmd /s /c "<body>"`, where `/s` strips exactly the one outer quote pair). The same root cause — std serializing argv with MSVCRT quoting (`"` → `\"`), which `cmd.exe` does not understand — affects the **other call sites** that spawn `cmd /c <command>`:

- `mise exec -c "<cmd>"` (`src/cli/exec.rs`)
- the tera `exec()` template function (`src/tera.rs`)
- `[[watch_files]]` hook commands (`src/watch_files.rs`)
- tool postinstall hooks (`src/backend/mod.rs`)
- `[deps]` commands (`src/deps/engine.rs`)
- credential commands (`src/tokens.rs`)

Each previously passed the command string as an ordinary `std::process::Command` argument, so an inner-quoted command like `python -c "import x"` reached the child mangled.

## Fix

Two shared helpers, both reusing #10301's `cmd_verbatim_args`:

- **`path::cmd_verbatim_command(program, flags, body) -> Option<Command>`** for the duct / raw-`Command` sites. Returns `None` for any non-cmd shell (or a cmd invocation without `/c`|`/k`), so the caller falls through to its existing path unchanged. The caller owns env/cwd/stdio/spawning, so each site keeps its own behavior (inherited stdio for `exec`, stdout→stderr for `watch_files`, captured `.output()` + newline-trim for `exec()`).
- **`CmdLineRunner::cmd_body_args(flags, body)`** for the `CmdLineRunner` sites (`backend`, `deps`). On Unix / non-cmd shells this is exactly `args(flags).arg(body)`.

**Windows-only behavior change.** Non-cmd shells (`pwsh`, `bash`) and **all Unix paths are byte-for-byte unchanged** — every site falls through to its pre-existing code.

`src/cli/test_tool.rs` is intentionally left out: it relies on `stderr_to_stdout().stdout_capture()` (an fd-level merge std can't faithfully replicate) and is diagnostic-only.

## Testing

- Unit gate tests for both helpers (`src/path.rs`, `src/cmd.rs`), including the Unix fall-through contract (`cmd_body_args` == `args(flags).arg(body)`).
- Unix non-regression: `e2e/env/test_env_template` now covers an inner-quoted `exec()` (exercises the shared `run_once` refactor).
- Windows e2e: `e2e-win/exec_inner_quotes.Tests.ps1` covers `mise exec -c 'echo "hello world"'`, `node -e "..."`, and the `exec()` template.

> Built on a Linux host, so the `#[cfg(windows)]` paths and `e2e-win` are verified by CI (`build-windows` / `windows-unit` / `windows-e2e`).

Follow-up to #10301. Refs #9355.

*This pull request was prepared with the help of an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve inner double quotes for commands run via exec -c on Windows (quoted strings like "hello world" remain unchanged).
  * Ensure exec() template values retain quoted content when resolved via env/template commands.
  * Improve Windows handling of quoted shell bodies for more reliable execution and correct exit-code propagation.

* **Tests**
  * Added end-to-end tests validating Windows cmd /c and template behaviors for inner-quoted arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->