### PR TITLE
test(backend): remove stale ubi ffmpeg fixture

### DIFF
--- a/e2e/backend/test_ubi
+++ b/e2e/backend/test_ubi
@@ -5,12 +5,6 @@ assert "mise x ubi:goreleaser/goreleaser@v1.25.0 -- goreleaser -v | grep -o 1.25
 mise use ubi:kellyjonbrazil/jc@1.25.3
 assert_contains "$MISE_DATA_DIR/shims/jc --version" "jc version:  1.25.3"
 
-# only run on linux/amd64
-if [ "$(uname -m)" = "x86_64" ] && [ "$(uname -s)" = "Linux" ]; then
-  mise use 'ubi:https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz[exe=ffmpeg]'
-  assert_contains "$MISE_DATA_DIR/shims/ffmpeg -version" "ffmpeg version"
-fi
-
 cat <<EOF >mise.toml
 [tools]
 "ubi:cilium/cilium-cli" = { version = "latest", exe = "cilium" }


### PR DESCRIPTION
## Summary
- remove the deprecated ubi FFmpeg e2e fixture
- avoid depending on BtbN's removed `releases/download/latest` FFmpeg asset
- leave ubi backend behavior unchanged because the backend is deprecated

## Failed CI log

From `e2e-7` on PR #10275:

```text
E2E backend/test_ubi
$ mise x ubi:goreleaser/goreleaser@v1.25.0 -- goreleaser -v | grep -o 1.25.0
[mise x ubi:goreleaser/goreleaser@v1.25.0 -- goreleaser -v | grep -o 1.25.0] output is equal to '1.25.0'
$ /tmp/test_ubi.h6XlJf/home/.local/share/mise/shims/jc --version
[/tmp/test_ubi.h6XlJf/home/.local/share/mise/shims/jc --version] 'jc version:  1.25.3' is in output
mise ubi:https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz@latest [1/3] install
Error:
   0: Failed to install ubi:https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz@latest: error requesting https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz: 404 Not Found
      Not Found

Failed e2e tests (1):
  - backend/test_ubi
```

## Test plan
- [ ] Not run locally by request; let CI run the e2e coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test infrastructure setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->