### PR TITLE
chore: graduate stable features from experimental

### DIFF
--- a/crates/mise-interactive-config/src/schema.rs
+++ b/crates/mise-interactive-config/src/schema.rs
@@ -152,11 +152,8 @@ mod tests {
     fn test_entry_types() {
         // redactions is an array
         assert_eq!(entry_type("redactions"), Some(SchemaType::Array));
-        // experimental_monorepo_root is a boolean
-        assert_eq!(
-            entry_type("experimental_monorepo_root"),
-            Some(SchemaType::Boolean)
-        );
+        // monorepo_root is a boolean
+        assert_eq!(entry_type("monorepo_root"), Some(SchemaType::Boolean));
     }
 
     #[test]

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -38,41 +38,41 @@ Number of jobs to run in parallel
 
 ### `--allow-env… <VAR>`
 
-[experimental] Allow specific env var through (implies --deny-env for everything else)
+Allow specific env var through (implies --deny-env for everything else)
 Supports wildcards, e.g. --allow-env='MYAPP_*'
 
 ### `--allow-net… <HOST>`
 
-[experimental] Allow network to specific host (implies --deny-net for everything else)
+Allow network to specific host (implies --deny-net for everything else)
 macOS only in v1; on Linux falls back to allowing all network
 
 ### `--allow-read… <PATH>`
 
-[experimental] Allow reads from specific path (implies --deny-read for everything else)
+Allow reads from specific path (implies --deny-read for everything else)
 
 ### `--allow-write… <PATH>`
 
-[experimental] Allow writes to specific path (implies --deny-write for everything else)
+Allow writes to specific path (implies --deny-write for everything else)
 
 ### `--deny-all`
 
-[experimental] Block reads, writes, network, and env vars
+Block reads, writes, network, and env vars
 
 ### `--deny-env`
 
-[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 
 ### `--deny-net`
 
-[experimental] Block all network access
+Block all network access
 
 ### `--deny-read`
 
-[experimental] Block filesystem reads (system libs and tool dirs still accessible)
+Block filesystem reads (system libs and tool dirs still accessible)
 
 ### `--deny-write`
 
-[experimental] Block all filesystem writes
+Block all filesystem writes
 
 ### `--fresh-env`
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -60,14 +60,14 @@ Connect backend install command stdin/stdout/stderr directly to the terminal Imp
 
 ### `--shared <SHARED>`
 
-[experimental] Install tool(s) to a shared directory
+Install tool(s) to a shared directory
 
 Installs to the specified directory instead of the default install location.
 May require elevated permissions depending on the path.
 
 ### `--system`
 
-[experimental] Install tool(s) to the system-wide shared directory
+Install tool(s) to the system-wide shared directory
 
 Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -4,7 +4,7 @@
 - **Usage**: `mise mcp`
 - **Source code**: [`src/cli/mcp.rs`](https://github.com/jdx/mise/blob/main/src/cli/mcp.rs)
 
-[experimental] Run Model Context Protocol (MCP) server
+Run Model Context Protocol (MCP) server
 
 This command starts an MCP server that exposes mise functionality
 to AI assistants over stdin/stdout using JSON-RPC protocol.
@@ -41,9 +41,7 @@ $ mise mcp
     "mise": {
       "command": "mise",
       "args": ["mcp"],
-      "env": {
-        "MISE_EXPERIMENTAL": "1"
-      }
+      "env": {}
     }
   }
 }

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -99,40 +99,40 @@ Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.
 
 ### `--allow-env… <VAR>`
 
-[experimental] Allow specific env var through (implies --deny-env for everything else)
+Allow specific env var through (implies --deny-env for everything else)
 Supports wildcards, e.g. --allow-env='MYAPP_*'
 
 ### `--allow-net… <HOST>`
 
-[experimental] Allow network to specific host (implies --deny-net for everything else)
+Allow network to specific host (implies --deny-net for everything else)
 
 ### `--allow-read… <PATH>`
 
-[experimental] Allow reads from specific path (implies --deny-read for everything else)
+Allow reads from specific path (implies --deny-read for everything else)
 
 ### `--allow-write… <PATH>`
 
-[experimental] Allow writes to specific path (implies --deny-write for everything else)
+Allow writes to specific path (implies --deny-write for everything else)
 
 ### `--deny-all`
 
-[experimental] Block reads, writes, network, and env vars
+Block reads, writes, network, and env vars
 
 ### `--deny-env`
 
-[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 
 ### `--deny-net`
 
-[experimental] Block all network access
+Block all network access
 
 ### `--deny-read`
 
-[experimental] Block filesystem reads (system libs and tool dirs still accessible)
+Block filesystem reads (system libs and tool dirs still accessible)
 
 ### `--deny-write`
 
-[experimental] Block all filesystem writes
+Block all filesystem writes
 
 ### `--fresh-env`
 

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -113,40 +113,40 @@ Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.
 
 ### `--allow-env… <VAR>`
 
-[experimental] Allow specific env var through (implies --deny-env for everything else)
+Allow specific env var through (implies --deny-env for everything else)
 Supports wildcards, e.g. --allow-env='MYAPP_*'
 
 ### `--allow-net… <HOST>`
 
-[experimental] Allow network to specific host (implies --deny-net for everything else)
+Allow network to specific host (implies --deny-net for everything else)
 
 ### `--allow-read… <PATH>`
 
-[experimental] Allow reads from specific path (implies --deny-read for everything else)
+Allow reads from specific path (implies --deny-read for everything else)
 
 ### `--allow-write… <PATH>`
 
-[experimental] Allow writes to specific path (implies --deny-write for everything else)
+Allow writes to specific path (implies --deny-write for everything else)
 
 ### `--deny-all`
 
-[experimental] Block reads, writes, network, and env vars
+Block reads, writes, network, and env vars
 
 ### `--deny-env`
 
-[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 
 ### `--deny-net`
 
-[experimental] Block all network access
+Block all network access
 
 ### `--deny-read`
 
-[experimental] Block filesystem reads (system libs and tool dirs still accessible)
+Block filesystem reads (system libs and tool dirs still accessible)
 
 ### `--deny-write`
 
-[experimental] Block all filesystem writes
+Block all filesystem writes
 
 ### `--fresh-env`
 

--- a/docs/cli/token/github.md
+++ b/docs/cli/token/github.md
@@ -18,7 +18,7 @@ GitHub hostname
 
 ### `--oauth`
 
-[experimental] Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources
+Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources
 
 ### `--raw`
 
@@ -26,7 +26,7 @@ Print only the token value
 
 ### `--refresh`
 
-[experimental] Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire
+Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire
 
 ### `--unmask`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,12 +279,12 @@ min_version = { hard = '2024.11.1', soft = '2024.9.0' }
 
 When a soft minimum is not met, mise will print a warning and (if available) show self-update instructions. When a hard minimum is not met, mise errors and shows self-update instructions.
 
-### Monorepo root <Badge type="warning" text="experimental" />
+### Monorepo root
 
-Mark a configuration file as a monorepo root to enable target path syntax for tasks. Requires `MISE_EXPERIMENTAL=1`.
+Mark a configuration file as a monorepo root to enable target path syntax for tasks.
 
 ```toml
-experimental_monorepo_root = true
+monorepo_root = true
 ```
 
 When enabled:

--- a/docs/core-tools.md
+++ b/docs/core-tools.md
@@ -17,5 +17,5 @@ You can see the core plugins with `mise registry -b core`.
 - [Python](/lang/python)
 - [Ruby](/lang/ruby)
 - [Rust](/lang/rust)
-- [Swift](/lang/swift) <Badge type="warning" text="experimental" />
+- [Swift](/lang/swift)
 - [Zig](/lang/zig)

--- a/docs/dev-tools/backends/index.md
+++ b/docs/dev-tools/backends/index.md
@@ -12,7 +12,7 @@ Below is a list of the available backends in mise:
 - [aqua](/dev-tools/backends/aqua)
 - [cargo](/dev-tools/backends/cargo)
 - [conda](/dev-tools/backends/conda)
-- [dotnet](/dev-tools/backends/dotnet) <Badge type="warning" text="experimental" />
+- [dotnet](/dev-tools/backends/dotnet)
 - [forgejo](/dev-tools/backends/forgejo)
 - [gem](/dev-tools/backends/gem)
 - [github](/dev-tools/backends/github)
@@ -21,8 +21,8 @@ Below is a list of the available backends in mise:
 - [http](/dev-tools/backends/http)
 - [npm](/dev-tools/backends/npm)
 - [pipx](/dev-tools/backends/pipx)
-- [s3](/dev-tools/backends/s3) <Badge type="warning" text="experimental" />
-- [spm](/dev-tools/backends/spm) <Badge type="warning" text="experimental" />
+- [s3](/dev-tools/backends/s3)
+- [spm](/dev-tools/backends/spm)
 - [ubi](/dev-tools/backends/ubi)
 - [vfox](/dev-tools/backends/vfox) (provide tools through [plugins](/plugins.html))
 - [custom backends](/backend-plugin-development) (build your own backend with a plugin which itself provides many tools)

--- a/docs/dev-tools/backends/s3.md
+++ b/docs/dev-tools/backends/s3.md
@@ -1,12 +1,8 @@
-# S3 Backend <Badge type="warning" text="experimental" />
+# S3 Backend
 
 You may install tools directly from Amazon S3 or S3-compatible storage (like MinIO) using the `s3` backend. This backend is ideal for enterprise teams hosting proprietary tools in private S3 buckets.
 
 The code for this is inside of the mise repository at [`./src/backend/s3.rs`](https://github.com/jdx/mise/blob/main/src/backend/s3.rs).
-
-::: warning
-The S3 backend is experimental and requires `experimental = true` in your mise settings.
-:::
 
 ## Usage
 

--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -1,4 +1,4 @@
-# SPM Backend <Badge type="warning" text="experimental" />
+# SPM Backend
 
 You may install executables managed by [Swift Package Manager](https://www.swift.org/documentation/package-manager) directly from GitHub or GitLab releases.
 

--- a/docs/dev-tools/github-tokens.md
+++ b/docs/dev-tools/github-tokens.md
@@ -144,20 +144,15 @@ Use `mise token github` to confirm mise can resolve the token:
 mise token github
 ```
 
-## Native GitHub OAuth <Badge type="warning" text="experimental" />
+## Native GitHub OAuth
 
 mise can create short-lived GitHub App user access tokens directly with GitHub's OAuth device flow. This does not require a personal access token, GitHub App private key, app client secret, `gh`, `ghtkn`, or any other external credential command.
 
 The design was inspired by [ghtkn](https://github.com/suzuki-shunsuke/ghtkn) — if you'd rather run a separate process and have mise pick up its token via `credential_command`, see [Using ghtkn](#using-ghtkn) above.
 
-::: warning
-This feature is experimental. Enable it with `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) before using it. Behavior, settings, and token cache format may change in future releases.
-:::
-
 Create a GitHub App with device flow enabled, then configure its client ID:
 
 ```sh
-mise settings set experimental=true
 mise settings set github.oauth_client_id=Iv1.yourgithubappclientid
 ```
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,4 +1,4 @@
-# Hooks <Badge type="warning" text="experimental" />
+# Hooks
 
 You can have mise automatically execute scripts during a `mise activate` session. You cannot use these
 without the `mise activate` shell hook installed in your shell—except the `preinstall` and `postinstall` hooks.

--- a/docs/lang/swift.md
+++ b/docs/lang/swift.md
@@ -1,4 +1,4 @@
-# Swift <Badge type="warning" text="experimental" />
+# Swift
 
 `mise` can be used to manage multiple versions of [`swift`](https://swift.org/) on the same system. Swift is supported for macos and linux.
 

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -1,10 +1,6 @@
-# Sandboxing <Badge type="warning" text="experimental" />
+# Sandboxing
 
 Mise supports lightweight process sandboxing for `mise exec` and `mise run`, inspired by [zerobox](https://github.com/afshinm/zerobox). Sandboxing restricts filesystem, network, and environment variable access with granular controls. No Docker required, minimal overhead.
-
-::: warning
-Sandboxing is an experimental feature. Enable it with `mise settings experimental=true`.
-:::
 
 ## Quick Start
 

--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -54,7 +54,7 @@ The following environment variables are passed to the task:
 - `MISE_ORIGINAL_CWD`: The original working directory from where the task was run.
 - `MISE_CONFIG_ROOT`: The directory containing the `mise.toml` file where the task was defined or if the config path is something like `~/src/myproj/.config/mise.toml`, it will be `~/src/myproj`.
 - `MISE_PROJECT_ROOT`: The root of the project that defines the task. For monorepo subproject tasks this is the subproject's directory and is stable regardless of the directory the task is invoked from.
-- `MISE_MONOREPO_ROOT`: The root of the monorepo (the directory containing the config with `experimental_monorepo_root = true`). Only set inside a monorepo.
+- `MISE_MONOREPO_ROOT`: The root of the monorepo (the directory containing the config with `monorepo_root = true`). Only set inside a monorepo.
 - `MISE_TASK_NAME`: The name of the task being run.
 - `MISE_TASK_DIR`: The directory containing the task script.
 - `MISE_TASK_FILE`: The full path to the task script.

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -1,10 +1,10 @@
-# Monorepo Tasks <Badge type="warning" text="experimental" />
+# Monorepo Tasks
 
 mise supports monorepo-style task organization with target path syntax. This feature allows you to manage tasks across multiple projects in a single repository, where each project can have its own `mise.toml` configuration with tools, environment variables, and tasks that may be different from where the task is called from.
 
 ## Overview
 
-When `experimental_monorepo_root` is enabled in your root `mise.toml`, mise will automatically discover tasks in subdirectories and prefix them with their relative path from the monorepo root. This creates a unified task namespace across your entire repository.
+When `monorepo_root` is enabled in your root `mise.toml`, mise will automatically discover tasks in subdirectories and prefix them with their relative path from the monorepo root. This creates a unified task namespace across your entire repository.
 
 ::: tip
 The directory containing a `mise.toml` file is called the **config_root**. In monorepo mode, each project can have its own config_root with its own configuration, separate from the monorepo root. Note that if you use one of the alternate paths in a subdirectory like `./projects/frontend/.mise/config.toml`, the config_root will be `./projects/frontend`–not `./projects/frontend/.mise`.
@@ -22,26 +22,22 @@ The directory containing a `mise.toml` file is called the **config_root**. In mo
 
 ### Enabling Monorepo Mode
 
-Add `experimental_monorepo_root = true` to your root `mise.toml`:
+Add `monorepo_root = true` to your root `mise.toml`:
 
 ```toml
 # /myproject/mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [tools]
 # Tools defined here apply to all subdirectories
 node = "20"
 ```
 
-::: warning
-This feature requires `MISE_EXPERIMENTAL=1` environment variable.
-:::
-
 ### Example Structure
 
 ```
 myproject/
-├── mise.toml (with experimental_monorepo_root = true)
+├── mise.toml (with monorepo_root = true)
 ├── projects/
 │   ├── frontend/
 │   │   └── mise.toml (with tasks: build, test)
@@ -190,7 +186,7 @@ running subdirectory tasks from the monorepo root.
 
 ```toml
 # /myproject/mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [tools]
 node = "20"      # Available to all subdirectories
@@ -233,7 +229,7 @@ You must explicitly list your config roots using the `[monorepo]` section:
 
 ```toml
 # /myproject/mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = [
@@ -304,7 +300,7 @@ Place commonly-used tools and environment in the root `mise.toml` to avoid repet
 
 ```toml
 # /myproject/mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [tools]
 node = "20"
@@ -445,8 +441,7 @@ For monorepos with similar task patterns across projects, [task templates](/task
 ```toml
 # Root mise.toml
 [settings]
-experimental = true
-experimental_monorepo_root = true
+monorepo_root = true
 
 [task_templates."python:build"]
 run = "uv build"

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -760,9 +760,9 @@ When `path` points at a directory, mise loads both executable file tasks and any
 
 Included `.toml` files use the [task toml file format](#task-config-includes) (the keys are task names — there is no `[tasks.…]` prefix). The repository will be cloned and cached in `MISE_CACHE_DIR/remote-git-tasks-cache`. Tasks from the include will be loaded as if they were local. You can disable caching with `MISE_TASK_REMOTE_NO_CACHE=true` or the `--no-cache` flag.
 
-## Monorepo Support <Badge type="warning" text="experimental" />
+## Monorepo Support
 
-mise supports monorepo-style task organization with target path syntax. Enable it by setting `experimental_monorepo_root = true` in your root `mise.toml`.
+mise supports monorepo-style task organization with target path syntax. Enable it by setting `monorepo_root = true` in your root `mise.toml`.
 
 For complete documentation on monorepo tasks including:
 

--- a/docs/tasks/templates.md
+++ b/docs/tasks/templates.md
@@ -1,9 +1,5 @@
 # Task Templates
 
-::: warning
-This feature is experimental and requires `experimental = true` in your settings.
-:::
-
 Task templates allow you to define reusable task definitions that can be extended by multiple tasks. This is particularly useful in monorepos or projects with similar task patterns across different components.
 
 ## Defining Templates
@@ -11,9 +7,6 @@ Task templates allow you to define reusable task definitions that can be extende
 Templates are defined in the `[task_templates.*]` section of your `mise.toml`:
 
 ```toml
-[settings]
-experimental = true
-
 [task_templates."python:build"]
 description = "Build a Python project"
 run = "uv build"
@@ -128,8 +121,7 @@ Task templates are especially useful in monorepos where multiple packages share 
 ```toml
 # Root mise.toml
 [settings]
-experimental = true
-experimental_monorepo_root = true
+monorepo_root = true
 
 [task_templates."python:build"]
 run = "uv build"

--- a/e2e-win/vfox.Tests.ps1
+++ b/e2e-win/vfox.Tests.ps1
@@ -1,7 +1,6 @@
 Describe 'vfox' {
     BeforeAll {
-        # vfox-npm is a custom backend which requires experimental mode
-        $env:MISE_EXPERIMENTAL = "1"
+        # vfox-npm exercises custom backend support
     }
 
     It 'executes vfox backend command execution' {

--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -534,7 +534,7 @@ export MISE_EXPERIMENTAL=1
 mkdir -p subapp
 
 cat >mise.toml <<'EOF'
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["subapp"]
@@ -558,7 +558,7 @@ assert_contains "mise run //subapp:check" "SUBAPP_PREPARE_OK"
 
 # Test that prepare steps also run when subtasks are reached via dependencies
 cat >mise.toml <<'EOF'
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["subapp"]

--- a/e2e/cli/test_lock_project_root_scope
+++ b/e2e/cli/test_lock_project_root_scope
@@ -43,7 +43,7 @@ echo "=== Testing monorepo lock scope follows the active config root ==="
 mkdir -p monorepo-root/packages/api
 
 cat >monorepo-root/mise.toml <<'EOF'
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["packages/*"]

--- a/e2e/cli/test_mcp
+++ b/e2e/cli/test_mcp
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 # Test mise mcp command
-export MISE_EXPERIMENTAL=1
 
 # Test that mcp command exists and shows help
-assert_contains "mise mcp --help" "[experimental] Run Model Context Protocol (MCP) server"
+assert_contains "mise mcp --help" "Run Model Context Protocol (MCP) server"
 assert_contains "mise mcp --help" "This command starts an MCP server that exposes mise functionality"
 assert_contains "mise mcp --help" "to AI assistants over stdin/stdout using JSON-RPC protocol."
 

--- a/e2e/cli/test_mcp_protocol
+++ b/e2e/cli/test_mcp_protocol
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
 
 # Test MCP protocol interactions in more detail
-export MISE_EXPERIMENTAL=1
 
-# Create a test environment with tools, tasks and env vars
+# Create a test environment with tasks and env vars
 cat >mise.toml <<EOF
-[tools]
-node = "20.11.0"
-python = "3.12"
-
 [env]
 TEST_MCP_VAR = "test_value"
 PROJECT_ENV = "development"
@@ -244,7 +239,7 @@ def main():
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={**dict(os.environ), "MISE_EXPERIMENTAL": "1"},
+        env=dict(os.environ),
     )
 
     try:

--- a/e2e/cli/test_token_github
+++ b/e2e/cli/test_token_github
@@ -102,11 +102,8 @@ assert_contains "MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS='$HOME/credential-shell -c'
 
 # Test 9a: OAuth configured but no cached token — must not prompt for device flow
 # during normal token resolution (would hang on the unreachable URL otherwise).
-NO_DEVICE_OAUTH="MISE_EXPERIMENTAL=1 MISE_GITHUB_OAUTH_CLIENT_ID=Iv1.mock MISE_GITHUB_OAUTH_OPEN_BROWSER=false MISE_GITHUB_OAUTH_AUTH_URL=http://127.0.0.1:1/login MISE_GITHUB_OAUTH_API_URL=http://127.0.0.1:1/api"
+NO_DEVICE_OAUTH="MISE_GITHUB_OAUTH_CLIENT_ID=Iv1.mock MISE_GITHUB_OAUTH_OPEN_BROWSER=false MISE_GITHUB_OAUTH_AUTH_URL=http://127.0.0.1:1/login MISE_GITHUB_OAUTH_API_URL=http://127.0.0.1:1/api"
 assert_contains "$NO_DEVICE_OAUTH mise token github 127.0.0.1" "(none)"
-
-# OAuth is experimental — calling --oauth without experimental enabled must fail
-assert_fail "MISE_GITHUB_OAUTH_CLIENT_ID=Iv1.mock mise token github --oauth"
 
 # Test 9: native GitHub OAuth device flow via token alias
 MOCK_PORT_FILE="$HOME/mock-github-oauth-port"
@@ -119,7 +116,7 @@ for _ in $(seq 1 30); do
   sleep 0.1
 done
 MOCK_PORT="$(cat "$MOCK_PORT_FILE")"
-OAUTH_ENV="MISE_EXPERIMENTAL=1 MISE_GITHUB_OAUTH_CLIENT_ID=Iv1.mock MISE_GITHUB_OAUTH_OPEN_BROWSER=false MISE_GITHUB_OAUTH_AUTH_URL=http://127.0.0.1:$MOCK_PORT/login MISE_GITHUB_OAUTH_API_URL=http://127.0.0.1:$MOCK_PORT/api"
+OAUTH_ENV="MISE_GITHUB_OAUTH_CLIENT_ID=Iv1.mock MISE_GITHUB_OAUTH_OPEN_BROWSER=false MISE_GITHUB_OAUTH_AUTH_URL=http://127.0.0.1:$MOCK_PORT/login MISE_GITHUB_OAUTH_API_URL=http://127.0.0.1:$MOCK_PORT/api"
 assert_contains "$OAUTH_ENV mise token github 127.0.0.1 --oauth --raw" "ghu-native-oauth-token"
 assert_contains "$OAUTH_ENV mise token github 127.0.0.1 --unmask" "GitHub OAuth"
 

--- a/e2e/tasks/test_task_colon_syntax
+++ b/e2e/tasks/test_task_colon_syntax
@@ -18,7 +18,7 @@ assert_fail "mise run ':build'" "require a monorepo root configuration"
 export MISE_EXPERIMENTAL=1
 
 cat <<'EOF' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["project", "app"]

--- a/e2e/tasks/test_task_file_alias_run
+++ b/e2e/tasks/test_task_file_alias_run
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # === Test 1: Monorepo with config_roots=["."] ===
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["."]
@@ -26,7 +26,7 @@ assert_contains "mise run prl my-arg" "pr-list ran with args: my-arg"
 
 # === Test 2: Monorepo with config_roots including subdirectories ===
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = [".", "projects/*"]

--- a/e2e/tasks/test_task_include_trust
+++ b/e2e/tasks/test_task_include_trust
@@ -43,7 +43,7 @@ fi
 rm -rf mise-tasks
 
 cat <<'EOF' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["pkg"]

--- a/e2e/tasks/test_task_info_monorepo
+++ b/e2e/tasks/test_task_info_monorepo
@@ -3,7 +3,7 @@
 # Tests for `mise tasks info` in a monorepo setup
 
 cat >mise.toml <<EOF
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["lib"]

--- a/e2e/tasks/test_task_ls_complete_monorepo
+++ b/e2e/tasks/test_task_ls_complete_monorepo
@@ -3,7 +3,7 @@
 
 # Root config marks repo as monorepo
 cat <<'CONFIG' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["apps/*"]

--- a/e2e/tasks/test_task_missing_suggestions
+++ b/e2e/tasks/test_task_missing_suggestions
@@ -20,7 +20,7 @@ rm mise.toml
 export MISE_EXPERIMENTAL=1
 
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_aliases
+++ b/e2e/tasks/test_task_monorepo_aliases
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config with tasks that have aliases
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]
@@ -62,7 +62,7 @@ echo "$output" | grep -q "building backend" || (echo "FAIL: Nested task alias di
 
 # Test 6: Task depends using alias
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]
@@ -84,7 +84,7 @@ echo "$output" | grep -q "deploying" || (echo "FAIL: Dependent task did not run"
 
 # Test 7: Task depends on unprefixed alias (should resolve to monorepo task)
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_circular_deps
+++ b/e2e/tasks/test_task_monorepo_circular_deps
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_config_context
+++ b/e2e/tasks/test_task_monorepo_config_context
@@ -5,7 +5,7 @@ export MISE_NODE_VERIFY=0 # Skip GPG verification to avoid keyboxd issues
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*", "libs/*"]

--- a/e2e/tasks/test_task_monorepo_config_roots
+++ b/e2e/tasks/test_task_monorepo_config_roots
@@ -4,7 +4,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config with explicit config_roots
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = [

--- a/e2e/tasks/test_task_monorepo_dependencies
+++ b/e2e/tasks/test_task_monorepo_dependencies
@@ -4,7 +4,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_dependency_chain
+++ b/e2e/tasks/test_task_monorepo_dependency_chain
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["ProjectA", "ProjectB"]

--- a/e2e/tasks/test_task_monorepo_deps
+++ b/e2e/tasks/test_task_monorepo_deps
@@ -10,7 +10,7 @@ export MISE_EXPERIMENTAL=1
 # Set up monorepo structure
 cat <<'EOF' >mise.toml
 min_version = "2025.10.6"
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["submodule", "project", "other"]

--- a/e2e/tasks/test_task_monorepo_deps_tool_install
+++ b/e2e/tasks/test_task_monorepo_deps_tool_install
@@ -14,7 +14,7 @@
 export MISE_EXPERIMENTAL=1
 
 cat <<'EOF' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [settings]
 experimental = true

--- a/e2e/tasks/test_task_monorepo_dots_in_dir
+++ b/e2e/tasks/test_task_monorepo_dots_in_dir
@@ -4,7 +4,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_edge_cases
+++ b/e2e/tasks/test_task_monorepo_edge_cases
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_env_version_override
+++ b/e2e/tasks/test_task_monorepo_env_version_override
@@ -3,7 +3,7 @@
 export MISE_EXPERIMENTAL=1
 
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_errors
+++ b/e2e/tasks/test_task_monorepo_errors
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # Test error cases: nested monorepos, malformed configs, circular dependencies
-export MISE_EXPERIMENTAL=1
 
 # Test 1: Malformed config in subdirectory should warn but not break
 echo "=== Test 1: Malformed config in subdirectory ==="
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]
@@ -33,13 +32,13 @@ echo "$output" | grep -q "good project built" || (echo "FAIL: Good project shoul
 # Check that warning was issued (optional - depends on log level)
 # echo "$output" | grep -q -i "failed to parse" && echo "Warning correctly issued for malformed config"
 
-# Test 2: Nested monorepo (subdirectory with experimental_monorepo_root)
+# Test 2: Nested monorepo (subdirectory with monorepo_root)
 echo "=== Test 2: Nested monorepo configuration ==="
 rm -rf projects
 mkdir -p projects/nested
 cat <<'TOML' >projects/nested/mise.toml
 # This is potentially problematic - nested monorepo root
-experimental_monorepo_root = true
+monorepo_root = true
 
 [tasks.nested-task]
 run = 'echo "nested task"'
@@ -83,7 +82,7 @@ fi
 echo "=== Test 4: Monorepo syntax without experimental mode ==="
 rm -f mise.toml
 cat <<'TOML' >mise.toml
-# No experimental_monorepo_root flag
+# No monorepo_root flag
 
 [tasks.normal-task]
 run = 'echo "normal"'
@@ -96,17 +95,15 @@ run = 'echo "app build"'
 TOML
 
 # Running with // syntax should fail or warn
-unset MISE_EXPERIMENTAL
 output=$(mise run '//projects/app:build' 2>&1 || true)
 echo "$output"
-# Should require experimental mode
-echo "$output" | grep -q -i "experimental" || echo "Note: May need experimental mode check"
+# Should require a monorepo root
+echo "$output" | grep -q -i "monorepo root" || echo "Note: May need monorepo root check"
 
 # Test 5: Empty subdirectory mise.toml should not cause issues
 echo "=== Test 5: Empty subdirectory config ==="
-export MISE_EXPERIMENTAL=1
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_file_tasks
+++ b/e2e/tasks/test_task_monorepo_file_tasks
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_global_tasks
+++ b/e2e/tasks/test_task_monorepo_global_tasks
@@ -11,7 +11,7 @@ TOML
 
 # Create monorepo root config
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["packages/*"]

--- a/e2e/tasks/test_task_monorepo_idiomatic_tools
+++ b/e2e/tasks/test_task_monorepo_idiomatic_tools
@@ -11,7 +11,7 @@ mise settings set idiomatic_version_file_enable_tools tiny
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["packages/*"]

--- a/e2e/tasks/test_task_monorepo_includes
+++ b/e2e/tasks/test_task_monorepo_includes
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_includes_relative_path
+++ b/e2e/tasks/test_task_monorepo_includes_relative_path
@@ -9,7 +9,7 @@ export MISE_EXPERIMENTAL=1
 # Create monorepo structure similar to the reported issue:
 # mise-monorepo/
 #   mise/
-#     config.toml (root config with experimental_monorepo_root)
+#     config.toml (root config with monorepo_root)
 #     common.tasks.toml (shared tasks)
 #   packages/
 #     foo/
@@ -21,7 +21,7 @@ mkdir -p packages/foo/mise
 
 # Create root config
 cat <<EOF >mise/config.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["packages/*"]
@@ -107,7 +107,7 @@ EOF
 
 # Update monorepo config_roots to include deeper path
 cat <<EOF >mise/config.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["packages/*", "packages/bar/src"]

--- a/e2e/tasks/test_task_monorepo_mise_env
+++ b/e2e/tasks/test_task_monorepo_mise_env
@@ -4,7 +4,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_name_conflicts
+++ b/e2e/tasks/test_task_monorepo_name_conflicts
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root with a "build" task
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/frontend"]

--- a/e2e/tasks/test_task_monorepo_nested_config
+++ b/e2e/tasks/test_task_monorepo_nested_config
@@ -11,7 +11,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_optional_colon
+++ b/e2e/tasks/test_task_monorepo_optional_colon
@@ -8,7 +8,7 @@ export MISE_EXPERIMENTAL=1
 # Set up monorepo structure
 cat <<'EOF' >mise.toml
 min_version = "2025.10.6"
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["app", "frontend", "backend", "services", "other"]

--- a/e2e/tasks/test_task_monorepo_path_directives
+++ b/e2e/tasks/test_task_monorepo_path_directives
@@ -4,7 +4,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_project_root
+++ b/e2e/tasks/test_task_monorepo_project_root
@@ -6,7 +6,7 @@
 export MISE_EXPERIMENTAL=1
 
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_relative_paths
+++ b/e2e/tasks/test_task_monorepo_relative_paths
@@ -4,7 +4,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_run_project_local_tasks
+++ b/e2e/tasks/test_task_monorepo_run_project_local_tasks
@@ -3,7 +3,7 @@
 export MISE_EXPERIMENTAL=1
 
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/backend"]

--- a/e2e/tasks/test_task_monorepo_run_project_tasks
+++ b/e2e/tasks/test_task_monorepo_run_project_tasks
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config with a task that calls a project task via run block
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]
@@ -42,7 +42,7 @@ echo "$output" | grep -q "after dependency" || (echo "FAIL: Root task did not ru
 
 # Test 3: Multiple project tasks in run block
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_syntax
+++ b/e2e/tasks/test_task_monorepo_syntax
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config with tasks
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["example-pkg", "libs/*"]

--- a/e2e/tasks/test_task_monorepo_tasks_deps_command
+++ b/e2e/tasks/test_task_monorepo_tasks_deps_command
@@ -8,7 +8,7 @@ export MISE_EXPERIMENTAL=1
 
 # Set up monorepo structure
 cat <<'EOF' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["mydir"]

--- a/e2e/tasks/test_task_monorepo_tera_templates
+++ b/e2e/tasks/test_task_monorepo_tera_templates
@@ -4,7 +4,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<'TOML' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*"]

--- a/e2e/tasks/test_task_monorepo_tool_inheritance
+++ b/e2e/tasks/test_task_monorepo_tool_inheritance
@@ -5,7 +5,7 @@ export MISE_NODE_VERIFY=0 # Skip GPG verification to avoid keyboxd issues
 
 # Create monorepo root config with shared tools
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*", "projects/backend/*"]

--- a/e2e/tasks/test_task_monorepo_tool_inheritance_intermediate
+++ b/e2e/tasks/test_task_monorepo_tool_inheritance_intermediate
@@ -4,7 +4,7 @@ export MISE_EXPERIMENTAL=1
 export MISE_NODE_VERIFY=0
 
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["parent/*"]

--- a/e2e/tasks/test_task_monorepo_triple_colon_with_deps
+++ b/e2e/tasks/test_task_monorepo_triple_colon_with_deps
@@ -12,7 +12,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<'EOF' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["libs/*", "apps/*", "tools/*"]

--- a/e2e/tasks/test_task_monorepo_trust
+++ b/e2e/tasks/test_task_monorepo_trust
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["projects/*", "projects/frontend/*"]

--- a/e2e/tasks/test_task_monorepo_usage_env
+++ b/e2e/tasks/test_task_monorepo_usage_env
@@ -6,7 +6,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["backend"]

--- a/e2e/tasks/test_task_monorepo_validation
+++ b/e2e/tasks/test_task_monorepo_validation
@@ -2,37 +2,33 @@
 
 # Test validation for monorepo task paths
 
-# Test 1: Running monorepo task without MISE_EXPERIMENTAL should error
-unset MISE_EXPERIMENTAL
+# Test 1: Running monorepo task without a monorepo root should error
+cat <<EOF >mise.toml
+[tasks.local]
+run = 'echo "local task"'
+EOF
+
+# Should fail with helpful error about monorepo_root
+assert_fail "mise run '//some:task'" "require a monorepo root configuration"
+
+# Test 2: Wildcard patterns should also trigger validation
+cat <<EOF >mise.toml
+[tasks.local]
+run = 'echo "local task"'
+EOF
+
+# Wildcard pattern without monorepo root should fail
+assert_fail "mise run '//...:build'" "require a monorepo root configuration"
+
+# Test 3: Three-dot syntax should also trigger validation
+assert_fail "mise run '...:build'" "require a monorepo root configuration"
+
+# Test 4: Legacy experimental_monorepo_root remains a hidden compatibility alias
 cat <<EOF >mise.toml
 experimental_monorepo_root = true
 
 [tasks.local]
-run = 'echo "local task"'
+run = 'echo "legacy alias works"'
 EOF
 
-# Should fail with helpful error about MISE_EXPERIMENTAL
-assert_fail "mise run '//some:task'" "require experimental mode"
-
-# Test 2: Running monorepo task with MISE_EXPERIMENTAL but without monorepo root should error
-export MISE_EXPERIMENTAL=1
-cat <<EOF >mise.toml
-[tasks.local]
-run = 'echo "local task"'
-EOF
-
-# Should fail with helpful error about experimental_monorepo_root
-assert_fail "mise run '//some:task'" "require a monorepo root configuration"
-
-# Test 3: Wildcard patterns should also trigger validation
-unset MISE_EXPERIMENTAL
-cat <<EOF >mise.toml
-[tasks.local]
-run = 'echo "local task"'
-EOF
-
-# Wildcard pattern without experimental mode should fail
-assert_fail "mise run '//...:build'" "require experimental mode"
-
-# Test 4: Three-dot syntax should also trigger validation
-assert_fail "mise run '...:build'" "require experimental mode"
+assert "mise run ':local'" "legacy alias works"

--- a/e2e/tasks/test_task_monorepo_vars
+++ b/e2e/tasks/test_task_monorepo_vars
@@ -4,7 +4,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config with vars
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["infra/stacks/*"]

--- a/e2e/tasks/test_task_monorepo_wildcard_with_deps
+++ b/e2e/tasks/test_task_monorepo_wildcard_with_deps
@@ -8,7 +8,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<'EOF' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["libs/*", "apps/*", "tools/*"]

--- a/e2e/tasks/test_task_monorepo_wildcards
+++ b/e2e/tasks/test_task_monorepo_wildcards
@@ -5,7 +5,7 @@ export MISE_EXPERIMENTAL=1
 
 # Create monorepo root config
 cat <<EOF >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = [

--- a/e2e/tasks/test_task_shorthand_monorepo
+++ b/e2e/tasks/test_task_shorthand_monorepo
@@ -6,7 +6,7 @@
 export MISE_EXPERIMENTAL=1
 
 cat <<'EOF' >mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["project", "app", "deep/nested/dir"]

--- a/e2e/tasks/test_task_templates
+++ b/e2e/tasks/test_task_templates
@@ -1,25 +1,8 @@
 #!/usr/bin/env bash
 
-# Test task templates feature (requires experimental = true)
+# Test task templates feature
 
-# First, test that extends fails without experimental flag
 cat <<'EOF' >mise.toml
-[task_templates."python:build"]
-run = "echo building python"
-description = "Build a Python project"
-
-[tasks.build]
-extends = "python:build"
-EOF
-
-# Should fail without experimental mode (override the env var)
-assert_fail "MISE_EXPERIMENTAL=0 mise run build" "experimental = true"
-
-# Now enable experimental mode and test basic template functionality
-cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."python:build"]
 run = "echo building python"
 description = "Build a Python project"
@@ -33,9 +16,6 @@ assert "mise run build" "building python"
 
 # Test local override of run command
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."python:build"]
 run = "echo template build"
 description = "Template description"
@@ -49,9 +29,6 @@ assert "mise run build" "local build"
 
 # Test tools deep merge
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."python:build"]
 run = "echo tools: python={{ env.MISE_TOOL_OPTS_PYTHON | default(value='none') }} node={{ env.MISE_TOOL_OPTS_NODE | default(value='none') }}"
 tools = { python = "3.12", node = "18" }
@@ -67,9 +44,6 @@ assert_contains "mise tasks build" "node"
 
 # Test env deep merge
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."python:build"]
 run = "echo FOO=$FOO BAR=$BAR"
 env = { FOO = "template_foo", BAR = "template_bar" }
@@ -83,9 +57,6 @@ assert "mise run build" "FOO=local_foo BAR=template_bar"
 
 # Test description from template (when local is empty)
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."python:build"]
 run = "echo build"
 description = "Template description"
@@ -98,9 +69,6 @@ assert_contains "mise tasks build" "Template description"
 
 # Test local description overrides template
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."python:build"]
 run = "echo build"
 description = "Template description"
@@ -115,9 +83,6 @@ assert_not_contains "mise tasks build" "Template description"
 
 # Test depends from template (using task name, not :prefix syntax)
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."python:test"]
 run = "echo testing"
 depends = ["build"]
@@ -134,9 +99,6 @@ testing"
 
 # Test depends local override (local takes precedence completely)
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."python:test"]
 run = "echo testing"
 depends = ["prep"]
@@ -158,9 +120,6 @@ assert_not_contains "mise run test" "prep"
 
 # Test template not found error
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [tasks.build]
 extends = "nonexistent:template"
 EOF
@@ -169,9 +128,6 @@ assert_fail "mise run build" "not found"
 
 # Test namespaced template names with colons
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."rust:cargo:build"]
 run = "echo cargo build"
 
@@ -183,9 +139,6 @@ assert "mise run build" "cargo build"
 
 # Test templates apply to tasks defined in included tasks.toml files
 cat <<'EOF' >mise.toml
-[settings]
-experimental = true
-
 [task_templates."template:failing-task"]
 run = "echo from template && exit 1"
 

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -257,7 +257,7 @@ rm -rf mise-tasks
 rm -f mise.toml
 mkdir -p monorepo-validate/pkg
 cat <<'EOF' >monorepo-validate/mise.toml
-experimental_monorepo_root = true
+monorepo_root = true
 
 [settings]
 experimental = true

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -287,7 +287,7 @@ List installed and active tool versions
 List runtime versions available for install.
 .TP
 \fBmcp\fR
-[experimental] Run Model Context Protocol (MCP) server
+Run Model Context Protocol (MCP) server
 .TP
 \fBoci\fR
 [experimental] Build OCI container images from a mise.toml
@@ -1005,33 +1005,33 @@ Number of jobs to run in parallel
 [default: 4]
 .TP
 \fB\-\-allow\-env\fR \fI<VAR>\fR
-[experimental] Allow specific env var through (implies \-\-deny\-env for everything else)
+Allow specific env var through (implies \-\-deny\-env for everything else)
 Supports wildcards, e.g. \-\-allow\-env='MYAPP_*'
 .TP
 \fB\-\-allow\-net\fR \fI<HOST>\fR
-[experimental] Allow network to specific host (implies \-\-deny\-net for everything else)
+Allow network to specific host (implies \-\-deny\-net for everything else)
 macOS only in v1; on Linux falls back to allowing all network
 .TP
 \fB\-\-allow\-read\fR \fI<PATH>\fR
-[experimental] Allow reads from specific path (implies \-\-deny\-read for everything else)
+Allow reads from specific path (implies \-\-deny\-read for everything else)
 .TP
 \fB\-\-allow\-write\fR \fI<PATH>\fR
-[experimental] Allow writes to specific path (implies \-\-deny\-write for everything else)
+Allow writes to specific path (implies \-\-deny\-write for everything else)
 .TP
 \fB\-\-deny\-all\fR
-[experimental] Block reads, writes, network, and env vars
+Block reads, writes, network, and env vars
 .TP
 \fB\-\-deny\-env\fR
-[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 .TP
 \fB\-\-deny\-net\fR
-[experimental] Block all network access
+Block all network access
 .TP
 \fB\-\-deny\-read\fR
-[experimental] Block filesystem reads (system libs and tool dirs still accessible)
+Block filesystem reads (system libs and tool dirs still accessible)
 .TP
 \fB\-\-deny\-write\fR
-[experimental] Block all filesystem writes
+Block all filesystem writes
 .TP
 \fB\-\-fresh\-env\fR
 Bypass the environment cache and recompute the environment
@@ -1404,13 +1404,13 @@ Supports absolute dates like "2024\-06\-01" and relative durations like "90d" or
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1
 .TP
 \fB\-\-shared\fR \fI<SHARED>\fR
-[experimental] Install tool(s) to a shared directory
+Install tool(s) to a shared directory
 
 Installs to the specified directory instead of the default install location.
 May require elevated permissions depending on the path.
 .TP
 \fB\-\-system\fR
-[experimental] Install tool(s) to the system\-wide shared directory
+Install tool(s) to the system\-wide shared directory
 
 Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
@@ -2305,32 +2305,32 @@ Don't show any output except for errors
 Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
 .TP
 \fB\-\-allow\-env\fR \fI<VAR>\fR
-[experimental] Allow specific env var through (implies \-\-deny\-env for everything else)
+Allow specific env var through (implies \-\-deny\-env for everything else)
 Supports wildcards, e.g. \-\-allow\-env='MYAPP_*'
 .TP
 \fB\-\-allow\-net\fR \fI<HOST>\fR
-[experimental] Allow network to specific host (implies \-\-deny\-net for everything else)
+Allow network to specific host (implies \-\-deny\-net for everything else)
 .TP
 \fB\-\-allow\-read\fR \fI<PATH>\fR
-[experimental] Allow reads from specific path (implies \-\-deny\-read for everything else)
+Allow reads from specific path (implies \-\-deny\-read for everything else)
 .TP
 \fB\-\-allow\-write\fR \fI<PATH>\fR
-[experimental] Allow writes to specific path (implies \-\-deny\-write for everything else)
+Allow writes to specific path (implies \-\-deny\-write for everything else)
 .TP
 \fB\-\-deny\-all\fR
-[experimental] Block reads, writes, network, and env vars
+Block reads, writes, network, and env vars
 .TP
 \fB\-\-deny\-env\fR
-[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 .TP
 \fB\-\-deny\-net\fR
-[experimental] Block all network access
+Block all network access
 .TP
 \fB\-\-deny\-read\fR
-[experimental] Block filesystem reads (system libs and tool dirs still accessible)
+Block filesystem reads (system libs and tool dirs still accessible)
 .TP
 \fB\-\-deny\-write\fR
-[experimental] Block all filesystem writes
+Block all filesystem writes
 .TP
 \fB\-\-fresh\-env\fR
 Bypass the environment cache and recompute the environment
@@ -3186,32 +3186,32 @@ Don't show any output except for errors
 Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
 .TP
 \fB\-\-allow\-env\fR \fI<VAR>\fR
-[experimental] Allow specific env var through (implies \-\-deny\-env for everything else)
+Allow specific env var through (implies \-\-deny\-env for everything else)
 Supports wildcards, e.g. \-\-allow\-env='MYAPP_*'
 .TP
 \fB\-\-allow\-net\fR \fI<HOST>\fR
-[experimental] Allow network to specific host (implies \-\-deny\-net for everything else)
+Allow network to specific host (implies \-\-deny\-net for everything else)
 .TP
 \fB\-\-allow\-read\fR \fI<PATH>\fR
-[experimental] Allow reads from specific path (implies \-\-deny\-read for everything else)
+Allow reads from specific path (implies \-\-deny\-read for everything else)
 .TP
 \fB\-\-allow\-write\fR \fI<PATH>\fR
-[experimental] Allow writes to specific path (implies \-\-deny\-write for everything else)
+Allow writes to specific path (implies \-\-deny\-write for everything else)
 .TP
 \fB\-\-deny\-all\fR
-[experimental] Block reads, writes, network, and env vars
+Block reads, writes, network, and env vars
 .TP
 \fB\-\-deny\-env\fR
-[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 .TP
 \fB\-\-deny\-net\fR
-[experimental] Block all network access
+Block all network access
 .TP
 \fB\-\-deny\-read\fR
-[experimental] Block filesystem reads (system libs and tool dirs still accessible)
+Block filesystem reads (system libs and tool dirs still accessible)
 .TP
 \fB\-\-deny\-write\fR
-[experimental] Block all filesystem writes
+Block all filesystem writes
 .TP
 \fB\-\-fresh\-env\fR
 Bypass the environment cache and recompute the environment
@@ -3334,13 +3334,13 @@ GitHub token
 .PP
 .TP
 \fB\-\-oauth\fR
-[experimental] Resolve only via the native GitHub OAuth source (cache, refresh, or device\-code flow), bypassing other token sources
+Resolve only via the native GitHub OAuth source (cache, refresh, or device\-code flow), bypassing other token sources
 .TP
 \fB\-\-raw\fR
 Print only the token value
 .TP
 \fB\-\-refresh\fR
-[experimental] Mint a fresh OAuth token even if the cached one has not expired, via the refresh\-token grant or a new device\-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire
+Mint a fresh OAuth token even if the cached one has not expired, via the refresh\-token grant or a new device\-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire
 .TP
 \fB\-\-unmask\fR
 Show the full unmasked token

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -657,28 +657,28 @@ Number of jobs to run in parallel
         arg <JOBS>
     }
     flag --allow-env help=#"""
-[experimental] Allow specific env var through (implies --deny-env for everything else)
+Allow specific env var through (implies --deny-env for everything else)
 Supports wildcards, e.g. --allow-env='MYAPP_*'
 """# var=#true {
         arg <VAR>
     }
     flag --allow-net help=#"""
-[experimental] Allow network to specific host (implies --deny-net for everything else)
+Allow network to specific host (implies --deny-net for everything else)
 macOS only in v1; on Linux falls back to allowing all network
 """# var=#true {
         arg <HOST>
     }
-    flag --allow-read help="[experimental] Allow reads from specific path (implies --deny-read for everything else)" var=#true {
+    flag --allow-read help="Allow reads from specific path (implies --deny-read for everything else)" var=#true {
         arg <PATH>
     }
-    flag --allow-write help="[experimental] Allow writes to specific path (implies --deny-write for everything else)" var=#true {
+    flag --allow-write help="Allow writes to specific path (implies --deny-write for everything else)" var=#true {
         arg <PATH>
     }
-    flag --deny-all help="[experimental] Block reads, writes, network, and env vars"
-    flag --deny-env help="[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)"
-    flag --deny-net help="[experimental] Block all network access"
-    flag --deny-read help="[experimental] Block filesystem reads (system libs and tool dirs still accessible)"
-    flag --deny-write help="[experimental] Block all filesystem writes"
+    flag --deny-all help="Block reads, writes, network, and env vars"
+    flag --deny-env help="Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)"
+    flag --deny-net help="Block all network access"
+    flag --deny-read help="Block filesystem reads (system libs and tool dirs still accessible)"
+    flag --deny-write help="Block all filesystem writes"
     flag --fresh-env help="Bypass the environment cache and recompute the environment"
     flag --no-deps help="Skip automatic dependency preparation"
     flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
@@ -1036,7 +1036,7 @@ Examples:
 """#
         flag --oauth help="Force native GitHub OAuth device flow instead of normal token resolution"
         flag --raw help="Print only the token value"
-        flag --refresh help="[experimental] Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow"
+        flag --refresh help="Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow"
         flag --unmask help="Show the full unmasked token"
         arg "[HOST]" help="GitHub hostname" required=#false default=github.com
     }
@@ -1192,18 +1192,18 @@ Supports absolute dates like "2024-06-01" and relative durations like "90d" or "
         arg <MINIMUM_RELEASE_AGE>
     }
     flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
-    flag --shared help="[experimental] Install tool(s) to a shared directory" {
+    flag --shared help="Install tool(s) to a shared directory" {
         long_help #"""
-[experimental] Install tool(s) to a shared directory
+Install tool(s) to a shared directory
 
 Installs to the specified directory instead of the default install location.
 May require elevated permissions depending on the path.
 """#
         arg <SHARED>
     }
-    flag --system help="[experimental] Install tool(s) to the system-wide shared directory" {
+    flag --system help="Install tool(s) to the system-wide shared directory" {
         long_help #"""
-[experimental] Install tool(s) to the system-wide shared directory
+Install tool(s) to the system-wide shared directory
 
 Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
@@ -1518,9 +1518,9 @@ The version prefix to use when querying the latest version
 same as the first argument after the "@"
 """# required=#false
 }
-cmd mcp help="[experimental] Run Model Context Protocol (MCP) server" {
+cmd mcp help="Run Model Context Protocol (MCP) server" {
     long_help #"""
-[experimental] Run Model Context Protocol (MCP) server
+Run Model Context Protocol (MCP) server
 
 This command starts an MCP server that exposes mise functionality
 to AI assistants over stdin/stdout using JSON-RPC protocol.
@@ -1557,9 +1557,7 @@ Examples:
         "mise": {
           "command": "mise",
           "args": ["mcp"],
-          "env": {
-            "MISE_EXPERIMENTAL": "1"
-          }
+          "env": {}
         }
       }
     }
@@ -2380,25 +2378,25 @@ Or it can be overridden with the `shell` property on a task.
         arg <TOOL@VERSION>
     }
     flag --allow-env help=#"""
-[experimental] Allow specific env var through (implies --deny-env for everything else)
+Allow specific env var through (implies --deny-env for everything else)
 Supports wildcards, e.g. --allow-env='MYAPP_*'
 """# var=#true {
         arg <VAR>
     }
-    flag --allow-net help="[experimental] Allow network to specific host (implies --deny-net for everything else)" var=#true {
+    flag --allow-net help="Allow network to specific host (implies --deny-net for everything else)" var=#true {
         arg <HOST>
     }
-    flag --allow-read help="[experimental] Allow reads from specific path (implies --deny-read for everything else)" var=#true {
+    flag --allow-read help="Allow reads from specific path (implies --deny-read for everything else)" var=#true {
         arg <PATH>
     }
-    flag --allow-write help="[experimental] Allow writes to specific path (implies --deny-write for everything else)" var=#true {
+    flag --allow-write help="Allow writes to specific path (implies --deny-write for everything else)" var=#true {
         arg <PATH>
     }
-    flag --deny-all help="[experimental] Block reads, writes, network, and env vars"
-    flag --deny-env help="[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)"
-    flag --deny-net help="[experimental] Block all network access"
-    flag --deny-read help="[experimental] Block filesystem reads (system libs and tool dirs still accessible)"
-    flag --deny-write help="[experimental] Block all filesystem writes"
+    flag --deny-all help="Block reads, writes, network, and env vars"
+    flag --deny-env help="Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)"
+    flag --deny-net help="Block all network access"
+    flag --deny-read help="Block filesystem reads (system libs and tool dirs still accessible)"
+    flag --deny-write help="Block all filesystem writes"
     flag --fresh-env help="Bypass the environment cache and recompute the environment"
     flag --no-cache help="Do not use cache on remote tasks"
     flag --no-deps help="Skip automatic dependency preparation"
@@ -3316,25 +3314,25 @@ Or it can be overridden with the `shell` property on a task.
             arg <TOOL@VERSION>
         }
         flag --allow-env help=#"""
-[experimental] Allow specific env var through (implies --deny-env for everything else)
+Allow specific env var through (implies --deny-env for everything else)
 Supports wildcards, e.g. --allow-env='MYAPP_*'
 """# var=#true {
             arg <VAR>
         }
-        flag --allow-net help="[experimental] Allow network to specific host (implies --deny-net for everything else)" var=#true {
+        flag --allow-net help="Allow network to specific host (implies --deny-net for everything else)" var=#true {
             arg <HOST>
         }
-        flag --allow-read help="[experimental] Allow reads from specific path (implies --deny-read for everything else)" var=#true {
+        flag --allow-read help="Allow reads from specific path (implies --deny-read for everything else)" var=#true {
             arg <PATH>
         }
-        flag --allow-write help="[experimental] Allow writes to specific path (implies --deny-write for everything else)" var=#true {
+        flag --allow-write help="Allow writes to specific path (implies --deny-write for everything else)" var=#true {
             arg <PATH>
         }
-        flag --deny-all help="[experimental] Block reads, writes, network, and env vars"
-        flag --deny-env help="[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)"
-        flag --deny-net help="[experimental] Block all network access"
-        flag --deny-read help="[experimental] Block filesystem reads (system libs and tool dirs still accessible)"
-        flag --deny-write help="[experimental] Block all filesystem writes"
+        flag --deny-all help="Block reads, writes, network, and env vars"
+        flag --deny-env help="Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)"
+        flag --deny-net help="Block all network access"
+        flag --deny-read help="Block filesystem reads (system libs and tool dirs still accessible)"
+        flag --deny-write help="Block all filesystem writes"
         flag --fresh-env help="Bypass the environment cache and recompute the environment"
         flag --no-cache help="Do not use cache on remote tasks"
         flag --no-deps help="Skip automatic dependency preparation"
@@ -3470,9 +3468,9 @@ Examples:
     github.com: gho_…xxxx (source: GitHub OAuth)
 
 """#
-        flag --oauth help="[experimental] Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources"
+        flag --oauth help="Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources"
         flag --raw help="Print only the token value"
-        flag --refresh help="[experimental] Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire"
+        flag --refresh help="Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire"
         flag --unmask help="Show the full unmasked token"
         arg "[HOST]" help="GitHub hostname" required=#false default=github.com
     }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -814,7 +814,7 @@
             },
             "oauth_client_id": {
               "default": "",
-              "description": "[experimental] GitHub App client ID for native OAuth device-flow tokens.",
+              "description": "GitHub App client ID for native OAuth device-flow tokens.",
               "type": "string"
             },
             "oauth_export_env": {
@@ -1472,7 +1472,7 @@
           }
         },
         "shared_install_dirs": {
-          "description": "[experimental] Additional read-only directories to search for installed tool versions.",
+          "description": "Additional read-only directories to search for installed tool versions.",
           "type": "array",
           "items": {
             "type": "string"
@@ -1982,8 +1982,8 @@
         }
       }
     },
-    "experimental_monorepo_root": {
-      "description": "Marks this config as a monorepo root, enabling target path syntax for tasks. Requires MISE_EXPERIMENTAL=1. When enabled, tasks can be referenced with paths like //projects/frontend:build",
+    "monorepo_root": {
+      "description": "Marks this config as a monorepo root, enabling target path syntax for tasks. When enabled, tasks can be referenced with paths like //projects/frontend:build",
       "type": "boolean"
     },
     "monorepo": {
@@ -2785,9 +2785,9 @@
         }
       ]
     },
-    "experimental_monorepo_root": {
+    "monorepo_root": {
       "description": "marks this config as a monorepo root for task path syntax",
-      "$ref": "#/$defs/experimental_monorepo_root"
+      "$ref": "#/$defs/monorepo_root"
     },
     "monorepo": {
       "description": "configuration for monorepo task discovery",

--- a/settings.toml
+++ b/settings.toml
@@ -816,10 +816,8 @@ type = "String"
 
 [github.oauth_client_id]
 default = ""
-description = "[experimental] GitHub App client ID for native OAuth device-flow tokens."
+description = "GitHub App client ID for native OAuth device-flow tokens."
 docs = """
-[experimental] Requires `experimental = true`.
-
 When set, mise can create short-lived GitHub App user access tokens using
 GitHub's OAuth device flow. This does not require a GitHub App private key,
 client secret, personal access token, or external credential helper.
@@ -2148,7 +2146,7 @@ optional = true
 type = "Path"
 
 [shared_install_dirs]
-description = "[experimental] Additional read-only directories to search for installed tool versions."
+description = "Additional read-only directories to search for installed tool versions."
 docs = """
 A list of additional directories to search for installed tool versions. These directories
 are checked after the primary install directory (`~/.local/share/mise/installs`) when
@@ -2384,7 +2382,7 @@ type = "Bool"
 default = 5
 description = "Maximum depth to search for task files in monorepo subdirectories."
 docs = """
-When using monorepo mode (experimental_monorepo_root = true), this controls how deep
+When using monorepo mode (monorepo_root = true), this controls how deep
 mise will search for task files in subdirectories.
 
 **Depth levels:**

--- a/src/backend/backend_type.rs
+++ b/src/backend/backend_type.rs
@@ -80,7 +80,7 @@ impl BackendType {
         }
     }
 
-    /// Returns true if this backend requires experimental mode to be enabled
+    /// Returns true if this backend is still gated behind experimental mode.
     pub fn is_experimental(&self) -> bool {
         use super::{dotnet, s3, spm};
         match self {

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -12,8 +12,7 @@ use crate::{backend::Backend, config::Config};
 use async_trait::async_trait;
 use eyre::eyre;
 
-/// Dotnet backend requires experimental mode to be enabled
-pub const EXPERIMENTAL: bool = true;
+pub const EXPERIMENTAL: bool = false;
 
 #[derive(Debug)]
 pub struct DotnetBackend {
@@ -93,8 +92,6 @@ impl Backend for DotnetBackend {
         ctx: &crate::install_context::InstallContext,
         tv: crate::toolset::ToolVersion,
     ) -> eyre::Result<crate::toolset::ToolVersion> {
-        Settings::get().ensure_experimental("dotnet backend")?;
-
         // Check if dotnet is available
         self.warn_if_dependency_missing(
             &ctx.config,

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -1,7 +1,5 @@
 //! S3 backend for mise - downloads tools from Amazon S3 or S3-compatible storage
 //!
-//! S3 backend requires experimental mode to be enabled.
-//!
 //! This backend allows installing tools from private or public S3 buckets.
 //! It supports version discovery via S3 object listing or manifest files.
 //!
@@ -34,8 +32,7 @@
 //! region = "us-east-1"
 //! ```
 
-/// S3 backend is experimental and requires `experimental = true` in settings
-pub const EXPERIMENTAL: bool = true;
+pub const EXPERIMENTAL: bool = false;
 
 use crate::backend::backend_type::BackendType;
 use crate::backend::options::BackendOptions;
@@ -513,7 +510,6 @@ impl Backend for S3Backend {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        Settings::get().ensure_experimental("s3 backend")?;
         let raw_opts = tv.request.options();
         let opts = S3Options::new(&raw_opts);
 

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -27,8 +27,7 @@ use strum::{AsRefStr, EnumString, VariantNames};
 use url::Url;
 use xx::regex;
 
-/// SPM backend requires experimental mode to be enabled
-pub const EXPERIMENTAL: bool = true;
+pub const EXPERIMENTAL: bool = false;
 
 #[derive(Debug)]
 pub struct SPMBackend {
@@ -205,9 +204,6 @@ impl Backend for SPMBackend {
         ctx: &InstallContext,
         tv: ToolVersion,
     ) -> eyre::Result<ToolVersion> {
-        let settings = Settings::get();
-        settings.ensure_experimental("spm backend")?;
-
         // Check if swift is available
         self.warn_if_dependency_missing(
             &ctx.config,

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -93,7 +93,6 @@ impl Backend for VfoxBackend {
 
                 // Use backend methods if the plugin supports them
                 if this.is_backend_plugin() {
-                    Settings::get().ensure_experimental("custom backends")?;
                     debug!("Using backend method for plugin: {}", this.pathname);
                     let tool_name = this.get_tool_name()?;
                     let opts = config
@@ -154,7 +153,6 @@ impl Backend for VfoxBackend {
 
         // Use backend methods if the plugin supports them
         if self.is_backend_plugin() {
-            Settings::get().ensure_experimental("custom backends")?;
             let tool_name = self.get_tool_name()?;
             let tool_opts = tv.request.options();
             vfox.backend_install(

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -49,41 +49,41 @@ pub struct Exec {
     #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     pub jobs: Option<usize>,
 
-    /// [experimental] Allow specific env var through (implies --deny-env for everything else)
+    /// Allow specific env var through (implies --deny-env for everything else)
     /// Supports wildcards, e.g. --allow-env='MYAPP_*'
     #[clap(long, value_name = "VAR", verbatim_doc_comment)]
     pub allow_env: Vec<String>,
 
-    /// [experimental] Allow network to specific host (implies --deny-net for everything else)
+    /// Allow network to specific host (implies --deny-net for everything else)
     /// macOS only in v1; on Linux falls back to allowing all network
     #[clap(long, value_name = "HOST", verbatim_doc_comment)]
     pub allow_net: Vec<String>,
 
-    /// [experimental] Allow reads from specific path (implies --deny-read for everything else)
+    /// Allow reads from specific path (implies --deny-read for everything else)
     #[clap(long, value_name = "PATH", verbatim_doc_comment)]
     pub allow_read: Vec<std::path::PathBuf>,
 
-    /// [experimental] Allow writes to specific path (implies --deny-write for everything else)
+    /// Allow writes to specific path (implies --deny-write for everything else)
     #[clap(long, value_name = "PATH", verbatim_doc_comment)]
     pub allow_write: Vec<std::path::PathBuf>,
 
-    /// [experimental] Block reads, writes, network, and env vars
+    /// Block reads, writes, network, and env vars
     #[clap(long, verbatim_doc_comment)]
     pub deny_all: bool,
 
-    /// [experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+    /// Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
     #[clap(long, verbatim_doc_comment)]
     pub deny_env: bool,
 
-    /// [experimental] Block all network access
+    /// Block all network access
     #[clap(long, verbatim_doc_comment)]
     pub deny_net: bool,
 
-    /// [experimental] Block filesystem reads (system libs and tool dirs still accessible)
+    /// Block filesystem reads (system libs and tool dirs still accessible)
     #[clap(long, verbatim_doc_comment)]
     pub deny_read: bool,
 
-    /// [experimental] Block all filesystem writes
+    /// Block all filesystem writes
     #[clap(long, verbatim_doc_comment)]
     pub deny_write: bool,
 
@@ -234,7 +234,7 @@ impl Exec {
             args.insert(0, "-C".into());
         }
 
-        // Build sandbox config from CLI flags (experimental feature)
+        // Build sandbox config from CLI flags.
         let mut sandbox = SandboxConfig {
             deny_read: self.deny_all || self.deny_read,
             deny_write: self.deny_all || self.deny_write,
@@ -247,9 +247,7 @@ impl Exec {
         };
         sandbox.resolve_paths();
 
-        // Check experimental flag if sandbox is being used
         if sandbox.is_active() {
-            Settings::get().ensure_experimental("sandbox")?;
             env = sandbox.filter_env(&env);
         }
 

--- a/src/cli/generate/task_docs.rs
+++ b/src/cli/generate/task_docs.rs
@@ -1,6 +1,5 @@
-use crate::config::{self, Config, Settings};
+use crate::config::{self, Config};
 use crate::{dirs, file};
-use indexmap::IndexMap;
 use std::path::PathBuf;
 
 /// Generate documentation for tasks in a project
@@ -43,17 +42,12 @@ impl TaskDocs {
     pub async fn run(self) -> eyre::Result<()> {
         let config = Config::get().await?;
         let dir = dirs::CWD.as_ref().unwrap();
-        // Collect task templates from config hierarchy
-        let templates = if Settings::get().experimental {
-            config
-                .config_files
-                .values()
-                .rev()
-                .flat_map(|cf| cf.task_templates())
-                .collect()
-        } else {
-            IndexMap::new()
-        };
+        let templates = config
+            .config_files
+            .values()
+            .rev()
+            .flat_map(|cf| cf.task_templates())
+            .collect();
         let tasks =
             config::load_tasks_in_dir(&config, dir, &config.config_files, &templates).await?;
         let visible_tasks: Vec<_> = tasks.iter().filter(|t| !t.hide).collect();

--- a/src/cli/github/token.rs
+++ b/src/cli/github/token.rs
@@ -19,7 +19,7 @@ pub struct Token {
     #[clap(long)]
     raw: bool,
 
-    /// [experimental] Mint a fresh OAuth token even if the cached one has not
+    /// Mint a fresh OAuth token even if the cached one has not
     /// expired, via the refresh-token grant or a new device-code flow
     #[clap(long, requires = "oauth")]
     refresh: bool,

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -70,14 +70,14 @@ pub struct Install {
     #[clap(long, overrides_with = "jobs")]
     raw: bool,
 
-    /// [experimental] Install tool(s) to a shared directory
+    /// Install tool(s) to a shared directory
     ///
     /// Installs to the specified directory instead of the default install location.
     /// May require elevated permissions depending on the path.
     #[clap(long, verbatim_doc_comment, value_hint = ValueHint::DirPath, conflicts_with = "system")]
     shared: Option<PathBuf>,
 
-    /// [experimental] Install tool(s) to the system-wide shared directory
+    /// Install tool(s) to the system-wide shared directory
     ///
     /// Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
     /// May require elevated permissions (e.g. sudo).

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -19,7 +19,7 @@ use serde_json::{Value, json};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-/// [experimental] Run Model Context Protocol (MCP) server
+/// Run Model Context Protocol (MCP) server
 ///
 /// This command starts an MCP server that exposes mise functionality
 /// to AI assistants over stdin/stdout using JSON-RPC protocol.
@@ -420,9 +420,6 @@ impl ServerHandler for MiseServer {
 
 impl Mcp {
     pub async fn run(self) -> Result<()> {
-        let settings = crate::config::Settings::get();
-        settings.ensure_experimental("mcp")?;
-
         eprintln!("Starting mise MCP server...");
 
         let server = MiseServer::new();
@@ -455,9 +452,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
         "mise": {
           "command": "mise",
           "args": ["mcp"],
-          "env": {
-            "MISE_EXPERIMENTAL": "1"
-          }
+          "env": {}
         }
       }
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -134,40 +134,40 @@ pub struct Run {
     #[clap(skip)]
     pub is_linear: bool,
 
-    /// [experimental] Allow specific env var through (implies --deny-env for everything else)
+    /// Allow specific env var through (implies --deny-env for everything else)
     /// Supports wildcards, e.g. --allow-env='MYAPP_*'
     #[clap(long, value_name = "VAR", verbatim_doc_comment)]
     pub allow_env: Vec<String>,
 
-    /// [experimental] Allow network to specific host (implies --deny-net for everything else)
+    /// Allow network to specific host (implies --deny-net for everything else)
     #[clap(long, value_name = "HOST", verbatim_doc_comment)]
     pub allow_net: Vec<String>,
 
-    /// [experimental] Allow reads from specific path (implies --deny-read for everything else)
+    /// Allow reads from specific path (implies --deny-read for everything else)
     #[clap(long, value_name = "PATH", verbatim_doc_comment)]
     pub allow_read: Vec<std::path::PathBuf>,
 
-    /// [experimental] Allow writes to specific path (implies --deny-write for everything else)
+    /// Allow writes to specific path (implies --deny-write for everything else)
     #[clap(long, value_name = "PATH", verbatim_doc_comment)]
     pub allow_write: Vec<std::path::PathBuf>,
 
-    /// [experimental] Block reads, writes, network, and env vars
+    /// Block reads, writes, network, and env vars
     #[clap(long, verbatim_doc_comment)]
     pub deny_all: bool,
 
-    /// [experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
+    /// Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
     #[clap(long, verbatim_doc_comment)]
     pub deny_env: bool,
 
-    /// [experimental] Block all network access
+    /// Block all network access
     #[clap(long, verbatim_doc_comment)]
     pub deny_net: bool,
 
-    /// [experimental] Block filesystem reads (system libs and tool dirs still accessible)
+    /// Block filesystem reads (system libs and tool dirs still accessible)
     #[clap(long, verbatim_doc_comment)]
     pub deny_read: bool,
 
-    /// [experimental] Block all filesystem writes
+    /// Block all filesystem writes
     #[clap(long, verbatim_doc_comment)]
     pub deny_write: bool,
 

--- a/src/cli/token/github.rs
+++ b/src/cli/token/github.rs
@@ -13,7 +13,7 @@ pub struct Github {
     #[clap(default_value = "github.com")]
     pub(crate) host: String,
 
-    /// [experimental] Resolve only via the native GitHub OAuth source (cache,
+    /// Resolve only via the native GitHub OAuth source (cache,
     /// refresh, or device-code flow), bypassing other token sources
     #[clap(long)]
     pub(crate) oauth: bool,
@@ -22,7 +22,7 @@ pub struct Github {
     #[clap(long)]
     pub(crate) raw: bool,
 
-    /// [experimental] Mint a fresh OAuth token even if the cached one has not
+    /// Mint a fresh OAuth token even if the cached one has not
     /// expired, via the refresh-token grant or a new device-code flow.
     /// Use after changing the GitHub App's installations or permissions:
     /// cached tokens keep their original access until they expire

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -185,8 +185,8 @@ pub struct MiseToml {
     #[serde(default)]
     settings: SettingsPartial,
     /// Marks this config as a monorepo root, enabling target path syntax for tasks
-    #[serde(default)]
-    experimental_monorepo_root: Option<bool>,
+    #[serde(default, alias = "experimental_monorepo_root")]
+    monorepo_root: Option<bool>,
     /// Configuration for monorepo task discovery
     #[serde(default)]
     monorepo: Option<MonorepoConfig>,
@@ -984,8 +984,8 @@ impl ConfigFile for MiseToml {
             .transpose()
     }
 
-    fn experimental_monorepo_root(&self) -> Option<bool> {
-        self.experimental_monorepo_root
+    fn monorepo_root(&self) -> Option<bool> {
+        self.monorepo_root
     }
 
     fn monorepo(&self) -> Option<&MonorepoConfig> {
@@ -1131,7 +1131,7 @@ impl Clone for MiseToml {
             oci: self.oci.clone(),
             system: self.system.clone(),
             vars: self.vars.clone(),
-            experimental_monorepo_root: self.experimental_monorepo_root,
+            monorepo_root: self.monorepo_root,
             monorepo: self.monorepo.clone(),
         }
     }

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -120,7 +120,7 @@ pub trait ConfigFile: Debug + Send + Sync {
         IndexMap::new()
     }
 
-    fn experimental_monorepo_root(&self) -> Option<bool> {
+    fn monorepo_root(&self) -> Option<bool> {
         None
     }
 
@@ -372,9 +372,7 @@ pub fn is_trusted(path: &Path) -> bool {
 
     // Check if this path is within a trusted monorepo root
     // Monorepo roots are marked with a special marker file when trusted
-    if settings.experimental
-        && let Some(parent) = canonicalized_path.parent()
-    {
+    if let Some(parent) = canonicalized_path.parent() {
         let mut current = parent;
         while let Some(dir) = current.parent() {
             let monorepo_marker = with_appended_extension(&trust_path(dir), "monorepo");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -502,12 +502,7 @@ impl Config {
         let config = Config::get().await?;
         time!("load_all_tasks");
 
-        // Collect all task templates from config hierarchy (experimental feature)
-        let templates = if Settings::get().experimental {
-            collect_task_templates(&config.config_files)
-        } else {
-            IndexMap::new()
-        };
+        let templates = collect_task_templates(&config.config_files);
 
         let local_tasks = load_local_tasks_with_context(&config, ctx, &templates).await?;
         let global_tasks = load_global_tasks(&config, &templates).await?;
@@ -928,15 +923,11 @@ fn find_monorepo_root(config_files: &ConfigMap) -> Option<PathBuf> {
     find_monorepo_config(config_files).and_then(|cf| cf.project_root().map(|p| p.to_path_buf()))
 }
 
-/// Find the config file that has experimental_monorepo_root = true
+/// Find the config file that has monorepo_root = true
 fn find_monorepo_config(config_files: &ConfigMap) -> Option<&Arc<dyn ConfigFile>> {
-    // This feature requires experimental mode
-    if !Settings::get().experimental {
-        return None;
-    }
     config_files
         .values()
-        .find(|cf| cf.experimental_monorepo_root() == Some(true))
+        .find(|cf| cf.monorepo_root() == Some(true))
 }
 
 async fn load_idiomatic_filenames() -> BTreeMap<String, Vec<String>> {
@@ -1590,7 +1581,7 @@ async fn load_all_config_files(
         }
 
         // Mark monorepo roots so descendant configs are implicitly trusted
-        if cf.experimental_monorepo_root() == Some(true)
+        if cf.monorepo_root() == Some(true)
             && let Err(err) = config_file::mark_as_monorepo_root(f)
         {
             warn!("failed to mark monorepo root: {err:#}");
@@ -1794,20 +1785,12 @@ fn collect_task_templates(config_files: &ConfigMap) -> IndexMap<String, TaskTemp
 }
 
 /// Resolve a task template and merge it into the task.
-/// Returns an error if the template is not found or if experimental mode is not enabled.
+/// Returns an error if the template is not found.
 fn resolve_task_template(
     task: &mut Task,
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<()> {
     if let Some(template_name) = &task.extends {
-        if !Settings::get().experimental {
-            bail!(
-                "Task '{}' uses 'extends = \"{}\"' which requires 'experimental = true' in settings",
-                task.name,
-                template_name
-            );
-        }
-
         let template = templates.get(template_name).ok_or_else(|| {
             eyre!(
                 "Task '{}' extends template '{}' which was not found. \

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -198,7 +198,6 @@ async fn refresh_cached_token(
 
 async fn token_async(req: TokenRequest) -> Result<String> {
     let settings = Settings::get();
-    settings.ensure_experimental("native GitHub OAuth")?;
     let client_id = settings.github.oauth_client_id.trim();
     let scopes = settings.github.oauth_scopes.trim();
     if client_id.is_empty() {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -480,7 +480,6 @@ async fn execute(
     hook: &Hook,
     installed_tools: Option<&[InstalledToolInfo]>,
 ) -> Result<()> {
-    Settings::get().ensure_experimental("hooks")?;
     let HookAction::Run {
         run,
         run_windows,
@@ -640,8 +639,6 @@ async fn execute_task(
     task_name: &str,
     installed_tools: Option<&[InstalledToolInfo]>,
 ) -> Result<()> {
-    Settings::get().ensure_experimental("hooks")?;
-
     let mise_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("mise"));
 
     let mut env = if hook.hook == Hooks::Preinstall {

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -500,12 +500,6 @@ impl PythonPlugin {
         let raw_opts = tv.request.options();
         let opts = PythonOptions::new(&raw_opts);
         if let Some(virtualenv) = opts.virtualenv() {
-            if !Settings::get().experimental {
-                warn!(
-                    "please enable experimental mode with `mise settings experimental=true` \
-                    to use python virtualenv activation"
-                );
-            }
             let mut virtualenv: PathBuf = file::replace_path(Path::new(virtualenv));
             if !virtualenv.is_absolute() {
                 // TODO: use the path of the config file that specified python, not the top one like this

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -64,7 +64,6 @@ impl SwiftPlugin {
     }
 
     fn install(&self, ctx: &InstallContext, tv: &ToolVersion, tarball_path: &Path) -> Result<()> {
-        Settings::get().ensure_experimental("swift")?;
         let filename = tarball_path.file_name().unwrap().to_string_lossy();
         let version = &tv.version;
         ctx.pr.set_message(format!("extract {filename}"));
@@ -245,11 +244,7 @@ impl Backend for SwiftPlugin {
     }
 
     async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        if Settings::get().experimental {
-            Ok(vec![".swift-version".into()])
-        } else {
-            Ok(vec![])
-        }
+        Ok(vec![".swift-version".into()])
     }
 
     async fn install_version_(

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -478,7 +478,7 @@ pub struct Task {
     #[serde(default)]
     pub allow_env: Vec<String>,
 
-    /// Name of the task template to extend (requires experimental = true)
+    /// Name of the task template to extend
     #[serde(default)]
     pub extends: Option<String>,
 

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1050,7 +1050,6 @@ impl TaskExecutor {
         let raw = self.raw(Some(task));
         let sandbox = self.build_sandbox_for_task(task, &config).await?;
         let env = if sandbox.is_active() {
-            Settings::get().ensure_experimental("sandbox")?;
             &sandbox.filter_env(env)
         } else {
             env

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -1,4 +1,4 @@
-use crate::config::{self, Config, Settings};
+use crate::config::{self, Config};
 use crate::file::display_path;
 use crate::task::{
     GetMatchingExt, Task, TaskLoadContext, extract_monorepo_path, resolve_task_pattern,
@@ -51,20 +51,6 @@ pub fn split_task_spec(spec: &str) -> (&str, Vec<String>) {
 
 /// Validate that monorepo features are properly configured
 fn validate_monorepo_setup(config: &Arc<Config>) -> Result<()> {
-    // Check if experimental mode is enabled
-    if !Settings::get().experimental {
-        bail!(
-            "Monorepo task paths (like `//path:task` or `:task`) require experimental mode.\n\
-            \n\
-            To enable experimental features, set:\n\
-            {}\n\
-            \n\
-            Or run with: {}",
-            style::eyellow("  export MISE_EXPERIMENTAL=true"),
-            style::eyellow("MISE_EXPERIMENTAL=1 mise run ...")
-        );
-    }
-
     // Check if a monorepo root is configured
     if !config.is_monorepo() {
         bail!(
@@ -75,7 +61,7 @@ fn validate_monorepo_setup(config: &Arc<Config>) -> Result<()> {
             \n\
             Then create task files in subdirectories that will be automatically discovered.\n\
             See {} for more information.",
-            style::eyellow("  experimental_monorepo_root = true"),
+            style::eyellow("  monorepo_root = true"),
             style::eunderline("https://mise.en.dev/tasks/task-configuration.html#monorepo-support")
         );
     }

--- a/src/task/task_load_context.rs
+++ b/src/task/task_load_context.rs
@@ -173,11 +173,11 @@ pub fn expand_colon_task_syntax(
         );
     }
 
-    // Get the monorepo root (the config file with experimental_monorepo_root = true)
+    // Get the monorepo root config file.
     let monorepo_root = config
         .config_files
         .values()
-        .find(|cf| cf.experimental_monorepo_root() == Some(true))
+        .find(|cf| cf.monorepo_root() == Some(true))
         .and_then(|cf| cf.project_root());
 
     // If not in monorepo context, only expand if it's a colon pattern (error), otherwise return as-is

--- a/src/watch_files.rs
+++ b/src/watch_files.rs
@@ -77,7 +77,6 @@ async fn execute(
     shell: Option<&str>,
     files: Vec<&PathBuf>,
 ) -> Result<()> {
-    Settings::get().ensure_experimental("watch_file_hooks")?;
     let modified_files_var = files
         .iter()
         .map(|f| f.to_string_lossy().replace(':', "\\:"))
@@ -144,7 +143,6 @@ async fn execute_task(
     task_name: &str,
     files: Vec<&PathBuf>,
 ) -> Result<()> {
-    Settings::get().ensure_experimental("watch_file_hooks")?;
     let modified_files_var = files
         .iter()
         .map(|f| f.to_string_lossy().replace(':', "\\:"))

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1017,7 +1017,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--allow-env",
           description:
-            "[experimental] Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
+            "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
           isRepeatable: true,
           args: {
             name: "var",
@@ -1026,7 +1026,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--allow-net",
           description:
-            "[experimental] Allow network to specific host (implies --deny-net for everything else)\nmacOS only in v1; on Linux falls back to allowing all network",
+            "Allow network to specific host (implies --deny-net for everything else)\nmacOS only in v1; on Linux falls back to allowing all network",
           isRepeatable: true,
           args: {
             name: "host",
@@ -1035,7 +1035,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--allow-read",
           description:
-            "[experimental] Allow reads from specific path (implies --deny-read for everything else)",
+            "Allow reads from specific path (implies --deny-read for everything else)",
           isRepeatable: true,
           args: {
             name: "path",
@@ -1045,7 +1045,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--allow-write",
           description:
-            "[experimental] Allow writes to specific path (implies --deny-write for everything else)",
+            "Allow writes to specific path (implies --deny-write for everything else)",
           isRepeatable: true,
           args: {
             name: "path",
@@ -1054,30 +1054,29 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--deny-all",
-          description:
-            "[experimental] Block reads, writes, network, and env vars",
+          description: "Block reads, writes, network, and env vars",
           isRepeatable: false,
         },
         {
           name: "--deny-env",
           description:
-            "[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)",
+            "Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)",
           isRepeatable: false,
         },
         {
           name: "--deny-net",
-          description: "[experimental] Block all network access",
+          description: "Block all network access",
           isRepeatable: false,
         },
         {
           name: "--deny-read",
           description:
-            "[experimental] Block filesystem reads (system libs and tool dirs still accessible)",
+            "Block filesystem reads (system libs and tool dirs still accessible)",
           isRepeatable: false,
         },
         {
           name: "--deny-write",
-          description: "[experimental] Block all filesystem writes",
+          description: "Block all filesystem writes",
           isRepeatable: false,
         },
         {
@@ -1568,7 +1567,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--shared",
-          description: "[experimental] Install tool(s) to a shared directory",
+          description: "Install tool(s) to a shared directory",
           isRepeatable: false,
           args: {
             name: "shared",
@@ -1576,8 +1575,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--system",
-          description:
-            "[experimental] Install tool(s) to the system-wide shared directory",
+          description: "Install tool(s) to the system-wide shared directory",
           isRepeatable: false,
         },
       ],
@@ -1860,7 +1858,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "mcp",
-      description: "[experimental] Run Model Context Protocol (MCP) server",
+      description: "Run Model Context Protocol (MCP) server",
     },
     {
       name: "oci",
@@ -2656,7 +2654,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--allow-env",
           description:
-            "[experimental] Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
+            "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
           isRepeatable: true,
           args: {
             name: "var",
@@ -2665,7 +2663,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--allow-net",
           description:
-            "[experimental] Allow network to specific host (implies --deny-net for everything else)",
+            "Allow network to specific host (implies --deny-net for everything else)",
           isRepeatable: true,
           args: {
             name: "host",
@@ -2674,7 +2672,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--allow-read",
           description:
-            "[experimental] Allow reads from specific path (implies --deny-read for everything else)",
+            "Allow reads from specific path (implies --deny-read for everything else)",
           isRepeatable: true,
           args: {
             name: "path",
@@ -2684,7 +2682,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--allow-write",
           description:
-            "[experimental] Allow writes to specific path (implies --deny-write for everything else)",
+            "Allow writes to specific path (implies --deny-write for everything else)",
           isRepeatable: true,
           args: {
             name: "path",
@@ -2693,30 +2691,29 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--deny-all",
-          description:
-            "[experimental] Block reads, writes, network, and env vars",
+          description: "Block reads, writes, network, and env vars",
           isRepeatable: false,
         },
         {
           name: "--deny-env",
           description:
-            "[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)",
+            "Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)",
           isRepeatable: false,
         },
         {
           name: "--deny-net",
-          description: "[experimental] Block all network access",
+          description: "Block all network access",
           isRepeatable: false,
         },
         {
           name: "--deny-read",
           description:
-            "[experimental] Block filesystem reads (system libs and tool dirs still accessible)",
+            "Block filesystem reads (system libs and tool dirs still accessible)",
           isRepeatable: false,
         },
         {
           name: "--deny-write",
-          description: "[experimental] Block all filesystem writes",
+          description: "Block all filesystem writes",
           isRepeatable: false,
         },
         {
@@ -3732,7 +3729,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--allow-env",
               description:
-                "[experimental] Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
+                "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
               isRepeatable: true,
               args: {
                 name: "var",
@@ -3741,7 +3738,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--allow-net",
               description:
-                "[experimental] Allow network to specific host (implies --deny-net for everything else)",
+                "Allow network to specific host (implies --deny-net for everything else)",
               isRepeatable: true,
               args: {
                 name: "host",
@@ -3750,7 +3747,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--allow-read",
               description:
-                "[experimental] Allow reads from specific path (implies --deny-read for everything else)",
+                "Allow reads from specific path (implies --deny-read for everything else)",
               isRepeatable: true,
               args: {
                 name: "path",
@@ -3760,7 +3757,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--allow-write",
               description:
-                "[experimental] Allow writes to specific path (implies --deny-write for everything else)",
+                "Allow writes to specific path (implies --deny-write for everything else)",
               isRepeatable: true,
               args: {
                 name: "path",
@@ -3769,30 +3766,29 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--deny-all",
-              description:
-                "[experimental] Block reads, writes, network, and env vars",
+              description: "Block reads, writes, network, and env vars",
               isRepeatable: false,
             },
             {
               name: "--deny-env",
               description:
-                "[experimental] Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)",
+                "Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)",
               isRepeatable: false,
             },
             {
               name: "--deny-net",
-              description: "[experimental] Block all network access",
+              description: "Block all network access",
               isRepeatable: false,
             },
             {
               name: "--deny-read",
               description:
-                "[experimental] Block filesystem reads (system libs and tool dirs still accessible)",
+                "Block filesystem reads (system libs and tool dirs still accessible)",
               isRepeatable: false,
             },
             {
               name: "--deny-write",
-              description: "[experimental] Block all filesystem writes",
+              description: "Block all filesystem writes",
               isRepeatable: false,
             },
             {
@@ -4021,7 +4017,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--oauth",
               description:
-                "[experimental] Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources",
+                "Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources",
               isRepeatable: false,
             },
             {
@@ -4032,7 +4028,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--refresh",
               description:
-                "[experimental] Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire",
+                "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire",
               isRepeatable: false,
             },
             {


### PR DESCRIPTION
## Summary
- remove experimental gates from MCP, sandboxing, hooks/watch_files, monorepo tasks, task templates, native GitHub OAuth, custom vfox backends, Swift, and dotnet/s3/spm backends
- rename the visible monorepo root config key to `monorepo_root`, while keeping `experimental_monorepo_root` as a hidden compatibility alias
- remove experimental labels from related settings, generated CLI docs, schemas, manpage, fig completion data, and hand-written docs
- update e2e coverage to exercise the promoted behavior without MISE_EXPERIMENTAL

## Verification
- mise run render
- cargo fmt
- mise run test:e2e e2e/tasks/test_task_templates e2e/tasks/test_task_monorepo_validation e2e/cli/test_mcp e2e/cli/test_token_github (the harness also ran e2e/cli/test_mcp_protocol; initial run exposed a test dependency on real Node/Python installs)
- mise run test:e2e e2e/cli/test_mcp_protocol e2e/cli/test_token_github
- mise run test:e2e e2e/tasks/test_task_monorepo_validation
- mise run build
- git diff --check

*This PR was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed experimental badges/warnings across CLI, docs, man pages, and config examples.

* **Features**
  * Sandboxing and access-control flags marked stable.
  * MCP server, task templates, monorepo support, hooks, watch-file hooks, and native GitHub OAuth promoted to stable.
  * S3, SPM, dotnet backends, Swift plugin, and shared/system install options are no longer experimental.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->