### PR TITLE
feat(bootstrap): add phase hooks

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -2,7 +2,8 @@
 
 `mise bootstrap` sets up the machine-level pieces around a mise config: OS
 packages, dotfiles, macOS defaults, macOS LaunchAgents, the user's login
-shell, tools, and any final project-specific task.
+shell, tools, and any final project-specific task. You can also add hooks that
+run at named points in the bootstrap sequence.
 
 Use bootstrap for things that are needed before a project or workstation is
 ready, but that do not belong in `[tools]`: native libraries, Homebrew
@@ -20,6 +21,12 @@ machine setup.
 5. `mise bootstrap user apply` applies `[bootstrap.user]`.
 6. `mise install` installs missing `[tools]`.
 7. `mise run bootstrap` runs a task named `bootstrap`, if one exists.
+8. `[bootstrap.hooks.final]` runs after the bootstrap task, if configured.
+
+Hook phases can also run before and after the built-in steps:
+`pre-packages`, `post-packages`, `pre-dotfiles`, `post-dotfiles`,
+`pre-defaults`, `post-defaults`, `pre-user`, `post-user`, `pre-tools`, and
+`post-tools`.
 
 The declarative steps converge: if a package is already installed, a dotfile
 already matches, or a default is already set, mise skips it. The `bootstrap`
@@ -47,6 +54,12 @@ run_at_load = true
 
 [bootstrap.user]
 login_shell = "/bin/zsh"
+
+[bootstrap.hooks.pre-packages]
+run = "softwareupdate --install-rosetta --agree-to-license"
+
+[bootstrap.hooks.post-defaults]
+run = "killall Dock || true"
 
 [tools]
 node = "lts"
@@ -96,6 +109,7 @@ place but should not install anything during that check.
 | `[bootstrap.macos.defaults]`       | macOS user preferences written through `defaults write`       |
 | `[bootstrap.macos.launchd.agents]` | macOS user LaunchAgents written and loaded with `launchctl`   |
 | `[bootstrap.user]`                 | Current-user settings such as `login_shell`                   |
+| `[bootstrap.hooks]`                | Commands that run at named bootstrap phases                   |
 | `[tools]`                          | Versioned dev tools managed by mise                           |
 | `[tasks.bootstrap]`                | Anything custom that should run after tools are installed     |
 
@@ -103,6 +117,40 @@ Use declarative sections when mise can inspect and converge the state. Use
 `[tasks.bootstrap]` for imperative setup that does not fit those sections,
 such as cloning a private repository, running an auth flow, or seeding local
 data.
+
+## Hooks
+
+Hooks run only during explicit `mise bootstrap` invocations. They may be
+specified as a command string, an array of command strings, or a table with a
+`run` field. They use the same default inline shell setting as tasks, stop the
+bootstrap if they fail, and print the command instead of running it during
+`mise bootstrap --dry-run`. Hooks run in the current process environment; use
+`mise exec -- ...` inside a hook, or use `[tasks.bootstrap]`, when the command
+needs tools from `[tools]` on PATH.
+
+```toml
+[bootstrap.hooks.pre-packages]
+run = "softwareupdate --install-rosetta --agree-to-license"
+
+[bootstrap.hooks.post-tools]
+run = [
+  "mise exec -- corepack enable",
+  "mise exec -- rustup component add rustfmt clippy",
+]
+
+[bootstrap.hooks.final]
+run = "gh auth status || gh auth login"
+```
+
+As shorthand, a hook phase can also be set directly:
+
+```toml
+[bootstrap.hooks]
+post-defaults = "killall Dock || true"
+```
+
+Hooks merge across the config hierarchy from global to local, so shared config
+can define broad machine setup while a project adds its own phase commands.
 
 ## Common Workflows
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -120,7 +120,7 @@ data.
 
 ## Hooks
 
-Hooks run only during explicit `mise bootstrap` invocations. They may be
+Hooks run only during explicit `mise bootstrap` invocations. A hook can be
 specified as a command string, an array of command strings, or a table with a
 `run` field. They use the same default inline shell setting as tasks, stop the
 bootstrap if they fail, and print the command instead of running it during

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -8,16 +8,23 @@
 
 Runs the bootstrap steps for the current config in order:
 
+0. `[bootstrap.hooks.pre-packages]` — optional setup hook
 1. `mise bootstrap packages install` — install missing
    `[bootstrap.packages]`
+   then `[bootstrap.hooks.post-packages]`
 2. `mise dotfiles apply` — apply dotfiles from `[dotfiles]`
+   surrounded by `pre-dotfiles`/`post-dotfiles` hooks
 3. `mise bootstrap macos-defaults apply` — write
    `[bootstrap.macos.defaults]` entries (macOS)
+   surrounded by `pre-defaults`/`post-defaults` hooks
 4. `mise bootstrap launchd apply` — install/load macOS LaunchAgents
 5. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`
    (Unix)
+   surrounded by `pre-user`/`post-user` hooks
 6. `mise install` — install missing tools from `[tools]`
+   surrounded by `pre-tools`/`post-tools` hooks
 7. `mise run bootstrap` — if a task named `bootstrap` is defined
+8. `[bootstrap.hooks.final]` — optional final hook
 
 The declarative steps converge — anything already in its desired state
 is skipped, so re-running is safe. The `bootstrap` task runs on every

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -102,6 +102,9 @@ run_at_load = true
 [bootstrap.user]                       # current user's login shell
 login_shell = "/bin/zsh"
 
+[bootstrap.hooks.post-defaults]        # optional phase hooks
+run = "killall Dock || true"
+
 [tasks.bootstrap]                      # anything else, with tools on PATH
 run = "gh auth status || gh auth login"
 ```

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -116,7 +116,10 @@ mise bootstrap --yes   # new laptop or container -> ready to work
 Everything is declarative and idempotent: re-running skips whatever is
 already in its desired state, `mise bootstrap packages status --missing` and
 `mise dotfiles status --missing` make CI checks, and nothing is ever applied
-implicitly. See
+implicitly. The exceptions are `[bootstrap.hooks]` and `[tasks.bootstrap]`,
+which are imperative commands run during `mise bootstrap` and may have side
+effects; treat hook commands as non-idempotent unless they are written to
+converge safely. See
 [Bootstrap](/bootstrap.html), [Bootstrap Packages](/bootstrap/packages/),
 [Dotfiles](/dotfiles.html), [macOS Defaults](/bootstrap/macos-defaults.html),
 [launchd](/bootstrap/launchd.html), and [User Login Shell](/bootstrap/user.html).

--- a/e2e/backend/test_ubi
+++ b/e2e/backend/test_ubi
@@ -7,8 +7,8 @@ assert_contains "$MISE_DATA_DIR/shims/jc --version" "jc version:  1.25.3"
 
 # only run on linux/amd64
 if [ "$(uname -m)" = "x86_64" ] && [ "$(uname -s)" = "Linux" ]; then
-  mise use 'ubi:https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz[exe=ffmpeg]'
-  assert_contains "$MISE_DATA_DIR/shims/ffmpeg -version" "ffmpeg version"
+  mise use 'ubi:https://github.com/sharkdp/fd/releases/download/v10.3.0/fd-v10.3.0-x86_64-unknown-linux-gnu.tar.gz[exe=fd]'
+  assert_contains "$MISE_DATA_DIR/shims/fd --version" "fd 10.3.0"
 fi
 
 cat <<EOF >mise.toml

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -60,3 +60,21 @@ cat <<EOF >mise.toml
 "pacman:bc" = "latest"
 EOF
 assert_succeed "mise bootstrap --dry-run"
+
+# dotfiles can add config that contributes hooks to later phases in the same run
+mkdir -p dotfiles/mise
+cat <<'EOF' >dotfiles/mise/config.toml
+[bootstrap.hooks.post-dotfiles]
+run = "echo post-dotfiles > post_dotfiles_hook_ran"
+
+[bootstrap.hooks.final]
+run = "echo final > final_hook_ran"
+EOF
+cat <<EOF >mise.toml
+[dotfiles]
+"~/.config/mise/config.toml" = "dotfiles/mise/config.toml"
+EOF
+rm -f post_dotfiles_hook_ran final_hook_ran
+assert_succeed "mise bootstrap --yes"
+assert "cat post_dotfiles_hook_ran" "post-dotfiles"
+assert "cat final_hook_ran" "final"

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -75,6 +75,10 @@ cat <<EOF >mise.toml
 "~/.config/mise/config.toml" = "dotfiles/mise/config.toml"
 EOF
 rm -f post_dotfiles_hook_ran final_hook_ran
+assert_contains "mise bootstrap --dry-run" "echo post-dotfiles > post_dotfiles_hook_ran"
+assert_contains "mise bootstrap --dry-run" "echo final > final_hook_ran"
+assert_fail "cat post_dotfiles_hook_ran"
+assert_fail "cat final_hook_ran"
 assert_succeed "mise bootstrap --yes"
 assert "cat post_dotfiles_hook_ran" "post-dotfiles"
 assert "cat final_hook_ran" "final"

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -82,3 +82,32 @@ assert_fail "cat final_hook_ran"
 assert_succeed "mise bootstrap --yes"
 assert "cat post_dotfiles_hook_ran" "post-dotfiles"
 assert "cat final_hook_ran" "final"
+
+# dry-run previews hooks from templated config dotfiles
+cat <<'EOF' >dotfiles/mise/config.local.toml.tmpl
+[bootstrap.hooks.final]
+run = "echo {{ vars.templated_hook_value }} > templated_hook_ran"
+EOF
+cat <<EOF >mise.toml
+[vars]
+templated_hook_value = "template-final"
+
+[dotfiles]
+"~/.config/mise/config.local.toml" = { source = "dotfiles/mise/config.local.toml.tmpl", mode = "template" }
+EOF
+rm -f templated_hook_ran
+assert_contains "mise bootstrap --dry-run" "echo template-final > templated_hook_ran"
+assert_fail "cat templated_hook_ran"
+
+# dry-run recognizes local config targets such as ~/.mise/config.toml
+cat <<'EOF' >dotfiles/mise/local-config.toml
+[bootstrap.hooks.post-dotfiles]
+run = "echo mise-dir > mise_dir_hook_ran"
+EOF
+cat <<EOF >mise.toml
+[dotfiles]
+"~/.mise/config.toml" = "dotfiles/mise/local-config.toml"
+EOF
+rm -f mise_dir_hook_ran
+assert_contains "mise bootstrap --dry-run" "echo mise-dir > mise_dir_hook_ran"
+assert_fail "cat mise_dir_hook_ran"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -793,16 +793,23 @@ e.g.: ruby@3
 
 Runs the bootstrap steps for the current config in order:
 
+0. `[bootstrap.hooks.pre\-packages]` — optional setup hook
 1. `mise bootstrap packages install` — install missing
    `[bootstrap.packages]`
+   then `[bootstrap.hooks.post\-packages]`
 2. `mise dotfiles apply` — apply dotfiles from `[dotfiles]`
+   surrounded by `pre\-dotfiles`/`post\-dotfiles` hooks
 3. `mise bootstrap macos\-defaults apply` — write
    `[bootstrap.macos.defaults]` entries (macOS)
+   surrounded by `pre\-defaults`/`post\-defaults` hooks
 4. `mise bootstrap launchd apply` — install/load macOS LaunchAgents
 5. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`
    (Unix)
+   surrounded by `pre\-user`/`post\-user` hooks
 6. `mise install` — install missing tools from `[tools]`
+   surrounded by `pre\-tools`/`post\-tools` hooks
 7. `mise run bootstrap` — if a task named `bootstrap` is defined
+8. `[bootstrap.hooks.final]` — optional final hook
 
 The declarative steps converge — anything already in its desired state
 is skipped, so re\-running is safe. The `bootstrap` task runs on every

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -286,16 +286,23 @@ cmd bootstrap help="[experimental] Set up a machine for the current config in on
 
 Runs the bootstrap steps for the current config in order:
 
+0. `[bootstrap.hooks.pre-packages]` — optional setup hook
 1. `mise bootstrap packages install` — install missing
    `[bootstrap.packages]`
+   then `[bootstrap.hooks.post-packages]`
 2. `mise dotfiles apply` — apply dotfiles from `[dotfiles]`
+   surrounded by `pre-dotfiles`/`post-dotfiles` hooks
 3. `mise bootstrap macos-defaults apply` — write
    `[bootstrap.macos.defaults]` entries (macOS)
+   surrounded by `pre-defaults`/`post-defaults` hooks
 4. `mise bootstrap launchd apply` — install/load macOS LaunchAgents
 5. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`
    (Unix)
+   surrounded by `pre-user`/`post-user` hooks
 6. `mise install` — install missing tools from `[tools]`
+   surrounded by `pre-tools`/`post-tools` hooks
 7. `mise run bootstrap` — if a task named `bootstrap` is defined
+8. `[bootstrap.hooks.final]` — optional final hook
 
 The declarative steps converge — anything already in its desired state
 is skipped, so re-running is safe. The `bootstrap` task runs on every

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use eyre::Result;
 use serde_json::json;
 
@@ -5,9 +7,12 @@ use super::install::Install;
 use super::run;
 use super::system::driver::{self, Action, DriverOpts};
 use super::system::{install, status, upgrade, r#use};
-use crate::config::{Config, Settings};
+use crate::config::{self, Config, Settings};
+use crate::dirs;
 use crate::system;
 use crate::system::defaults::DefaultsState;
+use crate::system::files::{FileMode, FileRequest};
+use crate::system::hooks::{self, BootstrapHookPhase};
 use crate::system::launchd::LaunchdState;
 use crate::system::login_shell::LoginShellState;
 use crate::ui::table::MiseTable;
@@ -17,16 +22,23 @@ use clap::Subcommand;
 ///
 /// Runs the bootstrap steps for the current config in order:
 ///
+/// 0. `[bootstrap.hooks.pre-packages]` — optional setup hook
 /// 1. `mise bootstrap packages install` — install missing
 ///    `[bootstrap.packages]`
+///    then `[bootstrap.hooks.post-packages]`
 /// 2. `mise dotfiles apply` — apply dotfiles from `[dotfiles]`
+///    surrounded by `pre-dotfiles`/`post-dotfiles` hooks
 /// 3. `mise bootstrap macos-defaults apply` — write
 ///    `[bootstrap.macos.defaults]` entries (macOS)
+///    surrounded by `pre-defaults`/`post-defaults` hooks
 /// 4. `mise bootstrap launchd apply` — install/load macOS LaunchAgents
 /// 5. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`
 ///    (Unix)
+///    surrounded by `pre-user`/`post-user` hooks
 /// 6. `mise install` — install missing tools from `[tools]`
+///    surrounded by `pre-tools`/`post-tools` hooks
 /// 7. `mise run bootstrap` — if a task named `bootstrap` is defined
+/// 8. `[bootstrap.hooks.final]` — optional final hook
 ///
 /// The declarative steps converge — anything already in its desired state
 /// is skipped, so re-running is safe. The `bootstrap` task runs on every
@@ -192,8 +204,11 @@ impl Bootstrap {
         if let Some(command) = self.command {
             return command.run().await;
         }
-        let config = Config::get().await?;
+        let mut config = Config::get().await?;
+        let mut hooks = system::hooks_from_config(&config);
 
+        self.run_hooks(&hooks, BootstrapHookPhase::PrePackages)
+            .await?;
         let mgrs = system::packages_from_config(&config);
         if mgrs.is_empty() {
             debug!("bootstrap: no [bootstrap.packages] configured, skipping");
@@ -208,7 +223,11 @@ impl Bootstrap {
             };
             driver::run(mgrs, Action::Install, &opts).await?;
         }
+        self.run_hooks(&hooks, BootstrapHookPhase::PostPackages)
+            .await?;
 
+        self.run_hooks(&hooks, BootstrapHookPhase::PreDotfiles)
+            .await?;
         let files = system::files::files_from_config(&config);
         if files.is_empty() {
             debug!("bootstrap: no whole-file [dotfiles] entries configured, skipping");
@@ -237,7 +256,17 @@ impl Bootstrap {
             };
             system::edits::apply(&config, &edits, &opts)?;
         }
+        if self.dry_run {
+            hooks = self.hooks_after_dotfiles_dry_run(&config, &files)?;
+        } else {
+            config = Config::reset().await?;
+            hooks = system::hooks_from_config(&config);
+        }
+        self.run_hooks(&hooks, BootstrapHookPhase::PostDotfiles)
+            .await?;
 
+        self.run_hooks(&hooks, BootstrapHookPhase::PreDefaults)
+            .await?;
         let defaults = system::defaults_from_config(&config);
         if defaults.is_empty() {
             debug!("bootstrap: no [bootstrap.macos.defaults] configured, skipping");
@@ -245,6 +274,8 @@ impl Bootstrap {
             info!("bootstrap: system defaults");
             install::apply_defaults(defaults, self.dry_run, self.yes).await?;
         }
+        self.run_hooks(&hooks, BootstrapHookPhase::PostDefaults)
+            .await?;
 
         let agents = system::launchd_from_config(&config);
         if agents.is_empty() {
@@ -254,6 +285,7 @@ impl Bootstrap {
             install::apply_launchd(agents, self.dry_run, self.yes).await?;
         }
 
+        self.run_hooks(&hooks, BootstrapHookPhase::PreUser).await?;
         let login_shell = system::login_shell_from_config(&config);
         if login_shell.is_none() {
             debug!("bootstrap: no [bootstrap.user].login_shell configured, skipping");
@@ -261,13 +293,18 @@ impl Bootstrap {
             info!("bootstrap: login shell");
             install::apply_login_shell(login_shell, self.dry_run, self.yes)?;
         }
+        self.run_hooks(&hooks, BootstrapHookPhase::PostUser).await?;
 
+        self.run_hooks(&hooks, BootstrapHookPhase::PreTools).await?;
         info!("bootstrap: tools");
         Install::new_bare(self.dry_run).run().await?;
+        if !self.dry_run {
+            config = Config::reset().await?;
+            hooks = system::hooks_from_config(&config);
+        }
+        self.run_hooks(&hooks, BootstrapHookPhase::PostTools)
+            .await?;
 
-        // installs may have changed the env (and `mise install` resets config
-        // internally), so re-fetch before looking up tasks
-        let config = Config::get().await?;
         let tasks = config.tasks().await?;
         if tasks.iter().any(|(_, t)| t.is_match("bootstrap")) {
             info!("bootstrap: running `bootstrap` task");
@@ -275,7 +312,42 @@ impl Bootstrap {
         } else {
             debug!("bootstrap: no `bootstrap` task defined, skipping");
         }
+        self.run_hooks(&hooks, BootstrapHookPhase::Final).await?;
         Ok(())
+    }
+
+    async fn run_hooks(
+        &self,
+        hooks: &[hooks::BootstrapHook],
+        phase: BootstrapHookPhase,
+    ) -> Result<()> {
+        hooks::run_phase(hooks, phase, self.dry_run).await
+    }
+
+    fn hooks_after_dotfiles_dry_run(
+        &self,
+        config: &Config,
+        files: &[FileRequest],
+    ) -> Result<Vec<hooks::BootstrapHook>> {
+        let mut config_files = config.config_files.clone();
+        for file in files {
+            if !is_mise_config_target(&file.target) || !file.source.is_file() {
+                continue;
+            }
+            match parse_dotfile_mise_config(config, file) {
+                Ok(cf) => {
+                    config_files.insert(file.target.clone(), cf);
+                }
+                Err(err) => {
+                    warn!(
+                        "[dotfiles].\"{}\": failed to parse config source {}: {err}",
+                        file.target_raw,
+                        file.source.display()
+                    );
+                }
+            }
+        }
+        Ok(system::hooks_from_config_files(&config_files))
     }
 
     async fn run_task(&self, task: &str) -> Result<()> {
@@ -322,6 +394,31 @@ impl Bootstrap {
         .run()
         .await
     }
+}
+
+fn parse_dotfile_mise_config(
+    config: &Config,
+    file: &FileRequest,
+) -> Result<Arc<dyn config::config_file::ConfigFile>> {
+    let body = match file.mode {
+        FileMode::Template => system::files::render_template(config, file)?,
+        _ => crate::file::read_to_string(&file.source)?,
+    };
+    Ok(Arc::new(
+        config::config_file::mise_toml::MiseToml::from_str(&body, &file.target)?,
+    ))
+}
+
+fn is_mise_config_target(path: &std::path::Path) -> bool {
+    path.starts_with(*dirs::CONFIG)
+        || path.starts_with(*dirs::SYSTEM_CONFIG)
+        || config::DEFAULT_CONFIG_FILENAMES.iter().any(|filename| {
+            filename.ends_with(".toml") && !filename.contains('*') && path.ends_with(filename)
+        })
+        || (path.extension().is_some_and(|ext| ext == "toml")
+            && path
+                .parent()
+                .is_some_and(|parent| parent.ends_with(".config/mise/conf.d")))
 }
 
 impl Commands {

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2215,6 +2215,12 @@ mod tests {
 
         [bootstrap.brew.taps]
         "railwaycat/emacsmacport" = "https://github.com/railwaycat/homebrew-emacsmacport"
+
+        [bootstrap.hooks.pre-packages]
+        run = "echo preparing"
+
+        [bootstrap.hooks.post-tools]
+        run = ["echo one", "echo two"]
         "#,
         )
         .unwrap();
@@ -2227,6 +2233,8 @@ mod tests {
             system.brew.taps.get("railwaycat/emacsmacport").unwrap(),
             "https://github.com/railwaycat/homebrew-emacsmacport"
         );
+        assert!(system.hooks.get("pre-packages").unwrap().is_table());
+        assert!(system.hooks.get("post-tools").unwrap().is_table());
         assert_eq!(system.user.login_shell, None);
         // unknown managers parse fine (forward compatibility)
         assert_eq!(

--- a/src/system/hooks.rs
+++ b/src/system/hooks.rs
@@ -1,0 +1,179 @@
+//! Bootstrap phase hooks for `[bootstrap.hooks]`.
+//!
+//! Hooks are imperative commands that run at named points during
+//! `mise bootstrap`. They are intentionally explicit bootstrap behavior, not
+//! part of `mise install` or shell activation.
+
+use std::fmt;
+
+use eyre::{Result, bail};
+use serde::Serialize;
+use strum::{EnumIter, IntoEnumIterator};
+
+use crate::config::Settings;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BootstrapHookPhase {
+    PrePackages,
+    PostPackages,
+    PreDotfiles,
+    PostDotfiles,
+    PreDefaults,
+    PostDefaults,
+    PreUser,
+    PostUser,
+    PreTools,
+    PostTools,
+    Final,
+}
+
+impl BootstrapHookPhase {
+    pub fn parse(raw: &str) -> Option<Self> {
+        let normalized = raw.replace('_', "-");
+        Self::iter().find(|phase| phase.as_str() == normalized)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PrePackages => "pre-packages",
+            Self::PostPackages => "post-packages",
+            Self::PreDotfiles => "pre-dotfiles",
+            Self::PostDotfiles => "post-dotfiles",
+            Self::PreDefaults => "pre-defaults",
+            Self::PostDefaults => "post-defaults",
+            Self::PreUser => "pre-user",
+            Self::PostUser => "post-user",
+            Self::PreTools => "pre-tools",
+            Self::PostTools => "post-tools",
+            Self::Final => "final",
+        }
+    }
+}
+
+impl fmt::Display for BootstrapHookPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootstrapHook {
+    pub phase: BootstrapHookPhase,
+    pub run: String,
+}
+
+impl BootstrapHook {
+    pub fn from_toml(phase_raw: &str, value: toml::Value) -> Result<Vec<Self>> {
+        let Some(phase) = BootstrapHookPhase::parse(phase_raw) else {
+            bail!("unknown bootstrap hook phase");
+        };
+        let runs = match value {
+            toml::Value::String(run) => vec![run],
+            toml::Value::Array(values) => string_array(values, "expected string commands")?,
+            toml::Value::Table(mut table) => match table.remove("run") {
+                Some(toml::Value::String(run)) => vec![run],
+                Some(toml::Value::Array(values)) => {
+                    string_array(values, "expected `run` to contain string commands")?
+                }
+                Some(_) => bail!("expected `run` to be a string or array of strings"),
+                None => bail!("expected a `run` command"),
+            },
+            _ => bail!("expected a string, array of strings, or table with `run`"),
+        };
+        let hooks = runs
+            .into_iter()
+            .filter_map(|run| {
+                let run = run.trim().to_string();
+                if run.is_empty() {
+                    warn!("[bootstrap.hooks.{phase}]: empty command, ignoring entry");
+                    None
+                } else {
+                    Some(Self { phase, run })
+                }
+            })
+            .collect();
+        Ok(hooks)
+    }
+}
+
+fn string_array(values: Vec<toml::Value>, message: &str) -> Result<Vec<String>> {
+    let mut out = vec![];
+    for value in values {
+        match value {
+            toml::Value::String(s) => out.push(s),
+            _ => bail!("{message}"),
+        }
+    }
+    Ok(out)
+}
+
+pub async fn run_phase(
+    hooks: &[BootstrapHook],
+    phase: BootstrapHookPhase,
+    dry_run: bool,
+) -> Result<()> {
+    let phase_hooks: Vec<_> = hooks.iter().filter(|hook| hook.phase == phase).collect();
+    if phase_hooks.is_empty() {
+        return Ok(());
+    }
+    info!("bootstrap: {phase} hooks");
+    let shell = Settings::get().default_inline_shell()?;
+    for hook in phase_hooks {
+        if dry_run {
+            miseprintln!("{} {}", shell.join(" "), shell_words::quote(&hook.run));
+            continue;
+        }
+        info!("$ {}", hook.run);
+        crate::cmd::CmdLineRunner::new(&shell[0])
+            .cmd_body_args(&shell[1..], &hook.run)
+            .raw(true)
+            .execute_async()
+            .await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_phases_with_hyphen_or_underscore() {
+        assert_eq!(
+            BootstrapHookPhase::parse("pre-packages"),
+            Some(BootstrapHookPhase::PrePackages)
+        );
+        assert_eq!(
+            BootstrapHookPhase::parse("post_tools"),
+            Some(BootstrapHookPhase::PostTools)
+        );
+        assert_eq!(BootstrapHookPhase::parse("nope"), None);
+    }
+
+    #[test]
+    fn parses_hook_values() {
+        let hooks =
+            BootstrapHook::from_toml("pre-packages", toml::Value::String("echo preparing".into()))
+                .unwrap();
+        assert_eq!(
+            hooks,
+            vec![BootstrapHook {
+                phase: BootstrapHookPhase::PrePackages,
+                run: "echo preparing".into(),
+            }]
+        );
+
+        let mut table = toml::map::Map::new();
+        table.insert(
+            "run".into(),
+            toml::Value::Array(vec![
+                toml::Value::String("echo one".into()),
+                toml::Value::String("echo two".into()),
+            ]),
+        );
+        let hooks = BootstrapHook::from_toml("final", toml::Value::Table(table)).unwrap();
+        assert_eq!(hooks.len(), 2);
+        assert_eq!(hooks[1].run, "echo two");
+    }
+}

--- a/src/system/hooks.rs
+++ b/src/system/hooks.rs
@@ -66,7 +66,13 @@ pub struct BootstrapHook {
 impl BootstrapHook {
     pub fn from_toml(phase_raw: &str, value: toml::Value) -> Result<Vec<Self>> {
         let Some(phase) = BootstrapHookPhase::parse(phase_raw) else {
-            bail!("unknown bootstrap hook phase");
+            let valid = BootstrapHookPhase::iter()
+                .map(|phase| phase.as_str())
+                .collect::<Vec<_>>();
+            bail!(
+                "unknown bootstrap hook phase {phase_raw:?}; valid phases are: {}",
+                valid.join(", ")
+            );
         };
         let runs = match value {
             toml::Value::String(run) => vec![run],
@@ -119,14 +125,17 @@ pub async fn run_phase(
     }
     info!("bootstrap: {phase} hooks");
     let shell = Settings::get().default_inline_shell()?;
+    let Some((program, shell_args)) = shell.split_first() else {
+        bail!("default inline shell args must not be empty");
+    };
     for hook in phase_hooks {
         if dry_run {
             miseprintln!("{} {}", shell.join(" "), shell_words::quote(&hook.run));
             continue;
         }
         info!("$ {}", hook.run);
-        crate::cmd::CmdLineRunner::new(&shell[0])
-            .cmd_body_args(&shell[1..], &hook.run)
+        crate::cmd::CmdLineRunner::new(program)
+            .cmd_body_args(shell_args, &hook.run)
             .raw(true)
             .execute_async()
             .await?;
@@ -149,6 +158,16 @@ mod tests {
             Some(BootstrapHookPhase::PostTools)
         );
         assert_eq!(BootstrapHookPhase::parse("nope"), None);
+    }
+
+    #[test]
+    fn unknown_phase_error_lists_valid_phases() {
+        let err = BootstrapHook::from_toml("pre-things", toml::Value::String("echo nope".into()))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("pre-things"));
+        assert!(msg.contains("pre-packages"));
+        assert!(msg.contains("final"));
     }
 
     #[test]

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -3,7 +3,9 @@
 //! This is `[bootstrap.packages]` — declarative system packages installed
 //! by `mise bootstrap packages install` — `[dotfiles]` — declarative config
 //! files applied by `mise dotfiles apply` — `[bootstrap.macos.defaults]`
-//! — declarative macOS user defaults — and `[bootstrap.user].login_shell`.
+//! — declarative macOS user defaults — `[bootstrap.macos.launchd.agents]`
+//! — declarative macOS LaunchAgents — `[bootstrap.user].login_shell` — and
+//! `[bootstrap.hooks]` bootstrap phase hooks.
 //! These are intentionally not part of `[tools]`: they're unversioned,
 //! machine-global settings and resources, not mise's per-project toolset.
 
@@ -23,6 +25,7 @@ use crate::system::packages::{PackageRequest, SystemPackageManager};
 pub mod defaults;
 pub mod edits;
 pub mod files;
+pub mod hooks;
 pub mod launchd;
 pub mod login_shell;
 pub mod packages;
@@ -45,6 +48,10 @@ pub struct BootstrapTomlConfig {
     /// Homebrew-specific bootstrap package config.
     #[serde(default)]
     pub brew: SystemBrewTomlConfig,
+    /// Bootstrap phase hooks. Values stay raw TOML so newer hook shapes can
+    /// warn and be skipped without rejecting the whole config.
+    #[serde(default)]
+    pub hooks: IndexMap<String, toml::Value>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -314,6 +321,25 @@ pub fn login_shell_from_config(config: &Config) -> Option<login_shell::LoginShel
         }
     }
     shell.map(|shell| login_shell::LoginShellRequest { shell })
+}
+
+/// Aggregate `[bootstrap.hooks]` across all loaded config files.
+///
+/// Hooks are additive and ordered global -> local. A hook value can be a string
+/// command, an array of string commands, or a table with a `run` string/array.
+pub fn hooks_from_config(config: &Config) -> Vec<hooks::BootstrapHook> {
+    let mut out = vec![];
+    for cf in config.config_files.values().rev() {
+        if let Some(sys) = cf.bootstrap_config() {
+            for (phase, value) in sys.hooks {
+                match hooks::BootstrapHook::from_toml(&phase, value) {
+                    Ok(hooks) => out.extend(hooks),
+                    Err(err) => warn!("[bootstrap.hooks.{phase}]: {err}"),
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Build [`ManagerPackages`] from explicit CLI specs, attaching configured

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -16,8 +16,7 @@ use eyre::bail;
 use indexmap::IndexMap;
 use serde::Deserialize;
 
-use crate::config::Config;
-use crate::config::ConfigMap;
+use crate::config::{Config, ConfigMap};
 use crate::system::defaults::{DefaultsRequest, DefaultsValue};
 use crate::system::launchd::{LaunchdRequest, LaunchdTomlConfig};
 use crate::system::packages::{PackageRequest, SystemPackageManager};
@@ -328,8 +327,12 @@ pub fn login_shell_from_config(config: &Config) -> Option<login_shell::LoginShel
 /// Hooks are additive and ordered global -> local. A hook value can be a string
 /// command, an array of string commands, or a table with a `run` string/array.
 pub fn hooks_from_config(config: &Config) -> Vec<hooks::BootstrapHook> {
+    hooks_from_config_files(&config.config_files)
+}
+
+pub(crate) fn hooks_from_config_files(config_files: &ConfigMap) -> Vec<hooks::BootstrapHook> {
     let mut out = vec![];
-    for cf in config.config_files.values().rev() {
+    for cf in config_files.values().rev() {
         if let Some(sys) = cf.bootstrap_config() {
             for (phase, value) in sys.hooks {
                 match hooks::BootstrapHook::from_toml(&phase, value) {


### PR DESCRIPTION
## Summary
- add `[bootstrap.hooks]` support for named bootstrap phases such as `pre-packages`, `post-dotfiles`, `post-tools`, and `final`
- execute hook commands via the configured default inline shell, with dry-run output and fail-fast behavior
- document hook syntax and refresh generated CLI usage docs

## Validation
- `cargo fmt --all --check`
- `cargo test bootstrap`
- `cargo test system::hooks`
- `cargo check`
- `mise run render:usage`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hooks execute arbitrary shell during bootstrap (including after dotfiles change config), so misconfiguration can abort setup or run unintended commands; scope is limited to explicit `mise bootstrap` and the experimental bootstrap surface.
> 
> **Overview**
> Adds **`[bootstrap.hooks]`** so `mise bootstrap` can run imperative shell commands at named phases (`pre-packages` through `post-tools`, plus `final` after the bootstrap task). Hook values support a string, string array, or `{ run = ... }`; they merge global→local, use the default inline shell like tasks, fail fast, and print instead of run under `--dry-run`.
> 
> The bootstrap runner now invokes hooks around packages, dotfiles, defaults, user, and tools, **reloads config** after dotfiles apply and tool install so hooks from newly applied mise config files take effect, and on dry-run **parses templated/dotfile mise config targets** so later-phase hooks show up in the preview.
> 
> Docs, generated CLI usage/man, config parsing tests, and e2e coverage for dotfile-sourced hooks are updated. The ubi e2e on linux/amd64 switches from an FFmpeg URL to **fd** as the direct-archive install case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bd40a8fbf9a48a0c30febb0cb7a98b65cc9eed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable bootstrap hooks at named phases (pre/post around packages, dotfiles, defaults, user, tools, plus a final phase); hooks run in the current environment, merge across configs, and respect --dry-run by showing commands.

* **Documentation**
  * Updated docs, CLI help, manpage, examples, and tips to document hook syntax, placement, failure/dry-run behavior, idempotency guidance, and sample hooks.

* **Tests**
  * Added/extended integration and e2e tests verifying hook parsing, phase ordering, execution, and dry-run semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->