### PR TITLE
fix(npm): warn when system pnpm/bun may not support minimum_release_age

### DIFF
--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -541,6 +541,12 @@ impl NPMBackend {
             .package_manager_version_for_release_age(&ctx.config, ctx, tool)
             .await
         else {
+            warn!(
+                "minimum_release_age is set for npm:{} but could not determine {} version required to verify {} support. Release-age filtering for transitive dependencies may not work as expected. See https://mise.en.dev/dev-tools/backends/npm.html",
+                self.tool_name(),
+                tool,
+                flag
+            );
             return;
         };
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -588,20 +588,23 @@ impl NPMBackend {
             .find(|(ba, _)| ba.short == tool)
             .map(|(_, tvl)| tvl)?;
 
-        if let Some(tv) = tvl
+        if let Some(version) = tvl
             .versions
             .iter()
-            .find(|tv| semver_triplet(&tv.version).is_some())
+            .find_map(|tv| Self::normalize_package_manager_version(&tv.version))
         {
-            return Some(tv.version.clone());
+            return Some(version);
         }
 
         tvl.requests
             .iter()
-            .map(|tr| tr.version())
-            .find(|version| semver_triplet(version).is_some())
+            .find_map(|tr| Self::normalize_package_manager_version(&tr.version()))
     }
 
+    /// Resolve the pnpm/bun version used to check release-age flag support.
+    ///
+    /// Prefers mise-managed versions from the install and dependency toolsets,
+    /// then falls back to `{tool} --version` on PATH.
     async fn package_manager_version_for_release_age(
         &self,
         config: &Arc<Config>,
@@ -619,6 +622,7 @@ impl NPMBackend {
         self.package_manager_version_from_path(config, tool).await
     }
 
+    /// Read `{tool} --version` using the npm-backend dependency environment.
     async fn package_manager_version_from_path(
         &self,
         config: &Arc<Config>,
@@ -629,11 +633,16 @@ impl NPMBackend {
         Self::parse_package_manager_version_output(&output)
     }
 
+    /// Parse the first line of a package manager `--version` response.
     fn parse_package_manager_version_output(output: &str) -> Option<String> {
-        let version = output.lines().next()?.trim().trim_start_matches('v');
-        semver_triplet(version)
-            .is_some()
-            .then(|| version.to_string())
+        let version = output.lines().next()?;
+        Self::normalize_package_manager_version(version)
+    }
+
+    fn normalize_package_manager_version(version: &str) -> Option<String> {
+        let version = version.trim().trim_start_matches(['v', 'V']);
+        semver_triplet(version)?;
+        Some(version.to_string())
     }
 
     /// Detect whether the locally installed npm supports --min-release-age.
@@ -1278,6 +1287,22 @@ mod tests {
         assert_eq!(
             NPMBackend::toolset_package_manager_version(&ts, "pnpm"),
             None
+        );
+    }
+
+    #[test]
+    fn test_toolset_package_manager_version_normalizes_v_prefix() {
+        let ba = create_test_backend_arg("pnpm");
+        let request = create_test_tool_request(ba.clone(), "v10.15.0");
+        let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
+        tvl.requests.push(request);
+
+        let mut ts = Toolset::default();
+        ts.versions.insert(ba, tvl);
+
+        assert_eq!(
+            NPMBackend::toolset_package_manager_version(&ts, "pnpm"),
+            Some("10.15.0".to_string())
         );
     }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -537,15 +537,10 @@ impl NPMBackend {
             return;
         };
 
-        let version = match Self::toolset_package_manager_version(&ctx.ts, tool) {
-            Some(version) => Some(version),
-            None => match self.dependency_toolset(&ctx.config).await {
-                Ok(ts) => Self::toolset_package_manager_version(&ts, tool),
-                Err(_) => None,
-            },
-        };
-
-        let Some(version) = version else {
+        let Some(version) = self
+            .package_manager_version_for_release_age(&ctx.config, ctx, tool)
+            .await
+        else {
             return;
         };
 
@@ -599,6 +594,40 @@ impl NPMBackend {
             .iter()
             .map(|tr| tr.version())
             .find(|version| semver_triplet(version).is_some())
+    }
+
+    async fn package_manager_version_for_release_age(
+        &self,
+        config: &Arc<Config>,
+        ctx: &InstallContext,
+        tool: &str,
+    ) -> Option<String> {
+        if let Some(version) = Self::toolset_package_manager_version(&ctx.ts, tool) {
+            return Some(version);
+        }
+        if let Ok(ts) = self.dependency_toolset(config).await
+            && let Some(version) = Self::toolset_package_manager_version(&ts, tool)
+        {
+            return Some(version);
+        }
+        self.package_manager_version_from_path(config, tool).await
+    }
+
+    async fn package_manager_version_from_path(
+        &self,
+        config: &Arc<Config>,
+        tool: &str,
+    ) -> Option<String> {
+        let env = self.dependency_env(config).await.ok()?;
+        let output = cmd!(tool, "--version").full_env(env).read().ok()?;
+        Self::parse_package_manager_version_output(&output)
+    }
+
+    fn parse_package_manager_version_output(output: &str) -> Option<String> {
+        let version = output.lines().next()?.trim().trim_start_matches('v');
+        semver_triplet(version)
+            .is_some()
+            .then(|| version.to_string())
     }
 
     /// Detect whether the locally installed npm supports --min-release-age.
@@ -1242,6 +1271,22 @@ mod tests {
 
         assert_eq!(
             NPMBackend::toolset_package_manager_version(&ts, "pnpm"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_package_manager_version_output() {
+        assert_eq!(
+            NPMBackend::parse_package_manager_version_output("10.15.0\n"),
+            Some("10.15.0".to_string())
+        );
+        assert_eq!(
+            NPMBackend::parse_package_manager_version_output("v1.3.0"),
+            Some("1.3.0".to_string())
+        );
+        assert_eq!(
+            NPMBackend::parse_package_manager_version_output("not-a-version"),
             None
         );
     }


### PR DESCRIPTION
## Summary

- When `minimum_release_age` is active during npm-backend installs, probe `pnpm --version` / `bun --version` if the package manager is not in the mise toolset, so compatibility warnings also apply to system-installed package managers.
- Previously, the warning only ran when pnpm/bun were mise-managed; system installs silently skipped the check even though release-age flags were still forwarded and could fail at CLI parse time.

## Why now

`minimum_release_age` is on by default (24h), so npm-backend installs routinely forward release-age settings to the configured package manager. Catching unsupported system pnpm/bun versions upfront is more valuable than when this was opt-in only.

## Past behavior

`warn_if_package_manager_may_not_support_release_age` looked up pnpm/bun versions only from the current install toolset and dependency toolset. If the tool was only on system PATH, no version was found and the function returned without warning — even though `--config.minimumReleaseAge=…` or `--minimum-release-age …` was still passed to the install command.

## Why not npm

npm is intentionally excluded from this warning path:

- npm has supported release-age filtering for a long time via `--before` (npm 6.9.0+), and mise already falls back to that flag when `--min-release-age` is unavailable (`npm_supports_min_release_age_flag` probes `npm --version` when npm is not mise-managed).
- There is no separate npm warning because older npm still gets a compatible flag rather than an unsupported one.

## Performance

This only runs during `install` when `ctx.before_date` is set (i.e. `minimum_release_age` is active for that install). It does not affect `latest`, `ls-remote`, `which`, or other commands.

## Test plan

- [x] `mise run test:unit -- npm`
- [x] `mise run lint-fix`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved compatibility warning accuracy by enhancing package manager version detection: it now prefers managed ToolSet versions first, then falls back to reading the tool’s reported version when necessary, with better normalization for `v`-prefixed outputs.

* **Tests**
  * Added unit test coverage for version output parsing (plain semver, `v`-prefixed semver, and invalid strings) and for version normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->