### PR TITLE
fix(aqua): render minisign asset templates with package asset

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -1253,14 +1253,17 @@ impl AquaMinisign {
         pkg.parse_aqua_str(self.url.as_ref().unwrap(), v, &Default::default(), os, arch)
     }
 
-    pub fn asset(&self, pkg: &AquaPackage, v: &str, os: &str, arch: &str) -> Result<String> {
-        pkg.parse_aqua_str(
-            self.asset.as_ref().unwrap(),
-            v,
-            &Default::default(),
-            os,
-            arch,
-        )
+    pub fn asset(
+        &self,
+        pkg: &AquaPackage,
+        package_asset: &str,
+        v: &str,
+        os: &str,
+        arch: &str,
+    ) -> Result<String> {
+        let mut ctx = HashMap::new();
+        ctx.insert("Asset".to_string(), package_asset.to_string());
+        pkg.parse_aqua_str(self.asset.as_ref().unwrap(), v, &ctx, os, arch)
     }
 
     pub fn public_key(&self, pkg: &AquaPackage, v: &str, os: &str, arch: &str) -> Result<String> {
@@ -2012,6 +2015,29 @@ packages:
         let cosign = pkg.cosign.unwrap();
         assert!(cosign.bundle.is_some());
         assert!(cosign.key.is_some());
+    }
+
+    #[test]
+    fn test_minisign_asset_template_uses_package_asset() {
+        let yml = r#"
+packages:
+  - asset: minisign-{{.Version}}-{{.OS}}.tar.gz
+    minisign:
+      type: github_release
+      asset: "{{.Asset}}.minisig"
+      public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
+"#;
+        let pkg = first_registry_package(yml);
+        let package_asset = pkg.asset("0.12", "linux", "amd64").unwrap();
+        let minisign_asset = pkg
+            .minisign
+            .as_ref()
+            .unwrap()
+            .asset(&pkg, &package_asset, "0.12", "linux", "amd64")
+            .unwrap();
+
+        assert_eq!(package_asset, "minisign-0.12-linux.tar.gz");
+        assert_eq!(minisign_asset, "minisign-0.12-linux.tar.gz.minisig");
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1342,7 +1342,7 @@ impl AquaBackend {
 
         let sig_path = match minisign_config._type() {
             AquaMinisignType::GithubRelease => {
-                let asset = minisign_config.asset(pkg, v, os(), arch())?;
+                let asset = minisign_config.asset(pkg, artifact_filename, v, os(), arch())?;
                 let (repo_owner, repo_name) = resolve_repo_info(
                     minisign_config.repo_owner.as_ref(),
                     minisign_config.repo_name.as_ref(),


### PR DESCRIPTION
## Summary
- pass the selected package asset into aqua minisign asset template rendering
- fix `{{.Asset}}.minisig` templates such as `jedisct1/minisign` 0.12
- add a focused regression test for minisign asset rendering

Addresses https://github.com/jdx/mise/discussions/10450.

## Tests
- `mise x cargo -- cargo test -p aqua-registry test_minisign_asset_template_uses_package_asset`
- `mise run format` (completed, including cargo check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Minisign asset templates now support dynamic, context-aware variable expansion, enabling more flexible configuration of asset paths and naming conventions.

* **Bug Fixes**
  * Improved minisign signature verification for GitHub releases by correctly resolving artifact identifiers using actual filenames, enhancing signature verification reliability.

* **Tests**
  * Added comprehensive unit tests to validate minisign asset template variable expansion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->