### PR TITLE
docs(css): align social links icons vertically center

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -196,6 +196,11 @@
   }
 }
 
+/* Social links */
+.VPSocialLinks {
+  align-items: center !important;
+}
+
 /* GitHub star count badge */
 .VPSocialLinks a[href*="github.com/jdx/mise"] {
   display: inline-flex !important;


### PR DESCRIPTION
## Summary
- Add `align-items: center` to `.VPSocialLinks` to fix vertical alignment of social media icons (GitHub, Discord) in the navbar
- Icons were not vertically centered, causing visual misalignment

#### Test plan
- [x] Visual verification of social links icon alignment in the navbar

Before
<img width="660" height="278" alt="2026-06-14 at 13 11 19" src="https://github.com/user-attachments/assets/5d088a1c-0c29-4453-8e69-2e738bc07807" />

After
<img width="658" height="274" alt="2026-06-14 at 13 12 03" src="https://github.com/user-attachments/assets/19a4f5e1-b76c-4e62-b4b3-9d4066a116c6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated vertical alignment of social links in the documentation theme for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->