### PR TITLE
fix(install): don't treat http cache symlinks as mise link when resolving lockfile

### DIFF
--- a/e2e/lockfile/test_lockfile_locked_idempotent_http
+++ b/e2e/lockfile/test_lockfile_locked_idempotent_http
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Regression test for HTTP install symlinks being mistaken for `mise link`
+# symlinks, which skipped lockfile hydration on the second --locked install.
+
+export MISE_LOCKFILE=1
+
+detect_platform
+PLATFORM="$MISE_PLATFORM"
+
+cat <<'EOF' >mise.toml
+[tools]
+"http:hello-locked-idempotent" = { version = "1.0.0", url = "https://mise.en.dev/test-fixtures/hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", postinstall = "chmod +x $MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world" }
+EOF
+
+cat <<EOF >mise.lock
+[[tools."http:hello-locked-idempotent"]]
+version = "1.0.0"
+backend = "http:hello-locked-idempotent"
+"platforms.$PLATFORM" = { url = "https://mise.en.dev/test-fixtures/hello-world-1.0.0.tar.gz", checksum = "blake3:71f774faa03daf1a58cc3339f8c73e6557348c8e0a2f3fb8148cc26e26bad83f" }
+EOF
+
+mise install --locked
+mise install --locked
+
+assert_contains "mise x -- hello-world" "hello world"

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -896,10 +896,10 @@ mod tests {
 
         let mut managed_targets = vec![];
         let mut roots = vec![
-            ("data".to_string(), *dirs::DATA),
-            ("cache".to_string(), *dirs::CACHE),
-            ("downloads".to_string(), *dirs::DOWNLOADS),
-            ("installs".to_string(), *dirs::INSTALLS),
+            ("data".to_string(), dirs::DATA.to_path_buf()),
+            ("cache".to_string(), dirs::CACHE.to_path_buf()),
+            ("downloads".to_string(), dirs::DOWNLOADS.to_path_buf()),
+            ("installs".to_string(), dirs::INSTALLS.to_path_buf()),
         ];
         roots.extend(
             env::shared_install_dirs()

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -1,14 +1,13 @@
 use std::fmt::{Display, Formatter};
 use std::fs;
 use std::hash::{Hash, Hasher};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::{cmp::Ordering, sync::LazyLock};
 use std::{collections::BTreeMap, sync::Arc};
 
 use crate::backend::{ABackend, VersionInfo};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
-use crate::{dirs, env};
 #[cfg(windows)]
 use crate::file;
 use crate::hash::hash_to_str;
@@ -16,6 +15,7 @@ use crate::install_before::{BeforeDateSource, resolve_before_date_for_tool_with_
 use crate::lockfile::{CondaPackageInfo, LockfileTool, PkgxPackageInfo, PlatformInfo};
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, tool_request};
+use crate::{dirs, env};
 use console::style;
 use dashmap::DashMap;
 use eyre::{Result, bail};
@@ -770,21 +770,31 @@ fn has_linked_version(ba: &BackendArg) -> bool {
 }
 
 fn is_mise_managed_symlink_target(target: &Path) -> bool {
-    if !target.is_absolute() {
-        return false;
-    }
+    debug_assert!(target.is_absolute(), "caller filters relative targets");
+    let target = normalize_path_components(target);
 
-    [
-        *dirs::DATA,
-        *dirs::CACHE,
-        *dirs::DOWNLOADS,
-        *dirs::INSTALLS,
-    ]
-    .into_iter()
-    .any(|root| target.starts_with(root))
+    [*dirs::DATA, *dirs::CACHE, *dirs::DOWNLOADS, *dirs::INSTALLS]
+        .into_iter()
+        .any(|root| target.starts_with(normalize_path_components(root)))
         || env::shared_install_dirs()
             .iter()
-            .any(|root| target.starts_with(root))
+            .any(|root| target.starts_with(normalize_path_components(root)))
+}
+
+fn normalize_path_components(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push("..");
+                }
+            }
+            Component::CurDir => {}
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 impl Display for ResolveOptions {
@@ -859,17 +869,50 @@ mod tests {
     }
 
     #[test]
+    fn has_linked_version_normalizes_absolute_targets_before_managed_check() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let backend = test_backend(temp_dir.path().join("installs").join("dummy"));
+        fs::create_dir_all(&backend.installs_path)?;
+
+        let escaped_target = dirs::DATA
+            .join("..")
+            .join("has-linked-version-external")
+            .join("tool");
+        if let Some(parent) = escaped_target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        crate::file::make_symlink_or_file(&escaped_target, &backend.installs_path.join("escaped"))?;
+
+        assert!(has_linked_version(&backend));
+
+        Ok(())
+    }
+
+    #[test]
     fn has_linked_version_ignores_mise_managed_absolute_targets() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let backend = test_backend(temp_dir.path().join("installs").join("dummy"));
         fs::create_dir_all(&backend.installs_path)?;
 
         let mut managed_targets = vec![];
-        for (name, root) in [("data", *dirs::DATA), ("cache", *dirs::CACHE)] {
+        let mut roots = vec![
+            ("data".to_string(), *dirs::DATA),
+            ("cache".to_string(), *dirs::CACHE),
+            ("downloads".to_string(), *dirs::DOWNLOADS),
+            ("installs".to_string(), *dirs::INSTALLS),
+        ];
+        roots.extend(
+            env::shared_install_dirs()
+                .into_iter()
+                .enumerate()
+                .map(|(i, root)| (format!("shared-{i}"), root)),
+        );
+
+        for (name, root) in roots {
             fs::create_dir_all(root)?;
             let target = tempfile::Builder::new()
                 .prefix(&format!("has-linked-version-{name}-"))
-                .tempdir_in(root)?;
+                .tempdir_in(&root)?;
             crate::file::make_symlink_or_file(
                 target.path(),
                 &backend.installs_path.join(format!("{name}-target")),

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -909,7 +909,7 @@ mod tests {
         );
 
         for (name, root) in roots {
-            fs::create_dir_all(root)?;
+            fs::create_dir_all(&root)?;
             let target = tempfile::Builder::new()
                 .prefix(&format!("has-linked-version-{name}-"))
                 .tempdir_in(&root)?;

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -1,14 +1,14 @@
 use std::fmt::{Display, Formatter};
 use std::fs;
 use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{cmp::Ordering, sync::LazyLock};
 use std::{collections::BTreeMap, sync::Arc};
 
 use crate::backend::{ABackend, VersionInfo};
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
-use crate::env;
+use crate::{dirs, env};
 #[cfg(windows)]
 use crate::file;
 use crate::hash::hash_to_str;
@@ -749,8 +749,8 @@ impl ResolveOptions {
 }
 
 /// Check if a tool has any user-linked versions (created by `mise link`).
-/// A linked version is an installed version whose path is a symlink to an absolute path,
-/// as opposed to runtime symlinks which point to relative paths (starting with "./").
+/// A linked version is an installed version whose path is a symlink to an external
+/// absolute path, as opposed to runtime symlinks or mise-managed install/cache links.
 fn has_linked_version(ba: &BackendArg) -> bool {
     let installs_dir = &ba.installs_path;
     let Ok(entries) = std::fs::read_dir(installs_dir) else {
@@ -761,12 +761,30 @@ fn has_linked_version(ba: &BackendArg) -> bool {
         if let Ok(Some(target)) = crate::file::resolve_symlink(&path) {
             // Runtime symlinks start with "./" (e.g., latest -> ./1.35.0)
             // User-linked symlinks point to absolute paths (e.g., brew -> /opt/homebrew/opt/hk)
-            if target.is_absolute() {
+            if target.is_absolute() && !is_mise_managed_symlink_target(&target) {
                 return true;
             }
         }
     }
     false
+}
+
+fn is_mise_managed_symlink_target(target: &Path) -> bool {
+    if !target.is_absolute() {
+        return false;
+    }
+
+    [
+        *dirs::DATA,
+        *dirs::CACHE,
+        *dirs::DOWNLOADS,
+        *dirs::INSTALLS,
+    ]
+    .into_iter()
+    .any(|root| target.starts_with(root))
+        || env::shared_install_dirs()
+            .iter()
+            .any(|root| target.starts_with(root))
 }
 
 impl Display for ResolveOptions {
@@ -800,6 +818,85 @@ mod tests {
     use super::*;
     use crate::cli::args::BackendResolution;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_name(prefix: &str) -> String {
+        format!(
+            "{}-{}",
+            prefix,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
+    }
+
+    fn test_backend(installs_path: PathBuf) -> BackendArg {
+        let short = unique_name("dummy-linked");
+        let mut backend = BackendArg::new_raw(
+            short.clone(),
+            None,
+            short,
+            None,
+            BackendResolution::new(false),
+        );
+        backend.installs_path = installs_path;
+        backend
+    }
+
+    #[test]
+    fn has_linked_version_detects_external_absolute_targets() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let backend = test_backend(temp_dir.path().join("installs").join("dummy"));
+        fs::create_dir_all(&backend.installs_path)?;
+
+        let external_target = temp_dir.path().join("external").join("tool");
+        fs::create_dir_all(&external_target)?;
+        crate::file::make_symlink_or_file(&external_target, &backend.installs_path.join("brew"))?;
+
+        assert!(has_linked_version(&backend));
+
+        Ok(())
+    }
+
+    #[test]
+    fn has_linked_version_ignores_mise_managed_absolute_targets() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let backend = test_backend(temp_dir.path().join("installs").join("dummy"));
+        fs::create_dir_all(&backend.installs_path)?;
+
+        let mut managed_targets = vec![];
+        for (name, root) in [("data", *dirs::DATA), ("cache", *dirs::CACHE)] {
+            fs::create_dir_all(root)?;
+            let target = tempfile::Builder::new()
+                .prefix(&format!("has-linked-version-{name}-"))
+                .tempdir_in(root)?;
+            crate::file::make_symlink_or_file(
+                target.path(),
+                &backend.installs_path.join(format!("{name}-target")),
+            )?;
+            managed_targets.push(target);
+        }
+
+        assert!(!has_linked_version(&backend));
+
+        Ok(())
+    }
+
+    #[test]
+    fn has_linked_version_ignores_runtime_relative_targets() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let backend = test_backend(temp_dir.path().join("installs").join("dummy"));
+        fs::create_dir_all(&backend.installs_path)?;
+
+        crate::file::make_symlink_or_file(
+            Path::new("./1.0.0"),
+            &backend.installs_path.join("latest"),
+        )?;
+
+        assert!(!has_linked_version(&backend));
+
+        Ok(())
+    }
 
     #[test]
     fn runtime_path_does_not_return_file_based_runtime_symlink() -> Result<()> {


### PR DESCRIPTION
## Summary
- treat absolute symlink targets under mise-managed data/cache/download/install/shared dirs as managed installs, not `mise link` versions
- keep external absolute symlink targets classified as linked versions
- add unit coverage for linked-version classification and an HTTP `mise install --locked` idempotence e2e regression

Supersedes and closes #10455.

## Tests
- Not run locally beyond attempted narrow checks; local `cargo` resolves to `/home/risu/.local/bin/cargo` and is not executable (`Permission denied`). CI should cover the full matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added an end-to-end regression test to ensure `install --locked` remains idempotent for HTTP-backed tools, verifies platform-specific lock behavior, and confirms the installed command outputs the expected result.

* **Bug Fixes**
  * Refined detection of “linked versions” so external absolute symlink targets are handled correctly, while mise-managed symlinks and symlink targets within managed roots are excluded more reliably, including normalization edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->