### PR TITLE
fix(config): ignore local credential commands

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -673,6 +673,12 @@ pub static SETTINGS_META: Lazy<IndexMap<&'static str, SettingsMeta>> = Lazy::new
             Some(v) => lines.push(format!("        deprecated_remove_at: Some({v:?}),")),
             None => lines.push("        deprecated_remove_at: None,".to_string()),
         }
+        lines.push(format!(
+            "        global_only: {},",
+            props
+                .get("global_only")
+                .is_some_and(|v| v.as_bool().unwrap())
+        ));
     };
     for (name, props) in &settings {
         let props = props.as_table().unwrap();

--- a/e2e/cli/test_token_github
+++ b/e2e/cli/test_token_github
@@ -8,6 +8,19 @@ unset GITHUB_TOKEN GITHUB_API_TOKEN MISE_GITHUB_TOKEN MISE_GITHUB_ENTERPRISE_TOK
 # Test 1: No token configured — should return (none)
 assert_contains "mise token github" "(none)"
 
+# Test 1b: local credential_command is ignored and must not execute
+LOCAL_CREDENTIAL_PROOF_DIR="$(mktemp -d)"
+LOCAL_CREDENTIAL_PROOF="$LOCAL_CREDENTIAL_PROOF_DIR/proof"
+trap 'rm -rf "$LOCAL_CREDENTIAL_PROOF_DIR"' EXIT
+cat >.mise.toml <<EOF
+[settings.github]
+credential_command = "echo local-credential-command-ran > '$LOCAL_CREDENTIAL_PROOF'; echo local-credential-token"
+EOF
+assert_contains "mise token github --unmask" "(none)"
+assert_fail "test -f '$LOCAL_CREDENTIAL_PROOF'"
+rm -rf "$LOCAL_CREDENTIAL_PROOF_DIR"
+rm .mise.toml
+
 # --raw with no token should exit non-zero (so $(...) capture fails loudly)
 assert_fail "mise token github --raw"
 

--- a/settings.toml
+++ b/settings.toml
@@ -705,6 +705,7 @@ is trimmed.
 Example: `op read "op://Private/Forgejo Token/credential"`
 """
 env = "MISE_FORGEJO_CREDENTIAL_COMMAND"
+global_only = true
 type = "String"
 
 [forgejo.fj_cli_tokens]
@@ -757,6 +758,7 @@ is trimmed.
 Example: `op read "op://Private/GitHub Token/credential"`
 """
 env = "MISE_GITHUB_CREDENTIAL_COMMAND"
+global_only = true
 type = "String"
 
 [github.gh_cli_tokens]
@@ -920,6 +922,7 @@ is trimmed.
 Example: `op read "op://Private/GitLab Token/credential"`
 """
 env = "MISE_GITLAB_CREDENTIAL_COMMAND"
+global_only = true
 type = "String"
 
 [gitlab.glab_cli_tokens]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -51,6 +51,7 @@ pub struct SettingsMeta {
     pub deprecated: Option<&'static str>,
     pub deprecated_warn_at: Option<&'static str>,
     pub deprecated_remove_at: Option<&'static str>,
+    pub global_only: bool,
 }
 
 #[derive(
@@ -258,6 +259,40 @@ fn normalize_hidden_config_aliases(mut partial: SettingsPartial) -> SettingsPart
         }
     }
     partial
+}
+
+fn strip_local_only_settings(settings: &mut toml::Table, path: &Path, is_global: bool) {
+    if is_global {
+        return;
+    }
+
+    for key in SETTINGS_META
+        .iter()
+        .filter_map(|(key, meta)| meta.global_only.then_some(*key))
+    {
+        if let Some(value) = remove_nested_toml_value(settings, key)
+            && should_warn_ignored_global_only_value(&value)
+        {
+            warn!(
+                "{key} in non-global config {} is ignored for security reasons",
+                path.display()
+            );
+        }
+    }
+}
+
+fn remove_nested_toml_value(table: &mut toml::Table, key: &str) -> Option<toml::Value> {
+    let mut parts = key.split('.').collect_vec();
+    let last = parts.pop()?;
+    let mut current = table;
+    for part in parts {
+        current = current.get_mut(part)?.as_table_mut()?;
+    }
+    current.remove(last)
+}
+
+fn should_warn_ignored_global_only_value(value: &toml::Value) -> bool {
+    !matches!(value, toml::Value::String(s) if s.is_empty())
 }
 
 impl Settings {
@@ -532,7 +567,11 @@ impl Settings {
 
     pub fn parse_settings_file(path: &Path) -> Result<SettingsPartial> {
         let raw = file::read_to_string(path)?;
-        let settings_file: SettingsFile = toml::from_str(&raw)?;
+        let mut raw: toml::Value = toml::from_str(&raw)?;
+        if let Some(settings) = raw.get_mut("settings").and_then(toml::Value::as_table_mut) {
+            strip_local_only_settings(settings, path, crate::config::is_global_config(path));
+        }
+        let settings_file: SettingsFile = raw.try_into()?;
 
         Ok(normalize_hidden_config_aliases(settings_file.settings))
     }
@@ -985,6 +1024,79 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn credential_command_settings_table() -> toml::Table {
+        toml::from_str::<toml::Value>(
+            r#"
+            [github]
+            credential_command = "echo github-token"
+
+            [gitlab]
+            credential_command = "echo gitlab-token"
+
+            [forgejo]
+            credential_command = "echo forgejo-token"
+            "#,
+        )
+        .unwrap()
+        .as_table()
+        .unwrap()
+        .clone()
+    }
+
+    fn settings_partial_from_table(settings: toml::Table) -> SettingsPartial {
+        let mut root = toml::Table::new();
+        root.insert("settings".to_string(), toml::Value::Table(settings));
+        let settings_file: SettingsFile = toml::Value::Table(root).try_into().unwrap();
+        settings_file.settings
+    }
+
+    #[test]
+    fn test_parse_settings_file_strips_local_credential_commands() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".mise.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [settings.github]
+            credential_command = "echo github-token"
+
+            [settings.gitlab]
+            credential_command = "echo gitlab-token"
+
+            [settings.forgejo]
+            credential_command = "echo forgejo-token"
+            "#,
+        )
+        .unwrap();
+
+        let partial = Settings::parse_settings_file(&path).unwrap();
+
+        assert_eq!(partial.github.credential_command, None);
+        assert_eq!(partial.gitlab.credential_command, None);
+        assert_eq!(partial.forgejo.credential_command, None);
+    }
+
+    #[test]
+    fn test_global_config_preserves_credential_commands() {
+        let path = Path::new("/tmp/global-config.toml");
+        let mut settings = credential_command_settings_table();
+        strip_local_only_settings(&mut settings, path, true);
+        let partial = settings_partial_from_table(settings);
+
+        assert_eq!(
+            partial.github.credential_command.as_deref(),
+            Some("echo github-token")
+        );
+        assert_eq!(
+            partial.gitlab.credential_command.as_deref(),
+            Some("echo gitlab-token")
+        );
+        assert_eq!(
+            partial.forgejo.credential_command.as_deref(),
+            Some("echo forgejo-token")
+        );
+    }
 
     #[test]
     fn test_set_by_comma_empty_string() {


### PR DESCRIPTION
## Summary
- ignore provider credential_command settings from non-global config files
- cover GitHub, GitLab, and Forgejo credential commands at settings parse time
- add an e2e regression proving a local GitHub credential_command is not executed

## Tests
- cargo fmt --check
- cargo test config::settings::tests::test_parse_settings_file_strips_local_credential_commands
- mise run test:e2e e2e/cli/test_token_github

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how shell commands that fetch tokens are sourced from config, blocking a path where untrusted project TOML could execute arbitrary commands.
> 
> **Overview**
> Introduces a **`global_only`** flag on settings metadata so certain keys are only honored from global config. **`github.credential_command`**, **`gitlab.credential_command`**, and **`forgejo.credential_command`** are marked global-only.
> 
> During **`parse_settings_file`**, non-global TOML has those keys **removed** before deserialization; non-empty values trigger a **security warning** that the setting was ignored. Global config keeps them unchanged.
> 
> **`build.rs`** emits `global_only` on generated **`SettingsMeta`**. Coverage includes unit tests for strip vs preserve and an e2e case where a local `.mise.toml` **`credential_command`** does not run and **`mise token github`** still reports no token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efefcc90d58b377c843e9113c4f20670f8fc1032. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credential-command settings for GitHub, Forgejo, and GitLab are now treated as global-only; they are ignored in local configuration and will emit a warning instead of being executed.

* **Tests**
  * Added end-to-end coverage ensuring local credential commands are not executed, produce no side effects, and do not affect token output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->