### PR TITLE
feat(bootstrap): summarize follow-up actions

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -115,6 +115,11 @@ For a dry run:
 mise bootstrap --dry-run
 ```
 
+When `mise bootstrap` applies or would apply something that needs user
+follow-up, it prints a final `bootstrap: follow-up` section. Dry runs use
+`bootstrap: follow-up if applied`. The section is omitted when there is
+nothing actionable to report.
+
 By default, bootstrap refuses dotfile conflicts rather than replacing local
 files. Use `mise bootstrap --force-dotfiles` when you explicitly want the
 dotfiles phase to replace conflicting whole-file dotfile targets.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -116,9 +116,11 @@ mise bootstrap --dry-run
 ```
 
 When `mise bootstrap` applies or would apply something that needs user
-follow-up, it prints a final `bootstrap: follow-up` section. Dry runs use
-`bootstrap: follow-up if applied`. The section is omitted when there is
-nothing actionable to report.
+follow-up, it prints a final `bootstrap: follow-up` section after a successful
+run. Dry runs use `bootstrap: follow-up if applied`. If a later bootstrap phase
+fails after earlier phases already produced follow-up items, mise prints those
+items before returning the error. The section is omitted when there is nothing
+actionable to report.
 
 By default, bootstrap refuses dotfile conflicts rather than replacing local
 files. Use `mise bootstrap --force-dotfiles` when you explicitly want the

--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -142,7 +142,8 @@ mise bootstrap macos-defaults apply --yes     # skip the confirmation prompt
 ## App restarts
 
 Some applications only pick up changed defaults after a relaunch — mise
-prints a reminder after writing. The usual suspects:
+prints a reminder after writing, and top-level `mise bootstrap` includes the
+same reminder in its final follow-up summary. The usual suspects:
 
 ```sh
 killall Dock

--- a/docs/bootstrap/user.md
+++ b/docs/bootstrap/user.md
@@ -17,6 +17,9 @@ runs:
 chsh -s /bin/zsh
 ```
 
+Top-level `mise bootstrap` also includes a final follow-up reminder to start a
+new login session when it changes or would change the login shell.
+
 ## Semantics
 
 `[bootstrap.user].login_shell` follows the same manual, idempotent model as

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -5,6 +5,7 @@ cat <<EOF >mise.toml
 [tools]
 EOF
 assert_succeed "mise bootstrap --yes"
+assert_not_contains "mise bootstrap --yes" "bootstrap: follow-up"
 
 # bootstrap applies dotfiles, installs tools, and runs the
 # `bootstrap` task afterwards, with the installed tools on PATH
@@ -171,6 +172,39 @@ cat <<EOF >mise.toml
 "pacman:bc" = "latest"
 EOF
 assert_succeed "mise bootstrap --dry-run"
+
+# bootstrap prints a final follow-up section for configured parts skipped
+# because they are unavailable on the current platform
+if [[ $(uname) == "Darwin" ]]; then
+  cat <<EOF >mise.toml
+[bootstrap.linux.systemd.units.follow-up-skip]
+description = "skip summary"
+exec_start = "~/.local/bin/skip-summary"
+EOF
+  assert_contains "mise bootstrap --dry-run" "bootstrap: follow-up if applied"
+  assert_contains "mise bootstrap --dry-run" "systemd: 1 unit(s) skipped"
+else
+  cat <<EOF >mise.toml
+[bootstrap.macos.launchd.agents.follow-up-skip]
+program = "~/.local/bin/skip-summary"
+run_at_load = true
+EOF
+  assert_contains "mise bootstrap --dry-run" "bootstrap: follow-up if applied"
+  assert_contains "mise bootstrap --dry-run" "launchd: 1 agent(s) skipped"
+fi
+
+# bootstrap summarizes macOS defaults follow-up when values would be written
+cat <<EOF >mise.toml
+[bootstrap.macos.defaults]
+"dev.mise.e2e.follow-up" = { BootstrapFollowUp = true }
+EOF
+if [[ $(uname) == "Darwin" ]]; then
+  assert_contains "mise bootstrap --dry-run" "bootstrap: follow-up if applied"
+  assert_contains "mise bootstrap --dry-run" 'killall Dock'
+else
+  assert_contains "mise bootstrap --dry-run" "macOS defaults: 1 entry(ies) skipped"
+  assert_not_contains "mise bootstrap --dry-run" 'killall Dock'
+fi
 
 # dotfiles can add config that contributes hooks to later phases in the same run
 mkdir -p dotfiles/mise

--- a/e2e/cli/test_system_login_shell
+++ b/e2e/cli/test_system_login_shell
@@ -27,6 +27,7 @@ EOF
 assert_succeed "mise bootstrap user status --missing"
 assert_contains "mise bootstrap user status --json" '"state": "set"'
 assert_succeed "mise bootstrap --yes"
+assert_not_contains "mise bootstrap --yes" "bootstrap: follow-up"
 assert_fail "test -f '$CHSH_LOG'"
 
 # A local config overrides the global login shell.
@@ -65,6 +66,8 @@ assert_succeed "mise bootstrap packages install --dry-run --yes"
 assert_not_contains "mise bootstrap packages install --dry-run --yes" "chsh -s /tmp/mise-test-shell"
 assert_contains "mise bootstrap user apply --dry-run --yes" "chsh -s /tmp/mise-test-shell"
 assert_contains "mise bootstrap --dry-run --yes" "chsh -s /tmp/mise-test-shell"
+assert_contains "mise bootstrap --dry-run --yes" "bootstrap: follow-up if applied"
+assert_contains "mise bootstrap --dry-run --yes" "start a new login session for /tmp/mise-test-shell to take effect"
 assert_fail "test -f '$CHSH_LOG'"
 assert_fail "grep -q /tmp/mise-test-shell '$MISE_TEST_SHELLS_FILE'"
 

--- a/e2e/cli/test_system_login_shell
+++ b/e2e/cli/test_system_login_shell
@@ -71,7 +71,39 @@ assert_contains "mise bootstrap --dry-run --yes" "start a new login session for 
 assert_fail "test -f '$CHSH_LOG'"
 assert_fail "grep -q /tmp/mise-test-shell '$MISE_TEST_SHELLS_FILE'"
 
+# If a later phase fails after the shell was changed, bootstrap still prints
+# the accumulated follow-up before returning the failure.
+cat <<'EOF' >>mise.toml
+
+[bootstrap.hooks.final]
+run = "exit 7"
+EOF
+failed_bootstrap_status=0
+failed_bootstrap_output="$(MISE_FRIENDLY_ERROR=1 RUST_BACKTRACE=0 mise bootstrap --yes 2>&1)" || failed_bootstrap_status=$?
+if [[ $failed_bootstrap_status -eq 0 ]]; then
+  fail "mise bootstrap --yes succeeded but was expected to fail"
+fi
+assert_contains_text "$failed_bootstrap_output" "bootstrap: follow-up"
+assert_contains_text "$failed_bootstrap_output" "start a new login session for /tmp/mise-test-shell to take effect"
+assert_contains "cat '$MISE_TEST_SHELLS_FILE'" "/tmp/mise-test-shell"
+assert "cat '$CHSH_LOG'" "-s /tmp/mise-test-shell"
+rm -f "$CHSH_LOG"
+
+# If the account shell already matches but is missing from /etc/shells,
+# bootstrap still applies a change and should keep the follow-up visible.
+cat <<EOF >mise.toml
+[bootstrap.user]
+login_shell = "$current"
+EOF
+printf '/tmp/other-shell\n' >"$MISE_TEST_SHELLS_FILE"
+assert_contains "mise bootstrap --dry-run --yes" "chsh -s $current"
+assert_contains "mise bootstrap --dry-run --yes" "start a new login session for $current to take effect"
+
 # Real apply lists the shell first, then invokes chsh with the requested shell.
+cat <<EOF >mise.toml
+[bootstrap.user]
+login_shell = "/tmp/mise-test-shell"
+EOF
 assert_succeed "mise bootstrap user apply --yes"
 assert_contains "cat '$MISE_TEST_SHELLS_FILE'" "/tmp/mise-test-shell"
 assert "cat '$CHSH_LOG'" "-s /tmp/mise-test-shell"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -298,6 +298,7 @@ impl Bootstrap {
         let mut config = Config::get().await?;
         let mut hooks = system::hooks_from_config(&config);
         let skip = self.skip_parts();
+        let mut follow_up = BootstrapFollowUp::new(self.dry_run);
 
         if skip.contains(&BootstrapPart::Packages) {
             debug!("bootstrap: system packages skipped");
@@ -309,6 +310,7 @@ impl Bootstrap {
                 debug!("bootstrap: no [bootstrap.packages] configured, skipping");
             } else {
                 info!("bootstrap: system packages");
+                follow_up.add_package_skips(&mgrs);
                 let opts = DriverOpts {
                     manager: None,
                     explicit: false,
@@ -378,7 +380,18 @@ impl Bootstrap {
                 debug!("bootstrap: no [bootstrap.macos.defaults] configured, skipping");
             } else {
                 info!("bootstrap: system defaults");
-                install::apply_defaults(defaults, self.dry_run, self.yes).await?;
+                let requested = defaults.len();
+                let report =
+                    install::apply_defaults_with_report(defaults, self.dry_run, self.yes, false)
+                        .await?;
+                if report.changed {
+                    follow_up.add_macos_defaults();
+                }
+                if let Some(reason) = report.skipped_reason {
+                    follow_up.add_skipped(format!(
+                        "macOS defaults: {requested} entry(ies) skipped ({reason})"
+                    ));
+                }
             }
             self.run_hooks(&hooks, BootstrapHookPhase::PostDefaults)
                 .await?;
@@ -392,7 +405,13 @@ impl Bootstrap {
                 debug!("bootstrap: no [bootstrap.macos.launchd.agents] configured, skipping");
             } else {
                 info!("bootstrap: launchd agents");
-                install::apply_launchd(agents, self.dry_run, self.yes).await?;
+                let requested = agents.len();
+                let report =
+                    install::apply_launchd_with_report(agents, self.dry_run, self.yes).await?;
+                if let Some(reason) = report.skipped_reason {
+                    follow_up
+                        .add_skipped(format!("launchd: {requested} agent(s) skipped ({reason})"));
+                }
             }
         }
 
@@ -404,7 +423,13 @@ impl Bootstrap {
                 debug!("bootstrap: no [bootstrap.linux.systemd.units] configured, skipping");
             } else {
                 info!("bootstrap: systemd user services");
-                install::apply_systemd(units, self.dry_run, self.yes).await?;
+                let requested = units.len();
+                let report =
+                    install::apply_systemd_with_report(units, self.dry_run, self.yes).await?;
+                if let Some(reason) = report.skipped_reason {
+                    follow_up
+                        .add_skipped(format!("systemd: {requested} unit(s) skipped ({reason})"));
+                }
             }
         }
 
@@ -416,8 +441,24 @@ impl Bootstrap {
             if login_shell.is_none() {
                 debug!("bootstrap: no [bootstrap.user].login_shell configured, skipping");
             } else {
+                let shell = login_shell.as_ref().map(|r| r.shell.clone());
                 info!("bootstrap: login shell");
-                install::apply_login_shell(login_shell, self.dry_run, self.yes)?;
+                let report = install::apply_login_shell_with_report(
+                    login_shell,
+                    self.dry_run,
+                    self.yes,
+                    false,
+                )?;
+                if report.changed
+                    && let Some(shell) = shell.as_ref()
+                {
+                    follow_up.add_login_shell(shell);
+                }
+                if let Some(reason) = report.skipped_reason
+                    && let Some(shell) = shell
+                {
+                    follow_up.add_skipped(format!("login shell {shell}: skipped ({reason})"));
+                }
             }
             self.run_hooks(&hooks, BootstrapHookPhase::PostUser).await?;
         }
@@ -453,6 +494,7 @@ impl Bootstrap {
         } else {
             self.run_hooks(&hooks, BootstrapHookPhase::Final).await?;
         }
+        follow_up.print()?;
         Ok(())
     }
 
@@ -546,6 +588,72 @@ impl Bootstrap {
         }
         .run()
         .await
+    }
+}
+
+struct BootstrapFollowUp {
+    dry_run: bool,
+    items: Vec<String>,
+}
+
+impl BootstrapFollowUp {
+    fn new(dry_run: bool) -> Self {
+        Self {
+            dry_run,
+            items: vec![],
+        }
+    }
+
+    fn add_package_skips(&mut self, mgrs: &[system::ManagerPackages]) {
+        for mp in mgrs {
+            let name = mp.manager.name();
+            let reason = if mp.disabled {
+                Some("excluded by the system_packages.managers setting".to_string())
+            } else if !mp.manager.is_available() {
+                Some(mp.manager.unavailable_reason())
+            } else {
+                None
+            };
+            if let Some(reason) = reason {
+                self.add_skipped(format!(
+                    "{name}: {} package(s) skipped ({reason})",
+                    mp.requests.len()
+                ));
+            }
+        }
+    }
+
+    fn add_macos_defaults(&mut self) {
+        self.items.push(
+            "relaunch apps that read changed macOS defaults (for example: `killall Dock`, \
+             `killall Finder`, `killall SystemUIServer`)"
+                .to_string(),
+        );
+    }
+
+    fn add_login_shell(&mut self, shell: &str) {
+        self.items.push(format!(
+            "start a new login session for {shell} to take effect"
+        ));
+    }
+
+    fn add_skipped(&mut self, message: String) {
+        self.items.push(message);
+    }
+
+    fn print(&self) -> Result<()> {
+        if self.items.is_empty() {
+            return Ok(());
+        }
+        if self.dry_run {
+            miseprintln!("bootstrap: follow-up if applied");
+        } else {
+            miseprintln!("bootstrap: follow-up");
+        }
+        for item in &self.items {
+            miseprintln!("  - {item}");
+        }
+        Ok(())
     }
 }
 

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -384,7 +384,7 @@ impl Bootstrap {
                 let report =
                     install::apply_defaults_with_report(defaults, self.dry_run, self.yes, false)
                         .await?;
-                if report.changed {
+                if report.needs_follow_up {
                     follow_up.add_macos_defaults();
                 }
                 if let Some(reason) = report.skipped_reason {
@@ -449,7 +449,7 @@ impl Bootstrap {
                     self.yes,
                     false,
                 )?;
-                if report.changed
+                if report.needs_follow_up
                     && let Some(shell) = shell.as_ref()
                 {
                     follow_up.add_login_shell(shell);
@@ -594,6 +594,7 @@ impl Bootstrap {
 struct BootstrapFollowUp {
     dry_run: bool,
     items: Vec<String>,
+    printed: bool,
 }
 
 impl BootstrapFollowUp {
@@ -601,6 +602,7 @@ impl BootstrapFollowUp {
         Self {
             dry_run,
             items: vec![],
+            printed: false,
         }
     }
 
@@ -641,7 +643,22 @@ impl BootstrapFollowUp {
         self.items.push(message);
     }
 
-    fn print(&self) -> Result<()> {
+    fn print(&mut self) -> Result<()> {
+        self.printed = true;
+        self.print_inner()
+    }
+
+    fn print_best_effort(&mut self) {
+        if self.printed {
+            return;
+        }
+        self.printed = true;
+        if let Err(err) = self.print_inner() {
+            debug!("bootstrap: failed to print follow-up after error: {err}");
+        }
+    }
+
+    fn print_inner(&self) -> Result<()> {
         if self.items.is_empty() {
             return Ok(());
         }
@@ -654,6 +671,12 @@ impl BootstrapFollowUp {
             miseprintln!("  - {item}");
         }
         Ok(())
+    }
+}
+
+impl Drop for BootstrapFollowUp {
+    fn drop(&mut self) {
+        self.print_best_effort();
     }
 }
 

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -6,7 +6,9 @@ use crate::system;
 
 #[derive(Debug, Default)]
 pub(crate) struct BootstrapApplyReport {
-    pub changed: bool,
+    /// Whether top-level `mise bootstrap` should print a user follow-up item
+    /// for this phase after a successful apply or dry-run.
+    pub needs_follow_up: bool,
     pub skipped_reason: Option<String>,
 }
 
@@ -93,7 +95,7 @@ pub(crate) async fn apply_defaults_with_report(
         let reason = defaults::unavailable_reason();
         debug!("defaults: skipping, {reason}");
         return Ok(BootstrapApplyReport {
-            changed: false,
+            needs_follow_up: false,
             skipped_reason: Some(reason),
         });
     }
@@ -131,7 +133,7 @@ pub(crate) async fn apply_defaults_with_report(
         }
     }
     Ok(BootstrapApplyReport {
-        changed: true,
+        needs_follow_up: true,
         skipped_reason: None,
     })
 }
@@ -160,7 +162,7 @@ pub(crate) fn apply_login_shell_with_report(
         let reason = login_shell::unavailable_reason();
         debug!("login_shell: skipping, {reason}");
         return Ok(BootstrapApplyReport {
-            changed: false,
+            needs_follow_up: false,
             skipped_reason: Some(reason),
         });
     }
@@ -169,7 +171,7 @@ pub(crate) fn apply_login_shell_with_report(
         info!("login_shell: already set to {}", request.shell);
         return Ok(BootstrapApplyReport::default());
     }
-    let needs_new_session = matches!(status.state, LoginShellState::Differs { .. });
+    let needs_follow_up = status.state != LoginShellState::Set;
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("login_shell: run `chsh -s {}`?", request.shell);
         if !crate::ui::prompt::confirm(msg)? {
@@ -189,7 +191,7 @@ pub(crate) fn apply_login_shell_with_report(
         }
     }
     Ok(BootstrapApplyReport {
-        changed: needs_new_session,
+        needs_follow_up,
         skipped_reason: None,
     })
 }
@@ -219,7 +221,7 @@ pub(crate) async fn apply_launchd_with_report(
         let reason = launchd::unavailable_reason();
         debug!("launchd: skipping, {reason}");
         return Ok(BootstrapApplyReport {
-            changed: false,
+            needs_follow_up: false,
             skipped_reason: Some(reason),
         });
     }
@@ -249,7 +251,7 @@ pub(crate) async fn apply_launchd_with_report(
         info!("launchd: installed/loaded {}", list.join(", "));
     }
     Ok(BootstrapApplyReport {
-        changed: true,
+        needs_follow_up: false,
         skipped_reason: None,
     })
 }
@@ -279,7 +281,7 @@ pub(crate) async fn apply_systemd_with_report(
         let reason = systemd::unavailable_reason();
         debug!("systemd: skipping, {reason}");
         return Ok(BootstrapApplyReport {
-            changed: false,
+            needs_follow_up: false,
             skipped_reason: Some(reason),
         });
     }
@@ -309,7 +311,7 @@ pub(crate) async fn apply_systemd_with_report(
         info!("systemd: applied {}", list.join(", "));
     }
     Ok(BootstrapApplyReport {
-        changed: true,
+        needs_follow_up: false,
         skipped_reason: None,
     })
 }

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -4,6 +4,12 @@ use super::driver::{self, Action, DriverOpts};
 use crate::config::{Config, Settings};
 use crate::system;
 
+#[derive(Debug, Default)]
+pub(crate) struct BootstrapApplyReport {
+    pub changed: bool,
+    pub skipped_reason: Option<String>,
+}
+
 /// Install missing system packages from `[bootstrap.packages]`
 ///
 /// Checks which configured packages are missing and installs them with the
@@ -67,14 +73,29 @@ pub(crate) async fn apply_defaults(
     dry_run: bool,
     yes: bool,
 ) -> Result<()> {
+    apply_defaults_with_report(defaults, dry_run, yes, true)
+        .await
+        .map(|_| ())
+}
+
+pub(crate) async fn apply_defaults_with_report(
+    defaults: Vec<system::defaults::DefaultsRequest>,
+    dry_run: bool,
+    yes: bool,
+    print_follow_up: bool,
+) -> Result<BootstrapApplyReport> {
     use crate::system::defaults::{self, DefaultsState};
     if defaults.is_empty() {
-        return Ok(());
+        return Ok(BootstrapApplyReport::default());
     }
     if !defaults::is_available() {
         // cross-platform config: [bootstrap.macos.defaults] is simply inert off-macOS
-        debug!("defaults: skipping, {}", defaults::unavailable_reason());
-        return Ok(());
+        let reason = defaults::unavailable_reason();
+        debug!("defaults: skipping, {reason}");
+        return Ok(BootstrapApplyReport {
+            changed: false,
+            skipped_reason: Some(reason),
+        });
     }
     let statuses = defaults::status(&defaults).await?;
     let targets: Vec<_> = statuses
@@ -87,25 +108,32 @@ pub(crate) async fn apply_defaults(
         info!("defaults: {set} value(s) already set");
     }
     if targets.is_empty() {
-        return Ok(());
+        return Ok(BootstrapApplyReport::default());
     }
     let list = targets.iter().map(|r| r.to_string()).collect::<Vec<_>>();
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("defaults: write {}?", list.join(", "));
         if !crate::ui::prompt::confirm(msg)? {
             info!("defaults: skipped");
-            return Ok(());
+            return Ok(BootstrapApplyReport::default());
         }
     }
     defaults::apply(&targets, dry_run).await?;
     if !dry_run {
-        info!(
-            "defaults: wrote {} — some apps only pick up changes after a relaunch \
-             (e.g. `killall Dock`)",
-            list.join(", ")
-        );
+        if print_follow_up {
+            info!(
+                "defaults: wrote {} — some apps only pick up changes after a relaunch \
+                 (e.g. `killall Dock`)",
+                list.join(", ")
+            );
+        } else {
+            info!("defaults: wrote {}", list.join(", "));
+        }
     }
-    Ok(())
+    Ok(BootstrapApplyReport {
+        changed: true,
+        skipped_reason: None,
+    })
 }
 
 /// Apply `[bootstrap.user].login_shell` when it differs for `mise bootstrap`.
@@ -115,37 +143,55 @@ pub(crate) fn apply_login_shell(
     dry_run: bool,
     yes: bool,
 ) -> Result<()> {
+    apply_login_shell_with_report(request, dry_run, yes, true).map(|_| ())
+}
+
+pub(crate) fn apply_login_shell_with_report(
+    request: Option<system::login_shell::LoginShellRequest>,
+    dry_run: bool,
+    yes: bool,
+    print_follow_up: bool,
+) -> Result<BootstrapApplyReport> {
     use crate::system::login_shell::{self, LoginShellState};
     let Some(request) = request else {
-        return Ok(());
+        return Ok(BootstrapApplyReport::default());
     };
     if !login_shell::is_available() {
-        debug!(
-            "login_shell: skipping, {}",
-            login_shell::unavailable_reason()
-        );
-        return Ok(());
+        let reason = login_shell::unavailable_reason();
+        debug!("login_shell: skipping, {reason}");
+        return Ok(BootstrapApplyReport {
+            changed: false,
+            skipped_reason: Some(reason),
+        });
     }
     let status = login_shell::status(&request)?;
     if status.state == LoginShellState::Set {
         info!("login_shell: already set to {}", request.shell);
-        return Ok(());
+        return Ok(BootstrapApplyReport::default());
     }
+    let needs_new_session = matches!(status.state, LoginShellState::Differs { .. });
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("login_shell: run `chsh -s {}`?", request.shell);
         if !crate::ui::prompt::confirm(msg)? {
             info!("login_shell: skipped");
-            return Ok(());
+            return Ok(BootstrapApplyReport::default());
         }
     }
     login_shell::apply(&request, dry_run)?;
     if !dry_run {
-        info!(
-            "login_shell: set to {} - start a new login session for it to take effect",
-            request.shell
-        );
+        if print_follow_up {
+            info!(
+                "login_shell: set to {} - start a new login session for it to take effect",
+                request.shell
+            );
+        } else {
+            info!("login_shell: set to {}", request.shell);
+        }
     }
-    Ok(())
+    Ok(BootstrapApplyReport {
+        changed: needs_new_session,
+        skipped_reason: None,
+    })
 }
 
 /// Apply `[bootstrap.macos.launchd.agents]` entries that are missing, changed,
@@ -155,13 +201,27 @@ pub(crate) async fn apply_launchd(
     dry_run: bool,
     yes: bool,
 ) -> Result<()> {
+    apply_launchd_with_report(agents, dry_run, yes)
+        .await
+        .map(|_| ())
+}
+
+pub(crate) async fn apply_launchd_with_report(
+    agents: Vec<system::launchd::LaunchdRequest>,
+    dry_run: bool,
+    yes: bool,
+) -> Result<BootstrapApplyReport> {
     use crate::system::launchd::{self, LaunchdState};
     if agents.is_empty() {
-        return Ok(());
+        return Ok(BootstrapApplyReport::default());
     }
     if !launchd::is_available() {
-        debug!("launchd: skipping, {}", launchd::unavailable_reason());
-        return Ok(());
+        let reason = launchd::unavailable_reason();
+        debug!("launchd: skipping, {reason}");
+        return Ok(BootstrapApplyReport {
+            changed: false,
+            skipped_reason: Some(reason),
+        });
     }
     let statuses = launchd::status(&agents).await?;
     let targets: Vec<_> = statuses
@@ -174,21 +234,24 @@ pub(crate) async fn apply_launchd(
         info!("launchd: {loaded} agent(s) already loaded");
     }
     if targets.is_empty() {
-        return Ok(());
+        return Ok(BootstrapApplyReport::default());
     }
     let list = targets.iter().map(|r| r.to_string()).collect::<Vec<_>>();
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("launchd: install/load {}?", list.join(", "));
         if !crate::ui::prompt::confirm(msg)? {
             info!("launchd: skipped");
-            return Ok(());
+            return Ok(BootstrapApplyReport::default());
         }
     }
     launchd::apply(&targets, dry_run).await?;
     if !dry_run {
         info!("launchd: installed/loaded {}", list.join(", "));
     }
-    Ok(())
+    Ok(BootstrapApplyReport {
+        changed: true,
+        skipped_reason: None,
+    })
 }
 
 /// Apply `[bootstrap.linux.systemd.units]` entries that are missing, changed,
@@ -198,13 +261,27 @@ pub(crate) async fn apply_systemd(
     dry_run: bool,
     yes: bool,
 ) -> Result<()> {
+    apply_systemd_with_report(units, dry_run, yes)
+        .await
+        .map(|_| ())
+}
+
+pub(crate) async fn apply_systemd_with_report(
+    units: Vec<system::systemd::SystemdRequest>,
+    dry_run: bool,
+    yes: bool,
+) -> Result<BootstrapApplyReport> {
     use crate::system::systemd;
     if units.is_empty() {
-        return Ok(());
+        return Ok(BootstrapApplyReport::default());
     }
     if !systemd::is_available() {
-        debug!("systemd: skipping, {}", systemd::unavailable_reason());
-        return Ok(());
+        let reason = systemd::unavailable_reason();
+        debug!("systemd: skipping, {reason}");
+        return Ok(BootstrapApplyReport {
+            changed: false,
+            skipped_reason: Some(reason),
+        });
     }
     let statuses = systemd::status(&units).await?;
     let targets: Vec<_> = statuses
@@ -217,21 +294,24 @@ pub(crate) async fn apply_systemd(
         info!("systemd: {applied} unit(s) already applied");
     }
     if targets.is_empty() {
-        return Ok(());
+        return Ok(BootstrapApplyReport::default());
     }
     let list = targets.iter().map(|r| r.to_string()).collect::<Vec<_>>();
     if !dry_run && !yes && console::user_attended_stderr() {
         let msg = format!("systemd: apply {}?", list.join(", "));
         if !crate::ui::prompt::confirm(msg)? {
             info!("systemd: skipped");
-            return Ok(());
+            return Ok(BootstrapApplyReport::default());
         }
     }
     systemd::apply(&targets, dry_run).await?;
     if !dry_run {
         info!("systemd: applied {}", list.join(", "));
     }
-    Ok(())
+    Ok(BootstrapApplyReport {
+        changed: true,
+        skipped_reason: None,
+    })
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(


### PR DESCRIPTION
## Summary
- add a final actionable follow-up summary to top-level `mise bootstrap`
- collect skipped unavailable/disabled bootstrap parts and deferred user actions
- document the summary behavior and cover it in bootstrap/login-shell e2e tests

## Tests
- `mise run format`
- `CMAKE_BIN=$(mise x cmake -- sh -lc 'command -v cmake') && CMAKE="$CMAKE_BIN" PATH="$(dirname "$CMAKE_BIN"):$PATH" mise run test:e2e e2e/cli/test_bootstrap e2e/cli/test_system_login_shell`
- `CMAKE_BIN=$(mise x cmake -- sh -lc 'command -v cmake') && CMAKE="$CMAKE_BIN" PATH="$(dirname "$CMAKE_BIN"):$PATH" mise run lint`

Note: this machine has cmake installed through mise but not active in the repo environment, so the e2e/lint commands explicitly put that cmake on PATH for Cargo's aws-lc-sys build.

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output and orchestration only; apply behavior is largely unchanged aside from deduplicated messaging. Login shell still uses `chsh` as before.
> 
> **Overview**
> Top-level **`mise bootstrap`** now ends with a consolidated **`bootstrap: follow-up`** section (dry runs use **`bootstrap: follow-up if applied`**) listing deferred user actions and skipped cross-platform config, instead of scattering those hints in per-phase logs.
> 
> The summary covers **unavailable or disabled package managers**, **macOS defaults** that need app relaunches, **login shell** changes that need a new session, and **launchd/systemd/defaults/login shell** phases skipped on the wrong OS. Subcommands keep their existing inline reminders via new **`BootstrapApplyReport`** / **`*_with_report`** helpers in **`install.rs`**, which top-level bootstrap calls with **`print_follow_up: false`**.
> 
> If a **later phase fails** after earlier steps queued follow-up items, **`BootstrapFollowUp`’s `Drop`** still prints the accumulated list before the error returns. Docs and e2e tests document and assert when the section appears or is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8475ef5cdb4799c7957909ea296187c4c014edee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise bootstrap` now accumulates and prints a dedicated follow-up summary only when user action is actually needed.
  * Dry runs include “follow-up if applied” messaging for relevant skipped or pending steps.
* **Bug Fixes**
  * Improved follow-up reminders for macOS app restarts, macOS defaults, and login-shell changes (including “start a new login session” when required).
  * Follow-up output is now preserved even when later bootstrap phases fail.
  * Platform-specific skips now show accurate, relevant follow-up content only.
* **Documentation**
  * Updated bootstrap docs to clarify follow-up reminder behavior and ordering across phases.
* **Tests**
  * Expanded e2e coverage for follow-up messaging, dry-run behavior, and platform-unavailable parts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->