### PR TITLE
fix(file): atomically replace symlinks to avoid spurious EEXIST warnings

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -9,6 +9,8 @@ use std::os::unix::fs::symlink;
 #[cfg(unix)]
 use std::os::unix::prelude::*;
 use std::sync::Mutex;
+#[cfg(unix)]
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use bzip2::read::BzDecoder;
@@ -487,11 +489,31 @@ pub fn recursive_ls(dir: &Path) -> Result<BTreeSet<PathBuf>> {
 #[cfg(unix)]
 pub fn make_symlink(target: &Path, link: &Path) -> Result<(PathBuf, PathBuf)> {
     trace!("ln -sf {} {}", target.display(), link.display());
-    if link.is_file() || link.is_symlink() {
-        fs::remove_file(link)?;
-    }
-    symlink(target, link)
+    // Create the symlink at a unique temporary name in the same directory, then
+    // atomically rename it over `link`. rename(2) replaces an existing path in a
+    // single step, so concurrent mise processes racing to create the same link all
+    // succeed (last writer wins) instead of one failing with EEXIST — which showed
+    // up as spurious "failed to ln -sf ...: File exists (os error 17)" warnings
+    // when several mise invocations start at once (e.g. spawning a git worktree,
+    // #10292). Approach based on the closed PR #9701.
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let file_name = link
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("symlink");
+    let tmp = link.with_file_name(format!(
+        ".{file_name}.tmp.{}.{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = fs::remove_file(&tmp);
+    symlink(target, &tmp)
         .wrap_err_with(|| format!("failed to ln -sf {} {}", target.display(), link.display()))?;
+    if let Err(err) = fs::rename(&tmp, link) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err)
+            .wrap_err_with(|| format!("failed to ln -sf {} {}", target.display(), link.display()));
+    }
     Ok((target.to_path_buf(), link.to_path_buf()))
 }
 
@@ -1685,6 +1707,37 @@ mod tests {
     use crate::config::Config;
 
     use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn test_make_symlink_creates_and_atomically_replaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_a = dir.path().join("a");
+        let target_b = dir.path().join("b");
+        fs::write(&target_a, "a").unwrap();
+        fs::write(&target_b, "b").unwrap();
+        let link = dir.path().join("link");
+
+        // Creates a new symlink.
+        make_symlink(&target_a, &link).unwrap();
+        assert_eq!(fs::read_link(&link).unwrap(), target_a);
+
+        // Atomically replaces an existing symlink (no EEXIST).
+        make_symlink(&target_b, &link).unwrap();
+        assert_eq!(fs::read_link(&link).unwrap(), target_b);
+
+        // The temporary symlink is consumed by the rename — nothing left behind.
+        let leftovers: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .map(|e| e.file_name())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temp symlink left behind: {leftovers:?}"
+        );
+    }
 
     #[test]
     fn test_archive_content_files_tar_hashes_regular_files() {


### PR DESCRIPTION
## Problem

Spawning a new git worktree sometimes prints:

```
mise WARN tracking config: failed to ln -sf <config> ~/.local/state/mise/tracked-configs/<hash>: File exists (os error 17)
```

Reported in #10292. It''s harmless (the link ends up correct) but noisy.

## Root cause

Unix `make_symlink` (`src/file.rs`) removed any existing link and then created the new one in two separate steps:

```rust
if link.is_file() || link.is_symlink() { fs::remove_file(link)?; }
symlink(target, link)?;
```

When several mise processes start at nearly the same moment — exactly what happens on worktree spawn (shell prompt `hook-env`, direnv, editor integrations) — one can create `link` in the window between another process''s check/remove and its `symlink()` call, so that `symlink()` fails with `EEXIST`, surfaced as the warning above. (The Windows path already retried on `AlreadyExists`.)

## Fix

Create the symlink at a unique temp name in the same directory and atomically `rename(2)` it over the destination. `rename` replaces an existing path in a single step, so concurrent creators of the same link all succeed (last-writer-wins). The link content is deterministic (e.g. for tracked configs the name is a hash of the target path), so last-writer-wins is safe. The Windows path is unchanged.

This is the approach from the closed PR #9701 by @garriguv (auto-closed for inactivity); credit to them.

## Testing

- Unit test (`#[cfg(unix)]`): `make_symlink` creates a new symlink, atomically replaces an existing one without error, and leaves no temp files behind.
- `cargo fmt --all -- --check` passes. The `AtomicU64`/`Ordering` import used by the (unix-only) helper is gated with `#[cfg(unix)]` so the Windows `-Dwarnings` build doesn''t trip on an unused import.

Addresses #10292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of concurrent symlink creation on Unix by preventing spurious “File exists” errors during races and ensuring atomic replacement behavior.

* **Tests**
  * Added a Unix-only test covering symlink creation, atomic replacement of an existing symlink target, and verification that no temporary symlink artifacts remain after the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->