### PR TITLE
fix(task): validate monorepo-relative task refs

### DIFF
--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -291,6 +291,9 @@ assert_contains "mise -C monorepo-validate run //pkg:w_bare" "arg=bare"
 assert_contains "mise -C monorepo-validate run //pkg:w_colon" "arg=colon"
 assert_contains "mise -C monorepo-validate run //pkg:w_full" "arg=full"
 
+# Clean up
+rm -rf monorepo-validate
+
 # Test that run.tasks entries with inline arguments are accepted
 mkdir -p mise-tasks
 cat <<'SCRIPT' >mise-tasks/test

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -269,6 +269,7 @@ EOF
 cat <<'EOF' >monorepo-validate/pkg/mise.toml
 [tasks._dep]
 hide = true
+alias = "dep-alias"
 usage = 'arg "<name>"'
 run = 'echo "arg=$usage_name"'
 
@@ -280,16 +281,20 @@ depends = [":_dep colon"]
 
 [tasks.w_full]
 depends = ["//pkg:_dep full"]
+
+[tasks.w_alias]
+depends = ["dep-alias alias"]
 EOF
 
 (
   cd monorepo-validate/pkg
-  assert_contains "mise tasks validate" "✓ All 4 task(s) validated successfully"
+  assert_contains "mise tasks validate" "✓ All 5 task(s) validated successfully"
 )
 
 assert_contains "mise -C monorepo-validate run //pkg:w_bare" "arg=bare"
 assert_contains "mise -C monorepo-validate run //pkg:w_colon" "arg=colon"
 assert_contains "mise -C monorepo-validate run //pkg:w_full" "arg=full"
+assert_contains "mise -C monorepo-validate run //pkg:w_alias" "arg=alias"
 
 # Clean up
 rm -rf monorepo-validate

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -253,6 +253,44 @@ assert_contains "mise tasks validate multiple-alias 2>&1 || true" "Cannot define
 # Clean up
 rm -rf mise-tasks
 
+# Test monorepo config_root dependency validation matches runtime resolution
+rm -f mise.toml
+mkdir -p monorepo-validate/pkg
+cat <<'EOF' >monorepo-validate/mise.toml
+experimental_monorepo_root = true
+
+[settings]
+experimental = true
+
+[monorepo]
+config_roots = ["pkg"]
+EOF
+
+cat <<'EOF' >monorepo-validate/pkg/mise.toml
+[tasks._dep]
+hide = true
+usage = 'arg "<name>"'
+run = 'echo "arg=$usage_name"'
+
+[tasks.w_bare]
+depends = ["_dep bare"]
+
+[tasks.w_colon]
+depends = [":_dep colon"]
+
+[tasks.w_full]
+depends = ["//pkg:_dep full"]
+EOF
+
+(
+  cd monorepo-validate/pkg
+  assert_contains "mise tasks validate" "✓ All 4 task(s) validated successfully"
+)
+
+assert_contains "mise -C monorepo-validate run //pkg:w_bare" "arg=bare"
+assert_contains "mise -C monorepo-validate run //pkg:w_colon" "arg=colon"
+assert_contains "mise -C monorepo-validate run //pkg:w_full" "arg=full"
+
 # Test that run.tasks entries with inline arguments are accepted
 mkdir -p mise-tasks
 cat <<'SCRIPT' >mise-tasks/test

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -6,7 +6,7 @@ use crate::config::Config;
 use crate::duration;
 use crate::file;
 use crate::task::task_fetcher::TaskFetcher;
-use crate::task::{Task, resolve_task_pattern};
+use crate::task::{GetMatchingExt, Task, build_task_ref_map, resolve_task_pattern};
 use crate::tera::contains_template_syntax;
 use crate::ui::style;
 use console::style as console_style;
@@ -230,11 +230,11 @@ impl TasksValidate {
     /// Monorepo-relative references are resolved the same way runtime task matching resolves them.
     fn task_exists(all_tasks: &BTreeMap<String, Task>, task_name: &str, parent: &Task) -> bool {
         let resolved_name = resolve_task_pattern(task_name, Some(parent));
-        all_tasks.contains_key(&resolved_name)
+        let task_refs = build_task_ref_map(all_tasks.iter());
+        task_refs
+            .get_matching(&resolved_name)
+            .is_ok_and(|matches| !matches.is_empty())
             || all_tasks.values().any(|t| t.display_name == resolved_name)
-            || all_tasks
-                .values()
-                .any(|t| t.aliases.contains(&resolved_name))
     }
 
     fn validate_missing_references(

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use crate::config::Config;
 use crate::duration;
 use crate::file;
-use crate::task::Task;
 use crate::task::task_fetcher::TaskFetcher;
+use crate::task::{Task, resolve_task_pattern};
 use crate::tera::contains_template_syntax;
 use crate::ui::style;
 use console::style as console_style;
@@ -226,13 +226,15 @@ impl TasksValidate {
         issues
     }
 
-    /// Check if a task exists by name, display_name, or alias
-    fn task_exists(all_tasks: &BTreeMap<String, Task>, task_name: &str) -> bool {
-        all_tasks.contains_key(task_name)
-            || all_tasks.values().any(|t| t.display_name == task_name)
+    /// Check if a task exists by name, display_name, or alias.
+    /// Monorepo-relative references are resolved the same way runtime task matching resolves them.
+    fn task_exists(all_tasks: &BTreeMap<String, Task>, task_name: &str, parent: &Task) -> bool {
+        let resolved_name = resolve_task_pattern(task_name, Some(parent));
+        all_tasks.contains_key(&resolved_name)
+            || all_tasks.values().any(|t| t.display_name == resolved_name)
             || all_tasks
                 .values()
-                .any(|t| t.aliases.contains(&task_name.to_string()))
+                .any(|t| t.aliases.contains(&resolved_name))
     }
 
     fn validate_missing_references(
@@ -257,7 +259,7 @@ impl TasksValidate {
             }
 
             // Check if task exists
-            if !Self::task_exists(all_tasks, dep_name) {
+            if !Self::task_exists(all_tasks, dep_name, task) {
                 issues.push(ValidationIssue {
                     task: task.name.clone(),
                     severity: Severity::Error,
@@ -561,7 +563,7 @@ impl TasksValidate {
                 } => {
                     // Strip inline arguments before checking existence, matching runtime behavior
                     let (name, _) = crate::task::task_list::split_task_spec(task_name);
-                    if !Self::task_exists(all_tasks, name) {
+                    if !Self::task_exists(all_tasks, name, task) {
                         issues.push(ValidationIssue {
                             task: task.name.clone(),
                             severity: Severity::Error,
@@ -575,7 +577,7 @@ impl TasksValidate {
                     // Strip inline arguments before checking existence, matching runtime behavior
                     for task_name in tasks {
                         let (name, _) = crate::task::task_list::split_task_spec(task_name);
-                        if !Self::task_exists(all_tasks, name) {
+                        if !Self::task_exists(all_tasks, name, task) {
                             issues.push(ValidationIssue {
                                 task: task.name.clone(),
                                 severity: Severity::Error,


### PR DESCRIPTION
## Summary
- resolve task references relative to their parent task before `tasks validate` checks for missing dependencies
- apply the same lookup path to task references inside `run` entries
- add e2e coverage for bare, `:task`, and `//pkg:task` dependencies inside a monorepo config_root

Discussion: https://github.com/jdx/mise/discussions/10329

## Tests
- `cargo fmt --check`
- `mise run test:e2e e2e/tasks/test_task_validate`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to validation-only lookup logic with e2e coverage; no changes to task execution paths beyond matching existing runtime behavior.
> 
> **Overview**
> **`mise tasks validate`** now resolves task references the same way runtime does, using the **parent task** for monorepo-relative patterns instead of treating dependency and `run` targets as plain global names.
> 
> `task_exists` calls **`resolve_task_pattern`** and **`build_task_ref_map` / `get_matching`**, so checks for **`depends`**, **`depends_post`**, **`wait_for`**, and **`run`** task entries accept bare names, **`:task`**, **`//pkg:task`**, and aliases inside monorepo **config roots** without false **missing-dependency** errors.
> 
> E2e coverage adds a small monorepo fixture and asserts **`tasks validate`** passes from **`pkg`** while **`mise run`** still executes those dependencies correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3f37aa7d20834acc409a168137b60b86c3367f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end validation that verifies monorepo task dependency patterns (bare, colon, full, alias) resolve and run with expected outputs.

* **Bug Fixes**
  * Improved task resolution in monorepo setups so referenced tasks are interpreted consistently during validation and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->