### PR TITLE
docs(macos): fix macos defaults documentation examples

### DIFF
--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -5,23 +5,23 @@ mise can declare macOS user defaults (preferences) in the
 `mise bootstrap macos-defaults apply`:
 
 ```toml
-[bootstrap.macos.dock]
+[bootstrap.macos.defaults.dock]
 autohide = true
 orientation = "left"
 tilesize = 48
 show_recents = false
 
-[bootstrap.macos.finder]
+[bootstrap.macos.defaults.finder]
 show_all_files = true
 show_pathbar = true
 preferred_view_style = "list"
 
-[bootstrap.macos.keyboard]
+[bootstrap.macos.defaults.keyboard]
 key_repeat = 2
 initial_key_repeat = 15
 press_and_hold = false
 
-[bootstrap.macos.trackpad]
+[bootstrap.macos.defaults.trackpad]
 tap_to_click = true
 
 [bootstrap.macos.defaults]
@@ -37,7 +37,7 @@ override a global raw default for the same pair.
 
 ## Friendly sections
 
-`[bootstrap.macos.dock]` supports:
+`[bootstrap.macos.defaults.dock]` supports:
 
 | Key             | Raw default                    |
 | --------------- | ------------------------------ |
@@ -51,7 +51,7 @@ override a global raw default for the same pair.
 
 `orientation` must be `bottom`, `left`, or `right`.
 
-`[bootstrap.macos.finder]` supports:
+`[bootstrap.macos.defaults.finder]` supports:
 
 | Key                       | Raw default                                       |
 | ------------------------- | ------------------------------------------------- |
@@ -63,7 +63,7 @@ override a global raw default for the same pair.
 
 `preferred_view_style` must be `icon`, `list`, `column`, or `gallery`.
 
-`[bootstrap.macos.keyboard]` supports:
+`[bootstrap.macos.defaults.keyboard]` supports:
 
 | Key                  | Raw default                                 |
 | -------------------- | ------------------------------------------- |
@@ -72,7 +72,7 @@ override a global raw default for the same pair.
 | `press_and_hold`     | `NSGlobalDomain.ApplePressAndHoldEnabled`   |
 | `fn_state`           | `NSGlobalDomain.com.apple.keyboard.fnState` |
 
-`[bootstrap.macos.trackpad]` supports:
+`[bootstrap.macos.defaults.trackpad]` supports:
 
 | Key                 | Raw defaults                                                                                                                              |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
The examples in the macOS Defaults documentation page for version `2026.6.6` are missing the `defaults` TOML section. <https://mise.jdx.dev/bootstrap/macos-defaults.html>

This leads to the following error when using mise:

```txt
$ mise bootstrap macos-defaults status
mise WARN  unknown field in ~/.dotfiles/mise.toml: bootstrap.?.macos.dock
mise nothing configured in [bootstrap.macos.defaults]
mise WARN  unknown field in ~/.dotfiles/mise.toml: bootstrap.?.macos.dock
```

Tested with mise version `2026.6.6 macos-arm64 (2026-06-13)`

## Changes

- Updated `macos-defaults.md` to add the missing `defaults` section name in TOML examples.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS defaults configuration documentation with friendly, typed section format and clear examples
  * Documented supported configuration keys for dock, finder, keyboard, and trackpad settings
  * Added value constraints and mappings to clarify configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->