### PR TITLE
fix(deno): parse PowerShell checksum files

### DIFF
--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -90,7 +90,7 @@ fn is_checksum_hex(s: &str, algo: &str) -> bool {
         "sha256" | "blake3" => 64,
         "sha512" => 128,
         "md5" => 32,
-        _ => return !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit()),
+        _ => return false,
     };
 
     s.len() == expected_len && s.chars().all(|c| c.is_ascii_hexdigit())
@@ -1055,6 +1055,11 @@ Path      : C:\\a\\deno\\deno\\target\\release\\deno-x86_64-pc-windows-msvc.zip
         let content = "Algorithm : SHA256\nPath      : deno.zip\n";
 
         assert_eq!(parse_checksum_file_content(content, "sha256"), None);
+    }
+
+    #[test]
+    fn test_parse_checksum_file_content_rejects_unknown_algorithms() {
+        assert_eq!(parse_checksum_file_content(SHA256_LOWER, "sha3-256"), None);
     }
 
     #[test]

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -55,18 +55,45 @@ pub async fn fetch_checksum_from_shasums(shasums_url: &str, filename: &str) -> O
 /// * `None` if the checksum file couldn't be fetched
 pub async fn fetch_checksum_from_file(checksum_url: &str, algo: &str) -> Option<String> {
     match HTTP.get_text(checksum_url).await {
-        Ok(content) => {
-            // Format is typically "<hash>  <filename>" or just "<hash>"
-            content
-                .split_whitespace()
-                .next()
-                .map(|h| format!("{algo}:{}", h.trim()))
-        }
+        Ok(content) => parse_checksum_file_content(&content, algo),
         Err(e) => {
             debug!("Failed to fetch checksum from {}: {e}", checksum_url);
             None
         }
     }
+}
+
+fn parse_checksum_file_content(content: &str, algo: &str) -> Option<String> {
+    // PowerShell Get-FileHash output:
+    // Hash      : 7FDD...
+    for line in content.lines() {
+        if let Some((key, value)) = line.split_once(':')
+            && key.trim().eq_ignore_ascii_case("hash")
+        {
+            let hash = value.trim();
+            if is_checksum_hex(hash, algo) {
+                return Some(format!("{algo}:{}", hash.to_lowercase()));
+            }
+        }
+    }
+
+    // Standard formats are typically "<hash>  <filename>" or just "<hash>".
+    content
+        .split_whitespace()
+        .find(|token| is_checksum_hex(token, algo))
+        .map(|hash| format!("{algo}:{}", hash.to_lowercase()))
+}
+
+fn is_checksum_hex(s: &str, algo: &str) -> bool {
+    let expected_len = match algo {
+        "sha1" => 40,
+        "sha256" | "blake3" => 64,
+        "sha512" => 128,
+        "md5" => 32,
+        _ => return !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit()),
+    };
+
+    s.len() == expected_len && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 pub trait VerifiableError: Sized + Send + Sync + 'static {
@@ -993,6 +1020,42 @@ mod tests {
     use super::*;
     use crate::toolset::ToolVersionOptions;
     use indexmap::IndexMap;
+
+    const SHA256_LOWER: &str = "7fdd1f42e6b0855421ecf27bb406e2492ade1087c85e30ebf0deab6280ea743c";
+    const SHA256_UPPER: &str = "7FDD1F42E6B0855421ECF27BB406E2492ADE1087C85E30EBF0DEAB6280EA743C";
+
+    #[test]
+    fn test_parse_checksum_file_content_standard_format() {
+        let content = format!("{SHA256_LOWER}  deno-x86_64-unknown-linux-gnu.zip\n");
+
+        assert_eq!(
+            parse_checksum_file_content(&content, "sha256"),
+            Some(format!("sha256:{SHA256_LOWER}"))
+        );
+    }
+
+    #[test]
+    fn test_parse_checksum_file_content_powershell_get_file_hash_format() {
+        let content = format!(
+            "\
+Algorithm : SHA256
+Hash      : {SHA256_UPPER}
+Path      : C:\\a\\deno\\deno\\target\\release\\deno-x86_64-pc-windows-msvc.zip
+"
+        );
+
+        assert_eq!(
+            parse_checksum_file_content(&content, "sha256"),
+            Some(format!("sha256:{SHA256_LOWER}"))
+        );
+    }
+
+    #[test]
+    fn test_parse_checksum_file_content_rejects_non_hash_tokens() {
+        let content = "Algorithm : SHA256\nPath      : deno.zip\n";
+
+        assert_eq!(parse_checksum_file_content(content, "sha256"), None);
+    }
 
     #[test]
     fn test_clean_binary_name() {


### PR DESCRIPTION
## Summary
- parse PowerShell Get-FileHash checksum output used by Deno Windows .sha256sum files
- validate checksum tokens before writing them to lockfile platform info
- normalize parsed checksum hex to lowercase for verification

## Discussion
Addresses https://github.com/jdx/mise/discussions/10405

## Testing
- `mise x rust -- cargo fmt --check`
- `mise x rust -- cargo test backend::static_helpers::tests::test_parse_checksum_file_content`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced checksum file parsing to correctly support both standard whitespace-delimited formats and PowerShell `Get-FileHash` output.
  * Added algorithm-specific validation to ensure only properly formatted hashes are accepted.
  * Normalizes accepted checksums into a consistent lowercase `"<algo>:<hash>"` form.

* **Tests**
  * Expanded unit tests to cover standard input, PowerShell multi-line output, rejection when no valid hash for the requested algorithm exists, and rejection for unknown algorithms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->