### PR TITLE
test(windows): restore github token env in e2e

### DIFF
--- a/e2e-win/github_token.Tests.ps1
+++ b/e2e-win/github_token.Tests.ps1
@@ -1,16 +1,28 @@
 Describe 'github token' {
+    BeforeAll {
+        $script:GitHubTokenEnvVars = @(
+            "GITHUB_TOKEN",
+            "GITHUB_API_TOKEN",
+            "MISE_GITHUB_TOKEN",
+            "MISE_GITHUB_ENTERPRISE_TOKEN",
+            "MISE_GITHUB_CREDENTIAL_COMMAND",
+            "MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS"
+        )
+    }
+
     BeforeEach {
-        Remove-Item -Path Env:\GITHUB_TOKEN -ErrorAction SilentlyContinue
-        Remove-Item -Path Env:\GITHUB_API_TOKEN -ErrorAction SilentlyContinue
-        Remove-Item -Path Env:\MISE_GITHUB_TOKEN -ErrorAction SilentlyContinue
-        Remove-Item -Path Env:\MISE_GITHUB_ENTERPRISE_TOKEN -ErrorAction SilentlyContinue
-        Remove-Item -Path Env:\MISE_GITHUB_CREDENTIAL_COMMAND -ErrorAction SilentlyContinue
-        Remove-Item -Path Env:\MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS -ErrorAction SilentlyContinue
+        $script:GitHubTokenEnv = @{}
+        foreach ($name in $script:GitHubTokenEnvVars) {
+            $script:GitHubTokenEnv[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+            [Environment]::SetEnvironmentVariable($name, $null, "Process")
+        }
     }
 
     AfterEach {
-        Remove-Item -Path Env:\MISE_GITHUB_CREDENTIAL_COMMAND -ErrorAction SilentlyContinue
-        Remove-Item -Path Env:\MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS -ErrorAction SilentlyContinue
+        foreach ($name in $script:GitHubTokenEnvVars) {
+            [Environment]::SetEnvironmentVariable($name, $script:GitHubTokenEnv[$name], "Process")
+        }
+        $script:GitHubTokenEnv = $null
     }
 
     It 'runs credential_command with the Windows default inline shell' {


### PR DESCRIPTION
## Summary
- snapshot GitHub-related environment variables before the Windows token e2e test clears them
- restore those variables after the test so later Windows e2e cases keep CI GitHub authentication

## Root cause
The Windows Pester suite runs in a single PowerShell process. `github_token.Tests.ps1` removed `GITHUB_TOKEN` and `MISE_GITHUB_TOKEN` to test credential-command behavior, but only cleaned up the credential-command variables afterward. Later tests inherited the missing token state and fell back to unauthenticated GitHub API calls.

## Validation
- `git diff --cached --check`
- Not run: Windows Pester suite locally because `pwsh` is not installed in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to Pester setup/teardown; no production code or runtime behavior.
> 
> **Overview**
> Fixes Windows Pester isolation for the GitHub token e2e test by **snapshotting** a fixed list of GitHub-related process env vars in `BeforeEach`, clearing them for the test, and **restoring** the saved values in `AfterEach`.
> 
> Previously the suite only removed token vars and restored two credential/shell vars afterward, so later cases in the same PowerShell run could lose CI `GITHUB_TOKEN` / `MISE_GITHUB_TOKEN` and hit unauthenticated GitHub API calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5edcfe02b2064af2cf555028ab7c81394450199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment variable handling and restoration logic for GitHub token testing, enhancing test reliability and maintainability.

**Note:** No end-user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->