### PR TITLE
fix(install): respect lockfile backend during locked installs

### DIFF
--- a/e2e/backend/test_npm_lock_backend
+++ b/e2e/backend/test_npm_lock_backend
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+cat <<EOF >mise.toml
+[tools]
+npm = "latest"
+EOF
+
+cat <<EOF >mise.lock
+$LOCKFILE_HEADER
+
+[[tools.npm]]
+version = "11.17.0"
+backend = "npm:npm"
+EOF
+
+assert_contains "MISE_LOG_LEVEL=trace mise install --locked --dry-run npm 2>&1" "[npm:npm@11.17.0]"
+
+mkdir -p "$MISE_DATA_DIR/installs/npm/11.17.0"
+cat <<EOF >"$MISE_DATA_DIR/installs/.mise-installs.toml"
+[npm]
+short = "npm"
+full = "aqua:npm/cli"
+explicit_backend = false
+EOF
+
+cat <<EOF >mise.lock
+$LOCKFILE_HEADER
+
+[[tools.npm]]
+version = "11.99.0"
+backend = "npm:npm"
+EOF
+
+assert_contains "MISE_LOG_LEVEL=trace mise install --locked --dry-run npm 2>&1" "[npm:npm@11.99.0]"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -357,8 +357,10 @@ pub fn list() -> BackendList {
 pub fn get(ba: &BackendArg) -> Option<ABackend> {
     // Inline opts are command-scoped, so a short-name cache hit must not drop
     // the caller's BackendArg options.
-    if ba.explicit_opts().is_some() {
-        return arg_to_backend(ba.clone());
+    if (ba.explicit_opts().is_some() || ba.has_explicit_backend())
+        && let Some(backend) = arg_to_backend(ba.clone())
+    {
+        return Some(backend);
     }
 
     let mut tools = TOOLS.lock().unwrap();

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -327,6 +327,15 @@ impl BackendArg {
             }
         }
 
+        if self.resolution.explicit {
+            let full = self.full();
+            if let Some((backend, _)) = full.split_once(':')
+                && let Ok(backend_type) = backend.parse()
+            {
+                return backend_type;
+            }
+        }
+
         // Only check install state for non-plugin:tool format entries
         if !self.short.contains(':')
             && let Ok(Some(backend_type)) = install_state::backend_type(&self.short)

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -131,7 +131,23 @@ impl ToolVersion {
         self
     }
 
-    fn from_lockfile(request: ToolRequest, lt: LockfileTool) -> Self {
+    fn from_lockfile(mut request: ToolRequest, lt: LockfileTool) -> Self {
+        if let Some(backend_full) = &lt.backend {
+            let backend = Arc::new(BackendArg::new(
+                request.ba().short.clone(),
+                Some(backend_full.clone()),
+            ));
+            match &mut request {
+                ToolRequest::Version { backend: b, .. }
+                | ToolRequest::Prefix { backend: b, .. }
+                | ToolRequest::Ref { backend: b, .. }
+                | ToolRequest::Sub { backend: b, .. }
+                | ToolRequest::Path { backend: b, .. }
+                | ToolRequest::System { backend: b, .. } => *b = backend,
+            }
+        }
+        // Lockfile options have already selected the matching lock entry; keep
+        // the original request options so config/core install behavior survives.
         let mut tv = Self::new(request, lt.version);
         tv.locked = true;
         tv.lock_platforms = lt.platforms;
@@ -858,6 +874,7 @@ impl Display for ResolveOptions {
 mod tests {
     use super::*;
     use crate::cli::args::BackendResolution;
+    use crate::toolset::CoreToolOptions;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn unique_name(prefix: &str) -> String {
@@ -882,6 +899,56 @@ mod tests {
         );
         backend.installs_path = installs_path;
         backend
+    }
+
+    #[test]
+    fn from_lockfile_applies_backend_and_preserves_request_options() {
+        let backend = Arc::new(BackendArg::new("npm".to_string(), None));
+        let mut options = ToolVersionOptions {
+            core: CoreToolOptions {
+                depends: Some(vec!["node".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        options.install_env.insert(
+            "NODE_OPTIONS".to_string(),
+            "--enable-source-maps".to_string(),
+        );
+        options.opts.insert(
+            "registry".to_string(),
+            toml::Value::String("https://registry.example.test".to_string()),
+        );
+        let request = ToolRequest::Version {
+            backend,
+            version: "latest".to_string(),
+            options,
+            source: ToolSource::Argument,
+        };
+        let lt = LockfileTool {
+            version: "11.17.0".to_string(),
+            backend: Some("npm:npm".to_string()),
+            options: BTreeMap::from([("registry".to_string(), "lockfile-value".to_string())]),
+            platforms: Default::default(),
+        };
+
+        let tv = ToolVersion::from_lockfile(request, lt);
+        let options = tv.request.options();
+
+        assert_eq!(tv.version, "11.17.0");
+        assert!(tv.locked);
+        assert_eq!(tv.ba().full_without_opts(), "npm:npm");
+        assert_eq!(options.depends, Some(vec!["node".to_string()]));
+        assert_eq!(
+            options.install_env.get("NODE_OPTIONS").map(String::as_str),
+            Some("--enable-source-maps")
+        );
+        assert_eq!(
+            options.opts.get("registry"),
+            Some(&toml::Value::String(
+                "https://registry.example.test".to_string()
+            ))
+        );
     }
 
     #[test]

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -466,13 +466,15 @@ impl Toolset {
         opts: &Arc<InstallOptions>,
     ) -> Result<ToolVersion> {
         let mpr = MultiProgressReport::get();
-        let backend = tr.backend()?;
-        backend::ensure_backend_enabled(&backend.get_type())?;
+        let pre_resolve_backend = tr.backend()?;
+        backend::ensure_backend_enabled(&pre_resolve_backend.get_type())?;
         let mut resolve_options = opts.resolve_options.clone();
-        if should_refresh_remote_versions(tr, &backend, &resolve_options) {
+        if should_refresh_remote_versions(tr, &pre_resolve_backend, &resolve_options) {
             resolve_options.refresh_remote_versions = true;
         }
         let mut tv = tr.resolve(config, &resolve_options).await?;
+        let backend = tv.backend()?;
+        backend::ensure_backend_enabled(&backend.get_type())?;
         if let Some(dir) = &opts.install_dir {
             let tool_dir_name = tv.ba().tool_dir_name();
             tv.install_path = Some(dir.join(tool_dir_name).join(tv.tv_pathname()));


### PR DESCRIPTION
This affects registry changes but also `tool_alias`. With this PR, users will no longer be able to override the backend with `tool_alias` if it's locked in `mise.lock`. I believe it's better in terms of security, but it might break some use cases.

## Summary
- preserve the backend recorded in lockfile entries when resolving tool versions
- avoid short-name backend cache hits for explicit backend requests
- install using the backend from the resolved tool version, not the pre-resolution request
- add an e2e regression for npm shorthand locked to the npm backend without URL metadata

## Context
This addresses the npm locked-mode failure reported in discussion #7983 where a lockfile entry recorded `backend = "npm:npm"`, but install still used the registry-preferred aqua backend and required a lockfile URL.

## Tests
- `mise run build`
- isolated repro from lumirelle/oxlint-config at `7e8a28a45393c7352cf2e037debd14271af55694`: `mise install --locked --dry-run`
- `mise run test:e2e e2e/backend/test_npm_lock_backend`
- `mise run format`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend handling when a backend is explicitly specified, ensuring the requested backend is respected more reliably.
  * Lockfile-based installs now apply the lockfile’s backend while preserving existing request options.
  * Refined backend enablement and remote refresh timing to better align backend availability with install steps.
* **Tests**
  * Added end-to-end coverage for locked npm installs, including dry-run verification and correct install cache/backend metadata updates when the locked version changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->