### PR TITLE
fix(backend): honor zero minimum release age flag

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1601,16 +1601,21 @@ pub trait Backend: Debug + Send + Sync {
             let version = latest.version.clone();
             match before_date {
                 Some(before) => {
-                    let versions = self
-                        .list_remote_versions_with_info_with_refresh(config, refresh)
-                        .await?;
-                    fallback_refresh = false;
-                    let info = latest
-                        .created_at
-                        .as_ref()
-                        .map(|_| &latest)
-                        .or_else(|| versions.iter().find(|v| v.version == version));
-                    if latest_stable_candidate_allowed_by_before_date(&version, info, before) {
+                    let allowed = if latest.created_at.is_some() {
+                        latest_stable_candidate_allowed_by_before_date(
+                            &version,
+                            Some(&latest),
+                            before,
+                        )
+                    } else {
+                        let versions = self
+                            .list_remote_versions_with_info_with_refresh(config, refresh)
+                            .await?;
+                        fallback_refresh = false;
+                        let info = versions.iter().find(|v| v.version == version);
+                        latest_stable_candidate_allowed_by_before_date(&version, info, before)
+                    };
+                    if allowed {
                         return Ok(Some(version));
                     }
                 }
@@ -2785,7 +2790,7 @@ mod latest_version_tests {
             Some("3.0.0")
         );
         assert_eq!(backend.stable_calls(), 0);
-        assert_eq!(backend.list_calls(), 1);
+        assert_eq!(backend.list_calls(), 0);
     }
 
     #[tokio::test]

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use crate::cli::args::ToolArg;
 use crate::config::Config;
 use crate::config::Settings;
-use crate::duration::parse_into_timestamp;
 use crate::hooks::Hooks;
+use crate::install_before::resolve_cli_minimum_release_age;
 use crate::toolset::{
     InstallOptions, ResolveOptions, ToolRequest, ToolSource, Toolset, tool_env_vars,
 };
@@ -263,10 +263,7 @@ impl Install {
     /// Get the minimum_release_age cutoff from the CLI --minimum-release-age flag only.
     /// Per-tool and global setting fallbacks are handled in ToolRequest::resolve.
     fn get_before_date(&self) -> Result<Option<Timestamp>> {
-        if let Some(minimum_release_age) = &self.minimum_release_age {
-            return Ok(Some(parse_into_timestamp(minimum_release_age)?));
-        }
-        Ok(None)
+        resolve_cli_minimum_release_age(self.minimum_release_age.as_deref())
     }
 
     fn get_requested_tool_versions(

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -3,7 +3,7 @@ use jiff::Timestamp;
 
 use crate::cli::args::ToolArg;
 use crate::config::Config;
-use crate::duration::parse_into_timestamp;
+use crate::install_before::resolve_cli_minimum_release_age;
 use crate::toolset::ToolRequest;
 use crate::ui::multi_progress_report::MultiProgressReport;
 
@@ -80,10 +80,7 @@ impl Latest {
     /// Get the minimum_release_age cutoff from the CLI --minimum-release-age flag only.
     /// Per-tool and global setting fallbacks are handled by backend latest resolution.
     fn get_before_date(&self) -> Result<Option<Timestamp>> {
-        if let Some(minimum_release_age) = &self.minimum_release_age {
-            return Ok(Some(parse_into_timestamp(minimum_release_age)?));
-        }
-        Ok(None)
+        resolve_cli_minimum_release_age(self.minimum_release_age.as_deref())
     }
 }
 

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::config::Config;
-use crate::duration::parse_into_timestamp;
 use crate::file::display_path;
+use crate::install_before::resolve_cli_minimum_release_age;
 use crate::lockfile::{self, LockResolutionResult, Lockfile};
 use crate::platform::Platform;
 use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, Toolset, ToolsetBuilder};
@@ -257,10 +257,7 @@ impl Lock {
     /// Get the before_date from the CLI --minimum-release-age flag only.
     /// Per-tool and global setting fallbacks are handled during tool request resolution.
     fn get_before_date(&self) -> Result<Option<Timestamp>> {
-        if let Some(minimum_release_age) = &self.minimum_release_age {
-            return Ok(Some(parse_into_timestamp(minimum_release_age)?));
-        }
-        Ok(None)
+        resolve_cli_minimum_release_age(self.minimum_release_age.as_deref())
     }
 
     fn is_unfiltered_lock_run(&self) -> bool {

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -7,8 +7,7 @@ use serde::Serialize;
 use crate::backend::{Backend, VersionInfo};
 use crate::cli::args::ToolArg;
 use crate::config::Settings;
-use crate::duration::parse_into_timestamp;
-use crate::install_before::resolve_before_date_for_backend;
+use crate::install_before::{resolve_before_date_for_backend, resolve_cli_minimum_release_age};
 use crate::toolset::{ToolRequest, tool_request};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{backend, config::Config};
@@ -91,11 +90,7 @@ impl LsRemote {
         }
         backend::set_strict_metadata(self.strict_metadata);
         let config = Config::get().await?;
-        let before_date = self
-            .minimum_release_age
-            .as_deref()
-            .map(parse_into_timestamp)
-            .transpose()?;
+        let before_date = resolve_cli_minimum_release_age(self.minimum_release_age.as_deref())?;
         if let Some(plugin) = self.get_plugin(&config).await? {
             self.run_single(&config, plugin, before_date).await
         } else {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use crate::backend::pipx::PIPXBackend;
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, config_file};
-use crate::duration::parse_into_timestamp;
 use crate::file::display_path;
+use crate::install_before::resolve_cli_minimum_release_age;
 use crate::semver::split_version_prefix;
 use crate::toolset::is_outdated_version;
 use crate::toolset::outdated_info::OutdatedInfo;
@@ -536,10 +536,7 @@ impl Upgrade {
     /// Get the minimum_release_age cutoff from the CLI --minimum-release-age flag only.
     /// Per-tool and global setting fallbacks are handled in ToolRequest::resolve.
     fn get_before_date(&self) -> Result<Option<Timestamp>> {
-        if let Some(minimum_release_age) = &self.minimum_release_age {
-            return Ok(Some(parse_into_timestamp(minimum_release_age)?));
-        }
-        Ok(None)
+        resolve_cli_minimum_release_age(self.minimum_release_age.as_deref())
     }
 
     async fn warn_if_newer_versions_hidden_by_minimum_release_age(

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -12,8 +12,8 @@ use path_absolutize::Absolutize;
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::config_file::ConfigFile;
 use crate::config::{Config, ConfigPathOptions, Settings, config_file, resolve_target_config_path};
-use crate::duration::parse_into_timestamp;
 use crate::file::display_path;
+use crate::install_before::resolve_cli_minimum_release_age;
 use crate::registry::REGISTRY;
 use crate::toolset::{
     ConfigScope, InstallOptions, ResolveOptions, ToolRequest, ToolSource, ToolVersion,
@@ -380,10 +380,7 @@ impl Use {
     /// Get the minimum_release_age cutoff from the CLI --minimum-release-age flag only.
     /// Per-tool and global setting fallbacks are handled in ToolRequest::resolve.
     fn get_before_date(&self) -> Result<Option<Timestamp>> {
-        if let Some(minimum_release_age) = &self.minimum_release_age {
-            return Ok(Some(parse_into_timestamp(minimum_release_age)?));
-        }
-        Ok(None)
+        resolve_cli_minimum_release_age(self.minimum_release_age.as_deref())
     }
 }
 

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -10,6 +10,7 @@ use crate::config::{Config, Settings};
 use crate::duration::{parse_duration, parse_into_timestamp};
 
 const DEFAULT_MINIMUM_RELEASE_AGE: &str = "24h";
+const DISABLED_MINIMUM_RELEASE_AGE_CUTOFF: &str = "2099-01-01";
 
 /// Where an effective release-age cutoff came from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,6 +51,21 @@ pub fn resolve_before_date(
         resolve_before_date_with_excludes(None, before_date, minimum_release_age, false)?
             .map(|(ts, _)| ts),
     )
+}
+
+/// Resolve the CLI `--minimum-release-age` flag without falling back to global
+/// settings or the built-in default when the flag is omitted.
+pub fn resolve_cli_minimum_release_age(
+    minimum_release_age: Option<&str>,
+) -> Result<Option<Timestamp>> {
+    if minimum_release_age
+        .is_some_and(|age| parse_duration(age).is_ok_and(|duration| duration.is_zero()))
+    {
+        return Ok(Some(parse_into_timestamp(
+            DISABLED_MINIMUM_RELEASE_AGE_CUTOFF,
+        )?));
+    }
+    Ok(resolve_before_date_with_excludes(None, None, minimum_release_age, true)?.map(|(ts, _)| ts))
 }
 
 pub fn resolve_before_date_for_tool(
@@ -233,6 +249,11 @@ mod tests {
     fn test_zero_minimum_release_age_disables_cutoff() {
         Settings::reset(None);
         assert_eq!(resolved_timestamp(None, Some("0s")), None);
+        assert_eq!(
+            super::resolve_cli_minimum_release_age(Some("0s")).unwrap(),
+            Some(crate::duration::parse_into_timestamp("2099-01-01").unwrap())
+        );
+        assert_eq!(super::resolve_cli_minimum_release_age(None).unwrap(), None);
 
         let mut partial = SettingsPartial::empty();
         partial.minimum_release_age = Some("0s".to_string());


### PR DESCRIPTION
## Summary
- add shared CLI minimum_release_age flag resolution so `--minimum-release-age=0s` overrides defaults instead of reintroducing the default cutoff
- apply the shared resolver to commands that accept the flag
- avoid fetching the full version list when latest-release metadata already includes `created_at`

## Verification
- `cargo fmt --all -- --check`
- `mise run test:unit install_before::tests::test_zero_minimum_release_age_disables_cutoff`
- `mise run test:unit latest_version_tests`
- `cargo run --all-features -- latest --minimum-release-age=0s uv` -> `0.11.21`

Fixes the remaining `2026.6.3` CLI-flag reproduction from discussion #10303.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches version resolution and release-age cutoffs across multiple CLI commands and backend latest logic; behavior change is intentional but could affect edge cases around stale metadata vs full list fallback.
> 
> **Overview**
> Fixes **`--minimum-release-age=0s`** so it disables release-age filtering on the CLI instead of falling through to global settings or the default **24h** cutoff.
> 
> A new **`resolve_cli_minimum_release_age`** helper maps zero durations to a far-future cutoff (**2099-01-01**) so “show everything” wins over defaults, returns **`None`** when the flag is omitted (per-tool/global rules still apply later), and replaces duplicated parsing in **`install`**, **`latest`**, **`lock`**, **`ls-remote`**, **`upgrade`**, and **`use`**.
> 
> **`latest_version_with_refresh`** skips a full remote version list fetch when the stable fast-path already includes **`created_at`**, using that metadata alone to apply the before-date filter (tests expect **`list_calls`** to drop from 1 to 0 in that case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ddae4f05079d4cd13ab96c8a856b08f9497855c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized version resolution to reduce unnecessary remote calls when release date metadata is available.

* **Refactor**
  * Consolidated minimum-release-age flag parsing across CLI commands for consistent behavior and simplified maintenance.
  * Improved handling of zero-duration release age values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->