### PR TITLE
fix(sigstore): apply url_replacements to Sigstore TUF root fetch

### DIFF
--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -7,7 +7,8 @@ use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sigstore_verify::VerificationPolicy;
-use sigstore_verify::trust_root::{SigstoreInstance, TrustedRoot};
+pub use sigstore_verify::trust_root::DEFAULT_TUF_URL;
+use sigstore_verify::trust_root::{PRODUCTION_TUF_ROOT, SigstoreInstance, TrustedRoot, TufConfig};
 use sigstore_verify::types::bundle::VerificationMaterialContent;
 use sigstore_verify::types::{
     Artifact, Bundle, DerCertificate, DerPublicKey, HashAlgorithm, Sha256Hash, SignatureBytes,
@@ -1385,8 +1386,47 @@ fn extract_spki_der(cert_der: &[u8]) -> Result<Vec<u8>> {
         })
 }
 
+/// Process-global override for the Sigstore public-good TUF repository URL.
+///
+/// Set by the embedding crate from `settings.url_replacements` so the TUF root
+/// fetch follows the same mirror/proxy as the rest of mise's HTTP traffic.
+/// `None` means "use the crate default" (unchanged behavior).
+static TUF_URL_OVERRIDE: std::sync::RwLock<Option<String>> = std::sync::RwLock::new(None);
+
+/// Override the Sigstore public-good TUF URL (e.g. a mirror derived from mise's
+/// `settings.url_replacements`). Passing a mirror URL still bootstraps from the
+/// embedded production root ([`PRODUCTION_TUF_ROOT`]), so a mirror cannot forge
+/// the chain of trust — TUF verifies all fetched metadata against that pinned
+/// root. Passing `None` restores the default behavior.
+pub fn set_tuf_url(url: Option<String>) {
+    // Recover from a poisoned lock rather than silently dropping the override:
+    // the guarded data is just a String, so a poisoned lock still holds a valid
+    // value and we must still apply the (mirror) URL.
+    let mut guard = TUF_URL_OVERRIDE.write().unwrap_or_else(|e| e.into_inner());
+    *guard = url;
+}
+
+/// Build the [`TufConfig`] for the Sigstore public-good root, honoring an
+/// optional URL override.
+fn select_tuf_config(override_url: Option<String>) -> TufConfig {
+    match override_url {
+        // SECURITY: pin the embedded production root even when fetching from a
+        // mirror. A custom URL has no embedded-root fallback, and the mirror
+        // serves identical TUF content; bootstrapping with PRODUCTION_TUF_ROOT
+        // means every metadata file is verified against the canonical root.
+        Some(url) => TufConfig::custom(url, PRODUCTION_TUF_ROOT),
+        // Equivalent to `TrustedRoot::production()` (which is itself
+        // `from_tuf(TufConfig::production())`) — the default path is unchanged.
+        None => TufConfig::production(),
+    }
+}
+
 async fn production_trusted_root() -> Result<TrustedRoot> {
-    Ok(TrustedRoot::production().await?)
+    let override_url = TUF_URL_OVERRIDE
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    Ok(TrustedRoot::from_tuf(select_tuf_config(override_url)).await?)
 }
 
 fn github_trusted_root() -> Result<TrustedRoot> {
@@ -1541,6 +1581,21 @@ pub async fn calculate_file_digest(path: &Path) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn select_tuf_config_default_uses_production_url() {
+        // No override → canonical Sigstore public-good TUF URL (default behavior).
+        assert_eq!(select_tuf_config(None).url, DEFAULT_TUF_URL);
+    }
+
+    #[test]
+    fn select_tuf_config_override_uses_mirror_url() {
+        // Override → the mirror URL, while still pinning PRODUCTION_TUF_ROOT
+        // (the latter is enforced by TufConfig::custom, covered by the
+        // sigstore-trust-root crate's own tests).
+        let mirror = "https://tuf-mirror.example.com/".to_string();
+        assert_eq!(select_tuf_config(Some(mirror.clone())).url, mirror);
+    }
 
     #[test]
     fn attestations_url_includes_predicate_type() {

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -56,6 +56,25 @@ fn routed_api_url(api_url: &str) -> String {
     }
 }
 
+/// Apply mise's `url_replacements` to the Sigstore public-good TUF URL.
+///
+/// Returns `Some(replaced)` only when a replacement actually changed the URL,
+/// otherwise `None` (meaning: keep the sigstore crate's default behavior). The
+/// result is pushed into `mise-sigstore` via [`mise_sigstore::set_tuf_url`] so
+/// the TUF root fetch follows the same mirror as the rest of mise's traffic.
+fn routed_tuf_url() -> Option<String> {
+    let Ok(mut url) = url::Url::parse(mise_sigstore::DEFAULT_TUF_URL) else {
+        debug!(
+            "invalid Sigstore TUF URL, skipping url_replacements: {}",
+            mise_sigstore::DEFAULT_TUF_URL
+        );
+        return None;
+    };
+    let original = url.clone();
+    crate::http::apply_url_replacements(&mut url);
+    (url != original).then(|| url.to_string())
+}
+
 /// Build a [`RetryConfig`] from mise's HTTP settings so attestation requests
 /// retry and time out exactly like the rest of mise's HTTP traffic rather than
 /// using a policy hardcoded in the `mise-sigstore` crate.
@@ -92,6 +111,7 @@ pub async fn verify_attestation(
     api_url: Option<&str>,
     use_versions_host: bool,
 ) -> AttestationResult<bool> {
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     let mut digest = None;
     if use_versions_host_for_attestations(api_url, use_versions_host) {
         let artifact_digest = mise_sigstore::calculate_file_digest(artifact_path).await?;
@@ -168,6 +188,7 @@ pub async fn verify_attestation_with_predicate_type(
     api_url: Option<&str>,
     use_versions_host: bool,
 ) -> AttestationResult<bool> {
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     let Some(predicate_type) = predicate_type else {
         return verify_attestation(
             artifact_path,
@@ -322,6 +343,7 @@ pub async fn verify_slsa_provenance(
     provenance_path: &Path,
     min_level: u8,
 ) -> AttestationResult<bool> {
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     mise_sigstore::verify_slsa_provenance(artifact_path, provenance_path, min_level).await
 }
 
@@ -330,6 +352,7 @@ pub async fn verify_slsa_provenance_artifacts(
     artifacts: &[SlsaArtifact],
     min_level: u8,
 ) -> AttestationResult<bool> {
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     mise_sigstore::verify_slsa_provenance_artifacts(provenance_path, artifacts, min_level).await
 }
 
@@ -346,6 +369,7 @@ pub async fn verify_cosign_signature(
     artifact_path: &Path,
     sig_or_bundle_path: &Path,
 ) -> AttestationResult<bool> {
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     mise_sigstore::verify_cosign_signature(artifact_path, sig_or_bundle_path).await
 }
 
@@ -355,6 +379,7 @@ pub async fn verify_cosign_signature_with_key(
     sig_or_bundle_path: &Path,
     public_key_path: &Path,
 ) -> AttestationResult<bool> {
+    mise_sigstore::set_tuf_url(routed_tuf_url());
     mise_sigstore::verify_cosign_signature_with_key(
         artifact_path,
         sig_or_bundle_path,
@@ -569,6 +594,25 @@ mod tests {
         let routed = routed_api_url(crate::github::API_URL);
 
         assert_eq!(routed, crate::github::API_URL);
+    }
+
+    #[test]
+    fn test_routed_tuf_url_applies_url_replacement() {
+        let _settings = SettingsGuard::new(Some(indexmap::indexmap! {
+            "https://tuf-repo-cdn.sigstore.dev".to_string()
+                => "https://tuf-mirror.example.com".to_string(),
+        }));
+
+        let routed = routed_tuf_url();
+
+        assert_eq!(routed.as_deref(), Some("https://tuf-mirror.example.com/"));
+    }
+
+    #[test]
+    fn test_routed_tuf_url_none_without_replacement() {
+        let _settings = SettingsGuard::new(None);
+
+        assert_eq!(routed_tuf_url(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes [discussion #10437](https://github.com/jdx/mise/discussions/10437): `mise install` of an aqua cosign-verified tool (e.g. `cosign = "3.1.1"`) fails behind a mirror because the Sigstore TUF root fetch ignores `settings.url_replacements`:

```
TUF repository load failed: Failed to fetch https://tuf-repo-cdn.sigstore.dev/15.root.json
```

## Root cause

The Sigstore public-good TUF root is fetched inside the external `sigstore-verify` crate via `TrustedRoot::production()` (`crates/mise-sigstore/src/lib.rs`), which hardcodes `https://tuf-repo-cdn.sigstore.dev` and uses its own HTTP client. That bypasses mise's `apply_url_replacements`, which only runs inside mise's own HTTP client.

## Fix

Route the TUF root fetch through the same mirror as the rest of mise's traffic:

- **`src/github/sigstore.rs`** (the sole bridge): add `routed_tuf_url()` (mirrors the existing `routed_api_url()`), which applies `url_replacements` to the canonical TUF URL and returns the replaced URL only when it actually changed. It is pushed into mise-sigstore via `set_tuf_url(...)` at the start of **every** entry point that can trigger a TUF fetch: cosign (`verify_cosign_signature`, `verify_cosign_signature_with_key`), SLSA (`verify_slsa_provenance`, `verify_slsa_provenance_artifacts`), and attestations (`verify_attestation`, `verify_attestation_with_predicate_type`).
- **`crates/mise-sigstore/src/lib.rs`**: add a process-global override (`set_tuf_url`) read at the single chokepoint `production_trusted_root()`. When an override is set it uses `TufConfig::custom(mirror_url, PRODUCTION_TUF_ROOT)` + `TrustedRoot::from_tuf`; otherwise it keeps the default (`TufConfig::production()`), which is identical to today's `TrustedRoot::production()`.

### Security

The mirror branch still bootstraps from the **embedded production root** (`PRODUCTION_TUF_ROOT`). TUF verifies all fetched metadata against this pinned root, so a malicious or compromised mirror **cannot forge the chain of trust** — it can only mirror the identical content. The custom-root pin is required: the sigstore crate only falls back to its embedded root for the known canonical URL, so a mirror URL without the explicit root fails closed. A code comment documents this to prevent regressions.

With no `url_replacements` configured, behavior is byte-for-byte unchanged.

## Testing

Pure, network-free unit tests (run by CI):
- `src/github/sigstore.rs`: `test_routed_tuf_url_applies_url_replacement`, `test_routed_tuf_url_none_without_replacement` (model on the existing `routed_api_url` tests, using `SettingsGuard`).
- `crates/mise-sigstore/src/lib.rs`: `select_tuf_config_default_uses_production_url`, `select_tuf_config_override_uses_mirror_url`.

`rustfmt --edition 2024 --check` passes on the changed files.

> [!NOTE]
> The authoring sandbox can't build mise (insufficient memory), so compilation/clippy/tests are left to CI. Manual end-to-end check for a maintainer: set `MISE_URL_REPLACEMENTS` mapping `https://tuf-repo-cdn.sigstore.dev` to a working mirror and run `mise install cosign@3.1.1` — the TUF fetch should hit the mirror and verification should still succeed; with no replacement it should still hit the default CDN.

## Known limitation

Custom (mirror) TUF URLs have no embedded offline-fallback targets in the sigstore crate, so `offline` + mirror is not supported (online mirror only). Not relevant to the reported use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Sigstore TUF trust-root URL support for custom verification sources.
  * Sigstore verification now honors routed/mirrored URL replacement rules across all related operations.
* **Tests**
  * Added coverage to confirm TUF URL selection and URL routing/replacement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->