### PR TITLE
fix(watch): forward --ignore, --ignore-file, and --print-events to watchexec

### DIFF
--- a/e2e/cli/test_watch_ignore
+++ b/e2e/cli/test_watch_ignore
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Regression test for #7776: --ignore / --ignore-file / --print-events are
+# parsed by `mise watch` but must be forwarded onto the watchexec command line
+# it builds. We assert on the `$ watchexec ...` line that mise logs (with
+# MISE_DEBUG=1) right before spawning watchexec.
+
+mise use -g watchexec@latest
+mise tasks add example -- echo 'running example'
+
+echo 'spec/**/*.rb' >.mise-watch-ignore
+
+output_file=.watch_ignore_output
+rm -f "${output_file}"
+
+MISE_DEBUG=1 mise watch --ignore 'spec/**/*.rb' --ignore-file .mise-watch-ignore --print-events example >"${output_file}" 2>&1 &
+PID_TO_KILL=$!
+
+# Wait for the constructed watchexec command line to be logged. Anchor on the
+# exact `$ watchexec ` debug prefix (debug!("$ watchexec {}", ...)) so unrelated
+# output mentioning "watchexec" (e.g. tool-resolution logs) can't satisfy the
+# loop early and kill the process before the command line is flushed.
+for _ in $(seq 1 40); do
+  grep -Fq '$ watchexec ' "${output_file}" && break
+  sleep 0.5
+done
+
+kill -SIGINT "$PID_TO_KILL" 2>/dev/null || true
+
+assert_contains "cat ${output_file}" "--ignore spec/**/*.rb"
+assert_contains "cat ${output_file}" "--ignore-file .mise-watch-ignore"
+assert_contains "cat ${output_file}" "--print-events"

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -190,6 +190,26 @@ impl Watch {
             args.push("--watch-file".to_string());
             args.push(watch_file.to_string_lossy().to_string());
         }
+        // Forward user-supplied filtering/debug flags that are parsed into
+        // WatchexecArgs but were never re-emitted onto the watchexec command
+        // line (#7776). watchexec unions repeated --ignore flags, so these
+        // combine with the source-derived ignores pushed below rather than
+        // clobbering them.
+        if !self.watchexec.ignore_patterns.is_empty() {
+            for pattern in &self.watchexec.ignore_patterns {
+                args.push("--ignore".to_string());
+                args.push(pattern.to_string());
+            }
+        }
+        if !self.watchexec.ignore_files.is_empty() {
+            for path in &self.watchexec.ignore_files {
+                args.push("--ignore-file".to_string());
+                args.push(path.to_string_lossy().to_string());
+            }
+        }
+        if self.watchexec.print_events {
+            args.push("--print-events".to_string());
+        }
         // Filter anchor: the path that --project-origin is set to and that
         // every glob filter is made relative to. watchexec interprets -f
         // patterns relative to the origin and silently rejects absolute


### PR DESCRIPTION
## Problem

`mise watch --ignore 'spec/**/*.rb' ...` has no effect — files matching the
pattern still trigger a restart (reported in discussion #7776).

`mise watch` is not a transparent pass-through to `watchexec`. It declares the
watchexec flags itself (`#[clap(flatten)] watchexec: WatchexecArgs`), parses
them, then **rebuilds** a fresh `watchexec ... -- mise run <task>` command line
in `Watch::run()`. Every flag has to be explicitly re-emitted there, and three
were parsed but never forwarded:

- `--ignore` → `WatchexecArgs::ignore_patterns`
- `--ignore-file` → `WatchexecArgs::ignore_files`
- `--print-events` → `WatchexecArgs::print_events`

The reporter's own `mise watch -v` debug log confirms it: the constructed
`watchexec --restart --exts .rb -- mise run ...` line contains `--exts` /
`--restart` (which have forwarding branches) but not `--ignore`.

Note: the existing `--ignore` push only emits the **auto-derived** ignores
computed from task sources (`merge_watch_patterns`), not the user's
`ignore_patterns` — a name collision that hid the missing forwarding.

## Fix

Add the three missing forwarding branches in `Watch::run()`, matching the
existing flag-forwarding style and the earlier #10392 (`--wrap-process`) fix for
the same class of bug. The user's `--ignore` patterns are emitted as an
additional `--ignore` occurrence; watchexec unions repeated `--ignore` flags, so
they combine with the source-derived ignores rather than clobbering them (the
existing auto-ignore block is untouched).

Scope is deliberately limited to the three flags named in the discussion to keep
the change minimal; other unforwarded `WatchexecArgs` flags are out of scope.

## Test

Adds `e2e/cli/test_watch_ignore`, which runs `mise watch` with the three flags
and asserts they appear on the constructed watchexec command line (the
`$ watchexec ...` line mise logs under `MISE_DEBUG=1`).

Resolves the issue reported in discussion #7776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `mise watch` now properly forwards user-specified watch filtering and debug options to the underlying watcher, including `--ignore` patterns, `--ignore-file`, and `--print-events`.
  * Improved behavior when combining these flags together.
* **Tests**
  * Added an end-to-end regression test covering correct argument forwarding for `--ignore`, `--ignore-file`, and `--print-events`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->