### PR TITLE
fix(task): skip mise configs in task include dirs

### DIFF
--- a/e2e/tasks/test_task_monorepo_includes
+++ b/e2e/tasks/test_task_monorepo_includes
@@ -74,3 +74,31 @@ output=$(mise run '//projects/frontend:*')
 assert_contains "echo '$output'" "task from toml"
 assert_contains "echo '$output'" "task from script"
 assert_contains "echo '$output'" "task with long name"
+
+# Verify includes = ["."] does not parse the child mise.toml as a task TOML.
+mkdir -p projects/colocated
+cat <<'EOF' >projects/colocated/mise.toml
+[task_config]
+includes = ["."]
+
+[tasks.config-task]
+run = 'echo "task from config"'
+EOF
+
+cat <<'EOF' >projects/colocated/tasks.toml
+[toml-task]
+run = 'echo "task from colocated toml"'
+EOF
+
+cat <<'EOF' >projects/colocated/file-task
+#!/usr/bin/env bash
+echo "task from colocated file"
+EOF
+chmod +x projects/colocated/file-task
+
+assert_contains "mise tasks ls --all" "//projects/colocated:config-task"
+assert_contains "mise tasks ls --all" "//projects/colocated:toml-task"
+assert_contains "mise tasks ls --all" "//projects/colocated:file-task"
+assert_contains "mise run '//projects/colocated:config-task'" "task from config"
+assert_contains "mise run '//projects/colocated:toml-task'" "task from colocated toml"
+assert_contains "mise run '//projects/colocated:file-task'" "task from colocated file"

--- a/e2e/tasks/test_task_monorepo_includes
+++ b/e2e/tasks/test_task_monorepo_includes
@@ -90,6 +90,15 @@ cat <<'EOF' >projects/colocated/tasks.toml
 run = 'echo "task from colocated toml"'
 EOF
 
+mkdir -p projects/colocated/nested
+cat <<'EOF' >projects/colocated/nested/mise.toml
+[task_config]
+includes = ["."]
+
+[tasks.nested-config-task]
+run = 'echo "task from nested config"'
+EOF
+
 cat <<'EOF' >projects/colocated/file-task
 #!/usr/bin/env bash
 echo "task from colocated file"
@@ -99,6 +108,8 @@ chmod +x projects/colocated/file-task
 assert_contains "mise tasks ls --all" "//projects/colocated:config-task"
 assert_contains "mise tasks ls --all" "//projects/colocated:toml-task"
 assert_contains "mise tasks ls --all" "//projects/colocated:file-task"
+assert_not_contains "mise tasks ls --all" "//projects/colocated:task_config"
+assert_not_contains "mise tasks ls --all" "//projects/colocated:nested-config-task"
 assert_contains "mise run '//projects/colocated:config-task'" "task from config"
 assert_contains "mise run '//projects/colocated:toml-task'" "task from colocated toml"
 assert_contains "mise run '//projects/colocated:file-task'" "task from colocated file"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1064,6 +1064,7 @@ static TOML_CONFIG_MATCHERS: Lazy<Vec<globset::GlobMatcher>> = Lazy::new(|| {
             globset::GlobBuilder::new(pattern)
                 .literal_separator(true)
                 .build()
+                .map_err(|e| warn!("failed to compile config glob pattern {pattern}: {e}"))
                 .ok()
                 .map(|glob| glob.compile_matcher())
         })
@@ -2556,9 +2557,12 @@ fn is_mise_config_file_in_task_include(root: &Path, path: &Path) -> bool {
         return false;
     };
     let relative_path = relative_path.to_string_lossy().replace('\\', "/");
-    TOML_CONFIG_MATCHERS
-        .iter()
-        .any(|matcher| matcher.is_match(&relative_path))
+    let file_name = path
+        .file_name()
+        .map(|file_name| file_name.to_string_lossy().replace('\\', "/"));
+    TOML_CONFIG_MATCHERS.iter().any(|matcher| {
+        matcher.is_match(&relative_path) || file_name.as_ref().is_some_and(|f| matcher.is_match(f))
+    })
 }
 
 async fn resolve_git_url_to_path(git_url: &str) -> Result<PathBuf> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1057,6 +1057,18 @@ static TOML_CONFIG_FILENAMES: Lazy<Vec<String>> = Lazy::new(|| {
         .map(|s| s.to_string())
         .collect()
 });
+static TOML_CONFIG_MATCHERS: Lazy<Vec<globset::GlobMatcher>> = Lazy::new(|| {
+    TOML_CONFIG_FILENAMES
+        .iter()
+        .filter_map(|pattern| {
+            globset::GlobBuilder::new(pattern)
+                .literal_separator(true)
+                .build()
+                .ok()
+                .map(|glob| glob.compile_matcher())
+        })
+        .collect()
+});
 pub static ALL_CONFIG_FILES: Lazy<IndexSet<PathBuf>> = Lazy::new(|| {
     load_config_paths(&DEFAULT_CONFIG_FILENAMES, false)
         .into_iter()
@@ -2500,7 +2512,10 @@ async fn load_tasks_includes(
         let is_toml = |p: &Path| p.extension().map(|e| e == "toml").unwrap_or(false);
         let (toml_files, exec_files): (Vec<_>, Vec<_>) = all_files
             .into_iter()
-            .filter(|p| is_toml(p) || file::is_executable(p))
+            .filter(|p| match is_toml(p) {
+                true => !is_mise_config_file_in_task_include(root, p),
+                false => file::is_executable(p),
+            })
             .partition(|p| is_toml(p));
         let mut tasks = vec![];
         for path in toml_files {
@@ -2534,6 +2549,16 @@ async fn load_tasks_includes(
     } else {
         Ok(vec![])
     }
+}
+
+fn is_mise_config_file_in_task_include(root: &Path, path: &Path) -> bool {
+    let Ok(relative_path) = path.strip_prefix(root) else {
+        return false;
+    };
+    let relative_path = relative_path.to_string_lossy().replace('\\', "/");
+    TOML_CONFIG_MATCHERS
+        .iter()
+        .any(|matcher| matcher.is_match(&relative_path))
 }
 
 async fn resolve_git_url_to_path(git_url: &str) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
- skip mise config TOML files when walking directory task includes
- keep colocated task TOML files, such as `tasks.toml`, loadable from those directories
- add a monorepo regression case for `task_config.includes = ["."]`

## Context
Directory task includes started loading `.toml` files in v2026.6.1, which means an include like `includes = ["."]` could accidentally parse the child project's own `mise.toml` as a task TOML file. That breaks colocated monorepo file-task layouts like the one reported in discussion #10499.

## Validation
- `mise run format`
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `git diff --check`
- `mise run test:e2e e2e/tasks/test_task_monorepo_includes`

Refs #10499

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task discovery for directory includes; wrong glob matching could hide legitimate task TOMLs or still mis-parse configs, though scope is limited to the include walk filter.
> 
> **Overview**
> Fixes **directory task includes** (`task_config.includes` pointing at a folder or `"."`) so they no longer treat **mise platform/config TOMLs** (e.g. `mise.toml`, `.mise/config.toml`) as standalone task definition files—a regression from loading all `.toml` files in include dirs.
> 
> When walking an include directory, TOML paths are now skipped if they match the same **glob patterns** used for normal config discovery (`TOML_CONFIG_MATCHERS` + `is_mise_config_file_in_task_include`). **Colocated task TOMLs** like `tasks.toml`, executable file tasks, and inline `[tasks.*]` in the project `mise.toml` still load as before.
> 
> Adds an e2e **monorepo** case for `includes = ["."]` asserting no bogus tasks such as `task_config` or nested-config tasks from parsed config files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67f50358223fae2d1716a48dd2803327b560bb2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task discovery for directory-based task includes to avoid mistakenly treating mise/config TOML files (and related platform/config TOMLs) as task include definitions.

* **Tests**
  * Added an end-to-end test covering colocated monorepo includes (`task_config.includes = ["."]`) with nested TOMLs and an executable task, asserting the exact set of discovered tasks and verifying expected output for each runnable task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->