### PR TITLE
docs: recommend keeping mise current

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,7 @@ min_version = { hard = '2024.11.1', soft = '2024.9.0' }
 
 When a soft minimum is not met, mise will print a warning and (if available) show self-update instructions. When a hard minimum is not met, mise errors and shows self-update instructions.
 
-Use `min_version` to communicate the oldest mise version your project supports. In general, users should keep mise up to date because mise integrates with external registries and backends that change over time. Projects and organizations should prefer a minimum version requirement over locking users to a specific mise executable, allowing them to float onto newer mise releases. Pinning users back is like pinning an apt or Homebrew repository in time: it can hide deprecation warnings and let upstream integrations drift out of date.
+Use `min_version` to communicate the oldest mise version your project supports. In general, users should keep mise up to date because mise integrates with external registries and backends that change over time. Projects and organizations should prefer a minimum version requirement over locking users to a specific mise executable; locking users to one mise version is generally discouraged. Pinning users back is like pinning an apt or Homebrew repository in time: it can hide deprecation warnings and let upstream integrations drift out of date.
 
 ### Monorepo root
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,7 @@ min_version = { hard = '2024.11.1', soft = '2024.9.0' }
 
 When a soft minimum is not met, mise will print a warning and (if available) show self-update instructions. When a hard minimum is not met, mise errors and shows self-update instructions.
 
-Use `min_version` to communicate the oldest mise version your project supports. In general, users should keep mise up to date because mise integrates with external registries and backends that change over time. Projects and organizations should prefer a minimum version requirement over locking users to a specific mise executable, allowing them to float onto newer mise releases. Pinning users back can hide deprecation warnings and let upstream integrations drift out of date.
+Use `min_version` to communicate the oldest mise version your project supports. In general, users should keep mise up to date because mise integrates with external registries and backends that change over time. Projects and organizations should prefer a minimum version requirement over locking users to a specific mise executable, allowing them to float onto newer mise releases. Pinning users back is like pinning an apt or Homebrew repository in time: it can hide deprecation warnings and let upstream integrations drift out of date.
 
 ### Monorepo root
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,7 @@ min_version = { hard = '2024.11.1', soft = '2024.9.0' }
 
 When a soft minimum is not met, mise will print a warning and (if available) show self-update instructions. When a hard minimum is not met, mise errors and shows self-update instructions.
 
-Use `min_version` to communicate the oldest mise version your project supports. In general, users should keep mise up to date because mise integrates with external registries and backends that change over time. Projects and organizations should prefer a minimum version requirement over locking users to a specific mise executable; locking users to one mise version is generally discouraged. Pinning users back is like pinning an apt or Homebrew repository in time: it can hide deprecation warnings and let upstream integrations drift out of date.
+Use `min_version` to communicate the oldest mise version your project supports. In general, users should keep mise up to date because mise integrates with external registries and backends that change over time. Projects and organizations should prefer a minimum version requirement over locking users to a specific mise executable; locking users to one mise version is generally discouraged. Pinning users back is like preventing `apt update` or `brew update` from refreshing package metadata: it can hide deprecation warnings and let upstream integrations drift out of date.
 
 ### Monorepo root
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,6 +279,8 @@ min_version = { hard = '2024.11.1', soft = '2024.9.0' }
 
 When a soft minimum is not met, mise will print a warning and (if available) show self-update instructions. When a hard minimum is not met, mise errors and shows self-update instructions.
 
+Use `min_version` to communicate the oldest mise version your project supports. In general, users should keep mise up to date because mise integrates with external registries and backends that change over time. Projects and organizations should prefer a minimum version requirement over locking users to a specific mise executable, allowing them to float onto newer mise releases. Pinning users back can hide deprecation warnings and let upstream integrations drift out of date.
+
 ### Monorepo root
 
 Mark a configuration file as a monorepo root to enable target path syntax for tasks.

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -24,7 +24,7 @@ Package managers (apt, dnf, brew, pacman, etc.) update mise when you update syst
 ::: tip Keep mise up to date
 mise connects to many external registries and backends, such as aqua, GitHub releases, language package registries, and system package managers. Those services change over time, so mise works best when the CLI is kept on a recent version.
 
-Projects and organizations should generally set a [`min_version`](/configuration.html#minimum-mise-version) when they need a newer mise feature instead of locking every user to a specific mise executable. While there are ways to pin or bootstrap a particular mise version, most users should be allowed to float onto the latest version. Pinning mise back can hide deprecation messages and cause bit rot with upstream integrations like aqua-registry. Breaking changes are avoided unless they go through a long deprecation process, so staying current should usually be low risk.
+Projects and organizations should generally set a [`min_version`](/configuration.html#minimum-mise-version) when they need a newer mise feature instead of locking every user to a specific mise executable. While there are ways to pin or bootstrap a particular mise version, most users should be allowed to float onto the latest version. Pinning mise back is like pinning an apt or Homebrew repository in time: it can hide deprecation messages and cause bit rot with upstream integrations like aqua-registry. Breaking changes are avoided unless they go through a long deprecation process, so staying current should usually be low risk.
 :::
 
 ### <https://mise.run>

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -24,7 +24,7 @@ Package managers (apt, dnf, brew, pacman, etc.) update mise when you update syst
 ::: tip Keep mise up to date
 mise connects to many external registries and backends, such as aqua, GitHub releases, language package registries, and system package managers. Those services change over time, so mise works best when the CLI is kept on a recent version.
 
-Projects and organizations should generally set a [`min_version`](/configuration.html#minimum-mise-version) when they need a newer mise feature instead of locking every user to a specific mise executable. While there are ways to pin or bootstrap a particular mise version, locking users to one mise version is generally discouraged. Pinning mise back is like pinning an apt or Homebrew repository in time: it can hide deprecation messages and cause bit rot with upstream integrations like aqua-registry. Breaking changes are avoided unless they go through a long deprecation process, so staying current should usually be low risk.
+Projects and organizations should generally set a [`min_version`](/configuration.html#minimum-mise-version) when they need a newer mise feature instead of locking every user to a specific mise executable. While there are ways to pin or bootstrap a particular mise version, locking users to one mise version is generally discouraged. Pinning mise back is like preventing `apt update` or `brew update` from refreshing package metadata: it can hide deprecation messages and cause bit rot with upstream integrations like aqua-registry. Breaking changes are avoided unless they go through a long deprecation process, so staying current should usually be low risk.
 :::
 
 ### <https://mise.run>

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -21,6 +21,12 @@ This page lists various ways to install `mise` on your system.
 Package managers (apt, dnf, brew, pacman, etc.) update mise when you update system packages. Other methods can be updated with `mise self-update`.
 :::
 
+::: tip Keep mise up to date
+mise connects to many external registries and backends, such as aqua, GitHub releases, language package registries, and system package managers. Those services change over time, so mise works best when the CLI is kept on a recent version.
+
+Projects and organizations should generally set a [`min_version`](/configuration.html#minimum-mise-version) when they need a newer mise feature instead of locking every user to a specific mise executable. While there are ways to pin or bootstrap a particular mise version, most users should be allowed to float onto the latest version. Pinning mise back can hide deprecation messages and cause bit rot with upstream integrations like aqua-registry. Breaking changes are avoided unless they go through a long deprecation process, so staying current should usually be low risk.
+:::
+
 ### <https://mise.run>
 
 Note that it isn't necessary for `mise` to be on `PATH`. If you run the activate script in your

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -24,7 +24,7 @@ Package managers (apt, dnf, brew, pacman, etc.) update mise when you update syst
 ::: tip Keep mise up to date
 mise connects to many external registries and backends, such as aqua, GitHub releases, language package registries, and system package managers. Those services change over time, so mise works best when the CLI is kept on a recent version.
 
-Projects and organizations should generally set a [`min_version`](/configuration.html#minimum-mise-version) when they need a newer mise feature instead of locking every user to a specific mise executable. While there are ways to pin or bootstrap a particular mise version, most users should be allowed to float onto the latest version. Pinning mise back is like pinning an apt or Homebrew repository in time: it can hide deprecation messages and cause bit rot with upstream integrations like aqua-registry. Breaking changes are avoided unless they go through a long deprecation process, so staying current should usually be low risk.
+Projects and organizations should generally set a [`min_version`](/configuration.html#minimum-mise-version) when they need a newer mise feature instead of locking every user to a specific mise executable. While there are ways to pin or bootstrap a particular mise version, locking users to one mise version is generally discouraged. Pinning mise back is like pinning an apt or Homebrew repository in time: it can hide deprecation messages and cause bit rot with upstream integrations like aqua-registry. Breaking changes are avoided unless they go through a long deprecation process, so staying current should usually be low risk.
 :::
 
 ### <https://mise.run>


### PR DESCRIPTION
## Summary
- add prominent guidance that mise works best when kept current
- recommend orgs use `min_version` instead of locking users to one mise executable
- explain that pinning back can hide deprecation messages and allow upstream integrations like aqua-registry to drift

## Validation
- Not run; docs-only change.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, config parsing, or install behavior changes.
> 
> **Overview**
> Documentation-only update that steers users and orgs toward **keeping mise on a recent CLI** and using **`min_version`** when a project needs a newer feature, instead of locking everyone to one mise binary.
> 
> **`docs/installing-mise.md`** adds a prominent **“Keep mise up to date”** tip (after the auto-update tip): external registries/backends evolve, so recent mise works best; prefer `min_version` over pinning; pinning is compared to blocking `apt`/`brew` metadata refresh and can hide deprecations and drift (e.g. aqua-registry).
> 
> **`docs/configuration.md`** adds a short paragraph under **Minimum mise version** with the same policy: `min_version` states the oldest supported mise; staying current is encouraged; pinning one executable is discouraged for the same metadata/integration reasons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37193d0c51db2d4554d038c20473069c767095ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the `min_version` setting to communicate the oldest supported mise version
  * Added a “Keep mise up to date” tip, explaining how external sources can change and recommending minimum-version requirements over pinning to a specific mise executable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->