### PR TITLE
refactor: remove os-release and sys-info deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5341,7 +5341,6 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "openssl",
- "os-release",
  "path-absolutize",
  "petgraph",
  "phf 0.13.1",
@@ -5375,7 +5374,6 @@ dependencies = [
  "siphasher",
  "strum 0.28.0",
  "supports-hyperlinks",
- "sys-info",
  "tabled",
  "taplo",
  "tar",
@@ -5838,15 +5836,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "os-release"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -8657,16 +8646,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,6 @@ nodejs-semver = "4.2"
 num_cpus = "1"
 once_cell = "1"
 openssl = { version = "0.10", optional = true }
-os-release = "0.1"
 path-absolutize = { version = "3", features = ["unsafe_cache"] }
 petgraph = "0.8"
 phf = "0.13"
@@ -182,7 +181,6 @@ signal-hook = "0.4"
 siphasher = "1"
 strum = { version = "0.28", features = ["derive"] }
 supports-hyperlinks = "3"
-sys-info = "0.9"
 tabled = { version = "0.21", features = ["ansi"] }
 taplo = "0.14"
 tar = "0.4"

--- a/src/env.rs
+++ b/src/env.rs
@@ -798,10 +798,7 @@ fn log_file_level() -> Option<LevelFilter> {
 }
 
 fn linux_distro() -> Option<String> {
-    match sys_info::linux_os_release() {
-        Ok(release) => release.id,
-        _ => None,
-    }
+    crate::platform::linux_os_release().map(|release| release.id.clone())
 }
 
 #[cfg(target_os = "linux")]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -477,8 +477,7 @@ mod tests {
     #[test]
     fn test_os_release_alpine_id_is_musl() {
         let release =
-            LinuxOsRelease::parse("NAME=\"Alpine Linux\"\nID=alpine\nVERSION_ID=3.22.4\n")
-                .unwrap();
+            LinuxOsRelease::parse("NAME=\"Alpine Linux\"\nID=alpine\nVERSION_ID=3.22.4\n").unwrap();
         assert!(linux_os_release_is_musl(&release));
     }
 
@@ -506,10 +505,9 @@ mod tests {
         // Regression: previously `split_once('=')?` returned None on the first
         // comment or blank line, causing the function to ignore the `ID=` line
         // that came after and silently fall back to linker-based detection.
-        let release = LinuxOsRelease::parse(
-            "# this is a comment\n\nNAME=\"Alpine Linux\"\nID=alpine\n",
-        )
-        .unwrap();
+        let release =
+            LinuxOsRelease::parse("# this is a comment\n\nNAME=\"Alpine Linux\"\nID=alpine\n")
+                .unwrap();
         assert_eq!(release.id, "alpine");
     }
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -273,7 +273,7 @@ fn parse_os_release_value(value: &str) -> String {
 pub fn detect_libc() -> Option<&'static str> {
     use std::sync::LazyLock;
     static DETECTED: LazyLock<Option<&'static str>> = LazyLock::new(|| {
-        if let Some(true) = musl_from_os_release() {
+        if linux_os_release().is_some_and(linux_os_release_is_musl) {
             return Some("musl");
         }
         for dir in ["/lib", "/lib64"] {
@@ -300,11 +300,6 @@ pub fn detect_libc() -> Option<&'static str> {
 #[cfg(not(target_os = "linux"))]
 pub fn detect_libc() -> Option<&'static str> {
     None
-}
-
-#[cfg(target_os = "linux")]
-fn musl_from_os_release() -> Option<bool> {
-    linux_os_release().map(linux_os_release_is_musl)
 }
 
 #[cfg(target_os = "linux")]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -216,6 +216,7 @@ impl LinuxOsRelease {
         })
     }
 
+    #[cfg(target_os = "linux")]
     fn ids(&self) -> impl Iterator<Item = &str> {
         std::iter::once(self.id.as_str()).chain(self.id_like.iter().map(String::as_str))
     }
@@ -303,7 +304,13 @@ pub fn detect_libc() -> Option<&'static str> {
 
 #[cfg(target_os = "linux")]
 fn musl_from_os_release(path: &str) -> Option<bool> {
-    let release = read_linux_os_release(path)?;
+    let parsed_release;
+    let release = if path == "/etc/os-release" {
+        linux_os_release()?
+    } else {
+        parsed_release = read_linux_os_release(path)?;
+        &parsed_release
+    };
     // Known musl-libc distros. Compat shims (gcompat) don't change this — the
     // underlying libc is still musl.
     const MUSL_DISTROS: &[&str] = &["alpine", "postmarketos", "chimera"];

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -273,7 +273,7 @@ fn parse_os_release_value(value: &str) -> String {
 pub fn detect_libc() -> Option<&'static str> {
     use std::sync::LazyLock;
     static DETECTED: LazyLock<Option<&'static str>> = LazyLock::new(|| {
-        if let Some(true) = musl_from_os_release("/etc/os-release") {
+        if let Some(true) = musl_from_os_release() {
             return Some("musl");
         }
         for dir in ["/lib", "/lib64"] {
@@ -303,21 +303,16 @@ pub fn detect_libc() -> Option<&'static str> {
 }
 
 #[cfg(target_os = "linux")]
-fn musl_from_os_release(path: &str) -> Option<bool> {
-    let parsed_release;
-    let release = if path == "/etc/os-release" {
-        linux_os_release()?
-    } else {
-        parsed_release = read_linux_os_release(path)?;
-        &parsed_release
-    };
+fn musl_from_os_release() -> Option<bool> {
+    linux_os_release().map(linux_os_release_is_musl)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_os_release_is_musl(release: &LinuxOsRelease) -> bool {
     // Known musl-libc distros. Compat shims (gcompat) don't change this — the
     // underlying libc is still musl.
     const MUSL_DISTROS: &[&str] = &["alpine", "postmarketos", "chimera"];
-    if release.ids().any(|id| MUSL_DISTROS.contains(&id)) {
-        return Some(true);
-    }
-    None
+    release.ids().any(|id| MUSL_DISTROS.contains(&id))
 }
 
 #[cfg(target_os = "linux")]
@@ -486,63 +481,47 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn test_os_release_alpine_id_is_musl() {
-        let tmp = std::env::temp_dir().join("mise-libc-alpine");
-        std::fs::write(
-            &tmp,
-            "NAME=\"Alpine Linux\"\nID=alpine\nVERSION_ID=3.22.4\n",
-        )
-        .unwrap();
-        assert_eq!(musl_from_os_release(tmp.to_str().unwrap()), Some(true));
-        let _ = std::fs::remove_file(&tmp);
+        let release =
+            LinuxOsRelease::parse("NAME=\"Alpine Linux\"\nID=alpine\nVERSION_ID=3.22.4\n")
+                .unwrap();
+        assert!(linux_os_release_is_musl(&release));
     }
 
     #[cfg(target_os = "linux")]
     #[test]
     fn test_os_release_id_like_alpine_is_musl() {
-        let tmp = std::env::temp_dir().join("mise-libc-id-like");
-        std::fs::write(&tmp, "ID=postmarketos\nID_LIKE=\"alpine\"\n").unwrap();
-        assert_eq!(musl_from_os_release(tmp.to_str().unwrap()), Some(true));
-        let _ = std::fs::remove_file(&tmp);
+        let release = LinuxOsRelease::parse("ID=postmarketos\nID_LIKE=\"alpine\"\n").unwrap();
+        assert!(linux_os_release_is_musl(&release));
     }
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn test_os_release_debian_returns_none() {
-        let tmp = std::env::temp_dir().join("mise-libc-debian");
-        std::fs::write(&tmp, "ID=debian\nID_LIKE=\"\"\n").unwrap();
-        assert_eq!(musl_from_os_release(tmp.to_str().unwrap()), None);
-        let _ = std::fs::remove_file(&tmp);
+    fn test_os_release_debian_returns_false() {
+        let release = LinuxOsRelease::parse("ID=debian\nID_LIKE=\"\"\n").unwrap();
+        assert!(!linux_os_release_is_musl(&release));
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
-    fn test_os_release_missing_returns_none() {
-        assert_eq!(musl_from_os_release("/nonexistent/os-release"), None);
+    fn test_os_release_missing_id_returns_none() {
+        assert_eq!(LinuxOsRelease::parse("NAME=\"Missing ID\"\n"), None);
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
     fn test_os_release_comments_and_blank_lines_do_not_short_circuit() {
         // Regression: previously `split_once('=')?` returned None on the first
         // comment or blank line, causing the function to ignore the `ID=` line
         // that came after and silently fall back to linker-based detection.
-        let tmp = std::env::temp_dir().join("mise-libc-comments");
-        std::fs::write(
-            &tmp,
+        let release = LinuxOsRelease::parse(
             "# this is a comment\n\nNAME=\"Alpine Linux\"\nID=alpine\n",
         )
         .unwrap();
-        assert_eq!(musl_from_os_release(tmp.to_str().unwrap()), Some(true));
-        let _ = std::fs::remove_file(&tmp);
+        assert_eq!(release.id, "alpine");
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
     fn test_os_release_whitespace_around_key_tolerated() {
-        let tmp = std::env::temp_dir().join("mise-libc-whitespace");
-        std::fs::write(&tmp, "  ID = alpine \n").unwrap();
-        assert_eq!(musl_from_os_release(tmp.to_str().unwrap()), Some(true));
-        let _ = std::fs::remove_file(&tmp);
+        let release = LinuxOsRelease::parse("  ID = alpine \n").unwrap();
+        assert_eq!(release.id, "alpine");
     }
 
     #[test]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,6 +1,6 @@
 use crate::config::Settings;
 use eyre::{Result, bail};
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 /// Represents a target platform for lockfile operations
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -183,6 +183,77 @@ impl From<&str> for Platform {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinuxOsRelease {
+    pub id: String,
+    pub version_id: String,
+    pub id_like: Vec<String>,
+}
+
+impl LinuxOsRelease {
+    fn parse(content: &str) -> Option<Self> {
+        let mut values = BTreeMap::new();
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            values.insert(key.trim().to_string(), parse_os_release_value(value.trim()));
+        }
+
+        Some(Self {
+            id: values.remove("ID")?,
+            version_id: values.remove("VERSION_ID").unwrap_or_default(),
+            id_like: values
+                .remove("ID_LIKE")
+                .unwrap_or_default()
+                .split_whitespace()
+                .map(str::to_string)
+                .collect(),
+        })
+    }
+
+    fn ids(&self) -> impl Iterator<Item = &str> {
+        std::iter::once(self.id.as_str()).chain(self.id_like.iter().map(String::as_str))
+    }
+}
+
+pub fn linux_os_release() -> Option<&'static LinuxOsRelease> {
+    use std::sync::LazyLock;
+    static OS_RELEASE: LazyLock<Option<LinuxOsRelease>> =
+        LazyLock::new(|| read_linux_os_release("/etc/os-release"));
+    OS_RELEASE.as_ref()
+}
+
+fn read_linux_os_release(path: &str) -> Option<LinuxOsRelease> {
+    LinuxOsRelease::parse(&std::fs::read_to_string(path).ok()?)
+}
+
+fn parse_os_release_value(value: &str) -> String {
+    let Some(quote) = value.chars().next().filter(|c| *c == '"' || *c == '\'') else {
+        return value.to_string();
+    };
+
+    let mut parsed = String::new();
+    let mut chars = value[quote.len_utf8()..].chars();
+    while let Some(ch) = chars.next() {
+        if ch == quote {
+            break;
+        }
+        if quote == '"' && ch == '\\' {
+            if let Some(next) = chars.next() {
+                parsed.push(next);
+            }
+        } else {
+            parsed.push(ch);
+        }
+    }
+    parsed
+}
+
 /// Detect the current libc variant on Linux.
 ///
 /// Returns `Some("gnu")` on glibc Linux, `Some("musl")` on musl Linux,
@@ -232,26 +303,11 @@ pub fn detect_libc() -> Option<&'static str> {
 
 #[cfg(target_os = "linux")]
 fn musl_from_os_release(path: &str) -> Option<bool> {
-    let content = std::fs::read_to_string(path).ok()?;
-    let mut ids: Vec<String> = Vec::new();
-    for line in content.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
-        };
-        let key = key.trim();
-        if key == "ID" || key == "ID_LIKE" {
-            let value = value.trim().trim_matches('"').trim_matches('\'');
-            ids.extend(value.split_whitespace().map(str::to_string));
-        }
-    }
+    let release = read_linux_os_release(path)?;
     // Known musl-libc distros. Compat shims (gcompat) don't change this — the
     // underlying libc is still musl.
     const MUSL_DISTROS: &[&str] = &["alpine", "postmarketos", "chimera"];
-    if ids.iter().any(|id| MUSL_DISTROS.contains(&id.as_str())) {
+    if release.ids().any(|id| MUSL_DISTROS.contains(&id)) {
         return Some(true);
     }
     None
@@ -480,5 +536,34 @@ mod tests {
         std::fs::write(&tmp, "  ID = alpine \n").unwrap();
         assert_eq!(musl_from_os_release(tmp.to_str().unwrap()), Some(true));
         let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn test_linux_os_release_parse_id_version_and_id_like() {
+        let release = LinuxOsRelease::parse(
+            r#"
+NAME="Ubuntu"
+ID=ubuntu
+VERSION_ID="24.04"
+ID_LIKE="debian"
+"#,
+        )
+        .unwrap();
+        assert_eq!(release.id, "ubuntu");
+        assert_eq!(release.version_id, "24.04");
+        assert_eq!(release.id_like, vec!["debian"]);
+    }
+
+    #[test]
+    fn test_linux_os_release_parse_quoted_escapes() {
+        let release = LinuxOsRelease::parse(
+            r#"
+ID="custom\"id"
+VERSION_ID='1.2'
+"#,
+        )
+        .unwrap();
+        assert_eq!(release.id, "custom\"id");
+        assert_eq!(release.version_id, "1.2");
     }
 }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -13,7 +13,7 @@ use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lock_file::LockFile;
 use crate::lockfile::PlatformInfo;
-use crate::platform::Platform;
+use crate::platform::{Platform, linux_os_release};
 use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{file, github, plugins};
 use async_trait::async_trait;
@@ -159,7 +159,7 @@ impl ErlangPlugin {
                     "ubuntu20" => "ubuntu-20.04".to_string(),
                     _ => os,
                 }
-            } else if let Ok(os_release) = &*os_release::OS_RELEASE {
+            } else if let Some(os_release) = linux_os_release() {
                 format!("{}-{}", os_release.id, os_release.version_id)
             } else {
                 bail!("could not determine OS release");

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -3,6 +3,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::Settings;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
+use crate::platform::linux_os_release;
 use crate::toolset::ToolVersion;
 use crate::ui::progress_report::SingleReport;
 use crate::{backend::Backend, backend::VersionInfo, config::Config};
@@ -274,7 +275,7 @@ fn platform_directory() -> String {
         "xcode".into()
     } else if cfg!(windows) {
         "windows10".into()
-    } else if let Ok(os_release) = &*os_release::OS_RELEASE {
+    } else if let Some(os_release) = linux_os_release() {
         let settings = Settings::get();
         let arch = settings.arch();
         if os_release.id == "ubuntu" && arch == "arm64" {
@@ -300,7 +301,7 @@ fn platform() -> String {
         "osx".to_string()
     } else if cfg!(windows) {
         "windows10".to_string()
-    } else if let Ok(os_release) = &*os_release::OS_RELEASE {
+    } else if let Some(os_release) = linux_os_release() {
         if os_release.id == "amzn" {
             format!("amazonlinux{}", os_release.version_id)
         } else if os_release.id == "ubi" {


### PR DESCRIPTION
## Summary
- add a small shared /etc/os-release parser in src/platform.rs
- use it for Linux distro detection in env, Swift, and Erlang code
- remove os-release and sys-info from Cargo.toml and Cargo.lock

## Rationale
- [`os-release`](https://crates.io/crates/os-release) is only used for `ID` and `VERSION_ID` in two plugin files. Its crate has not been published since 2018-11-02, and the [repo](https://github.com/pop-os/os-release) has 17 stars. Even though the repo had a recent push, this is a tiny/low-adoption dependency for a stable file format that mise can parse locally.
- [`sys-info`](https://crates.io/crates/sys-info) is only used once to read the Linux distro ID. Its crate has not been published since 2021-10-21, and the [repo](https://github.com/FillZpp/sys-info-rs) has 172 stars with the last push in 2024. That single use can share the same `/etc/os-release` parser.
- mise already had `/etc/os-release` parsing in `src/platform.rs` for libc detection, so extending that module gives mise one internal path for Linux OS release data and avoids external crates for a few fields.

## Verification
- Not run locally per request; CI will run on the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed unused external dependencies and switched Linux OS/version detection to a built-in, cached `/etc/os-release` parser.
* **Bug Fixes**
  * Improved Linux distro identification using the parsed `ID`, `VERSION_ID`, and `ID_LIKE`, with better tolerance for blank lines/comments and quoted/escaped values.
  * Refreshed musl detection to use the parsed release fields.
  * Updated Erlang and Swift Linux fallback logic to rely on the improved detection.
* **Tests**
  * Added/updated unit tests for `/etc/os-release` parsing and musl classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->