### PR TITLE
fix(task): require trust for config-less task includes

### DIFF
--- a/e2e/tasks/test_task_include_trust
+++ b/e2e/tasks/test_task_include_trust
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Config-less task include directories must not render task templates before trust.
+# This prevents arbitrary command execution from default task include files such as
+# mise-tasks/*.toml in a freshly cloned repository.
+
+marker="$MISE_TMP_DIR/mise-task-include-trust-marker"
+trap 'rm -f "$marker"' EXIT
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+mkdir -p mise-tasks
+cat <<EOF >mise-tasks/ci.toml
+[test]
+description = "{{ exec(command='echo PWNED > $marker') }}"
+run = "echo test"
+EOF
+
+set +e
+output=$(MISE_YES=0 MISE_PARANOID=1 mise tasks 2>&1)
+status=$?
+set -e
+
+if [[ $status -eq 0 ]]; then
+  echo "FAIL: Expected mise tasks to reject the untrusted task include"
+  echo "Output: $output"
+  exit 1
+fi
+
+if [[ -f $marker ]]; then
+  echo "FAIL: Tera exec() ran from an untrusted task include file"
+  echo "Output: $output"
+  exit 1
+fi
+
+if echo "$output" | grep -qi "not trusted"; then
+  echo "PASS: Untrusted task include file was blocked"
+else
+  echo "FAIL: Expected trust-related error, got: $output"
+  exit 1
+fi
+
+rm -rf mise-tasks
+
+cat <<'EOF' >mise.toml
+experimental_monorepo_root = true
+
+[monorepo]
+config_roots = ["pkg"]
+EOF
+
+mkdir -p pkg/mise-tasks
+cat <<EOF >pkg/mise-tasks/ci.toml
+[test]
+description = "{{ exec(command='echo PWNED > $marker') }}"
+run = "echo test"
+EOF
+
+set +e
+output=$(MISE_YES=0 MISE_PARANOID=1 MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise tasks --all 2>&1)
+status=$?
+set -e
+
+if [[ $status -eq 0 ]]; then
+  echo "FAIL: Expected mise tasks --all to reject the untrusted monorepo task include"
+  echo "Output: $output"
+  exit 1
+fi
+
+if [[ -f $marker ]]; then
+  echo "FAIL: Tera exec() ran from an untrusted monorepo task include file"
+  echo "Output: $output"
+  exit 1
+fi
+
+if echo "$output" | grep -qi "not trusted"; then
+  echo "PASS: Untrusted monorepo task include file was blocked"
+else
+  echo "FAIL: Expected trust-related monorepo error, got: $output"
+  exit 1
+fi

--- a/src/config/config_file/config_root.rs
+++ b/src/config/config_file/config_root.rs
@@ -54,7 +54,9 @@ pub fn config_root(path: &Path) -> PathBuf {
     let is_config_filename = |f: &str| {
         f == "config.toml" || f == "config.local.toml" || regex!(r"config\..+\.toml").is_match(f)
     };
-    let out = if parent == "conf.d" && is_mise_dir(grandparent) {
+    let out = if parent == "mise-tasks" || parent == ".mise-tasks" {
+        grandparent_path()
+    } else if (parent == "tasks" || parent == "conf.d") && is_mise_dir(grandparent) {
         if great_grandparent == ".config" {
             great_great_grandparent_path()
         } else {
@@ -96,16 +98,21 @@ mod tests {
             "/foo/bar/.mise/conf.d/foo.toml",
             "/foo/bar/.mise/config.local.toml",
             "/foo/bar/.mise/config.toml",
+            "/foo/bar/.mise/tasks/build.toml",
             "/foo/bar/.tool-versions",
             "/foo/bar/mise.env.toml",
             "/foo/bar/mise.local.toml",
             "/foo/bar/mise.toml",
             "/foo/bar/mise/config.local.toml",
             "/foo/bar/mise/config.toml",
+            "/foo/bar/mise/tasks/build.toml",
             "/foo/bar/.config/mise/config.env.toml",
             "/foo/bar/.config/mise.env.toml",
+            "/foo/bar/.config/mise/tasks/build.toml",
             "/foo/bar/.mise/config.env.toml",
             "/foo/bar/.mise.env.toml",
+            "/foo/bar/.mise-tasks/build.toml",
+            "/foo/bar/mise-tasks/build.toml",
         ] {
             println!("{p}");
             assert_eq!(config_root(Path::new(p)), PathBuf::from("/foo/bar"));
@@ -128,16 +135,21 @@ mod tests {
             "/foo/mise/.mise/conf.d/foo.toml",
             "/foo/mise/.mise/config.local.toml",
             "/foo/mise/.mise/config.toml",
+            "/foo/mise/.mise/tasks/build.toml",
             "/foo/mise/.tool-versions",
             "/foo/mise/mise.env.toml",
             "/foo/mise/mise.local.toml",
             "/foo/mise/mise.toml",
             "/foo/mise/mise/config.local.toml",
             "/foo/mise/mise/config.toml",
+            "/foo/mise/mise/tasks/build.toml",
             "/foo/mise/.config/mise/config.env.toml",
             "/foo/mise/.config/mise.env.toml",
+            "/foo/mise/.config/mise/tasks/build.toml",
             "/foo/mise/.mise/config.env.toml",
             "/foo/mise/.mise.env.toml",
+            "/foo/mise/.mise-tasks/build.toml",
+            "/foo/mise/mise-tasks/build.toml",
         ] {
             println!("{p}");
             assert_eq!(config_root(Path::new(p)), PathBuf::from("/foo/mise"));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,7 @@ use crate::cli::version;
 use crate::config::config_file::idiomatic_version::IdiomaticVersionFile;
 use crate::config::config_file::min_version::MinVersionSpec;
 use crate::config::config_file::mise_toml::{MiseToml, Tasks};
-use crate::config::config_file::{ConfigFile, config_trust_root};
+use crate::config::config_file::{ConfigFile, config_trust_root, trust_check};
 use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
@@ -2027,7 +2027,7 @@ async fn load_local_tasks_with_context(
                         let includes = task_includes_for_dir(&subdir, &config.config_files)?;
                         for include in includes {
                             let mut subdir_tasks = load_tasks_includes(
-                                &config, &include, &subdir, &None, &templates,
+                                &config, &include, &subdir, &None, &templates, true,
                             )
                             .await?;
                             if is_global_task_include_path(&include) {
@@ -2399,8 +2399,10 @@ async fn load_tasks_includes(
     config_root: &Path,
     task_config_dir: &Option<String>,
     templates: &IndexMap<String, TaskTemplate>,
+    require_trust: bool,
 ) -> Result<Vec<Task>> {
     if root.is_file() && root.extension().map(|e| e == "toml").unwrap_or(false) {
+        trust_check_task_include(root, require_trust)?;
         load_task_file(config, root, config_root, task_config_dir, templates).await
     } else if root.is_dir() {
         let all_files = WalkDir::new(root)
@@ -2427,6 +2429,7 @@ async fn load_tasks_includes(
             .partition(|p| is_toml(p));
         let mut tasks = vec![];
         for path in toml_files {
+            trust_check_task_include(&path, require_trust)?;
             tasks.extend(
                 load_task_file(config, &path, config_root, task_config_dir, templates).await?,
             );
@@ -2437,6 +2440,7 @@ async fn load_tasks_includes(
             let root = root.clone();
             let config_root = config_root.clone();
             let config = config.clone();
+            trust_check_task_include(&path, require_trust)?;
             let mut task = Task::from_path(&config, &path, &root, &config_root).await?;
             if task.dir.is_none()
                 && let Some(ref dir) = *task_config_dir
@@ -2537,9 +2541,15 @@ async fn load_file_tasks(
             expand_task_include(&cf_root, &include)
         };
         for path in paths {
-            let mut loaded =
-                load_tasks_includes(config, &path, &config_root, &task_config_dir, templates)
-                    .await?;
+            let mut loaded = load_tasks_includes(
+                config,
+                &path,
+                &config_root,
+                &task_config_dir,
+                templates,
+                false,
+            )
+            .await?;
             if is_global_task_include_path(&path) {
                 mark_tasks_as_global(&mut loaded);
             }
@@ -2590,6 +2600,7 @@ pub async fn load_tasks_in_dir(
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let configs = configs_at_root(dir, config_files);
+    let require_task_include_trust = configs.is_empty();
 
     let (includes, resolve_dir) = configs
         .iter()
@@ -2618,8 +2629,15 @@ pub async fn load_tasks_in_dir(
             expand_task_include(&resolve_dir, include)
         };
         for p in paths {
-            let mut loaded =
-                load_tasks_includes(config, &p, dir, &task_config_dir, templates).await?;
+            let mut loaded = load_tasks_includes(
+                config,
+                &p,
+                dir,
+                &task_config_dir,
+                templates,
+                require_task_include_trust,
+            )
+            .await?;
             if is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);
             }
@@ -2640,6 +2658,13 @@ pub async fn load_tasks_in_dir(
         task.display_name = task.display_name(&all_tasks);
     }
     Ok(tasks)
+}
+
+fn trust_check_task_include(path: &Path, require_trust: bool) -> Result<()> {
+    if require_trust && !is_global_task_include_path(path) {
+        trust_check(path)?;
+    }
+    Ok(())
 }
 
 async fn load_task_file(


### PR DESCRIPTION
## Summary
- require trust before loading default task include directories from config-less local repos
- keep global task include paths exempt from the local repo trust gate
- add an e2e regression that verifies task template rendering does not execute before trust

## Tests
- `cargo fmt --check`
- `mise run test:e2e e2e/tasks/test_task_include_trust`
- `mise run test:e2e e2e/tasks/test_task_untrusted_config_error`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix around trust boundaries and task template execution; behavior changes for untrusted clones that only have mise-tasks directories.
> 
> **Overview**
> Closes a security gap where **default task include directories** (e.g. `mise-tasks/`, `.mise-tasks/`) could be loaded and **Tera templates rendered** (including `exec()`) in repos with **no local mise config**, before the user trusts the project.
> 
> Task loading now runs **`trust_check`** on each include file/dir when discovery is **config-less** (`require_task_include_trust`), while includes declared from a trusted **`mise.toml`** still skip that extra gate (`require_trust: false`). **Global** task include paths under the user/system config dirs remain exempt.
> 
> **`config_root`** is updated so paths under `mise-tasks` / `.mise-tasks` (and related task file layouts) resolve to the **project root** for trust checks. An **e2e** test asserts untrusted includes fail with a trust error and never run `exec()` from task descriptions, including monorepo subdirs with `--all`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 306fe669cc545d202bacf4e83b2380748d802a3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Block untrusted task includes from rendering or executing templates when local config files are absent, including monorepo/subdirectory cases.
  * Improve detection of task-specific directories so they resolve to the correct config root used for trust checks.

* **Tests**
  * Added an end-to-end test that verifies untrusted task includes are prevented from running or creating files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->