### PR TITLE
fix(install): make install --locked idempotent for already-installed tools

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -417,6 +417,19 @@ pub fn is_install_time_option_key_for_type(backend_type: &BackendType, key: &str
 
 /// Normalize idiomatic file contents by removing comments and empty lines.
 /// Full-line and inline comments are supported by .python-version, .nvmrc, etc.
+// The lockfile URL is only needed to download; an already-installed tool downloads
+// nothing, so enforce the locked-mode URL check only when an install will actually
+// run (keeps `mise install --locked` idempotent).
+fn enforce_locked_url(
+    locked: bool,
+    forced: bool,
+    already_installed: bool,
+    is_tool_stub: bool,
+    supports_lockfile_url: bool,
+) -> bool {
+    locked && supports_lockfile_url && !is_tool_stub && (forced || !already_installed)
+}
+
 pub(crate) fn normalize_idiomatic_contents(contents: &str) -> String {
     contents
         .lines()
@@ -462,6 +475,20 @@ mod tests {
     use crate::toolset::{ToolSource, ToolVersionOptions};
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn test_enforce_locked_url_only_when_installing() {
+        // fresh install in locked mode -> enforce
+        assert!(enforce_locked_url(true, false, false, false, true));
+        // already installed, not forced -> skip (the idempotency fix)
+        assert!(!enforce_locked_url(true, false, true, false, true));
+        // --force reinstall -> enforce even if already installed
+        assert!(enforce_locked_url(true, true, true, false, true));
+        // not locked / tool stub / backend without URL support -> never enforced
+        assert!(!enforce_locked_url(false, false, false, false, true));
+        assert!(!enforce_locked_url(true, false, false, true, true));
+        assert!(!enforce_locked_url(true, false, false, false, false));
+    }
 
     #[test]
     fn test_normalize_idiomatic_contents() {
@@ -1823,7 +1850,14 @@ pub trait Backend: Debug + Send + Sync {
                 hint: Remove `lockfile = false` or set `lockfile = true`, or disable locked mode"
             );
         }
-        if ctx.locked && !tv.request.source().is_tool_stub() && self.supports_lockfile_url() {
+        let already_installed = self.is_version_installed(&ctx.config, &tv, true);
+        if enforce_locked_url(
+            ctx.locked,
+            ctx.force,
+            already_installed,
+            tv.request.source().is_tool_stub(),
+            self.supports_lockfile_url(),
+        ) {
             let platform_key = self.get_platform_key();
             let has_lockfile_url = tv
                 .lock_platforms

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -415,8 +415,6 @@ pub fn is_install_time_option_key_for_type(backend_type: &BackendType, key: &str
             .any(|itk| key.starts_with("platforms.") && key.ends_with(&format!(".{itk}")))
 }
 
-/// Normalize idiomatic file contents by removing comments and empty lines.
-/// Full-line and inline comments are supported by .python-version, .nvmrc, etc.
 // The lockfile URL is only needed to download; an already-installed tool downloads
 // nothing, so enforce the locked-mode URL check only when an install will actually
 // run (keeps `mise install --locked` idempotent).
@@ -430,6 +428,8 @@ fn enforce_locked_url(
     locked && supports_lockfile_url && !is_tool_stub && (forced || !already_installed)
 }
 
+/// Normalize idiomatic file contents by removing comments and empty lines.
+/// Full-line and inline comments are supported by .python-version, .nvmrc, etc.
 pub(crate) fn normalize_idiomatic_contents(contents: &str) -> String {
     contents
         .lines()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1851,8 +1851,9 @@ pub trait Backend: Debug + Send + Sync {
             );
         }
         let already_installed = self.is_version_installed(&ctx.config, &tv, true);
+        let locked_mode = ctx.locked || settings.locked;
         if enforce_locked_url(
-            ctx.locked,
+            locked_mode,
             ctx.force,
             already_installed,
             tv.request.source().is_tool_stub(),


### PR DESCRIPTION
## Problem

`mise install --locked` is not idempotent for backends that support lockfile URLs (e.g. the `http` backend). A fresh install succeeds, but **re-running it when the tool is already installed fails**:

```
mise ERROR Failed to install http:flutter@3.41.7: No lockfile URL found for flutter@3.41.7 on platform <platform> (--locked mode)
hint: Run `mise lock` to generate lockfile URLs, or disable locked mode
```

…even though `mise.lock` has a valid `url` + `checksum` for the current platform.

### Repro

```toml
# mise.toml
[tools]
flutter = "3.41.7"   # http:flutter backend

[settings]
experimental = true
lockfile = true
lockfile_platforms = ["linux-x64", "macos-arm64"]
```

```bash
mise lock
mise install --locked   # 1st run: ok (downloads + verifies)
mise install --locked   # 2nd run: "No lockfile URL found ... (--locked mode)"
```

This commonly bites CI that caches the mise install dir and runs `mise install --locked` (e.g. via `jdx/mise-action`, which auto-appends `--locked` when a lockfile is present): every cache hit fails, every cache miss passes.

## Cause

In `install_version` (`src/backend/mod.rs`), the locked-mode "must have a lockfile URL → bail" check runs **before** the "already installed → `return Ok`" early-skip, so an already-installed tool bails instead of no-op'ing. The lockfile URL is only needed to download an artifact — an already-installed tool downloads nothing.

## Fix

Enforce the locked-URL check only when an install will actually run (`--force`, or the version isn't installed yet). The decision is extracted into a small pure function (`enforce_locked_url`) with a unit test.

- `--locked --dry-run` on a not-yet-installed tool still validates.
- `--force --locked` still validates (it re-installs).

## Discussion

https://github.com/jdx/mise/discussions/10454


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `--locked` behavior so lockfile URL validation only runs when an installation will occur, and is skipped when the target version is already installed unless `--force` is used.
* **Tests**
  * Added unit coverage for the locked-mode enforcement rules across locked/force/already-installed combinations and URL-support scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->