### PR TITLE
fix(deps): In a pub workspace, look for package config in workspace root

### DIFF
--- a/src/deps/providers/dart.rs
+++ b/src/deps/providers/dart.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use eyre::Result;
+use path_absolutize::Absolutize;
 
 use crate::deps::rule::DepsProviderConfig;
 use crate::deps::{DepsCommand, DepsProvider};
@@ -40,11 +41,11 @@ impl DepsProvider for DartDepsProvider {
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![
-            self.base
-                .config_root()
-                .join(".dart_tool/package_config.json"),
-        ]
+        let root = self.base.config_root();
+        let pub_dir = root.join(".dart_tool/pub");
+        let output = workspace_package_config(&pub_dir)
+            .unwrap_or_else(|| root.join(".dart_tool/package_config.json"));
+        vec![output]
     }
 
     fn install_command(&self) -> Result<DepsCommand> {
@@ -100,5 +101,78 @@ impl DepsProvider for DartDepsProvider {
             cwd: Some(self.base.config_root()),
             description: format!("{program} pub remove {}", packages.join(" ")),
         })
+    }
+}
+
+/// In a pub workspace, `package_config.json` lives at the workspace root rather
+/// than in the member package.
+fn workspace_package_config(pub_dir: &Path) -> Option<PathBuf> {
+    let contents = crate::file::read_to_string(pub_dir.join("workspace_ref.json")).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let workspace_root = json.get("workspaceRoot")?.as_str()?;
+    let resolved = pub_dir
+        .join(workspace_root)
+        .join(".dart_tool/package_config.json");
+    // Collapse `..` segments
+    Some(
+        resolved
+            .absolutize()
+            .map(|p| p.to_path_buf())
+            .unwrap_or(resolved),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn provider(root: &Path) -> DartDepsProvider {
+        DartDepsProvider::new("dart", root, DepsProviderConfig::default())
+    }
+
+    #[test]
+    fn outputs_default_without_workspace_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("pkg");
+        fs::create_dir_all(&root).unwrap();
+        assert_eq!(
+            provider(&root).outputs(),
+            vec![root.join(".dart_tool/package_config.json")]
+        );
+    }
+
+    #[test]
+    fn outputs_follow_workspace_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("monorepo/modules/foo");
+        let pub_dir = root.join(".dart_tool/pub");
+        fs::create_dir_all(&pub_dir).unwrap();
+        // "../../../.." is relative to the pub dir and resolves to the monorepo root.
+        fs::write(
+            pub_dir.join("workspace_ref.json"),
+            r#"{"workspaceRoot": "../../../.."}"#,
+        )
+        .unwrap();
+
+        let expected = tmp.path().join("monorepo/.dart_tool/package_config.json");
+        assert_eq!(provider(&root).outputs(), vec![expected]);
+    }
+
+    #[test]
+    fn outputs_fall_back_on_malformed_or_missing_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("pkg");
+        let pub_dir = root.join(".dart_tool/pub");
+        fs::create_dir_all(&pub_dir).unwrap();
+        let default = root.join(".dart_tool/package_config.json");
+
+        // Malformed JSON
+        fs::write(pub_dir.join("workspace_ref.json"), "not json").unwrap();
+        assert_eq!(provider(&root).outputs(), vec![default.clone()]);
+
+        // Valid JSON but no workspaceRoot key
+        fs::write(pub_dir.join("workspace_ref.json"), r#"{"other": 1}"#).unwrap();
+        assert_eq!(provider(&root).outputs(), vec![default]);
     }
 }


### PR DESCRIPTION
In monorepo using a [pub workspace](https://dart.dev/tools/pub/workspaces), `package_config.json` lives at the workspace root rather than in each member package.

The relative path to the workspace root is in `.dart_tool/pub/workspace_ref.json`, e.g.:
```
{
  "workspaceRoot": "../.."
}
```

Where `workspaceRoot` is relative to the workspace ref file itself. 

For example, given a package in `workspace/packages/mypackage`:
 - The workspace ref will be in `workspace/packages/mypackage/.dart_tool/pub/workspace_ref.json`
 - `workspace_ref.json` contains `"workspaceRoot": "../../../.."`
 - We should look for `package_config.json` in `workspace/packages/mypackage/.dart_tool/pub/../../../../.dart_tool`, which resolves to `workspace/.dart_tool`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dart/Flutter dependency output path resolution to be workspace-aware, using workspace metadata to derive the correct `package_config.json` location.
  * Added robust fallback behavior when workspace data is missing or malformed to preserve compatibility.

* **Tests**
  * Added unit tests for default resolution, workspace-root based resolution, and fallback scenarios with incomplete workspace information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->