### PR TITLE
feat(upgrade): fix tool removal when minimum_release_age is set

### DIFF
--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -250,3 +250,21 @@ assert_contains "cat $MISE_CONFIG_DIR/mise.lock" "2.0.0"
 assert_not_contains "cat $MISE_CONFIG_DIR/mise.lock" "1.0.0"
 rm -f "$MISE_CONFIG_DIR/config.toml" "$MISE_CONFIG_DIR/mise.lock"
 unset MISE_LOCKFILE
+
+# Test: upgrade removes old version when minimum_release_age is set and "latest" resolves
+# to a version not yet installed on disk.
+# Regression test for https://github.com/jdx/mise/issues/7991
+mise settings set minimum_release_age "7d"
+mise uninstall dummy --all
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "latest"
+EOF
+mise install dummy@1.0.0
+assert_contains "mise ls --installed dummy" "1.0.0"
+# upgrade should install 2.0.0 and uninstall 1.0.0
+mise upgrade dummy
+assert_contains "mise ls --installed dummy" "2.0.0"
+assert_not_contains "mise ls --installed dummy" "1.0.0"
+rm -f mise.toml
+mise settings unset minimum_release_age

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -409,27 +409,29 @@ impl Upgrade {
 
         // Only uninstall old versions of tools that were successfully upgraded
         // and are not needed by any tracked config
-        for (o, tv) in to_remove {
+        for (o, old_version) in to_remove {
             if successful_versions
                 .iter()
                 .any(|v| v.ba() == o.tool_version.ba())
             {
-                // Check if this version is still needed by another tracked config
-                let version_key = (
-                    o.tool_version.ba().short.to_string(),
-                    o.tool_version.tv_pathname(),
-                );
+                // Build a ToolVersion that targets the actual installed old version
+                // (e.g., "1.0.0"), not the resolved latest (e.g., "2.0.0").
+                // When minimum_release_age forces a remote lookup for "latest",
+                // the toolset resolves to the remote version, and tv_pathname()
+                // on the toolset version would give the wrong key.
+                let old_tv = ToolVersion::new(o.tool_version.request.clone(), old_version.clone());
+                let version_key = (old_tv.ba().short.to_string(), old_tv.tv_pathname());
                 if versions_needed_by_tracked.contains(&version_key) {
                     debug!(
                         "Keeping {}@{} because it's still needed by a tracked config",
-                        o.name, tv
+                        o.name, old_version
                     );
                     continue;
                 }
 
-                let pr = mpr.add(&format!("uninstall {}@{}", o.name, tv));
+                let pr = mpr.add(&format!("uninstall {}@{}", o.name, old_version));
                 if let Err(e) = self
-                    .uninstall_old_version(config, &o.tool_version, pr.as_ref())
+                    .uninstall_old_version(config, &old_tv, pr.as_ref())
                     .await
                 {
                     warn!("Failed to uninstall old version of {}: {}", o.name, e);

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -56,6 +56,23 @@ impl OutdatedInfo {
             return Ok(Some(tv.version.clone()));
         }
         if matches!(&tv.request, ToolRequest::Version { version, .. } if version == "latest") {
+            if tv.request.version() == tv.version {
+                // "latest" was not resolved to a concrete version (e.g. plugin not
+                // installed yet). Don't try to infer an installed version; the
+                // generic path below would treat "latest" as a fuzzy prefix and
+                // incorrectly match any installed numeric version.
+                return Ok(None);
+            }
+            // When minimum_release_age causes "latest" to resolve to a version not yet
+            // installed on disk, fall back to finding the highest installed version.
+            // Otherwise to_remove in `mise up` won't know which old version to uninstall.
+            let Some(current) = backend.latest_installed_version(None)? else {
+                return Ok(None);
+            };
+            let current_tv = ToolVersion::new(tv.request.clone(), current);
+            if backend.is_version_installed(config, &current_tv, true) {
+                return Ok(Some(current_tv.version));
+            }
             return Ok(None);
         }
 
@@ -618,7 +635,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn current_version_does_not_infer_latest_alias() {
+    async fn current_version_falls_back_to_installed_when_latest_not_installed() {
         let config = Config::get().await.unwrap();
         let temp_dir = tempfile::tempdir().unwrap();
         let short = "summary-current-latest-test";
@@ -643,7 +660,7 @@ mod tests {
         let tv = ToolVersion::new(request, "1.25.10".into());
         let info = OutdatedInfo::new(&config, tv, "1.25.10".into()).unwrap();
 
-        assert_eq!(info.current, None);
+        assert_eq!(info.current.as_deref(), Some("1.25.9"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes an issue with tool removal on `upgrade` when setting `minimum_release_age` is set.

### 1. outdated_info.rs — `current_version()` fallback for `"latest"`

When the request is `"latest"` but the resolved version isn't installed on disk (which happens when `minimum_release_age` forces a remote lookup), the method now falls through to `backend.latest_installed_version(None)` to find the highest actually-installed version. Previously it returned `None` immediately, which caused `to_remove` in `mise up` to skip the tool entirely.

### 2. upgrade.rs — `version_key` uses actual old version, not resolved version  

`o.tool_version.tv_pathname()` returns the **resolved** target version (e.g. `"2.0.0"`), but `versions_needed_by_tracked` also resolves configs using `minimum_release_age`, so it returns `"2.0.0"` too — making the key always match and the uninstall always skip. Fixed by constructing a `ToolVersion` from the `current` (actually-installed) version string (`"1.0.0"`) instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the upgrade flow to uninstall the exact old version that was previously installed and is no longer required.
  * Improved behavior for `"latest"` when minimum release age blocks installation, now falling back to the highest installed concrete version.
* **Tests**
  * Added an end-to-end regression test verifying that upgrades under a minimum release age policy correctly install the newer version and remove the older one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->