### PR TITLE
fix(docs): align removal version of Tera task arguments with the CLI

### DIFF
--- a/docs/tasks/toml-tasks.md
+++ b/docs/tasks/toml-tasks.md
@@ -458,8 +458,8 @@ See the [Task Arguments](/tasks/task-arguments#usage-field) page for complete do
 
 ### Tera Template Functions <Badge type="danger" text="deprecated" />
 
-::: danger Deprecated - Removal in 2026.11.0
-Using Tera template functions (`arg()`, `option()`, `flag()`) in run scripts is **deprecated** and will be **removed in mise 2026.11.0**. Versions >= 2026.5.0 will show a deprecation warning.
+::: danger Deprecated - Removal in 2027.5.0
+Using Tera template functions (`arg()`, `option()`, `flag()`) in run scripts is **deprecated** and will be **removed in mise 2027.5.0**. Versions >= 2026.5.0 will show a deprecation warning.
 
 **Why it's being removed:**
 


### PR DESCRIPTION
The CLI outputs a version different from that given in the docs; cf. [jdx/mise@2d5d5ba6:src/task/task_script_parser.rs#92](https://github.com/jdx/mise/blob/2d5d5ba63e73c8e2be5ea7d8c1d86e0e4561ed2b/src/task/task_script_parser.rs#L92)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the deprecation timeline for Tera template functions in task scripts. Removal is now scheduled for 2027.5.0 (previously 2026.11.0), with deprecation warnings beginning in version 2026.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->