### PR TITLE
fix(zig): resolve master channel to the concrete nightly version

### DIFF
--- a/docs/lang/zig.md
+++ b/docs/lang/zig.md
@@ -32,6 +32,15 @@ command will list available Mach versions:
 curl https://machengine.org/zig/index.json | yq 'keys'
 ```
 
+### `master` (nightly channel)
+
+`zig@master` tracks a moving nightly. mise resolves it to the concrete dev version
+it currently points at (e.g. `0.17.0-dev.836+...`) at install time, so the install
+lands in a versioned directory and `mise upgrade zig` / `mise outdated` pick up
+newer nightlies — instead of the channel staying pinned to the build it was first
+installed from. Run `mise upgrade zig` (or `mise install -f zig@master`) to move to
+the current nightly.
+
 ## zig Language Server
 
 The `zig` language server ([zls](https://github.com/zigtools/zls)) needs to be installed separately.

--- a/e2e/core/test_zig_slow
+++ b/e2e/core/test_zig_slow
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
 
 assert "mise x zig@0.13.0 -- zig version" "0.13.0"
-assert "mise x zig@master -- zig version"
+
+# #10251: zig@master is a rolling channel. Even with only a STABLE zig installed
+# (0.13.0 above), zig@master must resolve to the concrete nightly (e.g.
+# 0.17.0-dev.NNN) -- it must NOT short-circuit to the unrelated installed stable --
+# and install under a versioned dir rather than a frozen "master" dir, so
+# `mise upgrade`/`outdated` can track new nightlies.
+assert_contains "mise x zig@master -- zig version" "-dev."
+[ ! -d "$MISE_DATA_DIR/installs/zig/master" ] || fail "zig@master must not create a frozen installs/zig/master dir"
+# A concrete nightly dir (e.g. 0.17.0-dev.NNN) must exist under installs/zig.
+# Use a glob rather than `ls | grep` (SC2010) to tolerate odd filenames.
+shopt -s nullglob
+dev_dirs=("$MISE_DATA_DIR"/installs/zig/*-dev.*)
+shopt -u nullglob
+[ ${#dev_dirs[@]} -gt 0 ] || fail "zig@master should install a concrete -dev nightly"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1311,6 +1311,37 @@ pub trait Backend: Debug + Send + Sync {
         Ok(None)
     }
 
+    /// Whether `version` names a rolling release channel (e.g. zig's "master")
+    /// rather than a concrete version. Cheap (no network). Channels are re-resolved
+    /// to a concrete version like "latest" so `mise upgrade`/`outdated` can track
+    /// new builds instead of pinning the channel name forever. (#10251)
+    fn is_rolling_channel(&self, _version: &str) -> bool {
+        false
+    }
+
+    /// The latest installed version that belongs to the rolling `channel` (see
+    /// [`Backend::is_rolling_channel`]), or `None`. Lets `mise x` / hook-env reuse
+    /// an installed channel build without a network round-trip, while never falling
+    /// back to an unrelated release (e.g. a stable Zig for `zig@master`). Cheap --
+    /// it filters already-installed versions, no network. (#10251)
+    fn latest_installed_channel_version(&self, _channel: &str) -> Option<String> {
+        None
+    }
+
+    /// Resolve a rolling channel (see [`Backend::is_rolling_channel`]) to the
+    /// concrete version it currently points at. Returns `Ok(None)` when `version`
+    /// is not a channel or cannot be resolved; callers fall back to normal
+    /// resolution. May hit the network, so it is only called when re-resolving is
+    /// wanted (install/upgrade or first-run exec), never on the prefer-offline
+    /// hook-env path. (#10251)
+    async fn resolve_channel_version(
+        &self,
+        _config: &Arc<Config>,
+        _version: &str,
+    ) -> eyre::Result<Option<String>> {
+        Ok(None)
+    }
+
     /// Backend opt-in for installing an unresolved `latest` request.
     ///
     /// Most backends must resolve `latest` to a concrete version before install.

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -49,6 +49,14 @@ impl ZigPlugin {
         }
     }
 
+    /// Nightly (`-dev.`) builds are not top-level download-index keys; they are
+    /// published under /builds/. Both get_tarball_url and resolve_lock_info need
+    /// this URL, so construct it in one place to keep the pattern in sync. (#10251)
+    fn nightly_tarball_url(arch: &str, os: &str, version: &str) -> String {
+        let ext = if os == "windows" { "zip" } else { "tar.xz" };
+        format!("https://ziglang.org/builds/zig-{arch}-{os}-{version}.{ext}")
+    }
+
     fn test_zig(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
         ctx.pr.set_message("zig version".into());
         CmdLineRunner::new(self.zig_bin(tv))
@@ -290,6 +298,61 @@ impl Backend for ZigPlugin {
         Ok(versions)
     }
 
+    fn is_rolling_channel(&self, version: &str) -> bool {
+        version == "master"
+    }
+
+    fn latest_installed_channel_version(&self, channel: &str) -> Option<String> {
+        if !self.is_rolling_channel(channel) {
+            return None;
+        }
+        // "master" builds are dev versions (e.g. 0.17.0-dev.NNN). Reuse the latest
+        // installed nightly so hook-env / exec stay network-free, but never fall
+        // back to a stable release that has nothing to do with the channel. (#10251)
+        //
+        // list_installed_versions() is already ordered ascending by install_state
+        // (the canonical version sort), so take the last "-dev." entry instead of
+        // re-sorting here. list_installed_versions_matching() is unusable: it drops
+        // prereleases (the "-dev." nightlies) unless the tool opts into them.
+        // rfind() walks from the newest end (the list is double-ended), giving the
+        // latest nightly without re-sorting.
+        self.list_installed_versions()
+            .into_iter()
+            .rfind(|v| v.contains("-dev."))
+    }
+
+    async fn resolve_channel_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> Result<Option<String>> {
+        if !self.is_rolling_channel(version) {
+            return Ok(None);
+        }
+        // The download index lists "master" as a moving channel whose `version`
+        // field is the concrete nightly it currently points at (e.g.
+        // "0.17.0-dev.836+e357134f0"). Resolve to that concrete version so the
+        // install lands in a versioned dir and `mise upgrade`/`outdated` can track
+        // new nightlies instead of pinning "master" forever. (#10251)
+        // Treat a failed fetch as "cannot resolve right now" (Ok(None)) rather than
+        // a hard error, so a transient network blip falls through to normal
+        // resolution instead of breaking hook-env / exec. (#10251)
+        let index_json: serde_json::Value = match HTTP_FETCH
+            .json("https://ziglang.org/download/index.json")
+            .await
+        {
+            Ok(v) => v,
+            Err(err) => {
+                debug!("zig: failed to fetch download index resolving {version}: {err:#}");
+                return Ok(None);
+            }
+        };
+        Ok(index_json
+            .pointer(&format!("/{version}/version"))
+            .and_then(|v| v.as_str())
+            .map(String::from))
+    }
+
     async fn list_bin_paths(
         &self,
         _config: &Arc<Config>,
@@ -388,6 +451,11 @@ impl Backend for ZigPlugin {
                     tv.version, os, arch, tv.version
                 )))
             }
+            Err(_) if tv.version.contains("-dev.") => {
+                // Resolved from a rolling channel (e.g. "master"): nightly builds
+                // are not top-level index keys; they live under /builds/. (#10251)
+                Ok(Some(Self::nightly_tarball_url(arch, os, &tv.version)))
+            }
             Err(_) => Ok(None),
         }
     }
@@ -446,6 +514,14 @@ impl Backend for ZigPlugin {
                         "https://ziglang.org/download/{}/zig-{}-{}-{}.tar.xz",
                         tv.version, os, arch, tv.version
                     )),
+                    ..Default::default()
+                })
+            }
+            Err(_) if tv.version.contains("-dev.") => {
+                // Resolved from a rolling channel (e.g. "master"): nightly lives
+                // under /builds/, no checksum (minisign verifies at install). (#10251)
+                Ok(PlatformInfo {
+                    url: Some(Self::nightly_tarball_url(arch, os, &tv.version)),
                     ..Default::default()
                 })
             }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -411,6 +411,36 @@ impl ToolVersion {
             }
             return Err(Self::no_versions_found(&backend, opts.before_date));
         }
+        // Rolling release channels (e.g. zig's "master") are moving pointers that
+        // mise must re-resolve to a concrete version -- like "latest" -- so they are
+        // not pinned forever. Mirror the "latest" fast paths: prefer an installed
+        // concrete version when not explicitly resolving latest (keeps hook-env /
+        // exec network-free), otherwise re-resolve the channel. (#10251)
+        if backend.is_rolling_channel(&v) {
+            // Reuse an installed build of THIS channel (e.g. a -dev nightly for
+            // zig@master), never an unrelated installed release, so we don't
+            // short-circuit zig@master to a stable version that happens to be
+            // installed.
+            if !opts.latest_versions
+                && !should_filter_installed_versions
+                && let Some(installed) = backend.latest_installed_channel_version(&v)
+            {
+                return build(installed);
+            }
+            if !is_offline
+                && let Some(concrete) = backend.resolve_channel_version(config, &v).await?
+            {
+                return build(concrete);
+            }
+            if opts.offline {
+                return build(v);
+            }
+            // Online but the channel did not resolve to a concrete version --
+            // either the index lacked the channel key, or the fetch failed
+            // transiently (resolve_channel_version maps both to Ok(None)). Fall
+            // through to normal resolution, which still matches the literal
+            // channel name in the backend's version list as before.
+        }
         if !opts.latest_versions {
             let matches = backend.list_installed_versions_matching(&v);
             if matches.contains(&v) {


### PR DESCRIPTION
## What

`zig@master` was effectively frozen: mise resolved it to the literal `"master"`, installed it under `installs/zig/master`, and never re-resolved it. So `mise upgrade` / `mise outdated` compared `"master" == "master"` and never picked up newer nightlies — a `master` install could sit weeks out of date (reported in #10251, stuck on a 23-day-old nightly).

Zig publishes `master` as a rolling channel in its download index (`ziglang.org/download/index.json`), whose `version` field points at the current nightly (e.g. `0.17.0-dev.836+...`), with the build hosted under `ziglang.org/builds/` (not on the source forge).

## Fix

Resolve rolling channels to their concrete version at resolution time — like `latest` — so installs land in versioned dirs and `mise upgrade`/`outdated` track new builds:

- Add `Backend::is_rolling_channel`, `Backend::latest_installed_channel_version`, and `Backend::resolve_channel_version` hooks (default no-op).
- In `ToolVersion::resolve_version`, handle a channel like `latest`: reuse an installed build *of that channel* (never an unrelated installed release, so `zig@master` is not short-circuited to an installed stable) to keep hook-env/exec network-free; otherwise re-resolve via the backend; offline falls back to the literal channel.
- Implement for zig `master`: read `/master/version` from the index, reuse the latest installed `-dev` nightly, and build the `/builds/` tarball URL for the resolved dev version (not a top-level index key) in `get_tarball_url` / `resolve_lock_info`. minisign verification is unchanged.

`mach-latest` is left as a follow-up (the machengine index format is unverified).

## Tests

- `e2e/core/test_zig_slow`: with only a stable Zig installed, `zig@master` must resolve to a `-dev` nightly (not short-circuit to the stable), install under a versioned dir, and not create a frozen `installs/zig/master`.

Addresses discussion #10251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treats Zig `master` as a rolling release channel that resolves to concrete nightly/dev builds, so installs and upgrades automatically follow newer nightly versions.
  * Reuses the latest already-installed nightly when available to reduce network reliance during install/exec.

* **Documentation**
  * Expanded Zig docs to clarify `zig@master` resolution and how upgrades keep moving forward.

* **Bug Fixes**
  * Improved dev/nightly download resolution and lock handling so nightly installs use the correct build URLs.

* **Tests**
  * Added slow end-to-end assertions covering `zig@master` nightly/dev behavior and naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->