### PR TITLE
fix(env): drop stale mise install dirs from mise x/run child PATH

### DIFF
--- a/e2e/cli/test_exec_stale_install_path
+++ b/e2e/cli/test_exec_stale_install_path
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Regression test for #10345: a stale mise-managed install dir left on PATH
+# (e.g. carried in from a frozen env snapshot of a previously activated shell)
+# must not shadow the version `mise x` selects. The requested version should win
+# for the whole process tree, not just the direct command.
+
+mise install dummy@1.0.0 dummy@2.0.0
+
+# Simulate a frozen env that prepended another version's bin dir to PATH.
+export PATH="$MISE_DATA_DIR/installs/dummy/2.0.0/bin:$PATH"
+
+# The direct command was already remapped before this fix.
+assert_contains "mise x dummy@1.0.0 -- dummy" "1.0.0"
+
+# A PATH lookup inside a child process must resolve the requested version, not
+# the stale 2.0.0 dir still on the inherited PATH.
+assert_contains "mise x dummy@1.0.0 -- sh -c 'command -v dummy'" "installs/dummy/1.0.0"
+assert_not_contains "mise x dummy@1.0.0 -- sh -c 'command -v dummy'" "installs/dummy/2.0.0"

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -7,14 +7,14 @@ use crate::file::{canonicalize_cached, display_rel_path};
 use crate::hook_env::{PREV_SESSION, WatchFilePattern};
 use crate::shell::{ShellType, get_shell};
 use crate::toolset::Toolset;
-use crate::{dirs, env, hook_env, hooks, watch_files};
+use crate::{env, hook_env, hooks, watch_files};
 use console::truncate_str;
 use eyre::Result;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use std::collections::{BTreeSet, HashSet};
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::{borrow::Cow, sync::Arc};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -274,6 +274,7 @@ impl HookEnv {
                 let mut orig_reordered = Vec::new();
                 let mut seen_orig = false;
                 let mut seen_in_current: HashSet<&PathBuf> = HashSet::new();
+                let mise_install_dirs = crate::path_env::mise_install_dirs();
                 for path in &current_paths {
                     if orig_set.contains(path) {
                         seen_orig = true;
@@ -291,7 +292,7 @@ impl HookEnv {
                     // the previous session diff did not claim them. Preserving a
                     // stale install path as a user prefix can shadow the active
                     // version selected by the current toolset.
-                    if is_mise_install_path(path) {
+                    if crate::path_env::is_mise_install_path(path, &mise_install_dirs) {
                         continue;
                     }
 
@@ -503,17 +504,6 @@ impl HookEnv {
             hook_env::serialize(&session)?,
         ))
     }
-}
-
-fn is_mise_install_path(path: &Path) -> bool {
-    if path.starts_with(*dirs::INSTALLS) {
-        return true;
-    }
-
-    let Some(path) = canonicalize_cached(path) else {
-        return false;
-    };
-    canonicalize_cached(*dirs::INSTALLS).is_some_and(|installs| path.starts_with(installs))
 }
 
 fn patch_to_status(patch: EnvDiffOperation) -> String {

--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -97,6 +97,34 @@ impl FromStr for PathEnv {
     }
 }
 
+/// All mise-managed install dirs: the primary install dir plus any shared/system
+/// install dirs (`MISE_SHARED_INSTALL_DIRS` and the system installs dir) that
+/// `env::find_in_shared_installs` resolves tool runtime paths into. Computed once
+/// and passed to [`is_mise_install_path`] so the per-PATH-entry check stays cheap.
+pub(crate) fn mise_install_dirs() -> Vec<PathBuf> {
+    let mut install_dirs = vec![dirs::INSTALLS.to_path_buf()];
+    install_dirs.extend(crate::env::shared_install_dirs());
+    install_dirs
+}
+
+/// Whether `path` is under one of `install_dirs` (see [`mise_install_dirs`]),
+/// checked both literally and via canonicalized paths. Such dirs are mise-managed,
+/// so a stale one left on PATH (e.g. carried in from a frozen env snapshot) must
+/// not outrank the version the current toolset selects. Shared by hook-env
+/// reactivation (#10162) and the `mise x`/`run`/`env` child PATH (#10345).
+pub(crate) fn is_mise_install_path(path: &std::path::Path, install_dirs: &[PathBuf]) -> bool {
+    if install_dirs.iter().any(|d| path.starts_with(d)) {
+        return true;
+    }
+    let Some(path) = crate::file::canonicalize_cached(path) else {
+        return false;
+    };
+    install_dirs
+        .iter()
+        .filter_map(|d| crate::file::canonicalize_cached(d))
+        .any(|d| path.starts_with(d))
+}
+
 #[cfg(unix)]
 #[cfg(test)]
 mod tests {

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -15,6 +15,20 @@ use crate::toolset::env_cache::{CachedEnv, compute_settings_hash, get_file_mtime
 use crate::toolset::tool_request::ToolRequest;
 use crate::{env, github, parallel, uv};
 
+/// PATH with mise-managed install dirs filtered out. mise re-adds the current
+/// toolset's bin dirs below, so a stale `installs/<tool>/<ver>/bin` left on PATH
+/// (e.g. carried in from a frozen env snapshot) does not outrank the version that
+/// `mise x`/`run`/`env` selects for the whole process tree. Mirrors the hook-env
+/// reactivation filter from #10162. (#10345)
+fn pristine_path_without_install_dirs() -> Vec<PathBuf> {
+    let install_dirs = crate::path_env::mise_install_dirs();
+    env::PATH
+        .iter()
+        .filter(|p| !crate::path_env::is_mise_install_path(p.as_path(), &install_dirs))
+        .cloned()
+        .collect()
+}
+
 impl Toolset {
     pub async fn full_env(&self, config: &Arc<Config>) -> Result<EnvMap> {
         let mut env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
@@ -38,7 +52,7 @@ impl Toolset {
     /// dependency_env to avoid triggering module hooks on a partial PATH.
     pub async fn env_with_path_without_tools(&self, config: &Arc<Config>) -> Result<EnvMap> {
         let (mut env, add_paths) = self.env(config).await?;
-        let mut path_env = PathEnv::from_iter(env::PATH.clone());
+        let mut path_env = PathEnv::from_iter(pristine_path_without_install_dirs());
         for p in config.path_dirs().await?.clone() {
             path_env.add(p);
         }
@@ -64,7 +78,7 @@ impl Toolset {
         }
 
         let (mut env, env_results) = self.final_env(config).await?;
-        let mut path_env = PathEnv::from_iter(env::PATH.clone());
+        let mut path_env = PathEnv::from_iter(pristine_path_without_install_dirs());
         // Use split paths so we save a cache compatible with env_with_path_and_split
         let (user_paths, tool_paths) = self
             .list_final_paths_split(config, env_results.clone())
@@ -105,7 +119,7 @@ impl Toolset {
             trace!("env_cache: using cached environment with split paths");
             let mut env = cached.env;
             // Reconstruct PATH from cached paths
-            let mut path_env = PathEnv::from_iter(env::PATH.clone());
+            let mut path_env = PathEnv::from_iter(pristine_path_without_install_dirs());
             for p in cached.user_paths.iter().chain(cached.tool_paths.iter()) {
                 path_env.add(p.clone());
             }
@@ -126,7 +140,7 @@ impl Toolset {
             .await?;
 
         // Build PATH
-        let mut path_env = PathEnv::from_iter(env::PATH.clone());
+        let mut path_env = PathEnv::from_iter(pristine_path_without_install_dirs());
         for p in user_paths.iter().chain(tool_paths.iter()) {
             path_env.add(p.clone());
         }
@@ -163,7 +177,7 @@ impl Toolset {
             Some(cached) => {
                 let mut env = cached.env;
                 // Reconstruct PATH from cached paths
-                let mut path_env = PathEnv::from_iter(env::PATH.clone());
+                let mut path_env = PathEnv::from_iter(pristine_path_without_install_dirs());
                 for p in cached.user_paths.into_iter().chain(cached.tool_paths) {
                     path_env.add(p);
                 }
@@ -362,7 +376,7 @@ impl Toolset {
         let (mut env, add_paths) = self.env(config).await?;
         let mut tera_env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
         tera_env.extend(env.clone());
-        let mut path_env = PathEnv::from_iter(env::PATH.clone());
+        let mut path_env = PathEnv::from_iter(pristine_path_without_install_dirs());
 
         for p in config.path_dirs().await?.clone() {
             path_env.add(p);


### PR DESCRIPTION
## What

`mise x tool@X` / `run` / `env` correctly remap the *direct* command, but a stale mise-managed install dir left earlier on PATH — e.g. carried in from a frozen env snapshot of a previously activated shell (IDE terminals, CI wrappers, AI-agent harnesses) — stayed *ahead* of the bin dir mise injects. So PATH lookups *inside* the process tree (subshells, `#!/usr/bin/env` shebangs, package managers spawning workers) still resolved the other version: a split-brain where `node --version` says 22 while the tests actually run on 24.

Reported in #10345 (repro with two node versions).

## Fix

When `Toolset` composes the child environment, filter mise-managed install dirs out of the inherited PATH (mise re-adds the current toolset's bin dirs, so the requested version wins for the whole process tree). Mirrors the hook-env reactivation fix (#10162): its `is_mise_install_path` helper is moved to `path_env`, shared, and extended to also cover shared/system install dirs (`MISE_SHARED_INSTALL_DIRS` + the system installs dir) that `find_in_shared_installs` resolves into. The install-dir list is computed once per PATH-composition pass to keep the per-entry check cheap (hook-env runs on every prompt).

## Tests

- `e2e/cli/test_exec_stale_install_path`: with `installs/dummy/2.0.0/bin` prepended to PATH, `mise x dummy@1.0.0 -- sh -c 'command -v dummy'` resolves into `installs/dummy/1.0.0`, not the stale 2.0.0 dir.

Addresses discussion #10345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version resolution when stale mise-managed install directories are left on `PATH`, ensuring `mise x` selects the requested version instead of being influenced by older remnants.
  * Updated PATH handling to exclude mise-managed install directory entries when building the effective environment, preventing incorrect PATH ordering.

* **Tests**
  * Added an end-to-end regression test covering stale install-path behavior and verifying correct resolution in both direct and child-process commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->