### PR TITLE
fix(github): only strip the tool name at a token boundary in asset matching

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -437,10 +437,21 @@ impl AssetPicker {
         let Some(preferred_name) = self.preferred_name.as_deref() else {
             return asset;
         };
-        match asset.get(..preferred_name.len()) {
-            Some(prefix) if prefix.eq_ignore_ascii_case(preferred_name) => {
-                &asset[preferred_name.len()..]
-            }
+        let Some(prefix) = asset.get(..preferred_name.len()) else {
+            return asset;
+        };
+        if !prefix.eq_ignore_ascii_case(preferred_name) {
+            return asset;
+        }
+        let rest = &asset[preferred_name.len()..];
+        // Only strip when the tool name is a complete leading token, i.e. it ends
+        // at a separator or version boundary. Otherwise the prefix would cut
+        // through a longer first token (e.g. preferred_name "win" inside
+        // "windows-...") and corrupt detection. Mirrors the boundary handling in
+        // asset_matches_preferred_name.
+        match rest.chars().next() {
+            None => rest,
+            Some(c) if c == '-' || c == '_' || c == '.' || c.is_ascii_digit() => rest,
             _ => asset,
         }
     }
@@ -1394,6 +1405,45 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
             .pick_best_asset(&assets)
             .unwrap();
         assert_eq!(picked, "win-tool-macos-x64.tar.gz");
+
+        // Complete the round-trip: the Windows target still resolves its asset.
+        let picked = AssetPicker::with_libc("windows".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("win-tool")
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "win-tool-windows-x64.zip");
+    }
+
+    #[test]
+    fn test_platform_part_only_strips_at_token_boundary() {
+        // A tool name that is a prefix of an OS token (e.g. "win" inside "windows")
+        // must NOT be stripped mid-token, or the OS evidence is lost. With the
+        // boundary guard the full token is kept and the OS still scores as a match
+        // (without it, "windows-x64.zip" would be cut to "dows-x64.zip" -> OS 0).
+        let picker = AssetPicker::with_libc("windows".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("win");
+        assert_eq!(picker.score_os_match("windows-x64.zip"), 100);
+
+        // The boundary cases that should still strip: separators, a version digit,
+        // and end-of-string.
+        let picker = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("tool");
+        assert_eq!(
+            picker.platform_part("tool-linux-x64.tar.gz"),
+            "-linux-x64.tar.gz"
+        );
+        assert_eq!(
+            picker.platform_part("tool_linux_x64.tar.gz"),
+            "_linux_x64.tar.gz"
+        );
+        assert_eq!(picker.platform_part("tool.linux.x64"), ".linux.x64");
+        assert_eq!(picker.platform_part("tool1.2.3-linux"), "1.2.3-linux");
+        assert_eq!(picker.platform_part("tool"), "");
+        // No boundary -> not stripped.
+        assert_eq!(
+            picker.platform_part("toolkit-linux-x64"),
+            "toolkit-linux-x64"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #10390, hardening `platform_part` per the Greptile / CodeRabbit review on that PR.

## Problem

`platform_part` (added in #10390) strips the picker''s `preferred_name` (tool name) from the front of an asset before OS/arch/libc detection. It stripped whenever the leading bytes matched the tool name, **without checking that the match ended at a token boundary**.

If the tool name is a strict prefix of a longer leading token — e.g. a tool named `win` with an asset `windows-x64.zip` — the prefix was cut mid-token (`"dows-x64.zip"`), destroying the platform token and breaking OS detection.

This is an edge case (it does not affect the #10208 case or normal tools, whose assets separate the name from the version/platform with `-`/`_`/`.`), but it is a real correctness gap and was flagged independently by both review bots. The analogous `asset_matches_preferred_name` helper already enforces such a boundary.

## Fix

Only strip when the character immediately after the prefix is a separator (`-`, `_`, `.`), a version digit, or end-of-string; otherwise keep the full asset. This mirrors `asset_matches_preferred_name`''s boundary handling.

## Testing

- `test_platform_part_only_strips_at_token_boundary` — asserts `score_os_match("windows-x64.zip")` with `preferred_name = "win"` still detects Windows (would be lost without the guard), plus the separator/digit/end-of-string strip cases and the no-boundary keep case.
- Completed the `win-tool` reverse-guard test with the previously-missing Windows-target assertion.
- `cargo fmt --all -- --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset selection logic to prevent incorrect removal of naming prefixes at token boundaries, ensuring accurate OS/architecture detection.

* **Tests**
  * Added test coverage for asset selection with preferred naming conventions and token boundary validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->