### PR TITLE
fix(swift): opt out of --locked URL check

### DIFF
--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -209,6 +209,17 @@ impl Backend for SwiftPlugin {
         &self.ba
     }
 
+    /// Swift download URLs are derived from the build host: OS, arch, and—on
+    /// Linux—the specific distro (e.g. `ubuntu24.04`, `amazonlinux2`,
+    /// `fedora39`, `ubi9`). The generic `<os>-<arch>` lock platform key can't
+    /// encode the distro, so a foreign-platform URL can't be resolved or
+    /// persisted to the lockfile from another host. Opt out of the `--locked`
+    /// URL requirement so installs don't hard-fail on platforms missing from
+    /// the lockfile; checksums are still verified at install time.
+    fn supports_lockfile_url(&self) -> bool {
+        false
+    }
+
     async fn security_info(&self) -> Vec<crate::backend::SecurityFeature> {
         use crate::backend::SecurityFeature;
 


### PR DESCRIPTION
## Problem

`core:swift` hard-fails under `--locked` on any platform missing from `mise.lock`:

```
core:swift@latest: No lockfile URL found for swift@6.3.1 on platform linux-x64 (--locked mode)
```

A lock generated on one OS (e.g. macOS) only gets that platform's entry. On a **cold tool cache** on another platform — fresh CI runner / new branch — locked mode demands a lockfile URL for the current platform, finds none, and aborts before install. With a warm cache the same setup passes, so it reads as flaky.

## Why it can't be resolved cross-platform

`src/plugins/core/swift.rs` builds the download URL from the **build host**: OS, arch, and — on Linux — the specific distro (`ubuntu24.04`, `amazonlinux2`, `fedora39`, `ubi9`). The generic `<os>-<arch>` lock platform key (`Platform { os, arch, qualifier }`, where `qualifier` only encodes libc) can't encode the distro, so a foreign-platform URL can't be resolved or persisted to the lockfile from another host. `mise lock -p linux-x64 swift` run on macOS can't write a usable `[[tools.swift]]` linux entry.

## Fix

Override `supports_lockfile_url()` to return `false` for `core:swift`, so `--locked` doesn't hard-fail on platforms absent from the lockfile. Checksums are still verified at install time via `verify_checksum`.

This mirrors `core:rust` (rustup, no lockable artifact URL) and follows the prior art:
- #9252 — `fix(vfox): opt backend plugins out of --locked URL check`
- #8679 — `fix(install): skip GitHub API calls for aqua tools in --locked mode`

## Notes

- Scoped to `core:swift`. `core:python` shows the same class of failure but already has `resolve_lock_info` and is tracked separately (#10474).
- `supports_lockfile_url()` is only consumed by the locked-URL check in `src/backend/mod.rs`, so this has no other behavioral effect.

Resolves the issue reported in discussion #10572.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Swift plugin installation handling to rely on checksum verification during installs, removing dependency on persisted lockfile URLs. Swift downloads will continue to be verified for integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->