### PR TITLE
docs: add mise song page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -234,6 +234,7 @@ export default withMermaid(
           text: "About",
           items: [
             { text: "About mise", link: "/about" },
+            { text: "mise-en-place: The Song", link: "/mise-en-place" },
             { text: "Glossary", link: "/glossary" },
             { text: "FAQs", link: "/faq" },
             { text: "Troubleshooting", link: "/troubleshooting" },

--- a/docs/mise-en-place.md
+++ b/docs/mise-en-place.md
@@ -1,0 +1,49 @@
+# mise-en-place: The Song
+
+<audio controls preload="metadata" src="/mise-en-place.mp3">
+  <a href="/mise-en-place.mp3">Download the MP3</a>
+</audio>
+
+## Lyrics
+
+```text
+I keep a tidy kitchen for the working software engineer,
+Where every runtime's labeled so the shell can find it bright and clear;
+I pin the Node and Python, Rust and Go all reproducibly,
+Then place them in the PATH so every shell behaves predictably.
+
+I read the mise.toml and respect the team's intention there,
+I make the CI match the laptop, terminal, and everywhere;
+No source-build ceremony when a plain old binary will do;
+The work remains ergonomic, repeatable, and practical.
+
+In short, it's Nix for people who have actual work to do now,
+No wrestling stupid flakes to make a shell that simply starts for you;
+The laptop and the CI both become interoperable,
+It's mise-en-place for dev machines: precise and operational.
+
+With hk at the doorway all my hooks are quite dependable,
+And aube can make the Node work feel suspiciously delectable;
+With fnox I keep the secrets out of all dotfiles accidental,
+And pitchfork keeps the daemons running steady, quite instrumental.
+
+They form a tidy lineup for a workflow quite methodical,
+Where every command-line detail turns conveniently practical;
+The hooks, the packages, the secrets, processes, and all of them,
+Are tidied up by mise before I think to make a call of them.
+
+In short, it's Nix for people who have actual work to do now,
+No wrestling stupid flakes to make a shell that simply starts for you;
+The laptop and the CI both become interoperable,
+It's mise-en-place for dev machines: precise and operational.
+
+With aqua I fetch builds where checksums all are verifiable,
+With provenance and policies the pathway is auditable;
+I ask the proper backend for the answer that's most suitable,
+Then lock a concrete version so the build remains repeatable.
+
+From worktrees into CI, every step remains operational,
+Exactly what you'd hope for from any dev-tool professional;
+So raise a tidy terminal, with every tool addressable,
+And start the whole production with the workspace quite impeccable.
+```


### PR DESCRIPTION
## Summary
- add a new docs page for the mise-en-place song with an embedded MP3 player
- include the full lyrics on the page
- add the page to the About sidebar

## Test
- mise run docs:build

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime, auth, or product logic changes.
> 
> **Overview**
> Adds a new **About** docs page, **mise-en-place: The Song**, with an embedded HTML5 audio player pointing at `/mise-en-place.mp3` and the full lyrics in a text block.
> 
> The VitePress sidebar in `docs/.vitepress/config.ts` now links to `/mise-en-place` right after **About mise**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 322ae38651d3784de314dcce9d55435cffa4b3bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “mise-en-place: The Song” page to the documentation site.
  * Included an embedded audio player and lyrics content on the new page.
  * Added a new sidebar link in the About section for easier access to the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->