### PR TITLE
chore(deps): group sigstore renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,12 @@
       "matchPackageNames": ["/^rattler($|_)/"],
       "matchManagers": ["cargo"],
       "groupName": "rattler"
+    },
+    {
+      "description": "Sigstore crates are versioned together; bump together.",
+      "matchPackageNames": ["/^sigstore-/"],
+      "matchManagers": ["cargo"],
+      "groupName": "sigstore crates"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a cargo Renovate package rule that groups `sigstore-*` crate updates together
- mirrors the existing grouped-crate pattern used for rattler

## Test
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes Renovate bot configuration; no application, auth, or runtime behavior.
> 
> **Overview**
> Adds a **Renovate `packageRules` entry** in `.github/renovate.json` so Cargo updates for crates matching `^sigstore-` are **grouped** under `sigstore crates`, following the same pattern as the existing **rattler** group.
> 
> This should produce **single grouped PRs** when multiple Sigstore crates need bumps, instead of separate Renovate PRs per crate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4a308b39dc4381b350ade22f5c73bbdf2e573c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management rules to group related Rust package updates together, improving maintenance consistency.
  * Added a dedicated grouping for a set of related crates so future updates are handled more uniformly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->