### PR TITLE
chore(ci): use shared coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-reviews:
-  auto_review:
-    drafts: true
+remote_config:
+  repository: "jdx/coderabbit"
+  ref: "main"
+  path: ".coderabbit.yaml"


### PR DESCRIPTION
## Summary
- Point this repository's CodeRabbit YAML at the shared `jdx/coderabbit` configuration.
- Keep CodeRabbit settings centralized across the en.dev CLI repositories.

## Validation
- YAML-only configuration change; not run.

*This PR was created by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only change to CodeRabbit wiring; no application or runtime code is affected.
> 
> **Overview**
> **CodeRabbit** settings in this repo are no longer defined inline. `.coderabbit.yaml` now pulls configuration from the shared **`jdx/coderabbit`** repository (`main`, path `.coderabbit.yaml`) via `remote_config`.
> 
> The previous local block (`reviews.auto_review.drafts: true`) is removed in favor of that centralized config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ba8e3345250e4e7f9e9e8200081396adc8ee371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to use remote settings management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->