### PR TITLE
registry: scope imagemagick aqua backend to windows-x64

### DIFF
--- a/registry/imagemagick.toml
+++ b/registry/imagemagick.toml
@@ -1,6 +1,6 @@
 backends = [
   { full = "aqua:ImageMagick/ImageMagick", platforms = [
-    "windows",
+    "windows-x64",
   ] },
   "conda:imagemagick",
   "asdf:mise-plugins/mise-imagemagick",


### PR DESCRIPTION
## Summary

- Scope the aqua ImageMagick backend to `windows-x64` instead of the broader `windows` platform selector.
- Uses mise's normalized `os-arch` registry platform key (`windows-x64`), not `windows-amd64`, which the registry schema rejects.

Follow-up to https://github.com/jdx/mise/discussions/10296.

## Test plan

- [ ] CI passes (registry schema validation)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ImageMagick backend platform configuration for Windows systems to specify 64-bit compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->