### PR TITLE
fix(activate): don't reorder PATH for the mise dir in --shims mode

### DIFF
--- a/e2e/shell/test_shims_activate_prepend
+++ b/e2e/shell/test_shims_activate_prepend
@@ -14,3 +14,21 @@ assert_contains "env PATH='$CUSTOM_PATH' $MISE_BIN activate bash --shims" "expor
 
 # Shims not in PATH: should also be emitted as a prepend with shims first
 assert_contains "env PATH='/some/other/bin:/usr/bin' $MISE_BIN activate bash --shims" "export PATH=\"$SHIMS_DIR:"
+
+# Regression #10264: when the dir containing the mise executable is already in
+# PATH (e.g. a deb install at /usr/bin), --shims must NOT re-prepend it, which
+# would reorder PATH (moving /usr/bin ahead of /usr/local/bin). Only the shims
+# dir should be prepended, so exactly one `export PATH=` line is emitted.
+EXE_DIR="$(dirname "$MISE_BIN")"
+if ! out="$(env PATH="$EXE_DIR:/usr/local/bin:/usr/bin" "$MISE_BIN" activate bash --shims 2>&1)"; then
+  echo "FAIL: 'mise activate bash --shims' exited non-zero:"
+  printf '%s\n' "$out"
+  exit 1
+fi
+assert_contains_text "$out" "export PATH=\"$SHIMS_DIR:"
+path_lines="$(printf '%s\n' "$out" | grep -c 'export PATH=' || true)"
+if [[ $path_lines != "1" ]]; then
+  echo "FAIL: expected exactly one 'export PATH=' line (shims only) since the mise dir is already in PATH, got $path_lines:"
+  printf '%s\n' "$out"
+  exit 1
+fi

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -102,10 +102,14 @@ impl Activate {
     fn activate_shims(&self, shell: &dyn Shell, mise_bin: &Path) -> std::io::Result<()> {
         let exe_dir = mise_bin.parent().unwrap();
         let mut prelude = vec![];
-        // For shells with native path dedup/reorder (fish), always emit path commands
-        // using MovePrependEnv so entries get moved to front on re-source (e.g. VS Code).
-        // For other shells, keep the is_dir_in_path guard to avoid PATH growth on re-source.
-        if let Some(p) = self.shims_prepend_path(shell, exe_dir) {
+        // The shims dir is always (move-)prepended so it stays at the front of PATH
+        // even when activation is re-sourced (e.g. VS Code terminals) — see #8757.
+        // The mise executable's own dir only needs to be present so `mise` is
+        // callable, so it uses the guarded prepend: this avoids re-prepending (and
+        // thereby reordering) a system dir such as /usr/bin that is already in PATH
+        // for deb/rpm installs, which would otherwise move it ahead of
+        // /usr/local/bin (#10264).
+        if let Some(p) = self.prepend_path(exe_dir) {
             prelude.push(p);
         }
         if let Some(p) = self.shims_prepend_path(shell, &dirs::SHIMS) {
@@ -165,9 +169,10 @@ impl Activate {
         }
     }
 
-    /// Used by activate_shims. Always prepends the path to the front, even if
-    /// already present (accepting a duplicate entry). For shells with native path
-    /// dedup (fish), uses MovePrependEnv to reorder without duplicating.
+    /// Used by activate_shims for the shims directory. Always prepends the path to
+    /// the front, even if already present (accepting a duplicate entry), so the
+    /// shims dir wins on re-source. For shells with native path dedup (fish), uses
+    /// MovePrependEnv to reorder without duplicating.
     fn shims_prepend_path(&self, shell: &dyn Shell, p: &Path) -> Option<ActivatePrelude> {
         if !is_dir_not_in_nix(p) || p.is_relative() {
             return None;


### PR DESCRIPTION
## Problem

On a deb/rpm install (mise at `/usr/bin/mise`), `mise activate bash --shims` emits:

```
export PATH="/usr/bin:$PATH"
export PATH="/home/viktor/.local/share/mise/shims:$PATH"
```

The first line duplicates `/usr/bin` and moves it **ahead of `/usr/local/bin`**, changing command resolution — locally/admin-installed binaries in `/usr/local/bin` no longer take precedence. Reported in #10264.

## Root cause

`activate_shims()` prepends both the shims dir and the directory containing the mise executable. PR #8757 made `--shims` activation *always* prepend (dropping the "already in PATH" guard) so the shims dir reliably moves to the front when shell config is re-sourced (e.g. VS Code terminals). But `activate_shims()` routes **both** the shims dir and the mise exe dir through that same unconditional helper, so the exe dir lost the guard too. For a deb install the exe dir is `/usr/bin`, which is already in PATH — so it gets re-prepended and reordered.

## Fix

Keep always-prepending the **shims dir** (preserving #8757''s re-source behavior), but emit the **mise executable''s own dir** through the guarded `prepend_path`, which skips directories already in PATH. The exe dir only needs to be *present* so `mise` is callable — never at the front.

For a deb install, activation now emits only:

```
export PATH="$HOME/.local/share/mise/shims:$PATH"
```

and never reorders existing PATH entries.

## Testing

- Extended `e2e/shell/test_shims_activate_prepend`: when the mise executable''s dir is already in PATH, exactly one `export PATH=` line (the shims dir) is emitted — the exe dir is not re-prepended. The existing assertions (shims dir is always prepended, with or without it already in PATH) still hold.
- `cargo fmt --all -- --check` passes.

Addresses #10264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented shim activation from reordering PATH when the tool's install directory is already present, avoiding redundant PATH modifications.

* **Tests**
  * Added a regression test to confirm activation emits a single PATH export and does not re-prepend an existing install directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->