### PR TITLE
fix(pipx): force pip backend for mise pipx subprocess calls

### DIFF
--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -552,6 +552,11 @@ impl PIPXBackend {
         cmd.with_pr(pr)
             .envs(ts.env_with_path_without_tools(config).await?)
             .envs(tv.install_env())
+            // pipx 1.12+ auto-selects the uv backend when uv is on PATH (pypa/pipx#1806).
+            // mise already installs via `uv tool install` when uv is available; the pipx
+            // fallback passes pip-only `--pip-args` (e.g. `--uploaded-prior-to` for
+            // minimum_release_age) which uv rejects — see jdx/mise#10484.
+            .env("PIPX_DEFAULT_BACKEND", "pip")
             .env("PIP_INDEX_URL", Self::get_index_url()?)
             .env_remove("PIPX_SHARED_LIBS")
             .env("PIPX_HOME", tv.install_path())

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -552,10 +552,7 @@ impl PIPXBackend {
         cmd.with_pr(pr)
             .envs(ts.env_with_path_without_tools(config).await?)
             .envs(tv.install_env())
-            // pipx 1.12+ auto-selects the uv backend when uv is on PATH (pypa/pipx#1806).
-            // mise already installs via `uv tool install` when uv is available; the pipx
-            // fallback passes pip-only `--pip-args` (e.g. `--uploaded-prior-to` for
-            // minimum_release_age) which uv rejects — see jdx/mise#10484.
+            // pipx 1.12+ auto-picks uv on PATH; this path passes pip-only --pip-args.
             .env("PIPX_DEFAULT_BACKEND", "pip")
             .env("PIP_INDEX_URL", Self::get_index_url()?)
             .env_remove("PIPX_SHARED_LIBS")


### PR DESCRIPTION
## Summary

- set `PIPX_DEFAULT_BACKEND=pip` on all mise `pipx` subprocess invocations (`pipx_cmd`)

## Background

[pipx 1.12+](https://github.com/pypa/pipx/releases/tag/1.12.0) added an opt-in uv backend ([pypa/pipx#1806](https://github.com/pypa/pipx/pull/1806)) and now auto-selects it when `uv` is on `PATH`.

The mise pipx backend **already** uses `uv tool install` directly when `uv` is available (the default path). The remaining `pipx install` fallback exists for pip-specific flows: `pipx_args`, `--include-deps`, `uvx = false`, etc.

When pipx auto-picks its internal uv backend on that fallback path, mise's `--pip-args=--uploaded-prior-to=…` (used for [`minimum_release_age`](https://mise.en.dev/configuration/settings.html#minimum_release_age)) is forwarded into uv, which rejects pip-only flags. This is the failure reported in [discussion #10484](https://github.com/jdx/mise/discussions/10484) (`pipx + uv backend is broken`).

Related: [#10472](https://github.com/jdx/mise/pull/10472) fixed the separate shared-pip bootstrap issue ([pypa/pipx#544](https://github.com/pypa/pipx/issues/544)) on the pip backend path; this PR ensures pipx stays on the pip backend so those pip flags reach pip.

## Why this does not break anything

- **When mise wants uv**, it already calls `uv tool install` — not pipx's uv wrapper. This change only affects the explicit pipx fallback path.
- **When mise calls pipx**, it relies on pip semantics (`--pip-args`, shared libs, `--include-deps`). Forcing the pip backend matches that intent; pipx's uv backend does not understand those flags ([pipx docs](https://pipx.pypa.io/latest/how-to/use-uv-backend/#limitations)).
- **`upgrade-shared`** and normal installs both work with the pip backend; mise sets an isolated `PIPX_HOME` per tool version anyway.
- **Standalone pipx users** are unaffected — this env var is only set on subprocesses mise spawns.

## Test plan

- [x] `mise run lint-fix`
- [ ] CI
- [ ] Manual: with system `uv` on PATH, `MISE_PIPX_UVX=0`, and `minimum_release_age` set, `mise install pipx:cowsay` succeeds (no uv `--uploaded-prior-to` error)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pipx backend selection with pipx v1.12+ to ensure it consistently uses the pip backend, preventing unexpected backend switching that could cause forwarded pip-specific arguments (e.g., `--uploaded-prior-to`) to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->