### PR TITLE
fix(backend): enable 7z archives on unix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,27 +1075,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
-dependencies = [
- "bit-vec 0.7.0",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bit-vec"
@@ -2593,7 +2578,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "regex-automata",
  "regex-syntax 0.8.10",
 ]
@@ -2641,17 +2626,6 @@ checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "filetime_creation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f"
-dependencies = [
- "cfg-if",
- "filetime",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5143,15 +5117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-rust"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "lzma-rust2"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5402,7 +5367,7 @@ dependencies = [
  "serde_ignored",
  "serde_json",
  "serde_yaml",
- "sevenz-rust",
+ "sevenz-rust2",
  "sha1 0.11.0",
  "sha2 0.11.0",
  "shell-escape",
@@ -5665,16 +5630,6 @@ name = "nonempty"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
-
-[[package]]
-name = "nt-time"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de419e64947cd8830e66beb584acc3fb42ed411d103e3c794dda355d1b374b5"
-dependencies = [
- "chrono",
- "time",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -6405,8 +6360,8 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags",
  "num-traits",
  "rand 0.9.4",
@@ -8081,31 +8036,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "sevenz-rust"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef"
-dependencies = [
- "bit-set 0.6.0",
- "byteorder",
- "crc",
- "filetime_creation",
- "js-sys",
- "lzma-rust",
- "nt-time",
- "sha2 0.10.9",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "sevenz-rust2"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29225600349ef74beda5a9fffb36ac660a24613c0bde9315d0c49be1d51e9c24"
 dependencies = [
+ "aes 0.8.4",
+ "bzip2 0.6.1",
+ "cbc",
  "crc32fast",
+ "getrandom 0.4.2",
  "js-sys",
  "lzma-rust2",
+ "ppmd-rust",
+ "sha2 0.10.9",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ serde = { version = "1", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1"
 serde_yaml = "0.9"
+sevenz-rust2 = "0.20"
 sha1 = "0.11"
 sha2 = "0.11"
 blake3 = "1"
@@ -233,7 +234,6 @@ self_update = { version = "0.44", optional = true, default-features = false, fea
   "rustls",
 ] }
 zipsign-api = "0.2"
-sevenz-rust = "0.6"
 winapi = { version = "0.3.9", features = ["consoleapi", "minwindef"] }
 
 [build-dependencies]

--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -165,7 +165,7 @@ The generator automatically detects and extracts various archive formats:
 - `.tar.bz2` / `.tbz2` (bzip2 compressed tarballs)
 - `.tar.zst` / `.tzst` (zstd compressed tarballs)
 - `.zip` (zip archives)
-- `.7z` (7-zip archives, Windows only)
+- `.7z` (7-zip archives)
 
 ### Generated Stub Example
 

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -433,10 +433,8 @@ impl HttpBackend {
             opts.strip_components().and_then(|s| s.parse().ok());
 
         // Auto-detect strip_components=1 for single-directory archives
-        let can_probe_strip = file_info.format != file::ExtractionFormat::SevenZip || cfg!(windows);
         if strip_components.is_none()
             && opts.bin_path().is_none()
-            && can_probe_strip
             && file::should_strip_components(file_path, file_info.format).unwrap_or(false)
         {
             debug!("Auto-detected single directory archive, using strip_components=1");

--- a/src/file.rs
+++ b/src/file.rs
@@ -1328,7 +1328,10 @@ pub fn un7z(archive: &Path, dest: &Path, opts: &ExtractOptions<'_>) -> Result<()
         ));
     }
     sevenz_rust2::decompress_file_with_extract_fn(archive, dest, |entry, reader, _| {
-        let dest_path = dest.join(normalize_7z_entry_path(entry.name()));
+        let dest_path = dest.join(
+            sanitize_7z_entry_path(entry.name())
+                .map_err(|err| sevenz_rust2::Error::Other(format!("{err:#}").into()))?,
+        );
         sevenz_rust2::default_entry_extract_fn(entry, reader, &dest_path)
     })
     .wrap_err_with(|| format!("failed to extract 7z archive: {}", display_path(archive)))?;
@@ -1345,8 +1348,23 @@ pub fn un7z(archive: &Path, dest: &Path, opts: &ExtractOptions<'_>) -> Result<()
     })
 }
 
-fn normalize_7z_entry_path(path: &str) -> PathBuf {
-    PathBuf::from(path.replace('\\', "/"))
+fn sanitize_7z_entry_path(path: &str) -> Result<PathBuf> {
+    let normalized = PathBuf::from(path.replace('\\', "/"));
+    let mut safe_path = PathBuf::new();
+
+    for component in normalized.components() {
+        match component {
+            std::path::Component::Normal(part) => safe_path.push(part),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => {
+                bail!("7z archive entry path escapes extraction directory: {path}")
+            }
+        }
+    }
+
+    Ok(safe_path)
 }
 
 pub fn split_file_name(path: &Path) -> (String, String) {
@@ -1459,7 +1477,7 @@ pub fn inspect_7z_contents(archive: &Path) -> Result<Vec<(String, bool)>> {
     let mut top_level_components = std::collections::HashMap::new();
 
     for file in &sevenz.files {
-        let path = normalize_7z_entry_path(file.name());
+        let path = sanitize_7z_entry_path(file.name())?;
 
         // Get the first non-CurDir component of the path (top-level directory/file)
         let mut components = skip_curdir_components(&path);
@@ -2267,6 +2285,12 @@ mod tests {
         let stripped_dest_dir = dir.path().join("stripped_out_dir");
         let backslash_archive_path = dir.path().join("backslash.7z");
         let backslash_dest_dir = dir.path().join("backslash_out_dir");
+        let traversal_archive_path = dir.path().join("traversal.7z");
+        let traversal_dest_dir = dir.path().join("traversal_out_dir");
+        let traversal_target_path = dir.path().join("traversal_target");
+        let absolute_archive_path = dir.path().join("absolute.7z");
+        let absolute_dest_dir = dir.path().join("absolute_out_dir");
+        let absolute_target_path = dir.path().join("absolute_target");
 
         std::fs::create_dir_all(&pkg_dir).unwrap();
         std::fs::write(pkg_dir.join("tool"), "hello world").unwrap();
@@ -2341,6 +2365,52 @@ mod tests {
         assert!(!backslash_dest_dir.join("pkg").exists());
         let content = std::fs::read_to_string(&backslash_stripped_path).unwrap();
         assert_eq!(content, "hello world");
+
+        let mut traversal_archive =
+            sevenz_rust2::ArchiveWriter::create(&traversal_archive_path).unwrap();
+        traversal_archive
+            .push_archive_entry(
+                sevenz_rust2::ArchiveEntry::new_file("../traversal_target"),
+                Some(Cursor::new(b"malicious")),
+            )
+            .unwrap();
+        traversal_archive.finish().unwrap();
+
+        let err = extract_archive(
+            &traversal_archive_path,
+            &traversal_dest_dir,
+            ExtractionFormat::SevenZip,
+            &ExtractOptions::default(),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("escapes extraction directory"),
+            "{err:#}"
+        );
+        assert!(!traversal_target_path.exists());
+
+        let mut absolute_archive =
+            sevenz_rust2::ArchiveWriter::create(&absolute_archive_path).unwrap();
+        absolute_archive
+            .push_archive_entry(
+                sevenz_rust2::ArchiveEntry::new_file(&absolute_target_path.to_string_lossy()),
+                Some(Cursor::new(b"malicious")),
+            )
+            .unwrap();
+        absolute_archive.finish().unwrap();
+
+        let err = extract_archive(
+            &absolute_archive_path,
+            &absolute_dest_dir,
+            ExtractionFormat::SevenZip,
+            &ExtractOptions::default(),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("escapes extraction directory"),
+            "{err:#}"
+        );
+        assert!(!absolute_target_path.exists());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -1069,16 +1069,7 @@ pub fn extract_archive(
         | ExtractionFormat::TarSz
         | ExtractionFormat::Raw => untar(archive, dest, format, opts),
         ExtractionFormat::Zip => unzip(archive, dest, opts),
-        ExtractionFormat::SevenZip => {
-            #[cfg(windows)]
-            {
-                return un7z(archive, dest, opts);
-            }
-            #[cfg(not(windows))]
-            {
-                bail!("7z format not supported on this platform");
-            }
-        }
+        ExtractionFormat::SevenZip => un7z(archive, dest, opts),
         ExtractionFormat::Gz
         | ExtractionFormat::Xz
         | ExtractionFormat::Bz2
@@ -1329,7 +1320,6 @@ pub fn un_pkg(archive: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(windows)]
 pub fn un7z(archive: &Path, dest: &Path, opts: &ExtractOptions<'_>) -> Result<()> {
     if let Some(pr) = &opts.pr {
         pr.set_message(format!(
@@ -1337,7 +1327,7 @@ pub fn un7z(archive: &Path, dest: &Path, opts: &ExtractOptions<'_>) -> Result<()
             archive.file_name().unwrap().to_string_lossy()
         ));
     }
-    sevenz_rust::decompress_file(archive, dest)
+    sevenz_rust2::decompress_file(archive, dest)
         .wrap_err_with(|| format!("failed to extract 7z archive: {}", display_path(archive)))?;
 
     if !opts.preserve_mtime {
@@ -1457,12 +1447,11 @@ pub fn inspect_zip_contents(archive: &Path) -> Result<Vec<(String, bool)>> {
 }
 
 /// Adapted from inspect_tar_contents for 7z archives
-#[cfg(windows)]
 pub fn inspect_7z_contents(archive: &Path) -> Result<Vec<(String, bool)>> {
-    let sevenz = sevenz_rust::SevenZReader::open(archive, sevenz_rust::Password::empty())?;
+    let sevenz = sevenz_rust2::Archive::open(archive)?;
     let mut top_level_components = std::collections::HashMap::new();
 
-    for file in &sevenz.archive().files {
+    for file in &sevenz.files {
         let path = PathBuf::from(file.name());
 
         // Get the first non-CurDir component of the path (top-level directory/file)
@@ -1479,11 +1468,6 @@ pub fn inspect_7z_contents(archive: &Path) -> Result<Vec<(String, bool)>> {
     }
 
     Ok(top_level_components.into_iter().collect())
-}
-
-#[cfg(not(windows))]
-pub fn inspect_7z_contents(_archive: &Path) -> Result<Vec<(String, bool)>> {
-    bail!("7z format not supported on this platform")
 }
 
 /// Determines if strip_components=1 should be applied based on archive structure
@@ -2264,6 +2248,39 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_archive_7z() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        let pkg_dir = src_dir.join("pkg");
+        let archive_path = dir.path().join("test.7z");
+        let dest_dir = dir.path().join("out_dir");
+
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("tool"), "hello world").unwrap();
+        sevenz_rust2::compress_to_path(&src_dir, &archive_path).unwrap();
+
+        let contents = inspect_7z_contents(&archive_path).unwrap();
+        assert!(contents.contains(&("pkg".to_string(), true)));
+        assert!(should_strip_components(&archive_path, ExtractionFormat::SevenZip).unwrap());
+
+        extract_archive(
+            &archive_path,
+            &dest_dir,
+            ExtractionFormat::SevenZip,
+            &ExtractOptions::default(),
+        )
+        .unwrap();
+
+        let extracted_path = dest_dir.join("pkg").join("tool");
+        assert!(extracted_path.exists());
+        assert!(extracted_path.is_file());
+        let content = std::fs::read_to_string(&extracted_path).unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[test]
     fn test_untar_rejects_single_file_compression() {
         use tempfile::tempdir;
 
@@ -2317,20 +2334,6 @@ mod tests {
         )
         .unwrap_err();
         assert!(format!("{err:#}").contains("lz4 format not supported"));
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn test_should_strip_components_7z_errors_on_non_windows() {
-        use tempfile::NamedTempFile;
-
-        let archive = NamedTempFile::new().unwrap();
-        let err = should_strip_components(archive.path(), ExtractionFormat::SevenZip).unwrap_err();
-
-        assert!(
-            format!("{err:#}").contains("7z format not supported on this platform"),
-            "{err:#}"
-        );
     }
 
     #[tokio::test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -1327,8 +1327,11 @@ pub fn un7z(archive: &Path, dest: &Path, opts: &ExtractOptions<'_>) -> Result<()
             archive.file_name().unwrap().to_string_lossy()
         ));
     }
-    sevenz_rust2::decompress_file(archive, dest)
-        .wrap_err_with(|| format!("failed to extract 7z archive: {}", display_path(archive)))?;
+    sevenz_rust2::decompress_file_with_extract_fn(archive, dest, |entry, reader, _| {
+        let dest_path = dest.join(normalize_7z_entry_path(entry.name()));
+        sevenz_rust2::default_entry_extract_fn(entry, reader, &dest_path)
+    })
+    .wrap_err_with(|| format!("failed to extract 7z archive: {}", display_path(archive)))?;
 
     if !opts.preserve_mtime {
         reset_dir_mtime_to_now(dest)?;
@@ -1340,6 +1343,10 @@ pub fn un7z(archive: &Path, dest: &Path, opts: &ExtractOptions<'_>) -> Result<()
             display_path(archive)
         )
     })
+}
+
+fn normalize_7z_entry_path(path: &str) -> PathBuf {
+    PathBuf::from(path.replace('\\', "/"))
 }
 
 pub fn split_file_name(path: &Path) -> (String, String) {
@@ -1452,7 +1459,7 @@ pub fn inspect_7z_contents(archive: &Path) -> Result<Vec<(String, bool)>> {
     let mut top_level_components = std::collections::HashMap::new();
 
     for file in &sevenz.files {
-        let path = PathBuf::from(file.name());
+        let path = normalize_7z_entry_path(file.name());
 
         // Get the first non-CurDir component of the path (top-level directory/file)
         let mut components = skip_curdir_components(&path);
@@ -2249,6 +2256,7 @@ mod tests {
 
     #[test]
     fn test_extract_archive_7z() {
+        use std::io::Cursor;
         use tempfile::tempdir;
 
         let dir = tempdir().unwrap();
@@ -2256,6 +2264,9 @@ mod tests {
         let pkg_dir = src_dir.join("pkg");
         let archive_path = dir.path().join("test.7z");
         let dest_dir = dir.path().join("out_dir");
+        let stripped_dest_dir = dir.path().join("stripped_out_dir");
+        let backslash_archive_path = dir.path().join("backslash.7z");
+        let backslash_dest_dir = dir.path().join("backslash_out_dir");
 
         std::fs::create_dir_all(&pkg_dir).unwrap();
         std::fs::write(pkg_dir.join("tool"), "hello world").unwrap();
@@ -2277,6 +2288,58 @@ mod tests {
         assert!(extracted_path.exists());
         assert!(extracted_path.is_file());
         let content = std::fs::read_to_string(&extracted_path).unwrap();
+        assert_eq!(content, "hello world");
+
+        extract_archive(
+            &archive_path,
+            &stripped_dest_dir,
+            ExtractionFormat::SevenZip,
+            &ExtractOptions {
+                strip_components: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let stripped_path = stripped_dest_dir.join("tool");
+        assert!(stripped_path.exists());
+        assert!(stripped_path.is_file());
+        assert!(!stripped_dest_dir.join("pkg").exists());
+        let content = std::fs::read_to_string(&stripped_path).unwrap();
+        assert_eq!(content, "hello world");
+
+        let mut backslash_archive =
+            sevenz_rust2::ArchiveWriter::create(&backslash_archive_path).unwrap();
+        backslash_archive
+            .push_archive_entry(
+                sevenz_rust2::ArchiveEntry::new_file("pkg\\tool"),
+                Some(Cursor::new(b"hello world")),
+            )
+            .unwrap();
+        backslash_archive.finish().unwrap();
+
+        let contents = inspect_7z_contents(&backslash_archive_path).unwrap();
+        assert!(contents.contains(&("pkg".to_string(), true)));
+        assert!(
+            should_strip_components(&backslash_archive_path, ExtractionFormat::SevenZip).unwrap()
+        );
+
+        extract_archive(
+            &backslash_archive_path,
+            &backslash_dest_dir,
+            ExtractionFormat::SevenZip,
+            &ExtractOptions {
+                strip_components: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let backslash_stripped_path = backslash_dest_dir.join("tool");
+        assert!(backslash_stripped_path.exists());
+        assert!(backslash_stripped_path.is_file());
+        assert!(!backslash_dest_dir.join("pkg").exists());
+        let content = std::fs::read_to_string(&backslash_stripped_path).unwrap();
         assert_eq!(content, "hello world");
     }
 


### PR DESCRIPTION
## Summary
- migrate direct 7z handling from [`sevenz-rust`](https://crates.io/crates/sevenz-rust) to [`sevenz-rust2`](https://crates.io/crates/sevenz-rust2)
- enable `.7z` extraction and strip-component probing on Unix as well as Windows
- update tool-stub docs and add a focused 7z extraction test

## Why
The old [`sevenz-rust` crate](https://crates.io/crates/sevenz-rust) points to the [`dyz1990/sevenz-rust` GitHub repo](https://github.com/dyz1990/sevenz-rust), which no longer resolves via GitHub and appears to have been deleted or made private. It is also no longer maintained.

[`sevenz-rust2`](https://crates.io/crates/sevenz-rust2) is the maintained fork/replacement, with the active library repository at [`hasenbanck/sevenz-rust2`](https://github.com/hasenbanck/sevenz-rust2). `ubi` already brings `sevenz-rust2` into the dependency graph.

This keeps the direct dependency on `sevenz-rust2 = "0.20"` because `0.21.0` currently requires Rust 1.93 while this crate declares `rust-version = "1.91"`.

Aqua supports `.7z` archives on Unix, so there is no need to keep the Windows-only guard around extraction or auto `strip_components` probing.

## Library links
- Old crate: [`sevenz-rust`](https://crates.io/crates/sevenz-rust)
- Old repo: [`dyz1990/sevenz-rust`](https://github.com/dyz1990/sevenz-rust)
- New crate: [`sevenz-rust2`](https://crates.io/crates/sevenz-rust2)
- New repo: [`hasenbanck/sevenz-rust2`](https://github.com/hasenbanck/sevenz-rust2)

## Validation
- `mise x cargo -- cargo check`
- `mise x cargo -- cargo test file::tests::test_extract_archive_7z -- --exact --test-threads=1`
- `mise x cargo -- cargo fmt --check`

Note: a broader `mise x cargo -- cargo test file::tests` run was not useful because Cargo's substring filter also matched unrelated `config::env_directive::file::tests`; one unrelated global-state panic poisoned later tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-platform support for extracting `.7z` archives (previously Windows-only).
* **Bug Fixes**
  * Improved `.7z` extraction path handling, including backslash-style entry names.
  * Safer extraction: rejects archive entries that attempt directory traversal or use absolute target paths.
  * Refined `strip_components` behavior for single-directory archives and made `.7z` inspection work consistently across platforms.
* **Documentation**
  * Updated developer docs to reflect that `.7z` is no longer Windows-only.
* **Tests**
  * Added unit tests covering `.7z` inspection, extraction, `strip_components`, and negative traversal cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->