### PR TITLE
chore: configure hk pre-commit hook

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -89,6 +89,11 @@ fi
 }
 
 hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = linters
+    }
     ["fix"] {
         fix = true
         steps = linters


### PR DESCRIPTION
## Summary
- add the documented `pre-commit` hook entry to `hk.pkl`
- reuse the existing `linters` steps with `fix = true` and git-backed stashing

## Testing
- `hk run pre-commit --plan --json hk.pkl`
- `hk validate`
- `mise run lint:hk`
- disposable `hk install --mise --json` smoke test

*This PR was generated by an AI coding assistant.*