### PR TITLE
registry: add aspire (github:microsoft/aspire)

### DIFF
--- a/registry/aspire.toml
+++ b/registry/aspire.toml
@@ -1,0 +1,4 @@
+description = "Aspire is the tool for code-first, extensible, observable dev and deploy."
+test = { cmd = "aspire --version", expected = "{{version}}" }
+
+backends = ["github:microsoft/aspire"]


### PR DESCRIPTION
## Summary
- Add Microsoft Aspire to the mise registry via `github:microsoft/aspire`
- Use the simple registry backend form: `backends = ["github:microsoft/aspire"]`
- Rely on the GitHub backend's platform archive autodetection and archive-root executable discovery so Unix archives expose `aspire` and Windows archives expose `aspire.exe`

## Backend choice
- Aspire is not currently in `aquaproj/aqua-registry`
- `github:microsoft/aspire` uses mise's preferred native archive backend instead of runtime-dependent `npm:` or `dotnet:` backends

## Popularity
- GitHub: 6,083 stars, 913 forks
- Latest release: v13.4.5, published 2026-06-17
- Recent activity: pushed 2026-06-18
- Used by: active Microsoft project for building observable distributed applications

## Validation
- `cargo build --quiet`
- `target/debug/mise test-tool aspire`
- `target/debug/mise run render`
- `target/debug/mise run lint-fix`
- `MISE_OS=windows MISE_ARCH=x64 target/debug/mise install -y aspire@13.4.5` in an isolated temp data dir, then `target/debug/mise bin-paths aspire@13.4.5` confirmed the install root containing `aspire.exe`
- Azure Windows Server 2025 VM smoke test: installed `mise 2026.6.11 windows-x64`, installed `github:microsoft/aspire@13.4.5`, verified it downloaded/extracted `aspire-cli-win-x64-13.4.5.zip`, confirmed `bin-paths` points at the install root containing `aspire.exe`, and ran `mise exec -- aspire --version` successfully (`13.4.5+73114e86c64aeb9f3f3c7da8e37df1ae4281b27e`)
- DigitalOcean Ubuntu 24.04 droplet smoke test: installed `mise 2026.6.11 linux-x64`, ran `mise exec github:microsoft/aspire@13.4.5 -- aspire --version`, verified it downloaded/extracted `aspire-cli-linux-x64-13.4.5.tar.gz`, and confirmed the same Aspire version output