### PR TITLE
feat: Android cross compilation binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
             target: armv7-unknown-linux-gnueabi
           - name: linux-armv7-musl
             target: armv7-unknown-linux-musleabi
+          - name: android-arm64
+            target: aarch64-linux-android
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install cross

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "961b955a666e25ee5a1091d219128d6e6401e3dab84efb1a2bf6b4035d797b39"
 dependencies = [
  "crmf",
- "der",
+ "der 0.7.10",
  "spki",
  "x509-cert",
 ]
@@ -1580,7 +1580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
 dependencies = [
  "const-oid 0.9.6",
- "der",
+ "der 0.7.10",
  "spki",
  "x509-cert",
 ]
@@ -1930,7 +1930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36fe21b96d5b87f5de4b5b7202ec41c00110ac817ce6728fe75fb2fe5962ed92"
 dependencies = [
  "cms",
- "der",
+ "der 0.7.10",
  "spki",
  "x509-cert",
 ]
@@ -2206,7 +2206,17 @@ dependencies = [
  "const-oid 0.9.6",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -6044,6 +6054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6219,7 +6238,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
+ "der 0.7.10",
  "pkcs8",
  "spki",
 ]
@@ -6230,7 +6249,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "spki",
 ]
 
@@ -6652,9 +6671,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c752d2553c0dc75d6fe041006ac6026b1f9e16c9cd071327a6bb850ce9ea661"
+checksum = "67961cc1ccb170208f10169542752dbe730353a874a13cb0749c13b960d72d5b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -6699,9 +6718,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1057d4a19f6ec09383cd00150a29119aace8e17019891c5a47eda9f1838a5955"
+checksum = "24205a6af611e71f346e5e170c32f00ce1a9b49077f699f18d8404e711dc2209"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6805,9 +6824,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0929ebccbf2e674fe03e4c338da00fccaf36248812675527b7181fb2b6220b5d"
+checksum = "957dbd0e8fb9ed66dce0bd6922914fb8bf795a4334d92e2190f34314a0b1f170"
 dependencies = [
  "configparser",
  "dirs",
@@ -6836,9 +6855,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ab3403a06270c88d721acd0b6c1eca2d3583644620912174af8c0283f75821"
+checksum = "5014e4f5aedcbe01a83a5be0e8669b305adc82cc10985fc83f51c5fe07e0d198"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -6864,9 +6883,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.5"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dae388123a82dac3b091ebe56d26ea4990cca85e92a6e86152378a89422034"
+checksum = "2b4440ad7368a66ddd370a8160d8fb2a4d0a825b7a050f9c421dac350b37bed2"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -6905,9 +6924,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a"
+checksum = "d19145200e8c578be6dca325fbacf375a57f86d4a7ccf85d2d8ee193ddfb10dd"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -6928,9 +6947,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.29.6"
+version = "0.29.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a8db70f13a7841d523b995c2b79669e3045e3e6a711ceb7fa00ffe681e2255"
+checksum = "dbd05b4c6fbad5fae62d1d67c22c2bb411a7d21a026aeb079893df1d6d157a61"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6991,9 +7010,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8905552b6405344ca5470d601d24488ad814f8bf79ae7687ea6137c0047d9192"
+checksum = "9794276d154c19579fe7982ab2c1e9a960f0d51e5e56cd8d9fafe36373a71dd3"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -8273,7 +8292,7 @@ dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "const-oid 0.9.6",
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "pem",
  "rand_core 0.9.5",
@@ -8353,7 +8372,7 @@ dependencies = [
  "cmpv2",
  "cms",
  "const-oid 0.9.6",
- "der",
+ "der 0.7.10",
  "hex",
  "jiff",
  "rand 0.9.4",
@@ -8557,7 +8576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -9581,9 +9600,11 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
+ "der 0.8.0",
  "encoding_rs",
  "flate2",
  "log",
+ "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
@@ -9592,6 +9613,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
+ "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -10536,7 +10558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid 0.9.6",
- "der",
+ "der 0.7.10",
  "sha1 0.10.6",
  "signature",
  "spki",
@@ -10551,7 +10573,7 @@ checksum = "f5ceece934a21607055b7ac5c25adb56a2ff559804b10705dc674d1d838c15e1"
 dependencies = [
  "cmpv2",
  "cms",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,6 +299,8 @@ pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-arm64{ 
 pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-x64{ archive-suffix }"
 [package.metadata.binstall.overrides.armv7-unknown-linux-gnueabihf]
 pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-armv7{ archive-suffix }"
+[package.metadata.binstall.overrides.aarch64-linux-android]
+pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-android-arm64{ archive-suffix }"
 
 [package.metadata.cargo-machete]
 ignored = ["aws-lc-rs", "built", "cfg_aliases", "openssl", "phf_codegen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ native-tls = [
   "ubi/native-tls",
   "vfox/native-tls",
   "xx/native-tls",
-  "self_update/default-tls",
+  "self_update?/default-tls",
 ]
 rustls = [
   "gix/blocking-http-transport-reqwest-rust-tls",
@@ -273,7 +273,7 @@ rustls = [
   "ubi/rustls-tls",
   "vfox/rustls",
   "xx/rustls",
-  "self_update/rustls",
+  "self_update?/rustls",
 ]
 rustls-native-roots = [
   "gix/blocking-http-transport-reqwest-rust-tls",
@@ -284,7 +284,7 @@ rustls-native-roots = [
   "ubi/rustls-tls-native-roots",
   "vfox/rustls-native-roots",
   "xx/rustls-native-roots",
-  "self_update/rustls",
+  "self_update?/rustls",
 ]
 
 [package.metadata.binstall]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ path-absolutize = { version = "3", features = ["unsafe_cache"] }
 petgraph = "0.8"
 phf = "0.13"
 rand = "0.10"
-rattler = { version = "0.45", default-features = false }
+rattler = { version = "0.46", default-features = false }
 rattler_conda_types = { version = "0.47", default-features = false }
 rattler_repodata_gateway = { version = "0.29", default-features = false, features = [
   "gateway",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,6 @@ self_update = { version = "0.44", optional = true, default-features = false, fea
   "compression-flate2",
   "signatures",
   "reqwest",
-  "rustls",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -228,7 +227,6 @@ self_update = { version = "0.44", optional = true, default-features = false, fea
   "compression-zip-deflate",
   "signatures",
   "reqwest",
-  "rustls",
 ] }
 zipsign-api = "0.2"
 winapi = { version = "0.3.9", features = ["consoleapi", "minwindef"] }
@@ -264,6 +262,7 @@ native-tls = [
   "ubi/native-tls",
   "vfox/native-tls",
   "xx/native-tls",
+  "self_update/default-tls",
 ]
 rustls = [
   "gix/blocking-http-transport-reqwest-rust-tls",
@@ -274,6 +273,7 @@ rustls = [
   "ubi/rustls-tls",
   "vfox/rustls",
   "xx/rustls",
+  "self_update/rustls",
 ]
 rustls-native-roots = [
   "gix/blocking-http-transport-reqwest-rust-tls",
@@ -284,6 +284,7 @@ rustls-native-roots = [
   "ubi/rustls-tls-native-roots",
   "vfox/rustls-native-roots",
   "xx/rustls-native-roots",
+  "self_update/rustls",
 ]
 
 [package.metadata.binstall]

--- a/Cross.toml
+++ b/Cross.toml
@@ -42,3 +42,9 @@ image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5"
 
 [target.armv7-unknown-linux-musleabi]
 image = "ghcr.io/cross-rs/armv7-unknown-linux-musleabi:0.2.5"
+
+## Android target
+[target.aarch64-linux-android]
+# Needs to use main to avoid -lunwind error while cross 0.3 is not released
+# https://github.com/cross-rs/cross/issues/1222
+image = "ghcr.io/cross-rs/aarch64-linux-android:main"

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -16,6 +16,9 @@ get_os() {
 	*-windows-*)
 		echo "windows"
 		;;
+	*-linux-android)
+		echo "android"
+		;;
 	*-linux-*)
 		echo "linux"
 		;;
@@ -64,7 +67,7 @@ version=$(./scripts/get-version.sh)
 basename=mise-$version-$os-$arch$suffix
 
 case "$os-$arch" in
-linux-arm*)
+linux-arm*|android-*)
 	# don't use sccache
 	unset RUSTC_WRAPPER
 	;;
@@ -75,7 +78,7 @@ if [[ $os == "linux" ]] && [[ $arch == "armv7" ]]; then
 	features="$features,aws-lc-rs"
 fi
 
-if [[ $os == "linux" ]]; then
+if [[ $os == "linux" ]] || [[ $os == "android" ]]; then
 	cross build --profile=serious --target "$RUST_TRIPLE" --no-default-features --features "$features"
 else
 	cargo build --profile=serious --target "$RUST_TRIPLE" --no-default-features --features "$features"

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -67,13 +67,13 @@ version=$(./scripts/get-version.sh)
 basename=mise-$version-$os-$arch$suffix
 
 case "$os-$arch" in
-linux-arm*|android-*)
+linux-arm* | android-*)
 	# don't use sccache
 	unset RUSTC_WRAPPER
 	;;
 esac
 
-features="vfox/vendored-lua,openssl/vendored,self_update"
+features="self_update,vfox/vendored-lua,openssl/vendored"
 if [[ $os == "android" ]]; then
 	# rustls not yet supported in Android/Termux
 	# https://github.com/rustls/rustls-platform-verifier/issues/219

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -73,13 +73,13 @@ linux-arm*|android-*)
 	;;
 esac
 
-features="vfox/vendored-lua,openssl/vendored"
+features="vfox/vendored-lua,openssl/vendored,self_update"
 if [[ $os == "android" ]]; then
 	# rustls not yet supported in Android/Termux
 	# https://github.com/rustls/rustls-platform-verifier/issues/219
 	features="$features,native-tls"
 else
-	features="$features,rustls-native-roots,self_update"
+	features="$features,rustls-native-roots"
 fi
 
 if [[ $os == "linux" ]] && [[ $arch == "armv7" ]]; then

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -73,7 +73,15 @@ linux-arm*|android-*)
 	;;
 esac
 
-features="rustls-native-roots,self_update,vfox/vendored-lua,openssl/vendored"
+features="vfox/vendored-lua,openssl/vendored"
+if [[ $os == "android" ]]; then
+	# rustls not yet supported in Android/Termux
+	# https://github.com/rustls/rustls-platform-verifier/issues/219
+	features="$features,native-tls"
+else
+	features="$features,rustls-native-roots,self_update"
+fi
+
 if [[ $os == "linux" ]] && [[ $arch == "armv7" ]]; then
 	features="$features,aws-lc-rs"
 fi


### PR DESCRIPTION
This is a followup on https://github.com/jdx/mise/pull/10653 based on the discussion on about enabling mise on Termux/Android (https://github.com/jdx/mise/discussions/7026).

This PR adds the additional configurations on `Cross.toml` and `build-tarball.sh` to cross-compile `mise` to `aarch64-linux-android`. To unblock cross compilation, there were a few dependency modifications to fit the platform:

- Update `ratttler` to pick fix on transitive dependency (https://github.com/conda/rattler/pull/2533)
- Adjust Android builds to use `native-tls` as `rustls` does not yet support Termux CLI (https://github.com/rustls/rustls-platform-verifier/issues/219)
- Adjust `self_update` feature activation to use `native-tls` or `rustls` according to mise's configured feature selection

This commit adds also the Android target triplet to Github Actions release workflow to distribute the Android cross-compiled binary on future updates.

The resulting cross binary passes `mise doctor` and `mise self-update`, ensuring that TLS and Android DNS (which tipically causes issues) are working.

When this PR and https://github.com/jdx/mise/pull/10653 are built together they also pass asset selection for `mise x github:...` on projects with pre-compiled Android binary releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android 64-bit (`aarch64-linux-android` / `android-arm64`) support to the Linux tarball release build and cross-compilation pipeline.

* **Bug Fixes**
  * Improved Android platform detection so the correct TLS/network configuration is applied during release packaging and builds.

* **Chores**
  * Updated build and release metadata: refreshed the dependency version and added an Android-specific download URL override for consistent artifact retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->