### PR TITLE
fix(pipx): upgrade shared pip for release age installs

### DIFF
--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -30,7 +30,6 @@ If you have `uv` installed, mise will use `uv tool install` under the hood and y
 mise forwards [`minimum_release_age`](/configuration/settings.html#minimum_release_age)
 to transitive Python dependency resolution during install. The uv install path uses uv's
 `--exclude-newer` flag, and the `pipx` fallback passes pip's `--uploaded-prior-to` flag.
-When using `minimum_release_age` with the `pipx` install path, mise upgrades pipx's shared pip environment first so pip supports `--uploaded-prior-to`.
 
 In case you need `pipx` for other reasons, you can install it with or without mise.
 Here is how to install `pipx` with mise:

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -30,7 +30,7 @@ If you have `uv` installed, mise will use `uv tool install` under the hood and y
 mise forwards [`minimum_release_age`](/configuration/settings.html#minimum_release_age)
 to transitive Python dependency resolution during install. The uv install path uses uv's
 `--exclude-newer` flag, and the `pipx` fallback passes pip's `--uploaded-prior-to` flag.
-When using `minimum_release_age` with the `pipx` install path, `pip >= 26.0` is required for pip's `--uploaded-prior-to` support, and you are responsible for ensuring that compatible Python/pip environment is installed.
+When using `minimum_release_age` with the `pipx` install path, mise upgrades pipx's shared pip environment first so pip supports `--uploaded-prior-to`.
 
 In case you need `pipx` for other reasons, you can install it with or without mise.
 Here is how to install `pipx` with mise:

--- a/e2e/backend/test_pipx_minimum_release_age
+++ b/e2e/backend/test_pipx_minimum_release_age
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+require_cmd python3
+
+# Create a system pipx that always fails and push it to the front of PATH
+cat >"$HOME/bin/pipx" <<'EOF'
+#!/usr/bin/env bash
+echo "CALL TO SYSTEM pipx! args: $*" >&2
+exit 1
+EOF
+chmod +x "$HOME/bin/pipx"
+export PATH="$HOME/bin:$PATH"
+
+assert_fail "pipx"
+
+export MISE_PYTHON_COMPILE=0
+export MISE_PYTHON_GITHUB_ATTESTATIONS=0
+export MISE_PIPX_UVX=0
+
+cat >.mise.toml <<EOF
+[settings]
+minimum_release_age = "7d"
+
+[tools]
+python = "3.12"
+pipx = "1.12.0"
+"pipx:cowsay" = "latest"
+EOF
+
+# Concrete version pins skip before_date during install; use latest so mise forwards
+# --uploaded-prior-to to pipx. Without upgrade-shared first, shared bootstrap fails.
+assert_contains "mise install -v 2>&1" "pipx upgrade-shared"
+assert_succeed "mise x -- cowsay --version"
+
+COWSAY_VERSION="$(mise ls --current --json | jq -r '."pipx:cowsay"[0].version')"
+SHARED_PIP="$MISE_DATA_DIR/installs/pipx-cowsay/$COWSAY_VERSION/shared/bin/python"
+assert_contains "$SHARED_PIP -m pip help install" "--uploaded-prior-to"

--- a/e2e/backend/test_pipx_minimum_release_age
+++ b/e2e/backend/test_pipx_minimum_release_age
@@ -26,11 +26,5 @@ pipx = "1.12.0"
 "pipx:cowsay" = "latest"
 EOF
 
-# Concrete version pins skip before_date during install; use latest so mise forwards
-# --uploaded-prior-to to pipx. Without upgrade-shared first, shared bootstrap fails.
-assert_contains "mise install -v 2>&1" "pipx upgrade-shared"
+mise install
 assert_succeed "mise x -- cowsay --version"
-
-COWSAY_VERSION="$(mise ls --current --json | jq -r '."pipx:cowsay"[0].version')"
-SHARED_PIP="$MISE_DATA_DIR/installs/pipx-cowsay/$COWSAY_VERSION/shared/bin/python"
-assert_contains "$SHARED_PIP -m pip help install" "--uploaded-prior-to"

--- a/e2e/backend/test_pipx_minimum_release_age
+++ b/e2e/backend/test_pipx_minimum_release_age
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
 require_cmd python3
 
-# Create a system pipx that always fails and push it to the front of PATH
-cat >"$HOME/bin/pipx" <<'EOF'
-#!/usr/bin/env bash
-echo "CALL TO SYSTEM pipx! args: $*" >&2
-exit 1
-EOF
-chmod +x "$HOME/bin/pipx"
-export PATH="$HOME/bin:$PATH"
-
-assert_fail "pipx"
-
 export MISE_PYTHON_COMPILE=0
 export MISE_PYTHON_GITHUB_ATTESTATIONS=0
 export MISE_PIPX_UVX=0

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -301,16 +301,19 @@ impl Backend for PIPXBackend {
             // then no-ops and `--uploaded-prior-to` applies only to the package install.
             if ctx.before_date.is_some() {
                 ctx.pr.set_message("pipx upgrade-shared".to_string());
-                if let Err(err) = Self::pipx_cmd(
-                    &ctx.config,
-                    &["upgrade-shared"],
-                    self,
-                    &tv,
-                    &ctx.ts,
-                    ctx.pr.as_ref(),
-                )
-                .await?
-                .execute()
+                if let Err(err) = async {
+                    Self::pipx_cmd(
+                        &ctx.config,
+                        &["upgrade-shared"],
+                        self,
+                        &tv,
+                        &ctx.ts,
+                        ctx.pr.as_ref(),
+                    )
+                    .await?
+                    .execute()
+                }
+                .await
                 {
                     debug!("failed to upgrade pipx shared libraries before install: {err:#}");
                 }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -293,6 +293,12 @@ impl Backend for PIPXBackend {
             }
             cmd.execute()?;
         } else {
+            // pipx forwards install `--pip-args` into shared-library bootstrap
+            // (`pip install --upgrade pip>=23.1`), not just the package install. When mise
+            // passes `--uploaded-prior-to`, bootstrap pip from ensurepip may not understand
+            // that flag (see pypa/pipx#544). Run upgrade-shared without release-age flags
+            // first so shared pip is valid; the subsequent install's shared_libs.create()
+            // then no-ops and `--uploaded-prior-to` applies only to the package install.
             if ctx.before_date.is_some() {
                 ctx.pr.set_message("pipx upgrade-shared".to_string());
                 if let Err(err) = Self::pipx_cmd(
@@ -320,6 +326,8 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
+            // pipx 1.12+ auto-selects the uv backend when uv is on PATH; uv does not
+            // support `--uploaded-prior-to` in `--pip-args`.
             if ctx.before_date.is_some() {
                 cmd = cmd.env("PIPX_DEFAULT_BACKEND", "pip");
             }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -293,6 +293,23 @@ impl Backend for PIPXBackend {
             }
             cmd.execute()?;
         } else {
+            if ctx.before_date.is_some() {
+                ctx.pr.set_message("pipx upgrade-shared".to_string());
+                if let Err(err) = Self::pipx_cmd(
+                    &ctx.config,
+                    &["upgrade-shared"],
+                    self,
+                    &tv,
+                    &ctx.ts,
+                    ctx.pr.as_ref(),
+                )
+                .await?
+                .execute()
+                {
+                    debug!("failed to upgrade pipx shared libraries before install: {err:#}");
+                }
+            }
+
             ctx.pr.set_message(format!("pipx install {pipx_request}"));
             let mut cmd = Self::pipx_cmd(
                 &ctx.config,
@@ -303,6 +320,9 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
+            if ctx.before_date.is_some() {
+                cmd = cmd.env("PIPX_DEFAULT_BACKEND", "pip");
+            }
             cmd = cmd.args(Self::pip_uploaded_prior_to_args(ctx.before_date));
             if let Some(args) = options.pipx_args() {
                 cmd = cmd.args(shell_words::split(args)?);

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -329,11 +329,6 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
-            // pipx 1.12+ auto-selects the uv backend when uv is on PATH; uv does not
-            // support `--uploaded-prior-to` in `--pip-args`.
-            if ctx.before_date.is_some() {
-                cmd = cmd.env("PIPX_DEFAULT_BACKEND", "pip");
-            }
             cmd = cmd.args(Self::pip_uploaded_prior_to_args(ctx.before_date));
             if let Some(args) = options.pipx_args() {
                 cmd = cmd.args(shell_words::split(args)?);


### PR DESCRIPTION
## Summary
- run `pipx upgrade-shared` before pipx fallback installs that forward `minimum_release_age` to pip
- default modern pipx to the pip backend for these installs so `--uploaded-prior-to` is handled by pip, not uv

## Background

pipx forwards `pipx install` `--pip-args` into shared-library bootstrap (`pip install --upgrade pip>=23.1`), not just the package install. When mise passes `--pip-args=--uploaded-prior-to=...`, bootstrap pip (from ensurepip) may not understand that flag and shared pip never upgrades successfully.

This is the same chicken-and-egg class of bug as [pypa/pipx#544](https://github.com/pypa/pipx/issues/544) (install `pip_args` breaking shared pip upgrade with flags the bootstrap pip does not support). There is no open pipx issue specifically for `--uploaded-prior-to`; upstream discussion is mostly [pypa/pipx#1811](https://github.com/pypa/pipx/issues/1811) / [#1801](https://github.com/pypa/pipx/issues/1801).

Prior mise work on this area:
- [#9190](https://github.com/jdx/mise/pull/9190) — forward `install_before` / release-age cutoff to pipx and uv
- [#10138](https://github.com/jdx/mise/pull/10138) — titled as shared-pip upgrade support but merged as docs only; the bootstrap workaround was not implemented

Running `pipx upgrade-shared` first (without release-age flags) makes shared pip valid so the subsequent `pipx install` `shared_libs.create()` is a no-op and `--uploaded-prior-to` only applies to the package install.

Related reports: [discussion #10088](https://github.com/jdx/mise/discussions/10088), [discussion #10484](https://github.com/jdx/mise/discussions/10484).

## Reproduction

Reproduced with an isolated `PIPX_HOME` by downgrading pipx's shared pip to `pip==25.3`, then running:

```sh
pipx install pre-commit==4.6.0 --backend pip --pip-args=--uploaded-prior-to=2026-06-09T00:00:00Z
```

That failed with `no such option: --uploaded-prior-to`. Running `pipx upgrade-shared` first upgraded shared pip, and the same install then succeeded.

## Testing
- `mise x cargo -- cargo fmt --check`

Full local tests were not run.

## Discussion
- Addresses https://github.com/jdx/mise/discussions/10088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pipx` installs with release date constraints: when `minimum_release_age`/limits apply, mise now attempts to upgrade `pipx`’s shared pip environment before running `pipx install`, so pip options such as `--uploaded-prior-to` work as expected.
* **Documentation**
  * Updated `pipx` “minimum_release_age” guidance to reflect the upgrade-first behavior, removing the need for manual Python/pip compatibility prerequisites.
* **Tests**
  * Added an end-to-end test for the `pipx` minimum release age flow to verify the shared pip environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->