### PR TITLE
fix(task): avoid remote resolution during task startup

### DIFF
--- a/e2e/cli/test_hook_env_prefer_offline_no_remote_versions
+++ b/e2e/cli/test_hook_env_prefer_offline_no_remote_versions
@@ -54,3 +54,8 @@ EOF
 
 assert_succeed "mise hook-env -s bash --force"
 assert_fail "test -f '$credential_marker'"
+
+rm -f "$credential_marker"
+offline_current="$(MISE_OFFLINE=1 mise current github:cli/cli 2>/dev/null || true)"
+assert_not_contains_text "$offline_current" "latest"
+assert_fail "test -f '$credential_marker'"

--- a/e2e/cli/test_hook_env_prefer_offline_no_remote_versions
+++ b/e2e/cli/test_hook_env_prefer_offline_no_remote_versions
@@ -30,3 +30,27 @@ EOF
 
 assert_succeed "mise hook-env -s bash --force"
 assert_fail "test -f '$HOME/list-all-called'"
+
+credential_marker="$HOME/github-credential-command-called"
+credential_command="$HOME/fake-github-credential-command"
+cat >"$credential_command" <<EOF
+#!/usr/bin/env bash
+touch "$credential_marker"
+echo fake-token
+EOF
+chmod +x "$credential_command"
+
+mkdir -p "$MISE_CONFIG_DIR"
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[settings]
+github.credential_command = "$credential_command"
+minimum_release_age = "3d"
+EOF
+
+cat >mise.toml <<EOF
+[tools]
+"github:cli/cli" = "latest"
+EOF
+
+assert_succeed "mise hook-env -s bash --force"
+assert_fail "test -f '$credential_marker'"

--- a/e2e/tasks/test_task_skip_tools
+++ b/e2e/tasks/test_task_skip_tools
@@ -23,3 +23,36 @@ assert "mise run echo-args --skip-tools" "args: --skip-tools"
 # verify --skip-tools skips task-level tool installation
 # task declares tools = { tiny = "1.0.0" } but --skip-tools prevents install attempt
 assert "mise run --skip-tools check-tiny" "ran"
+
+credential_marker="$HOME/github-credential-command-called"
+credential_command="$HOME/fake-github-credential-command"
+cat >"$credential_command" <<EOF
+#!/usr/bin/env bash
+touch "$credential_marker"
+echo fake-token
+EOF
+chmod +x "$credential_command"
+
+mkdir -p "$MISE_CONFIG_DIR"
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[settings]
+auto_install = false
+github.credential_command = "$credential_command"
+minimum_release_age = "3d"
+EOF
+
+cat >mise.toml <<EOF
+[tools]
+"github:cli/cli" = "latest"
+
+[tasks.nop-test]
+run = "echo Hello World!"
+EOF
+
+assert "mise run --skip-tools nop-test" "Hello World!"
+assert_fail "test -f '$credential_marker'"
+
+rm -f "$credential_marker"
+
+assert "mise run nop-test" "Hello World!"
+assert_fail "test -f '$credential_marker'"

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -6,7 +6,7 @@ use crate::env_diff::{EnvDiff, EnvDiffOperation, EnvMap};
 use crate::file::{canonicalize_cached, display_rel_path};
 use crate::hook_env::{PREV_SESSION, WatchFilePattern};
 use crate::shell::{ShellType, get_shell};
-use crate::toolset::Toolset;
+use crate::toolset::{ResolveOptions, Toolset, ToolsetBuilder};
 use crate::{env, hook_env, hooks, watch_files};
 use console::truncate_str;
 use eyre::Result;
@@ -52,7 +52,15 @@ pub struct HookEnv {
 impl HookEnv {
     pub async fn run(self) -> Result<()> {
         let config = Config::get().await?;
-        let ts = config.get_toolset().await?;
+        // Shell activation must stay fast and non-networked; missing tools are
+        // handled by the normal install paths instead of hook-env.
+        let ts = ToolsetBuilder::new()
+            .with_resolve_options(ResolveOptions {
+                offline: true,
+                ..Default::default()
+            })
+            .build(&config)
+            .await?;
         time!("hook-env");
 
         // Try to use cached watch_files for early exit check if env_cache is enabled
@@ -96,7 +104,7 @@ impl HookEnv {
 
         // Create config_paths from user_paths for display_status and build_session
         let config_paths: IndexSet<PathBuf> = user_paths.iter().cloned().collect();
-        self.display_status(&config, ts, &mise_env, &config_paths)
+        self.display_status(&config, &ts, &mise_env, &config_paths)
             .await?;
 
         let mut diff = EnvDiff::new(&env::PRISTINE_ENV, mise_env.clone());
@@ -142,7 +150,7 @@ impl HookEnv {
         patches.push(
             self.build_session_operation(
                 &config,
-                ts,
+                &ts,
                 mise_env,
                 new_aliases.clone(),
                 watch_files,
@@ -167,9 +175,9 @@ impl HookEnv {
             hook_env::build_alias_commands(&*shell, &PREV_SESSION.aliases, &new_aliases);
         miseprint!("{alias_output}")?;
 
-        hooks::run_all_hooks(&config, ts, &*shell).await;
-        hooks::run_enter_hooks_for_newly_loaded_configs(&config, ts, &*shell).await;
-        watch_files::execute_runs(&config, ts).await;
+        hooks::run_all_hooks(&config, &ts, &*shell).await;
+        hooks::run_enter_hooks_for_newly_loaded_configs(&config, &ts, &*shell).await;
+        watch_files::execute_runs(&config, &ts).await;
 
         Ok(())
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -17,7 +17,7 @@ use crate::task::task_list::{get_task_lists, resolve_depends};
 use crate::task::task_output::TaskOutput;
 use crate::task::task_output_handler::OutputHandler;
 use crate::task::{Deps, Task};
-use crate::toolset::{InstallOptions, ToolsetBuilder};
+use crate::toolset::{InstallOptions, ResolveOptions, ToolsetBuilder};
 use crate::ui::{ctrlc, info, style};
 use clap::{CommandFactory, ValueHint};
 use eyre::{Result, bail, eyre};
@@ -369,10 +369,18 @@ impl Run {
 
         // Build and install toolset only after tasks resolve. A naked run that
         // does not match any task should fail without installing project tools.
+        // Task startup should not fetch remote version metadata just to build
+        // the environment. If tools are missing and auto-install is enabled,
+        // install_missing_versions re-resolves those specific requests online.
+        let resolve_options = ResolveOptions {
+            offline: true,
+            ..Default::default()
+        };
         let mut ts = ToolsetBuilder::new()
             .with_args(&self.tool)
             .with_default_to_latest(true)
             .with_config_files(combined_configs)
+            .with_resolve_options(resolve_options)
             .build(&config)
             .await?;
 

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -376,10 +376,11 @@ impl ToolVersion {
             opts.filters_installed_versions() && !is_offline && !prefer_offline;
 
         if v == "latest" {
-            if prefer_offline_without_offline && !opts.latest_versions {
-                if let Some(v) = backend.latest_installed_version(None)? {
-                    return build(v);
-                }
+            if prefer_offline_without_offline
+                && !opts.latest_versions
+                && let Some(v) = backend.latest_installed_version(None)?
+            {
+                return build(v);
             }
             if !opts.latest_versions
                 && !should_filter_installed_versions
@@ -428,10 +429,11 @@ impl ToolVersion {
             // zig@master), never an unrelated installed release, so we don't
             // short-circuit zig@master to a stable version that happens to be
             // installed.
-            if prefer_offline && !opts.latest_versions {
-                if let Some(installed) = backend.latest_installed_channel_version(&v) {
-                    return build(installed);
-                }
+            if prefer_offline
+                && !opts.latest_versions
+                && let Some(installed) = backend.latest_installed_channel_version(&v)
+            {
+                return build(installed);
             }
             if !opts.latest_versions
                 && !should_filter_installed_versions
@@ -607,10 +609,11 @@ impl ToolVersion {
             settings.prefer_offline() && !matches!(request.source(), ToolSource::Argument);
         let should_filter_installed_versions =
             opts.filters_installed_versions() && !is_offline && !prefer_offline;
-        if prefer_offline && !opts.latest_versions {
-            if let Some(v) = backend.list_installed_versions_matching(prefix).last() {
-                return Ok(Self::new(request, v.to_string()));
-            }
+        if prefer_offline
+            && !opts.latest_versions
+            && let Some(v) = backend.list_installed_versions_matching(prefix).last()
+        {
+            return Ok(Self::new(request, v.to_string()));
         }
         if !opts.latest_versions
             && !should_filter_installed_versions

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -370,11 +370,12 @@ impl ToolVersion {
         let settings = Settings::get();
         let is_offline = settings.offline() || opts.offline;
         let prefer_offline = settings.prefer_offline();
+        let prefer_offline_without_offline = prefer_offline && !is_offline;
         let should_filter_installed_versions =
             opts.filters_installed_versions() && !is_offline && !prefer_offline;
 
         if v == "latest" {
-            if prefer_offline && !opts.latest_versions {
+            if prefer_offline_without_offline && !opts.latest_versions {
                 if let Some(v) = backend.latest_installed_version(None)? {
                     return build(v);
                 }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -374,6 +374,12 @@ impl ToolVersion {
             opts.filters_installed_versions() && !is_offline && !prefer_offline;
 
         if v == "latest" {
+            if prefer_offline && !opts.latest_versions {
+                if let Some(v) = backend.latest_installed_version(None)? {
+                    return build(v);
+                }
+                return build(v);
+            }
             if !opts.latest_versions
                 && !should_filter_installed_versions
                 && let Some(v) = backend.latest_installed_version(None)?
@@ -421,6 +427,12 @@ impl ToolVersion {
             // zig@master), never an unrelated installed release, so we don't
             // short-circuit zig@master to a stable version that happens to be
             // installed.
+            if prefer_offline && !opts.latest_versions {
+                if let Some(installed) = backend.latest_installed_channel_version(&v) {
+                    return build(installed);
+                }
+                return build(v);
+            }
             if !opts.latest_versions
                 && !should_filter_installed_versions
                 && let Some(installed) = backend.latest_installed_channel_version(&v)
@@ -456,6 +468,16 @@ impl ToolVersion {
                 if crate::config::config_file::idiomatic_version::package_json::is_package_json(path)
         ) && crate::semver::is_npm_semver_range_query(&v)
         {
+            if prefer_offline && !opts.latest_versions {
+                let installed_versions = backend.list_installed_versions();
+                if let Some(matches) =
+                    crate::semver::npm_semver_range_filter(&installed_versions, &v)
+                    && let Some(v) = matches.last()
+                {
+                    return build(v.clone());
+                }
+                return build(v);
+            }
             if !opts.latest_versions && !should_filter_installed_versions {
                 let installed_versions = backend.list_installed_versions();
                 if let Some(matches) =
@@ -584,6 +606,12 @@ impl ToolVersion {
         let is_offline = settings.offline() || opts.offline;
         let should_filter_installed_versions =
             opts.filters_installed_versions() && !is_offline && !settings.prefer_offline();
+        if settings.prefer_offline() && !opts.latest_versions {
+            if let Some(v) = backend.list_installed_versions_matching(prefix).last() {
+                return Ok(Self::new(request, v.to_string()));
+            }
+            return Ok(Self::new(request, prefix.to_string()));
+        }
         if !opts.latest_versions
             && !should_filter_installed_versions
             && let Some(v) = backend.list_installed_versions_matching(prefix).last()

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -369,7 +369,8 @@ impl ToolVersion {
 
         let settings = Settings::get();
         let is_offline = settings.offline() || opts.offline;
-        let prefer_offline = settings.prefer_offline();
+        let prefer_offline =
+            settings.prefer_offline() && !matches!(request.source(), ToolSource::Argument);
         let prefer_offline_without_offline = prefer_offline && !is_offline;
         let should_filter_installed_versions =
             opts.filters_installed_versions() && !is_offline && !prefer_offline;
@@ -379,7 +380,6 @@ impl ToolVersion {
                 if let Some(v) = backend.latest_installed_version(None)? {
                     return build(v);
                 }
-                return build(v);
             }
             if !opts.latest_versions
                 && !should_filter_installed_versions
@@ -432,7 +432,6 @@ impl ToolVersion {
                 if let Some(installed) = backend.latest_installed_channel_version(&v) {
                     return build(installed);
                 }
-                return build(v);
             }
             if !opts.latest_versions
                 && !should_filter_installed_versions
@@ -477,7 +476,6 @@ impl ToolVersion {
                 {
                     return build(v.clone());
                 }
-                return build(v);
             }
             if !opts.latest_versions && !should_filter_installed_versions {
                 let installed_versions = backend.list_installed_versions();
@@ -605,13 +603,14 @@ impl ToolVersion {
         let backend = request.backend()?;
         let settings = Settings::get();
         let is_offline = settings.offline() || opts.offline;
+        let prefer_offline =
+            settings.prefer_offline() && !matches!(request.source(), ToolSource::Argument);
         let should_filter_installed_versions =
-            opts.filters_installed_versions() && !is_offline && !settings.prefer_offline();
-        if settings.prefer_offline() && !opts.latest_versions {
+            opts.filters_installed_versions() && !is_offline && !prefer_offline;
+        if prefer_offline && !opts.latest_versions {
             if let Some(v) = backend.list_installed_versions_matching(prefix).last() {
                 return Ok(Self::new(request, v.to_string()));
             }
-            return Ok(Self::new(request, prefix.to_string()));
         }
         if !opts.latest_versions
             && !should_filter_installed_versions


### PR DESCRIPTION
## Summary
- keep prefer-offline version resolution local for `latest`, rolling channels, npm semver ranges, and prefixes instead of falling through to remote metadata
- make `mise run` build its initial task toolset in offline resolution mode; auto-install still re-resolves missing tools online when installation is actually needed
- add regression coverage that `hook-env`, `mise run --skip-tools`, and task startup with auto-install disabled do not invoke `github.credential_command` for a `github:` `latest` tool with `minimum_release_age`

## Tests
- `cargo fmt --check`
- `cargo check --bin mise`
- `mise run test:e2e e2e/cli/test_hook_env_prefer_offline_no_remote_versions e2e/tasks/test_task_skip_tools`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core version resolution and shell/task startup paths; wrong offline behavior could pin wrong versions or skip needed installs, but auto-install still re-resolves online when installation is required.
> 
> **Overview**
> **Shell activation and task runs** no longer hit the network to resolve tool versions during startup. `hook-env` builds its toolset with `ResolveOptions { offline: true }`, and `mise run` does the same for the initial toolset after tasks resolve; missing tools can still be installed online when auto-install actually runs.
> 
> **Prefer-offline resolution** is tightened in `tool_version.rs`: CLI `ToolSource::Argument` requests are excluded from prefer-offline shortcuts, and when prefer-offline applies (without full offline), resolution stops at installed versions for `latest`, rolling channels, npm semver ranges in `package.json`, and prefix specs—avoiding fall-through to remote metadata (e.g. GitHub releases that would run `github.credential_command`).
> 
> **E2E tests** assert `hook-env` and `mise run` (with `--skip-tools` or `auto_install = false`) do not invoke a fake credential command for `github:cli/cli@latest` with `minimum_release_age` set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c81ce207959dd2094322c7841871c183f9dc476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `mise run` to resolve tool versions with offline-first behavior to avoid remote version metadata lookups and prevent credential command invocations during task startup.
  * Updated `mise hook-env` to build its toolset using offline resolve, reducing network dependence during hook activation.
* **Improvements**
  * Refined “prefer offline” resolution to apply only for non-argument tool requests, improving `latest`, rolling channels, and semver-range handling.
* **Tests**
  * Added end-to-end coverage ensuring credential commands are not invoked when offline is preferred and when tools are skipped during task runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->