### PR TITLE
registry: add ldc (github:ldc-developers/ldc)

### DIFF
--- a/registry/ldc.toml
+++ b/registry/ldc.toml
@@ -1,0 +1,3 @@
+backends = ["github:ldc-developers/ldc"]
+description = "LLVM-based compiler for the D programming language"
+test = { cmd = "ldc2 --version", expected = "{{version}}" }


### PR DESCRIPTION
## Summary

Add [`ldc`](https://github.com/ldc-developers/ldc), the LLVM-based compiler for the [D programming language](https://dlang.org/), to the mise registry.

Relevant links:

- D programming language: <https://dlang.org/>
- LDC project page: <https://wiki.dlang.org/LDC>
- LDC GitHub repository: <https://github.com/ldc-developers/ldc>

## Registry entry

- Backend: [`github:ldc-developers/ldc`](https://github.com/ldc-developers/ldc)
- Test command: `ldc2 --version`
- Expected output: `{{version}}`

Upstream release archives expose the compiler binary as `ldc2`, so the registry test uses `ldc2 --version` rather than `ldc --version`.

LDC was not present in the current aqua registry at time of checking.

## Popularity

- GitHub: [`ldc-developers/ldc`](https://github.com/ldc-developers/ldc) has 1,344 stars and 289 forks; repo last pushed 2026-06-17
- Latest release: [`v1.42.0`](https://github.com/ldc-developers/ldc/releases/tag/v1.42.0), published 2026-03-01
- Latest release assets: ~55,991 total downloads at time of checking
- Homebrew: [`ldc`](https://formulae.brew.sh/formula/ldc) reports 1,198 installs in the last 365 days
- Ecosystem relevance: LDC is linked from the official D language download page as a D compiler option: <https://dlang.org/download.html>

## Testing

- `mise x cmake -- cargo build`
- `target/debug/mise test-tool ldc --raw`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LDC compiler support to the registry with automated version detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->