### PR TITLE
fix(doggo): use github backend for v1.2.0 asset naming

### DIFF
--- a/registry/doggo.toml
+++ b/registry/doggo.toml
@@ -1,3 +1,5 @@
-backends = ["aqua:mr-karan/doggo"]
+backends = [
+  { full = "github:mr-karan/doggo", options = { asset_pattern = "doggo-{{ os(macos='darwin') }}-{{ arch(x64='x86_64', arm64='aarch64', x86='i386') }}{% if os() == 'windows' %}.zip{% else %}.tar.gz{% endif %}" } },
+]
 description = ":dog: Command-line DNS Client for Humans. Written in Golang"
 test = { cmd = "doggo --version | awk '{print $1}'", expected = "v{{version}}" }


### PR DESCRIPTION
Doggo v1.2.0 changed its release asset naming from versioned (`doggo_{{version}}_{{OS}}_{{Arch}}.tar.gz`) to versionless (`doggo-{{os}}-{{arch}}.tar.gz`) with lowercase OS names and aarch64/i386 arch naming.

The vendored aqua registry doesn't yet handle this. The upstream fix has been submitted to [aquaproj/aqua-registry](https://github.com/aquaproj/aqua-registry) ([PR #55890](https://github.com/aquaproj/aqua-registry/pull/55890)) and will flow in on the next vendored registry sync.

In the meantime, this switches to the `github:` backend with an explicit `asset_pattern` so doggo v1.2.0+ can be installed immediately. Once the upstream fix is vendored, this can be reverted back to `aqua:mr-karan/doggo`.

*This PR was generated with the assistance of an AI coding agent.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded package release targeting to better match GitHub build assets across operating systems and CPU architectures.
  * Improved archive selection so downloads use the appropriate file format for Windows and other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->