### PR TITLE
fix(hooks): set MISE_INSTALLED_TOOLS to [] on no-op install (keep running postinstall)

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -59,7 +59,9 @@ postinstall = { run = "echo installed", run_windows = "Write-Output installed" }
 
 For `preinstall` and `postinstall`, `script = ...` is a legacy alias for `run = ...`. If a `shell` is also set on a `script`/`scripts` hook, mise warns that the shell is ignored and still runs the script with the default inline shell. Use `run = ...` with `shell = "bash -c"` to choose the inline shell command. The `script` alias for install hooks is deprecated.
 
-The `postinstall` hook receives a `MISE_INSTALLED_TOOLS` environment variable containing a JSON array of the tools that were just installed:
+A `mise install` that finds nothing to install (all configured tools are already present) still runs the `postinstall` hook — it is not skipped on a no-op install.
+
+The `postinstall` hook receives a `MISE_INSTALLED_TOOLS` environment variable containing a JSON array of the tools that were just installed, or `[]` when nothing was installed (e.g. a no-op install). Hooks that should only act on real installs can guard on `MISE_INSTALLED_TOOLS != "[]"`:
 
 ```toml
 [hooks]

--- a/e2e/config/test_hooks
+++ b/e2e/config/test_hooks
@@ -12,8 +12,10 @@ preinstall = { run = 'echo PREINSTALL' }
 postinstall = { run = 'echo POSTINSTALL' }
 EOF
 
+# preinstall + postinstall hooks fire when installing
 assert_contains "mise i 2>&1" "PREINSTALL"
 assert_contains "mise i dummy@1 2>&1" "POSTINSTALL"
+# `mise i` with nothing missing still runs postinstall (MISE_INSTALLED_TOOLS=[], #10574)
 assert_contains "mise i 2>&1" "POSTINSTALL"
 assert_contains "mise i dummy@1 2>&1" "POSTINSTALL"
 eval "$(mise hook-env)"

--- a/e2e/config/test_hooks_installed_tools
+++ b/e2e/config/test_hooks_installed_tools
@@ -33,3 +33,14 @@ else
   echo "Output: $output"
   exit 1
 fi
+
+# A no-op `mise install` (everything already installed) still runs postinstall,
+# now with an empty JSON array rather than an unset variable (#10574)
+output2=$(mise install 2>&1)
+if [[ $output2 == *'INSTALLED_TOOLS=[]'* ]]; then
+  echo "✓ MISE_INSTALLED_TOOLS is [] on a no-op install"
+else
+  echo "✗ MISE_INSTALLED_TOOLS should be [] on a no-op install"
+  echo "Output: $output2"
+  exit 1
+fi

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -422,11 +422,15 @@ impl Install {
         let (versions, install_error) = if missing.is_empty() {
             measure!("run_postinstall_hook", {
                 info!("all tools are installed");
-                hooks::run_one_hook(
+                // Nothing was installed, but postinstall still runs (idempotent
+                // project setup relies on it); MISE_INSTALLED_TOOLS is [] so hooks
+                // can guard on actual installs. (#10574)
+                hooks::run_one_hook_with_context(
                     &config,
                     config.get_toolset().await?,
                     Hooks::Postinstall,
                     None,
+                    Some(&[]),
                 )
                 .await;
                 (vec![], Ok(()))


### PR DESCRIPTION
## Summary

Addresses discussion #10574. On a no-op `mise install` (every configured tool already installed), the global `postinstall` hook left `MISE_INSTALLED_TOOLS` **unset**, contradicting the docs which promise a JSON array of installed tools.

Per review, this keeps `postinstall` running on every `mise install` — no change to *when* the hook fires (it's commonly relied on for idempotent project setup once the toolchain is ensured, even on a fresh clone that already has every tool installed) — and instead makes `MISE_INSTALLED_TOOLS` **consistently valid JSON**:

- `[]` when nothing was installed (no-op, or all installs failed)
- `[{"name":..,"version":..}, …]` when tools were installed

Hooks that should only act on real installs can guard on `MISE_INSTALLED_TOOLS != "[]"`.

## Change

The only behavioral change is on the no-op path in `src/cli/install.rs`: it now passes an empty installed-tools list (`Some(&[])`) to the postinstall hook instead of `None`, so the env-setter emits `[]` rather than skipping. The earlier skip logic (in `install.rs` and `src/toolset/toolset_install.rs`) is reverted.

## Tests / docs

- `e2e/config/test_hooks_installed_tools`: adds a no-op-install case asserting `MISE_INSTALLED_TOOLS=[]`.
- `e2e/config/test_hooks`: confirms `postinstall` still fires on a no-op `mise install`.
- `docs/hooks.md`: documents that `postinstall` always runs and `MISE_INSTALLED_TOOLS` is `[]` when nothing was installed.

Ref: discussion #10574

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that install commands still run post-install hooks even when nothing new is installed.
  * Updated hook environment variable guidance to show it contains a JSON array, including `[]` for no-op installs.

* **Bug Fixes**
  * Ensured hooks receive an empty installed-tools list during no-op installs, so scripts can reliably detect real installs.
  * Expanded end-to-end checks to verify hook behavior for both no-op and normal install flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->