### PR TITLE
chore: release 2026.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [2026.6.10](https://github.com/jdx/mise/compare/v2026.6.9..v2026.6.10) - 2026-06-14
+
+### 🚀 Features
+
+- **(env)** add default fallback shorthand by @jdx in [#10441](https://github.com/jdx/mise/pull/10441)
+
+### 🐛 Bug Fixes
+
+- **(backend)** enable 7z archives on unix by @risu729 in [#10434](https://github.com/jdx/mise/pull/10434)
+- **(env)** drop stale mise install dirs from mise x/run child PATH by @JamBalaya56562 in [#10422](https://github.com/jdx/mise/pull/10422)
+- **(env)** expand shell defaults like POSIX by @jdx in [#10445](https://github.com/jdx/mise/pull/10445)
+- **(file)** atomically replace symlinks to avoid spurious EEXIST warnings by @JamBalaya56562 in [#10414](https://github.com/jdx/mise/pull/10414)
+- **(shims)** guard Windows bash shims against WSL PATH interop by @JamBalaya56562 in [#10421](https://github.com/jdx/mise/pull/10421)
+- **(task)** prefer Windows script task siblings by @jdx in [#10443](https://github.com/jdx/mise/pull/10443)
+- **(vfox)** apply tools=true env to os.execute install hooks by @JamBalaya56562 in [#10432](https://github.com/jdx/mise/pull/10432)
+
+### 📦️ Dependency Updates
+
+- replace size formatting deps by @risu729 in [#10438](https://github.com/jdx/mise/pull/10438)
+
+### Chore
+
+- **(ci)** enable coderabbit for draft prs by @risu729 in [#10436](https://github.com/jdx/mise/pull/10436)
+- **(ci)** use shared coderabbit config by @jdx in [#10442](https://github.com/jdx/mise/pull/10442)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (1)
+
+- [`CycloneDX/cdxgen`](https://github.com/CycloneDX/cdxgen)
+
+#### Updated Packages (2)
+
+- [`aquaproj/registry-tool`](https://github.com/aquaproj/registry-tool)
+- [`haskell/ghcup-hs`](https://github.com/haskell/ghcup-hs)
+
 ## [2026.6.9](https://github.com/jdx/mise/compare/v2026.6.8..v2026.6.9) - 2026-06-14
 
 ### Chore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.6.9"
+version = "2026.6.10"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.6.9"
+version = "2026.6.10"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.6.9 macos-arm64 (2026-06-14)
+2026.6.10 macos-arm64 (2026-06-14)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_9.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_10.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_9.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_10.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_9.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_10.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_9.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_10.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.6.9";
+  version = "2026.6.10";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.6.9
+Version: 2026.6.10
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.6.9"
+version: "2026.6.10"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "4e1e686b8558cf90e8c6fe326e15a75cda30d2b2"
+  "tag": "3671967a551902d4f8cd74085405ec214d173315"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -2410,6 +2410,48 @@ packages:
           - amd64
   - type: github_release
     repo_owner: CycloneDX
+    repo_name: cdxgen
+    description: Creates CycloneDX Bill of Materials (BOM) from source code and container images
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 11.5.0")
+        error_message: The version is too old. Please use a version 11.5.0 or higher.
+      - version_constraint: semver("<= 11.9.0")
+        asset: cdxgen-{{.OS}}-{{.Arch}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: cdxgen-{{.OS}}-{{.Arch}}-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 12.0.0")
+        asset: cdxgen-{{.OS}}-{{.Arch}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: cdxgen-{{.OS}}-{{.Arch}}-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: "true"
+        asset: cdxgen-{{.OS}}-{{.Arch}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: cdxgen-{{.OS}}-{{.Arch}}-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+  - type: github_release
+    repo_owner: CycloneDX
     repo_name: cyclonedx-cli
     description: CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions
     files:
@@ -14178,7 +14220,7 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.5.4")
         asset: argd_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -14194,6 +14236,25 @@ packages:
             bundle:
               type: github_release
               asset: argd_checksums.txt.bundle
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+      - version_constraint: "true"
+        asset: argd_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: argd_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: argd_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
@@ -46672,18 +46733,16 @@ packages:
     repo_name: ghcup-hs
     url: https://downloads.haskell.org/~ghcup/{{trimV .Version}}/{{.Arch}}-{{.OS}}-ghcup-{{trimV .Version}}
     format: raw
+    windows_arm_emulation: true
     link: https://www.haskell.org/ghcup/
     description: GHCup is an installer for the general purpose language Haskell
     replacements:
       arm64: aarch64
       amd64: x86_64
       darwin: apple-darwin
+      windows: mingw64
     files:
       - name: ghcup
-        src: "{{.Arch}}-{{.OS}}-ghcup-{{trimV .Version}}"
-    supported_envs:
-      - linux
-      - darwin
   - type: github_release
     repo_owner: hasura
     repo_name: graphql-engine


### PR DESCRIPTION
### 🚀 Features

- **(env)** add default fallback shorthand by @jdx in [#10441](https://github.com/jdx/mise/pull/10441)

### 🐛 Bug Fixes

- **(backend)** enable 7z archives on unix by @risu729 in [#10434](https://github.com/jdx/mise/pull/10434)
- **(env)** drop stale mise install dirs from mise x/run child PATH by @JamBalaya56562 in [#10422](https://github.com/jdx/mise/pull/10422)
- **(env)** expand shell defaults like POSIX by @jdx in [#10445](https://github.com/jdx/mise/pull/10445)
- **(file)** atomically replace symlinks to avoid spurious EEXIST warnings by @JamBalaya56562 in [#10414](https://github.com/jdx/mise/pull/10414)
- **(shims)** guard Windows bash shims against WSL PATH interop by @JamBalaya56562 in [#10421](https://github.com/jdx/mise/pull/10421)
- **(task)** prefer Windows script task siblings by @jdx in [#10443](https://github.com/jdx/mise/pull/10443)
- **(vfox)** apply tools=true env to os.execute install hooks by @JamBalaya56562 in [#10432](https://github.com/jdx/mise/pull/10432)

### 📦️ Dependency Updates

- replace size formatting deps by @risu729 in [#10438](https://github.com/jdx/mise/pull/10438)

### Chore

- **(ci)** enable coderabbit for draft prs by @risu729 in [#10436](https://github.com/jdx/mise/pull/10436)
- **(ci)** use shared coderabbit config by @jdx in [#10442](https://github.com/jdx/mise/pull/10442)

## 📦 Aqua Registry Updates

### New Packages (1)

- [`CycloneDX/cdxgen`](https://github.com/CycloneDX/cdxgen)

### Updated Packages (2)

- [`aquaproj/registry-tool`](https://github.com/aquaproj/registry-tool)
- [`haskell/ghcup-hs`](https://github.com/haskell/ghcup-hs)