### PR TITLE
test(task): update zsh completion expectations for usage 3.5 three-column output

### DIFF
--- a/e2e/tasks/test_task_completion
+++ b/e2e/tasks/test_task_completion
@@ -9,5 +9,5 @@ run = 'echo build'
 EOF
 
 mise usage >./mise.usage.kdl
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run build -- -c ''" "mise.toml	mise.toml
-mise.usage.kdl	mise.usage.kdl"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run build -- -c ''" "mise.toml		mise.toml
+mise.usage.kdl		mise.usage.kdl"

--- a/e2e/tasks/test_task_completion_global_cd
+++ b/e2e/tasks/test_task_completion_global_cd
@@ -20,35 +20,35 @@ EOF
 mise usage >./mise.usage.kdl
 
 # baseline: completion of the profile arg works without the global flag
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
 
 # regression: with the global -C <dir> flag before `run`, completion must still
 # offer the choices (previously errored: Invalid choice for arg profile: -C)
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise -C . run sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise -C . run sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
 
 # also cover the `tasks run` path, which shares the same flags/mount
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise -C . tasks run sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise -C . tasks run sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
 
 # orphan-short flags: -r/--raw and -S/--silent have no short on the root global,
 # so usage#649 alone would drop the short. The completion-spec promotion keeps
 # them recognized before the mounted task (previously errored: unexpected word).
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -r sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -S sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -r sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -S sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
 
 # and the same two over the `tasks run` path
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run -r sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run -S sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run -r sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run -S sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"


### PR DESCRIPTION
## Problem

Two task-completion e2e tests have been failing on `main`:
- `e2e/tasks/test_task_completion` (CI `e2e-3`)
- `e2e/tasks/test_task_completion_global_cd` (CI `e2e-4`)

They assert the output of `usage complete-word --shell zsh`. usage **v3.5.0** ([jdx/usage#666](https://github.com/jdx/usage/pull/666), "Zsh Colon Fixes") intentionally changed that output from a two-column `value<TAB>insert` layout to an unconditional three-column `value<TAB>description<TAB>insert`. For completions with no description (the file/choice completions these tests exercise), the now-always-present empty middle column produces a **double tab** — e.g. `mise.toml\t\tmise.toml` and `alpha\t\talpha` — where the tests still expected a single tab.

mise already adopted the new format in #10313 (regenerated `completions/_mise` to the three-column consumer and pinned usage-lib / `mise.lock` to 3.5.0), but these two e2e expectation strings were not updated. Because the tests install the `usage` tool with `version = "latest"`, they only went red once the default 24h `minimum_release_age` window let `latest` resolve to v3.5.0 (~24h after the v3.5.0 release) — which is why #10313's own CI was still green at merge time.

## Change

Update the expected completion lines in both tests to the three-column format (insert the empty description column: `value\t\tvalue`). **Test-only change — no behavior change.** The new format is corroborated by the CI's actual output and by usage v3.5.0's own unit test (`complete_word_zsh_three_columns_without_descriptions`).

The tests keep `usage = { version = "latest" }`; pinning to a concrete version to avoid tracking future usage format changes is left as a separate maintainer decision.

Refs jdx/usage#666, #10313.

*This pull request was prepared with the help of an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test assertions for task completion output formatting to reflect adjusted spacing and display of completion candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->