### PR TITLE
feat(bootstrap): add --only flag

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -31,6 +31,11 @@ Use `mise bootstrap --skip <part>` to skip specific parts. Supported parts are
 `task`, and `final-hook`. The flag can be repeated or comma-separated, for
 example `mise bootstrap --skip tools,task`.
 
+Use `mise bootstrap --only <part>` to run only specific parts. It supports the
+same part names and can be repeated or comma-separated, for example
+`mise bootstrap --only dotfiles,tools`. `--only` and `--skip` are mutually
+exclusive.
+
 Hook phases can also run before and after the built-in steps:
 `pre-packages`, `post-packages`, `pre-dotfiles`, `post-dotfiles`,
 `pre-defaults`, `post-defaults`, `pre-user`, `post-user`, `pre-tools`, and

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -34,6 +34,9 @@ invocation; keep it idempotent. Use it for any project-specific setup
 that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
 
+Use `--skip <part>` to skip named parts, or `--only <part>` to run just
+named parts. Both flags can be repeated or comma-separated.
+
 ## Flags
 
 ### `-n --dry-run`
@@ -51,6 +54,24 @@ Overwrite existing files that conflict with whole-file dotfile entries
 ### `--skip… <SKIP>`
 
 Skip one or more bootstrap parts
+
+Can be passed multiple times or as a comma-separated list.
+
+**Choices:**
+
+- `packages`
+- `dotfiles`
+- `defaults`
+- `launchd`
+- `systemd`
+- `user`
+- `tools`
+- `task`
+- `final-hook`
+
+### `--only… <ONLY>`
+
+Run only one or more bootstrap parts
 
 Can be passed multiple times or as a comma-separated list.
 
@@ -84,6 +105,7 @@ Examples:
 mise bootstrap                    # packages + dotfiles + tools + bootstrap task
 mise bootstrap --force-dotfiles   # replace conflicting dotfile targets
 mise bootstrap --skip tools,task  # skip tool installation and the bootstrap task
+mise bootstrap --only tools       # run just tool installation
 mise bootstrap packages install --yes
 mise bootstrap macos-defaults status
 mise bootstrap launchd apply --dry-run

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -35,7 +35,8 @@ that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
 
 Use `--skip <part>` to skip named parts, or `--only <part>` to run just
-named parts. Both flags can be repeated or comma-separated.
+named parts. Both flags can be repeated or comma-separated, but they
+cannot be used together.
 
 ## Flags
 
@@ -51,11 +52,11 @@ Skip confirmation prompts
 
 Overwrite existing files that conflict with whole-file dotfile entries
 
-### `--skip… <SKIP>`
+### `--only… <ONLY>`
 
-Skip one or more bootstrap parts
+Run only one or more bootstrap parts
 
-Can be passed multiple times or as a comma-separated list.
+Can be passed multiple times or as a comma-separated list. Cannot be used with `--skip`.
 
 **Choices:**
 
@@ -69,9 +70,9 @@ Can be passed multiple times or as a comma-separated list.
 - `task`
 - `final-hook`
 
-### `--only… <ONLY>`
+### `--skip… <SKIP>`
 
-Run only one or more bootstrap parts
+Skip one or more bootstrap parts
 
 Can be passed multiple times or as a comma-separated list.
 

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -83,6 +83,27 @@ assert_succeed "mise bootstrap --yes --skip dotfiles --skip task"
 assert_fail "test -e ~/.bootstrap-skip-gitconfig"
 assert_fail "test -f bootstrap_ran"
 
+# --only runs just the selected parts
+echo "only gitconfig content" >gitconfig-only
+rm -f bootstrap_ran
+cat <<EOF >mise.toml
+[tools]
+tiny = "2.4.0"
+
+[dotfiles]
+"~/.bootstrap-only-gitconfig" = "gitconfig-only"
+
+[tasks.bootstrap]
+run = "touch bootstrap_ran"
+EOF
+assert_succeed "mise bootstrap --yes --only dotfiles,task"
+assert "readlink ~/.bootstrap-only-gitconfig" "$PWD/gitconfig-only"
+assert_directory_not_exists "$MISE_DATA_DIR/installs/tiny/2.4.0"
+assert "test -f bootstrap_ran"
+
+# --only and --skip are mutually exclusive
+assert_fail "mise bootstrap --yes --only dotfiles --skip tools"
+
 # --skip dotfiles still reloads config written by earlier phases
 rm -f mise.local.toml config_task_ran
 cat <<'EOF' >mise.toml

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -825,6 +825,10 @@ is skipped, so re\-running is safe. The `bootstrap` task runs on every
 invocation; keep it idempotent. Use it for any project\-specific setup
 that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
+
+Use `\-\-skip <part>` to skip named parts, or `\-\-only <part>` to run just
+named parts. Both flags can be repeated or comma\-separated, but they
+cannot be used together.
 .PP
 \fBUsage:\fR mise bootstrap [OPTIONS] [COMMAND]
 .PP
@@ -839,6 +843,11 @@ Skip confirmation prompts
 .TP
 \fB\-\-force\-dotfiles\fR
 Overwrite existing files that conflict with whole\-file dotfile entries
+.TP
+\fB\-\-only\fR \fI<ONLY>\fR
+Run only one or more bootstrap parts
+
+Can be passed multiple times or as a comma\-separated list. Cannot be used with `\-\-skip`.
 .TP
 \fB\-\-skip\fR \fI<SKIP>\fR
 Skip one or more bootstrap parts

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -313,7 +313,8 @@ that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
 
 Use `--skip <part>` to skip named parts, or `--only <part>` to run just
-named parts. Both flags can be repeated or comma-separated.
+named parts. Both flags can be repeated or comma-separated, but they
+cannot be used together.
 """#
     after_long_help #"""
 Examples:
@@ -332,6 +333,16 @@ Examples:
     flag "-n --dry-run" help="Print what would happen without installing anything"
     flag "-y --yes" help="Skip confirmation prompts"
     flag --force-dotfiles help="Overwrite existing files that conflict with whole-file dotfile entries"
+    flag --only help="Run only one or more bootstrap parts" var=#true {
+        long_help #"""
+Run only one or more bootstrap parts
+
+Can be passed multiple times or as a comma-separated list. Cannot be used with `--skip`.
+"""#
+        arg <ONLY> {
+            choices packages dotfiles defaults launchd systemd user tools task final-hook
+        }
+    }
     flag --skip help="Skip one or more bootstrap parts" var=#true {
         long_help #"""
 Skip one or more bootstrap parts
@@ -339,16 +350,6 @@ Skip one or more bootstrap parts
 Can be passed multiple times or as a comma-separated list.
 """#
         arg <SKIP> {
-            choices packages dotfiles defaults launchd systemd user tools task final-hook
-        }
-    }
-    flag --only help="Run only one or more bootstrap parts" var=#true {
-        long_help #"""
-Run only one or more bootstrap parts
-
-Can be passed multiple times or as a comma-separated list.
-"""#
-        arg <ONLY> {
             choices packages dotfiles defaults launchd systemd user tools task final-hook
         }
     }

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -311,6 +311,9 @@ is skipped, so re-running is safe. The `bootstrap` task runs on every
 invocation; keep it idempotent. Use it for any project-specific setup
 that doesn't fit the declarative sections (cloning repos, seeding
 databases, etc.) — it runs with the installed tools on PATH.
+
+Use `--skip <part>` to skip named parts, or `--only <part>` to run just
+named parts. Both flags can be repeated or comma-separated.
 """#
     after_long_help #"""
 Examples:
@@ -318,6 +321,7 @@ Examples:
     $ mise bootstrap                    # packages + dotfiles + tools + bootstrap task
     $ mise bootstrap --force-dotfiles   # replace conflicting dotfile targets
     $ mise bootstrap --skip tools,task  # skip tool installation and the bootstrap task
+    $ mise bootstrap --only tools       # run just tool installation
     $ mise bootstrap packages install --yes
     $ mise bootstrap macos-defaults status
     $ mise bootstrap launchd apply --dry-run
@@ -335,6 +339,16 @@ Skip one or more bootstrap parts
 Can be passed multiple times or as a comma-separated list.
 """#
         arg <SKIP> {
+            choices packages dotfiles defaults launchd systemd user tools task final-hook
+        }
+    }
+    flag --only help="Run only one or more bootstrap parts" var=#true {
+        long_help #"""
+Run only one or more bootstrap parts
+
+Can be passed multiple times or as a comma-separated list.
+"""#
+        arg <ONLY> {
             choices packages dotfiles defaults launchd systemd user tools task final-hook
         }
     }

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use eyre::Result;
@@ -48,6 +49,9 @@ use clap::{Subcommand, ValueEnum};
 /// invocation; keep it idempotent. Use it for any project-specific setup
 /// that doesn't fit the declarative sections (cloning repos, seeding
 /// databases, etc.) — it runs with the installed tools on PATH.
+///
+/// Use `--skip <part>` to skip named parts, or `--only <part>` to run just
+/// named parts. Both flags can be repeated or comma-separated.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Bootstrap {
@@ -72,6 +76,12 @@ pub struct Bootstrap {
     #[clap(long, value_enum, value_delimiter = ',')]
     skip: Vec<BootstrapPart>,
 
+    /// Run only one or more bootstrap parts
+    ///
+    /// Can be passed multiple times or as a comma-separated list.
+    #[clap(long, value_enum, value_delimiter = ',', conflicts_with = "skip")]
+    only: Vec<BootstrapPart>,
+
     /// Refresh system package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)
     #[clap(long)]
     update: bool,
@@ -88,6 +98,20 @@ enum BootstrapPart {
     Tools,
     Task,
     FinalHook,
+}
+
+impl BootstrapPart {
+    const ALL: [Self; 9] = [
+        Self::Packages,
+        Self::Dotfiles,
+        Self::Defaults,
+        Self::Launchd,
+        Self::Systemd,
+        Self::User,
+        Self::Tools,
+        Self::Task,
+        Self::FinalHook,
+    ];
 }
 
 #[derive(Debug, Subcommand)]
@@ -269,11 +293,7 @@ impl Bootstrap {
         }
         let mut config = Config::get().await?;
         let mut hooks = system::hooks_from_config(&config);
-        let skip = self
-            .skip
-            .iter()
-            .copied()
-            .collect::<std::collections::HashSet<_>>();
+        let skip = self.skip_parts();
 
         if skip.contains(&BootstrapPart::Packages) {
             debug!("bootstrap: system packages skipped");
@@ -438,6 +458,18 @@ impl Bootstrap {
         phase: BootstrapHookPhase,
     ) -> Result<()> {
         hooks::run_phase(hooks, phase, self.dry_run).await
+    }
+
+    fn skip_parts(&self) -> HashSet<BootstrapPart> {
+        if self.only.is_empty() {
+            self.skip.iter().copied().collect()
+        } else {
+            let only = self.only.iter().copied().collect::<HashSet<_>>();
+            BootstrapPart::ALL
+                .into_iter()
+                .filter(|part| !only.contains(part))
+                .collect()
+        }
     }
 
     fn hooks_after_dotfiles_dry_run(
@@ -987,6 +1019,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise bootstrap</bold>                    # packages + dotfiles + tools + bootstrap task
     $ <bold>mise bootstrap --force-dotfiles</bold>   # replace conflicting dotfile targets
     $ <bold>mise bootstrap --skip tools,task</bold>  # skip tool installation and the bootstrap task
+    $ <bold>mise bootstrap --only tools</bold>       # run just tool installation
     $ <bold>mise bootstrap packages install --yes</bold>
     $ <bold>mise bootstrap macos-defaults status</bold>
     $ <bold>mise bootstrap launchd apply --dry-run</bold>

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -51,7 +51,8 @@ use clap::{Subcommand, ValueEnum};
 /// databases, etc.) — it runs with the installed tools on PATH.
 ///
 /// Use `--skip <part>` to skip named parts, or `--only <part>` to run just
-/// named parts. Both flags can be repeated or comma-separated.
+/// named parts. Both flags can be repeated or comma-separated, but they
+/// cannot be used together.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Bootstrap {
@@ -70,17 +71,18 @@ pub struct Bootstrap {
     #[clap(long)]
     force_dotfiles: bool,
 
+    /// Run only one or more bootstrap parts
+    ///
+    /// Can be passed multiple times or as a comma-separated list.
+    /// Cannot be used with `--skip`.
+    #[clap(long, value_enum, value_delimiter = ',', conflicts_with = "skip")]
+    only: Vec<BootstrapPart>,
+
     /// Skip one or more bootstrap parts
     ///
     /// Can be passed multiple times or as a comma-separated list.
     #[clap(long, value_enum, value_delimiter = ',')]
     skip: Vec<BootstrapPart>,
-
-    /// Run only one or more bootstrap parts
-    ///
-    /// Can be passed multiple times or as a comma-separated list.
-    #[clap(long, value_enum, value_delimiter = ',', conflicts_with = "skip")]
-    only: Vec<BootstrapPart>,
 
     /// Refresh system package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)
     #[clap(long)]
@@ -101,6 +103,8 @@ enum BootstrapPart {
 }
 
 impl BootstrapPart {
+    // Keep this in sync with every enum variant. `--only` computes a
+    // complement from ALL, so an omitted variant would always run.
     const ALL: [Self; 9] = [
         Self::Packages,
         Self::Dotfiles,

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -1115,6 +1115,25 @@ const completionSpec: Fig.Spec = {
           isRepeatable: false,
         },
         {
+          name: "--only",
+          description: "Run only one or more bootstrap parts",
+          isRepeatable: true,
+          args: {
+            name: "only",
+            suggestions: [
+              "packages",
+              "dotfiles",
+              "defaults",
+              "launchd",
+              "systemd",
+              "user",
+              "tools",
+              "task",
+              "final-hook",
+            ],
+          },
+        },
+        {
           name: "--skip",
           description: "Skip one or more bootstrap parts",
           isRepeatable: true,


### PR DESCRIPTION
## Summary
- add `mise bootstrap --only <part>` as the inverse of `--skip`
- document the new flag in bootstrap docs and regenerated CLI usage
- cover selected-part execution and `--only`/`--skip` conflict in e2e

## Tests
- `cargo fmt --all -- --check`
- `mise run render:usage` with `CMAKE` supplied by `mise x cmake`
- `mise run test:e2e e2e/cli/test_bootstrap` with `CMAKE` supplied by `mise x cmake`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change to experimental bootstrap CLI; behavior mirrors existing `--skip` paths with clap enforcing mutual exclusion.
> 
> **Overview**
> Adds **`mise bootstrap --only <part>`** so you can run a subset of bootstrap steps without listing everything to **`--skip`**. Part names match **`--skip`** (`packages`, `dotfiles`, `tools`, `task`, etc.); the flag can be repeated or comma-separated. **`--only`** and **`--skip`** are mutually exclusive at the CLI.
> 
> Implementation reuses the existing skip checks: when **`--only`** is set, **`skip_parts()`** builds the skip set as all parts not in the selected list (via a **`BootstrapPart::ALL`** constant that must stay in sync with enum variants). Help text, usage specs, man page, Fig completions, and bootstrap docs are updated; e2e covers selective runs and the flag conflict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a45a00a7cba9a46c248af68e8fb6657056dd104d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise bootstrap` now supports `--only <part>` to run only selected bootstrap phases.
  * `--only` can be repeated and/or provided as a comma-separated list.
  * `--only` and `--skip` are mutually exclusive.

* **Documentation**
  * Updated CLI help, docs, and the manual page to describe `--only`/`--skip`, valid part names, and examples.

* **Testing**
  * Added end-to-end coverage for `--only`, including the mutual exclusivity check.

* **Completion**
  * Updated command completion to include `--only` with valid phase suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->