### PR TITLE
fix(dotnet): validate SDK installs with list-sdks

### DIFF
--- a/e2e/core/test_dotnet
+++ b/e2e/core/test_dotnet
@@ -2,10 +2,17 @@
 
 export MISE_DOTNET_ROOT="$MISE_DATA_DIR/dotnet-root"
 
-assert_contains "mise x dotnet@8.0.408 -- dotnet --version" "8.0.408"
+# SDK install validation should not use global.json-sensitive SDK selection.
+cat <<EOF >global.json
+{
+  "sdk": {
+    "version": "10.0.301",
+    "rollForward": "disable"
+  }
+}
+EOF
 
-# Test global.json idiomatic file support
-mise settings set idiomatic_version_file_enable_tools dotnet
+assert_contains "MISE_RAW=1 mise x dotnet@8.0.408 -- dotnet --list-sdks" "8.0.408"
 
 cat <<EOF >global.json
 {
@@ -14,6 +21,11 @@ cat <<EOF >global.json
   }
 }
 EOF
+
+assert_contains "mise x dotnet@8.0.408 -- dotnet --version" "8.0.408"
+
+# Test global.json idiomatic file support
+mise settings set idiomatic_version_file_enable_tools dotnet
 
 assert_contains "mise x -- dotnet --version" "8.0.408"
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -234,6 +234,25 @@ static RAW_LOCK: Lazy<tokio::sync::RwLock<()>> = Lazy::new(|| tokio::sync::RwLoc
 
 static RUNNING_PIDS: Lazy<Mutex<HashSet<u32>>> = Lazy::new(Default::default);
 
+struct RunningPidGuard(Option<u32>);
+
+impl RunningPidGuard {
+    fn new(pid: Option<u32>) -> Self {
+        if let Some(pid) = pid {
+            RUNNING_PIDS.lock().unwrap().insert(pid);
+        }
+        Self(pid)
+    }
+}
+
+impl Drop for RunningPidGuard {
+    fn drop(&mut self) {
+        if let Some(pid) = self.0 {
+            RUNNING_PIDS.lock().unwrap().remove(&pid);
+        }
+    }
+}
+
 /// Env var set on every spawned child when this mise process is managing
 /// process groups (calling setpgid + killpg). A nested mise that sees this
 /// var skips its own setpgid so descendants stay in the outer pgid — that
@@ -924,6 +943,66 @@ impl<'a> CmdLineRunner<'a> {
         Ok(())
     }
 
+    /// Run the command and return stdout, even when raw mode is enabled.
+    pub async fn read(mut self) -> Result<String> {
+        let _read_lock = RAW_LOCK.read().await;
+        debug!("$ {self}");
+        self.cmd.kill_on_drop(true);
+        #[cfg(unix)]
+        if should_use_pgroup() {
+            self.cmd.env(TASK_PGID_MANAGED_ENV, "1");
+            unsafe {
+                self.cmd.as_std_mut().pre_exec(|| {
+                    let stdin = std::os::fd::BorrowedFd::borrow_raw(0);
+                    if !std::io::IsTerminal::is_terminal(&stdin) {
+                        let _ = nix::unistd::setpgid(
+                            nix::unistd::Pid::from_raw(0),
+                            nix::unistd::Pid::from_raw(0),
+                        );
+                    }
+                    Ok(())
+                });
+            }
+        }
+        let mut cp = self
+            .spawn_async_with_etxtbsy_retry()
+            .await
+            .wrap_err_with(|| format!("failed to execute command: {self}"))?;
+        let id = cp.id();
+        let _running_pid = RunningPidGuard::new(id);
+        trace!(
+            "Started process: {} for {}",
+            id.unwrap_or_default(),
+            self.get_program()
+        );
+        if let Some(text) = self.stdin.take()
+            && let Some(mut stdin) = cp.stdin.take()
+        {
+            tokio::spawn(async move {
+                let _ = stdin.write_all(text.as_bytes()).await;
+            });
+        }
+
+        let wait = cp.wait_with_output();
+        let output = match self.timeout {
+            Some(timeout) => match tokio::time::timeout(timeout, wait).await {
+                Ok(output) => output?,
+                Err(_) => bail!("timed out after {timeout:?}"),
+            },
+            None => wait.await?,
+        };
+
+        if !output.status.success() {
+            let combined_output = captured_output_lines(&self, &output);
+            self.replay_captured_stderr(&combined_output);
+            self.on_error(combined_output, output.status)?;
+        }
+
+        let stdout = String::from_utf8(output.stdout)
+            .wrap_err_with(|| format!("{} produced invalid UTF-8 output", self.get_program()))?;
+        Ok(stdout.trim_end().to_string())
+    }
+
     fn execute_raw(mut self) -> Result<()> {
         // In raw mode, inherit stdio so the child can interact with the terminal
         // directly. Piped stdout/stderr would deadlock if the child produces >64KB
@@ -1193,6 +1272,14 @@ impl<'a> CmdLineRunner<'a> {
         Err(ScriptFailed(self.get_program(), Some(status)))?
     }
 
+    fn replay_captured_stderr(&self, output: &[(String, OutputSource)]) {
+        for (line, source) in output {
+            if matches!(source, OutputSource::Stderr) {
+                self.on_stderr(line.clone());
+            }
+        }
+    }
+
     fn get_program(&self) -> String {
         display_path(PathBuf::from(self.cmd.as_std().get_program()))
     }
@@ -1243,6 +1330,20 @@ impl Debug for CmdLineRunner<'_> {
 enum OutputSource {
     Stdout,
     Stderr,
+}
+
+fn captured_output_lines(
+    cmd: &CmdLineRunner<'_>,
+    output: &std::process::Output,
+) -> Vec<(String, OutputSource)> {
+    let mut combined = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        combined.push((cmd.redactor.redact(line), OutputSource::Stdout));
+    }
+    for line in String::from_utf8_lossy(&output.stderr).lines() {
+        combined.push((cmd.redactor.redact(line), OutputSource::Stderr));
+    }
+    combined
 }
 
 enum ChildProcessOutput {
@@ -1366,6 +1467,42 @@ mod tests {
             .unwrap();
         assert_eq!(stdout.lock().unwrap().as_slice(), ["out"]);
         assert_eq!(stderr.lock().unwrap().as_slice(), ["err"]);
+    }
+
+    #[tokio::test]
+    async fn test_cmd_line_runner_read_ignores_raw_mode() {
+        let output = super::CmdLineRunner::new("sh")
+            .args(["-c", "printf out"])
+            .raw(true)
+            .read()
+            .await
+            .unwrap();
+        assert_eq!(output, "out");
+    }
+
+    #[tokio::test]
+    async fn test_cmd_line_runner_read_replays_stderr_on_failure() {
+        let stderr = Arc::new(Mutex::new(Vec::new()));
+        let stderr_clone = stderr.clone();
+        let err = super::CmdLineRunner::new("sh")
+            .args(["-c", "printf err >&2; exit 1"])
+            .with_on_stderr(move |line| stderr_clone.lock().unwrap().push(line))
+            .read()
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("exited with non-zero status"));
+        assert_eq!(stderr.lock().unwrap().as_slice(), ["err"]);
+    }
+
+    #[test]
+    fn test_running_pid_guard_removes_pid() {
+        let pid = 424_242;
+        assert!(!super::RUNNING_PIDS.lock().unwrap().contains(&pid));
+        {
+            let _guard = super::RunningPidGuard::new(Some(pid));
+            assert!(super::RUNNING_PIDS.lock().unwrap().contains(&pid));
+        }
+        assert!(!super::RUNNING_PIDS.lock().unwrap().contains(&pid));
     }
 
     #[test]

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -69,17 +69,31 @@ impl DotnetPlugin {
         let raw_opts = tv.request.options();
         let opts = DotnetOptions::new(&raw_opts);
         if opts.runtime().is_some() {
-            // Skip version check for runtime-only installs — `dotnet --version` exits non-zero without an SDK
+            // Skip SDK check for runtime-only installs; no SDK is expected.
             return Ok(());
         }
-        ctx.pr.set_message("dotnet --version".into());
-        CmdLineRunner::new(DOTNET_BIN)
+        ctx.pr.set_message("dotnet --list-sdks".into());
+        let sdks = CmdLineRunner::new(DOTNET_BIN)
             .with_pr(ctx.pr.as_ref())
-            .arg("--version")
+            .arg("--list-sdks")
             .envs(tv.install_env())
             .envs(self.exec_env(&ctx.config, &ctx.ts, tv).await?)
             .prepend_path(self.list_bin_paths(&ctx.config, tv).await?)?
-            .execute()
+            .read()
+            .await?
+            .lines()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+
+        if sdk_list_contains_version(&sdks, &tv.version) {
+            Ok(())
+        } else {
+            eyre::bail!(
+                "dotnet SDK {} was not found in `dotnet --list-sdks` output:\n{}",
+                tv.version,
+                sdk_list_display(&sdks)
+            )
+        }
     }
 }
 
@@ -293,6 +307,20 @@ fn runtime_framework_name(runtime: &str) -> Option<&'static str> {
     }
 }
 
+fn sdk_list_contains_version(lines: &[String], version: &str) -> bool {
+    lines
+        .iter()
+        .any(|line| line.split_whitespace().next() == Some(version))
+}
+
+fn sdk_list_display(lines: &[String]) -> String {
+    if lines.is_empty() {
+        "(no SDKs listed)".to_string()
+    } else {
+        lines.join("\n")
+    }
+}
+
 fn dotnet_root() -> PathBuf {
     Settings::get()
         .dotnet
@@ -501,6 +529,44 @@ mod tests {
                 .resolve_lockfile_options(&request_no_runtime, &PlatformTarget::from_current())
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn sdk_list_contains_exact_installed_version() {
+        let lines = vec![
+            "8.0.128 [/Users/test/.local/share/mise/dotnet-root/sdk]".to_string(),
+            "10.0.301 [/opt/homebrew/Cellar/dotnet/10.0.301/libexec/sdk]".to_string(),
+        ];
+
+        assert!(sdk_list_contains_version(&lines, "8.0.128"));
+    }
+
+    #[test]
+    fn sdk_list_does_not_match_prefix_or_path_only() {
+        let lines = vec![
+            "8.0.1280 [/Users/test/.local/share/mise/dotnet-root/sdk]".to_string(),
+            "10.0.301 [/tmp/8.0.128/sdk]".to_string(),
+        ];
+
+        assert!(!sdk_list_contains_version(&lines, "8.0.128"));
+    }
+
+    #[test]
+    fn sdk_list_display_explains_empty_output() {
+        assert_eq!(sdk_list_display(&[]), "(no SDKs listed)");
+    }
+
+    #[test]
+    fn sdk_list_display_joins_lines() {
+        let lines = vec![
+            "8.0.128 [/path]".to_string(),
+            "10.0.301 [/path2]".to_string(),
+        ];
+
+        assert_eq!(
+            sdk_list_display(&lines),
+            "8.0.128 [/path]\n10.0.301 [/path2]"
         );
     }
 }


### PR DESCRIPTION
## Summary
- validate .NET SDK installs with `dotnet --list-sdks` instead of `dotnet --version`
- check the installed SDK inventory for the requested version and report a clearer error if it is missing
- add an e2e regression where `global.json` selects an unavailable SDK while installing an older SDK

## Context
`dotnet --version` is affected by `global.json` and SDK roll-forward rules, so it can fail even after `dotnet-install` successfully installs the requested SDK. `dotnet --list-sdks` checks the installed SDK inventory directly, which matches the shared `DOTNET_ROOT` model introduced for side-by-side SDK installs.

Addresses discussion #10688.

## Tests
- `cargo fmt --check`
- `cargo test plugins::core::dotnet::tests`
- `CMAKE="$(mise x cmake@latest -- command -v cmake)" mise run test:e2e test_dotnet`

Note: the e2e run also matched `backend/test_dotnet`, which skipped because system `dotnet` is not installed; `core/test_dotnet` passed. The run emitted the existing slow-test warning for `core/test_dotnet` taking over 20s.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared command execution (`CmdLineRunner::read`) and .NET install verification; behavior change is targeted but affects all SDK post-install checks.
> 
> **Overview**
> Fixes false failures when a repo’s **`global.json`** pins an SDK that isn’t installed: post-install verification no longer uses **`dotnet --version`** (selection/roll-forward) and instead checks **`dotnet --list-sdks`** for an **exact** match on the requested SDK version, with clearer errors that include the captured list output.
> 
> **`CmdLineRunner`** gains async **`read()`** so callers can capture stdout while still piping (including when **`MISE_RAW`** / raw mode would otherwise inherit stdio); failures replay captured stderr via **`replay_captured_stderr`**, and **`RunningPidGuard`** tracks PIDs for cleanup during **`read()`**.
> 
> E2E **`core/test_dotnet`** now installs SDK **8.0.408** under a **`global.json`** that demands **10.0.301** with roll-forward disabled, asserting **`--list-sdks`** still shows the installed SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db6432051db099f6d837d9fa23d84f59b30bfbc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved .NET SDK detection by checking for an exact installed SDK version in the full SDK list output, reducing false matches.
  - Enhanced failure diagnostics by including the captured `--list-sdks` output when the requested SDK isn’t found.
  - Made command output reading more consistent by returning the expected stdout even when raw mode is enabled.

- **Tests**
  - Updated SDK detection coverage with exact-match and non-exact variant cases.
  - Adjusted .NET SDK e2e checks to better validate SDK selection behavior around `global.json`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->