### PR TITLE
docs(settings): document 24h default for minimum_release_age

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -1392,6 +1392,7 @@ hide = true
 type = "String"
 
 [minimum_release_age]
+default_docs = "24h"
 description = "Minimum release age / supply chain protection — only install versions older than this threshold"
 docs = """
 Filter tool versions by release date to limit supply chain risk. Similar to Renovate's


### PR DESCRIPTION
## Summary

The settings docs for `minimum_release_age` state "Defaults to `24h`" in the prose, but the setting entry in `settings.toml` had no `default_docs` key, so the rendered settings page showed no default (and marked it as optional/unset).

This adds `default_docs = "24h"` to match the built-in default applied in `src/install_before.rs` (`DEFAULT_MINIMUM_RELEASE_AGE`). The field stays `optional` in the generated Rust code since the default is resolved at use-time (the code distinguishes an explicit setting from the built-in default for installed-version fast paths).

Docs-only change: `default_docs` is read by `docs/settings.data.ts` and not by the JSON schema renderer or codegen.

*This PR was generated with an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration documentation to clarify that the minimum release age defaults to 24 hours, aligning documented defaults with actual system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->