### PR TITLE
feat(upgrade): show release date and eligibility in minimum_release_age warning

### DIFF
--- a/e2e/cli/test_install_before
+++ b/e2e/cli/test_install_before
@@ -47,6 +47,8 @@ mise uninstall jq --all 2>/dev/null || true
 mise install jq@1.6
 output=$(mise upgrade jq --minimum-release-age 2019-01-01 --dry-run 2>&1)
 assert_contains "echo '$output'" "newer jq release"
+# The warning includes the effective minimum_release_age value
+assert_contains "echo '$output'" "ignored by minimum_release_age (2019-01-01)"
 
 # Test: install --minimum-release-age with relative duration "90d"
 mise uninstall tiny --all 2>/dev/null || true

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -237,7 +237,7 @@ fn is_false(v: &bool) -> bool {
 }
 
 impl VersionInfo {
-    fn created_at_timestamp(&self) -> Option<Timestamp> {
+    pub fn created_at_timestamp(&self) -> Option<Timestamp> {
         match &self.created_at {
             Some(ts) => {
                 let created = parse_into_timestamp(ts);

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use crate::backend::pipx::PIPXBackend;
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, config_file};
-use crate::duration::parse_duration;
 use crate::errors::split_install_result;
 use crate::file::display_path;
 use crate::install_before::{
@@ -24,7 +23,7 @@ use crate::{config, exit, runtime_symlinks, ui};
 use console::Term;
 use demand::DemandOption;
 use eyre::{Context, Result, eyre};
-use jiff::Timestamp;
+use jiff::{Span, Timestamp, civil::date};
 
 /// Upgrades outdated tools
 ///
@@ -614,20 +613,25 @@ impl Upgrade {
             };
             match (eligible_latest, baseline_latest) {
                 (Some(eligible), Some(baseline)) if is_outdated_version(&eligible, &baseline) => {
-                    let (released, age) =
-                        hidden_release_details(config, &tv, &baseline, age.as_deref()).await;
-                    warn!(
-                        "newer {} release {baseline}{released} ignored by minimum_release_age{age}; latest eligible release is {eligible}",
-                        tv.ba().short
-                    );
+                    let suffix = format!("latest eligible release is {eligible}");
+                    warn_hidden_release_ignored_by_minimum_release_age(
+                        config,
+                        &tv,
+                        &baseline,
+                        age.as_deref(),
+                        &suffix,
+                    )
+                    .await;
                 }
                 (None, Some(baseline)) => {
-                    let (released, age) =
-                        hidden_release_details(config, &tv, &baseline, age.as_deref()).await;
-                    warn!(
-                        "newer {} release {baseline}{released} ignored by minimum_release_age{age}; no eligible release found",
-                        tv.ba().short
-                    );
+                    warn_hidden_release_ignored_by_minimum_release_age(
+                        config,
+                        &tv,
+                        &baseline,
+                        age.as_deref(),
+                        "no eligible release found",
+                    )
+                    .await;
                 }
                 _ => {}
             }
@@ -679,6 +683,20 @@ fn backend_matches(backends: &HashSet<String>, ba: &BackendArg) -> bool {
         || backends.contains(&ba.full_without_opts())
 }
 
+async fn warn_hidden_release_ignored_by_minimum_release_age(
+    config: &Arc<Config>,
+    tv: &ToolVersion,
+    hidden_version: &str,
+    age: Option<&str>,
+    suffix: &str,
+) {
+    let (released, age) = hidden_release_details(config, tv, hidden_version, age).await;
+    warn!(
+        "newer {} release {hidden_version}{released} ignored by minimum_release_age{age}; {suffix}",
+        tv.ba().short
+    );
+}
+
 /// Fragments for the minimum_release_age warning: when the hidden release came
 /// out and when it becomes eligible, plus the configured age value. The remote
 /// version list is already cached in memory by the resolution that found the
@@ -715,10 +733,8 @@ fn format_hidden_release_details(
         Some(created) => {
             // An age given as an absolute date is a fixed cutoff, so the
             // release never becomes eligible — only show when it will for
-            // duration-style ages.
-            let eligible_at = age
-                .and_then(|age| parse_duration(age).ok())
-                .and_then(|age| created.checked_add(age).ok());
+            // relative ages.
+            let eligible_at = age.and_then(|age| release_eligible_at(created, age));
             let released = created.to_zoned(tz.clone()).strftime("%Y-%m-%d");
             match eligible_at {
                 Some(at) => format!(
@@ -731,6 +747,46 @@ fn format_hidden_release_details(
         None => String::new(),
     };
     (released_fragment, age_fragment)
+}
+
+fn release_eligible_at(created_at: Timestamp, age: &str) -> Option<Timestamp> {
+    const DAY_NANOS: i128 = 86_400 * 1_000_000_000;
+
+    let span = age.parse::<Span>().ok()?;
+    let duration = span.to_duration(date(2025, 1, 1)).ok()?;
+    if duration.is_negative() {
+        return None;
+    }
+    let mut high = created_at
+        .to_zoned(jiff::tz::TimeZone::UTC)
+        .checked_add(&span)
+        .ok()
+        .map(|eligible| eligible.timestamp())?;
+
+    for _ in 0..370 {
+        if release_is_eligible_at(created_at, high, &span) {
+            let mut low_nanos = created_at.as_nanosecond();
+            let mut high_nanos = high.as_nanosecond();
+            while low_nanos < high_nanos {
+                let mid_nanos = low_nanos + (high_nanos - low_nanos) / 2;
+                let mid = Timestamp::from_nanosecond(mid_nanos).ok()?;
+                if release_is_eligible_at(created_at, mid, &span) {
+                    high_nanos = mid_nanos;
+                } else {
+                    low_nanos = mid_nanos + 1;
+                }
+            }
+            return Timestamp::from_nanosecond(high_nanos).ok();
+        }
+        high = Timestamp::from_nanosecond(high.as_nanosecond().checked_add(DAY_NANOS)?).ok()?;
+    }
+    None
+}
+
+fn release_is_eligible_at(created_at: Timestamp, now: Timestamp, age: &Span) -> bool {
+    now.to_zoned(jiff::tz::TimeZone::UTC)
+        .checked_sub(age)
+        .is_ok_and(|cutoff| cutoff.timestamp() >= created_at)
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(
@@ -780,6 +836,30 @@ mod tests {
             " (released 2026-06-26, eligible 2026-06-29 14:03 UTC)"
         );
         assert_eq!(age, " (3d)");
+    }
+
+    #[test]
+    fn test_format_hidden_release_details_with_calendar_age() {
+        let created = "2023-03-01T14:03:00Z".parse().unwrap();
+        let (released, age) =
+            format_hidden_release_details(Some(created), Some("1y"), TimeZone::UTC);
+        assert_eq!(
+            released,
+            " (released 2023-03-01, eligible 2024-03-01 14:03 UTC)"
+        );
+        assert_eq!(age, " (1y)");
+    }
+
+    #[test]
+    fn test_format_hidden_release_details_with_non_reversible_calendar_age() {
+        let created = "2019-01-31T15:30:00Z".parse().unwrap();
+        let (released, age) =
+            format_hidden_release_details(Some(created), Some("1mo"), TimeZone::UTC);
+        assert_eq!(
+            released,
+            " (released 2019-01-31, eligible 2019-03-01 00:00 UTC)"
+        );
+        assert_eq!(age, " (1mo)");
     }
 
     #[test]

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -4,9 +4,12 @@ use std::sync::Arc;
 use crate::backend::pipx::PIPXBackend;
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, config_file};
+use crate::duration::parse_duration;
 use crate::errors::split_install_result;
 use crate::file::display_path;
-use crate::install_before::resolve_cli_minimum_release_age;
+use crate::install_before::{
+    effective_minimum_release_age_for_tool, resolve_cli_minimum_release_age,
+};
 use crate::semver::split_version_prefix;
 use crate::toolset::is_outdated_version;
 use crate::toolset::outdated_info::OutdatedInfo;
@@ -581,6 +584,17 @@ impl Upgrade {
             if opts_with_effective_before_date.before_date.is_none() {
                 continue;
             }
+            // The raw age value for display: a cutoff already present in
+            // `opts` came from the CLI flag; otherwise it resolved from the
+            // per-tool option, the global setting, or the built-in default.
+            let age = if opts.before_date.is_some() {
+                self.minimum_release_age.clone()
+            } else {
+                effective_minimum_release_age_for_tool(
+                    tv.ba(),
+                    tv.request.options().minimum_release_age(),
+                )
+            };
             let eligible_latest = self
                 .latest_for_upgrade(config, &tv, &opts_with_effective_before_date)
                 .await;
@@ -600,14 +614,18 @@ impl Upgrade {
             };
             match (eligible_latest, baseline_latest) {
                 (Some(eligible), Some(baseline)) if is_outdated_version(&eligible, &baseline) => {
+                    let (released, age) =
+                        hidden_release_details(config, &tv, &baseline, age.as_deref()).await;
                     warn!(
-                        "newer {} release {baseline} ignored by minimum_release_age; latest eligible release is {eligible}",
+                        "newer {} release {baseline}{released} ignored by minimum_release_age{age}; latest eligible release is {eligible}",
                         tv.ba().short
                     );
                 }
                 (None, Some(baseline)) => {
+                    let (released, age) =
+                        hidden_release_details(config, &tv, &baseline, age.as_deref()).await;
                     warn!(
-                        "newer {} release {baseline} ignored by minimum_release_age; no eligible release found",
+                        "newer {} release {baseline}{released} ignored by minimum_release_age{age}; no eligible release found",
                         tv.ba().short
                     );
                 }
@@ -661,6 +679,60 @@ fn backend_matches(backends: &HashSet<String>, ba: &BackendArg) -> bool {
         || backends.contains(&ba.full_without_opts())
 }
 
+/// Fragments for the minimum_release_age warning: when the hidden release came
+/// out and when it becomes eligible, plus the configured age value. The remote
+/// version list is already cached in memory by the resolution that found the
+/// hidden release, so this does not trigger another fetch.
+async fn hidden_release_details(
+    config: &Arc<Config>,
+    tv: &ToolVersion,
+    hidden_version: &str,
+    age: Option<&str>,
+) -> (String, String) {
+    let created_at = match tv.backend() {
+        Ok(backend) => backend
+            .list_remote_versions_with_info(config)
+            .await
+            .ok()
+            .and_then(|versions| {
+                versions
+                    .iter()
+                    .find(|v| v.version == hidden_version)
+                    .and_then(|v| v.created_at_timestamp())
+            }),
+        Err(_) => None,
+    };
+    format_hidden_release_details(created_at, age, jiff::tz::TimeZone::system())
+}
+
+fn format_hidden_release_details(
+    created_at: Option<Timestamp>,
+    age: Option<&str>,
+    tz: jiff::tz::TimeZone,
+) -> (String, String) {
+    let age_fragment = age.map(|age| format!(" ({age})")).unwrap_or_default();
+    let released_fragment = match created_at {
+        Some(created) => {
+            // An age given as an absolute date is a fixed cutoff, so the
+            // release never becomes eligible — only show when it will for
+            // duration-style ages.
+            let eligible_at = age
+                .and_then(|age| parse_duration(age).ok())
+                .and_then(|age| created.checked_add(age).ok());
+            let released = created.to_zoned(tz.clone()).strftime("%Y-%m-%d");
+            match eligible_at {
+                Some(at) => format!(
+                    " (released {released}, eligible {})",
+                    at.to_zoned(tz).strftime("%Y-%m-%d %H:%M %Z")
+                ),
+                None => format!(" (released {released})"),
+            }
+        }
+        None => String::new(),
+    };
+    (released_fragment, age_fragment)
+}
+
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
@@ -692,3 +764,46 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise upgrade --local</bold>
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::format_hidden_release_details;
+    use jiff::tz::TimeZone;
+
+    #[test]
+    fn test_format_hidden_release_details_with_duration_age() {
+        let created = "2026-06-26T14:03:00Z".parse().unwrap();
+        let (released, age) =
+            format_hidden_release_details(Some(created), Some("3d"), TimeZone::UTC);
+        assert_eq!(
+            released,
+            " (released 2026-06-26, eligible 2026-06-29 14:03 UTC)"
+        );
+        assert_eq!(age, " (3d)");
+    }
+
+    #[test]
+    fn test_format_hidden_release_details_with_absolute_age() {
+        // An absolute-date cutoff never becomes eligible, so no eligible time
+        let created = "2026-06-26T14:03:00Z".parse().unwrap();
+        let (released, age) =
+            format_hidden_release_details(Some(created), Some("2026-01-01"), TimeZone::UTC);
+        assert_eq!(released, " (released 2026-06-26)");
+        assert_eq!(age, " (2026-01-01)");
+    }
+
+    #[test]
+    fn test_format_hidden_release_details_without_release_date() {
+        let (released, age) = format_hidden_release_details(None, Some("24h"), TimeZone::UTC);
+        assert_eq!(released, "");
+        assert_eq!(age, " (24h)");
+    }
+
+    #[test]
+    fn test_format_hidden_release_details_without_age() {
+        let created = "2026-06-26T14:03:00Z".parse().unwrap();
+        let (released, age) = format_hidden_release_details(Some(created), None, TimeZone::UTC);
+        assert_eq!(released, " (released 2026-06-26)");
+        assert_eq!(age, "");
+    }
+}

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -786,7 +786,7 @@ fn release_eligible_at(created_at: Timestamp, age: &str) -> Option<Timestamp> {
 fn release_is_eligible_at(created_at: Timestamp, now: Timestamp, age: &Span) -> bool {
     now.to_zoned(jiff::tz::TimeZone::UTC)
         .checked_sub(age)
-        .is_ok_and(|cutoff| cutoff.timestamp() >= created_at)
+        .is_ok_and(|cutoff| cutoff.timestamp() > created_at)
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(
@@ -823,7 +823,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use super::format_hidden_release_details;
+    use super::{format_hidden_release_details, release_is_eligible_at};
     use jiff::tz::TimeZone;
 
     #[test]
@@ -860,6 +860,17 @@ mod tests {
             " (released 2019-01-31, eligible 2019-03-01 00:00 UTC)"
         );
         assert_eq!(age, " (1mo)");
+    }
+
+    #[test]
+    fn test_release_is_eligible_at_uses_strict_cutoff() {
+        let created = "2024-01-01T00:00:00Z".parse().unwrap();
+        let age = "24h".parse().unwrap();
+        let exact_cutoff = "2024-01-02T00:00:00Z".parse().unwrap();
+        let after_cutoff = "2024-01-02T00:00:00.000000001Z".parse().unwrap();
+
+        assert!(!release_is_eligible_at(created, exact_cutoff, &age));
+        assert!(release_is_eligible_at(created, after_cutoff, &age));
     }
 
     #[test]

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -759,7 +759,7 @@ fn release_eligible_at(created_at: Timestamp, age: &str) -> Option<Timestamp> {
     }
     let mut high = created_at
         .to_zoned(jiff::tz::TimeZone::UTC)
-        .checked_add(&span)
+        .checked_add(span)
         .ok()
         .map(|eligible| eligible.timestamp())?;
 

--- a/src/install_before.rs
+++ b/src/install_before.rs
@@ -49,7 +49,7 @@ pub fn resolve_before_date(
 ) -> Result<Option<Timestamp>> {
     Ok(
         resolve_before_date_with_excludes(None, before_date, minimum_release_age, false)?
-            .map(|(ts, _)| ts),
+            .map(|(ts, _, _)| ts),
     )
 }
 
@@ -65,7 +65,10 @@ pub fn resolve_cli_minimum_release_age(
             DISABLED_MINIMUM_RELEASE_AGE_CUTOFF,
         )?));
     }
-    Ok(resolve_before_date_with_excludes(None, None, minimum_release_age, true)?.map(|(ts, _)| ts))
+    Ok(
+        resolve_before_date_with_excludes(None, None, minimum_release_age, true)?
+            .map(|(ts, _, _)| ts),
+    )
 }
 
 pub fn resolve_before_date_for_tool(
@@ -87,12 +90,34 @@ pub fn resolve_before_date_for_tool_with_source(
     before_date: Option<Timestamp>,
     minimum_release_age: Option<&str>,
 ) -> Result<Option<(Timestamp, BeforeDateSource)>> {
-    resolve_before_date_with_excludes(
+    Ok(resolve_before_date_with_excludes(
         Some(backend_arg),
         before_date,
         minimum_release_age,
         is_minimum_release_age_excluded(backend_arg),
+    )?
+    .map(|(ts, source, _)| (ts, source)))
+}
+
+/// The raw `minimum_release_age` value (e.g. `"3d"`, `"24h"`, `"2024-01-01"`)
+/// that produces the effective cutoff for a tool, for display in user-facing
+/// messages. Follows the same precedence as
+/// `resolve_before_date_for_tool_with_source`, except cutoffs pre-resolved by
+/// the caller (e.g. the CLI flag) are not visible here — the caller already
+/// knows those. Returns `None` when no cutoff applies to the tool.
+pub fn effective_minimum_release_age_for_tool(
+    backend_arg: &BackendArg,
+    minimum_release_age: Option<&str>,
+) -> Option<String> {
+    resolve_before_date_with_excludes(
+        Some(backend_arg),
+        None,
+        minimum_release_age,
+        is_minimum_release_age_excluded(backend_arg),
     )
+    .ok()
+    .flatten()
+    .and_then(|(_, _, age)| age)
 }
 
 fn resolve_before_date_with_excludes(
@@ -100,9 +125,9 @@ fn resolve_before_date_with_excludes(
     before_date: Option<Timestamp>,
     minimum_release_age: Option<&str>,
     excluded: bool,
-) -> Result<Option<(Timestamp, BeforeDateSource)>> {
+) -> Result<Option<(Timestamp, BeforeDateSource, Option<String>)>> {
     if let Some(before_date) = before_date {
-        return Ok(Some((before_date, BeforeDateSource::Provided)));
+        return Ok(Some((before_date, BeforeDateSource::Provided, None)));
     }
     if let Some(before) = minimum_release_age {
         if parse_duration(before).is_ok_and(|duration| duration.is_zero()) {
@@ -111,6 +136,7 @@ fn resolve_before_date_with_excludes(
         return Ok(Some((
             parse_into_timestamp(before)?,
             BeforeDateSource::Explicit,
+            Some(before.to_string()),
         )));
     }
     if !excluded && let Some(before) = &Settings::get().minimum_release_age {
@@ -120,12 +146,14 @@ fn resolve_before_date_with_excludes(
         return Ok(Some((
             parse_into_timestamp(before)?,
             BeforeDateSource::Explicit,
+            Some(before.to_string()),
         )));
     }
     if !excluded && backend_arg.is_some_and(default_minimum_release_age_applies) {
         return Ok(Some((
             parse_into_timestamp(DEFAULT_MINIMUM_RELEASE_AGE)?,
             BeforeDateSource::Default,
+            Some(DEFAULT_MINIMUM_RELEASE_AGE.to_string()),
         )));
     }
     Ok(None)
@@ -199,8 +227,9 @@ pub(crate) async fn resolve_before_date_for_backend<B: Backend + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::{
-        BeforeDateSource, DEFAULT_MINIMUM_RELEASE_AGE, resolve_before_date,
-        resolve_before_date_for_tool, resolve_before_date_for_tool_with_source,
+        BeforeDateSource, DEFAULT_MINIMUM_RELEASE_AGE, effective_minimum_release_age_for_tool,
+        resolve_before_date, resolve_before_date_for_tool,
+        resolve_before_date_for_tool_with_source,
     };
     use crate::cli::args::BackendArg;
     use crate::config::settings::{Settings, SettingsPartial};
@@ -401,6 +430,39 @@ mod tests {
             .unwrap();
         assert_eq!(ts, cli_before);
         assert_eq!(source, BeforeDateSource::Provided);
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_effective_minimum_release_age_for_tool_reports_raw_value() {
+        Settings::reset(None);
+        let ba: BackendArg = "npm:prettier".into();
+
+        // Built-in default
+        assert_eq!(
+            effective_minimum_release_age_for_tool(&ba, None).as_deref(),
+            Some(DEFAULT_MINIMUM_RELEASE_AGE)
+        );
+
+        // Per-tool option
+        assert_eq!(
+            effective_minimum_release_age_for_tool(&ba, Some("7d")).as_deref(),
+            Some("7d")
+        );
+
+        // Explicit global setting
+        let mut partial = SettingsPartial::empty();
+        partial.minimum_release_age = Some("3d".to_string());
+        Settings::reset(Some(partial));
+        assert_eq!(
+            effective_minimum_release_age_for_tool(&ba, None).as_deref(),
+            Some("3d")
+        );
+        Settings::reset(None);
+
+        // Backend without release timestamps → no cutoff, no value
+        let asdf_ba: BackendArg = "asdf:tiny".into();
+        assert_eq!(effective_minimum_release_age_for_tool(&asdf_ba, None), None);
         Settings::reset(None);
     }
 


### PR DESCRIPTION
Implements the request in https://github.com/jdx/mise/discussions/10655: the `minimum_release_age` warning from `mise upgrade` now tells the user when the ignored version was released, when it becomes eligible, and what the effective `minimum_release_age` value is.

Before:

```
mise WARN  newer jq release 1.8.2 ignored by minimum_release_age; latest eligible release is 1.8.1
```

After (duration-style age — includes when the release becomes eligible, in the local timezone):

```
mise WARN  newer jq release 1.8.2 (released 2026-06-20, eligible 2026-07-20 04:58 PDT) ignored by minimum_release_age (30d); latest eligible release is 1.8.1
```

After (absolute-date cutoff — no eligible time, since a fixed cutoff never passes):

```
mise WARN  newer jq release 1.8.2 (released 2026-06-20) ignored by minimum_release_age (2019-01-01); latest eligible release is 1.6
```

## Implementation

- `src/install_before.rs`: the internal resolver now also carries the raw age value ("3d", "24h", "2024-01-01") that produced the cutoff; new `effective_minimum_release_age_for_tool` exposes it for display following the same precedence (per-tool option → global setting → built-in default). Public resolver signatures are unchanged.
- `src/cli/upgrade.rs`: both warning variants look up the ignored version's `created_at` from `list_remote_versions_with_info` (already cached in memory by the resolution that produced the warning, so no extra fetch) and compute the eligible time as `created_at + age` for duration-style ages. Each fragment degrades gracefully when unavailable (no release timestamp from the backend, CLI-provided cutoff, absolute-date age).
- `src/backend/mod.rs`: `VersionInfo::created_at_timestamp` made `pub`.

## Tests

- Unit tests for the message fragments (`cli::upgrade::tests`) and the raw-age resolution precedence (`install_before::tests`) — 20 pass.
- Extended `e2e/cli/test_install_before` to assert the age value appears in the warning; full `test_install_before*` e2e group passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing warning text and display-only resolution metadata; core install/upgrade version selection paths are unchanged aside from reusing existing cached version lists.
> 
> **Overview**
> **`mise upgrade`** warnings when a newer release is blocked by **`minimum_release_age`** now include the effective cutoff (e.g. `(30d)` or `(2019-01-01)`), the ignored version’s release date when metadata exists, and for relative ages when it becomes eligible (local timezone).
> 
> Resolution plumbing in **`install_before`** threads the raw age string through internal cutoff resolution and adds **`effective_minimum_release_age_for_tool`** so warnings reflect CLI, per-tool, global, or default precedence. **`VersionInfo::created_at_timestamp`** is public for lookup from the cached remote version list (no extra fetch).
> 
> Eligibility time uses calendar-aware span math with a strict cutoff check; absolute-date cutoffs omit an “eligible” time. Unit tests cover message formatting and age precedence; e2e **`test_install_before`** asserts the age appears in the upgrade warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608667103fe6c85e5437fae87ac00172ff201d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgrade warnings now include the effective cutoff date when a newer release is hidden, plus eligibility timing when applicable.
* **Bug Fixes**
  * Improved minimum-release-age handling to consistently reflect the correct source/value being applied across different age formats, including correct behavior at eligibility boundaries and graceful omission when release timestamps aren’t available.
* **Tests**
  * Expanded CLI dry-run assertions and added unit coverage to verify the displayed minimum-release-age string (or its absence) under multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->