### PR TITLE
registry: add nub

### DIFF
--- a/registry/nub.toml
+++ b/registry/nub.toml
@@ -1,0 +1,3 @@
+backends = ["npm:@nubjs/nub"]
+description = "A Rust CLI that augments Node.js - a fast script runner, a TypeScript-just-works runtime, and a pnpm-compatible package manager"
+test = { cmd = "nub --version", expected = "{{version}}" }


### PR DESCRIPTION
Adds a registry shorthand for **nub** so users can run `mise use nub` instead of the explicit `mise use npm:@nubjs/nub`.

nub is a Rust CLI for Node.js development, published to npm as [`@nubjs/nub`](https://www.npmjs.com/package/@nubjs/nub) (currently `0.1.6`). The package fronts per-platform prebuilt binaries via `@nubjs/nub-<platform>` optional dependencies (the same distribution shape as `@yarnpkg/cli-dist`, `@biomejs/biome`, etc.), and exposes the `nub` / `nubx` bins. It is a fast script runner, a TypeScript-just-works runtime, and a pnpm-compatible package manager.

```toml
backends = ["npm:@nubjs/nub"]
description = "A Rust CLI that augments Node.js - a fast script runner, a TypeScript-just-works runtime, and a pnpm-compatible package manager"
test = { cmd = "nub --version", expected = "{{version}}" }
```

Notes:
- Uses the `npm:` backend (node tool published to npm), mirroring how pnpm/yarn register their npm backend.
- No `detect` / `idiomatic_files` keys: nub does not have a lockfile or config file of its own (it is lockfile-compatible with whatever package manager the project already uses), so detecting `package.json` or another tool every PM-lockfile would mis-activate it. Omitting detection keeps `mise use nub` explicit.

Verified `@nubjs/nub@0.1.6` is published with the `nub` bin and resolves the platform binary; `nub --version` prints the version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for Nub, a Rust CLI that augments Node.js, including version verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->