### PR TITLE
fix(http): install ring as the default rustls crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,6 +5385,7 @@ dependencies = [
  "rmcp",
  "rmp-serde",
  "rops",
+ "rustls",
  "seccompiler",
  "self_update",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,15 @@ rattler_package_streaming = { version = "0.26", default-features = false }
 rattler_virtual_packages = { version = "3", default-features = false }
 regex = "1"
 plist = "1"
+# explicit dep (not just transitive) so the `ring` feature is compiled into
+# the unified rustls instance across the dependency graph -- see the
+# install_default() call in main.rs for why
+rustls = { version = "0.23", default-features = false, features = [
+  "ring",
+  "std",
+  "tls12",
+  "logging",
+] }
 reqwest = { version = "0.13", default-features = false, features = [
   "json",
   "form",

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,18 @@ pub(crate) use crate::result::Result;
 use crate::ui::multi_progress_report::MultiProgressReport;
 
 fn main() -> eyre::Result<()> {
+    // aws-config/aws-sdk-s3 pull in rustls with the aws-lc-rs crypto
+    // provider unconditionally (independent of this crate's own
+    // native-tls/rustls feature choice) via their `default-https-client`
+    // feature. aws-lc-rs's hand-written assembly only supports
+    // Linux/macOS/Windows and segfaults on other platforms (e.g. the BSDs).
+    // Installing `ring` as the process-wide default first means every
+    // rustls connection -- including the AWS SDK's -- uses it instead;
+    // first-install-wins, so this must run before anything else touches
+    // rustls. `ring` is otherwise unused dead code if this fails, which
+    // only happens if something already installed a provider before us.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let nprocs = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,9 +111,19 @@ fn main() -> eyre::Result<()> {
     // Installing `ring` as the process-wide default first means every
     // rustls connection -- including the AWS SDK's -- uses it instead;
     // first-install-wins, so this must run before anything else touches
-    // rustls. `ring` is otherwise unused dead code if this fails, which
-    // only happens if something already installed a provider before us.
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    // rustls. This only fails if something else (e.g. a transitive dep's
+    // static initializer) already installed a provider before us, which
+    // would silently reintroduce the segfault on affected platforms --
+    // eprintln! rather than warn!/debug! since logger::init() hasn't run
+    // yet this early in main().
+    if rustls::crypto::ring::default_provider()
+        .install_default()
+        .is_err()
+    {
+        eprintln!(
+            "mise: a rustls crypto provider was already installed before main() could set ring as the default; this may reintroduce a crash on platforms aws-lc-rs doesn't support (e.g. the BSDs)"
+        );
+    }
 
     let nprocs = std::thread::available_parallelism()
         .map(|n| n.get())


### PR DESCRIPTION
## Summary

`aws-config`/`aws-sdk-s3` pull in `rustls` with the `aws-lc-rs` crypto provider **unconditionally**, via their `default-https-client` feature -- independent of this crate's own `native-tls`/`rustls` feature choice. `aws-lc-rs`'s hand-written assembly only officially supports Linux/macOS/Windows, and segfaults on other Unix platforms (the BSDs) when actually exercised by a TLS handshake.

Concretely, on OpenBSD: `aws-lc-sys`'s vendored `s2n-bignum` assembly stores constants directly in `.text` instead of `.rodata` (fixed upstream in [awslabs/s2n-bignum#242](https://github.com/awslabs/s2n-bignum/pull/242), not yet propagated through a new `aws-lc-sys` release). This works fine when `.text` is readable, but segfaults under OpenBSD's execute-only page hardening. This is the same root cause OpenBSD's own `uv` port works around with a `USE_NOEXECONLY` linker flag (see the [Porter's Handbook](https://www.openbsd.org/faq/ports/specialtopics.html) section on shared libraries / the port's `Makefile` comment referencing the same s2n-bignum PR).

Rather than disabling an OS security hardening feature to keep using a crypto backend with a narrower support matrix, this installs `ring` as the process-wide default crypto provider before anything else runs (first-install-wins per `rustls`'s own API), so every `rustls` connection in the process -- including the AWS SDK's -- uses it instead. `ring` has long-standing, broader Unix support than `aws-lc-rs`.

**No behavior change on Linux/macOS/Windows**, where `aws-lc-rs` already worked fine -- this only changes which crypto backend handles TLS, not whether TLS itself works. `aws-lc-rs` stays in the dependency tree (still pulled in transitively); it just never gets a chance to run.

## Test plan

- [x] Confirmed via `gdb` backtrace on real OpenBSD 7.9/amd64 hardware that the crash was specifically inside `aws_lc_*_curve25519_x25519base_byte` (the exact function s2n-bignum#242 touches)
- [x] Confirmed the fix resolves it: a release that previously segfaulted on the first HTTPS call (`mise use <tool>`, hitting `aqua`'s GitHub API/release-download path through `rustls`) now completes that same network path successfully with this change applied
- [ ] Maintainers: existing CI (Linux/macOS/Windows) should be unaffected since this doesn't change feature flags for `reqwest`/`gix`/`rattler`, only which crypto provider ends up active process-wide

*This PR description was generated with AI assistance.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened secure connection stability by ensuring the TLS cryptography provider is initialized early during startup.
  * Adjusted TLS dependencies to compile and use a consistent crypto backend across the application.
  * Added a warning when the crypto provider was already installed, helping diagnose potential platform-specific crash regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->