### PR TITLE
perf(versions-host): fetch version lists from static assets

### DIFF
--- a/e2e/cli/test_ls_cache
+++ b/e2e/cli/test_ls_cache
@@ -14,7 +14,7 @@ fi
 if [[ $output == *"GET https://mise-versions.jdx.dev/api/github/repos/sharkdp/bat/releases/latest"* ]]; then
   fail "[mise -v ls bat] unexpectedly fetched the GitHub latest release from mise-versions"
 fi
-if [[ $output == *"GET https://mise-versions.jdx.dev/tools/bat.toml"* ]]; then
+if [[ $output == *"GET https://mise-versions.jdx.dev/data/bat.toml"* ]]; then
   fail "[mise -v ls bat] unexpectedly fetched the versions host"
 fi
 ok "[mise -v ls bat] reused cached metadata"

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -227,8 +227,8 @@ pub async fn list_versions(tool: &str) -> eyre::Result<Option<Vec<VersionInfo>>>
         return Ok(None);
     }
 
-    // Use TOML format which includes created_at timestamps
-    let url = format!("https://mise-versions.jdx.dev/tools/{}.toml", tool);
+    // Use the static TOML asset which includes created_at timestamps.
+    let url = version_list_url(tool);
     let versions: Vec<VersionInfo> = match HTTP_FETCH
         .get_text_request(&url)
         .headers(&VERSIONS_HOST_HEADERS)
@@ -612,6 +612,10 @@ fn track_install_url(tool: &str) -> String {
     )
 }
 
+fn version_list_url(tool: &str) -> String {
+    format!("https://mise-versions.jdx.dev/data/{}.toml", tool)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -629,6 +633,14 @@ mod tests {
         assert_eq!(
             track_install_url("node"),
             "https://mise-versions.jdx.dev/api/tools/node"
+        );
+    }
+
+    #[test]
+    fn test_version_list_url_uses_static_asset_path() {
+        assert_eq!(
+            version_list_url("node"),
+            "https://mise-versions.jdx.dev/data/node.toml"
         );
     }
 


### PR DESCRIPTION
## Summary
- fetch mise-versions TOML lists from `/data/{tool}.toml` so Cloudflare can serve them as static assets
- keep GitHub metadata, attestations, and install tracking on the existing API routes
- update the ls cache e2e guard for the new static asset URL

## Validation
- `cargo fmt --check`
- `cargo test versions_host`
- `mise run test:e2e e2e/cli/test_ls_cache`
- live smoke: isolated `target/debug/mise -v ls-remote bat` logged `GET https://mise-versions.jdx.dev/data/bat.toml 200 OK` and `version_list tool=bat outcome=success`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow URL-path change with a unit test and e2e update; depends on the host serving the same TOML at the new path.
> 
> **Overview**
> Version list TOML for mise-versions is now loaded from **`/data/{tool}.toml`** instead of **`/tools/{tool}.toml`**, via a new **`version_list_url`** helper, so lists can be served as static CDN assets while parsing and caching behavior stay the same.
> 
> GitHub release metadata, attestations, and install tracking still use the existing **`/api/...`** routes. The **`test_ls_cache`** e2e assertion was updated to expect the new URL when checking that **`mise ls`** does not refetch the versions host after cache warming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56444ebd595f38d41f319e8637554588e8ed4905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined version metadata endpoint resolution to improve cache handling and consistency.

* **Tests**
  * Updated validation tests to ensure proper cache detection for version metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->