### PR TITLE
fix(github): strip tool name before asset platform detection

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -427,7 +427,26 @@ impl AssetPicker {
         score
     }
 
+    /// Returns the part of the asset used for platform (OS/arch/libc) detection,
+    /// with the tool's own name stripped from the front when it is known. This
+    /// prevents OS/arch tokens that happen to appear in the tool name (e.g. the
+    /// "arch" in "go-arch-lint", or the "win" in "win-tool") from being matched
+    /// as the asset's platform. Falls back to the full asset when no preferred
+    /// name is set or the asset does not start with it.
+    fn platform_part<'a>(&self, asset: &'a str) -> &'a str {
+        let Some(preferred_name) = self.preferred_name.as_deref() else {
+            return asset;
+        };
+        match asset.get(..preferred_name.len()) {
+            Some(prefix) if prefix.eq_ignore_ascii_case(preferred_name) => {
+                &asset[preferred_name.len()..]
+            }
+            _ => asset,
+        }
+    }
+
     fn score_os_match(&self, asset: &str) -> i32 {
+        let asset = self.platform_part(asset);
         for (os, pattern) in OS_PATTERNS.iter() {
             if pattern.is_match(asset) {
                 return if os.matches_target(&self.target_os) {
@@ -450,6 +469,7 @@ impl AssetPicker {
     }
 
     fn score_arch_match(&self, asset: &str) -> i32 {
+        let asset = self.platform_part(asset);
         for (arch, pattern) in ARCH_PATTERNS.iter() {
             if pattern.is_match(asset) {
                 return if arch.matches_target(&self.target_arch) {
@@ -477,6 +497,7 @@ impl AssetPicker {
     }
 
     fn score_libc_match(&self, asset: &str) -> i32 {
+        let asset = self.platform_part(asset);
         for (libc, pattern) in LIBC_PATTERNS.iter() {
             if pattern.is_match(asset) {
                 return if libc.matches_target(&self.target_libc) {
@@ -1315,6 +1336,64 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
             .pick_best_asset(&assets)
             .unwrap();
         assert_eq!(picked, "tool-1.0.0-mingw-w64-x86_64.zip");
+    }
+
+    #[test]
+    fn test_asset_picker_tool_name_with_distro_alias() {
+        // Regression for #10208: a tool whose name contains a Linux distro alias
+        // (e.g. "go-arch-lint" -> "arch") must not have every asset classified as
+        // Linux. The tool name is stripped before platform detection, so the alias
+        // in the name does not shadow each asset's real OS token.
+        let assets = vec![
+            "go-arch-lint_1.15.0_darwin_amd64.tar.gz".to_string(),
+            "go-arch-lint_1.15.0_darwin_arm64.tar.gz".to_string(),
+            "go-arch-lint_1.15.0_linux_amd64.tar.gz".to_string(),
+            "go-arch-lint_1.15.0_linux_arm64.tar.gz".to_string(),
+            "go-arch-lint_1.15.0_windows_amd64.zip".to_string(),
+        ];
+
+        let picked = AssetPicker::with_libc("macos".to_string(), "aarch64".to_string(), None)
+            .with_preferred_name("go-arch-lint")
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "go-arch-lint_1.15.0_darwin_arm64.tar.gz");
+
+        let picked = AssetPicker::with_libc("windows".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("go-arch-lint")
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "go-arch-lint_1.15.0_windows_amd64.zip");
+
+        let picked = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("go-arch-lint")
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "go-arch-lint_1.15.0_linux_amd64.tar.gz");
+    }
+
+    #[test]
+    fn test_asset_picker_tool_name_with_os_token_keeps_distro_asset() {
+        // Reverse guard: a tool whose name contains an OS token (e.g. "win" in
+        // "win-tool") must not cause its Linux distro-alias asset to be detected as
+        // that OS. Stripping the tool name before platform detection avoids moving
+        // the #10208 problem onto another name/alias combination.
+        let assets = vec![
+            "win-tool-ubuntu-x64.tar.gz".to_string(),
+            "win-tool-macos-x64.tar.gz".to_string(),
+            "win-tool-windows-x64.zip".to_string(),
+        ];
+
+        let picked = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("win-tool")
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "win-tool-ubuntu-x64.tar.gz");
+
+        let picked = AssetPicker::with_libc("macos".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("win-tool")
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "win-tool-macos-x64.tar.gz");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`mise use github:fe3dback/go-arch-lint` fails on macOS/Windows with "No matching asset found for platform macos-arm64", even though correct darwin/windows assets exist. Reported in #10208.

## Root cause

mise''s asset matcher detects each release asset''s OS/arch by regex-matching the whole filename. The Linux OS regex includes bare distro aliases (ubuntu, debian, ..., arch). For a tool whose **name** contains such a token -- "go-arch-lint" contains "arch" -- every asset (including the `..._darwin_...` and `..._windows_...` ones) matches the Linux pattern, so on macOS/Windows every asset scores as the wrong OS and the install fails.

## Fix

Strip the tool name (the picker''s `preferred_name`, which the github backend already sets to the repo basename) from the front of each asset before OS/arch/libc detection, so only the platform portion of the filename is matched.

This was chosen over simply reordering the OS patterns (explicit tokens before distro aliases): reordering fixes go-arch-lint but introduces the inverse bug -- e.g. `win-tool-ubuntu-x64.tar.gz` would be read as Windows because the tool name contains "win". Stripping the tool name avoids any such name/alias collision.

- Purely additive; `OS_PATTERNS` is unchanged.
- Tools without a `preferred_name` are unaffected (identical behavior to before).
- `detect_platform_from_url` (used by `mise generate tool-stub`) has no tool name to strip and is intentionally left as-is; it is not the reported path. Robustly fixing it would need a different heuristic (prefer the platform token nearest the suffix) and is out of scope here.

## Testing

- `test_asset_picker_tool_name_with_distro_alias` -- go-arch-lint picks the darwin/windows/linux assets correctly per target.
- `test_asset_picker_tool_name_with_os_token_keeps_distro_asset` -- reverse guard: a "win-tool" name does not make its ubuntu (Linux) asset read as Windows.
- `cargo fmt --all -- --check` passes.

Addresses #10208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset selection to prevent false matches when tool names contain platform-related tokens (e.g., "arch", "win"). Platform detection now correctly strips tool name prefixes before analyzing OS/architecture/distribution information, ensuring proper asset selection across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->