### PR TITLE
fix(env): expand escaped dollar in env shell expansion

### DIFF
--- a/e2e/env/test_env_shell_expand
+++ b/e2e/env/test_env_shell_expand
@@ -9,6 +9,14 @@ BAR = "$FOO-world"
 EOF
 MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=hello-world"
 
+# Test $$ escapes a literal $
+cat <<'EOF' >mise.toml
+[env]
+SOME_VAR = "$$x"
+EOF
+MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash 2>&1" "export SOME_VAR='\$x'"
+MISE_ENV_SHELL_EXPAND=true assert_not_contains "mise env -s bash 2>&1" "env var 'x' is not defined"
+
 # Test ${VAR} brace syntax
 cat <<'EOF' >mise.toml
 [env]

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -804,6 +804,10 @@ fn shell_expand_env(
         }
 
         match chars.peek().copied() {
+            Some((_, '$')) => {
+                chars.next();
+                output.push('$');
+            }
             Some((_, '{')) => {
                 chars.next();
                 if let Some((end, expr)) = read_braced_expr(input, idx + 2) {


### PR DESCRIPTION
## Summary
- treat `$$` as an escaped literal `$` during `env_shell_expand`
- add regression coverage for `SOME_VAR = "$$x"` so it expands to `$x` without a missing-var warning

Fixes the regression reported in https://github.com/jdx/mise/discussions/10508.

## Test
- `mise run test:e2e e2e/env/test_env_shell_expand`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to env value parsing with dedicated e2e coverage; no auth or data-path impact.
> 
> **Overview**
> Fixes a regression in **`env_shell_expand`** where `$$` was not treated as an escaped dollar, so values like `"$$x"` incorrectly triggered expansion of a bare `$x` and missing-var warnings.
> 
> **`shell_expand_env`** now handles a `$` followed by another `$` by emitting a single literal `$` (same idea as shell escaping), before existing `${…}` and `$VAR` logic runs.
> 
> An e2e case asserts `SOME_VAR = "$$x"` exports as `$x` with no undefined-var warning when `MISE_ENV_SHELL_EXPAND=true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bdd3a6024e6bae967bc9dab6bacfd43ca3ac916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell environment variables now support `$$` as an escape sequence to represent a literal `$` character, preventing unintended variable expansion.

* **Tests**
  * Added end-to-end test coverage for `$$` escape sequence handling in environment variable expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->