### PR TITLE
fix(install-into): refuse to overwrite a non-empty target directory without --yes

### DIFF
--- a/e2e/cli/test_install_into
+++ b/e2e/cli/test_install_into
@@ -2,3 +2,13 @@
 
 assert "mise install-into node@22.0.0 ./mynode"
 assert "./mynode/bin/node -v" "v22.0.0"
+
+# #8115: must not clobber a non-empty, non-mise directory
+mkdir -p ./not_empty
+echo data >./not_empty/keep.txt
+assert_fail "MISE_YES=0 mise install-into node@22.0.0 ./not_empty"
+assert "cat ./not_empty/keep.txt" "data" # contents preserved (no rm -rf)
+
+# explicit opt-in via global --yes overrides the guard
+assert "mise install-into node@22.0.0 ./not_empty --yes"
+assert "./not_empty/bin/node -v" "v22.0.0"

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -1,11 +1,17 @@
 use crate::cli::args::ToolArg;
-use crate::config::Config;
+use crate::config::{Config, Settings};
+use crate::file::display_path;
 use crate::install_context::InstallContext;
 use crate::toolset::ToolsetBuilder;
 use crate::ui::multi_progress_report::MultiProgressReport;
+use crate::ui::prompt;
 use clap::ValueHint;
-use eyre::{Result, eyre};
-use std::{path::PathBuf, sync::Arc};
+use console::style;
+use eyre::{Result, bail, eyre};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// Install a tool version to a specific path
 ///
@@ -53,8 +59,45 @@ impl InstallInto {
             before_date,
         };
         tv.install_path = Some(self.path.clone());
+        // install-into force-reinstalls, which uninstalls (rm -rf) whatever
+        // already exists at the install path. Check immediately before the
+        // install performs that deletion (rather than at the start of `run`) so
+        // a directory that became non-empty during tool resolution can't be
+        // clobbered without an explicit opt-in. Refuse to overwrite a non-empty
+        // directory (e.g. `.`) unless the user passes -y/--yes or confirms
+        // interactively; the prompt defaults to "no" since it is destructive.
+        // (#8115)
+        if path_has_contents(&self.path) {
+            let proceed = Settings::get().yes
+                || prompt::confirm_with_default(
+                    format!(
+                        "{} is not empty; install-into will delete its contents. Continue?",
+                        display_path(&self.path)
+                    ),
+                    false,
+                )?;
+            if !proceed {
+                bail!(
+                    "refusing to overwrite non-empty directory {}; pass {} or choose an empty/new path",
+                    display_path(&self.path),
+                    style("--yes").yellow().for_stderr()
+                );
+            }
+        }
         backend.install_version(install_ctx, tv).await?;
         Ok(())
+    }
+}
+
+/// True if `path` exists and is anything other than an empty directory
+/// (a non-empty directory, or a regular file). Empty/new paths return false.
+fn path_has_contents(path: &Path) -> bool {
+    match std::fs::read_dir(path) {
+        Ok(mut entries) => entries.next().is_some(), // non-empty dir
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false, // missing -> false
+        // A file (NotADirectory) or an unreadable dir (e.g. PermissionDenied):
+        // err toward "occupied" so we never silently clobber it.
+        Err(_) => path.exists(),
     }
 }
 


### PR DESCRIPTION
## Problem

`mise install-into <tool> <dir>` `rm -rf`s the contents of an existing target
directory without any confirmation (discussion #8115). Running
`mise install-into kubectl@latest .` wipes the current directory — the reporter
lost their `.git` — and with `.` it even fails mid-delete.

Root cause: `src/cli/install_into.rs` hardcodes `force: true` and sets
`tv.install_path = Some(<user path>)`, then calls `install_version`. There,
`will_uninstall = ctx.force && self.is_version_installed(...)` is true for *any*
existing path (`is_version_installed` only checks `install_path.exists()`), so
`uninstall_version` → `remove_all` → `fs::remove_dir_all` deletes the directory.

## Fix

Guard `install-into` before it installs: if the target path already has contents
(a non-empty directory or a file), refuse to proceed unless the user explicitly
opts in via the global `-y/--yes` flag or an interactive confirmation. Empty or
non-existent paths are unaffected, so `install-into ./fresh-dir` keeps working.

This reuses the existing `Settings::get().yes` + `ui::prompt::confirm` pattern
(as in `implode` / `system install`), which returns `false` in non-interactive
contexts — so CI/non-interactive runs fail safely instead of deleting data. No
new CLI flag is introduced, so no docs/completions regeneration is required.

## Trade-off

Re-running `install-into` into a directory that already holds a previous output
now requires `--yes` (or an empty/fresh path). This is the intended safety
trade-off and matches the reporter's suggestion.

## Test

Extends `e2e/cli/test_install_into`: installing into a non-empty directory now
fails and leaves the existing file intact, while `--yes` overrides the guard and
installs successfully.

Resolves the issue reported in discussion #8115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `install-into` now performs an overwrite safety check right before installation. If the destination path already exists and contains data (including existing files), the command will refuse to proceed unless you confirm interactively or use `--yes`. It also advises using an empty/new path.

* **Tests**
  * Added/extended an end-to-end CLI test to ensure a non-empty target directory isn’t clobbered: verifies failure without `--yes`, preserves existing sentinel contents, and confirms successful installation with `--yes` (including the expected Node version).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->