### PR TITLE
registry: add elio

### DIFF
--- a/registry/elio.toml
+++ b/registry/elio.toml
@@ -1,0 +1,3 @@
+backends = ["github:elio-fm/elio"]
+description = "Snappy, batteries-included terminal file manager with rich previews, inline images, bulk actions, and trash support."
+test = { cmd = "elio --version", expected = "elio {{version}}" }


### PR DESCRIPTION
## Summary

Add [elio](https://github.com/elio-fm/elio) to the mise registry using its GitHub release archives.

Requested in elio-fm/elio#156.

Once merged, this allows users to install `elio` with the registry shorthand:

```sh
mise use elio@latest
```

The explicit backend already works today:

```sh
mise use github:elio-fm/elio@latest
```

## Backend choice

- Uses `github:elio-fm/elio`.
- `elio` publishes platform-specific GitHub release archives.
- No custom plugin is needed.
- No runtime package manager backend is needed.

## Popularity

- GitHub: 662 stars, 19 forks
- Site: https://elio-fm.github.io/
- Distribution: available via Homebrew/homebrew-core, AUR, Fedora COPR, a Debian/Ubuntu apt repository, crates.io, and GitHub Releases
- Homebrew analytics: 217 installs in the last 30 days
- crates.io: 620 total downloads
- Latest release: v1.9.0, published 2026-06-17
- Recent activity: pushed 2026-06-19

## Validation

Verified locally:

```sh
cargo fmt --check
cargo check --locked
cargo build --locked --bin mise
```

Also verified with the built `mise` binary:

```sh
./target/debug/mise registry elio
./target/debug/mise install elio@1.9.0
./target/debug/mise exec elio@1.9.0 -- elio --version
```

Output:

```text
github:elio-fm/elio
elio 1.9.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Registered Elio package in the registry with GitHub backend support and test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->