### PR TITLE
fix(aqua): support checksum verification fields

### DIFF
--- a/crates/aqua-registry/src/cache.rs
+++ b/crates/aqua-registry/src/cache.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-const COMPILED_REGISTRY_CACHE_VERSION: &str = "v4";
+const COMPILED_REGISTRY_CACHE_VERSION: &str = "v5";
 
 #[derive(Debug, Clone)]
 pub struct RegistryCache {

--- a/crates/aqua-registry/src/lib.rs
+++ b/crates/aqua-registry/src/lib.rs
@@ -17,8 +17,8 @@ pub use cache::RegistryCache;
 pub use codec::{decode_package_rkyv, encode_package_rkyv};
 pub use compiled::{CompiledRegistry, ParsedRegistry};
 pub use types::{
-    AquaChecksum, AquaChecksumType, AquaCosign, AquaFile, AquaMinisignType, AquaPackage,
-    AquaPackageType, AquaVar, RegistryYaml,
+    AquaChecksum, AquaChecksumType, AquaCosign, AquaFile, AquaGithubArtifactAttestations,
+    AquaMinisign, AquaMinisignType, AquaPackage, AquaPackageType, AquaVar, RegistryYaml,
 };
 
 use thiserror::Error;

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -702,16 +702,33 @@ impl AquaPackage {
         os: &str,
         arch: &str,
     ) -> Result<String> {
-        let mut actual_arch = arch;
-        if os == "darwin" && arch == "arm64" && self.rosetta2 {
-            actual_arch = "amd64";
-        }
-        if os == "windows" && arch == "arm64" && self.windows_arm_emulation {
-            actual_arch = "amd64";
-        }
+        let mut ctx = self.template_context(&self.replacements, v, os, arch);
+        ctx.extend(self.vars_ctx()?);
+        ctx.extend(overrides.clone());
 
+        crate::template::render(s, &ctx)
+    }
+
+    fn actual_arch<'a>(&self, os: &str, arch: &'a str) -> &'a str {
+        if (os == "darwin" && arch == "arm64" && self.rosetta2)
+            || (os == "windows" && arch == "arm64" && self.windows_arm_emulation)
+        {
+            "amd64"
+        } else {
+            arch
+        }
+    }
+
+    fn template_context(
+        &self,
+        replacements: &HashMap<String, String>,
+        v: &str,
+        os: &str,
+        arch: &str,
+    ) -> HashMap<String, String> {
+        let actual_arch = self.actual_arch(os, arch);
         let replace = |s: &str| {
-            self.replacements
+            replacements
                 .get(s)
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| s.to_string())
@@ -723,18 +740,15 @@ impl AquaPackage {
             v
         };
 
-        let mut ctx = HashMap::new();
-        ctx.insert("Version".to_string(), replace(v));
-        ctx.insert("SemVer".to_string(), replace(semver));
-        ctx.insert("OS".to_string(), replace(os));
-        ctx.insert("GOOS".to_string(), replace(os));
-        ctx.insert("GOARCH".to_string(), replace(actual_arch));
-        ctx.insert("Arch".to_string(), replace(actual_arch));
-        ctx.insert("Format".to_string(), replace(&self.format));
-        ctx.extend(self.vars_ctx()?);
-        ctx.extend(overrides.clone());
-
-        crate::template::render(s, &ctx)
+        HashMap::from([
+            ("Version".to_string(), replace(v)),
+            ("SemVer".to_string(), replace(semver)),
+            ("OS".to_string(), replace(os)),
+            ("GOOS".to_string(), replace(os)),
+            ("GOARCH".to_string(), replace(actual_arch)),
+            ("Arch".to_string(), replace(actual_arch)),
+            ("Format".to_string(), replace(&self.format)),
+        ])
     }
 
     fn vars_ctx(&self) -> Result<HashMap<String, String>> {
@@ -1190,20 +1204,7 @@ impl AquaChecksum {
         os: &str,
         arch: &str,
     ) -> Result<HashMap<String, String>> {
-        let replacements = self.effective_replacements(pkg);
-        let actual_arch = actual_arch(pkg, os, arch);
-        let replace = |s: &str| {
-            replacements
-                .get(s)
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| s.to_string())
-        };
-
-        let mut ctx = HashMap::new();
-        ctx.insert("OS".to_string(), replace(os));
-        ctx.insert("GOOS".to_string(), replace(os));
-        ctx.insert("Arch".to_string(), replace(actual_arch));
-        ctx.insert("GOARCH".to_string(), replace(actual_arch));
+        let mut ctx = pkg.template_context(&self.effective_replacements(pkg), v, os, arch);
         if pkg.r#type == AquaPackageType::Http {
             ctx.insert("AssetURL".to_string(), pkg.url(v, os, arch)?);
         }
@@ -1220,16 +1221,6 @@ impl AquaChecksum {
                 merged
             }
         }
-    }
-}
-
-fn actual_arch<'a>(pkg: &AquaPackage, os: &str, arch: &'a str) -> &'a str {
-    if (os == "darwin" && arch == "arm64" && pkg.rosetta2)
-        || (os == "windows" && arch == "arm64" && pkg.windows_arm_emulation)
-    {
-        "amd64"
-    } else {
-        arch
     }
 }
 

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -1224,9 +1224,9 @@ impl AquaChecksum {
 }
 
 fn actual_arch<'a>(pkg: &AquaPackage, os: &str, arch: &'a str) -> &'a str {
-    if os == "darwin" && arch == "arm64" && pkg.rosetta2 {
-        "amd64"
-    } else if os == "windows" && arch == "arm64" && pkg.windows_arm_emulation {
+    if (os == "darwin" && arch == "arm64" && pkg.rosetta2)
+        || (os == "windows" && arch == "arm64" && pkg.windows_arm_emulation)
+    {
         "amd64"
     } else {
         arch

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -247,6 +247,10 @@ pub struct AquaChecksum {
     pub algorithm: Option<AquaChecksumAlgorithm>,
     pub pattern: Option<AquaChecksumPattern>,
     pub cosign: Option<AquaCosign>,
+    pub minisign: Option<AquaMinisign>,
+    pub github_artifact_attestations: Option<AquaGithubArtifactAttestations>,
+    #[serde(default, deserialize_with = "deserialize_optional_string_map")]
+    replacements: Option<HashMap<String, String>>,
     file_format: Option<String>,
     enabled: Option<bool>,
     asset: Option<String>,
@@ -342,6 +346,39 @@ where
             Ok((key, value))
         })
         .collect()
+}
+
+fn deserialize_optional_string_map<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(value) = Option::<serde_yaml::Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    let serde_yaml::Value::Mapping(mapping) = value else {
+        return Err(<D::Error as serde::de::Error>::custom(
+            "invalid type: expected a scalar string map",
+        ));
+    };
+    mapping
+        .into_iter()
+        .map(|(key, value)| {
+            let key = yaml_scalar_to_string(key).ok_or_else(|| {
+                <D::Error as serde::de::Error>::custom(
+                    "invalid type: expected a scalar string map key",
+                )
+            })?;
+            let value = yaml_scalar_to_string(value).ok_or_else(|| {
+                <D::Error as serde::de::Error>::custom(
+                    "invalid type: expected a scalar string map value",
+                )
+            })?;
+            Ok((key, value))
+        })
+        .collect::<std::result::Result<HashMap<_, _>, D::Error>>()
+        .map(Some)
 }
 
 fn yaml_scalar_to_string(value: serde_yaml::Value) -> Option<String> {
@@ -1083,7 +1120,7 @@ impl AquaChecksum {
         let mut asset_strs = IndexSet::new();
         for asset in pkg.asset_strs(v, os, arch)? {
             let checksum_asset = self.asset.as_ref().unwrap();
-            let mut ctx = HashMap::new();
+            let mut ctx = self.template_ctx(pkg, v, os, arch)?;
             ctx.insert("Asset".to_string(), asset.to_string());
             asset_strs.insert(pkg.parse_aqua_str(checksum_asset, v, &ctx, os, arch)?);
         }
@@ -1103,7 +1140,13 @@ impl AquaChecksum {
     }
 
     pub fn url(&self, pkg: &AquaPackage, v: &str, os: &str, arch: &str) -> Result<String> {
-        pkg.parse_aqua_str(self.url.as_ref().unwrap(), v, &Default::default(), os, arch)
+        pkg.parse_aqua_str(
+            self.url.as_ref().unwrap(),
+            v,
+            &self.template_ctx(pkg, v, os, arch)?,
+            os,
+            arch,
+        )
     }
 
     fn merge(&mut self, other: Self) {
@@ -1128,12 +1171,79 @@ impl AquaChecksum {
         if let Some(file_format) = other.file_format {
             self.file_format = Some(file_format);
         }
+        if let Some(replacements) = other.replacements {
+            self.replacements = Some(replacements);
+        }
         if let Some(cosign) = other.cosign {
             if self.cosign.is_none() {
                 self.cosign = Some(cosign.clone());
             }
             self.cosign.as_mut().unwrap().merge(cosign);
         }
+        if let Some(minisign) = other.minisign {
+            if self.minisign.is_none() {
+                self.minisign = Some(minisign.clone());
+            }
+            self.minisign.as_mut().unwrap().merge(minisign);
+        }
+        if let Some(attestations) = other.github_artifact_attestations {
+            if self.github_artifact_attestations.is_none() {
+                self.github_artifact_attestations = Some(attestations.clone());
+            }
+            self.github_artifact_attestations
+                .as_mut()
+                .unwrap()
+                .merge(attestations);
+        }
+    }
+
+    fn template_ctx(
+        &self,
+        pkg: &AquaPackage,
+        v: &str,
+        os: &str,
+        arch: &str,
+    ) -> Result<HashMap<String, String>> {
+        let replacements = self.effective_replacements(pkg);
+        let actual_arch = actual_arch(pkg, os, arch);
+        let replace = |s: &str| {
+            replacements
+                .get(s)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| s.to_string())
+        };
+
+        let mut ctx = HashMap::new();
+        ctx.insert("OS".to_string(), replace(os));
+        ctx.insert("GOOS".to_string(), os.to_string());
+        ctx.insert("Arch".to_string(), replace(actual_arch));
+        ctx.insert("GOARCH".to_string(), actual_arch.to_string());
+        if pkg.r#type == AquaPackageType::Http {
+            ctx.insert("AssetURL".to_string(), pkg.url(v, os, arch)?);
+        }
+        Ok(ctx)
+    }
+
+    fn effective_replacements(&self, pkg: &AquaPackage) -> HashMap<String, String> {
+        match &self.replacements {
+            None => pkg.replacements.clone(),
+            Some(replacements) if replacements.is_empty() => HashMap::new(),
+            Some(replacements) => {
+                let mut merged = pkg.replacements.clone();
+                merged.extend(replacements.clone());
+                merged
+            }
+        }
+    }
+}
+
+fn actual_arch<'a>(pkg: &AquaPackage, os: &str, arch: &'a str) -> &'a str {
+    if os == "darwin" && arch == "arm64" && pkg.rosetta2 {
+        "amd64"
+    } else if os == "windows" && arch == "arm64" && pkg.windows_arm_emulation {
+        "amd64"
+    } else {
+        arch
     }
 }
 
@@ -1421,6 +1531,85 @@ packages:
         assert_eq!(
             attestations.signer_workflow.as_deref(),
             Some("canonical-workflow.yml")
+        );
+    }
+
+    #[test]
+    fn test_checksum_nested_verification_fields_are_deserialized() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+      replacements:
+        darwin: mac
+      minisign:
+        type: github_release
+        asset: checksums.txt.minisig
+        public_key: minisign-public-key
+      github_artifact_attestations:
+        enabled: true
+        predicate_type: https://slsa.dev/provenance/v1
+        signer_workflow: checksum-workflow.yml
+"#,
+        );
+
+        let checksum = pkg.checksum.unwrap();
+        assert_eq!(
+            checksum.replacements.as_ref().and_then(|r| r.get("darwin")),
+            Some(&"mac".to_string())
+        );
+        assert_eq!(
+            checksum
+                .minisign
+                .as_ref()
+                .and_then(|m| m.public_key.as_deref()),
+            Some("minisign-public-key")
+        );
+        let attestations = checksum.github_artifact_attestations.unwrap();
+        assert_eq!(attestations.enabled, Some(true));
+        assert_eq!(
+            attestations.predicate_type.as_deref(),
+            Some("https://slsa.dev/provenance/v1")
+        );
+        assert_eq!(
+            attestations.signer_workflow.as_deref(),
+            Some("checksum-workflow.yml")
+        );
+    }
+
+    #[test]
+    fn test_checksum_replacements_override_package_replacements() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - type: http
+    url: https://example.com/tool-{{.OS}}-{{.Arch}}.tar.gz
+    replacements:
+      darwin: macOS
+      arm64: aarch64
+    checksum:
+      type: http
+      url: "{{.AssetURL}}.{{.OS}}-{{.Arch}}.checksums"
+      replacements:
+        darwin: mac
+        arm64: arm64
+"#,
+        );
+
+        assert_eq!(
+            pkg.url("1.0.0", "darwin", "arm64").unwrap(),
+            "https://example.com/tool-macOS-aarch64.tar.gz"
+        );
+        assert_eq!(
+            pkg.checksum
+                .as_ref()
+                .unwrap()
+                .url(&pkg, "1.0.0", "darwin", "arm64")
+                .unwrap(),
+            "https://example.com/tool-macOS-aarch64.tar.gz.mac-arm64.checksums"
         );
     }
 

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -314,6 +314,25 @@ where
     }
 }
 
+fn yaml_mapping_to_string_map<D: serde::de::Error>(
+    value: serde_yaml::Value,
+) -> std::result::Result<HashMap<String, String>, D> {
+    let serde_yaml::Value::Mapping(mapping) = value else {
+        return Err(D::custom("invalid type: expected a scalar string map"));
+    };
+
+    mapping
+        .into_iter()
+        .map(|(key, value)| {
+            let key = yaml_scalar_to_string(key)
+                .ok_or_else(|| D::custom("invalid type: expected a scalar string map key"))?;
+            let value = yaml_scalar_to_string(value)
+                .ok_or_else(|| D::custom("invalid type: expected a scalar string map value"))?;
+            Ok((key, value))
+        })
+        .collect()
+}
+
 fn deserialize_string_map<'de, D>(
     deserializer: D,
 ) -> std::result::Result<HashMap<String, String>, D::Error>
@@ -324,28 +343,7 @@ where
     let Some(value) = value else {
         return Ok(HashMap::new());
     };
-    let serde_yaml::Value::Mapping(mapping) = value else {
-        return Err(<D::Error as serde::de::Error>::custom(
-            "invalid type: expected a string map",
-        ));
-    };
-
-    mapping
-        .into_iter()
-        .map(|(key, value)| {
-            let key = yaml_scalar_to_string(key).ok_or_else(|| {
-                <D::Error as serde::de::Error>::custom(
-                    "invalid type: expected a scalar string map key",
-                )
-            })?;
-            let value = yaml_scalar_to_string(value).ok_or_else(|| {
-                <D::Error as serde::de::Error>::custom(
-                    "invalid type: expected a scalar string map value",
-                )
-            })?;
-            Ok((key, value))
-        })
-        .collect()
+    yaml_mapping_to_string_map(value)
 }
 
 fn deserialize_optional_string_map<'de, D>(
@@ -357,28 +355,10 @@ where
     let Some(value) = Option::<serde_yaml::Value>::deserialize(deserializer)? else {
         return Ok(None);
     };
-    let serde_yaml::Value::Mapping(mapping) = value else {
-        return Err(<D::Error as serde::de::Error>::custom(
-            "invalid type: expected a scalar string map",
-        ));
-    };
-    mapping
-        .into_iter()
-        .map(|(key, value)| {
-            let key = yaml_scalar_to_string(key).ok_or_else(|| {
-                <D::Error as serde::de::Error>::custom(
-                    "invalid type: expected a scalar string map key",
-                )
-            })?;
-            let value = yaml_scalar_to_string(value).ok_or_else(|| {
-                <D::Error as serde::de::Error>::custom(
-                    "invalid type: expected a scalar string map value",
-                )
-            })?;
-            Ok((key, value))
-        })
-        .collect::<std::result::Result<HashMap<_, _>, D::Error>>()
-        .map(Some)
+    if matches!(value, serde_yaml::Value::Null) {
+        return Ok(None);
+    }
+    yaml_mapping_to_string_map(value).map(Some)
 }
 
 fn yaml_scalar_to_string(value: serde_yaml::Value) -> Option<String> {
@@ -1172,7 +1152,13 @@ impl AquaChecksum {
             self.file_format = Some(file_format);
         }
         if let Some(replacements) = other.replacements {
-            self.replacements = Some(replacements);
+            if replacements.is_empty() {
+                self.replacements = Some(HashMap::new());
+            } else {
+                self.replacements
+                    .get_or_insert_with(HashMap::new)
+                    .extend(replacements);
+            }
         }
         if let Some(cosign) = other.cosign {
             if self.cosign.is_none() {
@@ -1197,7 +1183,7 @@ impl AquaChecksum {
         }
     }
 
-    fn template_ctx(
+    pub fn template_ctx(
         &self,
         pkg: &AquaPackage,
         v: &str,
@@ -1215,9 +1201,9 @@ impl AquaChecksum {
 
         let mut ctx = HashMap::new();
         ctx.insert("OS".to_string(), replace(os));
-        ctx.insert("GOOS".to_string(), os.to_string());
+        ctx.insert("GOOS".to_string(), replace(os));
         ctx.insert("Arch".to_string(), replace(actual_arch));
-        ctx.insert("GOARCH".to_string(), actual_arch.to_string());
+        ctx.insert("GOARCH".to_string(), replace(actual_arch));
         if pkg.r#type == AquaPackageType::Http {
             ctx.insert("AssetURL".to_string(), pkg.url(v, os, arch)?);
         }
@@ -1610,6 +1596,80 @@ packages:
                 .url(&pkg, "1.0.0", "darwin", "arm64")
                 .unwrap(),
             "https://example.com/tool-macOS-aarch64.tar.gz.mac-arm64.checksums"
+        );
+    }
+
+    #[test]
+    fn test_checksum_replacements_merge_on_version_override() {
+        let mut checksum = first_registry_package(
+            r#"
+packages:
+  - checksum:
+      type: http
+      url: https://example.com/{{.OS}}.checksums
+      replacements:
+        darwin: mac
+"#,
+        )
+        .checksum
+        .unwrap();
+        let override_checksum = first_registry_package(
+            r#"
+packages:
+  - checksum:
+      replacements:
+        arm64: aarch64
+"#,
+        )
+        .checksum
+        .unwrap();
+        checksum.merge(override_checksum);
+        assert_eq!(
+            checksum.replacements,
+            Some(HashMap::from([
+                ("darwin".to_string(), "mac".to_string()),
+                ("arm64".to_string(), "aarch64".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_checksum_replacements_null_deserializes_to_none() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+      replacements: null
+"#,
+        );
+        assert_eq!(pkg.checksum.unwrap().replacements, None);
+    }
+
+    #[test]
+    fn test_checksum_url_applies_replacements_to_goos_and_goarch() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - type: http
+    url: https://example.com/tool.tar.gz
+    checksum:
+      type: http
+      url: https://example.com/{{.GOOS}}-{{.GOARCH}}.checksums
+      replacements:
+        darwin: mac
+        arm64: aarch64
+"#,
+        );
+        assert_eq!(
+            pkg.checksum
+                .as_ref()
+                .unwrap()
+                .url(&pkg, "1.0.0", "darwin", "arm64")
+                .unwrap(),
+            "https://example.com/mac-aarch64.checksums"
         );
     }
 

--- a/src/aqua/aqua_registry_wrapper.rs
+++ b/src/aqua/aqua_registry_wrapper.rs
@@ -478,7 +478,8 @@ pub fn aqua_suggest(query: &str) -> Vec<String> {
 
 // Re-export types and static for compatibility
 pub use aqua_registry::{
-    AquaChecksum, AquaChecksumType, AquaCosign, AquaMinisignType, AquaPackage, AquaPackageType,
+    AquaChecksum, AquaChecksumType, AquaCosign, AquaGithubArtifactAttestations, AquaMinisign,
+    AquaMinisignType, AquaPackage, AquaPackageType,
 };
 
 #[cfg(test)]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -248,7 +248,11 @@ impl Backend for AquaBackend {
         if has_attestations_config || has_attestations_assets {
             let signer_workflow = all_pkgs
                 .iter()
-                .filter_map(|p| p.github_artifact_attestations.as_ref())
+                .filter_map(|p| {
+                    p.github_artifact_attestations
+                        .as_ref()
+                        .filter(|a| a.enabled != Some(false))
+                })
                 .chain(all_pkgs.iter().filter_map(|p| {
                     Self::checksum_github_attestations_config(p)
                         .map(|(_, attestations)| attestations)
@@ -299,7 +303,7 @@ impl Backend for AquaBackend {
         if has_minisign_config || has_minisign_assets {
             let public_key = all_pkgs
                 .iter()
-                .filter_map(|p| p.minisign.as_ref())
+                .filter_map(|p| p.minisign.as_ref().filter(|m| m.enabled != Some(false)))
                 .chain(
                     all_pkgs
                         .iter()
@@ -887,6 +891,7 @@ impl Backend for AquaBackend {
                     &v,
                     artifact_url,
                     provenance.as_ref().unwrap(),
+                    checksum.as_deref(),
                 )
                 .await
             {
@@ -1155,6 +1160,7 @@ impl AquaBackend {
         v: &str,
         artifact_url: &str,
         detected: &ProvenanceType,
+        expected_checksum: Option<&str>,
     ) -> Result<Option<ProvenanceType>> {
         let tmp_dir = tempfile::tempdir()?;
         let filename = get_filename_from_url(artifact_url);
@@ -1169,7 +1175,11 @@ impl AquaBackend {
 
         match detected {
             ProvenanceType::GithubAttestations => {
-                if let Some(attestations) = &pkg.github_artifact_attestations {
+                if let Some(attestations) = pkg
+                    .github_artifact_attestations
+                    .as_ref()
+                    .filter(|attestations| attestations.enabled != Some(false))
+                {
                     match self
                         .run_github_attestation_check(&artifact_path, pkg, attestations)
                         .await?
@@ -1192,6 +1202,12 @@ impl AquaBackend {
                         .await?
                     {
                         GithubAttestationStatus::Verified => {
+                            self.verify_checksum_file_matches_expected(
+                                checksum_config,
+                                &checksum_path,
+                                &filename,
+                                expected_checksum,
+                            )?;
                             Ok(Some(ProvenanceType::GithubAttestations))
                         }
                         GithubAttestationStatus::Unavailable => Ok(None),
@@ -1207,7 +1223,11 @@ impl AquaBackend {
                 }))
             }
             ProvenanceType::Minisign => {
-                if let Some(minisign) = &pkg.minisign {
+                if let Some(minisign) = pkg
+                    .minisign
+                    .as_ref()
+                    .filter(|minisign| minisign.enabled != Some(false))
+                {
                     self.run_minisign_check(
                         &artifact_path,
                         &filename,
@@ -1241,6 +1261,12 @@ impl AquaBackend {
                         None,
                     )
                     .await?;
+                    self.verify_checksum_file_matches_expected(
+                        checksum_config,
+                        &checksum_path,
+                        &filename,
+                        expected_checksum,
+                    )?;
                 }
                 Ok(Some(ProvenanceType::Minisign))
             }
@@ -1257,6 +1283,12 @@ impl AquaBackend {
                         .await?;
                     self.run_cosign_check(&checksum_path, cosign, pkg, v, tmp_dir.path(), None)
                         .await?;
+                    self.verify_checksum_file_matches_expected(
+                        checksum_config,
+                        &checksum_path,
+                        &filename,
+                        expected_checksum,
+                    )?;
                 }
                 Ok(Some(ProvenanceType::Cosign))
             }
@@ -1422,6 +1454,7 @@ impl AquaBackend {
     }
 
     /// Download minisign signature and verify against an already-downloaded artifact.
+    #[allow(clippy::too_many_arguments)]
     async fn run_minisign_check(
         &self,
         artifact_path: &Path,
@@ -1601,16 +1634,49 @@ impl AquaBackend {
         download_dir: &Path,
         pr: Option<&dyn SingleReport>,
     ) -> Result<PathBuf> {
-        let url = match checksum._type() {
-            AquaChecksumType::GithubRelease => {
-                let asset_strs = checksum.asset_strs(pkg, v, os(), arch())?;
-                self.github_release_asset(pkg, v, asset_strs).await?.0
-            }
-            AquaChecksumType::Http => checksum.url(pkg, v, os(), arch())?,
-        };
+        let url = self.resolve_checksum_file_url(checksum, pkg, v).await?;
         let path = download_dir.join(get_filename_from_url(&url));
         HTTP.download_file(&url, &path, pr).await?;
         Ok(path)
+    }
+
+    async fn resolve_checksum_file_url(
+        &self,
+        checksum: &AquaChecksum,
+        pkg: &AquaPackage,
+        v: &str,
+    ) -> Result<String> {
+        match checksum._type() {
+            AquaChecksumType::GithubRelease => {
+                let asset_strs = checksum.asset_strs(pkg, v, os(), arch())?;
+                Ok(self.github_release_asset(pkg, v, asset_strs).await?.0)
+            }
+            AquaChecksumType::Http => checksum.url(pkg, v, os(), arch()),
+        }
+    }
+
+    fn verify_checksum_file_matches_expected(
+        &self,
+        checksum_config: &AquaChecksum,
+        checksum_path: &Path,
+        artifact_filename: &str,
+        expected_checksum: Option<&str>,
+    ) -> Result<()> {
+        let checksum_content = file::read_to_string(checksum_path)?;
+        let checksum_str = self.parse_checksum_from_content(
+            &checksum_content,
+            checksum_config,
+            artifact_filename,
+        )?;
+        let checksum_val = format!("{}:{}", checksum_config.algorithm(), checksum_str);
+        if let Some(expected) = expected_checksum
+            && expected != checksum_val
+        {
+            bail!(
+                "verified checksum file digest does not match expected checksum for {artifact_filename}"
+            );
+        }
+        Ok(())
     }
 
     pub fn from_arg(ba: BackendArg) -> Self {
@@ -2117,7 +2183,6 @@ impl AquaBackend {
         if let Some(checksum) = &pkg.checksum
             && checksum.enabled()
         {
-            let checksum_path = download_path.join(format!("{filename}.checksum"));
             let platform_key = self.get_platform_key();
             let needs_checksum = tv
                 .lock_platforms
@@ -2145,25 +2210,28 @@ impl AquaBackend {
                 || needs_github_attestations
                 || needs_minisign
                 || (needs_cosign && !cosign_already_verified);
+            let checksum_url = if needs_verified_checksum_binding {
+                Some(self.resolve_checksum_file_url(checksum, pkg, v).await?)
+            } else {
+                None
+            };
+            let checksum_path = checksum_url
+                .as_ref()
+                .map(|url| download_path.join(get_filename_from_url(url)))
+                .unwrap_or_else(|| download_path.join(format!("{filename}.checksum")));
             // Re-download only if the checksum file doesn't exist yet. An existing file
             // from a prior attempt is trusted because the download directory is version-specific
             // and the final artifact is independently verified by verify_checksum at the end.
-            if (needs_checksum
-                || needs_github_attestations
-                || needs_minisign
-                || (needs_cosign && !cosign_already_verified))
+            if let Some(url) = checksum_url.as_ref()
                 && !checksum_path.exists()
             {
-                let url = match checksum._type() {
-                    AquaChecksumType::GithubRelease => {
-                        let asset_strs = checksum.asset_strs(pkg, v, os(), arch())?;
-                        self.github_release_asset(pkg, v, asset_strs).await?.0
-                    }
-                    AquaChecksumType::Http => checksum.url(pkg, v, os(), arch())?,
-                };
-                HTTP.download_file(&url, &checksum_path, Some(ctx.pr.as_ref()))
+                HTTP.download_file(url, &checksum_path, Some(ctx.pr.as_ref()))
                     .await?;
             }
+            let checksum_asset_name = checksum_path
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or("checksum");
 
             if let Some(attestations) = checksum_github_attestations
                 && checksum_path.exists()
@@ -2192,10 +2260,7 @@ impl AquaBackend {
                     .and_then(|pi| pi.provenance.as_ref())
                     .is_some_and(|p| p.is_slsa() || p.is_github_attestations())
             {
-                let checksum_filename = checksum_path
-                    .file_name()
-                    .and_then(|f| f.to_str())
-                    .unwrap_or("checksum");
+                let checksum_filename = checksum_asset_name;
                 self.run_minisign_check(
                     &checksum_path,
                     checksum_filename,

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -249,6 +249,10 @@ impl Backend for AquaBackend {
             let signer_workflow = all_pkgs
                 .iter()
                 .filter_map(|p| p.github_artifact_attestations.as_ref())
+                .chain(all_pkgs.iter().filter_map(|p| {
+                    Self::checksum_github_attestations_config(p)
+                        .map(|(_, attestations)| attestations)
+                }))
                 .find_map(|a| a.signer_workflow.clone());
             features.push(SecurityFeature::GithubAttestations { signer_workflow });
         }
@@ -1209,6 +1213,7 @@ impl AquaBackend {
                         &filename,
                         pkg,
                         minisign,
+                        None,
                         v,
                         tmp_dir.path(),
                         None,
@@ -1230,6 +1235,7 @@ impl AquaBackend {
                         checksum_filename,
                         pkg,
                         minisign,
+                        Some(checksum_config),
                         v,
                         tmp_dir.path(),
                         None,
@@ -1422,13 +1428,29 @@ impl AquaBackend {
         artifact_filename: &str,
         pkg: &AquaPackage,
         minisign_config: &AquaMinisign,
+        checksum_config: Option<&AquaChecksum>,
         v: &str,
         download_dir: &Path,
         pr: Option<&dyn SingleReport>,
     ) -> Result<()> {
+        let template_ctx = checksum_config
+            .map(|checksum| checksum.template_ctx(pkg, v, os(), arch()))
+            .transpose()?;
         let sig_path = match minisign_config._type() {
             AquaMinisignType::GithubRelease => {
-                let asset = minisign_config.asset(pkg, artifact_filename, v, os(), arch())?;
+                let asset = if let Some(ctx) = &template_ctx {
+                    let mut overrides = ctx.clone();
+                    overrides.insert("Asset".to_string(), artifact_filename.to_string());
+                    pkg.parse_aqua_str(
+                        minisign_config.asset.as_ref().unwrap(),
+                        v,
+                        &overrides,
+                        os(),
+                        arch(),
+                    )?
+                } else {
+                    minisign_config.asset(pkg, artifact_filename, v, os(), arch())?
+                };
                 let asset_strs = IndexSet::from([asset]);
                 let (repo_owner, repo_name) = resolve_repo_info(
                     minisign_config.repo_owner.as_ref(),
@@ -1444,7 +1466,11 @@ impl AquaBackend {
                 path
             }
             AquaMinisignType::Http => {
-                let url = minisign_config.url(pkg, v, os(), arch())?;
+                let url = if let Some(ctx) = &template_ctx {
+                    pkg.parse_aqua_str(minisign_config.url.as_ref().unwrap(), v, ctx, os(), arch())?
+                } else {
+                    minisign_config.url(pkg, v, os(), arch())?
+                };
                 let path = download_dir.join(format!("{artifact_filename}.minisig"));
                 HTTP.download_file(&url, &path, pr).await?;
                 path
@@ -2115,6 +2141,10 @@ impl AquaBackend {
             let needs_cosign = checksum_cosign.is_some();
             let needs_github_attestations = checksum_github_attestations.is_some();
             let needs_minisign = checksum_minisign.is_some();
+            let needs_verified_checksum_binding = needs_checksum
+                || needs_github_attestations
+                || needs_minisign
+                || (needs_cosign && !cosign_already_verified);
             // Re-download only if the checksum file doesn't exist yet. An existing file
             // from a prior attempt is trusted because the download directory is version-specific
             // and the final artifact is independently verified by verify_checksum at the end.
@@ -2171,6 +2201,7 @@ impl AquaBackend {
                     checksum_filename,
                     pkg,
                     minisign,
+                    Some(checksum),
                     v,
                     &download_path,
                     Some(ctx.pr.as_ref()),
@@ -2187,13 +2218,20 @@ impl AquaBackend {
                     .await?;
             }
 
-            if needs_checksum && checksum_path.exists() {
+            if needs_verified_checksum_binding && checksum_path.exists() {
                 let checksum_content = file::read_to_string(&checksum_path)?;
                 let checksum_str =
                     self.parse_checksum_from_content(&checksum_content, checksum, filename)?;
                 let checksum_val = format!("{}:{}", checksum.algorithm(), checksum_str);
                 let platform_key = self.get_platform_key();
                 let platform_info = tv.lock_platforms.entry(platform_key).or_default();
+                if let Some(existing_checksum) = &platform_info.checksum
+                    && existing_checksum != &checksum_val
+                {
+                    bail!(
+                        "verified checksum file digest does not match existing checksum for {filename}"
+                    );
+                }
                 platform_info.checksum = Some(checksum_val);
             }
         }
@@ -2271,6 +2309,7 @@ impl AquaBackend {
                 filename,
                 pkg,
                 minisign,
+                None,
                 v,
                 &tv.download_path(),
                 Some(ctx.pr.as_ref()),

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -18,8 +18,8 @@ use crate::toolset::{EPHEMERAL_OPT_KEYS, ToolRequest, ToolVersion, ToolVersionOp
 use crate::ui::progress_report::SingleReport;
 use crate::{
     aqua::aqua_registry_wrapper::{
-        AQUA_REGISTRY, AquaChecksum, AquaChecksumType, AquaCosign, AquaMinisignType, AquaPackage,
-        AquaPackageType,
+        AQUA_REGISTRY, AquaChecksum, AquaChecksumType, AquaCosign, AquaGithubArtifactAttestations,
+        AquaMinisign, AquaMinisignType, AquaPackage, AquaPackageType,
     },
     cache::{CacheManager, CacheManagerBuilder},
 };
@@ -239,6 +239,7 @@ impl Backend for AquaBackend {
             p.github_artifact_attestations
                 .as_ref()
                 .is_some_and(|a| a.enabled.unwrap_or(true))
+                || Self::checksum_github_attestations_config(p).is_some()
         });
         let has_attestations_assets = release_assets.iter().any(|a| {
             let name = a.name.to_lowercase();
@@ -285,6 +286,7 @@ impl Backend for AquaBackend {
             p.minisign
                 .as_ref()
                 .is_some_and(|m| m.enabled.unwrap_or(true))
+                || Self::checksum_minisign_config(p).is_some()
         });
         let has_minisign_assets = release_assets.iter().any(|a| {
             let name = a.name.to_lowercase();
@@ -294,6 +296,11 @@ impl Backend for AquaBackend {
             let public_key = all_pkgs
                 .iter()
                 .filter_map(|p| p.minisign.as_ref())
+                .chain(
+                    all_pkgs
+                        .iter()
+                        .filter_map(|p| Self::checksum_minisign_config(p).map(|(_, m)| m)),
+                )
                 .find_map(|m| m.public_key.clone());
             features.push(SecurityFeature::Minisign { public_key });
         }
@@ -808,8 +815,12 @@ impl Backend for AquaBackend {
         let mut provenance = self.detect_provenance_type(&pkg);
         if matches!(provenance, Some(ProvenanceType::GithubAttestations))
             && let Some(digest) = checksum.as_deref().filter(|d| d.starts_with("sha256:"))
+            && let Some(attestations) = &pkg.github_artifact_attestations
         {
-            match self.detect_github_attestations(&pkg, digest).await {
+            match self
+                .detect_github_attestations(&pkg, attestations, digest)
+                .await
+            {
                 Ok(true) => {}
                 Ok(false) => {
                     provenance = self.detect_non_github_provenance_type(&pkg);
@@ -1018,6 +1029,32 @@ impl AquaBackend {
         Some((checksum, cosign))
     }
 
+    fn checksum_minisign_config(pkg: &AquaPackage) -> Option<(&AquaChecksum, &AquaMinisign)> {
+        let checksum = pkg
+            .checksum
+            .as_ref()
+            .filter(|checksum| checksum.enabled())?;
+        let minisign = checksum
+            .minisign
+            .as_ref()
+            .filter(|minisign| minisign.enabled != Some(false))?;
+        Some((checksum, minisign))
+    }
+
+    fn checksum_github_attestations_config(
+        pkg: &AquaPackage,
+    ) -> Option<(&AquaChecksum, &AquaGithubArtifactAttestations)> {
+        let checksum = pkg
+            .checksum
+            .as_ref()
+            .filter(|checksum| checksum.enabled())?;
+        let attestations = checksum
+            .github_artifact_attestations
+            .as_ref()
+            .filter(|attestations| attestations.enabled != Some(false))?;
+        Some((checksum, attestations))
+    }
+
     /// Detect provenance type from aqua registry package config.
     ///
     /// Returns the highest-priority provenance type that is configured and
@@ -1038,8 +1075,11 @@ impl AquaBackend {
         // or on first install when the lockfile doesn't yet have provenance).
         if settings.github_attestations
             && settings.aqua.github_attestations
-            && let Some(att) = &pkg.github_artifact_attestations
-            && att.enabled != Some(false)
+            && (pkg
+                .github_artifact_attestations
+                .as_ref()
+                .is_some_and(|att| att.enabled != Some(false))
+                || Self::checksum_github_attestations_config(pkg).is_some())
         {
             return Some(ProvenanceType::GithubAttestations);
         }
@@ -1072,8 +1112,11 @@ impl AquaBackend {
 
         // Check for minisign
         if settings.aqua.minisign
-            && let Some(minisign) = &pkg.minisign
-            && minisign.enabled != Some(false)
+            && (pkg
+                .minisign
+                .as_ref()
+                .is_some_and(|minisign| minisign.enabled != Some(false))
+                || Self::checksum_minisign_config(pkg).is_some())
         {
             return Some(ProvenanceType::Minisign);
         }
@@ -1084,6 +1127,7 @@ impl AquaBackend {
     async fn detect_github_attestations(
         &self,
         pkg: &AquaPackage,
+        attestations: &AquaGithubArtifactAttestations,
         digest: &str,
     ) -> std::result::Result<bool, crate::github::sigstore::DetectError> {
         let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
@@ -1092,9 +1136,7 @@ impl AquaBackend {
             &pkg.repo_name,
             github::API_URL,
             digest,
-            pkg.github_artifact_attestations
-                .as_ref()
-                .and_then(|att| att.predicate_type.as_deref()),
+            attestations.predicate_type.as_deref(),
             self.use_versions_host_for_github_metadata(&repo),
         )
         .await
@@ -1123,14 +1165,33 @@ impl AquaBackend {
 
         match detected {
             ProvenanceType::GithubAttestations => {
-                match self
-                    .run_github_attestation_check(&artifact_path, pkg)
-                    .await?
-                {
-                    GithubAttestationStatus::Verified => {
-                        Ok(Some(ProvenanceType::GithubAttestations))
+                if let Some(attestations) = &pkg.github_artifact_attestations {
+                    match self
+                        .run_github_attestation_check(&artifact_path, pkg, attestations)
+                        .await?
+                    {
+                        GithubAttestationStatus::Verified => {
+                            Ok(Some(ProvenanceType::GithubAttestations))
+                        }
+                        GithubAttestationStatus::Unavailable => Ok(None),
                     }
-                    GithubAttestationStatus::Unavailable => Ok(None),
+                } else {
+                    let (checksum_config, attestations) =
+                        Self::checksum_github_attestations_config(pkg).wrap_err(
+                            "GitHub attestation provenance detected but no supported binary/checksum config found",
+                        )?;
+                    let checksum_path = self
+                        .download_checksum_file(checksum_config, pkg, v, tmp_dir.path(), None)
+                        .await?;
+                    match self
+                        .run_github_attestation_check(&checksum_path, pkg, attestations)
+                        .await?
+                    {
+                        GithubAttestationStatus::Verified => {
+                            Ok(Some(ProvenanceType::GithubAttestations))
+                        }
+                        GithubAttestationStatus::Unavailable => Ok(None),
+                    }
                 }
             }
             ProvenanceType::Slsa { .. } => {
@@ -1142,8 +1203,39 @@ impl AquaBackend {
                 }))
             }
             ProvenanceType::Minisign => {
-                self.run_minisign_check(&artifact_path, &filename, pkg, v, tmp_dir.path(), None)
+                if let Some(minisign) = &pkg.minisign {
+                    self.run_minisign_check(
+                        &artifact_path,
+                        &filename,
+                        pkg,
+                        minisign,
+                        v,
+                        tmp_dir.path(),
+                        None,
+                    )
                     .await?;
+                } else {
+                    let (checksum_config, minisign) = Self::checksum_minisign_config(pkg).wrap_err(
+                        "minisign provenance detected but no supported binary/checksum config found",
+                    )?;
+                    let checksum_path = self
+                        .download_checksum_file(checksum_config, pkg, v, tmp_dir.path(), None)
+                        .await?;
+                    let checksum_filename = checksum_path
+                        .file_name()
+                        .and_then(|f| f.to_str())
+                        .unwrap_or("checksum");
+                    self.run_minisign_check(
+                        &checksum_path,
+                        checksum_filename,
+                        pkg,
+                        minisign,
+                        v,
+                        tmp_dir.path(),
+                        None,
+                    )
+                    .await?;
+                }
                 Ok(Some(ProvenanceType::Minisign))
             }
             ProvenanceType::Cosign => {
@@ -1172,19 +1264,17 @@ impl AquaBackend {
         &self,
         artifact_path: &Path,
         pkg: &AquaPackage,
+        attestations: &AquaGithubArtifactAttestations,
     ) -> Result<GithubAttestationStatus> {
         // The aqua registry stores signer_workflow as a regex pattern (e.g. `\.github/workflows/release\.yaml`).
         // sigstore-verification's verify_attestations() uses plain str::contains(), not regex, so we must
         // unescape regex metacharacter escapes (e.g. `\.` → `.`) before passing the value through.
-        let signer_workflow = pkg
-            .github_artifact_attestations
-            .as_ref()
-            .and_then(|att| att.signer_workflow.as_deref().map(unescape_regex_literal));
+        let signer_workflow = attestations
+            .signer_workflow
+            .as_deref()
+            .map(unescape_regex_literal);
         let repo = format!("{}/{}", pkg.repo_owner, pkg.repo_name);
-        let predicate_type = pkg
-            .github_artifact_attestations
-            .as_ref()
-            .and_then(|att| att.predicate_type.as_deref());
+        let predicate_type = attestations.predicate_type.as_deref();
 
         match crate::github::sigstore::verify_attestation_with_predicate_type(
             artifact_path,
@@ -1331,32 +1421,25 @@ impl AquaBackend {
         artifact_path: &Path,
         artifact_filename: &str,
         pkg: &AquaPackage,
+        minisign_config: &AquaMinisign,
         v: &str,
         download_dir: &Path,
         pr: Option<&dyn SingleReport>,
     ) -> Result<()> {
-        let minisign_config = pkg
-            .minisign
-            .as_ref()
-            .wrap_err("minisign provenance detected but no config found")?;
-
         let sig_path = match minisign_config._type() {
             AquaMinisignType::GithubRelease => {
                 let asset = minisign_config.asset(pkg, artifact_filename, v, os(), arch())?;
+                let asset_strs = IndexSet::from([asset]);
                 let (repo_owner, repo_name) = resolve_repo_info(
                     minisign_config.repo_owner.as_ref(),
                     minisign_config.repo_name.as_ref(),
                     pkg,
                 );
-                let url = self
-                    .get_github_release(&format!("{repo_owner}/{repo_name}"), v)
-                    .await?
-                    .assets
-                    .into_iter()
-                    .find(|a| a.name == asset)
-                    .map(|a| a.browser_download_url)
-                    .wrap_err_with(|| format!("no asset found for minisign: {asset}"))?;
-                let path = download_dir.join(&asset);
+                let mut sig_pkg = pkg.clone();
+                sig_pkg.repo_owner = repo_owner;
+                sig_pkg.repo_name = repo_name;
+                let url = self.github_release_asset(&sig_pkg, v, asset_strs).await?.0;
+                let path = download_dir.join(get_filename_from_url(&url));
                 HTTP.download_file(&url, &path, pr).await?;
                 path
             }
@@ -2018,11 +2101,27 @@ impl AquaBackend {
             let checksum_cosign = (!skip_cosign && Settings::get().aqua.cosign)
                 .then(|| Self::checksum_cosign_config(pkg).map(|(_, cosign)| cosign))
                 .flatten();
+            let checksum_github_attestations = (!skip_attestations
+                && Settings::get().github_attestations
+                && Settings::get().aqua.github_attestations)
+                .then(|| {
+                    Self::checksum_github_attestations_config(pkg)
+                        .map(|(_, attestations)| attestations)
+                })
+                .flatten();
+            let checksum_minisign = (!skip_minisign && Settings::get().aqua.minisign)
+                .then(|| Self::checksum_minisign_config(pkg).map(|(_, minisign)| minisign))
+                .flatten();
             let needs_cosign = checksum_cosign.is_some();
+            let needs_github_attestations = checksum_github_attestations.is_some();
+            let needs_minisign = checksum_minisign.is_some();
             // Re-download only if the checksum file doesn't exist yet. An existing file
             // from a prior attempt is trusted because the download directory is version-specific
             // and the final artifact is independently verified by verify_checksum at the end.
-            if (needs_checksum || (needs_cosign && !cosign_already_verified))
+            if (needs_checksum
+                || needs_github_attestations
+                || needs_minisign
+                || (needs_cosign && !cosign_already_verified))
                 && !checksum_path.exists()
             {
                 let url = match checksum._type() {
@@ -2034,6 +2133,50 @@ impl AquaBackend {
                 };
                 HTTP.download_file(&url, &checksum_path, Some(ctx.pr.as_ref()))
                     .await?;
+            }
+
+            if let Some(attestations) = checksum_github_attestations
+                && checksum_path.exists()
+                && !tv
+                    .lock_platforms
+                    .get(&platform_key)
+                    .and_then(|pi| pi.provenance.as_ref())
+                    .is_some_and(|p| p.is_github_attestations())
+            {
+                match self
+                    .run_github_attestation_check(&checksum_path, pkg, attestations)
+                    .await?
+                {
+                    GithubAttestationStatus::Verified => {
+                        self.record_provenance(tv, ProvenanceType::GithubAttestations);
+                    }
+                    GithubAttestationStatus::Unavailable => {}
+                }
+            }
+
+            if let Some(minisign) = checksum_minisign
+                && checksum_path.exists()
+                && !tv
+                    .lock_platforms
+                    .get(&platform_key)
+                    .and_then(|pi| pi.provenance.as_ref())
+                    .is_some_and(|p| p.is_slsa() || p.is_github_attestations())
+            {
+                let checksum_filename = checksum_path
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or("checksum");
+                self.run_minisign_check(
+                    &checksum_path,
+                    checksum_filename,
+                    pkg,
+                    minisign,
+                    v,
+                    &download_path,
+                    Some(ctx.pr.as_ref()),
+                )
+                .await?;
+                self.record_provenance(tv, ProvenanceType::Minisign);
             }
 
             if let Some(cosign) = checksum_cosign
@@ -2127,6 +2270,7 @@ impl AquaBackend {
                 &artifact_path,
                 filename,
                 pkg,
+                minisign,
                 v,
                 &tv.download_path(),
                 Some(ctx.pr.as_ref()),
@@ -2212,7 +2356,7 @@ impl AquaBackend {
                 .set_message("verify GitHub artifact attestations".to_string());
             let artifact_path = tv.download_path().join(filename);
             match self
-                .run_github_attestation_check(&artifact_path, pkg)
+                .run_github_attestation_check(&artifact_path, pkg, github_attestations)
                 .await?
             {
                 GithubAttestationStatus::Verified => {}
@@ -2284,14 +2428,14 @@ impl AquaBackend {
     }
 
     fn record_cosign_provenance(&self, tv: &mut ToolVersion) {
+        self.record_provenance(tv, ProvenanceType::Cosign);
+    }
+
+    fn record_provenance(&self, tv: &mut ToolVersion, provenance: ProvenanceType) {
         let platform_key = self.get_platform_key();
         let pi = tv.lock_platforms.entry(platform_key).or_default();
-        if pi
-            .provenance
-            .as_ref()
-            .is_none_or(|p| *p < ProvenanceType::Cosign)
-        {
-            pi.provenance = Some(ProvenanceType::Cosign);
+        if pi.provenance.as_ref().is_none_or(|p| *p < provenance) {
+            pi.provenance = Some(provenance);
         }
     }
 


### PR DESCRIPTION
## Summary

- Parse aqua `checksum.replacements`, `checksum.minisign`, and `checksum.github_artifact_attestations`.
- Render checksum file assets/URLs with checksum-specific replacements, `AssetURL` for HTTP checksum metadata, and consistent OS/arch template context (`GOOS`/`GOARCH` included).
- Verify checksum-file minisign/GitHub attestations in the aqua provenance flow, then continue using the parsed checksum to verify the downloaded artifact.
- Bind checksum-scoped provenance to the checksum digest used for the artifact at both install time and lock time.
- Bump the compiled aqua-registry cache namespace from `v4` to `v5` so existing compiled caches are invalidated after the `AquaChecksum` schema change.

## Scope

Addresses the `checksum.*` slice of the [remaining aqua-registry schema gaps tracker](https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=183902266). This does not close the tracker item.

## Changes

**Type layer (`crates/aqua-registry`)**
- Add checksum-level `replacements`, `minisign`, and `github_artifact_attestations` fields to `AquaChecksum`.
- Add `template_ctx` / `effective_replacements` helpers for checksum-specific OS/arch replacement merging.
- Handle `replacements: null`, partial version-override merges, and shared YAML map deserialization.
- Re-export `AquaMinisign` and `AquaGithubArtifactAttestations` from the crate.

**Backend (`src/backend/aqua.rs`)**
- Fall back to checksum-scoped minisign/attestation/cosign configs when top-level configs are absent or disabled.
- Preserve checksum release asset names for minisign `{{.Asset}}` rendering instead of local download filenames.
- Compare verified checksum file contents against expected/lockfile digests after checksum-scoped provenance verification.
- Include checksum-scoped attestations in `security_info()` signer workflow lookup.

## Verification

- `mise run lint`
- `cargo clippy -- -D warnings`
- `mise x sccache -- cargo test -p aqua-registry checksum --lib`
- `mise x sccache -- cargo test backend::aqua::tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checksum-level `replacements` support to customize URL and template values.
  * Extended GitHub Artifact Attestations and Minisign provenance to derive from checksum-provided configuration when package settings are missing.
* **Improvements**
  * Refined template rendering and replacement precedence for OS/architecture-aware URL generation.
  * Expanded the publicly available registry API to include additional attestation and signature configuration types.
* **Bug Fixes**
  * Correctly handles `replacements: null` and applies overrides only when explicitly provided.
  * Added a safeguard to prevent provenance verification when verified checksums conflict.
* **Chores**
  * Bumped the compiled registry cache version, invalidating older compiled caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->