### PR TITLE
feat(env): enable shell expansion by default

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -584,13 +584,9 @@ Of course the ordering matters when doing this.
 
 ## Shell-style variable expansion
 
-As a simpler alternative to Tera templates for referencing env vars, you can use shell-style `$VAR` syntax
-by enabling the [`env_shell_expand`](/configuration/settings.html#env_shell_expand) setting:
+As a simpler alternative to Tera templates for referencing env vars, you can use shell-style `$VAR` syntax:
 
 ```toml
-[settings]
-env_shell_expand = true
-
 [env]
 MY_PROJ_LIB = "{{config_root}}/lib"
 LD_LIBRARY_PATH = "$MY_PROJ_LIB:$LD_LIBRARY_PATH"
@@ -611,11 +607,5 @@ Undefined variables without a default are left unexpanded and produce a warning.
 The setting is a 3-way toggle:
 
 - **`true`** — enable shell expansion
-- **`false`** — disable shell expansion, no warning
-- **unset** (default) — disable shell expansion but warn if `$` is detected
-
-<!-- TODO(2026.7.0): update this to say shell expansion is enabled by default -->
-
-::: tip
-Shell expansion will become the default behavior in the 2026.7.0 release. Set `env_shell_expand = true` now to opt in early, or `env_shell_expand = false` to preserve the current behavior.
-:::
+- **`false`** — disable shell expansion
+- **unset** (default) — enable shell expansion

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -604,8 +604,7 @@ Supported syntax:
 Expansion runs after Tera template rendering, so both syntaxes can be mixed.
 Undefined variables without a default are left unexpanded and produce a warning.
 
-The setting is a 3-way toggle:
+The setting controls shell expansion:
 
-- **`true`** — enable shell expansion
+- **`true`** or **unset** (default) — enable shell expansion
 - **`false`** — disable shell expansion
-- **unset** (default) — enable shell expansion

--- a/e2e/env/test_env_default
+++ b/e2e/env/test_env_default
@@ -48,7 +48,7 @@ cat <<'EOF' >mise.toml
 BASE_DIR = "/opt/tools"
 TOOL_BIN = { default = "$BASE_DIR/bin", tools = true }
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep TOOL_BIN" "export TOOL_BIN=/opt/tools/bin"
+assert_contains "mise env -s bash | grep TOOL_BIN" "export TOOL_BIN=/opt/tools/bin"
 
 # tools=true defaults preserve existing non-empty vars too
 cat <<'EOF' >mise.toml

--- a/e2e/env/test_env_shell_expand
+++ b/e2e/env/test_env_shell_expand
@@ -7,15 +7,15 @@ cat <<'EOF' >mise.toml
 FOO = "hello"
 BAR = "$FOO-world"
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=hello-world"
+assert_contains "mise env -s bash | grep BAR" "export BAR=hello-world"
 
 # Test $$ escapes a literal $
 cat <<'EOF' >mise.toml
 [env]
 SOME_VAR = "$$x"
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash 2>&1" "export SOME_VAR='\$x'"
-MISE_ENV_SHELL_EXPAND=true assert_not_contains "mise env -s bash 2>&1" "env var 'x' is not defined"
+assert_contains "mise env -s bash 2>&1" "export SOME_VAR='\$x'"
+assert_not_contains "mise env -s bash 2>&1" "env var 'x' is not defined"
 
 # Test ${VAR} brace syntax
 cat <<'EOF' >mise.toml
@@ -23,56 +23,56 @@ cat <<'EOF' >mise.toml
 FOO = "hello"
 BAR = "${FOO}_world"
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=hello_world"
+assert_contains "mise env -s bash | grep BAR" "export BAR=hello_world"
 
 # Test ${VAR:-default} syntax
 cat <<'EOF' >mise.toml
 [env]
 BAR = "${NONEXISTENT:-fallback}"
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=fallback"
+assert_contains "mise env -s bash | grep BAR" "export BAR=fallback"
 
 # Test ${VAR:-default} treats empty strings as unset
 cat <<'EOF' >mise.toml
 [env]
 BAR = "${EMPTY_VAR:-fallback}"
 EOF
-EMPTY_VAR='' MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=fallback"
+EMPTY_VAR='' assert_contains "mise env -s bash | grep BAR" "export BAR=fallback"
 
 # Test ${VAR-default} treats empty strings as set
 cat <<'EOF' >mise.toml
 [env]
 BAR = "${EMPTY_VAR-fallback}"
 EOF
-EMPTY_VAR='' MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=''"
+EMPTY_VAR='' assert_contains "mise env -s bash | grep BAR" "export BAR=''"
 
 # Test default values are shell-expanded
 cat <<'EOF' >mise.toml
 [env]
 BAR = "${NONEXISTENT:-$OTHER}"
 EOF
-OTHER=hello MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=hello"
+OTHER=hello assert_contains "mise env -s bash | grep BAR" "export BAR=hello"
 
 # Test unterminated braced expressions stay literal
 cat <<'EOF' >mise.toml
 [env]
 BAR = "${NONEXISTENT:-$OTHER"
 EOF
-OTHER=hello MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR='\${NONEXISTENT:-\$OTHER'"
+OTHER=hello assert_contains "mise env -s bash | grep BAR" "export BAR='\${NONEXISTENT:-\$OTHER'"
 
 # Test } inside command substitution text does not close braced expressions
 cat <<'EOF' >mise.toml
 [env]
 BAR = "${NONEXISTENT:-$(echo })}"
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR='\$(echo })'"
+assert_contains "mise env -s bash | grep BAR" "export BAR='\$(echo })'"
 
 # Test expansion from initial environment
 cat <<'EOF' >mise.toml
 [env]
 FOO = "$INITIAL_VAR"
 EOF
-INITIAL_VAR=from_env MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep FOO" "export FOO=from_env"
+INITIAL_VAR=from_env assert_contains "mise env -s bash | grep FOO" "export FOO=from_env"
 
 # Test disabled explicitly ($ stays literal, no warning)
 cat <<'EOF' >mise.toml
@@ -88,7 +88,7 @@ cat <<'EOF' >mise.toml
 FOO = "hello"
 BAR = "{{ env.FOO }}-$FOO"
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep BAR" "export BAR=hello-hello"
+assert_contains "mise env -s bash | grep BAR" "export BAR=hello-hello"
 
 # Test tools=true vars can reference each other via $
 cat <<'EOF' >mise.toml
@@ -96,7 +96,7 @@ cat <<'EOF' >mise.toml
 TOOL_HOME = { value = "/opt/tools", tools = true }
 TOOL_BIN = { value = "$TOOL_HOME/bin", tools = true }
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep TOOL_BIN" "export TOOL_BIN=/opt/tools/bin"
+assert_contains "mise env -s bash | grep TOOL_BIN" "export TOOL_BIN=/opt/tools/bin"
 
 # Test tools=true var can reference a non-tools var via $
 # (non-tools vars are resolved first, so tools=true vars can see them)
@@ -105,7 +105,7 @@ cat <<'EOF' >mise.toml
 BASE_DIR = "/opt/tools"
 TOOL_BIN = { value = "$BASE_DIR/bin", tools = true }
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep TOOL_BIN" "export TOOL_BIN=/opt/tools/bin"
+assert_contains "mise env -s bash | grep TOOL_BIN" "export TOOL_BIN=/opt/tools/bin"
 
 # Test chained $ expansion across multiple vars
 cat <<'EOF' >mise.toml
@@ -114,18 +114,18 @@ A = "base"
 B = "$A/mid"
 C = "$B/end"
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash | grep '^export C='" "export C=base/mid/end"
+assert_contains "mise env -s bash | grep '^export C='" "export C=base/mid/end"
 
 # Test warning for undefined var (bare $VAR)
 cat <<'EOF' >mise.toml
 [env]
 BAR = "$UNDEFINED_VAR"
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_contains "mise env -s bash 2>&1" "env var 'UNDEFINED_VAR' is not defined"
+assert_contains "mise env -s bash 2>&1" "env var 'UNDEFINED_VAR' is not defined"
 
 # Test ${VAR:-} suppresses warning for undefined var
 cat <<'EOF' >mise.toml
 [env]
 BAR = "${UNDEFINED_VAR:-}"
 EOF
-MISE_ENV_SHELL_EXPAND=true assert_not_contains "mise env -s bash 2>&1" "is not defined"
+assert_not_contains "mise env -s bash 2>&1" "is not defined"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -792,6 +792,7 @@
           "type": "string"
         },
         "env_shell_expand": {
+          "default": true,
           "description": "Controls shell-style variable expansion in env values (e.g., $FOO, ${BAR:-default})",
           "type": "boolean"
         },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -792,7 +792,7 @@
           "type": "string"
         },
         "env_shell_expand": {
-          "description": "Enable shell-style variable expansion in env values (e.g., $FOO, ${BAR:-default})",
+          "description": "Controls shell-style variable expansion in env values (e.g., $FOO, ${BAR:-default})",
           "type": "boolean"
         },
         "erlang": {

--- a/settings.toml
+++ b/settings.toml
@@ -623,6 +623,7 @@ optional = true
 type = "Path"
 
 [env_shell_expand]
+default = true
 description = "Controls shell-style variable expansion in env values (e.g., $FOO, ${BAR:-default})"
 docs = """
 Controls shell-style variable expansion in `mise.toml` `[env]` values:
@@ -639,10 +640,9 @@ QUX = "${UNDEF:-fallback}" # "fallback"
 - `false` — disable shell expansion
 
 Expansion happens after Tera template rendering, so both syntaxes can be mixed.
-Undefined variables are left unexpanded (e.g., `$MISSING` stays as `$MISSING`).
+Undefined variables are left unexpanded (e.g., `$MISSING` stays as `$MISSING`) and produce a warning. Use `${MISSING:-}` to suppress the warning.
 """
 env = "MISE_ENV_SHELL_EXPAND"
-optional = true
 type = "Bool"
 
 [erlang.compile]

--- a/settings.toml
+++ b/settings.toml
@@ -623,7 +623,7 @@ optional = true
 type = "Path"
 
 [env_shell_expand]
-description = "Enable shell-style variable expansion in env values (e.g., $FOO, ${BAR:-default})"
+description = "Controls shell-style variable expansion in env values (e.g., $FOO, ${BAR:-default})"
 docs = """
 Controls shell-style variable expansion in `mise.toml` `[env]` values:
 
@@ -635,10 +635,8 @@ BAZ = "${FOO}_suffix"     # "hello_suffix"
 QUX = "${UNDEF:-fallback}" # "fallback"
 ```
 
-- `true` — enable shell expansion
-- `false` — disable shell expansion (no warning)
-- unset — disable shell expansion but warn if `$` is detected in env values
-  (shell expansion will become the default in a future release)
+- `true` or unset — enable shell expansion
+- `false` — disable shell expansion
 
 Expansion happens after Tera template rendering, so both syntaxes can be mixed.
 Undefined variables are left unexpanded (e.g., `$MISSING` stays as `$MISSING`).

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -744,12 +744,9 @@ impl EnvResults {
 
         // Step 2: Shell-style $VAR expansion
         if output.contains('$') {
-            debug_assert!(
-                !env!("CARGO_PKG_VERSION").starts_with("2026.7"),
-                "change env_shell_expand default to true and remove this warning"
-            );
             match Settings::get().env_shell_expand {
-                Some(true) => {
+                Some(false) => {}
+                Some(true) | None => {
                     let env_vars: BTreeMap<String, String> = ctx
                         .get("env")
                         .and_then(|v| serde_json::from_value(v.clone()).ok())
@@ -763,14 +760,6 @@ impl EnvResults {
                              this warning."
                         );
                     }
-                }
-                Some(false) => {}
-                None => {
-                    warn_once!(
-                        "env value contains '$' which will be expanded in a future release. \
-                         Set `env_shell_expand = true` to opt in or `env_shell_expand = false` to \
-                         keep current behavior and suppress this warning."
-                    );
                 }
             }
         }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -743,24 +743,19 @@ impl EnvResults {
         }
 
         // Step 2: Shell-style $VAR expansion
-        if output.contains('$') {
-            match Settings::get().env_shell_expand {
-                Some(false) => {}
-                Some(true) | None => {
-                    let env_vars: BTreeMap<String, String> = ctx
-                        .get("env")
-                        .and_then(|v| serde_json::from_value(v.clone()).ok())
-                        .unwrap_or_default();
-                    let mut missing_vars = Vec::new();
-                    output = shell_expand_env(&output, &env_vars, &mut missing_vars);
-                    for var in missing_vars {
-                        warn_once!(
-                            "env var '{var}' is not defined and will be left unexpanded. \
-                             Use ${{{var}:-}} to default to an empty string and suppress \
-                             this warning."
-                        );
-                    }
-                }
+        if output.contains('$') && Settings::get().env_shell_expand {
+            let env_vars: BTreeMap<String, String> = ctx
+                .get("env")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+            let mut missing_vars = Vec::new();
+            output = shell_expand_env(&output, &env_vars, &mut missing_vars);
+            for var in missing_vars {
+                warn_once!(
+                    "env var '{var}' is not defined and will be left unexpanded. \
+                     Use ${{{var}:-}} to default to an empty string and suppress \
+                     this warning."
+                );
             }
         }
 


### PR DESCRIPTION
## Summary
- make unset `env_shell_expand` expand shell-style `$VAR` env values by default
- keep explicit `env_shell_expand = false` / `MISE_ENV_SHELL_EXPAND=false` as the opt-out path
- remove the 2026.7 debug assertion and stale future-release warning docs
- update env docs, schema description, and e2e coverage for the new default

## Testing
- `mise run render:schema`
- `mise run test:e2e e2e/env/test_env_default e2e/env/test_env_shell_expand`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for configs that relied on literal `$` in env values without opting in; mitigated by `env_shell_expand = false`.
> 
> **Overview**
> **Shell-style `$VAR` expansion in `[env]` values is now on by default** (unset or `env_shell_expand = true`). Opt out with `env_shell_expand = false` or `MISE_ENV_SHELL_EXPAND=false`.
> 
> The env rendering path in `env_directive` no longer treats “unset” as disabled or emits the old “future release” `$` warnings; undefined vars still warn unless you use `${VAR:-}`.
> 
> Docs, `settings.toml`, and `schema/mise.json` reflect the new default and drop the 2026.7.0 opt-in tip. E2e env tests assert expansion without forcing `MISE_ENV_SHELL_EXPAND=true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a2831e149c54299f94a41ecd4d426379076097d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->