### PR TITLE
feat(bootstrap): support brew cask pkg artifacts

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -67,13 +67,15 @@ installs app bundles into `/Applications` while recording the version under
 "brew-cask:homebrew/cask/visual-studio-code" = "latest"
 ```
 
-`brew-cask` currently supports app-bundle casks (`app` artifacts) and macOS
-installer packages (`pkg` artifacts) from dmg, zip, and tar archives. Package
-installers run through mise's normal system-package sudo path, so
-non-interactive runs never hang waiting for a password. Casks that require
-custom installer choices, preflight scripts, services, or other cask artifact
-types fail with a clear unsupported artifact error instead of delegating to
-Homebrew.
+`brew-cask` currently supports app-bundle casks (`app` artifacts) and simple
+macOS installer packages (`pkg` artifacts) from dmg and common archive formats.
+Package installers run through mise's normal system-package sudo path, so
+non-interactive runs never hang waiting for a password. Pkg casks must include
+`pkgutil` receipt IDs in their `uninstall` or `zap` metadata so mise can verify
+installed state after the installer writes files outside the Caskroom. Casks
+that require custom installer choices, services, or other cask artifact types
+fail with a clear unsupported artifact error instead of delegating to Homebrew.
+Lifecycle metadata such as `preflight` and `postflight` is not executed.
 
 This exists because shared-library packages — postgres, ffmpeg, imagemagick,
 php — fundamentally can't be served by mise's per-project backends like
@@ -186,8 +188,9 @@ operation.
 ## Limitations
 
 - **Cask artifact coverage is intentionally narrow.** `brew-cask` supports
-  app bundles and pkg installers from common archive formats. Other artifact
-  types, and pkg installers with custom choices, fail explicitly.
+  app bundles and simple pkg installers from dmg and common archive formats.
+  Other artifact types, pkg installers without `pkgutil` IDs, and pkg
+  installers with custom choices fail explicitly.
 - **`brew services` is not implemented.**
 - **Source builds cover the common formula shapes.** mise's formula shim
   implements the widely-used subset of the DSL (see

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -67,10 +67,13 @@ installs app bundles into `/Applications` while recording the version under
 "brew-cask:homebrew/cask/visual-studio-code" = "latest"
 ```
 
-`brew-cask` currently supports app-bundle casks (`app` artifacts) from dmg,
-zip, and tar archives. Casks that only install pkg installers, preflight
-scripts, services, or other cask artifact types fail with a clear unsupported
-artifact error instead of delegating to Homebrew.
+`brew-cask` currently supports app-bundle casks (`app` artifacts) and macOS
+installer packages (`pkg` artifacts) from dmg, zip, and tar archives. Package
+installers run through mise's normal system-package sudo path, so
+non-interactive runs never hang waiting for a password. Casks that require
+custom installer choices, preflight scripts, services, or other cask artifact
+types fail with a clear unsupported artifact error instead of delegating to
+Homebrew.
 
 This exists because shared-library packages — postgres, ffmpeg, imagemagick,
 php — fundamentally can't be served by mise's per-project backends like
@@ -183,8 +186,8 @@ operation.
 ## Limitations
 
 - **Cask artifact coverage is intentionally narrow.** `brew-cask` supports
-  app bundles from common archive formats. Other artifact types fail
-  explicitly.
+  app bundles and pkg installers from common archive formats. Other artifact
+  types, and pkg installers with custom choices, fail explicitly.
 - **`brew services` is not implemented.**
 - **Source builds cover the common formula shapes.** mise's formula shim
   implements the widely-used subset of the DSL (see

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -511,7 +511,8 @@ fn installed_cask_version(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Opti
     let version_dir = caskroom_version_dir(&cask.token, &version);
     match read_receipt(&version_dir)? {
         Some(receipt) => {
-            let pkgs_installed = artifacts.pkgs.is_empty() || pkg_ids_installed(&receipt.pkg_ids)?;
+            let pkgs_installed =
+                artifacts.pkgs.is_empty() || pkg_ids_installed(&artifacts.pkg_ids)?;
             if receipt.apps.iter().all(|app| app.exists()) && pkgs_installed {
                 Ok(Some(receipt.version))
             } else {
@@ -792,6 +793,43 @@ mod tests {
                 }
             )?,
             Some("1.0.0".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn installed_cask_version_checks_current_pkg_ids_with_old_receipt() -> Result<()> {
+        if crate::file::which("pkgutil").is_none() {
+            return Ok(());
+        }
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let cask = test_cask("pkg-only", "1.0.0");
+        let caskroom = caskroom_version_dir(&cask.token, &cask.version);
+        file::create_dir_all(&caskroom)?;
+        let receipt = CaskReceipt {
+            version: cask.version.clone(),
+            apps: vec![],
+            pkg_ids: vec![],
+        };
+        crate::file::write(
+            caskroom.join(".mise-cask.toml"),
+            toml::to_string_pretty(&receipt)?,
+        )?;
+
+        assert_eq!(
+            installed_cask_version(
+                &cask,
+                &CaskArtifacts {
+                    pkgs: vec![PkgArtifact {
+                        source: "Example.pkg".to_string(),
+                    }],
+                    pkg_ids: vec!["com.example.missing".to_string()],
+                    ..Default::default()
+                }
+            )?,
+            None
         );
         Ok(())
     }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -14,6 +14,7 @@ use crate::result::Result;
 use crate::system::packages::{
     InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager,
 };
+use crate::system::sudo;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::{ProgressIcon, SingleReport};
 
@@ -38,10 +39,25 @@ struct AppArtifact {
     target: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PkgArtifact {
+    source: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct CaskArtifacts {
+    apps: Vec<AppArtifact>,
+    pkgs: Vec<PkgArtifact>,
+    pkg_ids: Vec<String>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct CaskReceipt {
     version: String,
+    #[serde(default)]
     apps: Vec<PathBuf>,
+    #[serde(default)]
+    pkgs: Vec<String>,
 }
 
 impl BrewCaskManager {
@@ -56,15 +72,18 @@ impl BrewCaskManager {
         pr: Option<&dyn SingleReport>,
     ) -> Result<String> {
         let cask = fetch_cask(req).await?;
-        let apps = app_artifacts(&cask)?;
-        if installed_cask_version(&cask, &apps)?.as_deref() == Some(cask.version.as_str()) {
+        let artifacts = cask_artifacts(&cask)?;
+        if installed_cask_version(&cask, &artifacts)?.as_deref() == Some(cask.version.as_str()) {
             info!("brew-cask:{}: already installed", cask.token);
             return Ok(cask.version);
         }
         if opts.dry_run {
             miseprintln!("install cask {}/{}", cask.token, cask.version);
-            for app in &apps {
+            for app in &artifacts.apps {
                 miseprintln!("link app {}", app.target_name());
+            }
+            for pkg in &artifacts.pkgs {
+                miseprintln!("install pkg {}", pkg.source);
             }
             return Ok(cask.version);
         }
@@ -76,10 +95,13 @@ impl BrewCaskManager {
         let tmp_caskroom = caskroom_tmp_dir(&cask);
         file::remove_all(&tmp_caskroom)?;
         file::create_dir_all(&tmp_caskroom)?;
-        for app in &apps {
+        for app in &artifacts.apps {
             install_app(&stage, &tmp_caskroom, app)?;
         }
-        write_receipt(&tmp_caskroom, &cask, &apps)?;
+        for pkg in &artifacts.pkgs {
+            install_pkg(&stage, pkg)?;
+        }
+        write_receipt(&tmp_caskroom, &cask, &artifacts)?;
         file::remove_all(&caskroom)?;
         file::rename(&tmp_caskroom, &caskroom)?;
         remove_stale_versions(&caskroom_token, &cask.version)?;
@@ -116,8 +138,8 @@ impl SystemPackageManager for BrewCaskManager {
         let mut statuses = Vec::with_capacity(pkgs.len());
         for req in pkgs {
             let cask = fetch_cask(req).await?;
-            let apps = app_artifacts(&cask)?;
-            let version = installed_cask_version(&cask, &apps)?;
+            let artifacts = cask_artifacts(&cask)?;
+            let version = installed_cask_version(&cask, &artifacts)?;
             let state = match version {
                 Some(version) => match &req.version {
                     Some(requested) if version != *requested => {
@@ -273,29 +295,49 @@ fn install_app(stage: &Path, caskroom: &Path, app: &AppArtifact) -> Result<()> {
     Ok(())
 }
 
-fn app_artifacts(cask: &Cask) -> Result<Vec<AppArtifact>> {
-    let mut apps = Vec::new();
+fn install_pkg(stage: &Path, pkg: &PkgArtifact) -> Result<()> {
+    let source = find_artifact(stage, &pkg.source)
+        .ok_or_else(|| eyre!("brew-cask: pkg artifact '{}' was not found", pkg.source))?;
+    let args = vec![
+        "-pkg".to_string(),
+        source.display().to_string(),
+        "-target".to_string(),
+        "/".to_string(),
+    ];
+    sudo::run("installer", &args, &[])
+}
+
+fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
+    let mut artifacts = CaskArtifacts::default();
     for artifact in &cask.artifacts {
         let artifact_type = artifact_type(artifact);
         if is_non_install_artifact(&artifact_type) {
+            collect_uninstall_pkg_ids(artifact, &mut artifacts.pkg_ids);
             continue;
         }
-        let Some(app) = parse_app_artifact(artifact) else {
-            bail!(
-                "brew-cask:{}: unsupported artifact type {}",
-                cask.token,
-                artifact_type
-            );
-        };
-        apps.push(app);
-    }
-    if apps.is_empty() {
+        if let Some(app) = parse_app_artifact(artifact) {
+            artifacts.apps.push(app);
+            continue;
+        }
+        if let Some(pkg) = parse_pkg_artifact(artifact)? {
+            artifacts.pkgs.push(pkg);
+            continue;
+        }
         bail!(
-            "brew-cask:{}: no app artifact found; only app-bundle casks are supported",
+            "brew-cask:{}: unsupported artifact type {}",
+            cask.token,
+            artifact_type
+        );
+    }
+    if artifacts.apps.is_empty() && artifacts.pkgs.is_empty() {
+        bail!(
+            "brew-cask:{}: no app or pkg artifact found; only app-bundle and pkg casks are supported",
             cask.token
         );
     }
-    Ok(apps)
+    artifacts.pkg_ids.sort();
+    artifacts.pkg_ids.dedup();
+    Ok(artifacts)
 }
 
 fn parse_app_artifact(value: &Value) -> Option<AppArtifact> {
@@ -320,17 +362,65 @@ fn parse_app_artifact(value: &Value) -> Option<AppArtifact> {
     }
 }
 
+fn parse_pkg_artifact(value: &Value) -> Result<Option<PkgArtifact>> {
+    let Some(pkg) = value.as_object().and_then(|o| o.get("pkg")) else {
+        return Ok(None);
+    };
+    match pkg {
+        Value::String(source) => Ok(Some(PkgArtifact {
+            source: source.clone(),
+        })),
+        Value::Array(values) => {
+            if values.len() > 1 {
+                bail!("brew-cask: pkg installer choices are not supported yet");
+            }
+            Ok(values
+                .first()
+                .and_then(Value::as_str)
+                .map(|source| PkgArtifact {
+                    source: source.to_string(),
+                }))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn collect_uninstall_pkg_ids(value: &Value, pkg_ids: &mut Vec<String>) {
+    let Some(uninstall) = value.as_object().and_then(|o| o.get("uninstall")) else {
+        return;
+    };
+    let values: Vec<&Value> = match uninstall {
+        Value::Array(values) => values.iter().collect(),
+        value => vec![value],
+    };
+    for value in values {
+        let Some(pkgutil) = value.as_object().and_then(|o| o.get("pkgutil")) else {
+            continue;
+        };
+        match pkgutil {
+            Value::String(id) => pkg_ids.push(id.clone()),
+            Value::Array(ids) => {
+                pkg_ids.extend(ids.iter().filter_map(Value::as_str).map(str::to_string))
+            }
+            _ => {}
+        }
+    }
+}
+
 fn find_app(root: &Path, name: &str) -> Option<PathBuf> {
+    find_artifact(root, name).filter(|path| path.is_dir())
+}
+
+fn find_artifact(root: &Path, name: &str) -> Option<PathBuf> {
     let name_path = Path::new(name);
     WalkDir::new(root)
         .into_iter()
         .filter_map(|entry| entry.ok())
         .find(|entry| {
-            entry.file_type().is_dir()
-                && entry
-                    .path()
-                    .strip_prefix(root)
-                    .is_ok_and(|relative| relative.ends_with(name_path))
+            entry
+                .path()
+                .strip_prefix(root)
+                .is_ok_and(|relative| relative.ends_with(name_path))
         })
         .map(|entry| entry.into_path())
 }
@@ -381,37 +471,62 @@ fn installed_version(token: &str) -> Option<String> {
     }
 }
 
-fn installed_cask_version(cask: &Cask, apps: &[AppArtifact]) -> Result<Option<String>> {
+fn pkg_id_installed(pkg_id: &str) -> Result<bool> {
+    let output = std::process::Command::new("pkgutil")
+        .arg("--pkg-info")
+        .arg(pkg_id)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+    Ok(output.success())
+}
+
+fn pkg_ids_installed(pkg_ids: &[String]) -> Result<bool> {
+    for pkg_id in pkg_ids {
+        if !pkg_id_installed(pkg_id)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn installed_cask_version(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Option<String>> {
     let Some(version) = installed_version(&cask.token) else {
         return Ok(None);
     };
     let version_dir = caskroom_version_dir(&cask.token, &version);
     match read_receipt(&version_dir)? {
         Some(receipt) => {
-            if receipt.apps.iter().all(|app| app.exists()) {
+            if receipt.apps.iter().all(|app| app.exists()) && pkg_ids_installed(&receipt.pkgs)? {
                 Ok(Some(receipt.version))
             } else {
                 Ok(None)
             }
         }
         None => {
-            for app in apps {
+            for app in &artifacts.apps {
                 if !app_target_path(app.target_name())?.exists() {
                     return Ok(None);
                 }
+            }
+            if !pkg_ids_installed(&artifacts.pkg_ids)? {
+                return Ok(None);
             }
             Ok(Some(version))
         }
     }
 }
 
-fn write_receipt(caskroom: &Path, cask: &Cask, apps: &[AppArtifact]) -> Result<()> {
+fn write_receipt(caskroom: &Path, cask: &Cask, artifacts: &CaskArtifacts) -> Result<()> {
     let receipt = CaskReceipt {
         version: cask.version.clone(),
-        apps: apps
+        apps: artifacts
+            .apps
             .iter()
             .map(|app| app_target_path(app.target_name()))
             .collect::<Result<Vec<_>>>()?,
+        pkgs: artifacts.pkg_ids.clone(),
     };
     let body = toml::to_string_pretty(&receipt)?;
     crate::file::write(caskroom.join(".mise-cask.toml"), body)?;
@@ -538,6 +653,49 @@ mod tests {
     }
 
     #[test]
+    fn parses_pkg_artifacts() {
+        let value: Value = serde_json::json!({"pkg": ["OpenJDK.pkg"]});
+        assert_eq!(
+            parse_pkg_artifact(&value).unwrap(),
+            Some(PkgArtifact {
+                source: "OpenJDK.pkg".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_pkg_installer_choices() {
+        let value: Value = serde_json::json!({
+            "pkg": [
+                "VirtualBox.pkg",
+                {"choices": [{"choiceIdentifier": "choiceVBox", "attributeSetting": 1}]}
+            ]
+        });
+        assert!(parse_pkg_artifact(&value).is_err());
+    }
+
+    #[test]
+    fn parses_uninstall_pkgutil_ids() -> Result<()> {
+        let mut cask = test_cask("temurin", "26.0.1,8");
+        cask.artifacts = vec![
+            serde_json::json!({"uninstall": [{"pkgutil": "net.temurin.26.jdk"}]}),
+            serde_json::json!({"pkg": ["OpenJDK26U-jdk.pkg"]}),
+        ];
+
+        assert_eq!(
+            cask_artifacts(&cask)?,
+            CaskArtifacts {
+                pkgs: vec![PkgArtifact {
+                    source: "OpenJDK26U-jdk.pkg".to_string()
+                }],
+                pkg_ids: vec!["net.temurin.26.jdk".to_string()],
+                ..Default::default()
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
     fn installed_cask_version_checks_apps_without_receipt() -> Result<()> {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir()?;
@@ -550,13 +708,25 @@ mod tests {
         file::create_dir_all(caskroom_version_dir(&cask.token, &cask.version))?;
 
         assert_eq!(
-            installed_cask_version(&cask, std::slice::from_ref(&app))?,
+            installed_cask_version(
+                &cask,
+                &CaskArtifacts {
+                    apps: vec![app.clone()],
+                    ..Default::default()
+                }
+            )?,
             None
         );
 
         file::create_dir_all(app_target_path(app.target_name())?)?;
         assert_eq!(
-            installed_cask_version(&cask, &[app])?,
+            installed_cask_version(
+                &cask,
+                &CaskArtifacts {
+                    apps: vec![app],
+                    ..Default::default()
+                }
+            )?,
             Some("1.0.0".to_string())
         );
         Ok(())
@@ -575,16 +745,28 @@ mod tests {
         file::create_dir_all(caskroom_version_dir("configured-name", &cask.version))?;
         file::create_dir_all(app_target_path(app.target_name())?)?;
 
-        assert_eq!(installed_cask_version(&cask, &[app])?, None);
+        assert_eq!(
+            installed_cask_version(
+                &cask,
+                &CaskArtifacts {
+                    apps: vec![app],
+                    ..Default::default()
+                }
+            )?,
+            None
+        );
 
         file::create_dir_all(caskroom_version_dir(&cask.token, &cask.version))?;
         assert_eq!(
             installed_cask_version(
                 &cask,
-                &[AppArtifact {
-                    source: "Example.app".to_string(),
-                    target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
-                }]
+                &CaskArtifacts {
+                    apps: vec![AppArtifact {
+                        source: "Example.app".to_string(),
+                        target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
+                    }],
+                    ..Default::default()
+                }
             )?,
             Some("2.0.0".to_string())
         );

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -57,7 +57,7 @@ struct CaskReceipt {
     #[serde(default)]
     apps: Vec<PathBuf>,
     #[serde(default)]
-    pkgs: Vec<String>,
+    pkg_ids: Vec<String>,
 }
 
 impl BrewCaskManager {
@@ -337,6 +337,12 @@ fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
     }
     artifacts.pkg_ids.sort();
     artifacts.pkg_ids.dedup();
+    if !artifacts.pkgs.is_empty() && artifacts.pkg_ids.is_empty() {
+        bail!(
+            "brew-cask:{}: pkg artifacts require pkgutil ids in uninstall or zap metadata",
+            cask.token
+        );
+    }
     Ok(artifacts)
 }
 
@@ -386,23 +392,28 @@ fn parse_pkg_artifact(value: &Value) -> Result<Option<PkgArtifact>> {
 }
 
 fn collect_uninstall_pkg_ids(value: &Value, pkg_ids: &mut Vec<String>) {
-    let Some(uninstall) = value.as_object().and_then(|o| o.get("uninstall")) else {
+    let Some(object) = value.as_object() else {
         return;
     };
-    let values: Vec<&Value> = match uninstall {
-        Value::Array(values) => values.iter().collect(),
-        value => vec![value],
-    };
-    for value in values {
-        let Some(pkgutil) = value.as_object().and_then(|o| o.get("pkgutil")) else {
+    for key in ["uninstall", "zap"] {
+        let Some(metadata) = object.get(key) else {
             continue;
         };
-        match pkgutil {
-            Value::String(id) => pkg_ids.push(id.clone()),
-            Value::Array(ids) => {
-                pkg_ids.extend(ids.iter().filter_map(Value::as_str).map(str::to_string))
+        let values: Vec<&Value> = match metadata {
+            Value::Array(values) => values.iter().collect(),
+            value => vec![value],
+        };
+        for value in values {
+            let Some(pkgutil) = value.as_object().and_then(|o| o.get("pkgutil")) else {
+                continue;
+            };
+            match pkgutil {
+                Value::String(id) => pkg_ids.push(id.clone()),
+                Value::Array(ids) => {
+                    pkg_ids.extend(ids.iter().filter_map(Value::as_str).map(str::to_string))
+                }
+                _ => {}
             }
-            _ => {}
         }
     }
 }
@@ -498,7 +509,7 @@ fn installed_cask_version(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Opti
     let version_dir = caskroom_version_dir(&cask.token, &version);
     match read_receipt(&version_dir)? {
         Some(receipt) => {
-            if receipt.apps.iter().all(|app| app.exists()) && pkg_ids_installed(&receipt.pkgs)? {
+            if receipt.apps.iter().all(|app| app.exists()) && pkg_ids_installed(&receipt.pkg_ids)? {
                 Ok(Some(receipt.version))
             } else {
                 Ok(None)
@@ -526,7 +537,7 @@ fn write_receipt(caskroom: &Path, cask: &Cask, artifacts: &CaskArtifacts) -> Res
             .iter()
             .map(|app| app_target_path(app.target_name()))
             .collect::<Result<Vec<_>>>()?,
-        pkgs: artifacts.pkg_ids.clone(),
+        pkg_ids: artifacts.pkg_ids.clone(),
     };
     let body = toml::to_string_pretty(&receipt)?;
     crate::file::write(caskroom.join(".mise-cask.toml"), body)?;
@@ -693,6 +704,36 @@ mod tests {
             }
         );
         Ok(())
+    }
+
+    #[test]
+    fn parses_zap_pkgutil_ids() -> Result<()> {
+        let mut cask = test_cask("example", "1.0.0");
+        cask.artifacts = vec![
+            serde_json::json!({"zap": [{"pkgutil": ["com.example.pkg"]}]}),
+            serde_json::json!({"pkg": ["Example.pkg"]}),
+        ];
+
+        assert_eq!(
+            cask_artifacts(&cask)?,
+            CaskArtifacts {
+                pkgs: vec![PkgArtifact {
+                    source: "Example.pkg".to_string()
+                }],
+                pkg_ids: vec!["com.example.pkg".to_string()],
+                ..Default::default()
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_pkg_artifacts_without_pkgutil_ids() {
+        let mut cask = test_cask("example", "1.0.0");
+        cask.artifacts = vec![serde_json::json!({"pkg": ["Example.pkg"]})];
+
+        let err = cask_artifacts(&cask).unwrap_err().to_string();
+        assert!(err.contains("pkg artifacts require pkgutil ids"));
     }
 
     #[test]

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -337,7 +337,9 @@ fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
     }
     artifacts.pkg_ids.sort();
     artifacts.pkg_ids.dedup();
-    if !artifacts.pkgs.is_empty() && artifacts.pkg_ids.is_empty() {
+    if artifacts.pkgs.is_empty() {
+        artifacts.pkg_ids.clear();
+    } else if artifacts.pkg_ids.is_empty() {
         bail!(
             "brew-cask:{}: pkg artifacts require pkgutil ids in uninstall or zap metadata",
             cask.token
@@ -509,7 +511,8 @@ fn installed_cask_version(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Opti
     let version_dir = caskroom_version_dir(&cask.token, &version);
     match read_receipt(&version_dir)? {
         Some(receipt) => {
-            if receipt.apps.iter().all(|app| app.exists()) && pkg_ids_installed(&receipt.pkg_ids)? {
+            let pkgs_installed = artifacts.pkgs.is_empty() || pkg_ids_installed(&receipt.pkg_ids)?;
+            if receipt.apps.iter().all(|app| app.exists()) && pkgs_installed {
                 Ok(Some(receipt.version))
             } else {
                 Ok(None)
@@ -521,7 +524,7 @@ fn installed_cask_version(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Opti
                     return Ok(None);
                 }
             }
-            if !pkg_ids_installed(&artifacts.pkg_ids)? {
+            if !artifacts.pkgs.is_empty() && !pkg_ids_installed(&artifacts.pkg_ids)? {
                 return Ok(None);
             }
             Ok(Some(version))
@@ -734,6 +737,63 @@ mod tests {
 
         let err = cask_artifacts(&cask).unwrap_err().to_string();
         assert!(err.contains("pkg artifacts require pkgutil ids"));
+    }
+
+    #[test]
+    fn app_only_casks_ignore_pkgutil_ids() -> Result<()> {
+        let mut cask = test_cask("example", "1.0.0");
+        cask.artifacts = vec![
+            serde_json::json!({"uninstall": [{"pkgutil": "com.example.helper"}]}),
+            serde_json::json!({"app": "Example.app"}),
+        ];
+
+        assert_eq!(
+            cask_artifacts(&cask)?,
+            CaskArtifacts {
+                apps: vec![AppArtifact {
+                    source: "Example.app".to_string(),
+                    target: None,
+                }],
+                ..Default::default()
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn installed_cask_version_ignores_receipt_pkg_ids_for_app_only_casks() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let cask = test_cask("app-only", "1.0.0");
+        let app = AppArtifact {
+            source: "Example.app".to_string(),
+            target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
+        };
+        let caskroom = caskroom_version_dir(&cask.token, &cask.version);
+        file::create_dir_all(&caskroom)?;
+        file::create_dir_all(app_target_path(app.target_name())?)?;
+        let receipt = CaskReceipt {
+            version: cask.version.clone(),
+            apps: vec![app_target_path(app.target_name())?],
+            pkg_ids: vec!["com.example.helper".to_string()],
+        };
+        crate::file::write(
+            caskroom.join(".mise-cask.toml"),
+            toml::to_string_pretty(&receipt)?,
+        )?;
+
+        assert_eq!(
+            installed_cask_version(
+                &cask,
+                &CaskArtifacts {
+                    apps: vec![app],
+                    ..Default::default()
+                }
+            )?,
+            Some("1.0.0".to_string())
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `brew-cask` support for simple macOS `pkg` artifacts
- install pkg artifacts via the existing system-package sudo path
- track pkgutil receipt ids from cask uninstall metadata when available for status checks
- document pkg artifact support and the current custom-choice limitation

## Notes
This intentionally rejects pkg artifacts with custom installer choices for now instead of silently ignoring those options. That leaves a smaller, safer first step toward broader cask coverage.

Refs discussion #10582.

## Tests
- `cargo test system::packages::brew::cask`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs privileged macOS package installs and depends on correct pkgutil metadata for status; scope is intentionally narrow with explicit errors for unsupported pkg shapes.
> 
> **Overview**
> **`brew-cask` now handles simple macOS `.pkg` casks** in addition to app bundles, using the same extract-and-stage flow before running `installer` via mise’s existing **`sudo::run`** path (so non-interactive installs fail clearly instead of hanging on a password prompt).
> 
> **Artifact parsing and install state** are generalized: casks can mix `app` and `pkg` artifacts; pkg casks **must** declare `pkgutil` receipt IDs in `uninstall`/`zap` metadata so status checks can see files the installer writes outside Caskroom. **Custom pkg installer choices** are rejected up front. Cask receipts (`.mise-cask.toml`) now record **`pkg_ids`**, and installed-version logic consults **`pkgutil --pkg-info`** when pkg artifacts are present.
> 
> **Docs** (`brew.md`) describe pkg support, the `pkgutil` requirement, and that `preflight`/`postflight` are not run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 026bd10d7e9e2d053ea190cb7d2bea639913a8be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for macOS `.pkg` installer casks alongside app bundles in brew-cask.
  * Installation and version detection now account for both app presence and installed pkg state, using receipts when available.
  * Dry runs now display both app linking and pkg installation steps for pkg casks.
* **Documentation**
  * Expanded brew-cask docs to cover pkg-artifact casks, including uninstall/zap verification via `pkgutil` receipt IDs and non-interactive behavior.
* **Bug Fixes**
  * Clear unsupported-artifact failures for unsupported pkg artifacts and casks that require custom installer choices.
* **Tests**
  * Expanded coverage for pkg artifact parsing and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->