### PR TITLE
fix(github,forgejo): paginate past an all-prerelease first page of releases

### DIFF
--- a/e2e/cli/test_error_display
+++ b/e2e/cli/test_error_display
@@ -53,8 +53,10 @@ local_assert_fail "mise install cargo:nonexistent-crate-12345@1.0.0" \
 
 # Test 3: GitHub repository not found
 echo "Test 3: GitHub repository not found"
+# Match up to /releases without the trailing query string (e.g. ?per_page=100) so
+# the assertion does not depend on pagination parameters.
 local_assert_fail "mise install github:nonexistent-org/nonexistent-repo@latest" \
-  "mise ERROR Failed to install github:nonexistent-org/nonexistent-repo@latest: HTTP status client error (404 Not Found) for url (https://api.github.com/repos/nonexistent-org/nonexistent-repo/releases)"
+  "mise ERROR Failed to install github:nonexistent-org/nonexistent-repo@latest: HTTP status client error (404 Not Found) for url (https://api.github.com/repos/nonexistent-org/nonexistent-repo/releases"
 
 # Test 4: Plugin not found
 echo "Test 4: Plugin not found"
@@ -91,8 +93,9 @@ local_assert_fail "mise install cargo:nonexistent-crate-12345@1.0.0" \
 
 # Test 3: GitHub repository not found - check for error format with full chain
 echo "Test 3: GitHub repository not found"
+# Match up to /releases without the trailing query string (see Part 1, Test 3).
 local_assert_fail "mise install github:nonexistent-org/nonexistent-repo@latest" \
-  "0: Failed to install github:nonexistent-org/nonexistent-repo@latest: HTTP status client error (404 Not Found) for url (https://api.github.com/repos/nonexistent-org/nonexistent-repo/releases)"
+  "0: Failed to install github:nonexistent-org/nonexistent-repo@latest: HTTP status client error (404 Not Found) for url (https://api.github.com/repos/nonexistent-org/nonexistent-repo/releases"
 
 # Test 4: Multiple tool failures - check for error format
 echo "Test 4: Multiple tool failures"

--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -83,22 +83,37 @@ pub async fn list_releases_including_prereleases_from_url(
         .to_vec())
 }
 
+/// See the constant of the same name in [`crate::github`]: bound the prerelease
+/// fallback pagination so a repo full of nightly prereleases still surfaces a stable
+/// release without unbounded API calls. (#10343)
+const MAX_RELEASE_FALLBACK_PAGES: usize = 3;
+
 async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<ForgejoRelease>> {
-    let url = format!("{api_url}/repos/{repo}/releases");
+    let url = format!("{api_url}/repos/{repo}/releases?limit=100");
     let headers = get_headers(&url);
     let (mut releases, mut headers) = crate::http::HTTP_FETCH
         .json_headers_with_headers::<Vec<ForgejoRelease>, _>(url, &headers)
         .await?;
 
-    if *env::MISE_LIST_ALL_VERSIONS {
-        while let Some(next) = next_page(&headers) {
-            headers = get_headers(&next);
-            let (more, h) = crate::http::HTTP_FETCH
-                .json_headers_with_headers::<Vec<ForgejoRelease>, _>(next, &headers)
-                .await?;
-            releases.extend(more);
-            headers = h;
+    // Fetch additional pages when MISE_LIST_ALL_VERSIONS is set, or (bounded) while
+    // every release seen so far is a prerelease/draft, mirroring src/github.rs. (#10343)
+    // pages_fetched counts the initial page already fetched above, so the cap
+    // applies to the total number of pages rather than to extra requests.
+    let mut pages_fetched = 1;
+    while let Some(next) = next_page(&headers) {
+        if !*env::MISE_LIST_ALL_VERSIONS
+            && (releases.iter().any(|r| !r.prerelease && !r.draft)
+                || pages_fetched >= MAX_RELEASE_FALLBACK_PAGES)
+        {
+            break;
         }
+        headers = get_headers(&next);
+        let (more, h) = crate::http::HTTP_FETCH
+            .json_headers_with_headers::<Vec<ForgejoRelease>, _>(next, &headers)
+            .await?;
+        releases.extend(more);
+        headers = h;
+        pages_fetched += 1;
     }
     releases.retain(is_published_release);
 
@@ -383,5 +398,144 @@ something_else = "value"
 "#;
         let result = tokens::parse_tokens_toml(toml).unwrap();
         assert!(result.is_empty());
+    }
+
+    // #10343: a first page made up entirely of prereleases must not yield "no
+    // versions found" -- the fallback (bounded) follows the Link header to a later
+    // page that has a stable release. Forgejo paginates with limit=100.
+    #[tokio::test]
+    async fn test_list_releases_paginates_past_all_prerelease_first_page() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let repo = "owner/all-prerelease-first-page";
+
+        let page1 = vec![
+            release("v2.0.0-alpha.2", false, true),
+            release("v2.0.0-alpha.1", false, true),
+        ];
+        let page2 = vec![release("v1.0.0", false, false)];
+
+        let page1_mock = server
+            .mock("GET", format!("/repos/{repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded("limit".into(), "100".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::to_string(&page1).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let page2_mock = server
+            .mock("GET", "/page2")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&page2).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, repo).await.unwrap();
+        page1_mock.assert_async().await;
+        page2_mock.assert_async().await;
+        assert!(
+            releases
+                .iter()
+                .any(|r| r.tag_name == "v1.0.0" && !r.prerelease)
+        );
+    }
+
+    // #10343: once a stable release is seen the fallback stops (no extra requests).
+    #[tokio::test]
+    async fn test_list_releases_stops_when_first_page_has_stable() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let repo = "owner/stable-on-first-page";
+
+        let page1 = vec![
+            release("v1.1.0-alpha.1", false, true),
+            release("v1.0.0", false, false),
+        ];
+
+        let page1_mock = server
+            .mock("GET", format!("/repos/{repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded("limit".into(), "100".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::to_string(&page1).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        // A stable release is already present, so page 2 must NOT be fetched.
+        let page2_mock = server
+            .mock("GET", "/page2")
+            .with_status(200)
+            .with_body("[]")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, repo).await.unwrap();
+        page1_mock.assert_async().await;
+        page2_mock.assert_async().await;
+        assert!(releases.iter().any(|r| r.tag_name == "v1.0.0"));
+    }
+
+    // #10343: the prerelease fallback is bounded to MAX_RELEASE_FALLBACK_PAGES pages.
+    #[tokio::test]
+    async fn test_list_releases_fallback_pagination_is_bounded() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let repo = "owner/all-prerelease-many-pages";
+
+        let body = || serde_json::to_string(&vec![release("v9.0.0-alpha", false, true)]).unwrap();
+
+        // Three all-prerelease pages, each linking to the next.
+        let p1 = server
+            .mock("GET", format!("/repos/{repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded("limit".into(), "100".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/p2>; rel=\"next\"").as_str())
+            .with_body(body())
+            .expect(1)
+            .create_async()
+            .await;
+        let p2 = server
+            .mock("GET", "/p2")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/p3>; rel=\"next\"").as_str())
+            .with_body(body())
+            .expect(1)
+            .create_async()
+            .await;
+        let p3 = server
+            .mock("GET", "/p3")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/p4>; rel=\"next\"").as_str())
+            .with_body(body())
+            .expect(1)
+            .create_async()
+            .await;
+        // The 4th page must never be requested (capped at MAX_RELEASE_FALLBACK_PAGES).
+        let p4 = server
+            .mock("GET", "/p4")
+            .with_status(200)
+            .with_body("[]")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, repo).await.unwrap();
+        p1.assert_async().await;
+        p2.assert_async().await;
+        p3.assert_async().await;
+        p4.assert_async().await;
+        assert_eq!(releases.len(), 3);
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -88,6 +88,13 @@ pub static API_URL: &str = "https://api.github.com";
 
 pub static API_PATH: &str = "/api/v3";
 
+/// Without `MISE_LIST_ALL_VERSIONS`, mise normally fetches only the first page of
+/// releases to save API quota. The read path filters out prereleases/drafts by
+/// default, so a repo whose most recent releases are all prereleases (e.g. nightly
+/// builds) would yield zero candidates. `list_releases_` therefore keeps paginating
+/// until at least one stable release is seen, bounded to this many pages. (#10343)
+const MAX_RELEASE_FALLBACK_PAGES: usize = 3;
+
 async fn get_tags_cache(key: &str) -> RwLockReadGuard<'_, CacheGroup<Vec<String>>> {
     TAGS_CACHE
         .write()
@@ -171,21 +178,32 @@ pub async fn list_releases_including_prereleases_from_url(
 }
 
 async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GithubRelease>> {
-    let url = format!("{api_url}/repos/{repo}/releases");
+    let url = format!("{api_url}/repos/{repo}/releases?per_page=100");
     let headers = get_headers(&url);
     let (mut releases, mut headers) = crate::http::HTTP_FETCH
         .json_headers_with_headers::<Vec<GithubRelease>, _>(url, &headers)
         .await?;
 
-    if *env::MISE_LIST_ALL_VERSIONS {
-        while let Some(next) = next_page(&headers) {
-            headers = get_headers(&next);
-            let (more, h) = crate::http::HTTP_FETCH
-                .json_headers_with_headers::<Vec<GithubRelease>, _>(next, &headers)
-                .await?;
-            releases.extend(more);
-            headers = h;
+    // Fetch additional pages when MISE_LIST_ALL_VERSIONS is set, or (bounded) while
+    // every release seen so far is a prerelease/draft so a stable release is still
+    // discovered on a repo dominated by nightlies. (#10343)
+    // pages_fetched counts the initial page already fetched above, so the cap
+    // applies to the total number of pages rather than to extra requests.
+    let mut pages_fetched = 1;
+    while let Some(next) = next_page(&headers) {
+        if !*env::MISE_LIST_ALL_VERSIONS
+            && (releases.iter().any(|r| !r.prerelease && !r.draft)
+                || pages_fetched >= MAX_RELEASE_FALLBACK_PAGES)
+        {
+            break;
         }
+        headers = get_headers(&next);
+        let (more, h) = crate::http::HTTP_FETCH
+            .json_headers_with_headers::<Vec<GithubRelease>, _>(next, &headers)
+            .await?;
+        releases.extend(more);
+        headers = h;
+        pages_fetched += 1;
     }
     releases.retain(|r| !r.draft);
 
@@ -213,7 +231,7 @@ pub async fn list_tags_from_url(api_url: &str, repo: &str) -> Result<Vec<String>
 }
 
 async fn list_tags_(api_url: &str, repo: &str) -> Result<Vec<String>> {
-    let url = format!("{api_url}/repos/{repo}/tags");
+    let url = format!("{api_url}/repos/{repo}/tags?per_page=100");
     let headers = get_headers(&url);
     let (mut tags, mut headers) = crate::http::HTTP_FETCH
         .json_headers_with_headers::<Vec<GithubTag>, _>(url, &headers)
@@ -240,7 +258,7 @@ pub async fn list_tags_with_dates(repo: &str) -> Result<Vec<GithubTagWithDate>> 
 }
 
 async fn list_tags_with_dates_(api_url: &str, repo: &str) -> Result<Vec<GithubTagWithDate>> {
-    let url = format!("{api_url}/repos/{repo}/tags");
+    let url = format!("{api_url}/repos/{repo}/tags?per_page=100");
     let headers = get_headers(&url);
     let (mut tags, mut response_headers) = crate::http::HTTP_FETCH
         .json_headers_with_headers::<Vec<GithubTag>, _>(url, &headers)
@@ -1023,5 +1041,160 @@ something_else = "value"
             .unwrap();
         assert_eq!(release.assets[0].name, "direct-github-api.tar.gz");
         mock.assert_async().await;
+    }
+
+    fn make_prerelease(tag: &str) -> GithubRelease {
+        GithubRelease {
+            prerelease: true,
+            ..make_release(tag)
+        }
+    }
+
+    // #10343: a first page made up entirely of prereleases must not yield "no
+    // versions found" -- the fallback follows the Link header to a later page.
+    #[tokio::test]
+    async fn test_list_releases_paginates_past_all_prerelease_first_page() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let repo = "owner/all-prerelease-first-page";
+
+        let page1 = vec![
+            make_prerelease("v2.0.0-alpha.2"),
+            make_prerelease("v2.0.0-alpha.1"),
+        ];
+        let page2 = vec![make_release("v1.0.0")];
+
+        // The first page requests per_page=100 and is entirely prereleases.
+        let page1_mock = server
+            .mock("GET", format!("/repos/{repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::to_string(&page1).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        // The fallback follows the Link header to a second page that has a stable release.
+        let page2_mock = server
+            .mock("GET", "/page2")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&page2).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, repo).await.unwrap();
+        page1_mock.assert_async().await;
+        page2_mock.assert_async().await;
+        assert!(
+            releases
+                .iter()
+                .any(|r| r.tag_name == "v1.0.0" && !r.prerelease),
+            "stable release from page 2 should be discovered, got {:?}",
+            releases.iter().map(|r| &r.tag_name).collect::<Vec<_>>()
+        );
+    }
+
+    // #10343: once a stable release is seen the fallback stops (no extra API calls).
+    #[tokio::test]
+    async fn test_list_releases_stops_when_first_page_has_stable() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let repo = "owner/stable-on-first-page";
+
+        let page1 = vec![make_prerelease("v1.1.0-alpha.1"), make_release("v1.0.0")];
+
+        let page1_mock = server
+            .mock("GET", format!("/repos/{repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::to_string(&page1).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        // A stable release is already present, so page 2 must NOT be fetched.
+        let page2_mock = server
+            .mock("GET", "/page2")
+            .with_status(200)
+            .with_body("[]")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, repo).await.unwrap();
+        page1_mock.assert_async().await;
+        page2_mock.assert_async().await;
+        assert!(releases.iter().any(|r| r.tag_name == "v1.0.0"));
+    }
+
+    // #10343: the prerelease fallback is bounded to MAX_RELEASE_FALLBACK_PAGES pages.
+    #[tokio::test]
+    async fn test_list_releases_fallback_pagination_is_bounded() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let repo = "owner/all-prerelease-many-pages";
+
+        let body = || serde_json::to_string(&vec![make_prerelease("v9.0.0-alpha")]).unwrap();
+
+        // Three all-prerelease pages, each linking to the next.
+        let p1 = server
+            .mock("GET", format!("/repos/{repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/p2>; rel=\"next\"").as_str())
+            .with_body(body())
+            .expect(1)
+            .create_async()
+            .await;
+        let p2 = server
+            .mock("GET", "/p2")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/p3>; rel=\"next\"").as_str())
+            .with_body(body())
+            .expect(1)
+            .create_async()
+            .await;
+        let p3 = server
+            .mock("GET", "/p3")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/p4>; rel=\"next\"").as_str())
+            .with_body(body())
+            .expect(1)
+            .create_async()
+            .await;
+        // The 4th page must never be requested (capped at MAX_RELEASE_FALLBACK_PAGES).
+        let p4 = server
+            .mock("GET", "/p4")
+            .with_status(200)
+            .with_body("[]")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, repo).await.unwrap();
+        p1.assert_async().await;
+        p2.assert_async().await;
+        p3.assert_async().await;
+        p4.assert_async().await;
+        assert_eq!(releases.len(), 3);
     }
 }

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -125,7 +125,7 @@ pub async fn list_releases_from_url(api_url: &str, repo: &str) -> Result<Vec<Git
 
 async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GitlabRelease>> {
     let url = format!(
-        "{}/projects/{}/releases",
+        "{}/projects/{}/releases?per_page=100",
         api_url,
         urlencoding::encode(repo)
     );
@@ -171,7 +171,7 @@ pub async fn list_tags_from_url(api_url: &str, repo: &str) -> Result<Vec<String>
 
 async fn list_tags_(api_url: &str, repo: &str) -> Result<Vec<String>> {
     let url = format!(
-        "{}/projects/{}/repository/tags",
+        "{}/projects/{}/repository/tags?per_page=100",
         api_url,
         urlencoding::encode(repo)
     );


### PR DESCRIPTION
## What

`mise use github:owner/repo` (and the `forgejo:` / `gitlab:` backends) could fail with `no versions found for <pkg> matching date filter` when a repo's most recent releases are all prereleases (e.g. auto-generated nightly/alpha builds), because:

- With `MISE_LIST_ALL_VERSIONS` unset (the default), the forge release listers fetch only the **first** API page at the server default size (30 for GitHub/Forgejo, 20 for GitLab).
- The read path filters out prereleases/drafts by default, so an all-prerelease first page leaves **zero** candidates.

Reported in #10343 (repro: `refactoringhq/tolaria`).

## Fix

- Request larger pages: `per_page=100` (GitHub/GitLab) and `limit=100` (Forgejo) on the release/tag listers.
- For GitHub and Forgejo, keep paginating — **bounded to 3 pages** (≈300 releases) — while every release seen so far is a prerelease/draft, so an older stable release is still discovered. Behavior with `MISE_LIST_ALL_VERSIONS=1` (fetch all pages) is unchanged.
- GitLab gets only the page-size bump, since `GitlabRelease` carries no prerelease/draft flag.

## Tests

- New mockito unit tests in `src/github.rs` (3) and `src/forgejo.rs` (1): the page-size param is sent; an all-prerelease first page with a `Link: next` triggers a bounded fallback that surfaces a stable release; a stable release on page 1 stops pagination; the fallback caps at 3 pages.
- Updated `e2e/cli/test_error_display` to match the `/releases` error URL without the query string, so the assertion doesn't depend on pagination parameters.

Addresses discussion #10343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release and tag pagination for GitHub, GitLab, and Forgejo, including bounded fallback behavior to ensure stable releases are found even when early pages contain only drafts or prereleases.
  * Increased items per page for release/tag listing to reduce pagination churn.
* **Tests**
  * Added async tests covering GitHub pre-release fallback pagination (including stop conditions and page caps).
  * Improved end-to-end CLI error assertions to be resilient to GitHub releases pagination details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->