### PR TITLE
fix(install): rebuild symlinks after partial installs

### DIFF
--- a/e2e/cli/test_install_parallel_failure
+++ b/e2e/cli/test_install_parallel_failure
@@ -26,6 +26,7 @@ assert_fail "mise install" "Failed to install asdf:dummy@other-dummy"
 
 # Verify tiny was installed successfully despite dummy failure
 assert_contains "mise ls --installed tiny" "3.1.0"
+assert "readlink $MISE_DATA_DIR/installs/tiny/latest" "./3.1.0"
 
 # Verify dummy failed to install the bad version
 assert_not_contains "mise ls --installed dummy" "other-dummy"
@@ -49,6 +50,7 @@ assert_fail "mise install tiny@latest jq@999.999.999" "Failed to install aqua:jq
 
 # Verify the valid tool was installed
 assert_contains "mise ls --installed tiny" "3.1.0"
+assert "readlink $MISE_DATA_DIR/installs/tiny/latest" "./3.1.0"
 
 # Verify the invalid tool was not installed
 assert_not_contains "mise ls --installed jq" "999.999.999"

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -8,7 +8,7 @@ use crate::config::Settings;
 use crate::hooks::Hooks;
 use crate::install_before::resolve_cli_minimum_release_age;
 use crate::toolset::{
-    InstallOptions, ResolveOptions, ToolRequest, ToolSource, Toolset, tool_env_vars,
+    InstallOptions, ResolveOptions, ToolRequest, ToolSource, ToolVersion, Toolset, tool_env_vars,
 };
 use crate::{config, env, exit, hooks};
 use clap::ValueHint;
@@ -255,13 +255,15 @@ impl Install {
             .collect();
         let mut ts: Toolset = trs.filter_by_tool(tools).into();
         let tool_versions = self.get_requested_tool_versions(&ts, &expanded_runtimes)?;
-        let mut versions = if tool_versions.is_empty() {
+        let (mut versions, install_error) = if tool_versions.is_empty() {
             warn!("no runtimes to install");
             warn!("specify a version with `mise install <TOOL>@<VERSION>`");
-            vec![]
+            (vec![], Ok(()))
         } else {
-            ts.install_all_versions(&mut config, tool_versions, &self.install_opts()?)
-                .await?
+            install_versions_or_successful(
+                ts.install_all_versions(&mut config, tool_versions, &self.install_opts()?)
+                    .await,
+            )
         };
         // In dry-run mode, check if any tools would be installed before filtering
         if self.is_dry_run() {
@@ -277,27 +279,29 @@ impl Install {
                     exit::exit(1);
                 }
             }
-            return Ok(());
+            return install_error;
         }
 
-        // because we may be installing a tool that is not in config, we need to restore the original tool args and reset everything
-        env::TOOL_ARGS
-            .write()
-            .unwrap()
-            .clone_from(&original_tool_args);
-        let config = Config::reset().await?;
-        let ts = config.get_toolset().await?;
-        let current_versions = ts.list_current_versions();
-        // ensure that only current versions are sent to lockfile rebuild
-        versions.retain(|tv| current_versions.iter().any(|(_, cv)| tv == cv));
+        if install_error.is_ok() || !versions.is_empty() {
+            // because we may be installing a tool that is not in config, we need to restore the original tool args and reset everything
+            env::TOOL_ARGS
+                .write()
+                .unwrap()
+                .clone_from(&original_tool_args);
+            let config = Config::reset().await?;
+            let ts = config.get_toolset().await?;
+            let current_versions = ts.list_current_versions();
+            // ensure that only current versions are sent to lockfile rebuild
+            versions.retain(|tv| current_versions.iter().any(|(_, cv)| tv == cv));
 
-        config::rebuild_shims_and_runtime_symlinks(
-            &config,
-            ts,
-            &versions,
-            crate::lockfile::LockfileUpdateMode::Normal,
-        )
-        .await?;
+            config::rebuild_shims_and_runtime_symlinks(
+                &config,
+                ts,
+                &versions,
+                crate::lockfile::LockfileUpdateMode::Normal,
+            )
+            .await?;
+        }
 
         // Warn about tools that were installed but not in any config file
         if !inactive_tools.is_empty() {
@@ -317,6 +321,7 @@ impl Install {
             );
         }
 
+        install_error?;
         Ok(())
     }
 
@@ -413,7 +418,7 @@ impl Install {
                 .collect_vec()
         });
         let has_missing = !missing.is_empty();
-        let versions = if missing.is_empty() {
+        let (versions, install_error) = if missing.is_empty() {
             measure!("run_postinstall_hook", {
                 info!("all tools are installed");
                 hooks::run_one_hook(
@@ -423,32 +428,55 @@ impl Install {
                     None,
                 )
                 .await;
-                vec![]
+                (vec![], Ok(()))
             })
         } else {
             let mut ts = Toolset::from(trs.clone());
             measure!("install_all_versions", {
-                ts.install_all_versions(&mut config, missing, &self.install_opts()?)
-                    .await?
+                install_versions_or_successful(
+                    ts.install_all_versions(&mut config, missing, &self.install_opts()?)
+                        .await,
+                )
             })
         };
         if self.is_dry_run() {
             if self.dry_run_code && has_missing {
                 exit::exit(1);
             }
-            return Ok(());
+            return install_error;
         }
-        measure!("rebuild_shims_and_runtime_symlinks", {
-            let ts = config.get_toolset().await?;
-            config::rebuild_shims_and_runtime_symlinks(
-                &config,
-                ts,
-                &versions,
-                crate::lockfile::LockfileUpdateMode::Normal,
-            )
-            .await?;
-        });
+        if install_error.is_ok() || !versions.is_empty() {
+            measure!("rebuild_shims_and_runtime_symlinks", {
+                let ts = config.get_toolset().await?;
+                config::rebuild_shims_and_runtime_symlinks(
+                    &config,
+                    ts,
+                    &versions,
+                    crate::lockfile::LockfileUpdateMode::Normal,
+                )
+                .await?;
+            });
+        }
+        install_error?;
         Ok(())
+    }
+}
+
+fn install_versions_or_successful(
+    result: Result<Vec<ToolVersion>>,
+) -> (Vec<ToolVersion>, Result<()>) {
+    match result {
+        Ok(versions) => (versions, Ok(())),
+        Err(err) => {
+            let versions = match err.downcast_ref::<crate::errors::Error>() {
+                Some(crate::errors::Error::InstallFailed {
+                    successful_installations,
+                    ..
+                }) => successful_installations.clone(),
+                _ => vec![],
+            };
+            (versions, Err(err))
+        }
     }
 }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -5,10 +5,11 @@ use std::sync::Arc;
 use crate::cli::args::ToolArg;
 use crate::config::Config;
 use crate::config::Settings;
+use crate::errors::split_install_result;
 use crate::hooks::Hooks;
 use crate::install_before::resolve_cli_minimum_release_age;
 use crate::toolset::{
-    InstallOptions, ResolveOptions, ToolRequest, ToolSource, ToolVersion, Toolset, tool_env_vars,
+    InstallOptions, ResolveOptions, ToolRequest, ToolSource, Toolset, tool_env_vars,
 };
 use crate::{config, env, exit, hooks};
 use clap::ValueHint;
@@ -260,7 +261,7 @@ impl Install {
             warn!("specify a version with `mise install <TOOL>@<VERSION>`");
             (vec![], Ok(()))
         } else {
-            install_versions_or_successful(
+            split_install_result(
                 ts.install_all_versions(&mut config, tool_versions, &self.install_opts()?)
                     .await,
             )
@@ -433,7 +434,7 @@ impl Install {
         } else {
             let mut ts = Toolset::from(trs.clone());
             measure!("install_all_versions", {
-                install_versions_or_successful(
+                split_install_result(
                     ts.install_all_versions(&mut config, missing, &self.install_opts()?)
                         .await,
                 )
@@ -459,24 +460,6 @@ impl Install {
         }
         install_error?;
         Ok(())
-    }
-}
-
-fn install_versions_or_successful(
-    result: Result<Vec<ToolVersion>>,
-) -> (Vec<ToolVersion>, Result<()>) {
-    match result {
-        Ok(versions) => (versions, Ok(())),
-        Err(err) => {
-            let versions = match err.downcast_ref::<crate::errors::Error>() {
-                Some(crate::errors::Error::InstallFailed {
-                    successful_installations,
-                    ..
-                }) => successful_installations.clone(),
-                _ => vec![],
-            };
-            (versions, Err(err))
-        }
     }
 }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::backend::pipx::PIPXBackend;
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, config_file};
+use crate::errors::split_install_result;
 use crate::file::display_path;
 use crate::install_before::resolve_cli_minimum_release_age;
 use crate::semver::split_version_prefix;
@@ -294,16 +295,7 @@ impl Upgrade {
 
         // Install all tools in parallel
         let (mut successful_versions, install_error) =
-            match ts.install_all_versions(config, tool_requests, &opts).await {
-                Ok(versions) => (versions, eyre::Result::Ok(())),
-                Err(e) => match e.downcast_ref::<crate::errors::Error>() {
-                    Some(crate::errors::Error::InstallFailed {
-                        successful_installations,
-                        ..
-                    }) => (successful_installations.clone(), eyre::Result::Err(e)),
-                    _ => (vec![], eyre::Result::Err(e)),
-                },
-            };
+            split_install_result(ts.install_all_versions(config, tool_requests, &opts).await);
 
         // Only update config files for tools that were successfully installed
         for (o, cf) in config_file_updates {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -87,6 +87,25 @@ fn format_install_failures(failed_installations: &[(ToolRequest, Report)]) -> St
     output.join("\n")
 }
 
+/// Split an install result into successful versions and a result preserving any error.
+pub fn split_install_result(
+    result: Result<Vec<ToolVersion>, Report>,
+) -> (Vec<ToolVersion>, Result<(), Report>) {
+    match result {
+        Ok(versions) => (versions, Ok(())),
+        Err(err) => {
+            let versions = match err.downcast_ref::<Error>() {
+                Some(Error::InstallFailed {
+                    successful_installations,
+                    ..
+                }) => successful_installations.clone(),
+                _ => vec![],
+            };
+            (versions, Err(err))
+        }
+    }
+}
+
 impl Error {
     pub fn get_exit_status(err: &Report) -> Option<i32> {
         if let Some(Error::ScriptFailed(_, Some(status))) = err.downcast_ref::<Error>() {


### PR DESCRIPTION
Fixes the follow-up reported in #9848 where successful tools from a partially failed `mise install` could be left without runtime version symlinks such as `installs/bun/latest`.

## What was wrong

`Toolset::install_all_versions()` already preserves partial success in `Error::InstallFailed { successful_installations, failed_installations }`. However, `mise install` used `?` on that result, so any failed tool skipped the later `rebuild_shims_and_runtime_symlinks()` call entirely. That meant tools that had already installed successfully during the same command could miss their runtime symlinks and shims until another successful install/rebuild path ran.

This is an install partial-failure problem, not a `mise reshim` problem. Runtime version symlinks remain owned by the install/runtime-symlink rebuild flow.

## How this fixes it

- Mirrors the existing `mise upgrade` pattern: extract `successful_installations` from `InstallFailed`, continue post-install rebuild work for those versions, then return the original install error.
- Applies that behavior to both explicit `mise install <tools>` and bare `mise install` from config.
- Extends `e2e/cli/test_install_parallel_failure` to assert that the successfully installed tool gets its `latest` runtime symlink even though another tool failed.

## Testing

- `/home/risu/.cargo/bin/cargo fmt --all --check`
- `git diff --check`
- `env -u MISE_PROJECT_ROOT -u MISE_ORIGINAL_CWD mise run test:e2e e2e/cli/test_install_parallel_failure`

Not run: full local test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during parallel installations to ensure shims and symlinks are properly rebuilt even when some tool installations fail.

* **Tests**
  * Enhanced end-to-end tests to verify correct installation symlinks after parallel install scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->