### PR TITLE
docs(dotfiles): make self-managing config first-run safe

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -230,8 +230,10 @@ dotfiles.root = "~/.dotfiles"
 
 [dotfiles]
 "~/.dotfiles" = "~/src/dotfiles"
-"~/.config/mise/config.toml" = "~/.dotfiles/mise/config.toml"
+"~/.config/mise/config.toml" = "~/src/dotfiles/mise/config.toml"
 ```
 
-The repo/source must exist before the first apply. Replacing the active
-global config affects future mise invocations, so use this pattern carefully.
+The repo/source must exist before the first apply. Use the real repo path for
+sources needed during the first run; `~/.dotfiles` does not exist until mise
+creates that symlink. Replacing the active global config affects future mise
+invocations, so use this pattern carefully.

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -206,11 +206,13 @@ dotfiles.root = "~/.dotfiles"
 
 [dotfiles]
 "~/.dotfiles" = "~/src/dotfiles"
-"~/.config/mise/config.toml" = "~/.dotfiles/mise/config.toml"
+"~/.config/mise/config.toml" = "~/src/dotfiles/mise/config.toml"
 ```
 
 This is a bootstrap pattern: clone the real repo (for example
 `~/src/dotfiles`) before the first `mise dotfiles apply` or `mise bootstrap`.
+Use the real repo path for sources needed during the first run; `~/.dotfiles`
+does not exist until mise creates that symlink.
 Replacing `~/.config/mise/config.toml` affects future mise invocations, so
 make sure the source contains a valid config before applying it.
 


### PR DESCRIPTION
## Summary
- update self-managing dotfiles examples to source the mise config from the real cloned repo path
- explain why first-run sources should not go through the `~/.dotfiles` symlink before mise creates it

## Context
This addresses the first-run bootstrap failure described in https://github.com/jdx/mise/discussions/10487.

## Validation
- `mise run docs:build`

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or config behavior impact.
> 
> **Overview**
> Updates the **self-managing mise config** examples in `bootstrap.md` and `dotfiles.md` so `~/.config/mise/config.toml` is sourced from the **real clone path** (`~/src/dotfiles/mise/config.toml`) instead of via `~/.dotfiles/...`.
> 
> Adds guidance that on the **first** `mise dotfiles apply` / `mise bootstrap`, sources must not depend on the `~/.dotfiles` symlink until mise has created it—addressing the bootstrap failure in [discussion #10487](https://github.com/jdx/mise/discussions/10487).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fde9bbe426ca0627f16b69e050479535c18bcef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and reflowed explanatory text in the bootstrap documentation's "Advanced: Self-Managing Config" section, adjusting code block spacing and following text for enhanced clarity.
  * Updated the self-managing mise config dotfiles configuration example with corrected source path references and refined the accompanying explanation to better reflect actual dotfiles repository structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->