### PR TITLE
fix(install): suggest source install for unsupported arches

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -38,8 +38,6 @@ unsupported_arch() {
   warn "mise does not provide prebuilt binaries for this platform."
   warn "If Rust/Cargo is available, install from source with:"
   warn "  cargo install --locked mise"
-  warn ""
-  warn "Or provide a compatible tarball with MISE_TARBALL_URL."
   exit 1
 }
 #endregion

--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -30,6 +30,18 @@ error() {
   echo "$@" >&2
   exit 1
 }
+
+unsupported_arch() {
+  arch="$1"
+  warn "unsupported architecture: $arch"
+  warn ""
+  warn "mise does not provide prebuilt binaries for this platform."
+  warn "If Rust/Cargo is available, install from source with:"
+  warn "  cargo install --locked mise"
+  warn ""
+  warn "Or provide a compatible tarball with MISE_TARBALL_URL."
+  exit 1
+}
 #endregion
 
 #region environment setup
@@ -67,7 +79,7 @@ get_arch() {
   elif [ "$arch" = armv7l ]; then
     echo "armv7$musl"
   else
-    error "unsupported architecture: $arch"
+    unsupported_arch "$arch"
   fi
 }
 


### PR DESCRIPTION
## Summary
- add a clearer unsupported-architecture message to the standalone installer
- suggest `cargo install --locked mise` for platforms without prebuilt artifacts
- mention `MISE_TARBALL_URL` for users with a compatible custom tarball

## Testing
- `{ sed '/^install_mise$/,$d' packaging/standalone/install.envsubst; printf '%s\\n' 'unsupported_arch loongarch64'; } | sh`
- `mise x shellcheck -- shellcheck -e SC2016 packaging/standalone/install.envsubst`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the unsupported-architecture installation warning with clearer details that no prebuilt binaries are available.
  * Added an install-from-source alternative (via `cargo install --locked …`) when running on unsupported platforms.
  * The installer now consistently prints the warning and exits immediately after the message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->