### PR TITLE
fix(dotnet): send semVerLevel=2.0.0 in NuGet search query

### DIFF
--- a/e2e/backend/test_dotnet
+++ b/e2e/backend/test_dotnet
@@ -23,3 +23,12 @@ assert_contains "mise ls-remote 'dotnet:GitVersion.Tool[prerelease=true]'" "-bet
 mise cache clear
 
 assert_contains "MISE_DOTNET_PACKAGE_FLAGS=prerelease mise ls-remote dotnet:GitVersion.Tool" "-beta"
+
+mise cache clear
+
+# Regression test for #10283: packages whose versions are all SemVer 2.0.0 (e.g.
+# roslyn-language-server) are hidden by NuGet's search API unless semVerLevel=2.0.0
+# is sent. Without that parameter the take=1 search returns a different package and
+# this errors with "Tool roslyn-language-server not found". Published NuGet versions
+# are immutable, so the asserted version is stable.
+assert_contains "mise ls-remote 'dotnet:roslyn-language-server[prerelease=true]'" "5.5.0-2.26103.6"

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -59,7 +59,11 @@ impl Backend for DotnetBackend {
 
         let feed: NugetFeedSearch = HTTP_FETCH
             .json(format!(
-                "{}?q={}&packageType=dotnettool&take=1&prerelease={}",
+                // semVerLevel=2.0.0 matches the official dotnet CLI: without it NuGet's
+                // search API hides packages whose versions are all SemVer 2.0.0 (e.g.
+                // roslyn-language-server), and omits SemVer2 versions from the returned
+                // version arrays of packages that are visible.
+                "{}?q={}&packageType=dotnettool&take=1&prerelease={}&semVerLevel=2.0.0",
                 feed_url,
                 &self.tool_name(),
                 true


### PR DESCRIPTION
## Problem

`mise ls-remote dotnet:roslyn-language-server` (and installing it) fails with `Tool roslyn-language-server not found`, even though the package exists and installs fine with the `dotnet` CLI. Reported in #10283.

## Root cause

The dotnet backend builds its NuGet [SearchQueryService](https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource) request in `_list_remote_versions` (`src/backend/dotnet.rs`) without the `semVerLevel=2.0.0` parameter that the official `dotnet` CLI always sends.

NuGet''s search API hides packages whose versions are **all** SemVer 2.0.0 unless `semVerLevel=2.0.0` is present (and it also omits SemVer2 versions from the version arrays of packages that *are* visible). Because mise queries with `take=1` and then performs an exact-name check, the hidden package causes a *different* tool to be returned as the first hit, so the lookup fails with "Tool ... not found".

Verified live against `azuresearch-usnc.nuget.org`:

- **without** the param: `q=roslyn-language-server&packageType=dotnettool&take=1&prerelease=true` → first hit is `csharp-ls` → not found
- **with** `&semVerLevel=2.0.0`: first hit is `roslyn-language-server` with its full version list

## Fix

Add `&semVerLevel=2.0.0` to the search query, matching `dotnet tool search` behavior. (Maintainer @risu729 endorsed this approach in the discussion.)

## Testing

- `cargo fmt --all -- --check` ✅
- `shellcheck` / `shfmt` (with the repo''s editorconfig settings) on the e2e test ✅
- Added a regression assertion to `e2e/backend/test_dotnet` for `dotnet:roslyn-language-server[prerelease=true]`. Published NuGet versions are immutable, so the asserted version is stable.

Note: every published `roslyn-language-server` version is a prerelease, so installing it still requires `prerelease=true` (or the `prereleases` setting) — that behavior is expected and unchanged.

Addresses #10283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dotnet pre-release version discovery to correctly return matching versions when using prerelease selectors

* **Tests**
  * Added regression test for dotnet pre-release version handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->