### PR TITLE
fix(config): use vars in task include templates

### DIFF
--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -181,6 +181,8 @@ Subdirectory tasks automatically use tools and environment variables from parent
 
 `vars` follow the same hierarchy for task templating, so child config vars are available when
 running subdirectory tasks from the monorepo root.
+Child `task_config.includes` templates can also reference inherited vars, which is useful for
+centralized task includes like <span v-pre>`git::https://example.com/tasks.git//go.toml?ref={{vars.central_ref}}`</span>.
 
 ### Layering Example
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -662,6 +662,8 @@ includes = [
 ```
 
 When `task_config.includes` is set, it replaces the default file-task directories for that config scope instead of adding to them.
+Include entries are rendered as Tera templates, so they can reference values such as `config_root`,
+`env`, and resolved `vars`.
 
 The default file-task directories are:
 

--- a/e2e/tasks/test_task_config_includes_templates
+++ b/e2e/tasks/test_task_config_includes_templates
@@ -35,3 +35,30 @@ assert_contains "mise tasks" "env_home_include"
 assert "mise run root_include" "root include"
 assert "mise run tilde_include" "tilde include"
 assert "mise run env_home_include" "env home include"
+
+# Root vars are available when rendering child config task includes.
+mkdir -p monorepo/folder1 monorepo/tasks-v1
+
+cat >monorepo/mise.toml <<'EOF'
+monorepo_root = true
+
+[vars]
+central_ref = "v1"
+
+[monorepo]
+config_roots = ["folder1"]
+EOF
+
+cat >monorepo/tasks-v1/tasks.toml <<'EOF'
+[shared_include]
+run = 'echo "shared include"'
+EOF
+
+cat >monorepo/folder1/mise.toml <<'EOF'
+[task_config]
+includes = ["../tasks-{{vars.central_ref}}/*.toml"]
+EOF
+
+cd monorepo
+assert_contains "mise tasks ls --all" "//folder1:shared_include"
+assert "mise run //folder1:shared_include" "shared include"

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -687,7 +687,7 @@ impl MiseToml {
     }
 
     fn parse_template(&self, input: &str) -> eyre::Result<String> {
-        self.parse_template_with_context(&self.context, input)
+        self.parse_template_with_context(&self.template_context(), input)
     }
 
     fn parse_template_with_context(
@@ -705,6 +705,31 @@ impl MiseToml {
             eyre!("failed to parse template {input} in {p}")
         })?;
         Ok(output)
+    }
+
+    fn template_context(&self) -> TeraContext {
+        let mut context = self.context.clone();
+        Self::insert_resolved_vars(&mut context);
+        context
+    }
+
+    fn insert_resolved_vars(context: &mut TeraContext) {
+        if context.get("vars").is_some() {
+            return;
+        }
+        let Some(config) = Config::maybe_get() else {
+            return;
+        };
+        if let Some(vars_results) = config.vars_results_cached() {
+            let vars = vars_results
+                .vars
+                .iter()
+                .map(|(k, (v, _))| (k.clone(), v.clone()))
+                .collect::<IndexMap<_, _>>();
+            context.insert("vars", &vars);
+        } else if !config.vars.is_empty() {
+            context.insert("vars", &config.vars);
+        }
     }
 
     /// Render a tool-option template at config-load time, resolving env/vars but
@@ -928,20 +953,7 @@ impl ConfigFile for MiseToml {
             );
             context.insert("env", &env_vars);
         }
-        if context.get("vars").is_none()
-            && let Some(config) = Config::maybe_get()
-        {
-            if let Some(vars_results) = config.vars_results_cached() {
-                let vars = vars_results
-                    .vars
-                    .iter()
-                    .map(|(k, (v, _))| (k.clone(), v.clone()))
-                    .collect::<IndexMap<_, _>>();
-                context.insert("vars", &vars);
-            } else if !config.vars.is_empty() {
-                context.insert("vars", &config.vars);
-            }
-        }
+        Self::insert_resolved_vars(&mut context);
         for (ba, tvp) in tools.iter() {
             for tool in &tvp.0 {
                 let version = self.parse_template_with_context(&context, &tool.tt.to_string())?;


### PR DESCRIPTION
## Summary
- render config templates with resolved `vars` once a config has loaded, including `task_config.includes`
- reuse the resolved-vars context helper for tool request rendering
- add a monorepo e2e covering root vars in child config task includes
- document vars in `task_config.includes` templates

Closes/discusses https://github.com/jdx/mise/discussions/10644.

## Tests
- `mise run build`
- `mise run test:e2e e2e/tasks/test_task_config_includes_templates`
- `mise run docs:release`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to config-load Tera context for templates; behavior change only affects include paths and other templated fields that reference `vars`, with e2e coverage for the reported gap.
> 
> **Overview**
> Config Tera rendering (including **`task_config.includes`**) now builds template context with **merged, resolved `vars`** from the loaded config, not only per-file context. A shared **`insert_resolved_vars`** helper supplies cached or raw config vars and is used for **`parse_template`** and tool-version templating.
> 
> **Monorepo:** child configs can template includes with inherited root vars (e.g. `../tasks-{{vars.central_ref}}/*.toml` or git refs). Docs note **`vars`** in include templates; e2e covers the monorepo case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f7edea1f758cb3460096c453970ad69d65ffda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Include patterns in task configuration can now use templated values from inherited settings, environment values, and resolved variables.
  * Monorepo setups can reference shared task configurations more flexibly from child projects.

* **Bug Fixes**
  * Improved template rendering so task includes work consistently across nested and monorepo configurations.

* **Documentation**
  * Updated task configuration docs with examples of templated include usage.
  * Clarified monorepo guidance for shared task includes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->