### PR TITLE
test(aqua): add regression e2e for aube v1.24.0 install panic

### DIFF
--- a/e2e/backend/test_aqua_aube_v1_24_0
+++ b/e2e/backend/test_aqua_aube_v1_24_0
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Regression test for aqua:jdx/aube@v1.24.0 install panic reported with mise 2026.6.13.
+#
+# Original failure:
+#   called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Builder, source: RelativeUrlWithoutBase }
+#   Location: src/github.rs:651 (get_headers -> url.into_url().unwrap())
+#
+# See fix(github): return error instead of panic on invalid request url (#10591)
+
+set -euo pipefail
+
+export MISE_EXPERIMENTAL=1
+export MISE_AQUA_GITHUB_ATTESTATIONS=true
+export MISE_GITHUB_ATTESTATIONS=true
+
+echo "=== aqua:jdx/aube@v1.24.0 install regression ==="
+
+mise uninstall aqua:jdx/aube@v1.24.0 2>/dev/null || true
+
+output=""
+status=0
+output=$(mise install aqua:jdx/aube@v1.24.0 2>&1) || status=$?
+
+echo "$output"
+
+if echo "$output" | grep -qE 'panicked|RelativeUrlWithoutBase'; then
+  echo "ERROR: install panicked instead of returning a normal error"
+  exit 1
+fi
+
+if [[ $status -ne 0 ]]; then
+  # A clean install failure is acceptable; panics are not.
+  if echo "$output" | grep -q 'invalid request URL for GitHub auth headers'; then
+    echo "Install failed with expected invalid-URL error (not a panic)"
+    exit 0
+  fi
+  echo "ERROR: install failed unexpectedly (status=$status)"
+  exit 1
+fi
+
+assert_contains "mise x aqua:jdx/aube@v1.24.0 -- aube --version" "1.24.0"
+
+mise uninstall aqua:jdx/aube@v1.24.0 || true
+
+echo "=== aqua:jdx/aube@v1.24.0 install regression passed ==="


### PR DESCRIPTION
## Summary

- Add `e2e/backend/test_aqua_aube_v1_24_0` covering `mise install aqua:jdx/aube@v1.24.0` with GitHub artifact attestations enabled
- Test fails CI if install panics with `RelativeUrlWithoutBase` (the reported failure mode)
- Documents investigation into whether the bug is aube-release-specific or a mise regression

## Reported failure

```
called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Builder, source: RelativeUrlWithoutBase }
Location: src/github.rs:651
```

Root cause in code: `get_headers` called `url.into_url().unwrap()` on a relative URL. Fix proposed in #10591.

## Version investigation

Tested on `2026.6.13` (2026-06-23) with `MISE_AQUA_GITHUB_ATTESTATIONS=true`:

| Version | Attestation step | Result |
|---------|------------------|--------|
| v1.24.0 | yes | ✓ installed |
| v1.23.0 | yes | ✓ installed |
| v1.22.0 | yes | ✓ installed |
| v1.20.0 | yes | ✓ installed |
| v1.18.0 | no | ✓ installed |

**Conclusion:** The panic is **not specific to aube v1.24.0 release artifacts**. GitHub release assets and mise-versions metadata for v1.24.0 have valid absolute URLs. v1.18.0 skips attestation verification (no `github_artifact_attestations` step in install output); v1.20.0+ runs attestation verification successfully.

The original panic was likely **transient** — e.g. stale/invalid release metadata from mise-versions during the v1.24.0 release window (2026-06-23), or a relative GitHub API `Link` pagination URL passed to `get_headers` during parallel `mise i`.

## Bisect

Could not bisect to a single introducing commit because the panic **does not reproduce** on current `main` / `v2026.6.13`. The latent bug (unwrap in `get_headers`) dates to the function's introduction (`384e35e98`). No recent mise commit between v1.23.0 and v1.24.0 install success was identified as the culprit.

## Not an aube release bug

[aube v1.24.0 release assets](https://github.com/jdx/aube/releases/tag/v1.24.0) have correct absolute `browser_download_url` values. [mise-versions](https://mise-versions.jdx.dev/api/github/repos/jdx/aube/releases/v1.24.0) also returns valid absolute URLs today.

## Test plan

- [x] `mise run test:e2e test_aqua_aube_v1_24_0`
- [ ] After #10591 merges: re-run to confirm invalid-URL path returns error instead of panic (if reproduced)

## Related

- Fix: #10591

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test coverage for `aube@v1.24.0` installation functionality and version validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->