### PR TITLE
fix(config): support required and redacted vars

### DIFF
--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -21,9 +21,10 @@ It's also compatible
 with asdf `.tool-versions` files as well as [idiomatic version files](/configuration#idiomatic-version-files) like `.node-version` and
 `.ruby-version`. See [configuration](/configuration) for more details.
 
-When specifying tool versions, you can also refer to environment variables defined in your config hierarchy,
-including values produced by env directives like `_.source`, `_.file`, or env modules. These are resolved
-before tool version templates are rendered.
+When specifying tool versions and tool options, you can also refer to environment variables or
+[`vars`](/tasks/task-configuration.html#vars) defined in your config hierarchy, including values
+produced by directives like `_.source`, `_.file`, or env modules. These are resolved before tool
+version and option templates are rendered.
 
 ::: info
 mise is compatible with asdf `.tool-versions` files and can still use asdf

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -606,9 +606,9 @@ mise run deploy secret123
 
 ## Vars
 
-Vars are variables that can be shared between tasks like environment variables but they are not
-passed as environment variables to the scripts. They are defined in the `vars` section of the
-`mise.toml` file.
+Vars are values that can be shared between TOML tasks and other Tera-rendered config like tool
+versions/options. They are similar to environment variables, but they are not exported to task
+processes. Reference them with <span v-pre>`{{vars.NAME}}`</span>.
 
 ```mise-toml
 [vars]
@@ -617,6 +617,22 @@ e2e_args = '--headless'
 [tasks.test]
 run = './scripts/test-e2e.sh {{vars.e2e_args}}'
 ```
+
+Vars can also use value-producing directive forms from `[env]`:
+
+```mise-toml
+[vars]
+e2e_args = { default = "--headless" }
+api_token = { required = "Set api_token in mise.local.toml" }
+secret_arg = { value = "--token=abc123", redact = true }
+_.file = ".env"
+```
+
+The `default` form reads from a process environment variable with the same name when it is set and
+non-empty; values from `[env]` are not used for this lookup. The `required` form must be satisfied by
+the process environment or by a later config file like `mise.local.toml`. Values marked with
+`redact = true` are hidden from task output. [Secrets](/environments/secrets/) are also supported as
+vars.
 
 Tasks can also define task-local vars that override config vars for that task:
 
@@ -793,35 +809,7 @@ You can also specify these as a glob pattern, e.g.: `redactions.env = ["SECRETS_
 
 ## `[vars]` options
 
-Vars are variables that can be shared between tasks like environment variables but they are not
-passed as environment variables to the scripts. They are defined in the `vars` section of the
-`mise.toml` file.
-
-```mise-toml
-[vars]
-e2e_args = '--headless'
-[tasks.test]
-run = './scripts/test-e2e.sh {{vars.e2e_args}}'
-vars = { e2e_args = '--headed' }
-```
-
-The task-level `vars` override any config-level vars with the same name. In the example above, `e2e_args` resolves to `'--headed'` instead of the config-level `'--headless'`.
-
-Config vars can read from process environment variables when using the `default` form. If a process environment variable with the same name exists and is non-empty, its value is used; otherwise, the default is applied. Values from the `[env]` section are not used for this lookup.
-
-```toml
-[vars]
-e2e_args = { default = "--headless" }
-```
-
-Like `[env]`, vars can also be read in as a file:
-
-```toml
-[vars]
-_.file = ".env"
-```
-
-[Secrets](/environments/secrets/) are also supported as vars.
+See [Vars](#vars).
 
 ## Task Configuration Settings
 

--- a/docs/tasks/toml-tasks.md
+++ b/docs/tasks/toml-tasks.md
@@ -54,7 +54,7 @@ description = 'Cut a new release'
 file = 'scripts/release.sh' # execute an external script
 ```
 
-You can use [environment variables](/environments/) or [`vars`](/tasks/task-configuration.html#vars-options) to define common arguments:
+You can use [environment variables](/environments/) or [`vars`](/tasks/task-configuration.html#vars) to define common arguments:
 
 ```mise-toml [mise.toml]
 [env]

--- a/e2e/config/test_tool_version_vars
+++ b/e2e/config/test_tool_version_vars
@@ -73,3 +73,31 @@ EOF
 
 # This should resolve to 20.11.0
 assert_contains "mise ls node" "20.11.0"
+
+# Test vars in nested tool option tables
+cat <<EOF >mise.toml
+[vars]
+PLATFORM_URL = "https://example.com/tool-linux-x64.tar.gz"
+
+[tools."http:nested-options"]
+version = "1.0.0"
+
+[tools."http:nested-options".platforms.linux-x64]
+url = "{{vars.PLATFORM_URL}}"
+EOF
+
+assert_contains "mise tool http:nested-options --tool-options" "https://example.com/tool-linux-x64.tar.gz"
+
+# Nested HTTP url templates should render vars but preserve backend directives
+cat <<EOF >mise.toml
+[vars]
+BASE_URL = "https://example.com/releases"
+
+[tools."http:nested-options"]
+version = "1.0.0"
+
+[tools."http:nested-options".platforms.linux-x64]
+url = "{{vars.BASE_URL}}/{{ version }}/tool-{{ os() }}-{{ arch() }}.tar.gz"
+EOF
+
+assert_contains "mise tool http:nested-options --tool-options" 'https://example.com/releases/{{ version }}/tool-{{ os() }}-{{ arch() }}.tar.gz'

--- a/e2e/tasks/test_task_vars
+++ b/e2e/tasks/test_task_vars
@@ -88,6 +88,20 @@ EOF
 assert "mise run a" "hello"
 greeting=hi assert "mise run a" "hi"
 
+# Task vars required also read from the process environment, not [env]
+cat <<EOF >mise.toml
+[env]
+required_from_env = "env-section"
+
+[tasks.a]
+run = "echo {{vars.required_from_env}}"
+
+[tasks.a.vars]
+required_from_env = { required = true }
+EOF
+assert_fail_contains "mise run a" "Required variable 'required_from_env' is not defined"
+required_from_env=from_process assert "mise run a" "from_process"
+
 # Task vars defaults override config-level vars when the process env is unset
 cat <<EOF >mise.toml
 [vars]
@@ -114,3 +128,99 @@ greeting = { default = "hello" }
 run = "echo {{vars.greeting}}"
 EOF
 assert "mise run a" "hello"
+
+# Required config vars show var-specific errors with help text
+cat <<EOF >mise.toml
+[vars]
+api_token = { required = "set api_token in mise.local.toml" }
+
+[tasks.a]
+run = "echo {{vars.api_token}}"
+EOF
+assert_fail_contains "mise run a" "Required variable 'api_token' is not defined"
+assert_fail_contains "mise run a" "Help: set api_token in mise.local.toml"
+
+# Required config vars can be supplied by the process environment
+cat <<EOF >mise.toml
+[vars]
+api_token = { required = true }
+
+[tasks.a]
+run = "echo {{vars.api_token}}"
+EOF
+api_token=from_env assert "mise run a" "from_env"
+
+# Required vars sourced from the process environment can be redacted
+cat <<EOF >mise.toml
+[vars]
+env_secret = { required = true, redact = true }
+
+[tasks.a]
+run = "echo {{vars.env_secret}}"
+EOF
+env_secret=env-secret-token assert_contains "mise run a" "[redacted]"
+env_secret=env-secret-token assert_not_contains "mise run a" "env-secret-token"
+
+# Required config vars can be supplied by a later config file
+cat <<EOF >mise.toml
+[vars]
+api_token = { required = true }
+
+[tasks.a]
+run = "echo {{vars.api_token}}"
+EOF
+cat <<EOF >mise.local.toml
+[vars]
+api_token = "from_local"
+EOF
+assert "mise run a" "from_local"
+
+# Task-local required vars validate without overwriting resolved base vars
+cat <<EOF >mise.toml
+[vars]
+existing = "from_config"
+
+[tasks.a]
+run = "echo {{vars.existing}}"
+
+[tasks.a.vars]
+existing = { required = true }
+EOF
+assert "mise run a" "from_config"
+existing=from_env assert "mise run a" "from_config"
+
+# Task-local required vars can redact values inherited from config vars
+cat <<EOF >mise.toml
+[vars]
+inherited_secret = "inherited-secret-token"
+
+[tasks.a]
+run = "echo {{vars.inherited_secret}}"
+
+[tasks.a.vars]
+inherited_secret = { required = true, redact = true }
+EOF
+assert_contains "mise run a" "[redacted]"
+assert_not_contains "mise run a" "inherited-secret-token"
+
+# Config vars with redact=true are redacted from task output
+cat <<EOF >mise.toml
+[vars]
+config_secret = { value = "config-secret-token", redact = true }
+
+[tasks.a]
+run = "echo {{vars.config_secret}}"
+EOF
+assert_contains "mise run a" "[redacted]"
+assert_not_contains "mise run a" "config-secret-token"
+
+# Task-local vars with redact=true are redacted from task output
+cat <<EOF >mise.toml
+[tasks.a]
+run = "echo {{vars.task_secret}}"
+
+[tasks.a.vars]
+task_secret = { value = "task-secret-token", redact = true }
+EOF
+assert_contains "mise run a" "[redacted]"
+assert_not_contains "mise run a" "task-secret-token"

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -727,6 +727,42 @@ impl MiseToml {
         })?;
         Ok(output)
     }
+
+    fn parse_tool_option_value_template(
+        &self,
+        context: &TeraContext,
+        key: Option<&str>,
+        value: &mut toml::Value,
+        defer_os_arch: bool,
+    ) -> eyre::Result<()> {
+        match value {
+            toml::Value::String(s) => {
+                let preserve_os_arch = defer_os_arch && matches!(key, Some("url" | "checksum_url"));
+                *s = if preserve_os_arch {
+                    self.parse_tool_option_template(context, s)?
+                } else {
+                    self.parse_template_with_context(context, s)?
+                };
+            }
+            toml::Value::Array(values) => {
+                for value in values {
+                    self.parse_tool_option_value_template(context, key, value, defer_os_arch)?;
+                }
+            }
+            toml::Value::Table(table) => {
+                for (key, value) in table.iter_mut() {
+                    self.parse_tool_option_value_template(
+                        context,
+                        Some(key),
+                        value,
+                        defer_os_arch,
+                    )?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
 }
 
 impl ConfigFile for MiseToml {
@@ -962,15 +998,12 @@ impl ConfigFile for MiseToml {
                         crate::backend::backend_type::BackendType::Http
                     );
                     for (k, v) in options.opts.iter_mut() {
-                        if let toml::Value::String(s) = v {
-                            let defer =
-                                defer_os_arch && matches!(k.as_str(), "url" | "checksum_url");
-                            *s = if defer {
-                                self.parse_tool_option_template(&opts_context, s)?
-                            } else {
-                                self.parse_template_with_context(&opts_context, s)?
-                            };
-                        }
+                        self.parse_tool_option_value_template(
+                            &opts_context,
+                            Some(k),
+                            v,
+                            defer_os_arch,
+                        )?;
                     }
                     let mut ba = ba.clone();
                     // Start with cached options but filter out install-time-only options

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -327,6 +327,11 @@ impl EnvResults {
 
         // Save filtered_input for validation after processing
         let filtered_input_for_validation = filtered_input.clone();
+        let required_env = if resolve_opts.vars {
+            &*env::PRISTINE_ENV
+        } else {
+            initial
+        };
 
         for (directive, source) in filtered_input {
             let mut tera = None;
@@ -344,14 +349,7 @@ impl EnvResults {
                 .collect::<EnvMap>();
             ctx.insert("env", &env_vars);
 
-            let context_vars: EnvMap = if let Some(Value::Object(existing_vars)) = ctx.get("vars") {
-                existing_vars
-                    .iter()
-                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                    .collect()
-            } else {
-                EnvMap::new()
-            };
+            let context_vars = Self::context_vars(&ctx);
 
             let mut vars = context_vars.clone();
             vars.extend(r.vars.iter().map(|(k, (v, _))| (k.clone(), v.clone())));
@@ -364,6 +362,9 @@ impl EnvResults {
                     let v = r.parse_template(&ctx, &mut tera, &source, &env_vars, &v)?;
 
                     if resolve_opts.vars {
+                        if redact.unwrap_or(false) {
+                            r.redactions.push(k.clone());
+                        }
                         r.vars.insert(k, (v, source.clone()));
                     } else {
                         r.env_remove.remove(&k);
@@ -400,6 +401,9 @@ impl EnvResults {
                     let v = r.parse_template(&ctx, &mut tera, &source, &env_vars, &v)?;
 
                     if resolve_opts.vars {
+                        if redact.unwrap_or(false) {
+                            r.redactions.push(k.clone());
+                        }
                         r.vars.insert(k, (v, source.clone()));
                     } else {
                         r.env_remove.remove(&k);
@@ -413,9 +417,19 @@ impl EnvResults {
                     env.shift_remove(&k);
                     r.env_remove.insert(k);
                 }
-                EnvDirective::Required(_k, _opts) => {
-                    // Required directives don't set any value - they only validate during validation phase
-                    // The actual value must come from the initial environment or a later config file
+                EnvDirective::Required(k, _opts) => {
+                    // Env required directives only validate. Var required directives also surface
+                    // process environment values so `{{vars.KEY}}` can render.
+                    if resolve_opts.vars {
+                        if redact.unwrap_or(false) {
+                            r.redactions.push(k.clone());
+                        }
+                        if !vars.contains_key(&k)
+                            && let Some(v) = required_env.get(&k)
+                        {
+                            r.vars.insert(k, (v.clone(), source.clone()));
+                        }
+                    }
                 }
                 EnvDirective::Age {
                     key: ref k,
@@ -444,6 +458,10 @@ impl EnvResults {
                     };
 
                     if resolve_opts.vars {
+                        match options.redact {
+                            Some(false) => {}
+                            Some(true) | None => r.redactions.push(k.clone()),
+                        }
                         r.vars.insert(k.clone(), (decrypted_v, source.clone()));
                     } else {
                         r.env_remove.remove(k);
@@ -501,6 +519,9 @@ impl EnvResults {
                         r.env_files.push(f.clone());
                         for (k, v) in new_env {
                             if resolve_opts.vars {
+                                if redact.unwrap_or(false) {
+                                    r.redactions.push(k.clone());
+                                }
                                 r.vars.insert(k, (v, f.clone()));
                             } else {
                                 if redact.unwrap_or(false) {
@@ -528,6 +549,9 @@ impl EnvResults {
                         r.env_scripts.push(f.clone());
                         for (k, v) in new_env {
                             if resolve_opts.vars {
+                                if redact.unwrap_or(false) {
+                                    r.redactions.push(k.clone());
+                                }
                                 r.vars.insert(k, (v, f.clone()));
                             } else {
                                 if redact.unwrap_or(false) {
@@ -644,26 +668,32 @@ impl EnvResults {
             r.env_paths = paths;
         }
 
-        // Validate required environment variables
-        Self::validate_required_env_vars(
+        let context_vars_for_validation = Self::context_vars(&ctx);
+
+        // Validate required variables
+        Self::validate_required_vars(
             &filtered_input_for_validation,
-            initial,
+            required_env,
             &r,
+            &context_vars_for_validation,
             resolve_opts.warn_on_missing_required,
+            resolve_opts.vars,
         )?;
 
         Ok(r)
     }
 
-    fn validate_required_env_vars(
+    fn validate_required_vars(
         input: &[(EnvDirective, PathBuf)],
         initial: &EnvMap,
         env_results: &EnvResults,
+        context_vars: &EnvMap,
         warn_mode: bool,
+        vars_mode: bool,
     ) -> eyre::Result<()> {
         let mut required_vars = Vec::new();
 
-        // Collect all required environment variables with their options
+        // Collect all required variables with their options
         for (directive, source) in input {
             match directive {
                 EnvDirective::Val(key, _, options) if options.required.is_required() => {
@@ -686,16 +716,29 @@ impl EnvResults {
             // 2. In a config file processed later than the one declaring it as required
             let is_predefined = initial.contains_key(&var_name);
 
-            let is_defined_later = if let Some((_, var_source)) = env_results.env.get(&var_name) {
+            let resolved_values = if vars_mode {
+                &env_results.vars
+            } else {
+                &env_results.env
+            };
+            let is_defined_later = if let Some((_, var_source)) = resolved_values.get(&var_name) {
                 // Check if the variable comes from a different config file
                 var_source != &declaring_source
             } else {
                 false
             };
+            let is_defined_in_context =
+                vars_mode && context_vars.get(&var_name).is_some_and(|v| !v.is_empty());
 
-            if !is_predefined && !is_defined_later {
+            if !is_predefined && !is_defined_later && !is_defined_in_context {
+                let variable_kind = if vars_mode {
+                    "variable"
+                } else {
+                    "environment variable"
+                };
                 let base_message = format!(
-                    "Required environment variable '{}' is not defined. It must be set before mise runs or in a later config file. (Required in: {})",
+                    "Required {} '{}' is not defined. It must be set before mise runs or in a later config file. (Required in: {})",
+                    variable_kind,
                     var_name,
                     display_path(declaring_source)
                 );
@@ -715,6 +758,17 @@ impl EnvResults {
         }
 
         Ok(())
+    }
+
+    fn context_vars(ctx: &tera::Context) -> EnvMap {
+        if let Some(Value::Object(existing_vars)) = ctx.get("vars") {
+            existing_vars
+                .iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        } else {
+            EnvMap::new()
+        }
     }
 
     fn parse_template(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -206,7 +206,10 @@ impl Config {
 
         measure!("config::load redactions", {
             config.add_redactions(
-                config.redaction_keys(),
+                config
+                    .redaction_keys()
+                    .into_iter()
+                    .chain(vars_results.redactions.iter().cloned()),
                 &config.vars.clone().into_iter().collect(),
             );
         });

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1220,6 +1220,10 @@ impl Task {
             .iter()
             .map(|(k, (v, _))| (k.clone(), v.clone()))
             .collect();
+        config.add_redactions(
+            vars_results.redactions.iter().cloned(),
+            &vars.clone().into_iter().collect(),
+        );
         TASK_VARS_CACHE
             .lock()
             .unwrap()
@@ -1261,11 +1265,18 @@ impl Task {
         )
         .await?;
 
-        Ok(results
+        let vars: IndexMap<String, String> = results
             .vars
             .iter()
             .map(|(k, (v, _))| (k.clone(), v.clone()))
-            .collect())
+            .collect();
+        let mut redaction_vars: EnvMap = tera_ctx
+            .get("vars")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+        redaction_vars.extend(vars.clone());
+        config.add_redactions(results.redactions.iter().cloned(), &redaction_vars);
+        Ok(vars)
     }
 
     pub fn cf<'a>(&'a self, config: &'a Config) -> Option<&'a Arc<dyn ConfigFile>> {

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -373,6 +373,10 @@ impl TaskContextBuilder {
                 for (k, (v, _)) in &vars_results.vars {
                     vars.insert(k.clone(), v.clone());
                 }
+                config.add_redactions(
+                    vars_results.redactions.iter().cloned(),
+                    &vars.clone().into_iter().collect(),
+                );
                 tera_ctx.insert("vars", &vars);
                 resolved_vars = Some(vars);
             }


### PR DESCRIPTION
## Summary
- make `[vars]` required validation check resolved vars and populate `{{vars.NAME}}` from the process environment when satisfied there
- make `redact = true` on config and task-local vars contribute task output redactions
- render tool option templates recursively so nested option tables can use `{{vars.*}}`
- consolidate `[vars]` docs and document required/redact/default/file behavior

## Tests
- `cargo fmt --all`
- `mise run build`
- `mise run test:e2e e2e/tasks/test_task_vars e2e/config/test_tool_version_vars`
- `mise run test:e2e e2e/config/test_required_env_vars e2e/config/test_required_env_vars_help e2e/config/test_required_env_vars_hook_env`

Discussion: https://github.com/jdx/mise/discussions/10668

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config/env directive resolution, task redaction, and tool option templating—user-visible behavior changes for required vars and secrets, but scope is bounded and covered by new e2e tests.
> 
> **Overview**
> **`[vars]`** now behaves more like env directives for validation and secrecy: **`required`** checks resolved vars (including values from the process environment or a later config file), with clearer errors and optional help text; **`default`** still reads only the process env, not **`[env]`**. **`redact = true`** on config or task-local vars registers those values for **`[redacted]`** in task output.
> 
> Tool **option** templates (including nested tables/arrays) render **`{{vars.*}}`** recursively; HTTP **`url`** / **`checksum_url`** still defer **`os()`** / **`arch()`** for install-time rendering.
> 
> Docs consolidate the **`[vars]`** section and note that vars apply to tool versions/options as well as tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23cb9ac794b6cdda18dca4785b91c84f157b58a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool version/option templates can now reference shared config `vars` via `{{ vars.NAME }}`, with recursive support for template rendering inside nested option arrays/tables.
  * Task/config `vars` gained clearer sourcing rules (including file loading directives) and more consistent `{{ vars.NAME }}` behavior.
* **Bug Fixes**
  * Required-variable validation and related error messaging are more consistent across process environment vs later config files.
  * Redaction is now applied more reliably for resolved vars across rendered task/tool output.
* **Documentation**
  * Updated dev-tools and vars documentation to reflect template resolution order and vars directives/precedence.
* **Tests**
  * Added end-to-end coverage for nested tool option templating and expanded required/redaction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->