### PR TITLE
fix(shims): don't point shims at a foreign `mise` wrapper on PATH

### DIFF
--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -745,7 +745,7 @@ impl Doctor {
     }
 
     async fn analyze_shims(&mut self, config: &Arc<Config>, toolset: &Toolset) {
-        let mise_bin = file::which_no_shims("mise").unwrap_or(env::MISE_BIN.clone());
+        let mise_bin = file::resolve_mise_bin();
 
         if let Ok((missing, extra)) = shims::get_shim_diffs(config, mise_bin, toolset).await {
             let cmd = style::nyellow("mise reshim");

--- a/src/file.rs
+++ b/src/file.rs
@@ -924,6 +924,58 @@ pub fn which_no_shims<P: AsRef<Path>>(name: P) -> Option<PathBuf> {
     _which(name, &paths)
 }
 
+/// True if `real` (an already symlink-resolved path) is actually the `mise`
+/// binary rather than some foreign program. Split out from
+/// [`resolve_mise_bin`] so the discriminating logic is unit-testable without
+/// touching the filesystem or PATH. The extension is ignored via `file_stem`
+/// (so `mise.exe` counts), and mise's own Windows shim (`mise-shim`) is
+/// accepted.
+fn canonical_is_mise(real: &Path) -> bool {
+    matches!(
+        real.file_stem().and_then(|s| s.to_str()),
+        Some("mise") | Some("mise-shim")
+    )
+}
+
+/// Resolve which `mise` binary the generated shims should point at.
+///
+/// Shims are symlinked to a *stable* `mise` found on PATH rather than to the
+/// running executable, so they survive in-place upgrades where `current_exe()`
+/// is a versioned/transient path — e.g. Homebrew's
+/// `.../Cellar/mise/<version>/bin/mise`, `cargo install`, or self-update
+/// (#1222). [`which_no_shims`] already skips mise's *own* shim dirs to avoid
+/// the `mise -> mise` self-reference reported in #9071.
+///
+/// But that guard only covers mise's own shim dirs. A *foreign* wrapper named
+/// `mise` sitting earlier on PATH (some third-party shim/launcher directory) is
+/// still returned by `which_no_shims`, and pointing every tool shim at it
+/// produces self-referential shims that loop until they error out. Guard
+/// against it: if the candidate does not symlink-resolve to a file actually
+/// named `mise`, treat it as an impostor and fall back to the running
+/// executable ([`env::MISE_BIN`]).
+///
+/// The returned path is the *un-canonicalized* PATH entry when it passes the
+/// check, preserving the upgrade-stability of #1222 — canonicalization is used
+/// only to verify identity, never as the shim target itself.
+pub fn resolve_mise_bin() -> PathBuf {
+    which_no_shims("mise")
+        .filter(|candidate| {
+            let real = canonicalize_or_self(candidate);
+            let ok = canonical_is_mise(&real);
+            if !ok {
+                warn!(
+                    "a program named `mise` on your PATH ({}) resolves to `{}`, which is not \
+                     the mise binary; using the running executable for shims instead. Remove or \
+                     reorder that PATH entry to silence this warning.",
+                    candidate.display(),
+                    real.display()
+                );
+            }
+            ok
+        })
+        .unwrap_or_else(|| env::MISE_BIN.clone())
+}
+
 fn _which<P: AsRef<Path>>(name: P, paths: &[PathBuf]) -> Option<PathBuf> {
     let name = name.as_ref();
     paths.iter().find_map(|path| {
@@ -1754,6 +1806,46 @@ mod tests {
     use crate::config::Config;
 
     use super::*;
+
+    #[test]
+    fn test_canonical_is_mise() {
+        // Real mise binaries are accepted regardless of install path/extension.
+        assert!(canonical_is_mise(Path::new(
+            "/opt/homebrew/Cellar/mise/2026.5.10/bin/mise"
+        )));
+        assert!(canonical_is_mise(Path::new("/home/u/.local/bin/mise")));
+        assert!(canonical_is_mise(Path::new("/usr/bin/mise.exe")));
+        // mise's own Windows shim.
+        assert!(canonical_is_mise(Path::new("/x/shims/mise-shim")));
+        // Foreign wrappers named `mise` (once symlink-resolved) are rejected.
+        assert!(!canonical_is_mise(Path::new("/home/u/.local/bin/vt")));
+        assert!(!canonical_is_mise(Path::new("/opt/wrapper/bin/direnv")));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_resolve_mise_bin_sees_through_foreign_wrapper_symlink() {
+        // A PATH entry literally named `mise` that is really a symlink to a
+        // foreign binary (e.g. another tool's launcher shim) must be seen
+        // through: canonicalize_or_self resolves it to the real target, whose
+        // name is not `mise`, so canonical_is_mise rejects it.
+        let dir = tempfile::tempdir().unwrap();
+        let foreign = dir.path().join("vt");
+        fs::write(&foreign, "#!/bin/sh\n").unwrap();
+        let impostor = dir.path().join("mise");
+        symlink(&foreign, &impostor).unwrap();
+        assert!(!canonical_is_mise(&canonicalize_or_self(&impostor)));
+
+        // A symlink `mise` -> a real file also named `mise` (the legitimate
+        // Homebrew/self-update case) is still accepted.
+        let real_dir = dir.path().join("bin");
+        fs::create_dir_all(&real_dir).unwrap();
+        let real_mise = real_dir.join("mise");
+        fs::write(&real_mise, "#!/bin/sh\n").unwrap();
+        let stable = dir.path().join("stable-mise");
+        symlink(&real_mise, &stable).unwrap();
+        assert!(canonical_is_mise(&canonicalize_or_self(&stable)));
+    }
 
     #[test]
     #[cfg(unix)]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -121,7 +121,7 @@ pub async fn reshim(config: &Arc<Config>, ts: &Toolset, force: bool) -> Result<(
         })
         .lock();
 
-    let mise_bin = file::which_no_shims("mise").unwrap_or(env::MISE_BIN.clone());
+    let mise_bin = file::resolve_mise_bin();
     let mise_bin = mise_bin.absolutize()?; // relative paths don't work as shims
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

`reshim` picks the target that every tool shim is symlinked to via
`file::which_no_shims("mise")`. That helper excludes mise's **own** shim
directories (added in #9071 to fix the `mise -> mise` self-reference when a
`mise` shim exists in mise's shims dir), but it still trusts **any other**
program named `mise` that happens to appear earlier on `PATH`.

If a third-party shim/launcher directory on `PATH` contains a `mise` wrapper —
for example a tool that intercepts `mise exec …` by putting its own `mise`
shim first on `PATH` — then `which_no_shims("mise")` returns that wrapper, and
**every** generated tool shim gets symlinked to it. Running any managed tool
(`node`, `gh`, `lsd`, …) now re-enters the wrapper, which resolves the tool
name back to the same wrapper, and the shim loops until it hits a recursion
guard and errors out. All shims are silently broken, and because mise reshims
automatically (on install/use), it recurs right after any manual fix.

This is the same bug class as #9071, just from a directory that the
`which_no_shims` guard doesn't cover.

## Reproduction

```sh
# A foreign wrapper named `mise` earlier on PATH than the real binary:
mkdir -p /tmp/wrapper && ln -sf "$(command -v some-other-tool)" /tmp/wrapper/mise
export PATH="/tmp/wrapper:$PATH"

mise reshim --force
readlink ~/.local/share/mise/shims/node
#   -> /tmp/wrapper/mise      (should be the real mise binary)
node --version
#   -> loops / recursion-guard error instead of running node
```

Before this change every shim points at `/tmp/wrapper/mise`; after it, mise
warns about the shadowing `mise` and points shims at the running executable.

## Fix

Add `file::resolve_mise_bin()` and route both call sites through it (`reshim`
in `src/shims.rs`, and `analyze_shims` in `src/cli/doctor/mod.rs`, mirroring
#9071). It keeps the existing `which_no_shims("mise")` behavior but validates
the result: if the candidate does **not** symlink-resolve to a file actually
named `mise` (or `mise-shim`), it warns that a non-mise `mise` is shadowing us
and falls back to the running executable (`env::MISE_BIN`).

## Compatibility with #1222

Shims intentionally point at a **stable** `mise` on `PATH` rather than
`current_exe()`, so they survive in-place upgrades where `current_exe()` is a
versioned/transient path (Homebrew `.../Cellar/mise/<version>/bin/mise`,
`cargo install`, self-update). This is preserved: when the candidate passes the
check, the **un-canonicalized** `PATH` entry is returned. Canonicalization is
used **only** to verify identity, never as the shim target. Behavior changes
**only** in the previously-broken case (a foreign `mise` wrapper), where the
running executable is strictly better than a self-referential loop.

## Tests

- `test_canonical_is_mise` — pure discriminator: accepts real mise binaries at
  any install path/extension (incl. `mise.exe`, `mise-shim`), rejects foreign
  names (`vt`, `direnv`).
- `test_resolve_mise_bin_sees_through_foreign_wrapper_symlink` (unix) — a
  `PATH` entry literally named `mise` that is a symlink to a foreign binary is
  rejected after resolution, while a `mise` symlink pointing at a real file
  named `mise` (the Homebrew/self-update case) is still accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the `mise` executable so shim diagnostics and reshimming use the correct binary more reliably.
  * Prevented misleading path resolution when a similarly named executable appears earlier on `PATH`, reducing incorrect shim behavior.
  * Added clearer fallback handling and warnings when the detected executable is not a valid `mise` binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->