### PR TITLE
chore: release 2026.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [2026.6.8](https://github.com/jdx/mise/compare/v2026.6.7..v2026.6.8) - 2026-06-14
+
+### 🐛 Bug Fixes
+
+- **(ruby)** require build revision releases by @jdx in [#10428](https://github.com/jdx/mise/pull/10428)
+- **(zig)** resolve master channel to the concrete nightly version by @JamBalaya56562 in [#10423](https://github.com/jdx/mise/pull/10423)
+
+### 📚 Documentation
+
+- **(css)** align social links icons vertically center by @smasato in [#10424](https://github.com/jdx/mise/pull/10424)
+
+### Chore
+
+- **(ci)** make release asset upload idempotent by @jdx in [#10430](https://github.com/jdx/mise/pull/10430)
+- **(ci)** increase release job timeout by @jdx in [#10431](https://github.com/jdx/mise/pull/10431)
+- silence platform-conditional dead-code warnings by @JamBalaya56562 in [#10425](https://github.com/jdx/mise/pull/10425)
+
+### New Contributors
+
+- @smasato made their first contribution in [#10424](https://github.com/jdx/mise/pull/10424)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (1)
+
+- [`fallow-rs/fallow`](https://github.com/fallow-rs/fallow)
+
 ## [2026.6.7](https://github.com/jdx/mise/compare/v2026.6.6..v2026.6.7) - 2026-06-14
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.6.7"
+version = "2026.6.8"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.6.7"
+version = "2026.6.8"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.6.7 macos-arm64 (2026-06-14)
+2026.6.8 macos-arm64 (2026-06-14)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_7.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_8.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_7.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_8.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_7.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_8.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_7.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_8.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.6.7";
+  version = "2026.6.8";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.6.7
+Version: 2026.6.8
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.6.7"
+version: "2026.6.8"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "9f8f5659488e27a09bdfb32614a49fdf828ed7bb"
+  "tag": "5e51aeb24e091d65248f6b81cf0b1f83f62eb451"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -36695,6 +36695,39 @@ packages:
     format: raw
     complete_windows_ext: false
   - type: github_release
+    repo_owner: fallow-rs
+    repo_name: fallow
+    description: "Codebase intelligence for TypeScript and JavaScript. Free static layer: unused code, duplication, circular deps, complexity hotspots, architecture boundaries. Optional paid runtime layer: hot-path review and cold-path deletion evidence from real production traffic. Rust-native, sub-second, zero-config framework support"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["v1.0.0", "v2.22.2"]
+        no_asset: true
+      - version_constraint: semver("<= 2.47.0")
+        asset: fallow-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: fallow-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: fastfetch-cli
     repo_name: fastfetch
     description: An actively maintained, feature-rich and performance oriented, neofetch like system information tool


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(ruby)** require build revision releases by @jdx in [#10428](https://github.com/jdx/mise/pull/10428)
- **(zig)** resolve master channel to the concrete nightly version by @JamBalaya56562 in [#10423](https://github.com/jdx/mise/pull/10423)

### 📚 Documentation

- **(css)** align social links icons vertically center by @smasato in [#10424](https://github.com/jdx/mise/pull/10424)

### Chore

- **(ci)** make release asset upload idempotent by @jdx in [#10430](https://github.com/jdx/mise/pull/10430)
- **(ci)** increase release job timeout by @jdx in [#10431](https://github.com/jdx/mise/pull/10431)
- silence platform-conditional dead-code warnings by @JamBalaya56562 in [#10425](https://github.com/jdx/mise/pull/10425)

### New Contributors

- @smasato made their first contribution in [#10424](https://github.com/jdx/mise/pull/10424)

## 📦 Aqua Registry Updates

### New Packages (1)

- [`fallow-rs/fallow`](https://github.com/fallow-rs/fallow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multiple bug fixes included in this release

* **Documentation**
  * Improved vertical alignment of CSS social link icons

* **Chores**
  * Version bumped to 2026.6.8
  * Updated shell completion specifications across all supported shells
  * Updated Aqua Registry with new configuration constraints and asset overrides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->