### PR TITLE
fix(hook-env): suppress repeated untrusted config warnings

### DIFF
--- a/e2e/cli/test_hook_env_untrusted_once_per_dir
+++ b/e2e/cli/test_hook_env_untrusted_once_per_dir
@@ -6,7 +6,7 @@ unset CI GITHUB_ACTIONS GITHUB_ACTION
 
 contains_trust_warning() {
   local file="$1"
-  grep -Eq "Config file(\\(s\\)|s)? in" "$file" && grep -q "are not trusted" "$file"
+  grep -Eq 'Config file(\(s\)|s)? in' "$file" && grep -q "are not trusted" "$file"
 }
 
 run_hook_env() {
@@ -29,16 +29,27 @@ FOO = "bar"
 run = "echo make"
 EOF
 
+parent_stdout="$(mktemp)"
+parent_stderr="$(mktemp)"
 first_stdout="$(mktemp)"
 first_stderr="$(mktemp)"
 second_stdout="$(mktemp)"
 second_stderr="$(mktemp)"
 changed_stdout="$(mktemp)"
 changed_stderr="$(mktemp)"
+left_stdout="$(mktemp)"
+left_stderr="$(mktemp)"
 reentered_stdout="$(mktemp)"
 reentered_stderr="$(mktemp)"
 explicit_stderr="$(mktemp)"
-trap 'rm -f "$first_stdout" "$first_stderr" "$second_stdout" "$second_stderr" "$changed_stdout" "$changed_stderr" "$reentered_stdout" "$reentered_stderr" "$explicit_stderr"' EXIT
+trap 'rm -f "$parent_stdout" "$parent_stderr" "$first_stdout" "$first_stderr" "$second_stdout" "$second_stderr" "$changed_stdout" "$changed_stderr" "$left_stdout" "$left_stderr" "$reentered_stdout" "$reentered_stderr" "$explicit_stderr"' EXIT
+
+run_hook_env "$parent_stdout" "$parent_stderr"
+if contains_trust_warning "$parent_stderr"; then
+  echo "expected parent hook-env to be trusted"
+  cat "$parent_stderr"
+  exit 1
+fi
 
 cd project
 
@@ -56,17 +67,23 @@ if contains_trust_warning "$second_stderr"; then
   exit 1
 fi
 
+sleep 1
 echo "# changed" >>.mise.toml
 
 run_hook_env "$changed_stdout" "$changed_stderr"
-if contains_trust_warning "$changed_stderr"; then
-  echo "expected hook-env to stay quiet in same directory after config changes"
+if ! contains_trust_warning "$changed_stderr"; then
+  echo "expected hook-env to warn again after config changes"
   cat "$changed_stderr"
   exit 1
 fi
 
 cd ..
-run_hook_env "$changed_stdout" "$changed_stderr"
+run_hook_env "$left_stdout" "$left_stderr"
+if contains_trust_warning "$left_stderr"; then
+  echo "expected parent hook-env after leaving project to be trusted"
+  cat "$left_stderr"
+  exit 1
+fi
 
 cd project
 run_hook_env "$reentered_stdout" "$reentered_stderr"

--- a/e2e/cli/test_hook_env_untrusted_once_per_dir
+++ b/e2e/cli/test_hook_env_untrusted_once_per_dir
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+unset CI GITHUB_ACTIONS GITHUB_ACTION
+
+contains_trust_warning() {
+  local file="$1"
+  grep -Eq "Config file(\\(s\\)|s)? in" "$file" && grep -q "are not trusted" "$file"
+}
+
+run_hook_env() {
+  local stdout_file="$1"
+  local stderr_file="$2"
+  : >"$stdout_file"
+  : >"$stderr_file"
+  mise hook-env -s bash >"$stdout_file" 2>"$stderr_file" || true
+  # Apply the marker exported by hook-env so the next prompt in this shell can
+  # suppress the same warning without trusting or ignoring the config.
+  eval "$(cat "$stdout_file")"
+}
+
+mkdir -p project
+cat >project/.mise.toml <<'EOF'
+[env]
+FOO = "bar"
+
+[tasks.make]
+run = "echo make"
+EOF
+
+first_stdout="$(mktemp)"
+first_stderr="$(mktemp)"
+second_stdout="$(mktemp)"
+second_stderr="$(mktemp)"
+changed_stdout="$(mktemp)"
+changed_stderr="$(mktemp)"
+reentered_stdout="$(mktemp)"
+reentered_stderr="$(mktemp)"
+explicit_stderr="$(mktemp)"
+trap 'rm -f "$first_stdout" "$first_stderr" "$second_stdout" "$second_stderr" "$changed_stdout" "$changed_stderr" "$reentered_stdout" "$reentered_stderr" "$explicit_stderr"' EXIT
+
+cd project
+
+run_hook_env "$first_stdout" "$first_stderr"
+if ! contains_trust_warning "$first_stderr"; then
+  echo "expected first hook-env to report untrusted config"
+  cat "$first_stderr"
+  exit 1
+fi
+
+run_hook_env "$second_stdout" "$second_stderr"
+if contains_trust_warning "$second_stderr"; then
+  echo "expected second hook-env in same directory to suppress untrusted config warning"
+  cat "$second_stderr"
+  exit 1
+fi
+
+echo "# changed" >>.mise.toml
+
+run_hook_env "$changed_stdout" "$changed_stderr"
+if contains_trust_warning "$changed_stderr"; then
+  echo "expected hook-env to stay quiet in same directory after config changes"
+  cat "$changed_stderr"
+  exit 1
+fi
+
+cd ..
+run_hook_env "$changed_stdout" "$changed_stderr"
+
+cd project
+run_hook_env "$reentered_stdout" "$reentered_stderr"
+if ! contains_trust_warning "$reentered_stderr"; then
+  echo "expected hook-env to warn again after leaving and re-entering directory"
+  cat "$reentered_stderr"
+  exit 1
+fi
+
+MISE_YES=0 mise run make 2>"$explicit_stderr" >/dev/null && {
+  echo "expected mise run to fail on untrusted config"
+  exit 1
+}
+if ! contains_trust_warning "$explicit_stderr"; then
+  echo "expected explicit mise run to keep reporting untrusted config"
+  cat "$explicit_stderr"
+  exit 1
+fi

--- a/e2e/cli/test_zsh_precmd_runs_once
+++ b/e2e/cli/test_zsh_precmd_runs_once
@@ -31,7 +31,7 @@ run_hooks_to_file() {
 
 contains_trust_warning() {
   local file="$1"
-  grep -q "Config files in" "$file" && grep -q "are not trusted" "$file"
+  grep -Eq 'Config file(\(s\)|s)? in' "$file" && grep -q "are not trusted" "$file"
 }
 
 contains_mise_precmd_hook() {
@@ -83,7 +83,7 @@ fi
 # zsh mode does not fire chpwd on `cd`, fall back to invoking the hook list
 # manually in the current shell so hook functions can still mutate shell state.
 { cd project; } >"$chpwd_file" 2>&1
-if [[ "${__MISE_ZSH_CHPWD_RAN:-0}" != "1" ]]; then
+if [[ ${__MISE_ZSH_CHPWD_RAN:-0} != "1" ]]; then
   run_hooks_to_file "$chpwd_file" "${chpwd_functions[@]}"
 fi
 run_hooks_to_file "$precmd_file" "${precmd_functions[@]-}"

--- a/e2e/cli/test_zsh_precmd_runs_once
+++ b/e2e/cli/test_zsh_precmd_runs_once
@@ -78,14 +78,14 @@ if ! contains_mise_precmd_hook; then
   exit 1
 fi
 
-# In an interactive zsh session, `cd` would trigger `chpwd` hooks and the next
-# prompt would trigger `precmd` hooks automatically. In this non-interactive
-# test script, we invoke both hook lists manually.
-cd project
-
-# Crucially, `run_hooks_to_file` executes the hooks in the current shell rather
-# than via command substitution, so hook functions can still mutate shell state.
-run_hooks_to_file "$chpwd_file" "${chpwd_functions[@]}"
+# In an interactive zsh session, `cd` triggers `chpwd` hooks and the next prompt
+# triggers `precmd` hooks automatically. Capture the real `cd` first; if this
+# zsh mode does not fire chpwd on `cd`, fall back to invoking the hook list
+# manually in the current shell so hook functions can still mutate shell state.
+{ cd project; } >"$chpwd_file" 2>&1
+if [[ "${__MISE_ZSH_CHPWD_RAN:-0}" != "1" ]]; then
+  run_hooks_to_file "$chpwd_file" "${chpwd_functions[@]}"
+fi
 run_hooks_to_file "$precmd_file" "${precmd_functions[@]-}"
 
 # The chpwd hook should surface the untrusted-config warning on directory entry.

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -54,14 +54,20 @@ impl HookEnv {
         let shell = get_shell(self.shell).expect("no shell provided, use `--shell=zsh`");
         let config = match Config::get().await {
             Ok(config) => config,
-            Err(err) if hook_env::is_untrusted_config_error(&err) => {
-                if hook_env::should_show_untrusted_config_warning() {
-                    hook_env::mark_untrusted_config_warning_seen(&*shell)?;
+            Err(err) => {
+                let Some(config_path) = hook_env::untrusted_config_error_path(&err) else {
+                    return Err(err);
+                };
+                if hook_env::should_show_untrusted_config_warning(&config_path) {
+                    if let Err(mark_err) =
+                        hook_env::mark_untrusted_config_warning_seen(&*shell, &config_path)
+                    {
+                        trace!("failed to mark untrusted config warning seen: {mark_err}");
+                    }
                     return Err(err);
                 }
                 exit(1);
             }
-            Err(err) => return Err(err),
         };
         // Shell activation must stay fast and non-networked; missing tools are
         // handled by the normal install paths instead of hook-env.
@@ -176,7 +182,7 @@ impl HookEnv {
                 "1".into(),
             ));
         }
-        hook_env::clear_untrusted_config_warning_if_dir_changed(&mut patches);
+        hook_env::clear_untrusted_config_warning(&mut patches);
 
         let output = hook_env::build_env_commands(&*shell, &patches);
         miseprint!("{output}")?;

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -7,7 +7,7 @@ use crate::file::{canonicalize_cached, display_rel_path};
 use crate::hook_env::{PREV_SESSION, WatchFilePattern};
 use crate::shell::{ShellType, get_shell};
 use crate::toolset::{ResolveOptions, Toolset, ToolsetBuilder};
-use crate::{env, hook_env, hooks, watch_files};
+use crate::{env, exit, hook_env, hooks, watch_files};
 use console::truncate_str;
 use eyre::Result;
 use indexmap::IndexSet;
@@ -51,7 +51,18 @@ pub struct HookEnv {
 
 impl HookEnv {
     pub async fn run(self) -> Result<()> {
-        let config = Config::get().await?;
+        let shell = get_shell(self.shell).expect("no shell provided, use `--shell=zsh`");
+        let config = match Config::get().await {
+            Ok(config) => config,
+            Err(err) if hook_env::is_untrusted_config_error(&err) => {
+                if hook_env::should_show_untrusted_config_warning() {
+                    hook_env::mark_untrusted_config_warning_seen(&*shell)?;
+                    return Err(err);
+                }
+                exit(1);
+            }
+            Err(err) => return Err(err),
+        };
         // Shell activation must stay fast and non-networked; missing tools are
         // handled by the normal install paths instead of hook-env.
         let ts = ToolsetBuilder::new()
@@ -94,7 +105,6 @@ impl HookEnv {
             return Ok(());
         }
         time!("should_exit_early false");
-        let shell = get_shell(self.shell).expect("no shell provided, use `--shell=zsh`");
         miseprint!("{}", hook_env::clear_old_env(&*shell))?;
 
         // Use env_with_path_and_split which handles caching internally
@@ -166,6 +176,7 @@ impl HookEnv {
                 "1".into(),
             ));
         }
+        hook_env::clear_untrusted_config_warning_if_dir_changed(&mut patches);
 
         let output = hook_env::build_env_commands(&*shell, &patches);
         miseprint!("{output}")?;

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -14,10 +14,10 @@ use serde::{Deserialize, Serialize};
 use std::sync::LazyLock as Lazy;
 
 use crate::cli::HookReason;
-use crate::config::{Config, DEFAULT_CONFIG_FILENAMES, Settings};
+use crate::config::{Config, DEFAULT_CONFIG_FILENAMES, Settings, config_file};
 use crate::env::PATH_KEY;
 use crate::env_diff::{EnvDiffOperation, EnvDiffPatches, EnvMap};
-use crate::errors::Error::UntrustedConfig;
+use crate::errors::Error;
 use crate::hash::hash_to_str;
 use crate::shell::Shell;
 use crate::{dirs, duration, env, file, hooks, watch_files};
@@ -26,7 +26,7 @@ use crate::{dirs, duration, env, file, hooks, watch_files};
 /// Timestamps are stored per-directory (using a hash of CWD) so that
 /// multiple shells in different directories don't interfere with each other.
 static LAST_CHECK_DIR: Lazy<PathBuf> = Lazy::new(|| dirs::STATE.join("hook-env-checks"));
-const LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV: &str = "__MISE_LAST_UNTRUSTED_CONFIG_WARNING_DIR";
+const LAST_UNTRUSTED_CONFIG_WARNING_KEY_ENV: &str = "__MISE_LAST_UNTRUSTED_CONFIG_WARNING_KEY";
 
 /// Get the path to the last check file for a specific directory.
 fn last_check_file_for_dir(dir: &Path) -> PathBuf {
@@ -67,45 +67,66 @@ fn mtime_to_millis(mtime: SystemTime) -> u128 {
         .as_millis()
 }
 
-pub fn is_untrusted_config_error(err: &eyre::Report) -> bool {
+pub fn untrusted_config_error_path(err: &eyre::Report) -> Option<PathBuf> {
     err.chain()
-        .any(|cause| matches!(cause.downcast_ref(), Some(UntrustedConfig(_))))
+        .find_map(|cause| match cause.downcast_ref::<Error>() {
+            Some(Error::UntrustedConfig(path)) => Some(path.clone()),
+            _ => None,
+        })
 }
 
-pub fn should_show_untrusted_config_warning() -> bool {
-    env::var(LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV).unwrap_or_default()
-        != current_untrusted_warning_dir()
+pub fn should_show_untrusted_config_warning(config_path: &Path) -> bool {
+    env::var(LAST_UNTRUSTED_CONFIG_WARNING_KEY_ENV).unwrap_or_default()
+        != current_untrusted_warning_key(config_path)
 }
 
-pub fn mark_untrusted_config_warning_seen(shell: &dyn Shell) -> Result<()> {
+pub fn mark_untrusted_config_warning_seen(shell: &dyn Shell, config_path: &Path) -> Result<()> {
     miseprint!(
         "{}",
         shell.set_env(
-            LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV,
-            &current_untrusted_warning_dir()
+            LAST_UNTRUSTED_CONFIG_WARNING_KEY_ENV,
+            &current_untrusted_warning_key(config_path)
         )
     )?;
     Ok(())
 }
 
-pub fn clear_untrusted_config_warning_if_dir_changed(patches: &mut EnvDiffPatches) {
-    if env::var(LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV)
-        .is_ok_and(|dir| !dir.is_empty() && dir != current_untrusted_warning_dir())
-    {
+pub fn clear_untrusted_config_warning(patches: &mut EnvDiffPatches) {
+    if has_untrusted_config_warning_marker() {
         patches.push(EnvDiffOperation::Remove(
-            LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV.into(),
+            LAST_UNTRUSTED_CONFIG_WARNING_KEY_ENV.into(),
         ));
     }
 }
 
-fn current_untrusted_warning_dir() -> String {
-    dirs::CWD
+fn has_untrusted_config_warning_marker() -> bool {
+    env::var(LAST_UNTRUSTED_CONFIG_WARNING_KEY_ENV).is_ok_and(|key| !key.is_empty())
+}
+
+fn current_untrusted_warning_key(config_path: &Path) -> String {
+    let cwd = dirs::CWD
         .as_ref()
-        .and_then(|p| p.canonicalize().ok())
-        .or_else(|| dirs::CWD.clone())
-        .unwrap_or_default()
+        .map(|p| canonical_path_key(p))
+        .unwrap_or_default();
+    let trust_root = canonical_path_key(&config_file::config_trust_root(config_path));
+    let config_path = canonical_path_key(config_path);
+    let mtime = config_path_mtime_millis(Path::new(&config_path));
+
+    hash_to_str(&(cwd, trust_root, config_path, mtime))
+}
+
+fn canonical_path_key(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
         .to_string_lossy()
         .to_string()
+}
+
+fn config_path_mtime_millis(path: &Path) -> u128 {
+    path.metadata()
+        .and_then(|m| m.modified())
+        .map(mtime_to_millis)
+        .unwrap_or_default()
 }
 
 pub static PREV_SESSION: Lazy<HookEnvSession> = Lazy::new(|| {
@@ -162,6 +183,9 @@ pub fn should_exit_early_fast() -> bool {
     }
     // Can't exit early if --force flag is present
     if args.iter().any(|a| a == "--force" || a == "-f") {
+        return false;
+    }
+    if has_untrusted_config_warning_marker() {
         return false;
     }
     // Check if running from precmd for the first time
@@ -293,6 +317,9 @@ pub fn should_exit_early(
     // This catches PATH modifications from shell initialization (e.g., path_helper in zsh)
     if reason == Some(HookReason::Precmd) && !*env::__MISE_ZSH_PRECMD_RUN {
         trace!("__MISE_ZSH_PRECMD_RUN=0 and reason=precmd, forcing hook-env to run");
+        return false;
+    }
+    if has_untrusted_config_warning_marker() {
         return false;
     }
     // Schedule hooks on directory change (can't do this in fast-path)

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -17,6 +17,7 @@ use crate::cli::HookReason;
 use crate::config::{Config, DEFAULT_CONFIG_FILENAMES, Settings};
 use crate::env::PATH_KEY;
 use crate::env_diff::{EnvDiffOperation, EnvDiffPatches, EnvMap};
+use crate::errors::Error::UntrustedConfig;
 use crate::hash::hash_to_str;
 use crate::shell::Shell;
 use crate::{dirs, duration, env, file, hooks, watch_files};
@@ -25,6 +26,7 @@ use crate::{dirs, duration, env, file, hooks, watch_files};
 /// Timestamps are stored per-directory (using a hash of CWD) so that
 /// multiple shells in different directories don't interfere with each other.
 static LAST_CHECK_DIR: Lazy<PathBuf> = Lazy::new(|| dirs::STATE.join("hook-env-checks"));
+const LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV: &str = "__MISE_LAST_UNTRUSTED_CONFIG_WARNING_DIR";
 
 /// Get the path to the last check file for a specific directory.
 fn last_check_file_for_dir(dir: &Path) -> PathBuf {
@@ -63,6 +65,47 @@ fn mtime_to_millis(mtime: SystemTime) -> u128 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis()
+}
+
+pub fn is_untrusted_config_error(err: &eyre::Report) -> bool {
+    err.chain()
+        .any(|cause| matches!(cause.downcast_ref(), Some(UntrustedConfig(_))))
+}
+
+pub fn should_show_untrusted_config_warning() -> bool {
+    env::var(LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV).unwrap_or_default()
+        != current_untrusted_warning_dir()
+}
+
+pub fn mark_untrusted_config_warning_seen(shell: &dyn Shell) -> Result<()> {
+    miseprint!(
+        "{}",
+        shell.set_env(
+            LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV,
+            &current_untrusted_warning_dir()
+        )
+    )?;
+    Ok(())
+}
+
+pub fn clear_untrusted_config_warning_if_dir_changed(patches: &mut EnvDiffPatches) {
+    if env::var(LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV)
+        .is_ok_and(|dir| !dir.is_empty() && dir != current_untrusted_warning_dir())
+    {
+        patches.push(EnvDiffOperation::Remove(
+            LAST_UNTRUSTED_CONFIG_WARNING_DIR_ENV.into(),
+        ));
+    }
+}
+
+fn current_untrusted_warning_dir() -> String {
+    dirs::CWD
+        .as_ref()
+        .and_then(|p| p.canonicalize().ok())
+        .or_else(|| dirs::CWD.clone())
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string()
 }
 
 pub static PREV_SESSION: Lazy<HookEnvSession> = Lazy::new(|| {


### PR DESCRIPTION
## Summary
- suppress repeated hook-env untrusted-config warnings while staying in the same directory
- clear the suppression marker after hook-env successfully runs from a different directory, so re-entering warns again
- keep explicit commands reporting the full trust error
- update zsh prompt-hook coverage and add a focused e2e for same-directory suppression and re-entry

## Tests
- mise run test:e2e e2e/cli/test_hook_env_untrusted_once_per_dir e2e/cli/test_zsh_precmd_runs_once

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shell activation trust handling and early-exit logic; mistakes could hide security warnings or break zsh hook timing, but scope is limited to hook-env and covered by new e2e tests.
> 
> **Overview**
> **`hook-env`** no longer spams the same untrusted-config message on every shell prompt in one directory. The first failure still prints the full trust error and exports **`__MISE_LAST_UNTRUSTED_CONFIG_WARNING_KEY`** (hashed from cwd, trust root, config path, and file mtime). Later **`hook-env`** calls with the same key exit quietly with code 1 instead of repeating stderr.
> 
> A successful **`hook-env`** run removes that marker so leaving and re-entering the project warns again; editing **`.mise.toml`** changes mtime and re-enables the warning in place. Early-exit fast paths are skipped while the marker is set so suppression stays consistent. Explicit commands like **`mise run`** are unchanged and still surface the full trust error.
> 
> E2e coverage adds **`test_hook_env_untrusted_once_per_dir`** and tightens the zsh **`chpwd`/`precmd`** test (trust-warning grep, real **`cd`** when hooks fire).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb16f1baf01e356931c8cf28d4c9d052fc7c847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Untrusted configuration warnings now show once per directory context, re-enabling when you return to a previously visited directory. The warning is still reported when runs are forced to fail.

* **Bug Fixes**
  * Improved zsh behavior to ensure hook/pre-command logic runs once per `cd`, avoiding duplicate side effects.
  * Expanded detection of untrusted-config warning text to match both singular/plural phrasing.

* **Tests**
  * Added end-to-end coverage for “warn once per directory,” including config changes, directory exit/re-entry, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->