### PR TITLE
fix(schema): allow registry backend platform selectors

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -13,6 +13,7 @@ mise use -g tombi@$TOMBI_VERSION
 
 SCHEMA_PATH="$ROOT/schema/mise.json"
 TASK_SCHEMA_PATH="$ROOT/schema/mise-task.json"
+REGISTRY_TOOL_SCHEMA_PATH="$ROOT/schema/mise-registry-tool.json"
 TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
 TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
 assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
@@ -32,6 +33,10 @@ include = ["mise.toml", "mise-age.toml", "mise-env-directives.toml", "mise-os.to
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
 include = ["mise-task-os.toml"]
+
+[[schemas]]
+path = "file://$REGISTRY_TOOL_SCHEMA_PATH"
+include = ["mise-registry-tool.toml"]
 EOF
 
 # Create a mise.toml exercising task properties that were previously broken
@@ -98,6 +103,15 @@ run = "echo ok"
 node = { version = "latest", os = ["linux/x64", "macos/arm64"], profile = "release" }
 TOML
 
+cat >"$HOME/workdir/mise-registry-tool.toml" <<'TOML'
+backends = [
+  { full = "aqua:ImageMagick/ImageMagick", platforms = ["windows-x64"] },
+  { full = "github:owner/repo", platforms = ["linux", "arm64"], options = { platforms = { linux-x64 = { asset_pattern = "tool-linux.tar.gz" }, darwin-aarch64 = { asset_pattern = "tool-darwin.tar.gz" } } } },
+]
+description = "Example tool"
+test = { cmd = "tool --version", expected = "tool {{version}}" }
+TOML
+
 # tombi lint should succeed with no errors (warnings about table order are ok)
 cd "$HOME/workdir"
 assert_succeed "$TOMBI_LINT mise.toml"
@@ -105,6 +119,7 @@ assert_succeed "$TOMBI_LINT mise-age.toml"
 assert_succeed "$TOMBI_LINT mise-env-directives.toml"
 assert_succeed "$TOMBI_LINT mise-os.toml"
 assert_succeed "$TOMBI_LINT mise-task-os.toml"
+assert_succeed "$TOMBI_LINT mise-registry-tool.toml"
 
 # Verify that invalid properties on tasks are rejected
 cat >"$HOME/workdir/mise-bad.toml" <<'TOML'
@@ -128,6 +143,10 @@ include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-directive.toml", 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
 include = ["mise-bad-task-os.toml", "mise-bad-task-tool-extra.toml"]
+
+[[schemas]]
+path = "file://$REGISTRY_TOOL_SCHEMA_PATH"
+include = ["mise-bad-registry-tool.toml"]
 EOF
 
 assert_fail "$TOMBI_LINT mise-bad.toml"
@@ -200,3 +219,12 @@ node = { version = "latest", os = "linux/x64", backend_options = { nested = true
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-task-tool-extra.toml"
+
+cat >"$HOME/workdir/mise-bad-registry-tool.toml" <<'TOML'
+backends = [
+  { full = "github:owner/repo", platforms = ["windows-amd64"] },
+  { full = "github:owner/repo", options = { platforms = { linux-x64-musl = { asset_pattern = "tool-linux.tar.gz" } } } },
+]
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-registry-tool.toml"

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -39,6 +39,29 @@
       "type": "string",
       "enum": ["freebsd", "linux", "macos", "openbsd", "windows"]
     },
+    "platform": {
+      "type": "string",
+      "pattern": "^(linux|macos|windows)-(x64|arm64|x86|loongarch64|riscv64)$"
+    },
+    "optionPlatform": {
+      "type": "string",
+      "pattern": "^(linux|macos|darwin|windows)-(x64|amd64|x86_64|arm64|aarch64|x86|loongarch64|riscv64)$"
+    },
+    "platformSelector": {
+      "description": "OS, architecture, or platform this backend supports.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/os"
+        },
+        {
+          "type": "string",
+          "enum": ["x64", "arm64", "x86", "loongarch64", "riscv64"]
+        },
+        {
+          "$ref": "#/$defs/platform"
+        }
+      ]
+    },
     "toolId": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9_.-]+$"
@@ -70,9 +93,9 @@
               "platforms": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/$defs/os"
+                  "$ref": "#/$defs/platformSelector"
                 },
-                "description": "Operating systems this backend supports"
+                "description": "Operating systems, architectures, or platforms this backend supports"
               },
               "options": {
                 "type": "object",
@@ -82,7 +105,7 @@
                     "type": "object",
                     "description": "Platform-specific options (e.g., macos-arm64, linux-x64)",
                     "propertyNames": {
-                      "pattern": "^(linux|macos|windows)-(x64|arm64|armv7)$"
+                      "$ref": "#/$defs/optionPlatform"
                     },
                     "additionalProperties": {
                       "type": "object",


### PR DESCRIPTION
## Summary
- allow registry backend `platforms` entries to use supported OS, architecture, or normalized `os-arch` selectors
- allow registry backend option platform tables for the unqualified OS/arch aliases the backend lookup helper reads
- add tombi schema coverage for valid `windows-x64` and invalid unsupported forms

## Supported registry platform formats
For `backends[].platforms`, the schema accepts:
- OS names: `freebsd`, `linux`, `macos`, `openbsd`, `windows`
- architecture names: `x64`, `arm64`, `x86`, `loongarch64`, `riscv64`
- normalized platform selectors: `<os>-<arch>`, for example `windows-x64`, `linux-arm64`, `macos-x64`

For `backends.options.platforms.<key>`, the schema accepts the unqualified OS/arch keys the option lookup helper probes:
- OS side: `linux`, `macos`, `darwin`, `windows`
- arch side: `x64`, `amd64`, `x86_64`, `arm64`, `aarch64`, `x86`, `loongarch64`, `riscv64`
- examples: `linux-x64`, `linux-amd64`, `macos-arm64`, `darwin-aarch64`, `windows-x64`

Qualified keys such as `linux-x64-musl` are not included because the current backend option lookup does not read them. `windows-amd64` is also left invalid as a `backends[].platforms` selector because mise normalizes that platform key to `windows-x64`.

## Context
Addresses the schema issue reported in discussion #10296.

## Validation
- `jq empty schema/mise-registry-tool.json`
- `mise run test:e2e config/test_schema_tombi`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended platform and architecture validation options in mise-registry-tool configurations.
  * Added flexible platform selector capability for backend definitions supporting additional architectures.

* **Tests**
  * Enhanced e2e regression testing for schema validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->