### PR TITLE
fix(copr): drop retired Fedora 42 chroots

### DIFF
--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 PACKAGE_NAME="${PACKAGE_NAME:-mise}"
 # TODO(epel-9): drop centos-stream+epel-next-9-* and switch back to epel-9-*
 # once RHEL 9 AppStream ships rust >= mise's MSRV (currently EL9 = 1.88).
-CHROOTS="${CHROOTS:-fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 centos-stream+epel-next-9-aarch64 centos-stream+epel-next-9-x86_64}"
+DEFAULT_CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 epel-10-aarch64 epel-10-x86_64 centos-stream+epel-next-9-aarch64 centos-stream+epel-next-9-x86_64"
+CHROOTS="${CHROOTS:-$DEFAULT_CHROOTS}"
 BUILD_PROFILE="${BUILD_PROFILE:-release}"
 MAINTAINER_NAME="${MAINTAINER_NAME:-mise Release Bot}"
 MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-noreply@mise.jdx.dev}"
@@ -25,7 +26,7 @@ usage() {
 	echo "Options:"
 	echo "  -v, --version VERSION        Package version (required)"
 	echo "  -p, --profile PROFILE        Build profile (default: release)"
-	echo "  -c, --chroots CHROOTS        COPR chroots (default: fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 centos-stream+epel-next-9-aarch64 centos-stream+epel-next-9-x86_64)"
+	echo "  -c, --chroots CHROOTS        COPR chroots (default: $DEFAULT_CHROOTS)"
 	echo "  -o, --owner OWNER            COPR owner (default: jdxcode)"
 	echo "  -j, --project PROJECT        COPR project (default: mise)"
 	echo "  -n, --name NAME              Package name (default: mise)"


### PR DESCRIPTION
## Summary
- Drop retired Fedora 42 COPR chroots from the default build list.
- Reuse `DEFAULT_CHROOTS` in the help output so usage text stays in sync with the real default.

Refs https://github.com/jdx/mise/discussions/10654.

## Validation
- `bash -n packaging/copr/build-copr.sh`
- `if rg -n "fedora-42" packaging/copr/build-copr.sh; then exit 1; else echo "No fedora-42 chroots remain"; fi`
- `bash packaging/copr/build-copr.sh --help | rg "COPR chroots"`
- Verified every remaining default chroot against `https://copr.fedorainfracloud.org/api_3/mock-chroots/list`.

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to COPR chroot defaults; no runtime or application code affected.
> 
> **Overview**
> Updates the COPR release script so **default builds no longer target retired Fedora 42** (`fedora-42-aarch64` / `fedora-42-x86_64`).
> 
> The default chroot list is now defined once in **`DEFAULT_CHROOTS`**, with `CHROOTS` defaulting to that value and **`--help` printing the same list**, so the documented defaults stay aligned with what the script actually submits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb0649707d3814357b34233fd4ff336428f2bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default COPR chroot selection to use the latest supported set.
  * Adjusted the `--chroots` help text so it now shows the current default values automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->