### PR TITLE
fix(lockfile): merge platform data when a tool's options newly diverge from an empty on-disk entry

### DIFF
--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1044,11 +1044,31 @@ impl Lockfile {
         platform_info: PlatformInfo,
     ) {
         let tools = self.tools.entry(short.to_string()).or_default();
-        // Find existing tool version with matching options or create new one
-        if let Some(tool) = tools
-            .iter_mut()
-            .find(|t| t.version == version && &t.options == options)
-        {
+        // Find existing tool version with matching options, or (if the resolved
+        // options are non-empty and there's no exact match) adopt an entry for the
+        // same version that still has empty options — this is a tool whose backend
+        // just started reporting deterministic lockfile options (e.g. java's
+        // shorthand_vendor) where it previously reported none. Updating that
+        // entry's options in place keeps its already-collected platform checksums
+        // instead of orphaning them as a stale, never-matched sibling entry.
+        // (#10564)
+        let idx = tools
+            .iter()
+            .position(|t| t.version == version && &t.options == options)
+            .or_else(|| {
+                if options.is_empty() {
+                    None
+                } else {
+                    tools
+                        .iter()
+                        .position(|t| t.version == version && t.options.is_empty())
+                }
+            });
+        if let Some(idx) = idx {
+            let tool = &mut tools[idx];
+            if tool.options.is_empty() && !options.is_empty() {
+                tool.options = options.clone();
+            }
             // Merge with existing platform info, preferring new values when present.
             // When the URL changes, drop existing checksum/size/url_api — those fields
             // describe a specific artifact and are stale once the URL points elsewhere.
@@ -2131,6 +2151,9 @@ pub fn apply_lock_result(lockfile: &mut Lockfile, result: LockResolutionResult) 
 /// Merge tool entries with deduplication by (version, options).
 /// Merges platform info for entries with the same key.
 /// Preserves existing platform info for matching entries.
+/// An existing entry with empty options is adopted into a freshly-resolved
+/// entry for the same version that now has non-empty options, instead of
+/// being silently dropped (#10564).
 fn merge_tool_entries(
     entries: Vec<LockfileTool>,
     existing_tools: Option<&Vec<LockfileTool>>,
@@ -2165,6 +2188,32 @@ fn merge_tool_entries(
                         .and_modify(|existing| *existing = existing.merge_with(info))
                         .or_insert(info.clone());
                 }
+                continue;
+            }
+            // No exact (version, options) match. If this existing entry has no
+            // options and a freshly-resolved entry exists for the same version
+            // that now reports options, adopt its platform data into that entry
+            // instead of silently dropping it — a backend that starts reporting
+            // deterministic lockfile options (e.g. java's shorthand_vendor) must
+            // not orphan previously-collected checksums/URLs. (#10564)
+            // Pick the smallest matching key so the adoption target is
+            // deterministic even if several optioned entries share the version
+            // (HashMap iteration order is not).
+            if existing_tool.options.is_empty()
+                && let Some(adopt_key) = by_key
+                    .keys()
+                    .filter(|(v, opts)| v == &existing_tool.version && !opts.is_empty())
+                    .min()
+                    .cloned()
+            {
+                let entry = by_key.get_mut(&adopt_key).unwrap();
+                for (platform, info) in &existing_tool.platforms {
+                    entry
+                        .platforms
+                        .entry(platform.clone())
+                        .and_modify(|existing| *existing = existing.merge_with(info))
+                        .or_insert(info.clone());
+                }
             }
         }
     }
@@ -2188,7 +2237,34 @@ fn preserve_absent_tool_entries(
         .map(|tool| (tool.version.clone(), tool.options.clone()))
         .collect();
 
+    // Versions that the freshly-merged output already carries with non-empty
+    // options. Snapshot BEFORE the loop below appends preserved entries, so the
+    // check only matches merge_tool_entries' output (where the #10564 adoption
+    // happened), not entries this loop itself resurrects.
+    //
+    // This over-approximates "was actually adopted" as "has non-empty options
+    // in the output" — the two coincide here because every entry in
+    // `merged_tools` originates from the freshly-resolved `entries` passed to
+    // merge_tool_entries (an existing-only tool is never inserted there, only
+    // merged into a matching fresh entry), and merge_tool_entries' adoption
+    // loop unconditionally processes every existing_tool for a given version.
+    // So whenever a version's fresh entry has non-empty options, any
+    // same-version empty-options entry in `existing_tools` below (the same
+    // list merge_tool_entries was called with) was already merged into it.
+    let adopted_versions: HashSet<String> = merged_tools
+        .iter()
+        .filter(|t| !t.options.is_empty())
+        .map(|t| t.version.clone())
+        .collect();
+
     for existing_tool in existing_tools {
+        // An empty-options entry whose version was freshly resolved with
+        // non-empty options was adopted by merge_tool_entries (#10564) — its
+        // platforms already live in the adopted entry, so don't resurrect it as
+        // a duplicate sibling.
+        if existing_tool.options.is_empty() && adopted_versions.contains(&existing_tool.version) {
+            continue;
+        }
         let key = (existing_tool.version.clone(), existing_tool.options.clone());
         if keys.insert(key) {
             merged_tools.push(existing_tool.clone());
@@ -3079,6 +3155,125 @@ options = { exe = "rg" }
     }
 
     #[test]
+    fn test_preserve_absent_does_not_resurrect_adopted_empty_options_entry() {
+        // #10564: after merge_tool_entries adopts an empty-options entry into a
+        // same-version optioned entry, the monorepo preserve pass must not
+        // resurrect the old empty-options entry as a duplicate sibling.
+        let mut platforms = BTreeMap::new();
+        platforms.insert(
+            "linux-x64".to_string(),
+            PlatformInfo {
+                checksum: Some("sha256:OLD".to_string()),
+                ..Default::default()
+            },
+        );
+        let existing = vec![LockfileTool {
+            version: "26.0.1".to_string(),
+            backend: Some("core:java".to_string()),
+            options: BTreeMap::new(),
+            platforms,
+        }];
+        let mut options = BTreeMap::new();
+        options.insert("shorthand_vendor".to_string(), "openjdk".to_string());
+        let mut merged = merge_tool_entries(
+            vec![LockfileTool {
+                version: "26.0.1".to_string(),
+                backend: Some("core:java".to_string()),
+                options,
+                platforms: BTreeMap::new(),
+            }],
+            Some(&existing),
+        );
+
+        preserve_absent_tool_entries(&mut merged, Some(&existing));
+
+        // Single entry: adopted, not duplicated — and it kept the platforms.
+        assert_eq!(merged.len(), 1, "adopted entry duplicated: {merged:?}");
+        assert_eq!(
+            merged[0].platforms["linux-x64"].checksum.as_deref(),
+            Some("sha256:OLD")
+        );
+
+        // Counter-case: when the tool was NOT resolved this run (merged has no
+        // same-version optioned entry), a fragmented existing lockfile must be
+        // preserved verbatim — both siblings survive, no data loss.
+        let mut fragmented = existing.clone();
+        fragmented.push(LockfileTool {
+            version: "26.0.1".to_string(),
+            backend: Some("core:java".to_string()),
+            options: BTreeMap::from([("shorthand_vendor".to_string(), "openjdk".to_string())]),
+            platforms: BTreeMap::new(),
+        });
+        let mut merged = vec![basic_tool("22.0.0", "core:node")];
+        preserve_absent_tool_entries(&mut merged, Some(&fragmented));
+        assert_eq!(
+            merged.len(),
+            3,
+            "unresolved entries must be preserved: {merged:?}"
+        );
+    }
+
+    #[test]
+    fn test_merge_tool_entries_adopts_empty_options_entry_on_new_options() {
+        // Regression guard for #10564: when a freshly-resolved entry for a
+        // version gains non-empty `options` (e.g. java's shorthand_vendor)
+        // while the on-disk lockfile still has that version keyed under empty
+        // options, the old entry's platforms must be adopted, not dropped.
+        let mut existing_platforms = BTreeMap::new();
+        existing_platforms.insert(
+            "linux-x64".to_string(),
+            PlatformInfo {
+                checksum: Some("sha256:OLD".to_string()),
+                url: Some("https://example.com/java-linux-x64.tar.gz".to_string()),
+                ..Default::default()
+            },
+        );
+        let existing = vec![LockfileTool {
+            version: "26.0.1".to_string(),
+            backend: Some("core:java".to_string()),
+            options: BTreeMap::new(),
+            platforms: existing_platforms,
+        }];
+
+        let mut new_options = BTreeMap::new();
+        new_options.insert("shorthand_vendor".to_string(), "openjdk".to_string());
+        let mut fresh_platforms = BTreeMap::new();
+        fresh_platforms.insert(
+            "macos-arm64".to_string(),
+            PlatformInfo {
+                checksum: Some("sha256:NEW".to_string()),
+                url: Some("https://example.com/java-macos-arm64.tar.gz".to_string()),
+                ..Default::default()
+            },
+        );
+        let fresh = vec![LockfileTool {
+            version: "26.0.1".to_string(),
+            backend: Some("core:java".to_string()),
+            options: new_options.clone(),
+            platforms: fresh_platforms,
+        }];
+
+        let merged = merge_tool_entries(fresh, Some(&existing));
+
+        assert_eq!(
+            merged.len(),
+            1,
+            "expected a single merged entry, got {merged:?}"
+        );
+        let tool = &merged[0];
+        assert_eq!(tool.options, new_options);
+        assert_eq!(tool.platforms.len(), 2);
+        assert_eq!(
+            tool.platforms["linux-x64"].checksum.as_deref(),
+            Some("sha256:OLD")
+        );
+        assert_eq!(
+            tool.platforms["macos-arm64"].checksum.as_deref(),
+            Some("sha256:NEW")
+        );
+    }
+
+    #[test]
     fn test_merge_lockfile_preserving_root_keeps_root_on_conflict() {
         let mut root = Lockfile::default();
         root.tools
@@ -3892,6 +4087,83 @@ backend = "conda:jq"
         assert_eq!(
             info.url.as_deref(),
             Some("https://example.com/binary.tar.gz")
+        );
+    }
+
+    #[test]
+    fn test_set_platform_info_adopts_empty_options_entry_on_new_options() {
+        // Regression guard for #10564: a backend that starts reporting lockfile
+        // options (e.g. java's shorthand_vendor) for a version whose lockfile
+        // entry previously had none must not orphan that entry's platforms.
+        let mut lockfile = Lockfile::default();
+        // Simulate a lockfile written before the tool reported any options: two
+        // platforms already carry checksums/URLs.
+        lockfile.set_platform_info(
+            "java",
+            "26.0.1",
+            Some("core:java"),
+            &BTreeMap::new(),
+            "linux-x64",
+            PlatformInfo {
+                checksum: Some("sha256:OLD1".to_string()),
+                url: Some("https://example.com/java-linux-x64.tar.gz".to_string()),
+                ..Default::default()
+            },
+        );
+        lockfile.set_platform_info(
+            "java",
+            "26.0.1",
+            Some("core:java"),
+            &BTreeMap::new(),
+            "macos-arm64",
+            PlatformInfo {
+                checksum: Some("sha256:OLD2".to_string()),
+                url: Some("https://example.com/java-macos-arm64.tar.gz".to_string()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(lockfile.tools["java"].len(), 1);
+
+        // The tool now resolves with a non-empty `options` map for the SAME
+        // version (e.g. shorthand_vendor newly attached). Only one platform
+        // resolves this run.
+        let mut options = BTreeMap::new();
+        options.insert("shorthand_vendor".to_string(), "openjdk".to_string());
+        lockfile.set_platform_info(
+            "java",
+            "26.0.1",
+            Some("core:java"),
+            &options,
+            "windows-x64",
+            PlatformInfo {
+                checksum: Some("sha256:NEW".to_string()),
+                url: Some("https://example.com/java-windows-x64.tar.gz".to_string()),
+                ..Default::default()
+            },
+        );
+
+        // Still a single entry — the empty-options entry was adopted, not left
+        // as an orphaned sibling — and it now carries ALL THREE platforms.
+        let tools = &lockfile.tools["java"];
+        assert_eq!(
+            tools.len(),
+            1,
+            "expected a single merged entry, got {tools:?}"
+        );
+        let tool = &tools[0];
+        assert_eq!(tool.options, options);
+        assert_eq!(tool.platforms.len(), 3);
+        assert_eq!(
+            tool.platforms["linux-x64"].checksum.as_deref(),
+            Some("sha256:OLD1")
+        );
+        assert_eq!(
+            tool.platforms["macos-arm64"].checksum.as_deref(),
+            Some("sha256:OLD2")
+        );
+        assert_eq!(
+            tool.platforms["windows-x64"].checksum.as_deref(),
+            Some("sha256:NEW")
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the lockfile data loss reported in discussion #10564: when a backend starts attaching deterministic lockfile options to a version that previously round-tripped with **no** options (e.g. java's `shorthand_vendor`, always attached for a shorthand request like `java = "26"`), `mise lock` fragments the tool into duplicate `[[tools.java]]` siblings and a subsequent run drops the entry holding all the platform checksums/URLs — leaving `core:java` pinned with **zero** platform info, so `mise install --locked` fails on every platform.

## Root cause

Both lockfile writers key/match entries by exact `(version, options)` equality:

- **`set_platform_info`** (the `mise lock` path): the freshly-resolved `(26.0.1, {shorthand_vendor})` no longer matches the on-disk `(26.0.1, {})` entry, so a brand-new sibling entry is pushed and the old entry's checksums/URLs become unreferenced.
- **`merge_tool_entries`** (the `mise install`/`mise use` lockfile-update path): worse — an existing entry whose key no longer matches anything freshly resolved is **silently dropped** from the merged result.

## Fix

When there is no exact `(version, options)` match and the freshly-resolved options are **non-empty**, adopt the existing entry for the same version that still has **empty** options: merge its platforms in and update its options in place, instead of creating (or losing) a sibling.

- The adoption target is picked by smallest key so the output stays deterministic even if several optioned entries share a version (HashMap iteration order is not).
- `preserve_absent_tool_entries` (monorepo root lockfiles) skips resurrecting an adopted empty-options entry as a duplicate sibling. The skip is snapshot-based so fragmented entries belonging to tools *not* resolved in the current run are still preserved verbatim (no new data-loss path).
- Scoped narrowly to the empty→non-empty transition from the report. Options that differ in other ways (e.g. a real `release_type` change) continue to produce separate entries — those genuinely describe different downloadable artifacts. The reverse transition (an entry *losing* its options, e.g. after a mise downgrade) is intentionally not handled: resurrecting options the current mise no longer reports would be wrong.

This matches suggested direction 2 from the report ("merge platforms from the existing entry into the new one rather than spawning a sibling").

## Tests

Three regression tests reproducing the reported java `shorthand_vendor` scenario:

- `test_set_platform_info_adopts_empty_options_entry_on_new_options` — an entry with existing platform checksums gains options on a later `mise lock`; all platforms must end up on a single entry.
- `test_merge_tool_entries_adopts_empty_options_entry_on_new_options` — same via the install-path merge; the existing entry's platforms must be adopted, not dropped.
- `test_preserve_absent_does_not_resurrect_adopted_empty_options_entry` — monorepo preserve pass must not duplicate an adopted entry, while still preserving fragmented entries for tools not resolved in the current run.

`cargo fmt --all -- --check` passes locally; `cargo check` / test run deferred to CI.

Fixes the issue reported in discussion #10564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lockfile tool-entry merging to preserve existing platform-specific URLs/checksums when a tool version later starts emitting deterministic options.
  * Prevented duplicate entries and ensured platform data is adopted into the correct resolved entry instead of being dropped or orphaned.
  * Updated monorepo “preserve absent” behavior to avoid resurrecting an already-adopted empty-options sibling.
* **Tests**
  * Added regression coverage for the adoption and preserve-absent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->