### PR TITLE
feat(monorepo): add install union and unified lockfiles

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -54,6 +54,13 @@ Only install versions released before this date or older than this duration
 
 Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
 
+### `--monorepo`
+
+Install tools from every [monorepo].config_roots config root
+
+Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+[monorepo].config_roots in the monorepo root config.
+
 ### `--raw`
 
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
@@ -71,13 +78,6 @@ Install tool(s) to the system-wide shared directory
 
 Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
-
-### `--monorepo`
-
-Install tools from every [monorepo].config_roots config root
-
-Uses the active MISE_ENV and requires monorepo_root = true plus explicit
-[monorepo].config_roots in the monorepo root config.
 
 Examples:
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -72,6 +72,13 @@ Install tool(s) to the system-wide shared directory
 Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
 
+### `--monorepo`
+
+Install tools from every [monorepo].config_roots config root
+
+Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+[monorepo].config_roots in the monorepo root config.
+
 Examples:
 
 ```

--- a/docs/cli/ls.md
+++ b/docs/cli/ls.md
@@ -65,6 +65,13 @@ Display versions matching this prefix
 
 List only tools that can be pruned with `mise prune`
 
+### `--monorepo`
+
+List tools from every [monorepo].config_roots config root
+
+Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+[monorepo].config_roots in the monorepo root config.
+
 Examples:
 
 ```

--- a/docs/cli/ls.md
+++ b/docs/cli/ls.md
@@ -49,6 +49,13 @@ Display missing tool versions
 
 Display all tracked config sources for tools
 
+### `--monorepo`
+
+List tools from every [monorepo].config_roots config root
+
+Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+[monorepo].config_roots in the monorepo root config.
+
 ### `--no-header`
 
 Don't display headers
@@ -64,13 +71,6 @@ Display versions matching this prefix
 ### `--prunable`
 
 List only tools that can be pruned with `mise prune`
-
-### `--monorepo`
-
-List tools from every [monorepo].config_roots config root
-
-Uses the active MISE_ENV and requires monorepo_root = true plus explicit
-[monorepo].config_roots in the monorepo root config.
 
 Examples:
 

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -46,7 +46,7 @@ will skip tools defined in the global config (~/.config/mise/config.toml).
 
 ### `--monorepo`
 
-Show outdated tools across every [monorepo].config_roots config root
+Placeholder for future monorepo outdated checks; `mise outdated --monorepo` is not implemented yet.
 
 ### `--no-header`
 

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -48,6 +48,10 @@ will skip tools defined in the global config (~/.config/mise/config.toml).
 
 Don't show table header
 
+### `--monorepo`
+
+Show outdated tools across every [monorepo].config_roots config root
+
 Examples:
 
 ```

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -44,13 +44,13 @@ Only show outdated tools defined in local config files
 This will only show tools that are defined in project-local mise.toml and
 will skip tools defined in the global config (~/.config/mise/config.toml).
 
-### `--no-header`
-
-Don't show table header
-
 ### `--monorepo`
 
 Show outdated tools across every [monorepo].config_roots config root
+
+### `--no-header`
+
+Don't show table header
 
 Examples:
 

--- a/docs/cli/prune.md
+++ b/docs/cli/prune.md
@@ -39,6 +39,10 @@ This is useful for scripts to check if tools need to be pruned.
 
 Prune only unused versions of tools
 
+### `--monorepo`
+
+Prune tools across every [monorepo].config_roots config root
+
 Examples:
 
 ```

--- a/docs/cli/prune.md
+++ b/docs/cli/prune.md
@@ -35,13 +35,13 @@ Like --dry-run but exits with code 1 if there are tools to prune
 
 This is useful for scripts to check if tools need to be pruned.
 
-### `--tools`
-
-Prune only unused versions of tools
-
 ### `--monorepo`
 
 Prune tools across every [monorepo].config_roots config root
+
+### `--tools`
+
+Prune only unused versions of tools
 
 Examples:
 

--- a/docs/cli/prune.md
+++ b/docs/cli/prune.md
@@ -37,7 +37,7 @@ This is useful for scripts to check if tools need to be pruned.
 
 ### `--monorepo`
 
-Prune tools across every [monorepo].config_roots config root
+Placeholder for future monorepo pruning; `mise prune --monorepo` is not implemented yet.
 
 ### `--tools`
 

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -82,6 +82,10 @@ Explicitly pinned versions like "22.5.0" are not filtered.
 
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
 
+### `--monorepo`
+
+Upgrade tools across every [monorepo].config_roots config root
+
 Examples:
 
 ```

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -78,13 +78,13 @@ This can be useful for reproducibility or security purposes.
 This only affects fuzzy version matches like "20" or "latest".
 Explicitly pinned versions like "22.5.0" are not filtered.
 
-### `--raw`
-
-Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-
 ### `--monorepo`
 
 Upgrade tools across every [monorepo].config_roots config root
+
+### `--raw`
+
+Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
 
 Examples:
 

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -80,7 +80,7 @@ Explicitly pinned versions like "22.5.0" are not filtered.
 
 ### `--monorepo`
 
-Upgrade tools across every [monorepo].config_roots config root
+Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.
 
 ### `--raw`
 

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -137,9 +137,9 @@ mise lock --local node python  # update specific tools in mise.local.lock
 
 ## Monorepos
 
-When `monorepo_root = true`, mise uses a single lockfile at the monorepo root by default. Subproject configs listed in `[monorepo].config_roots` write to root lockfile variants such as `mise.lock`, `mise.ci.lock`, and `mise.local.lock`.
+When `monorepo_root = true`, mise can use a single lockfile at the monorepo root. Set `[monorepo] lockfile = true` to opt into root lockfile variants such as `mise.lock`, `mise.ci.lock`, and `mise.local.lock`.
 
-Existing subproject lockfiles are migrated into the root lockfile on the next lock-aware command. Older mise versions do not understand this layout for subproject-owned tools, so projects that need mixed-version compatibility can opt out:
+Existing subproject lockfiles are migrated into the root lockfile on the next lock-aware command. Unset keeps per-subproject lockfiles during the rollout, starts warning in mise `2026.12.0`, and defaults to root lockfiles in mise `2027.6.0`. Older mise versions do not understand this layout for subproject-owned tools, so projects that need mixed-version compatibility can pin the old behavior:
 
 ```toml
 [monorepo]

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -139,7 +139,7 @@ mise lock --local node python  # update specific tools in mise.local.lock
 
 When `monorepo_root = true`, mise can use a single lockfile at the monorepo root. Set `[monorepo] lockfile = true` to opt into root lockfile variants such as `mise.lock`, `mise.ci.lock`, and `mise.local.lock`.
 
-Existing subproject lockfiles are migrated into the root lockfile on the next lock-aware command. Unset keeps per-subproject lockfiles during the rollout, starts warning in mise `2026.12.0`, and defaults to root lockfiles in mise `2027.6.0`. Older mise versions do not understand this layout for subproject-owned tools, so projects that need mixed-version compatibility can pin the old behavior:
+Existing subproject lockfiles are migrated into the root lockfile on the next lock-aware command. Unset keeps per-subproject lockfiles during the rollout. Monorepos using `mise*.lock` files start warning in mise `2026.12.0`, and unset defaults to root lockfiles in mise `2027.6.0`. Older mise versions do not understand this layout for subproject-owned tools, so projects that need mixed-version compatibility can pin the old behavior:
 
 ```toml
 [monorepo]

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -135,6 +135,19 @@ mise lock --local              # update mise.local.lock
 mise lock --local node python  # update specific tools in mise.local.lock
 ```
 
+## Monorepos
+
+When `monorepo_root = true`, mise uses a single lockfile at the monorepo root by default. Subproject configs listed in `[monorepo].config_roots` write to root lockfile variants such as `mise.lock`, `mise.ci.lock`, and `mise.local.lock`.
+
+Existing subproject lockfiles are migrated into the root lockfile on the next lock-aware command. Older mise versions do not understand this layout for subproject-owned tools, so projects that need mixed-version compatibility can opt out:
+
+```toml
+[monorepo]
+lockfile = false
+```
+
+See [Monorepo Tasks](/tasks/monorepo.html#lockfiles) for details.
+
 ## Strict Lockfile Mode
 
 The `locked` setting enforces that all tools have pre-resolved URLs in the lockfile before installation. This prevents API calls to GitHub, aqua registry, etc., ensuring fully reproducible installations.

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -261,7 +261,7 @@ To keep lockfiles next to each subproject config after the default changes, pin 
 lockfile = false
 ```
 
-Unset will start warning in mise `2026.12.0` and will default to root lockfiles in mise `2027.6.0`. Older mise versions do not understand unified monorepo lockfiles for subproject-owned tools. Teams that need mixed-version compatibility should use `lockfile = false` until everyone has upgraded.
+Unset monorepos that use `mise*.lock` files will start warning in mise `2026.12.0` and will default to root lockfiles in mise `2027.6.0`. Older mise versions do not understand unified monorepo lockfiles for subproject-owned tools. Teams that need mixed-version compatibility should use `lockfile = false` until everyone has upgraded.
 
 ## Config Roots
 

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -243,18 +243,25 @@ mise install --monorepo node
 
 ## Lockfiles
 
-By default, monorepos use one lockfile at the monorepo root. Tools from `packages/api/mise.toml` write to `<monorepo_root>/mise.lock`, while environment and local variants write to root files such as `mise.ci.lock` and `mise.local.lock`.
+Monorepos can use one lockfile at the monorepo root. Tools from `packages/api/mise.toml` write to `<monorepo_root>/mise.lock`, while environment and local variants write to root files such as `mise.ci.lock` and `mise.local.lock`.
+
+This is rolling out as a tri-state setting. During the rollout window, unset keeps today's per-subproject lockfile behavior. Set `lockfile = true` to opt into root lockfiles now:
+
+```toml
+[monorepo]
+lockfile = true
+```
 
 If mise finds old subproject lockfiles, it migrates them into the root lockfile the next time a lock-aware command runs. Root entries win on conflicts, unique subproject entries are preserved, and migrated subproject lockfiles are removed.
 
-To keep lockfiles next to each subproject config, opt out in the monorepo root:
+To keep lockfiles next to each subproject config after the default changes, pin the old behavior in the monorepo root:
 
 ```toml
 [monorepo]
 lockfile = false
 ```
 
-Older mise versions do not understand unified monorepo lockfiles for subproject-owned tools. Teams that need mixed-version compatibility should use `lockfile = false` until everyone has upgraded.
+Unset will start warning in mise `2026.12.0` and will default to root lockfiles in mise `2027.6.0`. Older mise versions do not understand unified monorepo lockfiles for subproject-owned tools. Teams that need mixed-version compatibility should use `lockfile = false` until everyone has upgraded.
 
 ## Config Roots
 

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -225,6 +225,37 @@ run = "npm run build"  # Uses node 20 and LOG_LEVEL=info from root
 2. **Subdirectory override**: Tools and environment defined in the subdirectory's config file are merged on top, allowing overrides
 3. **Task-specific tools and environment**: Values defined in the task's `tools` and `env` properties take highest precedence
 
+## Tools
+
+Use `mise install --monorepo` to install the union of tools from every directory listed in `[monorepo].config_roots`. This is useful in CI when you want to warm a cache for all projects in the repository:
+
+```bash
+MISE_ENV=ci mise install --monorepo
+```
+
+Passing a tool name filters the union while preserving multiple configured versions:
+
+```bash
+mise install --monorepo node
+```
+
+`mise ls --monorepo` lists the same union and can be used to inspect cache keys or debug which config roots are contributing tools. Both commands require `monorepo_root = true` and explicit `[monorepo].config_roots`.
+
+## Lockfiles
+
+By default, monorepos use one lockfile at the monorepo root. Tools from `packages/api/mise.toml` write to `<monorepo_root>/mise.lock`, while environment and local variants write to root files such as `mise.ci.lock` and `mise.local.lock`.
+
+If mise finds old subproject lockfiles, it migrates them into the root lockfile the next time a lock-aware command runs. Root entries win on conflicts, unique subproject entries are preserved, and migrated subproject lockfiles are removed.
+
+To keep lockfiles next to each subproject config, opt out in the monorepo root:
+
+```toml
+[monorepo]
+lockfile = false
+```
+
+Older mise versions do not understand unified monorepo lockfiles for subproject-owned tools. Teams that need mixed-version compatibility should use `lockfile = false` until everyone has upgraded.
+
 ## Config Roots
 
 You must explicitly list your config roots using the `[monorepo]` section:

--- a/e2e/cli/test_install_monorepo
+++ b/e2e/cli/test_install_monorepo
@@ -2,8 +2,8 @@
 
 export MISE_EXPERIMENTAL=1
 
-ln -sf "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
-ln -sf "$ROOT/test/data/plugins/dummy" "$MISE_DATA_DIR/plugins/dummy"
+rm -rf "$MISE_DATA_DIR/plugins/tiny"
+ln -s "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
 
 echo "=== install --monorepo installs every configured root ==="
 mkdir -p monorepo/packages/a monorepo/packages/b
@@ -43,12 +43,19 @@ assert_contains "echo '$output'" "2.1.0"
 assert_contains "echo '$output'" "dummy"
 
 echo "=== --monorepo requires monorepo_root and explicit config_roots ==="
-mkdir -p outside no-roots
+mkdir -p outside no-roots empty-roots
 cat >no-roots/mise.toml <<'EOF'
 monorepo_root = true
 EOF
+cat >empty-roots/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
 assert_fail_contains "cd outside && mise install --monorepo 2>&1" "monorepo_root = true"
 assert_fail_contains "cd no-roots && mise install --monorepo 2>&1" "[monorepo].config_roots is required"
+assert_fail_contains "cd empty-roots && mise install --monorepo 2>&1" "did not match any config roots"
 
 echo "=== deferred --monorepo commands are explicit stubs ==="
 assert_fail_contains "cd monorepo && mise upgrade --monorepo 2>&1" "not implemented"

--- a/e2e/cli/test_install_monorepo
+++ b/e2e/cli/test_install_monorepo
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+ln -sf "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
+ln -sf "$ROOT/test/data/plugins/dummy" "$MISE_DATA_DIR/plugins/dummy"
+
+echo "=== install --monorepo installs every configured root ==="
+mkdir -p monorepo/packages/a monorepo/packages/b
+cat >monorepo/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
+cat >monorepo/packages/a/mise.toml <<'EOF'
+[tools]
+tiny = "1.0.0"
+EOF
+cat >monorepo/packages/b/mise.toml <<'EOF'
+[tools]
+tiny = "2.1.0"
+dummy = "1.0.0"
+EOF
+
+assert "cd monorepo && mise install --monorepo"
+assert "test -d '$MISE_DATA_DIR/installs/tiny/1.0.0'"
+assert "test -d '$MISE_DATA_DIR/installs/tiny/2.1.0'"
+assert "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+
+echo "=== install --monorepo TOOL filters across roots ==="
+rm -rf "$MISE_DATA_DIR/installs/tiny" "$MISE_DATA_DIR/installs/dummy"
+assert "cd monorepo && mise install --monorepo tiny"
+assert "test -d '$MISE_DATA_DIR/installs/tiny/1.0.0'"
+assert "test -d '$MISE_DATA_DIR/installs/tiny/2.1.0'"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+
+echo "=== ls --monorepo includes every configured root ==="
+output=$(cd monorepo && mise ls --monorepo 2>&1)
+assert_contains "echo '$output'" "tiny"
+assert_contains "echo '$output'" "1.0.0"
+assert_contains "echo '$output'" "2.1.0"
+assert_contains "echo '$output'" "dummy"
+
+echo "=== --monorepo requires monorepo_root and explicit config_roots ==="
+mkdir -p outside no-roots
+cat >no-roots/mise.toml <<'EOF'
+monorepo_root = true
+EOF
+assert_fail_contains "cd outside && mise install --monorepo 2>&1" "monorepo_root = true"
+assert_fail_contains "cd no-roots && mise install --monorepo 2>&1" "[monorepo].config_roots is required"
+
+echo "=== deferred --monorepo commands are explicit stubs ==="
+assert_fail_contains "cd monorepo && mise upgrade --monorepo 2>&1" "not implemented"
+assert_fail_contains "cd monorepo && mise prune --monorepo 2>&1" "not implemented"
+assert_fail_contains "cd monorepo && mise outdated --monorepo 2>&1" "not implemented"

--- a/e2e/cli/test_install_monorepo
+++ b/e2e/cli/test_install_monorepo
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
 export MISE_EXPERIMENTAL=1
+export MISE_IDIOMATIC_VERSION_FILE_ENABLE_TOOLS=dummy
 
 rm -rf "$MISE_DATA_DIR/plugins/tiny"
 ln -s "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
 
 echo "=== install --monorepo installs every configured root ==="
-mkdir -p monorepo/packages/a monorepo/packages/b
+mkdir -p monorepo/packages/a monorepo/packages/b monorepo/packages/c
 cat >monorepo/mise.toml <<'EOF'
 monorepo_root = true
 
@@ -22,18 +23,22 @@ cat >monorepo/packages/b/mise.toml <<'EOF'
 tiny = "2.1.0"
 dummy = "1.0.0"
 EOF
+echo "2" >monorepo/packages/c/.dummy-version
 
 assert "cd monorepo && mise install --monorepo"
 assert "test -d '$MISE_DATA_DIR/installs/tiny/1.0.0'"
 assert "test -d '$MISE_DATA_DIR/installs/tiny/2.1.0'"
 assert "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert "test -d '$MISE_DATA_DIR/installs/dummy/2.0.0'"
 
 echo "=== install --monorepo TOOL filters across roots ==="
 rm -rf "$MISE_DATA_DIR/installs/tiny" "$MISE_DATA_DIR/installs/dummy"
 assert "cd monorepo && mise install --monorepo tiny"
 assert "test -d '$MISE_DATA_DIR/installs/tiny/1.0.0'"
 assert "test -d '$MISE_DATA_DIR/installs/tiny/2.1.0'"
+assert_fail "test -d '$MISE_DATA_DIR/installs/tiny/3.1.0'"
 assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/2.0.0'"
 
 echo "=== ls --monorepo includes every configured root ==="
 output=$(cd monorepo && mise ls --monorepo 2>&1)
@@ -41,6 +46,11 @@ assert_contains "echo '$output'" "tiny"
 assert_contains "echo '$output'" "1.0.0"
 assert_contains "echo '$output'" "2.1.0"
 assert_contains "echo '$output'" "dummy"
+assert_contains "echo '$output'" "2.0.0"
+
+echo "=== ls --monorepo rejects modes that bypass monorepo union ==="
+assert_fail_contains "cd monorepo && mise ls --monorepo --prunable 2>&1" "cannot be used with"
+assert_fail_contains "cd monorepo && mise ls --monorepo --all-sources 2>&1" "cannot be used with"
 
 echo "=== --monorepo requires monorepo_root and explicit config_roots ==="
 mkdir -p outside no-roots empty-roots

--- a/e2e/cli/test_lock_project_root_scope
+++ b/e2e/cli/test_lock_project_root_scope
@@ -39,13 +39,14 @@ assert_contains "echo '$output'" "jqlang/jq"
 assert_contains "echo '$output'" ".config/mise.lock"
 assert_not_contains "echo '$output'" "cli/cli"
 
-echo "=== Testing monorepo lock scope is full-view by default ==="
+echo "=== Testing [monorepo] lockfile = true uses full-view lock scope ==="
 mkdir -p monorepo-root/packages/api
 
 cat >monorepo-root/mise.toml <<'EOF'
 monorepo_root = true
 
 [monorepo]
+lockfile = true
 config_roots = ["packages/*"]
 
 [tools]
@@ -64,6 +65,32 @@ assert_contains "echo '$output'" "cli/cli"
 output=$(cd monorepo-root && env MISE_EXPERIMENTAL=1 mise lock --platform linux-x64 --dry-run 2>&1)
 assert_contains "echo '$output'" "cli/cli"
 assert_contains "echo '$output'" "mikefarah/yq"
+
+echo "=== Testing unset [monorepo].lockfile keeps active config root scope during rollout ==="
+mkdir -p monorepo-unset/packages/api
+
+cat >monorepo-unset/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+
+[tools]
+"aqua:cli/cli" = "2.65.0"
+EOF
+
+cat >monorepo-unset/packages/api/mise.toml <<'EOF'
+[tools]
+"aqua:mikefarah/yq" = "4.44.6"
+EOF
+
+output=$(cd monorepo-unset/packages/api && env MISE_EXPERIMENTAL=1 mise lock --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "mikefarah/yq"
+assert_not_contains "echo '$output'" "cli/cli"
+
+output=$(cd monorepo-unset && env MISE_EXPERIMENTAL=1 mise lock --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "cli/cli"
+assert_not_contains "echo '$output'" "mikefarah/yq"
 
 echo "=== Testing [monorepo] lockfile = false keeps active config root scope ==="
 mkdir -p monorepo-optout/packages/api
@@ -139,6 +166,6 @@ assert_not_contains "echo '$output'" "Would update"
 assert_not_contains "echo '$output'" "cli/cli"
 
 echo "=== Cleanup ==="
-rm -rf scope-root monorepo-root monorepo-optout bump-root global-only system-config "$MISE_CONFIG_DIR/config.toml"
+rm -rf scope-root monorepo-root monorepo-unset monorepo-optout bump-root global-only system-config "$MISE_CONFIG_DIR/config.toml"
 
 echo "mise lock project root scope tests passed!"

--- a/e2e/cli/test_lock_project_root_scope
+++ b/e2e/cli/test_lock_project_root_scope
@@ -39,7 +39,7 @@ assert_contains "echo '$output'" "jqlang/jq"
 assert_contains "echo '$output'" ".config/mise.lock"
 assert_not_contains "echo '$output'" "cli/cli"
 
-echo "=== Testing monorepo lock scope follows the active config root ==="
+echo "=== Testing monorepo lock scope is full-view by default ==="
 mkdir -p monorepo-root/packages/api
 
 cat >monorepo-root/mise.toml <<'EOF'
@@ -59,9 +59,36 @@ EOF
 
 output=$(cd monorepo-root/packages/api && env MISE_EXPERIMENTAL=1 mise lock --platform linux-x64 --dry-run 2>&1)
 assert_contains "echo '$output'" "mikefarah/yq"
-assert_not_contains "echo '$output'" "cli/cli"
+assert_contains "echo '$output'" "cli/cli"
 
 output=$(cd monorepo-root && env MISE_EXPERIMENTAL=1 mise lock --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "cli/cli"
+assert_contains "echo '$output'" "mikefarah/yq"
+
+echo "=== Testing [monorepo] lockfile = false keeps active config root scope ==="
+mkdir -p monorepo-optout/packages/api
+
+cat >monorepo-optout/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+lockfile = false
+config_roots = ["packages/*"]
+
+[tools]
+"aqua:cli/cli" = "2.65.0"
+EOF
+
+cat >monorepo-optout/packages/api/mise.toml <<'EOF'
+[tools]
+"aqua:mikefarah/yq" = "4.44.6"
+EOF
+
+output=$(cd monorepo-optout/packages/api && env MISE_EXPERIMENTAL=1 mise lock --platform linux-x64 --dry-run 2>&1)
+assert_contains "echo '$output'" "mikefarah/yq"
+assert_not_contains "echo '$output'" "cli/cli"
+
+output=$(cd monorepo-optout && env MISE_EXPERIMENTAL=1 mise lock --platform linux-x64 --dry-run 2>&1)
 assert_contains "echo '$output'" "cli/cli"
 assert_not_contains "echo '$output'" "mikefarah/yq"
 
@@ -112,6 +139,6 @@ assert_not_contains "echo '$output'" "Would update"
 assert_not_contains "echo '$output'" "cli/cli"
 
 echo "=== Cleanup ==="
-rm -rf scope-root monorepo-root bump-root global-only system-config "$MISE_CONFIG_DIR/config.toml"
+rm -rf scope-root monorepo-root monorepo-optout bump-root global-only system-config "$MISE_CONFIG_DIR/config.toml"
 
 echo "mise lock project root scope tests passed!"

--- a/e2e/lockfile/test_lockfile_monorepo
+++ b/e2e/lockfile/test_lockfile_monorepo
@@ -66,7 +66,7 @@ assert_contains "cat monorepo/mise.lock" 'version = "1.0.0"'
 assert_contains "cat monorepo/mise.lock" 'version = "2.1.0"'
 
 echo "=== subproject lockfiles migrate into root lockfiles ==="
-mkdir -p monorepo-migrate/packages/a
+mkdir -p monorepo-migrate/packages/a monorepo-migrate/packages/b/.mise
 cat >monorepo-migrate/mise.toml <<'EOF'
 monorepo_root = true
 
@@ -83,11 +83,22 @@ cat >monorepo-migrate/packages/a/mise.lock <<'EOF'
 version = "1.0.0"
 backend = "asdf:tiny"
 EOF
+cat >monorepo-migrate/packages/b/.mise/config.toml <<'EOF'
+[tools]
+dummy = "1.0.0"
+EOF
+cat >monorepo-migrate/packages/b/.mise/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+EOF
 
 output=$(cd monorepo-migrate && mise lock --platform linux-x64 2>&1)
-assert_contains "echo '$output'" "migrated 1 subproject lockfile"
+assert_contains "echo '$output'" "migrated 2 subproject lockfile"
 assert_contains "cat monorepo-migrate/mise.lock" 'version = "1.0.0"'
+assert_contains "cat monorepo-migrate/mise.lock" '[[tools.dummy]]'
 assert_fail "test -f monorepo-migrate/packages/a/mise.lock"
+assert_fail "test -f monorepo-migrate/packages/b/.mise/mise.lock"
 
 echo "=== [monorepo] lockfile = false keeps subproject lockfiles ==="
 mkdir -p monorepo-optout/packages/a

--- a/e2e/lockfile/test_lockfile_monorepo
+++ b/e2e/lockfile/test_lockfile_monorepo
@@ -2,6 +2,7 @@
 
 export MISE_EXPERIMENTAL=1
 export MISE_LOCKFILE=1
+export MISE_IDIOMATIC_VERSION_FILE_ENABLE_TOOLS=dummy
 
 rm -rf "$MISE_DATA_DIR/plugins/tiny"
 ln -s "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
@@ -99,6 +100,36 @@ assert_contains "cat monorepo-migrate/mise.lock" 'version = "1.0.0"'
 assert_contains "cat monorepo-migrate/mise.lock" '[[tools.dummy]]'
 assert_fail "test -f monorepo-migrate/packages/a/mise.lock"
 assert_fail "test -f monorepo-migrate/packages/b/.mise/mise.lock"
+
+echo "=== idiomatic roots migrate colocated lockfiles into root lockfiles ==="
+mkdir -p monorepo-idiomatic-migrate/packages/a
+cat >monorepo-idiomatic-migrate/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+lockfile = true
+config_roots = ["packages/*"]
+EOF
+echo "2" >monorepo-idiomatic-migrate/packages/a/.dummy-version
+cat >monorepo-idiomatic-migrate/packages/a/mise.lock <<'EOF'
+[[tools.dummy]]
+version = "2.0.0"
+backend = "asdf:dummy"
+EOF
+cat >monorepo-idiomatic-migrate/packages/a/mise.ci.lock <<'EOF'
+[[tools.dummy]]
+version = "2.0.0"
+backend = "asdf:dummy"
+EOF
+
+output=$(cd monorepo-idiomatic-migrate && mise lock --platform linux-x64 2>&1)
+assert_contains "echo '$output'" "migrated 2 subproject lockfile"
+assert_contains "cat monorepo-idiomatic-migrate/mise.lock" '[[tools.dummy]]'
+assert_contains "cat monorepo-idiomatic-migrate/mise.lock" 'version = "2.0.0"'
+assert_contains "cat monorepo-idiomatic-migrate/mise.ci.lock" '[[tools.dummy]]'
+assert_contains "cat monorepo-idiomatic-migrate/mise.ci.lock" 'version = "2.0.0"'
+assert_fail "test -f monorepo-idiomatic-migrate/packages/a/mise.lock"
+assert_fail "test -f monorepo-idiomatic-migrate/packages/a/mise.ci.lock"
 
 echo "=== dry-run reads legacy subproject lockfiles without migrating ==="
 mkdir -p monorepo-dry-run/packages/a

--- a/e2e/lockfile/test_lockfile_monorepo
+++ b/e2e/lockfile/test_lockfile_monorepo
@@ -3,8 +3,8 @@
 export MISE_EXPERIMENTAL=1
 export MISE_LOCKFILE=1
 
-ln -sf "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
-ln -sf "$ROOT/test/data/plugins/dummy" "$MISE_DATA_DIR/plugins/dummy"
+rm -rf "$MISE_DATA_DIR/plugins/tiny"
+ln -s "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
 
 echo "=== unset [monorepo].lockfile keeps subproject lockfiles during rollout ==="
 mkdir -p monorepo-unset/packages/a
@@ -99,6 +99,36 @@ assert_contains "cat monorepo-migrate/mise.lock" 'version = "1.0.0"'
 assert_contains "cat monorepo-migrate/mise.lock" '[[tools.dummy]]'
 assert_fail "test -f monorepo-migrate/packages/a/mise.lock"
 assert_fail "test -f monorepo-migrate/packages/b/.mise/mise.lock"
+
+echo "=== dry-run reads legacy subproject lockfiles without migrating ==="
+mkdir -p monorepo-dry-run/packages/a
+cat >monorepo-dry-run/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+lockfile = true
+config_roots = ["packages/*"]
+EOF
+cat >monorepo-dry-run/packages/a/mise.toml <<'EOF'
+[tools]
+tiny = "latest"
+EOF
+cat >monorepo-dry-run/packages/a/mise.lock <<'EOF'
+[[tools.tiny]]
+version = "1.0.0"
+backend = "asdf:tiny"
+EOF
+
+rm -rf "$MISE_DATA_DIR/installs/tiny"
+output=$(cd monorepo-dry-run/packages/a && mise install --dry-run 2>&1)
+assert_contains "echo '$output'" "tiny@1.0.0"
+assert "test -f monorepo-dry-run/packages/a/mise.lock"
+assert_fail "test -f monorepo-dry-run/mise.lock"
+
+output=$(cd monorepo-dry-run && mise lock --dry-run --platform linux-x64 2>&1)
+assert_contains "echo '$output'" "tiny@1.0.0"
+assert "test -f monorepo-dry-run/packages/a/mise.lock"
+assert_fail "test -f monorepo-dry-run/mise.lock"
 
 echo "=== [monorepo] lockfile = false keeps subproject lockfiles ==="
 mkdir -p monorepo-optout/packages/a

--- a/e2e/lockfile/test_lockfile_monorepo
+++ b/e2e/lockfile/test_lockfile_monorepo
@@ -6,12 +6,31 @@ export MISE_LOCKFILE=1
 ln -sf "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
 ln -sf "$ROOT/test/data/plugins/dummy" "$MISE_DATA_DIR/plugins/dummy"
 
-echo "=== default monorepo lockfile routes subprojects to root ==="
+echo "=== unset [monorepo].lockfile keeps subproject lockfiles during rollout ==="
+mkdir -p monorepo-unset/packages/a
+cat >monorepo-unset/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
+cat >monorepo-unset/packages/a/mise.toml <<'EOF'
+[tools]
+tiny = "1.0.0"
+EOF
+touch monorepo-unset/packages/a/mise.lock
+
+assert "cd monorepo-unset/packages/a && mise install"
+assert_contains "cat monorepo-unset/packages/a/mise.lock" '[[tools.tiny]]'
+assert_fail "test -f monorepo-unset/mise.lock"
+
+echo "=== [monorepo] lockfile = true routes subprojects to root ==="
 mkdir -p monorepo/packages/a monorepo/packages/b
 cat >monorepo/mise.toml <<'EOF'
 monorepo_root = true
 
 [monorepo]
+lockfile = true
 config_roots = ["packages/*"]
 EOF
 cat >monorepo/packages/a/mise.toml <<'EOF'
@@ -52,6 +71,7 @@ cat >monorepo-migrate/mise.toml <<'EOF'
 monorepo_root = true
 
 [monorepo]
+lockfile = true
 config_roots = ["packages/*"]
 EOF
 cat >monorepo-migrate/packages/a/mise.toml <<'EOF'

--- a/e2e/lockfile/test_lockfile_monorepo
+++ b/e2e/lockfile/test_lockfile_monorepo
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+export MISE_LOCKFILE=1
+
+ln -sf "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
+ln -sf "$ROOT/test/data/plugins/dummy" "$MISE_DATA_DIR/plugins/dummy"
+
+echo "=== default monorepo lockfile routes subprojects to root ==="
+mkdir -p monorepo/packages/a monorepo/packages/b
+cat >monorepo/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
+cat >monorepo/packages/a/mise.toml <<'EOF'
+[tools]
+tiny = "1.0.0"
+EOF
+cat >monorepo/packages/b/mise.toml <<'EOF'
+[tools]
+tiny = "2.1.0"
+dummy = "1.0.0"
+EOF
+touch monorepo/mise.lock
+
+assert "cd monorepo/packages/a && mise install"
+assert_contains "cat monorepo/mise.lock" 'version = "1.0.0"'
+assert_fail "test -f monorepo/packages/a/mise.lock"
+
+assert "cd monorepo/packages/b && mise install"
+assert_contains "cat monorepo/mise.lock" 'version = "1.0.0"'
+assert_contains "cat monorepo/mise.lock" 'version = "2.1.0"'
+assert_contains "cat monorepo/mise.lock" '[[tools.dummy]]'
+assert_fail "test -f monorepo/packages/b/mise.lock"
+
+echo "=== mise lock prunes from the full monorepo view ==="
+cat >monorepo/packages/b/mise.toml <<'EOF'
+[tools]
+tiny = "2.1.0"
+EOF
+output=$(cd monorepo && mise lock --platform linux-x64 2>&1)
+assert_contains "echo '$output'" "Pruned 1 stale tool entry"
+assert_not_contains "cat monorepo/mise.lock" '[[tools.dummy]]'
+assert_contains "cat monorepo/mise.lock" 'version = "1.0.0"'
+assert_contains "cat monorepo/mise.lock" 'version = "2.1.0"'
+
+echo "=== subproject lockfiles migrate into root lockfiles ==="
+mkdir -p monorepo-migrate/packages/a
+cat >monorepo-migrate/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
+cat >monorepo-migrate/packages/a/mise.toml <<'EOF'
+[tools]
+tiny = "1.0.0"
+EOF
+cat >monorepo-migrate/packages/a/mise.lock <<'EOF'
+[[tools.tiny]]
+version = "1.0.0"
+backend = "asdf:tiny"
+EOF
+
+output=$(cd monorepo-migrate && mise lock --platform linux-x64 2>&1)
+assert_contains "echo '$output'" "migrated 1 subproject lockfile"
+assert_contains "cat monorepo-migrate/mise.lock" 'version = "1.0.0"'
+assert_fail "test -f monorepo-migrate/packages/a/mise.lock"
+
+echo "=== [monorepo] lockfile = false keeps subproject lockfiles ==="
+mkdir -p monorepo-optout/packages/a
+cat >monorepo-optout/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+lockfile = false
+config_roots = ["packages/*"]
+
+[tools]
+dummy = "1.0.0"
+EOF
+cat >monorepo-optout/packages/a/mise.toml <<'EOF'
+[tools]
+tiny = "1.0.0"
+EOF
+touch monorepo-optout/packages/a/mise.lock
+
+assert "cd monorepo-optout/packages/a && mise install"
+assert_contains "cat monorepo-optout/packages/a/mise.lock" '[[tools.tiny]]'
+assert_fail "test -f monorepo-optout/mise.lock"
+
+output=$(cd monorepo-optout/packages/a && mise lock --dry-run --platform linux-x64 2>&1)
+assert_contains "echo '$output'" "tiny"
+assert_not_contains "echo '$output'" "dummy"

--- a/e2e/lockfile/test_lockfile_monorepo
+++ b/e2e/lockfile/test_lockfile_monorepo
@@ -161,6 +161,53 @@ assert_contains "echo '$output'" "tiny@1.0.0"
 assert "test -f monorepo-dry-run/packages/a/mise.lock"
 assert_fail "test -f monorepo-dry-run/mise.lock"
 
+echo "=== install --monorepo updates colocated subproject lockfiles ==="
+mkdir -p monorepo-install-colocated/packages/a monorepo-install-colocated/packages/b
+cat >monorepo-install-colocated/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+lockfile = false
+config_roots = ["packages/*"]
+EOF
+cat >monorepo-install-colocated/packages/a/mise.toml <<'EOF'
+[tools]
+tiny = "1.0.0"
+EOF
+cat >monorepo-install-colocated/packages/b/mise.toml <<'EOF'
+[tools]
+tiny = "2.1.0"
+EOF
+touch monorepo-install-colocated/packages/a/mise.lock
+touch monorepo-install-colocated/packages/b/mise.lock
+
+rm -rf "$MISE_DATA_DIR/installs/tiny"
+assert "cd monorepo-install-colocated && mise install --monorepo"
+assert_contains "cat monorepo-install-colocated/packages/a/mise.lock" 'version = "1.0.0"'
+assert_contains "cat monorepo-install-colocated/packages/b/mise.lock" 'version = "2.1.0"'
+assert_fail "test -f monorepo-install-colocated/mise.lock"
+
+echo "=== lockfile = true still routes to root when config_roots are invalid ==="
+mkdir -p monorepo-bad-roots/packages/a
+cat >monorepo-bad-roots/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+lockfile = true
+config_roots = ["missing/*"]
+EOF
+cat >monorepo-bad-roots/packages/a/mise.toml <<'EOF'
+[tools]
+tiny = "1.0.0"
+EOF
+touch monorepo-bad-roots/mise.lock
+
+rm -rf "$MISE_DATA_DIR/installs/tiny"
+output=$(cd monorepo-bad-roots/packages/a && mise install 2>&1)
+assert_contains "echo '$output'" "lockfile = true is set"
+assert_contains "cat monorepo-bad-roots/mise.lock" 'version = "1.0.0"'
+assert_fail "test -f monorepo-bad-roots/packages/a/mise.lock"
+
 echo "=== [monorepo] lockfile = false keeps subproject lockfiles ==="
 mkdir -p monorepo-optout/packages/a
 cat >monorepo-optout/mise.toml <<'EOF'

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2052,6 +2052,12 @@ Only install versions released before this date or older than this duration
 
 Supports absolute dates like "2024\-06\-01" and relative durations like "90d" or "1y".
 .TP
+\fB\-\-monorepo\fR
+Install tools from every [monorepo].config_roots config root
+
+Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+[monorepo].config_roots in the monorepo root config.
+.TP
 \fB\-\-raw\fR
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1
 .TP
@@ -2218,6 +2224,12 @@ Don't fetch information such as outdated versions
 .TP
 \fB\-\-all\-sources\fR
 Display all tracked config sources for tools
+.TP
+\fB\-\-monorepo\fR
+List tools from every [monorepo].config_roots config root
+
+Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+[monorepo].config_roots in the monorepo root config.
 .TP
 \fB\-\-no\-header\fR
 Don't display headers
@@ -2474,6 +2486,9 @@ Only show outdated tools defined in local config files
 
 This will only show tools that are defined in project\-local mise.toml and
 will skip tools defined in the global config (~/.config/mise/config.toml).
+.TP
+\fB\-\-monorepo\fR
+Show outdated tools across every [monorepo].config_roots config root
 .TP
 \fB\-\-no\-header\fR
 Don't show table header
@@ -2807,6 +2822,9 @@ Prune only tracked and trusted configuration links that point to nonexistent con
 Like \-\-dry\-run but exits with code 1 if there are tools to prune
 
 This is useful for scripts to check if tools need to be pruned.
+.TP
+\fB\-\-monorepo\fR
+Prune tools across every [monorepo].config_roots config root
 .TP
 \fB\-\-tools\fR
 Prune only unused versions of tools
@@ -4166,6 +4184,9 @@ This can be useful for reproducibility or security purposes.
 
 This only affects fuzzy version matches like "20" or "latest".
 Explicitly pinned versions like "22.5.0" are not filtered.
+.TP
+\fB\-\-monorepo\fR
+Upgrade tools across every [monorepo].config_roots config root
 .TP
 \fB\-\-raw\fR
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2488,7 +2488,7 @@ This will only show tools that are defined in project\-local mise.toml and
 will skip tools defined in the global config (~/.config/mise/config.toml).
 .TP
 \fB\-\-monorepo\fR
-Show outdated tools across every [monorepo].config_roots config root
+Placeholder for future monorepo outdated checks; `mise outdated \-\-monorepo` is not implemented yet.
 .TP
 \fB\-\-no\-header\fR
 Don't show table header
@@ -2824,7 +2824,7 @@ Like \-\-dry\-run but exits with code 1 if there are tools to prune
 This is useful for scripts to check if tools need to be pruned.
 .TP
 \fB\-\-monorepo\fR
-Prune tools across every [monorepo].config_roots config root
+Placeholder for future monorepo pruning; `mise prune \-\-monorepo` is not implemented yet.
 .TP
 \fB\-\-tools\fR
 Prune only unused versions of tools
@@ -4186,7 +4186,7 @@ This only affects fuzzy version matches like "20" or "latest".
 Explicitly pinned versions like "22.5.0" are not filtered.
 .TP
 \fB\-\-monorepo\fR
-Upgrade tools across every [monorepo].config_roots config root
+Placeholder for future monorepo upgrades; `mise upgrade \-\-monorepo` is not implemented yet.
 .TP
 \fB\-\-raw\fR
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1706,6 +1706,14 @@ Supports absolute dates like "2024-06-01" and relative durations like "90d" or "
 """#
         arg <MINIMUM_RELEASE_AGE>
     }
+    flag --monorepo help="Install tools from every [monorepo].config_roots config root" {
+        long_help #"""
+Install tools from every [monorepo].config_roots config root
+
+Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+[monorepo].config_roots in the monorepo root config.
+"""#
+    }
     flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
     flag --shared help="Install tool(s) to a shared directory" {
         long_help #"""
@@ -1722,14 +1730,6 @@ Install tool(s) to the system-wide shared directory
 
 Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
-"""#
-    }
-    flag --monorepo help="Install tools from every [monorepo].config_roots config root" {
-        long_help #"""
-Install tools from every [monorepo].config_roots config root
-
-Uses the active MISE_ENV and requires monorepo_root = true plus explicit
-[monorepo].config_roots in the monorepo root config.
 """#
     }
     arg "[TOOL@VERSION]…" help="Tool(s) to install e.g.: node@20" required=#false var=#true
@@ -1971,12 +1971,6 @@ Examples:
         arg <TOOL_FLAG>
     }
     flag --all-sources help="Display all tracked config sources for tools"
-    flag --no-header help="Don't display headers"
-    flag --outdated help="Display whether a version is outdated"
-    flag --prefix help="Display versions matching this prefix" {
-        arg <PREFIX>
-    }
-    flag --prunable help="List only tools that can be pruned with `mise prune`"
     flag --monorepo help="List tools from every [monorepo].config_roots config root" {
         long_help #"""
 List tools from every [monorepo].config_roots config root
@@ -1985,6 +1979,12 @@ Uses the active MISE_ENV and requires monorepo_root = true plus explicit
 [monorepo].config_roots in the monorepo root config.
 """#
     }
+    flag --no-header help="Don't display headers"
+    flag --outdated help="Display whether a version is outdated"
+    flag --prefix help="Display versions matching this prefix" {
+        arg <PREFIX>
+    }
+    flag --prunable help="List only tools that can be pruned with `mise prune`"
     arg "[INSTALLED_TOOL]…" help="Only show tool versions from [TOOL]" required=#false var=#true
 }
 cmd ls-remote help="List runtime versions available for install." {
@@ -2395,8 +2395,8 @@ This will only show tools that are defined in project-local mise.toml and
 will skip tools defined in the global config (~/.config/mise/config.toml).
 """#
     }
-    flag --no-header help="Don't show table header"
     flag --monorepo help="Show outdated tools across every [monorepo].config_roots config root"
+    flag --no-header help="Don't show table header"
     arg "[TOOL@VERSION]…" help=#"""
 Tool(s) to show outdated versions for
 e.g.: node@20 python@3.10
@@ -2740,8 +2740,8 @@ Like --dry-run but exits with code 1 if there are tools to prune
 This is useful for scripts to check if tools need to be pruned.
 """#
     }
-    flag --tools help="Prune only unused versions of tools"
     flag --monorepo help="Prune tools across every [monorepo].config_roots config root"
+    flag --tools help="Prune only unused versions of tools"
     arg "[INSTALLED_TOOL]…" help="Prune only these tools" required=#false var=#true
 }
 cmd registry help="List available tools to install" {
@@ -4182,8 +4182,8 @@ Explicitly pinned versions like "22.5.0" are not filtered.
 """#
         arg <MINIMUM_RELEASE_AGE>
     }
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
     flag --monorepo help="Upgrade tools across every [monorepo].config_roots config root"
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
     arg "[INSTALLED_TOOL@VERSION]…" help=#"""
 Tool(s) to upgrade
 e.g.: node@20 python@3.10

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1724,6 +1724,14 @@ Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
 """#
     }
+    flag --monorepo help="Install tools from every [monorepo].config_roots config root" {
+        long_help #"""
+Install tools from every [monorepo].config_roots config root
+
+Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+[monorepo].config_roots in the monorepo root config.
+"""#
+    }
     arg "[TOOL@VERSION]…" help="Tool(s) to install e.g.: node@20" required=#false var=#true
 }
 cmd install-into help="Install a tool version to a specific path" {
@@ -1969,6 +1977,14 @@ Examples:
         arg <PREFIX>
     }
     flag --prunable help="List only tools that can be pruned with `mise prune`"
+    flag --monorepo help="List tools from every [monorepo].config_roots config root" {
+        long_help #"""
+List tools from every [monorepo].config_roots config root
+
+Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+[monorepo].config_roots in the monorepo root config.
+"""#
+    }
     arg "[INSTALLED_TOOL]…" help="Only show tool versions from [TOOL]" required=#false var=#true
 }
 cmd ls-remote help="List runtime versions available for install." {
@@ -2380,6 +2396,7 @@ will skip tools defined in the global config (~/.config/mise/config.toml).
 """#
     }
     flag --no-header help="Don't show table header"
+    flag --monorepo help="Show outdated tools across every [monorepo].config_roots config root"
     arg "[TOOL@VERSION]…" help=#"""
 Tool(s) to show outdated versions for
 e.g.: node@20 python@3.10
@@ -2724,6 +2741,7 @@ This is useful for scripts to check if tools need to be pruned.
 """#
     }
     flag --tools help="Prune only unused versions of tools"
+    flag --monorepo help="Prune tools across every [monorepo].config_roots config root"
     arg "[INSTALLED_TOOL]…" help="Prune only these tools" required=#false var=#true
 }
 cmd registry help="List available tools to install" {
@@ -4165,6 +4183,7 @@ Explicitly pinned versions like "22.5.0" are not filtered.
         arg <MINIMUM_RELEASE_AGE>
     }
     flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
+    flag --monorepo help="Upgrade tools across every [monorepo].config_roots config root"
     arg "[INSTALLED_TOOL@VERSION]…" help=#"""
 Tool(s) to upgrade
 e.g.: node@20 python@3.10

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2395,7 +2395,7 @@ This will only show tools that are defined in project-local mise.toml and
 will skip tools defined in the global config (~/.config/mise/config.toml).
 """#
     }
-    flag --monorepo help="Show outdated tools across every [monorepo].config_roots config root"
+    flag --monorepo help="Placeholder for future monorepo outdated checks; `mise outdated --monorepo` is not implemented yet."
     flag --no-header help="Don't show table header"
     arg "[TOOL@VERSION]…" help=#"""
 Tool(s) to show outdated versions for
@@ -2740,7 +2740,7 @@ Like --dry-run but exits with code 1 if there are tools to prune
 This is useful for scripts to check if tools need to be pruned.
 """#
     }
-    flag --monorepo help="Prune tools across every [monorepo].config_roots config root"
+    flag --monorepo help="Placeholder for future monorepo pruning; `mise prune --monorepo` is not implemented yet."
     flag --tools help="Prune only unused versions of tools"
     arg "[INSTALLED_TOOL]…" help="Prune only these tools" required=#false var=#true
 }
@@ -4182,7 +4182,7 @@ Explicitly pinned versions like "22.5.0" are not filtered.
 """#
         arg <MINIMUM_RELEASE_AGE>
     }
-    flag --monorepo help="Upgrade tools across every [monorepo].config_roots config root"
+    flag --monorepo help="Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet."
     flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
     arg "[INSTALLED_TOOL@VERSION]…" help=#"""
 Tool(s) to upgrade

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2079,7 +2079,7 @@
           }
         },
         "lockfile": {
-          "description": "Use a single lockfile at the monorepo root for descendant config roots. Defaults to true. Set to false to keep lockfiles next to subproject configs.",
+          "description": "Use a single lockfile at the monorepo root for descendant config roots. true opts in now, false keeps lockfiles next to subproject configs, and unset keeps the current behavior until the scheduled default flip.",
           "type": "boolean"
         }
       }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2077,6 +2077,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "lockfile": {
+          "description": "Use a single lockfile at the monorepo root for descendant config roots. Defaults to true. Set to false to keep lockfiles next to subproject configs.",
+          "type": "boolean"
         }
       }
     },

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -11,7 +11,6 @@ use crate::config::Settings;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
 use crate::lockfile::{self, Lockfile, PlatformInfo};
-use crate::toolset::ToolSource;
 use crate::toolset::{ToolVersion, ToolVersionOptions};
 use crate::{backend::Backend, dirs, parallel};
 use crate::{file, hash};
@@ -366,12 +365,7 @@ impl CondaBackend {
     }
 
     fn read_lockfile_for_tool(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<Lockfile> {
-        match tv.request.source() {
-            ToolSource::MiseToml(path) => {
-                Ok(lockfile::read_lockfile_for_config_path(&ctx.config, path))
-            }
-            _ => Ok(Lockfile::default()),
-        }
+        lockfile::read_lockfile_for_tool_source(&ctx.config, tv.request.source())
     }
 
     /// Install from a fresh solve (no lockfile deps).

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -365,10 +365,12 @@ impl CondaBackend {
         })
     }
 
-    fn read_lockfile_for_tool(&self, tv: &ToolVersion) -> Result<Lockfile> {
+    fn read_lockfile_for_tool(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<Lockfile> {
         match tv.request.source() {
-            ToolSource::MiseToml(path) => {
-                let (lockfile_path, _) = lockfile::lockfile_path_for_config(path);
+            ToolSource::MiseToml(_) => {
+                let (lockfile_path, _) =
+                    lockfile::lockfile_path_for_tool_source(&ctx.config, tv.request.source())
+                        .ok_or_else(|| eyre::eyre!("could not determine conda lockfile path"))?;
                 Lockfile::read(&lockfile_path)
             }
             _ => Ok(Lockfile::default()),
@@ -492,7 +494,7 @@ impl CondaBackend {
         let main_checksum = platform_info.checksum.clone();
 
         let dep_basenames = platform_info.conda_deps.clone().unwrap_or_default();
-        let lockfile = self.read_lockfile_for_tool(tv)?;
+        let lockfile = self.read_lockfile_for_tool(ctx, tv)?;
 
         // Extract python info from basenames for noarch python packages
         let python_info =

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -367,11 +367,8 @@ impl CondaBackend {
 
     fn read_lockfile_for_tool(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<Lockfile> {
         match tv.request.source() {
-            ToolSource::MiseToml(_) => {
-                let (lockfile_path, _) =
-                    lockfile::lockfile_path_for_tool_source(&ctx.config, tv.request.source())
-                        .ok_or_else(|| eyre::eyre!("could not determine conda lockfile path"))?;
-                Lockfile::read(&lockfile_path)
+            ToolSource::MiseToml(path) => {
+                Ok(lockfile::read_lockfile_for_config_path(&ctx.config, path))
             }
             _ => Ok(Lockfile::default()),
         }

--- a/src/backend/pkgx.rs
+++ b/src/backend/pkgx.rs
@@ -8,7 +8,7 @@ use crate::hash;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lockfile::{self, Lockfile, PlatformInfo};
-use crate::toolset::{ToolRequest, ToolSource, ToolVersion};
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{backend::Backend, file};
 use async_trait::async_trait;
 use eyre::{Result, WrapErr, bail};
@@ -192,17 +192,7 @@ impl PkgxBackend {
     }
 
     fn read_lockfile_for_tool(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<Lockfile> {
-        match tv.request.source() {
-            ToolSource::MiseToml(path) => {
-                Ok(lockfile::read_lockfile_for_config_path(&ctx.config, path))
-            }
-            source => {
-                let (lockfile_path, _) =
-                    lockfile::lockfile_path_for_tool_source(&ctx.config, source)
-                        .ok_or_else(|| eyre::eyre!("could not determine pkgx lockfile path"))?;
-                Lockfile::read(&lockfile_path)
-            }
-        }
+        lockfile::read_lockfile_for_tool_source(&ctx.config, tv.request.source())
     }
 
     async fn install_from_locked(

--- a/src/backend/pkgx.rs
+++ b/src/backend/pkgx.rs
@@ -8,7 +8,7 @@ use crate::hash;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lockfile::{self, Lockfile, PlatformInfo};
-use crate::toolset::{ToolRequest, ToolVersion};
+use crate::toolset::{ToolRequest, ToolSource, ToolVersion};
 use crate::{backend::Backend, file};
 use async_trait::async_trait;
 use eyre::{Result, WrapErr, bail};
@@ -192,10 +192,17 @@ impl PkgxBackend {
     }
 
     fn read_lockfile_for_tool(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<Lockfile> {
-        let (lockfile_path, _) =
-            lockfile::lockfile_path_for_tool_source(&ctx.config, tv.request.source())
-                .ok_or_else(|| eyre::eyre!("could not determine pkgx lockfile path"))?;
-        Lockfile::read(&lockfile_path)
+        match tv.request.source() {
+            ToolSource::MiseToml(path) => {
+                Ok(lockfile::read_lockfile_for_config_path(&ctx.config, path))
+            }
+            source => {
+                let (lockfile_path, _) =
+                    lockfile::lockfile_path_for_tool_source(&ctx.config, source)
+                        .ok_or_else(|| eyre::eyre!("could not determine pkgx lockfile path"))?;
+                Lockfile::read(&lockfile_path)
+            }
+        }
     }
 
     async fn install_from_locked(

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -9,7 +9,7 @@ use crate::errors::split_install_result;
 use crate::hooks::Hooks;
 use crate::install_before::resolve_cli_minimum_release_age;
 use crate::toolset::{
-    InstallOptions, ResolveOptions, ToolRequest, ToolSource, Toolset, tool_env_vars,
+    InstallOptions, ResolveOptions, ToolRequest, ToolRequestSet, ToolSource, Toolset, tool_env_vars,
 };
 use crate::{config, env, exit, hooks};
 use clap::ValueHint;
@@ -210,10 +210,14 @@ impl Install {
         runtimes: &[ToolArg],
         original_tool_args: Vec<ToolArg>,
     ) -> Result<()> {
-        let trs = if self.monorepo {
-            config.monorepo_union_tool_request_set().await?
+        let monorepo_union = if self.monorepo {
+            Some(config.monorepo_union().await?)
         } else {
-            config.get_tool_request_set().await?.clone()
+            None
+        };
+        let trs = match &monorepo_union {
+            Some(union) => union.tool_request_set.clone(),
+            None => config.get_tool_request_set().await?.clone(),
         };
 
         // Expand wildcards (e.g., "pipx:*") to actual ToolArgs from config
@@ -256,10 +260,9 @@ impl Install {
         // load_runtime_args overrides the underlying source with
         // ToolSource::Argument whenever the user passes TOOL@VERSION, so config-
         // and env-sourced tools become indistinguishable from CLI-only ones.
-        let configured_config_files = if self.monorepo {
-            config.monorepo_union_config_files().await?
-        } else {
-            config.config_files.clone()
+        let configured_config_files = match &monorepo_union {
+            Some(union) => union.config_files.clone(),
+            None => config.config_files.clone(),
         };
         let configured_tools: HashSet<String> = configured_config_files
             .values()
@@ -279,6 +282,14 @@ impl Install {
             warn!("specify a version with `mise install <TOOL>@<VERSION>`");
             (vec![], Ok(()))
         } else {
+            if let Some(monorepo_union) = &monorepo_union {
+                Toolset::ensure_config_plugins_installed_from_urls(
+                    &config,
+                    &monorepo_union.repo_urls,
+                    self.is_dry_run(),
+                )
+                .await?;
+            }
             split_install_result(
                 ts.install_all_versions(&mut config, tool_versions, &self.install_opts()?)
                     .await,
@@ -310,10 +321,7 @@ impl Install {
             let config = Config::reset().await?;
             let ts_owned;
             let ts = if self.monorepo {
-                let mut monorepo_ts: Toolset =
-                    config.monorepo_union_tool_request_set().await?.into();
-                monorepo_ts.resolve(&config).await?;
-                ts_owned = monorepo_ts;
+                ts_owned = Self::resolved_toolset_from_trs(&config, trs.clone()).await?;
                 &ts_owned
             } else {
                 config.get_toolset().await?
@@ -424,17 +432,30 @@ impl Install {
     }
 
     async fn install_missing_runtimes(&self, mut config: Arc<Config>) -> eyre::Result<()> {
+        let monorepo_union = if self.monorepo {
+            Some(config.monorepo_union().await?)
+        } else {
+            None
+        };
         let trs = measure!("get_tool_request_set", {
-            if self.monorepo {
-                config.monorepo_union_tool_request_set().await?
-            } else {
-                config.get_tool_request_set().await?.clone()
+            match &monorepo_union {
+                Some(union) => union.tool_request_set.clone(),
+                None => config.get_tool_request_set().await?.clone(),
             }
         });
 
         // Install plugins from [plugins] config section first
         // This must happen before checking for missing tools so env-only plugins get installed
-        Toolset::ensure_config_plugins_installed(&config, self.is_dry_run()).await?;
+        if let Some(monorepo_union) = &monorepo_union {
+            Toolset::ensure_config_plugins_installed_from_urls(
+                &config,
+                &monorepo_union.repo_urls,
+                self.is_dry_run(),
+            )
+            .await?;
+        } else {
+            Toolset::ensure_config_plugins_installed(&config, self.is_dry_run()).await?;
+        }
 
         // Check for tools that don't exist in the registry
         // These were tracked during build() before being filtered out
@@ -456,14 +477,15 @@ impl Install {
                 // Nothing was installed, but postinstall still runs (idempotent
                 // project setup relies on it); MISE_INSTALLED_TOOLS is [] so hooks
                 // can guard on actual installs. (#10574)
-                hooks::run_one_hook_with_context(
-                    &config,
-                    config.get_toolset().await?,
-                    Hooks::Postinstall,
-                    None,
-                    Some(&[]),
-                )
-                .await;
+                let ts_owned;
+                let ts = if self.monorepo {
+                    ts_owned = Self::resolved_toolset_from_trs(&config, trs.clone()).await?;
+                    &ts_owned
+                } else {
+                    config.get_toolset().await?
+                };
+                hooks::run_one_hook_with_context(&config, ts, Hooks::Postinstall, None, Some(&[]))
+                    .await;
                 (vec![], Ok(()))
             })
         } else {
@@ -485,10 +507,7 @@ impl Install {
             measure!("rebuild_shims_and_runtime_symlinks", {
                 let ts_owned;
                 let ts = if self.monorepo {
-                    let mut monorepo_ts: Toolset =
-                        config.monorepo_union_tool_request_set().await?.into();
-                    monorepo_ts.resolve(&config).await?;
-                    ts_owned = monorepo_ts;
+                    ts_owned = Self::resolved_toolset_from_trs(&config, trs.clone()).await?;
                     &ts_owned
                 } else {
                     config.get_toolset().await?
@@ -504,6 +523,15 @@ impl Install {
         }
         install_error?;
         Ok(())
+    }
+
+    async fn resolved_toolset_from_trs(
+        config: &Arc<Config>,
+        trs: ToolRequestSet,
+    ) -> Result<Toolset> {
+        let mut ts: Toolset = trs.into();
+        ts.resolve(config).await?;
+        Ok(ts)
     }
 }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -206,7 +206,7 @@ impl Install {
     #[async_backtrace::framed]
     async fn install_runtimes(
         &self,
-        mut config: Arc<Config>,
+        config: Arc<Config>,
         runtimes: &[ToolArg],
         original_tool_args: Vec<ToolArg>,
     ) -> Result<()> {
@@ -215,6 +215,9 @@ impl Install {
         } else {
             None
         };
+        let mut install_config = self
+            .effective_config(&config, monorepo_union.as_ref())
+            .await?;
         let trs = match &monorepo_union {
             Some(union) => union.tool_request_set.clone(),
             None => config.get_tool_request_set().await?.clone(),
@@ -291,7 +294,7 @@ impl Install {
                 .await?;
             }
             split_install_result(
-                ts.install_all_versions(&mut config, tool_versions, &self.install_opts()?)
+                ts.install_all_versions(&mut install_config, tool_versions, &self.install_opts()?)
                     .await,
             )
         };
@@ -300,7 +303,7 @@ impl Install {
             if self.dry_run_code {
                 let has_work = versions.iter().any(|tv| {
                     if let Ok(backend) = tv.backend() {
-                        !backend.is_version_installed(&config, tv, true)
+                        !backend.is_version_installed(&install_config, tv, true)
                     } else {
                         true
                     }
@@ -319,19 +322,20 @@ impl Install {
                 .unwrap()
                 .clone_from(&original_tool_args);
             let config = Config::reset().await?;
+            let rebuild_config = self.effective_config(&config, None).await?;
             let ts_owned;
             let ts = if self.monorepo {
-                ts_owned = Self::resolved_toolset_from_trs(&config, trs.clone()).await?;
+                ts_owned = Self::resolved_toolset_from_trs(&rebuild_config, trs.clone()).await?;
                 &ts_owned
             } else {
-                config.get_toolset().await?
+                rebuild_config.get_toolset().await?
             };
             let current_versions = ts.list_current_versions();
             // ensure that only current versions are sent to lockfile rebuild
             versions.retain(|tv| current_versions.iter().any(|(_, cv)| tv == cv));
 
             config::rebuild_shims_and_runtime_symlinks(
-                &config,
+                &rebuild_config,
                 ts,
                 &versions,
                 crate::lockfile::LockfileUpdateMode::Normal,
@@ -434,7 +438,7 @@ impl Install {
         Ok(requests)
     }
 
-    async fn install_missing_runtimes(&self, mut config: Arc<Config>) -> eyre::Result<()> {
+    async fn install_missing_runtimes(&self, config: Arc<Config>) -> eyre::Result<()> {
         let monorepo_union = if self.monorepo {
             Some(config.monorepo_union().await?)
         } else {
@@ -446,6 +450,9 @@ impl Install {
                 None => config.get_tool_request_set().await?.clone(),
             }
         });
+        let mut install_config = self
+            .effective_config(&config, monorepo_union.as_ref())
+            .await?;
 
         // Install plugins from [plugins] config section first
         // This must happen before checking for missing tools so env-only plugins get installed
@@ -467,7 +474,7 @@ impl Install {
             ba.backend()?;
         }
         let missing = measure!("fetching missing runtimes", {
-            trs.missing_tools(&config)
+            trs.missing_tools(&install_config)
                 .await
                 .into_iter()
                 .cloned()
@@ -482,20 +489,27 @@ impl Install {
                 // can guard on actual installs. (#10574)
                 let ts_owned;
                 let ts = if self.monorepo {
-                    ts_owned = Self::resolved_toolset_from_trs(&config, trs.clone()).await?;
+                    ts_owned =
+                        Self::resolved_toolset_from_trs(&install_config, trs.clone()).await?;
                     &ts_owned
                 } else {
-                    config.get_toolset().await?
+                    install_config.get_toolset().await?
                 };
-                hooks::run_one_hook_with_context(&config, ts, Hooks::Postinstall, None, Some(&[]))
-                    .await;
+                hooks::run_one_hook_with_context(
+                    &install_config,
+                    ts,
+                    Hooks::Postinstall,
+                    None,
+                    Some(&[]),
+                )
+                .await;
                 (vec![], Ok(()))
             })
         } else {
             let mut ts = Toolset::from(trs.clone());
             measure!("install_all_versions", {
                 split_install_result(
-                    ts.install_all_versions(&mut config, missing, &self.install_opts()?)
+                    ts.install_all_versions(&mut install_config, missing, &self.install_opts()?)
                         .await,
                 )
             })
@@ -508,15 +522,17 @@ impl Install {
         }
         if install_error.is_ok() || !versions.is_empty() {
             measure!("rebuild_shims_and_runtime_symlinks", {
+                let rebuild_config = self.effective_config(&install_config, None).await?;
                 let ts_owned;
                 let ts = if self.monorepo {
-                    ts_owned = Self::resolved_toolset_from_trs(&config, trs.clone()).await?;
+                    ts_owned =
+                        Self::resolved_toolset_from_trs(&rebuild_config, trs.clone()).await?;
                     &ts_owned
                 } else {
-                    config.get_toolset().await?
+                    rebuild_config.get_toolset().await?
                 };
                 config::rebuild_shims_and_runtime_symlinks(
-                    &config,
+                    &rebuild_config,
                     ts,
                     &versions,
                     crate::lockfile::LockfileUpdateMode::Normal,
@@ -526,6 +542,21 @@ impl Install {
         }
         install_error?;
         Ok(())
+    }
+
+    async fn effective_config(
+        &self,
+        config: &Arc<Config>,
+        monorepo_union: Option<&config::MonorepoUnion>,
+    ) -> Result<Arc<Config>> {
+        if !self.monorepo {
+            return Ok(config.clone());
+        }
+        let config_files = match monorepo_union {
+            Some(union) => union.config_files.clone(),
+            None => config.monorepo_union().await?.config_files,
+        };
+        Ok(config.with_config_files(config_files))
     }
 
     async fn resolved_toolset_from_trs(

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -84,6 +84,13 @@ pub struct Install {
     /// May require elevated permissions (e.g. sudo).
     #[clap(long, verbatim_doc_comment, conflicts_with = "shared")]
     system: bool,
+
+    /// Install tools from every [monorepo].config_roots config root
+    ///
+    /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+    /// [monorepo].config_roots in the monorepo root config.
+    #[clap(long, env = "MISE_MONOREPO", verbatim_doc_comment)]
+    monorepo: bool,
 }
 
 impl Install {
@@ -103,6 +110,9 @@ impl Install {
     #[async_backtrace::framed]
     pub async fn run(self) -> Result<()> {
         let config = Config::get().await?;
+        if !self.is_dry_run() {
+            crate::lockfile::migrate_monorepo_lockfiles(&config)?;
+        }
         match &self.tool {
             Some(runtime) => {
                 let original_tool_args = env::TOOL_ARGS.read().unwrap().clone();
@@ -200,7 +210,11 @@ impl Install {
         runtimes: &[ToolArg],
         original_tool_args: Vec<ToolArg>,
     ) -> Result<()> {
-        let trs = config.get_tool_request_set().await?;
+        let trs = if self.monorepo {
+            config.monorepo_union_tool_request_set().await?
+        } else {
+            config.get_tool_request_set().await?.clone()
+        };
 
         // Expand wildcards (e.g., "pipx:*") to actual ToolArgs from config
         let mut has_unmatched_wildcard = false;
@@ -242,8 +256,12 @@ impl Install {
         // load_runtime_args overrides the underlying source with
         // ToolSource::Argument whenever the user passes TOOL@VERSION, so config-
         // and env-sourced tools become indistinguishable from CLI-only ones.
-        let configured_tools: HashSet<String> = config
-            .config_files
+        let configured_config_files = if self.monorepo {
+            config.monorepo_union_config_files().await?
+        } else {
+            config.config_files.clone()
+        };
+        let configured_tools: HashSet<String> = configured_config_files
             .values()
             .filter_map(|cf| cf.to_tool_request_set().ok())
             .flat_map(|cf_trs| cf_trs.tools.into_keys().map(|ba| ba.short.clone()))
@@ -290,7 +308,16 @@ impl Install {
                 .unwrap()
                 .clone_from(&original_tool_args);
             let config = Config::reset().await?;
-            let ts = config.get_toolset().await?;
+            let ts_owned;
+            let ts = if self.monorepo {
+                let mut monorepo_ts: Toolset =
+                    config.monorepo_union_tool_request_set().await?.into();
+                monorepo_ts.resolve(&config).await?;
+                ts_owned = monorepo_ts;
+                &ts_owned
+            } else {
+                config.get_toolset().await?
+            };
             let current_versions = ts.list_current_versions();
             // ensure that only current versions are sent to lockfile rebuild
             versions.retain(|tv| current_versions.iter().any(|(_, cv)| tv == cv));
@@ -398,7 +425,11 @@ impl Install {
 
     async fn install_missing_runtimes(&self, mut config: Arc<Config>) -> eyre::Result<()> {
         let trs = measure!("get_tool_request_set", {
-            config.get_tool_request_set().await?
+            if self.monorepo {
+                config.monorepo_union_tool_request_set().await?
+            } else {
+                config.get_tool_request_set().await?.clone()
+            }
         });
 
         // Install plugins from [plugins] config section first
@@ -452,7 +483,16 @@ impl Install {
         }
         if install_error.is_ok() || !versions.is_empty() {
             measure!("rebuild_shims_and_runtime_symlinks", {
-                let ts = config.get_toolset().await?;
+                let ts_owned;
+                let ts = if self.monorepo {
+                    let mut monorepo_ts: Toolset =
+                        config.monorepo_union_tool_request_set().await?.into();
+                    monorepo_ts.resolve(&config).await?;
+                    ts_owned = monorepo_ts;
+                    &ts_owned
+                } else {
+                    config.get_toolset().await?
+                };
                 config::rebuild_shims_and_runtime_symlinks(
                     &config,
                     ts,

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -66,6 +66,13 @@ pub struct Install {
     #[clap(long, alias = "before", verbatim_doc_comment)]
     minimum_release_age: Option<String>,
 
+    /// Install tools from every [monorepo].config_roots config root
+    ///
+    /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+    /// [monorepo].config_roots in the monorepo root config.
+    #[clap(long, env = "MISE_MONOREPO", verbatim_doc_comment)]
+    monorepo: bool,
+
     /// Connect backend install command stdin/stdout/stderr directly to the terminal
     /// Implies --jobs=1
     #[clap(long, overrides_with = "jobs")]
@@ -84,13 +91,6 @@ pub struct Install {
     /// May require elevated permissions (e.g. sudo).
     #[clap(long, verbatim_doc_comment, conflicts_with = "shared")]
     system: bool,
-
-    /// Install tools from every [monorepo].config_roots config root
-    ///
-    /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
-    /// [monorepo].config_roots in the monorepo root config.
-    #[clap(long, env = "MISE_MONOREPO", verbatim_doc_comment)]
-    monorepo: bool,
 }
 
 impl Install {

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -413,9 +413,12 @@ impl Install {
                                 requests.push(tvr.clone());
                             }
                         }
-                        // in this case the user specified a tool which is not in config
-                        // so we default to @latest with no options
+                        // In normal install mode, a bare tool absent from config defaults to
+                        // @latest. In monorepo mode, bare tools are filters over the union.
                         None => {
+                            if self.monorepo {
+                                continue;
+                            }
                             let tvr = ToolRequest::Version {
                                 backend: ta.ba.clone(),
                                 version: "latest".into(),

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::config::Config;
+use crate::config::{Config, ConfigMap};
 use crate::file::display_path;
 use crate::install_before::resolve_cli_minimum_release_age;
 use crate::lockfile::{self, LockResolutionResult, Lockfile};
@@ -81,25 +81,42 @@ impl Lock {
     pub async fn run(self) -> Result<()> {
         let settings = Settings::get();
         let config = Config::get().await?;
+        if !self.dry_run {
+            lockfile::migrate_monorepo_lockfiles(&config)?;
+        }
         let before_date = self.get_before_date()?;
         let lock_resolve_options = ResolveOptions {
             before_date,
             ..Default::default()
         };
+        let monorepo_config_files = if !self.global && config.monorepo_lockfile_root().is_some() {
+            Some(config.monorepo_union_config_files().await?)
+        } else {
+            None
+        };
+        let effective_config_files = monorepo_config_files
+            .as_ref()
+            .unwrap_or(&config.config_files);
 
         let ts_owned;
-        let ts = if before_date.is_some() {
-            ts_owned = ToolsetBuilder::new()
-                .with_resolve_options(lock_resolve_options.clone())
-                .build(&config)
+        let ts = if monorepo_config_files.is_some() {
+            let mut monorepo_ts: Toolset = config.monorepo_union_tool_request_set().await?.into();
+            monorepo_ts
+                .resolve_with_opts(&config, &lock_resolve_options)
                 .await?;
+            ts_owned = monorepo_ts;
+            &ts_owned
+        } else if before_date.is_some() {
+            let builder = ToolsetBuilder::new().with_resolve_options(lock_resolve_options.clone());
+            ts_owned = builder.build(&config).await?;
             &ts_owned
         } else {
             config.get_toolset().await?
         };
 
-        let scoped_config_paths = self.config_paths_in_lock_scope(&config);
-        let lockfile_targets = self.get_lockfile_targets(&config, &scoped_config_paths);
+        let scoped_config_paths = self.config_paths_in_lock_scope(&config, effective_config_files);
+        let lockfile_targets =
+            self.get_lockfile_targets(&config, effective_config_files, &scoped_config_paths);
         let mut has_lock_targets = false;
         let mut all_provenance_errors: Vec<String> = Vec::new();
 
@@ -110,6 +127,7 @@ impl Lock {
                     ts,
                     lockfile_path,
                     config_paths,
+                    effective_config_files,
                     &lock_resolve_options,
                 )
                 .await?;
@@ -117,14 +135,18 @@ impl Lock {
             if tools.is_empty() {
                 // `tools` can be empty either because config has no tools, or because a filter excludes all.
                 // For unfiltered runs (`mise lock`), this means "prune all stale lockfile entries".
-                let mut lockfile = Lockfile::read(lockfile_path)?;
                 if self.dry_run {
+                    let lockfile = Lockfile::read(lockfile_path)?;
                     let stale_tools = self.stale_entries_if_pruned(&lockfile, &tools);
                     self.show_stale_prune_message(lockfile_path, &stale_tools, true)?;
                     if !stale_tools.is_empty() {
                         has_lock_targets = true;
                     }
                 } else {
+                    let _lock = crate::lock_file::LockFile::new(lockfile_path)
+                        .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
+                        .lock()?;
+                    let mut lockfile = Lockfile::read(lockfile_path)?;
                     let pruned_tools = self.prune_stale_entries_if_needed(&mut lockfile, &tools);
                     if !pruned_tools.is_empty() {
                         lockfile.write(lockfile_path)?;
@@ -174,6 +196,9 @@ impl Lock {
             }
 
             // Process tools and update lockfile
+            let _lock = crate::lock_file::LockFile::new(lockfile_path)
+                .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
+                .lock()?;
             let mut lockfile = Lockfile::read(lockfile_path)?;
             let stale_tools = self.prune_stale_entries_if_needed(&mut lockfile, &tools);
             self.show_stale_prune_message(lockfile_path, &stale_tools, false)?;
@@ -427,19 +452,30 @@ impl Lock {
         Ok(())
     }
 
-    fn config_paths_in_lock_scope(&self, config: &Config) -> BTreeSet<PathBuf> {
+    fn config_paths_in_lock_scope(
+        &self,
+        config: &Config,
+        effective_config_files: &ConfigMap,
+    ) -> BTreeSet<PathBuf> {
         if self.global {
-            return config
-                .config_files
+            return effective_config_files
                 .keys()
                 .filter(|path| crate::config::is_global_config(path))
                 .cloned()
                 .collect();
         }
+        if let Some(monorepo_root) = config.monorepo_lockfile_root() {
+            return effective_config_files
+                .keys()
+                .filter(|path| {
+                    !crate::config::is_global_config(path) && path.starts_with(&monorepo_root)
+                })
+                .cloned()
+                .collect();
+        }
         let target_root = Self::target_lock_scope_root(config);
 
-        config
-            .config_files
+        effective_config_files
             .iter()
             .filter_map(|(path, cf)| {
                 if crate::config::is_global_config(path) {
@@ -472,17 +508,21 @@ impl Lock {
     fn get_lockfile_targets(
         &self,
         config: &Config,
+        effective_config_files: &ConfigMap,
         scoped_config_paths: &BTreeSet<PathBuf>,
     ) -> indexmap::IndexMap<PathBuf, Vec<PathBuf>> {
         let mut targets: indexmap::IndexMap<PathBuf, Vec<PathBuf>> = indexmap::IndexMap::new();
-        for (path, cf) in config.config_files.iter() {
+        for (path, cf) in effective_config_files.iter() {
             if !scoped_config_paths.contains(path) {
                 continue;
             }
             if !cf.source().is_mise_toml() {
                 continue;
             }
-            let (lockfile_path, is_local) = lockfile::lockfile_path_for_config(path);
+            let (lockfile_path, is_local) = lockfile::lockfile_path_for_config(
+                path,
+                config.monorepo_lockfile_root().as_deref(),
+            );
             if self.local && !is_local {
                 continue;
             }
@@ -508,6 +548,7 @@ impl Lock {
         ts: &Toolset,
         target_lockfile_path: &Path,
         config_paths: &[PathBuf],
+        effective_config_files: &ConfigMap,
         base_resolve_options: &ResolveOptions,
     ) -> Result<Vec<LockTool>> {
         let config_paths_set: BTreeSet<&PathBuf> = config_paths.iter().collect();
@@ -551,7 +592,7 @@ impl Lock {
 
         // Second pass: iterate config files matching this lockfile to catch
         // tools that were overridden by a higher-priority config
-        for (path, cf) in config.config_files.iter() {
+        for (path, cf) in effective_config_files.iter() {
             let source = cf.source();
             let source_lockfile_matches = lockfile::lockfile_path_for_tool_source(config, &source)
                 .is_some_and(|(source_lockfile, _)| source_lockfile == target_lockfile_path);

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -89,18 +89,19 @@ impl Lock {
             before_date,
             ..Default::default()
         };
-        let monorepo_config_files = if !self.global && config.monorepo_lockfile_root().is_some() {
-            Some(config.monorepo_union_config_files().await?)
+        let monorepo_union = if !self.global && config.monorepo_lockfile_root().is_some() {
+            Some(config.monorepo_union().await?)
         } else {
             None
         };
-        let effective_config_files = monorepo_config_files
+        let effective_config_files = monorepo_union
             .as_ref()
+            .map(|monorepo_union| &monorepo_union.config_files)
             .unwrap_or(&config.config_files);
 
         let ts_owned;
-        let ts = if monorepo_config_files.is_some() {
-            let mut monorepo_ts: Toolset = config.monorepo_union_tool_request_set().await?.into();
+        let ts = if let Some(monorepo_union) = &monorepo_union {
+            let mut monorepo_ts: Toolset = monorepo_union.tool_request_set.clone().into();
             monorepo_ts
                 .resolve_with_opts(&config, &lock_resolve_options)
                 .await?;

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -68,6 +68,13 @@ pub struct Ls {
     #[clap(long, conflicts_with_all = &["current", "global", "local", "prunable"])]
     all_sources: bool,
 
+    /// List tools from every [monorepo].config_roots config root
+    ///
+    /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+    /// [monorepo].config_roots in the monorepo root config.
+    #[clap(long, env = "MISE_MONOREPO", verbatim_doc_comment)]
+    monorepo: bool,
+
     /// Don't display headers
     #[clap(long, alias = "no-headers", verbatim_doc_comment, conflicts_with_all = &["json"])]
     no_header: bool,
@@ -83,13 +90,6 @@ pub struct Ls {
     /// List only tools that can be pruned with `mise prune`
     #[clap(long)]
     prunable: bool,
-
-    /// List tools from every [monorepo].config_roots config root
-    ///
-    /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
-    /// [monorepo].config_roots in the monorepo root config.
-    #[clap(long, env = "MISE_MONOREPO", verbatim_doc_comment)]
-    monorepo: bool,
 }
 
 impl Ls {

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -72,7 +72,12 @@ pub struct Ls {
     ///
     /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
     /// [monorepo].config_roots in the monorepo root config.
-    #[clap(long, env = "MISE_MONOREPO", verbatim_doc_comment)]
+    #[clap(
+        long,
+        env = "MISE_MONOREPO",
+        verbatim_doc_comment,
+        conflicts_with_all = &["all_sources", "prunable"]
+    )]
     monorepo: bool,
 
     /// Don't display headers

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -83,6 +83,13 @@ pub struct Ls {
     /// List only tools that can be pruned with `mise prune`
     #[clap(long)]
     prunable: bool,
+
+    /// List tools from every [monorepo].config_roots config root
+    ///
+    /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
+    /// [monorepo].config_roots in the monorepo root config.
+    #[clap(long, env = "MISE_MONOREPO", verbatim_doc_comment)]
+    monorepo: bool,
 }
 
 impl Ls {
@@ -266,7 +273,11 @@ impl Ls {
         )
     }
     async fn get_runtime_list(&self, config: &Arc<Config>) -> Result<Vec<RuntimeRow<'_>>> {
-        let mut trs = config.get_tool_request_set().await?.clone();
+        let mut trs = if self.monorepo {
+            config.monorepo_union_tool_request_set().await?
+        } else {
+            config.get_tool_request_set().await?.clone()
+        };
         if self.global {
             trs = trs
                 .iter()

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -48,13 +48,13 @@ pub struct Outdated {
     #[clap(long, verbatim_doc_comment)]
     pub local: bool,
 
-    /// Don't show table header
-    #[clap(long)]
-    pub no_header: bool,
-
     /// Show outdated tools across every [monorepo].config_roots config root
     #[clap(long, verbatim_doc_comment)]
     pub monorepo: bool,
+
+    /// Don't show table header
+    #[clap(long)]
+    pub no_header: bool,
 }
 
 impl Outdated {

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -51,10 +51,17 @@ pub struct Outdated {
     /// Don't show table header
     #[clap(long)]
     pub no_header: bool,
+
+    /// Show outdated tools across every [monorepo].config_roots config root
+    #[clap(long, verbatim_doc_comment)]
+    pub monorepo: bool,
 }
 
 impl Outdated {
     pub async fn run(self) -> Result<()> {
+        if self.monorepo {
+            unimplemented!("mise outdated --monorepo is not implemented yet");
+        }
         let config = Config::get().await?;
         let scope = if self.local {
             ConfigScope::LocalOnly

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -48,7 +48,7 @@ pub struct Outdated {
     #[clap(long, verbatim_doc_comment)]
     pub local: bool,
 
-    /// Show outdated tools across every [monorepo].config_roots config root
+    /// Placeholder for future monorepo outdated checks; `mise outdated --monorepo` is not implemented yet.
     #[clap(long, verbatim_doc_comment)]
     pub monorepo: bool,
 

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -43,13 +43,13 @@ pub struct Prune {
     #[clap(long, verbatim_doc_comment)]
     pub dry_run_code: bool,
 
-    /// Prune only unused versions of tools
-    #[clap(long)]
-    pub tools: bool,
-
     /// Prune tools across every [monorepo].config_roots config root
     #[clap(long, verbatim_doc_comment)]
     pub monorepo: bool,
+
+    /// Prune only unused versions of tools
+    #[clap(long)]
+    pub tools: bool,
 }
 
 impl Prune {

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -46,6 +46,10 @@ pub struct Prune {
     /// Prune only unused versions of tools
     #[clap(long)]
     pub tools: bool,
+
+    /// Prune tools across every [monorepo].config_roots config root
+    #[clap(long, verbatim_doc_comment)]
+    pub monorepo: bool,
 }
 
 impl Prune {
@@ -54,6 +58,9 @@ impl Prune {
     }
 
     pub async fn run(self) -> Result<()> {
+        if self.monorepo {
+            unimplemented!("mise prune --monorepo is not implemented yet");
+        }
         let mut config = Config::get().await?;
         if self.configs || !self.tools {
             self.prune_configs()?;

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -43,7 +43,7 @@ pub struct Prune {
     #[clap(long, verbatim_doc_comment)]
     pub dry_run_code: bool,
 
-    /// Prune tools across every [monorepo].config_roots config root
+    /// Placeholder for future monorepo pruning; `mise prune --monorepo` is not implemented yet.
     #[clap(long, verbatim_doc_comment)]
     pub monorepo: bool,
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -94,7 +94,7 @@ pub struct Upgrade {
     #[clap(long, alias = "before", verbatim_doc_comment)]
     minimum_release_age: Option<String>,
 
-    /// Upgrade tools across every [monorepo].config_roots config root
+    /// Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.
     #[clap(long, verbatim_doc_comment)]
     monorepo: bool,
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -98,6 +98,10 @@ pub struct Upgrade {
     /// Implies --jobs=1
     #[clap(long, overrides_with = "jobs")]
     raw: bool,
+
+    /// Upgrade tools across every [monorepo].config_roots config root
+    #[clap(long, verbatim_doc_comment)]
+    monorepo: bool,
 }
 
 impl Upgrade {
@@ -114,7 +118,13 @@ impl Upgrade {
     }
 
     pub async fn run(self) -> Result<()> {
+        if self.monorepo {
+            unimplemented!("mise upgrade --monorepo is not implemented yet");
+        }
         let mut config = Config::get().await?;
+        if !self.is_dry_run() {
+            crate::lockfile::migrate_monorepo_lockfiles(&config)?;
+        }
         let ts = ToolsetBuilder::new()
             .with_args(&self.tool)
             .with_scope(self.scope())

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -94,14 +94,14 @@ pub struct Upgrade {
     #[clap(long, alias = "before", verbatim_doc_comment)]
     minimum_release_age: Option<String>,
 
+    /// Upgrade tools across every [monorepo].config_roots config root
+    #[clap(long, verbatim_doc_comment)]
+    monorepo: bool,
+
     /// Connect backend install command stdin/stdout/stderr directly to the terminal
     /// Implies --jobs=1
     #[clap(long, overrides_with = "jobs")]
     raw: bool,
-
-    /// Upgrade tools across every [monorepo].config_roots config root
-    #[clap(long, verbatim_doc_comment)]
-    monorepo: bool,
 }
 
 impl Upgrade {

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -220,7 +220,7 @@ pub struct MonorepoConfig {
     #[serde(default)]
     pub config_roots: Vec<String>,
     /// Use a single lockfile at the monorepo root for descendant config roots.
-    /// Defaults to true. Set to false to keep lockfiles next to subproject configs.
+    /// None follows the rollout default; true opts in, false keeps colocated locks.
     pub lockfile: Option<bool>,
 }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -219,6 +219,9 @@ pub struct MonorepoConfig {
     /// Supports single-level glob patterns (*).
     #[serde(default)]
     pub config_roots: Vec<String>,
+    /// Use a single lockfile at the monorepo root for descendant config roots.
+    /// Defaults to true. Set to false to keep lockfiles next to subproject configs.
+    pub lockfile: Option<bool>,
 }
 
 impl EnvList {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -442,7 +442,11 @@ impl Config {
         if patterns.is_empty() {
             bail!("[monorepo].config_roots is required for monorepo operations");
         }
-        expand_config_roots(&monorepo_root, patterns, None)
+        let roots = expand_config_roots(&monorepo_root, patterns, None)?;
+        if roots.is_empty() {
+            bail!("[monorepo].config_roots did not match any config roots");
+        }
+        Ok(roots)
     }
 
     pub async fn monorepo_union_config_files(self: &Arc<Self>) -> Result<ConfigMap> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -430,6 +430,13 @@ impl Config {
     }
 
     pub fn monorepo_config_root_dirs(&self) -> Result<Vec<PathBuf>> {
+        self.monorepo_config_root_dirs_with_filenames(&DEFAULT_CONFIG_FILENAMES)
+    }
+
+    fn monorepo_config_root_dirs_with_filenames(
+        &self,
+        filenames: &[String],
+    ) -> Result<Vec<PathBuf>> {
         let monorepo_config = find_monorepo_config(&self.config_files)
             .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
         let monorepo_root = monorepo_config
@@ -442,7 +449,7 @@ impl Config {
         if patterns.is_empty() {
             bail!("[monorepo].config_roots is required for monorepo operations");
         }
-        let roots = expand_config_roots(&monorepo_root, patterns, None)?;
+        let roots = expand_config_roots_with_filenames(&monorepo_root, patterns, None, filenames)?;
         if roots.is_empty() {
             bail!("[monorepo].config_roots did not match any config roots");
         }
@@ -458,8 +465,13 @@ impl Config {
     }
 
     pub(crate) async fn monorepo_union(self: &Arc<Self>) -> Result<MonorepoUnion> {
-        let roots = self.monorepo_config_root_dirs()?;
         let idiomatic_filenames = load_idiomatic_filenames().await;
+        let config_filenames = idiomatic_filenames
+            .keys()
+            .chain(DEFAULT_CONFIG_FILENAMES.iter())
+            .cloned()
+            .collect_vec();
+        let roots = self.monorepo_config_root_dirs_with_filenames(&config_filenames)?;
         let mut config_files = self.config_files.clone();
         let mut base_config_files = self.config_files.clone();
         base_config_files.retain(|path, _| {
@@ -468,7 +480,7 @@ impl Config {
 
         let mut union = ToolRequestSet::new();
         for root in roots {
-            let root_paths = config_paths_in_dir(&root);
+            let root_paths = config_paths_in_dir_with_filenames(&root, &config_filenames);
             let mut root_config_files =
                 load_config_files_from_paths(&root_paths, &idiomatic_filenames).await?;
             for (path, cf) in root_config_files.clone() {
@@ -480,6 +492,7 @@ impl Config {
 
             let root_trs = ToolRequestSetBuilder::new()
                 .with_config_files(root_config_files)
+                .without_runtime_args()
                 .build(self)
                 .await?;
             union.unknown_tools.extend(root_trs.unknown_tools.clone());
@@ -1214,7 +1227,11 @@ pub fn config_files_in_dir(dir: &Path) -> IndexSet<PathBuf> {
 }
 
 pub(crate) fn config_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
-    let config_paths: Vec<PathBuf> = DEFAULT_CONFIG_FILENAMES
+    config_paths_in_dir_with_filenames(dir, &DEFAULT_CONFIG_FILENAMES)
+}
+
+fn config_paths_in_dir_with_filenames(dir: &Path, filenames: &[String]) -> Vec<PathBuf> {
+    let config_paths: Vec<PathBuf> = filenames
         .iter()
         .rev()
         .flat_map(|f| {
@@ -2272,6 +2289,15 @@ fn expand_config_roots(
     patterns: &[String],
     ctx: Option<&crate::task::TaskLoadContext>,
 ) -> Result<Vec<PathBuf>> {
+    expand_config_roots_with_filenames(root, patterns, ctx, &DEFAULT_CONFIG_FILENAMES)
+}
+
+fn expand_config_roots_with_filenames(
+    root: &Path,
+    patterns: &[String],
+    ctx: Option<&crate::task::TaskLoadContext>,
+    filenames: &[String],
+) -> Result<Vec<PathBuf>> {
     let mut subdirs = Vec::new();
 
     for pattern in patterns {
@@ -2309,7 +2335,8 @@ fn expand_config_roots(
                                     );
                                     continue;
                                 }
-                                if path.is_dir() && has_mise_config(&path) {
+                                if path.is_dir() && has_mise_config_with_filenames(&path, filenames)
+                                {
                                     subdirs.push(path);
                                 }
                             }
@@ -2338,7 +2365,7 @@ fn expand_config_roots(
                 continue;
             }
             if path.is_dir() {
-                if has_mise_config(&path) {
+                if has_mise_config_with_filenames(&path, filenames) {
                     subdirs.push(path);
                 } else {
                     warn!(
@@ -2367,11 +2394,8 @@ fn expand_config_roots(
     Ok(subdirs)
 }
 
-/// Check if a directory contains a mise config file or file tasks directory
-fn has_mise_config(dir: &Path) -> bool {
-    DEFAULT_CONFIG_FILENAMES
-        .iter()
-        .any(|f| dir.join(f).exists())
+fn has_mise_config_with_filenames(dir: &Path, filenames: &[String]) -> bool {
+    filenames.iter().any(|f| dir.join(f).exists())
         || dir.join(".mise/tasks").is_dir()
         || dir.join("mise-tasks").is_dir()
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -129,6 +129,30 @@ impl Config {
         Config::load().await
     }
 
+    pub(crate) fn with_config_files(&self, config_files: ConfigMap) -> Arc<Self> {
+        let project_root = get_project_root(&config_files).or_else(|| self.project_root.clone());
+        let repo_urls = load_plugins(&config_files).unwrap_or_else(|_| self.repo_urls.clone());
+        Arc::new(Self {
+            tera_ctx: self.tera_ctx.clone(),
+            config_files,
+            env: OnceCell::new(),
+            env_with_sources: OnceCell::new(),
+            shorthands: self.shorthands.clone(),
+            hooks: OnceCell::new(),
+            tasks_cache: Arc::new(DashMap::new()),
+            tool_request_set: OnceCell::new(),
+            toolset: OnceCell::new(),
+            all_aliases: self.all_aliases.clone(),
+            aliases: self.aliases.clone(),
+            project_root,
+            repo_urls,
+            shell_aliases: self.shell_aliases.clone(),
+            tera_files: self.tera_files.clone(),
+            vars: self.vars.clone(),
+            vars_results: OnceCell::new(),
+        })
+    }
+
     #[async_backtrace::framed]
     pub async fn load() -> Result<Arc<Self>> {
         backend::load_tools().await?;
@@ -426,8 +450,29 @@ impl Config {
             return None;
         }
         let monorepo_root = cf.project_root().map(|p| p.to_path_buf())?;
-        let config_roots = self.monorepo_config_root_dirs(None).ok()?;
-        (!config_roots.is_empty()).then_some(monorepo_root)
+        match self.monorepo_config_root_dirs(None) {
+            Ok(config_roots) if !config_roots.is_empty() => Some(monorepo_root),
+            Ok(_) => {
+                if setting == Some(true) {
+                    warn_once!(
+                        "[monorepo] lockfile = true is set, but [monorepo].config_roots did not match any directories; using root lockfiles without migration"
+                    );
+                    Some(monorepo_root)
+                } else {
+                    None
+                }
+            }
+            Err(err) => {
+                if setting == Some(true) {
+                    warn_once!(
+                        "[monorepo] lockfile = true is set, but [monorepo].config_roots could not be resolved: {err:#}; using root lockfiles without migration"
+                    );
+                    Some(monorepo_root)
+                } else {
+                    None
+                }
+            }
+        }
     }
 
     pub(crate) fn monorepo_config_root_dirs_for_lockfiles(&self) -> Result<Vec<PathBuf>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,6 +56,12 @@ type AliasMap = IndexMap<String, Alias>;
 pub(crate) type ConfigMap = IndexMap<PathBuf, Arc<dyn ConfigFile>>;
 pub type EnvWithSources = IndexMap<String, (String, PathBuf)>;
 
+pub(crate) struct MonorepoUnion {
+    pub config_files: ConfigMap,
+    pub tool_request_set: ToolRequestSet,
+    pub repo_urls: HashMap<String, String>,
+}
+
 pub struct Config {
     pub config_files: ConfigMap,
     pub project_root: Option<PathBuf>,
@@ -411,11 +417,16 @@ impl Config {
     pub fn monorepo_lockfile_root(&self) -> Option<PathBuf> {
         let cf = find_monorepo_config(&self.config_files)?;
         let setting = cf.monorepo().and_then(|m| m.lockfile);
-        if monorepo_lockfile_enabled_for_version(&version::V, setting) {
-            cf.project_root().map(|p| p.to_path_buf())
-        } else {
-            None
+        if !monorepo_lockfile_enabled_for_version(&version::V, setting) {
+            return None;
         }
+        let monorepo_root = cf.project_root().map(|p| p.to_path_buf())?;
+        let patterns = &cf.monorepo()?.config_roots;
+        if patterns.is_empty() {
+            return None;
+        }
+        let config_roots = expand_config_roots(&monorepo_root, patterns, None).ok()?;
+        (!config_roots.is_empty()).then_some(monorepo_root)
     }
 
     pub fn monorepo_config_root_dirs(&self) -> Result<Vec<PathBuf>> {
@@ -435,25 +446,17 @@ impl Config {
     }
 
     pub async fn monorepo_union_config_files(self: &Arc<Self>) -> Result<ConfigMap> {
-        let roots = self.monorepo_config_root_dirs()?;
-        let idiomatic_filenames = load_idiomatic_filenames().await;
-        let mut config_files = self.config_files.clone();
-
-        for root in roots {
-            let root_paths = config_paths_in_dir(&root);
-            let root_config_files =
-                load_config_files_from_paths(&root_paths, &idiomatic_filenames).await?;
-            for (path, cf) in root_config_files {
-                config_files.entry(path).or_insert(cf);
-            }
-        }
-
-        Ok(config_files)
+        Ok(self.monorepo_union().await?.config_files)
     }
 
     pub async fn monorepo_union_tool_request_set(self: &Arc<Self>) -> Result<ToolRequestSet> {
+        Ok(self.monorepo_union().await?.tool_request_set)
+    }
+
+    pub(crate) async fn monorepo_union(self: &Arc<Self>) -> Result<MonorepoUnion> {
         let roots = self.monorepo_config_root_dirs()?;
         let idiomatic_filenames = load_idiomatic_filenames().await;
+        let mut config_files = self.config_files.clone();
         let mut base_config_files = self.config_files.clone();
         base_config_files.retain(|path, _| {
             is_global_config(path) || !roots.iter().any(|root| path.starts_with(root))
@@ -464,6 +467,9 @@ impl Config {
             let root_paths = config_paths_in_dir(&root);
             let mut root_config_files =
                 load_config_files_from_paths(&root_paths, &idiomatic_filenames).await?;
+            for (path, cf) in root_config_files.clone() {
+                config_files.entry(path).or_insert(cf);
+            }
             for (path, cf) in base_config_files.clone() {
                 root_config_files.entry(path).or_insert(cf);
             }
@@ -488,7 +494,12 @@ impl Config {
         }
 
         union.unknown_tools = union.unknown_tools.into_iter().unique().collect();
-        Ok(union)
+        let repo_urls = load_plugins(&config_files)?;
+        Ok(MonorepoUnion {
+            config_files,
+            tool_request_set: union,
+            repo_urls,
+        })
     }
 
     pub async fn tasks(&self) -> Result<Arc<BTreeMap<String, Task>>> {
@@ -1198,7 +1209,7 @@ pub fn config_files_in_dir(dir: &Path) -> IndexSet<PathBuf> {
         .collect()
 }
 
-fn config_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
+pub(crate) fn config_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
     let config_paths: Vec<PathBuf> = DEFAULT_CONFIG_FILENAMES
         .iter()
         .rev()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -405,6 +405,88 @@ impl Config {
         find_monorepo_root(&self.config_files)
     }
 
+    pub fn monorepo_lockfile_root(&self) -> Option<PathBuf> {
+        let cf = find_monorepo_config(&self.config_files)?;
+        if cf.monorepo().and_then(|m| m.lockfile).unwrap_or(true) {
+            cf.project_root().map(|p| p.to_path_buf())
+        } else {
+            None
+        }
+    }
+
+    pub fn monorepo_config_root_dirs(&self) -> Result<Vec<PathBuf>> {
+        let monorepo_config = find_monorepo_config(&self.config_files)
+            .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
+        let monorepo_root = monorepo_config
+            .project_root()
+            .ok_or_else(|| eyre!("monorepo root config has no project root"))?;
+        let patterns = &monorepo_config
+            .monorepo()
+            .ok_or_else(|| eyre!("[monorepo].config_roots is required for monorepo operations"))?
+            .config_roots;
+        if patterns.is_empty() {
+            bail!("[monorepo].config_roots is required for monorepo operations");
+        }
+        expand_config_roots(&monorepo_root, patterns, None)
+    }
+
+    pub async fn monorepo_union_config_files(self: &Arc<Self>) -> Result<ConfigMap> {
+        let roots = self.monorepo_config_root_dirs()?;
+        let idiomatic_filenames = load_idiomatic_filenames().await;
+        let mut config_files = self.config_files.clone();
+
+        for root in roots {
+            let root_paths = config_paths_in_dir(&root);
+            let root_config_files =
+                load_config_files_from_paths(&root_paths, &idiomatic_filenames).await?;
+            for (path, cf) in root_config_files {
+                config_files.entry(path).or_insert(cf);
+            }
+        }
+
+        Ok(config_files)
+    }
+
+    pub async fn monorepo_union_tool_request_set(self: &Arc<Self>) -> Result<ToolRequestSet> {
+        let roots = self.monorepo_config_root_dirs()?;
+        let idiomatic_filenames = load_idiomatic_filenames().await;
+        let mut base_config_files = self.config_files.clone();
+        base_config_files.retain(|path, _| {
+            is_global_config(path) || !roots.iter().any(|root| path.starts_with(root))
+        });
+
+        let mut union = ToolRequestSet::new();
+        for root in roots {
+            let root_paths = config_paths_in_dir(&root);
+            let mut root_config_files =
+                load_config_files_from_paths(&root_paths, &idiomatic_filenames).await?;
+            for (path, cf) in base_config_files.clone() {
+                root_config_files.entry(path).or_insert(cf);
+            }
+
+            let root_trs = ToolRequestSetBuilder::new()
+                .with_config_files(root_config_files)
+                .build(self)
+                .await?;
+            union.unknown_tools.extend(root_trs.unknown_tools.clone());
+            for (_ba, requests, source) in root_trs.iter() {
+                for request in requests {
+                    let already_present = union.tools.get(request.ba()).is_some_and(|existing| {
+                        existing.iter().any(|r| {
+                            r.version() == request.version() && r.options() == request.options()
+                        })
+                    });
+                    if !already_present {
+                        union.add_version(request.clone(), source);
+                    }
+                }
+            }
+        }
+
+        union.unknown_tools = union.unknown_tools.into_iter().unique().collect();
+        Ok(union)
+    }
+
     pub async fn tasks(&self) -> Result<Arc<BTreeMap<String, Task>>> {
         self.tasks_with_context(None).await
     }
@@ -1109,6 +1191,27 @@ pub fn config_files_in_dir(dir: &Path) -> IndexSet<PathBuf> {
     DEFAULT_CONFIG_FILENAMES
         .iter()
         .flat_map(|f| glob(dir, f).unwrap_or_default())
+        .collect()
+}
+
+fn config_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
+    let config_paths: Vec<PathBuf> = DEFAULT_CONFIG_FILENAMES
+        .iter()
+        .rev()
+        .flat_map(|f| {
+            if f.contains('*') {
+                glob(dir, f).unwrap_or_default().into_iter().rev().collect()
+            } else {
+                let path = dir.join(f);
+                if path.exists() { vec![path] } else { vec![] }
+            }
+        })
+        .collect();
+
+    let mut seen = std::collections::HashSet::new();
+    config_paths
+        .into_iter()
+        .filter(|p| seen.insert(p.clone()))
         .collect()
 }
 
@@ -1871,6 +1974,7 @@ pub async fn rebuild_shims_and_runtime_symlinks(
             .await
             .wrap_err("failed to rebuild shims")?;
     });
+    lockfile::migrate_monorepo_lockfiles(config)?;
     // Snapshot the lockfiles' platform keys BEFORE update_lockfiles writes
     // current-platform entries — auto-lock uses this to tell a curated lockfile
     // (existing entries are authoritative) from a fresh one (expand to common).
@@ -1980,32 +2084,7 @@ async fn load_local_tasks_with_context(
                     // Later inserts win, so file tasks override config tasks with the same name
                     let mut task_map: IndexMap<String, Task> = IndexMap::new();
 
-                    // Load config files from subdirectory
-                    // Use .rev() so later files (like mise.local.toml) have higher precedence
-                    // Use glob() with .rev() for conf.d patterns so later files (02-override.toml) override earlier ones
-                    let config_paths: Vec<PathBuf> = DEFAULT_CONFIG_FILENAMES
-                        .iter()
-                        .rev()
-                        .flat_map(|f| {
-                            if f.contains('*') {
-                                glob(&subdir, f).unwrap_or_default().into_iter().rev().collect()
-                            } else {
-                                let path = subdir.join(f);
-                                if path.exists() {
-                                    vec![path]
-                                } else {
-                                    vec![]
-                                }
-                            }
-                        })
-                        .collect();
-
-                    // Deduplicate config paths while preserving precedence order
-                    let mut seen = std::collections::HashSet::new();
-                    let config_paths: Vec<PathBuf> = config_paths
-                        .into_iter()
-                        .filter(|p| seen.insert(p.clone()))
-                        .collect();
+                    let config_paths = config_paths_in_dir(&subdir);
 
                     let found_config = !config_paths.is_empty();
                     for config_path in config_paths {
@@ -3477,6 +3556,83 @@ mod tests {
         }
 
         result
+    }
+
+    #[tokio::test]
+    async fn test_monorepo_union_tool_request_set_preserves_matching_tools() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let root = temp_dir.path();
+        let api = root.join("apps/api");
+        let web = root.join("apps/web");
+        fs::create_dir_all(&api)?;
+        fs::create_dir_all(&web)?;
+
+        let root_config = root.join(".test.mise.toml");
+        fs::write(
+            &root_config,
+            r#"
+monorepo_root = true
+
+[monorepo]
+config_roots = ["apps/api", "apps/web"]
+"#,
+        )?;
+        fs::write(
+            api.join(".test.mise.toml"),
+            r#"
+[tools]
+"github:jdx/mise-test-fixtures" = "1"
+"#,
+        )?;
+        fs::write(
+            web.join(".test.mise.toml"),
+            r#"
+[tools]
+"github:jdx/mise-test-fixtures" = "2"
+"#,
+        )?;
+
+        let mut config_files: ConfigMap = Default::default();
+        config_files.insert(
+            root_config.clone(),
+            Arc::new(config_file::mise_toml::MiseToml::from_file(&root_config)?),
+        );
+        let config = Config {
+            tera_ctx: BASE_CONTEXT.clone(),
+            config_files,
+            env: OnceCell::new(),
+            env_with_sources: OnceCell::new(),
+            shorthands: get_shorthands(&Settings::get()),
+            hooks: OnceCell::new(),
+            tasks_cache: Arc::new(DashMap::new()),
+            tool_request_set: OnceCell::new(),
+            toolset: OnceCell::new(),
+            all_aliases: Default::default(),
+            aliases: Default::default(),
+            project_root: Default::default(),
+            repo_urls: Default::default(),
+            shell_aliases: Default::default(),
+            tera_files: Default::default(),
+            vars: Default::default(),
+            vars_results: OnceCell::new(),
+        };
+        let config = Arc::new(config);
+
+        assert_eq!(config.monorepo_config_root_dirs()?, vec![api, web]);
+        let trs = config.monorepo_union_tool_request_set().await?;
+        let fixture_versions = trs
+            .iter()
+            .find(|(ba, _, _)| ba.short.contains("mise-test-fixtures"))
+            .map(|(_, requests, _)| {
+                requests
+                    .iter()
+                    .map(|request| request.version().to_string())
+                    .collect_vec()
+            })
+            .unwrap_or_default();
+
+        assert_eq!(fixture_versions, vec!["1", "2"]);
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1333,8 +1333,12 @@ fn monorepo_lockfile_enabled_for_version(
 fn should_warn_monorepo_lockfile_default(
     version: &versions::Versioning,
     setting: Option<bool>,
+    lockfile_enabled: bool,
+    monorepo_lockfiles_exist: bool,
 ) -> bool {
     setting.is_none()
+        && lockfile_enabled
+        && monorepo_lockfiles_exist
         && *version >= versions::Versioning::new(MONOREPO_LOCKFILE_WARN_AT).unwrap()
         && !monorepo_lockfile_default_for_version(version)
 }
@@ -1350,7 +1354,12 @@ fn warn_if_monorepo_lockfile_default_changes(config: &Config) {
         return;
     };
     let setting = cf.monorepo().and_then(|m| m.lockfile);
-    if !should_warn_monorepo_lockfile_default(&version::V, setting) {
+    if !should_warn_monorepo_lockfile_default(
+        &version::V,
+        setting,
+        Settings::get().lockfile_enabled(),
+        monorepo_lockfiles_exist(config, cf),
+    ) {
         return;
     }
 
@@ -1359,6 +1368,39 @@ fn warn_if_monorepo_lockfile_default_changes(config: &Config) {
         Set `[monorepo] lockfile = true` in {} to opt in now, or `lockfile = false` to keep per-subproject lockfiles and silence this warning.",
         display_path(cf.get_path())
     );
+}
+
+fn monorepo_lockfiles_exist(config: &Config, monorepo_config: &Arc<dyn ConfigFile>) -> bool {
+    let Some(monorepo_root) = monorepo_config.project_root() else {
+        return false;
+    };
+    let mut lockfile_paths = IndexSet::new();
+
+    for (config_path, cf) in &config.config_files {
+        if !config_path.starts_with(&monorepo_root) || !cf.source().is_mise_toml() {
+            continue;
+        }
+        lockfile_paths.insert(lockfile::lockfile_path_for_config(config_path, None).0);
+        lockfile_paths.insert(
+            lockfile::lockfile_path_for_config(config_path, Some(monorepo_root.as_path())).0,
+        );
+    }
+
+    if let Some(monorepo) = monorepo_config.monorepo()
+        && let Ok(config_roots) = expand_config_roots(&monorepo_root, &monorepo.config_roots, None)
+    {
+        for config_root in config_roots {
+            for config_path in config_paths_in_dir(&config_root) {
+                lockfile_paths.insert(lockfile::lockfile_path_for_config(&config_path, None).0);
+                lockfile_paths.insert(
+                    lockfile::lockfile_path_for_config(&config_path, Some(monorepo_root.as_path()))
+                        .0,
+                );
+            }
+        }
+    }
+
+    lockfile_paths.iter().any(|path| path.exists())
 }
 
 /// Phase-2 rollout warning for auto_env: starting with 2026.12.0, tell users about
@@ -3262,19 +3304,52 @@ mod tests {
 
         assert!(!should_warn_monorepo_lockfile_default(
             &v("2026.11.9"),
-            None
+            None,
+            true,
+            true
         ));
-        assert!(should_warn_monorepo_lockfile_default(&v("2026.12.0"), None));
-        assert!(should_warn_monorepo_lockfile_default(&v("2027.5.9"), None));
+        assert!(should_warn_monorepo_lockfile_default(
+            &v("2026.12.0"),
+            None,
+            true,
+            true
+        ));
+        assert!(should_warn_monorepo_lockfile_default(
+            &v("2027.5.9"),
+            None,
+            true,
+            true
+        ));
         assert!(!should_warn_monorepo_lockfile_default(
             &v("2026.12.0"),
-            Some(true)
+            None,
+            false,
+            true
         ));
         assert!(!should_warn_monorepo_lockfile_default(
             &v("2026.12.0"),
-            Some(false)
+            None,
+            true,
+            false
         ));
-        assert!(!should_warn_monorepo_lockfile_default(&v("2027.6.0"), None));
+        assert!(!should_warn_monorepo_lockfile_default(
+            &v("2026.12.0"),
+            Some(true),
+            true,
+            true
+        ));
+        assert!(!should_warn_monorepo_lockfile_default(
+            &v("2026.12.0"),
+            Some(false),
+            true,
+            true
+        ));
+        assert!(!should_warn_monorepo_lockfile_default(
+            &v("2027.6.0"),
+            None,
+            true,
+            true
+        ));
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -86,6 +86,8 @@ pub struct Alias {
 
 static _CONFIG: RwLock<Option<Arc<Config>>> = RwLock::new(None);
 static _REDACTOR: Lazy<Mutex<Redactor>> = Lazy::new(Default::default);
+const MONOREPO_LOCKFILE_WARN_AT: &str = "2026.12.0";
+const MONOREPO_LOCKFILE_DEFAULT_AT: &str = "2027.6.0";
 
 pub fn is_loaded() -> bool {
     _CONFIG.read().unwrap().is_some()
@@ -220,6 +222,7 @@ impl Config {
         }
 
         warn_if_auto_env_files_exist();
+        warn_if_monorepo_lockfile_default_changes(&config);
 
         time!("load done");
 
@@ -407,7 +410,8 @@ impl Config {
 
     pub fn monorepo_lockfile_root(&self) -> Option<PathBuf> {
         let cf = find_monorepo_config(&self.config_files)?;
-        if cf.monorepo().and_then(|m| m.lockfile).unwrap_or(true) {
+        let setting = cf.monorepo().and_then(|m| m.lockfile);
+        if monorepo_lockfile_enabled_for_version(&version::V, setting) {
             cf.project_root().map(|p| p.to_path_buf())
         } else {
             None
@@ -1308,6 +1312,53 @@ fn should_warn_auto_env(
         && !auto_envs_active
         && *version >= versions::Versioning::new("2026.12.0").unwrap()
         && !env::auto_env_default_for_version(version)
+}
+
+/// Default for monorepo lockfile routing when `[monorepo].lockfile` is unset.
+/// Keep legacy colocated lockfiles until the scheduled default flip.
+fn monorepo_lockfile_default_for_version(version: &versions::Versioning) -> bool {
+    *version >= versions::Versioning::new(MONOREPO_LOCKFILE_DEFAULT_AT).unwrap()
+}
+
+fn monorepo_lockfile_enabled_for_version(
+    version: &versions::Versioning,
+    setting: Option<bool>,
+) -> bool {
+    setting.unwrap_or_else(|| monorepo_lockfile_default_for_version(version))
+}
+
+/// Whether to emit the phase-2 monorepo lockfile rollout warning. Pure for unit testing.
+/// Warns only when the user has not explicitly chosen `lockfile = true` or `false`
+/// and the mise version is in the warning window before the default flip.
+fn should_warn_monorepo_lockfile_default(
+    version: &versions::Versioning,
+    setting: Option<bool>,
+) -> bool {
+    setting.is_none()
+        && *version >= versions::Versioning::new(MONOREPO_LOCKFILE_WARN_AT).unwrap()
+        && !monorepo_lockfile_default_for_version(version)
+}
+
+fn warn_if_monorepo_lockfile_default_changes(config: &Config) {
+    // Dead code once the default flips on: unset configs use the new behavior,
+    // so this warning path should be removed when the rollout completes.
+    debug_assert!(
+        !monorepo_lockfile_default_for_version(&version::V),
+        "monorepo lockfiles are now default-on; remove warn_if_monorepo_lockfile_default_changes() and should_warn_monorepo_lockfile_default()"
+    );
+    let Some(cf) = find_monorepo_config(&config.config_files) else {
+        return;
+    };
+    let setting = cf.monorepo().and_then(|m| m.lockfile);
+    if !should_warn_monorepo_lockfile_default(&version::V, setting) {
+        return;
+    }
+
+    warn_once!(
+        "Monorepo lockfiles will default to a single root lockfile starting in mise {MONOREPO_LOCKFILE_DEFAULT_AT}. \
+        Set `[monorepo] lockfile = true` in {} to opt in now, or `lockfile = false` to keep per-subproject lockfiles and silence this warning.",
+        display_path(cf.get_path())
+    );
 }
 
 /// Phase-2 rollout warning for auto_env: starting with 2026.12.0, tell users about
@@ -3189,6 +3240,41 @@ mod tests {
         // default flipped on: warning is obsolete
         assert!(!should_warn_auto_env(&v("2027.6.0"), None, true));
         assert!(!should_warn_auto_env(&v("2027.6.0"), Some(false), false));
+    }
+
+    #[test]
+    fn test_monorepo_lockfile_rollout() {
+        let v = |s: &str| versions::Versioning::new(s).unwrap();
+
+        assert!(!monorepo_lockfile_enabled_for_version(
+            &v("2026.6.15"),
+            None
+        ));
+        assert!(monorepo_lockfile_enabled_for_version(
+            &v("2026.6.15"),
+            Some(true)
+        ));
+        assert!(!monorepo_lockfile_enabled_for_version(
+            &v("2027.6.0"),
+            Some(false)
+        ));
+        assert!(monorepo_lockfile_enabled_for_version(&v("2027.6.0"), None));
+
+        assert!(!should_warn_monorepo_lockfile_default(
+            &v("2026.11.9"),
+            None
+        ));
+        assert!(should_warn_monorepo_lockfile_default(&v("2026.12.0"), None));
+        assert!(should_warn_monorepo_lockfile_default(&v("2027.5.9"), None));
+        assert!(!should_warn_monorepo_lockfile_default(
+            &v("2026.12.0"),
+            Some(true)
+        ));
+        assert!(!should_warn_monorepo_lockfile_default(
+            &v("2026.12.0"),
+            Some(false)
+        ));
+        assert!(!should_warn_monorepo_lockfile_default(&v("2027.6.0"), None));
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -425,12 +425,28 @@ impl Config {
         if patterns.is_empty() {
             return None;
         }
-        let config_roots = expand_config_roots(&monorepo_root, patterns, None).ok()?;
+        let config_roots = expand_config_root_dirs(&monorepo_root, patterns, None).ok()?;
         (!config_roots.is_empty()).then_some(monorepo_root)
     }
 
-    pub fn monorepo_config_root_dirs(&self) -> Result<Vec<PathBuf>> {
-        self.monorepo_config_root_dirs_with_filenames(&DEFAULT_CONFIG_FILENAMES)
+    pub(crate) fn monorepo_config_root_dirs_for_lockfiles(&self) -> Result<Vec<PathBuf>> {
+        let monorepo_config = find_monorepo_config(&self.config_files)
+            .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
+        let monorepo_root = monorepo_config
+            .project_root()
+            .ok_or_else(|| eyre!("monorepo root config has no project root"))?;
+        let patterns = &monorepo_config
+            .monorepo()
+            .ok_or_else(|| eyre!("[monorepo].config_roots is required for monorepo operations"))?
+            .config_roots;
+        if patterns.is_empty() {
+            bail!("[monorepo].config_roots is required for monorepo operations");
+        }
+        let roots = expand_config_root_dirs(&monorepo_root, patterns, None)?;
+        if roots.is_empty() {
+            bail!("[monorepo].config_roots did not match any config roots");
+        }
+        Ok(roots)
     }
 
     fn monorepo_config_root_dirs_with_filenames(
@@ -454,10 +470,6 @@ impl Config {
             bail!("[monorepo].config_roots did not match any config roots");
         }
         Ok(roots)
-    }
-
-    pub async fn monorepo_union_config_files(self: &Arc<Self>) -> Result<ConfigMap> {
-        Ok(self.monorepo_union().await?.config_files)
     }
 
     pub async fn monorepo_union_tool_request_set(self: &Arc<Self>) -> Result<ToolRequestSet> {
@@ -1419,9 +1431,13 @@ fn monorepo_lockfiles_exist(config: &Config, monorepo_config: &Arc<dyn ConfigFil
     }
 
     if let Some(monorepo) = monorepo_config.monorepo()
-        && let Ok(config_roots) = expand_config_roots(&monorepo_root, &monorepo.config_roots, None)
+        && let Ok(config_roots) =
+            expand_config_root_dirs(&monorepo_root, &monorepo.config_roots, None)
     {
         for config_root in config_roots {
+            for lockfile_path in lockfile::lockfile_variant_paths_in_dir(&config_root) {
+                lockfile_paths.insert(lockfile_path);
+            }
             for config_path in config_paths_in_dir(&config_root) {
                 lockfile_paths.insert(lockfile::lockfile_path_for_config(&config_path, None).0);
                 lockfile_paths.insert(
@@ -2292,11 +2308,28 @@ fn expand_config_roots(
     expand_config_roots_with_filenames(root, patterns, ctx, &DEFAULT_CONFIG_FILENAMES)
 }
 
+fn expand_config_root_dirs(
+    root: &Path,
+    patterns: &[String],
+    ctx: Option<&crate::task::TaskLoadContext>,
+) -> Result<Vec<PathBuf>> {
+    expand_config_roots_inner(root, patterns, ctx, None)
+}
+
 fn expand_config_roots_with_filenames(
     root: &Path,
     patterns: &[String],
     ctx: Option<&crate::task::TaskLoadContext>,
     filenames: &[String],
+) -> Result<Vec<PathBuf>> {
+    expand_config_roots_inner(root, patterns, ctx, Some(filenames))
+}
+
+fn expand_config_roots_inner(
+    root: &Path,
+    patterns: &[String],
+    ctx: Option<&crate::task::TaskLoadContext>,
+    filenames: Option<&[String]>,
 ) -> Result<Vec<PathBuf>> {
     let mut subdirs = Vec::new();
 
@@ -2335,7 +2368,10 @@ fn expand_config_roots_with_filenames(
                                     );
                                     continue;
                                 }
-                                if path.is_dir() && has_mise_config_with_filenames(&path, filenames)
+                                if path.is_dir()
+                                    && filenames.is_none_or(|filenames| {
+                                        has_mise_config_with_filenames(&path, filenames)
+                                    })
                                 {
                                     subdirs.push(path);
                                 }
@@ -2365,7 +2401,9 @@ fn expand_config_roots_with_filenames(
                 continue;
             }
             if path.is_dir() {
-                if has_mise_config_with_filenames(&path, filenames) {
+                if filenames
+                    .is_none_or(|filenames| has_mise_config_with_filenames(&path, filenames))
+                {
                     subdirs.push(path);
                 } else {
                     warn!(
@@ -2395,8 +2433,13 @@ fn expand_config_roots_with_filenames(
 }
 
 fn has_mise_config_with_filenames(dir: &Path, filenames: &[String]) -> bool {
-    filenames.iter().any(|f| dir.join(f).exists())
-        || dir.join(".mise/tasks").is_dir()
+    filenames.iter().any(|f| {
+        if f.contains('*') {
+            !glob(dir, f).unwrap_or_default().is_empty()
+        } else {
+            dir.join(f).exists()
+        }
+    }) || dir.join(".mise/tasks").is_dir()
         || dir.join("mise-tasks").is_dir()
 }
 
@@ -3096,6 +3139,21 @@ mod tests {
         assert!(config_set_contains(&set, &aliased_file));
         // an unrelated path is not a member
         assert!(!config_set_contains(&set, &real_dir.join("other.toml")));
+    }
+
+    #[test]
+    fn test_has_mise_config_with_glob_filenames() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let confd = tmp.path().join(".config/mise/conf.d");
+        fs::create_dir_all(&confd)?;
+        fs::write(confd.join("tools.toml"), "[tools]\n")?;
+
+        assert!(has_mise_config_with_filenames(
+            tmp.path(),
+            &[".config/mise/conf.d/*.toml".to_string()]
+        ));
+
+        Ok(())
     }
 
     #[test]
@@ -3818,7 +3876,10 @@ config_roots = ["apps/api", "apps/web"]
         };
         let config = Arc::new(config);
 
-        assert_eq!(config.monorepo_config_root_dirs()?, vec![api, web]);
+        assert_eq!(
+            config.monorepo_config_root_dirs_with_filenames(&DEFAULT_CONFIG_FILENAMES)?,
+            vec![api, web]
+        );
         let trs = config.monorepo_union_tool_request_set().await?;
         let fixture_versions = trs
             .iter()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -414,6 +414,11 @@ impl Config {
         find_monorepo_root(&self.config_files)
     }
 
+    /// Returns the root lockfile directory when unified monorepo lockfiles are active.
+    ///
+    /// Lockfile discovery is intentionally lenient: it only requires
+    /// `[monorepo].config_roots` to match directories, because legacy lockfiles
+    /// can exist in roots whose live config is idiomatic-only or was removed.
     pub fn monorepo_lockfile_root(&self) -> Option<PathBuf> {
         let cf = find_monorepo_config(&self.config_files)?;
         let setting = cf.monorepo().and_then(|m| m.lockfile);
@@ -421,38 +426,27 @@ impl Config {
             return None;
         }
         let monorepo_root = cf.project_root().map(|p| p.to_path_buf())?;
-        let patterns = &cf.monorepo()?.config_roots;
-        if patterns.is_empty() {
-            return None;
-        }
-        let config_roots = expand_config_root_dirs(&monorepo_root, patterns, None).ok()?;
+        let config_roots = self.monorepo_config_root_dirs(None).ok()?;
         (!config_roots.is_empty()).then_some(monorepo_root)
     }
 
     pub(crate) fn monorepo_config_root_dirs_for_lockfiles(&self) -> Result<Vec<PathBuf>> {
-        let monorepo_config = find_monorepo_config(&self.config_files)
-            .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
-        let monorepo_root = monorepo_config
-            .project_root()
-            .ok_or_else(|| eyre!("monorepo root config has no project root"))?;
-        let patterns = &monorepo_config
-            .monorepo()
-            .ok_or_else(|| eyre!("[monorepo].config_roots is required for monorepo operations"))?
-            .config_roots;
-        if patterns.is_empty() {
-            bail!("[monorepo].config_roots is required for monorepo operations");
-        }
-        let roots = expand_config_root_dirs(&monorepo_root, patterns, None)?;
-        if roots.is_empty() {
-            bail!("[monorepo].config_roots did not match any config roots");
-        }
-        Ok(roots)
+        self.monorepo_config_root_dirs(None)
     }
 
     fn monorepo_config_root_dirs_with_filenames(
         &self,
         filenames: &[String],
     ) -> Result<Vec<PathBuf>> {
+        self.monorepo_config_root_dirs(Some(filenames))
+    }
+
+    /// Resolve `[monorepo].config_roots`.
+    ///
+    /// `None` matches any existing directory and is used for lockfile migration
+    /// and routing. `Some(filenames)` requires a recognized config or idiomatic
+    /// version file and is used for full monorepo union/task loading.
+    fn monorepo_config_root_dirs(&self, filenames: Option<&[String]>) -> Result<Vec<PathBuf>> {
         let monorepo_config = find_monorepo_config(&self.config_files)
             .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
         let monorepo_root = monorepo_config
@@ -465,7 +459,12 @@ impl Config {
         if patterns.is_empty() {
             bail!("[monorepo].config_roots is required for monorepo operations");
         }
-        let roots = expand_config_roots_with_filenames(&monorepo_root, patterns, None, filenames)?;
+        let roots = match filenames {
+            Some(filenames) => {
+                expand_config_roots_with_filenames(&monorepo_root, patterns, None, filenames)?
+            }
+            None => expand_config_root_dirs(&monorepo_root, patterns, None)?,
+        };
         if roots.is_empty() {
             bail!("[monorepo].config_roots did not match any config roots");
         }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -10,10 +10,11 @@ use crate::path::PathExt;
 use crate::platform::Platform;
 use crate::toolset::{ToolSource, ToolVersion, Toolset};
 use eyre::{Report, Result, bail, eyre};
+use indexmap::IndexSet;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock as Lazy;
 use std::sync::Mutex;
@@ -1285,40 +1286,52 @@ pub fn migrate_monorepo_lockfiles(config: &Config) -> Result<()> {
         Ok(roots) => roots,
         Err(_) => return Ok(()),
     };
-    let lockfile_name_re = regex!(r"^mise(\.[^.]+)?(\.local)?\.lock$");
-    let mut migrated = 0usize;
+    let mut source_lockfiles = IndexSet::new();
 
     for config_root in config_roots {
         if config_root == monorepo_root {
             continue;
         }
-        let Ok(entries) = fs::read_dir(&config_root) else {
+        for config_path in crate::config::config_paths_in_dir(&config_root) {
+            let (source, _) = lockfile_path_for_config(&config_path, None);
+            if source.parent() == Some(monorepo_root.as_path()) {
+                continue;
+            }
+            source_lockfiles.insert(source);
+        }
+    }
+
+    let mut migrated = 0usize;
+
+    for source in source_lockfiles {
+        if !source.exists() {
+            continue;
+        }
+        let Some(filename) = source.file_name() else {
             continue;
         };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_file() {
-                continue;
-            }
-            let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            if !lockfile_name_re.is_match(filename) {
-                continue;
-            }
-
-            let target = monorepo_root.join(filename);
-            let _lock = crate::lock_file::LockFile::new(&target)
-                .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
-                .lock()?;
-            let mut root_lockfile = Lockfile::read(&target)
-                .unwrap_or_else(|err| handle_lockfile_read_error(err, &target));
-            let subproject_lockfile = Lockfile::read(&path)?;
-            merge_lockfile_preserving_root(&mut root_lockfile, subproject_lockfile);
-            root_lockfile.save(&target)?;
-            fs::remove_file(&path)?;
-            migrated += 1;
+        let target = monorepo_root.join(filename);
+        if source == target {
+            continue;
         }
+        let _lock = crate::lock_file::LockFile::new(&target)
+            .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
+            .lock()?;
+        let mut root_lockfile =
+            Lockfile::read(&target).unwrap_or_else(|err| handle_lockfile_read_error(err, &target));
+        let subproject_lockfile = match Lockfile::read(&source) {
+            Ok(lockfile) => lockfile,
+            Err(err) if is_not_found_report(&err) => continue,
+            Err(err) => return Err(err),
+        };
+        merge_lockfile_preserving_root(&mut root_lockfile, subproject_lockfile);
+        root_lockfile.save(&target)?;
+        if let Err(err) = fs::remove_file(&source)
+            && err.kind() != ErrorKind::NotFound
+        {
+            return Err(err.into());
+        }
+        migrated += 1;
     }
 
     if migrated > 0 {
@@ -1329,6 +1342,11 @@ pub fn migrate_monorepo_lockfiles(config: &Config) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn is_not_found_report(err: &Report) -> bool {
+    err.downcast_ref::<std::io::Error>()
+        .is_some_and(|err| err.kind() == ErrorKind::NotFound)
 }
 
 fn merge_lockfile_preserving_root(root: &mut Lockfile, other: Lockfile) {
@@ -1370,7 +1388,6 @@ pub fn update_lockfiles(
     if !Settings::get().lockfile_enabled() || (Settings::get().locked && !mode.allow_locked()) {
         return Ok(());
     }
-    migrate_monorepo_lockfiles(config)?;
 
     // Collect tools by source (config file)
     let mut tools_by_source: HashMap<ToolSource, HashMap<String, Vec<ToolVersion>>> =

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1202,10 +1202,16 @@ pub fn lockfile_path_for_tool_source(
     source: &ToolSource,
 ) -> Option<(PathBuf, bool)> {
     let monorepo_root = config.monorepo_lockfile_root();
+    lockfile_path_for_tool_source_with_root(config, source, monorepo_root.as_deref())
+}
+
+fn lockfile_path_for_tool_source_with_root(
+    config: &Config,
+    source: &ToolSource,
+    monorepo_root: Option<&Path>,
+) -> Option<(PathBuf, bool)> {
     match source {
-        ToolSource::MiseToml(path) => {
-            Some(lockfile_path_for_config(path, monorepo_root.as_deref()))
-        }
+        ToolSource::MiseToml(path) => Some(lockfile_path_for_config(path, monorepo_root)),
         ToolSource::IdiomaticVersionFile(path) => config
             .config_files
             .iter()
@@ -1221,7 +1227,7 @@ pub fn lockfile_path_for_tool_source(
                         is_base,
                         // Tie-break same-root base configs by config_files order.
                         idx,
-                        lockfile_path_for_config(config_path, monorepo_root.as_deref()),
+                        lockfile_path_for_config(config_path, monorepo_root),
                     )
                 })
             })
@@ -2281,6 +2287,11 @@ fn read_lockfile_for(config: &Config, path: &Path) -> Arc<Lockfile> {
     let legacy_path = monorepo_root
         .as_deref()
         .and_then(|root| legacy_lockfile_path_for_config(config, path, root));
+
+    read_lockfile_at(lockfile_path, legacy_path)
+}
+
+fn read_lockfile_at(lockfile_path: PathBuf, legacy_path: Option<PathBuf>) -> Arc<Lockfile> {
     let cache_key: Vec<PathBuf> = std::iter::once(lockfile_path.clone())
         .chain(legacy_path.iter().cloned())
         .collect();
@@ -2311,6 +2322,31 @@ fn read_lockfile_for(config: &Config, path: &Path) -> Arc<Lockfile> {
 
 pub(crate) fn read_lockfile_for_config_path(config: &Config, path: &Path) -> Lockfile {
     read_lockfile_for(config, path).as_ref().clone()
+}
+
+pub(crate) fn read_lockfile_for_tool_source(
+    config: &Config,
+    source: &ToolSource,
+) -> Result<Lockfile> {
+    if let ToolSource::MiseToml(path) = source {
+        return Ok(read_lockfile_for_config_path(config, path));
+    }
+
+    let monorepo_root = config.monorepo_lockfile_root();
+    let Some((lockfile_path, _)) =
+        lockfile_path_for_tool_source_with_root(config, source, monorepo_root.as_deref())
+    else {
+        return Ok(Lockfile::default());
+    };
+    let legacy_path = monorepo_root
+        .as_deref()
+        .and_then(|_| lockfile_path_for_tool_source_with_root(config, source, None))
+        .map(|(path, _)| path)
+        .filter(|path| path != &lockfile_path);
+
+    Ok(read_lockfile_at(lockfile_path, legacy_path)
+        .as_ref()
+        .clone())
 }
 
 pub fn get_locked_version(

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1334,7 +1334,7 @@ fn monorepo_legacy_lockfile_paths(config: &Config) -> IndexSet<PathBuf> {
     let Some(monorepo_root) = config.monorepo_lockfile_root() else {
         return IndexSet::new();
     };
-    let Ok(config_roots) = config.monorepo_config_root_dirs() else {
+    let Ok(config_roots) = config.monorepo_config_root_dirs_for_lockfiles() else {
         return IndexSet::new();
     };
     let mut source_lockfiles = IndexSet::new();
@@ -1342,6 +1342,11 @@ fn monorepo_legacy_lockfile_paths(config: &Config) -> IndexSet<PathBuf> {
     for config_root in config_roots {
         if config_root == monorepo_root {
             continue;
+        }
+        for source in lockfile_variant_paths_in_dir(&config_root) {
+            if source.parent() != Some(monorepo_root.as_path()) {
+                source_lockfiles.insert(source);
+            }
         }
         for config_path in crate::config::config_paths_in_dir(&config_root) {
             if let Some(source) =
@@ -1353,6 +1358,22 @@ fn monorepo_legacy_lockfile_paths(config: &Config) -> IndexSet<PathBuf> {
     }
 
     source_lockfiles
+}
+
+pub(crate) fn lockfile_variant_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
+    let mut paths = IndexSet::new();
+
+    for path in crate::config::glob(dir, "mise*.lock").unwrap_or_default() {
+        paths.insert(path);
+    }
+    for env_name in env::MISE_ENV.iter().chain(env::AUTO_ENV_NAMES.iter()) {
+        paths.insert(dir.join(format!("mise.{env_name}.local.lock")));
+        paths.insert(dir.join(format!("mise.{env_name}.lock")));
+    }
+    paths.insert(dir.join("mise.local.lock"));
+    paths.insert(dir.join("mise.lock"));
+
+    paths.into_iter().collect()
 }
 
 fn legacy_lockfile_path_for_config(
@@ -2286,6 +2307,10 @@ fn read_lockfile_for(config: &Config, path: &Path) -> Arc<Lockfile> {
     let lockfile = Arc::new(lockfile);
     cache.insert(cache_key, Arc::clone(&lockfile));
     lockfile
+}
+
+pub(crate) fn read_lockfile_for_config_path(config: &Config, path: &Path) -> Lockfile {
+    read_lockfile_for(config, path).as_ref().clone()
 }
 
 pub fn get_locked_version(

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -8,7 +8,7 @@ use crate::file;
 use crate::file::display_path;
 use crate::path::PathExt;
 use crate::platform::Platform;
-use crate::toolset::{ToolSource, ToolVersion, ToolVersionList, Toolset};
+use crate::toolset::{ToolSource, ToolVersion, Toolset};
 use eyre::{Report, Result, bail, eyre};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -1151,7 +1151,10 @@ impl Lockfile {
 /// - `.config/mise.toml` -> `.config/mise.lock`
 /// - `.mise/config.toml` -> `.mise/mise.lock`
 /// - `.mise/conf.d/foo.toml` -> `.mise/mise.lock` (conf.d files share parent's lockfile)
-pub fn lockfile_path_for_config(config_path: &Path) -> (PathBuf, bool) {
+pub fn lockfile_path_for_config(
+    config_path: &Path,
+    monorepo_root: Option<&Path>,
+) -> (PathBuf, bool) {
     let is_local = is_local_config(config_path);
     let env = extract_env_from_config_path(config_path);
     let lockfile_name = match (&env, is_local) {
@@ -1174,6 +1177,15 @@ pub fn lockfile_path_for_config(config_path: &Path) -> (PathBuf, bool) {
         parent
     };
 
+    let lockfile_dir = if let Some(root) = monorepo_root
+        && config_path.starts_with(root)
+        && lockfile_dir != root
+    {
+        root
+    } else {
+        lockfile_dir
+    };
+
     (lockfile_dir.join(lockfile_name), is_local)
 }
 
@@ -1188,8 +1200,11 @@ pub fn lockfile_path_for_tool_source(
     config: &Config,
     source: &ToolSource,
 ) -> Option<(PathBuf, bool)> {
+    let monorepo_root = config.monorepo_lockfile_root();
     match source {
-        ToolSource::MiseToml(path) => Some(lockfile_path_for_config(path)),
+        ToolSource::MiseToml(path) => {
+            Some(lockfile_path_for_config(path, monorepo_root.as_deref()))
+        }
         ToolSource::IdiomaticVersionFile(path) => config
             .config_files
             .iter()
@@ -1205,7 +1220,7 @@ pub fn lockfile_path_for_tool_source(
                         is_base,
                         // Tie-break same-root base configs by config_files order.
                         idx,
-                        lockfile_path_for_config(config_path),
+                        lockfile_path_for_config(config_path, monorepo_root.as_deref()),
                     )
                 })
             })
@@ -1259,6 +1274,93 @@ impl LockfileUpdateMode {
     }
 }
 
+pub fn migrate_monorepo_lockfiles(config: &Config) -> Result<()> {
+    if !Settings::get().lockfile_enabled() {
+        return Ok(());
+    }
+    let Some(monorepo_root) = config.monorepo_lockfile_root() else {
+        return Ok(());
+    };
+    let config_roots = match config.monorepo_config_root_dirs() {
+        Ok(roots) => roots,
+        Err(_) => return Ok(()),
+    };
+    let lockfile_name_re = regex!(r"^mise(\.[^.]+)?(\.local)?\.lock$");
+    let mut migrated = 0usize;
+
+    for config_root in config_roots {
+        if config_root == monorepo_root {
+            continue;
+        }
+        let Ok(entries) = fs::read_dir(&config_root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if !lockfile_name_re.is_match(filename) {
+                continue;
+            }
+
+            let target = monorepo_root.join(filename);
+            let _lock = crate::lock_file::LockFile::new(&target)
+                .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
+                .lock()?;
+            let mut root_lockfile = Lockfile::read(&target)
+                .unwrap_or_else(|err| handle_lockfile_read_error(err, &target));
+            let subproject_lockfile = Lockfile::read(&path)?;
+            merge_lockfile_preserving_root(&mut root_lockfile, subproject_lockfile);
+            root_lockfile.save(&target)?;
+            fs::remove_file(&path)?;
+            migrated += 1;
+        }
+    }
+
+    if migrated > 0 {
+        miseprintln!(
+            "migrated {migrated} subproject lockfile(s) into {} (monorepo uses a single root lockfile)",
+            display_path(&monorepo_root)
+        );
+    }
+
+    Ok(())
+}
+
+fn merge_lockfile_preserving_root(root: &mut Lockfile, other: Lockfile) {
+    for (short, tools) in other.tools {
+        let root_tools = root.tools.entry(short).or_default();
+        let mut keys: HashSet<(String, BTreeMap<String, String>)> = root_tools
+            .iter()
+            .map(|tool| (tool.version.clone(), tool.options.clone()))
+            .collect();
+        for tool in tools {
+            let key = (tool.version.clone(), tool.options.clone());
+            if keys.insert(key) {
+                root_tools.push(tool);
+            }
+        }
+    }
+
+    for (platform, packages) in other.conda_packages {
+        let root_packages = root.conda_packages.entry(platform).or_default();
+        for (basename, info) in packages {
+            root_packages.entry(basename).or_insert(info);
+        }
+    }
+
+    for (platform, packages) in other.pkgx_packages {
+        let root_packages = root.pkgx_packages.entry(platform).or_default();
+        for (id, info) in packages {
+            root_packages.entry(id).or_insert(info);
+        }
+    }
+}
+
 pub fn update_lockfiles(
     config: &Config,
     ts: &Toolset,
@@ -1268,15 +1370,19 @@ pub fn update_lockfiles(
     if !Settings::get().lockfile_enabled() || (Settings::get().locked && !mode.allow_locked()) {
         return Ok(());
     }
+    migrate_monorepo_lockfiles(config)?;
 
     // Collect tools by source (config file)
-    let mut tools_by_source: HashMap<ToolSource, HashMap<String, ToolVersionList>> = HashMap::new();
-    for (source, group) in &ts.versions.iter().chunk_by(|(_, tvl)| &tvl.source) {
-        for (ba, tvl) in group {
+    let mut tools_by_source: HashMap<ToolSource, HashMap<String, Vec<ToolVersion>>> =
+        HashMap::new();
+    for (ba, tvl) in &ts.versions {
+        for tv in &tvl.versions {
             tools_by_source
-                .entry(source.clone())
+                .entry(tv.request.source().clone())
                 .or_default()
-                .insert(ba.short.to_string(), tvl.clone());
+                .entry(ba.short.to_string())
+                .or_default()
+                .push(tv.clone());
         }
     }
 
@@ -1286,17 +1392,10 @@ pub fn update_lockfiles(
         let source = tvs[0].request.source().clone();
         let source_tools = tools_by_source.entry(source.clone()).or_default();
 
-        if let Some(existing_tvl) = source_tools.get_mut(&backend.short) {
-            for new_tv in tvs {
-                existing_tvl
-                    .versions
-                    .retain(|tv| tv.request.version() != new_tv.request.version());
-                existing_tvl.versions.push(new_tv);
-            }
-        } else {
-            let mut tvl = ToolVersionList::new(Arc::new(backend.clone()), source.clone());
-            tvl.versions.extend(tvs);
-            source_tools.insert(backend.short.to_string(), tvl);
+        let existing_versions = source_tools.entry(backend.short.to_string()).or_default();
+        for new_tv in tvs {
+            existing_versions.retain(|tv| tv.request.version() != new_tv.request.version());
+            existing_versions.push(new_tv);
         }
     }
 
@@ -1306,7 +1405,8 @@ pub fn update_lockfiles(
         if !cf.source().is_mise_toml() {
             continue;
         }
-        let (lockfile_path, _is_local) = lockfile_path_for_config(config_path);
+        let (lockfile_path, _is_local) =
+            lockfile_path_for_config(config_path, config.monorepo_lockfile_root().as_deref());
         lockfile_configs
             .entry(lockfile_path)
             .or_default()
@@ -1323,6 +1423,12 @@ pub fn update_lockfiles(
         if !lockfile_path.exists() {
             continue;
         }
+        let is_monorepo_root_lockfile = config
+            .monorepo_lockfile_root()
+            .is_some_and(|root| lockfile_path.parent() == Some(root.as_path()));
+        let _lock = crate::lock_file::LockFile::new(&lockfile_path)
+            .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
+            .lock()?;
 
         let mut existing_lockfile = Lockfile::read(&lockfile_path)
             .unwrap_or_else(|err| handle_lockfile_read_error(err, &lockfile_path));
@@ -1340,11 +1446,11 @@ pub fn update_lockfiles(
             };
             if source_lockfile == lockfile_path {
                 contributing_sources += 1;
-                for (short, tvl) in tools {
+                for (short, versions) in tools {
                     tool_versions_by_short
                         .entry(short.clone())
                         .or_default()
-                        .extend(tvl.versions.clone());
+                        .extend(versions.clone());
                 }
             }
         }
@@ -1440,7 +1546,13 @@ pub fn update_lockfiles(
             if regressing_tools.contains(&short) {
                 continue;
             }
-            let merged_tools = merge_tool_entries(entries, existing_lockfile.tools.get(&short));
+            let mut merged_tools = merge_tool_entries(entries, existing_lockfile.tools.get(&short));
+            if is_monorepo_root_lockfile {
+                preserve_absent_tool_entries(
+                    &mut merged_tools,
+                    existing_lockfile.tools.get(&short),
+                );
+            }
             existing_lockfile.tools.insert(short, merged_tools);
         }
 
@@ -1695,6 +1807,9 @@ pub async fn auto_lock_new_versions(
             continue;
         }
 
+        let _lock = crate::lock_file::LockFile::new(&lockfile_path)
+            .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
+            .lock()?;
         let mut lockfile = Lockfile::read(&lockfile_path)
             .unwrap_or_else(|err| handle_lockfile_read_error(err, &lockfile_path));
 
@@ -1983,9 +2098,35 @@ fn merge_tool_entries(
         .collect()
 }
 
+fn preserve_absent_tool_entries(
+    merged_tools: &mut Vec<LockfileTool>,
+    existing_tools: Option<&Vec<LockfileTool>>,
+) {
+    let Some(existing_tools) = existing_tools else {
+        return;
+    };
+    let mut keys: HashSet<(String, BTreeMap<String, String>)> = merged_tools
+        .iter()
+        .map(|tool| (tool.version.clone(), tool.options.clone()))
+        .collect();
+
+    for existing_tool in existing_tools {
+        let key = (existing_tool.version.clone(), existing_tool.options.clone());
+        if keys.insert(key) {
+            merged_tools.push(existing_tool.clone());
+        }
+    }
+}
+
 fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
     // Create a cache key from the config file paths
-    let cache_key: Vec<PathBuf> = config.config_files.keys().cloned().collect();
+    let monorepo_root = config.monorepo_lockfile_root();
+    let cache_key: Vec<PathBuf> = config
+        .config_files
+        .keys()
+        .map(|path| lockfile_path_for_config(path, monorepo_root.as_deref()).0)
+        .unique()
+        .collect();
 
     // Use unwrap_or_else to recover from poisoned mutex (thread panicked while holding lock)
     let mut cache = ALL_LOCKFILES_CACHE
@@ -2003,7 +2144,7 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
             continue;
         }
 
-        let (lockfile_path, _) = lockfile_path_for_config(path);
+        let (lockfile_path, _) = lockfile_path_for_config(path, monorepo_root.as_deref());
         let root = lockfile_path.parent().unwrap_or(path).to_path_buf();
         if seen_roots.contains(&root) {
             continue;
@@ -2060,22 +2201,23 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
     result
 }
 
-fn read_lockfile_for(path: &Path) -> Arc<Lockfile> {
+fn read_lockfile_for(config: &Config, path: &Path) -> Arc<Lockfile> {
+    let (lockfile_path, _is_local) =
+        lockfile_path_for_config(path, config.monorepo_lockfile_root().as_deref());
+
     // Use unwrap_or_else to recover from poisoned mutex (thread panicked while holding lock)
     let mut cache = SINGLE_LOCKFILE_CACHE
         .lock()
         .unwrap_or_else(|e| e.into_inner());
-    if let Some(cached) = cache.get(path) {
+    if let Some(cached) = cache.get(&lockfile_path) {
         return Arc::clone(cached);
     }
 
-    // Only compute lockfile path when not cached
-    let (lockfile_path, _is_local) = lockfile_path_for_config(path);
     let lockfile = Lockfile::read(&lockfile_path)
         .unwrap_or_else(|err| handle_lockfile_read_error(err, &lockfile_path));
 
     let lockfile = Arc::new(lockfile);
-    cache.insert(path.to_path_buf(), Arc::clone(&lockfile));
+    cache.insert(lockfile_path, Arc::clone(&lockfile));
     lockfile
 }
 
@@ -2097,7 +2239,7 @@ pub fn get_locked_version(
                 "[{short}@{prefix}] reading lockfile for {}",
                 display_path(path)
             );
-            read_lockfile_for(path)
+            read_lockfile_for(config, path)
         }
         None => {
             trace!("[{short}@{prefix}] reading all lockfiles");
@@ -2708,36 +2850,123 @@ options = { exe = "rg" }
     #[test]
     fn test_lockfile_path_for_config() {
         // Simple case: mise.toml in project root
-        let (path, is_local) = lockfile_path_for_config(Path::new("/foo/bar/mise.toml"));
+        let (path, is_local) = lockfile_path_for_config(Path::new("/foo/bar/mise.toml"), None);
         assert_eq!(path, PathBuf::from("/foo/bar/mise.lock"));
         assert!(!is_local);
 
         // Local config
-        let (path, is_local) = lockfile_path_for_config(Path::new("/foo/bar/mise.local.toml"));
+        let (path, is_local) =
+            lockfile_path_for_config(Path::new("/foo/bar/mise.local.toml"), None);
         assert_eq!(path, PathBuf::from("/foo/bar/mise.local.lock"));
         assert!(is_local);
 
         // Config in .config directory
-        let (path, is_local) = lockfile_path_for_config(Path::new("/foo/bar/.config/mise.toml"));
+        let (path, is_local) =
+            lockfile_path_for_config(Path::new("/foo/bar/.config/mise.toml"), None);
         assert_eq!(path, PathBuf::from("/foo/bar/.config/mise.lock"));
         assert!(!is_local);
 
         // Config in .mise directory
-        let (path, is_local) = lockfile_path_for_config(Path::new("/foo/bar/.mise/config.toml"));
+        let (path, is_local) =
+            lockfile_path_for_config(Path::new("/foo/bar/.mise/config.toml"), None);
         assert_eq!(path, PathBuf::from("/foo/bar/.mise/mise.lock"));
         assert!(!is_local);
 
         // Config in conf.d directory - should go to parent of conf.d
         let (path, is_local) =
-            lockfile_path_for_config(Path::new("/foo/bar/.mise/conf.d/foo.toml"));
+            lockfile_path_for_config(Path::new("/foo/bar/.mise/conf.d/foo.toml"), None);
         assert_eq!(path, PathBuf::from("/foo/bar/.mise/mise.lock"));
         assert!(!is_local);
 
         // Config in .config/mise/conf.d directory
         let (path, is_local) =
-            lockfile_path_for_config(Path::new("/foo/bar/.config/mise/conf.d/foo.toml"));
+            lockfile_path_for_config(Path::new("/foo/bar/.config/mise/conf.d/foo.toml"), None);
         assert_eq!(path, PathBuf::from("/foo/bar/.config/mise/mise.lock"));
         assert!(!is_local);
+    }
+
+    #[test]
+    fn test_lockfile_path_for_config_monorepo_root_routing() {
+        let monorepo_root = Path::new("/repo");
+
+        let (path, is_local) = lockfile_path_for_config(
+            Path::new("/repo/packages/api/mise.toml"),
+            Some(monorepo_root),
+        );
+        assert_eq!(path, PathBuf::from("/repo/mise.lock"));
+        assert!(!is_local);
+
+        let (path, is_local) = lockfile_path_for_config(
+            Path::new("/repo/packages/api/mise.ci.toml"),
+            Some(monorepo_root),
+        );
+        assert_eq!(path, PathBuf::from("/repo/mise.ci.lock"));
+        assert!(!is_local);
+
+        let (path, is_local) = lockfile_path_for_config(
+            Path::new("/repo/packages/api/mise.local.toml"),
+            Some(monorepo_root),
+        );
+        assert_eq!(path, PathBuf::from("/repo/mise.local.lock"));
+        assert!(is_local);
+
+        let (path, is_local) =
+            lockfile_path_for_config(Path::new("/repo/mise.toml"), Some(monorepo_root));
+        assert_eq!(path, PathBuf::from("/repo/mise.lock"));
+        assert!(!is_local);
+
+        let (path, is_local) =
+            lockfile_path_for_config(Path::new("/outside/mise.toml"), Some(monorepo_root));
+        assert_eq!(path, PathBuf::from("/outside/mise.lock"));
+        assert!(!is_local);
+
+        let (path, is_local) = lockfile_path_for_config(
+            Path::new("/repo/packages/api/.mise/conf.d/foo.toml"),
+            Some(monorepo_root),
+        );
+        assert_eq!(path, PathBuf::from("/repo/mise.lock"));
+        assert!(!is_local);
+    }
+
+    #[test]
+    fn test_preserve_absent_tool_entries_for_monorepo_upsert() {
+        let existing = vec![basic_tool("20.0.0", "core:node")];
+        let mut merged =
+            merge_tool_entries(vec![basic_tool("22.0.0", "core:node")], Some(&existing));
+
+        preserve_absent_tool_entries(&mut merged, Some(&existing));
+
+        let versions = merged
+            .iter()
+            .map(|tool| tool.version.as_str())
+            .collect_vec();
+        assert_eq!(versions.len(), 2);
+        assert!(versions.contains(&"20.0.0"));
+        assert!(versions.contains(&"22.0.0"));
+    }
+
+    #[test]
+    fn test_merge_lockfile_preserving_root_keeps_root_on_conflict() {
+        let mut root = Lockfile::default();
+        root.tools
+            .insert("node".to_string(), vec![basic_tool("20.0.0", "core:node")]);
+
+        let mut subproject = Lockfile::default();
+        subproject.tools.insert(
+            "node".to_string(),
+            vec![
+                basic_tool("20.0.0", "core:node-alt"),
+                basic_tool("22.0.0", "core:node"),
+            ],
+        );
+
+        merge_lockfile_preserving_root(&mut root, subproject);
+
+        let tools = root.tools.get("node").unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].version, "20.0.0");
+        assert_eq!(tools[0].backend.as_deref(), Some("core:node"));
+        assert_eq!(tools[1].version, "22.0.0");
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -30,7 +30,7 @@ use xx::regex;
 /// Global caches for lockfile data - declared here so invalidation can access them
 static ALL_LOCKFILES_CACHE: Lazy<Mutex<HashMap<Vec<PathBuf>, Arc<Lockfile>>>> =
     Lazy::new(Default::default);
-static SINGLE_LOCKFILE_CACHE: Lazy<Mutex<HashMap<PathBuf, Arc<Lockfile>>>> =
+static SINGLE_LOCKFILE_CACHE: Lazy<Mutex<HashMap<Vec<PathBuf>, Arc<Lockfile>>>> =
     Lazy::new(Default::default);
 
 /// Invalidate all lockfile caches. Call this after modifying a lockfile.
@@ -1282,28 +1282,9 @@ pub fn migrate_monorepo_lockfiles(config: &Config) -> Result<()> {
     let Some(monorepo_root) = config.monorepo_lockfile_root() else {
         return Ok(());
     };
-    let config_roots = match config.monorepo_config_root_dirs() {
-        Ok(roots) => roots,
-        Err(_) => return Ok(()),
-    };
-    let mut source_lockfiles = IndexSet::new();
-
-    for config_root in config_roots {
-        if config_root == monorepo_root {
-            continue;
-        }
-        for config_path in crate::config::config_paths_in_dir(&config_root) {
-            let (source, _) = lockfile_path_for_config(&config_path, None);
-            if source.parent() == Some(monorepo_root.as_path()) {
-                continue;
-            }
-            source_lockfiles.insert(source);
-        }
-    }
-
     let mut migrated = 0usize;
 
-    for source in source_lockfiles {
+    for source in monorepo_legacy_lockfile_paths(config) {
         if !source.exists() {
             continue;
         }
@@ -1347,6 +1328,54 @@ pub fn migrate_monorepo_lockfiles(config: &Config) -> Result<()> {
 fn is_not_found_report(err: &Report) -> bool {
     err.downcast_ref::<std::io::Error>()
         .is_some_and(|err| err.kind() == ErrorKind::NotFound)
+}
+
+fn monorepo_legacy_lockfile_paths(config: &Config) -> IndexSet<PathBuf> {
+    let Some(monorepo_root) = config.monorepo_lockfile_root() else {
+        return IndexSet::new();
+    };
+    let Ok(config_roots) = config.monorepo_config_root_dirs() else {
+        return IndexSet::new();
+    };
+    let mut source_lockfiles = IndexSet::new();
+
+    for config_root in config_roots {
+        if config_root == monorepo_root {
+            continue;
+        }
+        for config_path in crate::config::config_paths_in_dir(&config_root) {
+            if let Some(source) =
+                legacy_lockfile_path_for_config(config, &config_path, &monorepo_root)
+            {
+                source_lockfiles.insert(source);
+            }
+        }
+    }
+
+    source_lockfiles
+}
+
+fn legacy_lockfile_path_for_config(
+    config: &Config,
+    config_path: &Path,
+    monorepo_root: &Path,
+) -> Option<PathBuf> {
+    if !config_path.starts_with(monorepo_root) || config.monorepo_lockfile_root().is_none() {
+        return None;
+    }
+    let (source, _) = lockfile_path_for_config(config_path, None);
+    (source.parent() != Some(monorepo_root)).then_some(source)
+}
+
+fn merge_legacy_lockfile_if_present(lockfile: &mut Lockfile, legacy_path: &Path) -> Result<()> {
+    match Lockfile::read(legacy_path) {
+        Ok(legacy) => {
+            merge_lockfile_preserving_root(lockfile, legacy);
+            Ok(())
+        }
+        Err(err) if is_not_found_report(&err) => Ok(()),
+        Err(err) => Err(err),
+    }
 }
 
 fn merge_lockfile_preserving_root(root: &mut Lockfile, other: Lockfile) {
@@ -2138,10 +2167,12 @@ fn preserve_absent_tool_entries(
 fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
     // Create a cache key from the config file paths
     let monorepo_root = config.monorepo_lockfile_root();
+    let legacy_lockfiles = monorepo_legacy_lockfile_paths(config);
     let cache_key: Vec<PathBuf> = config
         .config_files
         .keys()
         .map(|path| lockfile_path_for_config(path, monorepo_root.as_deref()).0)
+        .chain(legacy_lockfiles.iter().cloned())
         .unique()
         .collect();
 
@@ -2196,6 +2227,11 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
             all.push(main);
         }
     }
+    for legacy_path in legacy_lockfiles {
+        if let Ok(legacy) = Lockfile::read(&legacy_path) {
+            all.push(legacy);
+        }
+    }
 
     let result = all.into_iter().fold(Lockfile::default(), |mut acc, l| {
         for (short, tools) in l.tools {
@@ -2219,22 +2255,36 @@ fn read_all_lockfiles(config: &Config) -> Arc<Lockfile> {
 }
 
 fn read_lockfile_for(config: &Config, path: &Path) -> Arc<Lockfile> {
-    let (lockfile_path, _is_local) =
-        lockfile_path_for_config(path, config.monorepo_lockfile_root().as_deref());
+    let monorepo_root = config.monorepo_lockfile_root();
+    let (lockfile_path, _is_local) = lockfile_path_for_config(path, monorepo_root.as_deref());
+    let legacy_path = monorepo_root
+        .as_deref()
+        .and_then(|root| legacy_lockfile_path_for_config(config, path, root));
+    let cache_key: Vec<PathBuf> = std::iter::once(lockfile_path.clone())
+        .chain(legacy_path.iter().cloned())
+        .collect();
 
     // Use unwrap_or_else to recover from poisoned mutex (thread panicked while holding lock)
     let mut cache = SINGLE_LOCKFILE_CACHE
         .lock()
         .unwrap_or_else(|e| e.into_inner());
-    if let Some(cached) = cache.get(&lockfile_path) {
+    if let Some(cached) = cache.get(&cache_key) {
         return Arc::clone(cached);
     }
 
-    let lockfile = Lockfile::read(&lockfile_path)
+    let mut lockfile = Lockfile::read(&lockfile_path)
         .unwrap_or_else(|err| handle_lockfile_read_error(err, &lockfile_path));
+    if let Some(legacy_path) = &legacy_path
+        && let Err(err) = merge_legacy_lockfile_if_present(&mut lockfile, legacy_path)
+    {
+        warn!(
+            "failed to read legacy monorepo lockfile {} (possible corruption): {err:?}",
+            display_path(legacy_path)
+        );
+    }
 
     let lockfile = Arc::new(lockfile);
-    cache.insert(lockfile_path, Arc::clone(&lockfile));
+    cache.insert(cache_key, Arc::clone(&lockfile));
     lockfile
 }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1485,6 +1485,11 @@ pub fn update_lockfiles(
             .or_default()
             .push(config_path.clone());
     }
+    for source in tools_by_source.keys() {
+        if let Some((lockfile_path, _)) = lockfile_path_for_tool_source(config, source) {
+            lockfile_configs.entry(lockfile_path).or_default();
+        }
+    }
 
     debug!("updating {} lockfiles", lockfile_configs.len());
 

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -695,7 +695,8 @@ pub async fn get_versions_needed_by_tracked_configs_excluding_locks(
             ..Default::default()
         };
         if use_locked_version && Settings::get().lockfile_enabled() {
-            let (lockfile_path, _) = lockfile_path_for_config(&path);
+            let (lockfile_path, _) =
+                lockfile_path_for_config(&path, config.monorepo_lockfile_root().as_deref());
             match Lockfile::read(&lockfile_path) {
                 Ok(lockfile) => {
                     for (short, tools) in lockfile.tools() {

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::backend::backend_type::BackendType;
 use crate::cli::args::{BackendArg, ToolArg};
-use crate::config::{Config, Settings};
+use crate::config::{Config, ConfigMap, Settings};
 use crate::env;
 use crate::registry::{REGISTRY, tool_enabled};
 use crate::toolset::{ToolRequest, ToolSource, Toolset};
@@ -138,6 +138,7 @@ pub struct ToolRequestSetBuilder {
     disable_tools: BTreeSet<BackendArg>,
     /// tools which will be enabled
     enable_tools: Option<BTreeSet<BackendArg>>,
+    config_files: Option<ConfigMap>,
 }
 
 impl ToolRequestSetBuilder {
@@ -162,6 +163,12 @@ impl ToolRequestSetBuilder {
     //     self
     // }
     //
+
+    /// Use custom config files instead of config.config_files.
+    pub fn with_config_files(mut self, config_files: ConfigMap) -> Self {
+        self.config_files = Some(config_files);
+        self
+    }
 
     pub async fn build(&self, config: &Arc<Config>) -> eyre::Result<ToolRequestSet> {
         let mut trs = ToolRequestSet::default();
@@ -206,7 +213,8 @@ impl ToolRequestSetBuilder {
         config: &Arc<Config>,
         mut trs: ToolRequestSet,
     ) -> eyre::Result<ToolRequestSet> {
-        for cf in config.config_files.values().rev() {
+        let config_files = self.config_files.as_ref().unwrap_or(&config.config_files);
+        for cf in config_files.values().rev() {
             trs = merge(trs, cf.to_tool_request_set()?);
         }
         Ok(trs)

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -139,6 +139,7 @@ pub struct ToolRequestSetBuilder {
     /// tools which will be enabled
     enable_tools: Option<BTreeSet<BackendArg>>,
     config_files: Option<ConfigMap>,
+    skip_runtime_args: bool,
 }
 
 impl ToolRequestSetBuilder {
@@ -170,11 +171,18 @@ impl ToolRequestSetBuilder {
         self
     }
 
+    pub fn without_runtime_args(mut self) -> Self {
+        self.skip_runtime_args = true;
+        self
+    }
+
     pub async fn build(&self, config: &Arc<Config>) -> eyre::Result<ToolRequestSet> {
         let mut trs = ToolRequestSet::default();
         trs = self.load_config_files(config, trs).await?;
         trs = self.load_runtime_env(trs)?;
-        trs = self.load_runtime_args(trs)?;
+        if !self.skip_runtime_args {
+            trs = self.load_runtime_args(trs)?;
+        }
 
         for ba in trs.tools.keys().cloned().collect_vec() {
             if self.is_disabled(&ba) {

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -573,13 +573,22 @@ impl Toolset {
         config: &Arc<Config>,
         dry_run: bool,
     ) -> Result<()> {
-        if config.repo_urls.is_empty() {
+        Self::ensure_config_plugins_installed_from_urls(config, &config.repo_urls, dry_run).await
+    }
+
+    /// Install all plugins from an explicit plugin URL map.
+    pub async fn ensure_config_plugins_installed_from_urls(
+        config: &Arc<Config>,
+        repo_urls: &HashMap<String, String>,
+        dry_run: bool,
+    ) -> Result<()> {
+        if repo_urls.is_empty() {
             return Ok(());
         }
 
         let mpr = MultiProgressReport::get();
 
-        for plugin_key in config.repo_urls.keys() {
+        for (plugin_key, url) in repo_urls {
             let (plugin_type, name) = Self::parse_plugin_key(plugin_key);
 
             // Skip empty plugin names (e.g., from malformed keys like "" or "vfox:")
@@ -589,6 +598,7 @@ impl Toolset {
             }
 
             let plugin = plugin_type.plugin(name.to_string());
+            plugin.set_remote_url(url.clone());
 
             if !plugin.is_installed() {
                 plugin

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -3021,7 +3021,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--monorepo",
           description:
-            "Show outdated tools across every [monorepo].config_roots config root",
+            "Placeholder for future monorepo outdated checks; `mise outdated --monorepo` is not implemented yet.",
           isRepeatable: false,
         },
         {
@@ -3385,7 +3385,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--monorepo",
           description:
-            "Prune tools across every [monorepo].config_roots config root",
+            "Placeholder for future monorepo pruning; `mise prune --monorepo` is not implemented yet.",
           isRepeatable: false,
         },
         {
@@ -5078,7 +5078,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--monorepo",
           description:
-            "Upgrade tools across every [monorepo].config_roots config root",
+            "Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.",
           isRepeatable: false,
         },
         {

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -2420,6 +2420,12 @@ const completionSpec: Fig.Spec = {
           },
         },
         {
+          name: "--monorepo",
+          description:
+            "Install tools from every [monorepo].config_roots config root",
+          isRepeatable: false,
+        },
+        {
           name: "--raw",
           description:
             "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
@@ -2615,6 +2621,12 @@ const completionSpec: Fig.Spec = {
         {
           name: "--all-sources",
           description: "Display all tracked config sources for tools",
+          isRepeatable: false,
+        },
+        {
+          name: "--monorepo",
+          description:
+            "List tools from every [monorepo].config_roots config root",
           isRepeatable: false,
         },
         {
@@ -3007,6 +3019,12 @@ const completionSpec: Fig.Spec = {
           isRepeatable: false,
         },
         {
+          name: "--monorepo",
+          description:
+            "Show outdated tools across every [monorepo].config_roots config root",
+          isRepeatable: false,
+        },
+        {
           name: "--no-header",
           description: "Don't show table header",
           isRepeatable: false,
@@ -3362,6 +3380,12 @@ const completionSpec: Fig.Spec = {
           name: "--dry-run-code",
           description:
             "Like --dry-run but exits with code 1 if there are tools to prune",
+          isRepeatable: false,
+        },
+        {
+          name: "--monorepo",
+          description:
+            "Prune tools across every [monorepo].config_roots config root",
           isRepeatable: false,
         },
         {
@@ -5050,6 +5074,12 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "minimum_release_age",
           },
+        },
+        {
+          name: "--monorepo",
+          description:
+            "Upgrade tools across every [monorepo].config_roots config root",
+          isRepeatable: false,
         },
         {
           name: "--raw",


### PR DESCRIPTION
## Summary
- add `mise install --monorepo` and `mise ls --monorepo` over explicit `[monorepo].config_roots`
- add tri-state monorepo lockfile routing: unset preserves current colocated lockfiles during rollout, `lockfile = true` opts into unified root lockfiles, and `lockfile = false` pins colocated lockfiles
- migrate existing subproject lockfiles into root lockfiles only when unified monorepo lockfiles are enabled
- preserve sibling root lockfile entries during partial install updates; full pruning remains `mise lock`
- add CLI-only `--monorepo` stubs for `upgrade`, `prune`, and `outdated`
- update schema, usage docs, monorepo/lockfile docs, and targeted e2e coverage

## Rollout
- until mise `2026.12.0`: unset keeps existing per-subproject lockfile behavior with no warning
- from mise `2026.12.0` until `2027.6.0`: unset still keeps existing behavior and warns only when lockfiles are enabled and the monorepo has existing `mise*.lock` files
- starting mise `2027.6.0`: unset defaults to unified monorepo root lockfiles
- users can set `[monorepo] lockfile = true` to opt into root lockfiles now, or `lockfile = false` to keep the current behavior and silence the warning

## Compatibility
Older mise versions do not understand unified root lockfiles for subproject-owned tools. Mixed-version teams should set `[monorepo] lockfile = false` until everyone has upgraded.

## Tests
- `mise run build`
- `cargo test -q lockfile`
- `cargo test -q monorepo`
- `cargo test -q test_monorepo_union_tool_request_set_preserves_matching_tools -- --nocapture`
- `mise run test:e2e test_install_monorepo`
- `mise run test:e2e test_lockfile_monorepo`
- `mise run test:e2e test_lock_project_root_scope`
- `mise run render:usage`
- `mise run lint-fix`

Related to #10667.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--monorepo` to `mise install` and `mise ls` to aggregate tool versions across all configured monorepo config roots using the active `MISE_ENV`.
* **Bug Fixes**
  * Improved monorepo lockfile handling, including correct monorepo-root scoping and migration/merging of subproject lockfiles.
* **Documentation**
  * Updated CLI docs, usage spec, man page, and monorepo/lockfile documentation for `--monorepo`; added `[monorepo].lockfile` to the config schema.
* **Tests**
  * Added/expanded end-to-end coverage for monorepo install/list and monorepo lockfile migration and rollout modes.
* **Refactor**
  * Added placeholders for `mise outdated --monorepo`, `mise prune --monorepo`, and `mise upgrade --monorepo` (not implemented yet).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lockfile routing and migration change reproducible install behavior across monorepos; rollout flags limit blast radius, but mixed mise versions need `lockfile = false` until teams upgrade.
> 
> **Overview**
> Adds **`mise install --monorepo`** and **`mise ls --monorepo`** to install or list the **union** of tools from every path in **`[monorepo].config_roots`** (respecting **`MISE_ENV`**), with optional tool-name filtering on install. Both require **`monorepo_root = true`** and explicit **`config_roots`**.
> 
> Introduces tri-state **`[monorepo].lockfile`**: **`true`** routes subproject tools to root **`mise*.lock`** files and migrates legacy per-package locks on lock-aware commands; **`false`** keeps colocated lockfiles; **unset** preserves today’s colocated behavior until **`2027.6.0`**, with rollout warnings from **`2026.12.0`** when lockfiles exist. **`mise lock`** uses the full monorepo tool view when root lockfiles are enabled; partial installs preserve sibling entries in the root lockfile.
> 
> **`--monorepo`** flags on **`upgrade`**, **`prune`**, and **`outdated`** are documented stubs that error as not implemented yet. Schema, usage/man pages, monorepo/lockfile docs, and e2e coverage accompany the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f2841f4826dd328560fc6f713970661dc35e08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->