### PR TITLE
fix(cli): don't panic on arguments containing invalid UTF-8

### DIFF
--- a/e2e/cli/test_invalid_utf8_arg
+++ b/e2e/cli/test_invalid_utf8_arg
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Test that mise does not panic when an argv entry contains invalid UTF-8 (#10056).
+# std::env::args() panics on non-UTF-8 argv, so mise reads arguments via args_safe(),
+# which converts each argument lossily (invalid bytes become U+FFFD). A malformed
+# argument should produce a normal "unknown command" failure instead of a crash.
+
+# 0xC3 alone is an incomplete UTF-8 lead byte. This mirrors the reported repro
+# `mise u$(printf "u\xC3")pgrade`. Both a panic and a graceful error exit non-zero,
+# so the regression marker is the Rust panic text, not the exit status.
+out="$(MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 mise "u$(printf 'u\xc3')pgrade" 2>&1 || true)"
+assert_not_contains_text "$out" "panicked"
+
+# A malformed flag-shaped argument must not panic either.
+out="$(MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 mise "$(printf -- '-\xc3')" 2>&1 || true)"
+assert_not_contains_text "$out" "panicked"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -440,8 +440,12 @@ fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> Option<usiz
                 let flag_name = arg.split('=').next().unwrap();
                 flags_with_values.iter().any(|f| f == flag_name)
             }
-        } else if arg.len() >= 2 {
-            let flag_name = &arg[..2];
+        } else if let Some(flag_name) = arg.get(..2) {
+            // `arg.get(..2)` (not `&arg[..2]`) avoids panicking when the arg is
+            // not valid UTF-8 in the first place: args are read lossily, so a
+            // malformed byte becomes a multi-byte U+FFFD and byte index 2 may not
+            // be a char boundary. A short flag is always ASCII, so a non-ASCII
+            // prefix simply matches no value-taking flag.
             flags_with_values.iter().any(|f| f == flag_name)
         } else {
             false

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -373,9 +373,15 @@ impl Settings {
                 settings.trace = true;
             }
         }
-        let args = env::args().collect_vec();
-        // handle the special case of `mise -v` which should show version, not set verbose
-        if settings.verbose && !(args.len() == 2 && args[1] == "-v") {
+        // handle the special case of `mise -v` which should show version, not set verbose.
+        // Use the args mise was invoked with (already captured safely in Cli::run and kept
+        // in sync with internal re-dispatch like `mise asdf ...`) rather than re-reading the
+        // process argv. See also Settings::no_config().
+        let is_version_flag = {
+            let args = env::ARGS.read().unwrap();
+            args.len() == 2 && args[1] == "-v"
+        };
+        if settings.verbose && !is_version_flag {
             settings.quiet = false;
             if settings.log_level != "trace" {
                 settings.log_level = "debug".to_string();

--- a/src/env.rs
+++ b/src/env.rs
@@ -892,6 +892,16 @@ pub fn vars_safe() -> impl Iterator<Item = (String, String)> {
     })
 }
 
+/// Safe wrapper around std::env::args() that handles invalid UTF-8 gracefully.
+/// std::env::args() panics if any argument contains invalid UTF-8; this uses
+/// args_os() and lossily converts each argument (invalid sequences become U+FFFD).
+/// Unlike vars_safe() the conversion is lossy rather than skipping, so argument
+/// positions are preserved and a malformed argv yields a normal "unknown command"
+/// error instead of crashing.
+pub fn args_safe() -> Vec<String> {
+    args_os().map(|a| a.to_string_lossy().to_string()).collect()
+}
+
 pub fn set_current_dir<P: AsRef<Path>>(path: P) -> Result<()> {
     let path = path.as_ref();
     trace!("cd {}", display_path(path));

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use crate::cli::version::VERSION;
 use color_eyre::{Section, SectionExt};
 use eyre::Report;
 use indoc::indoc;
-use itertools::Itertools;
 
 #[cfg(test)]
 #[macro_use]
@@ -132,7 +131,7 @@ async fn main_() -> eyre::Result<()> {
         }
     }
     measure!("main", {
-        let args = env::args().collect_vec();
+        let args = env::args_safe();
         match Cli::run(&args)
             .await
             .with_section(|| VERSION.to_string().header("Version:"))


### PR DESCRIPTION
## Problem

Running mise with an argument that contains invalid UTF-8 crashes with a Rust panic instead of a normal error. Reported in #10056:

```sh
mise u$(printf "u\xC3")pgrade
```

## Root cause

`std::env::args()` **panics** the moment it iterates an argv entry that is not valid UTF-8. mise reads argv through it in two places:

- `src/main.rs` — `let args = env::args().collect_vec();`
- `src/config/settings.rs` — the `mise -v` special-case check

`Settings::get()` runs very early (logger setup, etc.), so a malformed byte anywhere in argv panics before the command is ever parsed. mise''s panic hook only emits an async backtrace; it can''t prevent the crash.

The codebase already has the same pattern for the environment: `env::vars_safe()` (used because non-UTF-8 env vars caused the same class of crash — see #6708).

## Fix

Add `env::args_safe()`, mirroring `vars_safe()` but reading argv via `args_os()` and converting each argument **lossily** (invalid sequences become U+FFFD). Use it in both call sites.

Lossy conversion (rather than skipping, as `vars_safe()` does for env entries) is deliberate: argument **positions and count must be preserved** so argv stays well-formed. A malformed argument now resolves to e.g. `up\u{FFFD}grade` and produces a normal "unknown command" error instead of crashing.

## Testing

- New e2e regression test `e2e/cli/test_invalid_utf8_arg` reproduces the reporter''s exact case (and a malformed flag-shaped arg) and asserts the output contains no Rust `panicked` text. Both a panic and a graceful error exit non-zero, so the panic text — not the exit status — is the regression marker.
- `cargo fmt --all -- --check` ✅
- `shellcheck` / `shfmt` (repo editorconfig settings) on the new test ✅

Note: invalid bytes are lossily replaced, so they can''t round-trip — but such an argv was never a valid command anyway; the goal is a clean error rather than a crash.

Addresses #10056

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI robustness when arguments contain invalid or non‑UTF‑8 bytes (including malformed flags or command-like inputs), preventing crashes and ensuring clear, graceful error messages.

* **Tests**
  * Added an end-to-end regression test verifying malformed command-line arguments are handled without triggering runtime panics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->