### PR TITLE
registry: add serve-d (github:Pure-D/serve-d)

### DIFF
--- a/registry/serve-d.toml
+++ b/registry/serve-d.toml
@@ -1,0 +1,10 @@
+backends = [
+  { full = "github:Pure-D/serve-d", platforms = [
+    "linux-x86_64",
+    "macos-x86_64",
+    "windows-x86_64",
+    "windows-x86",
+  ] },
+]
+description = "D language server"
+test = { cmd = "serve-d --version", expected = "{{version}}" }


### PR DESCRIPTION
## Summary

Add [`serve-d`](https://github.com/Pure-D/serve-d), the primary language server for the [D programming language](https://dlang.org/), to the mise registry.

This complements `ldc` D compiler support added in https://github.com/jdx/mise/pull/10527.

Stable `serve-d` releases currently publish binaries for `linux-x64`, `macos-x64`, `windows-x64`, and `windows-x86`. The `v0.8.0` beta releases also include `macos-arm64` assets, and a new stable release is planned soon but is not quite ready. This registry entry intentionally tracks stable releases for now; the platform list can be widened after the next stable release.

## Popularity

- VS Code: [`code-d`](https://marketplace.visualstudio.com/items?itemName=webfreak.code-d), which uses `serve-d` as its language server, reports ~87k installs
- DUB registry: [`serve-d`](https://code.dlang.org/packages/serve-d) has been published since 2018 and lists 63 package versions
- GitHub: [`Pure-D/serve-d`](https://github.com/Pure-D/serve-d) has 263 stars and 67 forks; repo last pushed 2026-05-02
- Latest stable release: [`v0.7.6`](https://github.com/Pure-D/serve-d/releases/tag/v0.7.6), published 2024-01-07, with 21,534 release-asset downloads at time of checking
- Ecosystem relevance: `serve-d` is used or referenced by D editor integrations including [`code-d`](https://github.com/Pure-D/code-d), Helix, nvim-lspconfig, and Zed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the D language server by introducing a new configuration that covers Linux x86_64, macOS x86_64, and Windows x64/x86.
  * Included an installation verification step that runs the server and confirms the version output matches the expected format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->