### PR TITLE
fix(github): handle missing lockfile url_api

### DIFF
--- a/e2e/backend/test_github_url_tracking
+++ b/e2e/backend/test_github_url_tracking
@@ -49,7 +49,7 @@ assert_contains "mise x -- hello-world" "hello world"
 # browser URL instead of treating the missing API URL as a custom API endpoint.
 echo "=== Reinstall from cached URL without url_api ==="
 mise uninstall "github:jdx/mise-test-fixtures@1.0.0"
-grep -v 'url_api = "https://api.github.com/repos/jdx/mise-test-fixtures/releases/assets/272317030"' mise.lock >mise.lock.tmp
+grep -v 'url_api = "' mise.lock >mise.lock.tmp
 mv mise.lock.tmp mise.lock
 assert_not_contains "cat mise.lock" 'url_api = "'
 mise install

--- a/e2e/backend/test_github_url_tracking
+++ b/e2e/backend/test_github_url_tracking
@@ -44,4 +44,16 @@ mise install
 # Should still work with cached URL
 assert_contains "mise x -- hello-world" "hello world"
 
+# Lockfiles created before url_api tracking can have a cached browser URL with
+# no matching API URL. Reinstalling from that lockfile should still use the
+# browser URL instead of treating the missing API URL as a custom API endpoint.
+echo "=== Reinstall from cached URL without url_api ==="
+mise uninstall "github:jdx/mise-test-fixtures@1.0.0"
+grep -v 'url_api = "https://api.github.com/repos/jdx/mise-test-fixtures/releases/assets/272317030"' mise.lock >mise.lock.tmp
+mv mise.lock.tmp mise.lock
+assert_not_contains "cat mise.lock" 'url_api = "'
+mise install
+assert_contains "mise x -- hello-world" "hello world"
+assert_not_contains "cat mise.lock" 'url_api = "'
+
 echo "Test completed successfully!"

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -675,7 +675,7 @@ impl Backend for UnifiedGitBackend {
                 }
                 Ok(PlatformInfo {
                     url: Some(asset.url),
-                    url_api: Some(asset.url_api),
+                    url_api: (!asset.url_api.is_empty()).then_some(asset.url_api),
                     checksum: asset.digest,
                     provenance,
                     github_attestations: None,
@@ -1093,46 +1093,50 @@ impl UnifiedGitBackend {
         let platform_key = self.get_platform_key();
         let platform_info = tv.lock_platforms.entry(platform_key).or_default();
         platform_info.url = Some(asset.url.clone());
-        platform_info.url_api = Some(asset.url_api.clone());
+        platform_info.url_api = (!asset.url_api.is_empty()).then(|| asset.url_api.clone());
         if let Some(digest) = &asset.digest {
             debug!("using GitHub API digest for checksum verification");
             platform_info.checksum = Some(digest.clone());
         }
 
-        let url = match asset.url_api.starts_with(DEFAULT_GITHUB_API_BASE_URL)
-            || asset.url_api.starts_with(DEFAULT_GITLAB_API_BASE_URL)
-            || asset.url_api.starts_with(DEFAULT_FORGEJO_API_BASE_URL)
-        {
-            // check if url is reachable, 404 might indicate a private repo or asset.
-            // This is needed, because private repos and assets cannot be downloaded
-            // via browser url, therefore a fallback to api_url is needed in such cases.
-            // Also check Content-Type - if it's text/html, we got a login page (private repo).
-            true => match HTTP.head(asset.url.clone()).await {
-                Ok(resp) => {
-                    let content_type = resp
-                        .headers()
-                        .get("content-type")
-                        .and_then(|v| v.to_str().ok())
-                        .unwrap_or("");
-                    if content_type.contains("text/html") {
-                        debug!("Browser URL returned HTML (likely auth page), using API URL");
-                        asset.url_api.clone()
-                    } else {
-                        asset.url.clone()
+        let url = if asset.url_api.is_empty() {
+            asset.url.clone()
+        } else {
+            match asset.url_api.starts_with(DEFAULT_GITHUB_API_BASE_URL)
+                || asset.url_api.starts_with(DEFAULT_GITLAB_API_BASE_URL)
+                || asset.url_api.starts_with(DEFAULT_FORGEJO_API_BASE_URL)
+            {
+                // check if url is reachable, 404 might indicate a private repo or asset.
+                // This is needed, because private repos and assets cannot be downloaded
+                // via browser url, therefore a fallback to api_url is needed in such cases.
+                // Also check Content-Type - if it's text/html, we got a login page (private repo).
+                true => match HTTP.head(asset.url.clone()).await {
+                    Ok(resp) => {
+                        let content_type = resp
+                            .headers()
+                            .get("content-type")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("");
+                        if content_type.contains("text/html") {
+                            debug!("Browser URL returned HTML (likely auth page), using API URL");
+                            asset.url_api.clone()
+                        } else {
+                            asset.url.clone()
+                        }
                     }
-                }
-                Err(_) => asset.url_api.clone(),
-            },
+                    Err(_) => asset.url_api.clone(),
+                },
 
-            // Custom API URLs usually imply that a custom GitHub/GitLab instance is used.
-            // Often times such instances do not allow browser URL downloads, e.g. due to
-            // upstream company SSOs. Therefore, using the api_url for downloading is the safer approach.
-            false => {
-                debug!(
-                    "Since the tool resides on a custom GitHub/GitLab API ({:?}), the asset download will be performed using the given API instead of browser URL download",
-                    asset.url_api
-                );
-                asset.url_api.clone()
+                // Custom API URLs usually imply that a custom GitHub/GitLab instance is used.
+                // Often times such instances do not allow browser URL downloads, e.g. due to
+                // upstream company SSOs. Therefore, using the api_url for downloading is the safer approach.
+                false => {
+                    debug!(
+                        "Since the tool resides on a custom GitHub/GitLab API ({:?}), the asset download will be performed using the given API instead of browser URL download",
+                        asset.url_api
+                    );
+                    asset.url_api.clone()
+                }
             }
         };
 


### PR DESCRIPTION
## Summary
- treat missing/empty lockfile `url_api` as absent when reusing cached GitHub-style asset URLs
- fall back to the cached browser `url` instead of passing an empty URL into auth/header handling
- avoid serializing empty `url_api` values back into the lockfile

## Test
- `cargo fmt --check`
- `git diff --check`
- `mise run test:e2e e2e/backend/test_github_url_tracking`

Fixes the failure reported in discussion #10664.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to GitHub/GitLab/Forgejo download URL selection and lockfile serialization for legacy lockfiles; covered by e2e.
> 
> **Overview**
> Fixes **GitHub-style installs from older lockfiles** that cache a browser `url` but omit `url_api`.
> 
> When `url_api` is missing or empty, the backend now treats it as absent: downloads use the cached **browser URL** instead of routing through an empty API URL (which was incorrectly handled like a custom enterprise API). Lockfile writes also **omit empty `url_api`** values so they are not re-serialized.
> 
> An e2e scenario strips `url_api` from `mise.lock` and asserts reinstall still succeeds and the lockfile stays without `url_api`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ecd3bf78239c021a4c25491b145ec61c4a55ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool installation and update behavior when a lockfile has no stored download URL.
  * Fixed downloads to fall back correctly so installs still complete and the tool continues to run after reinstall.
  * Preserved missing URL entries instead of unexpectedly adding them back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->