### PR TITLE
chore(deps): replace fuzzy matcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5312,7 +5312,6 @@ dependencies = [
  "filetime",
  "flate2",
  "fslock",
- "fuzzy-matcher",
  "gix",
  "glob",
  "globset",
@@ -5338,6 +5337,7 @@ dependencies = [
  "netrc-rs",
  "nix 0.31.3",
  "nodejs-semver",
+ "nucleo-matcher",
  "num_cpus",
  "once_cell",
  "openssl",
@@ -5409,7 +5409,7 @@ version = "2026.1.12"
 dependencies = [
  "async-trait",
  "console",
- "fuzzy-matcher",
+ "nucleo-matcher",
  "serde_json",
  "tokio",
  "toml_edit 0.25.12+spec-1.1.0",
@@ -5636,6 +5636,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,6 @@ filetime = "0.2"
 flate2 = "1"
 mise-sigstore = { path = "crates/mise-sigstore", default-features = false }
 fslock = "0.2.1"
-fuzzy-matcher = "0.3"
 gix = { version = "<1", features = ["worktree-mutation"] }
 glob = "0.3"
 globset = "0.4"
@@ -127,6 +126,7 @@ md-5 = "0.11"
 miette = { version = "7", features = ["fancy"] }
 netrc-rs = "0.1"
 nodejs-semver = "4.2"
+nucleo-matcher = "0.3"
 num_cpus = "1"
 once_cell = "1"
 openssl = { version = "0.10", optional = true }

--- a/crates/mise-interactive-config/Cargo.toml
+++ b/crates/mise-interactive-config/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = "0.1" # Async trait support
 console = "0.16" # Terminal control, key reading
-fuzzy-matcher = "0.3" # Fuzzy matching for tool/setting pickers
+nucleo-matcher = "0.3" # Fuzzy matching for tool/setting pickers
 tokio = { version = "1", features = [
   "rt",
   "sync",

--- a/crates/mise-interactive-config/src/picker.rs
+++ b/crates/mise-interactive-config/src/picker.rs
@@ -1,7 +1,7 @@
 //! Picker: Fuzzy-searchable list picker UI component
 
-use fuzzy_matcher::FuzzyMatcher;
-use fuzzy_matcher::skim::SkimMatcherV2;
+use nucleo_matcher::pattern::{Atom, AtomKind, CaseMatching, Normalization};
+use nucleo_matcher::{Config, Matcher, Utf32Str};
 
 /// An item that can be displayed in the picker
 #[derive(Debug, Clone)]
@@ -64,7 +64,7 @@ pub struct PickerState {
     /// Height of visible area (number of items)
     visible_height: usize,
     /// Fuzzy matcher instance (created fresh, not stored for Clone/Debug)
-    matcher: SkimMatcherV2,
+    matcher: Matcher,
 }
 
 impl std::fmt::Debug for PickerState {
@@ -89,7 +89,7 @@ impl Clone for PickerState {
             cursor: self.cursor,
             scroll_offset: self.scroll_offset,
             visible_height: self.visible_height,
-            matcher: SkimMatcherV2::default(),
+            matcher: Matcher::new(Config::DEFAULT),
         }
     }
 }
@@ -114,7 +114,7 @@ impl PickerState {
             cursor: 0,
             scroll_offset: 0,
             visible_height: 10,
-            matcher: SkimMatcherV2::default(),
+            matcher: Matcher::new(Config::DEFAULT),
         }
     }
 
@@ -221,17 +221,19 @@ impl PickerState {
                 .collect();
         } else {
             // Apply fuzzy matching
-            self.filtered = self
+            let pattern = fuzzy_pattern(&self.filter);
+            let mut haystack_buf = Vec::new();
+            let filtered = self
                 .items
                 .iter()
                 .enumerate()
                 .filter_map(|(i, item)| {
                     // Match against name and description
-                    let name_match = self.matcher.fuzzy_indices(&item.name, &self.filter);
-                    let desc_match = item
-                        .description
-                        .as_ref()
-                        .and_then(|d| self.matcher.fuzzy_match(d, &self.filter));
+                    let name_match =
+                        fuzzy_indices(&mut self.matcher, &mut haystack_buf, &item.name, &pattern);
+                    let desc_match = item.description.as_ref().and_then(|d| {
+                        fuzzy_match(&mut self.matcher, &mut haystack_buf, d, &pattern)
+                    });
 
                     // Take the best score
                     match (name_match, desc_match) {
@@ -254,6 +256,7 @@ impl PickerState {
                     }
                 })
                 .collect();
+            self.filtered = filtered;
 
             // Sort by score (highest first)
             self.filtered
@@ -273,6 +276,46 @@ impl PickerState {
             self.scroll_offset = self.cursor.saturating_sub(self.visible_height - 1);
         }
     }
+}
+
+fn fuzzy_pattern(needle: &str) -> Atom {
+    Atom::new(
+        needle,
+        CaseMatching::Smart,
+        Normalization::Smart,
+        AtomKind::Fuzzy,
+        false,
+    )
+}
+
+fn fuzzy_match(
+    matcher: &mut Matcher,
+    haystack_buf: &mut Vec<char>,
+    haystack: &str,
+    pattern: &Atom,
+) -> Option<i64> {
+    pattern
+        .score(Utf32Str::new(haystack, haystack_buf), matcher)
+        .map(i64::from)
+}
+
+fn fuzzy_indices(
+    matcher: &mut Matcher,
+    haystack_buf: &mut Vec<char>,
+    haystack: &str,
+    pattern: &Atom,
+) -> Option<(i64, Vec<usize>)> {
+    let mut indices = Vec::new();
+    pattern
+        .indices(Utf32Str::new(haystack, haystack_buf), matcher, &mut indices)
+        .map(|score| {
+            indices.sort_unstable();
+            indices.dedup();
+            (
+                i64::from(score),
+                indices.into_iter().map(|index| index as usize).collect(),
+            )
+        })
 }
 
 /// A visible item in the picker with display metadata

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -1,25 +1,19 @@
-use std::sync::LazyLock as Lazy;
-
 use clap::ValueEnum;
 use demand::DemandOption;
 use demand::Select;
 use eyre::Result;
 use eyre::bail;
 use eyre::eyre;
-use fuzzy_matcher::FuzzyMatcher;
-use fuzzy_matcher::skim::SkimMatcherV2;
 use itertools::Itertools;
 use xx::regex;
 
+use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
 use crate::registry::RegistryTool;
 use crate::{
     config::Settings,
     registry::{REGISTRY, tool_enabled},
     ui::table::MiseTable,
 };
-
-static FUZZY_MATCHER: Lazy<SkimMatcherV2> =
-    Lazy::new(|| SkimMatcherV2::default().use_cache(true).smart_case());
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum MatchType {
@@ -111,10 +105,12 @@ impl Search {
     }
 
     fn get_matches(&self) -> Vec<(String, String)> {
+        let name = self.name.as_deref().unwrap_or("");
+        let mut fuzzy_matcher = FuzzyMatcher::default();
+        let fuzzy_pattern = FuzzyPattern::new(&name.to_lowercase());
         self.get_tools()
             .iter()
             .filter_map(|(short, rt)| {
-                let name = self.name.as_deref().unwrap_or("");
                 if name.is_empty() {
                     Some((0, short, rt))
                 } else {
@@ -133,13 +129,13 @@ impl Search {
                                 None
                             }
                         }
-                        MatchType::Fuzzy => FUZZY_MATCHER
-                            .fuzzy_match(&short.to_lowercase(), name.to_lowercase().as_str())
+                        MatchType::Fuzzy => fuzzy_matcher
+                            .score_pattern(&short.to_lowercase(), &fuzzy_pattern)
                             .map(|score| (score, short, rt)),
                     }
                 }
             })
-            .sorted_by_key(|(score, _short, _rt)| -1 * *score)
+            .sorted_by_key(|(score, _short, _rt)| std::cmp::Reverse(*score))
             .map(|(_score, short, rt)| (short.to_string(), get_description(rt)))
             .collect()
     }

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,0 +1,44 @@
+use nucleo_matcher::pattern::{Atom, AtomKind, CaseMatching, Normalization};
+use nucleo_matcher::{Config, Matcher, Utf32Str};
+
+#[derive(Debug, Clone)]
+pub(crate) struct FuzzyPattern(Atom);
+
+impl FuzzyPattern {
+    pub(crate) fn new(needle: &str) -> Self {
+        Self(Atom::new(
+            needle,
+            CaseMatching::Smart,
+            Normalization::Smart,
+            AtomKind::Fuzzy,
+            false,
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FuzzyMatcher {
+    matcher: Matcher,
+    haystack_buf: Vec<char>,
+}
+
+impl Default for FuzzyMatcher {
+    fn default() -> Self {
+        Self {
+            matcher: Matcher::new(Config::DEFAULT),
+            haystack_buf: Vec::new(),
+        }
+    }
+}
+
+impl FuzzyMatcher {
+    pub(crate) fn score_pattern(&mut self, haystack: &str, pattern: &FuzzyPattern) -> Option<u32> {
+        pattern
+            .0
+            .score(
+                Utf32Str::new(haystack, &mut self.haystack_buf),
+                &mut self.matcher,
+            )
+            .map(u32::from)
+    }
+}

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -33,12 +33,9 @@ impl Default for FuzzyMatcher {
 
 impl FuzzyMatcher {
     pub(crate) fn score_pattern(&mut self, haystack: &str, pattern: &FuzzyPattern) -> Option<u32> {
-        pattern
-            .0
-            .score(
-                Utf32Str::new(haystack, &mut self.haystack_buf),
-                &mut self.matcher,
-            )
-            .map(u32::from)
+        pattern.0.score(
+            Utf32Str::new(haystack, &mut self.haystack_buf),
+            &mut self.matcher,
+        )
     }
 }

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -33,9 +33,12 @@ impl Default for FuzzyMatcher {
 
 impl FuzzyMatcher {
     pub(crate) fn score_pattern(&mut self, haystack: &str, pattern: &FuzzyPattern) -> Option<u32> {
-        pattern.0.score(
-            Utf32Str::new(haystack, &mut self.haystack_buf),
-            &mut self.matcher,
-        )
+        pattern
+            .0
+            .score(
+                Utf32Str::new(haystack, &mut self.haystack_buf),
+                &mut self.matcher,
+            )
+            .map(u32::from)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ mod exit;
 mod fake_asdf;
 mod file;
 pub(crate) mod forgejo;
+mod fuzzy;
 mod git;
 pub(crate) mod github;
 pub(crate) mod gitlab;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -9,8 +9,6 @@ use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};
 use console::{measure_text_width, truncate_str};
 use eyre::{Result, bail, eyre};
-use fuzzy_matcher::FuzzyMatcher;
-use fuzzy_matcher::skim::SkimMatcherV2;
 use globset::GlobBuilder;
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -29,8 +27,6 @@ use std::sync::LazyLock as Lazy;
 use std::{ffi, fmt, path};
 use xx::regex;
 
-static FUZZY_MATCHER: Lazy<SkimMatcherV2> =
-    Lazy::new(|| SkimMatcherV2::default().use_cache(true).smart_case());
 static TASK_VARS_CACHE: Lazy<std::sync::Mutex<IndexMap<PathBuf, IndexMap<String, String>>>> =
     Lazy::new(|| std::sync::Mutex::new(IndexMap::new()));
 
@@ -70,6 +66,7 @@ pub use task_template::TaskTemplate;
 use crate::config::config_file::ConfigFile;
 use crate::env_diff::EnvMap;
 use crate::file::display_path;
+use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
 use crate::toolset::{Toolset, serialize_tool_options};
 use crate::ui::style;
 pub use deps::{Deps, TaskKey};
@@ -1865,15 +1862,18 @@ fn match_tasks_with_context(
 
         // In monorepo mode, suggest similar tasks using fuzzy matching
         if resolved_pattern.starts_with("//") {
+            let mut matcher = FuzzyMatcher::default();
+            let resolved_pattern = resolved_pattern.to_lowercase();
+            let pattern = FuzzyPattern::new(&resolved_pattern);
             let similar: Vec<String> = tasks
                 .keys()
                 .filter(|k| k.starts_with("//"))
                 .filter_map(|k| {
-                    FUZZY_MATCHER
-                        .fuzzy_match(&k.to_lowercase(), &resolved_pattern.to_lowercase())
+                    matcher
+                        .score_pattern(&k.to_lowercase(), &pattern)
                         .map(|score| (score, k.clone()))
                 })
-                .sorted_by_key(|(score, _)| -1 * *score)
+                .sorted_by_key(|(score, _)| std::cmp::Reverse(*score))
                 .take(5)
                 .map(|(_, k)| k)
                 .collect();

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -81,7 +81,6 @@ fn suggest_similar_commands(name: &str) -> Vec<String> {
         .filter_map(|subcmd| {
             matcher
                 .score_pattern(subcmd, &pattern)
-                .filter(|&score| score > 0)
                 .map(|score| (score, subcmd.to_string()))
         })
         .sorted_by_key(|(score, _)| std::cmp::Reverse(*score))

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -9,12 +9,13 @@ use crate::{dirs, file};
 use console::Term;
 use demand::{DemandOption, Select};
 use eyre::{Result, bail, ensure, eyre};
-use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
 use itertools::Itertools;
 use std::collections::{BTreeMap, HashSet};
 use std::iter::once;
 use std::path::PathBuf;
 use std::sync::Arc;
+
+use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
 
 const MAX_AVAILABLE_TASKS_IN_ERROR: usize = 20;
 
@@ -73,16 +74,17 @@ fn validate_monorepo_setup(config: &Arc<Config>) -> Result<()> {
 fn suggest_similar_commands(name: &str) -> Vec<String> {
     use clap::CommandFactory;
     let cmd = crate::cli::Cli::command();
-    let matcher = SkimMatcherV2::default().use_cache(true).smart_case();
+    let mut matcher = FuzzyMatcher::default();
+    let pattern = FuzzyPattern::new(name);
     cmd.get_subcommands()
         .flat_map(|s| std::iter::once(s.get_name()).chain(s.get_all_aliases()))
         .filter_map(|subcmd| {
             matcher
-                .fuzzy_match(subcmd, name)
+                .score_pattern(subcmd, &pattern)
                 .filter(|&score| score > 0)
                 .map(|score| (score, subcmd.to_string()))
         })
-        .sorted_by_key(|(score, _)| -1 * *score)
+        .sorted_by_key(|(score, _)| std::cmp::Reverse(*score))
         .take(3)
         .map(|(_, subcmd)| subcmd)
         .collect()


### PR DESCRIPTION
## Summary
- replace direct `fuzzy-matcher` usage with `nucleo-matcher`
- add a small main-crate wrapper for scoring registry/task suggestions
- keep picker highlight positions by using `nucleo-matcher` indices directly
- address AI review feedback by removing the redundant `score > 0` filter; keep the `u32::from` conversion because `Atom::score` returns `Option<u16>`

## Dependency audit
- Direct `fuzzy-matcher` usage is removed from the root crate and `mise-interactive-config`.
- `fuzzy-matcher` may still appear in `Cargo.lock` transitively, but mise no longer owns it directly.

## Why nucleo-matcher
- `fuzzy-matcher`: latest crate is `0.3.7` from 2020-10-04. Its repo is archived at [`skim-rs/fuzzy-matcher`](https://github.com/skim-rs/fuzzy-matcher), last pushed 2024-06-29, with 297 stars. It is no longer actively published/maintained.
- `skim`: the parent/project ecosystem is healthy and much larger, with [`skim-rs/skim`](https://github.com/skim-rs/skim) at 6,851 stars, latest release `v4.7.0` published 2026-05-23, and last pushed 2026-06-12. However, `skim` is a full fuzzy-finder application/library stack, while mise only needs a low-level scoring/indices matcher.
- `nucleo-matcher`: focused low-level matcher from [`helix-editor/nucleo`](https://github.com/helix-editor/nucleo), 1,451 stars, latest release `nucleo-v0.4.0` published 2024-02-20, and last pushed 2026-01-21. It has fewer stars than skim, but it fits this use case better than pulling in skim itself.

## README comparison
- The [`nucleo` README](https://github.com/helix-editor/nucleo#readme) specifically says users who want a replacement for the `fuzzy-matcher` crate, rather than a fully managed fuzzy picker, should use [`nucleo-matcher`](https://crates.io/crates/nucleo-matcher). That matches mise's use case: score/filter registry and task candidates, and return indices for picker highlighting.
- Nucleo describes itself as targeting the same use case as `fzf`/`skim`, but with a faster matching algorithm. Its README benchmark section shows `nucleo` beating `skim` across matcher microbenchmarks, and the README calls out an often ~6x advantage over `skim`/`fuzzy-matcher`.
- Nucleo uses fzf-style scoring and claims a more faithful Smith-Waterman implementation, which should improve match choice/ranking quality compared with the skim matcher in edge cases.
- Nucleo's README also calls out better non-ASCII and grapheme handling. That matters for mise because registry/tool names and descriptions can include Unicode, and the interactive picker uses match indices for highlighting.
- The [`fuzzy-matcher` README](https://github.com/skim-rs/fuzzy-matcher#readme) documents the API mise currently uses and its skim-v2 Smith-Waterman basis, but it also documents the older `O(mn)` table shape and fallback behavior. Nucleo is designed as the newer low-level matcher crate with reusable scratch space and presegmented text support.

## API notes
- `fuzzy-matcher` exposed `SkimMatcherV2::fuzzy_match` and `fuzzy_indices` directly.
- `nucleo-matcher` expects normalized pattern atoms and reusable matcher scratch space, so the main crate now has a small wrapper around `Matcher` + `Atom`.
- `mise-interactive-config` keeps local helpers because it also needs match indices for highlighting.

## Verification
- `mise x cargo -- cargo fmt`
- `mise x cargo -- cargo metadata --format-version 1` to refresh `Cargo.lock`
- `git diff --check`
- `mise x cargo -- cargo build --all-features`

Local tests were not run.