### PR TITLE
chore(ci): make nightly rust informational

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -120,11 +120,6 @@ jobs:
             libssl-dev \
             pkg-config
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: stable
-
       - name: Install mise
         run: |
           curl https://mise.run | sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,8 @@ jobs:
   nightly:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux-nightly
     timeout-minutes: 10
+    # Track rolling nightly for early rustc regressions without blocking PRs on upstream compiler ICEs.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -342,10 +344,6 @@ jobs:
           fi
           if [ "${{ needs.unit.result }}" != "success" ]; then
             echo "unit failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.nightly.result }}" != "success" ]; then
-            echo "nightly failed or was skipped"
             exit 1
           fi
           if [ "${{ needs.lint.result }}" != "success" ]; then


### PR DESCRIPTION
## Summary
- Keep the CI `nightly` job on rolling Rust nightly.
- Mark the `nightly` job as `continue-on-error` so upstream rustc nightly regressions still show up without blocking PRs.
- Stop `test-ci` from failing solely because the informational nightly job failed.
- Remove the `dtolnay/rust-toolchain` setup step from `ppa-publish.yml`; the workflow only needs the hosted runner's preinstalled `cargo` for `cargo vendor`, while Launchpad gets `rustc`/`cargo` from the generated `Build-Depends`.

## Context
Recent `test` workflow runs were failing before mise tests ran because `rustc 1.98.0-nightly (f46ec5218 2026-06-30)` ICEs while compiling `rattler_package_streaming`.

I checked whether a rattler bump would be a better fix. `rattler 0.46.0` moves `rattler_package_streaming` from `0.26.5` to `0.26.6`, but both versions still ICE with the same `nightly-2026-07-01` compiler and the same feature set. So this PR keeps nightly coverage rolling, but treats that job as an early-warning signal rather than a required gate.

The `zizmor` run also exposed an unrelated existing workflow issue: `ppa-publish.yml` used a `dtolnay/rust-toolchain` commit that was not in the current upstream branch history. Since workflow changes trigger `zizmor`, this PR removes that third-party setup step entirely.

Failing examples:
- https://github.com/jdx/mise/actions/runs/28529765966
- https://github.com/jdx/mise/actions/runs/28492660284
- https://github.com/jdx/mise/actions/runs/28517308472

## Verification
- `git diff --check`
- `rg -n "dtolnay/rust-toolchain|rustup toolchain install stable|rustup default stable|Set up Rust" .github/workflows/ppa-publish.yml .github/workflows .github/actions || true`
- Confirmed the current `ubuntu-24.04` runner image documents preinstalled Rust/Cargo.
- `cargo +nightly-2026-07-01 check --no-default-features --features native-tls,reqwest,rustls` against `rattler_package_streaming` 0.26.5 reproduces the ICE
- Same check against `rattler_package_streaming` 0.26.6 also reproduces the ICE

`actionlint` was not available locally.

---
This PR was updated by an AI coding assistant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nightly CI job to be non-blocking, so early compiler checks no longer fail the overall workflow.
  * Updated the CI-results gate so it no longer depends on the nightly job outcome.
  * Updated the publish workflow to install the stable Rust toolchain directly via rustup and print Rust/Cargo versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->