### PR TITLE
docs: link to all sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://37signals.com">37signals</a>.
+  Sponsored by <a href="https://37signals.com">37signals</a>.<br>
+  <a href="https://en.dev/sponsors.html">View all sponsors</a>.
 </p>
 
 <hr />


### PR DESCRIPTION
## Summary
- add a README link to the full en.dev sponsors page

## Tests
- not run (README-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation change with no runtime or security impact.
> 
> **Overview**
> The README **sponsors** blurb now breaks onto a second line and adds a **View all sponsors** link to `https://en.dev/sponsors.html`, alongside the existing 37signals callout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5757590b19bc4b4cd52b8785ecf05e7bac95bbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the sponsor attribution section to include a link for viewing all available sponsors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->