### PR TITLE
chore: release 2026.6.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [2026.6.15](https://github.com/jdx/mise/compare/v2026.6.14..v2026.6.15) - 2026-06-26
+
+### 🚀 Features
+
+- **(bootstrap)** prune unmanaged brew formulae by @jdx in [#10618](https://github.com/jdx/mise/pull/10618)
+
+### 🐛 Bug Fixes
+
+- **(brew-cask)** handle raw binaries, $APPDIR paths, and app bundle copying by @arthurh4 in [#10626](https://github.com/jdx/mise/pull/10626)
+- **(hooks)** set MISE_INSTALLED_TOOLS to [] on no-op install (keep running postinstall) by @JamBalaya56562 in [#10615](https://github.com/jdx/mise/pull/10615)
+- **(install)** respect lockfile backend during locked installs by @risu729 in [#10599](https://github.com/jdx/mise/pull/10599)
+- **(install)** suggest source install for unsupported arches by @risu729 in [#10627](https://github.com/jdx/mise/pull/10627)
+- **(oci)** resolve host install symlinks and symlinked paths during `PATH` rebasing by @salim-b in [#10624](https://github.com/jdx/mise/pull/10624)
+- stop forcing no-yjit ruby on older glibc by @jdx in [#10620](https://github.com/jdx/mise/pull/10620)
+
+### New Contributors
+
+- @arthurh4 made their first contribution in [#10626](https://github.com/jdx/mise/pull/10626)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (4)
+
+- [`callumalpass/tasknotes-tui`](https://github.com/callumalpass/tasknotes-tui)
+- `glossia.ai/cli`
+- [`ogulcancelik/herdr`](https://github.com/ogulcancelik/herdr)
+- [`pvolok/dekit`](https://github.com/pvolok/dekit)
+
 ## [2026.6.14](https://github.com/jdx/mise/compare/v2026.6.13..v2026.6.14) - 2026-06-25
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.6.14"
+version = "2026.6.15"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.6.14"
+version = "2026.6.15"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.6.14 macos-arm64 (2026-06-25)
+2026.6.15 macos-arm64 (2026-06-26)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_14.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_15.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_14.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_6_15.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_14.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_6_15.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_14.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_6_15.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.6.14";
+  version = "2026.6.15";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.6.14
+Version: 2026.6.15
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.6.14"
+version: "2026.6.15"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "92c705cff220bcc5c3e545eed7f4923281b51942"
+  "tag": "8b9d2c6527205b4a73227cb6d82918408a73f9e5"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -22484,6 +22484,50 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: callumalpass
+    repo_name: tasknotes-tui
+    description: Terminal interface for managing markdown-based tasks
+    files:
+      - name: tasknotes-tui
+        src: tasknotes-tui-{{.Version}}-{{.OS}}-{{.Arch}}/tasknotes-tui
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: tasknotes-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: "true"
+        asset: tasknotes-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: cameron-martin
     repo_name: bazel-lsp
     description: A language server implementation for Bazel
@@ -41734,21 +41778,25 @@ packages:
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
           signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
-  - type: github_release
-    repo_owner: glossia
-    repo_name: cli
+  - type: http
+    name: glossia.ai/cli
     aliases:
-      - name: glossia.ai/cli
+      - name: glossia/cli
+    link: https://glossia.ai/en/docs/reference/cli/
     description: Localize like you ship software
     files:
       - name: glossia
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 0.15.1")
-        version_prefix: cli-v
-        type: http
+      - version_constraint: Version startsWith "cli-v" or Version startsWith "v"
+        error_message: Remove the prefix "cli-v" from the version
+      - version_constraint: Version startsWith "v"
+        error_message: Remove the prefix "v" from the version
+      - version_constraint: semver("<= 0.14.0")
+        error_message: The version is too old. Please upgrade to 0.16.0 or later.
+      - version_constraint: "true"
         windows_arm_emulation: true
-        url: https://glossia-releases.t3.storage.dev/cli/{{.SemVer}}/glossia-{{.OS}}-{{.Arch}}.{{.Format}}
+        url: https://releases.glossia.ai/cli/{{.Version}}/glossia-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
           amd64: x64
         format: tar.gz
@@ -41757,21 +41805,8 @@ packages:
             format: zip
         checksum:
           type: http
-          url: https://glossia-releases.t3.storage.dev/cli/{{.SemVer}}/SHA256SUMS
+          url: https://releases.glossia.ai/cli/{{.Version}}/SHA256SUMS
           algorithm: sha256
-      - version_constraint: "true"
-        asset: glossia-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x64
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
   - type: github_release
     repo_owner: go-acme
     repo_name: lego
@@ -68957,6 +68992,31 @@ packages:
       - name: exa
         src: bin/exa
   - type: github_release
+    repo_owner: ogulcancelik
+    repo_name: herdr
+    description: agent multiplexer that lives in your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.4.0"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: ohkrab
     repo_name: krab
     description: Krab is a migration and automation tool for PostgreSQL based on HCL syntax
@@ -75540,8 +75600,12 @@ packages:
           - darwin
   - type: github_release
     repo_owner: pvolok
-    repo_name: mprocs
+    repo_name: dekit
+    aliases:
+      - name: pvolok/mprocs
     description: Run multiple commands in parallel
+    files:
+      - name: mprocs
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.1")


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** prune unmanaged brew formulae by @jdx in [#10618](https://github.com/jdx/mise/pull/10618)

### 🐛 Bug Fixes

- **(brew-cask)** handle raw binaries, $APPDIR paths, and app bundle copying by @arthurh4 in [#10626](https://github.com/jdx/mise/pull/10626)
- **(hooks)** set MISE_INSTALLED_TOOLS to [] on no-op install (keep running postinstall) by @JamBalaya56562 in [#10615](https://github.com/jdx/mise/pull/10615)
- **(install)** respect lockfile backend during locked installs by @risu729 in [#10599](https://github.com/jdx/mise/pull/10599)
- **(install)** suggest source install for unsupported arches by @risu729 in [#10627](https://github.com/jdx/mise/pull/10627)
- **(oci)** resolve host install symlinks and symlinked paths during `PATH` rebasing by @salim-b in [#10624](https://github.com/jdx/mise/pull/10624)
- stop forcing no-yjit ruby on older glibc by @jdx in [#10620](https://github.com/jdx/mise/pull/10620)

### New Contributors

- @arthurh4 made their first contribution in [#10626](https://github.com/jdx/mise/pull/10626)

## 📦 Aqua Registry Updates

### New Packages (4)

- [`callumalpass/tasknotes-tui`](https://github.com/callumalpass/tasknotes-tui)
- `glossia.ai/cli`
- [`ogulcancelik/herdr`](https://github.com/ogulcancelik/herdr)
- [`pvolok/dekit`](https://github.com/pvolok/dekit)