### PR TITLE
fix(http): show github 403 response diagnostics

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use eyre::{Report, Result, bail, ensure};
+use eyre::{Report, Result, bail, ensure, eyre};
 use regex::Regex;
 use reqwest::StatusCode;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
@@ -635,20 +635,20 @@ impl Client {
                 }
             }
         }
-        if options.error_for_status
-            && is_authenticated_github_forbidden(&url, &final_headers, &resp)
-        {
+        if options.error_for_status && is_github_forbidden(&url, &resp) {
             let status = resp.status();
             let status_error = resp
                 .error_for_status_ref()
                 .expect_err("403 response should be an error");
+            let used_github_token = final_headers.contains_key(AUTHORIZATION);
+            let rate_limit = github_rate_limit_summary(&resp);
             let body = resp.text().await.unwrap_or_default();
             // Retry without auth when the response mentions IP allow lists: GitHub App
             // installation tokens (`ghs_*`) get 403 on public API resources for orgs with IP
             // allow lists; stripping auth avoids that path.
             // https://github.com/orgs/community/discussions/191185
             // https://github.com/jdx/mise/discussions/9119
-            if body.contains("IP allow list") {
+            if used_github_token && body.contains("IP allow list") {
                 let mut headers = final_headers;
                 headers.remove(AUTHORIZATION);
                 debug!(
@@ -664,7 +664,12 @@ impl Client {
                 ))
                 .await;
             }
-            return Err(status_error.into());
+            return Err(github_forbidden_report(
+                status_error,
+                used_github_token,
+                rate_limit,
+                &body,
+            ));
         }
         if options.error_for_status {
             resp.error_for_status_ref()?;
@@ -720,10 +725,68 @@ impl TextRequest<'_> {
     }
 }
 
-fn is_authenticated_github_forbidden(url: &Url, headers: &HeaderMap, resp: &Response) -> bool {
-    resp.status() == StatusCode::FORBIDDEN
-        && url.host_str() == Some("api.github.com")
-        && headers.contains_key(AUTHORIZATION)
+fn is_github_forbidden(url: &Url, resp: &Response) -> bool {
+    resp.status() == StatusCode::FORBIDDEN && url.host_str() == Some("api.github.com")
+}
+
+fn github_forbidden_report(
+    status_error: reqwest::Error,
+    used_github_token: bool,
+    rate_limit: Option<String>,
+    body: &str,
+) -> Report {
+    let token_status = if used_github_token { "yes" } else { "no" };
+    let rate_limit = rate_limit
+        .map(|summary| format!("\ngithub rate limit: {summary}"))
+        .unwrap_or_default();
+    let body = format_response_body(body);
+    eyre!("{status_error}\ngithub auth: {token_status}{rate_limit}\ngithub response: {body}")
+}
+
+fn format_response_body(body: &str) -> String {
+    const MAX_BODY_CHARS: usize = 4096;
+    if body.trim().is_empty() {
+        return "<empty>".to_string();
+    }
+
+    let mut chars = body.chars();
+    let mut formatted: String = chars.by_ref().take(MAX_BODY_CHARS).collect();
+    if chars.next().is_some() {
+        formatted.push_str("\n<truncated>");
+    }
+    formatted
+}
+
+fn github_rate_limit_summary(resp: &Response) -> Option<String> {
+    let headers = resp.headers();
+    let limit = headers
+        .get("x-ratelimit-limit")
+        .and_then(|h| h.to_str().ok());
+    let remaining = headers
+        .get("x-ratelimit-remaining")
+        .and_then(|h| h.to_str().ok());
+    let resource = headers
+        .get("x-ratelimit-resource")
+        .and_then(|h| h.to_str().ok());
+    let reset = headers
+        .get("x-ratelimit-reset")
+        .and_then(|h| h.to_str().ok());
+
+    if limit.is_none() && remaining.is_none() && resource.is_none() && reset.is_none() {
+        return None;
+    }
+
+    Some(format!(
+        "{}/{}{}{}",
+        remaining.unwrap_or("?"),
+        limit.unwrap_or("?"),
+        resource
+            .map(|resource| format!(" ({resource})"))
+            .unwrap_or_default(),
+        reset
+            .map(|reset| format!(", resets at {reset}"))
+            .unwrap_or_default()
+    ))
 }
 
 fn stale_github_oauth_unauthorized_token(
@@ -1232,6 +1295,20 @@ mod tests {
     fn unauthorized_response() -> &'static str {
         "HTTP/1.1 401 Unauthorized\r\nContent-Length: 15\r\nConnection: close\r\n\r\nBad credentials"
     }
+    fn github_forbidden_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 403 Forbidden\r\n",
+            "Content-Type: application/json\r\n",
+            "X-RateLimit-Limit: 5000\r\n",
+            "X-RateLimit-Remaining: 42\r\n",
+            "X-RateLimit-Resource: core\r\n",
+            "X-RateLimit-Reset: 1781337353\r\n",
+            "Content-Length: 47\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            r#"{"message":"secondary rate limit","docs":"url"}"#
+        )
+    }
     fn github_oauth_token_response() -> &'static str {
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 51\r\nConnection: close\r\n\r\n{\"access_token\":\"ghu-refreshed\",\"expires_in\":28800}"
     }
@@ -1299,6 +1376,34 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(retry_request.contains("authorization: bearer ghu-refreshed"));
         let cache = std::fs::read_to_string(cache_path).unwrap();
         assert!(cache.contains("ghu-refreshed"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_github_forbidden_report_includes_body_and_auth_state() {
+        let (port, _count) = spawn_canned_server(vec![github_forbidden_response()]).await;
+        let url = format!("http://127.0.0.1:{port}/repos/microsoft/edit/releases");
+        let resp = reqwest::Client::new().get(url).send().await.unwrap();
+        let rate_limit = github_rate_limit_summary(&resp);
+        let status_error = resp
+            .error_for_status_ref()
+            .expect_err("403 response should be an error");
+        let body = resp.text().await.unwrap();
+        let err = github_forbidden_report(status_error, true, rate_limit, &body);
+        let msg = format!("{err:?}");
+
+        assert!(msg.contains("github auth: yes"));
+        assert!(msg.contains("github rate limit: 42/5000 (core), resets at 1781337353"));
+        assert!(msg.contains(r#"{"message":"secondary rate limit","docs":"url"}"#));
+    }
+
+    #[test]
+    fn test_format_response_body_handles_empty_and_truncates() {
+        assert_eq!(format_response_body(" \n\t"), "<empty>");
+
+        let body = "a".repeat(4097);
+        let formatted = format_response_body(&body);
+        assert_eq!(formatted.strip_suffix("\n<truncated>").unwrap().len(), 4096);
+        assert!(formatted.ends_with("\n<truncated>"));
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary
- include GitHub 403 response bodies in the surfaced HTTP error
- report whether the failing request sent an Authorization header
- include GitHub rate-limit headers when available
- preserve the existing retry-without-auth behavior for IP allow-list responses

## Why
Recent e2e flakes only showed a generic `403 Forbidden` for GitHub release metadata, which hid whether the request was authenticated and what GitHub's response body said. This makes future failures actionable without exposing token values.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test http::tests::test_github_forbidden_report_includes_body_and_auth_state`
- `cargo test http::tests::test_format_response_body_handles_empty_and_truncates`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized HTTP error formatting and diagnostics for GitHub 403s; no auth or retry logic changes beyond requiring a token for the IP allow-list retry path.
> 
> **Overview**
> **GitHub `api.github.com` 403 errors** now return a richer `eyre` report instead of a bare `403 Forbidden`, so flakes (e.g. release metadata) show whether the request sent auth, GitHub rate-limit headers when present, and a truncated response body (up to 4096 chars) without leaking tokens.
> 
> The special **retry without `Authorization`** for org IP allow-list messages is unchanged in intent but only runs when a token was actually sent and the body mentions IP allow list.
> 
> Detection was broadened slightly: any 403 on `api.github.com` gets this path, not only requests that already had an `Authorization` header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8b70eace1114e9b3ec331d2350a40c6c142eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for GitHub API 403 responses: richer context including response body (truncated when long) and whether authentication was sent.
  * Added logic to better detect and handle IP allow-list restriction cases, including a one-time retry without repository-level auth when appropriate.

* **Tests**
  * Added and updated tests covering GitHub 403 scenarios and response-body formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->