### PR TITLE
fix(vfox): resolve tools=true env path templates against the dependency toolset

### DIFF
--- a/e2e/backend/test_vfox_install_tools_env_dep
+++ b/e2e/backend/test_vfox_install_tools_env_dep
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# #10282 / follow-up to #10432: a `tools = true` [env] value that references a
+# DEPENDENCY tool's path (e.g. `CLOUDSDK_PYTHON = "{{ tools.python.path }}/..."`)
+# must resolve to the dependency's REAL install path and reach the dependent
+# tool's install hooks during a combined `mise install`.
+#
+# The original fix resolved tools=true env against ctx.ts — the unresolved
+# install toolset — so `build_tools_tera_map` was empty and `{{ tools.<dep>.path }}`
+# rendered "" (gcloud then saw CLOUDSDK_PYTHON=/bin/python3 and failed). Its e2e
+# test only used a STATIC tools=true value, so it never caught this. This test
+# exercises a `{{ tools.<dep>.path }}` value through BOTH a vfox `os.execute`
+# install hook AND a tool-level `postinstall` hook, using the hermetic `dummy`
+# plugin as the dependency (clean short name + a real install dir).
+
+PLUGIN_DIR="$PWD/vfox-tools-env-dep"
+INSTALL_MARKER="$PWD/tools-env-install-marker"
+POSTINSTALL_MARKER="$PWD/tools-env-postinstall-marker"
+
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
+PLUGIN = {}
+PLUGIN.name = "tools-env-dep"
+PLUGIN.version = "0.1.0"
+PLUGIN.homepage = "https://example.com/tools-env-dep"
+PLUGIN.license = "MIT"
+PLUGIN.description = "tools=true dependency-path env test plugin"
+LUA
+
+cat >"$PLUGIN_DIR/hooks/available.lua" <<'LUA'
+function PLUGIN:Available(ctx)
+	return {
+		{ version = "1.0.0" },
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/pre_install.lua" <<'LUA'
+function PLUGIN:PreInstall(ctx)
+	return {
+		version = ctx.version,
+	}
+end
+LUA
+
+# PostInstall shells out via os.execute (NOT cmd.exec) to capture the tools=true
+# env value, mirroring how vfox-gcloud runs its install.sh.
+cat >"$PLUGIN_DIR/hooks/post_install.lua" <<LUA
+function PLUGIN:PostInstall(ctx)
+	os.execute("printf '%s' \"\$MISE_TEST_TOOLS_PATH\" > \"$INSTALL_MARKER\"")
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/env_keys.lua" <<'LUA'
+function PLUGIN:EnvKeys(ctx)
+	return {}
+end
+LUA
+
+git -C "$PLUGIN_DIR" init
+git -C "$PLUGIN_DIR" add .
+git -C "$PLUGIN_DIR" -c user.name="mise" -c user.email="mise@example.com" commit -m "initial plugin"
+
+# The vfox tool depends on `dummy`; the tools=true [env] value references the
+# dependency's resolved path. The tool-level `postinstall` writes the same value
+# to a second marker.
+cat >mise.toml <<EOF
+[settings]
+unix_default_inline_shell_args = "sh -c"
+
+[tools]
+dummy = "1.0.0"
+"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", depends = ["dummy"], postinstall = "printf '%s' \"\$MISE_TEST_TOOLS_PATH\" > \"$POSTINSTALL_MARKER\"" }
+
+[env]
+MISE_TEST_TOOLS_PATH = { value = "{{ tools.dummy.path | default(value='') }}", tools = true }
+EOF
+
+mise install
+
+DUMMY_PATH="$(mise where dummy)"
+
+# vfox os.execute install hook saw the resolved dependency path (Step 1)
+assert "cat '$INSTALL_MARKER'" "$DUMMY_PATH"
+# tool-level postinstall hook saw the resolved dependency path (Step 2)
+assert "cat '$POSTINSTALL_MARKER'" "$DUMMY_PATH"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2029,6 +2029,57 @@ pub trait Backend: Debug + Send + Sync {
         }
         env_vars.extend(tv.request.options().core.install_env);
 
+        // Surface `tools = true` `[env]` *value* directives (e.g. `CLOUDSDK_PYTHON =
+        // "{{ tools.python.path }}/bin/python3"`) for the tool-level `postinstall`
+        // hook, resolved against this tool's already-installed dependencies. The
+        // config env added above is resolved without tools (`NonToolsOnly`), so it
+        // omits these; `install_value_toolset` is fully resolved (offline) so
+        // `{{ tools.<dep>.path }}` maps to a real install path — `ctx.ts` is the raw,
+        // unresolved install toolset during a combined install. PATH stays owned by
+        // `path_env` below. Best-effort: any resolution error leaves the tool-less
+        // env untouched.
+        //
+        // Gated on the tool declaring dependencies. Only a `tools = true` value that
+        // can reference a dependency (installed first, by depends ordering) is
+        // meaningful at this tool's install time. Tools with NO dependencies keep the
+        // prior contract — `tools = true` env stays unavailable in `postinstall`
+        // (#6418, e2e/config/test_hooks_postinstall_env) — since a *static*
+        // `tools = true` value (no `{{ tools.* }}` reference) would otherwise leak in.
+        // (#10282, follow-up to #10432)
+        let declares_deps = self
+            .get_all_dependencies(true)
+            .map(|deps| !deps.is_empty())
+            .unwrap_or(false)
+            || tv_exact
+                .request
+                .options()
+                .core
+                .depends
+                .is_some_and(|deps| !deps.is_empty());
+        if declares_deps {
+            let base = env_vars.clone();
+            let tool_vals = match self.install_value_toolset(&ctx.config, &tv_exact).await {
+                Ok(dep_ts) => dep_ts.tool_val_env(&ctx.config, &base).await,
+                Err(e) => Err(e),
+            };
+            match tool_vals {
+                Ok(vals) => {
+                    for (k, v) in vals {
+                        // PATH is owned by path_env; exclude any casing on Windows.
+                        let is_path = if cfg!(windows) {
+                            k.eq_ignore_ascii_case(env::PATH_KEY.as_str())
+                        } else {
+                            k.as_str() == env::PATH_KEY.as_str()
+                        };
+                        if !is_path {
+                            env_vars.insert(k, v);
+                        }
+                    }
+                }
+                Err(e) => debug!("postinstall: skipping tools=true value directives: {e:#}"),
+            }
+        }
+
         // Use the backend's list_bin_paths to get the correct binary directories
         // instead of hardcoding install_path/bin, which may not match the actual
         // binary location for backends like aqua.
@@ -2255,6 +2306,43 @@ pub trait Backend: Debug + Send + Sync {
         // Dependency envs only need PATH entries for tools that are already
         // available. Resolving offline avoids applying global release-age
         // cutoffs to helper tools like node/npm while querying another backend.
+        ts.resolve_with_opts(
+            config,
+            &ResolveOptions {
+                offline: true,
+                ..Default::default()
+            },
+        )
+        .await?;
+        Ok(ts)
+    }
+
+    /// Like [`Self::dependency_toolset`] but also includes this tool's per-instance
+    /// mise.toml `depends` option (`tv.request.options().depends`). `get_dependencies`
+    /// only covers backend/plugin-metadata deps, so a user-declared
+    /// `gcloud = { depends = ["python"] }` is invisible to `dependency_toolset`. Used
+    /// to resolve `tools = true` `[env]` value templates like `{{ tools.python.path }}`
+    /// at install time. Resolved offline; the declared deps are installed before the
+    /// dependent (depends ordering), so their install paths are present. (#10282)
+    async fn install_value_toolset(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+    ) -> eyre::Result<Toolset> {
+        let mut names: std::collections::HashSet<String> = self
+            .get_all_dependencies(true)?
+            .into_iter()
+            .map(|ba| ba.short)
+            .collect();
+        let opts = tv.request.options();
+        if let Some(user_deps) = opts.core.depends {
+            names.extend(user_deps);
+        }
+        let mut ts: Toolset = config
+            .get_tool_request_set()
+            .await?
+            .filter_by_tool(names)
+            .into();
         ts.resolve_with_opts(
             config,
             &ResolveOptions {

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -148,18 +148,29 @@ impl Backend for VfoxBackend {
             .collect();
         cmd_env.extend(tv.install_env());
         // Surface `tools = true` `[env]` *value* directives (e.g.
-        // `CLOUDSDK_PYTHON = "{{ tools.python.path }}/bin/python3"`) resolved against
-        // the install toolset, which already has the dependency installed (depends
-        // ordering). Without this, a combined `mise install` would run the plugin's
-        // install hooks (including os.execute) without the resolved value, unlike the
-        // separate-install case where a re-activated shell re-exports it. Uses ctx.ts
-        // — NOT config.get_toolset(), which would re-enter the toolset OnceCell from
-        // backends' version listing and deadlock. Best-effort: env *modules* are
-        // excluded via ToolsFilter::ToolsOnlyVals, errors fall back to the tool-less
-        // env, and PATH is left to dependency_env. (#10282)
+        // `CLOUDSDK_PYTHON = "{{ tools.python.path }}/bin/python3"`) so the plugin's
+        // install hooks (including os.execute) see the resolved value during a
+        // combined `mise install`, mirroring the separate-install case where a
+        // re-activated shell re-exports it.
+        //
+        // Resolve against a fully-resolved toolset of this tool's dependencies, NOT
+        // ctx.ts: ctx.ts is the raw install toolset (`Toolset::from(ToolRequestSet)`)
+        // whose `.versions` are empty until `resolve()` runs *after* installs, so its
+        // `tools.*` tera map is empty and `{{ tools.python.path }}` would render "".
+        // `install_value_toolset` is resolved offline and includes both backend deps
+        // and the per-tool mise.toml `depends` option (`gcloud = { depends =
+        // ["python"] }`) with real install paths, and is install-safe (it uses
+        // `get_tool_request_set()`, not the deadlock-prone `config.get_toolset()`).
+        // Best-effort: env *modules* are excluded via `ToolsFilter::ToolsOnlyVals`,
+        // any resolution error falls back to the tool-less env, and PATH is left to
+        // `dependency_env`. (#10282, follow-up to #10432)
         {
             let base: EnvMap = cmd_env.clone().into_iter().collect();
-            match ctx.ts.tool_val_env(&ctx.config, &base).await {
+            let tool_vals = match self.install_value_toolset(&ctx.config, &tv).await {
+                Ok(dep_ts) => dep_ts.tool_val_env(&ctx.config, &base).await,
+                Err(e) => Err(e),
+            };
+            match tool_vals {
                 Ok(vals) => {
                     for (k, v) in vals {
                         // PATH stays owned by dependency_env. On Windows env var


### PR DESCRIPTION
## Summary

Follow-up to #10432 (discussion #10282). gcloud (vfox) reads `CLOUDSDK_PYTHON` in its `install.sh`; the value is a `tools = true` `[env]` directive that references a dependency tool:

```toml
python = "3.13"
gcloud = { version = "latest", depends = ["python"] }

[env]
CLOUDSDK_PYTHON = { value = "{{ tools.python.path }}/bin/python3", tools = true }
```

#10432 resolved `tools = true` values against `ctx.ts` — the **raw, unresolved** install toolset (`Toolset::from(ToolRequestSet)` populates only `.requests`; `resolve()` runs *after* installs). So `build_tools_tera_map(ctx.ts)` was empty, `{{ tools.python.path }}` rendered `""`, and gcloud saw `CLOUDSDK_PYTHON=/bin/python3` → `install.sh: 218: /bin/python3: not found`. #10432's e2e test only used a *static* `tools=true` value, so it never exercised `{{ tools.<dep>.path }}`.

## Fix

New `Backend::install_value_toolset(config, tv)` builds a **fully-resolved** (offline) toolset of this tool's dependencies — both backend/plugin-metadata deps **and** the per-tool `depends` option (`gcloud = { depends = ["python"] }`), which `dependency_toolset` misses. It is install-safe (uses `get_tool_request_set()`, not the deadlock-prone `config.get_toolset()`).

- **`src/backend/vfox.rs`** (`install_version_`): resolve `tools = true` value directives against `install_value_toolset` and inject them into `vfox.cmd_env`, so the plugin's install hooks (including `os.execute`, which runs gcloud's `install.sh`) see the resolved value. PATH excluded (case-insensitively on Windows); best-effort fallback preserved. **Unconditional** — preserves #10432's contract that even a *static* `tools = true` value reaches a vfox install hook (`backend/test_vfox_install_tools_env`).

- **`src/backend/mod.rs`** (`run_postinstall_hook`): inject the same dependency-resolved `tools = true` values into the tool-level `postinstall` hook env (which `ctx.config.env_maybe()` omits, being `NonToolsOnly`), so `postinstall = '$CLOUDSDK_PYTHON --version'`-style hooks also see them. **Gated on the tool declaring dependencies**: only a `tools = true` value that can reference an already-installed dependency (depends ordering guarantees it) is meaningful at this tool's install time. Tools with **no** dependencies keep the prior contract — `tools = true` env stays unavailable in `postinstall` (#6418, `config/test_hooks_postinstall_env`) — because a *static* `tools = true` value (no `{{ tools.* }}` reference) would otherwise leak in.

> The gate is the fix for the previous revision's CI failure: the earlier unconditional injection surfaced the static `POST_TOOLS_VAR` into `postinstall` and broke `config/test_hooks_postinstall_env`.

## Tests

- `backend/test_vfox_install_tools_env_dep` (new): a `tools = true` value referencing a dependency's `{{ tools.<dep>.path }}` must reach **both** a vfox `os.execute` install hook **and** a tool-level `postinstall` hook. Uses the hermetic `dummy` plugin as the dependency (declared via `depends`).
- `config/test_hooks_postinstall_env` (existing, #6418): unchanged and green — `dummy` declares no deps, so its static `tools = true` `POST_TOOLS_VAR` stays out of `postinstall`.
- `backend/test_vfox_install_tools_env` (existing, #10432): unchanged and green — static `tools = true` still reaches the vfox install hook.

**Known, out of scope:** a vfox `post_install` *script* that embeds `{{ tools.<dep>.path }}` directly (not via an `[env]` directive) still renders empty, because the script tera render uses `ctx.ts.tera_ctx` (the same unresolved toolset). The `$VAR`/`[env]` path above is what the report needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable resolution when tools declare dependencies. Dependency paths are now properly resolved and available within environment variables during tool installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->