### PR TITLE
fix(shim): don't create extension-less shims in exe mode on Windows

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -153,14 +153,17 @@ mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
 
 ### Shims leaking into WSL
 
-On Windows, mise writes an extension-less bash script next to each `<tool>.exe`
-shim (so Git Bash / Cygwin can resolve the tool). WSL's default Windows-PATH
-interop exposes the shims directory at `/mnt/c/...`, where every file is treated
-as executable, so running a shimmed tool inside WSL executes that script
-natively. mise guards the generated script: when it detects WSL it drops the
-shims directory from `PATH` and runs a native Linux tool if one is installed,
-otherwise it fails with a plain `<tool>: not found` rather than recursing
-endlessly or erroring with `mise: not found`.
+When `windows_shim_mode` is set to `file`, mise writes an extension-less bash
+script next to each `<tool>.cmd` shim (so Git Bash / Cygwin can resolve the
+tool). WSL's default Windows-PATH interop exposes the shims directory at
+`/mnt/c/...`, where every file is treated as executable, so running a shimmed
+tool inside WSL executes that script natively. mise guards the generated script:
+when it detects WSL it drops the shims directory from `PATH` and runs a native
+Linux tool if one is installed, otherwise it fails with a plain `<tool>: not
+found` rather than recursing endlessly or erroring with `mise: not found`.
+
+The default `exe` mode is not affected: it writes only native `<tool>.exe`
+files, which WSL ignores, so nothing leaks into Linux.
 
 To keep the Windows shims out of WSL entirely, either install/manage the tool
 with mise inside WSL, or disable the Windows-PATH interop in `/etc/wsl.conf`:

--- a/e2e-win/shim.Tests.ps1
+++ b/e2e-win/shim.Tests.ps1
@@ -33,6 +33,10 @@ Describe 'shim_mode' {
         mise x go@1.23.3 -- go version | Should -BeLike "go version go1.23.3 windows/*"
 
         (Get-Item -Path  (Join-Path -Path $shimPath -ChildPath go.cmd)).LinkType | Should -Be $null
+
+        # file mode needs the extension-less shim for Git Bash/Cygwin (no .exe,
+        # and Cygwin does not auto-append .cmd)
+        Test-Path -Path (Join-Path -Path $shimPath -ChildPath go) -PathType Leaf | Should -Be $true
     }
 
     It 'run on exe' {
@@ -46,6 +50,11 @@ Describe 'shim_mode' {
         $goShim = Get-Item -Path (Join-Path -Path $shimPath -ChildPath go.exe)
         $goShim.LinkType | Should -Be $null
         $goShim.Length | Should -BeGreaterThan 0
+
+        # exe mode must NOT create an extension-less shim: it leaks into WSL via
+        # /mnt/c PATH interop (#10299) and is unnecessary because Git Bash/Cygwin
+        # resolve `go` to `go.exe` via their `.exe` magic.
+        Test-Path -Path (Join-Path -Path $shimPath -ChildPath go) -PathType Leaf | Should -Be $false
     }
 
     It 'run on hardlink' {

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -315,7 +315,9 @@ fn effective_shim_mode(mise_bin: &Path) -> String {
     mode
 }
 
-/// Build the extension-less bash shim used on Windows (for Git Bash/Cygwin).
+/// Build the extension-less bash shim used on Windows in "file" mode (for Git
+/// Bash/Cygwin). "exe" mode does not emit this — its native <tool>.exe is found
+/// by those shells via `.exe` magic — so only "file" mode reaches this code.
 ///
 /// The shim's directory can leak into WSL via the default Windows-PATH interop
 /// (it is mounted under /mnt/c where every file is treated as executable), so WSL
@@ -354,31 +356,22 @@ fn bash_shim_script(tool: &str) -> String {
 fn add_shim(mise_bin: &Path, symlink_path: &Path, shim: &str) -> Result<()> {
     match effective_shim_mode(mise_bin).as_ref() {
         "exe" => {
-            if symlink_path.extension().and_then(|s| s.to_str()) == Some("exe") {
-                let mise_shim_bin =
-                    find_mise_shim_bin(mise_bin).ok_or_else(|| eyre!("mise-shim.exe not found"))?;
-                // Copy mise-shim.exe as <tool>.exe
-                fs::copy(&mise_shim_bin, symlink_path).wrap_err_with(|| {
-                    eyre!(
-                        "Failed to copy {} to {}",
-                        display_path(&mise_shim_bin),
-                        display_path(symlink_path)
-                    )
-                })?;
-                Ok(())
-            } else {
-                let shim_name = symlink_path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy();
-                // Create extensionless bash script for Git Bash/Cygwin
-                file::write(symlink_path, bash_shim_script(&shim_name)).wrap_err_with(|| {
-                    eyre!(
-                        "Failed to create shim script for {}",
-                        display_path(symlink_path)
-                    )
-                })
-            }
+            // In "exe" mode every desired shim is a native <tool>.exe copy of
+            // mise-shim.exe (see get_desired_shims). No extension-less bash shim is
+            // emitted: Git Bash / Cygwin resolve a bare name to the .exe via their
+            // `.exe` magic, so emitting one is redundant and only pollutes WSL via
+            // /mnt/c PATH interop (#10299).
+            let mise_shim_bin =
+                find_mise_shim_bin(mise_bin).ok_or_else(|| eyre!("mise-shim.exe not found"))?;
+            // Copy mise-shim.exe as <tool>.exe
+            fs::copy(&mise_shim_bin, symlink_path).wrap_err_with(|| {
+                eyre!(
+                    "Failed to copy {} to {}",
+                    display_path(&mise_shim_bin),
+                    display_path(symlink_path)
+                )
+            })?;
+            Ok(())
         }
         "file" => {
             let shim = shim.trim_end_matches(".cmd");
@@ -571,10 +564,15 @@ async fn get_desired_shims(
                         vec![p.with_extension("exe").to_string_lossy().to_string()]
                     }
                     "exe" => {
-                        vec![
-                            p.with_extension("exe").to_string_lossy().to_string(),
-                            p.with_extension("").to_string_lossy().to_string(),
-                        ]
+                        // Only the native <tool>.exe is needed. Git Bash / Cygwin /
+                        // MSYS2 resolve a bare `tool` to `tool.exe` via their `.exe`
+                        // magic, and mise-shim.exe derives the tool from its own file
+                        // name, so it runs correctly however it is invoked. We do NOT
+                        // emit an extension-less bash shim here: that variant is only
+                        // required in "file" mode (no .exe, and Cygwin won't auto-append
+                        // .cmd) and is what leaked into WSL via /mnt/c PATH interop
+                        // (#10299).
+                        vec![p.with_extension("exe").to_string_lossy().to_string()]
                     }
                     "file" => {
                         vec![


### PR DESCRIPTION
## Summary

In the default `exe` `windows_shim_mode`, mise wrote **two** files per tool: the native `<tool>.exe` (a copy of `mise-shim.exe`) **and** an extension-less bash script "for Git Bash/Cygwin". This PR drops the extension-less script in `exe` mode — only `<tool>.exe` is written.

The extension-less script is unnecessary in `exe` mode:

- Git Bash / Cygwin / MSYS2 resolve a bare `gh` to `gh.exe` via their `.exe` magic (the same reason `which powershell` shows the extension-less path), so the native `.exe` is found without it.
- `mise-shim.exe` derives the tool from `current_exe().file_stem()`, so it runs correctly however it is invoked.
- The settings docs already describe `exe` mode as writing only `<tool>.exe` ("Works with all shells").

It is also the file that **leaks into WSL** via the default Windows-PATH interop (`/mnt/c/...`), causing the `mise: not found` / infinite-recursion reported in #10299. Removing it in the default mode eliminates that leak at the source.

`file` mode is unchanged: it still writes the extension-less bash shim, which **is** required there (no `.exe`, and Cygwin does not auto-append `.cmd`). The WSL guard added in #10421 remains for `file` mode.

Follow-up to #10421 and discussion #10299 — felipecrs asked whether Git Bash / Cygwin actually need the extension-less shims; for `exe` mode, they don't.

## Changes

- `src/shims.rs`: `get_desired_shims` / `add_shim` emit only `<tool>.exe` in `exe` mode; `bash_shim_script` doc clarified as file-mode-only.
- `docs/troubleshooting.md`: "Shims leaking into WSL" now notes it applies to `file` mode; the default `exe` mode does not leak.
- `e2e-win/shim.Tests.ps1`: assert the extension-less shim is absent in `exe` mode and present in `file` mode.

## Migration

Existing extension-less shims created by the old `exe` mode are removed automatically on the next `reshim` (diff) or after a mise version update (full regeneration).

## Testing

- `cargo fmt --all -- --check`, `prettier`, and `markdownlint` pass clean.
- `cargo check` / the Windows build were **not** run locally (sandbox limits); the `#[cfg(windows)]` shim code can only be type-checked on a Windows target. The extended `e2e-win/shim.Tests.ps1` exercises the new behavior on Windows CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows **exe** shim mode to stop generating extension-less bash shims, ensuring consistent tool resolution and avoiding unintended WSL PATH interop.

* **Documentation**
  * Expanded Windows/WSL troubleshooting guidance to clarify that extension-less “bash script in shims” behavior applies only to **file** mode, and that the default **exe** mode is unaffected.

* **Tests**
  * Updated shim mode end-to-end assertions to reflect the expected extension-less shim behavior in **file** vs **exe** modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->