### PR TITLE
fix(env): expand shell defaults like POSIX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5371,7 +5371,6 @@ dependencies = [
  "sha2 0.11.0",
  "shell-escape",
  "shell-words",
- "shellexpand",
  "signal-hook 0.4.4",
  "siphasher",
  "strum 0.28.0",
@@ -8137,15 +8136,6 @@ name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
-dependencies = [
- "dirs",
-]
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,6 @@ blake3 = "1"
 chacha20poly1305 = "0.10"
 shell-escape = "0.1"
 shell-words = "1"
-shellexpand = "3"
 signal-hook = "0.4"
 siphasher = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/e2e/env/test_env_shell_expand
+++ b/e2e/env/test_env_shell_expand
@@ -24,6 +24,41 @@ BAR = "${NONEXISTENT:-fallback}"
 EOF
 MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=fallback"
 
+# Test ${VAR:-default} treats empty strings as unset
+cat <<'EOF' >mise.toml
+[env]
+BAR = "${EMPTY_VAR:-fallback}"
+EOF
+EMPTY_VAR='' MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=fallback"
+
+# Test ${VAR-default} treats empty strings as set
+cat <<'EOF' >mise.toml
+[env]
+BAR = "${EMPTY_VAR-fallback}"
+EOF
+EMPTY_VAR='' MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=''"
+
+# Test default values are shell-expanded
+cat <<'EOF' >mise.toml
+[env]
+BAR = "${NONEXISTENT:-$OTHER}"
+EOF
+OTHER=hello MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=hello"
+
+# Test unterminated braced expressions stay literal
+cat <<'EOF' >mise.toml
+[env]
+BAR = "${NONEXISTENT:-$OTHER"
+EOF
+OTHER=hello MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR='\${NONEXISTENT:-\$OTHER'"
+
+# Test } inside command substitution text does not close braced expressions
+cat <<'EOF' >mise.toml
+[env]
+BAR = "${NONEXISTENT:-$(echo })}"
+EOF
+MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR='\$(echo })'"
+
 # Test expansion from initial environment
 cat <<'EOF' >mise.toml
 [env]

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -9,7 +9,6 @@ use eyre::{Context, eyre};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use serde_json::Value;
-use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::{Debug, Display, Formatter};
 use std::path::{Path, PathBuf};
@@ -755,29 +754,14 @@ impl EnvResults {
                         .get("env")
                         .and_then(|v| serde_json::from_value(v.clone()).ok())
                         .unwrap_or_default();
-                    let before_expand = output.clone();
                     let mut missing_vars = Vec::new();
-                    output = shellexpand::env_with_context_no_errors(&output, |var| match env_vars
-                        .get(var)
-                    {
-                        Some(v) => Some(Cow::Borrowed(v.as_str())),
-                        None => {
-                            missing_vars.push(var.to_string());
-                            None
-                        }
-                    })
-                    .into_owned();
+                    output = shell_expand_env(&output, &env_vars, &mut missing_vars);
                     for var in missing_vars {
-                        // Don't warn if the user provided a default via ${VAR:-...} or ${VAR-...}
-                        if !before_expand.contains(&format!("${{{var}:-"))
-                            && !before_expand.contains(&format!("${{{var}-"))
-                        {
-                            warn_once!(
-                                "env var '{var}' is not defined and will be left unexpanded. \
-                                 Use ${{{var}:-}} to default to an empty string and suppress \
-                                 this warning."
-                            );
-                        }
+                        warn_once!(
+                            "env var '{var}' is not defined and will be left unexpanded. \
+                             Use ${{{var}:-}} to default to an empty string and suppress \
+                             this warning."
+                        );
                     }
                 }
                 Some(false) => {}
@@ -803,6 +787,156 @@ impl EnvResults {
             && self.env_scripts.is_empty()
             && self.tool_add_paths.is_empty()
     }
+}
+
+fn shell_expand_env(
+    input: &str,
+    env_vars: &BTreeMap<String, String>,
+    missing_vars: &mut Vec<String>,
+) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((idx, ch)) = chars.next() {
+        if ch != '$' {
+            output.push(ch);
+            continue;
+        }
+
+        match chars.peek().copied() {
+            Some((_, '{')) => {
+                chars.next();
+                if let Some((end, expr)) = read_braced_expr(input, idx + 2) {
+                    output.push_str(&expand_braced_expr(
+                        expr,
+                        &input[idx..=end],
+                        env_vars,
+                        missing_vars,
+                    ));
+                    while chars.peek().is_some_and(|(i, _)| *i <= end) {
+                        chars.next();
+                    }
+                } else {
+                    output.push_str(&input[idx..]);
+                    break;
+                }
+            }
+            Some((_, next)) if is_var_start(next) => {
+                let start = chars.peek().map(|(i, _)| *i).unwrap_or(idx + 1);
+                let mut end = start;
+                while let Some((i, next)) = chars.peek().copied() {
+                    if is_var_char(next) {
+                        end = i + next.len_utf8();
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                let var = &input[start..end];
+                if let Some(value) = env_vars.get(var) {
+                    output.push_str(value);
+                } else {
+                    missing_vars.push(var.to_string());
+                    output.push_str(&input[idx..end]);
+                }
+            }
+            _ => output.push('$'),
+        }
+    }
+
+    output
+}
+
+fn read_braced_expr(input: &str, start: usize) -> Option<(usize, &str)> {
+    let mut depth = 1;
+    let mut command_depth = 0;
+    let mut chars = input[start..].char_indices().peekable();
+
+    while let Some((offset, ch)) = chars.next() {
+        let idx = start + offset;
+        if command_depth > 0 {
+            match ch {
+                '(' => command_depth += 1,
+                ')' => command_depth -= 1,
+                _ => {}
+            }
+            continue;
+        }
+
+        match ch {
+            '$' if chars.peek().is_some_and(|(_, next)| *next == '{') => {
+                chars.next();
+                depth += 1;
+            }
+            '$' if chars.peek().is_some_and(|(_, next)| *next == '(') => {
+                chars.next();
+                command_depth = 1;
+            }
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((idx, &input[start..idx]));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn expand_braced_expr(
+    expr: &str,
+    original: &str,
+    env_vars: &BTreeMap<String, String>,
+    missing_vars: &mut Vec<String>,
+) -> String {
+    let Some(var_end) = expr
+        .char_indices()
+        .take_while(|(_, ch)| is_var_char(*ch))
+        .last()
+        .map(|(idx, ch)| idx + ch.len_utf8())
+    else {
+        return original.to_string();
+    };
+
+    let var = &expr[..var_end];
+    if !var.chars().next().is_some_and(is_var_start) {
+        return original.to_string();
+    }
+
+    match expr.get(var_end..) {
+        Some("") => match env_vars.get(var) {
+            Some(value) => value.to_string(),
+            None => {
+                missing_vars.push(var.to_string());
+                original.to_string()
+            }
+        },
+        Some(rest) if rest.starts_with(":-") => {
+            let default = &rest[2..];
+            match env_vars.get(var) {
+                Some(value) if !value.is_empty() => value.to_string(),
+                _ => shell_expand_env(default, env_vars, missing_vars),
+            }
+        }
+        Some(rest) if rest.starts_with('-') => {
+            let default = &rest[1..];
+            match env_vars.get(var) {
+                Some(value) => value.to_string(),
+                None => shell_expand_env(default, env_vars, missing_vars),
+            }
+        }
+        _ => original.to_string(),
+    }
+}
+
+fn is_var_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
+}
+
+fn is_var_char(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
 }
 
 impl Debug for EnvResults {


### PR DESCRIPTION
## Summary
- fix `env_shell_expand` handling of `${VAR:-default}` so empty strings use the default
- expand shell variables inside `${VAR:-...}` and `${VAR-...}` fallback branches
- add e2e coverage for POSIX-style empty/default behavior

## Root cause
The previous implementation delegated shell expansion to `shellexpand`, whose default handling treated empty strings as set and returned fallback text without recursively expanding shell variables.

## Discussion
- Fixes https://github.com/jdx/mise/discussions/10444

## Tests
- `mise run test:e2e e2e/env/test_env_shell_expand`
- `mise run format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for configs using env_shell_expand=true (especially ${VAR:-} with empty values); limited to env string resolution, not auth or installs.
> 
> **Overview**
> Replaces the **`shellexpand`** dependency with an in-tree **`shell_expand_env`** path when **`env_shell_expand`** is enabled, so mise env values follow POSIX-style **`${VAR:-default}`** and **`${VAR-default}`** rules.
> 
> **`${VAR:-…}`** now treats unset *and* empty values as missing (fallback applies), while **`${VAR-…}`** only substitutes when the variable is unset—empty strings stay empty. Fallback text is **recursively** expanded against the same env map (e.g. **`${NONEXISTENT:-$OTHER}`**). Braced parsing is stricter: unterminated **`${…`** stays literal, and **`}`** inside **`$(…)`** text no longer prematurely closes the brace expression.
> 
> E2E coverage in **`test_env_shell_expand`** exercises empty vs unset defaults, nested defaults, and those brace edge cases. Undefined bare **`$VAR`** warnings are unchanged; **`${VAR:-}`** still avoids missing-var warnings via the default branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6fa495d6b6cc9821d540a88da54d721146098f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced environment variable expansion to support default value syntax for both `${VAR:-default}` and `${VAR-default}`
  * Correctly distinguishes between unset variables and explicitly empty values when applying defaults
  * Improves how nested/edge-case braced expansions are interpreted, reducing incorrect literal output
* **Tests**
  * Added end-to-end coverage for shell-style brace expansion defaults, including nested expansions and edge-case brace/literal handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->