### PR TITLE
chore(ci): increase release job timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,7 @@ jobs:
           if-no-files-found: error
   release:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       contents: write
     needs:


### PR DESCRIPTION
## Summary
- increase the `release` workflow job timeout from 10 minutes to 30 minutes

## Context
The release job in https://github.com/jdx/mise/actions/runs/27487189873/job/81247212839 was canceled after running a little over 10 minutes, while it was still creating the GitHub release. The current timeout is too tight for release publishing when asset upload or release-note generation runs long.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`\n\n*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI timeout tweak with no application, auth, or release-script logic changes.
> 
> **Overview**
> Raises the **`release`** job limit in `.github/workflows/release.yml` from **10** to **30** minutes so tag releases can finish GitHub release creation, asset uploads, and related steps without being canceled at the old cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb340785c9a81dd551ef7130ccb2cd0302332a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved release process stability by increasing timeout allowance for release job completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->