### PR TITLE
fix: allow GHCUp to be installed on Windows

### DIFF
--- a/registry/ghcup.toml
+++ b/registry/ghcup.toml
@@ -1,4 +1,3 @@
 backends = ["aqua:haskell/ghcup-hs", "asdf:mise-plugins/mise-ghcup"]
 description = "GHCup is an installer for the general purpose language Haskell"
-os = ["linux", "macos"]
 test = { cmd = "ghcup --version", expected = "The GHCup Haskell installer, version v{{version}}" }


### PR DESCRIPTION
GHCUp on the Aqua registry allows Windows since https://github.com/aquaproj/aqua-registry/pull/55395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a platform restriction so the affected registry entry is no longer limited to specific operating systems.
  * Kept the existing configuration details unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->