### PR TITLE
feat(system): support wildcards in system files

### DIFF
--- a/docs/system-files.md
+++ b/docs/system-files.md
@@ -10,6 +10,7 @@ mise can place config files (dotfiles) at machine-global paths via the
 "~/.ssh/config" = { source = "dotfiles/ssh_config.tmpl", mode = "template" }
 "~/.config/nvim" = "dotfiles/nvim"                                   # symlink the directory itself
 "~/.local/bin" = { source = "dotfiles/bin", mode = "symlink-each" }  # symlink each file within
+"~/.config/*.toml" = { source = "dotfiles/config/*.toml", mode = "copy" }
 ```
 
 Each entry is keyed by the target path — absolute or starting with `~/` —
@@ -21,6 +22,18 @@ project config can ship machine setup from the repo.
 To manage one piece of a file something else owns (a line in `.zshrc`, an
 entry in `/etc/hosts`) rather than the whole file, see
 [System Edits](/system-edits.html).
+
+Source paths may contain glob wildcards like `*`, `**`, `?`, or `[ab]`.
+When a wildcard source matches multiple paths, the target path must contain
+matching wildcards so each source expands to a unique target:
+
+```toml
+[system.files]
+"~/.config/*.toml" = "dotfiles/config/*.toml"
+"~/.local/share/app/**/*.json" = { source = "dotfiles/app/**/*.json", mode = "copy" }
+"~/.config/app?.toml" = "dotfiles/config/app?.toml"
+"~/.config/theme-[ab].toml" = "dotfiles/config/theme-[ab].toml"
+```
 
 ## Modes
 

--- a/e2e/cli/test_system_files
+++ b/e2e/cli/test_system_files
@@ -33,6 +33,34 @@ assert "readlink ~/.config/nvim" "$PWD/dotfiles/nvim"
 assert "readlink ~/.local/mybin/one" "$PWD/dotfiles/bin/one"
 assert "readlink ~/.local/mybin/two" "$PWD/dotfiles/bin/two"
 
+# wildcard sources expand to concrete target paths using matching target wildcards
+mkdir -p dotfiles/config dotfiles/question dotfiles/classes dotfiles/tree/nested
+echo "bat config" >dotfiles/config/bat.conf
+echo "question config" >dotfiles/question/app1.conf
+echo "class config" >dotfiles/classes/theme-a.conf
+echo "root config" >dotfiles/tree/root.conf
+echo "tool config" >dotfiles/tree/nested/tool.conf
+cat <<EOF >>mise.toml
+"~/.config/*.conf" = { source = "dotfiles/config/*.conf", mode = "copy" }
+"~/.local/question/app?.conf" = { source = "dotfiles/question/app?.conf", mode = "copy" }
+"~/.local/classes/theme-[ab].conf" = { source = "dotfiles/classes/theme-[ab].conf", mode = "copy" }
+"~/.local/tree/**/*.conf" = "dotfiles/tree/**/*.conf"
+EOF
+assert_succeed "mise system install --yes"
+assert "cat ~/.config/bat.conf" "bat config"
+assert "cat ~/.local/question/app1.conf" "question config"
+assert "cat ~/.local/classes/theme-a.conf" "class config"
+assert "readlink ~/.local/tree/root.conf" "$PWD/dotfiles/tree/root.conf"
+assert "readlink ~/.local/tree/nested/tool.conf" "$PWD/dotfiles/tree/nested/tool.conf"
+
+# empty wildcard sources are skipped instead of blocking unrelated entries
+cat <<EOF >>mise.toml
+"~/.config/missing-*.conf" = "dotfiles/config/missing-*.conf"
+EOF
+assert_succeed "mise system status"
+assert_contains "mise system status 2>&1" "source pattern matched no files"
+assert_succeed "mise system install --yes"
+
 # symlink-each leaves room for files mise doesn't manage
 touch ~/.local/mybin/unmanaged
 
@@ -49,6 +77,7 @@ assert_succeed "mise system install --yes"
 assert "cat ~/.config/starship.toml" "starship v2"
 
 # template permission drift is detected and repaired
+chmod 644 ~/.ssh/config
 chmod 600 dotfiles/ssh_config.tmpl
 assert_contains "mise system status" "permissions differ"
 assert_succeed "mise system install --yes"

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -21,6 +21,8 @@ use std::path::{Path, PathBuf};
 
 use eyre::{Result, bail};
 use indexmap::IndexMap;
+use itertools::Itertools;
+use regex::Regex;
 use serde::Deserialize;
 
 use crate::config::Config;
@@ -148,19 +150,221 @@ pub fn files_from_config(config: &Config) -> Vec<FileRequest> {
             } else {
                 source
             };
-            merged.insert(
-                target.clone(),
-                FileRequest {
-                    target_raw,
-                    target,
-                    source,
-                    mode,
-                    base: base.clone(),
-                },
-            );
+            for req in expand_request(target_raw, target, source, mode, base.clone()) {
+                merged.insert(req.target.clone(), req);
+            }
         }
     }
     merged.into_values().collect()
+}
+
+fn expand_request(
+    target_raw: String,
+    target: PathBuf,
+    source: PathBuf,
+    mode: FileMode,
+    base: PathBuf,
+) -> Vec<FileRequest> {
+    if !is_glob_pattern(&source) {
+        return vec![FileRequest {
+            target_raw,
+            target,
+            source,
+            mode,
+            base,
+        }];
+    }
+
+    let source_pattern = source.to_string_lossy().to_string();
+    let matches = match glob::glob(&source_pattern) {
+        Ok(paths) => paths
+            .filter_map(|path| match path {
+                Ok(path) => Some(path),
+                Err(err) => {
+                    warn!(
+                        "[system.files].\"{target_raw}\": error reading source pattern {source_pattern}: {err}"
+                    );
+                    None
+                }
+            })
+            .sorted()
+            .collect_vec(),
+        Err(err) => {
+            warn!("[system.files].\"{target_raw}\": invalid source pattern: {err}");
+            return vec![];
+        }
+    };
+    if matches.is_empty() {
+        warn!("[system.files].\"{target_raw}\": source pattern matched no files, ignoring entry");
+        return vec![];
+    }
+
+    let target_pattern = target.to_string_lossy().to_string();
+    if !is_glob_pattern(&target) {
+        if matches.len() > 1 {
+            warn!(
+                "[system.files].\"{target_raw}\": source pattern matched multiple paths but target has no wildcard, ignoring entry"
+            );
+            return vec![];
+        }
+        return vec![FileRequest {
+            target_raw,
+            target,
+            source: matches[0].clone(),
+            mode,
+            base,
+        }];
+    }
+
+    matches
+        .into_iter()
+        .filter_map(|matched_source| {
+            let captures = match wildcard_captures(&source_pattern, &matched_source) {
+                Ok(captures) => captures,
+                Err(err) => {
+                    warn!("[system.files].\"{target_raw}\": {err}");
+                    return None;
+                }
+            };
+            let Some(target_path) = expand_target_pattern(&target_pattern, &captures) else {
+                warn!(
+                    "[system.files].\"{target_raw}\": target wildcard count does not match source pattern, ignoring {}",
+                    matched_source.display_user()
+                );
+                return None;
+            };
+            Some(FileRequest {
+                target_raw: target_path.display_user().to_string(),
+                target: target_path,
+                source: matched_source,
+                mode,
+                base: base.clone(),
+            })
+        })
+        .collect()
+}
+
+fn is_glob_pattern(path: &Path) -> bool {
+    path.to_string_lossy()
+        .chars()
+        .any(|c| matches!(c, '*' | '?' | '['))
+}
+
+fn wildcard_captures(pattern: &str, path: &Path) -> Result<Vec<String>> {
+    let path = normalize_path_separators(&path.to_string_lossy());
+    let re = wildcard_regex(pattern)?;
+    let Some(captures) = re.captures(&path) else {
+        bail!("source pattern did not match {path}");
+    };
+    Ok((1..captures.len())
+        .map(|i| {
+            captures
+                .get(i)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default()
+        })
+        .collect())
+}
+
+fn wildcard_regex(pattern: &str) -> Result<Regex> {
+    let mut re = String::from("^");
+    let pattern = normalize_path_separators(pattern);
+    let mut chars = pattern.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '*' if chars.peek() == Some(&'*') => {
+                chars.next();
+                if chars.peek() == Some(&'/') {
+                    chars.next();
+                    // Glob `**/` can match zero directories. Capture the
+                    // directory body without the trailing slash so target
+                    // expansion can omit the slash when the capture is empty.
+                    re.push_str("(?:(.*)/)?");
+                } else {
+                    re.push_str("(.*)");
+                }
+            }
+            '*' => re.push_str("([^/]*)"),
+            '?' => re.push_str("([^/])"),
+            '[' => {
+                let Some(class) = read_glob_class(&mut chars) else {
+                    re.push_str("\\[");
+                    continue;
+                };
+                re.push('(');
+                re.push_str(&class);
+                re.push(')');
+            }
+            _ => re.push_str(&regex::escape(&ch.to_string())),
+        }
+    }
+    re.push('$');
+    Ok(Regex::new(&re)?)
+}
+
+fn expand_target_pattern(pattern: &str, captures: &[String]) -> Option<PathBuf> {
+    let mut out = String::new();
+    let pattern = normalize_path_separators(pattern);
+    let mut chars = pattern.chars().peekable();
+    let mut captures = captures.iter();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '*' if chars.peek() == Some(&'*') => {
+                chars.next();
+                let capture = normalize_path_separators(captures.next()?);
+                if chars.peek() == Some(&'/') {
+                    chars.next();
+                    if !capture.is_empty() {
+                        out.push_str(&capture);
+                        out.push('/');
+                    }
+                } else {
+                    out.push_str(&capture);
+                }
+            }
+            '*' => out.push_str(&normalize_path_separators(captures.next()?)),
+            '?' => out.push_str(&normalize_path_separators(captures.next()?)),
+            '[' => {
+                read_glob_class(&mut chars)?;
+                out.push_str(&normalize_path_separators(captures.next()?));
+            }
+            _ => out.push(ch),
+        }
+    }
+    if captures.next().is_some() {
+        return None;
+    }
+    Some(PathBuf::from(native_path_separators(&out)))
+}
+
+fn normalize_path_separators(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn native_path_separators(path: &str) -> String {
+    if std::path::MAIN_SEPARATOR == '/' {
+        path.to_string()
+    } else {
+        path.replace('/', std::path::MAIN_SEPARATOR_STR)
+    }
+}
+
+fn read_glob_class<I>(chars: &mut std::iter::Peekable<I>) -> Option<String>
+where
+    I: Iterator<Item = char>,
+{
+    let mut class = String::from("[");
+    if chars.peek() == Some(&'!') {
+        chars.next();
+        class.push('^');
+    }
+    for ch in chars.by_ref() {
+        class.push(ch);
+        if ch == ']' {
+            return Some(class);
+        }
+    }
+    None
 }
 
 /// Current state of one entry on this machine.
@@ -661,5 +865,88 @@ mod tests {
         assert_eq!(FileMode::parse("copy"), Some(FileMode::Copy));
         assert_eq!(FileMode::parse("template"), Some(FileMode::Template));
         assert_eq!(FileMode::parse("hardlink"), None);
+    }
+
+    #[test]
+    fn test_wildcard_target_expansion() {
+        let captures = wildcard_captures(
+            "/repo/dotfiles/config/*.toml",
+            Path::new("/repo/dotfiles/config/starship.toml"),
+        )
+        .unwrap();
+        let target = expand_target_pattern("/home/me/.config/*.toml", &captures).unwrap();
+        assert_eq!(target, PathBuf::from("/home/me/.config/starship.toml"));
+    }
+
+    #[test]
+    fn test_recursive_wildcard_target_expansion() {
+        let captures = wildcard_captures(
+            "/repo/dotfiles/config/**/*.toml",
+            Path::new("/repo/dotfiles/config/a/b/tool.toml"),
+        )
+        .unwrap();
+        let target = expand_target_pattern("/home/me/.config/**/*.toml", &captures).unwrap();
+        assert_eq!(target, PathBuf::from("/home/me/.config/a/b/tool.toml"));
+    }
+
+    #[test]
+    fn test_recursive_wildcard_matches_zero_directories() {
+        let captures = wildcard_captures(
+            "/repo/dotfiles/config/**/*.toml",
+            Path::new("/repo/dotfiles/config/tool.toml"),
+        )
+        .unwrap();
+        let target = expand_target_pattern("/home/me/.config/**/*.toml", &captures).unwrap();
+        assert_eq!(target, PathBuf::from("/home/me/.config/tool.toml"));
+    }
+
+    #[test]
+    fn test_question_mark_target_expansion() {
+        let captures = wildcard_captures(
+            "/repo/dotfiles/config/app?.toml",
+            Path::new("/repo/dotfiles/config/app1.toml"),
+        )
+        .unwrap();
+        let target = expand_target_pattern("/home/me/.config/app?.toml", &captures).unwrap();
+        assert_eq!(target, PathBuf::from("/home/me/.config/app1.toml"));
+    }
+
+    #[test]
+    fn test_character_class_target_expansion() {
+        let captures = wildcard_captures(
+            "/repo/dotfiles/config/theme-[ab].toml",
+            Path::new("/repo/dotfiles/config/theme-a.toml"),
+        )
+        .unwrap();
+        let target = expand_target_pattern("/home/me/.config/theme-[ab].toml", &captures).unwrap();
+        assert_eq!(target, PathBuf::from("/home/me/.config/theme-a.toml"));
+    }
+
+    #[test]
+    fn test_windows_separator_wildcard_expansion() {
+        let captures = wildcard_captures(
+            r"C:\repo\dotfiles\config\*.toml",
+            Path::new(r"C:\repo\dotfiles\config\starship.toml"),
+        )
+        .unwrap();
+        let target = expand_target_pattern(r"C:\Users\me\.config\*.toml", &captures).unwrap();
+        assert_eq!(
+            target,
+            PathBuf::from(native_path_separators("C:/Users/me/.config/starship.toml"))
+        );
+    }
+
+    #[test]
+    fn test_windows_separator_recursive_wildcard_expansion() {
+        let captures = wildcard_captures(
+            r"C:\repo\dotfiles\config\**\*.toml",
+            Path::new(r"C:\repo\dotfiles\config\tool.toml"),
+        )
+        .unwrap();
+        let target = expand_target_pattern(r"C:\Users\me\.config\**\*.toml", &captures).unwrap();
+        assert_eq!(
+            target,
+            PathBuf::from(native_path_separators("C:/Users/me/.config/tool.toml"))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- expand wildcard source paths in `[system.files]` into concrete file requests
- map matching `*` and `**` captures into target paths
- document wildcard usage and cover it in system-files e2e tests

## Validation
- `cargo fmt --check`
- `cargo test system::files`
- `mise run test:e2e e2e/cli/test_system_files`

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New glob-to-target mapping drives where `mise system install` writes under the home directory; logic bugs could place or skip files incorrectly, though mismatches are mostly warned and skipped.
> 
> **Overview**
> Adds **glob wildcard expansion** for `[system.files]`: source paths may use `*`, `**`, `?`, and `[…]`, and when multiple files match, the target key must use aligned wildcards so each match maps to a concrete install path (copy, symlink, etc. unchanged per expanded entry).
> 
> **`files_from_config`** now runs entries through **`expand_request`** instead of one `FileRequest` per TOML row. Invalid or empty globs **warn and skip** that entry (including “multiple sources, non-wildcard target”); a single match with a literal target still works. Implementation builds regex captures from the source pattern (including `**/` matching zero directories and Windows path separators) and substitutes into the target pattern.
> 
> Docs and **e2e** cover `*`, `?`, classes, `**`, empty-pattern behavior; unit tests cover expansion edge cases. The system-files e2e also sets **`chmod 644`** on the SSH template output before permission-drift checks so the test is reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04db1010f838330a41bb6a568be0537bd801e50b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for glob/wildcard patterns in system file entries: matched sources are expanded into concrete installs with mapped targets.

* **Documentation**
  * Docs updated with examples and explicit rules for wildcard source→target expansion and pattern semantics.

* **Tests**
  * End-to-end tests covering wildcard expansion, recursive patterns, empty-match behavior, and permission setup for drift detection.

* **Bug Fixes**
  * Empty wildcard sources are skipped with warnings without blocking installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->