### PR TITLE
fix(oci): resolve host install symlinks and symlinked paths during `PATH` rebasing

### DIFF
--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -529,7 +529,7 @@ impl Builder {
         // install dir.
         let mut path_entries: Vec<String> = Vec::new();
         for (backend, tv) in versions {
-            let install_path = tv.install_path();
+            let install_path = crate::file::canonicalize_or_self(&tv.install_path());
             let in_image_tool_root = tool_in_image_path(mount_point, tv);
             let bin_paths = backend
                 .list_bin_paths(&self.cfg, tv)
@@ -537,6 +537,7 @@ impl Builder {
                 .unwrap_or_default();
             let mut had_one = false;
             for p in bin_paths {
+                let p = crate::file::canonicalize_or_self(&p);
                 if let Ok(rel) = p.strip_prefix(&install_path) {
                     let rel = rel.to_string_lossy();
                     let entry = if rel.is_empty() {


### PR DESCRIPTION
Fixes `mise oci build/run` on immutable systems like Bluefin where `/home` is a symlink (to `/var/home`).

# Problem diagnostics:

1. In `src/oci/builder.rs`, the system `PATH` is constructed by prepending each tool's bin directories. For each tool, `mise` fetches the bin paths from the backend using `backend.list_bin_paths()`, which returns absolute host directories.
2. `mise` then tries to strip the host's `tv.install_path()` prefix from these paths using `p.strip_prefix(&install_path)` to compute the relative directory structure inside the container.
3. On systems with symlinked home directories like Bluefin / Fedora Silverblue, which symlinks `/home` to `/var/home`:
   * `tv.install_path()` might resolve to one variation (e.g., starting with `/var/home/...`).
   * `backend.list_bin_paths()` might return candidates resolving to the other (e.g., starting with `/home/...`).
   * Since `p.strip_prefix(&install_path)` is a simple path-component match, the mismatch in `/home` vs `/var/home` prevents the prefix from being matched.
4. When `strip_prefix` fails, `mise oci` silently falls back to appending `{tool_in_image_root}/bin` to the `PATH`.
5. However, `age` does not have a `/bin` directory—its binaries are stored directly in `{install_root}/age/` (e.g., `/var/home/salim/.local/share/mise/installs/age/1.3.1/age/age`). Hence, `/mise/installs/age/1.3.1/bin` was added to `PATH` (which is empty/non-existent), leaving the actual `age` binary unreachable via the `PATH`.

# Solution

Canonicalize (resolve) each path using `crate::file::canonicalize_or_self()` before comparison.

*Assisted by Goose with Gemini 3.5 Flash*