### PR TITLE
fix(task): align duplicate config task precedence

### DIFF
--- a/e2e/tasks/test_task_config_precedence
+++ b/e2e/tasks/test_task_config_precedence
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+mkdir -p .config .mise
+
+cat <<'EOF' >.config/mise.toml
+[tasks.a]
+description = ".config/a"
+run = "echo .config/a"
+EOF
+
+cat <<'EOF' >.mise/config.toml
+[tasks.a]
+description = ".mise/a"
+run = "echo .mise/a"
+EOF
+
+assert_contains "mise tasks" "a  .mise/a"
+assert_not_contains "mise tasks" "a  .config/a"
+assert_contains "mise run a" ".mise/a"
+assert_not_contains "mise run a" ".config/a"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2340,7 +2340,9 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
     }
     for t in config_tasks {
         if let Some(existing) = by_name.get_mut(&t.name) {
-            existing.merge_toml_overlay(t);
+            if existing.file.is_some() {
+                existing.merge_toml_overlay(t);
+            }
         } else {
             by_name.insert(t.name.clone(), t);
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2323,14 +2323,17 @@ async fn load_config_and_file_tasks(
 }
 
 /// Combine file tasks (auto-discovered executable scripts and included TOML
-/// files) with inline `[tasks.*]` blocks from the same config file.
+/// files) with inline `[tasks.*]` blocks.
 ///
-/// When a name appears in both: the file task stays as the base and the TOML
-/// block is overlaid via [`Task::merge_toml_overlay`]. Otherwise both are kept.
-///
+/// `config_tasks` are collected in config-file precedence order (highest first;
+/// see [`configs_at_root`]). When a name appears in both a script file task
+/// (`file.is_some()`) and an inline block, the script stays as the base and the
+/// TOML block is overlaid via [`Task::merge_toml_overlay`]. When the same name
+/// appears in multiple inline blocks (e.g. `.config/mise.toml` and
+/// `.mise/config.toml`), the first entry wins and later ones are skipped.
 /// When the same name appears in more than one file task (e.g. a local
-/// `.mise/tasks` script and a same-named task from a `git::` include), the
-/// last one wins. Callers load `file_tasks` in declared `task_config.includes`
+/// `.mise/tasks` script and a same-named task from a `git::` include), the last
+/// one wins. Callers load `file_tasks` in declared `task_config.includes`
 /// order, so the later include in the list takes precedence — see
 /// `load_tasks_in_dir`.
 fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -> Vec<Task> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2865,11 +2865,13 @@ mod tests {
             Task {
                 name: "hello".to_string(),
                 config_source: PathBuf::from("mise-tasks/hello"),
+                file: Some(PathBuf::from("mise-tasks/hello")),
                 ..Default::default()
             },
             Task {
                 name: "hello.ps1".to_string(),
                 config_source: PathBuf::from("mise-tasks/hello.ps1"),
+                file: Some(PathBuf::from("mise-tasks/hello.ps1")),
                 ..Default::default()
             },
         ];


### PR DESCRIPTION
## Summary

- Preserve the highest-precedence TOML task when multiple config files define the same task name in one config root.
- Keep the existing TOML-overlay behavior for file tasks, so script-backed tasks can still receive metadata from `[tasks.<name>]`.
- Add an e2e regression for `.config/mise.toml` plus `.mise/config.toml` duplicate task definitions.

## Context

Investigates project item 190217576 / discussion jdx/mise#9947. The bug was still real on current `main`: `mise tasks` listed `.config/a`, while `mise run a` executed `.mise/a`.

## Verification

- `cargo fmt`
- `cargo build --bin mise --all-features`
- `e2e/run_test tasks/test_task_config_precedence`
- `e2e/run_test tasks/test_task_file_toml_merge`
- manual reproduction of duplicate `.config/mise.toml` and `.mise/config.toml` task definitions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task configuration merging so conflicting task definitions follow the correct precedence rules, ensuring higher-priority TOML values are respected.

* **Tests**
  * Added a new end-to-end test that creates two competing task config files for the same task key and verifies that both task listing and execution use the expected (higher-priority) configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->