### PR TITLE
docs: add more tips and tricks entries

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -58,6 +58,22 @@ calling `curl https://mise.run` dynamically—though of course this means it wil
 the version of mise that was current when the script was created.
 :::
 
+## Project-local task entrypoints
+
+If you want contributors to run project tasks without installing mise first, pair
+[`mise generate bootstrap`](/cli/generate/bootstrap.html) with
+[`mise generate task-stubs`](/cli/generate/task-stubs.html):
+
+```sh
+mkdir -p bin
+mise generate bootstrap --localize --write bin/mise
+mise generate task-stubs --mise-bin ./bin/mise
+./bin/test
+```
+
+The generated task stubs behave like small project commands, while `bin/mise`
+downloads and runs the pinned mise binary for the project.
+
 ## Installation via zsh zinit
 
 [Zinit](https://github.com/zdharma-continuum/zinit) is a plugin manager for ZSH, which this snippet you will get mise (and usage for shell completion):
@@ -145,6 +161,77 @@ mise test
 ::: warning
 Don't do this inside of scripts because mise may add a command in a future version and could conflict with your task.
 :::
+
+## Watch tasks while editing
+
+[`mise watch`](/cli/watch.html) reruns tasks when files change. It uses
+`watchexec`, which you can install globally with mise:
+
+```sh
+mise use -g watchexec@latest
+mise watch test
+```
+
+Use `--restart` for long-running processes that should restart on changes:
+
+```sh
+mise watch --restart dev
+```
+
+## Share task catalogs
+
+For projects with a lot of tasks,
+[`task_config.includes`](/tasks/task-configuration.html#task-config-includes)
+can load task definitions from additional directories, `tasks.toml` files, or
+remote git repositories:
+
+```toml
+[task_config]
+includes = [
+  "mise-tasks",
+  "tasks.toml",
+  "git::https://github.com/myorg/shared-tasks.git//tasks?ref=v1.0.0",
+]
+```
+
+Included `tasks.toml` files use the same shape as the `[tasks]` table without
+the `[tasks.]` prefix.
+
+## Reuse task definitions with templates
+
+Experimental [task templates](/tasks/templates.html) let multiple tasks share
+common tools, environment variables, and command defaults:
+
+```toml
+[settings]
+experimental = true
+
+[task_templates."node:test"]
+tools = { node = "24", pnpm = "latest" }
+run = "pnpm test"
+
+[tasks.test]
+extends = "node:test"
+run = "pnpm test -- --watch=false"
+```
+
+This is especially useful in monorepos where each package needs similar build,
+test, or lint tasks with small local overrides.
+
+## Redact secrets from task output
+
+If a task may echo secrets in CI logs, add `redactions` to the task or config.
+The listed environment variables are replaced with `[redacted]` in task output:
+
+```toml
+redactions = ["API_KEY", "PASSWORD"]
+```
+
+Glob patterns are also supported:
+
+```toml
+redactions.env = ["SECRETS_*"]
+```
 
 ## Software verification
 


### PR DESCRIPTION
## Summary
- add tips for project-local task entrypoints with generated bootstrap/task stubs
- add short tips for `mise watch`, shared task catalogs, task templates, and task output redactions

## Conflict note
- This touches `docs/tips-and-tricks.md` near the bootstrap section, which may conflict with #10368. That PR adds a broader machine bootstrapping tip in the same area; this PR intentionally focuses on the other discoverability tips so the sections can be reconciled if #10368 lands first.

## Tests
- `mise run docs:build`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `docs/tips-and-tricks.md` with no runtime or security behavior changes.
> 
> **Overview**
> Expands **Tips & Tricks** with five new sections aimed at task discoverability and contributor workflows.
> 
> Adds guidance on **project-local task entrypoints** using `mise generate bootstrap` (with `--localize`) and `mise generate task-stubs` so `./bin/test`-style commands work without a global mise install. Documents **`mise watch`** for rerunning tasks on file changes, including global `watchexec` and `--restart` for long-running dev tasks.
> 
> Covers **`task_config.includes`** for loading tasks from local dirs, `tasks.toml`, or remote git repos; experimental **task templates** (`extends`) for shared tools/env/defaults in monorepos; and **`redactions`** (including `redactions.env` globs) to mask secrets in task output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684333d82f163c0746ca968d4f88a8ff53103538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded tips-and-tricks guide with new sections on project-local task entrypoints and example commands
  * Added guidance for watching tasks while editing, sharing task catalogs, reusing task definitions with templates, and redacting sensitive information from task output with glob pattern support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->