### PR TITLE
fix(generate): respect lockfile_platforms for tool stubs

### DIFF
--- a/e2e/generate/test_generate_tool_stub_lock
+++ b/e2e/generate/test_generate_tool_stub_lock
@@ -48,17 +48,30 @@ assert_not_contains "cat bin/tiny" 'version = "1.'
 assert_contains "cat bin/tiny" "[lock.platforms."
 assert_contains "cat bin/tiny" "url ="
 
-# Test 3: Re-lock preserves version (idempotent)
+# Test 3: Execute the locked stub to verify it works
+if mise version | grep -q "windows-"; then
+  echo "Skipping locked stub execution on Windows because jdx/tiny has no Windows release asset"
+else
+  assert_contains "mise tool-stub bin/tiny" "tiny v2."
+fi
+
+# Test 4: Re-lock preserves version and respects lockfile_platforms
 locked_version=$(grep 'version = ' bin/tiny | head -1 | sed 's/.*"\(.*\)".*/\1/')
+export MISE_LOCKFILE_PLATFORMS=macos-arm64,linux-x64
+export MISE_OS=macos
+export MISE_ARCH=x64
 assert_succeed "mise generate tool-stub bin/tiny --lock"
 
 # Version should be the same after re-locking
 assert_contains "cat bin/tiny" "version = \"$locked_version\""
 
-# Test 4: Lock fails on nonexistent file
-assert_fail "mise generate tool-stub bin/nonexistent --lock"
+assert_contains "cat bin/tiny" "lock.platforms.macos-arm64"
+assert_contains "cat bin/tiny" "lock.platforms.linux-x64"
+assert_contains "cat bin/tiny" "lock.platforms.macos-x64"
+assert_not_contains "cat bin/tiny" "lock.platforms.windows-x64"
+unset MISE_LOCKFILE_PLATFORMS MISE_OS MISE_ARCH
 
-# Test 5: Execute the locked stub to verify it works
-assert_contains "mise tool-stub bin/tiny" "tiny v2."
+# Test 5: Lock fails on nonexistent file
+assert_fail "mise generate tool-stub bin/nonexistent --lock"
 
 echo "All tool-stub lock tests passed!"

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -3,7 +3,7 @@ use crate::backend::asset_matcher::detect_platform_from_url;
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::static_helpers::get_filename_from_url;
 use crate::cli::tool_stub::ToolStubFile;
-use crate::config::Config;
+use crate::config::{Config, Settings};
 use crate::file::{self, ExtractionFormat};
 use crate::http::HTTP;
 use crate::lockfile::PlatformInfo;
@@ -17,7 +17,7 @@ use bytesize::ByteSize;
 use clap::ValueHint;
 use color_eyre::eyre::bail;
 use indexmap::IndexMap;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use toml_edit::DocumentMut;
 use xx::file::display_path;
@@ -676,9 +676,9 @@ exec "$MISE_BIN" tool-stub "$0" "$@"
         };
         let tv = ToolVersion::resolve(&config, request, &resolve_opts).await?;
 
-        // Resolve lock info for each common platform (including variants)
+        // Resolve lock info for each target platform (including variants)
         let mut lock_platforms: BTreeMap<String, PlatformInfo> = BTreeMap::new();
-        for p in Platform::common_platforms() {
+        for p in lock_stub_target_platforms()? {
             for platform in backend.platform_variants(&p) {
                 let target = PlatformTarget::new(platform);
                 match backend.resolve_lock_info(&tv, &target).await {
@@ -800,6 +800,16 @@ exec "$MISE_BIN" tool-stub "$0" "$@"
 
             Ok(output.join("\n"))
         }
+    }
+}
+
+fn lock_stub_target_platforms() -> Result<Vec<Platform>> {
+    if let Some(configured) = Settings::get().lockfile_platforms()? {
+        let mut platforms: BTreeSet<Platform> = configured.into_iter().collect();
+        platforms.insert(Platform::current());
+        Ok(platforms.into_iter().collect())
+    } else {
+        Ok(Platform::common_platforms())
     }
 }
 


### PR DESCRIPTION
## Summary
- make `mise generate tool-stub --lock` respect configured `lockfile_platforms`
- keep the current platform included when the setting is present, matching lockfile behavior
- preserve the previous common-platform behavior when no setting is configured

## Details
`generate tool-stub --lock` previously always iterated over `Platform::common_platforms()`. This adds a small target-platform helper that reads `Settings::lockfile_platforms()`, deduplicates/sorts configured platforms with `BTreeSet`, and inserts `Platform::current()` before resolving platform variants.

## Tests
- `cargo fmt --check`
- `mise run test:e2e generate/test_generate_tool_stub_lock`

Closes #10585.

*This comment was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise generate tool-stub --lock` now respects your configured lockfile platform settings when deciding which platforms to include.
  * Locked stubs still include support for the current platform, with sensible defaults when no platform settings are provided.
* **Bug Fixes**
  * Improved cross-platform behavior and consistency when generating and re-locking tool stubs.
* **Tests**
  * Updated end-to-end coverage to verify locked stubs can execute, including conditional handling for Windows, and strengthened checks for platform lock entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->