### PR TITLE
fix(aqua): resolve bin paths with v-prefixed overrides

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -629,7 +629,9 @@ impl Backend for AquaBackend {
 
         let candidates = cache
             .get_or_try_init_async(async || {
-                let pkg = self.package_with_options(tv, &[&tv.version]).await?;
+                let versions = package_version_candidates(&tv.version);
+                let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
+                let pkg = self.package_with_options(tv, &versions).await?;
                 // Pure: no filesystem reads, so a mid-install call can never
                 // cache a transient-empty result.
                 Self::candidate_bin_paths_for_platform(
@@ -2992,6 +2994,14 @@ fn version_with_prefix<'a>(version: &'a str, version_prefix: Option<&str>) -> Co
     }
 }
 
+fn package_version_candidates(version: &str) -> Vec<Cow<'_, str>> {
+    let mut candidates = vec![Cow::Borrowed(version)];
+    if !starts_with_v(version) {
+        candidates.push(Cow::Owned(format!("v{version}")));
+    }
+    candidates.into_iter().unique().collect()
+}
+
 fn version_candidates<'a>(version: &'a str, version_prefix: Option<&str>) -> Vec<Cow<'a, str>> {
     let mut candidates = vec![version_with_prefix(version, version_prefix)];
     if let Some(prefix) = version_prefix {
@@ -3076,7 +3086,7 @@ pub fn is_install_time_option_key(key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aqua_registry::{AquaFile, AquaVar};
+    use aqua_registry::{AquaFile, AquaVar, ParsedRegistry};
 
     fn aqua_var(name: &str, required: bool) -> AquaVar {
         AquaVar {
@@ -3219,6 +3229,60 @@ mod tests {
             .collect_vec();
 
         assert_eq!(candidates, vec!["tool-v1.2.3"]);
+    }
+
+    #[test]
+    fn test_candidate_bin_paths_use_v_prefixed_package_override() {
+        let registry = ParsedRegistry::parse_yaml(
+            r#"
+packages:
+  - type: github_release
+    repo_owner: sharkdp
+    repo_name: fd
+    files:
+      - name: fd
+        src: "{{.AssetWithoutExt}}/fd"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v10.3.0"
+        asset: fd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+      - version_constraint: "true"
+        asset: fd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: amd64
+          darwin: apple-darwin
+"#,
+        )
+        .unwrap();
+        let pkg = registry.package("sharkdp/fd").unwrap();
+        let versions = package_version_candidates("10.3.0");
+        let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
+        let pkg = pkg.with_version(&versions, "darwin", "amd64");
+
+        let candidates = AquaBackend::candidate_bin_paths_for_platform(
+            &pkg,
+            "10.3.0",
+            Path::new("install"),
+            "darwin",
+            "amd64",
+        )
+        .unwrap();
+
+        assert!(
+            candidates.contains(&PathBuf::from("fd-v10.3.0-x86_64-apple-darwin")),
+            "{candidates:?}"
+        );
+        assert!(
+            candidates
+                .iter()
+                .all(|p| !p.to_string_lossy().contains("amd64-apple-darwin")),
+            "{candidates:?}"
+        );
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -157,7 +157,7 @@ impl Backend for AquaBackend {
     }
 
     async fn install_operation_count(&self, tv: &ToolVersion, _ctx: &InstallContext) -> usize {
-        let pkg = match self.package_with_options(tv, &[&tv.version]).await {
+        let pkg = match self.package_with_version_candidates(tv).await {
             Ok(pkg) => pkg,
             Err(_) => return 3, // fall back to default
         };
@@ -629,9 +629,7 @@ impl Backend for AquaBackend {
 
         let candidates = cache
             .get_or_try_init_async(async || {
-                let versions = package_version_candidates(&tv.version);
-                let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
-                let pkg = self.package_with_options(tv, &versions).await?;
+                let pkg = self.package_with_version_candidates(tv).await?;
                 // Pure: no filesystem reads, so a mid-install call can never
                 // cache a transient-empty result.
                 Self::candidate_bin_paths_for_platform(
@@ -938,6 +936,12 @@ impl AquaBackend {
         let raw_opts = tv.request.options();
         let opts = AquaOptions::new(&raw_opts);
         Self::apply_var_options(pkg, &opts)
+    }
+
+    async fn package_with_version_candidates(&self, tv: &ToolVersion) -> Result<AquaPackage> {
+        let versions = version_candidates(&tv.version, None);
+        let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
+        self.package_with_options(tv, &versions).await
     }
 
     fn to_aqua_platform(target: &PlatformTarget) -> (&str, &str) {
@@ -2994,14 +2998,6 @@ fn version_with_prefix<'a>(version: &'a str, version_prefix: Option<&str>) -> Co
     }
 }
 
-fn package_version_candidates(version: &str) -> Vec<Cow<'_, str>> {
-    let mut candidates = vec![Cow::Borrowed(version)];
-    if !starts_with_v(version) {
-        candidates.push(Cow::Owned(format!("v{version}")));
-    }
-    candidates.into_iter().unique().collect()
-}
-
 fn version_candidates<'a>(version: &'a str, version_prefix: Option<&str>) -> Vec<Cow<'a, str>> {
     let mut candidates = vec![version_with_prefix(version, version_prefix)];
     if let Some(prefix) = version_prefix {
@@ -3260,7 +3256,7 @@ packages:
         )
         .unwrap();
         let pkg = registry.package("sharkdp/fd").unwrap();
-        let versions = package_version_candidates("10.3.0");
+        let versions = version_candidates("10.3.0", None);
         let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
         let pkg = pkg.with_version(&versions, "darwin", "amd64");
 


### PR DESCRIPTION
## Summary
- resolve aqua `list_bin_paths` package metadata with both raw and `v`-prefixed version candidates, matching install-time override selection
- add regression coverage for the `sharkdp/fd@10.3.0` darwin/amd64 path mismatch from discussion #10628

## Tests
- `cargo fmt --check`
- `cargo test -p mise backend::aqua::tests::test_candidate_bin_paths_use_v_prefixed_package_override`
- `cargo test -p mise backend::aqua::tests::`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to aqua metadata resolution for bin paths and operation counts, aligned with existing install-time version candidate logic; regression test added.
> 
> **Overview**
> **Aqua bin-path and install metadata** now resolve registry package definitions using the same raw and `v`-prefixed version strings as install, via a new `package_with_version_candidates` helper wired into `list_bin_paths` and `install_operation_count`.
> 
> Previously those code paths only passed the bare pinned version (e.g. `10.3.0`), so version overrides keyed on `v10.3.0` could be skipped and bin candidates pointed at the wrong extracted directory (notably `sharkdp/fd` on darwin/amd64).
> 
> A regression test asserts the `v10.3.0` override path (`fd-v10.3.0-x86_64-apple-darwin`) is chosen over the default `amd64` replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a9ba120c825c065db31588c03b6fd77b35604e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Aqua package and binary path resolution by considering `v`-prefixed version candidates, so version overrides that match `v{...}` are now correctly applied.
  * Candidate package paths now include the additional `v`-prefixed form when applicable, increasing reliability in locating the right binaries.

* **Tests**
  * Added a unit test to verify that version override matching uses the `v`-prefixed candidate path (and avoids the non-`v` override path).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->