### PR TITLE
fix(config): preserve set values in config set

### DIFF
--- a/docs/cli/config/set.md
+++ b/docs/cli/config/set.md
@@ -44,7 +44,7 @@ Examples:
 $ mise config set tools.python 3.12
 $ mise config set settings.always_keep_download true
 $ mise config set env.TEST_ENV_VAR ABC
-$ mise config set settings.disable_tools --type list node,rust
+$ mise config set settings.disable_tools node,rust
 
 # Type for `settings` is inferred
 $ mise config set settings.jobs 4

--- a/e2e/cli/test_config_set
+++ b/e2e/cli/test_config_set
@@ -13,6 +13,21 @@ mise config set env._.python.venv.path '.venv'
 assert "mise config get env._.python.venv.path" ".venv"
 mise config set env._.python.venv.create true
 assert "mise config get env._.python.venv.create" "true"
+mise config set settings.disable_tools node,rust,node
+assert "mise config get settings.disable_tools" '["node", "rust"]'
+assert_contains "cat mise.toml" 'disable_tools = ["node", "rust"]'
+mise config set settings.disable_tools ""
+assert "mise config get settings.disable_tools" "[]"
+mise config set settings.disable_tools node
+mise config set settings.disable_tools "[]"
+assert "mise config get settings.disable_tools" "[]"
+mise config set settings.disable_tools node
+mise config set settings.disable_tools " [] "
+assert "mise config get settings.disable_tools" "[]"
+mise config set settings.disable_tools "node,, rust,"
+assert "mise config get settings.disable_tools" '["node", "rust"]'
+mise config set settings.task.skip build,test,build
+assert "mise config get settings.task.skip" '["build", "test"]'
 
 # test "config set key=value" format
 mise config set env._.python.venv.path=.venv2

--- a/e2e/cli/test_settings_set
+++ b/e2e/cli/test_settings_set
@@ -6,6 +6,10 @@ mise settings set always_keep_download y
 assert "mise settings get always_keep_download" "true"
 mise settings set status.missing_tools never
 assert "mise settings get status.missing_tools" 'never'
+mise settings set disable_tools "node,, rust,node"
+assert "mise settings get disable_tools" '["node", "rust"]'
+mise settings set disable_tools " [] "
+assert "mise settings get disable_tools" "[]"
 mise settings set plugin_autoupdate_last_check_duration 1
 assert "mise settings get plugin_autoupdate_last_check_duration" '1'
 mise settings set all_compile 1

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -847,7 +847,7 @@ Examples:
     $ mise config set tools.python 3.12
     $ mise config set settings.always_keep_download true
     $ mise config set env.TEST_ENV_VAR ABC
-    $ mise config set settings.disable_tools --type list node,rust
+    $ mise config set settings.disable_tools node,rust
 
     # Type for `settings` is inferred
     $ mise config set settings.jobs 4

--- a/src/cli/config/set.rs
+++ b/src/cli/config/set.rs
@@ -95,11 +95,9 @@ impl ConfigSet {
         };
         let type_to_use = match self.type_ {
             TomlValueTypes::Infer => {
-                let expected_type = if !full_key.starts_with("settings.") {
-                    None
-                } else {
-                    SETTINGS_META.get(*last_key)
-                };
+                let expected_type = full_key
+                    .strip_prefix("settings.")
+                    .and_then(|key| SETTINGS_META.get(key));
                 match expected_type {
                     Some(meta) => match meta.type_ {
                         SettingsType::Bool => TomlValueTypes::Bool,
@@ -133,7 +131,13 @@ impl ConfigSet {
                 toml_edit::Item::Value(toml_edit::Value::Array(list))
             }
             TomlValueTypes::Set => {
-                let set = toml_edit::Array::new();
+                let mut set = toml_edit::Array::new();
+                let value = value.trim();
+                if value != "[]" {
+                    for item in value.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                        set.push(item);
+                    }
+                }
                 toml_edit::Item::Value(toml_edit::Value::Array(dedup_toml_array(&set)))
             }
             TomlValueTypes::Infer => bail!("Type not found"),
@@ -160,7 +164,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise config set tools.python 3.12</bold>
     $ <bold>mise config set settings.always_keep_download true</bold>
     $ <bold>mise config set env.TEST_ENV_VAR ABC</bold>
-    $ <bold>mise config set settings.disable_tools --type list node,rust</bold>
+    $ <bold>mise config set settings.disable_tools node,rust</bold>
 
     # Type for `settings` is inferred
     $ <bold>mise config set settings.jobs 4</bold>

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -123,10 +123,16 @@ fn parse_list_by_colon(value: &str) -> Result<toml_edit::Value> {
 }
 
 fn parse_set_by_comma(value: &str) -> Result<toml_edit::Value> {
+    let value = value.trim();
     if value.is_empty() || value == "[]" {
         return Ok(toml_edit::Array::new().into());
     }
-    let array: toml_edit::Array = value.split(',').map(|s| s.trim().to_string()).collect();
+    let array: toml_edit::Array = value
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
     Ok(dedup_toml_array(&array).into())
 }
 


### PR DESCRIPTION
## Summary
- fix `mise config set` for set-typed settings so comma-separated values are preserved and deduplicated instead of writing an empty array
- infer nested `settings.*` metadata using the full key after `settings.`, including keys like `settings.task.skip`
- keep `mise settings set` SetString parsing consistent by trimming entries, dropping empty entries, deduplicating, and treating `[]` as an empty set
- update generated CLI usage docs/spec (`docs/cli/config/set.md` and `mise.usage.kdl`) to show the inferred settings-type path instead of forcing `--type list`

Only SetString parsing is changed; ListString/ListPath parsing is intentionally unchanged.

## Testing
- `mise run test:e2e e2e/cli/test_config_set e2e/cli/test_settings_set`
- `cargo fmt --all -- --check`
- `git diff --check`
- `mise run render:usage`
- `mise run lint`
- `./target/debug/mise config set --help`

*This PR description was updated by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved config and settings input handling so comma-separated values are trimmed, empty entries are ignored, duplicates are removed, and whitespace-wrapped empty lists are handled correctly.
  * `settings.disable_tools` and `settings.task.skip` now normalize more reliably when set through the CLI.

* **Documentation**
  * Updated CLI help and usage examples to show simpler input without requiring an explicit type flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->