### PR TITLE
fix(config): avoid idiomatic version file write panic

### DIFF
--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -46,6 +46,8 @@ MISE_PIN=1 mise use dummy@1 --path mise.local.toml
 assert "cat mise.local.toml" '[tools]
 dummy = "1.0.0"'
 
+assert_fail "mise use --dry-run --path package.json dummy@1" "cannot update idiomatic version file"
+
 mise use --rm dummy --path mise.local.toml
 assert "cat mise.local.toml" ""
 

--- a/src/config/config_file/idiomatic_version/mod.rs
+++ b/src/config/config_file/idiomatic_version/mod.rs
@@ -1,10 +1,11 @@
 use std::path::{Path, PathBuf};
 
-use eyre::Result;
+use eyre::{Result, eyre};
 
 use crate::backend::BackendList;
 use crate::cli::args::BackendArg;
 use crate::config::config_file::ConfigFile;
+use crate::file;
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource};
 
 pub mod package_json;
@@ -48,6 +49,13 @@ impl IdiomaticVersionFile {
 
         Ok(Self { tools, path })
     }
+
+    fn read_only_error(&self, action: &str) -> eyre::Report {
+        eyre!(
+            "cannot {action} idiomatic version file {}; use mise.toml, .tool-versions, or --path to choose a writable config file",
+            file::display_path(&self.path)
+        )
+    }
 }
 
 impl ConfigFile for IdiomaticVersionFile {
@@ -55,28 +63,26 @@ impl ConfigFile for IdiomaticVersionFile {
         self.path.as_path()
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn remove_tool(&self, _fa: &BackendArg) -> Result<()> {
-        unimplemented!()
+        Err(self.read_only_error("remove tools from"))
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn replace_versions(
         &self,
         _plugin_name: &BackendArg,
         _versions: Vec<ToolRequest>,
     ) -> Result<()> {
-        unimplemented!()
+        Err(self.read_only_error("update"))
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn save(&self) -> Result<()> {
-        unimplemented!()
+        Ok(())
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn dump(&self) -> Result<String> {
-        unimplemented!()
+        file::read_to_string(&self.path)
     }
 
     fn source(&self) -> ToolSource {
@@ -176,5 +182,23 @@ mod tests {
         let (ba, versions, _) = &tools[0];
         assert_eq!(ba.short, "python");
         assert_eq!(versions[0].version(), "3.10.0");
+    }
+
+    #[test]
+    fn test_idiomatic_mutations_return_errors() {
+        let file = IdiomaticVersionFile::init(PathBuf::from("package.json"));
+        let ba = MockBackend::new("node", false, None).ba;
+
+        let err = file.replace_versions(&ba, vec![]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot update idiomatic version file")
+        );
+
+        let err = file.remove_tool(&ba).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot remove tools from idiomatic version file")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- return a normal read-only error when code tries to update or remove tools from an idiomatic version file
- avoid panics from `save`/`dump` on `IdiomaticVersionFile`
- add unit and e2e coverage for the `mise use --path package.json` failure path

## Testing
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise x rust@latest -- cargo fmt --all -- --check`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise x rust@latest -- cargo test config::config_file::idiomatic_version::tests::test_idiomatic_mutations_return_errors`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run --tool rust@latest --tool cmake@latest test:e2e e2e/cli/test_use`

Discussion: https://github.com/jdx/mise/discussions/10590

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized config-layer behavior change with explicit errors and tests; no auth or data migration impact.
> 
> **Overview**
> **`IdiomaticVersionFile`** (e.g. `package.json`) is treated as read-only for tool changes: **`replace_versions`** and **`remove_tool`** now return a clear error instead of **`unimplemented!()`** panics, pointing users to **`mise.toml`**, **`.tool-versions`**, or **`--path`** for writable config.
> 
> **`save`** is a no-op and **`dump`** reads the file from disk so callers no longer hit panics on those paths.
> 
> E2e coverage asserts **`mise use --dry-run --path package.json`** fails with **"cannot update idiomatic version file"**; a unit test covers the update/remove error messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06381d698b01206af934265813d7cab5ad5a6955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `mise use --dry-run` now reliably fails with a clear message when it would attempt to modify an idiomatic version file.
  * Attempts to remove or update tools in this file now return consistent “read-only” error messages.
  * Reading/dumping the idiomatic version file now works reliably, and save operations safely act as a no-op when changes aren’t allowed.
* **Tests**
  * Added coverage to verify the expected error messages for forbidden mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->