### PR TITLE
feat: add `[system.edits]` for editing files mise doesn't own

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -89,29 +89,6 @@ export default withMermaid(
             { text: "OCI Images (experimental)", link: "/dev-tools/mise-oci" },
             { text: "Deps", link: "/dev-tools/deps" },
             {
-              text: "System Packages (experimental)",
-              link: "/system-packages/",
-              collapsed: true,
-              items: [
-                { text: "apt", link: "/system-packages/apt" },
-                { text: "dnf", link: "/system-packages/dnf" },
-                { text: "pacman", link: "/system-packages/pacman" },
-                { text: "brew", link: "/system-packages/brew" },
-                {
-                  text: "macOS Defaults",
-                  link: "/system-packages/defaults",
-                },
-              ],
-            },
-            {
-              text: "System Files (experimental)",
-              link: "/system-files",
-            },
-            {
-              text: "System Edits (experimental)",
-              link: "/system-edits",
-            },
-            {
               text: "Backend Architecture",
               link: "/dev-tools/backend_architecture",
             },
@@ -156,6 +133,38 @@ export default withMermaid(
                 { text: "ubi", link: "/dev-tools/backends/ubi" },
                 { text: "vfox", link: "/dev-tools/backends/vfox" },
               ],
+            },
+          ],
+        },
+        {
+          text: "System (experimental)",
+          items: [
+            {
+              text: "System Packages",
+              link: "/system-packages/",
+              collapsed: true,
+              items: [
+                { text: "apt", link: "/system-packages/apt" },
+                { text: "dnf", link: "/system-packages/dnf" },
+                { text: "pacman", link: "/system-packages/pacman" },
+                { text: "brew", link: "/system-packages/brew" },
+              ],
+            },
+            {
+              text: "System Files (dotfiles)",
+              link: "/system-files",
+            },
+            {
+              text: "System Edits",
+              link: "/system-edits",
+            },
+            {
+              text: "macOS Defaults",
+              link: "/system-packages/defaults",
+            },
+            {
+              text: "mise bootstrap",
+              link: "/cli/bootstrap",
             },
           ],
         },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -108,6 +108,10 @@ export default withMermaid(
               link: "/system-files",
             },
             {
+              text: "System Edits (experimental)",
+              link: "/system-edits",
+            },
+            {
               text: "Backend Architecture",
               link: "/dev-tools/backend_architecture",
             },

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -9,7 +9,7 @@
 Runs the bootstrap steps for the current config in order:
 
 1. `mise system install` — install missing `[system.packages]`, apply
-   `[system.files]` and `[[system.edits]]`, and write `[system.defaults]`
+   `[system.files]` and `[system.edits]`, and write `[system.defaults]`
    (macOS)
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -8,14 +8,13 @@
 
 Runs the bootstrap steps for the current config in order:
 
-1. `mise system install` — install missing `[system.packages]`, apply
-   `[system.files]`, and write `[system.defaults]` (macOS)
+1. `mise system install` — install missing `[system.packages]` and apply
+   `[system.files]` and `[[system.edits]]`
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
-The declarative steps converge — anything already in its desired state
-is skipped, so re-running is safe. The `bootstrap` task runs on every
-invocation; keep it idempotent. Use it for any project-specific setup
+Steps with nothing to do are skipped, so `mise bootstrap` is idempotent
+and safe to re-run. Use a `bootstrap` task for any project-specific setup
 that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
 

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -8,13 +8,15 @@
 
 Runs the bootstrap steps for the current config in order:
 
-1. `mise system install` — install missing `[system.packages]` and apply
-   `[system.files]` and `[[system.edits]]`
+1. `mise system install` — install missing `[system.packages]`, apply
+   `[system.files]` and `[[system.edits]]`, and write `[system.defaults]`
+   (macOS)
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
-Steps with nothing to do are skipped, so `mise bootstrap` is idempotent
-and safe to re-run. Use a `bootstrap` task for any project-specific setup
+The declarative steps converge — anything already in its desired state
+is skipped, so re-running is safe. The `bootstrap` task runs on every
+invocation; keep it idempotent. Use it for any project-specific setup
 that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
 

--- a/docs/cli/system.md
+++ b/docs/cli/system.md
@@ -5,14 +5,16 @@
 - **Source code**: [`src/cli/system/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/mod.rs)
 
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, and edits from `[[system.edits]]`
+from `[system.files]`, edits from `[[system.edits]]`, and macOS defaults
+from `[system.defaults]`
 
 System packages are machine-global packages installed by the OS package
 manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).
 System files are config files (dotfiles) symlinked, copied, or rendered
 to machine-global paths. System edits manage one piece of a file
-something else owns — a marker-delimited block or a single line. Unlike
-`[tools]`, none of these are version-pinned per-project and all are only
+something else owns — a marker-delimited block or a single line. macOS
+defaults are user preferences written with `defaults write`. Unlike
+`[tools]`, none of these are version-pinned per-project and they are only
 ever acted on when explicitly requested with `mise system install`.
 
 ## Subcommands

--- a/docs/cli/system.md
+++ b/docs/cli/system.md
@@ -5,15 +5,15 @@
 - **Source code**: [`src/cli/system/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/mod.rs)
 
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, and macOS defaults from `[system.defaults]`
+from `[system.files]`, and edits from `[[system.edits]]`
 
 System packages are machine-global packages installed by the OS package
 manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).
 System files are config files (dotfiles) symlinked, copied, or rendered
-to machine-global paths. macOS defaults are user preferences written
-with `defaults write`. Unlike `[tools]`, none of these are version-pinned
-per-project and they are only ever acted on when explicitly requested
-with `mise system install`.
+to machine-global paths. System edits manage one piece of a file
+something else owns — a marker-delimited block or a single line. Unlike
+`[tools]`, none of these are version-pinned per-project and all are only
+ever acted on when explicitly requested with `mise system install`.
 
 ## Subcommands
 

--- a/docs/cli/system.md
+++ b/docs/cli/system.md
@@ -15,7 +15,8 @@ to machine-global paths. System edits manage one piece of a file
 something else owns — a marker-delimited block or a single line. macOS
 defaults are user preferences written with `defaults write`. Unlike
 `[tools]`, none of these are version-pinned per-project and they are only
-ever acted on when explicitly requested with `mise system install`.
+ever acted on when explicitly requested with `mise system install` (or
+`mise bootstrap`).
 
 ## Subcommands
 

--- a/docs/cli/system.md
+++ b/docs/cli/system.md
@@ -5,7 +5,7 @@
 - **Source code**: [`src/cli/system/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/mod.rs)
 
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, edits from `[[system.edits]]`, and macOS defaults
+from `[system.files]`, edits from `[system.edits]`, and macOS defaults
 from `[system.defaults]`
 
 System packages are machine-global packages installed by the OS package

--- a/docs/cli/system/install.md
+++ b/docs/cli/system/install.md
@@ -5,19 +5,19 @@
 - **Aliases**: `i`
 - **Source code**: [`src/cli/system/install.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/install.rs)
 
-Install missing system packages from `[system.packages]`, apply files
-from `[system.files]`, and write macOS defaults from `[system.defaults]`
+Install missing system packages from `[system.packages]` and apply files
+from `[system.files]` and edits from `[[system.edits]]`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
-entries that aren't in their desired state are applied, and on macOS any
-`[system.defaults]` entries that are unset or differ are written.
+and `[[system.edits]]` entries that aren't in their desired state are
+applied.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in
-the config. Explicit packages and `--manager` scope the run to packages
-only.
+the config — files and edits are skipped in that case, as with
+`--manager`.
 
 ## Arguments
 

--- a/docs/cli/system/install.md
+++ b/docs/cli/system/install.md
@@ -5,19 +5,21 @@
 - **Aliases**: `i`
 - **Source code**: [`src/cli/system/install.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/install.rs)
 
-Install missing system packages from `[system.packages]` and apply files
-from `[system.files]` and edits from `[[system.edits]]`
+Install missing system packages from `[system.packages]`, apply files
+from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+defaults from `[system.defaults]`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 and `[[system.edits]]` entries that aren't in their desired state are
-applied.
+applied, and on macOS any `[system.defaults]` entries that are unset or
+differ are written.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in
-the config — files and edits are skipped in that case, as with
-`--manager`.
+the config. Explicit packages and `--manager` scope the run to packages
+only.
 
 ## Arguments
 

--- a/docs/cli/system/install.md
+++ b/docs/cli/system/install.md
@@ -6,13 +6,13 @@
 - **Source code**: [`src/cli/system/install.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/install.rs)
 
 Install missing system packages from `[system.packages]`, apply files
-from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+from `[system.files]` and edits from `[system.edits]`, and write macOS
 defaults from `[system.defaults]`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
-and `[[system.edits]]` entries that aren't in their desired state are
+and `[system.edits]` entries that aren't in their desired state are
 applied, and on macOS any `[system.defaults]` entries that are unset or
 differ are written.
 

--- a/docs/cli/system/status.md
+++ b/docs/cli/system/status.md
@@ -6,7 +6,7 @@
 - **Source code**: [`src/cli/system/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/status.rs)
 
 Show the status of system packages from `[system.packages]`, files from
-`[system.files]`, edits from `[[system.edits]]`, and macOS defaults from
+`[system.files]`, edits from `[system.edits]`, and macOS defaults from
 `[system.defaults]`
 
 ## Flags

--- a/docs/cli/system/status.md
+++ b/docs/cli/system/status.md
@@ -6,7 +6,8 @@
 - **Source code**: [`src/cli/system/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/status.rs)
 
 Show the status of system packages from `[system.packages]`, files from
-`[system.files]`, and edits from `[[system.edits]]`
+`[system.files]`, edits from `[[system.edits]]`, and macOS defaults from
+`[system.defaults]`
 
 ## Flags
 
@@ -16,13 +17,13 @@ Output in JSON format
 
 ### `--missing`
 
-Exit with code 1 if any configured packages or files are not in their
-desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages, files, or defaults are
+not in their desired state (missing, version mismatch, differs)
 
 Examples:
 
 ```
 mise system status
 mise system status --json
-mise system status --missing # exit 1 if anything is missing
+mise system status --missing # exit 1 if anything is out of sync
 ```

--- a/docs/cli/system/status.md
+++ b/docs/cli/system/status.md
@@ -6,7 +6,7 @@
 - **Source code**: [`src/cli/system/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/status.rs)
 
 Show the status of system packages from `[system.packages]`, files from
-`[system.files]`, and macOS defaults from `[system.defaults]`
+`[system.files]`, and edits from `[[system.edits]]`
 
 ## Flags
 
@@ -16,13 +16,13 @@ Output in JSON format
 
 ### `--missing`
 
-Exit with code 1 if any configured packages, files, or defaults are
-not in their desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages or files are not in their
+desired state (missing, version mismatch, differs)
 
 Examples:
 
 ```
 mise system status
 mise system status --json
-mise system status --missing # exit 1 if anything is out of sync
+mise system status --missing # exit 1 if anything is missing
 ```

--- a/docs/system-edits.md
+++ b/docs/system-edits.md
@@ -89,9 +89,11 @@ Edits follow the same rules as the rest of [`[system]`](/system-packages/):
   whatever the link points at (often a `[system.files]` source), so point
   the edit at the real file instead.
 
-Removing an entry from config leaves its block in the file (mise keeps no
-state database); delete the marker block by hand. The markers name mise and
-the id, so it's always clear where a block came from.
+Removing an entry from config leaves its block or line in the file (mise
+keeps no state database); delete it by hand. Blocks at least carry their
+provenance — the markers name mise and the id — while a stray line looks
+like any other, which is a reason to prefer blocks for anything
+non-obvious.
 
 ## Commands
 
@@ -105,8 +107,9 @@ mise system install --yes     # skip the confirmation prompt
 ```
 
 `mise system status` reports each edit as `applied`, `missing` (no markers
-or line yet), or `differs` (block content changed, corrupted markers, or a
-symlink target).
+or line yet), `differs` (block content changed, corrupted markers, or a
+symlink target), or `source missing` (a block whose `source` file doesn't
+exist).
 
 ## Root-owned files
 

--- a/docs/system-edits.md
+++ b/docs/system-edits.md
@@ -55,6 +55,12 @@ languages, `;` for INI, `"` for vim) and can be overridden with
 XML) aren't a fit for blocks — use [System Files](/system-files.html) to own
 the whole file instead.
 
+Detecting whether a template block has drifted requires rendering it, so
+`mise system status` (and a real install) evaluates templates — including
+any `exec()` calls — from your trusted config, just like `[env]` templates.
+`--dry-run` is the exception: it promises to execute nothing, so it skips
+template rendering and lists those entries as `(if changed)`.
+
 ## Lines
 
 A `line` ensures an exact line exists somewhere in the file, appending it at

--- a/docs/system-edits.md
+++ b/docs/system-edits.md
@@ -1,0 +1,109 @@
+# System Edits <Badge type="warning" text="experimental" />
+
+Where [System Files](/system-files.html) manages whole files, `[[system.edits]]`
+manages one small piece of a file something else owns — the `mise activate`
+line in your shell rc, an entry in `/etc/hosts`:
+
+```toml
+[[system.edits]]
+path = "~/.zshrc"
+id = "activate"                        # marker identity, default "mise"
+block = 'eval "$(mise activate zsh)"'
+
+[[system.edits]]
+path = "/etc/hosts"
+line = "127.0.0.1 dev.local"
+```
+
+## Blocks
+
+A `block` is delimited by marker comments in the target file:
+
+```sh
+# >>> mise:activate >>> managed by mise — do not edit between markers
+eval "$(mise activate zsh)"
+# <<< mise:activate <<<
+```
+
+The markers are the ownership record, stored in the file itself, so the
+design stays stateless: applying replaces only what's between them (or
+appends the block if absent), and everything else in the file is untouched.
+Content can come from three places:
+
+```toml
+[[system.edits]]
+path = "~/.zshrc"
+block = "..."                  # inline
+
+[[system.edits]]
+path = "~/.zshrc"
+id = "aliases"
+source = "snippets/aliases.sh" # from a file, relative to this config file
+
+[[system.edits]]
+path = "~/.gitconfig"
+id = "identity"
+source = "snippets/git-identity.tmpl"
+template = true                # rendered with the mise template engine
+```
+
+`id` distinguishes multiple blocks in one file and appears in the markers;
+it defaults to `mise`. The marker comment prefix is inferred from the file
+extension (`#` for shell/config files, `--` for Lua, `//` for C-like
+languages, `;` for INI, `"` for vim) and can be overridden with
+`comment = "..."`. Files that can't hold line comments at all (strict JSON,
+XML) aren't a fit for blocks — use [System Files](/system-files.html) to own
+the whole file instead.
+
+## Lines
+
+A `line` ensures an exact line exists somewhere in the file, appending it at
+the end if absent. It never modifies or removes other lines, which is what
+makes it safely idempotent — use it for files where a three-line marker
+block is overkill or comments aren't tolerated.
+
+## Semantics
+
+Edits follow the same rules as the rest of [`[system]`](/system-packages/):
+
+- **Declarative and additive** — entries merge across the
+  [config hierarchy](/configuration.html) (global → project) as a union,
+  keyed by `(path, id)` for blocks and `(path, line)` for lines; a more
+  local config overrides a block with the same id.
+- **Manual application only** — nothing is written implicitly. Only
+  `mise system install` (or [`mise bootstrap`](/cli/bootstrap.html)) applies
+  edits.
+- **Idempotent** — entries already in their desired state are skipped;
+  re-running is always safe.
+- **Surgical** — edits never create conflicts with existing content and
+  never need `--force`: a block owns only what's between its markers, a
+  line only ever appends. Two cases are refused with an error instead of
+  guessed at: corrupted markers (a begin without an end, or duplicates) and
+  targets that are symlinks — an edit through a symlink would modify
+  whatever the link points at (often a `[system.files]` source), so point
+  the edit at the real file instead.
+
+Removing an entry from config leaves its block in the file (mise keeps no
+state database); delete the marker block by hand. The markers name mise and
+the id, so it's always clear where a block came from.
+
+## Commands
+
+```sh
+mise system status            # shows edit state: applied/missing/differs
+mise system status --missing  # exit 1 if anything is missing (CI check)
+
+mise system install           # packages, then files, then edits (prompts first)
+mise system install --dry-run # print what would be done
+mise system install --yes     # skip the confirmation prompt
+```
+
+`mise system status` reports each edit as `applied`, `missing` (no markers
+or line yet), or `differs` (block content changed, corrupted markers, or a
+symlink target).
+
+## Root-owned files
+
+Edits write as the current user — there is no sudo here. Editing
+`/etc/hosts` works when running as root (containers, CI); otherwise mise
+fails with an ordinary permission error.

--- a/docs/system-edits.md
+++ b/docs/system-edits.md
@@ -1,23 +1,36 @@
 # System Edits <Badge type="warning" text="experimental" />
 
-Where [System Files](/system-files.html) manages whole files, `[[system.edits]]`
+Where [System Files](/system-files.html) manages whole files, `[system.edits]`
 manages one small piece of a file something else owns — the `mise activate`
-line in your shell rc, an entry in `/etc/hosts`:
+line in your shell rc, an entry in `/etc/hosts`. Entries are keyed by target
+path, then by an id naming each edit within the file:
 
 ```toml
-[[system.edits]]
-path = "~/.zshrc"
-id = "activate"                        # marker identity, default "mise"
-block = 'eval "$(mise activate zsh)"'
+[system.edits]
+"~/.zshrc" = {
+  activate = 'eval "$(mise activate zsh)"',
+  aliases = '''
+alias ll='ls -l'
+alias la='ls -la'
+''',
+}
+"/etc/hosts" = { dev = { line = "127.0.0.1 dev.local" } }
+```
 
-[[system.edits]]
-path = "/etc/hosts"
-line = "127.0.0.1 dev.local"
+A string value is inline block content (TOML multiline strings keep larger
+blocks readable); a table value spells out the operation. Dotted keys work
+too when you prefer one entry per line:
+
+```toml
+[system.edits]
+"~/.zshrc".activate = 'eval "$(mise activate zsh)"'
+"~/.gitconfig".identity = { source = "snippets/git-identity.tmpl", template = true }
 ```
 
 ## Blocks
 
-A `block` is delimited by marker comments in the target file:
+A `block` is delimited by marker comments in the target file, named by the
+entry's id:
 
 ```sh
 # >>> mise:activate >>> managed by mise — do not edit between markers
@@ -31,29 +44,18 @@ appends the block if absent), and everything else in the file is untouched.
 Content can come from three places:
 
 ```toml
-[[system.edits]]
-path = "~/.zshrc"
-block = "..."                  # inline
-
-[[system.edits]]
-path = "~/.zshrc"
-id = "aliases"
-source = "snippets/aliases.sh" # from a file, relative to this config file
-
-[[system.edits]]
-path = "~/.gitconfig"
-id = "identity"
-source = "snippets/git-identity.tmpl"
-template = true                # rendered with the mise template engine
+[system.edits."~/.zshrc"]
+activate = "..."                                    # inline (string shorthand)
+aliases = { source = "snippets/aliases.sh" }        # from a file, relative to this config
+prompt = { source = "snippets/prompt.tmpl", template = true } # rendered with the template engine
 ```
 
-`id` distinguishes multiple blocks in one file and appears in the markers;
-it defaults to `mise`. The marker comment prefix is inferred from the file
-extension (`#` for shell/config files, `--` for Lua, `//` for C-like
-languages, `;` for INI, `"` for vim) and can be overridden with
-`comment = "..."`. Files that can't hold line comments at all (strict JSON,
-XML) aren't a fit for blocks — use [System Files](/system-files.html) to own
-the whole file instead.
+Ids may contain letters, digits, `_`, `-`, and `.`. The marker comment
+prefix is inferred from the file extension (`#` for shell/config files,
+`--` for Lua, `//` for C-like languages, `;` for INI, `"` for vim) and can
+be overridden with `comment = "..."`. Files that can't hold line comments
+at all (strict JSON, XML) aren't a fit for blocks — use
+[System Files](/system-files.html) to own the whole file instead.
 
 Detecting whether a template block has drifted requires rendering it, so
 `mise system status` (and a real install) evaluates templates — including
@@ -66,7 +68,8 @@ template rendering and lists those entries as `(if changed)`.
 A `line` ensures an exact line exists somewhere in the file, appending it at
 the end if absent. It never modifies or removes other lines, which is what
 makes it safely idempotent — use it for files where a three-line marker
-block is overkill or comments aren't tolerated.
+block is overkill or comments aren't tolerated. The id is only a label (and
+the merge identity); it isn't written to the file.
 
 ## Semantics
 
@@ -74,8 +77,9 @@ Edits follow the same rules as the rest of [`[system]`](/system-packages/):
 
 - **Declarative and additive** — entries merge across the
   [config hierarchy](/configuration.html) (global → project) as a union,
-  keyed by `(path, id)` for blocks and `(path, line)` for lines; a more
-  local config overrides a block with the same id.
+  keyed by `(path, id)`; a more local config overrides an edit with the
+  same id, exactly like [System Files](/system-files.html) overrides by
+  target.
 - **Manual application only** — nothing is written implicitly. Only
   `mise system install` (or [`mise bootstrap`](/cli/bootstrap.html)) applies
   edits.

--- a/docs/system-edits.md
+++ b/docs/system-edits.md
@@ -24,7 +24,7 @@ too when you prefer one entry per line:
 ```toml
 [system.edits]
 "~/.zshrc".activate = 'eval "$(mise activate zsh)"'
-"~/.gitconfig".identity = { source = "snippets/git-identity.tmpl", template = true }
+"~/.gitconfig".identity = { source = "snippets/git-identity.tmpl", template = "tera" }
 ```
 
 ## Blocks
@@ -48,7 +48,7 @@ Content can come from three places:
 "~/.zshrc" = {
   activate = "...",                                  # inline (string shorthand)
   aliases = { source = "snippets/aliases.sh" },      # from a file, relative to this config
-  prompt = { source = "snippets/prompt.tmpl", template = true }, # rendered with the template engine
+  prompt = { source = "snippets/prompt.tmpl", template = "tera" }, # rendered with the template engine
 }
 ```
 
@@ -58,6 +58,10 @@ prefix is inferred from the file extension (`#` for shell/config files,
 be overridden with `comment = "..."`. Files that can't hold line comments
 at all (strict JSON, XML) aren't a fit for blocks — use
 [System Files](/system-files.html) to own the whole file instead.
+
+`template = "tera"` names the engine rather than being a boolean so other
+engines can be added later; unknown engines from newer mise versions warn
+and are skipped, like unrecognized operations.
 
 Detecting whether a template block has drifted requires rendering it, so
 `mise system status` (and a real install) evaluates templates — including

--- a/docs/system-edits.md
+++ b/docs/system-edits.md
@@ -74,8 +74,9 @@ template rendering and lists those entries as `(if changed)`.
 A `line` ensures an exact line exists somewhere in the file, appending it at
 the end if absent. It never modifies or removes other lines, which is what
 makes it safely idempotent — use it for files where a three-line marker
-block is overkill or comments aren't tolerated. The id is only a label (and
-the merge identity); it isn't written to the file.
+block is overkill or comments aren't tolerated. The value must be a single
+line (no embedded newline); use a block for multi-line content. The id is
+only a label (and the merge identity); it isn't written to the file.
 
 ## Semantics
 

--- a/docs/system-edits.md
+++ b/docs/system-edits.md
@@ -44,10 +44,12 @@ appends the block if absent), and everything else in the file is untouched.
 Content can come from three places:
 
 ```toml
-[system.edits."~/.zshrc"]
-activate = "..."                                    # inline (string shorthand)
-aliases = { source = "snippets/aliases.sh" }        # from a file, relative to this config
-prompt = { source = "snippets/prompt.tmpl", template = true } # rendered with the template engine
+[system.edits]
+"~/.zshrc" = {
+  activate = "...",                                  # inline (string shorthand)
+  aliases = { source = "snippets/aliases.sh" },      # from a file, relative to this config
+  prompt = { source = "snippets/prompt.tmpl", template = true }, # rendered with the template engine
+}
 ```
 
 Ids may contain letters, digits, `_`, `-`, and `.`. The marker comment

--- a/docs/system-files.md
+++ b/docs/system-files.md
@@ -18,6 +18,10 @@ the directory of the config file that declares the entry, so a global
 `~/.config/mise/config.toml` can manage dotfiles kept next to it, and a
 project config can ship machine setup from the repo.
 
+To manage one piece of a file something else owns (a line in `.zshrc`, an
+entry in `/etc/hosts`) rather than the whole file, see
+[System Edits](/system-edits.html).
+
 ## Modes
 
 | Mode           | Behavior                                                                                                                                                                                                                                               |

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -90,9 +90,8 @@ a `bootstrap` task if you define one:
 "~/.gitconfig" = "dotfiles/gitconfig"
 "~/.config/nvim" = "dotfiles/nvim"
 
-[[system.edits]]                       # one piece of a file you don't own
-path = "~/.zshrc"
-block = 'eval "$(mise activate zsh)"'
+[system.edits]                         # one piece of a file you don't own
+"~/.zshrc".activate = 'eval "$(mise activate zsh)"'
 
 [system.defaults]                      # macOS defaults write
 "com.apple.dock.autohide" = true

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -74,6 +74,44 @@ mise generate task-stubs --mise-bin ./bin/mise
 The generated task stubs behave like small project commands, while `bin/mise`
 downloads and runs the pinned mise binary for the project.
 
+## Machine bootstrapping with `[system]` <Badge type="warning" text="experimental" />
+
+Beyond `[tools]`, the `[system]` config section can declare everything else a
+machine needs, and [`mise bootstrap`](/cli/bootstrap.html) converges all of
+it in one command — system packages, then files and edits, then tools, then
+a `bootstrap` task if you define one:
+
+```toml
+[system.packages]                      # OS packages (apt/dnf/pacman/brew)
+"apt:build-essential" = "latest"
+"brew:postgresql@17" = "latest"
+
+[system.files]                         # dotfiles: symlink/copy/template
+"~/.gitconfig" = "dotfiles/gitconfig"
+"~/.config/nvim" = "dotfiles/nvim"
+
+[[system.edits]]                       # one piece of a file you don't own
+path = "~/.zshrc"
+block = 'eval "$(mise activate zsh)"'
+
+[system.defaults]                      # macOS defaults write
+"com.apple.dock.autohide" = true
+
+[tasks.bootstrap]                      # anything else, with tools on PATH
+run = "gh auth status || gh auth login"
+```
+
+```sh
+mise bootstrap --yes   # new laptop or container -> ready to work
+```
+
+Everything is declarative and idempotent: re-running skips whatever is
+already in its desired state, `mise system status --missing` makes a CI
+check, and nothing is ever applied implicitly. See
+[System Packages](/system-packages/), [System Files](/system-files.html),
+[System Edits](/system-edits.html), and
+[macOS Defaults](/system-packages/defaults.html).
+
 ## Installation via zsh zinit
 
 [Zinit](https://github.com/zdharma-continuum/zinit) is a plugin manager for ZSH, which this snippet you will get mise (and usage for shell completion):

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -6,15 +6,18 @@ cat <<EOF >mise.toml
 EOF
 assert_succeed "mise bootstrap --yes"
 
-# bootstrap applies system files, installs tools, and runs the `bootstrap`
-# task afterwards, with the installed tools on PATH
+# bootstrap applies system files and edits, installs tools, and runs the
+# `bootstrap` task afterwards, with the installed tools on PATH
 echo "gitconfig content" >gitconfig
-cat <<EOF >mise.toml
+cat <<'EOF' >mise.toml
 [tools]
 tiny = "1.0.0"
 
 [system.files]
 "~/.gitconfig" = "gitconfig"
+
+[system.edits]
+"~/.zshrc".activate = 'eval "$(mise activate zsh)"'
 
 # the task only succeeds if the installed tool is on PATH
 [tasks.bootstrap]
@@ -24,6 +27,7 @@ assert_succeed "mise bootstrap --yes"
 assert "cat bootstrap_ran" "task-done"
 assert_contains "mise ls tiny" "1.0.0"
 assert "readlink ~/.gitconfig" "$PWD/gitconfig"
+assert_contains "cat ~/.zshrc" ">>> mise:activate >>>"
 
 # idempotent: re-running is fine
 assert_succeed "mise bootstrap --yes"

--- a/e2e/cli/test_system_edits
+++ b/e2e/cli/test_system_edits
@@ -155,6 +155,23 @@ rm snippet.txt
 assert_contains "mise system status" "source missing"
 assert_fail "mise system install --yes"
 
+# all problems are reported in one pass: a broken template doesn't hide a
+# missing source
+cat <<'EOF' >mise.toml
+[[system.edits]]
+path = "~/broken.conf"
+block = "{{ not_a_real_function() }}"
+template = true
+
+[[system.edits]]
+path = "~/missing.conf"
+source = "no-such-snippet.txt"
+EOF
+assert_fail "mise system install --yes"
+install_out="$(mise system install --yes 2>&1 || true)"
+assert_contains_text "$install_out" "failed to render"
+assert_contains_text "$install_out" "source does not exist"
+
 # invalid entries warn but don't fail (forward compatibility)
 cat <<'EOF' >mise.toml
 [[system.edits]]

--- a/e2e/cli/test_system_edits
+++ b/e2e/cli/test_system_edits
@@ -81,6 +81,33 @@ assert_not_contains "cat ~/.zshrc" 'eval "$(mise activate zsh)"'
 assert_contains "cat ~/.zshrc" "alias ll='ls -l'"
 assert_contains "cat ~/.zshrc" "# user content at the end"
 
+# content that merely mentions a marker is not treated as one
+cat <<'EOF' >mise.toml
+[[system.edits]]
+path = "~/.zshrc"
+id = "activate"
+block = 'echo "keep the >>> mise:activate >>> line intact"'
+
+[[system.edits]]
+path = "~/.zshrc"
+id = "aliases"
+block = "alias ll='ls -l'"
+EOF
+assert_succeed "mise system install --yes"
+assert_succeed "mise system status --missing"
+cat <<'EOF' >mise.toml
+[[system.edits]]
+path = "~/.zshrc"
+id = "activate"
+block = 'eval "$(mise activate zsh --shims)"'
+
+[[system.edits]]
+path = "~/.zshrc"
+id = "aliases"
+block = "alias ll='ls -l'"
+EOF
+assert_succeed "mise system install --yes"
+
 # corrupted markers are an error, not a guess
 sed -i.bak '/<<< mise:activate <<</d' ~/.zshrc
 assert_contains "mise system status" "differs (begin marker without end marker)"

--- a/e2e/cli/test_system_edits
+++ b/e2e/cli/test_system_edits
@@ -25,6 +25,12 @@ block = "require('mise')"
 path = "~/rendered.conf"
 block = "sum = {{ 1 + 1 }}"
 template = true
+
+[[system.edits]]
+path = "~/execd.conf"
+id = "execd"
+block = '{{ exec(command="touch $HOME/exec-ran") }}ok'
+template = true
 EOF
 
 # everything is missing before applying
@@ -32,9 +38,15 @@ assert_contains "mise system status" "missing"
 assert_contains "mise system status" "block:activate"
 assert_fail "mise system status --missing"
 
-# dry-run prints actions without writing anything
-assert_contains "mise system install --dry-run" "block:activate"
+# dry-run prints actions without writing anything; template blocks are not
+# rendered (exec() must not run) and are listed as "(if changed)".
+# status, by contrast, renders templates by design — clear its exec traces
+rm -f ~/exec-ran
+dry_out="$(mise system install --dry-run 2>&1)"
+assert_contains_text "$dry_out" "block:activate"
+assert_contains_text "$dry_out" "(if changed)"
 assert_fail "cat ~/.zshrc"
+assert_fail "cat ~/exec-ran"
 
 # line edits append to existing files without touching other content
 echo "preexisting content" >~/hosts
@@ -53,6 +65,9 @@ assert_contains "cat ~/hosts" "127.0.0.1 dev.local"
 assert_contains "cat ~/init.lua" "-- >>> mise:mise >>>"
 # template rendered
 assert_contains "cat ~/rendered.conf" "sum = 2"
+# a real install does render templates — exec() ran this time
+assert_contains "cat ~/execd.conf" "ok"
+assert_succeed "test -f ~/exec-ran"
 
 # idempotent: re-running changes nothing
 assert_succeed "mise system status --missing"

--- a/e2e/cli/test_system_edits
+++ b/e2e/cli/test_system_edits
@@ -167,8 +167,9 @@ template = true
 path = "~/missing.conf"
 source = "no-such-snippet.txt"
 EOF
-assert_fail "mise system install --yes"
-install_out="$(mise system install --yes 2>&1 || true)"
+if install_out="$(mise system install --yes 2>&1)"; then
+  fail "[mise system install --yes] expected failure"
+fi
 assert_contains_text "$install_out" "failed to render"
 assert_contains_text "$install_out" "source does not exist"
 

--- a/e2e/cli/test_system_edits
+++ b/e2e/cli/test_system_edits
@@ -178,3 +178,11 @@ cat <<'EOF' >mise.toml
 EOF
 assert_succeed "mise system status"
 assert_contains "mise system status 2>&1" "unknown template engine"
+
+# a multi-line line value can never converge — rejected, use a block instead
+cat <<'EOF' >mise.toml
+[system.edits]
+"~/x.conf".multi = { line = "first\nsecond" }
+EOF
+assert_succeed "mise system status"
+assert_contains "mise system status 2>&1" "line may not contain a newline"

--- a/e2e/cli/test_system_edits
+++ b/e2e/cli/test_system_edits
@@ -2,40 +2,27 @@
 # the single-quoted activate lines are intentionally literal
 # shellcheck disable=SC2016
 
+# the multiline inline table exercises mise's TOML 1.1 parsing; the dotted
+# keys are the one-entry-per-line spelling of the same structure
 cat <<'EOF' >mise.toml
-[[system.edits]]
-path = "~/.zshrc"
-id = "activate"
-block = 'eval "$(mise activate zsh)"'
-
-[[system.edits]]
-path = "~/.zshrc"
-id = "aliases"
-block = "alias ll='ls -l'"
-
-[[system.edits]]
-path = "~/hosts"
-line = "127.0.0.1 dev.local"
-
-[[system.edits]]
-path = "~/init.lua"
-block = "require('mise')"
-
-[[system.edits]]
-path = "~/rendered.conf"
-block = "sum = {{ 1 + 1 }}"
-template = true
-
-[[system.edits]]
-path = "~/execd.conf"
-id = "execd"
-block = '{{ exec(command="touch $HOME/exec-ran") }}ok'
-template = true
+[system.edits]
+"~/.zshrc" = {
+  activate = 'eval "$(mise activate zsh)"',
+  aliases = '''
+alias ll='ls -l'
+alias la='ls -la'
+''',
+}
+"~/hosts".dev = { line = "127.0.0.1 dev.local" }
+"~/init.lua".mise = "require('mise')"
+"~/rendered.conf".sum = { block = "sum = {{ 1 + 1 }}", template = true }
+"~/execd.conf".execd = { block = '{{ exec(command="touch $HOME/exec-ran") }}ok', template = true }
 EOF
 
 # everything is missing before applying
 assert_contains "mise system status" "missing"
 assert_contains "mise system status" "block:activate"
+assert_contains "mise system status" "line:dev"
 assert_fail "mise system status --missing"
 
 # dry-run prints actions without writing anything; template blocks are not
@@ -53,11 +40,13 @@ echo "preexisting content" >~/hosts
 
 assert_succeed "mise system install --yes"
 
-# two blocks coexist in one file, delimited by id'd markers
+# two blocks coexist in one file, delimited by id'd markers; multiline
+# block content lands verbatim
 assert_contains "cat ~/.zshrc" ">>> mise:activate >>>"
 assert_contains "cat ~/.zshrc" 'eval "$(mise activate zsh)"'
 assert_contains "cat ~/.zshrc" ">>> mise:aliases >>>"
 assert_contains "cat ~/.zshrc" "alias ll='ls -l'"
+assert_contains "cat ~/.zshrc" "alias la='ls -la'"
 # line was appended, existing content kept
 assert "head -1 ~/hosts" "preexisting content"
 assert_contains "cat ~/hosts" "127.0.0.1 dev.local"
@@ -79,15 +68,9 @@ assert "grep -c 'mise:activate >>>' ~/.zshrc" "1"
 # everything around it
 echo "# user content at the end" >>~/.zshrc
 cat <<'EOF' >mise.toml
-[[system.edits]]
-path = "~/.zshrc"
-id = "activate"
-block = 'eval "$(mise activate zsh --shims)"'
-
-[[system.edits]]
-path = "~/.zshrc"
-id = "aliases"
-block = "alias ll='ls -l'"
+[system.edits]
+"~/.zshrc".activate = 'eval "$(mise activate zsh --shims)"'
+"~/.zshrc".aliases = "alias ll='ls -l'"
 EOF
 assert_contains "mise system status" "differs (block content differs)"
 assert_succeed "mise system install --yes"
@@ -98,28 +81,16 @@ assert_contains "cat ~/.zshrc" "# user content at the end"
 
 # content that merely mentions a marker is not treated as one
 cat <<'EOF' >mise.toml
-[[system.edits]]
-path = "~/.zshrc"
-id = "activate"
-block = 'echo "keep the >>> mise:activate >>> line intact"'
-
-[[system.edits]]
-path = "~/.zshrc"
-id = "aliases"
-block = "alias ll='ls -l'"
+[system.edits]
+"~/.zshrc".activate = 'echo "keep the >>> mise:activate >>> line intact"'
+"~/.zshrc".aliases = "alias ll='ls -l'"
 EOF
 assert_succeed "mise system install --yes"
 assert_succeed "mise system status --missing"
 cat <<'EOF' >mise.toml
-[[system.edits]]
-path = "~/.zshrc"
-id = "activate"
-block = 'eval "$(mise activate zsh --shims)"'
-
-[[system.edits]]
-path = "~/.zshrc"
-id = "aliases"
-block = "alias ll='ls -l'"
+[system.edits]
+"~/.zshrc".activate = 'eval "$(mise activate zsh --shims)"'
+"~/.zshrc".aliases = "alias ll='ls -l'"
 EOF
 assert_succeed "mise system install --yes"
 
@@ -133,9 +104,8 @@ rm ~/.zshrc ~/.zshrc.bak
 echo "real file" >real.conf
 ln -s "$PWD/real.conf" ~/linked.conf
 cat <<'EOF' >mise.toml
-[[system.edits]]
-path = "~/linked.conf"
-line = "added"
+[system.edits]
+"~/linked.conf".added = { line = "added" }
 EOF
 assert_contains "mise system status" "differs (target is a symlink"
 assert_fail "mise system install --yes"
@@ -144,9 +114,8 @@ assert "cat real.conf" "real file"
 # block content can come from a source file
 echo "source content" >snippet.txt
 cat <<'EOF' >mise.toml
-[[system.edits]]
-path = "~/fromfile.conf"
-source = "snippet.txt"
+[system.edits]
+"~/fromfile.conf".snippet = { source = "snippet.txt" }
 EOF
 assert_succeed "mise system install --yes"
 assert_contains "cat ~/fromfile.conf" "source content"
@@ -158,14 +127,9 @@ assert_fail "mise system install --yes"
 # all problems are reported in one pass: a broken template doesn't hide a
 # missing source
 cat <<'EOF' >mise.toml
-[[system.edits]]
-path = "~/broken.conf"
-block = "{{ not_a_real_function() }}"
-template = true
-
-[[system.edits]]
-path = "~/missing.conf"
-source = "no-such-snippet.txt"
+[system.edits]
+"~/broken.conf".tmpl = { block = "{{ not_a_real_function() }}", template = true }
+"~/missing.conf".snippet = { source = "no-such-snippet.txt" }
 EOF
 if install_out="$(mise system install --yes 2>&1)"; then
   fail "[mise system install --yes] expected failure"
@@ -175,17 +139,23 @@ assert_contains_text "$install_out" "source does not exist"
 
 # invalid entries warn but don't fail (forward compatibility)
 cat <<'EOF' >mise.toml
-[[system.edits]]
-path = "~/x.conf"
+[system.edits]
+"~/x.conf".noop = { something_else = true }
 EOF
 assert_succeed "mise system status"
 assert_contains "mise system status 2>&1" "no recognized operation"
 
 cat <<'EOF' >mise.toml
-[[system.edits]]
-path = "~/x.conf"
-block = "a"
-line = "b"
+[system.edits]
+"~/x.conf".both = { block = "a", line = "b" }
 EOF
 assert_succeed "mise system status"
 assert_contains "mise system status 2>&1" "mutually exclusive"
+
+# ids are restricted to marker-safe characters
+cat <<'EOF' >mise.toml
+[system.edits]
+"~/x.conf"."bad id!" = "content"
+EOF
+assert_succeed "mise system status"
+assert_contains "mise system status 2>&1" "ids may only contain"

--- a/e2e/cli/test_system_edits
+++ b/e2e/cli/test_system_edits
@@ -124,6 +124,17 @@ rm snippet.txt
 assert_contains "mise system status" "source missing"
 assert_fail "mise system install --yes"
 
+# two entries with different ids but identical line text don't write the
+# line twice in one batch
+cat <<'EOF' >mise.toml
+[system.edits]
+"~/dup.conf".a = { line = "same line" }
+"~/dup.conf".b = { line = "same line" }
+EOF
+assert_succeed "mise system install --yes"
+assert "grep -c 'same line' ~/dup.conf" "1"
+assert_succeed "mise system status --missing"
+
 # all problems are reported in one pass: a broken template doesn't hide a
 # missing source
 cat <<'EOF' >mise.toml

--- a/e2e/cli/test_system_edits
+++ b/e2e/cli/test_system_edits
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# the single-quoted activate lines are intentionally literal
+# shellcheck disable=SC2016
+
+cat <<'EOF' >mise.toml
+[[system.edits]]
+path = "~/.zshrc"
+id = "activate"
+block = 'eval "$(mise activate zsh)"'
+
+[[system.edits]]
+path = "~/.zshrc"
+id = "aliases"
+block = "alias ll='ls -l'"
+
+[[system.edits]]
+path = "~/hosts"
+line = "127.0.0.1 dev.local"
+
+[[system.edits]]
+path = "~/init.lua"
+block = "require('mise')"
+
+[[system.edits]]
+path = "~/rendered.conf"
+block = "sum = {{ 1 + 1 }}"
+template = true
+EOF
+
+# everything is missing before applying
+assert_contains "mise system status" "missing"
+assert_contains "mise system status" "block:activate"
+assert_fail "mise system status --missing"
+
+# dry-run prints actions without writing anything
+assert_contains "mise system install --dry-run" "block:activate"
+assert_fail "cat ~/.zshrc"
+
+# line edits append to existing files without touching other content
+echo "preexisting content" >~/hosts
+
+assert_succeed "mise system install --yes"
+
+# two blocks coexist in one file, delimited by id'd markers
+assert_contains "cat ~/.zshrc" ">>> mise:activate >>>"
+assert_contains "cat ~/.zshrc" 'eval "$(mise activate zsh)"'
+assert_contains "cat ~/.zshrc" ">>> mise:aliases >>>"
+assert_contains "cat ~/.zshrc" "alias ll='ls -l'"
+# line was appended, existing content kept
+assert "head -1 ~/hosts" "preexisting content"
+assert_contains "cat ~/hosts" "127.0.0.1 dev.local"
+# comment prefix inferred from extension
+assert_contains "cat ~/init.lua" "-- >>> mise:mise >>>"
+# template rendered
+assert_contains "cat ~/rendered.conf" "sum = 2"
+
+# idempotent: re-running changes nothing
+assert_succeed "mise system status --missing"
+assert_contains "mise system install --yes 2>&1" "all edits are applied"
+assert "grep -c 'dev.local' ~/hosts" "1"
+assert "grep -c 'mise:activate >>>' ~/.zshrc" "1"
+
+# content changes are detected and replace only the block, preserving
+# everything around it
+echo "# user content at the end" >>~/.zshrc
+cat <<'EOF' >mise.toml
+[[system.edits]]
+path = "~/.zshrc"
+id = "activate"
+block = 'eval "$(mise activate zsh --shims)"'
+
+[[system.edits]]
+path = "~/.zshrc"
+id = "aliases"
+block = "alias ll='ls -l'"
+EOF
+assert_contains "mise system status" "differs (block content differs)"
+assert_succeed "mise system install --yes"
+assert_contains "cat ~/.zshrc" "--shims"
+assert_not_contains "cat ~/.zshrc" 'eval "$(mise activate zsh)"'
+assert_contains "cat ~/.zshrc" "alias ll='ls -l'"
+assert_contains "cat ~/.zshrc" "# user content at the end"
+
+# corrupted markers are an error, not a guess
+sed -i.bak '/<<< mise:activate <<</d' ~/.zshrc
+assert_contains "mise system status" "differs (begin marker without end marker)"
+assert_fail "mise system install --yes"
+rm ~/.zshrc ~/.zshrc.bak
+
+# symlink targets are refused — edits would write through the link
+echo "real file" >real.conf
+ln -s "$PWD/real.conf" ~/linked.conf
+cat <<'EOF' >mise.toml
+[[system.edits]]
+path = "~/linked.conf"
+line = "added"
+EOF
+assert_contains "mise system status" "differs (target is a symlink"
+assert_fail "mise system install --yes"
+assert "cat real.conf" "real file"
+
+# block content can come from a source file
+echo "source content" >snippet.txt
+cat <<'EOF' >mise.toml
+[[system.edits]]
+path = "~/fromfile.conf"
+source = "snippet.txt"
+EOF
+assert_succeed "mise system install --yes"
+assert_contains "cat ~/fromfile.conf" "source content"
+# missing sources are visible and error on install
+rm snippet.txt
+assert_contains "mise system status" "source missing"
+assert_fail "mise system install --yes"
+
+# invalid entries warn but don't fail (forward compatibility)
+cat <<'EOF' >mise.toml
+[[system.edits]]
+path = "~/x.conf"
+EOF
+assert_succeed "mise system status"
+assert_contains "mise system status 2>&1" "no recognized operation"
+
+cat <<'EOF' >mise.toml
+[[system.edits]]
+path = "~/x.conf"
+block = "a"
+line = "b"
+EOF
+assert_succeed "mise system status"
+assert_contains "mise system status 2>&1" "mutually exclusive"

--- a/e2e/cli/test_system_edits
+++ b/e2e/cli/test_system_edits
@@ -15,8 +15,8 @@ alias la='ls -la'
 }
 "~/hosts".dev = { line = "127.0.0.1 dev.local" }
 "~/init.lua".mise = "require('mise')"
-"~/rendered.conf".sum = { block = "sum = {{ 1 + 1 }}", template = true }
-"~/execd.conf".execd = { block = '{{ exec(command="touch $HOME/exec-ran") }}ok', template = true }
+"~/rendered.conf".sum = { block = "sum = {{ 1 + 1 }}", template = "tera" }
+"~/execd.conf".execd = { block = '{{ exec(command="touch $HOME/exec-ran") }}ok', template = "tera" }
 EOF
 
 # everything is missing before applying
@@ -139,7 +139,7 @@ assert_succeed "mise system status --missing"
 # missing source
 cat <<'EOF' >mise.toml
 [system.edits]
-"~/broken.conf".tmpl = { block = "{{ not_a_real_function() }}", template = true }
+"~/broken.conf".tmpl = { block = "{{ not_a_real_function() }}", template = "tera" }
 "~/missing.conf".snippet = { source = "no-such-snippet.txt" }
 EOF
 if install_out="$(mise system install --yes 2>&1)"; then
@@ -170,3 +170,11 @@ cat <<'EOF' >mise.toml
 EOF
 assert_succeed "mise system status"
 assert_contains "mise system status 2>&1" "ids may only contain"
+
+# unknown template engines warn but don't fail (forward compatibility)
+cat <<'EOF' >mise.toml
+[system.edits]
+"~/x.conf".tmpl = { block = "a", template = "jinja" }
+EOF
+assert_succeed "mise system status"
+assert_contains "mise system status 2>&1" "unknown template engine"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -464,7 +464,7 @@ Symlinks all ruby tool versions from an external tool into mise
 [experimental] Manage system packages from `[system.packages]`, files
 .TP
 \fBsystem install\fR
-Install missing system packages from `[system.packages]`, apply files
+Install missing system packages from `[system.packages]` and apply files
 .RS
 \fIAliases: \fRi
 .RE
@@ -742,14 +742,13 @@ e.g.: ruby@3
 
 Runs the bootstrap steps for the current config in order:
 
-1. `mise system install` — install missing `[system.packages]`, apply
-   `[system.files]`, and write `[system.defaults]` (macOS)
+1. `mise system install` — install missing `[system.packages]` and apply
+   `[system.files]` and `[[system.edits]]`
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
-The declarative steps converge — anything already in its desired state
-is skipped, so re\-running is safe. The `bootstrap` task runs on every
-invocation; keep it idempotent. Use it for any project\-specific setup
+Steps with nothing to do are skipped, so `mise bootstrap` is idempotent
+and safe to re\-run. Use a `bootstrap` task for any project\-specific setup
 that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
 .PP
@@ -2777,19 +2776,19 @@ Symlinks all ruby tool versions from an external tool into mise
 \fB\-\-brew\fR
 Get tool versions from Homebrew
 .SH "MISE SYSTEM INSTALL"
-Install missing system packages from `[system.packages]`, apply files
-from `[system.files]`, and write macOS defaults from `[system.defaults]`
+Install missing system packages from `[system.packages]` and apply files
+from `[system.files]` and edits from `[[system.edits]]`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
-entries that aren't in their desired state are applied, and on macOS any
-`[system.defaults]` entries that are unset or differ are written.
+and `[[system.edits]]` entries that aren't in their desired state are
+applied.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in
-the config. Explicit packages and `\-\-manager` scope the run to packages
-only.
+the config — files and edits are skipped in that case, as with
+`\-\-manager`.
 .PP
 \fBUsage:\fR mise system install [OPTIONS] [<PACKAGE>] ...
 .PP
@@ -2817,7 +2816,7 @@ Refresh package manager metadata first (apt: `apt\-get update`)
 Packages in `manager:package` form; defaults to everything configured in [system.packages]
 .SH "MISE SYSTEM STATUS"
 Show the status of system packages from `[system.packages]`, files from
-`[system.files]`, and macOS defaults from `[system.defaults]`
+`[system.files]`, and edits from `[[system.edits]]`
 .PP
 \fBUsage:\fR mise system status [OPTIONS]
 .PP
@@ -2828,8 +2827,8 @@ Show the status of system packages from `[system.packages]`, files from
 Output in JSON format
 .TP
 \fB\-\-missing\fR
-Exit with code 1 if any configured packages, files, or defaults are
-not in their desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages or files are not in their
+desired state (missing, version mismatch, differs)
 .SH "MISE SYSTEM UPGRADE"
 Upgrade installed system packages from `[system.packages]`
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -464,7 +464,7 @@ Symlinks all ruby tool versions from an external tool into mise
 [experimental] Manage system packages from `[system.packages]`, files
 .TP
 \fBsystem install\fR
-Install missing system packages from `[system.packages]` and apply files
+Install missing system packages from `[system.packages]`, apply files
 .RS
 \fIAliases: \fRi
 .RE
@@ -742,13 +742,15 @@ e.g.: ruby@3
 
 Runs the bootstrap steps for the current config in order:
 
-1. `mise system install` — install missing `[system.packages]` and apply
-   `[system.files]` and `[[system.edits]]`
+1. `mise system install` — install missing `[system.packages]`, apply
+   `[system.files]` and `[[system.edits]]`, and write `[system.defaults]`
+   (macOS)
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
-Steps with nothing to do are skipped, so `mise bootstrap` is idempotent
-and safe to re\-run. Use a `bootstrap` task for any project\-specific setup
+The declarative steps converge — anything already in its desired state
+is skipped, so re\-running is safe. The `bootstrap` task runs on every
+invocation; keep it idempotent. Use it for any project\-specific setup
 that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
 .PP
@@ -2776,19 +2778,21 @@ Symlinks all ruby tool versions from an external tool into mise
 \fB\-\-brew\fR
 Get tool versions from Homebrew
 .SH "MISE SYSTEM INSTALL"
-Install missing system packages from `[system.packages]` and apply files
-from `[system.files]` and edits from `[[system.edits]]`
+Install missing system packages from `[system.packages]`, apply files
+from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+defaults from `[system.defaults]`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 and `[[system.edits]]` entries that aren't in their desired state are
-applied.
+applied, and on macOS any `[system.defaults]` entries that are unset or
+differ are written.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in
-the config — files and edits are skipped in that case, as with
-`\-\-manager`.
+the config. Explicit packages and `\-\-manager` scope the run to packages
+only.
 .PP
 \fBUsage:\fR mise system install [OPTIONS] [<PACKAGE>] ...
 .PP
@@ -2816,7 +2820,8 @@ Refresh package manager metadata first (apt: `apt\-get update`)
 Packages in `manager:package` form; defaults to everything configured in [system.packages]
 .SH "MISE SYSTEM STATUS"
 Show the status of system packages from `[system.packages]`, files from
-`[system.files]`, and edits from `[[system.edits]]`
+`[system.files]`, edits from `[[system.edits]]`, and macOS defaults from
+`[system.defaults]`
 .PP
 \fBUsage:\fR mise system status [OPTIONS]
 .PP
@@ -2827,8 +2832,8 @@ Show the status of system packages from `[system.packages]`, files from
 Output in JSON format
 .TP
 \fB\-\-missing\fR
-Exit with code 1 if any configured packages or files are not in their
-desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages, files, or defaults are
+not in their desired state (missing, version mismatch, differs)
 .SH "MISE SYSTEM UPGRADE"
 Upgrade installed system packages from `[system.packages]`
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -743,7 +743,7 @@ e.g.: ruby@3
 Runs the bootstrap steps for the current config in order:
 
 1. `mise system install` — install missing `[system.packages]`, apply
-   `[system.files]` and `[[system.edits]]`, and write `[system.defaults]`
+   `[system.files]` and `[system.edits]`, and write `[system.defaults]`
    (macOS)
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
@@ -2779,13 +2779,13 @@ Symlinks all ruby tool versions from an external tool into mise
 Get tool versions from Homebrew
 .SH "MISE SYSTEM INSTALL"
 Install missing system packages from `[system.packages]`, apply files
-from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+from `[system.files]` and edits from `[system.edits]`, and write macOS
 defaults from `[system.defaults]`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
-and `[[system.edits]]` entries that aren't in their desired state are
+and `[system.edits]` entries that aren't in their desired state are
 applied, and on macOS any `[system.defaults]` entries that are unset or
 differ are written.
 
@@ -2820,7 +2820,7 @@ Refresh package manager metadata first (apt: `apt\-get update`)
 Packages in `manager:package` form; defaults to everything configured in [system.packages]
 .SH "MISE SYSTEM STATUS"
 Show the status of system packages from `[system.packages]`, files from
-`[system.files]`, edits from `[[system.edits]]`, and macOS defaults from
+`[system.files]`, edits from `[system.edits]`, and macOS defaults from
 `[system.defaults]`
 .PP
 \fBUsage:\fR mise system status [OPTIONS]

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -286,14 +286,13 @@ cmd bootstrap help="[experimental] Set up a machine for the current config in on
 
 Runs the bootstrap steps for the current config in order:
 
-1. `mise system install` — install missing `[system.packages]`, apply
-   `[system.files]`, and write `[system.defaults]` (macOS)
+1. `mise system install` — install missing `[system.packages]` and apply
+   `[system.files]` and `[[system.edits]]`
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
-The declarative steps converge — anything already in its desired state
-is skipped, so re-running is safe. The `bootstrap` task runs on every
-invocation; keep it idempotent. Use it for any project-specific setup
+Steps with nothing to do are skipped, so `mise bootstrap` is idempotent
+and safe to re-run. Use a `bootstrap` task for any project-specific setup
 that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
 """#
@@ -2880,39 +2879,39 @@ Examples:
 }
 cmd system subcommand_required=#true help=#"""
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, and macOS defaults from `[system.defaults]`
+from `[system.files]`, and edits from `[[system.edits]]`
 """# {
     long_help #"""
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, and macOS defaults from `[system.defaults]`
+from `[system.files]`, and edits from `[[system.edits]]`
 
 System packages are machine-global packages installed by the OS package
 manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).
 System files are config files (dotfiles) symlinked, copied, or rendered
-to machine-global paths. macOS defaults are user preferences written
-with `defaults write`. Unlike `[tools]`, none of these are version-pinned
-per-project and they are only ever acted on when explicitly requested
-with `mise system install`.
+to machine-global paths. System edits manage one piece of a file
+something else owns — a marker-delimited block or a single line. Unlike
+`[tools]`, none of these are version-pinned per-project and all are only
+ever acted on when explicitly requested with `mise system install`.
 """#
     cmd install help=#"""
-Install missing system packages from `[system.packages]`, apply files
-from `[system.files]`, and write macOS defaults from `[system.defaults]`
+Install missing system packages from `[system.packages]` and apply files
+from `[system.files]` and edits from `[[system.edits]]`
 """# {
         alias i
         long_help #"""
-Install missing system packages from `[system.packages]`, apply files
-from `[system.files]`, and write macOS defaults from `[system.defaults]`
+Install missing system packages from `[system.packages]` and apply files
+from `[system.files]` and edits from `[[system.edits]]`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
-entries that aren't in their desired state are applied, and on macOS any
-`[system.defaults]` entries that are unset or differ are written.
+and `[[system.edits]]` entries that aren't in their desired state are
+applied.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in
-the config. Explicit packages and `--manager` scope the run to packages
-only.
+the config — files and edits are skipped in that case, as with
+`--manager`.
 """#
         after_long_help #"""
 Examples:
@@ -2936,7 +2935,7 @@ Examples:
     }
     cmd status help=#"""
 Show the status of system packages from `[system.packages]`, files from
-`[system.files]`, and macOS defaults from `[system.defaults]`
+`[system.files]`, and edits from `[[system.edits]]`
 """# {
         alias ls
         after_long_help #"""
@@ -2944,13 +2943,13 @@ Examples:
 
     $ mise system status
     $ mise system status --json
-    $ mise system status --missing # exit 1 if anything is out of sync
+    $ mise system status --missing # exit 1 if anything is missing
 
 """#
         flag "-J --json" help="Output in JSON format"
         flag --missing help=#"""
-Exit with code 1 if any configured packages, files, or defaults are
-not in their desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages or files are not in their
+desired state (missing, version mismatch, differs)
 """#
     }
     cmd upgrade help="Upgrade installed system packages from `[system.packages]`" {

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -287,7 +287,7 @@ cmd bootstrap help="[experimental] Set up a machine for the current config in on
 Runs the bootstrap steps for the current config in order:
 
 1. `mise system install` — install missing `[system.packages]`, apply
-   `[system.files]` and `[[system.edits]]`, and write `[system.defaults]`
+   `[system.files]` and `[system.edits]`, and write `[system.defaults]`
    (macOS)
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
@@ -2881,12 +2881,12 @@ Examples:
 }
 cmd system subcommand_required=#true help=#"""
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, edits from `[[system.edits]]`, and macOS defaults
+from `[system.files]`, edits from `[system.edits]`, and macOS defaults
 from `[system.defaults]`
 """# {
     long_help #"""
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, edits from `[[system.edits]]`, and macOS defaults
+from `[system.files]`, edits from `[system.edits]`, and macOS defaults
 from `[system.defaults]`
 
 System packages are machine-global packages installed by the OS package
@@ -2901,19 +2901,19 @@ ever acted on when explicitly requested with `mise system install` (or
 """#
     cmd install help=#"""
 Install missing system packages from `[system.packages]`, apply files
-from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+from `[system.files]` and edits from `[system.edits]`, and write macOS
 defaults from `[system.defaults]`
 """# {
         alias i
         long_help #"""
 Install missing system packages from `[system.packages]`, apply files
-from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+from `[system.files]` and edits from `[system.edits]`, and write macOS
 defaults from `[system.defaults]`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
-and `[[system.edits]]` entries that aren't in their desired state are
+and `[system.edits]` entries that aren't in their desired state are
 applied, and on macOS any `[system.defaults]` entries that are unset or
 differ are written.
 
@@ -2944,7 +2944,7 @@ Examples:
     }
     cmd status help=#"""
 Show the status of system packages from `[system.packages]`, files from
-`[system.files]`, edits from `[[system.edits]]`, and macOS defaults from
+`[system.files]`, edits from `[system.edits]`, and macOS defaults from
 `[system.defaults]`
 """# {
         alias ls

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -286,13 +286,15 @@ cmd bootstrap help="[experimental] Set up a machine for the current config in on
 
 Runs the bootstrap steps for the current config in order:
 
-1. `mise system install` — install missing `[system.packages]` and apply
-   `[system.files]` and `[[system.edits]]`
+1. `mise system install` — install missing `[system.packages]`, apply
+   `[system.files]` and `[[system.edits]]`, and write `[system.defaults]`
+   (macOS)
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
-Steps with nothing to do are skipped, so `mise bootstrap` is idempotent
-and safe to re-run. Use a `bootstrap` task for any project-specific setup
+The declarative steps converge — anything already in its desired state
+is skipped, so re-running is safe. The `bootstrap` task runs on every
+invocation; keep it idempotent. Use it for any project-specific setup
 that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
 """#
@@ -2879,39 +2881,45 @@ Examples:
 }
 cmd system subcommand_required=#true help=#"""
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, and edits from `[[system.edits]]`
+from `[system.files]`, edits from `[[system.edits]]`, and macOS defaults
+from `[system.defaults]`
 """# {
     long_help #"""
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, and edits from `[[system.edits]]`
+from `[system.files]`, edits from `[[system.edits]]`, and macOS defaults
+from `[system.defaults]`
 
 System packages are machine-global packages installed by the OS package
 manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).
 System files are config files (dotfiles) symlinked, copied, or rendered
 to machine-global paths. System edits manage one piece of a file
-something else owns — a marker-delimited block or a single line. Unlike
-`[tools]`, none of these are version-pinned per-project and all are only
+something else owns — a marker-delimited block or a single line. macOS
+defaults are user preferences written with `defaults write`. Unlike
+`[tools]`, none of these are version-pinned per-project and they are only
 ever acted on when explicitly requested with `mise system install`.
 """#
     cmd install help=#"""
-Install missing system packages from `[system.packages]` and apply files
-from `[system.files]` and edits from `[[system.edits]]`
+Install missing system packages from `[system.packages]`, apply files
+from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+defaults from `[system.defaults]`
 """# {
         alias i
         long_help #"""
-Install missing system packages from `[system.packages]` and apply files
-from `[system.files]` and edits from `[[system.edits]]`
+Install missing system packages from `[system.packages]`, apply files
+from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+defaults from `[system.defaults]`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 and `[[system.edits]]` entries that aren't in their desired state are
-applied.
+applied, and on macOS any `[system.defaults]` entries that are unset or
+differ are written.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in
-the config — files and edits are skipped in that case, as with
-`--manager`.
+the config. Explicit packages and `--manager` scope the run to packages
+only.
 """#
         after_long_help #"""
 Examples:
@@ -2935,7 +2943,8 @@ Examples:
     }
     cmd status help=#"""
 Show the status of system packages from `[system.packages]`, files from
-`[system.files]`, and edits from `[[system.edits]]`
+`[system.files]`, edits from `[[system.edits]]`, and macOS defaults from
+`[system.defaults]`
 """# {
         alias ls
         after_long_help #"""
@@ -2943,13 +2952,13 @@ Examples:
 
     $ mise system status
     $ mise system status --json
-    $ mise system status --missing # exit 1 if anything is missing
+    $ mise system status --missing # exit 1 if anything is out of sync
 
 """#
         flag "-J --json" help="Output in JSON format"
         flag --missing help=#"""
-Exit with code 1 if any configured packages or files are not in their
-desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages, files, or defaults are
+not in their desired state (missing, version mismatch, differs)
 """#
     }
     cmd upgrade help="Upgrade installed system packages from `[system.packages]`" {

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2896,7 +2896,8 @@ to machine-global paths. System edits manage one piece of a file
 something else owns — a marker-delimited block or a single line. macOS
 defaults are user preferences written with `defaults write`. Unlike
 `[tools]`, none of these are version-pinned per-project and they are only
-ever acted on when explicitly requested with `mise system install`.
+ever acted on when explicitly requested with `mise system install` (or
+`mise bootstrap`).
 """#
     cmd install help=#"""
 Install missing system packages from `[system.packages]`, apply files

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2985,8 +2985,16 @@
                       "description": "block content from a file, relative to this config file"
                     },
                     "template": {
-                      "type": "boolean",
-                      "description": "render the block content through the mise template engine"
+                      "type": "string",
+                      "description": "template engine to render the block content with; currently only \"tera\"",
+                      "anyOf": [
+                        {
+                          "enum": ["tera"]
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     },
                     "line": {
                       "type": "string",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2959,8 +2959,46 @@
     },
     "system": {
       "type": "object",
-      "description": "[experimental] machine-global bootstrapping (system packages, files, macOS defaults)",
+      "description": "[experimental] machine-global bootstrapping (system packages, files, edits, macOS defaults)",
       "properties": {
+        "edits": {
+          "type": "array",
+          "description": "edits to files mise doesn't own, applied with `mise system install`: a marker-delimited block or a single line per entry",
+          "items": {
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "file to edit (absolute or ~/)"
+              },
+              "id": {
+                "type": "string",
+                "description": "marker identity for blocks, so one file can hold several blocks; default \"mise\""
+              },
+              "block": {
+                "type": "string",
+                "description": "block content, maintained between marker comments"
+              },
+              "source": {
+                "type": "string",
+                "description": "block content from a file, relative to this config file"
+              },
+              "template": {
+                "type": "boolean",
+                "description": "render the block content through the mise template engine"
+              },
+              "line": {
+                "type": "string",
+                "description": "exact line to ensure exists (appended if absent)"
+              },
+              "comment": {
+                "type": "string",
+                "description": "comment prefix for the marker lines; inferred from the file extension when omitted"
+              }
+            }
+          }
+        },
         "files": {
           "type": "object",
           "description": "files to apply with `mise system install`, keyed by target path (e.g. \"~/.gitconfig\"); sources resolve relative to this config file",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2967,6 +2967,9 @@
           "additionalProperties": {
             "type": "object",
             "description": "edits for one file, keyed by id",
+            "propertyNames": {
+              "pattern": "^[A-Za-z0-9_.-]+$"
+            },
             "additionalProperties": {
               "oneOf": [
                 {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2962,40 +2962,43 @@
       "description": "[experimental] machine-global bootstrapping (system packages, files, edits, macOS defaults)",
       "properties": {
         "edits": {
-          "type": "array",
-          "description": "edits to files mise doesn't own, applied with `mise system install`: a marker-delimited block or a single line per entry",
-          "items": {
+          "type": "object",
+          "description": "edits to files mise doesn't own, applied with `mise system install`: keyed by target path, then by an id naming each edit (the block marker name)",
+          "additionalProperties": {
             "type": "object",
-            "required": ["path"],
-            "properties": {
-              "path": {
-                "type": "string",
-                "description": "file to edit (absolute or ~/)"
-              },
-              "id": {
-                "type": "string",
-                "description": "marker identity for blocks, so one file can hold several blocks; default \"mise\""
-              },
-              "block": {
-                "type": "string",
-                "description": "block content, maintained between marker comments"
-              },
-              "source": {
-                "type": "string",
-                "description": "block content from a file, relative to this config file"
-              },
-              "template": {
-                "type": "boolean",
-                "description": "render the block content through the mise template engine"
-              },
-              "line": {
-                "type": "string",
-                "description": "exact line to ensure exists (appended if absent)"
-              },
-              "comment": {
-                "type": "string",
-                "description": "comment prefix for the marker lines; inferred from the file extension when omitted"
-              }
+            "description": "edits for one file, keyed by id",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "inline block content, maintained between marker comments"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "block": {
+                      "type": "string",
+                      "description": "block content, maintained between marker comments"
+                    },
+                    "source": {
+                      "type": "string",
+                      "description": "block content from a file, relative to this config file"
+                    },
+                    "template": {
+                      "type": "boolean",
+                      "description": "render the block content through the mise template engine"
+                    },
+                    "line": {
+                      "type": "string",
+                      "description": "exact line to ensure exists (appended if absent)"
+                    },
+                    "comment": {
+                      "type": "string",
+                      "description": "comment prefix for the marker lines; inferred from the file extension when omitted"
+                    }
+                  }
+                }
+              ]
             }
           }
         },

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -11,7 +11,7 @@ use crate::system;
 /// Runs the bootstrap steps for the current config in order:
 ///
 /// 1. `mise system install` — install missing `[system.packages]`, apply
-///    `[system.files]` and `[[system.edits]]`, and write `[system.defaults]`
+///    `[system.files]` and `[system.edits]`, and write `[system.defaults]`
 ///    (macOS)
 /// 2. `mise install` — install missing tools from `[tools]`
 /// 3. `mise run bootstrap` — if a task named `bootstrap` is defined
@@ -74,7 +74,7 @@ impl Bootstrap {
 
         let edits = system::edits::edits_from_config(&config);
         if edits.is_empty() {
-            debug!("bootstrap: no [[system.edits]] configured, skipping");
+            debug!("bootstrap: no [system.edits] configured, skipping");
         } else {
             info!("bootstrap: system edits");
             let opts = system::edits::ApplyOpts {

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -11,7 +11,8 @@ use crate::system;
 /// Runs the bootstrap steps for the current config in order:
 ///
 /// 1. `mise system install` — install missing `[system.packages]`, apply
-///    `[system.files]`, and write `[system.defaults]` (macOS)
+///    `[system.files]` and `[[system.edits]]`, and write `[system.defaults]`
+///    (macOS)
 /// 2. `mise install` — install missing tools from `[tools]`
 /// 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 ///
@@ -69,6 +70,18 @@ impl Bootstrap {
                 yes: self.yes,
             };
             system::files::apply(&config, &files, &opts)?;
+        }
+
+        let edits = system::edits::edits_from_config(&config);
+        if edits.is_empty() {
+            debug!("bootstrap: no [[system.edits]] configured, skipping");
+        } else {
+            info!("bootstrap: system edits");
+            let opts = system::edits::ApplyOpts {
+                dry_run: self.dry_run,
+                yes: self.yes,
+            };
+            system::edits::apply(&config, &edits, &opts)?;
         }
 
         let defaults = system::defaults_from_config(&config);

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -5,13 +5,13 @@ use crate::config::{Config, Settings};
 use crate::system;
 
 /// Install missing system packages from `[system.packages]`, apply files
-/// from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+/// from `[system.files]` and edits from `[system.edits]`, and write macOS
 /// defaults from `[system.defaults]`
 ///
 /// Checks which configured packages are missing and installs them with the
 /// system package manager. This may elevate with sudo when not running as
 /// root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
-/// and `[[system.edits]]` entries that aren't in their desired state are
+/// and `[system.edits]` entries that aren't in their desired state are
 /// applied, and on macOS any `[system.defaults]` entries that are unset or
 /// differ are written.
 ///

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -5,13 +5,15 @@ use crate::config::{Config, Settings};
 use crate::system;
 
 /// Install missing system packages from `[system.packages]`, apply files
-/// from `[system.files]`, and write macOS defaults from `[system.defaults]`
+/// from `[system.files]` and edits from `[[system.edits]]`, and write macOS
+/// defaults from `[system.defaults]`
 ///
 /// Checks which configured packages are missing and installs them with the
 /// system package manager. This may elevate with sudo when not running as
 /// root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
-/// entries that aren't in their desired state are applied, and on macOS any
-/// `[system.defaults]` entries that are unset or differ are written.
+/// and `[[system.edits]]` entries that aren't in their desired state are
+/// applied, and on macOS any `[system.defaults]` entries that are unset or
+/// differ are written.
 ///
 /// Packages can also be given explicitly in `manager:package` form (e.g.
 /// `apt:curl`, `brew:jq`); they are installed whether or not they appear in
@@ -63,8 +65,8 @@ impl SystemInstall {
             system::packages_from_specs(&self.packages)?
         };
         // explicit packages or a --manager filter narrow the run to those
-        // packages; files and defaults are part of the "apply everything"
-        // form only
+        // packages; files, edits, and defaults are part of the "apply
+        // everything" form only
         let packages_only = !self.packages.is_empty() || self.manager.is_some();
         let opts = DriverOpts {
             manager: self.manager.clone(),
@@ -73,15 +75,18 @@ impl SystemInstall {
             update: self.update,
             yes: self.yes,
         };
-        let files = if packages_only {
-            vec![]
+        let (files, edits) = if packages_only {
+            (vec![], vec![])
         } else {
             let config = Config::get().await?;
-            system::files::files_from_config(&config)
+            (
+                system::files::files_from_config(&config),
+                system::edits::edits_from_config(&config),
+            )
         };
-        // when only defaults/files are configured, skip the driver so it
-        // doesn't print "no system packages configured"
-        if !mgrs.is_empty() || (defaults.is_empty() && files.is_empty()) {
+        // when only defaults/files/edits are configured, skip the driver so
+        // it doesn't print "no system packages configured"
+        if !mgrs.is_empty() || (defaults.is_empty() && files.is_empty() && edits.is_empty()) {
             driver::run(mgrs, Action::Install, &opts).await?;
         }
         if !files.is_empty() {
@@ -92,6 +97,14 @@ impl SystemInstall {
                 yes: self.yes,
             };
             system::files::apply(&config, &files, &apply_opts)?;
+        }
+        if !edits.is_empty() {
+            let config = Config::get().await?;
+            let apply_opts = system::edits::ApplyOpts {
+                dry_run: self.dry_run,
+                yes: self.yes,
+            };
+            system::edits::apply(&config, &edits, &apply_opts)?;
         }
         apply_defaults(defaults, self.dry_run, self.yes).await
     }

--- a/src/cli/system/mod.rs
+++ b/src/cli/system/mod.rs
@@ -9,7 +9,7 @@ mod upgrade;
 mod r#use;
 
 /// [experimental] Manage system packages from `[system.packages]`, files
-/// from `[system.files]`, edits from `[[system.edits]]`, and macOS defaults
+/// from `[system.files]`, edits from `[system.edits]`, and macOS defaults
 /// from `[system.defaults]`
 ///
 /// System packages are machine-global packages installed by the OS package

--- a/src/cli/system/mod.rs
+++ b/src/cli/system/mod.rs
@@ -19,7 +19,8 @@ mod r#use;
 /// something else owns — a marker-delimited block or a single line. macOS
 /// defaults are user preferences written with `defaults write`. Unlike
 /// `[tools]`, none of these are version-pinned per-project and they are only
-/// ever acted on when explicitly requested with `mise system install`.
+/// ever acted on when explicitly requested with `mise system install` (or
+/// `mise bootstrap`).
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment)]
 pub struct System {

--- a/src/cli/system/mod.rs
+++ b/src/cli/system/mod.rs
@@ -9,15 +9,17 @@ mod upgrade;
 mod r#use;
 
 /// [experimental] Manage system packages from `[system.packages]`, files
-/// from `[system.files]`, and macOS defaults from `[system.defaults]`
+/// from `[system.files]`, edits from `[[system.edits]]`, and macOS defaults
+/// from `[system.defaults]`
 ///
 /// System packages are machine-global packages installed by the OS package
 /// manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).
 /// System files are config files (dotfiles) symlinked, copied, or rendered
-/// to machine-global paths. macOS defaults are user preferences written
-/// with `defaults write`. Unlike `[tools]`, none of these are version-pinned
-/// per-project and they are only ever acted on when explicitly requested
-/// with `mise system install`.
+/// to machine-global paths. System edits manage one piece of a file
+/// something else owns — a marker-delimited block or a single line. macOS
+/// defaults are user preferences written with `defaults write`. Unlike
+/// `[tools]`, none of these are version-pinned per-project and they are only
+/// ever acted on when explicitly requested with `mise system install`.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment)]
 pub struct System {

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -10,7 +10,7 @@ use crate::system::packages::PackageState;
 use crate::ui::table::MiseTable;
 
 /// Show the status of system packages from `[system.packages]`, files from
-/// `[system.files]`, edits from `[[system.edits]]`, and macOS defaults from
+/// `[system.files]`, edits from `[system.edits]`, and macOS defaults from
 /// `[system.defaults]`
 #[derive(Debug, clap::Args)]
 #[clap(visible_alias = "ls", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
@@ -236,7 +236,7 @@ impl SystemStatus {
                 && defaults_rows.is_empty()
             {
                 info!(
-                    "nothing configured in [system.packages], [system.files], [[system.edits]], or [system.defaults]"
+                    "nothing configured in [system.packages], [system.files], [system.edits], or [system.defaults]"
                 );
             }
             if !rows.is_empty() {

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -10,7 +10,8 @@ use crate::system::packages::PackageState;
 use crate::ui::table::MiseTable;
 
 /// Show the status of system packages from `[system.packages]`, files from
-/// `[system.files]`, and macOS defaults from `[system.defaults]`
+/// `[system.files]`, edits from `[[system.edits]]`, and macOS defaults from
+/// `[system.defaults]`
 #[derive(Debug, clap::Args)]
 #[clap(visible_alias = "ls", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct SystemStatus {
@@ -131,6 +132,37 @@ impl SystemStatus {
                 ]);
             }
         }
+        let edits = system::edits::edits_from_config(&config);
+        let mut edit_rows: Vec<Vec<String>> = vec![];
+        let mut json_edits = vec![];
+        for req in &edits {
+            let state = match system::edits::check(&config, req) {
+                Ok(state) => state,
+                // e.g. a template that fails to render — visible, not fatal
+                Err(err) => FileState::Differs(format!("{err}")),
+            };
+            let state_str = match &state {
+                FileState::Applied => "applied".to_string(),
+                FileState::Missing => "missing".to_string(),
+                FileState::SourceMissing => "source missing".to_string(),
+                FileState::Differs(reason) => format!("differs ({reason})"),
+            };
+            any_missing |= state != FileState::Applied;
+            if self.json {
+                json_edits.push(json!({
+                    "path": req.path_raw,
+                    "edit": req.describe_op(),
+                    "state": match &state {
+                        FileState::Applied => "applied",
+                        FileState::Missing => "missing",
+                        FileState::SourceMissing => "source_missing",
+                        FileState::Differs(_) => "differs",
+                    },
+                }));
+            } else {
+                edit_rows.push(vec![req.path_raw.clone(), req.describe_op(), state_str]);
+            }
+        }
         let defaults = system::defaults_from_config(&config);
         let mut defaults_rows: Vec<Vec<String>> = vec![];
         if !defaults.is_empty() {
@@ -195,11 +227,16 @@ impl SystemStatus {
         }
         if self.json {
             json_out.insert("files".to_string(), json!(json_files));
+            json_out.insert("edits".to_string(), json!(json_edits));
             miseprintln!("{}", serde_json::to_string_pretty(&json_out)?);
         } else {
-            if rows.is_empty() && file_rows.is_empty() && defaults_rows.is_empty() {
+            if rows.is_empty()
+                && file_rows.is_empty()
+                && edit_rows.is_empty()
+                && defaults_rows.is_empty()
+            {
                 info!(
-                    "nothing configured in [system.packages], [system.files], or [system.defaults]"
+                    "nothing configured in [system.packages], [system.files], [[system.edits]], or [system.defaults]"
                 );
             }
             if !rows.is_empty() {
@@ -213,6 +250,13 @@ impl SystemStatus {
             if !file_rows.is_empty() {
                 let mut table = MiseTable::new(false, &["Target", "Mode", "Source", "State"]);
                 for row in file_rows {
+                    table.add_row(row);
+                }
+                table.print()?;
+            }
+            if !edit_rows.is_empty() {
+                let mut table = MiseTable::new(false, &["File", "Edit", "State"]);
+                for row in edit_rows {
                     table.add_row(row);
                 }
                 table.print()?;

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -46,7 +46,7 @@ use crate::ui::prompt;
 pub enum EditTomlEntry {
     /// `activate = 'eval "$(mise activate zsh)"'` — inline block content
     Block(String),
-    /// `aliases = { source = "...", template = true }` /
+    /// `aliases = { source = "...", template = "tera" }` /
     /// `dev = { line = "..." }`
     Table(EditTomlTable),
 }
@@ -59,9 +59,11 @@ pub struct EditTomlTable {
     /// block content from a file (relative to the declaring config file)
     #[serde(default)]
     pub source: Option<String>,
-    /// render the block content through the mise template engine
+    /// template engine to render the block content with; currently only
+    /// `"tera"` (string-typed so engines from newer mise versions warn and
+    /// skip instead of failing to parse)
     #[serde(default)]
-    pub template: Option<bool>,
+    pub template: Option<String>,
     /// exact line to ensure exists
     #[serde(default)]
     pub line: Option<String>,
@@ -199,12 +201,21 @@ fn resolve_entry(
                 }
                 (None, None) => unreachable!("is_block"),
             };
+            let template = match entry.template.as_deref() {
+                None => false,
+                Some("tera") => true,
+                Some(other) => {
+                    bail!(
+                        "\"{path_raw}\".{id}: unknown template engine '{other}' (expected \"tera\"), ignoring entry"
+                    )
+                }
+            };
             let comment = entry
                 .comment
                 .unwrap_or_else(|| infer_comment(&path).to_string());
             EditOp::Block {
                 source,
-                template: entry.template.unwrap_or(false),
+                template,
                 comment,
             }
         }

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -308,11 +308,12 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
 
 /// Current state of one edit on this machine.
 ///
-/// Note: computing a template block's state requires rendering it, so this
-/// runs the template engine — including `exec()` — from `mise system
-/// status`. That's the same trust model as `[env]` templates; only
-/// `--dry-run` promises to execute nothing and therefore skips template
-/// checks entirely (see [`apply`]).
+/// Note: comparing a template block against existing markers requires
+/// rendering it, so this can run the template engine — including `exec()` —
+/// from `mise system status`. That's the same trust model as `[env]`
+/// templates. Rendering only happens once every render-free outcome (symlink
+/// target, missing file, absent or corrupted markers) has been ruled out,
+/// and `--dry-run` skips template rendering entirely (see [`apply`]).
 pub fn check(config: &Config, req: &EditRequest) -> Result<FileState> {
     if let EditOp::Block {
         source: BlockSource::File(p),
@@ -322,11 +323,14 @@ pub fn check(config: &Config, req: &EditRequest) -> Result<FileState> {
     {
         return Ok(FileState::SourceMissing);
     }
-    let desired = desired_content(config, req)?;
-    Ok(match check_resolved(req, desired.as_deref())? {
-        EditCheck::State(state) => state,
-        EditCheck::Blocked(reason) => FileState::Differs(reason),
-    })
+    match precheck(req)? {
+        Some(EditCheck::State(state)) => Ok(state),
+        Some(EditCheck::Blocked(reason)) => Ok(FileState::Differs(reason)),
+        None => {
+            let desired = desired_content(config, req)?;
+            block_state(req, desired.as_deref())
+        }
+    }
 }
 
 const SYMLINK_REASON: &str = "target is a symlink; edit the real file instead";
@@ -338,41 +342,56 @@ enum EditCheck {
     Blocked(String),
 }
 
-/// [`check`] with block content already resolved, so callers that go on to
-/// write the file resolve and render only once
-fn check_resolved(req: &EditRequest, desired: Option<&str>) -> Result<EditCheck> {
+/// everything that can be decided without rendered content: symlink targets,
+/// file existence, marker integrity, and line presence. Returns Ok(None)
+/// when the entry's markers exist and a content comparison (which may
+/// require rendering) is still needed — callers must not render before this
+/// has been consulted, so blocked entries never execute template code
+fn precheck(req: &EditRequest) -> Result<Option<EditCheck>> {
     // edits write through symlinks into whatever they point at (often a
     // [system.files] source) — surface that instead of silently doing it
     if req.path.is_symlink() {
-        return Ok(EditCheck::Blocked(SYMLINK_REASON.into()));
+        return Ok(Some(EditCheck::Blocked(SYMLINK_REASON.into())));
     }
     if !req.path.exists() {
-        return Ok(EditCheck::State(FileState::Missing));
+        return Ok(Some(EditCheck::State(FileState::Missing)));
     }
     let text = file::read_to_string(&req.path)?;
     let lines: Vec<&str> = text.lines().collect();
-    let state = match &req.op {
+    match &req.op {
         EditOp::Block { id, comment, .. } => match find_block(&lines, id, comment) {
-            Err(reason) => return Ok(EditCheck::Blocked(reason)),
-            Ok(None) => FileState::Missing,
-            Ok(Some((begin, end))) => {
-                let current = lines[begin + 1..end].join("\n");
-                if current == desired.expect("resolved block content") {
-                    FileState::Applied
-                } else {
-                    FileState::Differs("block content differs".into())
-                }
-            }
+            Err(reason) => Ok(Some(EditCheck::Blocked(reason))),
+            Ok(None) => Ok(Some(EditCheck::State(FileState::Missing))),
+            Ok(Some(_)) => Ok(None),
         },
-        EditOp::Line { line } => {
-            if lines.contains(&line.as_str()) {
-                FileState::Applied
+        EditOp::Line { line } => Ok(Some(EditCheck::State(if lines.contains(&line.as_str()) {
+            FileState::Applied
+        } else {
+            FileState::Missing
+        }))),
+    }
+}
+
+/// content comparison for a block whose markers exist ([`precheck`]
+/// returned None)
+fn block_state(req: &EditRequest, desired: Option<&str>) -> Result<FileState> {
+    let EditOp::Block { id, comment, .. } = &req.op else {
+        unreachable!("only blocks reach a content comparison");
+    };
+    let text = file::read_to_string(&req.path)?;
+    let lines: Vec<&str> = text.lines().collect();
+    match find_block(&lines, id, comment) {
+        Ok(Some((begin, end))) => {
+            let current = lines[begin + 1..end].join("\n");
+            if current == desired.expect("resolved block content") {
+                Ok(FileState::Applied)
             } else {
-                FileState::Missing
+                Ok(FileState::Differs("block content differs".into()))
             }
         }
-    };
-    Ok(EditCheck::State(state))
+        // precheck just vetted the markers; a race is a plain differs
+        _ => Ok(FileState::Differs("markers changed during check".into())),
+    }
 }
 
 pub struct ApplyOpts {
@@ -401,43 +420,13 @@ pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Res
             ));
             continue;
         }
-        // rendering can run exec() — a dry run must not execute anything,
-        // so template blocks are listed without computing their state (same
-        // policy as [system.files])
-        let is_template = matches!(&req.op, EditOp::Block { template: true, .. });
-        if opts.dry_run && is_template {
-            if req.path.is_symlink() {
-                problems.push(format!(
-                    "  \"{}\" ({}): {SYMLINK_REASON}",
-                    req.path_raw,
-                    req.describe_op()
-                ));
-            } else {
-                todo.push((req, None));
-            }
-            continue;
-        }
         // a render or check failure on one entry must not hide problems
-        // with the others — keep evaluating, like status does
-        let desired = match desired_content(config, req) {
-            Ok(desired) => desired,
-            // already carries the entry's context
-            Err(err) => {
-                problems.push(format!("  {err}"));
-                continue;
-            }
-        };
-        match check_resolved(req, desired.as_deref()) {
-            Ok(EditCheck::State(FileState::Applied)) => continue,
-            Ok(EditCheck::Blocked(reason)) => {
-                problems.push(format!(
-                    "  \"{}\" ({}): {reason}",
-                    req.path_raw,
-                    req.describe_op()
-                ));
-                continue;
-            }
-            Ok(EditCheck::State(_)) => todo.push((req, desired)),
+        // with the others — keep evaluating, like status does. Render-free
+        // outcomes (symlink target, marker integrity, line presence) are
+        // decided first so blocked or already-applied entries never execute
+        // template code
+        let pre = match precheck(req) {
+            Ok(pre) => pre,
             Err(err) => {
                 problems.push(format!(
                     "  \"{}\" ({}): {err}",
@@ -446,6 +435,50 @@ pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Res
                 ));
                 continue;
             }
+        };
+        match &pre {
+            Some(EditCheck::Blocked(reason)) => {
+                problems.push(format!(
+                    "  \"{}\" ({}): {reason}",
+                    req.path_raw,
+                    req.describe_op()
+                ));
+                continue;
+            }
+            Some(EditCheck::State(FileState::Applied)) => continue,
+            _ => {}
+        }
+        // rendering can run exec() — a dry run must not execute anything,
+        // so template blocks are listed without computing their content
+        // (same policy as [system.files])
+        if opts.dry_run && matches!(&req.op, EditOp::Block { template: true, .. }) {
+            todo.push((req, None));
+            continue;
+        }
+        let desired = match desired_content(config, req) {
+            Ok(desired) => desired,
+            // already carries the entry's context
+            Err(err) => {
+                problems.push(format!("  {err}"));
+                continue;
+            }
+        };
+        match pre {
+            // markers exist: compare content to see if anything would change
+            None => match block_state(req, desired.as_deref()) {
+                Ok(FileState::Applied) => continue,
+                Ok(_) => todo.push((req, desired)),
+                Err(err) => {
+                    problems.push(format!(
+                        "  \"{}\" ({}): {err}",
+                        req.path_raw,
+                        req.describe_op()
+                    ));
+                    continue;
+                }
+            },
+            // missing — needs applying
+            Some(_) => todo.push((req, desired)),
         }
     }
     if !problems.is_empty() {

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -217,6 +217,21 @@ fn end_marker(comment: &str, id: &str) -> String {
     format!("{comment} <<< mise:{id} <<<")
 }
 
+/// a line is a marker only when the pattern sits at the start of the line,
+/// preceded by at most a short comment token (`# `, `// `, `-- `, `<!-- `) —
+/// content that merely *mentions* a marker (`echo ">>> mise:x >>>"`, docs)
+/// must not count as one
+fn is_marker_line(line: &str, pat: &str) -> bool {
+    let trimmed = line.trim_start();
+    match trimmed.find(pat) {
+        Some(idx) => {
+            let prefix = &trimmed[..idx];
+            prefix.len() <= 8 && !prefix.chars().any(|c| c.is_alphanumeric())
+        }
+        None => false,
+    }
+}
+
 /// locate an id's marker pair in the file's lines: Ok(None) = no markers,
 /// Ok(Some((begin, end))) = line indexes, Err = corrupted markers
 fn find_block(lines: &[&str], id: &str) -> std::result::Result<Option<(usize, usize)>, String> {
@@ -225,13 +240,13 @@ fn find_block(lines: &[&str], id: &str) -> std::result::Result<Option<(usize, us
     let begins: Vec<usize> = lines
         .iter()
         .enumerate()
-        .filter(|(_, l)| l.contains(&begin_pat))
+        .filter(|(_, l)| is_marker_line(l, &begin_pat))
         .map(|(i, _)| i)
         .collect();
     let ends: Vec<usize> = lines
         .iter()
         .enumerate()
-        .filter(|(_, l)| l.contains(&end_pat))
+        .filter(|(_, l)| is_marker_line(l, &end_pat))
         .map(|(i, _)| i)
         .collect();
     match (begins.as_slice(), ends.as_slice()) {
@@ -248,7 +263,10 @@ fn find_block(lines: &[&str], id: &str) -> std::result::Result<Option<(usize, us
 /// per check/apply cycle (templates may use exec())
 fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>> {
     let EditOp::Block {
-        source, template, ..
+        id,
+        source,
+        template,
+        ..
     } = &req.op
     else {
         return Ok(None);
@@ -268,7 +286,18 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
     } else {
         raw
     };
-    Ok(Some(content.trim_end_matches('\n').to_string()))
+    let content = content.trim_end_matches('\n').to_string();
+    // a block containing its own marker lines would write a file that can't
+    // be parsed back — refuse up front instead of corrupting on reapply
+    for pat in [format!(">>> mise:{id} >>>"), format!("<<< mise:{id} <<<")] {
+        if content.lines().any(|l| is_marker_line(l, &pat)) {
+            bail!(
+                "[[system.edits]] \"{}\": block content may not contain its own marker lines",
+                req.path_raw
+            );
+        }
+    }
+    Ok(Some(content))
 }
 
 /// Current state of one edit on this machine.
@@ -474,6 +503,18 @@ mod tests {
         // ids are delimited — "a" must not match "ab"
         let lines = vec!["# >>> mise:ab >>>", "# <<< mise:ab <<<"];
         assert_eq!(find_block(&lines, "a"), Ok(None));
+        // content that mentions a marker mid-line is not a marker
+        let lines = vec![
+            "# >>> mise:a >>>",
+            r#"echo "keep the >>> mise:a >>> line intact""#,
+            "# <<< mise:a <<<",
+        ];
+        assert_eq!(find_block(&lines, "a"), Ok(Some((0, 2))));
+        // ...but indented comment markers still count
+        let lines = vec!["  # >>> mise:a >>>", "  # <<< mise:a <<<"];
+        assert_eq!(find_block(&lines, "a"), Ok(Some((0, 1))));
+        let lines = vec!["<!-- >>> mise:a >>>", "<!-- <<< mise:a <<<"];
+        assert_eq!(find_block(&lines, "a"), Ok(Some((0, 1))));
         let lines = vec!["# >>> mise:a >>>"];
         assert!(find_block(&lines, "a").is_err());
         let lines = vec!["# <<< mise:a <<<", "# >>> mise:a >>>"];

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -301,6 +301,12 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
 }
 
 /// Current state of one edit on this machine.
+///
+/// Note: computing a template block's state requires rendering it, so this
+/// runs the template engine — including `exec()` — from `mise system
+/// status`. That's the same trust model as `[env]` templates; only
+/// `--dry-run` promises to execute nothing and therefore skips template
+/// checks entirely (see [`apply`]).
 pub fn check(config: &Config, req: &EditRequest) -> Result<FileState> {
     if let EditOp::Block {
         source: BlockSource::File(p),
@@ -378,6 +384,22 @@ pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Res
             ));
             continue;
         }
+        // rendering can run exec() — a dry run must not execute anything,
+        // so template blocks are listed without computing their state (same
+        // policy as [system.files])
+        let is_template = matches!(&req.op, EditOp::Block { template: true, .. });
+        if opts.dry_run && is_template {
+            if req.path.is_symlink() {
+                problems.push(format!(
+                    "  \"{}\" ({}): target is a symlink; edit the real file instead",
+                    req.path_raw,
+                    req.describe_op()
+                ));
+            } else {
+                todo.push((req, None));
+            }
+            continue;
+        }
         let desired = desired_content(config, req)?;
         match check_resolved(req, desired.as_deref())? {
             FileState::Applied => continue,
@@ -405,8 +427,17 @@ pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Res
         return Ok(());
     }
     if opts.dry_run {
-        for (req, _) in &todo {
-            miseprintln!("edit {} ({})", req.path.display_user(), req.describe_op());
+        for (req, desired) in &todo {
+            // template state wasn't computed (no rendering on dry runs), so
+            // the entry may already be converged
+            let conditional =
+                desired.is_none() && matches!(&req.op, EditOp::Block { template: true, .. });
+            let suffix = if conditional { " (if changed)" } else { "" };
+            miseprintln!(
+                "edit {} ({}){suffix}",
+                req.path.display_user(),
+                req.describe_op()
+            );
         }
         return Ok(());
     }

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -417,10 +417,19 @@ pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Res
             }
             continue;
         }
-        let desired = desired_content(config, req)?;
-        match check_resolved(req, desired.as_deref())? {
-            EditCheck::State(FileState::Applied) => continue,
-            EditCheck::Blocked(reason) => {
+        // a render or check failure on one entry must not hide problems
+        // with the others — keep evaluating, like status does
+        let desired = match desired_content(config, req) {
+            Ok(desired) => desired,
+            // already carries the entry's context
+            Err(err) => {
+                problems.push(format!("  {err}"));
+                continue;
+            }
+        };
+        match check_resolved(req, desired.as_deref()) {
+            Ok(EditCheck::State(FileState::Applied)) => continue,
+            Ok(EditCheck::Blocked(reason)) => {
                 problems.push(format!(
                     "  \"{}\" ({}): {reason}",
                     req.path_raw,
@@ -428,7 +437,15 @@ pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Res
                 ));
                 continue;
             }
-            EditCheck::State(_) => todo.push((req, desired)),
+            Ok(EditCheck::State(_)) => todo.push((req, desired)),
+            Err(err) => {
+                problems.push(format!(
+                    "  \"{}\" ({}): {err}",
+                    req.path_raw,
+                    req.describe_op()
+                ));
+                continue;
+            }
         }
     }
     if !problems.is_empty() {

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -1,19 +1,18 @@
-//! `[[system.edits]]` — declarative edits to files mise doesn't own,
+//! `[system.edits]` — declarative edits to files mise doesn't own,
 //! applied by `mise system install` or `mise bootstrap`.
 //!
 //! Where `[system.files]` manages whole files, an edit owns one small piece
 //! of a file something else owns — the `mise activate` line in a shell rc,
-//! an entry in /etc/hosts:
+//! an entry in /etc/hosts. Entries are keyed by target path (like
+//! `[system.files]`), then by an id naming each edit within the file:
 //!
 //! ```toml
-//! [[system.edits]]
-//! path = "~/.zshrc"
-//! id = "activate"                        # marker identity, default "mise"
-//! block = 'eval "$(mise activate zsh)"'  # or source = "...", template = true
-//!
-//! [[system.edits]]
-//! path = "/etc/hosts"
-//! line = "127.0.0.1 dev.local"
+//! [system.edits]
+//! "~/.zshrc" = {
+//!   activate = 'eval "$(mise activate zsh)"',  # string = inline block
+//!   aliases = { source = "snippets/aliases.sh" },
+//! }
+//! "/etc/hosts" = { dev = { line = "127.0.0.1 dev.local" } }
 //! ```
 //!
 //! A `block` is delimited by marker comments in the target file —
@@ -23,8 +22,8 @@
 //! exact line exists, appending it if absent.
 //!
 //! Entries merge across the config hierarchy as a union keyed by
-//! `(path, id)` for blocks and `(path, line)` for lines; a more local config
-//! overrides a block with the same id.
+//! `(path, id)` — a more local config overrides an edit with the same id,
+//! exactly like `[system.files]` overrides by target.
 
 use std::path::{Path, PathBuf};
 
@@ -38,15 +37,22 @@ use crate::path::PathExt;
 use crate::system::files::FileState;
 use crate::ui::prompt;
 
-/// one `[[system.edits]]` entry as written in mise.toml. Operations stay
-/// loosely typed so configs using operations from newer mise versions still
-/// parse (entries with no recognized operation warn and are skipped)
+/// one `[system.edits]` entry as written in mise.toml, keyed by
+/// `path -> id`. Operations stay loosely typed so configs using operations
+/// from newer mise versions still parse (entries with no recognized
+/// operation warn and are skipped)
 #[derive(Debug, Clone, Deserialize)]
-pub struct EditTomlEntry {
-    pub path: String,
-    /// marker identity for blocks; default "mise"
-    #[serde(default)]
-    pub id: Option<String>,
+#[serde(untagged)]
+pub enum EditTomlEntry {
+    /// `activate = 'eval "$(mise activate zsh)"'` — inline block content
+    Block(String),
+    /// `aliases = { source = "...", template = true }` /
+    /// `dev = { line = "..." }`
+    Table(EditTomlTable),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EditTomlTable {
     /// inline block content
     #[serde(default)]
     pub block: Option<String>,
@@ -76,7 +82,6 @@ pub enum BlockSource {
 #[derive(Debug, Clone)]
 pub enum EditOp {
     Block {
-        id: String,
         source: BlockSource,
         template: bool,
         comment: String,
@@ -93,6 +98,9 @@ pub struct EditRequest {
     pub path_raw: String,
     /// absolute target path (`~` expanded)
     pub path: PathBuf,
+    /// the entry's key within its file: merge identity and, for blocks, the
+    /// marker name
+    pub id: String,
     pub op: EditOp,
     /// directory of the declaring config file — base dir for relative
     /// sources and template functions like `exec` and `read_file`
@@ -103,16 +111,15 @@ impl EditRequest {
     /// short operation label for status tables and dry-run output
     pub fn describe_op(&self) -> String {
         match &self.op {
-            EditOp::Block { id, .. } => format!("block:{id}"),
-            EditOp::Line { line } => format!("line:{line}"),
+            EditOp::Block { .. } => format!("block:{}", self.id),
+            EditOp::Line { .. } => format!("line:{}", self.id),
         }
     }
 }
 
-/// Aggregate `[[system.edits]]` across all loaded config files. Entries
-/// union global -> local, keyed by `(path, id)` for blocks and
-/// `(path, line)` for lines; a more local config overrides a block with the
-/// same id. Malformed entries warn and are skipped.
+/// Aggregate `[system.edits]` across all loaded config files. Entries union
+/// global -> local, keyed by `(path, id)`; a more local config overrides an
+/// edit with the same id. Malformed entries warn and are skipped.
 pub fn edits_from_config(config: &Config) -> Vec<EditRequest> {
     let mut merged: IndexMap<String, EditRequest> = IndexMap::new();
     // config_files is ordered local -> global; reverse for global -> local
@@ -121,38 +128,65 @@ pub fn edits_from_config(config: &Config) -> Vec<EditRequest> {
             continue;
         };
         let base = cf_path.parent().unwrap_or(Path::new(".")).to_path_buf();
-        for entry in sys.edits {
-            match resolve_entry(entry, &base) {
-                Ok((key, req)) => {
-                    merged.insert(key, req);
+        for (path_raw, entries) in sys.edits {
+            for (id, entry) in entries {
+                match resolve_entry(&path_raw, id, entry, &base) {
+                    Ok(req) => {
+                        merged.insert(format!("{}\u{0}{}", req.path.display(), req.id), req);
+                    }
+                    Err(err) => warn!("[system.edits]: {err}"),
                 }
-                Err(err) => warn!("[[system.edits]]: {err}"),
             }
         }
     }
     merged.into_values().collect()
 }
 
-fn resolve_entry(entry: EditTomlEntry, base: &Path) -> Result<(String, EditRequest)> {
-    let path_raw = entry.path.clone();
-    let path = file::replace_path(&path_raw);
+fn resolve_entry(
+    path_raw: &str,
+    id: String,
+    entry: EditTomlEntry,
+    base: &Path,
+) -> Result<EditRequest> {
+    let path = file::replace_path(path_raw);
     if path.is_relative() {
         bail!("path \"{path_raw}\" must be absolute or start with ~/, ignoring entry");
     }
+    // ids end up inside marker lines — keep them to characters that can't
+    // collide with the marker syntax itself
+    if id.is_empty() || !id.chars().all(|c| c.is_alphanumeric() || "_-.".contains(c)) {
+        bail!(
+            "\"{path_raw}\".{id:?}: ids may only contain letters, digits, '_', '-', and '.', ignoring entry"
+        );
+    }
+    let entry = match entry {
+        EditTomlEntry::Block(inline) => EditTomlTable {
+            block: Some(inline),
+            source: None,
+            template: None,
+            line: None,
+            comment: None,
+        },
+        EditTomlEntry::Table(table) => table,
+    };
     let is_block = entry.block.is_some() || entry.source.is_some();
-    let (key, op) = match (&is_block, &entry.line) {
+    let op = match (&is_block, &entry.line) {
         (true, Some(_)) => {
-            bail!("\"{path_raw}\": block/source and line are mutually exclusive, ignoring entry")
+            bail!(
+                "\"{path_raw}\".{id}: block/source and line are mutually exclusive, ignoring entry"
+            )
         }
         (false, None) => {
             bail!(
-                "\"{path_raw}\": no recognized operation (block, source, or line), ignoring entry"
+                "\"{path_raw}\".{id}: no recognized operation (block, source, or line), ignoring entry"
             )
         }
         (true, None) => {
             let source = match (entry.block, entry.source) {
                 (Some(_), Some(_)) => {
-                    bail!("\"{path_raw}\": block and source are mutually exclusive, ignoring entry")
+                    bail!(
+                        "\"{path_raw}\".{id}: block and source are mutually exclusive, ignoring entry"
+                    )
                 }
                 (Some(inline), None) => BlockSource::Inline(inline),
                 (None, Some(src)) => {
@@ -165,34 +199,24 @@ fn resolve_entry(entry: EditTomlEntry, base: &Path) -> Result<(String, EditReque
                 }
                 (None, None) => unreachable!("is_block"),
             };
-            let id = entry.id.unwrap_or_else(|| "mise".to_string());
             let comment = entry
                 .comment
                 .unwrap_or_else(|| infer_comment(&path).to_string());
-            (
-                format!("{}\u{0}block:{id}", path.display()),
-                EditOp::Block {
-                    id,
-                    source,
-                    template: entry.template.unwrap_or(false),
-                    comment,
-                },
-            )
+            EditOp::Block {
+                source,
+                template: entry.template.unwrap_or(false),
+                comment,
+            }
         }
-        (false, Some(line)) => (
-            format!("{}\u{0}line:{line}", path.display()),
-            EditOp::Line { line: line.clone() },
-        ),
+        (false, Some(line)) => EditOp::Line { line: line.clone() },
     };
-    Ok((
-        key,
-        EditRequest {
-            path_raw,
-            path,
-            op,
-            base: base.to_path_buf(),
-        },
-    ))
+    Ok(EditRequest {
+        path_raw: path_raw.to_string(),
+        path,
+        id,
+        op,
+        base: base.to_path_buf(),
+    })
 }
 
 /// comment prefix for marker lines, by file extension; `#` covers most
@@ -269,7 +293,6 @@ fn find_block(
 /// per check/apply cycle (templates may use exec())
 fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>> {
     let EditOp::Block {
-        id,
         source,
         template,
         comment,
@@ -277,6 +300,7 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
     else {
         return Ok(None);
     };
+    let id = &req.id;
     let raw = match source {
         BlockSource::Inline(s) => s.clone(),
         BlockSource::File(p) => file::read_to_string(p)?,
@@ -285,8 +309,9 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
         let mut tera = crate::tera::get_tera(Some(&req.base));
         tera.render_str(&raw, &config.tera_ctx).map_err(|err| {
             eyre::eyre!(
-                "[[system.edits]] \"{}\": failed to render template: {err}",
-                req.path_raw
+                "[system.edits].\"{}\".{}: failed to render template: {err}",
+                req.path_raw,
+                req.id
             )
         })?
     } else {
@@ -298,8 +323,9 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
     for pat in [format!(">>> mise:{id} >>>"), format!("<<< mise:{id} <<<")] {
         if content.lines().any(|l| is_marker_line(l, &pat, comment)) {
             bail!(
-                "[[system.edits]] \"{}\": block content may not contain its own marker lines",
-                req.path_raw
+                "[system.edits].\"{}\".{}: block content may not contain its own marker lines",
+                req.path_raw,
+                req.id
             );
         }
     }
@@ -359,7 +385,7 @@ fn precheck(req: &EditRequest) -> Result<Option<EditCheck>> {
     let text = file::read_to_string(&req.path)?;
     let lines: Vec<&str> = text.lines().collect();
     match &req.op {
-        EditOp::Block { id, comment, .. } => match find_block(&lines, id, comment) {
+        EditOp::Block { comment, .. } => match find_block(&lines, &req.id, comment) {
             Err(reason) => Ok(Some(EditCheck::Blocked(reason))),
             Ok(None) => Ok(Some(EditCheck::State(FileState::Missing))),
             Ok(Some(_)) => Ok(None),
@@ -375,9 +401,10 @@ fn precheck(req: &EditRequest) -> Result<Option<EditCheck>> {
 /// content comparison for a block whose markers exist ([`precheck`]
 /// returned None)
 fn block_state(req: &EditRequest, desired: Option<&str>) -> Result<FileState> {
-    let EditOp::Block { id, comment, .. } = &req.op else {
+    let EditOp::Block { comment, .. } = &req.op else {
         unreachable!("only blocks reach a content comparison");
     };
+    let id = &req.id;
     let text = file::read_to_string(&req.path)?;
     let lines: Vec<&str> = text.lines().collect();
     match find_block(&lines, id, comment) {
@@ -542,7 +569,8 @@ fn apply_one(req: &EditRequest, desired: Option<&str>) -> Result<()> {
     };
     let mut lines: Vec<String> = text.lines().map(|l| l.to_string()).collect();
     match &req.op {
-        EditOp::Block { id, comment, .. } => {
+        EditOp::Block { comment, .. } => {
+            let id = &req.id;
             let desired = desired.expect("resolved block content");
             let mut block = vec![begin_marker(comment, id)];
             // a desired of "" means an empty block, not a blank line

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -219,7 +219,17 @@ fn resolve_entry(
                 comment,
             }
         }
-        (false, Some(line)) => EditOp::Line { line: line.clone() },
+        (false, Some(line)) => {
+            // a "line" is matched against the file's individual lines, so an
+            // embedded newline could never converge — use a block for
+            // multi-line content
+            if line.contains('\n') {
+                bail!(
+                    "\"{path_raw}\".{id}: line may not contain a newline; use a block for multi-line content, ignoring entry"
+                )
+            }
+            EditOp::Line { line: line.clone() }
+        }
     };
     Ok(EditRequest {
         path_raw: path_raw.to_string(),

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -1,0 +1,482 @@
+//! `[[system.edits]]` — declarative edits to files mise doesn't own,
+//! applied by `mise system install` or `mise bootstrap`.
+//!
+//! Where `[system.files]` manages whole files, an edit owns one small piece
+//! of a file something else owns — the `mise activate` line in a shell rc,
+//! an entry in /etc/hosts:
+//!
+//! ```toml
+//! [[system.edits]]
+//! path = "~/.zshrc"
+//! id = "activate"                        # marker identity, default "mise"
+//! block = 'eval "$(mise activate zsh)"'  # or source = "...", template = true
+//!
+//! [[system.edits]]
+//! path = "/etc/hosts"
+//! line = "127.0.0.1 dev.local"
+//! ```
+//!
+//! A `block` is delimited by marker comments in the target file —
+//! `# >>> mise:activate >>>` / `# <<< mise:activate <<<` — which double as
+//! the ownership record: apply replaces only what's between them, so the
+//! design stays stateless like the rest of `[system]`. A `line` ensures an
+//! exact line exists, appending it if absent.
+//!
+//! Entries merge across the config hierarchy as a union keyed by
+//! `(path, id)` for blocks and `(path, line)` for lines; a more local config
+//! overrides a block with the same id.
+
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, bail};
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+use crate::config::Config;
+use crate::file;
+use crate::path::PathExt;
+use crate::system::files::FileState;
+use crate::ui::prompt;
+
+/// one `[[system.edits]]` entry as written in mise.toml. Operations stay
+/// loosely typed so configs using operations from newer mise versions still
+/// parse (entries with no recognized operation warn and are skipped)
+#[derive(Debug, Clone, Deserialize)]
+pub struct EditTomlEntry {
+    pub path: String,
+    /// marker identity for blocks; default "mise"
+    #[serde(default)]
+    pub id: Option<String>,
+    /// inline block content
+    #[serde(default)]
+    pub block: Option<String>,
+    /// block content from a file (relative to the declaring config file)
+    #[serde(default)]
+    pub source: Option<String>,
+    /// render the block content through the mise template engine
+    #[serde(default)]
+    pub template: Option<bool>,
+    /// exact line to ensure exists
+    #[serde(default)]
+    pub line: Option<String>,
+    /// comment prefix for the markers; inferred from the file extension
+    /// when omitted
+    #[serde(default)]
+    pub comment: Option<String>,
+}
+
+/// where a block's content comes from
+#[derive(Debug, Clone)]
+pub enum BlockSource {
+    Inline(String),
+    /// absolute path, resolved against the declaring config file
+    File(PathBuf),
+}
+
+#[derive(Debug, Clone)]
+pub enum EditOp {
+    Block {
+        id: String,
+        source: BlockSource,
+        template: bool,
+        comment: String,
+    },
+    Line {
+        line: String,
+    },
+}
+
+/// one edit, resolved against the config file that declared it
+#[derive(Debug, Clone)]
+pub struct EditRequest {
+    /// target path as written in config (display)
+    pub path_raw: String,
+    /// absolute target path (`~` expanded)
+    pub path: PathBuf,
+    pub op: EditOp,
+    /// directory of the declaring config file — base dir for relative
+    /// sources and template functions like `exec` and `read_file`
+    pub base: PathBuf,
+}
+
+impl EditRequest {
+    /// short operation label for status tables and dry-run output
+    pub fn describe_op(&self) -> String {
+        match &self.op {
+            EditOp::Block { id, .. } => format!("block:{id}"),
+            EditOp::Line { line } => format!("line:{line}"),
+        }
+    }
+}
+
+/// Aggregate `[[system.edits]]` across all loaded config files. Entries
+/// union global -> local, keyed by `(path, id)` for blocks and
+/// `(path, line)` for lines; a more local config overrides a block with the
+/// same id. Malformed entries warn and are skipped.
+pub fn edits_from_config(config: &Config) -> Vec<EditRequest> {
+    let mut merged: IndexMap<String, EditRequest> = IndexMap::new();
+    // config_files is ordered local -> global; reverse for global -> local
+    for (cf_path, cf) in config.config_files.iter().rev() {
+        let Some(sys) = cf.system_config() else {
+            continue;
+        };
+        let base = cf_path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        for entry in sys.edits {
+            match resolve_entry(entry, &base) {
+                Ok((key, req)) => {
+                    merged.insert(key, req);
+                }
+                Err(err) => warn!("[[system.edits]]: {err}"),
+            }
+        }
+    }
+    merged.into_values().collect()
+}
+
+fn resolve_entry(entry: EditTomlEntry, base: &Path) -> Result<(String, EditRequest)> {
+    let path_raw = entry.path.clone();
+    let path = file::replace_path(&path_raw);
+    if path.is_relative() {
+        bail!("path \"{path_raw}\" must be absolute or start with ~/, ignoring entry");
+    }
+    let is_block = entry.block.is_some() || entry.source.is_some();
+    let (key, op) = match (&is_block, &entry.line) {
+        (true, Some(_)) => {
+            bail!("\"{path_raw}\": block/source and line are mutually exclusive, ignoring entry")
+        }
+        (false, None) => {
+            bail!(
+                "\"{path_raw}\": no recognized operation (block, source, or line), ignoring entry"
+            )
+        }
+        (true, None) => {
+            let source = match (entry.block, entry.source) {
+                (Some(_), Some(_)) => {
+                    bail!("\"{path_raw}\": block and source are mutually exclusive, ignoring entry")
+                }
+                (Some(inline), None) => BlockSource::Inline(inline),
+                (None, Some(src)) => {
+                    let src = file::replace_path(&src);
+                    BlockSource::File(if src.is_relative() {
+                        base.join(src)
+                    } else {
+                        src
+                    })
+                }
+                (None, None) => unreachable!("is_block"),
+            };
+            let id = entry.id.unwrap_or_else(|| "mise".to_string());
+            let comment = entry
+                .comment
+                .unwrap_or_else(|| infer_comment(&path).to_string());
+            (
+                format!("{path_raw}\u{0}block:{id}"),
+                EditOp::Block {
+                    id,
+                    source,
+                    template: entry.template.unwrap_or(false),
+                    comment,
+                },
+            )
+        }
+        (false, Some(line)) => (
+            format!("{path_raw}\u{0}line:{line}"),
+            EditOp::Line { line: line.clone() },
+        ),
+    };
+    Ok((
+        key,
+        EditRequest {
+            path_raw,
+            path,
+            op,
+            base: base.to_path_buf(),
+        },
+    ))
+}
+
+/// comment prefix for marker lines, by file extension; `#` covers most
+/// config and shell files (and extensionless files like `.zshrc`, `hosts`)
+fn infer_comment(path: &Path) -> &'static str {
+    match path.extension().and_then(|e| e.to_str()).unwrap_or("") {
+        "lua" => "--",
+        "vim" | "vimrc" => "\"",
+        "el" | "lisp" | "scm" => ";;",
+        "ini" | "reg" => ";",
+        "c" | "h" | "cpp" | "hpp" | "cc" | "js" | "ts" | "jsx" | "tsx" | "rs" | "go" | "java"
+        | "kt" | "swift" | "cs" | "scala" | "php" | "zig" => "//",
+        _ => "#",
+    }
+}
+
+fn begin_marker(comment: &str, id: &str) -> String {
+    format!("{comment} >>> mise:{id} >>> managed by mise — do not edit between markers")
+}
+
+fn end_marker(comment: &str, id: &str) -> String {
+    format!("{comment} <<< mise:{id} <<<")
+}
+
+/// locate an id's marker pair in the file's lines: Ok(None) = no markers,
+/// Ok(Some((begin, end))) = line indexes, Err = corrupted markers
+fn find_block(lines: &[&str], id: &str) -> std::result::Result<Option<(usize, usize)>, String> {
+    let begin_pat = format!(">>> mise:{id} >>>");
+    let end_pat = format!("<<< mise:{id} <<<");
+    let begins: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.contains(&begin_pat))
+        .map(|(i, _)| i)
+        .collect();
+    let ends: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.contains(&end_pat))
+        .map(|(i, _)| i)
+        .collect();
+    match (begins.as_slice(), ends.as_slice()) {
+        ([], []) => Ok(None),
+        ([b], [e]) if b < e => Ok(Some((*b, *e))),
+        ([_], [_]) => Err("end marker appears before begin marker".into()),
+        ([], _) => Err("end marker without begin marker".into()),
+        (_, []) => Err("begin marker without end marker".into()),
+        _ => Err("duplicate markers".into()),
+    }
+}
+
+/// the content a block should contain, resolved and rendered at most once
+/// per check/apply cycle (templates may use exec())
+fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>> {
+    let EditOp::Block {
+        source, template, ..
+    } = &req.op
+    else {
+        return Ok(None);
+    };
+    let raw = match source {
+        BlockSource::Inline(s) => s.clone(),
+        BlockSource::File(p) => file::read_to_string(p)?,
+    };
+    let content = if *template {
+        let mut tera = crate::tera::get_tera(Some(&req.base));
+        tera.render_str(&raw, &config.tera_ctx).map_err(|err| {
+            eyre::eyre!(
+                "[[system.edits]] \"{}\": failed to render template: {err}",
+                req.path_raw
+            )
+        })?
+    } else {
+        raw
+    };
+    Ok(Some(content.trim_end_matches('\n').to_string()))
+}
+
+/// Current state of one edit on this machine.
+pub fn check(config: &Config, req: &EditRequest) -> Result<FileState> {
+    if let EditOp::Block {
+        source: BlockSource::File(p),
+        ..
+    } = &req.op
+        && !p.exists()
+    {
+        return Ok(FileState::SourceMissing);
+    }
+    let desired = desired_content(config, req)?;
+    check_resolved(req, desired.as_deref())
+}
+
+/// [`check`] with block content already resolved, so callers that go on to
+/// write the file resolve and render only once
+fn check_resolved(req: &EditRequest, desired: Option<&str>) -> Result<FileState> {
+    // edits write through symlinks into whatever they point at (often a
+    // [system.files] source) — surface that instead of silently doing it
+    if req.path.is_symlink() {
+        return Ok(FileState::Differs(
+            "target is a symlink; edit the real file instead".into(),
+        ));
+    }
+    if !req.path.exists() {
+        return Ok(FileState::Missing);
+    }
+    let text = file::read_to_string(&req.path)?;
+    let lines: Vec<&str> = text.lines().collect();
+    match &req.op {
+        EditOp::Block { id, .. } => match find_block(&lines, id) {
+            Err(reason) => Ok(FileState::Differs(reason)),
+            Ok(None) => Ok(FileState::Missing),
+            Ok(Some((begin, end))) => {
+                let current = lines[begin + 1..end].join("\n");
+                if current == desired.expect("resolved block content") {
+                    Ok(FileState::Applied)
+                } else {
+                    Ok(FileState::Differs("block content differs".into()))
+                }
+            }
+        },
+        EditOp::Line { line } => {
+            if lines.contains(&line.as_str()) {
+                Ok(FileState::Applied)
+            } else {
+                Ok(FileState::Missing)
+            }
+        }
+    }
+}
+
+pub struct ApplyOpts {
+    pub dry_run: bool,
+    pub yes: bool,
+}
+
+/// Apply all edits that aren't already in the desired state. Edits never
+/// replace files, so there is no --force here — but corrupted markers and
+/// symlink targets are reported as errors rather than guessed at.
+pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Result<()> {
+    let mut todo: Vec<(&EditRequest, Option<String>)> = vec![];
+    let mut problems = vec![];
+    for req in requests {
+        if let EditOp::Block {
+            source: BlockSource::File(p),
+            ..
+        } = &req.op
+            && !p.exists()
+        {
+            problems.push(format!(
+                "  \"{}\" ({}): source does not exist: {}",
+                req.path_raw,
+                req.describe_op(),
+                p.display_user()
+            ));
+            continue;
+        }
+        let desired = desired_content(config, req)?;
+        match check_resolved(req, desired.as_deref())? {
+            FileState::Applied => continue,
+            FileState::Differs(reason)
+                if reason.contains("marker") || reason.contains("symlink") =>
+            {
+                problems.push(format!(
+                    "  \"{}\" ({}): {reason}",
+                    req.path_raw,
+                    req.describe_op()
+                ));
+                continue;
+            }
+            _ => todo.push((req, desired)),
+        }
+    }
+    if !problems.is_empty() {
+        bail!(
+            "edits: cannot apply these entries, fix them manually:\n{}",
+            problems.join("\n")
+        );
+    }
+    if todo.is_empty() {
+        info!("edits: all edits are applied");
+        return Ok(());
+    }
+    if opts.dry_run {
+        for (req, _) in &todo {
+            miseprintln!("edit {} ({})", req.path.display_user(), req.describe_op());
+        }
+        return Ok(());
+    }
+    if !opts.yes && console::user_attended_stderr() {
+        let list = todo
+            .iter()
+            .map(|(r, _)| format!("{} ({})", r.path_raw, r.describe_op()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        if !prompt::confirm(format!("edits: apply {list}?"))? {
+            info!("edits: skipped");
+            return Ok(());
+        }
+    }
+    for (req, desired) in &todo {
+        apply_one(req, desired.as_deref())?;
+    }
+    info!(
+        "edits: applied {}",
+        todo.iter()
+            .map(|(r, _)| format!("{} ({})", r.path_raw, r.describe_op()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    Ok(())
+}
+
+fn apply_one(req: &EditRequest, desired: Option<&str>) -> Result<()> {
+    debug!("edits: {} ({})", req.path.display_user(), req.describe_op());
+    if let Some(parent) = req.path.parent() {
+        file::create_dir_all(parent)?;
+    }
+    let text = if req.path.exists() {
+        file::read_to_string(&req.path)?
+    } else {
+        String::new()
+    };
+    let mut lines: Vec<String> = text.lines().map(|l| l.to_string()).collect();
+    match &req.op {
+        EditOp::Block { id, comment, .. } => {
+            let desired = desired.expect("resolved block content");
+            let mut block = vec![begin_marker(comment, id)];
+            // a desired of "" means an empty block, not a blank line
+            if !desired.is_empty() {
+                block.extend(desired.lines().map(|l| l.to_string()));
+            }
+            block.push(end_marker(comment, id));
+            match find_block(&lines.iter().map(|l| l.as_str()).collect::<Vec<_>>(), id) {
+                // markers are rewritten too, so a changed comment style or
+                // marker wording converges on reapply
+                Ok(Some((begin, end))) => {
+                    lines.splice(begin..=end, block);
+                }
+                Ok(None) => lines.extend(block),
+                Err(reason) => bail!(
+                    "edits: \"{}\": {reason}, fix the file manually",
+                    req.path_raw
+                ),
+            }
+        }
+        EditOp::Line { line } => lines.push(line.clone()),
+    }
+    let mut out = lines.join("\n");
+    out.push('\n');
+    // file::write truncates in place, preserving the file's permissions
+    file::write(&req.path, &out)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_infer_comment() {
+        assert_eq!(infer_comment(Path::new("/a/.zshrc")), "#");
+        assert_eq!(infer_comment(Path::new("/etc/hosts")), "#");
+        assert_eq!(infer_comment(Path::new("/a/init.lua")), "--");
+        assert_eq!(infer_comment(Path::new("/a/foo.rs")), "//");
+        assert_eq!(infer_comment(Path::new("/a/foo.ini")), ";");
+    }
+
+    #[test]
+    fn test_find_block() {
+        let lines = vec![
+            "before",
+            "# >>> mise:a >>> managed by mise",
+            "content",
+            "# <<< mise:a <<<",
+            "after",
+        ];
+        assert_eq!(find_block(&lines, "a"), Ok(Some((1, 3))));
+        assert_eq!(find_block(&lines, "b"), Ok(None));
+        // ids are delimited — "a" must not match "ab"
+        let lines = vec!["# >>> mise:ab >>>", "# <<< mise:ab <<<"];
+        assert_eq!(find_block(&lines, "a"), Ok(None));
+        let lines = vec!["# >>> mise:a >>>"];
+        assert!(find_block(&lines, "a").is_err());
+        let lines = vec!["# <<< mise:a <<<", "# >>> mise:a >>>"];
+        assert!(find_block(&lines, "a").is_err());
+    }
+}

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -595,7 +595,14 @@ fn apply_one(req: &EditRequest, desired: Option<&str>) -> Result<()> {
                 ),
             }
         }
-        EditOp::Line { line } => lines.push(line.clone()),
+        EditOp::Line { line } => {
+            // an earlier entry in the same batch may have just written an
+            // identical line (two ids, same text) — stay idempotent against
+            // the file's current content, not the state at plan time
+            if !lines.iter().any(|l| l == line) {
+                lines.push(line.clone());
+            }
+        }
     }
     let mut out = lines.join("\n");
     out.push('\n');

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -170,7 +170,7 @@ fn resolve_entry(entry: EditTomlEntry, base: &Path) -> Result<(String, EditReque
                 .comment
                 .unwrap_or_else(|| infer_comment(&path).to_string());
             (
-                format!("{path_raw}\u{0}block:{id}"),
+                format!("{}\u{0}block:{id}", path.display()),
                 EditOp::Block {
                     id,
                     source,
@@ -180,7 +180,7 @@ fn resolve_entry(entry: EditTomlEntry, base: &Path) -> Result<(String, EditReque
             )
         }
         (false, Some(line)) => (
-            format!("{path_raw}\u{0}line:{line}"),
+            format!("{}\u{0}line:{line}", path.display()),
             EditOp::Line { line: line.clone() },
         ),
     };
@@ -218,15 +218,17 @@ fn end_marker(comment: &str, id: &str) -> String {
 }
 
 /// a line is a marker only when the pattern sits at the start of the line,
-/// preceded by at most a short comment token (`# `, `// `, `-- `, `<!-- `) —
-/// content that merely *mentions* a marker (`echo ">>> mise:x >>>"`, docs)
-/// must not count as one
-fn is_marker_line(line: &str, pat: &str) -> bool {
+/// preceded by either the configured comment token or at most a short
+/// generic one (`# `, `// `, `-- `, `<!-- `) — content that merely
+/// *mentions* a marker (`echo ">>> mise:x >>>"`, docs) must not count as one
+fn is_marker_line(line: &str, pat: &str, comment: &str) -> bool {
     let trimmed = line.trim_start();
     match trimmed.find(pat) {
         Some(idx) => {
-            let prefix = &trimmed[..idx];
-            prefix.len() <= 8 && !prefix.chars().any(|c| c.is_alphanumeric())
+            let prefix = trimmed[..idx].trim();
+            // the configured comment always counts, however exotic (`REM`),
+            // so markers we write are always markers we can find again
+            prefix == comment || (prefix.len() <= 8 && !prefix.chars().any(|c| c.is_alphanumeric()))
         }
         None => false,
     }
@@ -234,19 +236,23 @@ fn is_marker_line(line: &str, pat: &str) -> bool {
 
 /// locate an id's marker pair in the file's lines: Ok(None) = no markers,
 /// Ok(Some((begin, end))) = line indexes, Err = corrupted markers
-fn find_block(lines: &[&str], id: &str) -> std::result::Result<Option<(usize, usize)>, String> {
+fn find_block(
+    lines: &[&str],
+    id: &str,
+    comment: &str,
+) -> std::result::Result<Option<(usize, usize)>, String> {
     let begin_pat = format!(">>> mise:{id} >>>");
     let end_pat = format!("<<< mise:{id} <<<");
     let begins: Vec<usize> = lines
         .iter()
         .enumerate()
-        .filter(|(_, l)| is_marker_line(l, &begin_pat))
+        .filter(|(_, l)| is_marker_line(l, &begin_pat, comment))
         .map(|(i, _)| i)
         .collect();
     let ends: Vec<usize> = lines
         .iter()
         .enumerate()
-        .filter(|(_, l)| is_marker_line(l, &end_pat))
+        .filter(|(_, l)| is_marker_line(l, &end_pat, comment))
         .map(|(i, _)| i)
         .collect();
     match (begins.as_slice(), ends.as_slice()) {
@@ -266,7 +272,7 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
         id,
         source,
         template,
-        ..
+        comment,
     } = &req.op
     else {
         return Ok(None);
@@ -290,7 +296,7 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
     // a block containing its own marker lines would write a file that can't
     // be parsed back — refuse up front instead of corrupting on reapply
     for pat in [format!(">>> mise:{id} >>>"), format!("<<< mise:{id} <<<")] {
-        if content.lines().any(|l| is_marker_line(l, &pat)) {
+        if content.lines().any(|l| is_marker_line(l, &pat, comment)) {
             bail!(
                 "[[system.edits]] \"{}\": block content may not contain its own marker lines",
                 req.path_raw
@@ -317,45 +323,56 @@ pub fn check(config: &Config, req: &EditRequest) -> Result<FileState> {
         return Ok(FileState::SourceMissing);
     }
     let desired = desired_content(config, req)?;
-    check_resolved(req, desired.as_deref())
+    Ok(match check_resolved(req, desired.as_deref())? {
+        EditCheck::State(state) => state,
+        EditCheck::Blocked(reason) => FileState::Differs(reason),
+    })
+}
+
+const SYMLINK_REASON: &str = "target is a symlink; edit the real file instead";
+
+/// outcome of inspecting one edit: an ordinary state, or a condition mise
+/// refuses to apply automatically (corrupted markers, symlink target)
+enum EditCheck {
+    State(FileState),
+    Blocked(String),
 }
 
 /// [`check`] with block content already resolved, so callers that go on to
 /// write the file resolve and render only once
-fn check_resolved(req: &EditRequest, desired: Option<&str>) -> Result<FileState> {
+fn check_resolved(req: &EditRequest, desired: Option<&str>) -> Result<EditCheck> {
     // edits write through symlinks into whatever they point at (often a
     // [system.files] source) — surface that instead of silently doing it
     if req.path.is_symlink() {
-        return Ok(FileState::Differs(
-            "target is a symlink; edit the real file instead".into(),
-        ));
+        return Ok(EditCheck::Blocked(SYMLINK_REASON.into()));
     }
     if !req.path.exists() {
-        return Ok(FileState::Missing);
+        return Ok(EditCheck::State(FileState::Missing));
     }
     let text = file::read_to_string(&req.path)?;
     let lines: Vec<&str> = text.lines().collect();
-    match &req.op {
-        EditOp::Block { id, .. } => match find_block(&lines, id) {
-            Err(reason) => Ok(FileState::Differs(reason)),
-            Ok(None) => Ok(FileState::Missing),
+    let state = match &req.op {
+        EditOp::Block { id, comment, .. } => match find_block(&lines, id, comment) {
+            Err(reason) => return Ok(EditCheck::Blocked(reason)),
+            Ok(None) => FileState::Missing,
             Ok(Some((begin, end))) => {
                 let current = lines[begin + 1..end].join("\n");
                 if current == desired.expect("resolved block content") {
-                    Ok(FileState::Applied)
+                    FileState::Applied
                 } else {
-                    Ok(FileState::Differs("block content differs".into()))
+                    FileState::Differs("block content differs".into())
                 }
             }
         },
         EditOp::Line { line } => {
             if lines.contains(&line.as_str()) {
-                Ok(FileState::Applied)
+                FileState::Applied
             } else {
-                Ok(FileState::Missing)
+                FileState::Missing
             }
         }
-    }
+    };
+    Ok(EditCheck::State(state))
 }
 
 pub struct ApplyOpts {
@@ -391,7 +408,7 @@ pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Res
         if opts.dry_run && is_template {
             if req.path.is_symlink() {
                 problems.push(format!(
-                    "  \"{}\" ({}): target is a symlink; edit the real file instead",
+                    "  \"{}\" ({}): {SYMLINK_REASON}",
                     req.path_raw,
                     req.describe_op()
                 ));
@@ -402,10 +419,8 @@ pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Res
         }
         let desired = desired_content(config, req)?;
         match check_resolved(req, desired.as_deref())? {
-            FileState::Applied => continue,
-            FileState::Differs(reason)
-                if reason.contains("marker") || reason.contains("symlink") =>
-            {
+            EditCheck::State(FileState::Applied) => continue,
+            EditCheck::Blocked(reason) => {
                 problems.push(format!(
                     "  \"{}\" ({}): {reason}",
                     req.path_raw,
@@ -413,7 +428,7 @@ pub fn apply(config: &Config, requests: &[EditRequest], opts: &ApplyOpts) -> Res
                 ));
                 continue;
             }
-            _ => todo.push((req, desired)),
+            EditCheck::State(_) => todo.push((req, desired)),
         }
     }
     if !problems.is_empty() {
@@ -485,7 +500,11 @@ fn apply_one(req: &EditRequest, desired: Option<&str>) -> Result<()> {
                 block.extend(desired.lines().map(|l| l.to_string()));
             }
             block.push(end_marker(comment, id));
-            match find_block(&lines.iter().map(|l| l.as_str()).collect::<Vec<_>>(), id) {
+            match find_block(
+                &lines.iter().map(|l| l.as_str()).collect::<Vec<_>>(),
+                id,
+                comment,
+            ) {
                 // markers are rewritten too, so a changed comment style or
                 // marker wording converges on reapply
                 Ok(Some((begin, end))) => {
@@ -529,26 +548,31 @@ mod tests {
             "# <<< mise:a <<<",
             "after",
         ];
-        assert_eq!(find_block(&lines, "a"), Ok(Some((1, 3))));
-        assert_eq!(find_block(&lines, "b"), Ok(None));
+        assert_eq!(find_block(&lines, "a", "#"), Ok(Some((1, 3))));
+        assert_eq!(find_block(&lines, "b", "#"), Ok(None));
         // ids are delimited — "a" must not match "ab"
         let lines = vec!["# >>> mise:ab >>>", "# <<< mise:ab <<<"];
-        assert_eq!(find_block(&lines, "a"), Ok(None));
+        assert_eq!(find_block(&lines, "a", "#"), Ok(None));
         // content that mentions a marker mid-line is not a marker
         let lines = vec![
             "# >>> mise:a >>>",
             r#"echo "keep the >>> mise:a >>> line intact""#,
             "# <<< mise:a <<<",
         ];
-        assert_eq!(find_block(&lines, "a"), Ok(Some((0, 2))));
+        assert_eq!(find_block(&lines, "a", "#"), Ok(Some((0, 2))));
         // ...but indented comment markers still count
         let lines = vec!["  # >>> mise:a >>>", "  # <<< mise:a <<<"];
-        assert_eq!(find_block(&lines, "a"), Ok(Some((0, 1))));
+        assert_eq!(find_block(&lines, "a", "#"), Ok(Some((0, 1))));
         let lines = vec!["<!-- >>> mise:a >>>", "<!-- <<< mise:a <<<"];
-        assert_eq!(find_block(&lines, "a"), Ok(Some((0, 1))));
+        assert_eq!(find_block(&lines, "a", "#"), Ok(Some((0, 1))));
         let lines = vec!["# >>> mise:a >>>"];
-        assert!(find_block(&lines, "a").is_err());
+        assert!(find_block(&lines, "a", "#").is_err());
         let lines = vec!["# <<< mise:a <<<", "# >>> mise:a >>>"];
-        assert!(find_block(&lines, "a").is_err());
+        assert!(find_block(&lines, "a", "#").is_err());
+        // an exotic configured comment token (alphanumeric, like batch REM)
+        // is always recognized, so written markers can be found again
+        let lines = vec!["REM >>> mise:a >>>", "REM <<< mise:a <<<"];
+        assert_eq!(find_block(&lines, "a", "REM"), Ok(Some((0, 1))));
+        assert_eq!(find_block(&lines, "a", "#"), Ok(None));
     }
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -42,9 +42,10 @@ pub struct SystemTomlConfig {
     /// target path -> source (see [`files`])
     #[serde(default)]
     pub files: IndexMap<String, files::FileTomlEntry>,
-    /// edits to files mise doesn't own (see [`edits`])
+    /// edits to files mise doesn't own, keyed by target path then edit id
+    /// (see [`edits`])
     #[serde(default)]
-    pub edits: Vec<edits::EditTomlEntry>,
+    pub edits: IndexMap<String, IndexMap<String, edits::EditTomlEntry>>,
 }
 
 /// Packages for one manager, aggregated across the config hierarchy

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -20,6 +20,7 @@ use crate::system::defaults::{DefaultsRequest, DefaultsValue};
 use crate::system::packages::{PackageRequest, SystemPackageManager};
 
 pub mod defaults;
+pub mod edits;
 pub mod files;
 pub mod packages;
 pub(crate) mod sudo;
@@ -41,6 +42,9 @@ pub struct SystemTomlConfig {
     /// target path -> source (see [`files`])
     #[serde(default)]
     pub files: IndexMap<String, files::FileTomlEntry>,
+    /// edits to files mise doesn't own (see [`edits`])
+    #[serde(default)]
+    pub edits: Vec<edits::EditTomlEntry>,
 }
 
 /// Packages for one manager, aggregated across the config hierarchy

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -3236,12 +3236,12 @@ const completionSpec: Fig.Spec = {
     {
       name: "system",
       description:
-        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, edits from `[[system.edits]]`, and macOS defaults\nfrom `[system.defaults]`",
+        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, edits from `[system.edits]`, and macOS defaults\nfrom `[system.defaults]`",
       subcommands: [
         {
           name: ["install", "i"],
           description:
-            "Install missing system packages from `[system.packages]`, apply files\nfrom `[system.files]` and edits from `[[system.edits]]`, and write macOS\ndefaults from `[system.defaults]`",
+            "Install missing system packages from `[system.packages]`, apply files\nfrom `[system.files]` and edits from `[system.edits]`, and write macOS\ndefaults from `[system.defaults]`",
           options: [
             {
               name: ["-f", "--force"],
@@ -3288,7 +3288,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["status", "ls"],
           description:
-            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, edits from `[[system.edits]]`, and macOS defaults from\n`[system.defaults]`",
+            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, edits from `[system.edits]`, and macOS defaults from\n`[system.defaults]`",
           options: [
             {
               name: ["-J", "--json"],

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -3236,12 +3236,12 @@ const completionSpec: Fig.Spec = {
     {
       name: "system",
       description:
-        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, and macOS defaults from `[system.defaults]`",
+        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, and edits from `[[system.edits]]`",
       subcommands: [
         {
           name: ["install", "i"],
           description:
-            "Install missing system packages from `[system.packages]`, apply files\nfrom `[system.files]`, and write macOS defaults from `[system.defaults]`",
+            "Install missing system packages from `[system.packages]` and apply files\nfrom `[system.files]` and edits from `[[system.edits]]`",
           options: [
             {
               name: ["-f", "--force"],
@@ -3288,7 +3288,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["status", "ls"],
           description:
-            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, and macOS defaults from `[system.defaults]`",
+            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, and edits from `[[system.edits]]`",
           options: [
             {
               name: ["-J", "--json"],
@@ -3298,7 +3298,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--missing",
               description:
-                "Exit with code 1 if any configured packages, files, or defaults are\nnot in their desired state (missing, version mismatch, differs)",
+                "Exit with code 1 if any configured packages or files are not in their\ndesired state (missing, version mismatch, differs)",
               isRepeatable: false,
             },
           ],

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -3236,12 +3236,12 @@ const completionSpec: Fig.Spec = {
     {
       name: "system",
       description:
-        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, and edits from `[[system.edits]]`",
+        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, edits from `[[system.edits]]`, and macOS defaults\nfrom `[system.defaults]`",
       subcommands: [
         {
           name: ["install", "i"],
           description:
-            "Install missing system packages from `[system.packages]` and apply files\nfrom `[system.files]` and edits from `[[system.edits]]`",
+            "Install missing system packages from `[system.packages]`, apply files\nfrom `[system.files]` and edits from `[[system.edits]]`, and write macOS\ndefaults from `[system.defaults]`",
           options: [
             {
               name: ["-f", "--force"],
@@ -3288,7 +3288,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["status", "ls"],
           description:
-            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, and edits from `[[system.edits]]`",
+            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, edits from `[[system.edits]]`, and macOS defaults from\n`[system.defaults]`",
           options: [
             {
               name: ["-J", "--json"],
@@ -3298,7 +3298,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--missing",
               description:
-                "Exit with code 1 if any configured packages or files are not in their\ndesired state (missing, version mismatch, differs)",
+                "Exit with code 1 if any configured packages, files, or defaults are\nnot in their desired state (missing, version mismatch, differs)",
               isRepeatable: false,
             },
           ],


### PR DESCRIPTION
Experimental, like the rest of `[system]`.

## `[system.edits]`

Where `[system.files]` manages whole files, an edit owns **one small piece of a file something else owns** — the `mise activate` line in a shell rc, an entry in `/etc/hosts`. Entries are keyed by target path (matching `[system.files]`), then by an id naming each edit within the file:

```toml
[system.edits]
"~/.zshrc" = {
  activate = 'eval "$(mise activate zsh)"',  # string = inline block content
  aliases = '''
alias ll='ls -l'
alias la='ls -la'
''',
}
"/etc/hosts".dev = { line = "127.0.0.1 dev.local" }
```

### Blocks

Delimited by marker comments in the target file, named by the entry's id:

```sh
# >>> mise:activate >>> managed by mise — do not edit between markers
eval "$(mise activate zsh)"
# <<< mise:activate <<<
```

The markers **are** the ownership record, stored in the file itself, so the design stays stateless like the rest of `[system]`: apply replaces only what's between them (or appends the block if absent); status (`applied`/`missing`/`differs`) falls out trivially. Content can be inline (string shorthand, with TOML multiline strings for larger blocks), from a file (`source`, relative to the declaring config), or rendered through the template engine (`template = "tera"` — a string naming the engine for future use; `env`, `vars`, `exec()`). The comment prefix is inferred from the file extension (`#`, `--`, `//`, `;`, `"`) and overridable with `comment`; ids are restricted to marker-safe characters.

### Lines

`line` ensures an exact line exists, appending it at the end if absent. It never modifies or removes other lines — that's what makes it safely idempotent. The id is a label and the merge identity; it isn't written to the file. (A `match`-regex replace mode was considered and deliberately left out of v1.)

### Semantics

- Merge across the config hierarchy as a union keyed by `(path, id)` — structural, exactly like `[system.files]` overrides by target; a local config can override a global edit by id
- Applied only by `mise system install` / `mise bootstrap` (after packages and files, before defaults), never implicitly; `mise system status` gains an edits table, JSON output, and `--missing` coverage
- Render-free outcomes (symlink targets, marker integrity, line presence) are decided before templates render, so blocked entries never execute `exec()`; `--dry-run` never renders templates at all and lists them as `(if changed)`, matching the `[system.files]` policy
- No `--force` interaction: edits never replace files. Corrupted markers and symlink targets (which edits would write through) are refused with errors; all problems across entries are reported in one pass
- Removing an entry leaves its block/line behind (no state database); markers carry provenance — documented tradeoff
- No sudo: edits write as the current user
- Unrecognized entries warn and are skipped, like unknown package managers and file modes

## Docs

- New `/system-edits` page; top-level **System (experimental)** sidebar section (System Packages, System Files *(dotfiles)*, System Edits, macOS Defaults, `mise bootstrap`); machine-bootstrapping section in tips & tricks

## Tests

- `e2e/cli/test_system_edits`: multiline-inline-table parsing, two blocks per file, line append preserving existing content, comment inference, template rendering + exec dry-run probe, idempotency, block replacement preserving surrounding content, corrupted-marker and symlink refusal, source-file blocks + missing sources, one-pass error aggregation, invalid entries and id validation
- Unit tests for marker parsing (id delimiting, mention-in-content, exotic comment tokens) and comment inference

*This PR was generated by an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental "System Edits" to declaratively manage marker-delimited blocks or single-line edits; supported by schema and integrated into install/bootstrap flows and status reporting.

* **Documentation**
  * Reorganized sidebar under “System (experimental)”; added System Edits docs and updated CLI help, man page, usage text, tips, and minor formatting tweaks.

* **Tests**
  * Added e2e tests validating edits, templates, idempotency, reporting, and failure cases.

* **CLI / UX**
  * Status output and help now show edits; bootstrap/install flows and completions mention edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write directly to user config paths and template evaluation on status/install can run `exec()` from config; mitigated by experimental flag, explicit install/bootstrap only, and hard errors for symlinks and bad markers.
> 
> **Overview**
> Introduces experimental **`[system.edits]`** so mise can manage **one piece** of a file it does not own (e.g. `mise activate` in `~/.zshrc`, a hosts entry), complementing whole-file **`[system.files]`**.
> 
> Config is keyed by **target path** then **edit id**. **Blocks** use `>>> mise:<id> >>>` / `<<< mise:<id> <<<` markers (inline string, `source`, optional `template = "tera"`). **Lines** append an exact line if missing. Entries merge on `(path, id)`; invalid or unknown shapes warn and skip.
> 
> **`mise system install`** and **`mise bootstrap`** apply edits after packages and files (before defaults on bootstrap); package-only installs still skip edits. **`mise system status`** adds an edits table, JSON `edits`, and `--missing` coverage. Apply refuses corrupted markers and symlink targets; `--dry-run` does not render templates (listed as `(if changed)`), while status/install may render tera including `exec()` like other trusted templates.
> 
> Docs add **`/system-edits`**, regroup the sidebar under **System (experimental)**, update CLI/man/usage/schema/completions, cross-link from system files and tips. E2e tests cover bootstrap + a broad `test_system_edits` suite; unit tests cover marker parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebd569d80707b466c3b821bda6dd9fcca1713287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

