### PR TITLE
fix(plugins): prompt before installing non-registry plugin URLs

### DIFF
--- a/e2e/config/test_trust_safe_config
+++ b/e2e/config/test_trust_safe_config
@@ -39,7 +39,11 @@ cat <<'EOF' >mise.toml
 [tools]
 "vfox:attacker/evil" = "latest"
 EOF
-output=$(MISE_YES=0 mise install 2>&1 || true)
+set +e
+output=$(MISE_YES=0 mise install 2>&1)
+status=$?
+set -e
+[[ $status -ne 0 ]] || fail "expected community plugin install to abort without confirmation"
 echo "$output" | grep -q "community-developed plugin" || fail "expected community plugin prompt, got: $output"
 echo "$output" | grep -q "github.com/attacker/evil" || fail "expected attacker plugin URL, got: $output"
 assert_no_trust_marker "community plugin prompt should not trust config"

--- a/e2e/config/test_trust_safe_config
+++ b/e2e/config/test_trust_safe_config
@@ -34,7 +34,26 @@ MISE_YES=0 mise install tiny
 assert_contains "MISE_YES=0 mise ls tiny" "3.1.0"
 assert_no_trust_marker "safe config should not be silently trusted"
 
+# safe config tool pins still prompt before installing non-registry plugin URLs
+cat <<'EOF' >mise.toml
+[tools]
+"vfox:attacker/evil" = "latest"
+EOF
+output=$(MISE_YES=0 mise install 2>&1 || true)
+echo "$output" | grep -q "community-developed plugin" || fail "expected community plugin prompt, got: $output"
+echo "$output" | grep -q "github.com/attacker/evil" || fail "expected attacker plugin URL, got: $output"
+assert_no_trust_marker "community plugin prompt should not trust config"
+
 # config tasks only execute on explicit `mise run`, so they don't need trust
+cat <<'EOF' >mise.toml
+min_version = "2024.1.1"
+
+[tools]
+tiny = "3.1.0"
+
+[tasks.hi]
+run = "echo task-ran-without-trust"
+EOF
 assert_contains "MISE_YES=0 mise run hi" "task-ran-without-trust"
 
 # template-free file tasks are inert at load time and runnable without trust

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -420,6 +420,13 @@ mod tests {
     }
 
     #[test]
+    fn test_is_trusted_plugin_rejects_non_normalizable_remote() {
+        use super::*;
+
+        assert!(!is_trusted_plugin("cmake", "not-a-url"));
+    }
+
+    #[test]
     fn test_is_trusted_plugin_rejects_non_registry_plugin_url() {
         use super::*;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -192,15 +192,35 @@ pub fn shorts_for_full(full: &str) -> &'static Vec<&'static str> {
 }
 
 pub fn is_trusted_plugin(name: &str, remote: &str) -> bool {
-    let normalized_url = normalize_remote(remote).unwrap_or("INVALID_URL".into());
-    let is_shorthand = REGISTRY
-        .get(name)
-        .and_then(|tool| tool.backends().first().copied())
-        .map(full_to_url)
-        .is_some_and(|s| normalize_remote(&s).unwrap_or_default() == normalized_url);
-    let is_mise_url = normalized_url.starts_with("github.com/mise-plugins/");
+    let Ok(normalized_url) = normalize_remote(remote) else {
+        return false;
+    };
+    if normalized_url.starts_with("github.com/mise-plugins/") {
+        return true;
+    }
 
-    !is_shorthand || is_mise_url
+    let official_registry_plugin_remotes = || {
+        static REMOTES: Lazy<HashSet<String>> = Lazy::new(|| {
+            REGISTRY
+                .values()
+                .flat_map(|tool| tool.backends.iter().map(|backend| backend.full))
+                .filter(|full| full.starts_with("asdf:") || full.starts_with("vfox:"))
+                .filter_map(|full| normalize_remote(&full_to_url(full)).ok())
+                .collect()
+        });
+        &*REMOTES
+    };
+
+    let name_matches_official_remote = REGISTRY.get(name).is_some_and(|tool| {
+        tool.backends
+            .iter()
+            .map(|backend| backend.full)
+            .filter(|full| full.starts_with("asdf:") || full.starts_with("vfox:"))
+            .filter_map(|full| normalize_remote(&full_to_url(full)).ok())
+            .any(|official_remote| official_remote == normalized_url)
+    });
+
+    name_matches_official_remote || official_registry_plugin_remotes().contains(&normalized_url)
 }
 
 pub fn normalize_remote(remote: &str) -> eyre::Result<String> {
@@ -397,5 +417,39 @@ mod tests {
         // Invalid URLs should return an error
         let result = normalize_remote("not-a-url");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_is_trusted_plugin_rejects_non_registry_plugin_url() {
+        use super::*;
+
+        assert!(!is_trusted_plugin(
+            "vfox-attacker-evil",
+            "https://github.com/attacker/evil.git"
+        ));
+    }
+
+    #[test]
+    fn test_is_trusted_plugin_accepts_official_registry_plugin_url() {
+        use super::*;
+
+        assert!(is_trusted_plugin(
+            "cmake",
+            "https://github.com/mise-plugins/vfox-cmake.git"
+        ));
+        assert!(is_trusted_plugin(
+            "vfox-echocat-vfox-mongod",
+            "https://github.com/echocat/vfox-mongod.git"
+        ));
+    }
+
+    #[test]
+    fn test_is_trusted_plugin_rejects_shorthand_mismatch() {
+        use super::*;
+
+        assert!(!is_trusted_plugin(
+            "cmake",
+            "https://github.com/attacker/vfox-cmake.git"
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Tighten plugin trust checks to an explicit allowlist instead of trusting unknown plugin URLs by default.
- Continue allowing `github.com/mise-plugins/*` plugin remotes and official asdf/vfox plugin backend URLs from the registry, including explicit registry backend URLs.
- Add unit and e2e coverage for a safe untrusted config that pins `vfox:attacker/evil` and must show the community plugin prompt before clone.

## Trusted plugin handling
| Plugin source | Before this PR | After this PR |
| --- | --- | --- |
| `github.com/mise-plugins/*` | Trusted without prompt | Trusted without prompt |
| Registry shorthand with matching official plugin URL | Trusted without prompt | Trusted without prompt |
| Explicit asdf/vfox URL matching any registry tool backend, including non-`mise-plugins` owners like `echocat/vfox-mongod` | Trusted without prompt | Trusted without prompt |
| Non-registry asdf/vfox URL such as `vfox:attacker/evil` | Trusted without prompt because it was not a registry shorthand mismatch | Community plugin prompt before clone |
| Invalid or non-normalizable plugin remote | Could fall through as trusted when not treated as a shorthand mismatch | Untrusted; community plugin prompt path applies |

## Context
#10360 is not related to this PR's code changes, but it is why I thought about this attack shape: safe configs can now load plain `[tools]` pins without `mise trust`, so a plain pin like `"vfox:attacker/evil" = "latest"` should not silently clone a non-registry plugin. This keeps that safe-config UX while closing the silent plugin-clone gap.

This is also in the same spirit as #9913: do not implicitly trust install paths or sources just because they are reachable through normal install flows.

## Tests
- `cargo fmt --check`
- `mise x rust -- cargo test registry::tests::test_is_trusted_plugin`
- `MISE_E2E_BIN=/home/risu/.worktrunk/risu729/mise/mise.codex-20260614-004629-bd49fd/target/debug/mise mise run test:e2e e2e/config/test_trust_safe_config`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened plugin trust checks to reject malformed or non-official plugin URLs and reliably recognize official plugin remotes.

* **Tests**
  * Expanded coverage for community plugin trust behavior, including prompts/output when trust is disabled.
  * Added tests confirming tasks defined in configuration run correctly without requiring trust markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->