### PR TITLE
chore(ci): bump pr-closer action

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -14,4 +14,4 @@ jobs:
       checks: read
       statuses: read
     steps:
-      - uses: jdx/pr-closer@44b9e7859d29e01b4b38e50e2ad6b5c5d00a6973 # v1.0.1
+      - uses: jdx/pr-closer@ddc40dfad5567fc7296a2463880c618344d26055 # v1.1.0


### PR DESCRIPTION
## Summary
- Bump `jdx/pr-closer` from `v1.0.1` to `v1.1.0`.
- Keep the action pinned by full commit SHA.

## Verification
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes a third-party CI action reference in a maintenance workflow; no application or auth logic is touched.
> 
> **Overview**
> Updates the scheduled **pr-closer** workflow to use **`jdx/pr-closer` v1.1.0** instead of v1.0.1, still pinned to the full commit SHA (`ddc40df…`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f7e00482ebabec726d1dc98ddfcf058c42a16e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflow version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->