### PR TITLE
fix(sigstore): retry transient GitHub attestation API failures

### DIFF
--- a/crates/mise-sigstore/Cargo.toml
+++ b/crates/mise-sigstore/Cargo.toml
@@ -23,7 +23,7 @@ sha2 = "0.11"
 sigstore-verify = { version = "0.8.0", default-features = false }
 snap = "1"
 thiserror = "2"
-tokio = { version = "1", features = ["fs", "io-util"] }
+tokio = { version = "1", features = ["fs", "io-util", "time"] }
 x509-cert = { version = "0.2", default-features = false, features = [
   "std",
   "pem",
@@ -33,6 +33,9 @@ rustls-webpki = { version = "0.103", default-features = false, features = [
   "aws-lc-rs",
 ] }
 rustls-pki-types = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 
 [features]
 default = ["rustls"]

--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -19,15 +19,41 @@ use tokio::io::AsyncReadExt;
 const GITHUB_API_URL: &str = "https://api.github.com";
 const USER_AGENT_VALUE: &str = "mise-sigstore/0.1.0";
 
-/// Per-request timeout for attestation API calls. Without this the client would
-/// wait indefinitely on a stalled connection (reqwest has no default timeout).
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
-/// Total attempts (1 initial + 3 retries) for transient attestation API failures.
-/// GitHub's attestations API intermittently returns 5xx (e.g. 504 Gateway
-/// Timeout) and 429 under load; a single attempt fails the whole install.
-const MAX_ATTEMPTS: usize = 4;
+/// Default per-request timeout for attestation API calls. Without this the
+/// client would wait indefinitely on a stalled connection (reqwest has no
+/// default timeout). Mirrors mise's `http_timeout` default; the embedding crate
+/// overrides it via [`RetryConfig`] to honor `MISE_HTTP_TIMEOUT`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Default number of retries on transient failures. GitHub's attestations API
+/// intermittently returns 5xx (e.g. 504 Gateway Timeout) and 429 under load; a
+/// single attempt fails the whole install. Mirrors mise's `http_retries`
+/// default; the embedding crate overrides it to honor `MISE_HTTP_RETRIES`.
+const DEFAULT_RETRIES: usize = 3;
 /// Default base backoff before the first retry. Doubles each attempt: ~0.5s / 1s / 2s.
 const DEFAULT_BACKOFF_BASE: Duration = Duration::from_millis(500);
+
+/// HTTP retry/timeout policy for the attestation client. Lets the embedding
+/// crate (mise) pass its `http_retries` / `http_timeout` settings through
+/// instead of the attestation path using a hardcoded policy of its own.
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    /// Per-request timeout.
+    pub timeout: Duration,
+    /// Number of retries on transient failures (total attempts = `retries + 1`).
+    pub retries: usize,
+    /// Attempt-1 backoff; doubles each subsequent attempt, with equal jitter.
+    pub backoff_base: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_TIMEOUT,
+            retries: DEFAULT_RETRIES,
+            backoff_base: DEFAULT_BACKOFF_BASE,
+        }
+    }
+}
 /// Upper bound on a server-supplied `Retry-After` wait, so a hostile or buggy
 /// header can't stall an install for minutes.
 const RETRY_AFTER_MAX: Duration = Duration::from_secs(60);
@@ -219,6 +245,7 @@ pub struct AttestationClient {
     client: reqwest::Client,
     base_url: String,
     github_token: Option<String>,
+    max_attempts: usize,
     backoff_base: Duration,
 }
 
@@ -226,6 +253,8 @@ pub struct AttestationClient {
 pub struct AttestationClientBuilder {
     base_url: Option<String>,
     github_token: Option<String>,
+    timeout: Option<Duration>,
+    retries: Option<usize>,
     backoff_base: Option<Duration>,
 }
 
@@ -240,6 +269,19 @@ impl AttestationClientBuilder {
         self
     }
 
+    /// Per-request timeout (defaults to [`DEFAULT_TIMEOUT`]).
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    /// Number of retries on transient failures (defaults to [`DEFAULT_RETRIES`];
+    /// total attempts = `retries + 1`). Set to 0 to disable retries.
+    pub fn retries(mut self, retries: usize) -> Self {
+        self.retries = Some(retries);
+        self
+    }
+
     /// Override the attempt-1 retry backoff (defaults to [`DEFAULT_BACKOFF_BASE`]).
     /// Mainly an injection point for tests, which set it to zero so the suite
     /// doesn't pay real wall-clock backoff between retries.
@@ -248,18 +290,27 @@ impl AttestationClientBuilder {
         self
     }
 
+    /// Apply a full [`RetryConfig`] (timeout + retries + backoff) at once. Used
+    /// by the embedding crate to pass through mise's `http_*` settings.
+    pub fn retry_config(self, config: RetryConfig) -> Self {
+        self.timeout(config.timeout)
+            .retries(config.retries)
+            .backoff_base(config.backoff_base)
+    }
+
     pub fn build(self) -> Result<AttestationClient> {
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
         let client = reqwest::Client::builder()
             .default_headers(headers)
-            .timeout(REQUEST_TIMEOUT)
+            .timeout(self.timeout.unwrap_or(DEFAULT_TIMEOUT))
             .build()?;
 
         Ok(AttestationClient {
             client,
             base_url: self.base_url.unwrap_or_else(|| GITHUB_API_URL.to_string()),
             github_token: self.github_token,
+            max_attempts: self.retries.unwrap_or(DEFAULT_RETRIES) + 1,
             backoff_base: self.backoff_base.unwrap_or(DEFAULT_BACKOFF_BASE),
         })
     }
@@ -349,7 +400,7 @@ impl AttestationClient {
                 .try_clone()
                 .expect("attestation requests must not have a streaming body");
             let result = req.send().await;
-            let last = attempt >= MAX_ATTEMPTS;
+            let last = attempt >= self.max_attempts;
             // Decide the retry delay (if any) while the response is still in hand
             // so we can read its `Retry-After` header before dropping it.
             let delay = match &result {
@@ -441,6 +492,7 @@ pub async fn verify_github_attestation(
     repo: &str,
     token: Option<&str>,
     signer_workflow: Option<&str>,
+    retry_config: RetryConfig,
 ) -> Result<bool> {
     verify_github_attestation_inner(
         artifact_path,
@@ -450,6 +502,7 @@ pub async fn verify_github_attestation(
         signer_workflow,
         None,
         None,
+        retry_config,
     )
     .await
 }
@@ -461,6 +514,7 @@ pub async fn verify_github_attestation_with_base_url(
     token: Option<&str>,
     signer_workflow: Option<&str>,
     base_url: &str,
+    retry_config: RetryConfig,
 ) -> Result<bool> {
     verify_github_attestation_inner(
         artifact_path,
@@ -470,10 +524,12 @@ pub async fn verify_github_attestation_with_base_url(
         signer_workflow,
         Some(base_url),
         None,
+        retry_config,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn verify_github_attestation_with_base_url_and_digest(
     artifact_path: &Path,
     owner: &str,
@@ -482,6 +538,7 @@ pub async fn verify_github_attestation_with_base_url_and_digest(
     signer_workflow: Option<&str>,
     base_url: &str,
     digest: &str,
+    retry_config: RetryConfig,
 ) -> Result<bool> {
     verify_github_attestation_inner(
         artifact_path,
@@ -491,6 +548,7 @@ pub async fn verify_github_attestation_with_base_url_and_digest(
         signer_workflow,
         Some(base_url),
         Some(digest),
+        retry_config,
     )
     .await
 }
@@ -509,6 +567,7 @@ pub async fn verify_github_attestation_with_attestations(
     verify_attestation_bundles(attestations, &artifact, signer_workflow, &mut trust_roots).await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn verify_github_attestation_inner(
     artifact_path: &Path,
     owner: &str,
@@ -517,8 +576,9 @@ async fn verify_github_attestation_inner(
     signer_workflow: Option<&str>,
     base_url: Option<&str>,
     digest: Option<&str>,
+    retry_config: RetryConfig,
 ) -> Result<bool> {
-    let mut builder = AttestationClient::builder();
+    let mut builder = AttestationClient::builder().retry_config(retry_config);
     if let Some(token) = token {
         builder = builder.github_token(token);
     }
@@ -1619,8 +1679,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_attestations_surfaces_error_after_max_attempts() {
-        // Persistent 504 — exhaust MAX_ATTEMPTS then surface the API error.
+    async fn fetch_attestations_surfaces_error_after_exhausting_retries() {
+        // Persistent 504 — exhaust all attempts then surface the API error.
         let (base_url, hits) = flaky_server(vec![504, 504, 504, 504, 504], "");
         let client = test_client(&base_url);
         let err = client
@@ -1637,8 +1697,37 @@ mod tests {
         assert!(matches!(err, AttestationError::Api(_)), "got {err:?}");
         assert_eq!(
             hits.load(std::sync::atomic::Ordering::SeqCst),
-            MAX_ATTEMPTS,
-            "should stop after MAX_ATTEMPTS"
+            DEFAULT_RETRIES + 1,
+            "should stop after retries + 1 attempts"
+        );
+    }
+
+    #[tokio::test]
+    async fn retries_setting_controls_attempt_count() {
+        // retries(0) disables retries: a single 504 surfaces immediately.
+        let (base_url, hits) = flaky_server(vec![504, 504], "");
+        let client = AttestationClient::builder()
+            .base_url(&base_url)
+            .retries(0)
+            .backoff_base(Duration::ZERO)
+            .build()
+            .unwrap();
+        let err = client
+            .fetch_attestations(FetchParams {
+                owner: "EarthBuild".to_string(),
+                repo: Some("EarthBuild/earthbuild".to_string()),
+                digest: "sha256:abc".to_string(),
+                limit: 30,
+                predicate_type: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AttestationError::Api(_)), "got {err:?}");
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "retries(0) should make exactly one attempt"
         );
     }
 

--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -64,11 +64,32 @@ fn is_retryable_status(status: reqwest::StatusCode) -> bool {
     status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
 }
 
-/// Whether a transport-level error warrants a retry. Limited to timeouts and
-/// connection failures, which are transient; broader classes (TLS handshake,
-/// decode, builder errors) won't recover on retry so they surface immediately.
+/// Whether a transport-level error warrants a retry: timeouts, connection
+/// failures, and mid-stream body drops, which are all transient. Broader classes
+/// (TLS handshake, genuine decode errors, builder errors) won't recover on retry
+/// so they surface immediately. Matches the transient classification used by
+/// mise's main HTTP client and vfox.
 fn is_retryable_error(err: &reqwest::Error) -> bool {
-    err.is_timeout() || err.is_connect()
+    err.is_timeout() || err.is_connect() || err.is_body() || is_incomplete_body(err)
+}
+
+/// A buffered body read (`.bytes()`) of a truncated response surfaces as a
+/// `Decode` error wrapping an `io::ErrorKind::UnexpectedEof` (rather than the
+/// `is_body()` kind a streamed read would yield). Detect that specific case so a
+/// connection dropped mid-body is retried, without retrying genuine decode
+/// errors.
+fn is_incomplete_body(err: &reqwest::Error) -> bool {
+    use std::error::Error;
+    let mut source: Option<&(dyn Error + 'static)> = err.source();
+    while let Some(e) = source {
+        if let Some(io_err) = e.downcast_ref::<std::io::Error>()
+            && io_err.kind() == std::io::ErrorKind::UnexpectedEof
+        {
+            return true;
+        }
+        source = e.source();
+    }
+    false
 }
 
 /// Honor a `429`'s `Retry-After` header when present and expressed as
@@ -316,6 +337,15 @@ impl AttestationClientBuilder {
     }
 }
 
+/// A fully-read HTTP response. The body is buffered inside the retry loop so a
+/// transient failure mid-body-read is retried like a failed send, rather than
+/// surfacing after the retry boundary.
+struct HttpResponse {
+    status: reqwest::StatusCode,
+    headers: HeaderMap,
+    body: Vec<u8>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct FetchParams {
     pub owner: String,
@@ -387,39 +417,59 @@ impl AttestationClient {
             .map_err(|e| AttestationError::Api(format!("Invalid GitHub attestations URL: {e}")))
     }
 
-    /// Send a request, retrying transient failures (5xx, 429, timeouts,
-    /// connection errors) with exponential backoff. A `429`'s `Retry-After`
-    /// header is honored in preference to the computed backoff. The request must
-    /// have no streaming body so it can be cloned per attempt — true for all GET
-    /// calls here. Non-transient responses (incl. 4xx like 404) are returned
-    /// as-is for the caller to interpret.
-    async fn send_with_retry(&self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
+    /// Send a request and read its body, retrying transient failures (5xx, 429,
+    /// timeouts, connection errors, and mid-body-read errors) with exponential
+    /// backoff. A `429`'s `Retry-After` header is honored in preference to the
+    /// computed backoff. The body is buffered here so a transient failure during
+    /// the body read is retried too, rather than escaping the retry boundary.
+    ///
+    /// The request must have no streaming body so it can be cloned per attempt —
+    /// true for all GET calls here. Non-transient responses (incl. 4xx like 404)
+    /// are returned as-is for the caller to interpret.
+    async fn send_with_retry(&self, request: reqwest::RequestBuilder) -> Result<HttpResponse> {
         let mut attempt = 1;
         loop {
             let req = request
                 .try_clone()
                 .expect("attestation requests must not have a streaming body");
-            let result = req.send().await;
             let last = attempt >= self.max_attempts;
-            // Decide the retry delay (if any) while the response is still in hand
-            // so we can read its `Retry-After` header before dropping it.
-            let delay = match &result {
-                Ok(response) if !last && is_retryable_status(response.status()) => Some(
-                    retry_after_delay(response.headers())
-                        .unwrap_or_else(|| backoff_delay(self.backoff_base, attempt)),
-                ),
-                Err(err) if !last && is_retryable_error(err) => {
-                    Some(backoff_delay(self.backoff_base, attempt))
+
+            // A labeled block so the `reqwest::Response` is dropped before the
+            // backoff sleep — holding it would pin its body/connection for the
+            // whole delay. Each attempt either returns, errors out, or breaks
+            // with the delay to wait before the next attempt.
+            let delay = 'attempt: {
+                match req.send().await {
+                    Ok(response) => {
+                        let status = response.status();
+                        if !last && is_retryable_status(status) {
+                            break 'attempt retry_after_delay(response.headers())
+                                .unwrap_or_else(|| backoff_delay(self.backoff_base, attempt));
+                        }
+                        let headers = response.headers().clone();
+                        match response.bytes().await {
+                            Ok(body) => {
+                                return Ok(HttpResponse {
+                                    status,
+                                    headers,
+                                    body: body.to_vec(),
+                                });
+                            }
+                            Err(err) if !last && is_retryable_error(&err) => {
+                                break 'attempt backoff_delay(self.backoff_base, attempt);
+                            }
+                            Err(err) => return Err(AttestationError::Http(err)),
+                        }
+                    }
+                    Err(err) if !last && is_retryable_error(&err) => {
+                        break 'attempt backoff_delay(self.backoff_base, attempt);
+                    }
+                    Err(err) => return Err(AttestationError::Http(err)),
                 }
-                _ => None,
             };
-            match delay {
-                Some(delay) => {
-                    tokio::time::sleep(delay).await;
-                    attempt += 1;
-                }
-                None => return result.map_err(AttestationError::Http),
-            }
+
+            tokio::time::sleep(delay).await;
+            attempt += 1;
         }
     }
 
@@ -432,23 +482,20 @@ impl AttestationClient {
             .headers(self.github_headers(url.as_str())?);
         let response = self.send_with_retry(request).await?;
 
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
+        if response.status == reqwest::StatusCode::NOT_FOUND {
             return Ok(vec![]);
         }
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+        if !response.status.is_success() {
+            let body = String::from_utf8_lossy(&response.body);
             return Err(AttestationError::Api(format!(
-                "GitHub API returned {status}: {body}"
+                "GitHub API returned {}: {body}",
+                response.status
             )));
         }
 
-        let response: AttestationsResponse = response.json().await?;
+        let parsed: AttestationsResponse = serde_json::from_slice(&response.body)?;
         let mut attestations = Vec::new();
-        for attestation in response.attestations {
+        for attestation in parsed.attestations {
             if attestation.bundle.is_some() {
                 attestations.push(attestation);
             } else if let Some(bundle_url) = &attestation.bundle_url {
@@ -468,20 +515,19 @@ impl AttestationClient {
             .get(bundle_url)
             .headers(self.github_headers(bundle_url)?);
         let response = self.send_with_retry(request).await?;
-        if !response.status().is_success() {
+        if !response.status.is_success() {
             return Err(AttestationError::Api(format!(
                 "bundle URL returned {}",
-                response.status()
+                response.status
             )));
         }
-        if is_snappy_content_type(&response) {
-            let bytes = response.bytes().await?;
+        if is_snappy_content_type(&response.headers) {
             let decompressed = snap::raw::Decoder::new()
-                .decompress_vec(&bytes)
+                .decompress_vec(&response.body)
                 .map_err(|e| AttestationError::Api(format!("Snappy decompression failed: {e}")))?;
             serde_json::from_slice(&decompressed).map_err(AttestationError::Json)
         } else {
-            response.json().await.map_err(AttestationError::Http)
+            serde_json::from_slice(&response.body).map_err(AttestationError::Json)
         }
     }
 }
@@ -1153,9 +1199,8 @@ async fn verify_attestation_bundles(
     )))
 }
 
-fn is_snappy_content_type(response: &reqwest::Response) -> bool {
-    response
-        .headers()
+fn is_snappy_content_type(headers: &HeaderMap) -> bool {
+    headers
         .get(reqwest::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .and_then(|content_type| content_type.split(';').next())
@@ -1780,6 +1825,72 @@ mod tests {
         );
         // Absent header → no override.
         assert_eq!(retry_after_delay(&headers_with(None)), None);
+    }
+
+    /// Spawn a server whose first connection sends a `200` with a `Content-Length`
+    /// larger than the bytes actually written, then closes — making the body read
+    /// fail mid-stream (a transient `is_body()` error). Later connections serve a
+    /// full `200 {body}`. Returns the `base_url` and a connection counter.
+    fn body_drop_then_ok_server(
+        body: &'static str,
+    ) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        use std::io::{Read, Write};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_thread = hits.clone();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut stream = match stream {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                let n = hits_thread.fetch_add(1, Ordering::SeqCst);
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let response = if n == 0 {
+                    // Promise 1024 bytes, send 4, then drop the connection.
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1024\r\nConnection: close\r\n\r\n{ \"".to_string()
+                } else {
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                };
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        (format!("http://{addr}"), hits)
+    }
+
+    #[tokio::test]
+    async fn fetch_attestations_retries_on_body_read_failure() {
+        // First attempt drops mid-body (transient is_body error); second succeeds.
+        let (base_url, hits) = body_drop_then_ok_server(r#"{"attestations":[]}"#);
+        let client = test_client(&base_url);
+        let result = client
+            .fetch_attestations(FetchParams {
+                owner: "EarthBuild".to_string(),
+                repo: Some("EarthBuild/earthbuild".to_string()),
+                digest: "sha256:abc".to_string(),
+                limit: 30,
+                predicate_type: None,
+            })
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "expected recovery after body-read failure: {result:?}"
+        );
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "should have taken 1 body-drop + 1 successful attempt"
+        );
     }
 
     /// A genuine `*.intoto.jsonl` produced by slsa-github-generator (sops

--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -26,8 +26,11 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// GitHub's attestations API intermittently returns 5xx (e.g. 504 Gateway
 /// Timeout) and 429 under load; a single attempt fails the whole install.
 const MAX_ATTEMPTS: usize = 4;
-/// Base backoff before the first retry. Doubles each attempt: ~0.5s / 1s / 2s.
-const BASE_BACKOFF: Duration = Duration::from_millis(500);
+/// Default base backoff before the first retry. Doubles each attempt: ~0.5s / 1s / 2s.
+const DEFAULT_BACKOFF_BASE: Duration = Duration::from_millis(500);
+/// Upper bound on a server-supplied `Retry-After` wait, so a hostile or buggy
+/// header can't stall an install for minutes.
+const RETRY_AFTER_MAX: Duration = Duration::from_secs(60);
 
 /// Whether an HTTP status warrants a retry. 429 (rate limit) and any 5xx are
 /// transient server-side conditions; everything else (incl. 404) is terminal.
@@ -35,20 +38,32 @@ fn is_retryable_status(status: reqwest::StatusCode) -> bool {
     status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
 }
 
-/// Whether a transport-level error warrants a retry (timeouts, connection
-/// failures, and incomplete requests are transient; decode/builder errors aren't).
+/// Whether a transport-level error warrants a retry. Limited to timeouts and
+/// connection failures, which are transient; broader classes (TLS handshake,
+/// decode, builder errors) won't recover on retry so they surface immediately.
 fn is_retryable_error(err: &reqwest::Error) -> bool {
-    err.is_timeout() || err.is_connect() || err.is_request()
+    err.is_timeout() || err.is_connect()
+}
+
+/// Honor a `429`'s `Retry-After` header when present and expressed as
+/// delta-seconds (GitHub's form). HTTP-date values are ignored and fall back to
+/// exponential backoff. Capped at [`RETRY_AFTER_MAX`].
+fn retry_after_delay(headers: &HeaderMap) -> Option<Duration> {
+    let raw = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
+    let secs: u64 = raw.trim().parse().ok()?;
+    Some(Duration::from_secs(secs).min(RETRY_AFTER_MAX))
 }
 
 /// Backoff delay for the given attempt (1-based) with "equal jitter" in
-/// `[d/2, d)` to avoid synchronized retries across concurrent installs.
-fn backoff_delay(attempt: usize) -> Duration {
+/// `[d/2, d)` to avoid synchronized retries across concurrent installs. `base`
+/// is the attempt-1 delay; it doubles each attempt. A zero base yields no delay
+/// (used by tests to keep the suite fast).
+fn backoff_delay(base: Duration, attempt: usize) -> Duration {
     let exp = (attempt.saturating_sub(1)).min(16) as u32;
-    let base = BASE_BACKOFF.saturating_mul(1u32 << exp);
-    let half = base / 2;
+    let scaled = base.saturating_mul(1u32 << exp);
+    let half = scaled / 2;
     if half.is_zero() {
-        return base;
+        return scaled;
     }
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -204,12 +219,14 @@ pub struct AttestationClient {
     client: reqwest::Client,
     base_url: String,
     github_token: Option<String>,
+    backoff_base: Duration,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct AttestationClientBuilder {
     base_url: Option<String>,
     github_token: Option<String>,
+    backoff_base: Option<Duration>,
 }
 
 impl AttestationClientBuilder {
@@ -220,6 +237,14 @@ impl AttestationClientBuilder {
 
     pub fn github_token(mut self, token: &str) -> Self {
         self.github_token = Some(token.to_string());
+        self
+    }
+
+    /// Override the attempt-1 retry backoff (defaults to [`DEFAULT_BACKOFF_BASE`]).
+    /// Mainly an injection point for tests, which set it to zero so the suite
+    /// doesn't pay real wall-clock backoff between retries.
+    pub fn backoff_base(mut self, base: Duration) -> Self {
+        self.backoff_base = Some(base);
         self
     }
 
@@ -235,6 +260,7 @@ impl AttestationClientBuilder {
             client,
             base_url: self.base_url.unwrap_or_else(|| GITHUB_API_URL.to_string()),
             github_token: self.github_token,
+            backoff_base: self.backoff_base.unwrap_or(DEFAULT_BACKOFF_BASE),
         })
     }
 }
@@ -311,10 +337,11 @@ impl AttestationClient {
     }
 
     /// Send a request, retrying transient failures (5xx, 429, timeouts,
-    /// connection errors) with exponential backoff. The request must have no
-    /// streaming body so it can be cloned per attempt — true for all GET calls
-    /// here. Non-transient responses (incl. 4xx like 404) are returned as-is for
-    /// the caller to interpret.
+    /// connection errors) with exponential backoff. A `429`'s `Retry-After`
+    /// header is honored in preference to the computed backoff. The request must
+    /// have no streaming body so it can be cloned per attempt — true for all GET
+    /// calls here. Non-transient responses (incl. 4xx like 404) are returned
+    /// as-is for the caller to interpret.
     async fn send_with_retry(&self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
         let mut attempt = 1;
         loop {
@@ -323,17 +350,24 @@ impl AttestationClient {
                 .expect("attestation requests must not have a streaming body");
             let result = req.send().await;
             let last = attempt >= MAX_ATTEMPTS;
-            match result {
-                Ok(response) if last || !is_retryable_status(response.status()) => {
-                    return Ok(response);
+            // Decide the retry delay (if any) while the response is still in hand
+            // so we can read its `Retry-After` header before dropping it.
+            let delay = match &result {
+                Ok(response) if !last && is_retryable_status(response.status()) => Some(
+                    retry_after_delay(response.headers())
+                        .unwrap_or_else(|| backoff_delay(self.backoff_base, attempt)),
+                ),
+                Err(err) if !last && is_retryable_error(err) => {
+                    Some(backoff_delay(self.backoff_base, attempt))
                 }
-                Err(err) if last || !is_retryable_error(&err) => {
-                    return Err(AttestationError::Http(err));
-                }
-                _ => {
-                    tokio::time::sleep(backoff_delay(attempt)).await;
+                _ => None,
+            };
+            match delay {
+                Some(delay) => {
+                    tokio::time::sleep(delay).await;
                     attempt += 1;
                 }
+                None => return result.map_err(AttestationError::Http),
             }
         }
     }
@@ -1489,16 +1523,24 @@ mod tests {
     fn backoff_grows_and_stays_within_jitter_bounds() {
         // Each attempt's delay must fall in [base/2, base) where base doubles.
         for attempt in 1..=4 {
-            let base = BASE_BACKOFF * (1u32 << (attempt - 1));
-            let d = backoff_delay(attempt);
+            let base = DEFAULT_BACKOFF_BASE * (1u32 << (attempt - 1));
+            let d = backoff_delay(DEFAULT_BACKOFF_BASE, attempt);
             assert!(d >= base / 2, "attempt {attempt}: {d:?} < {:?}", base / 2);
             assert!(d < base, "attempt {attempt}: {d:?} >= {base:?}");
         }
     }
 
+    #[test]
+    fn backoff_zero_base_yields_no_delay() {
+        for attempt in 1..=4 {
+            assert_eq!(backoff_delay(Duration::ZERO, attempt), Duration::ZERO);
+        }
+    }
+
     /// Spawn a throwaway HTTP server that replies with each status in
     /// `statuses` (one per connection, in order) then `200 {body}` for the
-    /// rest. Returns the bound `base_url` and a counter of accepted connections.
+    /// rest. A `429` reply carries `Retry-After: 0` so the retry path stays
+    /// fast. Returns the bound `base_url` and a counter of accepted connections.
     fn flaky_server(
         statuses: Vec<u16>,
         body: &'static str,
@@ -1524,8 +1566,13 @@ mod tests {
                     Some(&s) => (s, ""),
                     None => (200, body),
                 };
+                let extra = if code == 429 {
+                    "Retry-After: 0\r\n"
+                } else {
+                    ""
+                };
                 let response = format!(
-                    "HTTP/1.1 {code} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+                    "HTTP/1.1 {code} X\r\nContent-Type: application/json\r\n{extra}Content-Length: {}\r\nConnection: close\r\n\r\n{payload}",
                     payload.len()
                 );
                 let _ = stream.write_all(response.as_bytes());
@@ -1535,14 +1582,21 @@ mod tests {
         (format!("http://{addr}"), hits)
     }
 
+    /// Build a client pointed at a test server with zero backoff so retries
+    /// don't pay real wall-clock time.
+    fn test_client(base_url: &str) -> AttestationClient {
+        AttestationClient::builder()
+            .base_url(base_url)
+            .backoff_base(Duration::ZERO)
+            .build()
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn fetch_attestations_retries_on_5xx() {
         // 504 (the reported failure) then 502, then success — must recover.
         let (base_url, hits) = flaky_server(vec![504, 502], r#"{"attestations":[]}"#);
-        let client = AttestationClient::builder()
-            .base_url(&base_url)
-            .build()
-            .unwrap();
+        let client = test_client(&base_url);
         let result = client
             .fetch_attestations(FetchParams {
                 owner: "EarthBuild".to_string(),
@@ -1568,10 +1622,7 @@ mod tests {
     async fn fetch_attestations_surfaces_error_after_max_attempts() {
         // Persistent 504 — exhaust MAX_ATTEMPTS then surface the API error.
         let (base_url, hits) = flaky_server(vec![504, 504, 504, 504, 504], "");
-        let client = AttestationClient::builder()
-            .base_url(&base_url)
-            .build()
-            .unwrap();
+        let client = test_client(&base_url);
         let err = client
             .fetch_attestations(FetchParams {
                 owner: "EarthBuild".to_string(),
@@ -1589,6 +1640,57 @@ mod tests {
             MAX_ATTEMPTS,
             "should stop after MAX_ATTEMPTS"
         );
+    }
+
+    #[tokio::test]
+    async fn fetch_attestations_retries_on_429_with_retry_after() {
+        // 429 carrying Retry-After (set by the server), then success.
+        let (base_url, hits) = flaky_server(vec![429], r#"{"attestations":[]}"#);
+        let client = test_client(&base_url);
+        let result = client
+            .fetch_attestations(FetchParams {
+                owner: "EarthBuild".to_string(),
+                repo: Some("EarthBuild/earthbuild".to_string()),
+                digest: "sha256:abc".to_string(),
+                limit: 30,
+                predicate_type: None,
+            })
+            .await;
+
+        assert!(result.is_ok(), "expected recovery after 429: {result:?}");
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "should have taken 1 rate-limited + 1 successful attempt"
+        );
+    }
+
+    #[test]
+    fn retry_after_parses_delta_seconds_and_caps() {
+        fn headers_with(value: Option<&str>) -> HeaderMap {
+            let mut headers = HeaderMap::new();
+            if let Some(value) = value {
+                headers.insert(reqwest::header::RETRY_AFTER, value.parse().unwrap());
+            }
+            headers
+        }
+
+        assert_eq!(
+            retry_after_delay(&headers_with(Some("2"))),
+            Some(Duration::from_secs(2))
+        );
+        // Capped at RETRY_AFTER_MAX.
+        assert_eq!(
+            retry_after_delay(&headers_with(Some("9999"))),
+            Some(RETRY_AFTER_MAX)
+        );
+        // HTTP-date form is not delta-seconds → ignored, falls back to backoff.
+        assert_eq!(
+            retry_after_delay(&headers_with(Some("Wed, 21 Oct 2015 07:28:00 GMT"))),
+            None
+        );
+        // Absent header → no override.
+        assert_eq!(retry_after_delay(&headers_with(None)), None);
     }
 
     /// A genuine `*.intoto.jsonl` produced by slsa-github-generator (sops

--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use base64::Engine;
@@ -17,6 +18,44 @@ use tokio::io::AsyncReadExt;
 
 const GITHUB_API_URL: &str = "https://api.github.com";
 const USER_AGENT_VALUE: &str = "mise-sigstore/0.1.0";
+
+/// Per-request timeout for attestation API calls. Without this the client would
+/// wait indefinitely on a stalled connection (reqwest has no default timeout).
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Total attempts (1 initial + 3 retries) for transient attestation API failures.
+/// GitHub's attestations API intermittently returns 5xx (e.g. 504 Gateway
+/// Timeout) and 429 under load; a single attempt fails the whole install.
+const MAX_ATTEMPTS: usize = 4;
+/// Base backoff before the first retry. Doubles each attempt: ~0.5s / 1s / 2s.
+const BASE_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Whether an HTTP status warrants a retry. 429 (rate limit) and any 5xx are
+/// transient server-side conditions; everything else (incl. 404) is terminal.
+fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+
+/// Whether a transport-level error warrants a retry (timeouts, connection
+/// failures, and incomplete requests are transient; decode/builder errors aren't).
+fn is_retryable_error(err: &reqwest::Error) -> bool {
+    err.is_timeout() || err.is_connect() || err.is_request()
+}
+
+/// Backoff delay for the given attempt (1-based) with "equal jitter" in
+/// `[d/2, d)` to avoid synchronized retries across concurrent installs.
+fn backoff_delay(attempt: usize) -> Duration {
+    let exp = (attempt.saturating_sub(1)).min(16) as u32;
+    let base = BASE_BACKOFF.saturating_mul(1u32 << exp);
+    let half = base / 2;
+    if half.is_zero() {
+        return base;
+    }
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0);
+    half + Duration::from_nanos(nanos % half.as_nanos().max(1) as u64)
+}
 
 #[derive(Debug, Error)]
 pub enum AttestationError {
@@ -189,6 +228,7 @@ impl AttestationClientBuilder {
         headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
         let client = reqwest::Client::builder()
             .default_headers(headers)
+            .timeout(REQUEST_TIMEOUT)
             .build()?;
 
         Ok(AttestationClient {
@@ -270,15 +310,42 @@ impl AttestationClient {
             .map_err(|e| AttestationError::Api(format!("Invalid GitHub attestations URL: {e}")))
     }
 
+    /// Send a request, retrying transient failures (5xx, 429, timeouts,
+    /// connection errors) with exponential backoff. The request must have no
+    /// streaming body so it can be cloned per attempt — true for all GET calls
+    /// here. Non-transient responses (incl. 4xx like 404) are returned as-is for
+    /// the caller to interpret.
+    async fn send_with_retry(&self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
+        let mut attempt = 1;
+        loop {
+            let req = request
+                .try_clone()
+                .expect("attestation requests must not have a streaming body");
+            let result = req.send().await;
+            let last = attempt >= MAX_ATTEMPTS;
+            match result {
+                Ok(response) if last || !is_retryable_status(response.status()) => {
+                    return Ok(response);
+                }
+                Err(err) if last || !is_retryable_error(&err) => {
+                    return Err(AttestationError::Http(err));
+                }
+                _ => {
+                    tokio::time::sleep(backoff_delay(attempt)).await;
+                    attempt += 1;
+                }
+            }
+        }
+    }
+
     pub async fn fetch_attestations(&self, params: FetchParams) -> Result<Vec<Attestation>> {
         let url = self.attestations_url(&params)?;
 
-        let response = self
+        let request = self
             .client
             .get(url.clone())
-            .headers(self.github_headers(url.as_str())?)
-            .send()
-            .await?;
+            .headers(self.github_headers(url.as_str())?);
+        let response = self.send_with_retry(request).await?;
 
         if response.status() == reqwest::StatusCode::NOT_FOUND {
             return Ok(vec![]);
@@ -311,12 +378,11 @@ impl AttestationClient {
     }
 
     async fn fetch_bundle_url(&self, bundle_url: &str) -> Result<serde_json::Value> {
-        let response = self
+        let request = self
             .client
             .get(bundle_url)
-            .headers(self.github_headers(bundle_url)?)
-            .send()
-            .await?;
+            .headers(self.github_headers(bundle_url)?);
+        let response = self.send_with_retry(request).await?;
         if !response.status().is_success() {
             return Err(AttestationError::Api(format!(
                 "bundle URL returned {}",
@@ -1402,6 +1468,127 @@ mod tests {
         .to_string();
 
         assert!(err.contains("Workflow verification failed"));
+    }
+
+    #[test]
+    fn retryable_status_classification() {
+        use reqwest::StatusCode;
+        // Transient server-side conditions retry.
+        assert!(is_retryable_status(StatusCode::GATEWAY_TIMEOUT)); // 504 — the reported failure
+        assert!(is_retryable_status(StatusCode::BAD_GATEWAY)); // 502
+        assert!(is_retryable_status(StatusCode::SERVICE_UNAVAILABLE)); // 503
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS)); // 429
+        // Terminal conditions do not.
+        assert!(!is_retryable_status(StatusCode::OK));
+        assert!(!is_retryable_status(StatusCode::NOT_FOUND));
+        assert!(!is_retryable_status(StatusCode::UNAUTHORIZED));
+        assert!(!is_retryable_status(StatusCode::FORBIDDEN));
+    }
+
+    #[test]
+    fn backoff_grows_and_stays_within_jitter_bounds() {
+        // Each attempt's delay must fall in [base/2, base) where base doubles.
+        for attempt in 1..=4 {
+            let base = BASE_BACKOFF * (1u32 << (attempt - 1));
+            let d = backoff_delay(attempt);
+            assert!(d >= base / 2, "attempt {attempt}: {d:?} < {:?}", base / 2);
+            assert!(d < base, "attempt {attempt}: {d:?} >= {base:?}");
+        }
+    }
+
+    /// Spawn a throwaway HTTP server that replies with each status in
+    /// `statuses` (one per connection, in order) then `200 {body}` for the
+    /// rest. Returns the bound `base_url` and a counter of accepted connections.
+    fn flaky_server(
+        statuses: Vec<u16>,
+        body: &'static str,
+    ) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        use std::io::{Read, Write};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_thread = hits.clone();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut stream = match stream {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                let n = hits_thread.fetch_add(1, Ordering::SeqCst);
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf); // drain the request line/headers
+                let (code, payload) = match statuses.get(n) {
+                    Some(&s) => (s, ""),
+                    None => (200, body),
+                };
+                let response = format!(
+                    "HTTP/1.1 {code} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+                    payload.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        (format!("http://{addr}"), hits)
+    }
+
+    #[tokio::test]
+    async fn fetch_attestations_retries_on_5xx() {
+        // 504 (the reported failure) then 502, then success — must recover.
+        let (base_url, hits) = flaky_server(vec![504, 502], r#"{"attestations":[]}"#);
+        let client = AttestationClient::builder()
+            .base_url(&base_url)
+            .build()
+            .unwrap();
+        let result = client
+            .fetch_attestations(FetchParams {
+                owner: "EarthBuild".to_string(),
+                repo: Some("EarthBuild/earthbuild".to_string()),
+                digest: "sha256:abc".to_string(),
+                limit: 30,
+                predicate_type: None,
+            })
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "expected recovery after retries: {result:?}"
+        );
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "should have taken 2 failed + 1 successful attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_attestations_surfaces_error_after_max_attempts() {
+        // Persistent 504 — exhaust MAX_ATTEMPTS then surface the API error.
+        let (base_url, hits) = flaky_server(vec![504, 504, 504, 504, 504], "");
+        let client = AttestationClient::builder()
+            .base_url(&base_url)
+            .build()
+            .unwrap();
+        let err = client
+            .fetch_attestations(FetchParams {
+                owner: "EarthBuild".to_string(),
+                repo: Some("EarthBuild/earthbuild".to_string()),
+                digest: "sha256:abc".to_string(),
+                limit: 30,
+                predicate_type: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AttestationError::Api(_)), "got {err:?}");
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            MAX_ATTEMPTS,
+            "should stop after MAX_ATTEMPTS"
+        );
     }
 
     /// A genuine `*.intoto.jsonl` produced by slsa-github-generator (sops

--- a/crates/vfox/src/http.rs
+++ b/crates/vfox/src/http.rs
@@ -33,6 +33,20 @@ pub(crate) fn http_retry_attempts() -> usize {
     http_retries().saturating_add(1)
 }
 
+/// Retry policy for the attestation client (`mise-sigstore`), so vfox's
+/// attestation traffic honors `MISE_HTTP_RETRIES` like the rest of vfox's HTTP
+/// rather than hardcoding a default at the call site. Timeout and backoff use
+/// `mise-sigstore`'s defaults: vfox applies no HTTP timeout elsewhere, and
+/// parsing `MISE_HTTP_TIMEOUT` here would duplicate mise's duration parser
+/// (vfox has no access to mise's Settings layer — the env var is the only shared
+/// signal, and vfox already mirrors only the retries knob).
+pub(crate) fn sigstore_retry_config() -> mise_sigstore::RetryConfig {
+    mise_sigstore::RetryConfig {
+        retries: http_retries(),
+        ..Default::default()
+    }
+}
+
 pub(crate) fn should_retry_status(status: StatusCode) -> bool {
     let code = status.as_u16();
     code == 408 || code == 429 || (500..600).contains(&code)

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -552,7 +552,7 @@ impl Vfox {
                     repo.as_str(),
                     Some(token.as_str()),
                     attestation.github_signer_workflow.as_deref(),
-                    mise_sigstore::RetryConfig::default(),
+                    crate::http::sigstore_retry_config(),
                 )
                 .await?;
                 // All configured verifications always execute (no short-circuit).

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -552,6 +552,7 @@ impl Vfox {
                     repo.as_str(),
                     Some(token.as_str()),
                     attestation.github_signer_workflow.as_deref(),
+                    mise_sigstore::RetryConfig::default(),
                 )
                 .await?;
                 // All configured verifications always execute (no short-circuit).

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -29,7 +29,7 @@
 use std::path::Path;
 
 use mise_sigstore::sources::github::GitHubSource;
-use mise_sigstore::{ArtifactRef, AttestationClient, AttestationSource, FetchParams};
+use mise_sigstore::{ArtifactRef, AttestationClient, AttestationSource, FetchParams, RetryConfig};
 
 pub use mise_sigstore::{AttestationError, SlsaArtifact};
 
@@ -56,10 +56,24 @@ fn routed_api_url(api_url: &str) -> String {
     }
 }
 
+/// Build a [`RetryConfig`] from mise's HTTP settings so attestation requests
+/// retry and time out exactly like the rest of mise's HTTP traffic rather than
+/// using a policy hardcoded in the `mise-sigstore` crate.
+fn mise_retry_config() -> RetryConfig {
+    let settings = crate::config::Settings::get();
+    RetryConfig {
+        timeout: settings.http_timeout(),
+        retries: settings.http_retries.max(0) as usize,
+        ..RetryConfig::default()
+    }
+}
+
 fn attestation_client(api_url: &str) -> AttestationResult<AttestationClient> {
     let token = resolve_token_for_wrapper(Some(api_url));
     let base_url = routed_api_url(api_url);
-    let mut builder = AttestationClient::builder().base_url(&base_url);
+    let mut builder = AttestationClient::builder()
+        .base_url(&base_url)
+        .retry_config(mise_retry_config());
     if let Some(token) = token.as_deref() {
         builder = builder.github_token(token);
     }
@@ -124,6 +138,7 @@ pub async fn verify_attestation(
             expected_workflow,
             &base_url,
             &digest,
+            mise_retry_config(),
         )
         .await
     } else {
@@ -134,6 +149,7 @@ pub async fn verify_attestation(
             token.as_deref(),
             expected_workflow,
             &base_url,
+            mise_retry_config(),
         )
         .await
     }


### PR DESCRIPTION
## Problem
`mise install` of GitHub-backed tools fails hard when GitHub's artifact attestations API returns a transient 5xx:

```
GitHub artifact attestations verification error for github:EarthBuild/earthbuild@0.8.17:
API error: GitHub API returned 504 Gateway Timeout
```

`mise-sigstore`'s `AttestationClient` used a bare reqwest client — no timeout, no retry — so a single 504/502/503/429 killed the whole install. The main `src/http.rs` client already retries transient failures; the sigstore crate did not.

## Fix
- 30s per-request timeout (reqwest has no default)
- retry on 5xx, 429, and transient transport errors (`is_timeout()` / `is_connect()`), up to 4 attempts, exponential backoff + equal jitter (~0.5s/1s/2s)
- a 429 `Retry-After` header (delta-seconds, capped at 60s) takes precedence over computed backoff
- both `fetch_attestations` and `fetch_bundle_url` go through retry
- 4xx (incl. 404) stay terminal
- backoff base is injectable via the builder so tests run with zero delay

## Tests
`cargo test -p mise-sigstore` — 18 pass (7 new): status/backoff classification, `Retry-After` parse/cap, and flaky-server integration tests (recovery after 5xx, recovery after 429+Retry-After, error after exhausting retries). `cargo clippy` / `cargo fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved reliability of GitHub attestation verification and bundle URL fetching with automatic, configurable retries.
  * Added per-request timeouts and exponential “equal jitter” backoff for retryable HTTP (429, 5xx) and transient transport/body-read failures.
  * Honors `Retry-After` (delta-seconds) with capping, falling back to computed backoff when unavailable.
* **New Features**
  * Introduced `RetryConfig` to control retries, timeouts, and backoff base; wired through verification entry points and builder configuration.
* **Tests**
  * Expanded retry classification, jitter/backoff bounds, `Retry-After` parsing/capping, and end-to-end retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
