### PR TITLE
fix(core): gate platform-specific erlang/sandbox code to avoid dead-code warnings

### DIFF
--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -6,10 +6,12 @@ use crate::backend::VersionInfo;
 use crate::backend::platform_target::PlatformTarget;
 use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
-#[cfg(unix)]
+#[cfg(any(linux, macos))]
 use crate::file::ExtractOptions;
 use crate::file::display_path;
-use crate::http::{HTTP, HTTP_FETCH};
+#[cfg(any(linux, macos, windows))]
+use crate::http::HTTP;
+use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
 use crate::lock_file::LockFile;
 use crate::lockfile::PlatformInfo;
@@ -101,12 +103,14 @@ impl ErlangPlugin {
         format!("OTP-{version}")
     }
 
+    #[cfg(any(linux, macos, windows))]
     fn lockfile_url(&self, tv: &ToolVersion) -> Option<String> {
         tv.lock_platforms
             .get(&self.get_platform_key())
             .and_then(|p| p.url.clone())
     }
 
+    #[cfg(any(linux, macos, windows))]
     fn set_lockfile_info(&self, tv: &mut ToolVersion, url: &str, checksum: Option<String>) {
         let platform_info = tv
             .lock_platforms

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -84,26 +84,17 @@ impl SandboxConfig {
     }
 
     /// Compute effective deny flags, accounting for allow_* implying deny_*.
-    #[cfg_attr(
-        not(any(target_os = "linux", target_os = "macos")),
-        allow(dead_code)
-    )]
+    #[cfg_attr(not(any(target_os = "linux", target_os = "macos")), allow(dead_code))]
     pub fn effective_deny_read(&self) -> bool {
         self.deny_read || !self.allow_read.is_empty()
     }
 
-    #[cfg_attr(
-        not(any(target_os = "linux", target_os = "macos")),
-        allow(dead_code)
-    )]
+    #[cfg_attr(not(any(target_os = "linux", target_os = "macos")), allow(dead_code))]
     pub fn effective_deny_write(&self) -> bool {
         self.deny_write || !self.allow_write.is_empty()
     }
 
-    #[cfg_attr(
-        not(any(target_os = "linux", target_os = "macos")),
-        allow(dead_code)
-    )]
+    #[cfg_attr(not(any(target_os = "linux", target_os = "macos")), allow(dead_code))]
     pub fn effective_deny_net(&self) -> bool {
         self.deny_net || !self.allow_net.is_empty()
     }

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -84,17 +84,26 @@ impl SandboxConfig {
     }
 
     /// Compute effective deny flags, accounting for allow_* implying deny_*.
-    #[cfg_attr(windows, allow(dead_code))]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "macos")),
+        allow(dead_code)
+    )]
     pub fn effective_deny_read(&self) -> bool {
         self.deny_read || !self.allow_read.is_empty()
     }
 
-    #[cfg_attr(windows, allow(dead_code))]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "macos")),
+        allow(dead_code)
+    )]
     pub fn effective_deny_write(&self) -> bool {
         self.deny_write || !self.allow_write.is_empty()
     }
 
-    #[cfg_attr(windows, allow(dead_code))]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "macos")),
+        allow(dead_code)
+    )]
     pub fn effective_deny_net(&self) -> bool {
         self.deny_net || !self.allow_net.is_empty()
     }


### PR DESCRIPTION
## Summary

- `src/plugins/core/erlang.rs` imports `HTTP` and `ExtractOptions`, and defines `lockfile_url`/`set_lockfile_info`, but every call site lives inside the `linux`/`macos`/`windows`-specific `install_precompiled` variants. On any other unix target these trigger `unused_imports`/`dead_code` warnings.
- `src/sandbox/mod.rs` already had `#[cfg_attr(windows, allow(dead_code))]` on `effective_deny_read/write/net` since there's no Windows sandbox backend. Their only callers (`apply_linux`/`apply_macos`) are themselves gated to `target_os = "linux"`/`"macos"`, so the same dead-code gap exists on any other non-Linux/macOS target. Broadened the `cfg_attr` condition to `not(any(target_os = "linux", target_os = "macos"))` to match.

No behavior change on linux/macos/windows — this only affects which code is compiled in on other unix-like targets, silencing warnings that would otherwise show up there.

Found while getting mise building on OpenBSD, but the fix itself is general portability cleanup, independent of any OpenBSD-specific feature work.

## Test plan

- [x] Confirmed each gated item's call sites are all inside the corresponding platform-gated code (traced via grep, included in the commit message)
- [ ] Maintainers: existing CI (linux/macos/windows) should be unaffected since none of those `cfg` arms changed for those targets

*This PR description was generated with AI assistance.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved cross-platform build behavior by refining which platform-specific components are included on Linux/macOS vs Windows.
  * Tightened conditional compilation for related helper functionality to reduce unnecessary code on unsupported targets.
  * Updated lint handling in sandbox access checks for non–Linux/macOS environments to keep builds cleaner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->