### PR TITLE
chore: silence platform-conditional dead-code warnings

### DIFF
--- a/src/backend/pkgx.rs
+++ b/src/backend/pkgx.rs
@@ -931,6 +931,7 @@ fn pkgx_arch_for_target(target: &PlatformTarget) -> String {
     }
 }
 
+#[cfg(any(unix, test))]
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -506,7 +506,8 @@ impl<'a> CmdLineRunner<'a> {
     /// and discussion #9355.
     #[cfg(windows)]
     pub fn raw_arg<S: AsRef<OsStr>>(mut self, arg: S) -> Self {
-        use std::os::windows::process::CommandExt;
+        // tokio's `Command` exposes `raw_arg` as an inherent method, so the
+        // `std::os::windows::process::CommandExt` trait import is unnecessary.
         self.cmd.raw_arg(arg);
         self
     }

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -547,7 +547,8 @@ impl MiseToml {
     }
 
     /// Set `[bootstrap.brew.taps]."<owner>/<tap>" = "<url>"`, creating the
-    /// tables as needed.
+    /// tables as needed. Only used by the `#[cfg(unix)]` brew CLI commands.
+    #[cfg(unix)]
     pub fn update_bootstrap_brew_tap(&mut self, tap: &str, url: &str) -> eyre::Result<()> {
         self.bootstrap
             .get_or_insert_with(Default::default)
@@ -579,6 +580,7 @@ impl MiseToml {
         Ok(())
     }
 
+    #[cfg(unix)]
     pub fn remove_bootstrap_brew_tap(&mut self, tap: &str) -> eyre::Result<()> {
         if let Some(bootstrap) = &mut self.bootstrap {
             bootstrap.brew.taps.shift_remove(tap);

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -700,6 +700,7 @@ mod tests {
         assert!(entries_seen > 0, "expected at least one tar entry");
     }
 
+    #[cfg(unix)]
     fn assert_layer_mode(blob: &LayerBlob, expected_path: &str, expected_mode: u32) {
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
         let mut archive = tar::Archive::new(decoder);
@@ -720,6 +721,7 @@ mod tests {
         panic!("expected layer entry {expected_path}");
     }
 
+    #[cfg(unix)]
     fn assert_layer_entry_owner(blob: &LayerBlob, expected_path: &str, uid: u64, gid: u64) {
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
         let mut archive = tar::Archive::new(decoder);

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -134,6 +134,7 @@ impl ErlangPlugin {
         ))
     }
 
+    #[cfg(linux)]
     fn linux_precompiled_cache_name(url: &str) -> String {
         url.strip_prefix("https://builds.hex.pm/builds/otp/")
             .unwrap_or(url)

--- a/src/system/launchd.rs
+++ b/src/system/launchd.rs
@@ -301,6 +301,7 @@ fn current_uid() -> u32 {
     0
 }
 
+#[cfg(unix)]
 fn current_uid_from(euid: u32, sudo_uid: Option<&str>) -> u32 {
     if euid == 0
         && let Some(uid) = sudo_uid.and_then(|uid| uid.parse::<u32>().ok())
@@ -464,6 +465,7 @@ mod tests {
         assert!(plist_matches(&plist, &request));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_current_uid_prefers_sudo_uid_for_root() {
         assert_eq!(current_uid_from(0, Some("501")), 501);

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -18,6 +18,9 @@ pub enum ProgressIcon {
     Skipped,
     #[allow(dead_code)]
     Warning,
+    // Constructed only by the brew package managers (`#[cfg(unix)]`), so it reads
+    // as never-constructed on the windows build.
+    #[cfg_attr(windows, allow(dead_code))]
     Error,
 }
 


### PR DESCRIPTION
## Summary

Building the `mise` binary on Windows surfaced a handful of `dead_code` / `unused_import` warnings (one was also firing on macOS) coming from code that is only ever used on a subset of platforms. This PR gates each item to the platform(s) that actually use it, so the default `cargo check` / `cargo build` is warning-free on every target.

No behavior change — every item is still compiled on the platform that uses it; only the copies that are *unused on a given target* are removed.

## Changes

| File | Fix | Why |
|---|---|---|
| `src/system/launchd.rs` | `#[cfg(unix)]` on `current_uid_from` + its test | only called by the `#[cfg(unix)]` `current_uid()` (Windows uses a `cfg(not(unix))` fallback that returns 0) |
| `src/ui/progress_report.rs` | `#[cfg_attr(not(unix), allow(dead_code))]` on `ProgressIcon::Error` | the variant is matched in `Display`/`finish_with_icon` on all platforms, so it cannot be cfg-gated away, but it is only *constructed* by the `#[cfg(unix)]` brew package managers |
| `src/oci/layer.rs` | `#[cfg(unix)]` on `assert_layer_mode` / `assert_layer_entry_owner` | test helpers used only by `#[cfg(unix)]` permission-bit tests |
| `src/plugins/core/erlang.rs` | `#[cfg(linux)]` on `linux_precompiled_cache_name` | only called from the `#[cfg(linux)]` `install_precompiled` (also clears a pre-existing macOS warning, since the caller was already linux-gated) |
| `src/config/config_file/mise_toml.rs` | `#[cfg(unix)]` on `update_bootstrap_brew_tap` / `remove_bootstrap_brew_tap` | only called from the `#[cfg(unix)]` `mise system brew tap/untap` CLI |
| `src/backend/pkgx.rs` | `#[cfg(any(unix, test))]` on `shell_quote` | used by the `#[cfg(unix)]` wrapper writer and by a non-gated unit test (so `test` is needed for the Windows test build) |
| `src/cmd.rs` | drop the redundant `use std::os::windows::process::CommandExt` | `self.cmd` is a `tokio::process::Command`, whose `raw_arg` is an inherent method, so the trait import is unnecessary (`hooks.rs`/`path.rs` keep theirs because they use `std::process::Command`) |

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check --all-targets` on Windows (msvc): **0 warnings, 0 errors** (previously 8 warnings) ✅
- Each cfg gate was checked against every call site to confirm it does not exclude an item that any platform still uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cross-platform compatibility by restricting Unix-specific helpers and behaviors so Windows builds no longer include unnecessary Unix-only logic.

* **Chores**
  * Further refined conditional compilation for platform-specific utilities and test helpers (Linux/Unix/Windows) to keep builds clean and consistent.

* **Documentation**
  * Updated command documentation to reflect how raw argument handling is provided by the command interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->