### PR TITLE
refactor(file): return option from extraction format parsing

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -2297,11 +2297,10 @@ impl AquaBackend {
 
     fn effective_extraction_format(pkg: &AquaPackage, format: &str) -> Result<ExtractionFormat> {
         let extraction_format = ExtractionFormat::from_ext(format);
-        if extraction_format == ExtractionFormat::Raw
-            && !matches!(format, "" | "raw" | "dmg" | "pkg")
-        {
+        if extraction_format.is_none() && !matches!(format, "" | "dmg" | "pkg") {
             bail!("unsupported aqua package format: {format}");
         }
+        let extraction_format = extraction_format.unwrap_or(ExtractionFormat::Raw);
         if pkg.r#type == AquaPackageType::GithubArchive
             && extraction_format == ExtractionFormat::Raw
         {

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1989,7 +1989,7 @@ impl UnifiedGitBackend {
     ) -> Result<bool> {
         let raw_opts = tv.request.options();
         let format = if let Some(format_opt) = lookup_with_fallback(&raw_opts, "format") {
-            file::ExtractionFormat::from_ext(&format_opt)
+            file::ExtractionFormat::from_ext(&format_opt).unwrap_or(file::ExtractionFormat::Raw)
         } else {
             file::ExtractionFormat::from_file_name(
                 &file_path.file_name().unwrap_or_default().to_string_lossy(),

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -402,7 +402,7 @@ pub fn install_artifact(
     // Use ExtractionFormat for format detection
     // Check for explicit format option first, then fall back to file extension
     let format = if let Some(format_opt) = lookup_with_fallback(opts, "format") {
-        file::ExtractionFormat::from_ext(&format_opt)
+        file::ExtractionFormat::from_ext(&format_opt).unwrap_or(file::ExtractionFormat::Raw)
     } else {
         file::ExtractionFormat::from_file_name(
             &file_path.file_name().unwrap_or_default().to_string_lossy(),

--- a/src/file.rs
+++ b/src/file.rs
@@ -979,21 +979,20 @@ impl ExtractionFormat {
 
         if let Some(idx) = filename.rfind(".tar.") {
             let ext = &filename[idx + 1..];
-            let fmt = Self::from_ext(ext);
-            if fmt != ExtractionFormat::Raw {
+            if let Some(fmt) = Self::from_ext(ext) {
                 return fmt;
             }
         }
 
         if let Some(ext) = Path::new(&filename).extension().and_then(|s| s.to_str()) {
-            Self::from_ext(ext)
+            Self::from_ext(ext).unwrap_or(ExtractionFormat::Raw)
         } else {
             ExtractionFormat::Raw
         }
     }
 
-    pub fn from_ext(ext: &str) -> Self {
-        ext.to_lowercase().parse().unwrap_or(ExtractionFormat::Raw)
+    pub fn from_ext(ext: &str) -> Option<Self> {
+        ext.to_lowercase().parse().ok()
     }
 
     pub fn is_archive(&self) -> bool {
@@ -2067,7 +2066,10 @@ mod tests {
             ExtractionFormat::from_file_name("foo.tbz"),
             ExtractionFormat::TarBz2
         );
-        assert_eq!(ExtractionFormat::from_ext("tbz"), ExtractionFormat::TarBz2);
+        assert_eq!(
+            ExtractionFormat::from_ext("tbz"),
+            Some(ExtractionFormat::TarBz2)
+        );
         assert_eq!(
             ExtractionFormat::from_file_name("foo.tar.zst"),
             ExtractionFormat::TarZst
@@ -2172,9 +2174,9 @@ mod tests {
             ("sz", ExtractionFormat::Sz),
             ("rar", ExtractionFormat::Rar),
         ] {
-            assert_eq!(ExtractionFormat::from_ext(ext), expected);
-            assert_ne!(ExtractionFormat::from_ext(ext), ExtractionFormat::Raw);
+            assert_eq!(ExtractionFormat::from_ext(ext), Some(expected));
         }
+        assert_eq!(ExtractionFormat::from_ext("unknown"), None);
 
         assert!(ExtractionFormat::TarBr.is_archive());
         assert!(ExtractionFormat::TarLz4.is_archive());

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -232,8 +232,7 @@ impl JavaPlugin {
         let format = m
             .file_type
             .as_deref()
-            .map(ExtractionFormat::from_ext)
-            .filter(|f| *f != ExtractionFormat::Raw)
+            .and_then(ExtractionFormat::from_ext)
             .unwrap_or_else(|| ExtractionFormat::from_file_name(&filename));
         file::extract_archive(
             tarball_path,


### PR DESCRIPTION
## Summary
- change `ExtractionFormat::from_ext` to return `Option<ExtractionFormat>` instead of silently falling back to `Raw`
- keep filename detection and legacy explicit-format callers falling back to `Raw` where they already did
- simplify Java metadata format handling by using `and_then` for recognized file types

## Tests
- `cargo fmt`
- `cargo test test_extraction_format_from_file_name`
- `cargo test effective_extraction_format`
- `cargo check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive format detection to gracefully handle unsupported or unrecognized file formats by defaulting to raw extraction mode instead of failing, enhancing compatibility with various archive types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->