### PR TITLE
chore: release 2026.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## [2026.6.6](https://github.com/jdx/mise/compare/v2026.6.5..v2026.6.6) - 2026-06-13
+
+### 🚀 Features
+
+- **(bootstrap)** add dotfiles workflow by @jdx in [#10376](https://github.com/jdx/mise/pull/10376)
+- **(bootstrap)** support brew taps and casks directly by @jdx in [#10383](https://github.com/jdx/mise/pull/10383)
+- **(config)** load safe mise.toml files without trust by @jdx in [#10360](https://github.com/jdx/mise/pull/10360)
+- **(oci)** apply system files and apt packages by @jdx in [#10373](https://github.com/jdx/mise/pull/10373)
+- **(system)** add [system.defaults] for declarative macOS defaults by @jdx in [#10363](https://github.com/jdx/mise/pull/10363)
+- **(system)** build source formulae from source with a native formula DSL shim by @jdx in [#10364](https://github.com/jdx/mise/pull/10364)
+- **(system)** support wildcards in system files by @jdx in [#10374](https://github.com/jdx/mise/pull/10374)
+- **(system)** support custom brew taps by @jdx in [#10375](https://github.com/jdx/mise/pull/10375)
+- **(system)** add login shell bootstrap support by @jdx in [#10377](https://github.com/jdx/mise/pull/10377)
+- add `mise bootstrap` and declarative `[system.files]` by @jdx in [#10365](https://github.com/jdx/mise/pull/10365)
+- add `[system.edits]` for editing files mise doesn't own by @jdx in [#10368](https://github.com/jdx/mise/pull/10368)
+
+### 🐛 Bug Fixes
+
+- **(http)** show github 403 response diagnostics by @jdx in [#10382](https://github.com/jdx/mise/pull/10382)
+
+### 🚜 Refactor
+
+- **(file)** split extraction helpers and harden format handling by @risu729 in [#10274](https://github.com/jdx/mise/pull/10274)
+
+### 📚 Documentation
+
+- **(settings)** document 24h default for minimum_release_age by @ThijsdeJong-TomTom in [#10366](https://github.com/jdx/mise/pull/10366)
+- link to all sponsors by @jdx in [#10369](https://github.com/jdx/mise/pull/10369)
+- add more tips and tricks entries by @jdx in [#10370](https://github.com/jdx/mise/pull/10370)
+- clarify contribution fit by @jdx in [#10378](https://github.com/jdx/mise/pull/10378)
+- make contributing guide canonical by @jdx in [#10380](https://github.com/jdx/mise/pull/10380)
+
+### ⚡ Performance
+
+- **(versions-host)** fetch version lists from static assets by @jdx in [#10361](https://github.com/jdx/mise/pull/10361)
+
+### Chore
+
+- graduate stable features from experimental by @jdx in [#10371](https://github.com/jdx/mise/pull/10371)
+- remove stale cargo-deny advisory ignores by @jdx in [#10372](https://github.com/jdx/mise/pull/10372)
+
+### New Contributors
+
+- @ThijsdeJong-TomTom made their first contribution in [#10366](https://github.com/jdx/mise/pull/10366)
+
+### 📦 Aqua Registry Updates
+
+#### Updated Packages (5)
+
+- [`oracle.com/sqlcl`](https://github.com/jasonlyle88/sqlcl-releases)
+- [`oxc-project/oxc/oxlint`](https://github.com/oxc-project/oxc)
+- [`suzuki-shunsuke/docfresh`](https://github.com/suzuki-shunsuke/docfresh)
+- [`suzuki-shunsuke/ghaperf`](https://github.com/suzuki-shunsuke/ghaperf)
+- [`suzuki-shunsuke/ghir`](https://github.com/suzuki-shunsuke/ghir)
+
 ## [2026.6.5](https://github.com/jdx/mise/compare/v2026.6.4..v2026.6.5) - 2026-06-12
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.6.5"
+version = "2026.6.6"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.6.5"
+version = "2026.6.6"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.6.5 macos-arm64 (2026-06-12)
+2026.6.6 macos-arm64 (2026-06-13)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_5.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_6.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_5.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_6.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_5.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_6.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_5.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_6.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.6.5";
+  version = "2026.6.6";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "29.4k",
+      stars: "29.5k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.6.5
+Version: 2026.6.6
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.6.5"
+version: "2026.6.6"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "a8cba64b85b03e4fcda9a476e749c5ff695eeba2"
+  "tag": "93cd8ecfeef813610199913db392d0e8f8dc0c27"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -70581,10 +70581,23 @@ packages:
           - amd64
   - type: http
     name: oracle.com/sqlcl
+    repo_owner: jasonlyle88
+    repo_name: sqlcl-releases
     url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.Version}}.zip
+    format: zip
+    link: https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/
+    description: Oracle SQLcl command-line interface for Oracle Database
     files:
       - name: sql
         src: sqlcl/bin/sql
+    checksum:
+      type: github_release
+      asset: sqlcl-{{.Version}}.zip.sha256
+      algorithm: sha256
+      file_format: regexp
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: orangekame3
     repo_name: stree
@@ -71579,15 +71592,16 @@ packages:
     repo_owner: oxc-project
     repo_name: oxc
     description: The linter for oxc
+    version_filter: 'Version matches "^apps_v" || Version matches "^oxlint_v"'
+    files:
+      - name: oxlint
+        src: "{{.AssetWithoutExt}}"
     version_constraint: "false"
-    version_prefix: oxlint_v
     version_overrides:
-      - version_constraint: semver(">= 1.17.0")
-        error_message: |
-          aqua can't support oxlint 1.17.0 or later. 
-          > Newer versions of Oxlint require node.js. There isn’t a native executable alternative anymore.
-          https://github.com/oxc-project/oxc/discussions/14452#discussioncomment-14631344
+      - version_constraint: Version in ["apps_v1.47.0", "oxlint_v0.0.9", "oxlint_v0.1.1"]
+        no_asset: true
       - version_constraint: semver("<= 0.0.8")
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint
@@ -71595,9 +71609,8 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: Version == "oxlint_v0.0.9"
-        no_asset: true
       - version_constraint: semver("<= 0.0.19")
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint
@@ -71605,9 +71618,8 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: Version == "oxlint_v0.1.1"
-        no_asset: true
       - version_constraint: semver("<= 0.2.2")
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -71619,7 +71631,8 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.17.0")
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -71636,6 +71649,62 @@ packages:
         replacements:
           amd64: x64
           windows: win32
+      - version_constraint: semver(">= 1.17.0")
+        version_prefix: oxlint_v
+        error_message: |
+          This version is unavailable.
+          < 1.17.0: The version prefix is oxlint_v e.g. oxlint_v1.16.0
+          >= 1.17.0, < 1.28.0: These versions are unavailable
+          >= 1.28.0: The version prefix is apps_v e.g. apps_v1.28.0
+      - version_constraint: semver("< 1.28.0")
+        version_prefix: apps_v
+        error_message: |
+          The version was too old. Please ugrade to 1.28.0 or later.
+          < 1.17.0: The version prefix is oxlint_v
+          >= 1.17.0, < 1.28.0: These versions are unavailable
+          >= 1.28.0: The version prefix is apps_v
+      - version_constraint: semver("<= 1.43.0")
+        version_prefix: apps_v
+        asset: oxlint-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: darwin
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 1.51.0")
+        version_prefix: apps_v
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.53.0")
+        version_prefix: apps_v
+        no_asset: true
+      - version_constraint: "true"
+        version_prefix: apps_v
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: oxipng
     repo_name: oxipng
@@ -87027,7 +87096,7 @@ packages:
     description: Make document maintainable, reusable, and testable
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.2.0")
         asset: docfresh_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -87038,6 +87107,30 @@ packages:
             bundle:
               type: github_release
               asset: docfresh_checksums.txt.bundle
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: docfresh_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: docfresh_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: docfresh_checksums.txt.sigstore.json
             opts:
               - --certificate-identity-regexp
               - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
@@ -87145,7 +87238,7 @@ packages:
     description: ghaperf is a CLI to analyze the performance of GitHub Actions using GitHub API and raw job logs
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.1.1")
         asset: ghaperf_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -87161,6 +87254,28 @@ packages:
             bundle:
               type: github_release
               asset: ghaperf_checksums.txt.bundle
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: ghaperf_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ghaperf_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+            bundle:
+              type: github_release
+              asset: ghaperf_checksums.txt.sigstore.json
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
@@ -87269,7 +87384,7 @@ packages:
     description: ghir is a CLI making past GitHub Releases immutable
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.0.3")
         asset: ghir_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -87291,8 +87406,30 @@ packages:
           asset: multiple.intoto.jsonl
         github_artifact_attestations:
           signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
-        github_immutable_release: true
-        github_release_attestations: true
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: ghir_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ghir_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: ghir_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.+$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** add dotfiles workflow by @jdx in [#10376](https://github.com/jdx/mise/pull/10376)
- **(bootstrap)** support brew taps and casks directly by @jdx in [#10383](https://github.com/jdx/mise/pull/10383)
- **(config)** load safe mise.toml files without trust by @jdx in [#10360](https://github.com/jdx/mise/pull/10360)
- **(oci)** apply system files and apt packages by @jdx in [#10373](https://github.com/jdx/mise/pull/10373)
- **(system)** add [system.defaults] for declarative macOS defaults by @jdx in [#10363](https://github.com/jdx/mise/pull/10363)
- **(system)** build source formulae from source with a native formula DSL shim by @jdx in [#10364](https://github.com/jdx/mise/pull/10364)
- **(system)** support wildcards in system files by @jdx in [#10374](https://github.com/jdx/mise/pull/10374)
- **(system)** support custom brew taps by @jdx in [#10375](https://github.com/jdx/mise/pull/10375)
- **(system)** add login shell bootstrap support by @jdx in [#10377](https://github.com/jdx/mise/pull/10377)
- add `mise bootstrap` and declarative `[system.files]` by @jdx in [#10365](https://github.com/jdx/mise/pull/10365)
- add `[system.edits]` for editing files mise doesn't own by @jdx in [#10368](https://github.com/jdx/mise/pull/10368)

### 🐛 Bug Fixes

- **(http)** show github 403 response diagnostics by @jdx in [#10382](https://github.com/jdx/mise/pull/10382)

### 🚜 Refactor

- **(file)** split extraction helpers and harden format handling by @risu729 in [#10274](https://github.com/jdx/mise/pull/10274)

### 📚 Documentation

- **(settings)** document 24h default for minimum_release_age by @ThijsdeJong-TomTom in [#10366](https://github.com/jdx/mise/pull/10366)
- link to all sponsors by @jdx in [#10369](https://github.com/jdx/mise/pull/10369)
- add more tips and tricks entries by @jdx in [#10370](https://github.com/jdx/mise/pull/10370)
- clarify contribution fit by @jdx in [#10378](https://github.com/jdx/mise/pull/10378)
- make contributing guide canonical by @jdx in [#10380](https://github.com/jdx/mise/pull/10380)

### ⚡ Performance

- **(versions-host)** fetch version lists from static assets by @jdx in [#10361](https://github.com/jdx/mise/pull/10361)

### Chore

- graduate stable features from experimental by @jdx in [#10371](https://github.com/jdx/mise/pull/10371)
- remove stale cargo-deny advisory ignores by @jdx in [#10372](https://github.com/jdx/mise/pull/10372)

### New Contributors

- @ThijsdeJong-TomTom made their first contribution in [#10366](https://github.com/jdx/mise/pull/10366)

## 📦 Aqua Registry Updates

### Updated Packages (5)

- [`oracle.com/sqlcl`](https://github.com/jasonlyle88/sqlcl-releases)
- [`oxc-project/oxc/oxlint`](https://github.com/oxc-project/oxc)
- [`suzuki-shunsuke/docfresh`](https://github.com/suzuki-shunsuke/docfresh)
- [`suzuki-shunsuke/ghaperf`](https://github.com/suzuki-shunsuke/ghaperf)
- [`suzuki-shunsuke/ghir`](https://github.com/suzuki-shunsuke/ghir)