### PR TITLE
fix(install): run tool postinstall against the just-installed version

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1931,8 +1931,17 @@ pub trait Backend: Debug + Send + Sync {
         tv: &ToolVersion,
         script: &str,
     ) -> eyre::Result<()> {
+        // Resolve the hook against the exact version just installed (locked) rather
+        // than the request's runtime symlink: for a fuzzy request (e.g. `version = "3"`)
+        // the runtime symlink (installs/python/3) still points at the previous version
+        // until all installs finish and symlinks are rebuilt. Without this, both the
+        // hook's env (exec_env, e.g. a backend deriving PYTHONHOME/JAVA_HOME from
+        // runtime_path()) and its PATH (list_bin_paths, e.g. `pip`) would resolve to a
+        // stale install (#10347).
+        let tv_exact = tv.clone().with_locked();
+
         // Get pre-tools environment variables from config
-        let mut env_vars = self.exec_env(&ctx.config, &ctx.ts, tv).await?;
+        let mut env_vars = self.exec_env(&ctx.config, &ctx.ts, &tv_exact).await?;
 
         // Add pre-tools environment variables from config if available
         if let Some(config_env) = ctx.config.env_maybe() {
@@ -1944,8 +1953,8 @@ pub trait Backend: Debug + Send + Sync {
 
         // Use the backend's list_bin_paths to get the correct binary directories
         // instead of hardcoding install_path/bin, which may not match the actual
-        // binary location for backends like aqua
-        let bin_paths = self.list_bin_paths(&ctx.config, tv).await?;
+        // binary location for backends like aqua.
+        let bin_paths = self.list_bin_paths(&ctx.config, &tv_exact).await?;
         let mut path_env = PathEnv::from_iter(env::PATH.clone());
         for p in bin_paths {
             path_env.add(p);

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -122,6 +122,15 @@ impl ToolVersion {
         self
     }
 
+    /// Returns a copy locked to the exact resolved version, so `runtime_path()`
+    /// resolves to `install_path()` rather than a fuzzy runtime symlink (e.g.
+    /// `installs/python/3`). Used during postinstall so the hook sees the version
+    /// just installed, not a stale symlink target (#10347).
+    pub(crate) fn with_locked(mut self) -> Self {
+        self.locked = true;
+        self
+    }
+
     fn from_lockfile(request: ToolRequest, lt: LockfileTool) -> Self {
         let mut tv = Self::new(request, lt.version);
         tv.locked = true;
@@ -798,6 +807,65 @@ mod tests {
         let runtime_path = tv.runtime_path();
         assert_eq!(runtime_path, install_path);
         assert!(runtime_path.is_dir());
+
+        Ok(())
+    }
+
+    #[test]
+    fn with_locked_runtime_path_uses_install_path_for_fuzzy_request() -> Result<()> {
+        reset_install_path_cache();
+
+        let temp_dir = tempfile::tempdir()?;
+        let short = format!(
+            "dummy-locked-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let mut backend = BackendArg::new_raw(
+            short.clone(),
+            None,
+            short,
+            None,
+            BackendResolution::new(false),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join("dummy");
+
+        let install_path = backend.installs_path.join("3.14.6");
+        fs::create_dir_all(install_path.join("bin"))?;
+
+        // Reproduce the stale state during `mise up` (#10347): the fuzzy runtime
+        // symlink installs/dummy/3 still points at a previous version (3.13.9) while
+        // 3.14.6 is the version just installed -- runtime symlinks are only rebuilt
+        // after all installs finish. is_runtime_symlink() requires a "./" target; on
+        // Windows runtime symlinks are stored as a file containing the target.
+        let old_path = backend.installs_path.join("3.13.9");
+        fs::create_dir_all(old_path.join("bin"))?;
+        let runtime_link = backend.installs_path.join("3");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("./3.13.9", &runtime_link)?;
+        #[cfg(windows)]
+        fs::write(&runtime_link, "./3.13.9")?;
+
+        // Fuzzy request ("3") resolved to a concrete version ("3.14.6").
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "3".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let tv = ToolVersion::new(request, "3.14.6".into());
+
+        // Without locking, runtime_path() follows the stale fuzzy runtime symlink, so
+        // it does NOT resolve to the version just installed -- the bug behavior. (This
+        // also self-checks the stale-symlink setup above.)
+        assert_ne!(tv.runtime_path(), install_path);
+
+        // with_locked() pins runtime_path() to the exact install just made, not the
+        // fuzzy runtime symlink, so the postinstall hook sees 3.14.6 (#10347).
+        assert_eq!(tv.clone().with_locked().runtime_path(), install_path);
+        assert_eq!(tv.clone().with_locked().runtime_path(), tv.install_path());
 
         Ok(())
     }


### PR DESCRIPTION
## Problem

A tool-level `postinstall` hook can run against a *different* version of the tool than the one just installed. Reported in #10347:

```toml
[tools.python]
version = "3"
postinstall = "pip install numpy pandocfilters ptpython setuptools watchfiles"
```

Upgrading to Python 3.14.6 ran the hook''s `pip` from the previous `3.14.5` install, so the packages were installed into the `3.14.5` tree — which mise then uninstalled. The docs promise the tool''s bin path is on PATH during the hook.

## Root cause

`run_postinstall_hook` builds the hook''s PATH from `list_bin_paths`, whose default resolves `tv.runtime_path()`. For a **fuzzy** version request (e.g. `version = "3"`), `runtime_path()` returns the runtime symlink `installs/python/3`. During `mise up` that symlink still points at the previous version, because runtime symlinks are only rebuilt *after* all installs finish — while the postinstall hook runs *during* the install. So `pip` resolved from the stale `3.14.5` tree.

## Fix

Resolve the postinstall hook''s bin paths against the exact version just installed by locking a clone of the `ToolVersion`:

```rust
let tv_exact = tv.clone().with_locked(true);
let bin_paths = self.list_bin_paths(&ctx.config, &tv_exact).await?;
```

`runtime_path()` returns `install_path()` (the concrete version) when locked, so the hook''s PATH points at the version just installed. A new `ToolVersion::with_locked` builder sets this; `locked` is already ignored by `Eq`/`Hash`, so the install-path cache key is unchanged. The backend `list_bin_paths` indirection is preserved (aqua etc. still work via their install-path-based dirs).

## Testing

- Unit test: `with_locked(true).runtime_path()` resolves to `install_path()` for a fuzzy request.
- `cargo fmt --all -- --check` passes.

Note: the `$MISE_TOOL_INSTALL_PATH` env var mise already sets for the hook remains a deterministic workaround for older versions.

Addresses #10347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Post-install steps now consistently derive environment variables and PATH from the exact version just installed, avoiding stale binaries when fuzzy or ranged versions are involved.
* **Tests**
  * Added a regression test to verify that locked runtime paths use the concrete install path rather than a fuzzy runtime symlink target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->