### PR TITLE
fix(install): detect busybox tar so zstd tarballs are not mis-extracted

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -90,6 +90,11 @@ tar_supports_zstd() {
   # tar is bsdtar
   elif tar --version | grep -q 'bsdtar'; then
     true
+  # busybox tar reports a "1.3x" version that matches the GNU check below, but it
+  # cannot decompress .tar.zst itself. Detect it so we fall back to the zstd pipe
+  # (or a .tar.gz download) instead of running `tar -xf` on a zstd tarball.
+  elif tar --version 2>&1 | grep -qi 'busybox'; then
+    false
   # tar version is >= 1.31
   elif tar --version | grep -q '1\.\(3[1-9]\|[4-9][0-9]\)'; then
     true


### PR DESCRIPTION
## Problem

On Alpine 3.22, `curl https://mise.run | sh` fails to install with:

```
tar: invalid tar magic
```

Reported in #10074.

## Root cause

The install script (`packaging/standalone/install.envsubst`) decides whether to download the `.tar.zst` or `.tar.gz` build via `tar_supports_zstd()`, which checks the `tar` version:

```sh
elif tar --version | grep -q ''1\.\(3[1-9]\|[4-9][0-9]\)''; then
  true
```

Alpine''s busybox `tar` reports version **1.37.0**, which matches this GNU-tar `>= 1.31` regex. So the script concludes busybox tar can transparently decompress zstd, downloads the `.tar.zst` tarball, and then runs plain `tar -xf` on it — but busybox tar cannot decompress zstd, hence `invalid tar magic`.

## Fix

Detect busybox **before** the GNU version check and treat it as *not* supporting zstd:

```sh
elif tar --version 2>&1 | grep -qi ''busybox''; then
  false
```

With that, `tar_supports_zstd()` returns false on busybox, so:
- the default path downloads the `.tar.gz` build, which busybox extracts fine; and
- if `.tar.zst` is forced (e.g. `MISE_INSTALL_EXT=tar.zst`), extraction falls back to the existing zstd-pipe path `zstd -d -c "$cache_file" | tar -xf -` (the script already requires the `zstd` binary), which feeds busybox a plain tar on stdin.

GNU tar and bsdtar never print `busybox` in `--version`, so no other platform is affected. `2>&1` + `-i` make the check robust to busybox printing its `BusyBox v1.37.0` banner on stderr / with mixed case.

## Testing

- `shellcheck packaging/standalone/install.envsubst` ✅ (this is what `scripts/test-standalone.sh` runs against the rendered script)

Addresses #10074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability on systems with limited tar implementations by using fallback decompression methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->