### PR TITLE
registry: relax checkov test

### DIFF
--- a/registry/checkov.toml
+++ b/registry/checkov.toml
@@ -1,3 +1,3 @@
 backends = ["aqua:bridgecrewio/checkov", "asdf:bosmak/asdf-checkov"]
 description = "Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages with Checkov by Bridgecrew"
-test = { cmd = "checkov -v", expected = "{{version}}" }
+test = { cmd = "checkov --help", expected = "usage: checkov" }


### PR DESCRIPTION
## Summary
- change the Checkov registry smoke test to run `checkov --help` instead of asserting `checkov -v` equals the requested version
- avoid failing registry CI when upstream Checkov release artifacts report stale embedded version metadata

## Verification
- independently downloaded `checkov_darwin_X86_64.zip` from Checkov 3.3.1 and confirmed `./dist/checkov -v` prints `3.3.0`
- `mise run build`
- `target/debug/mise test-tool checkov`
- pre-commit hook: `cargo check --all-features` and lint suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only smoke-test change with no runtime or security impact on mise users.
> 
> **Overview**
> Updates the **Checkov** registry entry so the post-install smoke test runs `checkov --help` and expects `usage: checkov` instead of matching `checkov -v` to `{{version}}`.
> 
> This keeps registry CI from failing when upstream release binaries ship with outdated embedded version strings (e.g. 3.3.1 artifacts reporting 3.3.0), while still verifying the binary runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6cbfdbd34654109f17db91c48eb3d889c08b94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Checkov test validation method to verify tool functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->