### PR TITLE
fix(bootstrap): include shell activation in aggregate status

### DIFF
--- a/e2e/cli/test_bootstrap_shell_activate
+++ b/e2e/cli/test_bootstrap_shell_activate
@@ -10,6 +10,11 @@ bash = false
 EOF
 
 assert_fail "mise bootstrap shell status --missing"
+assert_fail "mise bootstrap status --missing" "zprofile"
+bootstrap_status_json="$(mise bootstrap status --json)"
+assert_contains_text "$bootstrap_status_json" '"mise_shell_activate"'
+assert_contains_text "$bootstrap_status_json" '"target": "zprofile"'
+assert_contains_text "$bootstrap_status_json" '"state": "missing"'
 status_json="$(mise bootstrap shell status --json)"
 assert_contains_text "$status_json" '"shell": "zsh"'
 assert_contains_text "$status_json" '"target": "zprofile"'
@@ -35,6 +40,7 @@ assert_contains "cat ~/.config/fish/config.fish" "mise activate fish | source"
 assert_fail "test -e ~/.bash_profile"
 assert_fail "test -e ~/.bashrc"
 assert_succeed "mise bootstrap shell status --missing"
+assert_succeed "mise bootstrap status --missing"
 status_json="$(mise bootstrap shell status --json)"
 assert_contains_text "$status_json" '"state": "applied"'
 
@@ -42,6 +48,7 @@ sed -i.bak 's/eval "$(mise activate zsh)"/echo changed/' ~/.zshrc
 status_json="$(mise bootstrap shell status --json)"
 assert_contains_text "$status_json" '"state": "differs"'
 assert_contains_text "$status_json" '"reason": "block content differs"'
+assert_fail "mise bootstrap status --missing" "differs"
 
 # idempotent: re-running does not duplicate managed blocks
 assert_succeed "mise bootstrap shell apply --yes"

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -917,6 +917,7 @@ impl BootstrapStatus {
         let mut report = BootstrapStatusReport::new();
         self.collect_packages(config, &mut report).await?;
         self.collect_dotfiles(config, &mut report)?;
+        self.collect_shell(config, &mut report)?;
         self.collect_defaults(config, &mut report).await?;
         self.collect_launchd(config, &mut report).await?;
         self.collect_systemd(config, &mut report).await?;
@@ -1066,6 +1067,36 @@ impl BootstrapStatus {
             "dotfiles".to_string(),
             json!({ "files": json_files, "edits": json_edits }),
         );
+        Ok(())
+    }
+
+    fn collect_shell(
+        &self,
+        config: &Arc<Config>,
+        report: &mut BootstrapStatusReport,
+    ) -> Result<()> {
+        let activations = system::shell_activation_from_config(config);
+        let mut json_entries = vec![];
+        for request in &activations {
+            let state = shell_activation_state(config, request);
+            let missing = state != FileState::Applied;
+            report.row(
+                "shell",
+                request.target.name(),
+                format!(
+                    "{} {} {}",
+                    request.shell.name(),
+                    request.edit.path_raw,
+                    request.mode.name()
+                ),
+                file_state_display(&state),
+                missing,
+            );
+            json_entries.push(shell_activation_json(request, &state));
+        }
+        report
+            .json
+            .insert("mise_shell_activate".to_string(), json!(json_entries));
         Ok(())
     }
 
@@ -1772,23 +1803,10 @@ impl BootstrapShellStatus {
         let mut rows: Vec<Vec<String>> = vec![];
         let mut json_entries = vec![];
         for request in &activations {
-            let state = match system::edits::check(&config, &request.edit) {
-                Ok(state) => state,
-                Err(err) => FileState::Differs(format!("{err}")),
-            };
+            let state = shell_activation_state(&config, request);
             any_missing |= state != FileState::Applied;
             if self.json {
-                let mut entry = json!({
-                    "target": request.target.name(),
-                    "shell": request.shell.name(),
-                    "path": request.edit.path_raw,
-                    "mode": request.mode.name(),
-                    "state": file_state_json(&state),
-                });
-                if let FileState::Differs(reason) = &state {
-                    entry["reason"] = json!(reason);
-                }
-                json_entries.push(entry);
+                json_entries.push(shell_activation_json(request, &state));
             } else {
                 rows.push(vec![
                     request.target.name().to_string(),
@@ -1937,6 +1955,33 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise bootstrap user apply --dry-run</bold>
 "#
 );
+
+fn shell_activation_state(
+    config: &Config,
+    request: &system::shell_activation::ShellActivationRequest,
+) -> FileState {
+    match system::edits::check(config, &request.edit) {
+        Ok(state) => state,
+        Err(err) => FileState::Differs(format!("{err}")),
+    }
+}
+
+fn shell_activation_json(
+    request: &system::shell_activation::ShellActivationRequest,
+    state: &FileState,
+) -> Value {
+    let mut entry = json!({
+        "target": request.target.name(),
+        "shell": request.shell.name(),
+        "path": request.edit.path_raw,
+        "mode": request.mode.name(),
+        "state": file_state_json(state),
+    });
+    if let FileState::Differs(reason) = state {
+        entry["reason"] = json!(reason);
+    }
+    entry
+}
 
 fn file_state_display(state: &FileState) -> String {
     match state {


### PR DESCRIPTION
## Summary
- include `[bootstrap.mise_shell_activate]` in top-level `mise bootstrap status` reports
- make aggregate `--missing` fail for missing or divergent shell activation blocks
- reuse shell activation status JSON/state helpers between aggregate and standalone shell status

## Tests
- `CMAKE=/Users/jdx/.local/share/mise/installs/cmake/4.3.3/cmake-4.3.3-macos-universal/CMake.app/Contents/bin/cmake mise run test:e2e e2e/cli/test_bootstrap_shell_activate`

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI status/reporting only; no change to apply logic or how shell blocks are written.
> 
> **Overview**
> **`mise bootstrap status`** now reports **`[bootstrap.mise_shell_activate]`** alongside other bootstrap parts: table rows under **shell** and a **`mise_shell_activate`** JSON array with the same fields as **`mise bootstrap shell status --json`**.
> 
> **`--missing`** on the aggregate command fails when any configured shell activation block is not **applied** (including **missing** or **differs**), matching standalone shell status behavior.
> 
> State evaluation and JSON entry shape are centralized in **`shell_activation_state`** and **`shell_activation_json`**, used by both aggregate collection and **`BootstrapShellStatus`**. E2E tests assert aggregate JSON and **`--missing`** for shell activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2f139e8385cd2b81a25a861319b581c2a4f1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `mise bootstrap status` now shows shell activation status in a dedicated shell section, including clearer missing/differs results.
  * JSON output now includes shell activation details for each target, with consistent status information.

* **Bug Fixes**
  * Improved detection of shell activation changes so altered shell config blocks are reported as differing.
  * Added coverage for missing shell activation states in bootstrap status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->