### PR TITLE
chore(deps): replace size formatting deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
 
 [[package]]
 name = "bzip2"
@@ -5319,6 +5319,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "built",
+ "bytesize",
  "bzip2 0.6.1",
  "calm_io",
  "cfg_aliases",
@@ -5353,7 +5354,6 @@ dependencies = [
  "heck",
  "hex",
  "homedir",
- "humansize",
  "ignore",
  "indenter",
  "indexmap 2.14.0",
@@ -5374,7 +5374,6 @@ dependencies = [
  "nix 0.31.3",
  "nodejs-semver",
  "num_cpus",
- "number_prefix",
  "once_cell",
  "openssl",
  "os-release",
@@ -5790,12 +5789,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ aws-sdk-s3 = { version = "1", default-features = false, features = [
   "default-https-client",
 ] }
 base64 = "0.22"
+bytesize = "2"
 bzip2 = "0.6"
 calm_io = "0.1"
 chrono = { version = "0.4", default-features = false, features = [
@@ -113,7 +114,6 @@ globset = "0.4"
 ignore = { version = "0.4", features = [] }
 heck = "0.5"
 hex = "0.4"
-humansize = "2"
 indenter = "0.3"
 indexmap = { version = "2", features = ["serde"] }
 clx = "2"
@@ -128,7 +128,6 @@ miette = { version = "7", features = ["fancy"] }
 netrc-rs = "0.1"
 nodejs-semver = "4.2"
 num_cpus = "1"
-number_prefix = "0.4"
 once_cell = "1"
 openssl = { version = "0.10", optional = true }
 os-release = "0.1"

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,6 @@ feature-depth = 1
 ignore = [
   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained - transitive via age/mlua/tabled/rops, no safe upgrade available" },
   { id = "RUSTSEC-2023-0071", reason = "rsa crate Marvin attack vulnerability from sigstore crate - no safe upgrade available" },
-  { id = "RUSTSEC-2025-0119", reason = "number_prefix crate is unmaintained - used by indicatif/self_update, no safe upgrade available" },
   #"RUSTSEC-0000-0000",
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish

--- a/e2e/generate/test_generate_tool_stub_jq
+++ b/e2e/generate/test_generate_tool_stub_jq
@@ -10,12 +10,12 @@ assert "cat ./bin/jq" '#!/usr/bin/env -S mise tool-stub
 [platforms.macos-arm64]
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-macos-arm64"
 checksum = "blake3:d7f94364d8375d9004ac8169fdbb665f61360c2bcc7cceed1d7306dc6f8958b7"
-size = 841408 # 821.69 KiB
+size = 841408 # 821.7 KiB
 
 [platforms.linux-x64]
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux64"
 checksum = "blake3:b0419e57743765a9682d7924816269862890716d7bd3c1b78b2a3dd1f311a7f9"
-size = 2255816 # 2.15 MiB'
+size = 2255816 # 2.2 MiB'
 
 mise cache clear
 
@@ -49,12 +49,12 @@ assert "cat ./bin/jq-fetch" '#!/usr/bin/env -S mise tool-stub
 [platforms.macos-arm64]
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-macos-arm64"
 checksum = "blake3:d7f94364d8375d9004ac8169fdbb665f61360c2bcc7cceed1d7306dc6f8958b7"
-size = 841408 # 821.69 KiB
+size = 841408 # 821.7 KiB
 
 [platforms.linux-x64]
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux64"
 checksum = "blake3:b0419e57743765a9682d7924816269862890716d7bd3c1b78b2a3dd1f311a7f9"
-size = 2255816 # 2.15 MiB'
+size = 2255816 # 2.2 MiB'
 
 # Test --fetch with partial existing checksums (should only fetch missing ones)
 cat >./bin/jq-partial <<EOF

--- a/src/cli/cache/prune.rs
+++ b/src/cli/cache/prune.rs
@@ -3,9 +3,9 @@ use crate::cache::{PruneOptions, PruneResults};
 use crate::config::Settings;
 use crate::dirs::CACHE;
 use crate::toolset::env_cache::CachedEnv;
+use bytesize::ByteSize;
 use eyre::Result;
 use heck::ToKebabCase;
-use number_prefix::NumberPrefix;
 use std::time::Duration;
 
 /// Removes stale mise cache files
@@ -91,8 +91,5 @@ impl CachePrune {
 }
 
 fn bytes_str(bytes: u64) -> String {
-    match NumberPrefix::binary(bytes as f64) {
-        NumberPrefix::Standalone(bytes) => format!("{bytes} bytes"),
-        NumberPrefix::Prefixed(prefix, n) => format!("{n:.1} {prefix}B"),
-    }
+    ByteSize::b(bytes).display().iec().to_string()
 }

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -13,9 +13,9 @@ use crate::toolset::{ResolveOptions, ToolVersion};
 use crate::ui::info;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
+use bytesize::ByteSize;
 use clap::ValueHint;
 use color_eyre::eyre::bail;
-use humansize::{BINARY, format_size};
 use indexmap::IndexMap;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -809,7 +809,7 @@ fn is_bootstrap_stub(content: &str) -> bool {
 }
 
 fn format_size_comment(bytes: u64) -> String {
-    format!(" # {}", format_size(bytes, BINARY))
+    format!(" # {}", ByteSize::b(bytes).display().iec())
 }
 
 /// Extract TOML content from a stub file (handles both regular and bootstrap stubs)


### PR DESCRIPTION
## Summary
- replace direct [`number_prefix`](https://crates.io/crates/number_prefix) and [`humansize`](https://crates.io/crates/humansize) usage with [`bytesize`](https://crates.io/crates/bytesize)
- remove the direct stale dependencies from `Cargo.toml` and `Cargo.lock`
- remove the now-unneeded [`RUSTSEC-2025-0119`](https://rustsec.org/advisories/RUSTSEC-2025-0119.html) `number_prefix` ignore from `deny.toml`

## Why
- `number_prefix`: [crates.io](https://crates.io/crates/number_prefix), [repo](https://github.com/ogham/rust-number-prefix). RustSec marks it unmaintained in [`RUSTSEC-2025-0119`](https://rustsec.org/advisories/RUSTSEC-2025-0119.html). Latest crate publish is `0.4.0` from 2020-04-07, the repo was last pushed on 2021-07-20, and the repo has 25 stars.
- `humansize`: [crates.io](https://crates.io/crates/humansize), [repo](https://github.com/LeopoldArkham/humansize). It is not RustSec-flagged, but it is also fairly stale: latest crate publish is `2.1.3` from 2022-12-31, the repo was last pushed on 2025-01-06, and the repo has 127 stars.
- `bytesize`: [crates.io](https://crates.io/crates/bytesize), [repo](https://github.com/bytesize-rs/bytesize). It covers the byte-size formatting use case directly, latest crate publish is `2.4.0` from 2026-06-13, the repo was last pushed on 2026-06-13, and the repo has 157 stars.

## Notes
- Lockfiles store `size` as a numeric value; the human-readable text affected here is only the generated `tool-stub` comment beside that numeric size.
- Tool-stub comments now use native `bytesize` IEC formatting, so the e2e fixture changes from `821.69 KiB` / `2.15 MiB` to `821.7 KiB` / `2.2 MiB`.
- Cache prune output now uses `bytesize` IEC formatting directly.

## Tests
- `mise x cargo -- cargo fmt`
- `mise x cargo -- cargo tree -i number_prefix` (confirms no package match)
- `mise x cargo -- cargo tree -i humansize`
- `mise x cargo -- cargo check --locked -p mise --bin mise`
- `mise run test:e2e e2e/generate/test_generate_tool_stub_jq` (local run used a stale binary path; CI log confirms the updated expected output)
- `mise x aqua:EmbarkStudios/cargo-deny -- cargo deny check advisories`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Replaced the size formatting library to provide consistent display format across cache operations and code generation features.
  * Enhanced security posture by enabling additional vulnerability checks for project dependencies.

* **Tests**
  * Updated test cases to reflect the revised size output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->