### PR TITLE
fix(bootstrap): scope forced dotfile conflicts

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -104,6 +104,10 @@ For a dry run:
 mise bootstrap --dry-run
 ```
 
+By default, bootstrap refuses dotfile conflicts rather than replacing local
+files. Use `mise bootstrap --force-dotfiles` when you explicitly want the
+dotfiles phase to replace conflicting whole-file dotfile targets.
+
 ## Inspecting State
 
 Use the narrower commands when you want to inspect one part of the bootstrap

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -44,13 +44,13 @@ Print what would happen without installing anything
 
 Skip confirmation prompts
 
-### `--update`
-
-Refresh system package manager metadata first (apt: `apt-get update`)
-
 ### `--force-dotfiles`
 
 Overwrite existing files that conflict with whole-file dotfile entries
+
+### `--update`
+
+Refresh system package manager metadata first (apt: `apt-get update`)
 
 ## Subcommands
 

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -48,6 +48,10 @@ Skip confirmation prompts
 
 Refresh system package manager metadata first (apt: `apt-get update`)
 
+### `--force-dotfiles`
+
+Overwrite existing files that conflict with whole-file dotfile entries
+
 ## Subcommands
 
 - [`mise bootstrap launchd <SUBCOMMAND>`](/cli/bootstrap/launchd.md)
@@ -60,6 +64,7 @@ Examples:
 
 ```
 mise bootstrap                    # packages + dotfiles + tools + bootstrap task
+mise bootstrap --force-dotfiles   # replace conflicting dotfile targets
 mise bootstrap packages install --yes
 mise bootstrap macos-defaults status
 mise bootstrap launchd apply --dry-run

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -145,6 +145,10 @@ directory where a symlink should go, or a directory where a file should go,
 is an error listing the conflicting paths. Pass
 `mise dotfiles apply --force` to replace them.
 
+For symlink entries, an existing regular file with identical content to the
+source is converged without `--force` by replacing it with the requested
+symlink. If the content differs, mise still treats it as a conflict.
+
 Content updates are not conflicts: a `copy` or `template` entry overwrites
 the target file's content without `--force` — that is the declared intent of
 those modes. Symlinks are re-pointed freely, since a symlink is never data.

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -50,7 +50,11 @@ program = "~/.local/bin/my-sync"
 run_at_load = true
 EOF
 assert_succeed "mise bootstrap --dry-run"
-assert_contains "mise bootstrap launchd status" "skipped"
+if [[ $(uname) == "Darwin" ]]; then
+  assert_contains "mise bootstrap launchd status" "my-sync"
+else
+  assert_contains "mise bootstrap launchd status" "skipped"
+fi
 
 # systemd user services are declarative and safe to inspect in dry-runs
 cat <<EOF >mise.toml
@@ -92,6 +96,18 @@ assert_fail "cat final_hook_ran"
 assert_succeed "mise bootstrap --yes"
 assert "cat post_dotfiles_hook_ran" "post-dotfiles"
 assert "cat final_hook_ran" "final"
+
+# bootstrap refuses dotfile conflicts unless scoped force is requested
+echo "bootstrap source" >dotfiles/bootstrap-force
+cat <<EOF >mise.toml
+[dotfiles]
+"~/.bootstrap-force-dotfiles" = "dotfiles/bootstrap-force"
+EOF
+echo "local content" >~/.bootstrap-force-dotfiles
+assert_fail "mise bootstrap --yes" "use --force-dotfiles"
+assert "cat ~/.bootstrap-force-dotfiles" "local content"
+assert_succeed "mise bootstrap --yes --force-dotfiles"
+assert "readlink ~/.bootstrap-force-dotfiles" "$PWD/dotfiles/bootstrap-force"
 
 # dry-run previews hooks from templated config dotfiles
 cat <<'EOF' >dotfiles/mise/config.local.toml.tmpl

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -151,6 +151,10 @@ assert "cat ~/.local/copydir/unmanaged" "keep me"
 
 # a real file where a symlink should go is a conflict: not clobbered
 rm ~/.gitconfig
+cat dotfiles/gitconfig >~/.gitconfig
+assert_succeed "mise dotfiles apply --yes"
+assert "readlink ~/.gitconfig" "$PWD/dotfiles/gitconfig"
+rm ~/.gitconfig
 echo "precious" >~/.gitconfig
 assert_fail "mise dotfiles apply --yes"
 assert "cat ~/.gitconfig" "precious"

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -151,6 +151,7 @@ assert "cat ~/.local/copydir/unmanaged" "keep me"
 
 # a real file where a symlink should go is a conflict: not clobbered
 rm ~/.gitconfig
+# identical content: regular file converges to symlink without --force
 cat dotfiles/gitconfig >~/.gitconfig
 assert_succeed "mise dotfiles apply --yes"
 assert "readlink ~/.gitconfig" "$PWD/dotfiles/gitconfig"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -837,6 +837,9 @@ Print what would happen without installing anything
 \fB\-y, \-\-yes\fR
 Skip confirmation prompts
 .TP
+\fB\-\-force\-dotfiles\fR
+Overwrite existing files that conflict with whole\-file dotfile entries
+.TP
 \fB\-\-update\fR
 Refresh system package manager metadata first (apt: `apt\-get update`)
 .SH "MISE BOOTSTRAP LAUNCHD APPLY"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -316,6 +316,7 @@ databases, etc.) — it runs with the installed tools on PATH.
 Examples:
 
     $ mise bootstrap                    # packages + dotfiles + tools + bootstrap task
+    $ mise bootstrap --force-dotfiles   # replace conflicting dotfile targets
     $ mise bootstrap packages install --yes
     $ mise bootstrap macos-defaults status
     $ mise bootstrap launchd apply --dry-run
@@ -326,6 +327,7 @@ Examples:
     flag "-n --dry-run" help="Print what would happen without installing anything"
     flag "-y --yes" help="Skip confirmation prompts"
     flag --update help="Refresh system package manager metadata first (apt: `apt-get update`)"
+    flag --force-dotfiles help="Overwrite existing files that conflict with whole-file dotfile entries"
     cmd launchd subcommand_required=#true help="Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`" {
         cmd apply {
             flag "-n --dry-run" help="Print the commands that would run without running them"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -326,8 +326,8 @@ Examples:
 """#
     flag "-n --dry-run" help="Print what would happen without installing anything"
     flag "-y --yes" help="Skip confirmation prompts"
-    flag --update help="Refresh system package manager metadata first (apt: `apt-get update`)"
     flag --force-dotfiles help="Overwrite existing files that conflict with whole-file dotfile entries"
+    flag --update help="Refresh system package manager metadata first (apt: `apt-get update`)"
     cmd launchd subcommand_required=#true help="Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`" {
         cmd apply {
             flag "-n --dry-run" help="Print the commands that would run without running them"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -65,6 +65,10 @@ pub struct Bootstrap {
     /// Refresh system package manager metadata first (apt: `apt-get update`)
     #[clap(long)]
     update: bool,
+
+    /// Overwrite existing files that conflict with whole-file dotfile entries
+    #[clap(long)]
+    force_dotfiles: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -276,9 +280,8 @@ impl Bootstrap {
             let opts = system::files::ApplyOpts {
                 dry_run: self.dry_run,
                 verbose: false,
-                // conflicts shouldn't be steamrolled by a bootstrap;
-                // `mise dotfiles apply --force` is the explicit way
-                force: false,
+                force: self.force_dotfiles,
+                force_hint: "use --force-dotfiles or run `mise dotfiles apply --force`",
                 yes: self.yes,
             };
             system::files::apply(&config, &files, &opts)?;
@@ -917,6 +920,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
     $ <bold>mise bootstrap</bold>                    # packages + dotfiles + tools + bootstrap task
+    $ <bold>mise bootstrap --force-dotfiles</bold>   # replace conflicting dotfile targets
     $ <bold>mise bootstrap packages install --yes</bold>
     $ <bold>mise bootstrap macos-defaults status</bold>
     $ <bold>mise bootstrap launchd apply --dry-run</bold>

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -62,13 +62,13 @@ pub struct Bootstrap {
     #[clap(long, short)]
     yes: bool,
 
-    /// Refresh system package manager metadata first (apt: `apt-get update`)
-    #[clap(long)]
-    update: bool,
-
     /// Overwrite existing files that conflict with whole-file dotfile entries
     #[clap(long)]
     force_dotfiles: bool,
+
+    /// Refresh system package manager metadata first (apt: `apt-get update`)
+    #[clap(long)]
+    update: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/cli/dotfiles/apply.rs
+++ b/src/cli/dotfiles/apply.rs
@@ -66,6 +66,7 @@ impl DotfilesApply {
                 dry_run: self.dry_run,
                 verbose: Settings::get().verbose,
                 force: self.force,
+                force_hint: "use --force",
                 yes: self.yes,
             };
             system::files::apply(&config, &files, &opts)?;

--- a/src/cli/dotfiles/edit.rs
+++ b/src/cli/dotfiles/edit.rs
@@ -156,6 +156,7 @@ async fn apply_target(target: &str) -> Result<()> {
             dry_run: false,
             verbose: false,
             force: false,
+            force_hint: "use `mise dotfiles apply --force`",
             yes: true,
         };
         system::files::apply(&config, &files, &opts)?;

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -847,7 +847,11 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
             if !(target.exists() && !target.is_symlink()) {
                 return Ok(false);
             }
-            if source.is_file() && target.is_file() && file::read(source)? == file::read(target)? {
+            if source.is_file()
+                && target.is_file()
+                && source.metadata()?.len() == target.metadata()?.len()
+                && file::read(source)? == file::read(target)?
+            {
                 return Ok(false);
             }
             Ok(true)

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -713,6 +713,7 @@ pub struct ApplyOpts {
     /// replace conflicting targets (existing real files where a symlink
     /// should go, or type mismatches) instead of erroring
     pub force: bool,
+    pub force_hint: &'static str,
     pub yes: bool,
 }
 
@@ -779,7 +780,8 @@ pub fn apply(config: &Config, requests: &[FileRequest], opts: &ApplyOpts) -> Res
     }
     if !conflicts.is_empty() && !opts.force {
         problems.push(format!(
-            "refusing to overwrite existing files (use --force):\n{}",
+            "refusing to overwrite existing files ({}):\n{}",
+            opts.force_hint,
             conflicts
                 .iter()
                 .map(|p| format!("  {}", p.display_user()))
@@ -838,17 +840,23 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
     // on Windows, file "symlinks" are applied as copies (see `link_path`),
     // so existing regular-file targets are routine content updates there,
     // not conflicts — only a type mismatch blocks
-    let file_link_conflicts = |source: &Path, target: &Path| {
+    let file_link_conflicts = |source: &Path, target: &Path| -> Result<bool> {
         if cfg!(windows) && source.is_file() {
-            target.exists() && target.is_dir()
+            return Ok(target.exists() && target.is_dir());
         } else {
-            target.exists() && !target.is_symlink()
+            if !(target.exists() && !target.is_symlink()) {
+                return Ok(false);
+            }
+            if source.is_file() && target.is_file() && file::read(source)? == file::read(target)? {
+                return Ok(false);
+            }
+            Ok(true)
         }
     };
     let mut out = vec![];
     match req.mode {
         FileMode::Symlink => {
-            if file_link_conflicts(&req.source, &req.target) {
+            if file_link_conflicts(&req.source, &req.target)? {
                 out.push(req.target.clone());
             }
         }
@@ -861,7 +869,7 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
                 }
             }
             for (source, target) in walk_source_files(req)? {
-                if file_link_conflicts(&source, &target) {
+                if file_link_conflicts(&source, &target)? {
                     out.push(target);
                 }
             }

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -842,9 +842,9 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
     // not conflicts — only a type mismatch blocks
     let file_link_conflicts = |source: &Path, target: &Path| -> Result<bool> {
         if cfg!(windows) && source.is_file() {
-            return Ok(target.exists() && target.is_dir());
+            Ok(target.exists() && target.is_dir())
         } else {
-            if !(target.exists() && !target.is_symlink()) {
+            if !target.exists() || target.is_symlink() {
                 return Ok(false);
             }
             if source.is_file()

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -837,6 +837,16 @@ pub fn apply(config: &Config, requests: &[FileRequest], opts: &ApplyOpts) -> Res
 /// content overwrites by copy/template (those are the declared intent) or
 /// re-pointing symlinks (always mise-owned territory)
 fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
+    let regular_files_have_same_content = |source: &Path, target: &Path| -> Result<bool> {
+        if !source.is_file() || !target.is_file() {
+            return Ok(false);
+        }
+        if source.metadata()?.len() != target.metadata()?.len() {
+            return Ok(false);
+        }
+        Ok(file::read(source)? == file::read(target)?)
+    };
+
     // on Windows, file "symlinks" are applied as copies (see `link_path`),
     // so existing regular-file targets are routine content updates there,
     // not conflicts — only a type mismatch blocks
@@ -847,14 +857,9 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
             if !target.exists() || target.is_symlink() {
                 return Ok(false);
             }
-            if source.is_file()
-                && target.is_file()
-                && source.metadata()?.len() == target.metadata()?.len()
-                && file::read(source)? == file::read(target)?
-            {
-                return Ok(false);
-            }
-            Ok(true)
+            // If this equality check cannot read either side, keep the
+            // conservative conflict path so --force can still handle it.
+            Ok(!regular_files_have_same_content(source, target).unwrap_or(false))
         }
     };
     let mut out = vec![];

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1107,6 +1107,12 @@ const completionSpec: Fig.Spec = {
           isRepeatable: false,
         },
         {
+          name: "--force-dotfiles",
+          description:
+            "Overwrite existing files that conflict with whole-file dotfile entries",
+          isRepeatable: false,
+        },
+        {
           name: "--update",
           description:
             "Refresh system package manager metadata first (apt: `apt-get update`)",


### PR DESCRIPTION
## Summary
- add `mise bootstrap --force-dotfiles` for explicitly replacing conflicting whole-file dotfile targets during bootstrap
- allow symlink dotfiles to replace an existing regular file without force when the content is identical
- make dotfile conflict hints caller-specific and document the bootstrap behavior

## Tests
- `cargo fmt --all -- --check`
- `mise run render:usage`
- `mise run test:e2e e2e/cli/test_bootstrap`
- `mise run test:e2e e2e/cli/test_dotfiles_files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem overwrite behavior during bootstrap and dotfile apply; mistakes could replace local files, though defaults remain conservative and force is explicit.
> 
> **Overview**
> Adds **`mise bootstrap --force-dotfiles`** so the bootstrap dotfiles step can replace conflicting whole-file targets only when you opt in; without it, bootstrap still errors on conflicts and points you at **`--force-dotfiles`** or **`mise dotfiles apply --force`**.
> 
> Symlink apply now treats an existing regular file as a **non-conflict** when its bytes match the source, and replaces it with the symlink without **`--force`**; differing content still requires force. Conflict messages use a caller-specific **`force_hint`** on **`ApplyOpts`** instead of always saying **`--force`**.
> 
> Docs, usage spec, man page, and shell completions are updated; e2e tests cover bootstrap force behavior, identical-file symlink convergence, and OS-conditional launchd status expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4373c06ca1a28c73a64dad3c8dd070bcc2a7245a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --force-dotfiles to allow overwriting conflicting whole-file dotfile targets.
  * Refined symlink conflict handling: on non-Windows platforms, identical file contents are converted to symlinks without requiring force.

* **Documentation**
  * Updated help text, man page, CLI completion, and docs with the new flag, examples, and conflict guidance.

* **Tests**
  * Expanded e2e tests to cover dotfile conflict handling and bootstrap scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->