### PR TITLE
feat(config): load safe mise.toml files without trust

### DIFF
--- a/docs/cli/trust.md
+++ b/docs/cli/trust.md
@@ -13,10 +13,10 @@ discovery paths, fail with an untrusted-config error when it cannot prompt,
 or assume trust in detected CI unless paranoid mode is enabled.
 
 Safe config files do not require trust: files that only contain
-`min_version`, `[tools]` entries with plain version strings, and
-`[tasks]` (no templates and no tool options) are loaded without
-prompting, since nothing in them executes code at load time — tools
-install and tasks run only on explicit commands like `mise install`
+`min_version`, `[tools]` entries with plain version strings (or arrays
+of them), and `[tasks]` (no templates and no tool options) are loaded
+without prompting, since nothing in them executes code at load time —
+tools install and tasks run only on explicit commands like `mise install`
 or `mise run`.
 
 ## Arguments

--- a/docs/cli/trust.md
+++ b/docs/cli/trust.md
@@ -13,9 +13,11 @@ discovery paths, fail with an untrusted-config error when it cannot prompt,
 or assume trust in detected CI unless paranoid mode is enabled.
 
 Safe config files do not require trust: files that only contain
-`min_version` and `[tools]` entries with plain version strings (no
-templates and no tool options) are loaded without prompting, since
-nothing in them can execute code or change mise's behavior.
+`min_version`, `[tools]` entries with plain version strings, and
+`[tasks]` (no templates and no tool options) are loaded without
+prompting, since nothing in them executes code at load time — tools
+install and tasks run only on explicit commands like `mise install`
+or `mise run`.
 
 ## Arguments
 

--- a/docs/cli/trust.md
+++ b/docs/cli/trust.md
@@ -12,6 +12,11 @@ parsing `mise.toml`. Without trust, mise may prompt, skip the config in some
 discovery paths, fail with an untrusted-config error when it cannot prompt,
 or assume trust in detected CI unless paranoid mode is enabled.
 
+Safe config files do not require trust: files that only contain
+`min_version` and `[tools]` entries with plain version strings (no
+templates and no tool options) are loaded without prompting, since
+nothing in them can execute code or change mise's behavior.
+
 ## Arguments
 
 ### `[CONFIG_FILE]`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -241,7 +241,11 @@ mise upgrade --bump node
 
 ## My config file is being ignored / `mise trust` issues
 
-mise requires you to trust config files that were not created by you. Common issues:
+mise requires you to trust config files that were not created by you. Safe config files —
+those that only contain `min_version` and `[tools]` entries with plain version strings (no
+templates and no tool options) — are loaded without trust, since nothing in them can execute
+code or change mise's behavior. Everything else (env vars, tasks, hooks, settings, aliases,
+templates, tool options) requires trust. Common issues:
 
 - **Accidentally denied trust**: If mise prompted you to trust a file and you said no, it gets
   added to the ignore list. Check the `ignored-configs` directory in your

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -242,8 +242,8 @@ mise upgrade --bump node
 ## My config file is being ignored / `mise trust` issues
 
 mise requires you to trust config files that were not created by you. Safe config files —
-those that only contain `min_version`, `[tools]` entries with plain version strings, and
-`[tasks]` (no templates and no tool options) — are loaded without trust, since nothing in
+those that only contain `min_version`, `[tools]` entries with plain version strings (or
+arrays of them), and `[tasks]` (no templates and no tool options) — are loaded without trust, since nothing in
 them executes code at load time: tools install and tasks run only on explicit commands like
 `mise install` or `mise run`. Everything else (env vars, hooks, settings, aliases, templates,
 tool options) requires trust. Common issues:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -242,10 +242,11 @@ mise upgrade --bump node
 ## My config file is being ignored / `mise trust` issues
 
 mise requires you to trust config files that were not created by you. Safe config files —
-those that only contain `min_version` and `[tools]` entries with plain version strings (no
-templates and no tool options) — are loaded without trust, since nothing in them can execute
-code or change mise's behavior. Everything else (env vars, tasks, hooks, settings, aliases,
-templates, tool options) requires trust. Common issues:
+those that only contain `min_version`, `[tools]` entries with plain version strings, and
+`[tasks]` (no templates and no tool options) — are loaded without trust, since nothing in
+them executes code at load time: tools install and tasks run only on explicit commands like
+`mise install` or `mise run`. Everything else (env vars, hooks, settings, aliases, templates,
+tool options) requires trust. Common issues:
 
 - **Accidentally denied trust**: If mise prompted you to trust a file and you said no, it gets
   added to the ignore list. Check the `ignored-configs` directory in your

--- a/e2e/config/test_trust_safe_config
+++ b/e2e/config/test_trust_safe_config
@@ -7,6 +7,15 @@
 export MISE_TRUSTED_CONFIG_PATHS=""
 unset CI GITHUB_ACTIONS GITHUB_ACTION 2>/dev/null || true
 
+# Fail if any trust marker file/symlink exists under trusted-configs. This is
+# precise (a stale empty dir won't mask a wrongly-written marker) unlike a bare
+# directory-existence check.
+assert_no_trust_marker() {
+  local found
+  found=$(find "$MISE_STATE_DIR/trusted-configs" -mindepth 1 \( -type f -o -type l \) 2>/dev/null || true)
+  [[ -z $found ]] || fail "$1 (found trust markers: $found)"
+}
+
 mkdir -p project
 cd project || exit 1
 
@@ -23,7 +32,7 @@ EOF
 # loads without prompting and without creating a trust marker
 MISE_YES=0 mise install tiny
 assert_contains "MISE_YES=0 mise ls tiny" "3.1.0"
-[[ ! -e $MISE_STATE_DIR/trusted-configs ]] || fail "safe config should not be silently trusted"
+assert_no_trust_marker "safe config should not be silently trusted"
 
 # config tasks only execute on explicit `mise run`, so they don't need trust
 assert_contains "MISE_YES=0 mise run hi" "task-ran-without-trust"
@@ -37,7 +46,7 @@ echo file-task-ran-without-trust
 EOF
 chmod +x mise-tasks/filetask
 assert_contains "MISE_YES=0 mise run filetask" "file-task-ran-without-trust"
-[[ ! -e $MISE_STATE_DIR/trusted-configs ]] || fail "file task should not require or create trust"
+assert_no_trust_marker "file task should not require or create trust"
 
 # a template in a file task header renders at load time, so it requires trust
 cat <<'EOF' >mise-tasks/evil
@@ -69,6 +78,18 @@ EOF
 output=$(MISE_YES=0 mise tasks 2>&1 || true)
 [[ ! -f marker ]] || fail "task template executed in untrusted config"
 echo "$output" | grep -qi "trust" || fail "expected trust error for task template, got: $output"
+
+# escaped Tera delimiters ({ == '{', } == '}') decode to a template
+# after TOML parsing; this must not bypass the safety check and exec
+printf '[tools]\ntiny = "\\u007b\\u007b exec(command=%stouch marker%s) \\u007d\\u007d"\n' "'" "'" >mise.toml
+output=$(MISE_YES=0 mise ls 2>&1 || true)
+[[ ! -f marker ]] || fail "escaped template executed in untrusted config (tools)"
+echo "$output" | grep -qi "trust" || fail "expected trust error for escaped tools template, got: $output"
+
+printf '[tasks.hi]\nrun = "echo hi"\ndescription = "\\u007b\\u007b exec(command=%stouch marker%s) \\u007d\\u007d"\n' "'" "'" >mise.toml
+output=$(MISE_YES=0 mise tasks 2>&1 || true)
+[[ ! -f marker ]] || fail "escaped template executed in untrusted config (tasks)"
+echo "$output" | grep -qi "trust" || fail "expected trust error for escaped task template, got: $output"
 
 # tool options can run code (postinstall) or alter installs (install_env)
 cat <<'EOF' >mise.toml

--- a/e2e/config/test_trust_safe_config
+++ b/e2e/config/test_trust_safe_config
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Safe mise.toml files (only min_version + [tools] with plain version strings)
+# can be loaded without trusting them first. Anything that can execute code or
+# change mise's behavior still requires trust.
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+unset CI GITHUB_ACTIONS GITHUB_ACTION 2>/dev/null || true
+
+mkdir -p project
+cd project || exit 1
+
+cat <<'EOF' >mise.toml
+min_version = "2024.1.1"
+
+[tools]
+tiny = "3.1.0"
+EOF
+
+# loads without prompting and without creating a trust marker
+MISE_YES=0 mise install tiny
+assert_contains "MISE_YES=0 mise ls tiny" "3.1.0"
+[[ ! -e $MISE_STATE_DIR/trusted-configs ]] || fail "safe config should not be silently trusted"
+
+# a template in a version string requires trust and must not execute
+cat <<'EOF' >mise.toml
+[tools]
+tiny = "{{ exec(command='echo PWNED > marker') }}"
+EOF
+output=$(MISE_YES=0 mise ls 2>&1 || true)
+[[ ! -f marker ]] || fail "template executed in untrusted config"
+echo "$output" | grep -qi "trust" || fail "expected trust error for template, got: $output"
+
+# tool options can run code (postinstall) or alter installs (install_env)
+cat <<'EOF' >mise.toml
+[tools]
+tiny = { version = "3.1.0", postinstall = "touch marker" }
+EOF
+output=$(MISE_YES=0 mise ls 2>&1 || true)
+echo "$output" | grep -qi "trust" || fail "expected trust error for tool options, got: $output"
+
+# env vars require trust
+cat <<'EOF' >mise.toml
+[env]
+FOO = "bar"
+EOF
+output=$(MISE_YES=0 mise env 2>&1 || true)
+echo "$output" | grep -qi "trust" || fail "expected trust error for env, got: $output"
+
+# unsafe configs still load normally once trusted
+mise trust
+assert_contains "mise env" "FOO=bar"

--- a/e2e/config/test_trust_safe_config
+++ b/e2e/config/test_trust_safe_config
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# Safe mise.toml files (only min_version + [tools] with plain version strings)
-# can be loaded without trusting them first. Anything that can execute code or
-# change mise's behavior still requires trust.
+# Safe mise.toml files (min_version, [tools] with plain version strings, and
+# [tasks]) can be loaded without trusting them first. Anything that can execute
+# code at load time or change mise's behavior still requires trust.
 
 export MISE_TRUSTED_CONFIG_PATHS=""
 unset CI GITHUB_ACTIONS GITHUB_ACTION 2>/dev/null || true
@@ -15,12 +15,41 @@ min_version = "2024.1.1"
 
 [tools]
 tiny = "3.1.0"
+
+[tasks.hi]
+run = "echo task-ran-without-trust"
 EOF
 
 # loads without prompting and without creating a trust marker
 MISE_YES=0 mise install tiny
 assert_contains "MISE_YES=0 mise ls tiny" "3.1.0"
 [[ ! -e $MISE_STATE_DIR/trusted-configs ]] || fail "safe config should not be silently trusted"
+
+# config tasks only execute on explicit `mise run`, so they don't need trust
+assert_contains "MISE_YES=0 mise run hi" "task-ran-without-trust"
+
+# template-free file tasks are inert at load time and runnable without trust
+mkdir -p mise-tasks
+cat <<'EOF' >mise-tasks/filetask
+#!/usr/bin/env bash
+#MISE description="a plain file task"
+echo file-task-ran-without-trust
+EOF
+chmod +x mise-tasks/filetask
+assert_contains "MISE_YES=0 mise run filetask" "file-task-ran-without-trust"
+[[ ! -e $MISE_STATE_DIR/trusted-configs ]] || fail "file task should not require or create trust"
+
+# a template in a file task header renders at load time, so it requires trust
+cat <<'EOF' >mise-tasks/evil
+#!/usr/bin/env bash
+#MISE description="{{ exec(command='echo PWNED > marker') }}"
+echo evil
+EOF
+chmod +x mise-tasks/evil
+output=$(MISE_YES=0 mise tasks 2>&1 || true)
+[[ ! -f marker ]] || fail "file task header template executed without trust"
+echo "$output" | grep -qi "trust" || fail "expected trust error for templated file task, got: $output"
+rm mise-tasks/evil
 
 # a template in a version string requires trust and must not execute
 cat <<'EOF' >mise.toml
@@ -30,6 +59,16 @@ EOF
 output=$(MISE_YES=0 mise ls 2>&1 || true)
 [[ ! -f marker ]] || fail "template executed in untrusted config"
 echo "$output" | grep -qi "trust" || fail "expected trust error for template, got: $output"
+
+# a template in a task renders at load time, so it requires trust
+cat <<'EOF' >mise.toml
+[tasks.hi]
+run = "echo hi"
+description = "{{ exec(command='echo PWNED > marker') }}"
+EOF
+output=$(MISE_YES=0 mise tasks 2>&1 || true)
+[[ ! -f marker ]] || fail "task template executed in untrusted config"
+echo "$output" | grep -qi "trust" || fail "expected trust error for task template, got: $output"
 
 # tool options can run code (postinstall) or alter installs (install_env)
 cat <<'EOF' >mise.toml

--- a/e2e/config/test_trust_safe_config_tracked
+++ b/e2e/config/test_trust_safe_config_tracked
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# A safe (untrusted) mise.toml is tracked and its tool pins remain visible
+# through tracked-config reload paths like `mise ls --all-sources`, even when
+# invoked from a different directory. Regression: tracked-config loading used
+# to skip any config without a trust marker, which safe configs don't create.
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+unset CI GITHUB_ACTIONS GITHUB_ACTION 2>/dev/null || true
+
+mkdir -p proj other
+cat <<'EOF' >proj/mise.toml
+[tools]
+tiny = "3.1.0"
+EOF
+
+# install from the safe config (loads + tracks it, no trust prompt/marker)
+(cd proj && MISE_YES=0 mise install tiny)
+
+# from an unrelated directory, the tracked safe config's pin is still listed
+cd other || exit 1
+assert_contains "MISE_YES=0 mise ls --all-sources 2>&1" "proj/mise.toml"
+assert_contains "MISE_YES=0 mise ls --all-sources 2>&1" "tiny"

--- a/e2e/tasks/test_task_include_trust_escaped
+++ b/e2e/tasks/test_task_include_trust_escaped
@@ -18,12 +18,14 @@ output=$(MISE_YES=0 mise tasks 2>&1 || true)
 echo "$output" | grep -qi "not trusted" || fail "expected trust error for escaped .toml include, got: $output"
 rm -f mise-tasks/ci.toml
 
-# 2. escaped template in a #MISE script header
-cat <<'EOF' >mise-tasks/evil.sh
-#!/usr/bin/env bash
-#MISE description="{{ exec(command='touch script-marker') }}"
-echo hi
-EOF
+# 2. escaped template in a #MISE script header (printf so the \u escapes reach
+# the file literally, exercising the decoded-header path rather than the
+# raw-text gate)
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '#MISE description="\\u007b\\u007b exec(command=%stouch script-marker%s) \\u007d\\u007d"\n' "'" "'"
+  printf 'echo hi\n'
+} >mise-tasks/evil.sh
 chmod +x mise-tasks/evil.sh
 output=$(MISE_YES=0 mise tasks 2>&1 || true)
 [[ ! -f script-marker ]] || fail "escaped template executed from untrusted script header"

--- a/e2e/tasks/test_task_include_trust_escaped
+++ b/e2e/tasks/test_task_include_trust_escaped
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Task include files (mise-tasks/*.toml and #MISE script headers) that hide a
+# Tera template behind escaped delimiters ({ -> '{', } -> '}') must
+# still require trust: the escapes decode to a real template that renders — and
+# can exec() — at load time. A raw-text scan alone would miss them. This is the
+# non-paranoid case (paranoid mode trivially requires trust for everything).
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+unset CI GITHUB_ACTIONS GITHUB_ACTION 2>/dev/null || true
+
+mkdir -p mise-tasks
+
+# 1. escaped template in a .toml task file
+printf '[evil]\nrun = "echo hi"\ndescription = "\\u007b\\u007b exec(command=%stouch toml-marker%s) \\u007d\\u007d"\n' "'" "'" >mise-tasks/ci.toml
+output=$(MISE_YES=0 mise tasks 2>&1 || true)
+[[ ! -f toml-marker ]] || fail "escaped template executed from untrusted .toml task include"
+echo "$output" | grep -qi "not trusted" || fail "expected trust error for escaped .toml include, got: $output"
+rm -f mise-tasks/ci.toml
+
+# 2. escaped template in a #MISE script header
+cat <<'EOF' >mise-tasks/evil.sh
+#!/usr/bin/env bash
+#MISE description="{{ exec(command='touch script-marker') }}"
+echo hi
+EOF
+chmod +x mise-tasks/evil.sh
+output=$(MISE_YES=0 mise tasks 2>&1 || true)
+[[ ! -f script-marker ]] || fail "escaped template executed from untrusted script header"
+echo "$output" | grep -qi "not trusted" || fail "expected trust error for escaped script header, got: $output"
+rm -f mise-tasks/evil.sh
+
+# 3. sanity: a plain (template-free) file task still loads without trust
+cat <<'EOF' >mise-tasks/hello.sh
+#!/usr/bin/env bash
+#MISE description="a plain task"
+echo plain-task-ran
+EOF
+chmod +x mise-tasks/hello.sh
+assert_contains "MISE_YES=0 mise run hello" "plain-task-ran"

--- a/e2e/tasks/test_task_monorepo_trust
+++ b/e2e/tasks/test_task_monorepo_trust
@@ -43,10 +43,14 @@ assert_not_contains "mise tasks ls --all 2>&1" "Trust them"
 assert_contains "mise run '//projects/frontend:build'" "frontend build"
 assert_contains "mise run '//projects/frontend/components:test'" "component test"
 
-# Test that trust warnings DO appear for configs outside monorepo
-# Create a parent directory with its own config (not part of monorepo)
+# Test that trust warnings DO appear for unsafe configs outside monorepo
+# (tasks-only configs are safe and load without trust, so use [env] to make
+# this one require trust)
 mkdir -p ../parent-dir
 cat <<EOF >../parent-dir/mise.toml
+[env]
+FOO = "bar"
+
 [tasks.parent-task]
 run = 'echo "parent task"'
 EOF

--- a/e2e/tasks/test_task_untrusted_config_error
+++ b/e2e/tasks/test_task_untrusted_config_error
@@ -5,18 +5,29 @@
 
 # Ensure we start with a clean slate - no trusted configs
 export MISE_TRUSTED_CONFIG_PATHS=""
+unset CI GITHUB_ACTIONS GITHUB_ACTION 2>/dev/null || true
 
-# Create a config file with a task
+# A config that only defines tasks is safe: tasks execute nothing until the
+# user explicitly runs one, so no trust is required
 cat <<EOF >mise.toml
 [tasks.make]
 run = "echo 'hello from task'"
 EOF
 
-# Running a task from an untrusted config should give a helpful error
-# It should either:
+assert_contains "MISE_YES=0 mise run make" "hello from task"
+
+# Unsafe configs (here: [env]) still require trust. Running a task from one
+# should give a helpful error message:
 # 1. Prompt the user to trust the config (when interactive), or
 # 2. Show a clear "config not trusted" error (not "no tasks defined")
-#
+cat <<EOF >mise.toml
+[env]
+FOO = "bar"
+
+[tasks.make]
+run = "echo 'hello from task'"
+EOF
+
 # This test verifies we don't get the misleading "no tasks defined" error
 output=$(MISE_YES=0 mise run make 2>&1 || true)
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3402,6 +3402,13 @@ that may execute code or affect the environment. mise checks trust before
 parsing `mise.toml`. Without trust, mise may prompt, skip the config in some
 discovery paths, fail with an untrusted\-config error when it cannot prompt,
 or assume trust in detected CI unless paranoid mode is enabled.
+
+Safe config files do not require trust: files that only contain
+`min_version`, `[tools]` entries with plain version strings (or arrays
+of them), and `[tasks]` (no templates and no tool options) are loaded
+without prompting, since nothing in them executes code at load time —
+tools install and tasks run only on explicit commands like `mise install`
+or `mise run`.
 .PP
 \fBUsage:\fR mise trust [OPTIONS] [<CONFIG_FILE>]
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3505,9 +3505,11 @@ discovery paths, fail with an untrusted-config error when it cannot prompt,
 or assume trust in detected CI unless paranoid mode is enabled.
 
 Safe config files do not require trust: files that only contain
-`min_version` and `[tools]` entries with plain version strings (no
-templates and no tool options) are loaded without prompting, since
-nothing in them can execute code or change mise's behavior.
+`min_version`, `[tools]` entries with plain version strings, and
+`[tasks]` (no templates and no tool options) are loaded without
+prompting, since nothing in them executes code at load time — tools
+install and tasks run only on explicit commands like `mise install`
+or `mise run`.
 """#
     after_long_help #"""
 Examples:

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3503,6 +3503,11 @@ that may execute code or affect the environment. mise checks trust before
 parsing `mise.toml`. Without trust, mise may prompt, skip the config in some
 discovery paths, fail with an untrusted-config error when it cannot prompt,
 or assume trust in detected CI unless paranoid mode is enabled.
+
+Safe config files do not require trust: files that only contain
+`min_version` and `[tools]` entries with plain version strings (no
+templates and no tool options) are loaded without prompting, since
+nothing in them can execute code or change mise's behavior.
 """#
     after_long_help #"""
 Examples:

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3505,10 +3505,10 @@ discovery paths, fail with an untrusted-config error when it cannot prompt,
 or assume trust in detected CI unless paranoid mode is enabled.
 
 Safe config files do not require trust: files that only contain
-`min_version`, `[tools]` entries with plain version strings, and
-`[tasks]` (no templates and no tool options) are loaded without
-prompting, since nothing in them executes code at load time — tools
-install and tasks run only on explicit commands like `mise install`
+`min_version`, `[tools]` entries with plain version strings (or arrays
+of them), and `[tasks]` (no templates and no tool options) are loaded
+without prompting, since nothing in them executes code at load time —
+tools install and tasks run only on explicit commands like `mise install`
 or `mise run`.
 """#
     after_long_help #"""

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -18,6 +18,11 @@ use itertools::Itertools;
 /// parsing `mise.toml`. Without trust, mise may prompt, skip the config in some
 /// discovery paths, fail with an untrusted-config error when it cannot prompt,
 /// or assume trust in detected CI unless paranoid mode is enabled.
+///
+/// Safe config files do not require trust: files that only contain
+/// `min_version` and `[tools]` entries with plain version strings (no
+/// templates and no tool options) are loaded without prompting, since
+/// nothing in them can execute code or change mise's behavior.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Trust {

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -20,9 +20,11 @@ use itertools::Itertools;
 /// or assume trust in detected CI unless paranoid mode is enabled.
 ///
 /// Safe config files do not require trust: files that only contain
-/// `min_version` and `[tools]` entries with plain version strings (no
-/// templates and no tool options) are loaded without prompting, since
-/// nothing in them can execute code or change mise's behavior.
+/// `min_version`, `[tools]` entries with plain version strings, and
+/// `[tasks]` (no templates and no tool options) are loaded without
+/// prompting, since nothing in them executes code at load time — tools
+/// install and tasks run only on explicit commands like `mise install`
+/// or `mise run`.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Trust {

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -20,10 +20,10 @@ use itertools::Itertools;
 /// or assume trust in detected CI unless paranoid mode is enabled.
 ///
 /// Safe config files do not require trust: files that only contain
-/// `min_version`, `[tools]` entries with plain version strings, and
-/// `[tasks]` (no templates and no tool options) are loaded without
-/// prompting, since nothing in them executes code at load time — tools
-/// install and tasks run only on explicit commands like `mise install`
+/// `min_version`, `[tools]` entries with plain version strings (or arrays
+/// of them), and `[tasks]` (no templates and no tool options) are loaded
+/// without prompting, since nothing in them executes code at load time —
+/// tools install and tasks run only on explicit commands like `mise install`
 /// or `mise run`.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -18,11 +18,13 @@ use toml_edit::{Array, DocumentMut, InlineTable, Item, Key, Value, table, value}
 use versions::Versioning;
 
 use crate::cli::args::{BackendArg, ToolVersionType};
-use crate::config::config_file::{ConfigFile, TaskConfig, config_trust_root, trust, trust_check};
+use crate::config::config_file::{
+    ConfigFile, TaskConfig, config_trust_root, is_ignored, trust, trust_check,
+};
 use crate::config::config_file::{config_root, toml::deserialize_arr};
 use crate::config::env_directive::{AgeFormat, EnvDirective, EnvDirectiveOptions, RequiredValue};
 use crate::config::settings::SettingsPartial;
-use crate::config::{Alias, AliasMap, Config};
+use crate::config::{Alias, AliasMap, Config, Settings};
 use crate::deps::DepsConfig;
 use crate::env_diff::EnvMap;
 use crate::file::{create_dir_all, display_path};
@@ -273,7 +275,9 @@ impl MiseToml {
     }
 
     pub fn from_str(body: &str, path: &Path) -> eyre::Result<Self> {
-        trust_check(path)?;
+        if !Self::is_trust_exempt(body, path) {
+            trust_check(path)?;
+        }
         trace!("parsing: {}", display_path(path));
         let des = toml::Deserializer::parse(body).map_err(|e| toml_parse_error(&e, body, path))?;
         let de_res = serde_ignored::deserialize(des, |p| {
@@ -300,6 +304,25 @@ impl MiseToml {
         }
         // trace!("{}", rf.dump()?);
         Ok(rf)
+    }
+
+    /// Whether this config body can be loaded without trusting the file.
+    ///
+    /// Safe configs cannot execute code or change mise's behavior beyond
+    /// requesting tool versions, so there is nothing to gate behind a trust
+    /// prompt. Anything else — env vars, tasks, hooks, settings, aliases,
+    /// templates, tool options like `postinstall`/`install_env` — still
+    /// requires trust.
+    fn is_trust_exempt(body: &str, path: &Path) -> bool {
+        if Settings::try_get().is_ok_and(|settings| settings.paranoid) {
+            return false;
+        }
+        // configs the user chose to ignore should stay unloaded rather than
+        // becoming loadable because their content happens to be safe
+        if is_ignored(&config_trust_root(path)) || is_ignored(path) {
+            return false;
+        }
+        is_safe_config_body(body)
     }
 
     fn doc(&self) -> eyre::Result<DocumentMut> {
@@ -1947,6 +1970,36 @@ impl<'de> de::Deserialize<'de> for Alias {
     }
 }
 
+/// A config body is safe to load without trust when it only requests tool
+/// versions. `min_version` and `[tools]` entries with plain version strings
+/// cannot execute anything by themselves — installation only happens when the
+/// user explicitly runs a command like `mise install`. Tool entries with
+/// options (tables) are excluded because options like `postinstall` and
+/// `install_env` run code or alter the install environment.
+fn is_safe_config_body(body: &str) -> bool {
+    // Tera templates can run arbitrary commands via exec() when rendered
+    if contains_template_syntax(body) {
+        return false;
+    }
+    let Ok(toml::Value::Table(table)) = toml::from_str::<toml::Value>(body) else {
+        // let the normal trust + parse flow handle invalid TOML
+        return false;
+    };
+    table.iter().all(|(key, value)| match key.as_str() {
+        "min_version" => true,
+        "tools" => value.as_table().is_some_and(|tools| {
+            tools.values().all(|version| match version {
+                toml::Value::String(_) => true,
+                toml::Value::Array(versions) => {
+                    versions.iter().all(|v| matches!(v, toml::Value::String(_)))
+                }
+                _ => false,
+            })
+        }),
+        _ => false,
+    })
+}
+
 fn is_tools_sorted(tools: &IndexMap<BackendArg, MiseTomlToolList>) -> bool {
     let mut last = None;
     for k in tools.keys() {
@@ -1965,7 +2018,7 @@ fn is_tools_sorted(tools: &IndexMap<BackendArg, MiseTomlToolList>) -> bool {
 mod tests {
     use std::sync::Arc;
 
-    use indoc::formatdoc;
+    use indoc::{formatdoc, indoc};
     use insta::{assert_debug_snapshot, assert_snapshot};
     use test_log::test;
 
@@ -2530,6 +2583,47 @@ run = 'echo "template"'
 
     fn parse_env(toml: String) -> String {
         parse(toml).env_entries().unwrap().into_iter().join("\n")
+    }
+
+    #[test]
+    fn test_is_safe_config_body() {
+        assert!(is_safe_config_body(""));
+        assert!(is_safe_config_body(indoc! {r#"
+        min_version = "2024.1.1"
+        [tools]
+        node = "20"
+        python = ["3.11", "3.12"]
+        "cargo:eza" = "latest"
+        "#}));
+
+        // templates can execute commands
+        assert!(!is_safe_config_body(indoc! {r#"
+        [tools]
+        node = "{{ exec(command='echo 20') }}"
+        "#}));
+        // tool options like postinstall/install_env run code
+        assert!(!is_safe_config_body(indoc! {r#"
+        [tools]
+        node = { version = "20", postinstall = "corepack enable" }
+        "#}));
+        assert!(!is_safe_config_body(indoc! {r#"
+        [tools]
+        node = [{ version = "20" }]
+        "#}));
+        // anything beyond min_version/tools requires trust
+        for body in [
+            "[env]\nFOO = \"bar\"",
+            "[tasks.build]\nrun = \"echo hi\"",
+            "[hooks]\nenter = \"echo hi\"",
+            "[settings]\nparanoid = false",
+            "[alias]\nnode = \"asdf:foo/bar\"",
+            "[plugins]\nfoo = \"https://example.com/foo.git\"",
+            "env_file = \".env\"",
+        ] {
+            assert!(!is_safe_config_body(body), "should require trust: {body}");
+        }
+        // invalid toml falls back to the normal trust + parse flow
+        assert!(!is_safe_config_body("[tools"));
     }
 
     #[tokio::test]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -306,6 +306,13 @@ impl MiseToml {
         Ok(rf)
     }
 
+    /// Whether the config file at `path` loads without trust (see
+    /// [`Self::is_trust_exempt`]). Returns false for unreadable files and for
+    /// non-mise.toml files (e.g. `.tool-versions`), which have their own flow.
+    pub fn path_is_trust_exempt(path: &Path) -> bool {
+        file::read_to_string(path).is_ok_and(|body| Self::is_trust_exempt(&body, path))
+    }
+
     /// Whether this config body can be loaded without trusting the file.
     ///
     /// Safe configs cannot execute code or change mise's behavior beyond
@@ -1982,7 +1989,7 @@ impl<'de> de::Deserialize<'de> for Alias {
 /// - no Tera template syntax anywhere — templates render while config and
 ///   tasks load and can run arbitrary commands via exec()
 fn is_safe_config_body(body: &str) -> bool {
-    // Tera templates can run arbitrary commands via exec() when rendered
+    // Fast reject: literal Tera delimiters in the raw text.
     if contains_template_syntax(body) {
         return false;
     }
@@ -1990,6 +1997,14 @@ fn is_safe_config_body(body: &str) -> bool {
         // let the normal trust + parse flow handle invalid TOML
         return false;
     };
+    // The raw-body check above misses escaped delimiters that TOML decodes,
+    // e.g. `"{{ exec(...) }}"` becomes `{{ exec(...) }}`
+    // after parsing and would still render via Tera. Re-check every decoded
+    // string (keys and values, at any depth) so no exec()-capable template
+    // can slip through into tool versions or task fields.
+    if toml_table_has_template(&table) {
+        return false;
+    }
     table.iter().all(|(key, value)| match key.as_str() {
         "min_version" | "tasks" => true,
         "tools" => value.as_table().is_some_and(|tools| {
@@ -2003,6 +2018,23 @@ fn is_safe_config_body(body: &str) -> bool {
         }),
         _ => false,
     })
+}
+
+/// Whether any decoded string (table key or value, at any depth) contains
+/// Tera template syntax.
+fn toml_value_has_template(value: &toml::Value) -> bool {
+    match value {
+        toml::Value::String(s) => contains_template_syntax(s),
+        toml::Value::Array(arr) => arr.iter().any(toml_value_has_template),
+        toml::Value::Table(t) => toml_table_has_template(t),
+        _ => false,
+    }
+}
+
+fn toml_table_has_template(table: &toml::Table) -> bool {
+    table
+        .iter()
+        .any(|(k, v)| contains_template_syntax(k) || toml_value_has_template(v))
 }
 
 fn is_tools_sorted(tools: &IndexMap<BackendArg, MiseTomlToolList>) -> bool {
@@ -2631,6 +2663,18 @@ run = 'echo "template"'
         run = "cargo build"
         description = "{{ exec(command='echo hi') }}"
         "#}));
+        // escaped Tera delimiters ({ == '{', } == '}') decode to
+        // `{{ exec(...) }}` after TOML parsing and must not bypass the check
+        assert!(!is_safe_config_body(
+            "[tools]\nnode = \"\\u007b\\u007b exec(command='echo 20') \\u007d\\u007d\"\n"
+        ));
+        assert!(!is_safe_config_body(
+            "[tasks.build]\nrun = \"cargo build\"\ndescription = \"\\u007b\\u007b exec(command='echo hi') \\u007d\\u007d\"\n"
+        ));
+        // an escaped delimiter in a key must also be caught
+        assert!(!is_safe_config_body(
+            "[tasks]\n\"\\u007b\\u007b exec() \\u007d\\u007d\" = { run = \"x\" }\n"
+        ));
         // anything beyond min_version/tools/tasks requires trust
         for body in [
             "[env]\nFOO = \"bar\"",

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2021,8 +2021,9 @@ fn is_safe_config_body(body: &str) -> bool {
 }
 
 /// Whether any decoded string (table key or value, at any depth) contains
-/// Tera template syntax.
-fn toml_value_has_template(value: &toml::Value) -> bool {
+/// Tera template syntax. Used to catch escaped delimiters (e.g. `{{`)
+/// that a raw-text scan misses but that still render after TOML parsing.
+pub(crate) fn toml_value_has_template(value: &toml::Value) -> bool {
     match value {
         toml::Value::String(s) => contains_template_syntax(s),
         toml::Value::Array(arr) => arr.iter().any(toml_value_has_template),

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -309,10 +309,10 @@ impl MiseToml {
     /// Whether this config body can be loaded without trusting the file.
     ///
     /// Safe configs cannot execute code or change mise's behavior beyond
-    /// requesting tool versions, so there is nothing to gate behind a trust
-    /// prompt. Anything else — env vars, tasks, hooks, settings, aliases,
-    /// templates, tool options like `postinstall`/`install_env` — still
-    /// requires trust.
+    /// requesting tool versions and defining tasks, so there is nothing to
+    /// gate behind a trust prompt. Anything else — env vars, hooks, settings,
+    /// aliases, templates, tool options like `postinstall`/`install_env` —
+    /// still requires trust.
     fn is_trust_exempt(body: &str, path: &Path) -> bool {
         if Settings::try_get().is_ok_and(|settings| settings.paranoid) {
             return false;
@@ -1970,12 +1970,17 @@ impl<'de> de::Deserialize<'de> for Alias {
     }
 }
 
-/// A config body is safe to load without trust when it only requests tool
-/// versions. `min_version` and `[tools]` entries with plain version strings
-/// cannot execute anything by themselves — installation only happens when the
-/// user explicitly runs a command like `mise install`. Tool entries with
-/// options (tables) are excluded because options like `postinstall` and
-/// `install_env` run code or alter the install environment.
+/// A config body is safe to load without trust when nothing in it can execute
+/// code at load time or change mise's behavior without an explicit user
+/// action:
+/// - `min_version` is inert
+/// - `[tools]` entries with plain version strings only matter when the user
+///   runs something like `mise install`. Entries with options (tables) are
+///   excluded because options like `postinstall` and `install_env` run code
+///   or alter the install environment.
+/// - `[tasks]` definitions are inert until the user explicitly runs one
+/// - no Tera template syntax anywhere — templates render while config and
+///   tasks load and can run arbitrary commands via exec()
 fn is_safe_config_body(body: &str) -> bool {
     // Tera templates can run arbitrary commands via exec() when rendered
     if contains_template_syntax(body) {
@@ -1986,7 +1991,7 @@ fn is_safe_config_body(body: &str) -> bool {
         return false;
     };
     table.iter().all(|(key, value)| match key.as_str() {
-        "min_version" => true,
+        "min_version" | "tasks" => true,
         "tools" => value.as_table().is_some_and(|tools| {
             tools.values().all(|version| match version {
                 toml::Value::String(_) => true,
@@ -2595,6 +2600,16 @@ run = 'echo "template"'
         python = ["3.11", "3.12"]
         "cargo:eza" = "latest"
         "#}));
+        // tasks are inert until the user explicitly runs one
+        assert!(is_safe_config_body(indoc! {r#"
+        [tasks.build]
+        run = "cargo build"
+        dir = "src"
+        env = { FOO = "bar" }
+        [tasks.test]
+        depends = ["build"]
+        run = ["cargo test"]
+        "#}));
 
         // templates can execute commands
         assert!(!is_safe_config_body(indoc! {r#"
@@ -2610,10 +2625,16 @@ run = 'echo "template"'
         [tools]
         node = [{ version = "20" }]
         "#}));
-        // anything beyond min_version/tools requires trust
+        // tasks with templates render (and can exec) while loading
+        assert!(!is_safe_config_body(indoc! {r#"
+        [tasks.build]
+        run = "cargo build"
+        description = "{{ exec(command='echo hi') }}"
+        "#}));
+        // anything beyond min_version/tools/tasks requires trust
         for body in [
             "[env]\nFOO = \"bar\"",
-            "[tasks.build]\nrun = \"echo hi\"",
+            "[task_config]\nincludes = [\"tasks.toml\"]",
             "[hooks]\nenter = \"echo hi\"",
             "[settings]\nparanoid = false",
             "[alias]\nnode = \"asdf:foo/bar\"",

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -305,6 +305,14 @@ pub fn config_trust_root(path: &Path) -> PathBuf {
     }
 }
 
+/// Whether the file or its trust root has been trusted.
+///
+/// Unlike a passing [`trust_check`], this is false for files that merely do
+/// not *need* trust (e.g. safe configs loaded without it).
+pub fn is_path_trusted(path: &Path) -> bool {
+    is_trusted(&config_trust_root(path)) || is_trusted(path)
+}
+
 pub fn trust_check(path: &Path) -> eyre::Result<()> {
     static MUTEX: Mutex<()> = Mutex::new(());
     let _lock = MUTEX.lock().unwrap(); // Prevent multiple checks at once so we don't prompt multiple times for the same path
@@ -312,7 +320,7 @@ pub fn trust_check(path: &Path) -> eyre::Result<()> {
     let default_cmd = String::new();
     let args = env::ARGS.read().unwrap();
     let cmd = args.get(1).unwrap_or(&default_cmd).as_str();
-    if is_trusted(&config_root) || is_trusted(path) || cmd == "trust" || cfg!(test) {
+    if is_path_trusted(path) || cmd == "trust" || cfg!(test) {
         return Ok(());
     }
     if cmd != "hook-env" && !is_ignored(&config_root) && !is_ignored(path) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,7 @@ use crate::cli::version;
 use crate::config::config_file::idiomatic_version::IdiomaticVersionFile;
 use crate::config::config_file::min_version::MinVersionSpec;
 use crate::config::config_file::mise_toml::{MiseToml, Tasks};
-use crate::config::config_file::{ConfigFile, config_trust_root, trust_check};
+use crate::config::config_file::{ConfigFile, config_trust_root, is_path_trusted, trust_check};
 use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
@@ -2533,6 +2533,9 @@ async fn load_file_tasks(
     let config_root = Arc::new(config_root.to_path_buf());
     let cf_root = cf.config_root();
     let task_config_dir = cf.task_config().dir.clone();
+    // a config can only vouch for task include files when it was actually
+    // trusted — safe configs load without trust and cannot vouch for anything
+    let require_task_include_trust = !is_path_trusted(cf.get_path());
 
     for include in includes {
         let paths = if include.starts_with("git::") {
@@ -2547,7 +2550,7 @@ async fn load_file_tasks(
                 &config_root,
                 &task_config_dir,
                 templates,
-                false,
+                require_task_include_trust,
             )
             .await?;
             if is_global_task_include_path(&path) {
@@ -2600,7 +2603,9 @@ pub async fn load_tasks_in_dir(
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let configs = configs_at_root(dir, config_files);
-    let require_task_include_trust = configs.is_empty();
+    // a config can only vouch for task include files when it was actually
+    // trusted — safe configs load without trust and cannot vouch for anything
+    let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
 
     let (includes, resolve_dir) = configs
         .iter()
@@ -2661,10 +2666,22 @@ pub async fn load_tasks_in_dir(
 }
 
 fn trust_check_task_include(path: &Path, require_trust: bool) -> Result<()> {
-    if require_trust && !is_global_task_include_path(path) {
+    if require_trust && !is_global_task_include_path(path) && task_include_requires_trust(path) {
         trust_check(path)?;
     }
     Ok(())
+}
+
+/// Template-free task files are inert at load time: TOML and `#MISE` headers
+/// are only parsed, and the scripts themselves only run on an explicit
+/// `mise run`. Templates are what can execute code while tasks load (via
+/// exec() etc. when task fields render), so only files containing template
+/// syntax need trust. Paranoid mode keeps requiring trust for everything.
+fn task_include_requires_trust(path: &Path) -> bool {
+    if Settings::try_get().is_ok_and(|settings| settings.paranoid) {
+        return true;
+    }
+    file::read_to_string(path).map_or(true, |body| contains_template_syntax(&body))
 }
 
 async fn load_task_file(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -542,7 +542,12 @@ impl Config {
             // to parse for trusted files. Untrusted non-MiseToml files (like
             // .tool-versions) don't need trust and will parse fine regardless.
             let trust_root = config_file::config_trust_root(&path);
-            if !config_file::is_trusted(&trust_root) && !config_file::is_trusted(&path) {
+            if !config_file::is_trusted(&trust_root)
+                && !config_file::is_trusted(&path)
+                // safe mise.toml files load without a trust marker, so a missing
+                // marker doesn't mean they should be skipped here
+                && !MiseToml::path_is_trust_exempt(&path)
+            {
                 debug!("skipping untrusted tracked config: {}", display_path(&path));
                 continue;
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2686,7 +2686,13 @@ fn task_include_requires_trust(path: &Path) -> bool {
     if Settings::try_get().is_ok_and(|settings| settings.paranoid) {
         return true;
     }
-    file::read_to_string(path).map_or(true, |body| contains_template_syntax(&body))
+    let Ok(body) = file::read_to_string(path) else {
+        // can't read it — fall back to requiring trust
+        return true;
+    };
+    // literal delimiters, plus escaped ones (e.g. `{{`) that decode to
+    // templates after TOML parsing and would render at load time
+    contains_template_syntax(&body) || crate::task::file_has_decoded_template(path, &body)
 }
 
 async fn load_task_file(

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -504,6 +504,41 @@ pub struct Task {
     pub trailing_args: Vec<String>,
 }
 
+/// Parse the `#MISE key=value` (and `// MISE`, `:: MISE`, `[MISE]`) header
+/// lines out of a task script into their decoded TOML values.
+fn parse_mise_header_toml(body: &str) -> Result<Vec<toml::Value>> {
+    body.lines()
+        .filter_map(|line| {
+            regex!(r"^(?:#|//|::)(?:MISE| ?\[MISE\]) ([a-z0-9_.-]+\s*=\s*[^\n]+)$").captures(line)
+        })
+        .map(|captures| captures.extract().1)
+        .map(|[toml]| {
+            toml::de::from_str::<toml::Value>(toml)
+                .map_err(|e| eyre::eyre!("failed to parse task header TOML {toml:?}: {e}"))
+        })
+        .collect()
+}
+
+/// Whether a task include file contains Tera template syntax only after TOML
+/// decoding (e.g. `{{` written as `{{`). Such escapes pass a
+/// raw-text scan but decode to real templates that render — and can `exec()` —
+/// at load time, so they must still require trust. `.toml` task files are
+/// checked whole; script files are checked through their `#MISE` headers (the
+/// only part parsed and rendered at load).
+pub(crate) fn file_has_decoded_template(path: &Path, body: &str) -> bool {
+    use crate::config::config_file::mise_toml::toml_value_has_template;
+    if path.extension().is_some_and(|e| e == "toml") {
+        // Unparseable TOML won't load as a task file (it errors before any
+        // render), so it doesn't need trust on this account.
+        toml::from_str::<toml::Value>(body).is_ok_and(|v| toml_value_has_template(&v))
+    } else {
+        parse_mise_header_toml(body)
+            .unwrap_or_default()
+            .iter()
+            .any(toml_value_has_template)
+    }
+}
+
 impl Task {
     pub fn new(path: &Path, prefix: &Path, config_root: &Path) -> Result<Task> {
         Ok(Self {
@@ -521,18 +556,7 @@ impl Task {
         config_root: &Path,
     ) -> Result<Task> {
         let mut task = Task::new(path, prefix, config_root)?;
-        let info = file::read_to_string(path)?
-            .lines()
-            .filter_map(|line| {
-                regex!(r"^(?:#|//|::)(?:MISE| ?\[MISE\]) ([a-z0-9_.-]+\s*=\s*[^\n]+)$")
-                    .captures(line)
-            })
-            .map(|captures| captures.extract().1)
-            .map(|[toml]| {
-                toml::de::from_str::<toml::Value>(toml)
-                    .map_err(|e| eyre::eyre!("failed to parse task header TOML {toml:?}: {e}"))
-            })
-            .collect::<Result<Vec<_>>>()?
+        let info = parse_mise_header_toml(&file::read_to_string(path)?)?
             .into_iter()
             .filter_map(|toml| toml.as_table().cloned())
             .flatten()
@@ -2305,6 +2329,33 @@ mod tests {
         CAPTURED_PARSER_FIELDS.with(|captured| {
             *captured.lock().unwrap() = Some(fields);
         });
+    }
+
+    #[test]
+    fn test_file_has_decoded_template() {
+        use super::file_has_decoded_template;
+        let toml = Path::new("ci.toml");
+        let script = Path::new("script.sh");
+
+        // plain template-free includes do not need trust
+        assert!(!file_has_decoded_template(
+            toml,
+            "[hello]\nrun = \"echo hi\"\ndescription = \"a plain task\"\n"
+        ));
+        assert!(!file_has_decoded_template(
+            script,
+            "#!/usr/bin/env bash\n#MISE description=\"a plain task\"\necho hi\n"
+        ));
+
+        // escaped delimiters ({ == '{', } == '}') decode to a template
+        assert!(file_has_decoded_template(
+            toml,
+            "[hello]\nrun = \"echo hi\"\ndescription = \"\\u007b\\u007b exec(command='x') \\u007d\\u007d\"\n"
+        ));
+        assert!(file_has_decoded_template(
+            script,
+            "#!/usr/bin/env bash\n#MISE description=\"\\u007b\\u007b exec(command='x') \\u007d\\u007d\"\necho hi\n"
+        ));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

`mise.toml` files that cannot execute code at load time or change mise's behavior without an explicit user action no longer require trust. A config is exempt from the trust gate only when:

- it contains no Tera template syntax — checked both on the raw body (`{{`, `{%`, `{#`) **and** on every decoded TOML string (keys/values, any depth) so escaped delimiters can't slip through — and
- its top-level keys are limited to `min_version`, `[tasks]`, and `[tools]` entries whose values are plain version strings (or arrays of them)

Tools install and tasks run only on explicit commands (`mise install`, `mise run`), so loading these configs executes nothing. Template-free file tasks (`mise-tasks/` scripts and included TOML task files) are likewise loadable without trust — templates are the only thing that can execute while tasks load.

Everything else keeps the existing trust prompt/error: `[env]`, `[hooks]`, `[settings]`, `[alias]`, `[plugins]`, `[task_config]`, `env_file`/`dotenv`, tool entries with options (tables) — since options like `postinstall` run shell commands and `install_env` can alter the install environment — and any file with template syntax. Paranoid mode still requires trust for every file, and ignored configs stay unloaded even when safe.

The check is allowlist-based, so an unrecognized or future config construct fails safe (still prompts for trust).

## Security hardening

- **Escaped-template trust bypass (critical, caught in review).** `is_safe_config_body` originally only scanned the *raw* TOML body, so `tiny = "{{ exec(...) }}"` — which TOML decodes to `{{ exec(...) }}` — passed as "safe" and then executed via Tera when the tool version / task field rendered, with no trust prompt. Fixed by recursively re-checking every decoded TOML string for template syntax. Regression tests added (unit + e2e) for both the tools and tasks paths.
- **Task-include trust hole (pre-existing).** `load_tasks_in_dir` skipped the include trust check whenever *any* config existed at the root, even one loaded without trust (e.g. a plain `.tool-versions`), so a templated `mise-tasks/*.toml` could render `exec()` at `mise tasks` time. Includes now require trust unless a root config was actually trusted (new `config_file::is_path_trusted`).

## Other fixes

- **Tracked safe configs.** `get_tracked_config_files` skipped any path without a trust marker, which safe configs don't create — so their tool pins went missing from `mise ls --all-sources`, `mise upgrade`, and `mise prune`. Safe configs are now loaded there too (`MiseToml::path_is_trust_exempt`). Regression test: `e2e/config/test_trust_safe_config_tracked`.

## Tests

- Unit `test_is_safe_config_body`: tools/tasks safe cases, plus rejection of templates, tool-options, and **escaped** templates in tool versions, task fields, and keys
- `e2e/config/test_trust_safe_config`: safe tools+tasks (config and file tasks) load/run with no trust marker; literal- and escaped-template variants in versions, task fields, and file-task headers, plus tool-options and `[env]`, are all blocked with nothing executing
- `e2e/config/test_trust_safe_config_tracked`: safe config's pins survive tracked-config reload from another directory
- `test_task_untrusted_config_error` / `test_task_monorepo_trust` updated for the new semantics; all other trust e2e tests pass unchanged
- Trust-marker e2e assertions made precise (check for marker *files*, not just the directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safe config files (only min_version, plain tool versions, and tasks without templates/options) auto-load without a trust prompt.

* **Documentation**
  * Help text, man page, CLI docs, and FAQ updated to define which configs auto-load and which require trust.

* **Refactor**
  * Trust and load logic enhanced to recognize safe configs and detect encoded/escaped template markers.

* **Tests**
  * Added unit and E2E tests for safe-config loading, tracked safe configs, escaped-template edge cases, and unsafe cases requiring trust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes when untrusted config is parsed and when templates can run at load time; mistakes could allow code execution without a trust prompt.
> 
> **Overview**
> **Untrusted `mise.toml` files that only pin tools and define tasks can now load without `mise trust`**, when their content is allowlisted (`min_version`, plain `[tools]` strings/arrays, `[tasks]` with no tool-option tables) and has no Tera templates. Parsing skips `trust_check` via `is_trust_exempt` / `path_is_trust_exempt`; everything else (`[env]`, hooks, settings, templates, `postinstall`, etc.) still requires trust, and **paranoid** / **ignored** configs stay gated.
> 
> **Security tightening:** decoded TOML strings are scanned for templates so Unicode-escaped `{{ exec(...) }}` cannot bypass a raw-body check. Task includes and `mise-tasks` files only auto-load without trust when template-free; templated `#MISE` headers and included TOML still require trust. **Trusted** vs **trust-exempt** is split with `is_path_trusted` so safe configs cannot vouch for includes, and tracked-config reload no longer drops safe configs missing a trust marker.
> 
> Docs/CLI help and e2e tests document and cover safe load, escaped-template blocks, and tracked-config visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd9a7e26b997603fb3fccb097c60e8cab47f3d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->