### PR TITLE
chore: remove stale cargo-deny advisory ignores

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -70,18 +70,9 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  { id = "RUSTSEC-2024-0370", reason = "proc-macro-error dependency from sigstore crate - no safe upgrade available" },
   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained - transitive via age/mlua/tabled/rops, no safe upgrade available" },
   { id = "RUSTSEC-2023-0071", reason = "rsa crate Marvin attack vulnerability from sigstore crate - no safe upgrade available" },
   { id = "RUSTSEC-2025-0119", reason = "number_prefix crate is unmaintained - used by indicatif/self_update, no safe upgrade available" },
-  # rustls-webpki 0.102.8 advisories — pulled in transitively by sigstore-tsa
-  # 0.7.0 (pinned to `rustls-webpki = \"0.102\"`); fix requires sigstore-rust
-  # upstream to bump to 0.103.x. Not directly exploitable in mise's verification
-  # paths (we don't pass CRLs or URI-name-constrained certs to webpki).
-  { id = "RUSTSEC-2026-0049", reason = "rustls-webpki 0.102 CRL distribution-point matching - via sigstore-tsa 0.7.0, no safe upgrade available" },
-  { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.102 URI name constraints - via sigstore-tsa 0.7.0, no safe upgrade available" },
-  { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.102 wildcard name constraints - via sigstore-tsa 0.7.0, no safe upgrade available" },
-  { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102 reachable panic in CRL parsing - via sigstore-tsa 0.7.0, no safe upgrade available" },
   #"RUSTSEC-0000-0000",
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
## Summary
- remove cargo-deny advisory ignores that no longer match dependency advisories
- remove the obsolete rustls-webpki explanatory block tied to those ignores

## Test
- cargo deny check

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only cleanup with no runtime code changes; risk is limited to `cargo deny check` failing if any removed advisory still matches the lockfile.
> 
> **Overview**
> Trims **`deny.toml`** so `cargo deny check advisories` only lists ignores that still apply to the current dependency graph.
> 
> Removes **`RUSTSEC-2024-0370`** (`proc-macro-error` via sigstore) and four **`rustls-webpki` 0.102** entries (**`RUSTSEC-2026-0049`**, **0098**, **0099**, **0104**) plus the long comment about sigstore-tsa / `rustls-webpki = "0.102"`. **Unchanged** ignores: **`RUSTSEC-2026-0173`**, **`RUSTSEC-2023-0071`**, **`RUSTSEC-2025-0119`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d125c146b59603128d2452e0eb06da30fae9c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security advisory configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->