### PR TITLE
registry: add antigravity-cli

### DIFF
--- a/registry/antigravity-cli.toml
+++ b/registry/antigravity-cli.toml
@@ -1,0 +1,5 @@
+aliases = ["agy"]
+backends = ["aqua:google-antigravity/antigravity-cli"]
+description = "Google's agentic development platform CLI companion"
+test = { cmd = "agy --version", expected = "{{version}}" }
+

--- a/registry/antigravity-cli.toml
+++ b/registry/antigravity-cli.toml
@@ -2,4 +2,3 @@ aliases = ["agy"]
 backends = ["aqua:google-antigravity/antigravity-cli"]
 description = "Google's agentic development platform CLI companion"
 test = { cmd = "agy --version", expected = "{{version}}" }
-


### PR DESCRIPTION
Adds a registry entry for the Antigravity CLI, Google's agentic development platform CLI companion, backed by the existing `aqua:google-antigravity/antigravity-cli` package.

> [!NOTE]
> Antigravity CLI is the official successor to [Gemini CLI](https://github.com/google-gemini/gemini-cli) (already in the registry as gemini-cli.toml), which Google is shutting down on June 18, 2026 per their [official transition announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/). The aqua registry has already accepted it.
>
> GitHub [google-antigravity/antigravity-cli](https://github.com/google-antigravity/antigravity-cli), 1030 stars, repo created 2026-05-13
aqua entry [google-antigravity/antigravity-cli](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/google-antigravity/antigravity-cli/registry.yaml) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A new CLI tool is available via the `agy` command alias for convenient access.

* **Tests**
  * Added an automated check to verify the CLI reports the expected version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->