### PR TITLE
fix(pipx): warn for unsupported uv exclude-newer

### DIFF
--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -29,7 +29,8 @@ If you have `uv` installed, mise will use `uv tool install` under the hood and y
 
 mise forwards [`minimum_release_age`](/configuration/settings.html#minimum_release_age)
 to transitive Python dependency resolution during install. The uv install path uses uv's
-`--exclude-newer` flag, and the `pipx` fallback passes pip's `--uploaded-prior-to` flag.
+`--exclude-newer` flag and requires `uv >= 0.2.22`. The `pipx` fallback passes pip's
+`--uploaded-prior-to` flag.
 
 In case you need `pipx` for other reasons, you can install it with or without mise.
 Here is how to install `pipx` with mise:

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -30,6 +30,7 @@ use crate::plugins::core::CORE_PLUGINS;
 use crate::plugins::{PEP440_PRERELEASE_REGEX, PluginType, VERSION_REGEX};
 use crate::registry::{REGISTRY, full_to_url, normalize_remote, tool_enabled};
 use crate::runtime_symlinks::is_runtime_symlink;
+use crate::semver::semver_triplet;
 use crate::tera::{contains_template_syntax, get_tera, render_str};
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{
@@ -91,6 +92,69 @@ pub(crate) fn backend_arg_matches_registry_backend(ba: &BackendArg) -> bool {
     REGISTRY
         .get(ba.short.as_str())
         .is_some_and(|rt| rt.backends().iter().any(|b| *b == full))
+}
+
+pub(crate) fn toolset_semver_version(ts: &Toolset, tool: &str) -> Option<String> {
+    let tvl = ts
+        .versions
+        .iter()
+        .find(|(ba, _)| ba.short == tool)
+        .map(|(_, tvl)| tvl)?;
+
+    if let Some(version) = tvl.versions.iter().find_map(|tv| {
+        let version = tv.version.trim().trim_start_matches(['v', 'V']);
+        semver_triplet(version)?;
+        Some(version.to_string())
+    }) {
+        return Some(version);
+    }
+
+    tvl.requests.iter().find_map(|tr| {
+        let version = tr.version();
+        let version = version.trim().trim_start_matches(['v', 'V']);
+        semver_triplet(version)?;
+        Some(version.to_string())
+    })
+}
+
+pub(crate) async fn semver_version_from_toolsets_or_path(
+    backend: &dyn Backend,
+    config: &Arc<Config>,
+    ts: &Toolset,
+    tool: &str,
+) -> Option<String> {
+    if let Some(version) = toolset_semver_version(ts, tool) {
+        return Some(version);
+    }
+    if let Ok(ts) = backend.dependency_toolset(config).await
+        && let Some(version) = toolset_semver_version(&ts, tool)
+    {
+        return Some(version);
+    }
+    semver_version_from_path(backend, config, tool).await
+}
+
+async fn semver_version_from_path(
+    backend: &dyn Backend,
+    config: &Arc<Config>,
+    tool: &str,
+) -> Option<String> {
+    let env = backend.dependency_env(config).await.ok()?;
+    let output = cmd!(tool, "--version").full_env(env).read().ok()?;
+    parse_cli_version_output(&output)
+}
+
+pub(crate) fn parse_cli_version_output(output: &str) -> Option<String> {
+    let line = output.lines().next()?;
+    let version = line.trim().trim_start_matches(['v', 'V']);
+    if semver_triplet(version).is_some() {
+        return Some(version.to_string());
+    }
+    line.split_whitespace().find_map(|version| {
+        let version = version.trim().trim_start_matches(['v', 'V']);
+        semver_triplet(version)?;
+        Some(version.to_string())
+    })
 }
 
 const VERSIONS_HOST_LOCAL_OPT_SOURCES: &[ToolOptionSource] = &[
@@ -459,10 +523,30 @@ pub(crate) fn normalize_idiomatic_contents(contents: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::args::BackendResolution;
-    use crate::toolset::{ToolSource, ToolVersionOptions};
+    use crate::cli::args::{BackendArg, BackendResolution};
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersionList, ToolVersionOptions};
     use std::fs;
+    use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn create_test_backend_arg(tool: &str) -> Arc<BackendArg> {
+        Arc::new(BackendArg::new_raw(
+            tool.to_string(),
+            None,
+            tool.to_string(),
+            None,
+            BackendResolution::new(true),
+        ))
+    }
+
+    fn create_test_tool_request(ba: Arc<BackendArg>, version: &str) -> ToolRequest {
+        ToolRequest::Version {
+            backend: ba,
+            version: version.to_string(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        }
+    }
 
     #[test]
     fn test_normalize_idiomatic_contents() {
@@ -485,6 +569,86 @@ mod tests {
             normalize_idiomatic_contents("# full line comment\n3.14.2 # inline comment\n   \n\n"),
             "3.14.2"
         );
+    }
+
+    #[test]
+    fn test_toolset_semver_version_prefers_resolved_version() {
+        let ba = create_test_backend_arg("bun");
+        let request = create_test_tool_request(ba.clone(), "1.2.0");
+        let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
+        tvl.requests.push(request.clone());
+        tvl.versions
+            .push(ToolVersion::new(request, "1.3.0".to_string()));
+
+        let mut ts = Toolset::default();
+        ts.versions.insert(ba, tvl);
+
+        assert_eq!(
+            toolset_semver_version(&ts, "bun"),
+            Some("1.3.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_toolset_semver_version_uses_exact_request() {
+        let ba = create_test_backend_arg("pnpm");
+        let request = create_test_tool_request(ba.clone(), "10.15.0");
+        let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
+        tvl.requests.push(request);
+
+        let mut ts = Toolset::default();
+        ts.versions.insert(ba, tvl);
+
+        assert_eq!(
+            toolset_semver_version(&ts, "pnpm"),
+            Some("10.15.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_toolset_semver_version_ignores_unresolved_request() {
+        let ba = create_test_backend_arg("pnpm");
+        let request = create_test_tool_request(ba.clone(), "10");
+        let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
+        tvl.requests.push(request);
+
+        let mut ts = Toolset::default();
+        ts.versions.insert(ba, tvl);
+
+        assert_eq!(toolset_semver_version(&ts, "pnpm"), None);
+    }
+
+    #[test]
+    fn test_toolset_semver_version_normalizes_v_prefix() {
+        let ba = create_test_backend_arg("pnpm");
+        let request = create_test_tool_request(ba.clone(), "v10.15.0");
+        let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
+        tvl.requests.push(request);
+
+        let mut ts = Toolset::default();
+        ts.versions.insert(ba, tvl);
+
+        assert_eq!(
+            toolset_semver_version(&ts, "pnpm"),
+            Some("10.15.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_cli_version_output() {
+        assert_eq!(
+            parse_cli_version_output("10.15.0\n"),
+            Some("10.15.0".to_string())
+        );
+        assert_eq!(
+            parse_cli_version_output("v1.3.0"),
+            Some("1.3.0".to_string())
+        );
+        assert_eq!(
+            parse_cli_version_output("uv 0.2.22"),
+            Some("0.2.22".to_string())
+        );
+        assert_eq!(parse_cli_version_output("not-a-version"), None);
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -13,7 +13,7 @@ use crate::config::settings::NpmPackageManager;
 use crate::config::{Config, Settings};
 use crate::duration::{elapsed_seconds_ceil, process_now};
 use crate::install_context::InstallContext;
-use crate::semver::{semver_is_at_least, semver_is_older_than, semver_triplet};
+use crate::semver::{semver_is_at_least, semver_is_older_than};
 use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 use async_trait::async_trait;
@@ -537,9 +537,9 @@ impl NPMBackend {
             return;
         };
 
-        let Some(version) = self
-            .package_manager_version_for_release_age(&ctx.config, ctx, tool)
-            .await
+        let Some(version) =
+            crate::backend::semver_version_from_toolsets_or_path(self, &ctx.config, &ctx.ts, tool)
+                .await
         else {
             warn!(
                 "minimum_release_age is set for npm:{} but could not determine {} version required to verify {} support. Release-age filtering for transitive dependencies may not work as expected. See https://mise.en.dev/dev-tools/backends/npm.html",
@@ -579,70 +579,6 @@ impl NPMBackend {
                 "--config.minimumReleaseAge",
             )),
         }
-    }
-
-    fn toolset_package_manager_version(ts: &Toolset, tool: &str) -> Option<String> {
-        let tvl = ts
-            .versions
-            .iter()
-            .find(|(ba, _)| ba.short == tool)
-            .map(|(_, tvl)| tvl)?;
-
-        if let Some(version) = tvl
-            .versions
-            .iter()
-            .find_map(|tv| Self::normalize_package_manager_version(&tv.version))
-        {
-            return Some(version);
-        }
-
-        tvl.requests
-            .iter()
-            .find_map(|tr| Self::normalize_package_manager_version(&tr.version()))
-    }
-
-    /// Resolve the pnpm/bun version used to check release-age flag support.
-    ///
-    /// Prefers mise-managed versions from the install and dependency toolsets,
-    /// then falls back to `{tool} --version` on PATH.
-    async fn package_manager_version_for_release_age(
-        &self,
-        config: &Arc<Config>,
-        ctx: &InstallContext,
-        tool: &str,
-    ) -> Option<String> {
-        if let Some(version) = Self::toolset_package_manager_version(&ctx.ts, tool) {
-            return Some(version);
-        }
-        if let Ok(ts) = self.dependency_toolset(config).await
-            && let Some(version) = Self::toolset_package_manager_version(&ts, tool)
-        {
-            return Some(version);
-        }
-        self.package_manager_version_from_path(config, tool).await
-    }
-
-    /// Read `{tool} --version` using the npm-backend dependency environment.
-    async fn package_manager_version_from_path(
-        &self,
-        config: &Arc<Config>,
-        tool: &str,
-    ) -> Option<String> {
-        let env = self.dependency_env(config).await.ok()?;
-        let output = cmd!(tool, "--version").full_env(env).read().ok()?;
-        Self::parse_package_manager_version_output(&output)
-    }
-
-    /// Parse the first line of a package manager `--version` response.
-    fn parse_package_manager_version_output(output: &str) -> Option<String> {
-        let version = output.lines().next()?;
-        Self::normalize_package_manager_version(version)
-    }
-
-    fn normalize_package_manager_version(version: &str) -> Option<String> {
-        let version = version.trim().trim_start_matches(['v', 'V']);
-        semver_triplet(version)?;
-        Some(version.to_string())
     }
 
     /// Detect whether the locally installed npm supports --min-release-age.
@@ -969,9 +905,8 @@ pub fn install_time_option_keys() -> Vec<String> {
 mod tests {
     use super::*;
     use crate::cli::args::{BackendArg, BackendResolution};
-    use crate::toolset::{ToolRequest, ToolSource, ToolVersionList, ToolVersionOptions};
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions};
     use pretty_assertions::assert_eq;
-    use std::sync::Arc;
 
     fn create_npm_backend(tool: &str) -> NPMBackend {
         let ba = BackendArg::new_raw(
@@ -982,25 +917,6 @@ mod tests {
             BackendResolution::new(true),
         );
         NPMBackend::from_arg(ba)
-    }
-
-    fn create_test_backend_arg(tool: &str) -> Arc<BackendArg> {
-        Arc::new(BackendArg::new_raw(
-            tool.to_string(),
-            None,
-            tool.to_string(),
-            None,
-            BackendResolution::new(true),
-        ))
-    }
-
-    fn create_test_tool_request(ba: Arc<BackendArg>, version: &str) -> ToolRequest {
-        ToolRequest::Version {
-            backend: ba,
-            version: version.to_string(),
-            options: ToolVersionOptions::default(),
-            source: ToolSource::Argument,
-        }
     }
 
     #[test]
@@ -1237,88 +1153,6 @@ mod tests {
         assert_eq!(
             crate::semver::semver_is_at_least("11.9.9", NPM_MIN_RELEASE_AGE_VERSION),
             Some(false)
-        );
-    }
-
-    #[test]
-    fn test_toolset_package_manager_version_prefers_resolved_version() {
-        let ba = create_test_backend_arg("bun");
-        let request = create_test_tool_request(ba.clone(), "1.2.0");
-        let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
-        tvl.requests.push(request.clone());
-        tvl.versions
-            .push(ToolVersion::new(request, "1.3.0".to_string()));
-
-        let mut ts = Toolset::default();
-        ts.versions.insert(ba, tvl);
-
-        assert_eq!(
-            NPMBackend::toolset_package_manager_version(&ts, "bun"),
-            Some("1.3.0".to_string())
-        );
-    }
-
-    #[test]
-    fn test_toolset_package_manager_version_uses_exact_request() {
-        let ba = create_test_backend_arg("pnpm");
-        let request = create_test_tool_request(ba.clone(), "10.15.0");
-        let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
-        tvl.requests.push(request);
-
-        let mut ts = Toolset::default();
-        ts.versions.insert(ba, tvl);
-
-        assert_eq!(
-            NPMBackend::toolset_package_manager_version(&ts, "pnpm"),
-            Some("10.15.0".to_string())
-        );
-    }
-
-    #[test]
-    fn test_toolset_package_manager_version_ignores_unresolved_request() {
-        let ba = create_test_backend_arg("pnpm");
-        let request = create_test_tool_request(ba.clone(), "10");
-        let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
-        tvl.requests.push(request);
-
-        let mut ts = Toolset::default();
-        ts.versions.insert(ba, tvl);
-
-        assert_eq!(
-            NPMBackend::toolset_package_manager_version(&ts, "pnpm"),
-            None
-        );
-    }
-
-    #[test]
-    fn test_toolset_package_manager_version_normalizes_v_prefix() {
-        let ba = create_test_backend_arg("pnpm");
-        let request = create_test_tool_request(ba.clone(), "v10.15.0");
-        let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
-        tvl.requests.push(request);
-
-        let mut ts = Toolset::default();
-        ts.versions.insert(ba, tvl);
-
-        assert_eq!(
-            NPMBackend::toolset_package_manager_version(&ts, "pnpm"),
-            Some("10.15.0".to_string())
-        );
-    }
-
-    #[test]
-    fn test_parse_package_manager_version_output() {
-        assert_eq!(
-            NPMBackend::parse_package_manager_version_output("10.15.0\n"),
-            Some("10.15.0".to_string())
-        );
-        assert_eq!(
-            NPMBackend::parse_package_manager_version_output("v1.3.0"),
-            Some("1.3.0".to_string())
-        );
-        assert_eq!(
-            NPMBackend::parse_package_manager_version_output("not-a-version"),
-            None
         );
     }
 

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -14,6 +14,7 @@ use crate::github::{self, GithubRelease};
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
 use crate::plugins::PEP440_PRERELEASE_REGEX;
+use crate::semver::semver_is_older_than;
 use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset, ToolsetBuilder};
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -35,6 +36,8 @@ use std::str::FromStr;
 use std::{fmt::Debug, sync::Arc};
 use versions::Versioning;
 use xx::regex;
+
+const UV_EXCLUDE_NEWER_VERSION: &str = "0.2.22";
 
 #[derive(Debug)]
 pub struct PIPXBackend {
@@ -276,6 +279,7 @@ impl Backend for PIPXBackend {
             .pipx_request(&tv.version, &options);
 
         if use_uvx {
+            self.warn_if_uv_may_not_support_exclude_newer(ctx).await;
             ctx.pr
                 .set_message(format!("uv tool install {pipx_request}"));
             let mut cmd = Self::uvx_cmd(
@@ -560,6 +564,32 @@ impl PIPXBackend {
     async fn uv_is_installed(&self, config: &Arc<Config>) -> bool {
         self.dependency_which(config, "uv").await.is_some()
     }
+
+    async fn warn_if_uv_may_not_support_exclude_newer(&self, ctx: &InstallContext) {
+        if ctx.before_date.is_none() {
+            return;
+        }
+
+        let Some(version) =
+            crate::backend::semver_version_from_toolsets_or_path(self, &ctx.config, &ctx.ts, "uv")
+                .await
+        else {
+            warn!(
+                "minimum_release_age is set for pipx:{} but could not determine uv version required to verify --exclude-newer support. Release-age filtering for transitive dependencies may not work as expected. See https://mise.en.dev/dev-tools/backends/pipx.html",
+                self.tool_name(),
+            );
+            return;
+        };
+
+        if semver_is_older_than(&version, UV_EXCLUDE_NEWER_VERSION).unwrap_or(false) {
+            warn!(
+                "minimum_release_age is set for pipx:{} but uv@{} is older than the documented minimum uv@{} required for --exclude-newer. Older versions may fail while processing the forwarded argument. See https://mise.en.dev/dev-tools/backends/pipx.html",
+                self.tool_name(),
+                version,
+                UV_EXCLUDE_NEWER_VERSION,
+            );
+        }
+    }
 }
 
 enum PipxRequest {
@@ -782,7 +812,7 @@ fn fix_venv_python_symlink(_install_path: &Path, _pkg_name: &str) -> Result<()> 
 
 #[cfg(test)]
 mod tests {
-    use super::{PIPXBackend, PypiPackage, PypiRelease};
+    use super::{PIPXBackend, PypiPackage, PypiRelease, UV_EXCLUDE_NEWER_VERSION};
     use crate::github::GithubRelease;
     use indexmap::IndexMap;
     use pretty_assertions::assert_eq;
@@ -919,6 +949,19 @@ mod tests {
         assert_eq!(
             PIPXBackend::uv_exclude_newer_args(None),
             Vec::<OsString>::new()
+        );
+    }
+
+    #[test]
+    fn test_uv_exclude_newer_version_requirement() {
+        assert_eq!(UV_EXCLUDE_NEWER_VERSION, "0.2.22");
+        assert_eq!(
+            crate::semver::semver_is_at_least("0.2.22", UV_EXCLUDE_NEWER_VERSION),
+            Some(true)
+        );
+        assert_eq!(
+            crate::semver::semver_is_at_least("0.2.21", UV_EXCLUDE_NEWER_VERSION),
+            Some(false)
         );
     }
 


### PR DESCRIPTION
## Summary
- warn when `minimum_release_age` is forwarded to `uv tool install` but the uv version cannot be verified or is older than `0.2.22`
- move npm package-manager version parsing/toolset lookup helpers into `backend::mod` for reuse
- document the uv minimum for the pipx backend

## Notes
- This does not stack on #10472 because the changes do not conflict mechanically; #10472 changes the pipx fallback path, while this change only checks the uv install path.

## Testing
- `mise x cargo -- cargo fmt --check`
- `git diff --check`
- `mise x cargo -- cargo test backend::npm::tests`
- `mise x cargo -- cargo test backend::pipx::tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pipx backend docs to describe release-age fallback behavior separately for `uv` (`--exclude-newer`, requires `uv >= 0.2.22`) and pip (`--uploaded-prior-to`).

* **Improvements**
  * Added `uvx` pre-install warnings when release-age forwarding is enabled, including a minimum `uv` version gate for reliable `--exclude-newer` handling.
  * Standardized how `{tool}` versions are detected for consistent release-age comparisons (including npm).

* **Tests**
  * Expanded semver precedence, `v`-prefix normalization, and CLI version parsing fallback coverage.

* **Refactor**
  * Centralized semver-based `{tool}` version resolution across backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->