### PR TITLE
fix(task): reject bare monorepo task paths

### DIFF
--- a/e2e/tasks/test_task_monorepo_wildcards
+++ b/e2e/tasks/test_task_monorepo_wildcards
@@ -101,6 +101,10 @@ assert_contains "mise run '//projects/backend:*'" "backend build"
 assert_contains "mise run '//projects/backend:*'" "backend test"
 assert_contains "mise run '//projects/backend:*'" "backend deploy"
 
+# Bare monorepo paths should not implicitly run every task. Use :* explicitly.
+assert_fail "mise run '//projects/backend'" "missing task name in monorepo path"
+assert_fail "mise run '//...'" "missing task name in monorepo path"
+
 # Test asterisk with prefix - match tasks starting with test:
 assert_contains "mise run '//projects/frontend:test:*'" "frontend test:unit"
 assert_contains "mise run '//projects/frontend:test:*'" "frontend test:integration"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2107,6 +2107,14 @@ where
         // Split pattern into path and task parts
         // Pattern format: //path/...:task* or //path:task*
         let parts: Vec<&str> = normalized_pat.splitn(2, ':').collect();
+        if pat.starts_with("//") && parts.len() == 1 {
+            bail!(
+                "missing task name in monorepo path '{}', use '{}:<task>' or '{}:*' to run all tasks in that path",
+                pat,
+                pat,
+                pat
+            );
+        }
         let has_explicit_task_glob = parts.len() > 1;
         let (path_pattern, task_pattern) = match parts.as_slice() {
             [path, task] => (*path, *task),


### PR DESCRIPTION
## Summary
- reject absolute monorepo task paths that omit the `:task` portion
- keep explicit all-task execution available via `:*`
- add e2e coverage for `//projects/backend` and `//...`

## Root cause
The monorepo pattern parser treated a path-only target as if the task pattern were `*`, so `mise run //pkg` behaved like `mise run //pkg:*`.

## Validation
- `cargo fmt --check`
- `mise run test:e2e e2e/tasks/test_task_monorepo_wildcards`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to monorepo pattern parsing with clearer errors; explicit `:*` still runs all tasks in a path.
> 
> **Overview**
> **Monorepo `mise run` targets must include a task name.** Absolute paths like `//projects/backend` or `//...` no longer run every task in that path; they fail with a clear error pointing users to `//path:<task>` or `//path:*`.
> 
> Matching logic in `get_matching` now rejects `//` patterns that omit the `:task` segment instead of treating the task part as `*`. E2e tests lock in the new behavior for `//projects/backend` and `//...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f342324a28d8dfc6a48efd5d2049f3cc998daa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monorepo path patterns without explicit task name separators now properly fail with clear error messages, preventing ambiguous matching and guiding users to proper syntax.

* **Tests**
  * Enhanced e2e test coverage for monorepo wildcard patterns with explicit validation that missing task names in path specifications generate appropriate error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->