### PR TITLE
feat(backend): add pkgx backend

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -129,6 +129,7 @@ export default withMermaid(
                 { text: "http", link: "/dev-tools/backends/http" },
                 { text: "npm", link: "/dev-tools/backends/npm" },
                 { text: "pipx", link: "/dev-tools/backends/pipx" },
+                { text: "pkgx", link: "/dev-tools/backends/pkgx" },
                 { text: "spm", link: "/dev-tools/backends/spm" },
                 { text: "ubi", link: "/dev-tools/backends/ubi" },
                 { text: "vfox", link: "/dev-tools/backends/vfox" },

--- a/docs/dev-tools/backends/index.md
+++ b/docs/dev-tools/backends/index.md
@@ -21,6 +21,7 @@ Below is a list of the available backends in mise:
 - [http](/dev-tools/backends/http)
 - [npm](/dev-tools/backends/npm)
 - [pipx](/dev-tools/backends/pipx)
+- [pkgx](/dev-tools/backends/pkgx) <Badge type="warning" text="experimental" />
 - [s3](/dev-tools/backends/s3)
 - [spm](/dev-tools/backends/spm)
 - [ubi](/dev-tools/backends/ubi)

--- a/docs/dev-tools/backends/pkgx.md
+++ b/docs/dev-tools/backends/pkgx.md
@@ -1,0 +1,44 @@
+# pkgx Backend <Badge type="warning" text="experimental" />
+
+The `pkgx` backend installs packages from the [pkgx pantry](https://github.com/pkgxdev/pantry) without shelling out to the `pkgx` CLI. mise resolves pantry metadata, downloads pkgx bottles from `dist.pkgx.dev`, verifies bottle checksums when available, and writes wrapper scripts that set the package runtime environment.
+
+This backend is experimental. Enable it with:
+
+```sh
+mise settings experimental=true
+```
+
+Or set `MISE_EXPERIMENTAL=1` for a single shell/session.
+
+## Usage
+
+Install a pkgx package by its pantry project name:
+
+```sh
+mise use pkgx:stedolan.github.io/jq@1.7.1
+jq --version
+```
+
+The version will be set in `mise.toml` with the following format:
+
+```toml
+[tools]
+"pkgx:stedolan.github.io/jq" = "1.7.1"
+```
+
+## Lockfiles
+
+The pkgx backend supports [`mise.lock`](/dev-tools/mise-lock). Locking records the main bottle URL and checksum on the tool entry, and records transitive pkgx dependencies in the shared `[pkgx-packages]` lockfile section.
+
+```sh
+mise lock
+mise install --locked
+```
+
+When `--locked` is enabled, mise requires a lockfile URL for the current platform and will fail instead of doing a live pantry resolution if the lockfile is missing or incomplete.
+
+## Notes
+
+- This backend currently supports platforms that pkgx publishes bottles for.
+- Version requirements are resolved from pkgx pantry metadata using npm-style semver ranges.
+- Runtime environment from pantry manifests is applied through generated wrappers.

--- a/e2e/backend/test_pkgx
+++ b/e2e/backend/test_pkgx
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+
+detect_platform
+
+cat <<EOF >mise.toml
+[tools]
+"pkgx:stedolan.github.io/jq" = "1.7.1"
+EOF
+
+assert_fail_contains "MISE_EXPERIMENTAL=0 mise ls-remote pkgx:stedolan.github.io/jq 2>&1" "pkgx backend is experimental"
+assert_fail_contains "mise install --locked 2>&1" "is not in the lockfile"
+
+cat <<EOF >mise.lock
+[[tools."pkgx:stedolan.github.io/jq"]]
+version = "1.7.1"
+backend = "pkgx:stedolan.github.io/jq"
+EOF
+assert_fail_contains "mise install --locked 2>&1" "No lockfile URL found"
+rm -f mise.lock
+
+mise lock --platform "$MISE_PLATFORM"
+assert_contains "cat mise.lock" '[[tools."pkgx:stedolan.github.io/jq"]]'
+assert_contains "cat mise.lock" 'version = "1.7.1"'
+assert_contains "cat mise.lock" 'backend = "pkgx:stedolan.github.io/jq"'
+assert_contains "cat mise.lock" "platforms.$MISE_PLATFORM"
+assert_contains "cat mise.lock" 'url = "https://dist.pkgx.dev/stedolan.github.io/jq/'
+assert_contains "cat mise.lock" 'pkgx_deps = ["github.com/kkos/oniguruma@'
+assert_contains "cat mise.lock" 'pkgx_provides = ["bin/jq"]'
+assert_contains "cat mise.lock" "[pkgx-packages.$MISE_PLATFORM.\"github.com/kkos/oniguruma@"
+assert_contains "cat mise.lock" 'pkgx_provides = ["bin/onig-config"]'
+
+mise install --locked
+assert_contains "mise x -- jq --version" "jq-1.7.1"

--- a/licenses/pkgx-LICENSE.txt
+++ b/licenses/pkgx-LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2022–23 pkgx inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/backend/backend_type.rs
+++ b/src/backend/backend_type.rs
@@ -27,6 +27,7 @@ pub enum BackendType {
     Go,
     Npm,
     Pipx,
+    Pkgx,
     Spm,
     Http,
     S3,
@@ -71,6 +72,7 @@ impl BackendType {
             "go" => BackendType::Go,
             "npm" => BackendType::Npm,
             "pipx" => BackendType::Pipx,
+            "pkgx" => BackendType::Pkgx,
             "spm" => BackendType::Spm,
             "http" => BackendType::Http,
             "s3" => BackendType::S3,
@@ -82,9 +84,10 @@ impl BackendType {
 
     /// Returns true if this backend is still gated behind experimental mode.
     pub fn is_experimental(&self) -> bool {
-        use super::{dotnet, s3, spm};
+        use super::{dotnet, pkgx, s3, spm};
         match self {
             BackendType::Dotnet => dotnet::EXPERIMENTAL,
+            BackendType::Pkgx => pkgx::EXPERIMENTAL,
             BackendType::S3 => s3::EXPERIMENTAL,
             BackendType::Spm => spm::EXPERIMENTAL,
             _ => false,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -68,6 +68,7 @@ pub mod jq;
 pub mod npm;
 pub(crate) mod options;
 pub mod pipx;
+pub mod pkgx;
 pub mod platform_target;
 mod platform_tokens;
 pub mod s3;
@@ -363,6 +364,7 @@ pub fn arg_to_backend(ba: BackendArg) -> Option<ABackend> {
         BackendType::Go => Some(Arc::new(go::GoBackend::from_arg(ba))),
         BackendType::Npm => Some(Arc::new(npm::NPMBackend::from_arg(ba))),
         BackendType::Pipx => Some(Arc::new(pipx::PIPXBackend::from_arg(ba))),
+        BackendType::Pkgx => Some(Arc::new(pkgx::PkgxBackend::from_arg(ba))),
         BackendType::Spm => Some(Arc::new(spm::SPMBackend::from_arg(ba))),
         BackendType::Http => Some(Arc::new(http::HttpBackend::from_arg(ba))),
         BackendType::S3 => Some(Arc::new(s3::S3Backend::from_arg(ba))),
@@ -393,6 +395,7 @@ pub fn install_time_option_keys_for_type(backend_type: &BackendType) -> Vec<Stri
         BackendType::Go => go::install_time_option_keys(),
         BackendType::Npm => npm::install_time_option_keys(),
         BackendType::Pipx => pipx::install_time_option_keys(),
+        BackendType::Pkgx => pkgx::install_time_option_keys(),
         BackendType::Aqua => aqua::install_time_option_keys(),
         BackendType::Spm => spm::install_time_option_keys(),
         _ => vec![],

--- a/src/backend/pkgx.rs
+++ b/src/backend/pkgx.rs
@@ -1,0 +1,1194 @@
+use crate::backend::backend_type::BackendType;
+use crate::backend::platform_target::PlatformTarget;
+use crate::backend::{VersionInfo, runtime_path_for_install_path};
+use crate::cli::args::BackendArg;
+use crate::config::{Config, Settings};
+use crate::file::{ExtractOptions, ExtractionFormat};
+use crate::hash;
+use crate::http::{HTTP, HTTP_FETCH};
+use crate::install_context::InstallContext;
+use crate::lockfile::{self, Lockfile, PlatformInfo};
+use crate::toolset::{ToolRequest, ToolVersion};
+use crate::{backend::Backend, file};
+use async_trait::async_trait;
+use eyre::{Result, WrapErr, bail};
+use indexmap::IndexMap;
+use nodejs_semver::{Range, Version as NodeVersion};
+use serde::Deserialize;
+use serde_yaml::{Mapping, Value};
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+const DIST_URL: &str = "https://dist.pkgx.dev";
+const PANTRY_RAW_URL: &str = "https://raw.githubusercontent.com/pkgxdev/pantry/main/projects";
+pub const EXPERIMENTAL: bool = true;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct PkgxPackageInfo {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checksum: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pkgx_provides: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pkgx_runtime_env: Option<BTreeMap<String, String>>,
+}
+
+pub fn install_time_option_keys() -> Vec<String> {
+    vec![]
+}
+
+#[derive(Debug)]
+pub struct PkgxBackend {
+    ba: Arc<BackendArg>,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedPackage {
+    name: String,
+    version: String,
+    manifest: PackageManifest,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+struct PackageManifest {
+    provides: Vec<String>,
+    dependencies: Value,
+    companions: Value,
+    runtime: RuntimeManifest,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+struct RuntimeManifest {
+    env: Value,
+}
+
+#[async_trait]
+impl Backend for PkgxBackend {
+    fn get_type(&self) -> BackendType {
+        BackendType::Pkgx
+    }
+
+    fn ba(&self) -> &Arc<BackendArg> {
+        &self.ba
+    }
+
+    fn supports_lockfile_url(&self) -> bool {
+        true
+    }
+
+    fn mark_prereleases_from_version_pattern(&self) -> bool {
+        true
+    }
+
+    async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
+        self.ensure_experimental()?;
+        Ok(list_pkg_versions(&self.tool_name()).await?)
+    }
+
+    async fn install_version_(
+        &self,
+        ctx: &InstallContext,
+        mut tv: ToolVersion,
+    ) -> Result<ToolVersion> {
+        self.ensure_experimental()?;
+        let pkgx_root = pkgx_root(&tv);
+        file::create_dir_all(&pkgx_root)?;
+
+        let platform_key = self.get_platform_key();
+        let packages = if tv
+            .lock_platforms
+            .get(&platform_key)
+            .and_then(|p| p.url.as_ref())
+            .is_some()
+        {
+            self.install_from_locked(ctx, &mut tv, &pkgx_root, &platform_key)
+                .await?
+        } else {
+            let target = PlatformTarget::from_current();
+            let packages = resolve_closure(&self.tool_name(), &tv.version, &target).await?;
+            let mut bottles = BTreeMap::new();
+            for package in &packages {
+                let bottle = resolve_bottle_info(&package.name, &package.version, &target).await?;
+                install_package(ctx, &tv, &pkgx_root, package, &bottle).await?;
+                bottles.insert(pkgx_package_id(package), bottle);
+            }
+            self.populate_lock_info(&mut tv, &platform_key, &packages, &bottles)
+                .await?;
+            packages
+        };
+
+        write_wrappers(&tv, &packages)?;
+        Ok(tv)
+    }
+
+    async fn resolve_lock_info(
+        &self,
+        tv: &ToolVersion,
+        target: &PlatformTarget,
+    ) -> Result<PlatformInfo> {
+        self.ensure_experimental()?;
+        let packages = resolve_closure(&self.tool_name(), &tv.version, target).await?;
+        let Some(main) = packages
+            .iter()
+            .find(|package| package.name == self.tool_name())
+        else {
+            return Ok(PlatformInfo::default());
+        };
+        let main_bottle = resolve_bottle_info(&main.name, &main.version, target).await?;
+        let deps = packages
+            .iter()
+            .filter(|package| package.name != main.name)
+            .map(pkgx_package_id)
+            .collect::<Vec<_>>();
+
+        Ok(PlatformInfo {
+            checksum: main_bottle.checksum,
+            url: Some(main_bottle.url),
+            pkgx_deps: Some(deps),
+            pkgx_provides: optional_vec(main.manifest.provided_bins()),
+            pkgx_runtime_env: optional_map(
+                main.manifest
+                    .runtime_env_for_target(target)
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        })
+    }
+
+    async fn list_bin_paths(
+        &self,
+        _config: &Arc<Config>,
+        tv: &ToolVersion,
+    ) -> Result<Vec<PathBuf>> {
+        Ok(vec![runtime_path_for_install_path(
+            tv,
+            tv.install_path().join("bin"),
+        )])
+    }
+
+    fn resolve_lockfile_options(
+        &self,
+        _request: &ToolRequest,
+        _target: &PlatformTarget,
+    ) -> Result<BTreeMap<String, String>> {
+        Ok(BTreeMap::new())
+    }
+}
+
+impl PkgxBackend {
+    pub fn from_arg(ba: BackendArg) -> Self {
+        Self { ba: Arc::new(ba) }
+    }
+
+    fn ensure_experimental(&self) -> Result<()> {
+        Settings::get().ensure_experimental("pkgx backend")
+    }
+
+    fn read_lockfile_for_tool(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<Lockfile> {
+        let (lockfile_path, _) =
+            lockfile::lockfile_path_for_tool_source(&ctx.config, tv.request.source())
+                .ok_or_else(|| eyre::eyre!("could not determine pkgx lockfile path"))?;
+        Lockfile::read(&lockfile_path)
+    }
+
+    async fn install_from_locked(
+        &self,
+        ctx: &InstallContext,
+        tv: &mut ToolVersion,
+        pkgx_root: &Path,
+        platform_key: &str,
+    ) -> Result<Vec<ResolvedPackage>> {
+        let platform_info = tv
+            .lock_platforms
+            .get(platform_key)
+            .ok_or_else(|| eyre::eyre!("no pkgx lock info for platform {platform_key}"))?;
+        let main_url = platform_info
+            .url
+            .clone()
+            .ok_or_else(|| eyre::eyre!("no pkgx URL in lockfile for {}", self.tool_name()))?;
+        let main = ResolvedPackage {
+            name: self.tool_name(),
+            version: tv.version.clone(),
+            manifest: PackageManifest::from_locked_metadata(
+                platform_info.pkgx_provides.clone(),
+                platform_info.pkgx_runtime_env.clone(),
+            ),
+        };
+
+        let lockfile = self.read_lockfile_for_tool(ctx, tv)?;
+        let mut packages = Vec::new();
+        for dep_id in platform_info.pkgx_deps.clone().unwrap_or_default() {
+            let (name, version) = parse_pkgx_package_id(&dep_id)?;
+            let pkg_info = lockfile
+                .get_pkgx_package(platform_key, &dep_id)
+                .ok_or_else(|| {
+                    eyre::eyre!("pkgx package {dep_id} not found in lockfile for {platform_key}")
+                })?
+                .clone();
+            let package = ResolvedPackage {
+                name,
+                version,
+                manifest: PackageManifest::from_locked_metadata(
+                    pkg_info.pkgx_provides.clone(),
+                    pkg_info.pkgx_runtime_env.clone(),
+                ),
+            };
+            install_package(ctx, tv, pkgx_root, &package, &pkg_info).await?;
+            tv.pkgx_packages
+                .insert((platform_key.to_string(), dep_id), pkg_info);
+            packages.push(package);
+        }
+
+        let main_info = PkgxPackageInfo {
+            url: main_url,
+            checksum: platform_info.checksum.clone(),
+            pkgx_provides: platform_info.pkgx_provides.clone(),
+            pkgx_runtime_env: platform_info.pkgx_runtime_env.clone(),
+        };
+        install_package(ctx, tv, pkgx_root, &main, &main_info).await?;
+        packages.push(main);
+
+        Ok(packages)
+    }
+
+    async fn populate_lock_info(
+        &self,
+        tv: &mut ToolVersion,
+        platform_key: &str,
+        packages: &[ResolvedPackage],
+        bottles: &BTreeMap<String, PkgxPackageInfo>,
+    ) -> Result<()> {
+        let Some(main) = packages
+            .iter()
+            .find(|package| package.name == self.tool_name())
+        else {
+            return Ok(());
+        };
+        let main_bottle = bottles
+            .get(&pkgx_package_id(main))
+            .ok_or_else(|| eyre::eyre!("missing pkgx bottle info for {}", pkgx_package_id(main)))?;
+        let deps = packages
+            .iter()
+            .filter(|package| package.name != main.name)
+            .map(pkgx_package_id)
+            .collect::<Vec<_>>();
+
+        let platform_info = tv
+            .lock_platforms
+            .entry(platform_key.to_string())
+            .or_default();
+        platform_info.url = Some(main_bottle.url.clone());
+        platform_info.checksum = main_bottle.checksum.clone();
+        platform_info.pkgx_deps = Some(deps);
+        platform_info.pkgx_provides = optional_vec(main.manifest.provided_bins());
+        platform_info.pkgx_runtime_env = optional_map(
+            main.manifest
+                .runtime_env_for_current_platform()
+                .into_iter()
+                .collect(),
+        );
+
+        for package in packages.iter().filter(|package| package.name != main.name) {
+            let id = pkgx_package_id(package);
+            let bottle = bottles
+                .get(&id)
+                .ok_or_else(|| eyre::eyre!("missing pkgx bottle info for {id}"))?;
+            tv.pkgx_packages.insert(
+                (platform_key.to_string(), id),
+                pkgx_package_info_with_metadata(
+                    bottle,
+                    package.manifest.provided_bins(),
+                    package.manifest.runtime_env_for_current_platform(),
+                ),
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn resolve_pkgx_packages(
+        &self,
+        tv: &ToolVersion,
+        target: &PlatformTarget,
+    ) -> Result<BTreeMap<String, PkgxPackageInfo>> {
+        self.ensure_experimental()?;
+        let packages = resolve_closure(&self.tool_name(), &tv.version, target).await?;
+        let mut result = BTreeMap::new();
+        for package in packages
+            .iter()
+            .filter(|package| package.name != self.tool_name())
+        {
+            let bottle = resolve_bottle_info(&package.name, &package.version, target).await?;
+            result.insert(
+                pkgx_package_id(package),
+                pkgx_package_info_with_metadata(
+                    &bottle,
+                    package.manifest.provided_bins(),
+                    package.manifest.runtime_env_for_target(target),
+                ),
+            );
+        }
+        Ok(result)
+    }
+}
+
+async fn resolve_closure(
+    root_name: &str,
+    root_version: &str,
+    target: &PlatformTarget,
+) -> Result<Vec<ResolvedPackage>> {
+    let mut resolved: IndexMap<String, ResolvedPackage> = IndexMap::new();
+    let mut requirements = BTreeMap::new();
+    let mut pending = vec![root_name.to_string()];
+    requirements.insert(root_name.to_string(), root_version.to_string());
+
+    while let Some(name) = pending.pop() {
+        if resolved.contains_key(&name) {
+            continue;
+        }
+        let requirement = requirements
+            .get(&name)
+            .cloned()
+            .ok_or_else(|| eyre::eyre!("missing pkgx requirement for {name}"))?;
+        let version = resolve_version(&name, &requirement, target).await?;
+        let manifest = fetch_manifest(&name).await?;
+        let deps = manifest.dependencies_for_target(target);
+        let companions = manifest.companions_for_target(target);
+
+        for (dep_name, dep_requirement) in deps.into_iter().chain(companions) {
+            if let Some(package) = resolved.get(&dep_name) {
+                ensure_resolved_requirement(&dep_name, &package.version, &dep_requirement)?;
+                continue;
+            }
+            let next_requirement = if let Some(existing) = requirements.get(&dep_name) {
+                merge_requirements(&dep_name, existing, &dep_requirement)?
+            } else {
+                dep_requirement
+            };
+            if requirements.get(&dep_name) != Some(&next_requirement) {
+                requirements.insert(dep_name.clone(), next_requirement);
+                pending.push(dep_name);
+            }
+        }
+
+        resolved.insert(
+            name.to_string(),
+            ResolvedPackage {
+                name: name.to_string(),
+                version,
+                manifest,
+            },
+        );
+    }
+
+    Ok(resolved.into_values().collect())
+}
+
+async fn resolve_version(name: &str, requirement: &str, target: &PlatformTarget) -> Result<String> {
+    let requirement = requirement.trim();
+    if requirement.is_empty() || requirement == "*" || requirement.eq_ignore_ascii_case("latest") {
+        return latest_version(name, target).await;
+    }
+
+    let versions = list_pkg_versions_for_target(name, target).await?;
+    let version_strings = versions
+        .iter()
+        .map(|v| v.version.as_str())
+        .collect::<Vec<_>>();
+
+    if version_strings.contains(&requirement) {
+        return Ok(requirement.to_string());
+    }
+
+    if let Some(stripped) = requirement.strip_prefix('v')
+        && version_strings.contains(&stripped)
+    {
+        return Ok(stripped.to_string());
+    }
+
+    let range = parse_requirement_range(name, requirement)?;
+
+    version_strings
+        .iter()
+        .rev()
+        .find(|version| semver_satisfies(version, &range))
+        .map(|version| (*version).to_string())
+        .ok_or_else(|| eyre::eyre!("no pkgx version for {name} satisfies {requirement}"))
+}
+
+async fn latest_version(name: &str, target: &PlatformTarget) -> Result<String> {
+    list_pkg_versions_for_target(name, target)
+        .await?
+        .last()
+        .map(|v| v.version.clone())
+        .ok_or_else(|| eyre::eyre!("no pkgx versions found for {name}"))
+}
+
+fn ensure_resolved_requirement(name: &str, version: &str, requirement: &str) -> Result<()> {
+    if version_satisfies_requirement(version, requirement)? {
+        Ok(())
+    } else {
+        bail!("resolved pkgx package {name}@{version} does not satisfy {requirement:?}")
+    }
+}
+
+fn merge_requirements(name: &str, left: &str, right: &str) -> Result<String> {
+    let left = left.trim();
+    let right = right.trim();
+    if is_any_requirement(left) {
+        return Ok(right.to_string());
+    }
+    if is_any_requirement(right) || left == right {
+        return Ok(left.to_string());
+    }
+    let merged = format!("{left} {right}");
+    parse_requirement_range(name, &merged)?;
+    Ok(merged)
+}
+
+fn version_satisfies_requirement(version: &str, requirement: &str) -> Result<bool> {
+    let requirement = requirement.trim();
+    if is_any_requirement(requirement) {
+        return Ok(true);
+    }
+    if version == requirement || version.trim_start_matches(['v', 'V']) == requirement {
+        return Ok(true);
+    }
+    Ok(semver_satisfies(
+        version,
+        &parse_requirement_range("pkgx package", requirement)?,
+    ))
+}
+
+fn is_any_requirement(requirement: &str) -> bool {
+    requirement.is_empty() || requirement == "*" || requirement.eq_ignore_ascii_case("latest")
+}
+
+fn parse_requirement_range(name: &str, requirement: &str) -> Result<Range> {
+    Range::parse(requirement)
+        .or_else(|_| Range::parse(format!("{requirement}.x")))
+        .wrap_err_with(|| {
+            format!("unsupported pkgx version requirement {requirement:?} for {name}")
+        })
+}
+
+fn semver_satisfies(version: &str, range: &Range) -> bool {
+    NodeVersion::parse(version)
+        .or_else(|_| NodeVersion::parse(version.trim_start_matches(['v', 'V'])))
+        .is_ok_and(|version| range.satisfies(&version))
+}
+
+async fn list_pkg_versions(name: &str) -> Result<Vec<VersionInfo>> {
+    list_pkg_versions_for_target(name, &PlatformTarget::from_current()).await
+}
+
+async fn list_pkg_versions_for_target(
+    name: &str,
+    target: &PlatformTarget,
+) -> Result<Vec<VersionInfo>> {
+    let url = format!(
+        "{DIST_URL}/{name}/{}/{}/versions.txt",
+        pkgx_os_for_target(target),
+        pkgx_arch_for_target(target)
+    );
+    let text = HTTP_FETCH
+        .get_text(url)
+        .await
+        .wrap_err_with(|| format!("failed to list pkgx versions for {name}"))?;
+    Ok(text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|version| VersionInfo {
+            version: version.trim_start_matches('v').to_string(),
+            ..Default::default()
+        })
+        .collect())
+}
+
+async fn resolve_bottle_info(
+    name: &str,
+    version: &str,
+    target: &PlatformTarget,
+) -> Result<PkgxPackageInfo> {
+    let base = format!(
+        "{DIST_URL}/{}/{}/{}/v{}",
+        name,
+        pkgx_os_for_target(target),
+        pkgx_arch_for_target(target),
+        version
+    );
+    let mut last_err = None;
+    for extension in ["tar.xz", "tar.gz"] {
+        let url = format!("{base}.{extension}");
+        let checksum_url = format!("{url}.sha256sum");
+        match HTTP_FETCH.get_text(&checksum_url).await {
+            Ok(text) => {
+                let checksum = text
+                    .split_whitespace()
+                    .next()
+                    .ok_or_else(|| eyre::eyre!("empty pkgx checksum file for {name}"))?;
+                return Ok(PkgxPackageInfo {
+                    url,
+                    checksum: Some(format!("sha256:{checksum}")),
+                    pkgx_provides: None,
+                    pkgx_runtime_env: None,
+                });
+            }
+            Err(err) => match HTTP.head(&url).await {
+                Ok(_) => {
+                    return Ok(PkgxPackageInfo {
+                        url,
+                        checksum: None,
+                        pkgx_provides: None,
+                        pkgx_runtime_env: None,
+                    });
+                }
+                Err(head_err) => {
+                    debug!(
+                        "pkgx bottle URL {url} was not reachable after checksum miss: {head_err}"
+                    );
+                    last_err = Some(err);
+                }
+            },
+        }
+    }
+    Err(last_err.unwrap_or_else(|| eyre::eyre!("failed to resolve pkgx bottle for {name}")))
+}
+
+async fn fetch_manifest(name: &str) -> Result<PackageManifest> {
+    let url = format!("{PANTRY_RAW_URL}/{name}/package.yml");
+    let text = HTTP_FETCH
+        .get_text(url)
+        .await
+        .wrap_err_with(|| format!("failed to fetch pkgx pantry manifest for {name}"))?;
+    serde_yaml::from_str(&text)
+        .wrap_err_with(|| format!("failed to parse pkgx manifest for {name}"))
+}
+
+async fn install_package(
+    ctx: &InstallContext,
+    tv: &ToolVersion,
+    pkgx_root: &Path,
+    package: &ResolvedPackage,
+    bottle: &PkgxPackageInfo,
+) -> Result<()> {
+    let prefix = package_prefix(pkgx_root, &package.name, &package.version);
+    if package_is_installed(&prefix, bottle)? {
+        return Ok(());
+    }
+
+    let archive_path = download_bottle(ctx, tv, package, bottle).await?;
+    let format = ExtractionFormat::from_file_name(&archive_path.to_string_lossy());
+    if let Some(checksum) = bottle
+        .checksum
+        .as_deref()
+        .and_then(|c| c.strip_prefix("sha256:"))
+    {
+        hash::ensure_checksum(&archive_path, checksum, Some(ctx.pr.as_ref()), "sha256")?;
+    }
+
+    let parent = prefix.parent().unwrap();
+    file::create_dir_all(parent)?;
+    let tmp = tempfile::Builder::new()
+        .prefix("mise-pkgx-")
+        .tempdir_in(parent)?;
+    file::untar(
+        &archive_path,
+        tmp.path(),
+        format,
+        &ExtractOptions {
+            strip_components: 0,
+            pr: Some(ctx.pr.as_ref()),
+            preserve_mtime: false,
+        },
+    )?;
+    if tmp
+        .path()
+        .join(&package.name)
+        .join(format!("v{}", package.version))
+        .exists()
+    {
+        file::copy_dir_all(tmp.path(), pkgx_root)?;
+    } else {
+        file::rename(tmp.path(), &prefix)?;
+    }
+    if !prefix.exists() {
+        bail!(
+            "pkgx bottle for {} did not contain {}",
+            package.name,
+            prefix.display()
+        );
+    }
+    file::write(package_receipt_path(&prefix), package_receipt(bottle))?;
+    Ok(())
+}
+
+fn package_is_installed(prefix: &Path, bottle: &PkgxPackageInfo) -> Result<bool> {
+    if !prefix.exists() {
+        return Ok(false);
+    }
+    if fs::read_to_string(package_receipt_path(prefix)).ok() == Some(package_receipt(bottle)) {
+        return Ok(true);
+    }
+    file::remove_all(prefix)?;
+    Ok(false)
+}
+
+fn package_receipt_path(prefix: &Path) -> PathBuf {
+    prefix.join(".mise-pkgx.toml")
+}
+
+fn package_receipt(bottle: &PkgxPackageInfo) -> String {
+    let checksum = bottle.checksum.as_deref().unwrap_or_default();
+    format!("url = {:?}\nchecksum = {:?}\n", bottle.url, checksum)
+}
+
+async fn download_bottle(
+    ctx: &InstallContext,
+    tv: &ToolVersion,
+    package: &ResolvedPackage,
+    bottle: &PkgxPackageInfo,
+) -> Result<PathBuf> {
+    let filename = bottle
+        .url
+        .rsplit('/')
+        .next()
+        .unwrap_or("pkgx-bottle.tar.xz");
+    let archive_path = tv.download_path().join(format!(
+        "pkgx-{}-{filename}",
+        package.name.replace('/', "-")
+    ));
+    if archive_path.exists()
+        && let Some(checksum) = bottle
+            .checksum
+            .as_deref()
+            .and_then(|c| c.strip_prefix("sha256:"))
+        && hash::ensure_checksum(&archive_path, checksum, None, "sha256").is_ok()
+    {
+        return Ok(archive_path);
+    }
+
+    ctx.pr
+        .set_message(format!("download pkgx {}", package.name));
+    HTTP.download_file(&bottle.url, &archive_path, Some(ctx.pr.as_ref()))
+        .await?;
+    Ok(archive_path)
+}
+
+fn write_wrappers(tv: &ToolVersion, packages: &[ResolvedPackage]) -> Result<()> {
+    let root = packages
+        .iter()
+        .find(|package| package.name == tv.ba().tool_name)
+        .or_else(|| packages.first())
+        .ok_or_else(|| eyre::eyre!("pkgx install did not resolve any packages"))?;
+
+    let bin_dir = tv.install_path().join("bin");
+    file::create_dir_all(&bin_dir)?;
+    let env = runtime_env(&pkgx_root(tv), packages, &root.name);
+    let provides = root.manifest.provided_bins();
+    let bins = if provides.is_empty() {
+        discover_bins(&package_prefix(&pkgx_root(tv), &root.name, &root.version))?
+    } else {
+        provides
+    };
+
+    for rel_bin in bins {
+        let exe_name = Path::new(&rel_bin)
+            .file_name()
+            .ok_or_else(|| eyre::eyre!("invalid pkgx provided binary path: {rel_bin}"))?
+            .to_string_lossy()
+            .to_string();
+        let target = package_prefix(&pkgx_root(tv), &root.name, &root.version).join(&rel_bin);
+        write_wrapper(&bin_dir.join(exe_name), &target, &env)?;
+    }
+    Ok(())
+}
+
+fn write_wrapper(path: &Path, target: &Path, env: &BTreeMap<String, String>) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let mut script = String::from("#!/usr/bin/env bash\n");
+        for (key, value) in env {
+            if is_path_env_key(key) {
+                script.push_str("export ");
+                script.push_str(key);
+                script.push('=');
+                script.push_str(&shell_quote(value));
+                script.push_str("${");
+                script.push_str(key);
+                script.push_str(":+:${");
+                script.push_str(key);
+                script.push_str("}}\n");
+            } else {
+                script.push_str("export ");
+                script.push_str(key);
+                script.push('=');
+                script.push_str(&shell_quote(value));
+                script.push('\n');
+            }
+        }
+        script.push_str("exec ");
+        script.push_str(&shell_quote(&target.to_string_lossy()));
+        script.push_str(" \"$@\"\n");
+        file::write(path, script)?;
+        file::make_executable(path)?;
+    }
+
+    #[cfg(windows)]
+    {
+        let mut script = String::from("@echo off\r\n");
+        for (key, value) in env {
+            script.push_str("set \"");
+            script.push_str(key);
+            script.push('=');
+            script.push_str(&cmd_escape_value(value));
+            if is_path_env_key(key) {
+                script.push_str(";%");
+                script.push_str(key);
+                script.push('%');
+            }
+            script.push_str("\"\r\n");
+        }
+        script.push('"');
+        script.push_str(&cmd_escape_value(&target.to_string_lossy()));
+        script.push_str("\" %*\r\n");
+        file::write(path.with_extension("cmd"), script)?;
+    }
+
+    Ok(())
+}
+
+fn runtime_env(
+    pkgx_root: &Path,
+    packages: &[ResolvedPackage],
+    root_name: &str,
+) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    prepend_env_paths(&mut env, "PATH", pkg_paths(pkgx_root, packages, "bin"));
+    prepend_env_paths(&mut env, "PATH", pkg_paths(pkgx_root, packages, "sbin"));
+    prepend_env_paths(
+        &mut env,
+        "MANPATH",
+        pkg_paths(pkgx_root, packages, "share/man"),
+    );
+    prepend_env_paths(
+        &mut env,
+        "PKG_CONFIG_PATH",
+        pkg_paths(pkgx_root, packages, "lib/pkgconfig"),
+    );
+    prepend_env_paths(
+        &mut env,
+        "LIBRARY_PATH",
+        pkg_paths(pkgx_root, packages, "lib"),
+    );
+    prepend_env_paths(
+        &mut env,
+        "LD_LIBRARY_PATH",
+        pkg_paths(pkgx_root, packages, "lib"),
+    );
+    prepend_env_paths(
+        &mut env,
+        "DYLD_FALLBACK_LIBRARY_PATH",
+        pkg_paths(pkgx_root, packages, "lib"),
+    );
+    prepend_env_paths(&mut env, "CPATH", pkg_paths(pkgx_root, packages, "include"));
+    prepend_env_paths(
+        &mut env,
+        "XDG_DATA_DIRS",
+        pkg_paths(pkgx_root, packages, "share"),
+    );
+
+    for package in packages
+        .iter()
+        .filter(|package| package.name != root_name)
+        .chain(packages.iter().filter(|package| package.name == root_name))
+    {
+        let prefix = package_prefix(pkgx_root, &package.name, &package.version);
+        for (key, value) in package.manifest.runtime_env_for_current_platform() {
+            env.insert(key, render_pkgx_env_value(&value, &prefix, &env));
+        }
+    }
+
+    if let Some(ca_certs) = packages
+        .iter()
+        .map(|p| package_prefix(pkgx_root, &p.name, &p.version).join("ssl/cert.pem"))
+        .find(|p| p.exists())
+    {
+        env.entry("SSL_CERT_FILE".into())
+            .or_insert_with(|| ca_certs.to_string_lossy().to_string());
+    }
+
+    env
+}
+
+fn pkg_paths(pkgx_root: &Path, packages: &[ResolvedPackage], rel: &str) -> Vec<PathBuf> {
+    packages
+        .iter()
+        .map(|p| package_prefix(pkgx_root, &p.name, &p.version).join(rel))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+fn prepend_env_paths(env: &mut BTreeMap<String, String>, key: &str, paths: Vec<PathBuf>) {
+    if paths.is_empty() {
+        return;
+    }
+    let joined = std::env::join_paths(paths)
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    env.entry(key.to_string())
+        .and_modify(|existing| {
+            let sep = if cfg!(windows) { ";" } else { ":" };
+            *existing = format!("{joined}{sep}{}", existing);
+        })
+        .or_insert(joined);
+}
+
+fn is_path_env_key(key: &str) -> bool {
+    matches!(
+        key,
+        "PATH"
+            | "MANPATH"
+            | "PKG_CONFIG_PATH"
+            | "LIBRARY_PATH"
+            | "LD_LIBRARY_PATH"
+            | "DYLD_FALLBACK_LIBRARY_PATH"
+            | "CPATH"
+            | "XDG_DATA_DIRS"
+    )
+}
+
+fn render_pkgx_env_value(
+    value: &str,
+    prefix: &Path,
+    current_env: &BTreeMap<String, String>,
+) -> String {
+    let mut rendered = value
+        .replace("{{prefix}}", &prefix.to_string_lossy())
+        .replace("{{ prefix }}", &prefix.to_string_lossy());
+    for (key, env_value) in current_env {
+        rendered = rendered.replace(&format!("${key}"), env_value);
+    }
+    rendered
+}
+
+fn discover_bins(prefix: &Path) -> Result<Vec<String>> {
+    let bin = prefix.join("bin");
+    if !bin.exists() {
+        return Ok(vec![]);
+    }
+    Ok(file::ls(&bin)?
+        .into_iter()
+        .filter(|path| path.is_file())
+        .filter_map(|path| {
+            path.file_name()
+                .map(|name| format!("bin/{}", name.to_string_lossy()))
+        })
+        .collect())
+}
+
+fn pkgx_root(tv: &ToolVersion) -> PathBuf {
+    tv.install_path().join("pkgx-root")
+}
+
+fn package_prefix(pkgx_root: &Path, name: &str, version: &str) -> PathBuf {
+    pkgx_root.join(name).join(format!("v{version}"))
+}
+
+fn pkgx_package_id(package: &ResolvedPackage) -> String {
+    format!("{}@{}", package.name, package.version)
+}
+
+fn parse_pkgx_package_id(id: &str) -> Result<(String, String)> {
+    let (name, version) = id
+        .rsplit_once('@')
+        .ok_or_else(|| eyre::eyre!("invalid pkgx package id {id:?}"))?;
+    Ok((name.to_string(), version.to_string()))
+}
+
+fn pkgx_os_for_target(target: &PlatformTarget) -> String {
+    match target.os_name() {
+        "macos" => "darwin".to_string(),
+        "linux" => "linux".to_string(),
+        "windows" => "windows".to_string(),
+        os => os.to_string(),
+    }
+}
+
+fn pkgx_arch_for_target(target: &PlatformTarget) -> String {
+    match target.arch_name() {
+        "x64" => "x86-64".to_string(),
+        "arm64" => "aarch64".to_string(),
+        arch => arch.to_string(),
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(any(windows, test))]
+fn cmd_escape_value(value: &str) -> String {
+    value
+        .replace('^', "^^")
+        .replace('%', "%%")
+        .replace('&', "^&")
+        .replace('|', "^|")
+        .replace('<', "^<")
+        .replace('>', "^>")
+        .replace('"', "^\"")
+}
+
+impl PackageManifest {
+    fn from_locked_metadata(
+        provides: Option<Vec<String>>,
+        runtime_env: Option<BTreeMap<String, String>>,
+    ) -> Self {
+        PackageManifest {
+            provides: provides.unwrap_or_default(),
+            runtime: RuntimeManifest {
+                env: value_from_string_map(runtime_env.unwrap_or_default()),
+            },
+            ..Default::default()
+        }
+    }
+
+    fn provided_bins(&self) -> Vec<String> {
+        self.provides
+            .iter()
+            .filter(|provide| provide.starts_with("bin/") || provide.starts_with("sbin/"))
+            .cloned()
+            .collect()
+    }
+
+    fn dependencies_for_target(&self, target: &PlatformTarget) -> Vec<(String, String)> {
+        dependency_map_for_target(&self.dependencies, target)
+    }
+
+    fn companions_for_target(&self, target: &PlatformTarget) -> Vec<(String, String)> {
+        dependency_map_for_target(&self.companions, target)
+    }
+
+    fn runtime_env_for_current_platform(&self) -> Vec<(String, String)> {
+        string_map_for_current_platform(&self.runtime.env)
+    }
+
+    fn runtime_env_for_target(&self, target: &PlatformTarget) -> Vec<(String, String)> {
+        string_map_for_target(&self.runtime.env, target)
+    }
+}
+
+fn dependency_map_for_target(value: &Value, target: &PlatformTarget) -> Vec<(String, String)> {
+    string_map_for_target(value, target)
+}
+
+fn string_map_for_current_platform(value: &Value) -> Vec<(String, String)> {
+    string_map_for_target(value, &PlatformTarget::from_current())
+}
+
+fn string_map_for_target(value: &Value, target: &PlatformTarget) -> Vec<(String, String)> {
+    let mut out = BTreeMap::new();
+    collect_string_map(value, &mut out);
+    if let Some(mapping) = value.as_mapping() {
+        for key in platform_keys_for_target(target) {
+            if let Some(nested) = mapping.get(Value::String(key)) {
+                collect_string_map(nested, &mut out);
+            }
+        }
+    }
+    out.into_iter().collect()
+}
+
+fn collect_string_map(value: &Value, out: &mut BTreeMap<String, String>) {
+    let Some(mapping) = value.as_mapping() else {
+        return;
+    };
+    for (key, value) in mapping {
+        let Some(key) = yaml_string(key) else {
+            continue;
+        };
+        if is_platform_key(&key) {
+            continue;
+        }
+        if let Some(value) = yaml_string(value) {
+            out.insert(key, value);
+        }
+    }
+}
+
+fn platform_keys_for_target(target: &PlatformTarget) -> Vec<String> {
+    vec![
+        pkgx_os_for_target(target),
+        pkgx_arch_for_target(target),
+        format!(
+            "{}/{}",
+            pkgx_os_for_target(target),
+            pkgx_arch_for_target(target)
+        ),
+    ]
+}
+
+fn is_platform_key(key: &str) -> bool {
+    if matches!(key, "linux" | "darwin" | "windows" | "x86-64" | "aarch64") {
+        return true;
+    }
+    let Some((os, arch)) = key.split_once('/') else {
+        return false;
+    };
+    matches!(os, "linux" | "darwin" | "windows") && matches!(arch, "x86-64" | "aarch64")
+}
+
+fn yaml_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+fn pkgx_package_info_with_metadata(
+    bottle: &PkgxPackageInfo,
+    provides: Vec<String>,
+    runtime_env: Vec<(String, String)>,
+) -> PkgxPackageInfo {
+    PkgxPackageInfo {
+        url: bottle.url.clone(),
+        checksum: bottle.checksum.clone(),
+        pkgx_provides: optional_vec(provides),
+        pkgx_runtime_env: optional_map(runtime_env.into_iter().collect()),
+    }
+}
+
+fn optional_vec(values: Vec<String>) -> Option<Vec<String>> {
+    if values.is_empty() {
+        None
+    } else {
+        Some(values)
+    }
+}
+
+fn optional_map(values: BTreeMap<String, String>) -> Option<BTreeMap<String, String>> {
+    if values.is_empty() {
+        None
+    } else {
+        Some(values)
+    }
+}
+
+fn value_from_string_map(values: BTreeMap<String, String>) -> Value {
+    let mut mapping = Mapping::new();
+    for (key, value) in values {
+        mapping.insert(Value::String(key), Value::String(value));
+    }
+    Value::Mapping(mapping)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_platform_dependencies() {
+        let manifest: PackageManifest = serde_yaml::from_str(
+            r#"
+dependencies:
+  openssl.org: 1.1
+  linux:
+    zlib.net: 1
+  darwin/aarch64:
+    apple.com/xcode/clt: '*'
+  github.com/kkos/oniguruma: 6
+"#,
+        )
+        .unwrap();
+
+        let target = PlatformTarget::from_current();
+        let deps = manifest.dependencies_for_target(&target);
+        assert!(
+            deps.iter()
+                .any(|(name, req)| name == "openssl.org" && req == "1.1")
+        );
+        assert!(
+            deps.iter()
+                .any(|(name, req)| name == "github.com/kkos/oniguruma" && req == "6")
+        );
+        if target.os_name() == "linux" {
+            assert!(
+                deps.iter()
+                    .any(|(name, req)| name == "zlib.net" && req == "1")
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_short_dependency_names() {
+        let manifest: PackageManifest = serde_yaml::from_str(
+            r#"
+dependencies:
+  zlib: 1
+"#,
+        )
+        .unwrap();
+        let target = PlatformTarget::from_current();
+
+        assert_eq!(
+            manifest.dependencies_for_target(&target),
+            vec![("zlib".to_string(), "1".to_string())]
+        );
+    }
+
+    #[test]
+    fn resolves_dependencies_for_target_platform() {
+        let manifest: PackageManifest = serde_yaml::from_str(
+            r#"
+dependencies:
+  common.example: 1
+  linux/x86-64:
+    linux.example: 2
+  darwin/aarch64:
+    macos.example: 3
+"#,
+        )
+        .unwrap();
+        let target = PlatformTarget::new(crate::platform::Platform::parse("linux-x64").unwrap());
+        let deps = manifest.dependencies_for_target(&target);
+
+        assert!(
+            deps.iter()
+                .any(|(name, req)| name == "common.example" && req == "1")
+        );
+        assert!(
+            deps.iter()
+                .any(|(name, req)| name == "linux.example" && req == "2")
+        );
+        assert!(
+            !deps
+                .iter()
+                .any(|(name, req)| name == "macos.example" && req == "3")
+        );
+    }
+
+    #[test]
+    fn quotes_shell_values() {
+        assert_eq!(shell_quote("a'b"), "'a'\\''b'");
+    }
+
+    #[test]
+    fn escapes_cmd_values() {
+        assert_eq!(
+            cmd_escape_value(r#"C:\pkgx & "bin"\100%"#),
+            r#"C:\pkgx ^& ^"bin^"\100%%"#
+        );
+        assert_eq!(cmd_escape_value("a|b<c>d"), "a^|b^<c^>d");
+        assert_eq!(cmd_escape_value("a^b"), "a^^b");
+    }
+}

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -82,6 +82,7 @@ impl BackendProvider for MiseBackendProvider {
                 BackendType::Go => ("go", Some("Install Go modules")),
                 BackendType::Npm => ("npm", Some("Install npm packages globally")),
                 BackendType::Pipx => ("pipx", Some("Install Python CLI tools")),
+                BackendType::Pkgx => ("pkgx", Some("Install pkgx pantry packages")),
                 BackendType::Spm => ("spm", Some("Install Swift packages")),
                 BackendType::Http => ("http", Some("Download files from HTTP URLs")),
                 BackendType::S3 => ("s3", Some("Download from S3 buckets")),

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,5 +1,6 @@
 use crate::backend::backend_type::BackendType;
 use crate::backend::conda::CondaBackend;
+use crate::backend::pkgx::PkgxBackend;
 use crate::backend::platform_target::PlatformTarget;
 use crate::config::{Config, Settings};
 use crate::env;
@@ -50,6 +51,9 @@ pub struct Lockfile {
     /// Basename includes version+build (e.g., "ncurses-6.4-h7ea286d_0")
     #[serde(skip)]
     conda_packages: BTreeMap<String, BTreeMap<String, CondaPackageInfo>>,
+    /// Shared pkgx packages: platform -> package@version -> PkgxPackageInfo
+    #[serde(skip)]
+    pkgx_packages: BTreeMap<String, BTreeMap<String, PkgxPackageInfo>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -234,6 +238,15 @@ pub struct PlatformInfo {
     /// References to conda packages in the shared conda-packages section (by basename)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conda_deps: Option<Vec<String>>,
+    /// References to pkgx packages in the shared pkgx-packages section (by package@version)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pkgx_deps: Option<Vec<String>>,
+    /// Pkgx-provided binaries for the main package, captured for locked installs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pkgx_provides: Option<Vec<String>>,
+    /// Pkgx runtime environment for the main package, captured for locked installs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pkgx_runtime_env: Option<BTreeMap<String, String>>,
     /// Type of provenance verification that succeeded (SLSA carries its URL)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provenance: Option<ProvenanceType>,
@@ -244,6 +257,7 @@ pub struct PlatformInfo {
 
 // Re-export CondaPackageInfo from conda backend for lockfile serialization
 pub use crate::backend::conda::CondaPackageInfo;
+pub use crate::backend::pkgx::PkgxPackageInfo;
 
 impl<'de> Deserialize<'de> for PlatformInfo {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
@@ -262,6 +276,9 @@ impl PlatformInfo {
             && self.url.is_none()
             && self.url_api.is_none()
             && self.conda_deps.is_none()
+            && self.pkgx_deps.is_none()
+            && self.pkgx_provides.is_none()
+            && self.pkgx_runtime_env.is_none()
             && self.provenance.is_none()
     }
 
@@ -323,6 +340,15 @@ impl PlatformInfo {
             url: self.url.clone().or_else(|| other.url.clone()),
             url_api,
             conda_deps: self.conda_deps.clone().or_else(|| other.conda_deps.clone()),
+            pkgx_deps: self.pkgx_deps.clone().or_else(|| other.pkgx_deps.clone()),
+            pkgx_provides: self
+                .pkgx_provides
+                .clone()
+                .or_else(|| other.pkgx_provides.clone()),
+            pkgx_runtime_env: self
+                .pkgx_runtime_env
+                .clone()
+                .or_else(|| other.pkgx_runtime_env.clone()),
             provenance,
             github_attestations: None,
         }
@@ -369,6 +395,28 @@ impl TryFrom<toml::Value> for PlatformInfo {
                     }
                     Some(toml::Value::String(s)) => {
                         bail!("unrecognized github_attestations status {s:?} in lockfile")
+                    }
+                    _ => None,
+                };
+                let pkgx_deps = match t.remove("pkgx_deps") {
+                    Some(toml::Value::Array(arr)) => Some(
+                        arr.into_iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect(),
+                    ),
+                    _ => None,
+                };
+                let pkgx_provides = match t.remove("pkgx_provides") {
+                    Some(toml::Value::Array(arr)) => Some(
+                        arr.into_iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect(),
+                    ),
+                    _ => None,
+                };
+                let pkgx_runtime_env = match t.remove("pkgx_runtime_env") {
+                    Some(toml::Value::Table(table)) => {
+                        Some(string_table_from_toml_value(toml::Value::Table(table))?)
                     }
                     _ => None,
                 };
@@ -420,6 +468,9 @@ impl TryFrom<toml::Value> for PlatformInfo {
                     url,
                     url_api,
                     conda_deps,
+                    pkgx_deps,
+                    pkgx_provides,
+                    pkgx_runtime_env,
                     provenance,
                     github_attestations,
                 })
@@ -448,6 +499,28 @@ impl From<PlatformInfo> for toml::Value {
                 .collect::<Vec<_>>()
                 .into();
             table.insert("conda_deps".to_string(), deps);
+        }
+        if let Some(pkgx_deps) = platform_info.pkgx_deps {
+            let deps: toml::Value = pkgx_deps
+                .into_iter()
+                .map(toml::Value::String)
+                .collect::<Vec<_>>()
+                .into();
+            table.insert("pkgx_deps".to_string(), deps);
+        }
+        if let Some(pkgx_provides) = platform_info.pkgx_provides {
+            let provides: toml::Value = pkgx_provides
+                .into_iter()
+                .map(toml::Value::String)
+                .collect::<Vec<_>>()
+                .into();
+            table.insert("pkgx_provides".to_string(), provides);
+        }
+        if let Some(pkgx_runtime_env) = platform_info.pkgx_runtime_env {
+            table.insert(
+                "pkgx_runtime_env".to_string(),
+                toml::Value::Table(toml_table_from_string_map(pkgx_runtime_env)),
+            );
         }
         if let Some(ref provenance) = platform_info.provenance {
             match provenance {
@@ -489,6 +562,65 @@ impl TryFrom<toml::Value> for CondaPackageInfo {
             _ => bail!("unsupported conda package info format"),
         }
     }
+}
+
+impl TryFrom<toml::Value> for PkgxPackageInfo {
+    type Error = Report;
+    fn try_from(value: toml::Value) -> Result<Self> {
+        match value {
+            toml::Value::Table(mut t) => {
+                let url = t
+                    .remove("url")
+                    .and_then(|v| match v {
+                        toml::Value::String(s) => Some(s),
+                        _ => None,
+                    })
+                    .ok_or_else(|| eyre::eyre!("missing url in pkgx package info"))?;
+                let checksum = match t.remove("checksum") {
+                    Some(toml::Value::String(s)) => Some(s),
+                    _ => None,
+                };
+                let pkgx_provides = match t.remove("pkgx_provides") {
+                    Some(toml::Value::Array(arr)) => Some(
+                        arr.into_iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect(),
+                    ),
+                    _ => None,
+                };
+                let pkgx_runtime_env = match t.remove("pkgx_runtime_env") {
+                    Some(toml::Value::Table(table)) => {
+                        Some(string_table_from_toml_value(toml::Value::Table(table))?)
+                    }
+                    _ => None,
+                };
+                Ok(PkgxPackageInfo {
+                    url,
+                    checksum,
+                    pkgx_provides,
+                    pkgx_runtime_env,
+                })
+            }
+            _ => bail!("unsupported pkgx package info format"),
+        }
+    }
+}
+
+fn string_table_from_toml_value(value: toml::Value) -> Result<BTreeMap<String, String>> {
+    match value {
+        toml::Value::Table(table) => Ok(table
+            .into_iter()
+            .filter_map(|(key, value)| match value {
+                toml::Value::String(value) => Some((key, value)),
+                _ => None,
+            })
+            .collect()),
+        _ => Ok(BTreeMap::new()),
+    }
+}
+
+fn toml_table_from_string_map(values: BTreeMap<String, String>) -> toml::Table {
+    values.into_iter().map(|(k, v)| (k, v.into())).collect()
 }
 
 impl Lockfile {
@@ -537,6 +669,22 @@ impl Lockfile {
             }
         }
 
+        // Parse pkgx-packages section: platform -> package@version -> PkgxPackageInfo
+        if let Some(pkgx_packages) = table.remove("pkgx-packages") {
+            let platforms: toml::Table = pkgx_packages.try_into()?;
+            for (platform, packages) in platforms {
+                let packages_table: toml::Table = packages.try_into()?;
+                for (id, info) in packages_table {
+                    let info: PkgxPackageInfo = info.try_into()?;
+                    lockfile
+                        .pkgx_packages
+                        .entry(platform.clone())
+                        .or_default()
+                        .insert(id, info);
+                }
+            }
+        }
+
         Ok(lockfile)
     }
 
@@ -559,6 +707,40 @@ impl Lockfile {
                 conda_packages.insert(platform.clone(), platform_table.into());
             }
             lockfile.insert("conda-packages".to_string(), conda_packages.into());
+        }
+
+        if !self.pkgx_packages.is_empty() {
+            let mut pkgx_packages = toml::Table::new();
+            for (platform, packages) in &self.pkgx_packages {
+                let mut platform_table = toml::Table::new();
+                for (id, info) in packages {
+                    let mut pkg_table = toml::Table::new();
+                    pkg_table.insert("url".to_string(), info.url.clone().into());
+                    if let Some(checksum) = &info.checksum {
+                        pkg_table.insert("checksum".to_string(), checksum.clone().into());
+                    }
+                    if let Some(provides) = &info.pkgx_provides {
+                        pkg_table.insert(
+                            "pkgx_provides".to_string(),
+                            provides
+                                .iter()
+                                .cloned()
+                                .map(toml::Value::String)
+                                .collect::<Vec<_>>()
+                                .into(),
+                        );
+                    }
+                    if let Some(runtime_env) = &info.pkgx_runtime_env {
+                        pkg_table.insert(
+                            "pkgx_runtime_env".to_string(),
+                            toml::Value::Table(toml_table_from_string_map(runtime_env.clone())),
+                        );
+                    }
+                    platform_table.insert(id.clone(), pkg_table.into());
+                }
+                pkgx_packages.insert(platform.clone(), platform_table.into());
+            }
+            lockfile.insert("pkgx-packages".to_string(), pkgx_packages.into());
         }
 
         // Write tools section
@@ -650,6 +832,17 @@ impl Lockfile {
         self.conda_packages.get(platform)?.get(basename)
     }
 
+    pub fn set_pkgx_package(&mut self, platform: &str, id: &str, info: PkgxPackageInfo) {
+        self.pkgx_packages
+            .entry(platform.to_string())
+            .or_default()
+            .insert(id.to_string(), info);
+    }
+
+    pub fn get_pkgx_package(&self, platform: &str, id: &str) -> Option<&PkgxPackageInfo> {
+        self.pkgx_packages.get(platform)?.get(id)
+    }
+
     /// Remove unreferenced conda packages from the shared section.
     /// A package is unreferenced if no tool's conda_deps references it.
     fn cleanup_unreferenced_conda_packages(&mut self) {
@@ -685,6 +878,36 @@ impl Lockfile {
             .retain(|_, packages| !packages.is_empty());
     }
 
+    fn cleanup_unreferenced_pkgx_packages(&mut self) {
+        let mut referenced: HashMap<String, HashSet<String>> = HashMap::new();
+        for tools in self.tools.values() {
+            for tool in tools {
+                for (platform, info) in &tool.platforms {
+                    if let Some(deps) = &info.pkgx_deps {
+                        for dep in deps {
+                            referenced
+                                .entry(platform.clone())
+                                .or_default()
+                                .insert(dep.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        for (platform, packages) in &mut self.pkgx_packages {
+            let referenced_for_platform = referenced.get(platform);
+            packages.retain(|id, _| {
+                referenced_for_platform
+                    .map(|refs| refs.contains(id))
+                    .unwrap_or(false)
+            });
+        }
+
+        self.pkgx_packages
+            .retain(|_, packages| !packages.is_empty());
+    }
+
     /// Get all platform keys present in the lockfile
     pub fn all_platform_keys(&self) -> BTreeSet<String> {
         let mut platforms = BTreeSet::new();
@@ -713,6 +936,7 @@ impl Lockfile {
             Self::should_keep_tool(short, versions, keep_shorts, keep_backends)
         });
         self.cleanup_unreferenced_conda_packages();
+        self.cleanup_unreferenced_pkgx_packages();
     }
 
     /// Remove entries for a tool whose version is not in the given set.
@@ -725,6 +949,7 @@ impl Lockfile {
             }
         }
         self.cleanup_unreferenced_conda_packages();
+        self.cleanup_unreferenced_pkgx_packages();
     }
 
     /// Return versions of a tool that would be removed by `retain_tool_versions`.
@@ -826,9 +1051,12 @@ impl Lockfile {
                             None
                         }
                     }),
-                    // For conda_deps, always use the new value - None means "no dependencies"
+                    // For dependency lists, always use the new value - None means "no dependencies"
                     // rather than "not computed", so we shouldn't preserve stale deps
                     conda_deps: platform_info.conda_deps,
+                    pkgx_deps: platform_info.pkgx_deps,
+                    pkgx_provides: platform_info.pkgx_provides,
+                    pkgx_runtime_env: platform_info.pkgx_runtime_env,
                     provenance,
                     github_attestations: None,
                 }
@@ -1166,10 +1394,14 @@ pub fn update_lockfiles(
             for ((platform, basename), pkg_info) in &tv.conda_packages {
                 existing_lockfile.set_conda_package(platform, basename, pkg_info.clone());
             }
+            for ((platform, id), pkg_info) in &tv.pkgx_packages {
+                existing_lockfile.set_pkgx_package(platform, id, pkg_info.clone());
+            }
         }
 
         // Clean up any conda packages that are no longer referenced by any tool
         existing_lockfile.cleanup_unreferenced_conda_packages();
+        existing_lockfile.cleanup_unreferenced_pkgx_packages();
 
         existing_lockfile.save(&lockfile_path)?;
     }
@@ -1501,6 +1733,7 @@ pub type LockResolutionResult = (
     Result<PlatformInfo, String>,
     BTreeMap<String, String>,
     BTreeMap<String, CondaPackageInfo>,
+    BTreeMap<String, PkgxPackageInfo>,
 );
 
 /// Resolve lock info for a single tool/platform combination.
@@ -1515,7 +1748,7 @@ pub async fn resolve_tool_lock_info(
 ) -> LockResolutionResult {
     let target = PlatformTarget::new(platform.clone());
 
-    let (info, options, conda_packages) = if let Some(backend) = backend {
+    let (info, options, conda_packages, pkgx_packages) = if let Some(backend) = backend {
         let options = match backend.resolve_lockfile_options(&tv.request, &target) {
             Ok(options) => options,
             Err(e) => {
@@ -1525,6 +1758,7 @@ pub async fn resolve_tool_lock_info(
                     ba.stored_full(),
                     platform,
                     Err(e.to_string()),
+                    BTreeMap::new(),
                     BTreeMap::new(),
                     BTreeMap::new(),
                 );
@@ -1549,7 +1783,32 @@ pub async fn resolve_tool_lock_info(
                 } else {
                     BTreeMap::new()
                 };
-                (Ok(info), options, conda_packages)
+                let pkgx_packages = if backend.get_type() == BackendType::Pkgx {
+                    let pkgx_backend = PkgxBackend::from_arg(ba.clone());
+                    match pkgx_backend.resolve_pkgx_packages(&tv, &target).await {
+                        Ok(packages) => packages,
+                        Err(e) => {
+                            return (
+                                ba.short.clone(),
+                                tv.version.clone(),
+                                ba.stored_full(),
+                                platform,
+                                Err(format!(
+                                    "failed to resolve pkgx packages for {} on {}: {}",
+                                    ba.short,
+                                    target.to_key(),
+                                    e
+                                )),
+                                options,
+                                BTreeMap::new(),
+                                BTreeMap::new(),
+                            );
+                        }
+                    }
+                } else {
+                    BTreeMap::new()
+                };
+                (Ok(info), options, conda_packages, pkgx_packages)
             }
             Err(e) => (
                 Err(format!(
@@ -1560,11 +1819,13 @@ pub async fn resolve_tool_lock_info(
                 )),
                 options,
                 BTreeMap::new(),
+                BTreeMap::new(),
             ),
         }
     } else {
         (
             Err(format!("backend not found for {}", ba.short)),
+            BTreeMap::new(),
             BTreeMap::new(),
             BTreeMap::new(),
         )
@@ -1578,6 +1839,7 @@ pub async fn resolve_tool_lock_info(
         info,
         options,
         conda_packages,
+        pkgx_packages,
     )
 }
 
@@ -1587,7 +1849,7 @@ pub async fn resolve_tool_lock_info(
 /// Returns an error if a github backend tool loses provenance on version upgrade,
 /// which could indicate a supply chain attack.
 pub fn apply_lock_result(lockfile: &mut Lockfile, result: LockResolutionResult) -> Result<()> {
-    let (short, version, backend, platform, info, options, conda_packages) = result;
+    let (short, version, backend, platform, info, options, conda_packages, pkgx_packages) = result;
     let platform_key = platform.to_key();
     if let Ok(ref info) = info {
         if let Some(err) = check_single_tool_provenance(
@@ -1611,6 +1873,9 @@ pub fn apply_lock_result(lockfile: &mut Lockfile, result: LockResolutionResult) 
     }
     for (basename, pkg_info) in conda_packages {
         lockfile.set_conda_package(&platform_key, &basename, pkg_info);
+    }
+    for (id, pkg_info) in pkgx_packages {
+        lockfile.set_pkgx_package(&platform_key, &id, pkg_info);
     }
     Ok(())
 }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -13,7 +13,7 @@ use crate::env;
 use crate::file;
 use crate::hash::hash_to_str;
 use crate::install_before::{BeforeDateSource, resolve_before_date_for_tool_with_source};
-use crate::lockfile::{CondaPackageInfo, LockfileTool, PlatformInfo};
+use crate::lockfile::{CondaPackageInfo, LockfileTool, PkgxPackageInfo, PlatformInfo};
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, tool_request};
 use console::style;
@@ -44,6 +44,8 @@ pub struct ToolVersion {
     pub install_path: Option<PathBuf>,
     /// Conda packages resolved during installation: (platform, basename) -> CondaPackageInfo
     pub conda_packages: BTreeMap<(String, String), CondaPackageInfo>,
+    /// pkgx packages resolved during installation: (platform, package@version) -> PkgxPackageInfo
+    pub pkgx_packages: BTreeMap<(String, String), PkgxPackageInfo>,
 }
 
 impl ToolVersion {
@@ -68,6 +70,7 @@ impl ToolVersion {
             lock_platforms: Default::default(),
             install_path: None,
             conda_packages: Default::default(),
+            pkgx_packages: Default::default(),
         }
     }
 


### PR DESCRIPTION
## Summary
- add a native `pkgx:` backend that resolves pkgx pantry metadata and installs pkgx bottles without shelling out to pkgx
- record pkgx dependency bottles in `mise.lock` via `pkgx_deps` and a shared `[pkgx-packages]` section
- add pkgx's Apache-2.0 license notice under `licenses/`

## Details
The backend lists versions from `dist.pkgx.dev`, fetches pantry `package.yml` metadata, resolves simple semver dependency constraints, verifies bottle checksums, extracts relocatable bottle prefixes into a mise-owned `pkgx-root`, and writes wrappers for provided binaries with the resolved runtime environment.

The lockfile handling mirrors the conda package model: the main package URL/checksum is stored on the tool platform entry, while transitive pkgx package URLs/checksums are stored in the shared `pkgx-packages` section and referenced by `pkgx_deps`.

## Validation
- `cargo fmt --check`
- `cargo check -q`
- `cargo test -q backend::pkgx`
- `cargo test -q lockfile::tests::test_conda_packages`
- temp install smoke for `pkgx:crates.io/ripgrep@14.1.1`
- temp lock + `--locked` install smoke for `pkgx:stedolan.github.io/jq@1.7.1`

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new install path with network downloads, checksum handling, and lockfile schema changes; gated as experimental but still affects supply-chain reproducibility for adopters.
> 
> **Overview**
> Adds an **experimental `pkgx:` backend** so mise can install pkgx pantry packages natively (pantry metadata + `dist.pkgx.dev` bottles, checksum verification, dependency closure, and shell/cmd wrappers with runtime env) without invoking the pkgx CLI. Use is gated behind `experimental` / `MISE_EXPERIMENTAL`.
> 
> **Lockfile support** follows the conda-style model: tool platform entries get bottle URL/checksum plus `pkgx_deps`, `pkgx_provides`, and `pkgx_runtime_env`; transitive packages live in a shared `[pkgx-packages]` section. `ToolVersion` carries resolved pkgx package metadata through install and lock flows; `--locked` installs from the lockfile only.
> 
> Docs, VitePress nav, CLI edit hints, Apache 2.0 license text, unit tests in `pkgx.rs`, and an e2e script for jq lock/install are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ea5f206a4b1f4fc3fa6d1411c7383dceb2e9482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental pkgx backend to install pkgx pantry packages (remote resolution, semver ranges, platform artifacts, checksum support, generated wrappers, runtime env)
  * Lockfile integration for pkgx packages for reproducible installs and pruning

* **Documentation**
  * Docs and sidebar updated with pkgx usage, enablement, and lockfile behavior

* **Tests**
  * End-to-end test validating pkgx lock/install flows

* **Chores**
  * Added Apache 2.0 license file for pkgx inc.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->