### PR TITLE
feat(oci): apply system files and apt packages

### DIFF
--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -70,7 +70,10 @@ jq = "1.8.1"
 3. **One layer per tool**, each rooted at
    `/mise/installs/<plugin>/<version>/`. Annotated with
    `dev.mise.tool.short` and `dev.mise.tool.version`.
-4. **Synthesized `/etc/mise/config.toml`** referencing `/mise` as the data
+4. **Configured apt `[system.packages]`**, if any, installed into the base
+   rootfs and emitted as one package layer.
+5. **Configured `[system.files]`**, if any, baked as image files.
+6. **Synthesized `/etc/mise/config.toml`** referencing `/mise` as the data
    directory.
 
 Bumping `node` from `20.10` to `20.11` only invalidates the node layer.
@@ -203,6 +206,38 @@ CLI flags override the `[oci]` section. The `[oci]` section overrides the
 
 When `mise.toml` files are layered (global + project), sections are merged
 field-by-field with the more specific file winning per field.
+
+### `[system]` in OCI images
+
+`mise oci build` applies project-scoped `[system.packages]` and
+`[system.files]` entries to the image. This is the OCI equivalent of the
+declarative parts of `mise bootstrap` / `mise system install`.
+Pass `--include-global` to also include `[system.packages]` and
+`[system.files]` from global configs.
+
+```toml
+[system.packages]
+"apt:curl" = "latest"
+
+[system.files]
+"/etc/profile.d/project.sh" = { source = "profile.sh", mode = "copy" }
+"~/.config/app/config.toml" = { source = "config.toml", mode = "template" }
+```
+
+For packages, OCI builds currently support `apt:` entries with a Debian/Ubuntu
+base image. mise unpacks the base image into a temporary rootfs, calls the
+host `apt-get` to install into that rootfs, then emits the filesystem changes
+as one OCI layer annotated with `dev.mise.system.packages=apt`. Other system
+package managers are rejected for OCI builds for now.
+
+For image builds, `symlink` and `symlink-each` entries are copied as file
+content. Host symlinks would usually point back to the checkout path and be
+broken inside the container, so the image receives the resolved contents
+instead. Targets beginning with `~/` are written under `/root/`.
+
+`[system.defaults]` and the imperative `bootstrap` task are not run by
+`mise oci build`. macOS defaults do not apply to Linux OCI images, and
+container-specific startup work belongs in the image entrypoint or command.
 
 ### Settings
 

--- a/e2e/oci/test_oci_build_slow
+++ b/e2e/oci/test_oci_build_slow
@@ -100,7 +100,41 @@ mf_oci="$(jq -r '.manifests[0].digest | ltrimstr("sha256:")' ./out-oci-scope/ind
 config_oci_digest="$(jq -r '.config.digest | ltrimstr("sha256:")' "./out-oci-scope/blobs/sha256/$mf_oci")"
 assert_not_contains "jq -r '.config.Env | join(\"\n\")' ./out-oci-scope/blobs/sha256/$config_oci_digest" "/should-not-appear"
 
-# --- 9. No project config + no --include-global → clear error ---
+# --- 9. [system.files] is baked into its own image layer ---
+cat >profile.sh <<EOF
+export PROJECT_READY=1
+EOF
+cat >app.tmpl <<EOF
+tool={{env.MISE_ENV | default(value="dev")}}
+EOF
+cat >mise.toml <<EOF
+[tools]
+jq = "1.8.1"
+
+[system.files]
+"/etc/profile.d/project.sh" = { source = "profile.sh", mode = "copy" }
+"~/.config/app/config.toml" = { source = "app.tmpl", mode = "template" }
+EOF
+export MISE_ENV=dev
+assert_succeed "mise oci build -o ./out-files --from scratch"
+unset MISE_ENV
+mf_files="$(jq -r '.manifests[0].digest | ltrimstr("sha256:")' ./out-files/index.json)"
+files_layer="$(jq -r '.layers[] | select(.annotations."dev.mise.system.files" == "true") | .digest | ltrimstr("sha256:")' ./out-files/blobs/sha256/"$mf_files")"
+assert_contains "tar -tzf ./out-files/blobs/sha256/$files_layer" "etc/profile.d/project.sh"
+assert_contains "tar -tzf ./out-files/blobs/sha256/$files_layer" "root/.config/app/config.toml"
+assert_contains "tar -xOzf ./out-files/blobs/sha256/$files_layer etc/profile.d/project.sh" "PROJECT_READY=1"
+assert_contains "tar -xOzf ./out-files/blobs/sha256/$files_layer root/.config/app/config.toml" "tool=dev"
+
+# --- 10. [system.packages] participates in OCI builds ---
+# scratch has no apt metadata, so this exercises the OCI package path without
+# requiring network access in the e2e test environment.
+cat >mise.toml <<EOF
+[system.packages]
+"apt:curl" = "latest"
+EOF
+assert_fail "mise oci build -o ./out-system-packages --from scratch" "requires an apt-based base image"
+
+# --- 11. No project config + no --include-global → clear error ---
 # Error message is shared between build/run/push, so it must NOT name a
 # specific subcommand (just "mise oci").
 rm -f mise.toml

--- a/src/cli/oci/common.rs
+++ b/src/cli/oci/common.rs
@@ -4,6 +4,7 @@ use eyre::{Result, bail};
 
 use crate::config::{Config, ConfigMap};
 use crate::oci::{BuildOptions, BuildOutput, Builder, OciConfig};
+use crate::system;
 use crate::toolset::{ConfigScope, ToolsetBuilder};
 
 /// Merge `[oci]` sections from the given config files, with more specific
@@ -53,12 +54,26 @@ pub async fn perform_build(opts: BuildOptions, include_global: bool) -> Result<B
     if include_global {
         let ts = ToolsetBuilder::new().build(&config).await?;
         let oci = merged_oci_config(&config);
-        return Builder::new(config.clone(), ts, oci, opts).build().await;
+        reject_unsupported_system_defaults(&config.config_files)?;
+        let files = system::files::files_from_config_files(&config.config_files);
+        let packages = system::packages_from_config_files(&config.config_files);
+        return Builder::new(config.clone(), ts, oci, opts)
+            .with_system_files(files)
+            .with_system_packages(packages)
+            .build()
+            .await;
     }
     let project_files = project_config_files(&config)?;
     let ts = build_project_toolset(&config, project_files.clone()).await?;
     let oci = merged_oci_config_from(project_files.values());
-    Builder::new(config.clone(), ts, oci, opts).build().await
+    reject_unsupported_system_defaults(&project_files)?;
+    let files = system::files::files_from_config_files(&project_files);
+    let packages = system::packages_from_config_files(&project_files);
+    Builder::new(config.clone(), ts, oci, opts)
+        .with_system_files(files)
+        .with_system_packages(packages)
+        .build()
+        .await
 }
 
 /// Configs at-or-below the project root.
@@ -100,6 +115,28 @@ async fn build_project_toolset(
         .with_scope(ConfigScope::LocalOnly)
         .build(config)
         .await
+}
+
+fn reject_unsupported_system_defaults(config_files: &ConfigMap) -> Result<()> {
+    let mut defaults = 0usize;
+    for cf in config_files.values() {
+        let Some(system) = cf.system_config() else {
+            continue;
+        };
+        defaults += system
+            .defaults
+            .values()
+            .map(|v| v.as_table().map_or(1, |t| t.len()))
+            .sum::<usize>();
+    }
+
+    if defaults > 0 {
+        bail!(
+            "mise oci does not support [system.defaults] (found {defaults} default entries); \
+             macOS defaults do not apply to OCI images."
+        );
+    }
+    Ok(())
 }
 
 pub fn short_digest(d: &str) -> String {

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use eyre::{Context, Result, bail};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 
 use crate::backend::backend_type::BackendType;
 use crate::config::{Config, Settings};
@@ -17,7 +17,10 @@ use crate::oci::OciConfig;
 use crate::oci::layer::{self, LayerBlob, LayerOwner};
 use crate::oci::layout::ImageLayout;
 use crate::oci::manifest::{self, Descriptor, ImageConfig, ImageManifest, Platform, RootFs};
+use crate::oci::packages;
 use crate::oci::registry;
+use crate::system::ManagerPackages;
+use crate::system::files::{FileMode, FileRequest};
 use crate::toolset::{ToolVersion, Toolset};
 
 /// Options passed to the builder from the CLI.
@@ -42,6 +45,8 @@ pub struct Builder {
     pub ts: Toolset,
     pub oci: OciConfig,
     pub opts: BuildOptions,
+    pub system_files: Vec<FileRequest>,
+    pub system_packages: Vec<ManagerPackages>,
 }
 
 /// Output summary returned to the CLI.
@@ -60,7 +65,24 @@ pub struct ToolLayerInfo {
 
 impl Builder {
     pub fn new(cfg: Arc<Config>, ts: Toolset, oci: OciConfig, opts: BuildOptions) -> Self {
-        Self { cfg, ts, oci, opts }
+        Self {
+            cfg,
+            ts,
+            oci,
+            opts,
+            system_files: vec![],
+            system_packages: vec![],
+        }
+    }
+
+    pub fn with_system_files(mut self, system_files: Vec<FileRequest>) -> Self {
+        self.system_files = system_files;
+        self
+    }
+
+    pub fn with_system_packages(mut self, system_packages: Vec<ManagerPackages>) -> Self {
+        self.system_packages = system_packages;
+        self
     }
 
     /// Build the image and write it to the output directory.
@@ -168,7 +190,7 @@ impl Builder {
             base_config_json = Some(pull.config_json);
         }
 
-        // --- 2. Per-tool layers ---
+        // --- 2. Validate tool installs before any package work ---
         // Tool installs are host-native binaries. On non-linux hosts they'll
         // fail at runtime inside the linux container with `Exec format error`
         // — emit a single warning up front so the user isn't surprised after
@@ -184,7 +206,6 @@ impl Builder {
                 n = versions.len()
             );
         }
-        let mut tool_layers: Vec<(String, String, LayerBlob)> = Vec::new();
         for (_, tv) in &versions {
             let install_path = tv.install_path();
             if !install_path.is_dir() {
@@ -194,13 +215,30 @@ impl Builder {
                     install_path.display()
                 );
             }
+        }
+
+        // --- 3. System package layer (optional) ---
+        let system_packages_layer = packages::build_system_packages_layer(
+            &layout,
+            &base_layers,
+            &self.system_packages,
+            platform
+                .as_ref()
+                .map(|p| p.architecture.as_str())
+                .unwrap_or_else(|| crate::oci::normalize_arch(std::env::consts::ARCH)),
+        )?;
+
+        // --- 4. Per-tool layers ---
+        let mut tool_layers: Vec<(String, String, LayerBlob)> = Vec::new();
+        for (_, tv) in &versions {
+            let install_path = tv.install_path();
             let tv_prefix = tool_tar_prefix(&mount_point, tv);
             let blob = layer::build_layer_from_dir(&install_path, &tv_prefix, owner)
                 .wrap_err_with(|| format!("building layer for {}", tv.style()))?;
             tool_layers.push((tv.ba().short.clone(), tv.version.clone(), blob));
         }
 
-        // --- 3. mise binary layer (optional) ---
+        // --- 5. mise binary layer (optional) ---
         let mut mise_layer: Option<LayerBlob> = None;
         if self.opts.include_mise {
             // OCI images are linux-targeted in v1 (we normalize `os` to
@@ -227,7 +265,18 @@ impl Builder {
             }
         }
 
-        // --- 4. Config layer: /etc/mise/config.toml ---
+        // --- 5. System files layer (optional) ---
+        let system_files_layer = if self.system_files.is_empty() {
+            None
+        } else {
+            Some(build_system_files_layer(
+                &self.cfg,
+                &self.system_files,
+                owner,
+            )?)
+        };
+
+        // --- 6. Config layer: /etc/mise/config.toml ---
         let config_layer = {
             let config_toml = synthesize_embedded_config_toml(&versions, &mount_point);
             let files = vec![(
@@ -238,7 +287,7 @@ impl Builder {
             layer::build_layer_from_files(&files, owner)?
         };
 
-        // --- 5. Write all layer blobs into the layout ---
+        // --- 7. Write all layer blobs into the layout ---
         let mut tool_layer_infos = Vec::new();
         let mut manifest_layers: Vec<Descriptor> = base_layers.clone();
         let mut all_diff_ids: Vec<String> = base_diff_ids.clone();
@@ -253,6 +302,20 @@ impl Builder {
                 platform: None,
             });
             all_diff_ids.push(m.diff_id.clone());
+        }
+
+        if let Some(blob) = &system_packages_layer {
+            layout.write_blob_with_digest(&blob.digest, &blob.bytes)?;
+            let mut annotations = IndexMap::new();
+            annotations.insert("dev.mise.system.packages".to_string(), "apt".to_string());
+            manifest_layers.push(Descriptor {
+                media_type: manifest::MEDIA_TYPE_OCI_LAYER_GZIP.to_string(),
+                size: blob.size,
+                digest: blob.digest.clone(),
+                annotations,
+                platform: None,
+            });
+            all_diff_ids.push(blob.diff_id.clone());
         }
 
         for (short, version, blob) in &tool_layers {
@@ -276,6 +339,20 @@ impl Builder {
             });
         }
 
+        if let Some(blob) = &system_files_layer {
+            layout.write_blob_with_digest(&blob.digest, &blob.bytes)?;
+            let mut annotations = IndexMap::new();
+            annotations.insert("dev.mise.system.files".to_string(), "true".to_string());
+            manifest_layers.push(Descriptor {
+                media_type: manifest::MEDIA_TYPE_OCI_LAYER_GZIP.to_string(),
+                size: blob.size,
+                digest: blob.digest.clone(),
+                annotations,
+                platform: None,
+            });
+            all_diff_ids.push(blob.diff_id.clone());
+        }
+
         {
             layout.write_blob_with_digest(&config_layer.digest, &config_layer.bytes)?;
             manifest_layers.push(Descriptor {
@@ -288,7 +365,7 @@ impl Builder {
             all_diff_ids.push(config_layer.diff_id.clone());
         }
 
-        // --- 6. Image config ---
+        // --- 8. Image config ---
         let image_config = self
             .build_image_config(
                 &versions,
@@ -310,7 +387,7 @@ impl Builder {
             platform: None,
         };
 
-        // --- 7. Manifest ---
+        // --- 9. Manifest ---
         let image_manifest = ImageManifest {
             schema_version: 2,
             media_type: manifest::MEDIA_TYPE_OCI_MANIFEST.to_string(),
@@ -320,7 +397,7 @@ impl Builder {
         };
         let (manifest_digest, manifest_size) = layout.write_manifest(&image_manifest)?;
 
-        // --- 8. index.json ---
+        // --- 10. index.json ---
         let tag = self.opts.tag.clone().or_else(|| self.oci.tag.clone());
         layout.write_index(&manifest_digest, manifest_size, platform, tag.as_deref())?;
 
@@ -577,6 +654,191 @@ fn resolve_layer_owner(opts_owner: Option<LayerOwner>, oci: &OciConfig) -> Layer
         let gid = oci.group_id.unwrap_or(uid);
         LayerOwner::new(uid, gid)
     })
+}
+
+fn build_system_files_layer(
+    cfg: &Config,
+    requests: &[FileRequest],
+    owner: LayerOwner,
+) -> Result<LayerBlob> {
+    let mut entries = SystemFileLayerEntries::default();
+
+    for req in requests {
+        if !req.source.exists() {
+            bail!(
+                "[system.files].\"{}\": source does not exist: {}",
+                req.target_raw,
+                req.source.display()
+            );
+        }
+
+        match req.mode {
+            FileMode::Symlink | FileMode::Copy => {
+                collect_source_as_files(&req.source, &oci_target_path(req)?, &mut entries)
+                    .wrap_err_with(|| {
+                        format!("adding [system.files].\"{}\" to OCI image", req.target_raw)
+                    })?;
+            }
+            FileMode::SymlinkEach => {
+                if !req.source.is_dir() {
+                    bail!(
+                        "[system.files].\"{}\": mode symlink-each requires a directory source: {}",
+                        req.target_raw,
+                        req.source.display()
+                    );
+                }
+                let target = oci_target_path(req)?;
+                entries.add_dir(target.clone())?;
+                for entry in walkdir::WalkDir::new(&req.source).sort_by_file_name() {
+                    let entry = entry?;
+                    let ft = entry.file_type();
+                    if !(ft.is_file() || ft.is_symlink()) {
+                        continue;
+                    }
+                    let rel = entry.path().strip_prefix(&req.source)?;
+                    let path = format!("{target}/{}", rel.to_string_lossy().replace('\\', "/"));
+                    entries.add_file(
+                        path,
+                        file::read(entry.path())?,
+                        source_mode(entry.path())?,
+                    )?;
+                }
+            }
+            FileMode::Template => {
+                let rendered = crate::system::files::render_template(cfg, req)?;
+                entries.add_file(
+                    oci_target_path(req)?,
+                    rendered.into_bytes(),
+                    source_mode(&req.source)?,
+                )?;
+            }
+        }
+    }
+
+    info!("oci: adding {} [system.files] entries", requests.len());
+    let (files, dirs) = entries.into_layer_inputs();
+    layer::build_layer_from_files_and_dirs(&files, &dirs, owner)
+}
+
+fn collect_source_as_files(
+    source: &std::path::Path,
+    target: &str,
+    entries: &mut SystemFileLayerEntries,
+) -> Result<()> {
+    if source.is_dir() {
+        entries.add_dir(target.to_string())?;
+        for entry in walkdir::WalkDir::new(source).sort_by_file_name() {
+            let entry = entry?;
+            if entry.file_type().is_dir() {
+                let rel = entry.path().strip_prefix(source)?;
+                if !rel.as_os_str().is_empty() {
+                    entries.add_dir(format!(
+                        "{target}/{}",
+                        rel.to_string_lossy().replace('\\', "/")
+                    ))?;
+                }
+                continue;
+            }
+            let ft = entry.file_type();
+            if !(ft.is_file() || ft.is_symlink()) {
+                warn!(
+                    "oci: skipping non-file [system.files] source entry {}",
+                    entry.path().display()
+                );
+                continue;
+            }
+            let rel = entry.path().strip_prefix(source)?;
+            let path = format!("{target}/{}", rel.to_string_lossy().replace('\\', "/"));
+            entries.add_file(path, file::read(entry.path())?, source_mode(entry.path())?)?;
+        }
+    } else {
+        entries.add_file(
+            target.to_string(),
+            file::read(source)?,
+            source_mode(source)?,
+        )?;
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct SystemFileLayerEntries {
+    files: IndexMap<String, (Vec<u8>, u32)>,
+    dirs: IndexSet<String>,
+}
+
+type SystemFileLayerFile = (String, Vec<u8>, u32);
+type SystemFileLayerFiles = Vec<SystemFileLayerFile>;
+type SystemFileLayerDirs = Vec<String>;
+
+impl SystemFileLayerEntries {
+    fn add_file(&mut self, path: String, contents: Vec<u8>, mode: u32) -> Result<()> {
+        if self.dirs.contains(&path) {
+            bail!("[system.files]: duplicate OCI path {path:?} as both file and directory");
+        }
+        if let Some((existing_contents, existing_mode)) = self.files.get(&path) {
+            if existing_contents != &contents || *existing_mode != mode {
+                bail!("[system.files]: duplicate OCI file path {path:?}");
+            }
+            return Ok(());
+        }
+        self.files.insert(path, (contents, mode));
+        Ok(())
+    }
+
+    fn add_dir(&mut self, path: String) -> Result<()> {
+        if self.files.contains_key(&path) {
+            bail!("[system.files]: duplicate OCI path {path:?} as both file and directory");
+        }
+        self.dirs.insert(path);
+        Ok(())
+    }
+
+    fn into_layer_inputs(self) -> (SystemFileLayerFiles, SystemFileLayerDirs) {
+        let files = self
+            .files
+            .into_iter()
+            .map(|(path, (contents, mode))| (path, contents, mode))
+            .collect();
+        let dirs = self.dirs.into_iter().collect();
+        (files, dirs)
+    }
+}
+
+fn oci_target_path(req: &FileRequest) -> Result<String> {
+    let raw = req.target_raw.as_str();
+    let path = if raw == "~" {
+        "root".to_string()
+    } else if let Some(rest) = raw.strip_prefix("~/") {
+        format!("root/{rest}")
+    } else {
+        req.target
+            .strip_prefix("/")
+            .map_err(|_| eyre::eyre!("system file target must be absolute: {}", req.target_raw))?
+            .to_string_lossy()
+            .replace('\\', "/")
+    };
+    if path.is_empty() || path.split('/').any(|p| p == "..") {
+        bail!(
+            "[system.files].\"{}\": target is not a safe OCI path",
+            req.target_raw
+        );
+    }
+    Ok(path)
+}
+
+fn source_mode(path: &std::path::Path) -> Result<u32> {
+    let md = path.metadata()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        Ok(md.permissions().mode() & 0o7777)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = md;
+        Ok(0o644)
+    }
 }
 
 fn reject_unsupported_backends(

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -98,8 +98,21 @@ pub fn build_layer_from_dir(
         eyre::bail!("not a directory: {}", src_dir.display());
     }
 
-    let entries = collect_sorted_entries(src_dir)?;
+    let entries = collect_sorted_entries(src_dir, false, owner)?;
     build_layer_from_entries(&entries, target_prefix, owner)
+}
+
+/// Build a layer from a source directory, preserving uid/gid/mode from disk.
+pub fn build_layer_from_dir_preserve_metadata(
+    src_dir: &Path,
+    target_prefix: &str,
+) -> Result<LayerBlob> {
+    if !src_dir.is_dir() {
+        eyre::bail!("not a directory: {}", src_dir.display());
+    }
+
+    let entries = collect_sorted_entries(src_dir, true, LayerOwner::default())?;
+    build_layer_from_entries(&entries, target_prefix, LayerOwner::default())
 }
 
 /// Build a layer from an in-memory list of (path_in_tar, content) pairs.
@@ -109,8 +122,19 @@ pub fn build_layer_from_files(
     files: &[(String, Vec<u8>, u32)],
     owner: LayerOwner,
 ) -> Result<LayerBlob> {
+    build_layer_from_files_and_dirs(files, &[], owner)
+}
+
+/// Build a layer from in-memory file and directory entries.
+pub fn build_layer_from_files_and_dirs(
+    files: &[(String, Vec<u8>, u32)],
+    dirs: &[String],
+    owner: LayerOwner,
+) -> Result<LayerBlob> {
     let mut sorted: Vec<&(String, Vec<u8>, u32)> = files.iter().collect();
     sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut sorted_dirs: Vec<&String> = dirs.iter().collect();
+    sorted_dirs.sort();
 
     let mut tar_bytes = Vec::new();
     {
@@ -119,6 +143,17 @@ pub fn build_layer_from_files(
 
         // Track which parent directories we've emitted so we don't repeat them.
         let mut emitted_dirs: std::collections::BTreeSet<String> = Default::default();
+
+        for dir in sorted_dirs {
+            for parent in parent_dirs(dir) {
+                if emitted_dirs.insert(parent.clone()) {
+                    emit_dir(&mut builder, &parent, owner)?;
+                }
+            }
+            if emitted_dirs.insert((*dir).clone()) {
+                emit_dir(&mut builder, dir, owner)?;
+            }
+        }
 
         for (path, contents, mode) in sorted {
             for dir in parent_dirs(path) {
@@ -149,6 +184,7 @@ struct Entry {
     abs: PathBuf,
     kind: EntryKind,
     mode: u32,
+    owner: LayerOwner,
     size: u64,
 }
 
@@ -159,7 +195,11 @@ enum EntryKind {
     Symlink(PathBuf),
 }
 
-fn collect_sorted_entries(src_dir: &Path) -> Result<Vec<Entry>> {
+fn collect_sorted_entries(
+    src_dir: &Path,
+    preserve_metadata: bool,
+    owner: LayerOwner,
+) -> Result<Vec<Entry>> {
     // Canonicalize once so we can match symlink targets that traverse via
     // different path spellings (e.g. with `..` components or through
     // intermediate symlinks).
@@ -176,21 +216,41 @@ fn collect_sorted_entries(src_dir: &Path) -> Result<Vec<Entry>> {
         let file_type = entry.file_type();
         let md = entry.path().symlink_metadata()?;
         let (kind, mode, size) = if file_type.is_dir() {
-            (EntryKind::Dir, 0o755u32, 0u64)
+            let mode = if preserve_metadata {
+                mode_from_metadata(&md)
+            } else {
+                0o755u32
+            };
+            (EntryKind::Dir, mode, 0u64)
         } else if file_type.is_symlink() {
             let raw_target = std::fs::read_link(entry.path())?;
             let target = rebase_symlink_target(&raw_target, &abs, &canonical_src, src_dir);
-            (EntryKind::Symlink(target), 0o777u32, 0u64)
+            let mode = if preserve_metadata {
+                mode_from_metadata(&md)
+            } else {
+                0o777u32
+            };
+            (EntryKind::Symlink(target), mode, 0u64)
         } else {
-            let is_exec = file_is_executable(entry.path(), &md);
-            let mode = if is_exec { 0o755 } else { 0o644 };
+            let mode = if preserve_metadata {
+                mode_from_metadata(&md)
+            } else {
+                let is_exec = file_is_executable(entry.path(), &md);
+                if is_exec { 0o755 } else { 0o644 }
+            };
             (EntryKind::File, mode, md.len())
+        };
+        let entry_owner = if preserve_metadata {
+            owner_from_metadata(&md)
+        } else {
+            owner
         };
         entries.push(Entry {
             rel,
             abs,
             kind,
             mode,
+            owner: entry_owner,
             size,
         });
     }
@@ -238,14 +298,14 @@ fn build_layer_from_entries(
             match &e.kind {
                 EntryKind::Dir => {
                     if emitted_dirs.insert(path_in_tar.clone()) {
-                        emit_dir(&mut builder, &path_in_tar, owner)?;
+                        emit_dir_with_mode(&mut builder, &path_in_tar, e.owner, e.mode)?;
                     }
                 }
                 EntryKind::File => {
                     let mut header = Header::new_gnu();
                     header.set_entry_type(EntryType::Regular);
                     header.set_mode(e.mode);
-                    apply_owner(&mut header, owner);
+                    apply_owner(&mut header, e.owner);
                     header.set_size(e.size);
                     header.set_mtime(0);
                     header.set_cksum();
@@ -259,7 +319,7 @@ fn build_layer_from_entries(
                     let mut header = Header::new_gnu();
                     header.set_entry_type(EntryType::Symlink);
                     header.set_mode(e.mode);
-                    apply_owner(&mut header, owner);
+                    apply_owner(&mut header, e.owner);
                     header.set_size(0);
                     header.set_mtime(0);
                     header
@@ -283,10 +343,39 @@ fn apply_owner(header: &mut Header, owner: LayerOwner) {
     header.set_gid(owner.gid as u64);
 }
 
+#[cfg(unix)]
+fn mode_from_metadata(md: &std::fs::Metadata) -> u32 {
+    md.mode() & 0o7777
+}
+
+#[cfg(not(unix))]
+fn mode_from_metadata(md: &std::fs::Metadata) -> u32 {
+    if md.is_dir() { 0o755 } else { 0o644 }
+}
+
+#[cfg(unix)]
+fn owner_from_metadata(md: &std::fs::Metadata) -> LayerOwner {
+    LayerOwner::new(md.uid(), md.gid())
+}
+
+#[cfg(not(unix))]
+fn owner_from_metadata(_md: &std::fs::Metadata) -> LayerOwner {
+    LayerOwner::default()
+}
+
 fn emit_dir<W: Write>(builder: &mut tar::Builder<W>, path: &str, owner: LayerOwner) -> Result<()> {
+    emit_dir_with_mode(builder, path, owner, 0o755)
+}
+
+fn emit_dir_with_mode<W: Write>(
+    builder: &mut tar::Builder<W>,
+    path: &str,
+    owner: LayerOwner,
+    mode: u32,
+) -> Result<()> {
     let mut header = Header::new_gnu();
     header.set_entry_type(EntryType::Directory);
-    header.set_mode(0o755);
+    header.set_mode(mode);
     apply_owner(&mut header, owner);
     header.set_size(0);
     header.set_mtime(0);
@@ -555,6 +644,27 @@ mod tests {
         assert_layer_owner(&blob, 1000, 1000);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn preserve_metadata_dir_layer_keeps_special_permission_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o1777)).unwrap();
+        let helper = bin.join("helper");
+        fs::write(&helper, b"#!/bin/sh\necho hi\n").unwrap();
+        fs::set_permissions(&helper, fs::Permissions::from_mode(0o4755)).unwrap();
+
+        let blob = build_layer_from_dir_preserve_metadata(dir.path(), "").unwrap();
+
+        assert_layer_mode(&blob, "bin", 0o1777);
+        assert_layer_mode(&blob, "bin/helper", 0o4755);
+        let md = fs::symlink_metadata(&helper).unwrap();
+        assert_layer_entry_owner(&blob, "bin/helper", md.uid() as u64, md.gid() as u64);
+    }
+
     #[test]
     fn layer_owner_parses_uid_and_optional_gid() {
         assert_eq!(
@@ -590,6 +700,43 @@ mod tests {
         assert!(entries_seen > 0, "expected at least one tar entry");
     }
 
+    fn assert_layer_mode(blob: &LayerBlob, expected_path: &str, expected_mode: u32) {
+        let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
+        let mut archive = tar::Archive::new(decoder);
+
+        for entry in archive.entries().unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            if path.trim_end_matches('/') == expected_path.trim_end_matches('/') {
+                assert_eq!(
+                    entry.header().mode().unwrap(),
+                    expected_mode,
+                    "mode for {path}"
+                );
+                return;
+            }
+        }
+
+        panic!("expected layer entry {expected_path}");
+    }
+
+    fn assert_layer_entry_owner(blob: &LayerBlob, expected_path: &str, uid: u64, gid: u64) {
+        let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
+        let mut archive = tar::Archive::new(decoder);
+
+        for entry in archive.entries().unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            if path == expected_path {
+                assert_eq!(entry.header().uid().unwrap(), uid, "uid for {path}");
+                assert_eq!(entry.header().gid().unwrap(), gid, "gid for {path}");
+                return;
+            }
+        }
+
+        panic!("expected layer entry {expected_path}");
+    }
+
     #[cfg(unix)]
     #[test]
     fn absolute_intra_tree_symlinks_become_relative() {
@@ -614,7 +761,7 @@ mod tests {
         // as-is with a warning; we only assert it doesn't panic).
         symlink("/usr/bin/false", src.join("bin/external")).unwrap();
 
-        let entries = collect_sorted_entries(src).unwrap();
+        let entries = collect_sorted_entries(src, false, LayerOwner::default()).unwrap();
         let npm = entries
             .iter()
             .find(|e| e.rel == Path::new("bin/npm"))

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -10,6 +10,7 @@ pub mod builder;
 pub mod layer;
 pub mod layout;
 pub mod manifest;
+pub mod packages;
 pub mod registry;
 
 use indexmap::IndexMap;

--- a/src/oci/packages.rs
+++ b/src/oci/packages.rs
@@ -1,0 +1,555 @@
+//! Native `[system.packages]` support for OCI builds.
+//!
+//! This intentionally does not use a container engine. For apt-based base
+//! images, mise unpacks the pulled base image into a temporary rootfs, asks
+//! host `apt-get`/`dpkg` to install into that rootfs, then emits the filesystem
+//! changes as one OCI layer.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{BufRead, BufReader, Read};
+#[cfg(unix)]
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use eyre::{Context, Result, bail};
+use flate2::read::GzDecoder;
+use tempfile::TempDir;
+use walkdir::WalkDir;
+
+use crate::file;
+use crate::oci::layer::{self, LayerBlob};
+use crate::oci::layout::ImageLayout;
+use crate::oci::manifest::Descriptor;
+use crate::system::ManagerPackages;
+use crate::system::packages::PackageRequest;
+
+#[derive(Debug, Clone)]
+struct FsEntry {
+    kind: FsEntryKind,
+    mode: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FsEntryKind {
+    Dir,
+    File { size: u64, hash: [u8; 32] },
+    Symlink { target: PathBuf },
+    Other,
+}
+
+pub fn build_system_packages_layer(
+    layout: &ImageLayout,
+    base_layers: &[Descriptor],
+    managers: &[ManagerPackages],
+    architecture: &str,
+) -> Result<Option<LayerBlob>> {
+    let apt_requests = collect_apt_requests(managers)?;
+    if apt_requests.is_empty() {
+        return Ok(None);
+    }
+    if base_layers.is_empty() {
+        bail!(
+            "mise oci requires an apt-based base image when [system.packages] is configured; \
+             `scratch` has no apt metadata"
+        );
+    }
+    if file::which("apt-get").is_none() {
+        bail!("mise oci needs `apt-get` on PATH to install apt system packages into the image");
+    }
+    if file::which("dpkg").is_none() {
+        bail!("mise oci needs `dpkg` on PATH to install apt system packages into the image");
+    }
+
+    let td = TempDir::with_prefix("mise-oci-apt-rootfs-")
+        .wrap_err("creating temp rootfs for apt system packages")?;
+    let rootfs = td.path().join("rootfs");
+    file::create_dir_all(&rootfs)?;
+    unpack_base_layers(layout, base_layers, &rootfs)?;
+    if !rootfs.join("etc/apt").is_dir() {
+        bail!(
+            "mise oci found apt packages in [system.packages], but the base image does not \
+             contain /etc/apt. Use a Debian/Ubuntu base image or remove the apt entries."
+        );
+    }
+    prepare_apt_rootfs(&rootfs)?;
+
+    let before = snapshot(&rootfs)?;
+    apt_install_into_rootfs(&rootfs, &apt_requests, architecture)?;
+    clean_apt_transients(&rootfs)?;
+    let diff_dir = td.path().join("diff");
+    materialize_diff(&rootfs, &before, &diff_dir)?;
+    if WalkDir::new(&diff_dir).into_iter().count() <= 1 {
+        info!("oci: apt system packages produced no filesystem changes");
+        return Ok(None);
+    }
+    info!(
+        "oci: adding apt system packages: {}",
+        apt_requests
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    layer::build_layer_from_dir_preserve_metadata(&diff_dir, "").map(Some)
+}
+
+fn collect_apt_requests(managers: &[ManagerPackages]) -> Result<Vec<PackageRequest>> {
+    let mut out = vec![];
+    let mut unsupported = vec![];
+    for mgr in managers {
+        if mgr.disabled || mgr.requests.is_empty() {
+            continue;
+        }
+        match mgr.manager.name() {
+            "apt" => out.extend(mgr.requests.clone()),
+            other => unsupported.push(other.to_string()),
+        }
+    }
+    if !unsupported.is_empty() {
+        unsupported.sort();
+        unsupported.dedup();
+        bail!(
+            "mise oci currently supports only apt entries in [system.packages]; unsupported \
+             manager(s): {}",
+            unsupported.join(", ")
+        );
+    }
+    Ok(out)
+}
+
+fn unpack_base_layers(layout: &ImageLayout, layers: &[Descriptor], rootfs: &Path) -> Result<()> {
+    for layer in layers {
+        let path = layout.blob_path(&layer.digest);
+        let reader = open_layer_reader(layer, &path)?;
+        let mut archive = tar::Archive::new(reader);
+        for entry in archive
+            .entries()
+            .wrap_err_with(|| format!("reading base layer {}", layer.digest))?
+        {
+            let mut entry =
+                entry.wrap_err_with(|| format!("reading base layer entry {}", layer.digest))?;
+            let rel = clean_layer_path(&entry.path()?)
+                .wrap_err_with(|| format!("reading base layer entry path {}", layer.digest))?;
+            if rel.as_os_str().is_empty() || apply_oci_whiteout(rootfs, &rel)? {
+                continue;
+            }
+            entry
+                .unpack_in(rootfs)
+                .wrap_err_with(|| format!("unpacking base layer {}", layer.digest))?;
+        }
+    }
+    Ok(())
+}
+
+fn open_layer_reader(layer: &Descriptor, path: &Path) -> Result<Box<dyn Read>> {
+    let file =
+        fs::File::open(path).wrap_err_with(|| format!("opening base layer {}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    Ok(match layer_compression(layer, &mut reader)? {
+        LayerCompression::Gzip => Box::new(GzDecoder::new(reader)),
+        LayerCompression::Zstd => Box::new(zstd::stream::read::Decoder::new(reader)?),
+        LayerCompression::Tar => Box::new(reader),
+    })
+}
+
+enum LayerCompression {
+    Gzip,
+    Zstd,
+    Tar,
+}
+
+fn layer_compression<R: BufRead>(layer: &Descriptor, reader: &mut R) -> Result<LayerCompression> {
+    if layer.media_type.ends_with("+gzip")
+        || layer.media_type.ends_with(".gzip")
+        || layer.media_type.ends_with(".tar.gzip")
+    {
+        return Ok(LayerCompression::Gzip);
+    }
+    if layer.media_type.ends_with("+zstd") || layer.media_type.ends_with(".zstd") {
+        return Ok(LayerCompression::Zstd);
+    }
+    if layer.media_type.ends_with(".tar") || layer.media_type.ends_with("+tar") {
+        return Ok(LayerCompression::Tar);
+    }
+
+    let magic = reader.fill_buf()?;
+    if magic.starts_with(&[0x1f, 0x8b]) {
+        Ok(LayerCompression::Gzip)
+    } else if magic.starts_with(&[0x28, 0xb5, 0x2f, 0xfd]) {
+        Ok(LayerCompression::Zstd)
+    } else {
+        Ok(LayerCompression::Tar)
+    }
+}
+
+fn clean_layer_path(path: &Path) -> Result<PathBuf> {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir | Component::RootDir => {}
+            Component::Normal(part) => out.push(part),
+            Component::ParentDir | Component::Prefix(_) => {
+                bail!("invalid OCI layer path {}", path.display())
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn apply_oci_whiteout(rootfs: &Path, rel: &Path) -> Result<bool> {
+    let Some(name) = rel.file_name().and_then(|n| n.to_str()) else {
+        return Ok(false);
+    };
+    let parent = rel.parent().unwrap_or_else(|| Path::new(""));
+    if name == ".wh..wh..opq" {
+        let dir = rootfs.join(parent);
+        if dir.is_dir() {
+            for entry in fs::read_dir(&dir)? {
+                remove_path(&entry?.path())?;
+            }
+        }
+        return Ok(true);
+    }
+    let Some(target) = name.strip_prefix(".wh.") else {
+        return Ok(false);
+    };
+    remove_path(&rootfs.join(parent).join(target))?;
+    Ok(true)
+}
+
+fn remove_path(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path).map(|m| m.file_type()) {
+        Ok(ft) if ft.is_dir() && !ft.is_symlink() => fs::remove_dir_all(path)
+            .wrap_err_with(|| format!("removing directory {}", path.display()))?,
+        Ok(_) => fs::remove_file(path).wrap_err_with(|| format!("removing {}", path.display()))?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(e).wrap_err_with(|| format!("reading metadata for {}", path.display()));
+        }
+    }
+    Ok(())
+}
+
+fn apt_install_into_rootfs(
+    rootfs: &Path,
+    requests: &[PackageRequest],
+    architecture: &str,
+) -> Result<()> {
+    let status = rootfs.join("var/lib/dpkg/status");
+    if let Some(parent) = status.parent() {
+        file::create_dir_all(parent)?;
+    }
+    if !status.exists() {
+        file::write(&status, "")?;
+    }
+    file::create_dir_all(rootfs.join("var/cache/apt/archives/partial"))?;
+    file::create_dir_all(rootfs.join("var/lib/apt/lists/partial"))?;
+
+    let update_args = apt_root_args(rootfs, &status, architecture)?
+        .into_iter()
+        .chain(["update".to_string()])
+        .collect();
+    run_apt_get(update_args)?;
+
+    let install_args = vec![
+        "install".to_string(),
+        "-y".to_string(),
+        "--no-install-recommends".to_string(),
+        "--".to_string(),
+    ];
+    let package_args = requests.iter().map(|p| match &p.version {
+        Some(v) => format!("{}={v}", p.name),
+        None => p.name.clone(),
+    });
+    let args = apt_root_args(rootfs, &status, architecture)?
+        .into_iter()
+        .chain(install_args)
+        .chain(package_args)
+        .collect();
+    run_apt_get(args)
+}
+
+fn prepare_apt_rootfs(rootfs: &Path) -> Result<()> {
+    let apt_dir = rootfs.join("etc/apt");
+    for entry in WalkDir::new(&apt_dir)
+        .follow_links(false)
+        .sort_by_file_name()
+    {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let bytes = file::read(path)?;
+        let Ok(mut s) = String::from_utf8(bytes) else {
+            continue;
+        };
+        let original = s.clone();
+        let root = rootfs.to_string_lossy();
+        for p in [
+            "/usr/share/keyrings/",
+            "/etc/apt/",
+            "/var/cache/apt",
+            "/var/lib/apt",
+            "/var/log/apt",
+        ] {
+            s = s.replace(p, &format!("{root}{p}"));
+        }
+        if s != original {
+            file::write(path, s)?;
+        }
+    }
+    Ok(())
+}
+
+fn apt_root_args(rootfs: &Path, status: &Path, architecture: &str) -> Result<Vec<String>> {
+    Ok(vec![
+        "-o".to_string(),
+        format!("Dir={}", rootfs.display()),
+        "-o".to_string(),
+        "Dir::Etc=etc/apt".to_string(),
+        "-o".to_string(),
+        "Dir::Etc::sourcelist=sources.list".to_string(),
+        "-o".to_string(),
+        "Dir::Etc::sourceparts=sources.list.d".to_string(),
+        "-o".to_string(),
+        "Dir::Etc::trusted=trusted.gpg".to_string(),
+        "-o".to_string(),
+        "Dir::Etc::trustedparts=trusted.gpg.d".to_string(),
+        "-o".to_string(),
+        "Dir::State=var/lib/apt".to_string(),
+        "-o".to_string(),
+        format!("Dir::State::status={}", status.display()),
+        "-o".to_string(),
+        "Dir::Cache=var/cache/apt".to_string(),
+        "-o".to_string(),
+        "Dir::Log=var/log/apt".to_string(),
+        "-o".to_string(),
+        "APT::Sandbox::User=root".to_string(),
+        "-o".to_string(),
+        format!("APT::Architecture={}", apt_architecture(architecture)?),
+        "-o".to_string(),
+        format!("DPkg::Options::=--root={}", rootfs.display()),
+        "-o".to_string(),
+        "DPkg::Options::=--force-not-root".to_string(),
+    ])
+}
+
+fn run_apt_get(args: Vec<String>) -> Result<()> {
+    info!("apt-get {}", args.join(" "));
+    let output = Command::new("apt-get")
+        .args(&args)
+        .env("DEBIAN_FRONTEND", "noninteractive")
+        .output()
+        .wrap_err("running apt-get for OCI system packages")?;
+    if !output.status.success() {
+        bail!(
+            "apt-get failed while installing OCI system packages: {}\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+fn clean_apt_transients(rootfs: &Path) -> Result<()> {
+    remove_dir_children(&rootfs.join("var/cache/apt/archives"))?;
+    remove_path(&rootfs.join("var/cache/apt/pkgcache.bin"))?;
+    remove_path(&rootfs.join("var/cache/apt/srcpkgcache.bin"))?;
+
+    remove_dir_children(&rootfs.join("var/lib/apt/lists"))?;
+
+    remove_dir_children(&rootfs.join("var/log/apt"))?;
+    Ok(())
+}
+
+fn remove_dir_children(path: &Path) -> Result<()> {
+    match fs::read_dir(path) {
+        Ok(entries) => {
+            for entry in entries {
+                remove_path(&entry?.path())?;
+            }
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e).wrap_err_with(|| format!("reading directory {}", path.display())),
+    }
+}
+
+fn apt_architecture(oci_arch: &str) -> Result<&'static str> {
+    match oci_arch {
+        "amd64" | "x86_64" => Ok("amd64"),
+        "arm64" | "aarch64" => Ok("arm64"),
+        other => bail!("apt system packages are not supported for OCI architecture {other:?}"),
+    }
+}
+
+fn snapshot(root: &Path) -> Result<BTreeMap<PathBuf, FsEntry>> {
+    let mut out = BTreeMap::new();
+    for entry in WalkDir::new(root).follow_links(false).sort_by_file_name() {
+        let entry = entry?;
+        let rel = entry.path().strip_prefix(root)?;
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+        out.insert(rel.to_path_buf(), fs_entry(entry.path())?);
+    }
+    Ok(out)
+}
+
+fn fs_entry(path: &Path) -> Result<FsEntry> {
+    let md = fs::symlink_metadata(path)?;
+    let mode = mode(&md);
+    let ft = md.file_type();
+    let kind = if ft.is_dir() {
+        FsEntryKind::Dir
+    } else if ft.is_symlink() {
+        FsEntryKind::Symlink {
+            target: fs::read_link(path)?,
+        }
+    } else if ft.is_file() {
+        FsEntryKind::File {
+            size: md.len(),
+            hash: file_hash(path)?,
+        }
+    } else {
+        FsEntryKind::Other
+    };
+    Ok(FsEntry { kind, mode })
+}
+
+#[cfg(unix)]
+fn mode(md: &fs::Metadata) -> u32 {
+    md.permissions().mode() & 0o7777
+}
+
+#[cfg(not(unix))]
+fn mode(_md: &fs::Metadata) -> u32 {
+    0o644
+}
+
+fn file_hash(path: &Path) -> Result<[u8; 32]> {
+    use sha2::{Digest, Sha256};
+    let mut f = fs::File::open(path)?;
+    let mut h = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = f.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        h.update(&buf[..n]);
+    }
+    Ok(h.finalize().into())
+}
+
+fn materialize_diff(
+    rootfs: &Path,
+    before: &BTreeMap<PathBuf, FsEntry>,
+    diff_dir: &Path,
+) -> Result<()> {
+    file::create_dir_all(diff_dir)?;
+    let after = snapshot(rootfs)?;
+
+    let mut whiteouted_dirs: Vec<PathBuf> = vec![];
+    for (rel, old) in before {
+        if after.contains_key(rel) {
+            continue;
+        }
+        if whiteouted_dirs.iter().any(|dir| rel.starts_with(dir)) {
+            continue;
+        }
+        write_whiteout(diff_dir, rel)?;
+        if matches!(old.kind, FsEntryKind::Dir) {
+            whiteouted_dirs.push(rel.clone());
+        }
+    }
+
+    for (rel, entry) in after {
+        if let Some(old) = before.get(&rel) {
+            if same_entry(old, &entry) {
+                continue;
+            }
+            if !same_entry_type(old, &entry) {
+                write_whiteout(diff_dir, &rel)?;
+            }
+        }
+        copy_entry(rootfs, diff_dir, &rel, &entry)?;
+    }
+    Ok(())
+}
+
+fn same_entry(a: &FsEntry, b: &FsEntry) -> bool {
+    a.mode == b.mode && a.kind == b.kind
+}
+
+fn same_entry_type(a: &FsEntry, b: &FsEntry) -> bool {
+    matches!(
+        (&a.kind, &b.kind),
+        (FsEntryKind::Dir, FsEntryKind::Dir)
+            | (FsEntryKind::File { .. }, FsEntryKind::File { .. })
+            | (FsEntryKind::Symlink { .. }, FsEntryKind::Symlink { .. })
+            | (FsEntryKind::Other, FsEntryKind::Other)
+    )
+}
+
+fn write_whiteout(diff_dir: &Path, rel: &Path) -> Result<()> {
+    let Some(name) = rel.file_name() else {
+        return Ok(());
+    };
+    let parent = rel.parent().unwrap_or_else(|| Path::new(""));
+    let whiteout = diff_dir
+        .join(parent)
+        .join(format!(".wh.{}", name.to_string_lossy()));
+    if let Some(parent) = whiteout.parent() {
+        file::create_dir_all(parent)?;
+    }
+    file::write(whiteout, "")?;
+    Ok(())
+}
+
+fn copy_entry(rootfs: &Path, diff_dir: &Path, rel: &Path, entry: &FsEntry) -> Result<()> {
+    let src = rootfs.join(rel);
+    let dst = diff_dir.join(rel);
+    if let Some(parent) = dst.parent() {
+        file::create_dir_all(parent)?;
+    }
+    match &entry.kind {
+        FsEntryKind::Dir => {
+            file::create_dir_all(&dst)?;
+            set_mode(&dst, entry.mode)?;
+        }
+        FsEntryKind::File { .. } => {
+            file::copy(&src, &dst)?;
+            set_mode(&dst, entry.mode)?;
+        }
+        FsEntryKind::Symlink { target } => {
+            #[cfg(unix)]
+            symlink(target, &dst)?;
+            #[cfg(not(unix))]
+            {
+                let _ = target;
+                bail!("OCI apt package layers with symlinks require a unix host");
+            }
+        }
+        FsEntryKind::Other => {
+            warn!(
+                "oci: skipping unsupported filesystem entry {}",
+                src.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn set_mode(path: &Path, mode: u32) -> Result<()> {
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
+    #[cfg(not(unix))]
+    {
+        let _ = (path, mode);
+    }
+    Ok(())
+}

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -25,7 +25,7 @@ use itertools::Itertools;
 use regex::Regex;
 use serde::Deserialize;
 
-use crate::config::Config;
+use crate::config::{Config, ConfigMap};
 use crate::file;
 use crate::path::PathExt;
 use crate::ui::prompt;
@@ -111,11 +111,18 @@ pub enum FileState {
 /// global -> local; a more local config overrides an entry for the same
 /// target. Malformed entries and unknown modes warn and are skipped.
 pub fn files_from_config(config: &Config) -> Vec<FileRequest> {
+    files_from_config_files(&config.config_files)
+}
+
+/// Aggregate `[system.files]` across a specific set of config files. This is
+/// used by OCI builds, which intentionally scope config to project files by
+/// default instead of blindly inheriting global dotfiles.
+pub fn files_from_config_files(config_files: &ConfigMap) -> Vec<FileRequest> {
     // keyed by the *expanded* target so "~/.gitconfig" in one config and
     // its absolute spelling in another are one entry, not two
     let mut merged: IndexMap<PathBuf, FileRequest> = IndexMap::new();
     // config_files is ordered local -> global; reverse for global -> local
-    for (path, cf) in config.config_files.iter().rev() {
+    for (path, cf) in config_files.iter().rev() {
         let Some(sys) = cf.system_config() else {
             continue;
         };
@@ -534,7 +541,7 @@ fn check_content(target: &Path, expected: &[u8]) -> Result<FileState> {
     }
 }
 
-fn render_template(config: &Config, req: &FileRequest) -> Result<String> {
+pub fn render_template(config: &Config, req: &FileRequest) -> Result<String> {
     let raw = file::read_to_string(&req.source)?;
     let mut tera = crate::tera::get_tera(Some(&req.base));
     let rendered = tera.render_str(&raw, &config.tera_ctx).map_err(|err| {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -16,6 +16,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 
 use crate::config::Config;
+use crate::config::ConfigMap;
 use crate::system::defaults::{DefaultsRequest, DefaultsValue};
 use crate::system::packages::{PackageRequest, SystemPackageManager};
 
@@ -152,10 +153,22 @@ pub fn attach_brew_tap_urls(config: &Config, by_mgr: &mut IndexMap<String, Vec<P
 /// `system_packages.managers` setting restricts which managers are used at
 /// all.
 pub fn packages_from_config(config: &Config) -> Vec<ManagerPackages> {
-    let mut merged: IndexMap<String, String> = IndexMap::new();
     let brew_taps = brew_taps_from_config(config);
+    packages_from_config_files_with_brew_taps(&config.config_files, &brew_taps)
+}
+
+/// Aggregate `[system.packages]` across a specific set of config files.
+pub fn packages_from_config_files(config_files: &ConfigMap) -> Vec<ManagerPackages> {
+    packages_from_config_files_with_brew_taps(config_files, &IndexMap::new())
+}
+
+fn packages_from_config_files_with_brew_taps(
+    config_files: &ConfigMap,
+    brew_taps: &IndexMap<String, String>,
+) -> Vec<ManagerPackages> {
+    let mut merged: IndexMap<String, String> = IndexMap::new();
     // config_files is ordered local -> global; reverse for global -> local
-    for cf in config.config_files.values().rev() {
+    for cf in config_files.values().rev() {
         if let Some(sys) = cf.system_config() {
             for (spec, version) in sys.packages {
                 merged.insert(spec, version);


### PR DESCRIPTION
## Summary
- bake project-scoped `[system.files]` into `mise oci` images as a dedicated annotated OCI layer
- support project-scoped `apt:` `[system.packages]` natively by unpacking the base image into a temp rootfs, calling host `apt-get` against that rootfs, and emitting the filesystem diff as an OCI package layer
- reconstruct apt rootfs inputs from gzip, zstd, or uncompressed OCI layers while applying OCI whiteouts, and emit whiteouts for package-layer deletions
- keep `--include-global` behavior aligned with existing OCI scoping, and reject `[system.defaults]` for OCI images

## Tests
- `cargo fmt`
- `cargo check`
- `cargo build`
- `shellcheck e2e/oci/test_oci_build_slow`
- `git diff --check`
- `mise run test:e2e e2e/oci/test_oci_build_slow`
- live smoke: `mise oci build --from debian:bookworm-slim --no-mise` with `[system.packages] "apt:hello" = "latest"`

*This PR was generated by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCI builds now include dedicated system file and apt-based system package layers; the builder accepts injected system files/packages.

* **Bug Fixes**
  * Builds now fail early when unsupported [system.defaults] are present.

* **Documentation**
  * Clarified OCI layer ordering, how system.files (copy/template/symlink) are materialized, ~/→/root/ mapping, apt-only package support, and that [system.defaults]/bootstrap aren’t executed.

* **Tests**
  * Added e2e tests covering system.files materialization and apt-based package failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large apt-in-rootfs path that shells out to `apt-get` and mutates unpacked base filesystems; behavior depends on host tools and network for real Debian bases, though scope is limited to OCI image output rather than host system install.
> 
> **Overview**
> **`mise oci build`** now applies declarative **`[system.files]`** and **`apt:` `[system.packages]`** from the same project-scoped config as tools (optional **`--include-global`**), parallel to `mise bootstrap` / `mise system install` but without running **`[system.defaults]`** or bootstrap tasks.
> 
> **`[system.files]`** become a separate annotated layer (`dev.mise.system.files`). Copy and template modes write real file content; symlink modes are materialized as contents so paths are not tied to the checkout. **`~/`** targets land under **`/root/`**.
> 
> **`[system.packages]`** (apt only for now) unpack base image layers into a temp rootfs (gzip/zstd/tar, with whiteout handling), run host **`apt-get`** / **`dpkg`** against that root, strip apt caches, diff before/after (including whiteouts for removals), and add one **`dev.mise.system.packages=apt`** layer. Non-apt managers and **`scratch`** without **`/etc/apt`** fail with clear errors.
> 
> The OCI builder and layer helpers gain **`with_system_*`**, **`build_layer_from_files_and_dirs`**, and metadata-preserving tar builds for package diffs. Docs and slow e2e cover file/template layers and the apt-on-scratch failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6ab69b58158c78030ec337be0fd364a6bf94b0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->