### PR TITLE
feat(system): add login shell bootstrap support

### DIFF
--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -10,7 +10,7 @@ Runs the bootstrap steps for the current config in order:
 
 1. `mise system install` — install missing `[system.packages]`, apply
    `[system.files]` and `[system.edits]`, and write `[system.defaults]`
-   (macOS)
+   (macOS) and `[system].login_shell`
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -9,8 +9,8 @@
 Runs the bootstrap steps for the current config in order:
 
 1. `mise system install` — install missing `[system.packages]`, apply
-   `[system.files]` and `[system.edits]`, and write `[system.defaults]`
-   (macOS) and `[system].login_shell`
+   `[system.files]` and `[system.edits]`, write `[system.defaults]`
+   (macOS), and set `[system].login_shell` (Unix)
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 

--- a/docs/cli/system.md
+++ b/docs/cli/system.md
@@ -6,7 +6,7 @@
 
 [experimental] Manage system packages from `[system.packages]`, files
 from `[system.files]`, edits from `[system.edits]`, macOS defaults
-from `[system.defaults]`, and `[system].login_shell`
+from `[system.defaults]`, and Unix login shell from `[system].login_shell`
 
 System packages are machine-global packages installed by the OS package
 manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).

--- a/docs/cli/system.md
+++ b/docs/cli/system.md
@@ -5,8 +5,8 @@
 - **Source code**: [`src/cli/system/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/mod.rs)
 
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, edits from `[system.edits]`, and macOS defaults
-from `[system.defaults]`
+from `[system.files]`, edits from `[system.edits]`, macOS defaults
+from `[system.defaults]`, and `[system].login_shell`
 
 System packages are machine-global packages installed by the OS package
 manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).
@@ -16,7 +16,8 @@ something else owns — a marker-delimited block or a single line. macOS
 defaults are user preferences written with `defaults write`. Unlike
 `[tools]`, none of these are version-pinned per-project and they are only
 ever acted on when explicitly requested with `mise system install` (or
-`mise bootstrap`).
+`mise bootstrap`). Login shell changes are current-user settings applied
+with `chsh -s`.
 
 ## Subcommands
 

--- a/docs/cli/system/install.md
+++ b/docs/cli/system/install.md
@@ -6,15 +6,16 @@
 - **Source code**: [`src/cli/system/install.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/install.rs)
 
 Install missing system packages from `[system.packages]`, apply files
-from `[system.files]` and edits from `[system.edits]`, and write macOS
-defaults from `[system.defaults]`
+from `[system.files]` and edits from `[system.edits]`, write macOS
+defaults from `[system.defaults]`, and set `[system].login_shell`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 and `[system.edits]` entries that aren't in their desired state are
-applied, and on macOS any `[system.defaults]` entries that are unset or
-differ are written.
+applied, on macOS any `[system.defaults]` entries that are unset or
+differ are written, and on Unix `[system].login_shell` is applied with
+`chsh -s` when it differs.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in

--- a/docs/cli/system/install.md
+++ b/docs/cli/system/install.md
@@ -14,8 +14,8 @@ system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 and `[system.edits]` entries that aren't in their desired state are
 applied, on macOS any `[system.defaults]` entries that are unset or
-differ are written, and on Unix `[system].login_shell` is applied with
-`chsh -s` when it differs.
+differ are written, and on Unix `[system].login_shell` is added to
+`/etc/shells` if needed before `chsh -s` applies it.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in

--- a/docs/cli/system/install.md
+++ b/docs/cli/system/install.md
@@ -7,7 +7,8 @@
 
 Install missing system packages from `[system.packages]`, apply files
 from `[system.files]` and edits from `[system.edits]`, write macOS
-defaults from `[system.defaults]`, and set `[system].login_shell`
+defaults from `[system.defaults]`, and set Unix login shell from
+`[system].login_shell`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as

--- a/docs/cli/system/status.md
+++ b/docs/cli/system/status.md
@@ -7,7 +7,7 @@
 
 Show the status of system packages from `[system.packages]`, files from
 `[system.files]`, edits from `[system.edits]`, and macOS defaults from
-`[system.defaults]`
+`[system.defaults]`, and `[system].login_shell`
 
 ## Flags
 
@@ -17,8 +17,8 @@ Output in JSON format
 
 ### `--missing`
 
-Exit with code 1 if any configured packages, files, or defaults are
-not in their desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages, files, defaults, or login
+shell are not in their desired state (missing, version mismatch, differs)
 
 Examples:
 

--- a/docs/cli/system/status.md
+++ b/docs/cli/system/status.md
@@ -7,7 +7,7 @@
 
 Show the status of system packages from `[system.packages]`, files from
 `[system.files]`, edits from `[system.edits]`, and macOS defaults from
-`[system.defaults]`, and `[system].login_shell`
+`[system.defaults]`, and Unix login shell from `[system].login_shell`
 
 ## Flags
 
@@ -17,8 +17,8 @@ Output in JSON format
 
 ### `--missing`
 
-Exit with code 1 if any configured packages, files, defaults, or login
-shell are not in their desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages, files, edits, defaults, or
+login shell are not in their desired state
 
 Examples:
 

--- a/docs/system-login-shell.md
+++ b/docs/system-login-shell.md
@@ -1,0 +1,49 @@
+# System Login Shell <Badge type="warning" text="experimental" />
+
+mise can declare the current user's login shell in the `[system]` section of
+`mise.toml` and apply it with `mise system install`:
+
+```toml
+[system]
+login_shell = "/bin/zsh"
+```
+
+When the configured shell differs from the user's account entry, mise runs:
+
+```sh
+chsh -s /bin/zsh
+```
+
+## Semantics
+
+`[system].login_shell` follows the same manual, idempotent model as
+[system packages](/system-packages/):
+
+- **Most local wins** - a project config can override a global
+  `login_shell`; unlike package/file lists, there is only one desired value.
+- **Manual application only** - mise never changes your login shell
+  implicitly. Only `mise system install` or [`mise bootstrap`](/cli/bootstrap.html)
+  applies it.
+- **Unix-only** - on non-Unix platforms, or when `chsh` is not available,
+  `mise system status` reports the entry as skipped and install ignores it.
+- **Absolute path required** - relative shell names are skipped with a
+  warning. Use the full path, such as `/bin/zsh` or `/opt/homebrew/bin/fish`.
+
+mise does not edit `/etc/shells`. If your platform requires the shell to be
+listed there, add it yourself before applying this setting; any `chsh` error
+is surfaced as-is.
+
+## Commands
+
+```sh
+mise system status            # shows login shell state
+mise system status --missing  # exit 1 if the configured shell differs
+
+mise system install           # runs chsh -s when needed
+mise system install --dry-run # print the chsh command instead
+mise system install --yes     # skip the confirmation prompt
+```
+
+Explicit package arguments and `--manager` scope `mise system install` to
+packages only, so `login_shell` is applied by the bare converge-everything
+form.

--- a/docs/system-login-shell.md
+++ b/docs/system-login-shell.md
@@ -8,7 +8,9 @@ mise can declare the current user's login shell in the `[system]` section of
 login_shell = "/bin/zsh"
 ```
 
-When the configured shell differs from the user's account entry, mise runs:
+When the configured shell is not listed in `/etc/shells`, mise appends it
+first. When the configured shell differs from the user's account entry, mise
+runs:
 
 ```sh
 chsh -s /bin/zsh
@@ -24,23 +26,31 @@ chsh -s /bin/zsh
 - **Manual application only** - mise never changes your login shell
   implicitly. Only `mise system install` or [`mise bootstrap`](/cli/bootstrap.html)
   applies it.
+- **Listed shell** - the shell must appear in `/etc/shells` before `chsh`
+  accepts it on many platforms. mise adds the configured path to that file
+  when it is missing.
 - **Unix-only** - on non-Unix platforms, or when `chsh` is not available,
   `mise system status` reports the entry as skipped and install ignores it.
 - **Absolute path required** - relative shell names are skipped with a
   warning. Use the full path, such as `/bin/zsh` or `/opt/homebrew/bin/fish`.
 
-mise does not edit `/etc/shells`. If your platform requires the shell to be
-listed there, add it yourself before applying this setting; any `chsh` error
-is surfaced as-is.
+`/etc/shells` is usually root-owned. If the file is not writable, mise uses
+the same non-interactive sudo behavior as system packages: it can prompt in an
+interactive terminal, uses passwordless sudo in non-interactive contexts, and
+honors `system_packages.sudo = false`.
+
+When `mise` itself is started under `sudo`, login shell status and `chsh`
+target `SUDO_USER` rather than root. Plain root sessions, such as containers,
+still target root.
 
 ## Commands
 
 ```sh
 mise system status            # shows login shell state
-mise system status --missing  # exit 1 if the configured shell differs
+mise system status --missing  # exit 1 if the shell differs or is not listed
 
-mise system install           # runs chsh -s when needed
-mise system install --dry-run # print the chsh command instead
+mise system install           # updates /etc/shells and runs chsh -s when needed
+mise system install --dry-run # print the commands instead
 mise system install --yes     # skip the confirmation prompt
 ```
 

--- a/docs/system-packages/index.md
+++ b/docs/system-packages/index.md
@@ -133,9 +133,9 @@ OS.
 ## sudo
 
 The Linux package managers require root. When not running as root, mise
-elevates with `sudo`, which prompts for your password as usual. This is the
-only place mise ever elevates privileges, and it only happens during an
-explicit `mise system install`:
+elevates with `sudo`, which prompts for your password as usual. The same
+sudo path is used when `[system].login_shell` needs to add a shell to
+`/etc/shells`, and it only happens during an explicit `mise system install`:
 
 - already root (containers, CI): no sudo, commands run directly
 - interactive terminal: e.g. `sudo apt-get install ...` with a normal sudo

--- a/docs/system-packages/index.md
+++ b/docs/system-packages/index.md
@@ -30,7 +30,8 @@ themselves — those belong in `[tools]`.
 
 The `[system]` section can also declare
 [macOS defaults](/system-packages/defaults.html) (`[system.defaults]`),
-applied by the same `mise system install` command.
+[login shells](/system-login-shell.html) (`[system].login_shell`), applied
+by the same `mise system install` command.
 
 ## Supported package managers
 
@@ -57,6 +58,15 @@ applied by the same `mise system install` command.
   missing, but only `mise system install` ever installs anything.
 - **Unknown managers are ignored with a warning** so configs using managers
   from newer mise versions still parse.
+
+For current-user login shell setup, use `[system].login_shell`:
+
+```toml
+[system]
+login_shell = "/bin/zsh"
+```
+
+See [System Login Shell](/system-login-shell.html) for details.
 
 ## Commands
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -96,6 +96,9 @@ a `bootstrap` task if you define one:
 [system.defaults]                      # macOS defaults write
 "com.apple.dock.autohide" = true
 
+[system]                               # current user's login shell
+login_shell = "/bin/zsh"
+
 [tasks.bootstrap]                      # anything else, with tools on PATH
 run = "gh auth status || gh auth login"
 ```
@@ -109,7 +112,8 @@ already in its desired state, `mise system status --missing` makes a CI
 check, and nothing is ever applied implicitly. See
 [System Packages](/system-packages/), [System Files](/system-files.html),
 [System Edits](/system-edits.html), and
-[macOS Defaults](/system-packages/defaults.html).
+[macOS Defaults](/system-packages/defaults.html), and
+[System Login Shell](/system-login-shell.html).
 
 ## Installation via zsh zinit
 

--- a/e2e/cli/test_system_login_shell
+++ b/e2e/cli/test_system_login_shell
@@ -6,6 +6,7 @@ printf '%s\n' "$*" >>"$CHSH_LOG"
 EOF
 chmod +x "$HOME/bin/chsh"
 export CHSH_LOG="$PWD/chsh.log"
+export MISE_TEST_SHELLS_FILE="$PWD/shells"
 
 cat <<EOF >mise.toml
 [system]
@@ -14,6 +15,7 @@ EOF
 
 current="$(mise system status --json | jq -r '.login_shell.current')"
 assert_not_empty "printf '%s' '$current'"
+printf '%s\n' "$current" >"$MISE_TEST_SHELLS_FILE"
 
 # Matching login shell is in sync and install is a no-op.
 cat <<EOF >mise.toml
@@ -56,11 +58,14 @@ cat <<EOF >mise.toml
 login_shell = "/tmp/mise-test-shell"
 EOF
 assert_fail "mise system status --missing"
+assert_contains "mise system status --json" '"shell_listed": false'
 assert_contains "mise system install --dry-run --yes" "chsh -s /tmp/mise-test-shell"
 assert_fail "test -f '$CHSH_LOG'"
+assert_fail "grep -q /tmp/mise-test-shell '$MISE_TEST_SHELLS_FILE'"
 
-# Real apply invokes chsh with the requested shell.
+# Real apply lists the shell first, then invokes chsh with the requested shell.
 assert_succeed "mise system install --yes"
+assert_contains "cat '$MISE_TEST_SHELLS_FILE'" "/tmp/mise-test-shell"
 assert "cat '$CHSH_LOG'" "-s /tmp/mise-test-shell"
 
 # Invalid values warn and are skipped like other malformed [system] entries.

--- a/e2e/cli/test_system_login_shell
+++ b/e2e/cli/test_system_login_shell
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+mkdir -p "$HOME/bin"
+export CHSH_LOG="$PWD/chsh.log"
+rm -f "$CHSH_LOG"
 cat <<'EOF' >"$HOME/bin/chsh"
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$CHSH_LOG"
 EOF
 chmod +x "$HOME/bin/chsh"
-export CHSH_LOG="$PWD/chsh.log"
 export MISE_TEST_SHELLS_FILE="$PWD/shells"
 
 cat <<EOF >mise.toml

--- a/e2e/cli/test_system_login_shell
+++ b/e2e/cli/test_system_login_shell
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >"$HOME/bin/chsh"
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CHSH_LOG"
+EOF
+chmod +x "$HOME/bin/chsh"
+export CHSH_LOG="$PWD/chsh.log"
+
+cat <<EOF >mise.toml
+[system]
+login_shell = "/bin/sh"
+EOF
+
+current="$(mise system status --json | jq -r '.login_shell.current')"
+assert_not_empty "printf '%s' '$current'"
+
+# Matching login shell is in sync and install is a no-op.
+cat <<EOF >mise.toml
+[system]
+login_shell = "$current"
+EOF
+assert_succeed "mise system status --missing"
+assert_contains "mise system status --json" '"state": "set"'
+assert_succeed "mise system install --yes"
+assert_fail "test -f '$CHSH_LOG'"
+
+# A local config overrides the global login shell.
+cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
+[system]
+login_shell = "/tmp/global-shell"
+EOF
+cat <<EOF >mise.toml
+[system]
+login_shell = "/tmp/local-shell"
+EOF
+assert_contains "mise system status --json | jq -r '.login_shell.shell'" "/tmp/local-shell"
+rm "$MISE_CONFIG_DIR/config.toml"
+
+# Invalid local values are skipped, so a valid global value can still apply.
+cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
+[system]
+login_shell = "/tmp/global-shell"
+EOF
+cat <<EOF >mise.toml
+[system]
+login_shell = "relative-shell"
+EOF
+assert_contains "mise system status --json 2>&1" "shell must be an absolute path"
+assert_contains "mise system status --json | jq -r '.login_shell.shell'" "/tmp/global-shell"
+rm "$MISE_CONFIG_DIR/config.toml"
+
+# Dry-run prints the chsh command without calling it.
+cat <<EOF >mise.toml
+[system]
+login_shell = "/tmp/mise-test-shell"
+EOF
+assert_fail "mise system status --missing"
+assert_contains "mise system install --dry-run --yes" "chsh -s /tmp/mise-test-shell"
+assert_fail "test -f '$CHSH_LOG'"
+
+# Real apply invokes chsh with the requested shell.
+assert_succeed "mise system install --yes"
+assert "cat '$CHSH_LOG'" "-s /tmp/mise-test-shell"
+
+# Invalid values warn and are skipped like other malformed [system] entries.
+cat <<EOF >mise.toml
+[system]
+login_shell = "relative-shell"
+EOF
+assert_succeed "mise system status"
+assert_contains "mise system status 2>&1" "shell must be an absolute path"

--- a/e2e/cli/test_system_login_shell
+++ b/e2e/cli/test_system_login_shell
@@ -36,7 +36,7 @@ login_shell = "/tmp/global-shell"
 EOF
 cat <<EOF >mise.toml
 [system]
-login_shell = "/tmp/local-shell"
+login_shell = " /tmp/local-shell "
 EOF
 assert_contains "mise system status --json | jq -r '.login_shell.shell'" "/tmp/local-shell"
 rm "$MISE_CONFIG_DIR/config.toml"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -755,8 +755,8 @@ e.g.: ruby@3
 Runs the bootstrap steps for the current config in order:
 
 1. `mise system install` — install missing `[system.packages]`, apply
-   `[system.files]` and `[system.edits]`, and write `[system.defaults]`
-   (macOS) and `[system].login_shell`
+   `[system.files]` and `[system.edits]`, write `[system.defaults]`
+   (macOS), and set `[system].login_shell` (Unix)
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
@@ -2825,7 +2825,8 @@ Tap name(s), e.g. `owner/repo`
 .SH "MISE SYSTEM INSTALL"
 Install missing system packages from `[system.packages]`, apply files
 from `[system.files]` and edits from `[system.edits]`, write macOS
-defaults from `[system.defaults]`, and set `[system].login_shell`
+defaults from `[system.defaults]`, and set Unix login shell from
+`[system].login_shell`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
@@ -2867,7 +2868,7 @@ Packages in `manager:package` form; defaults to everything configured in [system
 .SH "MISE SYSTEM STATUS"
 Show the status of system packages from `[system.packages]`, files from
 `[system.files]`, edits from `[system.edits]`, and macOS defaults from
-`[system.defaults]`, and `[system].login_shell`
+`[system.defaults]`, and Unix login shell from `[system].login_shell`
 .PP
 \fBUsage:\fR mise system status [OPTIONS]
 .PP
@@ -2878,8 +2879,8 @@ Show the status of system packages from `[system.packages]`, files from
 Output in JSON format
 .TP
 \fB\-\-missing\fR
-Exit with code 1 if any configured packages, files, defaults, or login
-shell are not in their desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages, files, edits, defaults, or
+login shell are not in their desired state
 .SH "MISE SYSTEM UPGRADE"
 Upgrade installed system packages from `[system.packages]`
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2832,8 +2832,8 @@ system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 and `[system.edits]` entries that aren't in their desired state are
 applied, on macOS any `[system.defaults]` entries that are unset or
-differ are written, and on Unix `[system].login_shell` is applied with
-`chsh \-s` when it differs.
+differ are written, and on Unix `[system].login_shell` is added to
+`/etc/shells` if needed before `chsh \-s` applies it.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -756,7 +756,7 @@ Runs the bootstrap steps for the current config in order:
 
 1. `mise system install` — install missing `[system.packages]`, apply
    `[system.files]` and `[system.edits]`, and write `[system.defaults]`
-   (macOS)
+   (macOS) and `[system].login_shell`
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
@@ -2824,15 +2824,16 @@ Print the command that would run without running it
 Tap name(s), e.g. `owner/repo`
 .SH "MISE SYSTEM INSTALL"
 Install missing system packages from `[system.packages]`, apply files
-from `[system.files]` and edits from `[system.edits]`, and write macOS
-defaults from `[system.defaults]`
+from `[system.files]` and edits from `[system.edits]`, write macOS
+defaults from `[system.defaults]`, and set `[system].login_shell`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 and `[system.edits]` entries that aren't in their desired state are
-applied, and on macOS any `[system.defaults]` entries that are unset or
-differ are written.
+applied, on macOS any `[system.defaults]` entries that are unset or
+differ are written, and on Unix `[system].login_shell` is applied with
+`chsh \-s` when it differs.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in
@@ -2866,7 +2867,7 @@ Packages in `manager:package` form; defaults to everything configured in [system
 .SH "MISE SYSTEM STATUS"
 Show the status of system packages from `[system.packages]`, files from
 `[system.files]`, edits from `[system.edits]`, and macOS defaults from
-`[system.defaults]`
+`[system.defaults]`, and `[system].login_shell`
 .PP
 \fBUsage:\fR mise system status [OPTIONS]
 .PP
@@ -2877,8 +2878,8 @@ Show the status of system packages from `[system.packages]`, files from
 Output in JSON format
 .TP
 \fB\-\-missing\fR
-Exit with code 1 if any configured packages, files, or defaults are
-not in their desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages, files, defaults, or login
+shell are not in their desired state (missing, version mismatch, differs)
 .SH "MISE SYSTEM UPGRADE"
 Upgrade installed system packages from `[system.packages]`
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -288,7 +288,7 @@ Runs the bootstrap steps for the current config in order:
 
 1. `mise system install` — install missing `[system.packages]`, apply
    `[system.files]` and `[system.edits]`, and write `[system.defaults]`
-   (macOS)
+   (macOS) and `[system].login_shell`
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
@@ -2879,13 +2879,13 @@ Examples:
 }
 cmd system subcommand_required=#true help=#"""
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, edits from `[system.edits]`, and macOS defaults
-from `[system.defaults]`
+from `[system.files]`, edits from `[system.edits]`, macOS defaults
+from `[system.defaults]`, and `[system].login_shell`
 """# {
     long_help #"""
 [experimental] Manage system packages from `[system.packages]`, files
-from `[system.files]`, edits from `[system.edits]`, and macOS defaults
-from `[system.defaults]`
+from `[system.files]`, edits from `[system.edits]`, macOS defaults
+from `[system.defaults]`, and `[system].login_shell`
 
 System packages are machine-global packages installed by the OS package
 manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).
@@ -2895,7 +2895,8 @@ something else owns — a marker-delimited block or a single line. macOS
 defaults are user preferences written with `defaults write`. Unlike
 `[tools]`, none of these are version-pinned per-project and they are only
 ever acted on when explicitly requested with `mise system install` (or
-`mise bootstrap`).
+`mise bootstrap`). Login shell changes are current-user settings applied
+with `chsh -s`.
 """#
     cmd brew subcommand_required=#true help="Manage Homebrew taps used by system packages" {
         long_help #"""
@@ -2930,21 +2931,22 @@ Examples:
     }
     cmd install help=#"""
 Install missing system packages from `[system.packages]`, apply files
-from `[system.files]` and edits from `[system.edits]`, and write macOS
-defaults from `[system.defaults]`
+from `[system.files]` and edits from `[system.edits]`, write macOS
+defaults from `[system.defaults]`, and set `[system].login_shell`
 """# {
         alias i
         long_help #"""
 Install missing system packages from `[system.packages]`, apply files
-from `[system.files]` and edits from `[system.edits]`, and write macOS
-defaults from `[system.defaults]`
+from `[system.files]` and edits from `[system.edits]`, write macOS
+defaults from `[system.defaults]`, and set `[system].login_shell`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 and `[system.edits]` entries that aren't in their desired state are
-applied, and on macOS any `[system.defaults]` entries that are unset or
-differ are written.
+applied, on macOS any `[system.defaults]` entries that are unset or
+differ are written, and on Unix `[system].login_shell` is applied with
+`chsh -s` when it differs.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in
@@ -2974,7 +2976,7 @@ Examples:
     cmd status help=#"""
 Show the status of system packages from `[system.packages]`, files from
 `[system.files]`, edits from `[system.edits]`, and macOS defaults from
-`[system.defaults]`
+`[system.defaults]`, and `[system].login_shell`
 """# {
         alias ls
         after_long_help #"""
@@ -2987,8 +2989,8 @@ Examples:
 """#
         flag "-J --json" help="Output in JSON format"
         flag --missing help=#"""
-Exit with code 1 if any configured packages, files, or defaults are
-not in their desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages, files, defaults, or login
+shell are not in their desired state (missing, version mismatch, differs)
 """#
     }
     cmd upgrade help="Upgrade installed system packages from `[system.packages]`" {

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2945,8 +2945,8 @@ system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 and `[system.edits]` entries that aren't in their desired state are
 applied, on macOS any `[system.defaults]` entries that are unset or
-differ are written, and on Unix `[system].login_shell` is applied with
-`chsh -s` when it differs.
+differ are written, and on Unix `[system].login_shell` is added to
+`/etc/shells` if needed before `chsh -s` applies it.
 
 Packages can also be given explicitly in `manager:package` form (e.g.
 `apt:curl`, `brew:jq`); they are installed whether or not they appear in

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -287,8 +287,8 @@ cmd bootstrap help="[experimental] Set up a machine for the current config in on
 Runs the bootstrap steps for the current config in order:
 
 1. `mise system install` — install missing `[system.packages]`, apply
-   `[system.files]` and `[system.edits]`, and write `[system.defaults]`
-   (macOS) and `[system].login_shell`
+   `[system.files]` and `[system.edits]`, write `[system.defaults]`
+   (macOS), and set `[system].login_shell` (Unix)
 2. `mise install` — install missing tools from `[tools]`
 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 
@@ -2880,12 +2880,12 @@ Examples:
 cmd system subcommand_required=#true help=#"""
 [experimental] Manage system packages from `[system.packages]`, files
 from `[system.files]`, edits from `[system.edits]`, macOS defaults
-from `[system.defaults]`, and `[system].login_shell`
+from `[system.defaults]`, and Unix login shell from `[system].login_shell`
 """# {
     long_help #"""
 [experimental] Manage system packages from `[system.packages]`, files
 from `[system.files]`, edits from `[system.edits]`, macOS defaults
-from `[system.defaults]`, and `[system].login_shell`
+from `[system.defaults]`, and Unix login shell from `[system].login_shell`
 
 System packages are machine-global packages installed by the OS package
 manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).
@@ -2932,13 +2932,15 @@ Examples:
     cmd install help=#"""
 Install missing system packages from `[system.packages]`, apply files
 from `[system.files]` and edits from `[system.edits]`, write macOS
-defaults from `[system.defaults]`, and set `[system].login_shell`
+defaults from `[system.defaults]`, and set Unix login shell from
+`[system].login_shell`
 """# {
         alias i
         long_help #"""
 Install missing system packages from `[system.packages]`, apply files
 from `[system.files]` and edits from `[system.edits]`, write macOS
-defaults from `[system.defaults]`, and set `[system].login_shell`
+defaults from `[system.defaults]`, and set Unix login shell from
+`[system].login_shell`
 
 Checks which configured packages are missing and installs them with the
 system package manager. This may elevate with sudo when not running as
@@ -2976,7 +2978,7 @@ Examples:
     cmd status help=#"""
 Show the status of system packages from `[system.packages]`, files from
 `[system.files]`, edits from `[system.edits]`, and macOS defaults from
-`[system.defaults]`, and `[system].login_shell`
+`[system.defaults]`, and Unix login shell from `[system].login_shell`
 """# {
         alias ls
         after_long_help #"""
@@ -2989,8 +2991,8 @@ Examples:
 """#
         flag "-J --json" help="Output in JSON format"
         flag --missing help=#"""
-Exit with code 1 if any configured packages, files, defaults, or login
-shell are not in their desired state (missing, version mismatch, differs)
+Exit with code 1 if any configured packages, files, edits, defaults, or
+login shell are not in their desired state
 """#
     }
     cmd upgrade help="Upgrade installed system packages from `[system.packages]`" {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2959,8 +2959,12 @@
     },
     "system": {
       "type": "object",
-      "description": "[experimental] machine-global bootstrapping (system packages, files, edits, macOS defaults)",
+      "description": "[experimental] machine-global bootstrapping (system packages, files, edits, macOS defaults, login shell)",
       "properties": {
+        "login_shell": {
+          "type": "string",
+          "description": "current user's desired login shell, applied with `chsh -s`; must be an absolute path"
+        },
         "edits": {
           "type": "object",
           "description": "edits to files mise doesn't own, applied with `mise system install`: keyed by target path, then by an id naming each edit (the block marker name)",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2963,6 +2963,7 @@
       "properties": {
         "login_shell": {
           "type": "string",
+          "pattern": "^/",
           "description": "current user's desired login shell, applied with `chsh -s`; must be an absolute path"
         },
         "edits": {

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -12,7 +12,7 @@ use crate::system;
 ///
 /// 1. `mise system install` — install missing `[system.packages]`, apply
 ///    `[system.files]` and `[system.edits]`, and write `[system.defaults]`
-///    (macOS)
+///    (macOS) and `[system].login_shell`
 /// 2. `mise install` — install missing tools from `[tools]`
 /// 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 ///
@@ -90,6 +90,14 @@ impl Bootstrap {
         } else {
             info!("bootstrap: system defaults");
             super::system::install::apply_defaults(defaults, self.dry_run, self.yes).await?;
+        }
+
+        let login_shell = system::login_shell_from_config(&config);
+        if login_shell.is_none() {
+            debug!("bootstrap: no [system].login_shell configured, skipping");
+        } else {
+            info!("bootstrap: login shell");
+            super::system::install::apply_login_shell(login_shell, self.dry_run, self.yes)?;
         }
 
         info!("bootstrap: tools");

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -11,8 +11,8 @@ use crate::system;
 /// Runs the bootstrap steps for the current config in order:
 ///
 /// 1. `mise system install` — install missing `[system.packages]`, apply
-///    `[system.files]` and `[system.edits]`, and write `[system.defaults]`
-///    (macOS) and `[system].login_shell`
+///    `[system.files]` and `[system.edits]`, write `[system.defaults]`
+///    (macOS), and set `[system].login_shell` (Unix)
 /// 2. `mise install` — install missing tools from `[tools]`
 /// 3. `mise run bootstrap` — if a task named `bootstrap` is defined
 ///

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -64,6 +64,23 @@ enum SystemDefaultsDiagnosis {
     },
 }
 
+/// outcome of the `[system].login_shell` doctor check
+enum SystemLoginShellDiagnosis {
+    Unavailable {
+        reason: String,
+        shell: String,
+    },
+    Checked {
+        shell: String,
+        current: String,
+        out_of_sync: bool,
+    },
+    CheckFailed {
+        shell: String,
+        error: String,
+    },
+}
+
 impl Doctor {
     pub async fn run(self) -> eyre::Result<()> {
         if let Some(cmd) = self.subcommand {
@@ -213,6 +230,10 @@ impl Doctor {
 
         if let Some(system_defaults) = self.system_defaults_json(&config).await {
             data.insert("system_defaults".into(), system_defaults);
+        }
+
+        if let Some(system_login_shell) = self.system_login_shell_json(&config).await {
+            data.insert("system_login_shell".into(), system_login_shell);
         }
 
         if !self.errors.is_empty() {
@@ -386,6 +407,7 @@ impl Doctor {
 
         self.analyze_system_packages(config).await?;
         self.analyze_system_defaults(config).await?;
+        self.analyze_system_login_shell(config).await?;
 
         Ok(())
     }
@@ -542,6 +564,96 @@ impl Doctor {
             }
         };
         info::section("system_defaults", line)?;
+        Ok(())
+    }
+
+    /// Shared `[system].login_shell` check for the text and JSON doctor paths.
+    /// Pushes the relevant warnings; returns None when nothing is configured.
+    async fn check_system_login_shell(
+        &mut self,
+        config: &Arc<Config>,
+    ) -> Option<SystemLoginShellDiagnosis> {
+        if !Settings::get().experimental {
+            return None;
+        }
+        let request = crate::system::login_shell_from_config(config)?;
+        if !crate::system::login_shell::is_available() {
+            return Some(SystemLoginShellDiagnosis::Unavailable {
+                reason: crate::system::login_shell::unavailable_reason(),
+                shell: request.shell,
+            });
+        }
+        match crate::system::login_shell::status(&request) {
+            Ok(status) => {
+                let out_of_sync = status.state != crate::system::login_shell::LoginShellState::Set;
+                if out_of_sync {
+                    self.warnings.push(
+                        "login shell is out of sync, apply it with `mise system install`"
+                            .to_string(),
+                    );
+                }
+                Some(SystemLoginShellDiagnosis::Checked {
+                    shell: status.request.shell,
+                    current: status.current,
+                    out_of_sync,
+                })
+            }
+            Err(err) => {
+                self.warnings
+                    .push(format!("failed to check login shell: {err}"));
+                Some(SystemLoginShellDiagnosis::CheckFailed {
+                    shell: request.shell,
+                    error: err.to_string(),
+                })
+            }
+        }
+    }
+
+    /// same diagnostics as [`Self::analyze_system_login_shell`] for `doctor -J`
+    async fn system_login_shell_json(&mut self, config: &Arc<Config>) -> Option<serde_json::Value> {
+        let json = match self.check_system_login_shell(config).await? {
+            SystemLoginShellDiagnosis::Unavailable { reason, shell } => serde_json::json!({
+                "available": false,
+                "reason": reason,
+                "shell": shell,
+            }),
+            SystemLoginShellDiagnosis::Checked {
+                shell,
+                current,
+                out_of_sync,
+            } => serde_json::json!({
+                "available": true,
+                "shell": shell,
+                "current": current,
+                "out_of_sync": out_of_sync,
+            }),
+            SystemLoginShellDiagnosis::CheckFailed { shell, error } => serde_json::json!({
+                "available": true,
+                "shell": shell,
+                "error": error,
+            }),
+        };
+        Some(json)
+    }
+
+    async fn analyze_system_login_shell(&mut self, config: &Arc<Config>) -> eyre::Result<()> {
+        let Some(diagnosis) = self.check_system_login_shell(config).await else {
+            return Ok(());
+        };
+        let line = match diagnosis {
+            SystemLoginShellDiagnosis::Unavailable { reason, shell } => {
+                format!("{shell}: unavailable ({reason}), skipped")
+            }
+            SystemLoginShellDiagnosis::Checked {
+                shell,
+                current,
+                out_of_sync,
+            } => format!("{shell} requested, current {current}, out_of_sync={out_of_sync}"),
+            SystemLoginShellDiagnosis::CheckFailed { shell, error } => {
+                format!("{shell} requested, check failed: {error}")
+            }
+        };
+        info::section("system_login_shell", line)?;
         Ok(())
     }
 

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -6,7 +6,8 @@ use crate::system;
 
 /// Install missing system packages from `[system.packages]`, apply files
 /// from `[system.files]` and edits from `[system.edits]`, write macOS
-/// defaults from `[system.defaults]`, and set `[system].login_shell`
+/// defaults from `[system.defaults]`, and set Unix login shell from
+/// `[system].login_shell`
 ///
 /// Checks which configured packages are missing and installs them with the
 /// system package manager. This may elevate with sudo when not running as

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -5,15 +5,16 @@ use crate::config::{Config, Settings};
 use crate::system;
 
 /// Install missing system packages from `[system.packages]`, apply files
-/// from `[system.files]` and edits from `[system.edits]`, and write macOS
-/// defaults from `[system.defaults]`
+/// from `[system.files]` and edits from `[system.edits]`, write macOS
+/// defaults from `[system.defaults]`, and set `[system].login_shell`
 ///
 /// Checks which configured packages are missing and installs them with the
 /// system package manager. This may elevate with sudo when not running as
 /// root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 /// and `[system.edits]` entries that aren't in their desired state are
-/// applied, and on macOS any `[system.defaults]` entries that are unset or
-/// differ are written.
+/// applied, on macOS any `[system.defaults]` entries that are unset or
+/// differ are written, and on Unix `[system].login_shell` is applied with
+/// `chsh -s` when it differs.
 ///
 /// Packages can also be given explicitly in `manager:package` form (e.g.
 /// `apt:curl`, `brew:jq`); they are installed whether or not they appear in
@@ -55,10 +56,12 @@ impl SystemInstall {
         // explicit package specs and --manager filters scope the run to
         // packages
         let mut defaults = vec![];
+        let mut login_shell = None;
         let mgrs = if self.packages.is_empty() {
             let config = Config::get().await?;
             if self.manager.is_none() {
                 defaults = system::defaults_from_config(&config);
+                login_shell = system::login_shell_from_config(&config);
             }
             system::packages_from_config(&config)
         } else {
@@ -87,7 +90,12 @@ impl SystemInstall {
         };
         // when only defaults/files/edits are configured, skip the driver so
         // it doesn't print "no system packages configured"
-        if !mgrs.is_empty() || (defaults.is_empty() && files.is_empty() && edits.is_empty()) {
+        if !mgrs.is_empty()
+            || (defaults.is_empty()
+                && login_shell.is_none()
+                && files.is_empty()
+                && edits.is_empty())
+        {
             driver::run(mgrs, Action::Install, &opts).await?;
         }
         if !files.is_empty() {
@@ -107,7 +115,8 @@ impl SystemInstall {
             };
             system::edits::apply(&config, &edits, &apply_opts)?;
         }
-        apply_defaults(defaults, self.dry_run, self.yes).await
+        apply_defaults(defaults, self.dry_run, self.yes).await?;
+        apply_login_shell(login_shell, self.dry_run, self.yes)
     }
 }
 
@@ -154,6 +163,46 @@ pub(crate) async fn apply_defaults(
             "defaults: wrote {} — some apps only pick up changes after a relaunch \
              (e.g. `killall Dock`)",
             list.join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// Apply `[system].login_shell` when it differs - shared by `mise system
+/// install` and `mise bootstrap`. Inert off-Unix or when `chsh` is missing.
+pub(crate) fn apply_login_shell(
+    request: Option<system::login_shell::LoginShellRequest>,
+    dry_run: bool,
+    yes: bool,
+) -> Result<()> {
+    use crate::system::login_shell::{self, LoginShellState};
+    let Some(request) = request else {
+        return Ok(());
+    };
+    if !login_shell::is_available() {
+        debug!(
+            "login_shell: skipping, {}",
+            login_shell::unavailable_reason()
+        );
+        return Ok(());
+    }
+    let status = login_shell::status(&request)?;
+    if status.state == LoginShellState::Set {
+        info!("login_shell: already set to {}", request.shell);
+        return Ok(());
+    }
+    if !dry_run && !yes && console::user_attended_stderr() {
+        let msg = format!("login_shell: run `chsh -s {}`?", request.shell);
+        if !crate::ui::prompt::confirm(msg)? {
+            info!("login_shell: skipped");
+            return Ok(());
+        }
+    }
+    login_shell::apply(&request, dry_run)?;
+    if !dry_run {
+        info!(
+            "login_shell: set to {} - start a new login session for it to take effect",
+            request.shell
         );
     }
     Ok(())

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -13,8 +13,8 @@ use crate::system;
 /// root (see the `system_packages.sudo` setting). Afterwards, `[system.files]`
 /// and `[system.edits]` entries that aren't in their desired state are
 /// applied, on macOS any `[system.defaults]` entries that are unset or
-/// differ are written, and on Unix `[system].login_shell` is applied with
-/// `chsh -s` when it differs.
+/// differ are written, and on Unix `[system].login_shell` is added to
+/// `/etc/shells` if needed before `chsh -s` applies it.
 ///
 /// Packages can also be given explicitly in `manager:package` form (e.g.
 /// `apt:curl`, `brew:jq`); they are installed whether or not they appear in

--- a/src/cli/system/mod.rs
+++ b/src/cli/system/mod.rs
@@ -12,7 +12,7 @@ mod r#use;
 
 /// [experimental] Manage system packages from `[system.packages]`, files
 /// from `[system.files]`, edits from `[system.edits]`, macOS defaults
-/// from `[system.defaults]`, and `[system].login_shell`
+/// from `[system.defaults]`, and Unix login shell from `[system].login_shell`
 ///
 /// System packages are machine-global packages installed by the OS package
 /// manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).

--- a/src/cli/system/mod.rs
+++ b/src/cli/system/mod.rs
@@ -11,8 +11,8 @@ mod upgrade;
 mod r#use;
 
 /// [experimental] Manage system packages from `[system.packages]`, files
-/// from `[system.files]`, edits from `[system.edits]`, and macOS defaults
-/// from `[system.defaults]`
+/// from `[system.files]`, edits from `[system.edits]`, macOS defaults
+/// from `[system.defaults]`, and `[system].login_shell`
 ///
 /// System packages are machine-global packages installed by the OS package
 /// manager (apt, dnf, pacman) or mise's Homebrew-bottle installer (brew).
@@ -22,7 +22,8 @@ mod r#use;
 /// defaults are user preferences written with `defaults write`. Unlike
 /// `[tools]`, none of these are version-pinned per-project and they are only
 /// ever acted on when explicitly requested with `mise system install` (or
-/// `mise bootstrap`).
+/// `mise bootstrap`). Login shell changes are current-user settings applied
+/// with `chsh -s`.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment)]
 pub struct System {

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -6,12 +6,13 @@ use crate::path::PathExt;
 use crate::system;
 use crate::system::defaults::DefaultsState;
 use crate::system::files::FileState;
+use crate::system::login_shell::LoginShellState;
 use crate::system::packages::PackageState;
 use crate::ui::table::MiseTable;
 
 /// Show the status of system packages from `[system.packages]`, files from
 /// `[system.files]`, edits from `[system.edits]`, and macOS defaults from
-/// `[system.defaults]`
+/// `[system.defaults]`, and `[system].login_shell`
 #[derive(Debug, clap::Args)]
 #[clap(visible_alias = "ls", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct SystemStatus {
@@ -19,8 +20,8 @@ pub struct SystemStatus {
     #[clap(long, short = 'J')]
     json: bool,
 
-    /// Exit with code 1 if any configured packages, files, or defaults are
-    /// not in their desired state (missing, version mismatch, differs)
+    /// Exit with code 1 if any configured packages, files, defaults, or login
+    /// shell are not in their desired state (missing, version mismatch, differs)
     #[clap(long, verbatim_doc_comment)]
     missing: bool,
 }
@@ -225,6 +226,55 @@ impl SystemStatus {
                 }
             }
         }
+        let login_shell = system::login_shell_from_config(&config);
+        let mut login_shell_rows: Vec<Vec<String>> = vec![];
+        if let Some(req) = login_shell {
+            if !system::login_shell::is_available() {
+                let reason = system::login_shell::unavailable_reason();
+                if self.json {
+                    json_out.insert(
+                        "login_shell".to_string(),
+                        json!({
+                            "available": false,
+                            "reason": reason,
+                            "shell": req.shell,
+                        }),
+                    );
+                } else {
+                    login_shell_rows.push(vec![
+                        req.shell,
+                        "".to_string(),
+                        format!("skipped ({reason})"),
+                    ]);
+                }
+            } else {
+                let status = system::login_shell::status(&req)?;
+                let state = match &status.state {
+                    LoginShellState::Set => "set",
+                    LoginShellState::Differs { .. } => {
+                        any_missing = true;
+                        "differs"
+                    }
+                };
+                if self.json {
+                    json_out.insert(
+                        "login_shell".to_string(),
+                        json!({
+                            "available": true,
+                            "shell": status.request.shell,
+                            "current": status.current,
+                            "state": state,
+                        }),
+                    );
+                } else {
+                    login_shell_rows.push(vec![
+                        status.request.shell,
+                        status.current,
+                        state.to_string(),
+                    ]);
+                }
+            }
+        }
         if self.json {
             json_out.insert("files".to_string(), json!(json_files));
             json_out.insert("edits".to_string(), json!(json_edits));
@@ -234,9 +284,10 @@ impl SystemStatus {
                 && file_rows.is_empty()
                 && edit_rows.is_empty()
                 && defaults_rows.is_empty()
+                && login_shell_rows.is_empty()
             {
                 info!(
-                    "nothing configured in [system.packages], [system.files], [system.edits], or [system.defaults]"
+                    "nothing configured in [system.packages], [system.files], [system.edits], [system.defaults], or [system].login_shell"
                 );
             }
             if !rows.is_empty() {
@@ -265,6 +316,13 @@ impl SystemStatus {
                 let mut table =
                     MiseTable::new(false, &["Domain", "Key", "Value", "Current", "State"]);
                 for row in defaults_rows {
+                    table.add_row(row);
+                }
+                table.print()?;
+            }
+            if !login_shell_rows.is_empty() {
+                let mut table = MiseTable::new(false, &["Shell", "Current", "State"]);
+                for row in login_shell_rows {
                     table.add_row(row);
                 }
                 table.print()?;

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -12,7 +12,7 @@ use crate::ui::table::MiseTable;
 
 /// Show the status of system packages from `[system.packages]`, files from
 /// `[system.files]`, edits from `[system.edits]`, and macOS defaults from
-/// `[system.defaults]`, and `[system].login_shell`
+/// `[system.defaults]`, and Unix login shell from `[system].login_shell`
 #[derive(Debug, clap::Args)]
 #[clap(visible_alias = "ls", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct SystemStatus {
@@ -20,8 +20,8 @@ pub struct SystemStatus {
     #[clap(long, short = 'J')]
     json: bool,
 
-    /// Exit with code 1 if any configured packages, files, defaults, or login
-    /// shell are not in their desired state (missing, version mismatch, differs)
+    /// Exit with code 1 if any configured packages, files, edits, defaults, or
+    /// login shell are not in their desired state
     #[clap(long, verbatim_doc_comment)]
     missing: bool,
 }

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -255,6 +255,10 @@ impl SystemStatus {
                         any_missing = true;
                         "differs"
                     }
+                    LoginShellState::MissingFromShells { .. } => {
+                        any_missing = true;
+                        "missing from /etc/shells"
+                    }
                 };
                 if self.json {
                     json_out.insert(
@@ -262,7 +266,9 @@ impl SystemStatus {
                         json!({
                             "available": true,
                             "shell": status.request.shell,
+                            "user": status.user,
                             "current": status.current,
+                            "shell_listed": status.shell_listed,
                             "state": state,
                         }),
                     );

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2163,6 +2163,7 @@ mod tests {
             system.brew.taps.get("railwaycat/emacsmacport").unwrap(),
             "https://github.com/railwaycat/homebrew-emacsmacport"
         );
+        assert_eq!(system.login_shell, None);
         // unknown managers parse fine (forward compatibility)
         assert_eq!(
             system.packages.get("future-manager:whatever").unwrap(),
@@ -2173,6 +2174,24 @@ mod tests {
         file::write(&p, "[tools]\n").unwrap();
         let cf = MiseToml::from_file(&p).unwrap();
         assert!(cf.system_config().is_none());
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_system_login_shell() {
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".test.mise.toml");
+        file::write(
+            &p,
+            r#"
+        [system]
+        login_shell = "/bin/zsh"
+        "#,
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let system = cf.system_config().unwrap();
+        assert_eq!(system.login_shell.as_deref(), Some("/bin/zsh"));
         file::remove_file(&p).unwrap();
     }
 

--- a/src/system/login_shell.rs
+++ b/src/system/login_shell.rs
@@ -1,0 +1,125 @@
+//! `[system].login_shell` - declarative current-user login shell, applied by
+//! `mise system install` or `mise bootstrap`.
+
+use std::path::PathBuf;
+
+use crate::result::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginShellRequest {
+    pub shell: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoginShellState {
+    Set,
+    Differs { current: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginShellStatus {
+    pub request: LoginShellRequest,
+    pub current: String,
+    pub state: LoginShellState,
+}
+
+pub fn is_available() -> bool {
+    cfg!(unix) && crate::file::which("chsh").is_some()
+}
+
+pub fn unavailable_reason() -> String {
+    if cfg!(unix) {
+        "`chsh` not found".to_string()
+    } else {
+        "only available on unix".to_string()
+    }
+}
+
+pub fn status(request: &LoginShellRequest) -> Result<LoginShellStatus> {
+    let current = current_login_shell()?;
+    let state = if current == request.shell {
+        LoginShellState::Set
+    } else {
+        LoginShellState::Differs {
+            current: current.clone(),
+        }
+    };
+    Ok(LoginShellStatus {
+        request: request.clone(),
+        current,
+        state,
+    })
+}
+
+pub fn apply(request: &LoginShellRequest, dry_run: bool) -> Result<()> {
+    let args = vec!["-s".to_string(), request.shell.clone()];
+    let display = shell_words::join(&args);
+    if dry_run {
+        miseprintln!("chsh {display}");
+        return Ok(());
+    }
+    info!("$ chsh {display}");
+    crate::cmd::CmdLineRunner::new("chsh")
+        .arg("-s")
+        .arg(&request.shell)
+        .raw(true)
+        .execute()
+}
+
+#[cfg(unix)]
+fn current_login_shell() -> Result<String> {
+    use eyre::eyre;
+    use nix::unistd::{User, geteuid};
+
+    let uid = geteuid();
+    let user = User::from_uid(uid)?.ok_or_else(|| eyre!("failed to find user for uid {uid}"))?;
+    Ok(display_shell(user.shell))
+}
+
+#[cfg(not(unix))]
+fn current_login_shell() -> Result<String> {
+    eyre::bail!("{}", unavailable_reason())
+}
+
+fn display_shell(shell: PathBuf) -> String {
+    shell.to_string_lossy().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_shell() {
+        assert_eq!(display_shell(PathBuf::from("/bin/zsh")), "/bin/zsh");
+    }
+
+    #[test]
+    fn test_status_state_set_and_differs() {
+        let request = LoginShellRequest {
+            shell: "/bin/zsh".to_string(),
+        };
+        let set = if "/bin/zsh" == request.shell {
+            LoginShellState::Set
+        } else {
+            LoginShellState::Differs {
+                current: "/bin/zsh".to_string(),
+            }
+        };
+        assert_eq!(set, LoginShellState::Set);
+
+        let differs = if "/bin/bash" == request.shell {
+            LoginShellState::Set
+        } else {
+            LoginShellState::Differs {
+                current: "/bin/bash".to_string(),
+            }
+        };
+        assert_eq!(
+            differs,
+            LoginShellState::Differs {
+                current: "/bin/bash".to_string()
+            }
+        );
+    }
+}

--- a/src/system/login_shell.rs
+++ b/src/system/login_shell.rs
@@ -69,9 +69,9 @@ fn login_shell_state(current: &str, requested: &str, shell_listed: bool) -> Logi
 }
 
 pub fn apply(request: &LoginShellRequest, dry_run: bool) -> Result<()> {
-    ensure_shell_listed(&request.shell, dry_run)?;
     let user = target_user()?;
     let args = chsh_args(request, &user);
+    ensure_shell_listed(&request.shell, dry_run)?;
     let display = shell_words::join(&args);
     if dry_run {
         miseprintln!("chsh {display}");

--- a/src/system/login_shell.rs
+++ b/src/system/login_shell.rs
@@ -1,6 +1,8 @@
 //! `[system].login_shell` - declarative current-user login shell, applied by
 //! `mise system install` or `mise bootstrap`.
 
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::PathBuf;
 
 use crate::result::Result;
@@ -14,12 +16,15 @@ pub struct LoginShellRequest {
 pub enum LoginShellState {
     Set,
     Differs { current: String },
+    MissingFromShells { current: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoginShellStatus {
     pub request: LoginShellRequest,
+    pub user: String,
     pub current: String,
+    pub shell_listed: bool,
     pub state: LoginShellState,
 }
 
@@ -36,9 +41,15 @@ pub fn unavailable_reason() -> String {
 }
 
 pub fn status(request: &LoginShellRequest) -> Result<LoginShellStatus> {
-    let current = current_login_shell()?;
-    let state = if current == request.shell {
+    let user = target_user()?;
+    let current = display_shell(user.shell);
+    let shell_listed = shell_is_listed(&request.shell)?;
+    let state = if current == request.shell && shell_listed {
         LoginShellState::Set
+    } else if current == request.shell {
+        LoginShellState::MissingFromShells {
+            current: current.clone(),
+        }
     } else {
         LoginShellState::Differs {
             current: current.clone(),
@@ -46,13 +57,17 @@ pub fn status(request: &LoginShellRequest) -> Result<LoginShellStatus> {
     };
     Ok(LoginShellStatus {
         request: request.clone(),
+        user: user.name,
         current,
+        shell_listed,
         state,
     })
 }
 
 pub fn apply(request: &LoginShellRequest, dry_run: bool) -> Result<()> {
-    let args = vec!["-s".to_string(), request.shell.clone()];
+    ensure_shell_listed(&request.shell, dry_run)?;
+    let user = target_user()?;
+    let args = chsh_args(request, &user);
     let display = shell_words::join(&args);
     if dry_run {
         miseprintln!("chsh {display}");
@@ -60,29 +75,125 @@ pub fn apply(request: &LoginShellRequest, dry_run: bool) -> Result<()> {
     }
     info!("$ chsh {display}");
     crate::cmd::CmdLineRunner::new("chsh")
-        .arg("-s")
-        .arg(&request.shell)
+        .args(args)
         .raw(true)
         .execute()
 }
 
 #[cfg(unix)]
-fn current_login_shell() -> Result<String> {
+fn target_user() -> Result<nix::unistd::User> {
     use eyre::eyre;
     use nix::unistd::{User, geteuid};
 
+    if geteuid().is_root()
+        && let Ok(sudo_user) = crate::env::var("SUDO_USER")
+        && !sudo_user.is_empty()
+        && sudo_user != "root"
+    {
+        return User::from_name(&sudo_user)?
+            .ok_or_else(|| eyre!("failed to find user from SUDO_USER={sudo_user}"));
+    }
     let uid = geteuid();
-    let user = User::from_uid(uid)?.ok_or_else(|| eyre!("failed to find user for uid {uid}"))?;
-    Ok(display_shell(user.shell))
+    User::from_uid(uid)?.ok_or_else(|| eyre!("failed to find user for uid {uid}"))
 }
 
 #[cfg(not(unix))]
-fn current_login_shell() -> Result<String> {
+fn target_user() -> Result<TargetUser> {
     eyre::bail!("{}", unavailable_reason())
+}
+
+#[cfg(not(unix))]
+struct TargetUser {
+    name: String,
+    shell: PathBuf,
 }
 
 fn display_shell(shell: PathBuf) -> String {
     shell.to_string_lossy().to_string()
+}
+
+#[cfg(unix)]
+fn chsh_args(request: &LoginShellRequest, user: &nix::unistd::User) -> Vec<String> {
+    let mut args = vec!["-s".to_string(), request.shell.clone()];
+    if nix::unistd::geteuid().is_root()
+        && let Ok(sudo_user) = crate::env::var("SUDO_USER")
+        && !sudo_user.is_empty()
+        && sudo_user != "root"
+    {
+        args.push(user.name.clone());
+    }
+    args
+}
+
+#[cfg(not(unix))]
+fn chsh_args(request: &LoginShellRequest, _user: &TargetUser) -> Vec<String> {
+    vec!["-s".to_string(), request.shell.clone()]
+}
+
+fn shells_file() -> PathBuf {
+    crate::env::var("MISE_TEST_SHELLS_FILE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/etc/shells"))
+}
+
+fn shell_is_listed(shell: &str) -> Result<bool> {
+    Ok(shells_file_contents()?
+        .lines()
+        .filter_map(shells_line_entry)
+        .any(|entry| entry == shell))
+}
+
+fn shells_file_contents() -> Result<String> {
+    match std::fs::read_to_string(shells_file()) {
+        Ok(contents) => Ok(contents),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn shells_line_entry(line: &str) -> Option<&str> {
+    let line = line.split_once('#').map_or(line, |(entry, _)| entry).trim();
+    (!line.is_empty()).then_some(line)
+}
+
+fn ensure_shell_listed(shell: &str, dry_run: bool) -> Result<()> {
+    if shell_is_listed(shell)? {
+        return Ok(());
+    }
+    let path = shells_file();
+    let args = vec![
+        "-c".to_string(),
+        r#"printf '%s\n' "$1" >> "$2""#.to_string(),
+        "sh".to_string(),
+        shell.to_string(),
+        path.to_string_lossy().to_string(),
+    ];
+    if dry_run {
+        miseprintln!("sh {}", shell_words::join(&args));
+        return Ok(());
+    }
+    match append_shell_directly(&path, shell) {
+        Ok(()) => {
+            info!("login_shell: added {shell} to {}", path.display());
+            Ok(())
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            crate::system::sudo::run("sh", &args, &[])
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn append_shell_directly(path: &PathBuf, shell: &str) -> std::io::Result<()> {
+    let needs_leading_newline = std::fs::metadata(path).is_ok_and(|m| m.len() > 0)
+        && !shells_file_contents()
+            .unwrap_or_default()
+            .ends_with(['\n', '\r']);
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    if needs_leading_newline {
+        writeln!(file)?;
+    }
+    writeln!(file, "{shell}")
 }
 
 #[cfg(test)]
@@ -121,5 +232,40 @@ mod tests {
                 current: "/bin/bash".to_string()
             }
         );
+    }
+
+    #[test]
+    fn test_shells_line_entry() {
+        assert_eq!(shells_line_entry("/bin/zsh"), Some("/bin/zsh"));
+        assert_eq!(shells_line_entry(" /bin/fish # comment"), Some("/bin/fish"));
+        assert_eq!(shells_line_entry("# comment"), None);
+        assert_eq!(shells_line_entry("   "), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_chsh_args_for_root_sudo_user() {
+        use std::ffi::CString;
+
+        unsafe { std::env::set_var("SUDO_USER", "alice") };
+        let user = nix::unistd::User {
+            name: "alice".to_string(),
+            passwd: CString::new("x").unwrap(),
+            uid: nix::unistd::Uid::from_raw(1000),
+            gid: nix::unistd::Gid::from_raw(1000),
+            gecos: CString::new("").unwrap(),
+            dir: PathBuf::from("/home/alice"),
+            shell: PathBuf::from("/bin/bash"),
+        };
+        let request = LoginShellRequest {
+            shell: "/bin/zsh".to_string(),
+        };
+        let args = chsh_args(&request, &user);
+        if nix::unistd::geteuid().is_root() {
+            assert_eq!(args, vec!["-s", "/bin/zsh", "alice"]);
+        } else {
+            assert_eq!(args, vec!["-s", "/bin/zsh"]);
+        }
+        unsafe { std::env::remove_var("SUDO_USER") };
     }
 }

--- a/src/system/login_shell.rs
+++ b/src/system/login_shell.rs
@@ -44,17 +44,7 @@ pub fn status(request: &LoginShellRequest) -> Result<LoginShellStatus> {
     let user = target_user()?;
     let current = display_shell(user.shell);
     let shell_listed = shell_is_listed(&request.shell)?;
-    let state = if current == request.shell && shell_listed {
-        LoginShellState::Set
-    } else if current == request.shell {
-        LoginShellState::MissingFromShells {
-            current: current.clone(),
-        }
-    } else {
-        LoginShellState::Differs {
-            current: current.clone(),
-        }
-    };
+    let state = login_shell_state(&current, &request.shell, shell_listed);
     Ok(LoginShellStatus {
         request: request.clone(),
         user: user.name,
@@ -62,6 +52,20 @@ pub fn status(request: &LoginShellRequest) -> Result<LoginShellStatus> {
         shell_listed,
         state,
     })
+}
+
+fn login_shell_state(current: &str, requested: &str, shell_listed: bool) -> LoginShellState {
+    if current == requested && shell_listed {
+        LoginShellState::Set
+    } else if current == requested {
+        LoginShellState::MissingFromShells {
+            current: current.to_string(),
+        }
+    } else {
+        LoginShellState::Differs {
+            current: current.to_string(),
+        }
+    }
 }
 
 pub fn apply(request: &LoginShellRequest, dry_run: bool) -> Result<()> {
@@ -207,27 +211,18 @@ mod tests {
 
     #[test]
     fn test_status_state_set_and_differs() {
-        let request = LoginShellRequest {
-            shell: "/bin/zsh".to_string(),
-        };
-        let set = if "/bin/zsh" == request.shell {
-            LoginShellState::Set
-        } else {
-            LoginShellState::Differs {
-                current: "/bin/zsh".to_string(),
-            }
-        };
-        assert_eq!(set, LoginShellState::Set);
-
-        let differs = if "/bin/bash" == request.shell {
-            LoginShellState::Set
-        } else {
-            LoginShellState::Differs {
-                current: "/bin/bash".to_string(),
-            }
-        };
         assert_eq!(
-            differs,
+            login_shell_state("/bin/zsh", "/bin/zsh", true),
+            LoginShellState::Set
+        );
+        assert_eq!(
+            login_shell_state("/bin/zsh", "/bin/zsh", false),
+            LoginShellState::MissingFromShells {
+                current: "/bin/zsh".to_string()
+            }
+        );
+        assert_eq!(
+            login_shell_state("/bin/bash", "/bin/zsh", true),
             LoginShellState::Differs {
                 current: "/bin/bash".to_string()
             }

--- a/src/system/login_shell.rs
+++ b/src/system/login_shell.rs
@@ -118,13 +118,18 @@ fn display_shell(shell: PathBuf) -> String {
 
 #[cfg(unix)]
 fn chsh_args(request: &LoginShellRequest, user: &nix::unistd::User) -> Vec<String> {
+    chsh_args_for_user_name(request, &user.name)
+}
+
+#[cfg(unix)]
+fn chsh_args_for_user_name(request: &LoginShellRequest, user_name: &str) -> Vec<String> {
     let mut args = vec!["-s".to_string(), request.shell.clone()];
     if nix::unistd::geteuid().is_root()
         && let Ok(sudo_user) = crate::env::var("SUDO_USER")
         && !sudo_user.is_empty()
         && sudo_user != "root"
     {
-        args.push(user.name.clone());
+        args.push(user_name.to_string());
     }
     args
 }
@@ -173,7 +178,14 @@ fn ensure_shell_listed(shell: &str, dry_run: bool) -> Result<()> {
         path.to_string_lossy().to_string(),
     ];
     if dry_run {
-        miseprintln!("sh {}", shell_words::join(&args));
+        if can_append_shell_directly(&path) {
+            miseprintln!("sh {}", shell_words::join(&args));
+        } else {
+            miseprintln!(
+                "{}",
+                shell_words::join(crate::system::sudo::argv("sh", &args))
+            );
+        }
         return Ok(());
     }
     match append_shell_directly(&path, shell) {
@@ -198,6 +210,10 @@ fn append_shell_directly(path: &PathBuf, shell: &str) -> std::io::Result<()> {
         writeln!(file)?;
     }
     writeln!(file, "{shell}")
+}
+
+fn can_append_shell_directly(path: &PathBuf) -> bool {
+    OpenOptions::new().append(true).open(path).is_ok()
 }
 
 #[cfg(test)]
@@ -240,22 +256,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_chsh_args_for_root_sudo_user() {
-        use std::ffi::CString;
-
         unsafe { std::env::set_var("SUDO_USER", "alice") };
-        let user = nix::unistd::User {
-            name: "alice".to_string(),
-            passwd: CString::new("x").unwrap(),
-            uid: nix::unistd::Uid::from_raw(1000),
-            gid: nix::unistd::Gid::from_raw(1000),
-            gecos: CString::new("").unwrap(),
-            dir: PathBuf::from("/home/alice"),
-            shell: PathBuf::from("/bin/bash"),
-        };
         let request = LoginShellRequest {
             shell: "/bin/zsh".to_string(),
         };
-        let args = chsh_args(&request, &user);
+        let args = chsh_args_for_user_name(&request, "alice");
         if nix::unistd::geteuid().is_root() {
             assert_eq!(args, vec!["-s", "/bin/zsh", "alice"]);
         } else {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -2,13 +2,14 @@
 //!
 //! This is `[system.packages]` — declarative system packages installed by
 //! `mise system install` — `[system.files]` — declarative config files
-//! (dotfiles) — and `[system.defaults]` — declarative macOS user defaults,
-//! all applied by the same command. These are intentionally not part of
-//! `[tools]`: they're unversioned, machine-global, and managed by the OS
-//! package manager (or mise's own Homebrew-bottle installer), plain
-//! filesystem operations, or macOS `defaults`, not mise's per-project
-//! toolset.
+//! (dotfiles) — `[system.defaults]` — declarative macOS user defaults, and
+//! `[system].login_shell`, all applied by the same command. These are
+//! intentionally not part of `[tools]`: they're unversioned, machine-global,
+//! and managed by the OS package manager (or mise's own Homebrew-bottle
+//! installer), plain filesystem operations, macOS `defaults`, or system user
+//! account tooling, not mise's per-project toolset.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use eyre::bail;
@@ -23,6 +24,7 @@ use crate::system::packages::{PackageRequest, SystemPackageManager};
 pub mod defaults;
 pub mod edits;
 pub mod files;
+pub mod login_shell;
 pub mod packages;
 pub(crate) mod sudo;
 
@@ -47,6 +49,9 @@ pub struct SystemTomlConfig {
     /// (see [`edits`])
     #[serde(default)]
     pub edits: IndexMap<String, IndexMap<String, edits::EditTomlEntry>>,
+    /// desired login shell for the current user, applied with `chsh -s`
+    #[serde(default)]
+    pub login_shell: Option<String>,
     /// Homebrew-specific system config.
     #[serde(default)]
     pub brew: SystemBrewTomlConfig,
@@ -232,6 +237,28 @@ pub fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
         }
     }
     out
+}
+
+/// Desired login shell from the most local config that declares it.
+pub fn login_shell_from_config(config: &Config) -> Option<login_shell::LoginShellRequest> {
+    let mut shell = None;
+    // config_files is ordered local -> global; reverse for global -> local
+    for cf in config.config_files.values().rev() {
+        if let Some(sys) = cf.system_config()
+            && let Some(login_shell) = sys.login_shell
+        {
+            if login_shell.trim().is_empty() {
+                warn!("[system].login_shell: must not be empty, ignoring entry");
+                continue;
+            }
+            if !Path::new(&login_shell).is_absolute() {
+                warn!("[system].login_shell: shell must be an absolute path, ignoring entry");
+                continue;
+            }
+            shell = Some(login_shell);
+        }
+    }
+    shell.map(|shell| login_shell::LoginShellRequest { shell })
 }
 
 /// Build [`ManagerPackages`] from explicit CLI specs, attaching configured

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -247,7 +247,8 @@ pub fn login_shell_from_config(config: &Config) -> Option<login_shell::LoginShel
         if let Some(sys) = cf.system_config()
             && let Some(login_shell) = sys.login_shell
         {
-            if login_shell.trim().is_empty() {
+            let login_shell = login_shell.trim().to_string();
+            if login_shell.is_empty() {
                 warn!("[system].login_shell: must not be empty, ignoring entry");
                 continue;
             }

--- a/src/system/sudo.rs
+++ b/src/system/sudo.rs
@@ -1,9 +1,9 @@
 //! The single place in mise that may elevate privileges.
 //!
-//! Only system package managers that mutate machine-global state (apt) use
-//! this. Every elevated command logs its full argv before running, never
-//! prompts for a password without a TTY, and can be disabled entirely with
-//! `system_packages.sudo = false`.
+//! System package managers and declarative system mutations that require
+//! root use this. Every elevated command logs its full argv before running,
+//! never prompts for a password without a TTY, and can be disabled entirely
+//! with `system_packages.sudo = false`.
 
 use std::process::{Command, Stdio};
 

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -3233,7 +3233,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "system",
       description:
-        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, edits from `[system.edits]`, macOS defaults\nfrom `[system.defaults]`, and `[system].login_shell`",
+        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, edits from `[system.edits]`, macOS defaults\nfrom `[system.defaults]`, and Unix login shell from `[system].login_shell`",
       subcommands: [
         {
           name: "brew",
@@ -3285,7 +3285,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["install", "i"],
           description:
-            "Install missing system packages from `[system.packages]`, apply files\nfrom `[system.files]` and edits from `[system.edits]`, write macOS\ndefaults from `[system.defaults]`, and set `[system].login_shell`",
+            "Install missing system packages from `[system.packages]`, apply files\nfrom `[system.files]` and edits from `[system.edits]`, write macOS\ndefaults from `[system.defaults]`, and set Unix login shell from\n`[system].login_shell`",
           options: [
             {
               name: ["-f", "--force"],
@@ -3332,7 +3332,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["status", "ls"],
           description:
-            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, edits from `[system.edits]`, and macOS defaults from\n`[system.defaults]`, and `[system].login_shell`",
+            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, edits from `[system.edits]`, and macOS defaults from\n`[system.defaults]`, and Unix login shell from `[system].login_shell`",
           options: [
             {
               name: ["-J", "--json"],
@@ -3342,7 +3342,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--missing",
               description:
-                "Exit with code 1 if any configured packages, files, defaults, or login\nshell are not in their desired state (missing, version mismatch, differs)",
+                "Exit with code 1 if any configured packages, files, edits, defaults, or\nlogin shell are not in their desired state",
               isRepeatable: false,
             },
           ],

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -3233,7 +3233,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "system",
       description:
-        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, edits from `[system.edits]`, and macOS defaults\nfrom `[system.defaults]`",
+        "[experimental] Manage system packages from `[system.packages]`, files\nfrom `[system.files]`, edits from `[system.edits]`, macOS defaults\nfrom `[system.defaults]`, and `[system].login_shell`",
       subcommands: [
         {
           name: "brew",
@@ -3285,7 +3285,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["install", "i"],
           description:
-            "Install missing system packages from `[system.packages]`, apply files\nfrom `[system.files]` and edits from `[system.edits]`, and write macOS\ndefaults from `[system.defaults]`",
+            "Install missing system packages from `[system.packages]`, apply files\nfrom `[system.files]` and edits from `[system.edits]`, write macOS\ndefaults from `[system.defaults]`, and set `[system].login_shell`",
           options: [
             {
               name: ["-f", "--force"],
@@ -3332,7 +3332,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["status", "ls"],
           description:
-            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, edits from `[system.edits]`, and macOS defaults from\n`[system.defaults]`",
+            "Show the status of system packages from `[system.packages]`, files from\n`[system.files]`, edits from `[system.edits]`, and macOS defaults from\n`[system.defaults]`, and `[system].login_shell`",
           options: [
             {
               name: ["-J", "--json"],
@@ -3342,7 +3342,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--missing",
               description:
-                "Exit with code 1 if any configured packages, files, or defaults are\nnot in their desired state (missing, version mismatch, differs)",
+                "Exit with code 1 if any configured packages, files, defaults, or login\nshell are not in their desired state (missing, version mismatch, differs)",
               isRepeatable: false,
             },
           ],


### PR DESCRIPTION
## Summary
- add `[system].login_shell` as a declarative current-user login shell setting
- apply drift with `chsh -s` from `mise system install` and `mise bootstrap`
- report login shell state in `mise system status`, `mise doctor`, schema, and docs

## Tests
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `mise run render`
- `mise run test:e2e e2e/cli/test_system_login_shell`
- `mise run test:unit`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the user's login shell and may modify `/etc/shells` via sudo—account-level, irreversible-feeling effects that only run on explicit install/bootstrap but warrant careful review.
> 
> **Overview**
> Adds **`[system].login_shell`** so `mise.toml` can declare the current user's desired login shell (absolute path) and converge it with **`mise system install`** or **`mise bootstrap`**, alongside existing system packages, files, edits, and defaults.
> 
> On Unix when `chsh` is available, install **appends the shell to `/etc/shells` if needed** (reusing the system-packages **sudo** path when the file isn't writable), then runs **`chsh -s`** with optional confirmation, dry-run, and `--yes`. Under sudo it targets **`SUDO_USER`**; invalid or relative paths are warned and skipped. **Most-local config wins** for the single desired value.
> 
> **`mise system status`** (table + JSON) and **`--missing`** now include login-shell drift; scoped installs (`--manager` or explicit packages) still apply **packages only**. **`mise doctor`** reports `system_login_shell` in text and JSON. Schema, CLI help, man page, and a new **System Login Shell** doc page are updated; an **e2e** test covers status, override, dry-run, and apply with stubbed `chsh` and `/etc/shells`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4404ebe0bbfa0b88253813853fda5475b9e9613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental system.login_shell setting added; install/bootstrap can apply it (with dry-run/confirmation) and ensure the shell is allowed on Unix.

* **Behavior & UX**
  * status/--missing, doctor, and exit codes now report and validate login-shell state; messages note current-user application and advise restarting sessions.

* **Documentation**
  * CLI help, man page, and docs updated with semantics, examples, and macOS/Unix details.

* **Tests**
  * New end-to-end and unit tests cover parsing, dry-run, and install flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->