### PR TITLE
chore: release 2026.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [2026.6.5](https://github.com/jdx/mise/compare/v2026.6.4..v2026.6.5) - 2026-06-12
+
+### 🐛 Bug Fixes
+
+- **(aqua)** support GitHub attestation predicate fields by @risu729 in [#10169](https://github.com/jdx/mise/pull/10169)
+- **(aqua)** canonicalize and reject duplicate vars by @risu729 in [#10187](https://github.com/jdx/mise/pull/10187)
+- **(config)** ignore local credential commands by @jdx in [#10356](https://github.com/jdx/mise/pull/10356)
+- **(config)** ignore local trust controls by @jdx in [#10357](https://github.com/jdx/mise/pull/10357)
+- **(schema)** forbid task-only bool fields on task templates by @risu729 in [#10242](https://github.com/jdx/mise/pull/10242)
+- **(schema)** allow registry backend platform selectors by @risu729 in [#10358](https://github.com/jdx/mise/pull/10358)
+- **(task)** require trust for config-less task includes by @jdx in [#10355](https://github.com/jdx/mise/pull/10355)
+
+### 🧪 Testing
+
+- **(windows)** restore github token env in e2e by @jdx in [#10359](https://github.com/jdx/mise/pull/10359)
+
+### 📦️ Dependency Updates
+
+- update ghcr.io/jdx/mise:deb docker digest to 5b1ef5e by @renovate[bot] in [#10349](https://github.com/jdx/mise/pull/10349)
+- update ghcr.io/jdx/mise:alpine docker digest to 1218930 by @renovate[bot] in [#10348](https://github.com/jdx/mise/pull/10348)
+- update ghcr.io/jdx/mise:rpm docker digest to 5907998 by @renovate[bot] in [#10350](https://github.com/jdx/mise/pull/10350)
+
+### Chore
+
+- **(ci)** bump pr-closer action by @jdx in [#10354](https://github.com/jdx/mise/pull/10354)
+
 ## [2026.6.4](https://github.com/jdx/mise/compare/v2026.6.3..v2026.6.4) - 2026-06-12
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.6.4"
+version = "2026.6.5"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.6.4"
+version = "2026.6.5"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.6.4 macos-arm64 (2026-06-12)
+2026.6.5 macos-arm64 (2026-06-12)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_4.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_5.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_4.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_5.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_4.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_5.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_4.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_5.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.6.4";
+  version = "2026.6.5";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.6.4
+Version: 2026.6.5
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.6.4"
+version: "2026.6.5"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "65a9b1fd22924a0a075067605725031175c121df"
+  "tag": "a8cba64b85b03e4fcda9a476e749c5ff695eeba2"
 }


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(aqua)** support GitHub attestation predicate fields by @risu729 in [#10169](https://github.com/jdx/mise/pull/10169)
- **(aqua)** canonicalize and reject duplicate vars by @risu729 in [#10187](https://github.com/jdx/mise/pull/10187)
- **(config)** ignore local credential commands by @jdx in [#10356](https://github.com/jdx/mise/pull/10356)
- **(config)** ignore local trust controls by @jdx in [#10357](https://github.com/jdx/mise/pull/10357)
- **(schema)** forbid task-only bool fields on task templates by @risu729 in [#10242](https://github.com/jdx/mise/pull/10242)
- **(schema)** allow registry backend platform selectors by @risu729 in [#10358](https://github.com/jdx/mise/pull/10358)
- **(task)** require trust for config-less task includes by @jdx in [#10355](https://github.com/jdx/mise/pull/10355)

### 🧪 Testing

- **(windows)** restore github token env in e2e by @jdx in [#10359](https://github.com/jdx/mise/pull/10359)

### 📦️ Dependency Updates

- update ghcr.io/jdx/mise:deb docker digest to 5b1ef5e by @renovate[bot] in [#10349](https://github.com/jdx/mise/pull/10349)
- update ghcr.io/jdx/mise:alpine docker digest to 1218930 by @renovate[bot] in [#10348](https://github.com/jdx/mise/pull/10348)
- update ghcr.io/jdx/mise:rpm docker digest to 5907998 by @renovate[bot] in [#10350](https://github.com/jdx/mise/pull/10350)

### Chore

- **(ci)** bump pr-closer action by @jdx in [#10354](https://github.com/jdx/mise/pull/10354)