### PR TITLE
feat(github): allow disabling attestations per tool

### DIFF
--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -341,6 +341,24 @@ For GitHub Enterprise or self-hosted GitHub instances, specify the API URL. mise
 "github:myorg/mytool" = { version = "latest", api_url = "https://github.mycompany.com/api/v3" }
 ```
 
+### `github_attestations`
+
+By default, mise checks GitHub Artifact Attestations when they are available for a
+GitHub release asset. Set `github_attestations = false` on a single tool to skip
+that check while keeping GitHub attestation verification enabled globally:
+
+```toml
+[tools]
+"github:myorg/mytool" = { version = "latest", github_attestations = false }
+```
+
+Use this as a temporary escape hatch for a specific tool if GitHub's attestation
+service or trusted-root data is causing installs to fail. Other verification
+paths, such as checksums and SLSA provenance, still run when they are configured
+and available. If `mise.lock` already records `github-attestations` provenance
+for the tool, re-run `mise lock` after disabling this option so the lockfile no
+longer requires a verifier that the tool config has turned off.
+
 ### `prerelease`
 
 By default, releases flagged `prerelease: true` on GitHub are excluded from `mise ls-remote` and from `latest` resolution. Set `prerelease = true` to include them:

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -69,6 +69,10 @@ impl<'a> GitBackendOptions<'a> {
             .to_string()
     }
 
+    fn github_attestations(&self) -> bool {
+        self.values.bool_with_default("github_attestations", true)
+    }
+
     fn version_prefix(&self) -> Option<&'a str> {
         self.values.str("version_prefix")
     }
@@ -176,6 +180,14 @@ impl<'a> GitBackendOptions<'a> {
 /// don't have to disable `MISE_GITHUB_ATTESTATIONS` globally for GHE tools.
 fn attestations_supported(api_url: &str) -> bool {
     api_url.trim_end_matches('/') == DEFAULT_GITHUB_API_BASE_URL
+}
+
+fn github_attestations_disabled_for_tool_error(tv: &ToolVersion) -> eyre::Report {
+    eyre::eyre!(
+        "Lockfile requires github-attestations provenance for {tv} but \
+         github_attestations is disabled for this tool. Re-run `mise lock` \
+         to refresh the lockfile, or remove github_attestations = false."
+    )
 }
 
 /// Status returned from verification attempts
@@ -761,6 +773,7 @@ impl UnifiedGitBackend {
         // Uses the asset digest from the GitHub API to query attestations without downloading
         if settings.github_attestations
             && settings.github.github_attestations
+            && opts.github_attestations()
             && attestations_supported(api_url)
             && let Some(digest) = asset_digest
         {
@@ -879,6 +892,7 @@ impl UnifiedGitBackend {
         // Try GitHub artifact attestations first (highest priority)
         if settings.github_attestations
             && settings.github.github_attestations
+            && opts.github_attestations()
             && attestations_supported(api_url)
         {
             let parts: Vec<&str> = repo.split('/').collect();
@@ -1756,6 +1770,18 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         platform_key: &str,
     ) -> Result<()> {
+        let raw_opts = tv.request.options();
+        let opts = self.options(&raw_opts);
+        if !opts.github_attestations()
+            && let Some(provenance) = tv
+                .lock_platforms
+                .get(platform_key)
+                .and_then(|pi| pi.provenance.as_ref())
+            && provenance.is_github_attestations()
+        {
+            return Err(github_attestations_disabled_for_tool_error(tv));
+        }
+
         super::ensure_provenance_setting_enabled(tv, platform_key, |provenance| {
             let settings = Settings::get();
             match provenance {
@@ -1828,11 +1854,18 @@ impl UnifiedGitBackend {
                  Re-run `mise lock` to refresh the lockfile, or remove the custom api_url."
             ));
         }
+        if !opts.github_attestations()
+            && let Some(expected) = expected_provenance
+            && expected.is_github_attestations()
+        {
+            return Err(github_attestations_disabled_for_tool_error(tv));
+        }
 
         // Try GitHub artifact attestations first (if enabled globally and for github backend)
         if !skip_attestations
             && settings.github_attestations
             && settings.github.github_attestations
+            && opts.github_attestations()
             && attestations_supported(&api_url)
         {
             match self
@@ -2492,6 +2525,43 @@ mod tests {
                 ("version_prefix".to_string(), "release-".to_string()),
             ])
         );
+    }
+
+    #[test]
+    fn test_github_attestations_option_defaults_enabled() {
+        let backend = create_test_backend();
+        let opts = ToolVersionOptions::default();
+
+        assert!(backend.options(&opts).github_attestations());
+    }
+
+    #[test]
+    fn test_github_attestations_option_can_disable() {
+        let backend = create_test_backend();
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "github_attestations".to_string(),
+            toml::Value::Boolean(false),
+        );
+
+        assert!(!backend.options(&opts).github_attestations());
+    }
+
+    #[test]
+    fn test_github_attestations_disabled_error_is_actionable() {
+        let backend = Arc::new(BackendArg::new(
+            "github:test/repo".to_string(),
+            Some("github:test/repo".to_string()),
+        ));
+        let request =
+            ToolRequest::new(backend, "1.0.0", crate::toolset::ToolSource::Unknown).unwrap();
+        let tv = ToolVersion::new(request, "1.0.0".to_string());
+
+        let msg = github_attestations_disabled_for_tool_error(&tv).to_string();
+
+        assert!(msg.contains("github_attestations is disabled for this tool"));
+        assert!(msg.contains("mise lock"));
+        assert!(msg.contains("remove github_attestations = false"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a per-tool `github_attestations` option for the GitHub backend, defaulting to enabled
- skip GitHub attestation detection and verification when the option is disabled
- document the option as a temporary per-tool escape hatch

## Testing
- `cargo test test_github_attestations_option`
- `git diff --check`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install and lock verification behavior for supply-chain security; mistakes could weaken attestation for specific tools, but defaults remain enabled and lockfile mismatch is fail-closed.
> 
> **Overview**
> Adds a per-tool **`github_attestations`** option on the GitHub backend (default **on**). When set to `false`, mise skips GitHub Artifact Attestation detection and verification for that tool only, while global attestation settings stay unchanged; checksums and SLSA still apply when configured.
> 
> The option is wired through lock-time provenance detection, install-time verification, and the fast path that trusts lockfile provenance. If **`mise.lock`** still records `github-attestations` provenance but the tool has attestations disabled, installs fail with guidance to re-run **`mise lock`** or remove the opt-out.
> 
> Docs in `docs/dev-tools/backends/github.md` describe the option as a temporary escape hatch when attestation APIs or trust roots break installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b1aa7f76f34a0b22af1d9c905fe5959ee123e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-tool `github_attestations` option to enable/disable GitHub Artifact Attestation checks (enabled by default).
  * GitHub attestation verification is now consistently controlled by this tool-level setting across install and lock workflows.

* **Bug Fixes**
  * Improved behavior when a lockfile expects GitHub attestations but the option is disabled, including clearer, actionable error messaging.
  * Reduced unnecessary attestation verification when the option is turned off.

* **Documentation**
  * Documented how to configure `github_attestations`, including re-running `mise lock` after disabling if existing lockfiles record GitHub attestation provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->