### PR TITLE
fix(file): support Windows plugin symlinks for UNC paths

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -1783,9 +1783,7 @@ mod tests {
             r"\\?\UNC\wsl.localhost\DistroName\github\verzly\mise-php"
         )));
 
-        assert!(!is_unc_path(Path::new(
-            r"D:\github\verzly\mise-php"
-        )));
+        assert!(!is_unc_path(Path::new(r"D:\github\verzly\mise-php")));
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -542,9 +542,25 @@ fn is_unc_path(path: &Path) -> bool {
 }
 
 #[cfg(windows)]
+fn create_windows_unc_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(target, link).map_err(|err| {
+        if err.kind() == std::io::ErrorKind::PermissionDenied {
+            std::io::Error::new(
+                err.kind(),
+                format!(
+                    "{err}. Creating directory symlinks on Windows may require administrator privileges or Developer Mode"
+                ),
+            )
+        } else {
+            err
+        }
+    })
+}
+
+#[cfg(windows)]
 fn create_windows_dir_link(target: &Path, link: &Path) -> std::io::Result<()> {
     if is_unc_path(target) {
-        std::os::windows::fs::symlink_dir(target, link)
+        create_windows_unc_symlink(target, link)
     } else {
         junction::create(target, link)
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -530,11 +530,33 @@ pub fn make_symlink_or_copy(target: &Path, link: &Path) -> Result<()> {
 }
 
 #[cfg(windows)]
+fn is_unc_path(path: &Path) -> bool {
+    matches!(
+        path.components().next(),
+        Some(std::path::Component::Prefix(prefix))
+            if matches!(
+                prefix.kind(),
+                std::path::Prefix::UNC(..) | std::path::Prefix::VerbatimUNC(..)
+            )
+    )
+}
+
+#[cfg(windows)]
+fn create_windows_dir_link(target: &Path, link: &Path) -> std::io::Result<()> {
+    if is_unc_path(target) {
+        std::os::windows::fs::symlink_dir(target, link)
+    } else {
+        junction::create(target, link)
+    }
+}
+
+#[cfg(windows)]
 pub fn make_symlink(target: &Path, link: &Path) -> Result<(PathBuf, PathBuf)> {
-    if let Err(err) = junction::create(target, link) {
+    if let Err(err) = create_windows_dir_link(target, link) {
         if err.kind() == std::io::ErrorKind::AlreadyExists {
             let _ = fs::remove_file(link);
-            junction::create(target, link)
+            let _ = fs::remove_dir(link);
+            create_windows_dir_link(target, link)
         } else {
             Err(err)
         }
@@ -1746,6 +1768,24 @@ mod tests {
             leftovers.is_empty(),
             "temp symlink left behind: {leftovers:?}"
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_is_unc_path() {
+        assert!(is_unc_path(Path::new(
+            r"\\wsl.localhost\DistroName\github\verzly\mise-php"
+        )));
+        assert!(is_unc_path(Path::new(
+            r"\\wsl$\DistroName\github\verzly\mise-php"
+        )));
+        assert!(is_unc_path(Path::new(
+            r"\\?\UNC\wsl.localhost\DistroName\github\verzly\mise-php"
+        )));
+
+        assert!(!is_unc_path(Path::new(
+            r"D:\github\verzly\mise-php"
+        )));
     }
 
     #[test]


### PR DESCRIPTION
Resolves #10562 

On Windows, linked plugins that point to UNC paths such as `\\wsl.localhost\...` were created as junctions. These links existed on disk, but Windows did not expose the target contents through the junction as expected, so mise did not detect the plugin in `mise plugins ls` and could not remove it with `mise plugins rm`.

This keeps using junctions for local Windows paths, but uses directory symlinks for UNC plugin targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows directory link creation to handle UNC path targets.
  * Enhanced retry logic when links already exist by removing conflicting files or directories.

* **Tests**
  * Added unit tests for path detection validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->