### PR TITLE
fix(bootstrap): detect systemd user manager socket

### DIFF
--- a/docs/bootstrap/systemd.md
+++ b/docs/bootstrap/systemd.md
@@ -57,8 +57,8 @@ and enable without keeping the unit running.
 - **User services only** — mise writes to `~/.config/systemd/user` and uses
   `systemctl --user`. System services in `/etc/systemd/system` are not
   supported.
-- **Target user only** — run mise as the user that owns the services, with an
-  active systemd user bus. `sudo mise` is skipped because `systemctl --user`
+- **Target user only** — run mise as the user who owns the services, with a
+  reachable systemd user manager. `sudo mise` is skipped because `systemctl --user`
   would target the wrong user manager.
 - **Manual application only** — mise never writes or starts systemd services
   implicitly; only `mise bootstrap systemd apply` and `mise bootstrap` do.

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -138,8 +138,9 @@ description = "sync files"
 exec_start = "~/.local/bin/my-sync --watch"
 restart = "on-failure"
 EOF
-DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/mise-test-bus assert_succeed "mise bootstrap --dry-run"
-DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/mise-test-bus assert_contains "mise bootstrap systemd status" "my-sync"
+mkdir -p runtime/systemd/private
+XDG_RUNTIME_DIR="$PWD/runtime" assert_succeed "mise bootstrap --dry-run"
+XDG_RUNTIME_DIR="$PWD/runtime" assert_contains "mise bootstrap systemd status" "my-sync"
 
 # unavailable system package managers are skipped, not errors
 cat <<EOF >mise.toml

--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -128,7 +128,7 @@ pub fn is_available() -> bool {
     cfg!(target_os = "linux")
         && crate::file::which("systemctl").is_some()
         && sudo_invoking_user().is_none()
-        && user_bus_available()
+        && user_manager_available()
 }
 
 pub fn unavailable_reason() -> String {
@@ -138,8 +138,8 @@ pub fn unavailable_reason() -> String {
         "`systemctl` not found".to_string()
     } else if sudo_invoking_user().is_some() {
         "`systemctl --user` cannot target SUDO_USER; run mise as the target user".to_string()
-    } else if !user_bus_available() {
-        "systemd user bus not available".to_string()
+    } else if !user_manager_available() {
+        "systemd user manager not available".to_string()
     } else {
         "systemd unavailable".to_string()
     }
@@ -360,13 +360,17 @@ fn normalize(value: &str) -> String {
     value.replace("\r\n", "\n").trim_end().to_string()
 }
 
-fn user_bus_available() -> bool {
+fn user_manager_available() -> bool {
     if crate::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
         return true;
     }
     crate::env::var("XDG_RUNTIME_DIR")
-        .map(|dir| Path::new(&dir).join("bus").exists())
+        .map(|dir| user_manager_socket_available(Path::new(&dir)))
         .unwrap_or(false)
+}
+
+fn user_manager_socket_available(runtime_dir: &Path) -> bool {
+    runtime_dir.join("systemd/private").exists() || runtime_dir.join("bus").exists()
 }
 
 fn sudo_invoking_user() -> Option<String> {
@@ -564,5 +568,18 @@ mod tests {
             state: SystemdState::Inactive,
         };
         assert!(inactive_stopped.is_desired());
+    }
+
+    #[test]
+    fn test_user_manager_socket_available() {
+        let runtime_dir = tempfile::tempdir().unwrap();
+        assert!(!user_manager_socket_available(runtime_dir.path()));
+
+        crate::file::create_dir_all(runtime_dir.path().join("systemd/private")).unwrap();
+        assert!(user_manager_socket_available(runtime_dir.path()));
+
+        crate::file::remove_file_or_dir(runtime_dir.path().join("systemd/private")).unwrap();
+        std::fs::write(runtime_dir.path().join("bus"), "").unwrap();
+        assert!(user_manager_socket_available(runtime_dir.path()));
     }
 }


### PR DESCRIPTION
## Summary
- detect a reachable systemd user manager via `$XDG_RUNTIME_DIR/systemd/private`, not only a D-Bus session bus
- update systemd bootstrap docs to describe the user manager requirement
- cover the headless user-manager case in e2e and add unit coverage for accepted runtime sockets

## Root cause
`mise bootstrap systemd` gated availability on `DBUS_SESSION_BUS_ADDRESS` or `$XDG_RUNTIME_DIR/bus`, but the implementation uses `systemctl --user`. On headless/minimal systems, `systemctl --user` can still reach the user manager through `$XDG_RUNTIME_DIR/systemd/private`, so mise skipped valid configurations.

## Validation
- `mise run format`
- `cargo test system::systemd::tests::test_user_manager_socket_available`
- `mise run test:e2e e2e/cli/test_bootstrap`

Fixes discussion #10524.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow gating change for when systemd bootstrap runs, with matching tests and doc wording; no changes to how units are written or started.
> 
> **Overview**
> **Fixes** bootstrap treating systemd as unavailable on headless Linux when `systemctl --user` can still talk to the user manager through `$XDG_RUNTIME_DIR/systemd/private`, not only a session D-Bus bus at `$XDG_RUNTIME_DIR/bus`.
> 
> Availability now uses `user_manager_available()` (replacing bus-only checks): non-empty `DBUS_SESSION_BUS_ADDRESS` still counts, and under `XDG_RUNTIME_DIR` either `systemd/private` or `bus` must exist. Skip messages and docs refer to a **reachable systemd user manager** instead of a user bus.
> 
> E2e bootstrap tests simulate the headless case with `XDG_RUNTIME_DIR` + `systemd/private`; a unit test covers both accepted runtime socket paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56c18c89c1465ce4ff33da3627a23a2fbbf6681d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified “Target user only” semantics for systemd user services and updated wording around when user-scoped commands are appropriate.
* **Bug Fixes**
  * Improved detection of systemd user manager availability to make bootstrap operations more dependable across varied runtime environments.
* **Tests**
  * Updated systemd bootstrap dry-run e2e setup to prepare the correct runtime directory context, and added coverage for the user manager socket availability logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->