### PR TITLE
fix(backend): resolve dependency executables on Windows

### DIFF
--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
@@ -16,10 +17,9 @@ use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::env::GITHUB_TOKEN;
-use crate::file;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
-use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions};
+use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 
 #[derive(Debug)]
 pub struct CargoBackend {
@@ -84,7 +84,7 @@ impl<'a> CargoOptions<'a> {
 
 #[derive(Debug)]
 enum BinstallStatus {
-    Enabled,
+    Enabled(PathBuf),
     Disabled,
     Unavailable,
     UnsupportedOptions(Vec<&'static str>),
@@ -183,9 +183,9 @@ impl Backend for CargoBackend {
             }
             cmd
         } else {
-            match self.binstall_status(&config, &tv).await {
-                BinstallStatus::Enabled => {
-                    let mut cmd = CmdLineRunner::new("cargo-binstall").arg("-y");
+            match self.binstall_status(&config, Some(&ctx.ts), &tv).await {
+                BinstallStatus::Enabled(cargo_binstall) => {
+                    let mut cmd = CmdLineRunner::new(cargo_binstall).arg("-y");
                     if let Some(token) = &*GITHUB_TOKEN {
                         cmd = cmd.env("GITHUB_TOKEN", token)
                     }
@@ -298,7 +298,12 @@ impl CargoBackend {
         options
     }
 
-    async fn binstall_status(&self, config: &Arc<Config>, tv: &ToolVersion) -> BinstallStatus {
+    async fn binstall_status(
+        &self,
+        config: &Arc<Config>,
+        ts: Option<&Toolset>,
+        tv: &ToolVersion,
+    ) -> BinstallStatus {
         if !Settings::get().cargo.binstall {
             return BinstallStatus::Disabled;
         }
@@ -307,19 +312,13 @@ impl CargoBackend {
         if !cargo_install_required_options.is_empty() {
             return BinstallStatus::UnsupportedOptions(cargo_install_required_options);
         }
-        if file::which_non_pristine("cargo-binstall").is_none() {
-            match self.dependency_toolset(config).await {
-                Ok(ts) => {
-                    if ts.which(config, "cargo-binstall").await.is_none() {
-                        return BinstallStatus::Unavailable;
-                    }
-                }
-                Err(_e) => {
-                    return BinstallStatus::Unavailable;
-                }
-            }
+        if let Some(cargo_binstall) = self
+            .dependency_path_for_install(config, ts, "cargo-binstall")
+            .await
+        {
+            return BinstallStatus::Enabled(cargo_binstall);
         }
-        BinstallStatus::Enabled
+        BinstallStatus::Unavailable
     }
 
     /// if the name is a git repo, return the git url

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -520,6 +520,48 @@ pub(crate) fn normalize_idiomatic_contents(contents: &str) -> String {
         .join("\n")
 }
 
+fn executable_names(bin: &str) -> Vec<String> {
+    let mut names = vec![bin.to_string()];
+    if cfg!(target_os = "windows") && Path::new(bin).extension().is_none() {
+        for ext in &Settings::get().windows_executable_extensions {
+            let name = if ext.is_empty() {
+                bin.to_string()
+            } else {
+                format!("{bin}.{ext}")
+            };
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+    }
+    names
+}
+
+fn which_non_pristine_executable(bin: &str) -> Option<PathBuf> {
+    executable_names(bin)
+        .into_iter()
+        .find_map(file::which_non_pristine)
+}
+
+pub(crate) async fn configured_toolset_or_path_which(
+    config: &Arc<Config>,
+    tools: impl IntoIterator<Item = String>,
+    bin: &str,
+) -> Result<Option<PathBuf>> {
+    let filtered = config
+        .get_tool_request_set()
+        .await?
+        .filter_by_tool(tools.into_iter().collect::<std::collections::HashSet<_>>());
+    if !filtered.tools.is_empty() {
+        let mut ts = filtered.into_toolset();
+        Box::pin(ts.resolve(config)).await?;
+        if let Some(bin) = ts.which_bin(config, bin).await {
+            return Ok(Some(bin));
+        }
+    }
+    Ok(which_non_pristine_executable(bin))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2371,18 +2413,10 @@ pub trait Backend: Debug + Send + Sync {
             .into_iter()
             .filter(|p| p.parent().is_some());
         for bin_path in bin_paths {
-            let paths_with_ext = if cfg!(windows) {
-                vec![
-                    bin_path.clone(),
-                    bin_path.join(bin_name).with_extension("exe"),
-                    bin_path.join(bin_name).with_extension("cmd"),
-                    bin_path.join(bin_name).with_extension("bat"),
-                    bin_path.join(bin_name).with_extension("ps1"),
-                ]
-            } else {
-                vec![bin_path.join(bin_name)]
-            };
-            for bin_path in paths_with_ext {
+            for bin_path in executable_names(bin_name)
+                .into_iter()
+                .map(|bin| bin_path.join(bin))
+            {
                 if bin_path.exists() && file::is_executable(&bin_path) {
                     return Ok(Some(bin_path));
                 }
@@ -2519,7 +2553,7 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     async fn dependency_which(&self, config: &Arc<Config>, bin: &str) -> Option<PathBuf> {
-        if let Some(bin) = file::which_non_pristine(bin) {
+        if let Some(bin) = which_non_pristine_executable(bin) {
             return Some(bin);
         }
         let Ok(ts) = self.dependency_toolset(config).await else {
@@ -2527,6 +2561,20 @@ pub trait Backend: Debug + Send + Sync {
         };
         let (b, tv) = ts.which(config, bin).await?;
         b.which(config, &tv, bin).await.ok().flatten()
+    }
+
+    async fn dependency_path_for_install(
+        &self,
+        config: &Arc<Config>,
+        ts: Option<&Toolset>,
+        bin: &str,
+    ) -> Option<PathBuf> {
+        if let Some(ts) = ts
+            && let Some(bin) = ts.which_bin(config, bin).await
+        {
+            return Some(bin);
+        }
+        self.dependency_which(config, bin).await
     }
 
     /// Check if a required dependency is available and show a warning if not.
@@ -2541,26 +2589,7 @@ pub trait Backend: Debug + Send + Sync {
         provided_by: &[&str],
         install_instructions: &str,
     ) {
-        let found = if self.dependency_which(config, program).await.is_some() {
-            true
-        } else if cfg!(windows) {
-            // On Windows, also check for program with Windows executable extensions
-            let settings = Settings::get();
-            let mut found = false;
-            for ext in &settings.windows_executable_extensions {
-                if self
-                    .dependency_which(config, &format!("{}.{}", program, ext))
-                    .await
-                    .is_some()
-                {
-                    found = true;
-                    break;
-                }
-            }
-            found
-        } else {
-            false
-        };
+        let found = self.dependency_which(config, program).await.is_some();
 
         if !found {
             // Check if a tool that provides this program is configured in the toolset

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -331,7 +331,7 @@ impl Backend for NPMBackend {
             NpmPackageManager::Auto => unreachable!("auto package manager should be resolved"),
             NpmPackageManager::Aube => {
                 let aube_program = self
-                    .aube_path_for_install(&ctx.config, Some(&ctx.ts))
+                    .dependency_path_for_install(&ctx.config, Some(&ctx.ts), AUBE_PROGRAM)
                     .await
                     .unwrap_or_else(|| AUBE_PROGRAM.into());
                 self.write_aube_npmrc(&tv.install_path(), ctx.before_date)?;
@@ -729,20 +729,9 @@ impl NPMBackend {
     }
 
     async fn aube_is_installed(&self, config: &Arc<Config>, ts: Option<&Toolset>) -> bool {
-        self.aube_path_for_install(config, ts).await.is_some()
-    }
-
-    async fn aube_path_for_install(
-        &self,
-        config: &Arc<Config>,
-        ts: Option<&Toolset>,
-    ) -> Option<std::path::PathBuf> {
-        if let Some(ts) = ts
-            && let Some(bin) = ts.which_bin(config, AUBE_PROGRAM).await
-        {
-            return Some(bin);
-        }
-        self.dependency_which(config, AUBE_PROGRAM).await
+        self.dependency_path_for_install(config, ts, AUBE_PROGRAM)
+            .await
+            .is_some()
     }
 
     fn write_aube_npmrc(&self, install_path: &Path, before_date: Option<Timestamp>) -> Result<()> {

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -29,9 +29,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
-use std::path::Path;
-#[cfg(unix)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fmt::Debug, sync::Arc};
 use versions::Versioning;
@@ -256,11 +254,14 @@ impl Backend for PIPXBackend {
         let options = PipxOptions::new(&request_options);
 
         // Check if pipx is available (unless uvx is being used)
-        let use_uvx = self.uv_is_installed(&ctx.config).await
-            && Settings::get().pipx.uvx != Some(false)
-            && !options.uvx_disabled();
+        let uv_program = if Settings::get().pipx.uvx != Some(false) && !options.uvx_disabled() {
+            self.dependency_path_for_install(&ctx.config, Some(&ctx.ts), "uv")
+                .await
+        } else {
+            None
+        };
 
-        if !use_uvx {
+        if uv_program.is_none() {
             self.warn_if_dependency_missing(
                 &ctx.config,
                 "pipx",
@@ -278,11 +279,12 @@ impl Backend for PIPXBackend {
             .parse::<PipxRequest>()?
             .pipx_request(&tv.version, &options);
 
-        if use_uvx {
+        if let Some(uv_program) = uv_program {
             self.warn_if_uv_may_not_support_exclude_newer(ctx).await;
             ctx.pr
                 .set_message(format!("uv tool install {pipx_request}"));
             let mut cmd = Self::uvx_cmd(
+                &uv_program,
                 &ctx.config,
                 &["tool", "install", &pipx_request],
                 self,
@@ -515,6 +517,7 @@ impl PIPXBackend {
     }
 
     async fn uvx_cmd<'a>(
+        uv_program: &Path,
         config: &Arc<Config>,
         args: &[&str],
         b: &dyn Backend,
@@ -522,7 +525,7 @@ impl PIPXBackend {
         ts: &Toolset,
         pr: &'a dyn SingleReport,
     ) -> Result<CmdLineRunner<'a>> {
-        let mut cmd = CmdLineRunner::new("uv");
+        let mut cmd = CmdLineRunner::new(uv_program);
         for arg in args {
             cmd = cmd.arg(arg);
         }
@@ -559,10 +562,6 @@ impl PIPXBackend {
             .prepend_path(ts.list_paths(config).await)?
             .prepend_path(vec![tv.install_path().join("bin")])?
             .prepend_path(b.dependency_toolset(config).await?.list_paths(config).await)
-    }
-
-    async fn uv_is_installed(&self, config: &Arc<Config>) -> bool {
-        self.dependency_which(config, "uv").await.is_some()
     }
 
     async fn warn_if_uv_may_not_support_exclude_newer(&self, ctx: &InstallContext) {

--- a/src/sops.rs
+++ b/src/sops.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::backend::configured_toolset_or_path_which;
 use crate::config::{Config, Settings};
 use crate::env;
 use crate::file::replace_path;
@@ -178,15 +179,8 @@ where
             }
         }
     } else {
-        let mut ts = config
-            .get_tool_request_set()
-            .await
-            .cloned()
-            .unwrap_or_default()
-            .filter_by_tool(["sops".into()].into())
-            .into_toolset();
-        Box::pin(ts.resolve(config)).await?;
-        let sops_path = ts.which_bin(config, "sops").await;
+        let sops_path =
+            configured_toolset_or_path_which(config, ["sops".to_string()], "sops").await?;
 
         match sops_path {
             None => {


### PR DESCRIPTION
## Summary
- centralize dependency executable resolution for PATH, active toolsets, and backend dependency toolsets
- apply configured Windows executable extensions to shared dependency lookup instead of only dependency warnings
- use resolved binary paths for uv, aube, and cargo-binstall install commands
- keep gpg verification unchanged because gpg is not managed by mise

## Behavior Changes
- `Backend::which` now uses `windows_executable_extensions` on Windows instead of the previous hardcoded `exe/cmd/bat/ps1` list.
- `dependency_which` now checks non-pristine PATH with Windows executable extensions before checking dependency toolsets.
- `warn_if_dependency_missing` relies on the shared dependency lookup instead of doing its own Windows extension retry.
- pipx selects uv when `uv`/`uv.exe` is available from the active toolset, dependency toolset, or PATH, and invokes the resolved uv path for `uv tool install`.
- npm/aube uses the shared resolved-path helper for aube detection and execution.
- cargo-binstall detection now uses the same active-toolset/dependency/PATH lookup and invokes the resolved cargo-binstall path.
- sops external-CLI mode resolves configured `sops` first and propagates configured tool resolution failures; when `sops` is not configured, it falls back to PATH with the same executable-extension handling.

## Root Cause
`warn_if_dependency_missing` retried Windows executable extensions, but direct dependency decisions such as uv and cargo-binstall detection did not. That meant `uv.exe`/`cargo-binstall.exe` style binaries could be missed, and command execution could fall back to bare program names even after a path was resolved elsewhere.

## Review Notes
- Addressed review feedback by preserving sops resolution errors for configured `sops` tools instead of silently falling back to PATH.
- Addressed review feedback around the Windows gate by making the target-platform check explicit with `cfg!(target_os = "windows")`.

## Validation
- `mise x cargo -- cargo fmt`
- `mise x cargo -- cargo check`
- `mise x cargo -- cargo test backend::tests`
- `mise x cargo -- cargo test backend::cargo::tests`
- `mise x cargo -- cargo test backend::npm::tests`
- `mise x cargo -- cargo test backend::pipx::tests`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified executable discovery for dependencies and tools, with consistent Windows handling for extensionless binaries.
  * Added install-time dependency path resolution that prefers toolset-aware lookup with fallback behavior.
* **Bug Fixes**
  * Improved install execution by using resolved program paths for Cargo Binstall, Aube, Npm, and Pipx, including more accurate “installed” detection.
  * Updated Sops command resolution to use the improved lookup for more reliable decrypts.
* **Tests**
  * Added Windows coverage for extension expansion and explicit-extension preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->