### PR TITLE
fix(task): render monorepo subproject task templates with their own env

### DIFF
--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -181,9 +181,11 @@ Subdirectory tasks automatically use tools and environment variables from parent
 
 `vars` follow the same hierarchy for task templating, so child config vars are available when
 running subdirectory tasks from the monorepo root.
+
 Task templates like <span v-pre>`sources = ["{{env.SRC_DIR}}/*"]`</span> are rendered with env from the
 task's own config hierarchy, so a subproject's `[env]` section applies no matter where the task
 is invoked from.
+
 Child `task_config.includes` templates can also reference inherited vars, which is useful for
 centralized task includes like <span v-pre>`git::https://example.com/tasks.git//go.toml?ref={{vars.central_ref}}`</span>.
 

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -181,6 +181,9 @@ Subdirectory tasks automatically use tools and environment variables from parent
 
 `vars` follow the same hierarchy for task templating, so child config vars are available when
 running subdirectory tasks from the monorepo root.
+Task templates like <span v-pre>`sources = ["{{env.SRC_DIR}}/*"]`</span> are rendered with env from the
+task's own config hierarchy, so a subproject's `[env]` section applies no matter where the task
+is invoked from.
 Child `task_config.includes` templates can also reference inherited vars, which is useful for
 centralized task includes like <span v-pre>`git::https://example.com/tasks.git//go.toml?ref={{vars.central_ref}}`</span>.
 

--- a/e2e/tasks/test_task_ls_complete_monorepo
+++ b/e2e/tasks/test_task_ls_complete_monorepo
@@ -34,13 +34,27 @@ sources = ["{{env.WEB_SOURCE}}/*.txt"]
 outputs = ["{{env.WEB_OUTPUT}}/done.txt"]
 run = 'mkdir -p "$WEB_OUTPUT" && echo updating snapshots > "$WEB_OUTPUT/done.txt" && echo updating snapshots'
 CONFIG
+mkdir -p apps/web/mise-tasks
+cat <<'CONFIG' >apps/web/mise-tasks/script-snapshots
+#!/usr/bin/env bash
+#MISE description="Update monorepo script snapshots"
+#MISE sources=["{{env.WEB_SOURCE}}/*.txt"]
+#MISE outputs=["{{env.WEB_OUTPUT}}/script-done.txt"]
+mkdir -p "$WEB_OUTPUT"
+echo script snapshots >"$WEB_OUTPUT/script-done.txt"
+echo script snapshots
+CONFIG
+chmod +x apps/web/mise-tasks/script-snapshots
 
 # Completion output should include the //-prefixed task path with escaped colon
 assert_contains "mise task ls --complete" '//apps/web\:update-snapshots:Update monorepo snapshots'
+assert_contains "mise task ls --complete" '//apps/web\:script-snapshots:Update monorepo script snapshots'
 # Running from the monorepo root renders the task templates with the
 # subproject's env (WEB_OUTPUT=dist, not the root's root-dist)
 assert "mise -q run //apps/web:update-snapshots" "updating snapshots"
 assert "cat apps/web/dist/done.txt" "updating snapshots"
+assert "mise -q run //apps/web:script-snapshots" "script snapshots"
+assert "cat apps/web/dist/script-done.txt" "script snapshots"
 
 # A task with a template that legitimately fails to render must not break
 # loading tasks from other subprojects

--- a/e2e/tasks/test_task_ls_complete_monorepo
+++ b/e2e/tasks/test_task_ls_complete_monorepo
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 # Verify task completion output includes monorepo tasks when using // paths
 
-# Root config marks repo as monorepo
+# Root config marks repo as monorepo. WEB_OUTPUT is also defined here with a
+# different value to verify subproject env wins when rendering subproject tasks.
 cat <<'CONFIG' >mise.toml
 monorepo_root = true
+
+[env]
+WEB_OUTPUT = "root-dist"
 
 [monorepo]
 config_roots = ["apps/*"]
@@ -12,13 +16,38 @@ config_roots = ["apps/*"]
 run = 'echo root'
 CONFIG
 
-# App subproject task that should appear in completions
-mkdir -p apps/web
+# App subproject task that should appear in completions. Its sources/outputs
+# reference env vars from the subproject's own [env] section — rendering these
+# from the monorepo root used to fail with "Variable `env...` not found" and
+# break completion for the whole monorepo:
+# https://github.com/jdx/mise/discussions/10126
+mkdir -p apps/web/src
+echo "snapshot input" >apps/web/src/input.txt
 cat <<'CONFIG' >apps/web/mise.toml
+[env]
+WEB_SOURCE = "src"
+WEB_OUTPUT = "dist"
+
 [tasks.update-snapshots]
 description = "Update monorepo snapshots"
-run = 'echo updating snapshots'
+sources = ["{{env.WEB_SOURCE}}/*.txt"]
+outputs = ["{{env.WEB_OUTPUT}}/done.txt"]
+run = 'mkdir -p "$WEB_OUTPUT" && echo updating snapshots > "$WEB_OUTPUT/done.txt" && echo updating snapshots'
 CONFIG
 
 # Completion output should include the //-prefixed task path with escaped colon
+assert_contains "mise task ls --complete" '//apps/web\:update-snapshots:Update monorepo snapshots'
+# Running from the monorepo root renders the task templates with the
+# subproject's env (WEB_OUTPUT=dist, not the root's root-dist)
+assert "mise -q run //apps/web:update-snapshots" "updating snapshots"
+assert "cat apps/web/dist/done.txt" "updating snapshots"
+
+# A task with a template that legitimately fails to render must not break
+# loading tasks from other subprojects
+mkdir -p apps/broken
+cat <<'CONFIG' >apps/broken/mise.toml
+[tasks.broken-task]
+sources = ["{{env.DOES_NOT_EXIST}}/*"]
+run = 'echo broken'
+CONFIG
 assert_contains "mise task ls --complete" '//apps/web\:update-snapshots:Update monorepo snapshots'

--- a/e2e/tasks/test_task_ls_complete_monorepo
+++ b/e2e/tasks/test_task_ls_complete_monorepo
@@ -61,7 +61,7 @@ assert "cat apps/web/dist/script-done.txt" "script snapshots"
 mkdir -p apps/broken
 cat <<'CONFIG' >apps/broken/mise.toml
 [task_config]
-includes = ["tasks.toml"]
+includes = ["tasks.toml", "mise-tasks"]
 
 [tasks.broken-task]
 sources = ["{{env.DOES_NOT_EXIST}}/*"]
@@ -72,6 +72,14 @@ cat <<'CONFIG' >apps/broken/tasks.toml
 sources = ["{{env.DOES_NOT_EXIST}}/*"]
 run = 'echo broken include'
 CONFIG
+mkdir -p apps/broken/mise-tasks
+cat <<'CONFIG' >apps/broken/mise-tasks/broken-script
+#!/usr/bin/env bash
+#MISE sources=["{{env.DOES_NOT_EXIST}}/*"]
+echo broken script
+CONFIG
+chmod +x apps/broken/mise-tasks/broken-script
 assert_contains "mise task ls --complete" '//apps/web\:update-snapshots:Update monorepo snapshots'
 assert_not_contains "mise task ls --complete" '//apps/broken\:broken-task'
 assert_not_contains "mise task ls --complete" '//apps/broken\:broken-included-task'
+assert_not_contains "mise task ls --complete" '//apps/broken\:broken-script'

--- a/e2e/tasks/test_task_ls_complete_monorepo
+++ b/e2e/tasks/test_task_ls_complete_monorepo
@@ -46,8 +46,18 @@ assert "cat apps/web/dist/done.txt" "updating snapshots"
 # loading tasks from other subprojects
 mkdir -p apps/broken
 cat <<'CONFIG' >apps/broken/mise.toml
+[task_config]
+includes = ["tasks.toml"]
+
 [tasks.broken-task]
 sources = ["{{env.DOES_NOT_EXIST}}/*"]
 run = 'echo broken'
 CONFIG
+cat <<'CONFIG' >apps/broken/tasks.toml
+[broken-included-task]
+sources = ["{{env.DOES_NOT_EXIST}}/*"]
+run = 'echo broken include'
+CONFIG
 assert_contains "mise task ls --complete" '//apps/web\:update-snapshots:Update monorepo snapshots'
+assert_not_contains "mise task ls --complete" '//apps/broken\:broken-task'
+assert_not_contains "mise task ls --complete" '//apps/broken\:broken-included-task'

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2590,9 +2590,24 @@ async fn load_tasks_includes(
             let config_root = config_root.clone();
             let config = config.clone();
             trust_check_task_include(&path, require_trust)?;
-            let mut task =
-                Task::from_path_with_cf(&config, &path, &root, &config_root, monorepo_cf.cloned())
-                    .await?;
+            let mut task = Task::from_path_unrendered_with_cf(
+                &path,
+                &root,
+                &config_root,
+                monorepo_cf.cloned(),
+            )?;
+            if let Err(err) = task.render(&config, &config_root).await {
+                if monorepo_cf.is_some() {
+                    warn!(
+                        "Failed to render task {} in {}: {err:#}. Task will not be available.",
+                        task.name,
+                        display_path(&path)
+                    );
+                    continue;
+                } else {
+                    return Err(err);
+                }
+            }
             if task.dir.is_none()
                 && let Some(ref dir) = *task_config_dir
             {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2885,10 +2885,23 @@ async fn load_task_file(
     for (_, mut task) in tasks {
         let config_root = config_root.to_path_buf();
         resolve_task_template(&mut task, templates)?;
-        if let Err(err) = task.render(config, &config_root).await {
-            warn!("rendering task: {err:?}");
+        match task.render(config, &config_root).await {
+            Ok(()) => {
+                out.push(task);
+            }
+            Err(err) => {
+                if monorepo_cf.is_some() {
+                    warn!(
+                        "Failed to render task {} in {}: {err:#}. Task will not be available.",
+                        task.name,
+                        display_path(path)
+                    );
+                } else {
+                    warn!("rendering task: {err:?}");
+                    out.push(task);
+                }
+            }
         }
-        out.push(task);
     }
     Ok(out)
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2590,10 +2590,9 @@ async fn load_tasks_includes(
             let config_root = config_root.clone();
             let config = config.clone();
             trust_check_task_include(&path, require_trust)?;
-            let mut task = Task::from_path(&config, &path, &root, &config_root).await?;
-            if let Some(monorepo_cf) = monorepo_cf {
-                task.cf = Some(monorepo_cf.clone());
-            }
+            let mut task =
+                Task::from_path_with_cf(&config, &path, &root, &config_root, monorepo_cf.cloned())
+                    .await?;
             if task.dir.is_none()
                 && let Some(ref dir) = *task_config_dir
             {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2011,14 +2011,19 @@ async fn load_local_tasks_with_context(
                     for config_path in config_paths {
                         match config_file::parse(&config_path).await {
                             Ok(cf) => {
-                                let mut subdir_tasks =
-                                    load_config_and_file_tasks(&config, cf.clone(), &templates).await?;
+                                // Pass the owning config file so tasks get `task.cf` set
+                                // before templates render — Task::tera_ctx needs it to
+                                // resolve vars/env from the subproject's own config
+                                // hierarchy rather than the caller's.
+                                let mut subdir_tasks = load_config_and_file_tasks(
+                                    &config,
+                                    cf.clone(),
+                                    &templates,
+                                    Some(&cf),
+                                )
+                                .await?;
 
                                 prefix_monorepo_task_names(&mut subdir_tasks, &subdir, &monorepo_root);
-                                for task in subdir_tasks.iter_mut() {
-                                    // Store reference to config file for later use
-                                    task.cf = Some(cf.clone());
-                                }
 
                                 // Add tasks to map - later tasks override earlier ones with same name
                                 for task in subdir_tasks {
@@ -2044,7 +2049,7 @@ async fn load_local_tasks_with_context(
                         let includes = task_includes_for_dir(&subdir, &config.config_files)?;
                         for include in includes {
                             let mut subdir_tasks = load_tasks_includes(
-                                &config, &include, &subdir, &None, &templates, true,
+                                &config, &include, &subdir, &None, &templates, None, true,
                             )
                             .await?;
                             if is_global_task_include_path(&include) {
@@ -2335,19 +2340,27 @@ async fn load_global_tasks(
         .collect::<Vec<_>>();
     let mut tasks = vec![];
     for cf in config_files {
-        tasks.extend(load_config_and_file_tasks(config, cf.clone(), templates).await?);
+        tasks.extend(load_config_and_file_tasks(config, cf.clone(), templates, None).await?);
     }
     Ok(tasks)
 }
 
+/// `monorepo_cf` is the owning config file when loading a monorepo subdirectory
+/// outside the current config hierarchy. It is stored on each task as `task.cf`
+/// *before* rendering so templates resolve vars/env from the subproject's own
+/// config hierarchy, and it makes render errors non-fatal so one broken
+/// subproject doesn't break task loading for the whole monorepo.
 async fn load_config_and_file_tasks(
     config: &Arc<Config>,
     cf: Arc<dyn ConfigFile>,
     templates: &IndexMap<String, TaskTemplate>,
+    monorepo_cf: Option<&Arc<dyn ConfigFile>>,
 ) -> Result<Vec<Task>> {
     let config_root = cf.config_root();
-    let config_tasks = load_config_tasks(config, cf.clone(), &config_root, templates).await?;
-    let file_tasks = load_file_tasks(config, cf.clone(), &config_root, templates).await?;
+    let config_tasks =
+        load_config_tasks(config, cf.clone(), &config_root, templates, monorepo_cf).await?;
+    let file_tasks =
+        load_file_tasks(config, cf.clone(), &config_root, templates, monorepo_cf).await?;
     Ok(merge_file_and_config_tasks(file_tasks, config_tasks))
 }
 
@@ -2469,6 +2482,7 @@ async fn load_config_tasks(
     cf: Arc<dyn ConfigFile>,
     config_root: &Path,
     templates: &IndexMap<String, TaskTemplate>,
+    monorepo_cf: Option<&Arc<dyn ConfigFile>>,
 ) -> Result<Vec<Task>> {
     let is_global = is_global_config(cf.get_path());
     let config_root = Arc::new(config_root.to_path_buf());
@@ -2483,6 +2497,9 @@ async fn load_config_tasks(
         if t.config_root.is_none() {
             t.config_root = Some(config_root.to_path_buf());
         }
+        if let Some(monorepo_cf) = monorepo_cf {
+            t.cf = Some(monorepo_cf.clone());
+        }
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
         match t.render(&config, &config_root).await {
@@ -2490,7 +2507,15 @@ async fn load_config_tasks(
                 tasks.push(t);
             }
             Err(e) => {
-                return Err(e);
+                if monorepo_cf.is_some() {
+                    warn!(
+                        "Failed to render task {} in {}: {e:#}. Task will not be available.",
+                        t.name,
+                        display_path(cf.get_path())
+                    );
+                } else {
+                    return Err(e);
+                }
             }
         }
     }
@@ -2503,11 +2528,20 @@ async fn load_tasks_includes(
     config_root: &Path,
     task_config_dir: &Option<String>,
     templates: &IndexMap<String, TaskTemplate>,
+    monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     require_trust: bool,
 ) -> Result<Vec<Task>> {
     if root.is_file() && root.extension().map(|e| e == "toml").unwrap_or(false) {
         trust_check_task_include(root, require_trust)?;
-        load_task_file(config, root, config_root, task_config_dir, templates).await
+        load_task_file(
+            config,
+            root,
+            config_root,
+            task_config_dir,
+            templates,
+            monorepo_cf,
+        )
+        .await
     } else if root.is_dir() {
         let all_files = WalkDir::new(root)
             .follow_links(true)
@@ -2538,7 +2572,15 @@ async fn load_tasks_includes(
         for path in toml_files {
             trust_check_task_include(&path, require_trust)?;
             tasks.extend(
-                load_task_file(config, &path, config_root, task_config_dir, templates).await?,
+                load_task_file(
+                    config,
+                    &path,
+                    config_root,
+                    task_config_dir,
+                    templates,
+                    monorepo_cf,
+                )
+                .await?,
             );
         }
         let root = Arc::new(root.to_path_buf());
@@ -2549,6 +2591,9 @@ async fn load_tasks_includes(
             let config = config.clone();
             trust_check_task_include(&path, require_trust)?;
             let mut task = Task::from_path(&config, &path, &root, &config_root).await?;
+            if let Some(monorepo_cf) = monorepo_cf {
+                task.cf = Some(monorepo_cf.clone());
+            }
             if task.dir.is_none()
                 && let Some(ref dir) = *task_config_dir
             {
@@ -2644,6 +2689,7 @@ async fn load_file_tasks(
     cf: Arc<dyn ConfigFile>,
     config_root: &Path,
     templates: &IndexMap<String, TaskTemplate>,
+    monorepo_cf: Option<&Arc<dyn ConfigFile>>,
 ) -> Result<Vec<Task>> {
     let includes = cf
         .task_config_includes()?
@@ -2670,6 +2716,7 @@ async fn load_file_tasks(
                 &config_root,
                 &task_config_dir,
                 templates,
+                monorepo_cf,
                 require_task_include_trust,
             )
             .await?;
@@ -2740,7 +2787,7 @@ pub async fn load_tasks_in_dir(
     let mut config_tasks = vec![];
     for cf in &configs {
         let dir = dir.to_path_buf();
-        config_tasks.extend(load_config_tasks(config, (*cf).clone(), &dir, templates).await?);
+        config_tasks.extend(load_config_tasks(config, (*cf).clone(), &dir, templates, None).await?);
     }
 
     // Find task_config.dir from the highest-precedence config that defines it
@@ -2760,6 +2807,7 @@ pub async fn load_tasks_in_dir(
                 dir,
                 &task_config_dir,
                 templates,
+                None,
                 require_task_include_trust,
             )
             .await?;
@@ -2816,6 +2864,7 @@ async fn load_task_file(
     config_root: &Path,
     task_config_dir: &Option<String>,
     templates: &IndexMap<String, TaskTemplate>,
+    monorepo_cf: Option<&Arc<dyn ConfigFile>>,
 ) -> Result<Vec<Task>> {
     let raw = file::read_to_string_async(path).await?;
     let mut tasks = toml::from_str::<Tasks>(&raw)
@@ -2827,6 +2876,9 @@ async fn load_task_file(
         task.config_root = Some(config_root.to_path_buf());
         if task.dir.is_none() {
             task.dir = task_config_dir.clone();
+        }
+        if let Some(monorepo_cf) = monorepo_cf {
+            task.cf = Some(monorepo_cf.clone());
         }
     }
     let mut out = vec![];
@@ -3553,6 +3605,7 @@ vars = { target = "linux" }
             temp_dir.path(),
             &None,
             &IndexMap::new(),
+            None,
         )
         .await?;
         assert_eq!(tasks.len(), 1);

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -566,6 +566,17 @@ impl Task {
         config_root: &Path,
         cf: Option<Arc<dyn ConfigFile>>,
     ) -> Result<Task> {
+        let mut task = Self::from_path_unrendered_with_cf(path, prefix, config_root, cf)?;
+        task.render(config, config_root).await?;
+        Ok(task)
+    }
+
+    pub(crate) fn from_path_unrendered_with_cf(
+        path: &Path,
+        prefix: &Path,
+        config_root: &Path,
+        cf: Option<Arc<dyn ConfigFile>>,
+    ) -> Result<Task> {
         let mut task = Task::new(path, prefix, config_root)?;
         task.cf = cf;
         let info = parse_mise_header_toml(&file::read_to_string(path)?)?
@@ -692,7 +703,6 @@ impl Task {
             let fields: Vec<String> = p.parsed_keys().map(|s| s.to_string()).collect();
             tests::capture_parsed_fields(fields);
         }
-        task.render(config, config_root).await?;
         Ok(task)
     }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -556,7 +556,18 @@ impl Task {
         prefix: &Path,
         config_root: &Path,
     ) -> Result<Task> {
+        Self::from_path_with_cf(config, path, prefix, config_root, None).await
+    }
+
+    pub async fn from_path_with_cf(
+        config: &Arc<Config>,
+        path: &Path,
+        prefix: &Path,
+        config_root: &Path,
+        cf: Option<Arc<dyn ConfigFile>>,
+    ) -> Result<Task> {
         let mut task = Task::new(path, prefix, config_root)?;
+        task.cf = cf;
         let info = parse_mise_header_toml(&file::read_to_string(path)?)?
             .into_iter()
             .filter_map(|toml| toml.as_table().cloned())
@@ -1285,10 +1296,7 @@ impl Task {
             .into_iter()
             .flatten()
             .collect();
-        let mut env: EnvMap = tera_ctx
-            .get("env")
-            .and_then(|v| serde_json::from_value(v.clone()).ok())
-            .unwrap_or_else(|| env::PRISTINE_ENV.clone());
+        let mut env: EnvMap = env::PRISTINE_ENV.clone();
         let mut resolve_ctx = tera_ctx.clone();
         resolve_ctx.insert("config_root", &task_project_root);
         let results = EnvResults::resolve(

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -30,8 +30,12 @@ use xx::regex;
 static TASK_VARS_CACHE: Lazy<std::sync::Mutex<IndexMap<PathBuf, IndexMap<String, String>>>> =
     Lazy::new(|| std::sync::Mutex::new(IndexMap::new()));
 
+static TASK_ENV_CACHE: Lazy<std::sync::Mutex<IndexMap<PathBuf, EnvMap>>> =
+    Lazy::new(|| std::sync::Mutex::new(IndexMap::new()));
+
 pub(crate) fn reset() {
     TASK_VARS_CACHE.lock().unwrap().clear();
+    TASK_ENV_CACHE.lock().unwrap().clear();
 }
 
 /// Type alias for tracking failed tasks with their exit codes
@@ -1185,6 +1189,7 @@ impl Task {
         // Insert base vars first so that task-level var templates can reference them
         // (e.g. a task var `foo = "{{vars.bar}}"` can read a config-level `bar`).
         tera_ctx.insert("vars", &vars);
+        self.resolve_base_env(config, &mut tera_ctx).await?;
         vars.extend(self.resolve_task_vars(config, &tera_ctx).await?);
         // Re-insert with task-level vars merged in so callers see the final combined map,
         // with task-level values taking precedence over config-level ones.
@@ -1225,6 +1230,103 @@ impl Task {
             .unwrap()
             .insert(config_path, vars.clone());
         Ok(vars)
+    }
+
+    /// For tasks belonging to a different config hierarchy than the current one
+    /// (monorepo subproject tasks loaded from outside their directory), replace the
+    /// `env` in the tera context with env resolved from the task's own config
+    /// hierarchy. Otherwise templates like `{{env.FOO}}` in `sources`/`outputs`
+    /// only see the caller's env and fail or render stale values
+    /// (https://github.com/jdx/mise/discussions/10126).
+    async fn resolve_base_env(
+        &self,
+        config: &Arc<Config>,
+        tera_ctx: &mut tera::Context,
+    ) -> Result<()> {
+        if config::Settings::no_env() || config::Settings::get().no_env.unwrap_or(false) {
+            return Ok(());
+        }
+        // Remote tasks use the full config hierarchy, not a task-local one
+        if self.is_remote() {
+            return Ok(());
+        }
+        let Some(task_cf) = self.cf(config) else {
+            return Ok(());
+        };
+        // Global/system configs have no project root; their env is already in the
+        // base context. Only tasks from a *different* project hierarchy need this.
+        let Some(task_project_root) = task_cf.project_root() else {
+            return Ok(());
+        };
+        if Some(&task_project_root) == config.project_root.as_ref() {
+            return Ok(());
+        }
+
+        let config_path = task_cf.get_path().to_path_buf();
+        if let Some(env) = TASK_ENV_CACHE.lock().unwrap().get(&config_path) {
+            tera_ctx.insert("env", env);
+            return Ok(());
+        }
+
+        let task_dir = task_cf.get_path().parent().unwrap_or(task_cf.get_path());
+        let (config_paths, idiomatic_filenames) =
+            crate::config::load_config_hierarchy_from_dir(task_dir).await?;
+        let task_config_files =
+            crate::config::load_config_files_from_paths(&config_paths, &idiomatic_filenames)
+                .await?;
+        let entries: Vec<(EnvDirective, PathBuf)> = task_config_files
+            .iter()
+            .rev()
+            .map(|(source, cf)| {
+                cf.env_entries()
+                    .map(|ee| ee.into_iter().map(|e| (e, source.clone())))
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect();
+        let mut env: EnvMap = tera_ctx
+            .get("env")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_else(|| env::PRISTINE_ENV.clone());
+        let mut resolve_ctx = tera_ctx.clone();
+        resolve_ctx.insert("config_root", &task_project_root);
+        let results = EnvResults::resolve(
+            config,
+            resolve_ctx,
+            &env,
+            entries,
+            EnvResolveOptions {
+                vars: false,
+                tools: ToolsFilter::NonToolsOnly,
+                warn_on_missing_required: false,
+            },
+        )
+        .await?;
+        for (k, (v, _)) in results.env {
+            env.insert(k, v);
+        }
+        for key in &results.env_remove {
+            env.remove(key);
+        }
+        if !results.env_paths.is_empty() {
+            let mut path_env = PathEnv::from_iter(env::split_paths(
+                &env.get(&*env::PATH_KEY).cloned().unwrap_or_default(),
+            ));
+            for path in results.env_paths {
+                path_env.add(path);
+            }
+            env.insert(env::PATH_KEY.to_string(), path_env.to_string());
+        }
+        if !results.redactions.is_empty() {
+            config.add_redactions(results.redactions, &env);
+        }
+        TASK_ENV_CACHE
+            .lock()
+            .unwrap()
+            .insert(config_path, env.clone());
+        tera_ctx.insert("env", &env);
+        Ok(())
     }
 
     async fn resolve_task_vars(


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/10126 — supersedes #10699 with a smaller approach that reuses the existing per-task context machinery instead of adding a parallel env-resolution pipeline to task loading.

## Problem

In a monorepo, task metadata templates (`sources`, `outputs`, `dir`, …) in subproject configs were rendered at discovery time with the *caller's* config env. `{{env.FOO}}` referencing the subproject's own `[env]` failed with `Variable env.FOO not found` when tasks were loaded from anywhere outside that subproject, and the error was fatal — breaking `mise run //path:task` and `mise tasks ls --complete` for the entire monorepo.

## Approach

`Task::tera_ctx` already resolves `vars` from the task's own config hierarchy via `resolve_base_vars` (#8248), cached per config file. This PR adds the exact analog for `env` (`resolve_base_env` + `TASK_ENV_CACHE`): when the task's config belongs to a different project root, env is resolved from that hierarchy (`ToolsFilter::NonToolsOnly`, no toolset build) and overlaid on the base context, so subproject values win over same-named root values.

To make this reachable at discovery time, monorepo subdirectory task loading now sets `task.cf` *before* rendering instead of after (threaded as `monorepo_cf` through `load_config_tasks`/`load_task_file` etc. — `task.cf` is still only ever set for monorepo subdir tasks, so non-monorepo toolset behavior is unchanged).

Compared with #10699 this:

- resolves env lazily (only for tasks that actually contain template syntax, via the existing `has_render_templates` gate) and caches per config file, rather than eagerly resolving env for every subdir on every `task ls` — this was Bugbot's high-severity finding there (env `_.source` scripts executing during completion for every subproject)
- keeps the full tera context (toolset env base, `vars`, `config_root`, task-level vars) instead of a minimal vars+env-only context — Bugbot's other finding
- benefits every `Task::tera_ctx` consumer (deps re-render, usage spec parsing, `dir`/`file` rendering), not just the initial metadata render

Additionally, a render error in one subproject's task now warns and skips that task instead of aborting task loading repo-wide, matching how config parse errors in monorepo subdirs are already handled — one broken subproject no longer kills completion for the whole monorepo.

## Tests

- Extended `e2e/tasks/test_task_ls_complete_monorepo`: subproject `sources`/`outputs` env templates render from the monorepo root (with a same-named root env var proving subproject precedence), and a subproject with an unresolvable template no longer breaks other subprojects' tasks
- Verified the exact repro from the discussion manually (`mise run //foo:test` + completion from the monorepo root)
- Full monorepo e2e suite (41 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task discovery/rendering and env resolution for monorepo subprojects (affects completion and `//` task runs), but scope is limited to tasks whose project root differs from the caller and non-monorepo paths are unchanged.
> 
> **Overview**
> Fixes monorepo subproject tasks whose `sources`/`outputs` (and other metadata) use `{{env.*}}` when loaded from the repo root: templates now resolve **env from the subproject’s config hierarchy** (with subproject values winning over same-named root env), mirroring existing per-task `vars` resolution.
> 
> **Implementation:** `Task::tera_ctx` gains `resolve_base_env` with a per-config-file cache; monorepo subdir loading sets `task.cf` **before** render via a threaded `monorepo_cf` path through config/file/include task loaders. Script tasks use `from_path_unrendered_with_cf` so `#MISE` headers render with the same context.
> 
> **Resilience:** For monorepo-owned tasks only, template render failures warn and skip that task instead of aborting discovery/completion for the whole monorepo.
> 
> Docs note the `{{env.*}}` scoping behavior; e2e covers completion, run-from-root, env precedence, and a “broken” subproject not breaking siblings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c1bd6f1f686fb821900ecbb29118cc295ca678d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Monorepo subproject tasks now correctly scope and apply `env` values from the subproject’s configuration hierarchy, even when invoked from the monorepo root.
  * Template rendering failures for monorepo-owned tasks no longer break discovery/completion; unaffected tasks still appear and run, while broken ones are omitted.
* **Documentation**
  * Added clarification on how `{{env.*}}` template values are resolved in monorepos.
* **Tests**
  * Expanded e2e coverage for `ls --complete`, escaped `:` task paths, env scoping, and omission of tasks with missing env variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->