### PR TITLE
fix(task): honor show_full_cmd in the task command header

### DIFF
--- a/e2e/tasks/test_task_show_full_cmd
+++ b/e2e/tasks/test_task_show_full_cmd
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# #10469: the `task.show_full_cmd` setting (env MISE_TASK_SHOW_CMD_NO_TRUNC) must
+# echo the FULL multi-line command in the task header, not just the first real
+# command. PR #9844 added display_first_command(), which reduced the echoed header
+# to the first real command (skipping leading shebang/blank/`set ...` lines)
+# UNCONDITIONALLY — making show_full_cmd a no-op. The reduction is now gated on the
+# setting: the whole script when on, the first command when off.
+
+cat <<'EOF' >mise.toml
+[tasks.multi]
+run = """
+#!/usr/bin/env bash
+set -e
+echo first-line
+echo second-line
+"""
+EOF
+
+# show_full_cmd ON: the echoed header includes the LATER command line. The literal
+# "echo second-line" only appears in the echoed command (execution prints
+# "second-line", not "echo second-line").
+assert_contains "MISE_TASK_SHOW_CMD_NO_TRUNC=1 mise run multi 2>&1" "echo second-line"
+
+# show_full_cmd OFF (#9844 behavior preserved): the header shows the first REAL
+# command, skipping the shebang/`set` boilerplate, and later lines are truncated.
+assert_contains "mise run multi 2>&1" "echo first-line"
+assert_not_contains "mise run multi 2>&1" "echo second-line"

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -855,8 +855,14 @@ impl TaskExecutor {
         let script = script.trim_start();
         // For display, skip leading shebang/blank/`set ...` boilerplate and join
         // backslash-continued lines so the header shows the first real command as a
-        // single logical line (see display_first_command).
-        let display_script = display_first_command(script);
+        // single logical line (see display_first_command). When show_full_cmd is set,
+        // keep the whole script instead — the reduction would otherwise discard every
+        // line past the first command, making the setting a no-op (#10469, #9844).
+        let display_script = if Settings::get().task.show_full_cmd {
+            script.to_string()
+        } else {
+            display_first_command(script)
+        };
         let args_str = args.join(" ");
         let cmd = match (display_script.is_empty(), args_str.is_empty()) {
             (true, true) => "$".to_string(),


### PR DESCRIPTION
## Summary

The `task.show_full_cmd` setting (env `MISE_TASK_SHOW_CMD_NO_TRUNC`) is meant to echo the **full, untruncated** command in the `[task] $ …` header. It became a no-op after #9844 — see discussion #10469.

## Root cause

#9844 added `display_first_command()` to skip leading shebang / blank / `set …` boilerplate so the header shows the first *real* command. But in `exec_script` (`src/task/task_executor.rs`) it ran **unconditionally**:

```rust
let display_script = display_first_command(script);   // reduces to the first command
...
let msg = style::ebold(trunc(prefix, config.redact(&cmd).trim()))…   // show_full_cmd only checked here
```

`trunc` (`src/task/task_output.rs`) *does* honor `show_full_cmd` (it returns the message untouched when the setting is on), but by then `cmd` had already been reduced to the single first command — so the full command was gone before the setting was consulted. (`exec_file` is unaffected: it builds a one-line `path + args` command.)

## Fix

Gate the reduction on the setting — keep the whole script when `show_full_cmd` is on, otherwise reduce to the first command as before:

```rust
let display_script = if Settings::get().task.show_full_cmd {
    script.to_string()
} else {
    display_first_command(script)
};
```

No change to `trunc` / `task_output.rs`; the full multi-line `cmd` now flows through unchanged, and redaction still applies. The existing `display_first_command` unit tests are unaffected.

## Testing

- New e2e test `e2e/tasks/test_task_show_full_cmd`: with `MISE_TASK_SHOW_CMD_NO_TRUNC=1` the header echoes a *later* command line (`echo second-line`); with the setting off it shows the first real command and truncates the rest (locking in #9844's behavior).
- `cargo fmt --all -- --check` and `shellcheck` pass locally; `cargo check` / e2e deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task command display now respects the configurable option for showing full inline task scripts: when enabled, task headers include the entire trimmed multi-line command; when disabled, headers are still condensed to the first meaningful command.

* **Tests**
  * Added/updated an end-to-end test covering `task.show_full_cmd` behavior, verifying output both when the setting is enabled and when it is left at default/disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->