### PR TITLE
registry: add checksums for http-backend tools

### DIFF
--- a/e2e/backend/test_http_lock_checksum_expr
+++ b/e2e/backend/test_http_lock_checksum_expr
@@ -20,16 +20,22 @@ mkdir -p "$SRV"
 # Published sha256/sha512 values embedded in the served manifests. `mise lock`
 # only fetches the manifest (checksum_url) and evaluates the expression; it never
 # downloads the artifact, so these are manifest data, not artifact hashes.
-A_LINUX="90cf53c033071b194c3dd79d00c390afb8b79faadc486b6fd50101409134fdc4" # platform-keyed, linux-x64
-A_MACOS="de494e8d180cc5ee5d67c4d2c39b383dd4f3261620c99c3c8a2e9e3e3768a368" # platform-keyed, macos-x64 (darwin-x64 key)
-B_LINUX="13bbd2c8c52d1724f8036c3e36b4a134f3c9d130ce8aa2ed54df55d3c946faf4" # filename filter, linux
-B_MACOS="790617f1a756760762e2e73f92c28b412b031c65bf4e9e02d5ee7f9d19f0e3c5" # filename filter, macos
-C_LINUX="4140664dfd1d31f89f4114e45c4956be36d9b59e10da978489d3e08839b01ca5" # version-keyed + url match, linux-x64
-C_MACOS="a583fafff7ee5ac0a056f1e90001c8d7e8c5d9341b42ded610f692ce81acbfee" # version-keyed + url match, macos-x64
-BARE_SHA="678eee372a3e8e207b3780d258e14e5c46fb7c7b28340b35ecc896ca9b3dd18b" # bare-hash negative case
-UPPER_LOWER="69b59884ac4d802179d77dbcd43b3d475e2d0a4f82afd0dc43f7b2301ba40259" # uppercase normalization (lowercased form)
-UPPER_UPPER="69B59884AC4D802179D77DBCD43B3D475E2D0A4F82AFD0DC43F7B2301BA40259" # same value, as stored in the manifest
-ALGO512="f073412a6d4865a42afcfd465fa0d60d7fca7c37ef2d0c4f602e0411f0ba5c10dba925ffa1b6f67a5d696194a64eb04f739b33e4beb55c68c998e4dbda92529e" # algo from manifest (sha512)
+# platform-keyed object (claude shape), linux-x64 / macos-x64 (darwin-x64 key)
+A_LINUX="90cf53c033071b194c3dd79d00c390afb8b79faadc486b6fd50101409134fdc4"
+A_MACOS="de494e8d180cc5ee5d67c4d2c39b383dd4f3261620c99c3c8a2e9e3e3768a368"
+# filename filter (flutter shape), linux / macos
+B_LINUX="13bbd2c8c52d1724f8036c3e36b4a134f3c9d130ce8aa2ed54df55d3c946faf4"
+B_MACOS="790617f1a756760762e2e73f92c28b412b031c65bf4e9e02d5ee7f9d19f0e3c5"
+# version-keyed + url match (julia shape), linux-x64 / macos-x64
+C_LINUX="4140664dfd1d31f89f4114e45c4956be36d9b59e10da978489d3e08839b01ca5"
+C_MACOS="a583fafff7ee5ac0a056f1e90001c8d7e8c5d9341b42ded610f692ce81acbfee"
+# bare-hash negative case
+BARE_SHA="678eee372a3e8e207b3780d258e14e5c46fb7c7b28340b35ecc896ca9b3dd18b"
+# uppercase normalization: same value stored uppercase, expected lowercased
+UPPER_LOWER="69b59884ac4d802179d77dbcd43b3d475e2d0a4f82afd0dc43f7b2301ba40259"
+UPPER_UPPER="69B59884AC4D802179D77DBCD43B3D475E2D0A4F82AFD0DC43F7B2301BA40259"
+# algorithm taken from the manifest (sha512)
+ALGO512="f073412a6d4865a42afcfd465fa0d60d7fca7c37ef2d0c4f602e0411f0ba5c10dba925ffa1b6f67a5d696194a64eb04f739b33e4beb55c68c998e4dbda92529e"
 
 # Start a static file server on an ephemeral port
 PORT_FILE="$TMPDIR/mise_lock_expr_port"

--- a/e2e/backend/test_http_lock_checksum_expr
+++ b/e2e/backend/test_http_lock_checksum_expr
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+# Cross-platform `mise lock` for the http backend resolving published checksums
+# from a JSON manifest via `checksum_expr`. The expression must evaluate to an
+# `algo:hash` string; the manifest is fetched once and shared across platforms,
+# and no artifact is downloaded. Covers:
+#   - the three manifest shapes used by registry entries (platform-keyed object,
+#     filename filter, version-keyed + url match), exercising the os/arch/
+#     version/url/filename template vars exposed to the expression;
+#   - the fail-closed rule that a bare-hash result (no `algo:`) is rejected
+#     rather than silently locked without verification;
+#   - an algorithm taken from the manifest (sha512), and case-insensitive
+#     normalization of the algorithm name and hex.
+
+export MISE_LOCKFILE=1
+
+SRV="$PWD/srv"
+mkdir -p "$SRV"
+
+# Published sha256/sha512 values embedded in the served manifests. `mise lock`
+# only fetches the manifest (checksum_url) and evaluates the expression; it never
+# downloads the artifact, so these are manifest data, not artifact hashes.
+A_LINUX="90cf53c033071b194c3dd79d00c390afb8b79faadc486b6fd50101409134fdc4" # platform-keyed, linux-x64
+A_MACOS="de494e8d180cc5ee5d67c4d2c39b383dd4f3261620c99c3c8a2e9e3e3768a368" # platform-keyed, macos-x64 (darwin-x64 key)
+B_LINUX="13bbd2c8c52d1724f8036c3e36b4a134f3c9d130ce8aa2ed54df55d3c946faf4" # filename filter, linux
+B_MACOS="790617f1a756760762e2e73f92c28b412b031c65bf4e9e02d5ee7f9d19f0e3c5" # filename filter, macos
+C_LINUX="4140664dfd1d31f89f4114e45c4956be36d9b59e10da978489d3e08839b01ca5" # version-keyed + url match, linux-x64
+C_MACOS="a583fafff7ee5ac0a056f1e90001c8d7e8c5d9341b42ded610f692ce81acbfee" # version-keyed + url match, macos-x64
+BARE_SHA="678eee372a3e8e207b3780d258e14e5c46fb7c7b28340b35ecc896ca9b3dd18b" # bare-hash negative case
+UPPER_LOWER="69b59884ac4d802179d77dbcd43b3d475e2d0a4f82afd0dc43f7b2301ba40259" # uppercase normalization (lowercased form)
+UPPER_UPPER="69B59884AC4D802179D77DBCD43B3D475E2D0A4F82AFD0DC43F7B2301BA40259" # same value, as stored in the manifest
+ALGO512="f073412a6d4865a42afcfd465fa0d60d7fca7c37ef2d0c4f602e0411f0ba5c10dba925ffa1b6f67a5d696194a64eb04f739b33e4beb55c68c998e4dbda92529e" # algo from manifest (sha512)
+
+# Start a static file server on an ephemeral port
+PORT_FILE="$TMPDIR/mise_lock_expr_port"
+python3 - "$SRV" "$PORT_FILE" <<'PY' &
+import http.server, socketserver, sys, os
+srv, port_file = sys.argv[1], sys.argv[2]
+os.chdir(srv)
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler) as httpd:
+    with open(port_file, "w") as f:
+        f.write(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+wait_for_file "$PORT_FILE" "lock expr port file" 30 "$SERVER_PID"
+PORT=$(cat "$PORT_FILE")
+
+# === Test 1: platform-keyed object (claude shape) ===
+# manifest.platforms.<os-arch>.checksum, where os maps macos->darwin /
+# windows->win32. The expression builds the key from the target os/arch vars.
+cat >"$SRV/a_manifest.json" <<JSON
+{ "platforms": {
+    "linux-x64":  { "checksum": "${A_LINUX}" },
+    "darwin-x64": { "checksum": "${A_MACOS}" }
+} }
+JSON
+
+rm -f mise.lock
+cat >mise.toml <<EOF
+[tools."http:expr-platform-keyed"]
+version = "1.0.0"
+url = 'http://127.0.0.1:${PORT}/atool_{{ version }}_{{ os(macos="darwin") }}-{{ arch() }}.bin'
+checksum_url = "http://127.0.0.1:${PORT}/a_manifest.json"
+checksum_expr = '"sha256:" + fromJSON(body).platforms[(os == "macos" ? "darwin" : (os == "windows" ? "win32" : "linux")) + "-" + arch].checksum'
+EOF
+mise lock --platform linux-x64,macos-x64
+assert_contains "cat mise.lock" "sha256:${A_LINUX}"
+assert_contains "cat mise.lock" "sha256:${A_MACOS}"
+
+# === Test 2: filename filter, per-OS manifest (flutter shape) ===
+# The sha256 lives in an OS-specific manifest (checksum_url is per platform),
+# matched against the resolved artifact filename via `endsWith`.
+cat >"$SRV/b_linux.json" <<JSON
+{ "releases": [ { "archive": "stable/linux/btool_1.0.0_linux.tar.xz", "sha256": "${B_LINUX}" } ] }
+JSON
+cat >"$SRV/b_macos.json" <<JSON
+{ "releases": [ { "archive": "stable/macos/btool_1.0.0_macos.zip", "sha256": "${B_MACOS}" } ] }
+JSON
+
+rm -f mise.lock
+cat >mise.toml <<EOF
+[tools."http:expr-filename-filter"]
+version = "1.0.0"
+checksum_expr = '"sha256:" + filter(fromJSON(body).releases, { #.archive endsWith filename })[0].sha256'
+
+[tools."http:expr-filename-filter".platforms.linux-x64]
+checksum_url = "http://127.0.0.1:${PORT}/b_linux.json"
+url = "http://127.0.0.1:${PORT}/btool_{{ version }}_linux.tar.xz"
+
+[tools."http:expr-filename-filter".platforms.macos-x64]
+checksum_url = "http://127.0.0.1:${PORT}/b_macos.json"
+url = "http://127.0.0.1:${PORT}/btool_{{ version }}_macos.zip"
+EOF
+mise lock --platform linux-x64,macos-x64
+assert_contains "cat mise.lock" "sha256:${B_LINUX}"
+assert_contains "cat mise.lock" "sha256:${B_MACOS}"
+
+# === Test 3: version-keyed manifest + url match (julia shape) ===
+# manifest[version].files[].url is the fully-resolved artifact URL; the entry is
+# selected by matching the `url` var, exercising both the version and url vars.
+cat >"$SRV/c_versions.json" <<JSON
+{ "1.0.0": { "files": [
+    { "url": "http://127.0.0.1:${PORT}/ctool_1.0.0_linux-x64.tar.gz", "sha256": "${C_LINUX}" },
+    { "url": "http://127.0.0.1:${PORT}/ctool_1.0.0_macos-x64.tar.gz", "sha256": "${C_MACOS}" }
+] } }
+JSON
+
+rm -f mise.lock
+cat >mise.toml <<EOF
+[tools."http:expr-version-keyed"]
+version = "1.0.0"
+url = "http://127.0.0.1:${PORT}/ctool_{{ version }}_{{ os() }}-{{ arch() }}.tar.gz"
+checksum_url = "http://127.0.0.1:${PORT}/c_versions.json"
+checksum_expr = '"sha256:" + filter(fromJSON(body)[version + ""].files, { #.url == url })[0].sha256'
+EOF
+mise lock --platform linux-x64,macos-x64
+assert_contains "cat mise.lock" "sha256:${C_LINUX}"
+assert_contains "cat mise.lock" "sha256:${C_MACOS}"
+
+# === Test 4: bare-hash result is rejected (fail closed) ===
+# An expression that returns a bare hash (no `algo:`) must NOT be locked: mise
+# stores checksums as algo:hash everywhere and refuses to guess. The platform is
+# still locked URL-only, with a warning, rather than writing an unusable value.
+cat >"$SRV/bare_manifest.json" <<JSON
+{ "platforms": { "linux-x64": { "checksum": "${BARE_SHA}" } } }
+JSON
+
+rm -f mise.lock
+cat >mise.toml <<EOF
+[tools."http:expr-bare-hash"]
+version = "1.0.0"
+checksum_url = "http://127.0.0.1:${PORT}/bare_manifest.json"
+checksum_expr = 'fromJSON(body).platforms[os + "-" + arch].checksum'
+
+[tools."http:expr-bare-hash".platforms.linux-x64]
+url = "http://127.0.0.1:${PORT}/baretool_{{ version }}_linux-x64.tar.gz"
+EOF
+output="$(mise lock --platform linux-x64 2>&1)"
+# The artifact is still locked (URL present)...
+assert_contains "cat mise.lock" "baretool_1.0.0_linux-x64.tar.gz"
+# ...but the bare hash is never written as a checksum.
+assert_not_contains "cat mise.lock" "${BARE_SHA}"
+assert_contains "echo '$output'" "could not resolve a checksum"
+
+# === Test 5: algorithm taken from the manifest (sha512) ===
+# When the manifest carries the algorithm, the expression builds the prefix from
+# it (algo + ":" + hash). A non-sha256 algorithm round-trips as algo:hash.
+cat >"$SRV/algo_manifest.json" <<JSON
+{ "platforms": { "linux-x64": { "algo": "sha512", "hash": "${ALGO512}" } } }
+JSON
+
+rm -f mise.lock
+cat >mise.toml <<EOF
+[tools."http:expr-manifest-algo"]
+version = "1.0.0"
+checksum_url = "http://127.0.0.1:${PORT}/algo_manifest.json"
+checksum_expr = 'fromJSON(body).platforms[os + "-" + arch].algo + ":" + fromJSON(body).platforms[os + "-" + arch].hash'
+
+[tools."http:expr-manifest-algo".platforms.linux-x64]
+url = "http://127.0.0.1:${PORT}/algotool_{{ version }}_linux-x64.tar.gz"
+EOF
+mise lock --platform linux-x64
+assert_contains "cat mise.lock" "sha512:${ALGO512}"
+
+# === Test 6: algorithm name and hex are normalized case-insensitively ===
+# An uppercase algorithm (SHA256) and uppercase hex from a manifest are lowered
+# to the canonical algo:hash form mise stores.
+cat >"$SRV/upper_manifest.json" <<JSON
+{ "platforms": { "linux-x64": { "algo": "SHA256", "hash": "${UPPER_UPPER}" } } }
+JSON
+
+rm -f mise.lock
+cat >mise.toml <<EOF
+[tools."http:expr-uppercase-algo"]
+version = "1.0.0"
+checksum_url = "http://127.0.0.1:${PORT}/upper_manifest.json"
+checksum_expr = 'fromJSON(body).platforms[os + "-" + arch].algo + ":" + fromJSON(body).platforms[os + "-" + arch].hash'
+
+[tools."http:expr-uppercase-algo".platforms.linux-x64]
+url = "http://127.0.0.1:${PORT}/uppertool_{{ version }}_linux-x64.tar.gz"
+EOF
+mise lock --platform linux-x64
+assert_contains "cat mise.lock" "sha256:${UPPER_LOWER}"
+assert_not_contains "cat mise.lock" "SHA256:${UPPER_UPPER}"

--- a/e2e/backend/test_http_lock_install_verify
+++ b/e2e/backend/test_http_lock_install_verify
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-# Full loop: `mise lock` resolves a published checksum (SHASUMS) for the http
-# backend, and a subsequent install verifies the artifact against that locked
-# checksum. A tampered lock checksum must make the install fail.
+# Full loop: `mise lock` resolves a published checksum for the http backend, and
+# a subsequent install verifies the artifact against that locked checksum. A
+# tampered lock checksum must make the install fail. Covers both the SHASUMS
+# checksum source and a JSON manifest resolved via `checksum_expr`.
 
 export MISE_LOCKFILE=1
 
@@ -56,4 +57,41 @@ assert_contains "mise x -- mytool" "mytool ok"
 
 # Tamper with the locked checksum: install must now fail on mismatch.
 sed "s/${REAL_SHA}/${BAD_SHA}/" mise.lock >mise.lock.tmp && mv mise.lock.tmp mise.lock
+assert_fail "mise install --locked -f"
+
+# === Same loop, but the checksum comes from a JSON manifest via checksum_expr ===
+# sha256 of the exprtool artifact bytes, published under the host's platform key
+# (os mapped macos->darwin / windows->win32) in a manifest.
+EXPR_SHA="27a981b64e117ad76f205346574c47bff47693a0fc73e30c6e86587e0d1aeb05"
+printf '#!/bin/sh\necho exprtool ok\n' >"$SRV/exprtool"
+
+os="${PLATFORM%%-*}"
+arch="${PLATFORM#*-}"
+case "$os" in
+macos) mapped_os="darwin" ;;
+windows) mapped_os="win32" ;;
+*) mapped_os="linux" ;;
+esac
+cat >"$SRV/expr_manifest.json" <<JSON
+{ "platforms": { "${mapped_os}-${arch}": { "checksum": "${EXPR_SHA}" } } }
+JSON
+
+rm -f mise.lock
+cat >mise.toml <<EOF
+[tools."http:exprtool-lock-verify"]
+version = "1.0.0"
+bin = "exprtool"
+url = "http://127.0.0.1:${PORT}/exprtool"
+checksum_url = "http://127.0.0.1:${PORT}/expr_manifest.json"
+checksum_expr = '"sha256:" + fromJSON(body).platforms[(os == "macos" ? "darwin" : (os == "windows" ? "win32" : "linux")) + "-" + arch].checksum'
+EOF
+
+# Lock resolves the manifest checksum, and install verifies the artifact.
+mise lock --platform "$PLATFORM"
+assert_contains "cat mise.lock" "sha256:${EXPR_SHA}"
+mise install --locked
+assert_contains "mise x -- exprtool" "exprtool ok"
+
+# A tampered manifest-resolved checksum must also fail the install.
+sed "s/${EXPR_SHA}/${BAD_SHA}/" mise.lock >mise.lock.tmp && mv mise.lock.tmp mise.lock
 assert_fail "mise install --locked -f"

--- a/e2e/backend/test_http_lock_install_verify
+++ b/e2e/backend/test_http_lock_install_verify
@@ -68,9 +68,9 @@ printf '#!/bin/sh\necho exprtool ok\n' >"$SRV/exprtool"
 os="${PLATFORM%%-*}"
 arch="${PLATFORM#*-}"
 case "$os" in
-macos) mapped_os="darwin" ;;
-windows) mapped_os="win32" ;;
-*) mapped_os="linux" ;;
+  macos) mapped_os="darwin" ;;
+  windows) mapped_os="win32" ;;
+  *) mapped_os="linux" ;;
 esac
 cat >"$SRV/expr_manifest.json" <<JSON
 { "platforms": { "${mapped_os}-${arch}": { "checksum": "${EXPR_SHA}" } } }

--- a/registry/claude.toml
+++ b/registry/claude.toml
@@ -12,6 +12,10 @@ full = "http:claude"
 
 [backends.options]
 bin = "claude"
+# Per-version manifest.json carries each platform's sha256 under platforms.<os>-<arch>
+# (os: darwin/linux/win32), so map mise's os/arch onto that key.
+checksum_expr = '"sha256:" + fromJSON(body).platforms[(os == "macos" ? "darwin" : (os == "windows" ? "win32" : "linux")) + "-" + arch].checksum'
+checksum_url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{ version }}/manifest.json"
 # NOTE: upstream `/stable` is often stale; prefer `/latest` for correct `mise latest claude`
 # See: https://github.com/jdx/mise/discussions/7329
 url = 'https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{ version }}/{{ os(macos="darwin") }}-{{ arch() }}/claude'

--- a/registry/dart.toml
+++ b/registry/dart.toml
@@ -4,6 +4,7 @@ description = "An approachable, portable, and productive language for high-quali
 full = "http:dart"
 
 [backends.options]
+checksum_url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{ version }}/sdk/dartsdk-{{ os() }}-{{ arch() }}-release.zip.sha256sum"
 url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{ version }}/sdk/dartsdk-{{ os() }}-{{ arch() }}-release.zip"
 version_expr = 'fromJSON(body).prefixes | filter({ # matches "^channels/stable/release/(\\d+\\.\\d+\\.\\d+)/$" }) | map({split(#, "/")[3]}) | sortVersions()'
 version_list_url = "https://storage.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/stable/release/&delimiter=/"

--- a/registry/flutter.toml
+++ b/registry/flutter.toml
@@ -4,20 +4,27 @@ description = "Flutter is an open source framework for building beautiful, nativ
 full = "http:flutter"
 
 [backends.options]
+# Each platform's sha256 lives in its OS-specific releases manifest, matched by
+# the resolved artifact's archive path (checksum_url is set per platform below).
+checksum_expr = '"sha256:" + filter(fromJSON(body).releases, { #.archive endsWith filename })[0].sha256'
 version_expr = 'fromJSON(body).releases | filter({ #.channel == "stable" }) | map({ replace(#.version, "-stable", "") }) | sortVersions()'
 version_list_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json"
 
 # Linux uses .tar.xz instead of .zip
 [backends.options.platforms.linux-x64]
+checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json"
 url = 'https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_{{ version }}-stable.tar.xz'
 
 [backends.options.platforms.macos-x64]
+checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_macos.json"
 url = 'https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_{{ version }}-stable.zip'
 
 [backends.options.platforms.macos-arm64]
+checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_macos.json"
 url = 'https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_{{ version }}-stable.zip'
 
 [backends.options.platforms.windows-x64]
+checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_windows.json"
 url = 'https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_{{ version }}-stable.zip'
 
 [[backends]]

--- a/registry/julia.toml
+++ b/registry/julia.toml
@@ -6,6 +6,8 @@ test = { cmd = "julia --version", expected = "julia version" }
 full = "http:julia"
 
 [backends.options]
+checksum_expr = '"sha256:" + filter(fromJSON(body)[version + ""].files, { #.url == url })[0].sha256'
+checksum_url = "https://julialang-s3.julialang.org/bin/versions.json"
 version_expr = 'sortVersions(filter(keys(fromJSON(body)), { # matches "^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z\\.-]+)?$" }))'
 version_list_url = "https://julialang-s3.julialang.org/bin/versions.json"
 

--- a/registry/neo4j.toml
+++ b/registry/neo4j.toml
@@ -6,6 +6,7 @@ full = "http:neo4j"
 platforms = ["linux", "macos"]
 
 [backends.options]
+checksum_url = "https://dist.neo4j.org/neo4j-community-{{ version }}-unix.tar.gz.sha256"
 strip_components = "1"
 url = "https://dist.neo4j.org/neo4j-community-{{ version }}-unix.tar.gz"
 version_json_path = ".response.docs[].v"

--- a/registry/nomad-pack.toml
+++ b/registry/nomad-pack.toml
@@ -5,6 +5,7 @@ test = { cmd = "nomad-pack version", expected = "{{version}}" }
 full = "http:nomad-pack"
 
 [backends.options]
+checksum_url = "https://releases.hashicorp.com/nomad-pack/{{ version }}/nomad-pack_{{ version }}_SHA256SUMS"
 url = 'https://releases.hashicorp.com/nomad-pack/{{ version }}/nomad-pack_{{ version }}_{{ os(macos="darwin") }}_{{ arch(x64="amd64") }}.zip'
 version_expr = 'fromJSON(body).versions | keys() | sortVersions()'
 version_list_url = "https://releases.hashicorp.com/nomad-pack/index.json"

--- a/registry/oc.toml
+++ b/registry/oc.toml
@@ -7,6 +7,7 @@ full = "http:oc"
 
 [backends.options]
 bin = "oc"
+checksum_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/sha256sum.txt"
 version_expr = 'sortVersions(versions)'
 version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
 version_regex = 'href="(\d+\.\d+\.\d+)/"'

--- a/registry/openshift-install.toml
+++ b/registry/openshift-install.toml
@@ -7,6 +7,7 @@ full = "http:openshift-install"
 
 [backends.options]
 bin = "openshift-install"
+checksum_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/sha256sum.txt"
 version_expr = 'sortVersions(versions)'
 version_list_url = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
 version_regex = 'href="(\d+\.\d+\.\d+)/"'

--- a/registry/sentinel.toml
+++ b/registry/sentinel.toml
@@ -5,6 +5,7 @@ test = { cmd = "sentinel version", expected = "Sentinel v{{version}}" }
 full = "http:sentinel"
 
 [backends.options]
+checksum_url = "https://releases.hashicorp.com/sentinel/{{ version }}/sentinel_{{ version }}_SHA256SUMS"
 url = 'https://releases.hashicorp.com/sentinel/{{ version }}/sentinel_{{ version }}_{{ os(macos="darwin") }}_{{ arch(x64="amd64") }}.zip'
 version_expr = 'fromJSON(body).versions | keys() | sortVersions()'
 version_list_url = "https://releases.hashicorp.com/sentinel/index.json"

--- a/registry/tfc-agent.toml
+++ b/registry/tfc-agent.toml
@@ -5,6 +5,7 @@ os = ["linux"]
 full = "http:tfc-agent"
 
 [backends.options]
+checksum_url = "https://releases.hashicorp.com/tfc-agent/{{ version }}/tfc-agent_{{ version }}_SHA256SUMS"
 url = 'https://releases.hashicorp.com/tfc-agent/{{ version }}/tfc-agent_{{ version }}_linux_{{ arch(x64="amd64") }}.zip'
 version_expr = 'fromJSON(body).versions | keys() | sortVersions()'
 version_list_url = "https://releases.hashicorp.com/tfc-agent/index.json"


### PR DESCRIPTION
## Summary

Adds published-checksum resolution to the registry entries that use the `http` backend, building on cross-platform lock checksum support (#10509). With these, `mise lock` records a verified `algo:hash` for each platform instead of locking the URL without verification.

Two checksum sources are used, matching each upstream's published format:

- **`checksum_url`** (SHASUMS / individual checksum file): `dart`, `neo4j`, `nomad-pack`, `sentinel`, `tfc-agent`, `oc`, `openshift-install`
- **`checksum_url` + `checksum_expr`** (sha256 extracted from a JSON manifest): `claude`, `flutter`, `julia`

The three manifest-based entries build an `algo:hash` string in the expression (e.g. `"sha256:" + ...`), as required by the resolver merged in #10509 — a bare hash is intentionally rejected rather than locked unverified.

## Verification

`mise lock` was run against the real upstream endpoints for all 10 tools across every platform they ship:

- 48/48 supported (tool, platform) entries resolved a real `sha256:`/`sha512:`; **zero** url-only (unverified) entries.
- The only skips are platforms a tool does not ship (e.g. `flutter` linux-arm64, `openshift-install` windows-x64).

## Tests

The `checksum_expr` lock path previously had only Rust unit tests, so this adds e2e coverage (synthetic local server, ~9s):

- **`test_http_lock_checksum_expr`** — the three manifest shapes (platform-keyed object / filename filter / version-keyed + url match), exercising the `os`/`arch`/`version`/`url`/`filename` template vars; fail-closed rejection of a bare-hash result; an algorithm taken from the manifest (sha512); and case-insensitive algo/hex normalization.
- **`test_http_lock_install_verify`** — extended so a manifest-resolved checksum is enforced at install and a tampered value fails the install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved checksum verification across multiple tool backends (Claude, Dart, Flutter, Julia, Neo4j, Nomad Pack, OpenShift, Sentinel, TFC Agent) by adding `checksum_url` support and enabling `checksum_expr` where needed for platform- and version-specific manifest resolution.
  * Locking now canonicalizes checksums (normalized `algo:hash`) and fails closed when an invalid checksum format is returned.

* **Tests**
  * Added end-to-end coverage for `checksum_expr` resolution in the HTTP backend and for the full `mise lock` → `mise install --locked` verification loop, including tamper and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->