### PR TITLE
fix(npm): support allow_builds with npm allow-scripts

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -83,8 +83,8 @@ explicitly. The `allow_builds`, `aube_args`, `pnpm_args`, `bun_args`, and `npm_a
 affect the package manager that is actually used; an approval option for one package manager does
 not change the behavior of another.
 
-For tools that need reviewed dependency build scripts, consider using `aube` or `pnpm` because they
-support package-level build approvals.
+For tools that need reviewed dependency build scripts, use `allow_builds` with `aube`, `pnpm`, or
+npm 11.16.0+.
 
 ### `aube`
 
@@ -140,13 +140,28 @@ script trust:
 
 ### `npm`
 
-`npm` normally runs lifecycle scripts by default and does not provide a native per-dependency build
-approval allowlist in its current docs. mise passes
+`npm` normally runs lifecycle scripts by default. mise passes
 [`--ignore-scripts=true`](https://docs.npmjs.com/cli/v11/using-npm/config/#ignore-scripts) by
 default for npm-backed installs.
 
-You can opt into npm's default script behavior with `npm_args` when you accept that every package in
-the install graph can run lifecycle scripts:
+With npm 11.16.0+, `allow_builds = ["<pkg>"]` is passed as
+[`--allow-scripts=<pkg>`](https://docs.npmjs.com/cli/v11/using-npm/config/#allow-scripts) for
+reviewed global installs. When `allow_builds` is used and npm supports `--allow-scripts`, mise does
+not pass `--ignore-scripts=true` because npm's `ignore-scripts` setting takes precedence over the
+allowlist.
+
+```toml
+[tools]
+"npm:some-tool" = { version = "latest", allow_builds = ["esbuild"] }
+```
+
+Set `allow_builds = true` to pass
+[`--dangerously-allow-all-scripts`](https://docs.npmjs.com/cli/v11/using-npm/config/#dangerously-allow-all-scripts)
+when you explicitly accept that every dependency build script may run.
+
+For older npm versions, mise keeps `--ignore-scripts=true`; use `aube`/`pnpm`, upgrade npm, or opt
+into npm's default script behavior with `npm_args` when you accept that every package in the install
+graph can run lifecycle scripts:
 
 ```toml
 [tools]
@@ -161,8 +176,8 @@ go in `[tools]` in `mise.toml`.
 ### `allow_builds`
 
 Packages whose dependency lifecycle build scripts should be approved when
-`settings.npm.package_manager = "aube"` or `"pnpm"`. Use this instead of spelling out
-`--allow-build` in both `aube_args` and `pnpm_args`.
+`settings.npm.package_manager = "aube"`, `"pnpm"`, or npm 11.16.0+. Use this instead of spelling out
+package-manager-specific approval flags in `aube_args`, `pnpm_args`, or `npm_args`.
 
 For example, to allow one verified dependency build script:
 
@@ -185,8 +200,9 @@ To allow all dependency build scripts for the install:
 "npm:some-tool" = { version = "latest", allow_builds = true }
 ```
 
-`allow_builds` does not affect `npm` or `bun` installs because those package managers do not expose
-the same package-level build approval model for this global install path.
+`allow_builds` does not affect `bun` installs because mise's Bun path is a global install and does
+not write a per-transitive `trustedDependencies` allowlist. For npm installs, `allow_builds`
+requires npm 11.16.0+.
 
 ### `aube_args`
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -31,6 +31,7 @@ use tokio::sync::Mutex as TokioMutex;
 /// of elapsed time between when mise resolved the cutoff and when it invoked
 /// the package manager.
 const BEFORE_DATE_TOLERANCE_SECS: u64 = 60;
+const NPM_ALLOW_SCRIPTS_VERSION: &str = "11.16.0";
 const NPM_MIN_RELEASE_AGE_VERSION: &str = "11.10.0";
 const AUBE_PROGRAM: &str = if cfg!(windows) { "aube.exe" } else { "aube" };
 const BUN_MIN_RELEASE_AGE_VERSION: &str = "1.3.0";
@@ -86,6 +87,12 @@ impl<'a> NpmOptions<'a> {
         match value {
             toml::Value::Boolean(true) => Ok(AllowBuilds::All),
             toml::Value::Boolean(false) => Ok(AllowBuilds::None),
+            toml::Value::String(value) if value.eq_ignore_ascii_case("true") => {
+                Ok(AllowBuilds::All)
+            }
+            toml::Value::String(value) if value.eq_ignore_ascii_case("false") => {
+                Ok(AllowBuilds::None)
+            }
             toml::Value::String(value) => {
                 Ok(Self::canonical_allow_build_packages(vec![value.clone()]))
             }
@@ -115,6 +122,29 @@ impl<'a> NpmOptions<'a> {
                 .map(|package| OsString::from(format!("--allow-build={package}")))
                 .collect(),
         })
+    }
+
+    fn npm_lifecycle_script_args(
+        allow_builds: AllowBuilds,
+        supports_allow_scripts: bool,
+    ) -> (Vec<OsString>, bool) {
+        if !supports_allow_scripts {
+            return (vec![OsString::from(NPM_IGNORE_SCRIPTS_ARG)], true);
+        }
+        match allow_builds {
+            AllowBuilds::None => (vec![OsString::from(NPM_IGNORE_SCRIPTS_ARG)], true),
+            AllowBuilds::All => (
+                vec![OsString::from("--dangerously-allow-all-scripts")],
+                false,
+            ),
+            AllowBuilds::Packages(packages) => (
+                vec![OsString::from(format!(
+                    "--allow-scripts={}",
+                    packages.join(",")
+                ))],
+                false,
+            ),
+        }
     }
 
     fn canonical_allow_build_packages(mut packages: Vec<String>) -> AllowBuilds {
@@ -417,7 +447,22 @@ impl Backend for NPMBackend {
             }
             _ => {
                 let npm_args = options.npm_args().map(shell_words::split).transpose()?;
-                let skipped_lifecycle_scripts = Self::effective_npm_ignore_scripts(&npm_args);
+                let allow_builds = options.allow_builds()?;
+                let allow_builds_requested = !matches!(allow_builds, AllowBuilds::None);
+                let supports_allow_scripts = allow_builds_requested
+                    && self.npm_supports_allow_scripts_flag(&ctx.config).await;
+                if allow_builds_requested && !supports_allow_scripts {
+                    warn!(
+                        "allow_builds for npm:{} requires npm >= {} for per-package script approvals. mise will keep {} for this install. Use aube/pnpm, upgrade npm, or explicitly set `npm_args = \"--ignore-scripts=false\"` if you accept all install scripts.",
+                        self.tool_name(),
+                        NPM_ALLOW_SCRIPTS_VERSION,
+                        NPM_IGNORE_SCRIPTS_ARG
+                    );
+                }
+                let (lifecycle_script_args, default_ignore_scripts) =
+                    NpmOptions::npm_lifecycle_script_args(allow_builds, supports_allow_scripts);
+                let skipped_lifecycle_scripts =
+                    Self::effective_npm_ignore_scripts(default_ignore_scripts, &npm_args);
                 let mut cmd = CmdLineRunner::new(NPM_PROGRAM)
                     .arg("install")
                     .arg("-g")
@@ -436,7 +481,7 @@ impl Backend for NPMBackend {
                             .list_paths(&ctx.config)
                             .await,
                     )?;
-                cmd = cmd.arg(NPM_IGNORE_SCRIPTS_ARG);
+                cmd = cmd.args(lifecycle_script_args);
                 if let Some(args) = &npm_args {
                     cmd = cmd.args(args);
                 }
@@ -581,12 +626,27 @@ impl NPMBackend {
         }
     }
 
-    /// Detect whether the locally installed npm supports --min-release-age.
+    async fn npm_supports_allow_scripts_flag(&self, config: &Arc<Config>) -> bool {
+        self.npm_version_is_at_least(config, NPM_ALLOW_SCRIPTS_VERSION, "--allow-scripts")
+            .await
+    }
+
+    async fn npm_supports_min_release_age_flag(&self, config: &Arc<Config>) -> bool {
+        self.npm_version_is_at_least(config, NPM_MIN_RELEASE_AGE_VERSION, "--min-release-age")
+            .await
+    }
+
+    /// Detect whether the locally installed npm supports a version-gated flag.
     /// When npm is explicitly managed by mise, the version is read from the
     /// dependency ToolSet without spawning a subprocess. Otherwise falls back
     /// to `npm --version`. Returns false on any failure so callers
-    /// transparently fall back to the older --before flag.
-    async fn npm_supports_min_release_age_flag(&self, config: &Arc<Config>) -> bool {
+    /// transparently fall back to older behavior.
+    async fn npm_version_is_at_least(
+        &self,
+        config: &Arc<Config>,
+        min_version: &str,
+        flag: &str,
+    ) -> bool {
         // When npm is explicitly managed by mise (e.g. `mise use npm@11.10.0`),
         // pull the resolved version from the dependency ToolSet and skip the
         // subprocess entirely.
@@ -596,11 +656,10 @@ impl NPMBackend {
                     && let Some(tv) = tvl.versions.first()
                 {
                     debug!(
-                        "npm version detection: found npm {} in ToolSet, skipping subprocess",
-                        tv.version
+                        "npm version detection for {flag}: found npm {} in ToolSet, skipping subprocess",
+                        tv.version,
                     );
-                    return semver_is_at_least(&tv.version, NPM_MIN_RELEASE_AGE_VERSION)
-                        .unwrap_or(false);
+                    return semver_is_at_least(&tv.version, min_version).unwrap_or(false);
                 }
             }
         }
@@ -610,7 +669,7 @@ impl NPMBackend {
             Ok(env) => env,
             Err(e) => {
                 debug!(
-                    "npm version detection: dependency_env failed, using --before fallback: {e:#}"
+                    "npm version detection for {flag}: dependency_env failed, using fallback: {e:#}"
                 );
                 return false;
             }
@@ -623,12 +682,12 @@ impl NPMBackend {
             Ok(s) => s,
             Err(e) => {
                 debug!(
-                    "npm version detection: `npm --version` failed, using --before fallback: {e:#}"
+                    "npm version detection for {flag}: `npm --version` failed, using fallback: {e:#}"
                 );
                 return false;
             }
         };
-        semver_is_at_least(&output, NPM_MIN_RELEASE_AGE_VERSION).unwrap_or(false)
+        semver_is_at_least(&output, min_version).unwrap_or(false)
     }
 
     /// Check dependencies for version checking (always needs npm)
@@ -763,11 +822,11 @@ impl NPMBackend {
         seconds.div_ceil(60)
     }
 
-    fn effective_npm_ignore_scripts(args: &Option<Vec<String>>) -> bool {
+    fn effective_npm_ignore_scripts(default: bool, args: &Option<Vec<String>>) -> bool {
         let Some(args) = args else {
-            return true;
+            return default;
         };
-        let mut ignore_scripts = true;
+        let mut ignore_scripts = default;
         let mut iter = args.iter().peekable();
         while let Some(arg) = iter.next() {
             if arg == "--ignore-scripts" {
@@ -796,7 +855,7 @@ impl NPMBackend {
             return;
         };
         warn!(
-            "{}@{} declares npm lifecycle script(s) ({}) in {}, but mise skipped them with {}. Review the package before opting in with `npm_args = \"--ignore-scripts=false\"`.",
+            "{}@{} declares npm lifecycle script(s) ({}) in {}, but mise skipped them with {}. Review the package before opting in with `allow_builds` on npm 11.16+ or `npm_args = \"--ignore-scripts=false\"`.",
             self.ba().full(),
             tv.version,
             hooks.join(", "),
@@ -1043,42 +1102,52 @@ mod tests {
 
     #[test]
     fn test_effective_npm_ignore_scripts_defaults_to_true() {
-        assert!(NPMBackend::effective_npm_ignore_scripts(&None));
+        assert!(NPMBackend::effective_npm_ignore_scripts(true, &None));
+        assert!(!NPMBackend::effective_npm_ignore_scripts(false, &None));
     }
 
     #[test]
     fn test_effective_npm_ignore_scripts_honors_later_false_arg() {
-        assert!(!NPMBackend::effective_npm_ignore_scripts(&Some(vec![
-            "--ignore-scripts=false".into()
-        ])));
-        assert!(!NPMBackend::effective_npm_ignore_scripts(&Some(vec![
-            "--ignore-scripts=0".into()
-        ])));
-        assert!(!NPMBackend::effective_npm_ignore_scripts(&Some(vec![
-            "--ignore-scripts".into(),
-            "false".into()
-        ])));
-        assert!(!NPMBackend::effective_npm_ignore_scripts(&Some(vec![
-            "--ignore-scripts".into(),
-            "0".into()
-        ])));
-        assert!(!NPMBackend::effective_npm_ignore_scripts(&Some(vec![
-            "--no-ignore-scripts".into()
-        ])));
+        assert!(!NPMBackend::effective_npm_ignore_scripts(
+            true,
+            &Some(vec!["--ignore-scripts=false".into()])
+        ));
+        assert!(!NPMBackend::effective_npm_ignore_scripts(
+            true,
+            &Some(vec!["--ignore-scripts=0".into()])
+        ));
+        assert!(!NPMBackend::effective_npm_ignore_scripts(
+            true,
+            &Some(vec!["--ignore-scripts".into(), "false".into()])
+        ));
+        assert!(!NPMBackend::effective_npm_ignore_scripts(
+            true,
+            &Some(vec!["--ignore-scripts".into(), "0".into()])
+        ));
+        assert!(!NPMBackend::effective_npm_ignore_scripts(
+            true,
+            &Some(vec!["--no-ignore-scripts".into()])
+        ));
     }
 
     #[test]
     fn test_effective_npm_ignore_scripts_later_arg_wins() {
-        assert!(NPMBackend::effective_npm_ignore_scripts(&Some(vec![
-            "--ignore-scripts=false".into(),
-            "--ignore-scripts=true".into()
-        ])));
-        assert!(NPMBackend::effective_npm_ignore_scripts(&Some(vec![
-            "--ignore-scripts".into(),
-            "false".into(),
-            "--ignore-scripts".into(),
-            "1".into()
-        ])));
+        assert!(NPMBackend::effective_npm_ignore_scripts(
+            false,
+            &Some(vec![
+                "--ignore-scripts=false".into(),
+                "--ignore-scripts=true".into()
+            ])
+        ));
+        assert!(NPMBackend::effective_npm_ignore_scripts(
+            false,
+            &Some(vec![
+                "--ignore-scripts".into(),
+                "false".into(),
+                "--ignore-scripts".into(),
+                "1".into()
+            ])
+        ));
     }
 
     #[test]
@@ -1141,6 +1210,19 @@ mod tests {
         );
         assert_eq!(
             crate::semver::semver_is_at_least("11.9.9", NPM_MIN_RELEASE_AGE_VERSION),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn test_npm_allow_scripts_version_requirement() {
+        assert_eq!(NPM_ALLOW_SCRIPTS_VERSION, "11.16.0");
+        assert_eq!(
+            crate::semver::semver_is_at_least("11.16.0", NPM_ALLOW_SCRIPTS_VERSION),
+            Some(true)
+        );
+        assert_eq!(
+            crate::semver::semver_is_at_least("11.15.9", NPM_ALLOW_SCRIPTS_VERSION),
             Some(false)
         );
     }
@@ -1234,6 +1316,51 @@ mod tests {
         assert_eq!(
             NpmOptions::new(&true_options).allow_build_args().unwrap(),
             vec![OsString::from("--dangerously-allow-all-builds")]
+        );
+
+        let mut true_string_options = ToolVersionOptions::default();
+        true_string_options.opts.insert(
+            "allow_builds".to_string(),
+            toml::Value::String("true".into()),
+        );
+        assert_eq!(
+            NpmOptions::new(&true_string_options)
+                .allow_build_args()
+                .unwrap(),
+            vec![OsString::from("--dangerously-allow-all-builds")]
+        );
+    }
+
+    #[test]
+    fn test_npm_lifecycle_script_args_uses_allow_scripts_when_supported() {
+        assert_eq!(
+            NpmOptions::npm_lifecycle_script_args(
+                AllowBuilds::Packages(vec!["esbuild".into(), "sharp".into()]),
+                true
+            ),
+            (vec![OsString::from("--allow-scripts=esbuild,sharp")], false)
+        );
+        assert_eq!(
+            NpmOptions::npm_lifecycle_script_args(AllowBuilds::All, true),
+            (
+                vec![OsString::from("--dangerously-allow-all-scripts")],
+                false
+            )
+        );
+    }
+
+    #[test]
+    fn test_npm_lifecycle_script_args_keeps_ignore_scripts_without_support() {
+        assert_eq!(
+            NpmOptions::npm_lifecycle_script_args(
+                AllowBuilds::Packages(vec!["esbuild".into()]),
+                false
+            ),
+            (vec![OsString::from(NPM_IGNORE_SCRIPTS_ARG)], true)
+        );
+        assert_eq!(
+            NpmOptions::npm_lifecycle_script_args(AllowBuilds::None, true),
+            (vec![OsString::from(NPM_IGNORE_SCRIPTS_ARG)], true)
         );
     }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -453,10 +453,11 @@ impl Backend for NPMBackend {
                     && self.npm_supports_allow_scripts_flag(&ctx.config).await;
                 if allow_builds_requested && !supports_allow_scripts {
                     warn!(
-                        "allow_builds for npm:{} requires npm >= {} for per-package script approvals. mise will keep {} for this install. Use aube/pnpm, upgrade npm, or explicitly set `npm_args = \"--ignore-scripts=false\"` if you accept all install scripts.",
+                        "allow_builds for npm:{} requires npm >= {} for per-package script approvals. mise will keep {} for this install. {}",
                         self.tool_name(),
                         NPM_ALLOW_SCRIPTS_VERSION,
-                        NPM_IGNORE_SCRIPTS_ARG
+                        NPM_IGNORE_SCRIPTS_ARG,
+                        Self::npm_lifecycle_script_remediation()
                     );
                 }
                 let (lifecycle_script_args, default_ignore_scripts) =
@@ -855,13 +856,20 @@ impl NPMBackend {
             return;
         };
         warn!(
-            "{}@{} declares npm lifecycle script(s) ({}) in {}, but mise skipped them with {}. Review the package before opting in with `allow_builds` on npm 11.16+ or `npm_args = \"--ignore-scripts=false\"`.",
+            "{}@{} declares npm lifecycle script(s) ({}) in {}, but mise skipped them with {}. Review the package before opting in. {}",
             self.ba().full(),
             tv.version,
             hooks.join(", "),
             package_json_path.display(),
-            NPM_IGNORE_SCRIPTS_ARG
+            NPM_IGNORE_SCRIPTS_ARG,
+            Self::npm_lifecycle_script_remediation()
         );
+    }
+
+    fn npm_lifecycle_script_remediation() -> String {
+        format!(
+            "Use `allow_builds` with npm {NPM_ALLOW_SCRIPTS_VERSION}+, use aube/pnpm, or explicitly set `npm_args = \"--ignore-scripts=false\"` if you accept all install scripts."
+        )
     }
 
     fn installed_package_lifecycle_scripts(
@@ -1359,7 +1367,7 @@ mod tests {
             (vec![OsString::from(NPM_IGNORE_SCRIPTS_ARG)], true)
         );
         assert_eq!(
-            NpmOptions::npm_lifecycle_script_args(AllowBuilds::None, true),
+            NpmOptions::npm_lifecycle_script_args(AllowBuilds::None, false),
             (vec![OsString::from(NPM_IGNORE_SCRIPTS_ARG)], true)
         );
     }

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -328,7 +328,8 @@ impl ToolOptions {
         if self.insert_core_option(&key, &value)? {
             return Ok(());
         }
-        self.opts.insert(key, normalize_backend_option_value(value));
+        let value = normalize_backend_option_value(&key, value);
+        self.opts.insert(key, value);
         Ok(())
     }
 
@@ -510,11 +511,18 @@ fn env_value_to_string(value: &toml::Value) -> Result<String, String> {
     }
 }
 
-fn normalize_backend_option_value(value: toml::Value) -> toml::Value {
+fn normalize_backend_option_value(key: &str, value: toml::Value) -> toml::Value {
+    if preserves_backend_option_type(key) {
+        return value;
+    }
     match value {
         toml::Value::Table(_) | toml::Value::Array(_) | toml::Value::String(_) => value,
         _ => toml::Value::String(value.to_string().trim_matches('"').to_string()),
     }
+}
+
+fn preserves_backend_option_type(key: &str) -> bool {
+    matches!(key, "allow_builds")
 }
 
 fn scalar_value_to_string(value: &toml::Value) -> Option<String> {
@@ -837,6 +845,23 @@ mod tests {
         let opts = parse_tool_options(input);
         assert_eq!(opts.get("bin_path"), Some("bin"));
         assert_eq!(opts.get("strip_components"), Some("1"));
+    }
+
+    #[test]
+    fn test_parse_tool_options_preserves_allow_builds_type() {
+        let opts = parse_tool_options(r#"allow_builds=true"#);
+        assert_eq!(
+            opts.opts.get("allow_builds"),
+            Some(&toml::Value::Boolean(true))
+        );
+
+        let opts = parse_tool_options(r#"allow_builds=["esbuild"]"#);
+        assert_eq!(
+            opts.opts.get("allow_builds"),
+            Some(&toml::Value::Array(vec![toml::Value::String(
+                "esbuild".into()
+            )]))
+        );
     }
 
     #[test]

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -862,6 +862,12 @@ mod tests {
                 "esbuild".into()
             )]))
         );
+
+        let opts = parse_tool_options(r#"allow_builds=false"#);
+        assert_eq!(
+            opts.opts.get("allow_builds"),
+            Some(&toml::Value::Boolean(false))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve `allow_builds = true` as a boolean tool option and accept previously stringified `"true"`/`"false"` values
- map npm `allow_builds` to npm 11.16+ `--allow-scripts` / `--dangerously-allow-all-scripts` instead of always pairing approvals with `--ignore-scripts=true`
- update npm backend lifecycle-script docs for npm 11.16+ behavior and fallbacks

## Tests
- `cargo test backend::npm::tests:: --quiet`
- `cargo test toolset::tool_version_options::tests::test_parse_tool_options_preserves_allow_builds_type --quiet`
- `git diff --check`
- `mise run format` (completed via lint-fix; initial cargo-check leg reported missing local `cmake` for `aws-lc-sys`, then cargo-fix completed for touched Rust files)

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global npm install command flags and script execution policy when `allow_builds` is set; incorrect version gating or flag interaction could allow or block dependency lifecycle scripts unexpectedly.
> 
> **Overview**
> **`allow_builds` on npm installs** now maps to npm’s script-approval flags when npm is **11.16.0+**: package lists become `--allow-scripts=…`, `allow_builds = true` becomes `--dangerously-allow-all-scripts`, and mise **stops** passing `--ignore-scripts=true` in those cases so the allowlist can take effect. Older npm keeps the previous default (`--ignore-scripts=true`) and logs a warning with upgrade/alternate remediation.
> 
> **Tool option parsing** keeps `allow_builds` as real booleans/arrays (not coerced to strings), and the npm backend also treats string `"true"` / `"false"` for compatibility.
> 
> **Docs** describe npm 11.16+ lifecycle-script behavior, fallbacks, and that `allow_builds` applies to aube/pnpm/npm (still not Bun’s global install path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf92de6dbae6b5718f6f24a46c20b0fe71fcea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added npm 11.16.0+ support for per-package lifecycle script approvals via `allow_builds`.
  * Improved `allow_builds` parsing to accept `true`/`false` values in configuration.
* **Bug Fixes**
  * Updated npm install behavior so lifecycle scripts follow the configured approval/ignore logic based on npm capability.
  * Improved warnings and guidance when `allow_builds` is requested but the npm version is unsupported.
* **Documentation**
  * Refreshed npm lifecycle-script and `allow_builds` behavior documentation, including precedence and limitations (not affecting Bun installs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->