### PR TITLE
test(task): avoid pipefail in trust include assertions

### DIFF
--- a/e2e/tasks/test_task_include_trust
+++ b/e2e/tasks/test_task_include_trust
@@ -33,7 +33,7 @@ if [[ -f $marker ]]; then
   exit 1
 fi
 
-if echo "$output" | grep -qi "not trusted"; then
+if grep -qi "not trusted" <<<"$output"; then
   echo "PASS: Untrusted task include file was blocked"
 else
   echo "FAIL: Expected trust-related error, got: $output"
@@ -73,7 +73,7 @@ if [[ -f $marker ]]; then
   exit 1
 fi
 
-if echo "$output" | grep -qi "not trusted"; then
+if grep -qi "not trusted" <<<"$output"; then
   echo "PASS: Untrusted monorepo task include file was blocked"
 else
   echo "FAIL: Expected trust-related monorepo error, got: $output"


### PR DESCRIPTION
## Summary
- avoid pipe-based `grep -q` checks in `test_task_include_trust`
- keep matching the trust error while avoiding SIGPIPE/pipefail false negatives when backtraces are present

## Context
The failing job was `e2e-2` in https://github.com/jdx/mise/actions/runs/28557212037/job/84667634627. The trust error was emitted correctly, but the test assertion could fail under `set -o pipefail` when `grep -q` exited before the full captured output was written.

## Tests
- `mise run test:e2e tasks/test_task_include_trust`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion style change with no production or security logic touched.
> 
> **Overview**
> Updates **`e2e/tasks/test_task_include_trust`** so trust-error checks no longer use a pipe into `grep -q`.
> 
> Both assertions that look for **"not trusted"** in captured `mise` output now use a **here-string** (`grep -qi "not trusted" <<<"$output"`) instead of `echo "$output" | grep -qi ...`. The expected behavior is unchanged; the goal is to stop **false failures under `set -o pipefail`** when `grep -q` exits early (e.g. with long output or backtraces) and the pipeline gets **SIGPIPE**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e72fcfc315935d36448bda4fd7631c85be5dc894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end trust validation checks to confirm “not trusted” output more reliably in both single-task and monorepo-wide runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->