### PR TITLE
chore: release 2026.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## [2026.6.11](https://github.com/jdx/mise/compare/v2026.6.10..v2026.6.11) - 2026-06-16
+
+### 🚀 Features
+
+- **(bootstrap)** add apk package support by @jdx in [#10476](https://github.com/jdx/mise/pull/10476)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** render minisign asset templates with package asset by @risu729 in [#10462](https://github.com/jdx/mise/pull/10462)
+- **(aqua)** support format overrides by @risu729 in [#10461](https://github.com/jdx/mise/pull/10461)
+- **(deno)** parse PowerShell checksum files by @risu729 in [#10464](https://github.com/jdx/mise/pull/10464)
+- **(docs)** align removal version of Tera task arguments with the CLI by @reitzig in [#10453](https://github.com/jdx/mise/pull/10453)
+- **(http)** include auto strip in cache key by @risu729 in [#10468](https://github.com/jdx/mise/pull/10468)
+- **(install)** don't treat http cache symlinks as mise link when resolving lockfile by @risu729 in [#10463](https://github.com/jdx/mise/pull/10463)
+- **(rust)** store toolchain options on idiomatic requests by @risu729 in [#10178](https://github.com/jdx/mise/pull/10178)
+- **(shim)** don't create extension-less shims in exe mode on Windows by @JamBalaya56562 in [#10475](https://github.com/jdx/mise/pull/10475)
+- **(task)** reject bare monorepo task paths by @jdx in [#10479](https://github.com/jdx/mise/pull/10479)
+
+### 🚜 Refactor
+
+- remove os-release and sys-info deps by @risu729 in [#10465](https://github.com/jdx/mise/pull/10465)
+
+### 📚 Documentation
+
+- fix relative duration example for months by @sisp in [#10193](https://github.com/jdx/mise/pull/10193)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance lockfile maintenance by @renovate[bot] in [#10448](https://github.com/jdx/mise/pull/10448)
+- replace fuzzy matcher by @risu729 in [#10467](https://github.com/jdx/mise/pull/10467)
+
+### 📦 Registry
+
+- added pinniped by @tony-sol in [#10456](https://github.com/jdx/mise/pull/10456)
+
+### Chore
+
+- **(exec)** Also pass-through the `COLORTERM` environment variable by @sschuberth in [#10451](https://github.com/jdx/mise/pull/10451)
+
+### New Contributors
+
+- @sschuberth made their first contribution in [#10451](https://github.com/jdx/mise/pull/10451)
+- @sisp made their first contribution in [#10193](https://github.com/jdx/mise/pull/10193)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (3)
+
+- [`Latias94/merman`](https://github.com/Latias94/merman)
+- [`bitnami/sealed-secrets`](https://github.com/bitnami/sealed-secrets)
+- [`coder/boo`](https://github.com/coder/boo)
+
+#### Updated Packages (1)
+
+- [`suzuki-shunsuke/ghtkn`](https://github.com/suzuki-shunsuke/ghtkn)
+
 ## [2026.6.10](https://github.com/jdx/mise/compare/v2026.6.9..v2026.6.10) - 2026-06-14
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.6.10"
+version = "2026.6.11"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.6.10"
+version = "2026.6.11"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.6.10 macos-arm64 (2026-06-14)
+2026.6.11 macos-arm64 (2026-06-16)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -23,7 +23,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_10.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_11.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_10.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_11.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_10.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_11.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_10.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_11.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.6.10";
+  version = "2026.6.11";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.6.10
+Version: 2026.6.11
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.6.10"
+version: "2026.6.11"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "3671967a551902d4f8cd74085405ec214d173315"
+  "tag": "d974f158358577be8c7a98ed03341307846de58e"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -5314,6 +5314,42 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: Latias94
+    repo_name: merman
+    description: Mermaid.js, but headless, in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.7.0-alpha.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: merman-cli-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: merman-cli
+            src: "{{.AssetWithoutExt}}/merman-cli"
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: merman-cli
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: Lifailon
     repo_name: lazyjournal
     description: TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering with fuzzy find, regex support (like fzf and grep) and coloring the output, written in Go with the gocui library
@@ -19625,8 +19661,92 @@ packages:
           - darwin
         rosetta2: true
   - type: github_release
-    repo_owner: bitnami-labs
+    repo_owner: bitnami
+    repo_name: charts-syncer
+    aliases:
+      - name: bitnami-labs/charts-syncer
+    description: Tool for synchronizing Helm Chart repositories
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.1")
+        asset: c3tsyncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: c3tsyncer
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.6.2")
+        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.9.1")
+        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.19.0")
+        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.20.1")
+        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: bitnami
     repo_name: sealed-secrets
+    aliases:
+      - name: bitnami-labs/sealed-secrets
     description: A Kubernetes controller and tool for one-way encrypted Secrets
     files:
       - name: kubeseal
@@ -19731,88 +19851,6 @@ packages:
               - https://github.com/bitnami-labs/sealed-secrets/releases/download/{{.Version}}/cosign.pub
               - --signature
               - https://github.com/bitnami-labs/sealed-secrets/releases/download/{{.Version}}/sealed-secrets_{{trimV .Version}}_checksums.txt.sig
-  - type: github_release
-    repo_owner: bitnami
-    repo_name: charts-syncer
-    aliases:
-      - name: bitnami-labs/charts-syncer
-    description: Tool for synchronizing Helm Chart repositories
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.2.1")
-        asset: c3tsyncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: c3tsyncer
-        replacements:
-          amd64: x86_64
-        supported_envs:
-          - linux/amd64
-          - darwin
-        rosetta2: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-      - version_constraint: semver("<= 0.6.2")
-        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-        supported_envs:
-          - linux/amd64
-          - darwin
-        rosetta2: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-      - version_constraint: semver("<= 0.9.1")
-        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-        supported_envs:
-          - linux
-          - darwin
-        rosetta2: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-      - version_constraint: semver("<= 0.19.0")
-        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-        supported_envs:
-          - linux
-          - darwin
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-      - version_constraint: semver("<= 0.20.1")
-        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-      - version_constraint: "true"
-        asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        overrides:
-          - goos: windows
-            format: zip
-        replacements:
-          amd64: x86_64
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
   - type: github_release
     repo_owner: bitwarden
     repo_name: clients
@@ -26724,6 +26762,42 @@ packages:
     files:
       - name: cc-test-reporter
         src: test-reporter
+  - type: github_release
+    repo_owner: coder
+    repo_name: boo
+    description: A GNU screen style terminal multiplexer built on libghostty
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.4")
+        asset: ghostscreen-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: ghostscreen
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: boo-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: coder
     repo_name: coder
@@ -87555,11 +87629,19 @@ packages:
     repo_owner: suzuki-shunsuke
     repo_name: ghtkn
     description: A CLI to create GitHub App User Access Token for secure local development
+    asset: ghtkn_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    slsa_provenance:
+      type: github_release
+      asset: multiple.intoto.jsonl
+    github_artifact_attestations:
+      signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
+    overrides:
+      - goos: windows
+        format: zip
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
-        asset: ghtkn_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
+      - version_constraint: semver("<= 0.2.2")
         checksum:
           type: github_release
           asset: ghtkn_checksums.txt
@@ -87574,14 +87656,34 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/suzuki-shunsuke/ghtkn/releases/download/{{.Version}}/ghtkn_checksums.txt.sig
-        slsa_provenance:
+      - version_constraint: semver("<= 0.2.5")
+        checksum:
           type: github_release
-          asset: multiple.intoto.jsonl
-        github_artifact_attestations:
-          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
-        overrides:
-          - goos: windows
-            format: zip
+          asset: ghtkn_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: ghtkn_checksums.txt.bundle
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.+$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: ghtkn_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: ghtkn_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.+$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
   - type: github_release
     repo_owner: suzuki-shunsuke
     repo_name: git-rm-branch


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** add apk package support by @jdx in [#10476](https://github.com/jdx/mise/pull/10476)

### 🐛 Bug Fixes

- **(aqua)** render minisign asset templates with package asset by @risu729 in [#10462](https://github.com/jdx/mise/pull/10462)
- **(aqua)** support format overrides by @risu729 in [#10461](https://github.com/jdx/mise/pull/10461)
- **(deno)** parse PowerShell checksum files by @risu729 in [#10464](https://github.com/jdx/mise/pull/10464)
- **(docs)** align removal version of Tera task arguments with the CLI by @reitzig in [#10453](https://github.com/jdx/mise/pull/10453)
- **(http)** include auto strip in cache key by @risu729 in [#10468](https://github.com/jdx/mise/pull/10468)
- **(install)** don't treat http cache symlinks as mise link when resolving lockfile by @risu729 in [#10463](https://github.com/jdx/mise/pull/10463)
- **(rust)** store toolchain options on idiomatic requests by @risu729 in [#10178](https://github.com/jdx/mise/pull/10178)
- **(shim)** don't create extension-less shims in exe mode on Windows by @JamBalaya56562 in [#10475](https://github.com/jdx/mise/pull/10475)
- **(task)** reject bare monorepo task paths by @jdx in [#10479](https://github.com/jdx/mise/pull/10479)

### 🚜 Refactor

- remove os-release and sys-info deps by @risu729 in [#10465](https://github.com/jdx/mise/pull/10465)

### 📚 Documentation

- fix relative duration example for months by @sisp in [#10193](https://github.com/jdx/mise/pull/10193)

### 📦️ Dependency Updates

- lock file maintenance lockfile maintenance by @renovate[bot] in [#10448](https://github.com/jdx/mise/pull/10448)
- replace fuzzy matcher by @risu729 in [#10467](https://github.com/jdx/mise/pull/10467)

### 📦 Registry

- added pinniped by @tony-sol in [#10456](https://github.com/jdx/mise/pull/10456)

### Chore

- **(exec)** Also pass-through the `COLORTERM` environment variable by @sschuberth in [#10451](https://github.com/jdx/mise/pull/10451)

### New Contributors

- @sschuberth made their first contribution in [#10451](https://github.com/jdx/mise/pull/10451)
- @sisp made their first contribution in [#10193](https://github.com/jdx/mise/pull/10193)

## 📦 Aqua Registry Updates

### New Packages (3)

- [`Latias94/merman`](https://github.com/Latias94/merman)
- [`bitnami/sealed-secrets`](https://github.com/bitnami/sealed-secrets)
- [`coder/boo`](https://github.com/coder/boo)

### Updated Packages (1)

- [`suzuki-shunsuke/ghtkn`](https://github.com/suzuki-shunsuke/ghtkn)