### PR TITLE
fix(aqua): don't cache transient filesystem state in list_bin_paths

### DIFF
--- a/e2e/backend/test_aqua_bin_paths_stale_cache_slow
+++ b/e2e/backend/test_aqua_bin_paths_stale_cache_slow
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression test for #6468: aqua list_bin_paths must not cache transient
+# filesystem state. The old code cached the result of `.filter(|p| p.exists())`
+# computed inside the cache closure; if the binary dir was not on disk yet
+# (mid-install during a concurrent `mise upgrade`), it cached an empty list and
+# every later reshim trusted that empty snapshot, so the uv/uvx shims were
+# never (re)created — and `mise reshim` could not repair it.
+#
+# This reproduces the poisoning deterministically (no concurrency race):
+#   1. install uv (shims present; cache holds the real bin dir)
+#   2. drop the bin_paths cache and move uv's binary dir aside so it "doesn't exist"
+#   3. reshim -> recomputes list_bin_paths with the dir absent
+#        buggy code: caches []  (the .exists() filter strips everything)
+#        fixed code: caches the registry-derived candidate dir (no .exists())
+#   4. restore the dir, then freeze the install dir's mtime into the past so the
+#      freshly-written cache stays "fresh" (a normal mtime bump would invalidate
+#      the cache and mask the bug)
+#   5. reshim again -> consumes the cached value
+#        buggy code: cached [] -> uv shim NOT created  (this test fails = RED)
+#        fixed code: cached candidate -> live .exists() now passes -> shim created (GREEN)
+
+export MISE_AQUA_GITHUB_ATTESTATIONS=0
+
+mise use -g "aqua:astral-sh/uv@0.8.21"
+mise reshim
+assert "test -f \"$MISE_DATA_DIR/shims/uv\""
+
+# Locate the install from the executable itself. The install short-name for the
+# explicit `aqua:astral-sh/uv` backend is `aqua-astral-sh-uv` (not `uv`), and the
+# binary lives in a per-platform subdir (e.g. uv-aarch64-apple-darwin/uv), so we
+# derive both the bin dir and the version dir (= tv.install_path()) from the exe.
+uv_exe="$(find "$MISE_DATA_DIR/installs" -type f -name uv | head -n1)"
+# Fail clearly if the executable wasn't located, so an empty result can't make
+# the dirname calls below fall back to "." and have the later mv/touch operate
+# on the current directory instead of the install.
+assert "test -n \"$uv_exe\""
+uv_bin_dir="$(dirname "$uv_exe")"         # .../<version>/uv-<triple>
+uv_version_dir="$(dirname "$uv_bin_dir")" # .../<version>  (== tv.install_path())
+
+# drop the cached bin paths so the next reshim recomputes (and re-caches) them
+find "$MISE_CACHE_DIR" -name 'bin_paths*.msgpack.z' -delete
+
+# make the candidate dir "not exist" at recompute time
+mv "$uv_bin_dir" "${uv_bin_dir}.bak"
+
+# recompute + cache list_bin_paths while the dir is absent
+mise reshim
+
+# restore the dir, then freeze the install dir mtime in the past so the cache
+# written above is still considered fresh on the next reshim
+mv "${uv_bin_dir}.bak" "$uv_bin_dir"
+touch -t 200001010000 "$uv_version_dir"
+
+# consume the cached value written while the dir was absent
+mise reshim
+
+# fixed: candidate was cached + dir now present -> shims exist
+# buggy: empty was cached -> shims missing (asserts fail = RED)
+assert "test -f \"$MISE_DATA_DIR/shims/uv\""
+assert "test -f \"$MISE_DATA_DIR/shims/uvx\""

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -621,11 +621,13 @@ impl Backend for AquaBackend {
 
         let cache_key = opts.lockfile_options()?;
         let cache: CacheManager<Vec<PathBuf>> =
-            // `bin_paths_v2`: the cached value changed meaning (now the
-            // unfiltered candidate dirs, existence checked live below), so old
-            // `bin_paths` caches — including ones poisoned with `[]` before this
-            // fix — are ignored rather than trusted (#6468).
-            CacheManagerBuilder::new(tv.cache_path().join("bin_paths_v2.msgpack.z"))
+            // The cached value now holds the unfiltered candidate dirs (existence
+            // checked live below), so pre-fix caches poisoned with `[]` (#6468)
+            // must not be trusted. No filename version bump is needed for that:
+            // `CacheManagerBuilder` folds `built_info::PKG_VERSION` into the cache
+            // key, so old caches are ignored automatically once this ships in a
+            // new mise version.
+            CacheManagerBuilder::new(tv.cache_path().join("bin_paths.msgpack.z"))
                 .with_fresh_file(install_path.clone())
                 .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .with_cache_key(format!("{cache_key:?}"))

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -621,34 +621,38 @@ impl Backend for AquaBackend {
 
         let cache_key = opts.lockfile_options()?;
         let cache: CacheManager<Vec<PathBuf>> =
-            CacheManagerBuilder::new(tv.cache_path().join("bin_paths.msgpack.z"))
+            // `bin_paths_v2`: the cached value changed meaning (now the
+            // unfiltered candidate dirs, existence checked live below), so old
+            // `bin_paths` caches — including ones poisoned with `[]` before this
+            // fix — are ignored rather than trusted (#6468).
+            CacheManagerBuilder::new(tv.cache_path().join("bin_paths_v2.msgpack.z"))
                 .with_fresh_file(install_path.clone())
                 .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                 .with_cache_key(format!("{cache_key:?}"))
                 .build();
 
-        let paths = cache
+        let candidates = cache
             .get_or_try_init_async(async || {
                 let pkg = self.package_with_options(tv, &[&tv.version]).await?;
-
-                let srcs = Self::srcs(&pkg, tv)?;
-                let paths = if srcs.is_empty() {
-                    vec![install_path.clone()]
-                } else {
-                    srcs.iter()
-                        .map(|link| link.dst.parent().unwrap().to_path_buf())
-                        .collect()
-                };
-                Ok(paths
-                    .into_iter()
-                    .unique()
-                    .filter(|p| p.exists())
-                    .filter_map(|p| p.strip_prefix(&install_path).ok().map(|p| p.to_path_buf()))
-                    .collect())
+                // Pure: no filesystem reads, so a mid-install call can never
+                // cache a transient-empty result.
+                Self::candidate_bin_paths_for_platform(
+                    &pkg,
+                    &tv.version,
+                    &install_path,
+                    os(),
+                    arch(),
+                )
             })
-            .await?
+            .await?;
+
+        let paths = candidates
             .iter()
-            .map(|p| p.mount(&runtime_path))
+            // Existence checked LIVE, on the install_path basis (matches the
+            // original pre-`strip_prefix` filter). Returned paths are
+            // runtime_path-based, exactly as before.
+            .filter(|rel| install_path.join(rel).exists())
+            .map(|rel| rel.mount(&runtime_path))
             .collect();
         Ok(paths)
     }
@@ -1792,45 +1796,52 @@ impl AquaBackend {
         }
     }
 
-    async fn get_version_tags(&self) -> Result<&Vec<(String, String)>> {
+    async fn get_version_tags(&self) -> Result<Vec<(String, String)>> {
         self.version_tags_cache
-            .get_or_try_init_async(|| async {
-                let pkg = AQUA_REGISTRY.package(&self.id).await?;
-                let mut versions = Vec::new();
-                if !pkg.repo_owner.is_empty() && !pkg.repo_name.is_empty() {
-                    // Always fetch the superset; install/lock resolution needs
-                    // every tag (including pre-releases) regardless of the
-                    // current `prerelease` opt, since the user may have pinned
-                    // a pre-release version under a project-local override.
-                    let tags = get_tags(&pkg).await?;
-                    let target = PlatformTarget::from_current();
-                    let (target_os, target_arch) = Self::to_aqua_platform(&target);
-                    let target_libc = Self::target_variant_libc(&target);
-                    for tag in tags.into_iter().rev() {
-                        let (version, _) = match versioned_package_from_tag(
-                            &pkg,
-                            &tag,
-                            target_os,
-                            target_arch,
-                            target_libc.as_deref(),
-                        ) {
-                            Ok(Some(versioned)) => versioned,
-                            Ok(None) => continue,
-                            Err(e) => {
-                                warn!("[{}] aqua version filter error: {e}", self.ba());
-                                continue;
-                            }
-                        };
-                        versions.push((version, tag));
+            .get_or_try_init_async_if(
+                || async {
+                    let pkg = AQUA_REGISTRY.package(&self.id).await?;
+                    let mut versions = Vec::new();
+                    if !pkg.repo_owner.is_empty() && !pkg.repo_name.is_empty() {
+                        // Always fetch the superset; install/lock resolution needs
+                        // every tag (including pre-releases) regardless of the
+                        // current `prerelease` opt, since the user may have pinned
+                        // a pre-release version under a project-local override.
+                        let tags = get_tags(&pkg).await?;
+                        let target = PlatformTarget::from_current();
+                        let (target_os, target_arch) = Self::to_aqua_platform(&target);
+                        let target_libc = Self::target_variant_libc(&target);
+                        for tag in tags.into_iter().rev() {
+                            let (version, _) = match versioned_package_from_tag(
+                                &pkg,
+                                &tag,
+                                target_os,
+                                target_arch,
+                                target_libc.as_deref(),
+                            ) {
+                                Ok(Some(versioned)) => versioned,
+                                Ok(None) => continue,
+                                Err(e) => {
+                                    warn!("[{}] aqua version filter error: {e}", self.ba());
+                                    continue;
+                                }
+                            };
+                            versions.push((version, tag));
+                        }
+                    } else {
+                        bail!(
+                            "aqua package {} does not have repo_owner and/or repo_name.",
+                            self.id
+                        );
                     }
-                } else {
-                    bail!(
-                        "aqua package {} does not have repo_owner and/or repo_name.",
-                        self.id
-                    );
-                }
-                Ok(versions)
-            })
+                    Ok(versions)
+                },
+                // Don't cache an empty tag list: the all-filtered happy path can
+                // produce `[]` (valid repo, but no platform-matching release), and
+                // a transient registry blip could too. Caching it would persist a
+                // miss — same class as #9444 "don't cache empty version lists".
+                |versions| !versions.is_empty(),
+            )
             .await
     }
 
@@ -2688,8 +2699,34 @@ impl AquaBackend {
         Ok(())
     }
 
-    fn srcs(pkg: &AquaPackage, tv: &ToolVersion) -> Result<Vec<AquaFileLink>> {
-        Self::srcs_for_platform(pkg, &tv.version, &tv.install_path(), os(), arch())
+    /// Candidate bin-path *directories* for a package, relative to `install_path`.
+    ///
+    /// Pure with respect to install state: depends only on the package
+    /// definition and the target platform, NEVER on whether the paths currently
+    /// exist on disk. Callers (and the shim layer) filter existence live.
+    /// Keeping `.exists()` out of this function is what makes the result safe to
+    /// cache across processes — caching an existence-filtered value computed
+    /// mid-install is what dropped shims in #6468.
+    fn candidate_bin_paths_for_platform(
+        pkg: &AquaPackage,
+        version: &str,
+        install_path: &Path,
+        os: &str,
+        arch: &str,
+    ) -> Result<Vec<PathBuf>> {
+        let srcs = Self::srcs_for_platform(pkg, version, install_path, os, arch)?;
+        let paths: Vec<PathBuf> = if srcs.is_empty() {
+            vec![install_path.to_path_buf()]
+        } else {
+            srcs.iter()
+                .map(|link| link.dst.parent().unwrap().to_path_buf())
+                .collect()
+        };
+        Ok(paths
+            .into_iter()
+            .unique()
+            .filter_map(|p| p.strip_prefix(install_path).ok().map(|p| p.to_path_buf()))
+            .collect())
     }
 
     fn srcs_for_platform(
@@ -3542,6 +3579,37 @@ mod tests {
                 explicit_link: true,
             }]
         );
+    }
+
+    #[test]
+    fn test_candidate_bin_paths_independent_of_filesystem() {
+        // A package whose binary lives in a subdir of the install dir.
+        let mut pkg = AquaPackage::default();
+        pkg.files = vec![AquaFile {
+            name: "uv".to_string(),
+            src: Some("uv-bin/uv".to_string()),
+            ..Default::default()
+        }];
+
+        // An install path that does NOT exist on disk (simulates a mid-install
+        // call, before the binaries have been extracted).
+        let install_path = Path::new("/definitely/not/here/installs/uv/0.8.21");
+
+        let candidates = AquaBackend::candidate_bin_paths_for_platform(
+            &pkg,
+            "0.8.21",
+            install_path,
+            "linux",
+            "amd64",
+        )
+        .unwrap();
+
+        // The candidate dir is derived purely from the package definition; the
+        // fact that nothing exists on disk does NOT empty the result. This is
+        // the property that makes the cached value safe to persist — the old
+        // code's `.filter(|p| p.exists())` here is exactly what poisoned the
+        // cache mid-install (#6468).
+        assert_eq!(candidates, vec![PathBuf::from("uv-bin")]);
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2381,6 +2381,15 @@ pub trait Backend: Debug + Send + Sync {
     ) -> Result<()> {
         Ok(())
     }
+    /// Return the candidate bin directories for this tool version.
+    ///
+    /// Return *candidates*: do NOT filter on whether they currently exist, and
+    /// do NOT cache an existence-filtered result. Existence is checked live by
+    /// the callers that need it (shim generation in `shims::list_tool_bins`, and
+    /// `which`); PATH-building callers tolerate missing dirs. Caching a
+    /// `.exists()`-filtered value computed mid-install is what dropped shims in
+    /// <https://github.com/jdx/mise/discussions/6468>: the cached value should be
+    /// a pure function of the tool definition, not of transient install state.
     async fn list_bin_paths(
         &self,
         _config: &Arc<Config>,


### PR DESCRIPTION
## Problem
After `mise upgrade` with concurrent installs (the report uses python + aqua:uv +
npm:prettier), the `uv`/`uvx` shims are intermittently not created, and `mise reshim`
can't repair it. Fixes #6468.

## Root cause
`aqua list_bin_paths` memoized the result of a `.filter(|p| p.exists())` computed *inside*
the cache closure. During a concurrent upgrade it ran before uv's binaries were extracted,
cached `[]`, and every later shim generation / `mise reshim` then trusted that frozen empty
snapshot (it's "fresh" by the install-dir mtime) — which is why a separate `reshim` process
also observed `[]`.

## Fix
- **`list_bin_paths`**: cache only the registry-derived candidate dirs (a pure function of
  the package definition, extracted as `candidate_bin_paths_for_platform`); check existence
  **live** on each call, on the install_path basis, before mounting onto runtime_path. The
  cached value can no longer encode transient install state. The cache filename is bumped to
  `bin_paths_v2` so pre-fix poisoned caches are ignored. The shim layer (`list_tool_bins`)
  already filters existence live, so this loses no behavior. Also documents the
  `Backend::list_bin_paths` contract ("return candidates; don't cache existence; callers
  filter live") to prevent recurrence.
- **`get_version_tags`**: an adjacent same-class fix found during the work — guard with
  `get_or_try_init_async_if(.., |v| !v.is_empty())` (the #9616/#9444 pattern) so an empty
  tag list (valid repo, all tags filtered out for the platform) isn't cached.

## Tests
- Unit test pinning that the candidate derivation is filesystem-independent.
- A deterministic e2e (`test_aqua_bin_paths_stale_cache_slow`) that reproduces the
  cache-poisoning (install uv, drop cache, hide the binary dir, reshim, restore + freeze
  mtime, reshim) and asserts the shims survive.
- Note: as a `_slow` test it runs in the release lane (`TEST_ALL=1`), not on per-PR CI —
  consistent with the repo's other slow network-installing e2e tests.

*This PR was prepared with the help of an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `aqua list_bin_paths` caching so a temporary missing backend directory no longer causes empty cache entries and prevents later shim/bin discovery.
* **Tests**
  * Added an end-to-end regression test for stale-cache behavior when an install directory is temporarily absent.
  * Added coverage to ensure platform-specific bin-path candidates are derived consistently even if install paths aren’t present.
* **Documentation**
  * Clarified expected behavior of bin-path candidate discovery versus runtime existence checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->