### PR TITLE
feat(file): support tbz extraction format alias

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -938,7 +938,7 @@ pub enum ExtractionFormat {
     TarXz,
     #[strum(serialize = "xz")]
     Xz,
-    #[strum(serialize = "tar.bz2", serialize = "tbz2")]
+    #[strum(serialize = "tar.bz2", serialize = "tbz2", serialize = "tbz")]
     TarBz2,
     #[strum(serialize = "bz2")]
     Bz2,
@@ -2008,6 +2008,11 @@ mod tests {
             ExtractionFormat::from_file_name("foo.tbz2"),
             ExtractionFormat::TarBz2
         );
+        assert_eq!(
+            ExtractionFormat::from_file_name("foo.tbz"),
+            ExtractionFormat::TarBz2
+        );
+        assert_eq!(ExtractionFormat::from_ext("tbz"), ExtractionFormat::TarBz2);
         assert_eq!(
             ExtractionFormat::from_file_name("foo.tar.zst"),
             ExtractionFormat::TarZst


### PR DESCRIPTION
## Summary
- add `tbz` as an alias for `ExtractionFormat::TarBz2`
- restore coverage for `foo.tbz` filename detection and `from_ext("tbz")`

## Context
This is the first follow-up after #10275. That PR stayed as a pure rename refactor; this PR carries the separate behavior change for the `tbz` tar.bz2 shorthand.

Branched from latest `upstream/main`.

## Test plan
- [x] `mise x cargo -- cargo test file::tests::test_extraction_format_from_file_name`
- [x] `mise x cargo -- cargo fmt --all -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `.tbz` as an additional recognized file extension for TarBz2 compressed archives, providing users with an extra shorthand option alongside the existing `.tar.bz2` and `.tbz2` extensions.

* **Tests**
  * Expanded test coverage to validate proper recognition and handling of `.tbz` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->