### PR TITLE
registry: add metabase-cli (npm:@metabase/cli)

### DIFF
--- a/registry/metabase-cli.toml
+++ b/registry/metabase-cli.toml
@@ -1,0 +1,3 @@
+backends = ["npm:@metabase/cli"]
+description = "Command-line interface for Metabase, the open-source business intelligence platform. Manage questions, dashboards, databases, and other Metabase resources from the terminal"
+test = { cmd = "mb --version", expected = "{{version}}" }


### PR DESCRIPTION
## What

Adds a registry short name for the official [Metabase CLI](https://www.npmjs.com/package/@metabase/cli), so users can `mise use metabase-cli` instead of `mise use npm:@metabase/cli`.

## Popularity summary

- Official CLI for [Metabase](https://github.com/metabase/metabase) (47.6k stars), published on npm under the `@metabase` org.
- The CLI itself is new (first published 2026, latest release 0.1.12 on 2026-06-09, ~300 weekly npm downloads and growing) and actively developed by the Metabase team. I work at Metabase.

## Backend choice

npm is the only distribution channel today — there are no GitHub release binaries yet, so no aqua/github option exists. I'm aware npm is a tier-3 backend with a very high bar; happy to close this if it doesn't meet it, or to revisit with a github/aqua primary backend once we ship standalone binaries. The package has no native dependencies and works with lifecycle scripts disabled.

## Testing

Verified locally:

```
$ mise install npm:@metabase/cli@latest
mise npm:@metabase/cli@0.1.12 ✓ installed
$ mise exec npm:@metabase/cli@latest -- mb --version
0.1.12
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Metabase CLI package registry configuration with backend source definition and automated verification command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->