### PR TITLE
fix(watch): forward --wrap-process to watchexec

### DIFF
--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -148,6 +148,14 @@ impl Watch {
             args.push("--on-busy-update".to_string());
             args.push(self.watchexec.on_busy_update.to_string());
         }
+        // Forward --wrap-process to watchexec when it differs from watchexec's
+        // default ("group"). Without this the flag is parsed but dropped, so e.g.
+        // `mise watch --wrap-process none` had no effect and a TUI task launched in
+        // the default process group would block on terminal I/O (#10212).
+        if self.watchexec.wrap_process != WrapMode::Group {
+            args.push("--wrap-process".to_string());
+            args.push(self.watchexec.wrap_process.to_string());
+        }
         if !self.watchexec.signal_map.is_empty() {
             for signal_map in &self.watchexec.signal_map {
                 args.push("--map-signal".to_string());
@@ -1422,7 +1430,8 @@ pub enum OnBusyUpdate {
     Signal,
 }
 
-#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+#[derive(Clone, Copy, Debug, Default, ValueEnum, PartialEq, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum WrapMode {
     #[default]
     Group,
@@ -1469,8 +1478,8 @@ pub enum ColourMode {
 #[cfg(test)]
 mod tests {
     use super::{
-        common_ancestor, merge_watch_patterns, normalize_path, parse_source, relativize_source,
-        source_watch_dir,
+        WrapMode, common_ancestor, merge_watch_patterns, normalize_path, parse_source,
+        relativize_source, source_watch_dir,
     };
     use std::path::{Path, PathBuf};
 
@@ -1481,6 +1490,15 @@ mod tests {
     fn resolve_source(s: &str, cwd: &Path, anchor: &Path) -> String {
         let (k, abs) = parse_source(s, cwd);
         relativize_source(k, &abs, anchor)
+    }
+
+    #[test]
+    fn wrap_mode_serializes_to_watchexec_values() {
+        // These strings are forwarded verbatim to `watchexec --wrap-process`, so
+        // they must match the values watchexec accepts (#10212).
+        assert_eq!(WrapMode::Group.to_string(), "group");
+        assert_eq!(WrapMode::Session.to_string(), "session");
+        assert_eq!(WrapMode::None.to_string(), "none");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`mise watch --restart --wrap-process none <task>` hangs when the task launches a TUI, while the equivalent direct `watchexec --restart --wrap-process none mise run <task>` works fine. Reported in #10212.

## Root cause

`mise watch` accepts `--wrap-process` (it mirrors watchexec''s options for help/completion), but `Watch::run()` never forwards the flag when building the watchexec command line — a repo-wide search finds `wrap_process` only in the clap definition. So `mise watch --wrap-process none foo` actually runs:

```
watchexec --restart -- mise run foo
```

and watchexec falls back to its default `--wrap-process group`. In `group` mode the TUI ends up in a non-foreground process group and blocks on terminal I/O, hence the hang.

## Fix

- Forward `--wrap-process` in `Watch::run()` when it differs from watchexec''s default (`group`), right next to the existing `--on-busy-update` forwarding.
- Add `PartialEq` and a kebab-case `strum::Display` to `WrapMode` (mirroring `OnBusyUpdate`) so it serializes to watchexec''s accepted values: `group` / `session` / `none`.

## Testing

- Unit test pinning `WrapMode`''s serialized values (`group`/`session`/`none`) — these are forwarded verbatim to watchexec.
- Manual: `mise watch --restart --wrap-process none <task>` under `MISE_DEBUG` now shows `--wrap-process none` in the spawned `watchexec` command, and the TUI no longer hangs. (The argv construction lives in the long-running `Watch::run()`, which isn''t covered by the existing e2e suite.)
- `cargo fmt --all -- --check` passes.

Note: several other watchexec flags are similarly parsed-but-not-forwarded (e.g. `-i/--ignore`, `--workdir`); this PR is scoped to `--wrap-process` (the reported bug) and those can be a follow-up.

Addresses #10212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `mise watch` now correctly forwards the `--wrap-process` option to the process watcher instead of silently dropping it, ensuring process wrapping behavior is applied as specified.

* **Tests**
  * Added regression tests to verify process wrapping configuration is handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->