### PR TITLE
fix: stop forcing no-yjit ruby on older glibc

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -477,10 +477,6 @@ pub static __MISE_DIFF: Lazy<EnvDiff> = Lazy::new(get_env_diff);
 pub static __MISE_ORIG_PATH: Lazy<Option<String>> = Lazy::new(|| var("__MISE_ORIG_PATH").ok());
 pub static __MISE_ZSH_PRECMD_RUN: Lazy<bool> = Lazy::new(|| !var_is_false("__MISE_ZSH_PRECMD_RUN"));
 pub static LINUX_DISTRO: Lazy<Option<String>> = Lazy::new(linux_distro);
-/// Detected glibc version on Linux as (major, minor), e.g. (2, 17).
-/// Returns None on non-Linux or if detection fails.
-#[cfg_attr(windows, allow(dead_code))]
-pub static LINUX_GLIBC_VERSION: Lazy<Option<(u32, u32)>> = Lazy::new(linux_glibc_version);
 pub static PREFER_OFFLINE: Lazy<AtomicBool> =
     Lazy::new(|| prefer_offline(&ARGS.read().unwrap()).into());
 pub static OFFLINE: Lazy<bool> = Lazy::new(|| offline(&ARGS.read().unwrap()));
@@ -800,34 +796,6 @@ fn log_file_level() -> Option<LevelFilter> {
 
 fn linux_distro() -> Option<String> {
     crate::platform::linux_os_release().map(|release| release.id.clone())
-}
-
-#[cfg(target_os = "linux")]
-fn linux_glibc_version() -> Option<(u32, u32)> {
-    let output = std::process::Command::new("ldd")
-        .arg("--version")
-        .output()
-        .ok()?;
-    // ldd --version prints to stdout on glibc, stderr on some systems
-    let text = String::from_utf8_lossy(&output.stdout);
-    let text = if text.is_empty() {
-        String::from_utf8_lossy(&output.stderr)
-    } else {
-        text
-    };
-    let first_line = text.lines().next()?;
-    let version_str = first_line.rsplit(' ').next()?;
-    let mut parts = version_str.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    debug!("detected glibc version: {}.{}", major, minor);
-    Some((major, minor))
-}
-
-#[cfg(not(target_os = "linux"))]
-#[cfg_attr(windows, allow(dead_code))]
-fn linux_glibc_version() -> Option<(u32, u32)> {
-    None
 }
 
 /// Split a colon-separated string into a set, filtering empty segments.

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -535,15 +535,6 @@ impl RubyPlugin {
             .replace("{arch}", arch)
     }
 
-    /// Check if the system needs the no-YJIT variant (glibc < 2.35 on Linux).
-    /// YJIT builds from jdx/ruby require glibc 2.35+.
-    fn needs_no_yjit() -> bool {
-        match *crate::env::LINUX_GLIBC_VERSION {
-            Some((major, minor)) => major < 2 || (major == 2 && minor < 35),
-            None => false, // non-Linux or can't detect, assume modern system
-        }
-    }
-
     /// Extract the build revision tag from existing lock_platforms URLs.
     ///
     /// URLs look like: `.../releases/download/3.3.11-1/ruby-3.3.11...`
@@ -581,14 +572,11 @@ impl RubyPlugin {
     }
 
     /// Find precompiled asset from a GitHub repo's releases.
-    /// On Linux with glibc < 2.35, prefers the no-YJIT variant (.no_yjit.) which
-    /// targets glibc 2.17. Falls back to the standard build if no variant is found.
     async fn find_precompiled_asset_in_repo(
         &self,
         repo: &str,
         version: &str,
         platform: &str,
-        prefer_no_yjit: bool,
         locked_build_revision: Option<&str>,
     ) -> Result<Option<(String, Option<String>)>> {
         let requires_build_revision = Self::source_requires_build_revision(repo);
@@ -636,30 +624,17 @@ impl RubyPlugin {
             );
         }
         let standard_name = format!("ruby-{}.{}.tar.gz", version, platform);
-        let no_yjit_name = format!("ruby-{}.{}.no_yjit.tar.gz", version, platform);
-
-        if prefer_no_yjit {
-            debug!("glibc < 2.35 detected, preferring no-YJIT Ruby variant");
-        }
-
-        let mut standard_asset = None;
-        let mut no_yjit_asset = None;
 
         for asset in &release.assets {
-            if no_yjit_asset.is_none() && asset.name == no_yjit_name {
-                no_yjit_asset = Some((asset.browser_download_url.clone(), asset.digest.clone()));
-            } else if standard_asset.is_none() && asset.name == standard_name {
-                standard_asset = Some((asset.browser_download_url.clone(), asset.digest.clone()));
+            if asset.name == standard_name {
+                return Ok(Some((
+                    asset.browser_download_url.clone(),
+                    asset.digest.clone(),
+                )));
             }
         }
 
-        if prefer_no_yjit {
-            if no_yjit_asset.is_some() {
-                return Ok(no_yjit_asset);
-            }
-            debug!("no-YJIT variant not found, falling back to standard build");
-        }
-        Ok(standard_asset)
+        Ok(None)
     }
 
     /// Resolve precompiled binary URL and checksum for a given version and platform
@@ -667,7 +642,6 @@ impl RubyPlugin {
         &self,
         version: &str,
         platform: &str,
-        prefer_no_yjit: bool,
         locked_build_revision: Option<&str>,
     ) -> Result<Option<(String, Option<String>)>> {
         let settings = Settings::get();
@@ -681,14 +655,8 @@ impl RubyPlugin {
             )))
         } else {
             // GitHub repo shorthand (default: "jdx/ruby")
-            self.find_precompiled_asset_in_repo(
-                source,
-                version,
-                platform,
-                prefer_no_yjit,
-                locked_build_revision,
-            )
-            .await
+            self.find_precompiled_asset_in_repo(source, version, platform, locked_build_revision)
+                .await
         }
     }
 
@@ -747,12 +715,7 @@ impl RubyPlugin {
         let locked_build_revision =
             Self::extract_build_revision_from_lock_platforms(tv, &tv.version);
         let Some((url, checksum)) = self
-            .resolve_precompiled_url(
-                &tv.version,
-                &platform,
-                Self::needs_no_yjit(),
-                locked_build_revision.as_deref(),
-            )
+            .resolve_precompiled_url(&tv.version, &platform, locked_build_revision.as_deref())
             .await?
         else {
             return Ok(None);
@@ -1128,7 +1091,6 @@ impl Backend for RubyPlugin {
                 self.resolve_precompiled_url(
                     &tv.version,
                     &platform,
-                    false,
                     locked_build_revision.as_deref(),
                 )
                 .await?


### PR DESCRIPTION
## Summary
- remove the glibc < 2.35 check that forced precompiled Ruby installs to prefer `.no_yjit` Linux assets
- always resolve the standard `ruby-VERSION.{x86_64,arm64}_linux.tar.gz` asset for the detected Linux platform
- remove the now-unused Linux glibc version detector from `env`

## Notes
This assumes newly built `jdx/ruby` Linux YJIT artifacts are capped at GLIBC_2.17 by the Homebrew-free release pipeline. Existing release assets built before that change may still need to be re-released before this behavior is safe for glibc 2.17-2.34 hosts.

## Verification
- `cargo fmt --check`
- `cargo test plugins::core::ruby::tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ruby version installation by simplifying artifact selection, which should make downloads more consistent across Linux environments.
  * Removed a special-case fallback that could choose alternate Ruby builds, reducing unexpected install behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which precompiled binary Linux users download; older glibc systems may get standard YJIT builds that fail at runtime until `jdx/ruby` assets are rebuilt, but there is no auth or data-path impact.
> 
> **Overview**
> **Linux precompiled Ruby installs** no longer run `ldd --version` or compare glibc to 2.35. The `LINUX_GLIBC_VERSION` static and `linux_glibc_version()` helper are removed from `env`.
> 
> **Asset resolution** in the Ruby core plugin is simplified: `needs_no_yjit()`, the `prefer_no_yjit` parameter, and logic that preferred `ruby-{version}.{platform}.no_yjit.tar.gz` with fallback to the standard tarball are gone. `find_precompiled_asset_in_repo` now returns only the standard `ruby-{version}.{platform}.tar.gz` name from GitHub releases (install and lockfile resolution use the same path).
> 
> This assumes current `jdx/ruby` YJIT Linux builds are compatible with older glibc (e.g. GLIBC_2.17); hosts on glibc 2.17–2.34 may still break if release assets predate that pipeline change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a2c024ecc72668cdc510ab3f2f48ee29b6306ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->