### PR TITLE
feat(bootstrap): add apk package support

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -146,6 +146,7 @@ export default withMermaid(
               link: "/bootstrap/packages/",
               collapsed: true,
               items: [
+                { text: "apk", link: "/bootstrap/packages/apk" },
                 { text: "apt", link: "/bootstrap/packages/apt" },
                 { text: "dnf", link: "/bootstrap/packages/dnf" },
                 { text: "pacman", link: "/bootstrap/packages/pacman" },

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -39,6 +39,7 @@ task runs every time, so keep it idempotent.
 
 ```toml
 [bootstrap.packages]
+"apk:build-base" = "latest"
 "apt:build-essential" = "latest"
 "brew:postgresql@17" = "latest"
 
@@ -132,7 +133,7 @@ place but should not install anything during that check.
 
 | Config                             | Use for                                                       |
 | ---------------------------------- | ------------------------------------------------------------- |
-| `[bootstrap.packages]`             | OS packages from apt, dnf, pacman, or brew                    |
+| `[bootstrap.packages]`             | OS packages from apk, apt, dnf, pacman, or brew               |
 | `[dotfiles]`                       | Whole-file dotfiles and small managed edits to existing files |
 | `[bootstrap.macos.*]`              | Curated macOS preferences for Dock/Finder/keyboard/trackpad   |
 | `[bootstrap.macos.defaults]`       | macOS user preferences written through `defaults write`       |
@@ -194,7 +195,7 @@ mise bootstrap --yes
 ### Add A Package
 
 ```sh
-mise bootstrap packages use apt:libssl-dev
+mise bootstrap packages use apk:zlib-dev apt:libssl-dev
 ```
 
 This writes `[bootstrap.packages]` and installs what is missing.

--- a/docs/bootstrap/packages/apk.md
+++ b/docs/bootstrap/packages/apk.md
@@ -1,0 +1,29 @@
+# apk <Badge type="warning" text="experimental" />
+
+System packages for Alpine Linux.
+
+```toml
+[bootstrap.packages]
+"apk:build-base" = "latest"
+"apk:zlib-dev" = "1.3.1-r2" # version pin
+```
+
+## Behavior
+
+- Package state is checked with `apk info -e -v` (read-only, never elevates).
+- Missing packages are installed with `apk add`, elevated with sudo when
+  necessary (see [sudo](/bootstrap/packages/#sudo)).
+- Version pins are passed to apk as its native `name=version` syntax.
+- `mise bootstrap packages install --update` adds `--update-cache` to refresh
+  apk metadata.
+- `mise bootstrap packages upgrade` runs `apk upgrade --available --update-cache`
+  for the configured packages that are already installed.
+
+## Version pins
+
+A pinned entry (`"apk:zlib-dev" = "1.3.1-r2"`) shows as `version mismatch`
+in `mise bootstrap packages status` when a different version is installed,
+and `mise bootstrap packages install` passes the pin to apk to correct it.
+`"latest"` entries are satisfied by any installed version — use
+`mise bootstrap packages upgrade` to move them to the newest available
+version.

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -5,6 +5,7 @@ mise can ensure machine-global system packages are installed via the
 
 ```toml
 [bootstrap.packages]
+"apk:build-base" = "latest"
 "apt:libssl-dev" = "latest"
 "apt:build-essential" = "latest"
 "brew:postgresql@17" = "latest"
@@ -43,6 +44,7 @@ applied by `mise bootstrap user apply` or [`mise bootstrap`](/cli/bootstrap.html
 
 | Manager     | Platform                                                       | Page                                      |
 | ----------- | -------------------------------------------------------------- | ----------------------------------------- |
+| `apk`       | Alpine Linux                                                   | [apk](/bootstrap/packages/apk.html)       |
 | `apt`       | Debian, Ubuntu                                                 | [apt](/bootstrap/packages/apt.html)       |
 | `dnf`       | Fedora, RHEL, CentOS, Rocky, Alma                              | [dnf](/bootstrap/packages/dnf.html)       |
 | `pacman`    | Arch, Manjaro                                                  | [pacman](/bootstrap/packages/pacman.html) |
@@ -91,7 +93,7 @@ mise bootstrap packages install --yes     # skip the confirmation prompt
 mise bootstrap packages install --manager apt
 mise bootstrap packages install --update  # refresh package manager metadata first
 
-mise bootstrap packages use apt:curl brew:jq brew-cask:firefox mas:497799835
+mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox mas:497799835
 mise bootstrap packages use -g brew:ffmpeg                      # write globally
 mise bootstrap packages use apt:curl@8.5.0-2   # pin a version (brew pins via the
                                    # formula name: brew:postgresql@17)
@@ -111,7 +113,7 @@ Mac.
 
 `mise bootstrap packages upgrade` refreshes package manager metadata and upgrades the
 configured packages that are already installed to the newest available
-version — apt and dnf also honor a version pinned in config (pacman, brew,
+version — apk, apt, and dnf also honor a version pinned in config (pacman, brew,
 brew-cask, and mas [can't install pins](/bootstrap/packages/pacman.html), so
 pinned entries are skipped with a warning). Packages that aren't installed
 yet are skipped — that's `mise bootstrap packages install`'s job. For brew

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -50,7 +50,7 @@ Overwrite existing files that conflict with whole-file dotfile entries
 
 ### `--update`
 
-Refresh system package manager metadata first (apt: `apt-get update`)
+Refresh system package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)
 
 ## Subcommands
 

--- a/docs/cli/bootstrap/packages/install.md
+++ b/docs/cli/bootstrap/packages/install.md
@@ -12,7 +12,7 @@ system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting).
 
 Packages can also be given explicitly in `manager:package` form (e.g.
-`apt:curl`, `brew:jq`); they are installed whether or not they appear in
+`apk:zlib-dev`, `apt:curl`, `brew:jq`); they are installed whether or not they appear in
 the config. Explicit packages and `--manager` scope the run to packages
 only.
 
@@ -26,10 +26,11 @@ Packages in `manager:package` form; defaults to everything configured in [bootst
 
 ### `-m --manager <MANAGER>`
 
-Only install packages for this manager, e.g. `apt`, `brew`, `brew-cask`, or `mas`
+Only install packages for this manager, e.g. `apk`, `apt`, `brew`, `brew-cask`, or `mas`
 
 **Choices:**
 
+- `apk`
 - `apt`
 - `brew`
 - `brew-cask`
@@ -47,13 +48,13 @@ Skip the confirmation prompt
 
 ### `--update`
 
-Refresh package manager metadata first (apt: `apt-get update`)
+Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)
 
 Examples:
 
 ```
 mise bootstrap packages install
-mise bootstrap packages install apt:curl brew:jq brew-cask:firefox mas:497799835
+mise bootstrap packages install apk:zlib-dev apt:curl brew:jq brew-cask:firefox mas:497799835
 mise bootstrap packages install --dry-run
 mise bootstrap packages install --manager apt --yes
 ```

--- a/docs/cli/bootstrap/packages/upgrade.md
+++ b/docs/cli/bootstrap/packages/upgrade.md
@@ -8,8 +8,8 @@
 Upgrade installed bootstrap packages from `[bootstrap.packages]`
 
 Refreshes package manager metadata and upgrades the configured packages
-that are already installed: apt/dnf/pacman upgrade to the newest available
-version (apt and dnf honor a version pinned in config), brew pours the
+that are already installed: apk/apt/dnf/pacman upgrade to the newest available
+version (apk, apt, and dnf honor a version pinned in config), brew pours the
 formula's current bottle and replaces the old keg, brew-cask installs
 the current cask artifact, and mas upgrades App Store apps. Packages that
 are not installed yet are skipped — use `mise bootstrap packages install`
@@ -27,10 +27,11 @@ Packages in `manager:package` form; defaults to everything configured in [bootst
 
 ### `-m --manager <MANAGER>`
 
-Only upgrade packages for this manager, e.g. `apt`, `brew`, `brew-cask`, or `mas`
+Only upgrade packages for this manager, e.g. `apk`, `apt`, `brew`, `brew-cask`, or `mas`
 
 **Choices:**
 
+- `apk`
 - `apt`
 - `brew`
 - `brew-cask`

--- a/docs/cli/bootstrap/packages/use.md
+++ b/docs/cli/bootstrap/packages/use.md
@@ -48,7 +48,7 @@ Skip the confirmation prompt
 Examples:
 
 ```
-mise bootstrap packages use apt:curl brew:jq brew-cask:firefox mas:497799835
+mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox mas:497799835
 mise bootstrap packages use -g brew:postgresql@17
 mise bootstrap packages use apt:curl@8.5.0-2
 ```

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -83,7 +83,8 @@ defaults, then LaunchAgents, then login shell, then tools, then a
 `bootstrap` task if you define one:
 
 ```toml
-[bootstrap.packages]                      # OS packages (apt/dnf/pacman/brew)
+[bootstrap.packages]                      # OS packages (apk/apt/dnf/pacman/brew)
+"apk:build-base" = "latest"
 "apt:build-essential" = "latest"
 "brew:postgresql@17" = "latest"
 

--- a/e2e/cli/test_system_install_apk
+++ b/e2e/cli/test_system_install_apk
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+if [[ "$(uname)" != "Linux" ]] || ! command -v apk >/dev/null || [[ "$(id -u)" != 0 ]]; then
+  exit 0
+fi
+
+cat <<EOF >mise.toml
+[bootstrap.packages]
+"apk:bc" = "latest"
+EOF
+
+apk del bc >/dev/null 2>&1 || true
+
+assert_contains "mise bootstrap packages status" "missing"
+assert_fail "mise bootstrap packages status --missing"
+
+assert_contains "mise bootstrap packages install --dry-run" "apk add -- bc"
+assert_contains "mise bootstrap packages install apk:bc --dry-run" "apk add -- bc"
+
+mise bootstrap packages install --yes
+assert_contains "mise bootstrap packages status" "installed"
+assert_succeed "mise bootstrap packages status --missing"
+
+assert_contains "mise bootstrap packages install --yes 2>&1" "already installed"
+
+assert_contains "mise bootstrap packages upgrade --dry-run" "apk upgrade --available --update-cache -- bc"
+
+apk del bc >/dev/null 2>&1 || true
+assert_succeed "mise bootstrap packages use --yes apk:bc"
+assert_contains "cat mise.toml" '"apk:bc" = "latest"'
+assert_contains "mise bootstrap packages status" "installed"

--- a/e2e/cli/test_system_status
+++ b/e2e/cli/test_system_status
@@ -3,6 +3,7 @@
 cat <<EOF >mise.toml
 [bootstrap.packages]
 "apt:bc" = "latest"
+"apk:bc" = "latest"
 "brew:jq" = "latest"
 "dnf:bc" = "latest"
 "mas:497799835" = "latest"
@@ -14,7 +15,11 @@ assert_succeed "mise bootstrap packages status"
 assert_contains "mise bootstrap packages status" "bc"
 assert_contains "mise bootstrap packages status" "497799835"
 assert_contains "mise bootstrap packages status --json" '"apt"'
+assert_contains "mise bootstrap packages status --json" '"apk"'
 assert_contains "mise bootstrap packages status --json" '"mas"'
+if ! command -v apk >/dev/null; then
+  assert_fail_contains "mise bootstrap packages install --manager apk --dry-run --yes" "apk is not available"
+fi
 if [[ "$(uname)" == "Darwin" ]] && command -v mas >/dev/null; then
   assert_succeed "mise bootstrap packages install --manager mas --dry-run --yes"
 else

--- a/e2e/cli/test_system_use
+++ b/e2e/cli/test_system_use
@@ -7,10 +7,12 @@
 
 # dry-run prints what would be written without creating the file
 assert_contains "mise bootstrap packages use --dry-run apt:zlib1g-dev" '"apt:zlib1g-dev" = "latest"'
+assert_contains "mise bootstrap packages use --dry-run apk:zlib-dev" '"apk:zlib-dev" = "latest"'
 assert_fail "cat mise.toml"
 
 # version pins use @, like mise use
 assert_contains "mise bootstrap packages use --dry-run apt:curl@8.5.0-2" '"apt:curl" = "8.5.0-2"'
+assert_contains "mise bootstrap packages use --dry-run apk:zlib-dev@1.3.1-r2" '"apk:zlib-dev" = "1.3.1-r2"'
 
 # mas uses numeric ADAM IDs
 assert_contains "mise bootstrap packages use --dry-run mas:497799835" '"mas:497799835" = "latest"'

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -841,7 +841,7 @@ Skip confirmation prompts
 Overwrite existing files that conflict with whole\-file dotfile entries
 .TP
 \fB\-\-update\fR
-Refresh system package manager metadata first (apt: `apt\-get update`)
+Refresh system package manager metadata first (apk: `\-\-update\-cache`, apt: `apt\-get update`)
 .SH "MISE BOOTSTRAP LAUNCHD APPLY"
 \fBUsage:\fR mise bootstrap launchd apply [OPTIONS]
 .PP
@@ -939,7 +939,7 @@ system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting).
 
 Packages can also be given explicitly in `manager:package` form (e.g.
-`apt:curl`, `brew:jq`); they are installed whether or not they appear in
+`apk:zlib\-dev`, `apt:curl`, `brew:jq`); they are installed whether or not they appear in
 the config. Explicit packages and `\-\-manager` scope the run to packages
 only.
 .PP
@@ -949,7 +949,7 @@ only.
 .PP
 .TP
 \fB\-m, \-\-manager\fR \fI<MANAGER>\fR
-Only install packages for this manager, e.g. `apt`, `brew`, `brew\-cask`, or `mas`
+Only install packages for this manager, e.g. `apk`, `apt`, `brew`, `brew\-cask`, or `mas`
 .TP
 \fB\-n, \-\-dry\-run\fR
 Print the commands that would run without running them
@@ -958,7 +958,7 @@ Print the commands that would run without running them
 Skip the confirmation prompt
 .TP
 \fB\-\-update\fR
-Refresh package manager metadata first (apt: `apt\-get update`)
+Refresh package manager metadata first (apk: `\-\-update\-cache`, apt: `apt\-get update`)
 \fBArguments:\fR
 .PP
 .TP
@@ -981,8 +981,8 @@ Exit with code 1 if any configured packages are not in their desired state
 Upgrade installed bootstrap packages from `[bootstrap.packages]`
 
 Refreshes package manager metadata and upgrades the configured packages
-that are already installed: apt/dnf/pacman upgrade to the newest available
-version (apt and dnf honor a version pinned in config), brew pours the
+that are already installed: apk/apt/dnf/pacman upgrade to the newest available
+version (apk, apt, and dnf honor a version pinned in config), brew pours the
 formula's current bottle and replaces the old keg, brew\-cask installs
 the current cask artifact, and mas upgrades App Store apps. Packages that
 are not installed yet are skipped — use `mise bootstrap packages install`
@@ -996,7 +996,7 @@ Packages can also be given explicitly in `manager:package` form.
 .PP
 .TP
 \fB\-m, \-\-manager\fR \fI<MANAGER>\fR
-Only upgrade packages for this manager, e.g. `apt`, `brew`, `brew\-cask`, or `mas`
+Only upgrade packages for this manager, e.g. `apk`, `apt`, `brew`, `brew\-cask`, or `mas`
 .TP
 \fB\-n, \-\-dry\-run\fR
 Print the commands that would run without running them

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -327,7 +327,7 @@ Examples:
     flag "-n --dry-run" help="Print what would happen without installing anything"
     flag "-y --yes" help="Skip confirmation prompts"
     flag --force-dotfiles help="Overwrite existing files that conflict with whole-file dotfile entries"
-    flag --update help="Refresh system package manager metadata first (apt: `apt-get update`)"
+    flag --update help="Refresh system package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)"
     cmd launchd subcommand_required=#true help="Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`" {
         cmd apply {
             flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -398,7 +398,7 @@ system package manager. This may elevate with sudo when not running as
 root (see the `system_packages.sudo` setting).
 
 Packages can also be given explicitly in `manager:package` form (e.g.
-`apt:curl`, `brew:jq`); they are installed whether or not they appear in
+`apk:zlib-dev`, `apt:curl`, `brew:jq`); they are installed whether or not they appear in
 the config. Explicit packages and `--manager` scope the run to packages
 only.
 """#
@@ -406,19 +406,19 @@ only.
 Examples:
 
     $ mise bootstrap packages install
-    $ mise bootstrap packages install apt:curl brew:jq brew-cask:firefox mas:497799835
+    $ mise bootstrap packages install apk:zlib-dev apt:curl brew:jq brew-cask:firefox mas:497799835
     $ mise bootstrap packages install --dry-run
     $ mise bootstrap packages install --manager apt --yes
 
 """#
-            flag "-m --manager" help="Only install packages for this manager, e.g. `apt`, `brew`, `brew-cask`, or `mas`" {
+            flag "-m --manager" help="Only install packages for this manager, e.g. `apk`, `apt`, `brew`, `brew-cask`, or `mas`" {
                 arg <MANAGER> {
-                    choices apt brew brew-cask dnf mas pacman
+                    choices apk apt brew brew-cask dnf mas pacman
                 }
             }
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-y --yes" help="Skip the confirmation prompt"
-            flag --update help="Refresh package manager metadata first (apt: `apt-get update`)"
+            flag --update help="Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)"
             arg "[PACKAGE]…" help="Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]" required=#false var=#true
         }
         cmd status help="Show the status of system packages from `[bootstrap.packages]`" {
@@ -440,8 +440,8 @@ Examples:
 Upgrade installed bootstrap packages from `[bootstrap.packages]`
 
 Refreshes package manager metadata and upgrades the configured packages
-that are already installed: apt/dnf/pacman upgrade to the newest available
-version (apt and dnf honor a version pinned in config), brew pours the
+that are already installed: apk/apt/dnf/pacman upgrade to the newest available
+version (apk, apt, and dnf honor a version pinned in config), brew pours the
 formula's current bottle and replaces the old keg, brew-cask installs
 the current cask artifact, and mas upgrades App Store apps. Packages that
 are not installed yet are skipped — use `mise bootstrap packages install`
@@ -460,9 +460,9 @@ Examples:
     $ mise bootstrap packages upgrade --dry-run
 
 """#
-            flag "-m --manager" help="Only upgrade packages for this manager, e.g. `apt`, `brew`, `brew-cask`, or `mas`" {
+            flag "-m --manager" help="Only upgrade packages for this manager, e.g. `apk`, `apt`, `brew`, `brew-cask`, or `mas`" {
                 arg <MANAGER> {
-                    choices apt brew brew-cask dnf mas pacman
+                    choices apk apt brew brew-cask dnf mas pacman
                 }
             }
             flag "-n --dry-run" help="Print the commands that would run without running them"
@@ -487,7 +487,7 @@ a mise version selector. mas uses numeric ADAM IDs and does not support pins.
             after_long_help #"""
 Examples:
 
-    $ mise bootstrap packages use apt:curl brew:jq brew-cask:firefox mas:497799835
+    $ mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox mas:497799835
     $ mise bootstrap packages use -g brew:postgresql@17
     $ mise bootstrap packages use apt:curl@8.5.0-2
 

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -66,7 +66,7 @@ pub struct Bootstrap {
     #[clap(long)]
     force_dotfiles: bool,
 
-    /// Refresh system package manager metadata first (apt: `apt-get update`)
+    /// Refresh system package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)
     #[clap(long)]
     update: bool,
 }

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -11,7 +11,7 @@ use crate::system;
 /// root (see the `system_packages.sudo` setting).
 ///
 /// Packages can also be given explicitly in `manager:package` form (e.g.
-/// `apt:curl`, `brew:jq`); they are installed whether or not they appear in
+/// `apk:zlib-dev`, `apt:curl`, `brew:jq`); they are installed whether or not they appear in
 /// the config. Explicit packages and `--manager` scope the run to packages
 /// only.
 #[derive(Debug, clap::Args)]
@@ -22,8 +22,8 @@ pub struct SystemInstall {
     #[clap(value_name = "PACKAGE")]
     packages: Vec<String>,
 
-    /// Only install packages for this manager, e.g. `apt`, `brew`, `brew-cask`, or `mas`
-    #[clap(long, short, value_parser = ["apt", "brew", "brew-cask", "dnf", "mas", "pacman"])]
+    /// Only install packages for this manager, e.g. `apk`, `apt`, `brew`, `brew-cask`, or `mas`
+    #[clap(long, short, value_parser = ["apk", "apt", "brew", "brew-cask", "dnf", "mas", "pacman"])]
     manager: Option<String>,
 
     /// Print the commands that would run without running them
@@ -34,7 +34,7 @@ pub struct SystemInstall {
     #[clap(long, short)]
     yes: bool,
 
-    /// Refresh package manager metadata first (apt: `apt-get update`)
+    /// Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)
     #[clap(long)]
     update: bool,
 }
@@ -238,7 +238,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
     $ <bold>mise bootstrap packages install</bold>
-    $ <bold>mise bootstrap packages install apt:curl brew:jq brew-cask:firefox mas:497799835</bold>
+    $ <bold>mise bootstrap packages install apk:zlib-dev apt:curl brew:jq brew-cask:firefox mas:497799835</bold>
     $ <bold>mise bootstrap packages install --dry-run</bold>
     $ <bold>mise bootstrap packages install --manager apt --yes</bold>
 "#

--- a/src/cli/system/upgrade.rs
+++ b/src/cli/system/upgrade.rs
@@ -7,8 +7,8 @@ use crate::system;
 /// Upgrade installed bootstrap packages from `[bootstrap.packages]`
 ///
 /// Refreshes package manager metadata and upgrades the configured packages
-/// that are already installed: apt/dnf/pacman upgrade to the newest available
-/// version (apt and dnf honor a version pinned in config), brew pours the
+/// that are already installed: apk/apt/dnf/pacman upgrade to the newest available
+/// version (apk, apt, and dnf honor a version pinned in config), brew pours the
 /// formula's current bottle and replaces the old keg, brew-cask installs
 /// the current cask artifact, and mas upgrades App Store apps. Packages that
 /// are not installed yet are skipped — use `mise bootstrap packages install`
@@ -23,8 +23,8 @@ pub struct SystemUpgrade {
     #[clap(value_name = "PACKAGE")]
     packages: Vec<String>,
 
-    /// Only upgrade packages for this manager, e.g. `apt`, `brew`, `brew-cask`, or `mas`
-    #[clap(long, short, value_parser = ["apt", "brew", "brew-cask", "dnf", "mas", "pacman"])]
+    /// Only upgrade packages for this manager, e.g. `apk`, `apt`, `brew`, `brew-cask`, or `mas`
+    #[clap(long, short, value_parser = ["apk", "apt", "brew", "brew-cask", "dnf", "mas", "pacman"])]
     manager: Option<String>,
 
     /// Print the commands that would run without running them

--- a/src/cli/system/use.rs
+++ b/src/cli/system/use.rs
@@ -141,7 +141,7 @@ impl SystemUse {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    $ <bold>mise bootstrap packages use apt:curl brew:jq brew-cask:firefox mas:497799835</bold>
+    $ <bold>mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox mas:497799835</bold>
     $ <bold>mise bootstrap packages use -g brew:postgresql@17</bold>
     $ <bold>mise bootstrap packages use apt:curl@8.5.0-2</bold>
 "#

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -961,6 +961,11 @@ mod tests {
         let (_, req) = parse_use_spec("dnf:bash@latest").unwrap();
         assert_eq!(req.version, None);
 
+        let (mgr, req) = parse_use_spec("apk:zlib-dev@1.3.1-r2").unwrap();
+        assert_eq!(mgr, "apk");
+        assert_eq!(req.name, "zlib-dev");
+        assert_eq!(req.version.as_deref(), Some("1.3.1-r2"));
+
         // apt arch qualifiers stay in the name
         let (_, req) = parse_use_spec("apt:gcc:arm64@13.2").unwrap();
         assert_eq!(req.name, "gcc:arm64");

--- a/src/system/packages/apk.rs
+++ b/src/system/packages/apk.rs
@@ -1,0 +1,172 @@
+use std::process::Stdio;
+
+use async_trait::async_trait;
+use eyre::bail;
+
+use super::{InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager};
+use crate::result::Result;
+use crate::system::sudo;
+
+/// Alpine Linux via apk
+pub struct ApkManager {}
+
+impl ApkManager {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+fn parse_apk_info(output: &str, requests: &[PackageRequest]) -> Vec<PackageStatus> {
+    requests
+        .iter()
+        .map(|req| {
+            let prefix = format!("{}-", req.name);
+            let version = output.lines().find_map(|line| {
+                line.strip_prefix(&prefix)
+                    .filter(|version| version.starts_with(|c: char| c.is_ascii_digit()))
+                    .map(str::to_string)
+            });
+            let state = match version {
+                Some(installed) => match &req.version {
+                    Some(requested) if requested != &installed => {
+                        PackageState::VersionMismatch { installed }
+                    }
+                    _ => PackageState::Installed { version: installed },
+                },
+                None => PackageState::Missing,
+            };
+            PackageStatus {
+                request: req.clone(),
+                state,
+            }
+        })
+        .collect()
+}
+
+fn apk_name(req: &PackageRequest) -> String {
+    match &req.version {
+        Some(version) => format!("{}={version}", req.name),
+        None => req.name.clone(),
+    }
+}
+
+#[async_trait(?Send)]
+impl SystemPackageManager for ApkManager {
+    fn name(&self) -> &'static str {
+        "apk"
+    }
+
+    fn is_available(&self) -> bool {
+        cfg!(target_os = "linux") && crate::file::which("apk").is_some()
+    }
+
+    fn unavailable_reason(&self) -> String {
+        if cfg!(target_os = "linux") {
+            "apk not found".to_string()
+        } else {
+            "only available on linux".to_string()
+        }
+    }
+
+    async fn installed(&self, pkgs: &[PackageRequest]) -> Result<Vec<PackageStatus>> {
+        if pkgs.is_empty() {
+            return Ok(vec![]);
+        }
+        let mut args = vec!["info".to_string(), "-e".to_string(), "-v".to_string()];
+        args.extend(pkgs.iter().map(|p| p.name.clone()));
+        debug!("$ apk {}", args.join(" "));
+        let output = tokio::process::Command::new("apk")
+            .args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await?;
+        // apk info exits nonzero when any named package is not installed, but
+        // still prints installed package versions. Treat unexpected stderr as
+        // real apk failure instead of silently reporting everything missing.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !output.status.success()
+            && !stderr.is_empty()
+            && !stderr
+                .lines()
+                .all(|l| l.trim().is_empty() || l.contains("not found"))
+        {
+            bail!("apk info failed: {}", stderr.trim());
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(parse_apk_info(&stdout, pkgs))
+    }
+
+    async fn install(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
+        let mut args = vec!["add".to_string()];
+        if opts.update {
+            args.push("--update-cache".to_string());
+        }
+        args.push("--".to_string());
+        args.extend(pkgs.iter().map(apk_name));
+        if opts.dry_run {
+            miseprintln!("{}", sudo::argv("apk", &args).join(" "));
+            return Ok(());
+        }
+        sudo::run("apk", &args, &[])
+    }
+
+    async fn upgrade(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
+        let mut args = vec!["upgrade".to_string(), "--available".to_string()];
+        args.push("--update-cache".to_string());
+        args.push("--".to_string());
+        args.extend(pkgs.iter().map(apk_name));
+        if opts.dry_run {
+            miseprintln!("{}", sudo::argv("apk", &args).join(" "));
+            return Ok(());
+        }
+        sudo::run("apk", &args, &[])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(name: &str, version: Option<&str>) -> PackageRequest {
+        PackageRequest {
+            name: name.to_string(),
+            version: version.map(str::to_string),
+            tap_url: None,
+        }
+    }
+
+    #[test]
+    fn test_parse_apk_info() {
+        let requests = vec![
+            req("bc", None),
+            req("zlib", None),
+            req("nonexistent", None),
+            req("zlib-dev", Some("1.3.1-r2")),
+            req("curl", Some("8.14.1-r1")),
+        ];
+        let output = "bc-1.08.2-r0\nzlib-dev-1.3.1-r2\ncurl-8.14.1-r0\n";
+        let statuses = parse_apk_info(output, &requests);
+        assert_eq!(
+            statuses[0].state,
+            PackageState::Installed {
+                version: "1.08.2-r0".to_string()
+            }
+        );
+        assert_eq!(statuses[1].state, PackageState::Missing);
+        assert_eq!(statuses[2].state, PackageState::Missing);
+        assert_eq!(
+            statuses[3].state,
+            PackageState::Installed {
+                version: "1.3.1-r2".to_string()
+            }
+        );
+        assert_eq!(
+            statuses[4].state,
+            PackageState::VersionMismatch {
+                installed: "8.14.1-r0".to_string()
+            }
+        );
+    }
+}

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -1,4 +1,4 @@
-//! System package managers (apt, brew, brew-cask, mas) for the `[bootstrap.packages]` config section.
+//! System package managers (apk, apt, brew, brew-cask, mas) for the `[bootstrap.packages]` config section.
 //!
 //! These are machine-global, unversioned packages — deliberately separate from
 //! the `Backend` system, which manages per-project, version-pinned dev tools.
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 
 use crate::result::Result;
 
+pub mod apk;
 pub mod apt;
 #[cfg(unix)]
 pub mod brew;
@@ -64,7 +65,7 @@ pub struct PackageStatus {
 pub struct InstallOpts {
     /// print what would be done without doing it
     pub dry_run: bool,
-    /// apt: force `apt-get update` before installing
+    /// force a package manager metadata refresh before installing
     pub update: bool,
 }
 
@@ -112,6 +113,7 @@ pub trait SystemPackageManager: Send + Sync {
 
 pub fn all_managers() -> Vec<Arc<dyn SystemPackageManager>> {
     vec![
+        Arc::new(apk::ApkManager::new()),
         Arc::new(apt::AptManager::new()),
         #[cfg(unix)]
         Arc::new(brew::BrewManager::new()),

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -867,11 +867,12 @@ const completionSpec: Fig.Spec = {
                 {
                   name: ["-m", "--manager"],
                   description:
-                    "Only install packages for this manager, e.g. `apt`, `brew`, `brew-cask`, or `mas`",
+                    "Only install packages for this manager, e.g. `apk`, `apt`, `brew`, `brew-cask`, or `mas`",
                   isRepeatable: false,
                   args: {
                     name: "manager",
                     suggestions: [
+                      "apk",
                       "apt",
                       "brew",
                       "brew-cask",
@@ -895,7 +896,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--update",
                   description:
-                    "Refresh package manager metadata first (apt: `apt-get update`)",
+                    "Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)",
                   isRepeatable: false,
                 },
               ],
@@ -933,11 +934,12 @@ const completionSpec: Fig.Spec = {
                 {
                   name: ["-m", "--manager"],
                   description:
-                    "Only upgrade packages for this manager, e.g. `apt`, `brew`, `brew-cask`, or `mas`",
+                    "Only upgrade packages for this manager, e.g. `apk`, `apt`, `brew`, `brew-cask`, or `mas`",
                   isRepeatable: false,
                   args: {
                     name: "manager",
                     suggestions: [
+                      "apk",
                       "apt",
                       "brew",
                       "brew-cask",
@@ -1115,7 +1117,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--update",
           description:
-            "Refresh system package manager metadata first (apt: `apt-get update`)",
+            "Refresh system package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)",
           isRepeatable: false,
         },
       ],


### PR DESCRIPTION
## Summary
- Add Alpine `apk` as a bootstrap package manager for `[bootstrap.packages]`
- Support `status`, `install`, `upgrade`, explicit `--manager apk`, and `use` version pins
- Document `apk` bootstrap packages and regenerate CLI usage docs

Closes https://github.com/jdx/mise/discussions/10449

## Testing
- `cargo fmt --check`
- `cargo test system::packages::apk`
- `cargo test system::tests::test_parse_use_spec`
- `mise run render:usage`
- `mise run test:e2e e2e/cli/test_system_status e2e/cli/test_system_use e2e/cli/test_system_install_apk`

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Follows the existing bootstrap package-manager pattern; changes apply only on Linux when `apk` is present and may run elevated `apk` commands during explicit bootstrap installs.
> 
> **Overview**
> Adds **Alpine Linux `apk`** as a bootstrap package manager for `[bootstrap.packages]`, using the `apk:package` key form alongside apt, dnf, pacman, and brew.
> 
> A new `ApkManager` implements status (`apk info -e -v`), install (`apk add`, with optional `--update-cache`), and upgrade (`apk upgrade --available --update-cache`), including version pins via `name=version`. CLI `--manager` choices, `mise bootstrap --update` help, and `packages use` parsing for `apk:…@version` are wired through the same paths as other Linux managers.
> 
> Docs gain a dedicated **apk** page and cross-links; usage/man/fig completions are regenerated. E2E coverage includes Alpine-only install/upgrade/`use` tests plus shared status/use checks when `apk` is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043fe80e3b2234cd71d139450cb85392a65375f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Alpine Linux (`apk`) package manager support for bootstrap packages
  * Allow specifying Alpine packages via `apk:package-name` (including `@version` pinning)
  * Expanded `--manager` and related upgrade/install behavior to cover `apk`
* **Documentation**
  * Updated CLI help, manuals, and guides with `apk` examples and metadata-refresh details
* **Tests**
  * Added/extended Linux e2e coverage for `apk` install, status, upgrade, and use/pinning behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->