### PR TITLE
test(completions): update usage 3.5 expectations

### DIFF
--- a/e2e/tasks/test_task_completion
+++ b/e2e/tasks/test_task_completion
@@ -9,5 +9,5 @@ run = 'echo build'
 EOF
 
 mise usage >./mise.usage.kdl
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run build -- -c ''" "mise.toml	mise.toml
-mise.usage.kdl	mise.usage.kdl"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run build -- -c ''" "mise.toml		mise.toml
+mise.usage.kdl		mise.usage.kdl"

--- a/e2e/tasks/test_task_completion_global_cd
+++ b/e2e/tasks/test_task_completion_global_cd
@@ -20,35 +20,35 @@ EOF
 mise usage >./mise.usage.kdl
 
 # baseline: completion of the profile arg works without the global flag
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
 
 # regression: with the global -C <dir> flag before `run`, completion must still
 # offer the choices (previously errored: Invalid choice for arg profile: -C)
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise -C . run sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise -C . run sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
 
 # also cover the `tasks run` path, which shares the same flags/mount
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise -C . tasks run sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise -C . tasks run sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
 
 # orphan-short flags: -r/--raw and -S/--silent have no short on the root global,
 # so usage#649 alone would drop the short. The completion-spec promotion keeps
 # them recognized before the mounted task (previously errored: unexpected word).
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -r sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -S sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -r sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -S sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
 
 # and the same two over the `tasks run` path
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run -r sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
-assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run -S sample:run -- ''" "alpha	alpha
-beta	beta
-gamma	gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run -r sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run -S sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"


### PR DESCRIPTION
## Summary
- Update zsh completion e2e expectations for usage 3.5's two-tab description separator
- Keep the PR scoped to the test fallout from the latest usage CLI behavior

## Test
- mise run test:e2e e2e/tasks/test_task_completion e2e/tasks/test_task_completion_global_cd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion updates with no production code or behavior changes in mise itself.
> 
> **Overview**
> Updates zsh task-completion e2e tests to match **usage 3.5** output from `usage complete-word --shell zsh`: the value/description pair now uses a **two-tab** separator instead of one.
> 
> Expected strings in `test_task_completion` and `test_task_completion_global_cd` are adjusted accordingly (e.g. `alpha\talpha` → `alpha\t\talpha`). No mise runtime or completion logic changes—only test expectations for the newer usage CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86133aa3bd79b6b43af8481abde772c44e687ea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated e2e test assertions for task completion output formatting to ensure accurate validation of completion behavior across various scenarios and flag combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->