### PR TITLE
feat: Android asset detection

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -1489,8 +1489,8 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
     }
 
     #[test]
-    fn test_asset_picker_functionality_rust_triplets() {
-        // rust triplet platofmrs contain linux OS for Android binaries
+    fn test_asset_picker_functionality_rust_triplets_with_android() {
+        // rust triplet platforms contain linux as segment in filname for Android binaries
         let assets = vec![
             "tool-1.0.0-aarch64-apple-darwin.zip".to_string(),
             "tool-1.0.0-aarch64-linux-android.zip".to_string(),
@@ -1521,6 +1521,38 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
         assert_eq!(picked, "tool-1.0.0-aarch64-linux-android.zip");
     }
 
+    #[test]
+    fn test_asset_picker_functionality_goreleaser_with_android() {
+        let assets = vec![
+            "tool-1.0.0-android-arm64".to_string(),
+            "tool-1.0.0-linux-amd64".to_string(),
+            "tool-1.0.0-linux-arm64".to_string(),
+            "tool-1.0.0-osx-amd64".to_string(),
+            "tool-1.0.0-osx-arm64".to_string(),
+            "tool-1.0.0-windows-amd64.exe".to_string(),
+            "tool-1.0.0-windows-arm64.exe".to_string(),
+        ];
+
+        let picked = AssetPicker::with_libc("linux".to_string(), "aarch64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "tool-1.0.0-linux-arm64");
+
+        let picked = AssetPicker::with_libc("macos".to_string(), "aarch64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "tool-1.0.0-osx-arm64");
+
+        let picked = AssetPicker::with_libc("windows".to_string(), "aarch64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "tool-1.0.0-windows-arm64.exe");
+
+        let picked = AssetPicker::with_libc("android".to_string(), "aarch64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "tool-1.0.0-android-arm64");
+    }
 
     #[test]
     fn test_asset_scoring() {
@@ -1529,7 +1561,7 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
         let score_linux = picker.score_asset("tool-1.0.0-linux-x86_64.tar.gz");
         let score_windows = picker.score_asset("tool-1.0.0-windows-x86_64.zip");
         let score_linux_arm = picker.score_asset("tool-1.0.0-linux-arm64.tar.gz");
-        let score_android = picker.score_asset("tool-1.0.0-aarch64-linux-android.tar.gz");
+        let score_android = picker.score_asset("tool-1.0.0-x86_64-linux-android.tar.gz");
 
         assert!(
             score_linux > score_windows,

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -32,6 +32,7 @@ pub enum AssetOs {
     Linux,
     Macos,
     Windows,
+    Android,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -57,6 +58,7 @@ impl AssetOs {
             AssetOs::Linux => target == "linux",
             AssetOs::Macos => target == "macos" || target == "darwin",
             AssetOs::Windows => target == "windows",
+            AssetOs::Android => target == "android",
         }
     }
 }
@@ -100,6 +102,7 @@ impl DetectedPlatform {
             AssetOs::Linux => "linux",
             AssetOs::Macos => "macos",
             AssetOs::Windows => "windows",
+            AssetOs::Android => "android",
         };
 
         let arch_str = match self.arch {
@@ -118,6 +121,10 @@ impl DetectedPlatform {
 // Platform detection patterns
 static OS_PATTERNS: LazyLock<Vec<(AssetOs, Regex)>> = LazyLock::new(|| {
     vec![
+        (
+            AssetOs::Android,
+            Regex::new(r"(?i)(?:\b|_)(?:android)(?:\b|_)").unwrap(),
+        ),
         (
             AssetOs::Linux,
             Regex::new(r"(?i)(?:\b|_)(?:linux|manylinux(?:[0-9_]+)?|musllinux(?:[0-9_]+)?|ubuntu|debian|fedora|centos|rhel|alpine|arch)(?:\b|_|32|64|-)")
@@ -1482,12 +1489,47 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
     }
 
     #[test]
+    fn test_asset_picker_functionality_rust_triplets() {
+        // rust triplet platofmrs contain linux OS for Android binaries
+        let assets = vec![
+            "tool-1.0.0-aarch64-apple-darwin.zip".to_string(),
+            "tool-1.0.0-aarch64-linux-android.zip".to_string(),
+            "tool-1.0.0-aarch64-pc-windows-gnu.zip".to_string(),
+            "tool-1.0.0-aarch64-pc-windows-msvc.zip".to_string(),
+            "tool-1.0.0-aarch64-unknown-linux-gnu.zip".to_string(),
+            "tool-1.0.0-aarch64-unknown-linux-musl.zip".to_string(),
+        ];
+
+        let picked = AssetPicker::with_libc("linux".to_string(), "aarch64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "tool-1.0.0-aarch64-unknown-linux-gnu.zip");
+
+        let picked = AssetPicker::with_libc("macos".to_string(), "aarch64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "tool-1.0.0-aarch64-apple-darwin.zip");
+
+        let picked = AssetPicker::with_libc("windows".to_string(), "aarch64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "tool-1.0.0-aarch64-pc-windows-msvc.zip");
+
+        let picked = AssetPicker::with_libc("android".to_string(), "aarch64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "tool-1.0.0-aarch64-linux-android.zip");
+    }
+
+
+    #[test]
     fn test_asset_scoring() {
         let picker = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None);
 
         let score_linux = picker.score_asset("tool-1.0.0-linux-x86_64.tar.gz");
         let score_windows = picker.score_asset("tool-1.0.0-windows-x86_64.zip");
         let score_linux_arm = picker.score_asset("tool-1.0.0-linux-arm64.tar.gz");
+        let score_android = picker.score_asset("tool-1.0.0-aarch64-linux-android.tar.gz");
 
         assert!(
             score_linux > score_windows,
@@ -1502,6 +1544,12 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
             score_linux_arm < 0,
             "Architecture mismatch should be negative, got {}",
             score_linux_arm
+        );
+        // Android Linux triplet should have a negative score
+        assert!(
+            score_android < 0,
+            "Platform mismatch should be negative, got {}",
+            score_android
         );
     }
 
@@ -1570,6 +1618,13 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
             libc: None,
         };
         assert_eq!(platform.to_platform_string(), "windows-x86");
+
+        let platform = DetectedPlatform {
+            os: AssetOs::Android,
+            arch: AssetArch::Arm64,
+            libc: None,
+        };
+        assert_eq!(platform.to_platform_string(), "android-arm64");
     }
 
     #[test]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -75,9 +75,9 @@ impl Platform {
     pub fn validate(&self) -> Result<()> {
         // Validate OS
         match self.os.as_str() {
-            "linux" | "macos" | "windows" => {}
+            "linux" | "macos" | "windows" | "android" => {}
             _ => bail!(
-                "Unsupported OS '{}'. Supported: linux, macos, windows",
+                "Unsupported OS '{}'. Supported: linux, macos, windows, android",
                 self.os
             ),
         }


### PR DESCRIPTION
Since the achievement of having `mise` in Termux packages (https://github.com/jdx/mise/discussions/7026)
I've noticed it does not detect yet Android binaries.

This commit introduces Android asset detection. It expects the `android`
term to be present to pickup the asset. I've not added it as a `fn common_platform()` 
as most tools don't have `linux-android` releases and it would increase the lockfile for all
users with little gains. `Platform` will still accept a valid value as an argument, but it
will not add entries by default on lockfiles unless running on Android as `current`.

I've considered both how `goreleaser` (Go) and `cargo cross` generate
binaries for triplet detection. Rust ecosystem uses
`aarch64-linux-android`, which would trigger the Linux package regex as
well. That is why the Android matcher comes first on the `OS_PATTERNS`.

I've tested this with 2 different packages:

- github:bltavares/opkssh - Go raw binary with `goreleaser` typical GOOS and GOOARCH
- github:bltavares/rotz - Rust .zip with `cross` target triplets

Now `mise x` can downlod the right binary and `.zip`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Android to platform detection to improve asset selection and downloads.
  * Android is now supported across common artifact naming formats, including `android-<arch>` platform strings.

* **Bug Fixes**
  * Platform validation now accepts `android`, and unsupported-OS messaging reflects it.
  * Android-labeled assets are correctly prioritized for Android targets and not favored for non-Android targets.

* **Tests**
  * Expanded platform selection and scoring coverage to include Android for both naming schemes and additional conversion cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->