### PR TITLE
fix(vfox): apply tools=true env to os.execute install hooks (#10282)

### DIFF
--- a/crates/vfox/src/lua_mod/cmd.rs
+++ b/crates/vfox/src/lua_mod/cmd.rs
@@ -9,6 +9,28 @@ pub fn mod_cmd(lua: &Lua) -> LuaResult<()> {
     let cmd = lua.create_table_from(vec![("exec", lua.create_function(exec)?)])?;
     loaded.set("cmd", cmd.clone())?;
     loaded.set("vfox.cmd", cmd)?;
+
+    // Route Lua's `os.execute` through mise's sanitized env (registry `mise_env`),
+    // matching cmd.exec. Stock `os.execute` inherits mise's raw process env, which
+    // during a combined `mise install` can carry stale `tools = true` values
+    // (e.g. a `CLOUDSDK_PYTHON` rendered before its python dependency was
+    // installed). Plugins that shell out via `os.execute` (e.g. vfox-gcloud's
+    // install.sh) would otherwise use the stale value and fail. When `mise_env`
+    // is unset, `os.execute` behaves exactly as stock. (#10282)
+    //
+    // Reuse the existing `os` table so `os.time`/`os.date`/etc. are preserved; only
+    // create one if `os` is absent (`nil`). A non-table `os` propagates the error
+    // rather than being silently overwritten.
+    let globals = lua.globals();
+    let os: Table = match globals.get::<Option<Table>>("os")? {
+        Some(os) => os,
+        None => {
+            let os = lua.create_table()?;
+            globals.set("os", os.clone())?;
+            os
+        }
+    };
+    os.set("execute", lua.create_function(os_execute)?)?;
     Ok(())
 }
 
@@ -36,16 +58,7 @@ fn exec(lua: &Lua, args: mlua::MultiValue) -> LuaResult<String> {
 
     // Apply mise-constructed environment if available in Lua registry.
     // This ensures mise-managed tools are on PATH when called from env module hooks.
-    let has_mise_env = if let Ok(mise_env) = lua.named_registry_value::<Table>("mise_env") {
-        cmd.env_clear();
-        for pair in mise_env.pairs::<String, String>() {
-            let (key, value) = pair?;
-            cmd.env(key, value);
-        }
-        true
-    } else {
-        false
-    };
+    let has_mise_env = apply_mise_env(lua, &mut cmd)?;
     debug!("[cmd.exec] command={command:?} shell={shell:?} has_mise_env={has_mise_env}");
 
     // Apply options if provided (explicit env vars override mise env)
@@ -85,6 +98,44 @@ fn exec(lua: &Lua, args: mlua::MultiValue) -> LuaResult<String> {
             output.status, stderr
         )))
     }
+}
+
+/// Apply the mise-constructed environment (Lua registry `mise_env`) to `cmd`,
+/// clearing the inherited environment first so the child sees exactly the env
+/// mise built. Returns true if it was applied; when `mise_env` is absent the
+/// command's inherited environment is left untouched (stock behavior).
+fn apply_mise_env(lua: &Lua, cmd: &mut Command) -> LuaResult<bool> {
+    if let Ok(mise_env) = lua.named_registry_value::<Table>("mise_env") {
+        cmd.env_clear();
+        for pair in mise_env.pairs::<String, String>() {
+            let (key, value) = pair?;
+            cmd.env(key, value);
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Drop-in replacement for Lua's `os.execute` that applies mise's sanitized env
+/// (see [`apply_mise_env`]) and runs through the same shell as cmd.exec, while
+/// keeping `os.execute`'s streaming stdio (output goes to the terminal rather
+/// than being captured). Returns the process exit code (Lua 5.1 convention:
+/// `0` on success); `os.execute()` with no argument reports shell availability.
+/// (#10282)
+fn os_execute(lua: &Lua, command: Option<String>) -> LuaResult<i64> {
+    let Some(command) = command else {
+        // `os.execute()` with no argument: report that a shell is available.
+        return Ok(1);
+    };
+    let shell = cmd_shell(lua)?;
+    let mut cmd = command_from_shell(&shell, &command)?;
+    let has_mise_env = apply_mise_env(lua, &mut cmd)?;
+    debug!("[os.execute] command={command:?} shell={shell:?} has_mise_env={has_mise_env}");
+    let status = cmd
+        .status()
+        .map_err(|e| mlua::Error::RuntimeError(format!("Failed to execute command: {e}")))?;
+    Ok(status.code().unwrap_or(-1) as i64)
 }
 
 fn cmd_shell(lua: &Lua) -> LuaResult<Vec<String>> {
@@ -181,6 +232,32 @@ mod tests {
             assert(result:find("hello world") ~= nil)
         "#
         ))
+        .exec()
+        .unwrap();
+    }
+
+    // os.execute must honor the mise_env registry (env_clear + mise_env) so
+    // plugins shelling out via os.execute get mise's sanitized env, not the raw
+    // process env (which may carry stale tools=true values). (#10282)
+    #[test]
+    #[cfg(unix)]
+    fn test_os_execute_applies_mise_env() {
+        let lua = Lua::new();
+        mod_cmd(&lua).unwrap();
+        let env = lua.create_table().unwrap();
+        // env_clear wipes PATH, so re-supply it for `sh` to resolve.
+        env.set("PATH", std::env::var("PATH").unwrap_or_default())
+            .unwrap();
+        env.set("MISE_OS_EXEC_MARKER", "yes").unwrap();
+        lua.set_named_registry_value("mise_env", env).unwrap();
+        lua.load(
+            r#"
+            local ok = os.execute('[ "$MISE_OS_EXEC_MARKER" = yes ]')
+            assert(ok == 0, "mise_env not applied to os.execute: " .. tostring(ok))
+            local bad = os.execute('[ "$MISE_OS_EXEC_MARKER" = no ]')
+            assert(bad ~= 0, "expected non-zero exit on false test")
+        "#,
+        )
         .exec()
         .unwrap();
     }

--- a/e2e/backend/test_vfox_install_tools_env
+++ b/e2e/backend/test_vfox_install_tools_env
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# #10282: a `tools = true` [env] value must reach a vfox plugin's install hook
+# even when the hook shells out via Lua `os.execute` (not cmd.exec). Before the
+# fix, os.execute inherited mise's raw process env (which lacks the tools=true
+# var during a non-activated `mise install`), so the value was missing and
+# installs like gcloud (which reads CLOUDSDK_PYTHON in its install.sh) failed.
+
+PLUGIN_DIR="$PWD/vfox-tools-env"
+MARKER="$PWD/tools-env-marker"
+
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
+PLUGIN = {}
+PLUGIN.name = "tools-env"
+PLUGIN.version = "0.1.0"
+PLUGIN.homepage = "https://example.com/tools-env"
+PLUGIN.license = "MIT"
+PLUGIN.description = "tools=true env test plugin"
+LUA
+
+cat >"$PLUGIN_DIR/hooks/available.lua" <<'LUA'
+function PLUGIN:Available(ctx)
+	return {
+		{ version = "1.0.0" },
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/pre_install.lua" <<'LUA'
+function PLUGIN:PreInstall(ctx)
+	return {
+		version = ctx.version,
+	}
+end
+LUA
+
+# PostInstall shells out via os.execute (NOT cmd.exec) to capture the
+# tools=true env var, mirroring how vfox-gcloud runs its install.sh.
+cat >"$PLUGIN_DIR/hooks/post_install.lua" <<LUA
+function PLUGIN:PostInstall(ctx)
+	os.execute("printf '%s' \"\$MISE_TEST_TOOLS_VAR\" > \"$MARKER\"")
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/env_keys.lua" <<'LUA'
+function PLUGIN:EnvKeys(ctx)
+	return {}
+end
+LUA
+
+git -C "$PLUGIN_DIR" init
+git -C "$PLUGIN_DIR" add .
+git -C "$PLUGIN_DIR" -c user.name="mise" -c user.email="mise@example.com" commit -m "initial plugin"
+
+cat >mise.toml <<EOF
+[settings]
+unix_default_inline_shell_args = "sh -c"
+
+[tools]
+"vfox:file://$PLUGIN_DIR" = "1.0.0"
+
+[env]
+MISE_TEST_TOOLS_VAR = { value = "resolved-via-tools-env", tools = true }
+EOF
+
+mise install
+assert "cat '$MARKER'" "resolved-via-tools-env"

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -147,6 +147,37 @@ impl Backend for VfoxBackend {
             .into_iter()
             .collect();
         cmd_env.extend(tv.install_env());
+        // Surface `tools = true` `[env]` *value* directives (e.g.
+        // `CLOUDSDK_PYTHON = "{{ tools.python.path }}/bin/python3"`) resolved against
+        // the install toolset, which already has the dependency installed (depends
+        // ordering). Without this, a combined `mise install` would run the plugin's
+        // install hooks (including os.execute) without the resolved value, unlike the
+        // separate-install case where a re-activated shell re-exports it. Uses ctx.ts
+        // — NOT config.get_toolset(), which would re-enter the toolset OnceCell from
+        // backends' version listing and deadlock. Best-effort: env *modules* are
+        // excluded via ToolsFilter::ToolsOnlyVals, errors fall back to the tool-less
+        // env, and PATH is left to dependency_env. (#10282)
+        {
+            let base: EnvMap = cmd_env.clone().into_iter().collect();
+            match ctx.ts.tool_val_env(&ctx.config, &base).await {
+                Ok(vals) => {
+                    for (k, v) in vals {
+                        // PATH stays owned by dependency_env. On Windows env var
+                        // names are case-insensitive, so exclude any casing
+                        // (e.g. a lowercase `path`); on unix only exact `PATH`.
+                        let is_path = if cfg!(windows) {
+                            k.eq_ignore_ascii_case(crate::env::PATH_KEY.as_str())
+                        } else {
+                            k.as_str() == crate::env::PATH_KEY.as_str()
+                        };
+                        if !is_path {
+                            cmd_env.insert(k, v);
+                        }
+                    }
+                }
+                Err(e) => debug!("vfox: skipping tools=true value directives: {e:#}"),
+            }
+        }
         if !cmd_env.is_empty() {
             vfox.cmd_env = Some(cmd_env);
         }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -253,6 +253,12 @@ pub enum ToolsFilter {
     #[default]
     NonToolsOnly,
     Both,
+    /// `tools = true` directives, but only plain `Val` (`KEY = value`) entries.
+    /// Env *modules* (PythonVenv/Module/Source/File/Path) are skipped because they
+    /// may reference tools outside a partial (dependency) toolset and would error.
+    /// Used by `dependency_env` so a dependent tool's install sees `tools = true`
+    /// value vars like `CLOUDSDK_PYTHON = "{{ tools.python.path }}/..."`. (#10282)
+    ToolsOnlyVals,
 }
 
 pub struct EnvResolveOptions {
@@ -296,6 +302,9 @@ impl EnvResults {
                     ToolsFilter::ToolsOnly => directive.options().tools,
                     ToolsFilter::NonToolsOnly => !directive.options().tools,
                     ToolsFilter::Both => true,
+                    ToolsFilter::ToolsOnlyVals => {
+                        directive.options().tools && matches!(directive, EnvDirective::Val(..))
+                    }
                 };
 
                 if !should_include {
@@ -775,5 +784,60 @@ impl Debug for EnvResults {
             ds.field("tool_add_paths", &self.tool_add_paths);
         }
         ds.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::env_diff::EnvMap;
+    use crate::tera::BASE_CONTEXT;
+
+    /// `ToolsFilter::ToolsOnlyVals` must select only `tools = true` `Val`
+    /// directives — excluding `tools = false` vars and `tools = true` *modules*
+    /// (here a `Path`). This is what `dependency_env` relies on to surface vars
+    /// like `CLOUDSDK_PYTHON = "{{ tools.python.path }}/..."` during a dependent
+    /// tool's install without running env modules on a partial toolset. (#10282)
+    #[tokio::test]
+    async fn test_tools_only_vals_filter() {
+        let env = EnvMap::new();
+        let config = Config::get().await.unwrap();
+        let tools = EnvDirectiveOptions {
+            tools: true,
+            ..Default::default()
+        };
+        let results = EnvResults::resolve(
+            &config,
+            BASE_CONTEXT.clone(),
+            &env,
+            vec![
+                // tools = true Val -> included
+                (
+                    EnvDirective::Val("TOOLS_VAL".into(), "yes".into(), tools.clone()),
+                    PathBuf::from("/config"),
+                ),
+                // tools = false Val -> excluded
+                (
+                    EnvDirective::Val("PLAIN_VAL".into(), "no".into(), Default::default()),
+                    PathBuf::from("/config"),
+                ),
+                // tools = true module (Path) -> excluded
+                (
+                    EnvDirective::Path("/should/not/appear".into(), tools.clone()),
+                    PathBuf::from("/config"),
+                ),
+            ],
+            EnvResolveOptions {
+                vars: false,
+                tools: ToolsFilter::ToolsOnlyVals,
+                warn_on_missing_required: false,
+            },
+        )
+        .await
+        .unwrap();
+        let keys: Vec<String> = results.env.keys().cloned().collect();
+        assert_eq!(keys, vec!["TOOLS_VAL".to_string()]);
+        assert!(results.env_paths.is_empty());
     }
 }

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -377,7 +377,9 @@ impl Toolset {
         let mut ctx = config.tera_ctx.clone();
         ctx.insert("env", &tera_env);
         ctx.insert("tools", &self.build_tools_tera_map(config));
-        let mut env_results = self.load_post_env(config, ctx, &tera_env).await?;
+        let mut env_results = self
+            .load_post_env(config, ctx, &tera_env, ToolsFilter::ToolsOnly)
+            .await?;
 
         // Include watch_files from tools=false plugins so the env cache tracks all
         // plugin watch_files, not just tools=true ones. env_results_cached()
@@ -412,6 +414,7 @@ impl Toolset {
         config: &Arc<Config>,
         ctx: tera::Context,
         env: &EnvMap,
+        tools_filter: ToolsFilter,
     ) -> Result<EnvResults> {
         if Settings::no_env() || Settings::get().no_env.unwrap_or(false) {
             return Ok(EnvResults::default());
@@ -436,7 +439,7 @@ impl Toolset {
             entries,
             EnvResolveOptions {
                 vars: false,
-                tools: ToolsFilter::ToolsOnly,
+                tools: tools_filter,
                 warn_on_missing_required: *WARN_ON_MISSING_REQUIRED_ENV,
             },
         )
@@ -447,5 +450,31 @@ impl Toolset {
             debug!("{env_results:?}");
         }
         Ok(env_results)
+    }
+
+    /// Resolve only `tools = true` `[env]` *value* directives (plain
+    /// `KEY = value` templates such as `{{ tools.python.path }}`) against this
+    /// toolset's currently-installed tools, layered on top of `base_env`, and
+    /// return just those vars. Env *modules* are skipped (see
+    /// [`ToolsFilter::ToolsOnlyVals`]).
+    ///
+    /// Deliberately lean: it builds only the `tools.*` tera map (cheap; no
+    /// `exec_env`) rather than recomputing the full env, so `dependency_env` can
+    /// call it per-install without the cost/recursion of `final_env`. Used so a
+    /// dependent tool's install picks up vars like `CLOUDSDK_PYTHON` during a
+    /// combined `mise install`, mirroring what a re-activated shell exports
+    /// between separate installs. (#10282)
+    pub async fn tool_val_env(&self, config: &Arc<Config>, base_env: &EnvMap) -> Result<EnvMap> {
+        let mut ctx = config.tera_ctx.clone();
+        ctx.insert("env", base_env);
+        ctx.insert("tools", &self.build_tools_tera_map(config));
+        let env_results = self
+            .load_post_env(config, ctx, base_env, ToolsFilter::ToolsOnlyVals)
+            .await?;
+        Ok(env_results
+            .env
+            .into_iter()
+            .map(|(k, (v, _))| (k, v))
+            .collect())
     }
 }


### PR DESCRIPTION
## Summary

Fixes [#10282](https://github.com/jdx/mise/discussions/10282). When `mise install` installs several tools at once, a `tools = true` `[env]` var that depends on another tool — e.g. a gcloud + python setup:

```toml
[tools]
python = "3.13"
gcloud = { version = "latest", depends = ["python"] }

[env]
CLOUDSDK_PYTHON = { value = "{{ tools.python.path }}/bin/python3", tools = true }
```

— did not reach the dependent tool's install. Installing separately (`mise install python` then `mise install gcloud`) worked, but a combined `mise install` failed.

## Root cause

Two interacting gaps:

1. **`os.execute` bypasses the sanitized env.** vfox plugins that shell out via Lua `os.execute` (e.g. [vfox-gcloud](https://github.com/mise-plugins/vfox-gcloud)'s `install.sh`) inherit mise's *raw process env*, ignoring the `mise_env` registry that `cmd.exec` applies. During a combined install that raw env still carried the **stale** `CLOUDSDK_PYTHON` rendered before python was installed (`{{ tools.python.path }}` was empty → `/bin/python3`), so `install.sh` used a nonexistent python and failed.
2. **`tools = true` values were never computed for the install.** `dependency_env` resolves with `full_env_without_tools`, so `tools = true` `[env]` values weren't applied to the install environment at all.

The separate-install case only worked because the (activated) shell re-exported the now-correct `CLOUDSDK_PYTHON` between the two commands — something a single combined `mise install` process never does.

## Fix

- **crates/vfox**: route Lua `os.execute` through `mise_env` (`env_clear` + `mise_env`), matching `cmd.exec`. Factored the env application into a shared `apply_mise_env` helper. When `mise_env` is unset (i.e. not a mise-managed install) `os.execute` behaves exactly as stock, so the blast radius is limited to installs.
- **env resolution**: a new `ToolsFilter::ToolsOnlyVals` selects `tools = true` *value* directives only. `Toolset::tool_val_env` resolves those against the full (installed) toolset and `dependency_env` merges them in **best-effort** (PATH untouched; errors fall back to the tool-less env). Env *modules* (PythonVenv/Module/Source/File/Path) are deliberately skipped so modules are never run on a partial toolset.

The full toolset (not the dependency toolset) is used for the value resolution because `depends` ordering installs the dependency first, but `dependency_toolset` only tracks backend/registry-declared deps, not user `depends`.

## Tests

- `crates/vfox` unit test: `os.execute` honors `mise_env`.
- `env_directive` unit test: `ToolsOnlyVals` includes `tools = true` Vals and excludes `tools = false` vars and modules.
- e2e `e2e/backend/test_vfox_install_tools_env`: a local vfox plugin whose `PostInstall` reads a `tools = true` var via `os.execute` (network-free, deterministic).

## Notes / scope

- Only `os.execute` is rerouted; `io.popen` (file-handle semantics) is left as a follow-up. vfox-gcloud uses `os.execute`.
- This delivers the `tools = true` value (here `CLOUDSDK_PYTHON`, an absolute path). Putting a user-`depends` tool's bin on `PATH` during install is a separate concern (`dependency_toolset` doesn't track user `depends`) and not required for this report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Lua `os.execute` so shell execution uses the same sanitized `mise_env` environment as command execution.
  * Tool-related environment is now available in vfox plugin install hooks: only `tools = true` value directives are resolved, and `PATH` updates are intentionally avoided.

* **Tests**
  * Added a Unix regression test asserting `os.execute` honors `mise_env`, including `env_clear` behavior for shell resolution.
  * Added an end-to-end backend test verifying `tools = true` env vars are readable inside plugin `PostInstall` hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->