### PR TITLE
fix(aqua): support doggo v1.2.0 asset naming in vendored registry

### DIFF
--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -65696,6 +65696,23 @@ packages:
           type: github_release
           asset: doggo_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+      - version_constraint: semver(">= 1.2.0")
+        asset: doggo-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: doggo
+            src: "{{.AssetWithoutExt}}/doggo"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          386: i386
+        checksum:
+          type: github_release
+          asset: doggo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: doggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
Doggo v1.2.0 changed its release asset naming from versioned (`doggo_{{version}}_{{OS}}_{{Arch}}.tar.gz`) to versionless (`doggo-{{os}}-{{arch}}.tar.gz`) with lowercase OS names and aarch64/i386 arch names.

Added a version override for >= 1.2.0 in the vendored aqua registry to match the new naming while the existing catch-all continues handling older versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release artifact handling for a packaged download to better match operating systems, architectures, and archive formats.
  * Added checksum-based verification and improved platform-specific packaging, including a Windows zip download option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->