### PR TITLE
fix(ruby): require build revision releases

### DIFF
--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -294,8 +294,7 @@ revision in the platform `url`:
 url = "https://github.com/jdx/ruby/releases/download/3.3.11-1/ruby-3.3.11.x86_64_linux.tar.gz"
 ```
 
-Here `3.3.11-1` is build revision `1`; `3.3.11` without a suffix is the base
-release. See [Ruby precompiled build revisions](/lang/ruby.html#precompiled-build-revisions)
+Here `3.3.11-1` is build revision `1`. See [Ruby precompiled build revisions](/lang/ruby.html#precompiled-build-revisions)
 for details on why revisions exist, how unlocked installs behave, and how to
 update older lockfiles.
 

--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -49,6 +49,8 @@ falls back to compiling from source using ruby-build.
 ### Precompiled build revisions
 
 Precompiled Ruby binaries are released from `jdx/ruby`. Sometimes the binary for a Ruby version is rebuilt without changing the Ruby version itself. Those rebuilds use build revision release tags like `3.3.11-1` or `3.3.11-2`.
+Mise uses these build revision tags for `jdx/ruby` precompiled binaries instead
+of the floating base release tag.
 
 Rebuilds are for changes to the portable binary package, not changes to Ruby's
 own version number. The `jdx/ruby` release history includes rebuilds for
@@ -80,11 +82,10 @@ url = "https://github.com/jdx/ruby/releases/download/3.3.11-1/ruby-3.3.11.x86_64
 
 To see which precompiled build revision you have, inspect the release tag in the platform `url`:
 
-- `/releases/download/3.3.11/` means the base release, also called revision `0`
 - `/releases/download/3.3.11-1/` means build revision `1`
 - `/releases/download/3.3.11-2/` means build revision `2`
 
-If the lockfile already points at a build revision such as `3.3.11-1`, mise keeps using that exact revision for reproducibility. To update to the newest precompiled build revision for the same Ruby version, remove the Ruby entry (or the relevant platform URL) from `mise.lock`, then regenerate the lock entry and reinstall:
+If the lockfile already points at a build revision such as `3.3.11-1`, mise keeps using that exact revision for reproducibility. To update to the newest precompiled build revision for the same Ruby version, remove the entire Ruby entry from `mise.lock` or remove every Ruby platform `url`, then regenerate the lock entry and reinstall:
 
 ```sh
 mise lock ruby

--- a/src/github.rs
+++ b/src/github.rs
@@ -347,7 +347,8 @@ fn should_cache_release(release: &GithubRelease) -> bool {
 ///
 /// Build revisions use the pattern `{version}-{N}` where N is an incrementing integer.
 /// For example, given version "3.3.11", this will prefer tag "3.3.11-2" over "3.3.11-1"
-/// over "3.3.11". Returns the release with the highest build revision.
+/// over "3.3.11". Returns the release with the highest build revision and whether
+/// a numeric build revision tag was found.
 ///
 /// This is used by precompiled binary repos (e.g., jdx/ruby) where binaries may be
 /// rebuilt with different checksums while keeping the same upstream version.
@@ -356,12 +357,41 @@ fn should_cache_release(release: &GithubRelease) -> bool {
 /// when `MISE_LIST_ALL_VERSIONS` is not set. For repos with many releases, older versions
 /// may not be found, falling back to the exact version tag via `get_release`.
 #[cfg_attr(windows, allow(dead_code))]
-pub async fn get_release_with_build_revision(repo: &str, version: &str) -> Result<GithubRelease> {
+pub async fn get_release_with_build_revision_status(
+    repo: &str,
+    version: &str,
+) -> Result<(GithubRelease, bool)> {
     let releases = list_releases(repo).await?;
-    match pick_best_build_revision(releases, version) {
-        Some(release) => Ok(release),
-        None => get_release(repo, version).await,
+    match pick_best_numeric_build_revision(releases.clone(), version) {
+        Some(release) => Ok((release, true)),
+        None => match pick_best_build_revision(releases, version) {
+            Some(release) => Ok((release, false)),
+            None => Ok((get_release(repo, version).await?, false)),
+        },
     }
+}
+
+/// Select the highest numeric build revision for a given version.
+///
+/// Given releases with tags like "3.3.11", "3.3.11-1", "3.3.11-2", picks the
+/// highest numeric `-N` suffix and ignores the base version.
+#[cfg_attr(windows, allow(dead_code))]
+fn pick_best_numeric_build_revision(
+    releases: Vec<GithubRelease>,
+    version: &str,
+) -> Option<GithubRelease> {
+    let prefix = format!("{version}-");
+    releases
+        .into_iter()
+        .filter_map(|r| {
+            let revision = r
+                .tag_name
+                .strip_prefix(&prefix)
+                .and_then(|suffix| suffix.parse::<u32>().ok())?;
+            Some((revision, r))
+        })
+        .max_by_key(|(revision, _)| *revision)
+        .map(|(_, release)| release)
 }
 
 /// Select the release with the highest build revision for a given version.
@@ -909,6 +939,21 @@ something_else = "value"
         ];
         let best = pick_best_build_revision(releases, "3.3.11").unwrap();
         assert_eq!(best.tag_name, "3.3.11-2");
+    }
+
+    #[test]
+    fn test_numeric_build_revision_selects_highest_without_base_fallback() {
+        let releases = vec![
+            make_release("3.3.11"),
+            make_release("3.3.11-1"),
+            make_release("3.3.11-2"),
+            make_release("3.3.10-1"),
+        ];
+        let best = pick_best_numeric_build_revision(releases, "3.3.11").unwrap();
+        assert_eq!(best.tag_name, "3.3.11-2");
+
+        let releases = vec![make_release("3.3.11"), make_release("3.3.10-1")];
+        assert!(pick_best_numeric_build_revision(releases, "3.3.11").is_none());
     }
 
     #[test]

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -437,8 +437,12 @@ impl RubyPlugin {
         Some(ProvenanceType::GithubAttestations)
     }
 
-    fn use_versions_host_for_precompiled_attestations(source: &str) -> bool {
+    fn is_default_ruby_source(source: &str) -> bool {
         source == DEFAULT_RUBY_PRECOMPILED_URL
+    }
+
+    fn use_versions_host_for_precompiled_attestations(source: &str) -> bool {
+        Self::is_default_ruby_source(source)
     }
 
     /// Check if precompiled binaries should be tried
@@ -557,11 +561,7 @@ impl RubyPlugin {
                     if let Some(end) = after.find('/') {
                         let tag = &after[..end];
                         // Check if this is a build revision of the version
-                        if tag != version
-                            && tag.starts_with(&format!("{version}-"))
-                            && let Some(suffix) = tag.strip_prefix(&format!("{version}-"))
-                            && suffix.parse::<u32>().is_ok()
-                        {
+                        if Self::is_build_revision_tag(version, tag) {
                             return Some(tag.to_string());
                         }
                     }
@@ -569,6 +569,15 @@ impl RubyPlugin {
             }
         }
         None
+    }
+
+    fn source_requires_build_revision(source: &str) -> bool {
+        Self::is_default_ruby_source(source)
+    }
+
+    fn is_build_revision_tag(version: &str, tag: &str) -> bool {
+        tag.strip_prefix(&format!("{version}-"))
+            .is_some_and(|suffix| suffix.parse::<u32>().is_ok())
     }
 
     /// Find precompiled asset from a GitHub repo's releases.
@@ -582,6 +591,7 @@ impl RubyPlugin {
         prefer_no_yjit: bool,
         locked_build_revision: Option<&str>,
     ) -> Result<Option<(String, Option<String>)>> {
+        let requires_build_revision = Self::source_requires_build_revision(repo);
         let release = if let Some(tag) = locked_build_revision {
             // Use the exact build revision from the lockfile
             debug!("using locked build revision {tag} for ruby {version}");
@@ -589,8 +599,14 @@ impl RubyPlugin {
                 Ok(r) => r,
                 Err(err) => {
                     debug!("locked build revision {tag} not found, finding latest: {err}");
-                    match github::get_release_with_build_revision(repo, version).await {
-                        Ok(r) => r,
+                    match github::get_release_with_build_revision_status(repo, version).await {
+                        Ok((r, found_build_revision)) => {
+                            if requires_build_revision && !found_build_revision {
+                                debug!("no build revision release found for ruby {version}");
+                                return Ok(None);
+                            }
+                            r
+                        }
                         Err(err) => {
                             debug!("no precompiled ruby found for {version}: {err}");
                             return Ok(None);
@@ -599,8 +615,14 @@ impl RubyPlugin {
                 }
             }
         } else {
-            match github::get_release_with_build_revision(repo, version).await {
-                Ok(r) => r,
+            match github::get_release_with_build_revision_status(repo, version).await {
+                Ok((r, found_build_revision)) => {
+                    if requires_build_revision && !found_build_revision {
+                        debug!("no build revision release found for ruby {version}");
+                        return Ok(None);
+                    }
+                    r
+                }
                 Err(err) => {
                     debug!("no precompiled ruby found for {version}: {err}");
                     return Ok(None);
@@ -1295,6 +1317,26 @@ mod tests {
         assert!(!RubyPlugin::use_versions_host_for_precompiled_attestations(
             "acme/ruby"
         ));
+    }
+
+    #[test]
+    fn test_ruby_default_precompiled_source_requires_build_revision() {
+        assert!(RubyPlugin::source_requires_build_revision(
+            DEFAULT_RUBY_PRECOMPILED_URL
+        ));
+        assert!(!RubyPlugin::source_requires_build_revision("acme/ruby"));
+    }
+
+    #[test]
+    fn test_ruby_build_revision_tags_are_numeric_suffixes() {
+        assert!(RubyPlugin::is_build_revision_tag("3.3.11", "3.3.11-1"));
+        assert!(RubyPlugin::is_build_revision_tag("3.3.11", "3.3.11-10"));
+        assert!(!RubyPlugin::is_build_revision_tag("3.3.11", "3.3.11"));
+        assert!(!RubyPlugin::is_build_revision_tag(
+            "3.3.11",
+            "3.3.11-preview1"
+        ));
+        assert!(!RubyPlugin::is_build_revision_tag("3.3.11", "3.3.10-1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require the default `jdx/ruby` precompiled source to resolve numeric build revision tags instead of using the floating base release tag
- keep custom Ruby precompiled GitHub sources on the existing behavior
- update docs to stop describing the base release as an expected Ruby precompiled lockfile target

## Context
`jdx/ruby` publishes immutable build revision releases like `3.3.11-1` alongside the floating base release. Since every `jdx/ruby` precompiled Ruby version should have a build revision, mise should not lock or install the base release tag for that default source.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test ruby_build_revision`
- `cargo test test_ruby_default_precompiled_source_requires_build_revision`
- `cargo test test_build_revision`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Ruby install/lock resolution for the default precompiled source; versions that only have a base tag may stop using precompiled binaries until a build revision exists, while custom sources are unchanged.
> 
> **Overview**
> **Default `jdx/ruby` precompiled installs and lock URLs no longer target the floating base release tag** (e.g. `3.3.11`). Resolution prefers the highest numeric build revision (`3.3.11-1`, `3.3.11-2`, …) and **aborts the precompiled path** when no such tag exists, so mise can fall back to source compile instead of locking a mutable base asset.
> 
> GitHub release selection gains `get_release_with_build_revision_status` and `pick_best_numeric_build_revision`, which report whether a numeric `-N` suffix was found; the Ruby plugin applies that **only when the precompiled source is the default `jdx/ruby` repo**—custom `ruby.precompiled_url` GitHub sources still allow the old base-tag fallback.
> 
> Docs drop treating the base release as an expected lockfile revision and state that mise uses build-revision tags for `jdx/ruby`, with slightly clearer lockfile refresh steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a85a475e8adfb30a436ea299810a1d2ec150921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for Ruby precompiled build revisions, including how `mise.lock` pins a specific build-revision tag (e.g., `3.3.11-1`, `3.3.11-2`), how “latest available” behavior works without the lockfile, and how to interpret the corresponding release URL paths.
* **Improvements**
  * Improved Ruby precompiled binary selection to properly recognize numeric build-revision tags, ignore non-matching tag formats, and behave more predictably when a locked revision is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->