### PR TITLE
chore(exec): Also pass-through the `COLORTERM` environment variable

### DIFF
--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -27,7 +27,7 @@ pub struct SandboxConfig {
 }
 
 /// Minimal env vars inherited when deny_env is active.
-const DEFAULT_ENV_KEYS: &[&str] = &["PATH", "HOME", "USER", "SHELL", "TERM", "LANG"];
+const DEFAULT_ENV_KEYS: &[&str] = &["PATH", "HOME", "USER", "SHELL", "TERM", "COLORTERM", "LANG"];
 
 /// Check if an env var name matches an allow_env pattern.
 /// Patterns can contain `*` as a wildcard (e.g., `MYAPP_*` matches `MYAPP_FOO`).


### PR DESCRIPTION
The `COLORTERM` variable extends `TERM` to indicate support for modern 24-bit True Color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color output support in sandboxed environments with restricted environment variable access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->