### PR TITLE
fix(erlang): lock install method outcomes

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -653,40 +653,50 @@ url = "https://github.com/LuaLS/lua-language-server/releases/download/3.18.2/lua
 [[tools.node]]
 version = "24.16.0"
 backend = "core:node"
+options = { compile = "if_available" }
 
 [tools.node."platforms.linux-arm64"]
+install_method = "precompiled"
 checksum = "sha256:589f5b6dd4fcfee4dfda73013903c966abaa8abd93dbc9d436544e472b4f0e74"
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
+install_method = "precompiled"
 checksum = "sha256:85dde27aa73503b03dadfa0410a800067b4e3f702fb7fcaa3beaf284dfcc69e9"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
+install_method = "precompiled"
 checksum = "sha256:2faf6a387e9b62b888e21c54f01249fb27537ffecf1842f29f4c919d0a59a0ff"
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-baseline"]
+install_method = "precompiled"
 checksum = "sha256:2faf6a387e9b62b888e21c54f01249fb27537ffecf1842f29f4c919d0a59a0ff"
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
+install_method = "precompiled"
 checksum = "sha256:50df5d8d474892d4f7b906167df36f77f5b93908f63dc532dc568219cab65841"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64-musl-baseline"]
+install_method = "precompiled"
 checksum = "sha256:50df5d8d474892d4f7b906167df36f77f5b93908f63dc532dc568219cab65841"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
+install_method = "precompiled"
 checksum = "sha256:39189dab4eeb15706c424af0ac08a3044c9e48f7db12a7d77f6b7aafc7dd5df6"
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-arm64.tar.gz"
 
 [tools.node."platforms.windows-x64"]
+install_method = "precompiled"
 checksum = "sha256:edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111cd56"
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-win-x64.zip"
 
 [tools.node."platforms.windows-x64-baseline"]
+install_method = "precompiled"
 checksum = "sha256:edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111cd56"
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-win-x64.zip"
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -23,7 +23,7 @@ use crate::file::{
 };
 use crate::install_before::resolve_before_date_for_tool;
 use crate::install_context::InstallContext;
-use crate::lockfile::{PlatformInfo, ProvenanceType};
+use crate::lockfile::{InstallMethod, PlatformInfo, ProvenanceType};
 use crate::path_env::PathEnv;
 use crate::platform::Platform;
 use crate::plugins::core::CORE_PLUGINS;
@@ -1870,14 +1870,16 @@ pub trait Backend: Debug + Send + Sync {
                 hint: Remove `lockfile = false` or set `lockfile = true`, or disable locked mode"
             );
         }
-        if ctx.locked && !tv.request.source().is_tool_stub() && self.supports_lockfile_url() {
+        if ctx.locked && !tv.request.source().is_tool_stub() {
             let platform_key = self.get_platform_key();
-            let has_lockfile_url = tv
-                .lock_platforms
-                .get(&platform_key)
-                .and_then(|p| p.url.as_ref())
-                .is_some();
-            if !has_lockfile_url {
+            let platform_info = tv.lock_platforms.get(&platform_key);
+            let requires_lockfile_url = match platform_info.and_then(|p| p.install_method) {
+                Some(InstallMethod::Precompiled) => true,
+                Some(InstallMethod::Compile) => false,
+                None => self.supports_lockfile_url(),
+            };
+            let has_lockfile_url = platform_info.and_then(|p| p.url.as_ref()).is_some();
+            if requires_lockfile_url && !has_lockfile_url {
                 bail!(
                     "No lockfile URL found for {} on platform {} (--locked mode)\n\
                     hint: Run `mise lock` to generate lockfile URLs, or disable locked mode",

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -224,8 +224,20 @@ pub enum GithubAttestationsStatus {
     Unavailable,
 }
 
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, strum::Display, strum::EnumString,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum InstallMethod {
+    Precompiled,
+    Compile,
+}
+
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
 pub struct PlatformInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_method: Option<InstallMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checksum: Option<String>,
     /// Size in bytes (read-only field, preserved from existing lockfiles but not written)
@@ -272,7 +284,8 @@ impl<'de> Deserialize<'de> for PlatformInfo {
 impl PlatformInfo {
     /// Returns true if this PlatformInfo has no meaningful data (for serde skip)
     pub fn is_empty(&self) -> bool {
-        self.checksum.is_none()
+        self.install_method.is_none()
+            && self.checksum.is_none()
             && self.url.is_none()
             && self.url_api.is_none()
             && self.conda_deps.is_none()
@@ -280,6 +293,7 @@ impl PlatformInfo {
             && self.pkgx_provides.is_none()
             && self.pkgx_runtime_env.is_none()
             && self.provenance.is_none()
+            && self.github_attestations.is_none()
     }
 
     /// True when the lockfile has checksum-backed, successfully verified provenance.
@@ -335,6 +349,7 @@ impl PlatformInfo {
             (a, b) => a.or(b),
         };
         PlatformInfo {
+            install_method: self.install_method.or(other.install_method),
             checksum,
             size,
             url: self.url.clone().or_else(|| other.url.clone()),
@@ -364,6 +379,13 @@ impl TryFrom<toml::Value> for PlatformInfo {
                 ..Default::default()
             }),
             toml::Value::Table(mut t) => {
+                let install_method = match t.remove("install_method") {
+                    Some(toml::Value::String(s)) => Some(
+                        s.parse()
+                            .map_err(|_| eyre!("unrecognized install_method {s:?} in lockfile"))?,
+                    ),
+                    _ => None,
+                };
                 let checksum = match t.remove("checksum") {
                     Some(toml::Value::String(s)) => Some(s),
                     _ => None,
@@ -463,6 +485,7 @@ impl TryFrom<toml::Value> for PlatformInfo {
                     github_attestations
                 };
                 Ok(PlatformInfo {
+                    install_method,
                     checksum,
                     size,
                     url,
@@ -483,6 +506,12 @@ impl TryFrom<toml::Value> for PlatformInfo {
 impl From<PlatformInfo> for toml::Value {
     fn from(platform_info: PlatformInfo) -> Self {
         let mut table = toml::Table::new();
+        if let Some(install_method) = platform_info.install_method {
+            table.insert(
+                "install_method".to_string(),
+                install_method.to_string().into(),
+            );
+        }
         if let Some(checksum) = platform_info.checksum {
             table.insert("checksum".to_string(), checksum.into());
         }
@@ -1031,6 +1060,7 @@ impl Lockfile {
                     (a, b) => a.or(b),
                 };
                 PlatformInfo {
+                    install_method: platform_info.install_method.or(existing.install_method),
                     checksum: platform_info.checksum.or_else(|| {
                         if preserve_artifact_fields {
                             existing.checksum.clone()

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -12,7 +12,7 @@ use crate::file::display_path;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lock_file::LockFile;
-use crate::lockfile::PlatformInfo;
+use crate::lockfile::{InstallMethod, PlatformInfo};
 use crate::platform::Platform;
 use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{file, github, plugins};
@@ -112,10 +112,18 @@ impl ErlangPlugin {
             .lock_platforms
             .entry(self.get_platform_key())
             .or_default();
+        platform_info.install_method = Some(InstallMethod::Precompiled);
         platform_info.url = Some(url.to_string());
         if let Some(checksum) = checksum {
             platform_info.checksum.get_or_insert(checksum);
         }
+    }
+
+    fn set_lockfile_install_method(&self, tv: &mut ToolVersion, install_method: InstallMethod) {
+        tv.lock_platforms
+            .entry(self.get_platform_key())
+            .or_default()
+            .install_method = Some(install_method);
     }
 
     fn linux_precompiled_url(version: &str, target: &PlatformTarget) -> Result<String> {
@@ -487,9 +495,23 @@ impl Backend for ErlangPlugin {
     }
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
+        let locked_install_method = if ctx.locked {
+            tv.lock_platforms
+                .get(&self.get_platform_key())
+                .and_then(|pi| pi.install_method)
+        } else {
+            None
+        };
+        if locked_install_method == Some(InstallMethod::Compile) {
+            let mut tv = tv;
+            self.set_lockfile_install_method(&mut tv, InstallMethod::Compile);
+            return self.install_via_kerl(ctx, tv).await;
+        }
         if let Some(tv) = self.install_precompiled(ctx, tv.clone()).await? {
             return Ok(tv);
         }
+        let mut tv = tv;
+        self.set_lockfile_install_method(&mut tv, InstallMethod::Compile);
         self.install_via_kerl(ctx, tv).await
     }
 
@@ -538,18 +560,25 @@ impl Backend for ErlangPlugin {
     ) -> Result<PlatformInfo> {
         let compile = Settings::get().erlang.compile;
         if compile == Some(true) {
-            return Ok(PlatformInfo::default());
+            return Ok(PlatformInfo {
+                install_method: Some(InstallMethod::Compile),
+                ..Default::default()
+            });
         }
 
         let release_tag = Self::release_tag(&tv.version);
         match target.os_name() {
             "linux" => match Self::linux_precompiled_url(&tv.version, target) {
                 Ok(url) => Ok(PlatformInfo {
+                    install_method: Some(InstallMethod::Precompiled),
                     url: Some(url),
                     ..Default::default()
                 }),
                 Err(err) if compile == Some(false) => Err(err),
-                Err(_) => Ok(PlatformInfo::default()),
+                Err(_) => Ok(PlatformInfo {
+                    install_method: Some(InstallMethod::Compile),
+                    ..Default::default()
+                }),
             },
             "macos" => {
                 let info = match Self::macos_asset_name(target) {
@@ -560,9 +589,15 @@ impl Backend for ErlangPlugin {
                     Err(err) => Err(err),
                 };
                 match info {
-                    Ok(info) => Ok(info),
+                    Ok(mut info) => {
+                        info.install_method = Some(InstallMethod::Precompiled);
+                        Ok(info)
+                    }
                     Err(err) if compile == Some(false) => Err(err),
-                    Err(_) => Ok(PlatformInfo::default()),
+                    Err(_) => Ok(PlatformInfo {
+                        install_method: Some(InstallMethod::Compile),
+                        ..Default::default()
+                    }),
                 }
             }
             "windows" => {
@@ -573,12 +608,21 @@ impl Backend for ErlangPlugin {
                     Err(err) => Err(err),
                 };
                 match info {
-                    Ok(info) => Ok(info),
+                    Ok(mut info) => {
+                        info.install_method = Some(InstallMethod::Precompiled);
+                        Ok(info)
+                    }
                     Err(err) if compile == Some(false) => Err(err),
-                    Err(_) => Ok(PlatformInfo::default()),
+                    Err(_) => Ok(PlatformInfo {
+                        install_method: Some(InstallMethod::Compile),
+                        ..Default::default()
+                    }),
                 }
             }
-            _ => Ok(PlatformInfo::default()),
+            _ => Ok(PlatformInfo {
+                install_method: Some(InstallMethod::Compile),
+                ..Default::default()
+            }),
         }
     }
 }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -748,16 +748,13 @@ impl Backend for NodePlugin {
         let settings = Settings::get();
         let node = &settings.node;
 
-        opts.insert("mirror_url".to_string(), node.mirror_url().to_string());
+        let mirror = node.mirror_url();
+        if mirror.as_str() != DEFAULT_NODE_MIRROR_URL {
+            opts.insert("mirror_url".to_string(), mirror.to_string());
+        }
 
-        let compile = match node.compile {
-            Some(true) => "true",
-            Some(false) => "false",
-            None => "auto",
-        };
-        opts.insert("compile".to_string(), compile.to_string());
-
-        if node.compile != Some(false) {
+        if node.compile == Some(true) {
+            opts.insert("compile".to_string(), "true".to_string());
             if let Some(cflags) = node.cflags().filter(|cflags| !cflags.is_empty()) {
                 opts.insert("cflags".to_string(), cflags);
             }
@@ -769,8 +766,7 @@ impl Backend for NodePlugin {
             {
                 opts.insert("configure_opts".to_string(), configure_opts);
             }
-            let make = node.make.clone().unwrap_or_else(|| "make".into());
-            if !make.is_empty() {
+            if let Some(make) = node.make.clone().filter(|make| make != "make") {
                 opts.insert("make".to_string(), make);
             }
             if let Some(make_opts) = node
@@ -789,23 +785,11 @@ impl Backend for NodePlugin {
             {
                 opts.insert("make_install_opts".to_string(), make_install_opts);
             }
-            let ninja = node
-                .ninja
-                .map(|ninja| ninja.to_string())
-                .unwrap_or_else(|| "auto".to_string());
-            opts.insert("ninja".to_string(), ninja);
-            let concurrency = node
-                .concurrency
-                .map(|concurrency| std::cmp::max(concurrency, 1).to_string())
-                .or_else(|| {
-                    if node.ninja == Some(true) {
-                        None
-                    } else {
-                        Some("auto".to_string())
-                    }
-                });
-            if let Some(concurrency) = concurrency {
-                opts.insert("concurrency".to_string(), concurrency);
+            if let Some(ninja) = node.ninja {
+                opts.insert("ninja".to_string(), ninja.to_string());
+            }
+            if let Some(concurrency) = node.concurrency.map(|concurrency| std::cmp::max(concurrency, 1)) {
+                opts.insert("concurrency".to_string(), concurrency.to_string());
             }
         }
 
@@ -1078,17 +1062,10 @@ mod tests {
     }
 
     #[test]
-    fn test_node_lockfile_options_include_default_settings() {
+    fn test_node_lockfile_options_omit_default_precompiled_settings() {
         let opts = resolve_node_lockfile_options(|_| {});
 
-        assert_eq!(
-            opts.get("mirror_url").map(String::as_str),
-            Some(DEFAULT_NODE_MIRROR_URL)
-        );
-        assert_eq!(opts.get("compile").map(String::as_str), Some("auto"));
-        assert_eq!(opts.get("concurrency").map(String::as_str), Some("auto"));
-        assert_eq!(opts.get("make").map(String::as_str), Some("make"));
-        assert_eq!(opts.get("ninja").map(String::as_str), Some("auto"));
+        assert!(opts.is_empty());
     }
 
     #[test]
@@ -1102,7 +1079,6 @@ mod tests {
         assert_eq!(
             opts,
             BTreeMap::from([
-                ("compile".to_string(), "false".to_string()),
                 ("flavor".to_string(), "musl".to_string()),
                 (
                     "mirror_url".to_string(),
@@ -1116,7 +1092,6 @@ mod tests {
     fn test_node_lockfile_options_include_source_build_settings() {
         let opts = resolve_node_lockfile_options(|settings| {
             settings.node.compile = Some(true);
-            settings.node.mirror_url = Some(DEFAULT_NODE_MIRROR_URL.to_string());
             settings.node.cflags = Some("-O2".to_string());
             settings.node.configure_opts = Some("--openssl-no-asm".to_string());
             settings.node.make = Some("gmake".to_string());
@@ -1136,10 +1111,6 @@ mod tests {
                 ("make".to_string(), "gmake".to_string()),
                 ("make_install_opts".to_string(), "--no-strip".to_string()),
                 ("make_opts".to_string(), "-s".to_string()),
-                (
-                    "mirror_url".to_string(),
-                    DEFAULT_NODE_MIRROR_URL.to_string()
-                ),
                 ("ninja".to_string(), "false".to_string()),
             ])
         );

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -742,25 +742,76 @@ impl Backend for NodePlugin {
     fn resolve_lockfile_options(
         &self,
         _request: &ToolRequest,
-        target: &PlatformTarget,
+        _target: &PlatformTarget,
     ) -> Result<BTreeMap<String, String>> {
         let mut opts = BTreeMap::new();
         let settings = Settings::get();
-        let is_current_platform = target.is_current();
+        let node = &settings.node;
 
-        // Only include compile option if true (non-default)
-        let compile = if is_current_platform {
-            settings.node.compile.unwrap_or(false)
-        } else {
-            false
+        opts.insert("mirror_url".to_string(), node.mirror_url().to_string());
+
+        let compile = match node.compile {
+            Some(true) => "true",
+            Some(false) => "false",
+            None => "auto",
         };
-        if compile {
-            opts.insert("compile".to_string(), "true".to_string());
+        opts.insert("compile".to_string(), compile.to_string());
+
+        if node.compile != Some(false) {
+            if let Some(cflags) = node.cflags().filter(|cflags| !cflags.is_empty()) {
+                opts.insert("cflags".to_string(), cflags);
+            }
+            if let Some(configure_opts) = node
+                .configure_opts
+                .clone()
+                .or_else(|| env::var("NODE_CONFIGURE_OPTS").ok())
+                .filter(|configure_opts| !configure_opts.is_empty())
+            {
+                opts.insert("configure_opts".to_string(), configure_opts);
+            }
+            let make = node.make.clone().unwrap_or_else(|| "make".into());
+            if !make.is_empty() {
+                opts.insert("make".to_string(), make);
+            }
+            if let Some(make_opts) = node
+                .make_opts
+                .clone()
+                .or_else(|| env::var("NODE_MAKE_OPTS").ok())
+                .filter(|make_opts| !make_opts.is_empty())
+            {
+                opts.insert("make_opts".to_string(), make_opts);
+            }
+            if let Some(make_install_opts) = node
+                .make_install_opts
+                .clone()
+                .or_else(|| env::var("NODE_MAKE_INSTALL_OPTS").ok())
+                .filter(|make_install_opts| !make_install_opts.is_empty())
+            {
+                opts.insert("make_install_opts".to_string(), make_install_opts);
+            }
+            let ninja = node
+                .ninja
+                .map(|ninja| ninja.to_string())
+                .unwrap_or_else(|| "auto".to_string());
+            opts.insert("ninja".to_string(), ninja);
+            let concurrency = node
+                .concurrency
+                .map(|concurrency| std::cmp::max(concurrency, 1).to_string())
+                .or_else(|| {
+                    if node.ninja == Some(true) {
+                        None
+                    } else {
+                        Some("auto".to_string())
+                    }
+                });
+            if let Some(concurrency) = concurrency {
+                opts.insert("concurrency".to_string(), concurrency);
+            }
         }
 
-        // Flavor affects which binary variant is downloaded
-        // Apply to all platforms to avoid splitting lockfile entries (#8390)
-        if let Some(flavor) = settings.node.flavor.clone() {
+        // Flavor affects which binary variant is downloaded.
+        // Apply to all platforms to avoid splitting lockfile entries (#8390).
+        if let Some(flavor) = node.flavor.clone().filter(|flavor| !flavor.is_empty()) {
             opts.insert("flavor".to_string(), flavor);
         }
 
@@ -965,7 +1016,38 @@ struct NodeVersion {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::settings::SettingsNode;
+    use crate::config::settings::{SettingsNode, SettingsPartial};
+    use crate::toolset::ToolSource;
+    use confique::Layer;
+
+    static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct SettingsResetGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for SettingsResetGuard {
+        fn drop(&mut self) {
+            Settings::reset(None);
+        }
+    }
+
+    fn resolve_node_lockfile_options(
+        configure_settings: impl FnOnce(&mut SettingsPartial),
+    ) -> BTreeMap<String, String> {
+        let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let mut settings = SettingsPartial::empty();
+        configure_settings(&mut settings);
+        Settings::reset(Some(settings));
+        let _guard = SettingsResetGuard { _lock: lock };
+
+        let backend = NodePlugin::new();
+        let request = ToolRequest::new(backend.ba().clone(), "22.0.0", ToolSource::Unknown)
+            .expect("valid node request");
+        backend
+            .resolve_lockfile_options(&request, &PlatformTarget::from_current())
+            .expect("node lockfile options")
+    }
 
     #[test]
     fn test_mirror_url_for_routes_musl_to_unofficial_builds() {
@@ -993,5 +1075,73 @@ mod tests {
         let musl = mirror_url_for(&node, "node-v24.14.0-linux-x64-musl.tar.gz");
         assert_eq!(glibc.as_str(), "https://corp.example/node/");
         assert_eq!(musl.as_str(), "https://corp.example/node/");
+    }
+
+    #[test]
+    fn test_node_lockfile_options_include_default_settings() {
+        let opts = resolve_node_lockfile_options(|_| {});
+
+        assert_eq!(
+            opts.get("mirror_url").map(String::as_str),
+            Some(DEFAULT_NODE_MIRROR_URL)
+        );
+        assert_eq!(opts.get("compile").map(String::as_str), Some("auto"));
+        assert_eq!(opts.get("concurrency").map(String::as_str), Some("auto"));
+        assert_eq!(opts.get("make").map(String::as_str), Some("make"));
+        assert_eq!(opts.get("ninja").map(String::as_str), Some("auto"));
+    }
+
+    #[test]
+    fn test_node_lockfile_options_include_binary_settings() {
+        let opts = resolve_node_lockfile_options(|settings| {
+            settings.node.compile = Some(false);
+            settings.node.mirror_url = Some("https://corp.example/node/".to_string());
+            settings.node.flavor = Some("musl".to_string());
+        });
+
+        assert_eq!(
+            opts,
+            BTreeMap::from([
+                ("compile".to_string(), "false".to_string()),
+                ("flavor".to_string(), "musl".to_string()),
+                (
+                    "mirror_url".to_string(),
+                    "https://corp.example/node/".to_string()
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_node_lockfile_options_include_source_build_settings() {
+        let opts = resolve_node_lockfile_options(|settings| {
+            settings.node.compile = Some(true);
+            settings.node.mirror_url = Some(DEFAULT_NODE_MIRROR_URL.to_string());
+            settings.node.cflags = Some("-O2".to_string());
+            settings.node.configure_opts = Some("--openssl-no-asm".to_string());
+            settings.node.make = Some("gmake".to_string());
+            settings.node.make_opts = Some("-s".to_string());
+            settings.node.make_install_opts = Some("--no-strip".to_string());
+            settings.node.concurrency = Some(16);
+            settings.node.ninja = Some(false);
+        });
+
+        assert_eq!(
+            opts,
+            BTreeMap::from([
+                ("cflags".to_string(), "-O2".to_string()),
+                ("compile".to_string(), "true".to_string()),
+                ("concurrency".to_string(), "16".to_string()),
+                ("configure_opts".to_string(), "--openssl-no-asm".to_string()),
+                ("make".to_string(), "gmake".to_string()),
+                ("make_install_opts".to_string(), "--no-strip".to_string()),
+                ("make_opts".to_string(), "-s".to_string()),
+                (
+                    "mirror_url".to_string(),
+                    DEFAULT_NODE_MIRROR_URL.to_string()
+                ),
+                ("ninja".to_string(), "false".to_string()),
+            ])
+        );
     }
 }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -1,5 +1,4 @@
 use crate::backend::VersionInfo;
-use crate::backend::static_helpers::fetch_checksum_from_shasums;
 use crate::backend::{
     Backend, VersionCacheManager, normalize_idiomatic_contents, platform_target::PlatformTarget,
 };
@@ -12,7 +11,7 @@ use crate::config::{Config, Settings};
 use crate::file::{ExtractOptions, ExtractionFormat};
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
-use crate::lockfile::PlatformInfo;
+use crate::lockfile::{InstallMethod, PlatformInfo};
 use crate::platform::Platform;
 use crate::toolset::{ToolRequest, ToolVersion};
 use crate::ui::progress_report::SingleReport;
@@ -63,6 +62,7 @@ impl NodePlugin {
                 &opts.binary_tarball_url,
                 &opts.binary_tarball_path,
                 &opts.version,
+                InstallMethod::Precompiled,
             )
             .await
         {
@@ -169,6 +169,7 @@ impl NodePlugin {
                 &opts.source_tarball_url,
                 &opts.source_tarball_path,
                 &opts.version,
+                InstallMethod::Compile,
             )
             .await
         {
@@ -208,6 +209,7 @@ impl NodePlugin {
         url: &Url,
         local: &Path,
         version: &str,
+        install_method: InstallMethod,
     ) -> Result<()> {
         let settings = Settings::get();
         let tarball_name = local.file_name().unwrap().to_string_lossy().to_string();
@@ -231,7 +233,10 @@ impl NodePlugin {
             None
         };
         let platform_info = tv.lock_platforms.entry(platform_key).or_default();
-        platform_info.url = Some(url.to_string());
+        platform_info.install_method = Some(install_method);
+        if install_method == InstallMethod::Precompiled {
+            platform_info.url = Some(url.to_string());
+        }
         if let Some(checksum) = checksum {
             platform_info.checksum.get_or_insert(checksum);
         }
@@ -654,10 +659,19 @@ impl Backend for NodePlugin {
         let settings = Settings::get();
         let opts = BuildOpts::new(ctx, &tv).await?;
         trace!("node build opts: {:#?}", opts);
+        let locked_install_method = if ctx.locked {
+            tv.lock_platforms
+                .get(&self.get_platform_key())
+                .and_then(|pi| pi.install_method)
+        } else {
+            None
+        };
 
         if cfg!(windows) {
             self.install_windows(ctx, &mut tv, &opts).await?;
-        } else if settings.node.compile == Some(true) {
+        } else if locked_install_method == Some(InstallMethod::Compile)
+            || settings.node.compile == Some(true)
+        {
             self.install_compiling(ctx, &mut tv, &opts).await?;
         } else {
             self.install_precompiled(ctx, &mut tv, &opts).await?;
@@ -753,8 +767,20 @@ impl Backend for NodePlugin {
             opts.insert("mirror_url".to_string(), mirror.to_string());
         }
 
-        if node.compile == Some(true) {
-            opts.insert("compile".to_string(), "true".to_string());
+        let compile = node.compile;
+        match compile {
+            Some(true) => {
+                opts.insert("compile".to_string(), "true".to_string());
+            }
+            Some(false) => {
+                opts.insert("compile".to_string(), "false".to_string());
+            }
+            None => {
+                opts.insert("compile".to_string(), "if_available".to_string());
+            }
+        }
+
+        if compile != Some(false) {
             if let Some(cflags) = node.cflags().filter(|cflags| !cflags.is_empty()) {
                 opts.insert("cflags".to_string(), cflags);
             }
@@ -788,7 +814,10 @@ impl Backend for NodePlugin {
             if let Some(ninja) = node.ninja {
                 opts.insert("ninja".to_string(), ninja.to_string());
             }
-            if let Some(concurrency) = node.concurrency.map(|concurrency| std::cmp::max(concurrency, 1)) {
+            if let Some(concurrency) = node
+                .concurrency
+                .map(|concurrency| std::cmp::max(concurrency, 1))
+            {
                 opts.insert("concurrency".to_string(), concurrency.to_string());
             }
         }
@@ -826,11 +855,36 @@ impl Backend for NodePlugin {
             .join(&format!("v{version}/{filename}"))
             .map_err(|e| eyre::eyre!("Failed to construct Node.js download URL: {e}"))?;
 
-        // Fetch SHASUMS256.txt to get checksum without downloading the tarball
+        if settings.node.compile == Some(true) && target.os_name() != "windows" {
+            return Ok(PlatformInfo {
+                install_method: Some(InstallMethod::Compile),
+                ..Default::default()
+            });
+        }
+
+        // Fetch SHASUMS256.txt to get checksum without downloading the tarball.
+        // If the file is absent from SHASUMS in fallback mode, lock the source
+        // compile outcome instead of recording a binary URL that install would 404.
         let shasums_url = mirror.join(&format!("v{version}/SHASUMS256.txt"))?;
-        let checksum = fetch_checksum_from_shasums(shasums_url.as_str(), &filename).await;
+        let checksum = match HTTP.get_text_cached(shasums_url.as_str()).await {
+            Ok(shasums_content) => match hash::parse_shasums(&shasums_content).get(&filename) {
+                Some(shasum) => Some(format!("sha256:{shasum}")),
+                None if settings.node.compile != Some(false) => {
+                    return Ok(PlatformInfo {
+                        install_method: Some(InstallMethod::Compile),
+                        ..Default::default()
+                    });
+                }
+                None => None,
+            },
+            Err(e) => {
+                debug!("Failed to fetch SHASUMS from {}: {e}", shasums_url);
+                None
+            }
+        };
 
         Ok(PlatformInfo {
+            install_method: Some(InstallMethod::Precompiled),
             url: Some(url.to_string()),
             checksum,
             size: None,
@@ -922,6 +976,25 @@ impl BuildOpts {
         let binary_tarball_name = format!("{slug}.tar.gz");
 
         let settings = Settings::get();
+        let default_binary_tarball_url = mirror_url_for(&settings.node, &binary_tarball_name)
+            .join(&format!("v{v}/{binary_tarball_name}"))?;
+        let platform_key = Platform::current().to_key();
+        let binary_tarball_url = if ctx.locked {
+            tv.lock_platforms
+                .get(&platform_key)
+                .and_then(|pi| pi.url.as_deref())
+                .map(Url::parse)
+                .transpose()?
+                .unwrap_or_else(|| default_binary_tarball_url.clone())
+        } else {
+            default_binary_tarball_url
+        };
+        let binary_tarball_name = binary_tarball_url
+            .path_segments()
+            .and_then(|mut segments| segments.next_back())
+            .filter(|name| !name.is_empty())
+            .unwrap_or(&binary_tarball_name)
+            .to_string();
         Ok(Self {
             version: v.clone(),
             path: ctx.ts.list_paths(&ctx.config).await,
@@ -936,8 +1009,7 @@ impl BuildOpts {
                 .join(&format!("v{v}/{source_tarball_name}"))?,
             source_tarball_name,
             binary_tarball_path: tv.download_path().join(&binary_tarball_name),
-            binary_tarball_url: mirror_url_for(&settings.node, &binary_tarball_name)
-                .join(&format!("v{v}/{binary_tarball_name}"))?,
+            binary_tarball_url,
             binary_tarball_name,
             install_path,
         })
@@ -1016,10 +1088,48 @@ mod tests {
         }
     }
 
+    struct NodeEnvResetGuard {
+        vars: BTreeMap<String, String>,
+    }
+
+    impl NodeEnvResetGuard {
+        fn clear() -> Self {
+            let vars = std::env::vars()
+                .filter(|(key, _)| key.starts_with("NODE_"))
+                .collect::<BTreeMap<_, _>>();
+            for key in vars.keys() {
+                unsafe {
+                    std::env::remove_var(key);
+                }
+            }
+            Self { vars }
+        }
+    }
+
+    impl Drop for NodeEnvResetGuard {
+        fn drop(&mut self) {
+            for key in std::env::vars()
+                .map(|(key, _)| key)
+                .filter(|key| key.starts_with("NODE_"))
+                .collect::<Vec<_>>()
+            {
+                unsafe {
+                    std::env::remove_var(key);
+                }
+            }
+            for (key, value) in &self.vars {
+                unsafe {
+                    std::env::set_var(key, value);
+                }
+            }
+        }
+    }
+
     fn resolve_node_lockfile_options(
         configure_settings: impl FnOnce(&mut SettingsPartial),
     ) -> BTreeMap<String, String> {
         let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let _env_guard = NodeEnvResetGuard::clear();
         let mut settings = SettingsPartial::empty();
         configure_settings(&mut settings);
         Settings::reset(Some(settings));
@@ -1065,7 +1175,10 @@ mod tests {
     fn test_node_lockfile_options_omit_default_precompiled_settings() {
         let opts = resolve_node_lockfile_options(|_| {});
 
-        assert!(opts.is_empty());
+        assert_eq!(
+            opts,
+            BTreeMap::from([("compile".to_string(), "if_available".to_string())])
+        );
     }
 
     #[test]
@@ -1080,6 +1193,7 @@ mod tests {
             opts,
             BTreeMap::from([
                 ("flavor".to_string(), "musl".to_string()),
+                ("compile".to_string(), "false".to_string()),
                 (
                     "mirror_url".to_string(),
                     "https://corp.example/node/".to_string()
@@ -1112,6 +1226,23 @@ mod tests {
                 ("make_install_opts".to_string(), "--no-strip".to_string()),
                 ("make_opts".to_string(), "-s".to_string()),
                 ("ninja".to_string(), "false".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_node_lockfile_options_include_auto_source_build_settings() {
+        let opts = resolve_node_lockfile_options(|settings| {
+            settings.node.configure_opts = Some("--openssl-no-asm".to_string());
+            settings.node.make_opts = Some("-s".to_string());
+        });
+
+        assert_eq!(
+            opts,
+            BTreeMap::from([
+                ("compile".to_string(), "if_available".to_string()),
+                ("configure_opts".to_string(), "--openssl-no-asm".to_string()),
+                ("make_opts".to_string(), "-s".to_string()),
             ])
         );
     }


### PR DESCRIPTION
## Summary
- record Erlang kerl fallbacks as per-platform `install = "source"` outcomes with the exact OTP source URL and checksum
- make locked installs follow the recorded source or precompiled outcome instead of re-evaluating local `erlang.compile` settings
- download and verify locked OTP source inputs before seeding kerl's archive cache
- require a lockfile URL for both source and precompiled Erlang outcomes
- extend Erlang lockfile coverage for default fallback, forced source builds, and invalid source entries

## Context
This resumes the work from the original draft after #10547 merged. It now follows the source-outcome contract established for Node:

- a platform URL without an install marker is a precompiled outcome
- `install = "source"` plus a URL is a source-build outcome
- a missing platform URL is invalid in locked mode

The obsolete Node commits and draft `install_method` lockfile changes have been removed; this PR is now Erlang-only.

## Verification
- `mise run lint-fix`
- `mise run test:unit -- plugins::core::erlang::tests`
- `mise run test:e2e e2e/core/test_erlang_lockfile`
- `git diff --check`

A full OTP source compilation was not run locally.