### PR TITLE
fix(aqua): require config for attestation badge

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -234,18 +234,12 @@ impl Backend for AquaBackend {
             features.push(SecurityFeature::Checksum { algorithm });
         }
 
-        // GitHub Artifact Attestations - check registry config OR actual release assets
-        let has_attestations_config = all_pkgs.iter().any(|p| {
-            p.github_artifact_attestations
-                .as_ref()
-                .is_some_and(|a| a.enabled.unwrap_or(true))
-                || Self::checksum_github_attestations_config(p).is_some()
-        });
-        let has_attestations_assets = release_assets.iter().any(|a| {
-            let name = a.name.to_lowercase();
-            name.ends_with(".sigstore.json") || name.ends_with(".sigstore")
-        });
-        if has_attestations_config || has_attestations_assets {
+        // GitHub Artifact Attestations require registry config so the badge
+        // matches lock/install provenance verification behavior.
+        if all_pkgs
+            .iter()
+            .any(|p| Self::has_github_attestations_config(p))
+        {
             let signer_workflow = all_pkgs
                 .iter()
                 .filter_map(|p| {
@@ -1064,6 +1058,13 @@ impl AquaBackend {
         Some((checksum, attestations))
     }
 
+    fn has_github_attestations_config(pkg: &AquaPackage) -> bool {
+        pkg.github_artifact_attestations
+            .as_ref()
+            .is_some_and(|attestations| attestations.enabled != Some(false))
+            || Self::checksum_github_attestations_config(pkg).is_some()
+    }
+
     /// Detect provenance type from aqua registry package config.
     ///
     /// Returns the highest-priority provenance type that is configured and
@@ -1084,11 +1085,7 @@ impl AquaBackend {
         // or on first install when the lockfile doesn't yet have provenance).
         if settings.github_attestations
             && settings.aqua.github_attestations
-            && (pkg
-                .github_artifact_attestations
-                .as_ref()
-                .is_some_and(|att| att.enabled != Some(false))
-                || Self::checksum_github_attestations_config(pkg).is_some())
+            && Self::has_github_attestations_config(pkg)
         {
             return Some(ProvenanceType::GithubAttestations);
         }
@@ -3069,6 +3066,26 @@ mod tests {
         assert!(
             !direct_backend.use_versions_host_for_github_metadata("aws/session-manager-plugin")
         );
+    }
+
+    #[test]
+    fn test_has_github_attestations_config_requires_enabled_config() {
+        let mut pkg = AquaPackage::default();
+        assert!(!AquaBackend::has_github_attestations_config(&pkg));
+
+        pkg.github_artifact_attestations = Some(AquaGithubArtifactAttestations {
+            enabled: Some(false),
+            predicate_type: None,
+            signer_workflow: None,
+        });
+        assert!(!AquaBackend::has_github_attestations_config(&pkg));
+
+        pkg.github_artifact_attestations = Some(AquaGithubArtifactAttestations {
+            enabled: None,
+            predicate_type: None,
+            signer_workflow: None,
+        });
+        assert!(AquaBackend::has_github_attestations_config(&pkg));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- stop treating .sigstore release assets as GitHub Artifact Attestations in aqua security metadata
- reuse the same config-backed predicate for the security badge and provenance detection
- add unit coverage for enabled/disabled aqua attestation config

## Root cause
The mise-versions security badge used release asset names ending in `.sigstore`/`.sigstore.json` as a proxy for GitHub Artifact Attestations. That could show an attestation badge even when aqua registry config did not enable GitHub attestation verification and `mise lock` would not record `github-attestations` provenance.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test backend::aqua::tests::test_has_github_attestations_config_requires_enabled_config`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in security UI/metadata only; reduces false-positive badges without altering install verification when config is present.
> 
> **Overview**
> Fixes **misleading GitHub Artifact Attestations badges** on aqua tools when releases happen to ship `.sigstore` / `.sigstore.json` assets but the aqua registry does not enable attestation verification.
> 
> **Security metadata** (`security_info`) no longer infers attestations from release asset names. The badge is shown only when aqua registry config enables GitHub artifact attestations (package-level or via checksum config), aligned with **`mise lock`** provenance detection and install-time verification.
> 
> Introduces **`has_github_attestations_config`** and uses it for both the badge and **`detect_provenance_type`**, with unit tests for enabled / disabled / default config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36b34e0d04484a0883e16e12dd6abc3897d587b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined GitHub Artifact Attestations detection logic to depend exclusively on registry configuration settings, improving consistency in attestation identification.

* **Tests**
  * Added tests to validate proper handling of attestation configuration states, including explicit enablement and default configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->