### PR TITLE
fix(aqua): route versions host by registry repo

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1318,7 +1318,8 @@ impl AquaBackend {
                     minisign_config.repo_name.as_ref(),
                     pkg,
                 );
-                let url = github::get_release(&format!("{repo_owner}/{repo_name}"), v)
+                let url = self
+                    .get_github_release(&format!("{repo_owner}/{repo_name}"), v)
                     .await?
                     .assets
                     .into_iter()
@@ -1501,6 +1502,29 @@ impl AquaBackend {
         }
     }
 
+    fn use_versions_host_for_github_metadata(&self, repo: &str) -> bool {
+        if !backend_arg_matches_registry_backend(&self.ba) {
+            return false;
+        }
+        let full = self.ba.full_without_opts();
+        let Some(aqua_id) = full.strip_prefix("aqua:") else {
+            return false;
+        };
+        let aqua_id = aqua_id.to_ascii_lowercase();
+        let repo = repo.to_ascii_lowercase();
+        aqua_id == repo || aqua_id.starts_with(&format!("{repo}/"))
+    }
+
+    async fn get_github_release(&self, repo: &str, tag: &str) -> Result<github::GithubRelease> {
+        github::get_release_for_url_with_versions_host(
+            github::API_URL,
+            repo,
+            tag,
+            self.use_versions_host_for_github_metadata(repo),
+        )
+        .await
+    }
+
     async fn latest_marked_release_version(&self) -> Result<Option<String>> {
         if Settings::get().offline() {
             trace!("Skipping latest stable version due to offline mode");
@@ -1528,7 +1552,7 @@ impl AquaBackend {
         }
 
         let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
-        let release = match github::get_release(&repo, "latest").await {
+        let release = match self.get_github_release(&repo, "latest").await {
             Ok(release) => release,
             Err(e) => {
                 debug!(
@@ -1669,7 +1693,7 @@ impl AquaBackend {
         prefer_musl: bool,
     ) -> Result<(String, Option<String>)> {
         let gh_id = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
-        let gh_release = github::get_release(&gh_id, v).await?;
+        let gh_release = self.get_github_release(&gh_id, v).await?;
 
         // Prioritize order of asset_strs
         let asset = select_github_release_asset(&gh_release.assets, &asset_strs, prefer_musl)
@@ -2722,6 +2746,30 @@ mod tests {
             default: None,
             required,
         }
+    }
+
+    #[test]
+    fn test_use_versions_host_for_github_metadata_only_for_registry_backends() {
+        let registry_backend = AquaBackend::from_arg(BackendArg::new(
+            "act".to_string(),
+            Some("aqua:nektos/act".to_string()),
+        ));
+        assert!(registry_backend.use_versions_host_for_github_metadata("nektos/act"));
+        assert!(!registry_backend.use_versions_host_for_github_metadata("sigstore/foreign"));
+
+        let subpackage_backend = AquaBackend::from_arg(BackendArg::new(
+            "fly".to_string(),
+            Some("aqua:concourse/concourse/fly".to_string()),
+        ));
+        assert!(subpackage_backend.use_versions_host_for_github_metadata("concourse/concourse"));
+
+        let direct_backend = AquaBackend::from_arg(BackendArg::new(
+            "aws/session-manager-plugin".to_string(),
+            Some("aqua:aws/session-manager-plugin".to_string()),
+        ));
+        assert!(
+            !direct_backend.use_versions_host_for_github_metadata("aws/session-manager-plugin")
+        );
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -13,7 +13,7 @@ use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::path::{Path, PathBuf, PathExt};
 use crate::plugins::VERSION_REGEX;
-use crate::registry::REGISTRY;
+use crate::registry::{REGISTRY, shorts_for_full};
 use crate::toolset::{EPHEMERAL_OPT_KEYS, ToolRequest, ToolVersion, ToolVersionOptions};
 use crate::ui::progress_report::SingleReport;
 use crate::{
@@ -1066,12 +1066,13 @@ impl AquaBackend {
         pkg: &AquaPackage,
         digest: &str,
     ) -> std::result::Result<bool, crate::github::sigstore::DetectError> {
+        let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
         crate::github::sigstore::detect_attestations(
             &pkg.repo_owner,
             &pkg.repo_name,
             github::API_URL,
             digest,
-            backend_arg_matches_registry_backend(&self.ba),
+            self.use_versions_host_for_github_metadata(&repo),
         )
         .await
     }
@@ -1156,6 +1157,7 @@ impl AquaBackend {
             .github_artifact_attestations
             .as_ref()
             .and_then(|att| att.signer_workflow.as_deref().map(unescape_regex_literal));
+        let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
 
         match crate::github::sigstore::verify_attestation(
             artifact_path,
@@ -1163,7 +1165,7 @@ impl AquaBackend {
             &pkg.repo_name,
             signer_workflow.as_deref(),
             None,
-            backend_arg_matches_registry_backend(&self.ba),
+            self.use_versions_host_for_github_metadata(&repo),
         )
         .await
         {
@@ -1503,10 +1505,10 @@ impl AquaBackend {
     }
 
     fn use_versions_host_for_github_metadata(&self, repo: &str) -> bool {
-        if !backend_arg_matches_registry_backend(&self.ba) {
+        let full = self.ba.full_without_opts();
+        if !backend_arg_matches_registry_backend(&self.ba) && shorts_for_full(&full).is_empty() {
             return false;
         }
-        let full = self.ba.full_without_opts();
         let Some(aqua_id) = full.strip_prefix("aqua:") else {
             return false;
         };
@@ -2749,13 +2751,19 @@ mod tests {
     }
 
     #[test]
-    fn test_use_versions_host_for_github_metadata_only_for_registry_backends() {
+    fn test_use_versions_host_for_github_metadata_only_for_registry_tools() {
         let registry_backend = AquaBackend::from_arg(BackendArg::new(
             "act".to_string(),
             Some("aqua:nektos/act".to_string()),
         ));
         assert!(registry_backend.use_versions_host_for_github_metadata("nektos/act"));
         assert!(!registry_backend.use_versions_host_for_github_metadata("sigstore/foreign"));
+
+        let explicit_registry_backend = AquaBackend::from_arg(BackendArg::new(
+            "nektos/act".to_string(),
+            Some("aqua:nektos/act".to_string()),
+        ));
+        assert!(explicit_registry_backend.use_versions_host_for_github_metadata("nektos/act"));
 
         let subpackage_backend = AquaBackend::from_arg(BackendArg::new(
             "fly".to_string(),

--- a/src/github.rs
+++ b/src/github.rs
@@ -284,12 +284,12 @@ async fn list_tags_with_dates_(api_url: &str, repo: &str) -> Result<Vec<GithubTa
 }
 
 pub async fn get_release(repo: &str, tag: &str) -> Result<GithubRelease> {
-    let key = format!("{repo}-{tag}").to_kebab_case();
+    let key = format!("{repo}-{tag}-versions-host-true").to_kebab_case();
     let cache = get_release_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     cache
         .get_or_try_init_async_if(
-            async || get_release_(API_URL, repo, tag).await,
+            async || get_release_with_options(API_URL, repo, tag, true).await,
             should_cache_release,
         )
         .await
@@ -359,10 +359,6 @@ fn pick_best_build_revision(releases: Vec<GithubRelease>, version: &str) -> Opti
                 .and_then(|s| s.parse::<u32>().ok())
                 .unwrap_or(0)
         })
-}
-
-async fn get_release_(api_url: &str, repo: &str, tag: &str) -> Result<GithubRelease> {
-    get_release_with_options(api_url, repo, tag, true).await
 }
 
 async fn get_release_with_options(
@@ -977,6 +973,46 @@ something_else = "value"
             .await
             .unwrap();
         assert_eq!(release.assets.len(), 1);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_versions_host_flag_splits_release_cache() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let repo = "owner/versions-host-cache-split-test";
+        let tag = "v1.0.0";
+        let path = format!("/repos/{repo}/releases/tags/{tag}");
+        let true_key = format!("{}-{repo}-{tag}-versions-host-true", server.url()).to_kebab_case();
+
+        {
+            let cache_group = get_release_cache(&true_key).await;
+            let cache = cache_group.get(&true_key).unwrap();
+            cache
+                .write(&GithubRelease {
+                    assets: vec![make_asset("cached-from-versions-host.tar.gz")],
+                    ..make_release(tag)
+                })
+                .unwrap();
+        }
+
+        let direct_release = GithubRelease {
+            assets: vec![make_asset("direct-github-api.tar.gz")],
+            ..make_release(tag)
+        };
+        let mock = server
+            .mock("GET", path.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&direct_release).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let release = get_release_for_url_with_versions_host(&server.url(), repo, tag, false)
+            .await
+            .unwrap();
+        assert_eq!(release.assets[0].name, "direct-github-api.tar.gz");
         mock.assert_async().await;
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -284,7 +284,7 @@ async fn list_tags_with_dates_(api_url: &str, repo: &str) -> Result<Vec<GithubTa
 }
 
 pub async fn get_release(repo: &str, tag: &str) -> Result<GithubRelease> {
-    let key = format!("{repo}-{tag}-versions-host-true").to_kebab_case();
+    let key = release_cache_key(API_URL, repo, tag, true);
     let cache = get_release_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     cache
@@ -301,7 +301,7 @@ pub async fn get_release_for_url_with_versions_host(
     tag: &str,
     use_versions_host: bool,
 ) -> Result<GithubRelease> {
-    let key = format!("{api_url}-{repo}-{tag}-versions-host-{use_versions_host}").to_kebab_case();
+    let key = release_cache_key(api_url, repo, tag, use_versions_host);
     let cache = get_release_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     cache
@@ -310,6 +310,15 @@ pub async fn get_release_for_url_with_versions_host(
             should_cache_release,
         )
         .await
+}
+
+fn release_cache_key(api_url: &str, repo: &str, tag: &str, use_versions_host: bool) -> String {
+    let source = if use_versions_host {
+        "hosted"
+    } else {
+        "direct"
+    };
+    format!("{api_url}-{repo}-{tag}-{source}").to_kebab_case()
 }
 
 fn should_cache_release(release: &GithubRelease) -> bool {
@@ -925,7 +934,7 @@ something_else = "value"
         let repo = "owner/empty-assets-cache-test";
         let tag = "v1.0.0";
         let path = format!("/repos/{repo}/releases/tags/{tag}");
-        let key = format!("{}-{repo}-{tag}-versions-host-true", server.url()).to_kebab_case();
+        let key = release_cache_key(&server.url(), repo, tag, true);
 
         let cached_empty_release = make_release(tag);
         {
@@ -983,7 +992,7 @@ something_else = "value"
         let repo = "owner/versions-host-cache-split-test";
         let tag = "v1.0.0";
         let path = format!("/repos/{repo}/releases/tags/{tag}");
-        let true_key = format!("{}-{repo}-{tag}-versions-host-true", server.url()).to_kebab_case();
+        let true_key = release_cache_key(&server.url(), repo, tag, true);
 
         {
             let cache_group = get_release_cache(&true_key).await;

--- a/src/http.rs
+++ b/src/http.rs
@@ -460,14 +460,18 @@ impl Client {
                 let state = retry_state.lock().unwrap();
                 (state.headers.clone(), state.use_netrc)
             };
+            let options = SendOnceOptions::new(Some(retry_state.clone()), use_netrc);
+            let options = if error_for_status {
+                options
+            } else {
+                options.allow_error_status()
+            };
             self.send_once_with_https_fallback_with_retry_headers(
                 method.clone(),
                 url.clone(),
                 &headers,
                 verb_label,
-                Some(retry_state.clone()),
-                use_netrc,
-                error_for_status,
+                options,
             )
             .await
         })
@@ -489,7 +493,11 @@ impl Client {
         verb_label: &str,
     ) -> Result<Response> {
         self.send_once_with_https_fallback_with_retry_headers(
-            method, url, headers, verb_label, None, true, true,
+            method,
+            url,
+            headers,
+            verb_label,
+            SendOnceOptions::new(None, true),
         )
         .await
     }
@@ -500,9 +508,7 @@ impl Client {
         url: Url,
         headers: &HeaderMap,
         verb_label: &str,
-        retry_state: Option<RetryStateHandle>,
-        use_netrc: bool,
-        error_for_status: bool,
+        options: SendOnceOptions,
     ) -> Result<Response> {
         match self
             .send_once_with_retry_headers(
@@ -510,9 +516,7 @@ impl Client {
                 url.clone(),
                 headers,
                 verb_label,
-                retry_state.clone(),
-                use_netrc,
-                error_for_status,
+                options.clone(),
             )
             .await
         {
@@ -525,9 +529,7 @@ impl Client {
                     url,
                     headers,
                     verb_label,
-                    retry_state,
-                    use_netrc,
-                    error_for_status,
+                    options,
                 )
                 .await
             }
@@ -541,16 +543,8 @@ impl Client {
         url: Url,
         headers: &HeaderMap,
         verb_label: &str,
-        retry_state: Option<RetryStateHandle>,
-        use_netrc: bool,
-        error_for_status: bool,
+        options: SendOnceOptions,
     ) -> Result<Response> {
-        let options = SendOnceOptions::new(retry_state, use_netrc);
-        let options = if error_for_status {
-            options
-        } else {
-            options.allow_error_status()
-        };
         self.send_once_inner(method, url, headers, verb_label, options)
             .await
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -52,6 +52,7 @@ struct RetryState {
 struct SendOnceOptions {
     use_netrc: bool,
     retry_github_oauth_401: bool,
+    error_for_status: bool,
     retry_state: Option<RetryStateHandle>,
 }
 
@@ -60,14 +61,21 @@ impl SendOnceOptions {
         Self {
             use_netrc,
             retry_github_oauth_401: true,
+            error_for_status: true,
             retry_state,
         }
+    }
+
+    fn allow_error_status(mut self) -> Self {
+        self.error_for_status = false;
+        self
     }
 
     fn recursive_retry(&self) -> Self {
         Self {
             use_netrc: false,
             retry_github_oauth_401: false,
+            error_for_status: self.error_for_status,
             retry_state: self.retry_state.clone(),
         }
     }
@@ -156,6 +164,17 @@ impl Client {
             .await?;
         resp.error_for_status_ref()?;
         Ok(resp)
+    }
+
+    pub async fn get_async_with_headers_allow_error_status<U: IntoUrl>(
+        &self,
+        url: U,
+        headers: &HeaderMap,
+    ) -> Result<Response> {
+        ensure!(!Settings::get().offline(), "offline mode is enabled");
+        let url = url.into_url().unwrap();
+        self.send_with_https_fallback_allow_error_status(Method::GET, url, headers, "GET")
+            .await
     }
 
     pub async fn head<U: IntoUrl>(&self, url: U) -> Result<Response> {
@@ -400,6 +419,25 @@ impl Client {
             headers,
             verb_label,
             Settings::get().http_retries,
+            true,
+        )
+        .await
+    }
+
+    async fn send_with_https_fallback_allow_error_status(
+        &self,
+        method: Method,
+        url: Url,
+        headers: &HeaderMap,
+        verb_label: &str,
+    ) -> Result<Response> {
+        self.send_with_https_fallback_with_retries(
+            method,
+            url,
+            headers,
+            verb_label,
+            Settings::get().http_retries,
+            false,
         )
         .await
     }
@@ -411,6 +449,7 @@ impl Client {
         headers: &HeaderMap,
         verb_label: &str,
         retries: i64,
+        error_for_status: bool,
     ) -> Result<Response> {
         let retry_state = Arc::new(Mutex::new(RetryState {
             headers: headers.clone(),
@@ -428,6 +467,7 @@ impl Client {
                 verb_label,
                 Some(retry_state.clone()),
                 use_netrc,
+                error_for_status,
             )
             .await
         })
@@ -449,7 +489,7 @@ impl Client {
         verb_label: &str,
     ) -> Result<Response> {
         self.send_once_with_https_fallback_with_retry_headers(
-            method, url, headers, verb_label, None, true,
+            method, url, headers, verb_label, None, true, true,
         )
         .await
     }
@@ -462,6 +502,7 @@ impl Client {
         verb_label: &str,
         retry_state: Option<RetryStateHandle>,
         use_netrc: bool,
+        error_for_status: bool,
     ) -> Result<Response> {
         match self
             .send_once_with_retry_headers(
@@ -471,6 +512,7 @@ impl Client {
                 verb_label,
                 retry_state.clone(),
                 use_netrc,
+                error_for_status,
             )
             .await
         {
@@ -485,6 +527,7 @@ impl Client {
                     verb_label,
                     retry_state,
                     use_netrc,
+                    error_for_status,
                 )
                 .await
             }
@@ -500,15 +543,16 @@ impl Client {
         verb_label: &str,
         retry_state: Option<RetryStateHandle>,
         use_netrc: bool,
+        error_for_status: bool,
     ) -> Result<Response> {
-        self.send_once_inner(
-            method,
-            url,
-            headers,
-            verb_label,
-            SendOnceOptions::new(retry_state, use_netrc),
-        )
-        .await
+        let options = SendOnceOptions::new(retry_state, use_netrc);
+        let options = if error_for_status {
+            options
+        } else {
+            options.allow_error_status()
+        };
+        self.send_once_inner(method, url, headers, verb_label, options)
+            .await
     }
 
     async fn send_once_inner(
@@ -603,7 +647,9 @@ impl Client {
                 }
             }
         }
-        if is_authenticated_github_forbidden(&url, &final_headers, &resp) {
+        if options.error_for_status
+            && is_authenticated_github_forbidden(&url, &final_headers, &resp)
+        {
             let status = resp.status();
             let status_error = resp
                 .error_for_status_ref()
@@ -632,7 +678,9 @@ impl Client {
             }
             return Err(status_error.into());
         }
-        resp.error_for_status_ref()?;
+        if options.error_for_status {
+            resp.error_for_status_ref()?;
+        }
         Ok(resp)
     }
 }
@@ -668,6 +716,7 @@ impl TextRequest<'_> {
                 &headers,
                 "GET",
                 self.retries,
+                true,
             )
             .await?;
         let text = resp.text().await?;

--- a/src/http.rs
+++ b/src/http.rs
@@ -524,14 +524,8 @@ impl Client {
             Err(err) if url.scheme() == "http" && is_connection_error(&err) => {
                 let mut url = url;
                 url.set_scheme("https").unwrap();
-                self.send_once_with_retry_headers(
-                    method,
-                    url,
-                    headers,
-                    verb_label,
-                    options,
-                )
-                .await
+                self.send_once_with_retry_headers(method, url, headers, verb_label, options)
+                    .await
             }
             Err(err) => Err(err),
         }

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -371,33 +371,78 @@ async fn fetch_optional_json<T>(
 where
     T: serde::de::DeserializeOwned,
 {
+    if Settings::get().offline() {
+        log_versions_host_trace(ctx, "disabled", "fallback=true");
+        return Ok(None);
+    }
+
+    debug!("GET {url}");
     match HTTP_FETCH
-        .json_with_headers(url, &VERSIONS_HOST_HEADERS)
+        .get_async_with_headers_allow_error_status(url, &VERSIONS_HOST_HEADERS)
         .await
     {
-        Ok(value) => Ok(Some(value)),
-        Err(err) => match http::error_code(&err).unwrap_or(0) {
-            404 => {
-                log_versions_host_trace(ctx, "not_found", "status=404 fallback=true");
-                Ok(None)
+        Ok(resp) => {
+            let status = resp.status();
+            debug!("GET {url} {status}");
+            if status.is_success() {
+                return Ok(Some(resp.json().await?));
             }
-            429 => {
-                log_versions_host_warn(ctx, "rate_limited", "status=429 fallback=true");
-                Ok(None)
+            let body = resp.text().await.unwrap_or_default();
+            match status.as_u16() {
+                404 => {
+                    log_versions_host_trace(ctx, "not_found", "status=404 fallback=true");
+                    Ok(None)
+                }
+                429 => {
+                    log_versions_host_warn(ctx, "rate_limited", "status=429 fallback=true");
+                    Ok(None)
+                }
+                status => {
+                    log_versions_host_warn(
+                        ctx,
+                        "failed",
+                        &format!(
+                            "status={status} fallback=true error={}",
+                            log_value(&versions_host_error_message(status, &body))
+                        ),
+                    );
+                    Ok(None)
+                }
             }
-            status => {
-                log_versions_host_warn(
-                    ctx,
-                    "failed",
-                    &format!(
-                        "status={status} fallback=true error={}",
-                        log_value(&err.to_string())
-                    ),
-                );
-                Ok(None)
-            }
-        },
+        }
+        Err(err) => {
+            log_versions_host_warn(
+                ctx,
+                "failed",
+                &format!(
+                    "status={} fallback=true error={}",
+                    http::error_code(&err).unwrap_or(0),
+                    log_value(&err.to_string())
+                ),
+            );
+            Ok(None)
+        }
     }
+}
+
+fn versions_host_error_message(status: u16, body: &str) -> String {
+    let body = body.trim();
+    let status_code = reqwest::StatusCode::from_u16(status);
+    let label = match status_code {
+        Ok(status) if status.is_client_error() => "HTTP status client error",
+        Ok(status) if status.is_server_error() => "HTTP status server error",
+        _ => "HTTP status error",
+    };
+    let status = status_code
+        .map(|status| status.to_string())
+        .unwrap_or_else(|_| status.to_string());
+    if body.is_empty() {
+        return format!("{label} ({status})");
+    }
+    format!(
+        "{label} ({status}): {}",
+        body.chars().take(200).collect::<String>()
+    )
 }
 
 fn enabled_for_github_metadata() -> bool {
@@ -736,6 +781,32 @@ mod tests {
         assert!(valid_github_release_tag(&release, "v1.0.0"));
         assert!(valid_github_release_tag(&release, "latest"));
         assert!(!valid_github_release_tag(&release, "v2.0.0"));
+    }
+
+    #[test]
+    fn test_versions_host_error_message_includes_body() {
+        assert_eq!(
+            versions_host_error_message(403, "GitHub repo is not in the mise registry\n"),
+            "HTTP status client error (403 Forbidden): GitHub repo is not in the mise registry"
+        );
+    }
+
+    #[test]
+    fn test_versions_host_error_message_caps_body() {
+        let body = "x".repeat(250);
+        let message = versions_host_error_message(502, &body);
+        assert_eq!(
+            message.len(),
+            "HTTP status server error (502 Bad Gateway): ".len() + 200
+        );
+    }
+
+    #[test]
+    fn test_versions_host_error_message_uses_generic_label_for_other_statuses() {
+        assert_eq!(
+            versions_host_error_message(302, ""),
+            "HTTP status error (302 Found)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep using `mise-versions` for Aqua tools that come from the mise registry, including explicit `aqua:owner/repo` forms that reverse-map to a registry backend
- skip `mise-versions` for fully qualified/non-registry Aqua GitHub metadata, including foreign override repos used by verification paths
- include capped versions-host response bodies in fallback warnings so policy failures explain themselves
- preserve the shared HTTP retry and HTTPS-fallback path while still allowing versions-host callers to inspect non-2xx responses

## Context
This fixes noisy `403` warnings like the one reported in discussion #10339 for `aqua:aws/session-manager-plugin@latest` on 2026.6.2. That package is in the Aqua registry but not the mise registry, and `mise-versions` intentionally serves GitHub metadata only for repos known to the mise registry.

The fix is not to remove the versions host from Aqua. Registry-backed tools such as `act` still use `mise-versions` for shared GitHub metadata and unauthenticated GitHub rate-limit avoidance, whether invoked as `act` or explicitly as `aqua:nektos/act`. The client now makes that decision using the resolved GitHub repo plus the mise registry mapping, so non-registry and foreign override repos go directly to GitHub instead of producing avoidable versions-host warnings.

Separately, versions-host warnings now include a capped response body. This keeps expected fallbacks visible without hiding useful server-side policy messages. The fetch path still uses the normal mise HTTP client retry/fallback behavior.

## Tests
- `cargo test test_use_versions_host_for_github_metadata_only_for_registry_tools`
- `cargo test versions_host_error_message`
- `cargo test versions_host_flag_splits_release_cache`
- `cargo check`
- `MISE_DEBUG=1 cargo run --quiet -- latest aqua:aws/session-manager-plugin` (direct GitHub, no `mise-versions`)
- `MISE_DEBUG=1 cargo run --quiet -- latest act` (`mise-versions` is still used)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which network path Aqua uses for GitHub releases and attestations and alters release cache keys; mistakes could mis-route metadata or serve stale/wrong cached releases for some tools.
> 
> **Overview**
> Limits **mise-versions** usage for Aqua so only **mise-registry-backed** tools whose resolved GitHub repo matches the Aqua package id (including subpackages) fetch releases and attestation metadata through the versions host; explicit non-registry Aqua tools and **foreign override repos** go straight to GitHub instead of triggering avoidable **403** warnings.
> 
> Aqua GitHub release lookups (latest, assets, minisign) now go through **`get_github_release`**, which passes that per-repo flag into **`get_release_for_url_with_versions_host`**. GitHub release caching keys are split by **`hosted` vs `direct`** so versions-host and direct API results cannot overwrite each other.
> 
> The HTTP client gains an opt-out from **`error_for_status`** on GET (retries and HTTPS fallback unchanged). Versions-host JSON fetches use it to treat non-2xx as soft fallbacks, respect **offline** mode, and log warnings with a **capped response body** for clearer policy messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b29ad3314bdf09c8cbb1679c8fa989d6f5563a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline mode handling for version checks.
  * Enhanced error messages for failed GitHub requests, including better handling of rate limiting (429) and not-found (404) scenarios.
  * Better resilience in release metadata fetching with refined cache key handling.

* **Tests**
  * Added unit test coverage for cache behavior and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->