### PR TITLE
fix(release): include brew shim in crate package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ include = [
   "/src/**/*.rs",
   "/src/assets/**",
   "/src/plugins/core/assets/**",
+  "/src/system/packages/brew/shim.rb",
   "/vendor/aqua-registry/LICENSE",
   "/vendor/aqua-registry/metadata.json",
   "/vendor/aqua-registry/registry.yml",


### PR DESCRIPTION
## Summary
- include `src/system/packages/brew/shim.rb` in the published `mise` crate package
- fix release packaging for the brew source builder, which embeds the shim with `include_str!`

## Root Cause
The release job failed during `cargo publish` verification because `source.rs` references `shim.rb`, but the package include whitelist only covered Rust source files and selected asset directories.

## Validation
- `cargo package --allow-dirty --list | rg 'src/system/packages/brew/(source.rs|shim.rb)'`

Full `cargo package --allow-dirty` is blocked in this checkout before packaging by existing workspace path dependencies without crates.io version requirements (`aqua-registry`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to the Cargo `include` list; no runtime or security behavior changes.
> 
> **Overview**
> Adds **`src/system/packages/brew/shim.rb`** to the `mise` crate **`include`** whitelist so it ships in the published package.
> 
> **`source.rs`** embeds that file at compile time with **`include_str!("shim.rb")`** for native Homebrew formula source builds; without this path, **`cargo publish`** / package verification fails because the shim was not part of the crate tarball.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4096da9ce0a3a0e93cb9046ce0d2c3edc5b36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to ensure an additional runtime file is included in published packages so all necessary files are distributed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->