### PR TITLE
potentially fix --uploaded-prior-to errors with pipx backend

### DIFF
--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -34,6 +34,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::{fmt::Debug, sync::Arc};
+use tokio::sync::Mutex as TokioMutex;
 use versions::Versioning;
 use xx::regex;
 
@@ -44,6 +45,8 @@ const UV_MIN_EXCLUDE_NEWER_VERSION: &str = "0.1.15";
 pub struct PIPXBackend {
     ba: Arc<BackendArg>,
     latest_version_cache: CacheManager<Option<String>>,
+    pip_date_filter_cache: TokioMutex<Option<bool>>,
+    uv_date_filter_cache: TokioMutex<Option<bool>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -430,6 +433,8 @@ impl PIPXBackend {
             .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
             .build(),
             ba: Arc::new(ba),
+            pip_date_filter_cache: TokioMutex::new(None),
+            uv_date_filter_cache: TokioMutex::new(None),
         }
     }
 
@@ -557,7 +562,27 @@ impl PIPXBackend {
 
     /// Returns true if the pip available to pipx supports `--uploaded-prior-to`
     /// (requires pip >= 26.0.0).
+    ///
+    /// Note: this probes the pip reachable via the dependency toolset's `python`
+    /// binary, which is the same Python pipx uses to seed new venvs.  In the
+    /// unlikely case where pipx was installed with a different Python whose
+    /// bundled pip is older, the check may produce a false positive and pipx
+    /// will still fail.  The result is cached per-backend-instance so only one
+    /// subprocess is spawned even when many pipx packages are installed in a
+    /// single `mise install` run.
     async fn pip_supports_uploaded_prior_to(&self, config: &Arc<Config>) -> bool {
+        {
+            let cache = self.pip_date_filter_cache.lock().await;
+            if let Some(cached) = *cache {
+                return cached;
+            }
+        }
+        let result = self.probe_pip_supports_uploaded_prior_to(config).await;
+        *self.pip_date_filter_cache.lock().await = Some(result);
+        result
+    }
+
+    async fn probe_pip_supports_uploaded_prior_to(&self, config: &Arc<Config>) -> bool {
         let env = match self.dependency_env(config).await {
             Ok(env) => env,
             Err(e) => {
@@ -590,19 +615,32 @@ impl PIPXBackend {
     }
 
     /// Returns true if the uv available supports `--exclude-newer` in `uv tool install`
-    /// (requires uv >= 0.1.37).
+    /// (requires uv >= 0.1.15).  Result is cached per-backend-instance.
     async fn uv_supports_exclude_newer(&self, config: &Arc<Config>) -> bool {
+        {
+            let cache = self.uv_date_filter_cache.lock().await;
+            if let Some(cached) = *cache {
+                return cached;
+            }
+        }
+        let result = self.probe_uv_supports_exclude_newer(config).await;
+        *self.uv_date_filter_cache.lock().await = Some(result);
+        result
+    }
+
+    async fn probe_uv_supports_exclude_newer(&self, config: &Arc<Config>) -> bool {
         // Fast path: if uv is explicitly managed by mise, read the version from the ToolSet.
         if let Ok(ts) = self.dependency_toolset(config).await {
             for (ba, tvl) in &ts.versions {
-                if ba.short == "uv" 
-                    && let Some(tv) = tvl.versions.first() {
-                        debug!(
-                            "uv version detection: found uv {} in ToolSet, skipping subprocess",
-                            tv.version
-                        );
-                        return semver_is_at_least(&tv.version, UV_MIN_EXCLUDE_NEWER_VERSION)
-                            .unwrap_or(false);
+                if ba.short == "uv"
+                    && let Some(tv) = tvl.versions.first()
+                {
+                    debug!(
+                        "uv version detection: found uv {} in ToolSet, skipping subprocess",
+                        tv.version
+                    );
+                    return semver_is_at_least(&tv.version, UV_MIN_EXCLUDE_NEWER_VERSION)
+                        .unwrap_or(false);
                 }
             }
         }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -33,8 +33,12 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::{fmt::Debug, sync::Arc};
+use crate::semver::semver_is_at_least;
 use versions::Versioning;
 use xx::regex;
+
+const PIP_MIN_UPLOADED_PRIOR_TO_VERSION: &str = "26.0.0";
+const UV_MIN_EXCLUDE_NEWER_VERSION: &str = "0.1.37";
 
 #[derive(Debug)]
 pub struct PIPXBackend {
@@ -287,7 +291,17 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
-            cmd = cmd.args(Self::uv_exclude_newer_args(ctx.before_date));
+            if ctx.before_date.is_some() {
+                if self.uv_supports_exclude_newer(&ctx.config).await {
+                    cmd = cmd.args(Self::uv_exclude_newer_args(ctx.before_date));
+                } else {
+                    warn!(
+                        "uv >= {} is required for --exclude-newer; minimum_release_age will not be enforced for {}",
+                        UV_MIN_EXCLUDE_NEWER_VERSION,
+                        self.tool_name()
+                    );
+                }
+            }
             if let Some(args) = options.uvx_args() {
                 cmd = cmd.args(shell_words::split(args)?);
             }
@@ -303,7 +317,17 @@ impl Backend for PIPXBackend {
                 ctx.pr.as_ref(),
             )
             .await?;
-            cmd = cmd.args(Self::pip_uploaded_prior_to_args(ctx.before_date));
+            if ctx.before_date.is_some() {
+                if self.pip_supports_uploaded_prior_to(&ctx.config).await {
+                    cmd = cmd.args(Self::pip_uploaded_prior_to_args(ctx.before_date));
+                } else {
+                    warn!(
+                        "pip >= {} is required for --uploaded-prior-to; minimum_release_age will not be enforced for {}",
+                        PIP_MIN_UPLOADED_PRIOR_TO_VERSION,
+                        self.tool_name()
+                    );
+                }
+            }
             if let Some(args) = options.pipx_args() {
                 cmd = cmd.args(shell_words::split(args)?);
             }
@@ -529,6 +553,88 @@ impl PIPXBackend {
             .prepend_path(ts.list_paths(config).await)?
             .prepend_path(vec![tv.install_path().join("bin")])?
             .prepend_path(b.dependency_toolset(config).await?.list_paths(config).await)
+    }
+
+    /// Returns true if the pip available to pipx supports `--uploaded-prior-to`
+    /// (requires pip >= 26.0.0).
+    async fn pip_supports_uploaded_prior_to(&self, config: &Arc<Config>) -> bool {
+        let env = match self.dependency_env(config).await {
+            Ok(env) => env,
+            Err(e) => {
+                debug!(
+                    "pip version detection: dependency_env failed, skipping --uploaded-prior-to: {e:#}"
+                );
+                return false;
+            }
+        };
+        let python = if let Some(p) = self.dependency_which(config, "python").await {
+            p
+        } else if let Some(p) = self.dependency_which(config, "python3").await {
+            p
+        } else {
+            debug!("pip version detection: python not found, skipping --uploaded-prior-to");
+            return false;
+        };
+        let output = match cmd!(python, "-m", "pip", "--version").full_env(env).read() {
+            Ok(s) => s,
+            Err(e) => {
+                debug!(
+                    "pip version detection: `python -m pip --version` failed, skipping --uploaded-prior-to: {e:#}"
+                );
+                return false;
+            }
+        };
+        // Output: "pip 26.0.0 from /path (python 3.12)"
+        let version = output.split_whitespace().nth(1).unwrap_or("");
+        semver_is_at_least(version, PIP_MIN_UPLOADED_PRIOR_TO_VERSION).unwrap_or(false)
+    }
+
+    /// Returns true if the uv available supports `--exclude-newer` in `uv tool install`
+    /// (requires uv >= 0.1.37).
+    async fn uv_supports_exclude_newer(&self, config: &Arc<Config>) -> bool {
+        // Fast path: if uv is explicitly managed by mise, read the version from the ToolSet.
+        if let Ok(ts) = self.dependency_toolset(config).await {
+            for (ba, tvl) in &ts.versions {
+                if ba.short == "uv" {
+                    if let Some(tv) = tvl.versions.first() {
+                        debug!(
+                            "uv version detection: found uv {} in ToolSet, skipping subprocess",
+                            tv.version
+                        );
+                        return semver_is_at_least(&tv.version, UV_MIN_EXCLUDE_NEWER_VERSION)
+                            .unwrap_or(false);
+                    }
+                }
+            }
+        }
+        let env = match self.dependency_env(config).await {
+            Ok(env) => env,
+            Err(e) => {
+                debug!(
+                    "uv version detection: dependency_env failed, skipping --exclude-newer: {e:#}"
+                );
+                return false;
+            }
+        };
+        let uv = match self.dependency_which(config, "uv").await {
+            Some(p) => p,
+            None => {
+                debug!("uv version detection: uv not found, skipping --exclude-newer");
+                return false;
+            }
+        };
+        let output = match cmd!(uv, "--version").full_env(env).read() {
+            Ok(s) => s,
+            Err(e) => {
+                debug!(
+                    "uv version detection: `uv --version` failed, skipping --exclude-newer: {e:#}"
+                );
+                return false;
+            }
+        };
+        // Output: "uv 0.6.0 (abc 2024-01-01)"
+        let version = output.split_whitespace().nth(1).unwrap_or("");
+        semver_is_at_least(version, UV_MIN_EXCLUDE_NEWER_VERSION).unwrap_or(false)
     }
 
     async fn uv_is_installed(&self, config: &Arc<Config>) -> bool {

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -595,15 +595,14 @@ impl PIPXBackend {
         // Fast path: if uv is explicitly managed by mise, read the version from the ToolSet.
         if let Ok(ts) = self.dependency_toolset(config).await {
             for (ba, tvl) in &ts.versions {
-                if ba.short == "uv" {
-                    if let Some(tv) = tvl.versions.first() {
+                if ba.short == "uv" 
+                    && let Some(tv) = tvl.versions.first() {
                         debug!(
                             "uv version detection: found uv {} in ToolSet, skipping subprocess",
                             tv.version
                         );
                         return semver_is_at_least(&tv.version, UV_MIN_EXCLUDE_NEWER_VERSION)
                             .unwrap_or(false);
-                    }
                 }
             }
         }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -14,6 +14,7 @@ use crate::github::{self, GithubRelease};
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
 use crate::plugins::PEP440_PRERELEASE_REGEX;
+use crate::semver::semver_is_at_least;
 use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset, ToolsetBuilder};
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -33,12 +34,11 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::{fmt::Debug, sync::Arc};
-use crate::semver::semver_is_at_least;
 use versions::Versioning;
 use xx::regex;
 
 const PIP_MIN_UPLOADED_PRIOR_TO_VERSION: &str = "26.0.0";
-const UV_MIN_EXCLUDE_NEWER_VERSION: &str = "0.1.37";
+const UV_MIN_EXCLUDE_NEWER_VERSION: &str = "0.1.15";
 
 #[derive(Debug)]
 pub struct PIPXBackend {


### PR DESCRIPTION
A potential solution to the bug surfaced in https://github.com/jdx/mise/discussions/10484.

Co-authored with Claude Code/Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved date-constrained installation handling: when a `before_date` is provided, the backend now checks whether the available `uv`/`pip` versions support the corresponding enforcement options.
* If support isn’t available, installations no longer fail—unsupported enforcement flags are automatically omitted, and a warning is displayed instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->