### PR TITLE
fix(config): ignore local trust controls

### DIFF
--- a/e2e/config/test_local_settings_trust_controls
+++ b/e2e/config/test_local_settings_trust_controls
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+marker="$MISE_TMP_DIR/local-settings-trust-controls"
+
+cat >poc.sh <<EOF
+echo trusted_paths_hookenv > "$marker"
+EOF
+
+cat >.mise.toml <<EOF
+[settings]
+ci = "true"
+paranoid = false
+trusted_config_paths = ["/"]
+yes = true
+
+[env]
+_.source = ["./poc.sh"]
+EOF
+
+output=$(MISE_YES=0 MISE_PARANOID=1 mise hook-env -s bash --force 2>&1 || true)
+
+if [[ -f $marker ]]; then
+  echo "FAIL: local trust-control settings allowed untrusted env source execution"
+  echo "Output: $output"
+  exit 1
+fi
+
+if ! echo "$output" | grep -qi "not trusted"; then
+  echo "FAIL: expected untrusted config error, got: $output"
+  exit 1
+fi

--- a/e2e/config/test_local_settings_trust_controls
+++ b/e2e/config/test_local_settings_trust_controls
@@ -19,7 +19,16 @@ yes = true
 _.source = ["./poc.sh"]
 EOF
 
-output=$(MISE_YES=0 MISE_PARANOID=1 mise hook-env -s bash --force 2>&1 || true)
+set +e
+output=$(MISE_YES=0 MISE_PARANOID=1 mise hook-env -s bash --force 2>&1)
+status=$?
+set -e
+
+if [[ $status -eq 0 ]]; then
+  echo "FAIL: expected hook-env to reject untrusted local config"
+  echo "Output: $output"
+  exit 1
+fi
 
 if [[ -f $marker ]]; then
   echo "FAIL: local trust-control settings allowed untrusted env source execution"

--- a/settings.toml
+++ b/settings.toml
@@ -351,6 +351,7 @@ default = "false"
 description = "Set to true if running in a CI environment"
 deserialize_with = "bool_string"
 env = "CI"
+global_only = true
 hide = true
 type = "Bool"
 
@@ -1781,6 +1782,7 @@ docs = """
 Enables extra-secure behavior. See [Paranoid](/paranoid.html).
 """
 env = "MISE_PARANOID"
+global_only = true
 type = "Bool"
 
 [pin]
@@ -2629,6 +2631,7 @@ Set to `["/"]` to trust all config files, effectively disabling the trust mechan
 Paths are separated by the OS path separator when using the environment variable \
 (`:` on Unix, `;` on Windows)."""
 env = "MISE_TRUSTED_CONFIG_PATHS"
+global_only = true
 parse_env = "list_by_os_path_separator"
 rust_type = "BTreeSet<PathBuf>"
 type = "ListPath"
@@ -2753,6 +2756,7 @@ type = "String"
 [yes]
 description = "This will automatically answer yes or no to prompts. This is useful for scripting."
 env = "MISE_YES"
+global_only = true
 type = "Bool"
 
 [zig.use_community_mirrors]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1099,7 +1099,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_settings_file_strips_local_trust_controls() {
+    fn test_parse_settings_file_strips_non_global_trust_controls() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".mise.toml");
         std::fs::write(
@@ -1123,25 +1123,22 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_settings_file_preserves_global_trust_controls() {
-        let global_path = crate::config::global_config_files()
-            .first()
-            .unwrap()
-            .to_path_buf();
-        let partial = strip_local_trust_controls(
-            toml::from_str::<SettingsFile>(
-                r#"
-                [settings]
-                ci = "true"
-                paranoid = true
-                trusted_config_paths = ["/"]
-                yes = true
-                "#,
-            )
-            .unwrap()
-            .settings,
-            &global_path,
-        );
+    fn test_global_config_preserves_trust_controls() {
+        let path = Path::new("/tmp/global-config.toml");
+        let mut settings = toml::from_str::<toml::Value>(
+            r#"
+            ci = "true"
+            paranoid = true
+            trusted_config_paths = ["/"]
+            yes = true
+            "#,
+        )
+        .unwrap()
+        .as_table()
+        .unwrap()
+        .clone();
+        strip_local_only_settings(&mut settings, path, true);
+        let partial = settings_partial_from_table(settings);
 
         assert_eq!(partial.ci, Some(true));
         assert_eq!(partial.paranoid, Some(true));

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1123,6 +1123,36 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_settings_file_preserves_global_trust_controls() {
+        let global_path = crate::config::global_config_files()
+            .first()
+            .unwrap()
+            .to_path_buf();
+        let partial = strip_local_trust_controls(
+            toml::from_str::<SettingsFile>(
+                r#"
+                [settings]
+                ci = "true"
+                paranoid = true
+                trusted_config_paths = ["/"]
+                yes = true
+                "#,
+            )
+            .unwrap()
+            .settings,
+            &global_path,
+        );
+
+        assert_eq!(partial.ci, Some(true));
+        assert_eq!(partial.paranoid, Some(true));
+        assert_eq!(
+            partial.trusted_config_paths,
+            Some([PathBuf::from("/")].into_iter().collect())
+        );
+        assert_eq!(partial.yes, Some(true));
+    }
+
+    #[test]
     fn test_set_by_comma_empty_string() {
         let result: Result<BTreeSet<String>, _> = set_by_comma("");
         assert!(result.is_ok());

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1099,6 +1099,30 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_settings_file_strips_local_trust_controls() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".mise.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [settings]
+            ci = "true"
+            paranoid = true
+            trusted_config_paths = ["/"]
+            yes = true
+            "#,
+        )
+        .unwrap();
+
+        let partial = Settings::parse_settings_file(&path).unwrap();
+
+        assert_eq!(partial.ci, None);
+        assert_eq!(partial.paranoid, None);
+        assert_eq!(partial.trusted_config_paths, None);
+        assert_eq!(partial.yes, None);
+    }
+
+    #[test]
     fn test_set_by_comma_empty_string() {
         let result: Result<BTreeSet<String>, _> = set_by_comma("");
         assert!(result.is_ok());


### PR DESCRIPTION
Fixes GHSA-436v-8fw5-4mj8 by ignoring trust-control settings from non-global config files before trust checks run.

## Summary
- ignore local project values for trust-control settings before settings are loaded
- keep global config, CLI, and environment settings behavior unchanged
- add unit and e2e regression coverage for the trust bypass

## Tests
- mise run format
- cargo test test_parse_settings_file_strips_local_trust_controls
- mise run test:e2e e2e/config/test_local_settings_trust_controls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix for config trust bypass; behavior change for anyone who relied on project-level `trusted_config_paths`, `paranoid`, `ci`, or `yes` in local mise.toml files.
> 
> **Overview**
> Fixes a trust bypass (GHSA-436v-8fw5-4mj8) by treating **`ci`**, **`paranoid`**, **`trusted_config_paths`**, and **`yes`** as **global-only** settings in `settings.toml`, so they are stripped when loading project/local config via the existing `strip_local_only_settings` path in `parse_settings_file`.
> 
> A malicious local `.mise.toml` can no longer set e.g. `trusted_config_paths = ["/"]` or `paranoid = false` to auto-trust itself or skip prompts before env sources run. **Global config, CLI flags, and environment variables are unchanged.**
> 
> Regression coverage adds unit tests for strip vs preserve behavior and an e2e script that asserts `hook-env` rejects an untrusted config (with `MISE_PARANOID=1`) and does not run `_.source` scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e253803227c7122ad6c8bd113248d813951595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trust-related configuration keys are no longer honored from non-global/local config files, preventing local overrides of global trust behavior.

* **Tests**
  * Added unit tests for stripping trust keys in local configs and an end-to-end test that simulates an untrusted local config, verifies the command fails with a “not trusted” message, and ensures no side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->