### PR TITLE
fix(oci): account for darwin mode stripping

### DIFF
--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -658,11 +658,12 @@ mod tests {
         let helper = bin.join("helper");
         fs::write(&helper, b"#!/bin/sh\necho hi\n").unwrap();
         fs::set_permissions(&helper, fs::Permissions::from_mode(0o4755)).unwrap();
+        let helper_mode = fs::symlink_metadata(&helper).unwrap().permissions().mode() & 0o7777;
 
         let blob = build_layer_from_dir_preserve_metadata(dir.path(), "").unwrap();
 
         assert_layer_mode(&blob, "bin", 0o1777);
-        assert_layer_mode(&blob, "bin/helper", 0o4755);
+        assert_layer_mode(&blob, "bin/helper", helper_mode);
         let md = fs::symlink_metadata(&helper).unwrap();
         assert_layer_entry_owner(&blob, "bin/helper", md.uid() as u64, md.gid() as u64);
     }


### PR DESCRIPTION
## Summary
Fix the Darwin Nix build failure by making the OCI layer test assert the mode that the filesystem actually retains after `set_permissions`.

On this filesystem, the setuid bit is stripped from the test file, so the previous hard-coded `04755` expectation was too strict.

## Verification
- `nix build .#mise --print-build-logs`
- Result: `test result: ok. 1460 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out`

## Notes
- The production layer code was already preserving the metadata that the filesystem exposed.
- This change keeps the sticky-bit check for the directory case and makes the file-mode expectation reflect the platform behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for preserving special permission bits in Unix layer builds by validating the actual helper file permissions instead of relying on a fixed expected value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->