### PR TITLE
fix(gem): opt out of --locked URL check

### DIFF
--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -45,6 +45,13 @@ impl Backend for GemBackend {
         true
     }
 
+    /// Gem installs packages from rubygems.org via `gem install <name> --version`.
+    /// It doesn't download a single lockable artifact URL, so lockfile URLs are not
+    /// applicable and `--locked` mode should not require one.
+    fn supports_lockfile_url(&self) -> bool {
+        false
+    }
+
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         // Get the gem source URL using the mise-managed Ruby environment
         let source_url = self.get_gem_source(config).await;

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -45,9 +45,9 @@ impl Backend for GemBackend {
         true
     }
 
-    /// Gem installs packages from rubygems.org via `gem install <name> --version`.
-    /// It doesn't download a single lockable artifact URL, so lockfile URLs are not
-    /// applicable and `--locked` mode should not require one.
+    /// Gem installs via `gem install`, delegating fetch/resolve to RubyGems rather
+    /// than downloading an artifact mise verifies, so a lockfile URL can't be
+    /// enforced even though rubygems.org exposes one. Opt out of `--locked`.
     fn supports_lockfile_url(&self) -> bool {
         false
     }


### PR DESCRIPTION
## Problem

`mise install --locked` fails for the `gem:` backend even though the lockfile was generated correctly:

```
mise ERROR Failed to install gem:cocoapods@1.16.2: No lockfile URL found for gem:cocoapods@1.16.2 on platform macos-arm64 (--locked mode)
hint: Run `mise lock` to generate lockfile URLs, or disable locked mode
```

The gem backend installs from rubygems.org via `gem install <name> --version` (`src/backend/gem.rs`). There is no single downloadable artifact URL for mise to record in the lockfile, so the `--locked` URL requirement in `src/backend/mod.rs` (`if ctx.locked && ... && self.supports_lockfile_url()`) can never be satisfied.

`gem` was simply missing the `supports_lockfile_url()` override that the other package-manager-style backends already have.

## Why this surfaces now

As of [`jdx/mise-action` #495](https://github.com/jdx/mise-action/pull/495) (released in **v4.1.0**, 2026-06-04), the action automatically adds `--locked` when a repo lock file (`mise.lock`) is present:

> If a repo mise lock file such as `mise.lock` is present in the working directory or one of its parents, this action automatically runs `mise install --locked`.

So any CI using `mise-action` with a committed `mise.lock` that includes a `gem:` tool now hits this hard failure without opting into `--locked` explicitly. This is how it was encountered (`gem:cocoapods` in CI).

## Fix

Override `supports_lockfile_url()` to return `false` for the gem backend, matching the existing behavior of `npm` / `cargo` / `pipx` / `go` / `ubi` / `asdf`. Version pinning via the lockfile still works; only the URL requirement is lifted.

This follows the same pattern as recent fixes:
- #10575 `fix(swift): opt out of --locked URL check`
- #9252 `fix(vfox): opt backend plugins out of --locked URL check`
- #8790 `fix: go backend missing supports_lockfile_url() override`

As @jdx noted in [discussion #7308](https://github.com/jdx/mise/discussions/7308):

> I don't think this is realistic, I can't imagine what a "resolved url" would be for things like pip/gem

## Why opt out instead of locking a URL + checksum?

RubyGems does expose the data needed to lock gems (each version has a stable `.gem` URL like `https://rubygems.org/gems/<name>-<version>[-<platform>].gem`, and a SHA256 — the `sha` field in the versions API / the `checksum:` field in the compact index `/info/<gem>`, which is exactly what Bundler records in the `CHECKSUMS` section of `Gemfile.lock`). So in principle the gem backend could populate lockfile URLs instead of opting out.

It doesn't fit cleanly today, for three reasons:

1. **Install method.** The backend installs via `gem install <name> --version` and lets RubyGems fetch/resolve, rather than downloading a single artifact that mise verifies itself (as aqua/github/http backends do). A recorded checksum wouldn't actually gate the installed bytes without switching to downloading the `.gem` and installing the local file.

2. **Platform-variant gems.** Many gems ship per-platform binaries (e.g. `nokogiri` has 15+ variants for one version, each with its own SHA256). Bundler can key checksums per platform-qualified name because *Bundler is the resolver* and knows which variant it will install. mise delegates variant selection to `gem install` at install time, so mise can't deterministically know (without re-implementing RubyGems' platform matching) which variant will land — a mismatch would cause false checksum failures.

3. **Dependency tree.** Bundler locks the full resolved dependency graph. The gem backend installs a single CLI tool and lets `gem install` pull runtime deps implicitly, so locking only the top-level gem would leave transitive deps unverified.

Opting out keeps version pinning working under `--locked` without these hazards. Proper URL/checksum locking for gems (at least pure-ruby gems, where variant selection is unambiguous) can be explored separately — see discussion #7308 on a strict/permissive split for backends that can't provide URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)