### PR TITLE
fix(backend): add riscv64/loongarch64 archs, patterns

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -40,6 +40,8 @@ pub enum AssetArch {
     Arm64,
     X86,
     Arm,
+    Riscv64,
+    Loongarch64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -66,6 +68,8 @@ impl AssetArch {
             AssetArch::Arm64 => target == "aarch64" || target == "arm64",
             AssetArch::X86 => target == "x86" || target == "i386" || target == "i686",
             AssetArch::Arm => target == "arm",
+            AssetArch::Riscv64 => target == "riscv64" || target == "riscv64gc",
+            AssetArch::Loongarch64 => target == "loongarch64" || target == "loong64",
         }
     }
 }
@@ -103,6 +107,8 @@ impl DetectedPlatform {
             AssetArch::Arm64 => "arm64",
             AssetArch::X86 => "x86",
             AssetArch::Arm => "arm",
+            AssetArch::Riscv64 => "riscv64",
+            AssetArch::Loongarch64 => "loongarch64",
         };
 
         format!("{os_str}-{arch_str}")
@@ -145,6 +151,14 @@ static ARCH_PATTERNS: LazyLock<Vec<(AssetArch, Regex)>> = LazyLock::new(|| {
         (
             AssetArch::Arm,
             Regex::new(r"(?i)(?:\b|_)arm(?:v[0-7])?(?:\b|_)").unwrap(),
+        ),
+        (
+            AssetArch::Riscv64,
+            Regex::new(r"(?i)(?:\b|_)riscv_?64(?:gc)?(?:\b|_)").unwrap(),
+        ),
+        (
+            AssetArch::Loongarch64,
+            Regex::new(r"(?i)(?:\b|_)loong(?:arch)?_?64(?:\b|_)").unwrap(),
         ),
     ]
 });
@@ -1152,6 +1166,27 @@ fn is_valid_hash(s: &str, algorithm: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_asset_picker_riscv64_not_shadowed_by_s390x() {
+        // Regression: uv/prek ship riscv64gc, s390x, and powerpc64 linux assets.
+        // s390x/powerpc64 match no arch regex, so before riscv64 was known they tied
+        // with the riscv asset at the same score and the shortest-name tiebreak
+        // picked the s390x asset on a riscv64 host. riscv64 must win on riscv64 host.
+        let assets = vec![
+            "uv-aarch64-unknown-linux-gnu.tar.gz".to_string(),
+            "uv-x86_64-unknown-linux-gnu.tar.gz".to_string(),
+            "uv-s390x-unknown-linux-gnu.tar.gz".to_string(),
+            "uv-powerpc64-unknown-linux-gnu.tar.gz".to_string(),
+            "uv-powerpc64le-unknown-linux-gnu.tar.gz".to_string(),
+            "uv-riscv64gc-unknown-linux-gnu.tar.gz".to_string(),
+            "uv-riscv64gc-unknown-linux-musl.tar.gz".to_string(),
+        ];
+        let picked = AssetPicker::with_libc("linux".to_string(), "riscv64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "uv-riscv64gc-unknown-linux-gnu.tar.gz");
+    }
 
     fn test_assets() -> Vec<String> {
         vec![


### PR DESCRIPTION
I have a [spacemit k3 soc](https://www.spacemit.com/community/development-kit/k3-pico-itx) which is based on riscv64, and wanted to do some development on it using mise. However, installing `github:astral-sh/uv` resulted in mise attempting to download the s390x version. This change adds Riscv64 (and loongarch64) as architectures and adds the necessary regex patterns to create a real match.

The regex is likely a bit limited here...uv uses "riscv64gc" in its tarball name. That pattern is a bit dated, and I would expect most others to simply use "riscv64". The "gc" are a couple common extensions to the specification, but lately people have been dropping that. The full regex pattern for any set of extensions could be a bit unwieldy (but also unlikely to encounter in practice), so I thought it was best to defer additional work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for RISC-V 64-bit and Loongarch64 CPU architectures in asset platform detection, enabling proper recognition and selection of matching assets.
* **Bug Fixes**
  * Improved platform scoring to prevent RISC-V 64-bit assets (including `riscv64gc`) from being incorrectly shadowed by similarly scored architectures.
* **Tests**
  * Added a regression test to cover correct selection behavior for RISC-V 64-bit assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->