### PR TITLE
fix(schema): allow tool alias versions

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -71,6 +71,9 @@ description = "Lint the project"
 
 [vars]
 e2e_args = { default = "--headless", redact = true }
+
+[tool_alias.java.versions]
+"11.0" = "temurin-11"
 TOML
 
 # Create a separate file for age schema coverage so mise does not try to decrypt
@@ -142,7 +145,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-tool-alias.toml", "mise-bad-watch-files.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -208,6 +211,13 @@ node = { version = "latest", os = true }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-os.toml"
+
+cat >"$HOME/workdir/mise-bad-tool-alias.toml" <<'TOML'
+[tool_alias.node.versions]
+lts = { bad = true }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-tool-alias.toml"
 
 cat >"$HOME/workdir/mise-bad-watch-files.toml" <<'TOML'
 [[watch_files]]

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -28,7 +28,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise.toml", "mise-age.toml", "mise-env-directives.toml", "mise-os.toml"]
+include = ["mise.toml", "mise-age.toml", "mise-env-directives.toml", "mise-os.toml", "mise-vars.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -93,6 +93,23 @@ _.source = [{ path = "env.sh", tools = true, redact = true, required = "source e
 _.path = { paths = ["./bin", "./scripts"], tools = true }
 TOML
 
+cat >"$HOME/workdir/mise-vars.toml" <<'TOML'
+[vars]
+STRING = "value"
+INTEGER = 123
+TRUE_BOOL = true
+VALUE_STRING = { value = "value", redact = true }
+VALUE_INTEGER = { value = 123 }
+VALUE_TRUE = { value = true }
+VALUE_DEFAULT = { default = 123, redact = true }
+REQUIRED_TRUE = { required = true, redact = true }
+REQUIRED_HELP = { required = "set REQUIRED_HELP in mise.local.toml" }
+SECRET_SIMPLE = { age = "AGE-SECRET", redact = false }
+SECRET_COMPLEX = { age = { value = "AGE-SECRET", format = "raw", redact = true } }
+_.file = ".env"
+_.source = ["env.sh"]
+TOML
+
 cat >"$HOME/workdir/mise-os.toml" <<'TOML'
 [tools]
 node = { version = "latest", os = ["linux", "macos/arm64", "darwin/aarch64", "win/amd64"], backend_options = { nested = true } }
@@ -124,6 +141,7 @@ cd "$HOME/workdir"
 assert_succeed "$TOMBI_LINT mise.toml"
 assert_succeed "$TOMBI_LINT mise-age.toml"
 assert_succeed "$TOMBI_LINT mise-env-directives.toml"
+assert_succeed "$TOMBI_LINT mise-vars.toml"
 assert_succeed "$TOMBI_LINT mise-os.toml"
 assert_succeed "$TOMBI_LINT mise-task-os.toml"
 assert_succeed "$TOMBI_LINT mise-registry-tool.toml"
@@ -145,7 +163,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-tool-alias.toml", "mise-bad-watch-files.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -154,6 +172,10 @@ include = ["mise-bad-task-os.toml", "mise-bad-task-tool-extra.toml"]
 [[schemas]]
 path = "file://$REGISTRY_TOOL_SCHEMA_PATH"
 include = ["mise-bad-registry-tool.toml"]
+
+[[schemas]]
+path = "file://$SCHEMA_PATH"
+include = ["mise-bad-tool-alias.toml"]
 EOF
 
 assert_fail "$TOMBI_LINT mise-bad.toml"
@@ -187,6 +209,18 @@ _.file = { path = ".env", required = 123 }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-env-directive.toml"
+
+cat >"$HOME/workdir/mise-bad-vars.toml" <<'TOML'
+[vars]
+FALSE_BOOL = false
+VALUE_FALSE = { value = false }
+REQUIRED_FALSE = { required = false }
+FLOAT = 1.23
+VALUE_FLOAT = { value = 1.23 }
+TOOLS_FILTERED = { value = "not actually resolved as a var", tools = true }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-vars.toml"
 
 # Verify that extends is rejected on task_templates (not supported at runtime)
 cat >"$HOME/workdir/mise-bad-tmpl.toml" <<'TOML'

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2061,6 +2061,37 @@
             "type": "string"
           },
           {
+            "description": "value of variable",
+            "type": "integer"
+          },
+          {
+            "description": "value of variable",
+            "const": true
+          },
+          {
+            "type": "object",
+            "properties": {
+              "value": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "const": true
+                  }
+                ]
+              },
+              "redact": {
+                "$ref": "#/$defs/env_redact"
+              }
+            },
+            "required": ["value"],
+            "unevaluatedProperties": false
+          },
+          {
             "type": "object",
             "properties": {
               "default": {
@@ -2071,6 +2102,64 @@
               }
             },
             "required": ["default"],
+            "unevaluatedProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "redact": {
+                "$ref": "#/$defs/env_redact"
+              },
+              "required": {
+                "oneOf": [
+                  {
+                    "const": true
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": ["required"],
+            "unevaluatedProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "age": {
+                "$ref": "#/$defs/env_age"
+              },
+              "redact": {
+                "$ref": "#/$defs/env_redact"
+              }
+            },
+            "required": ["age"],
+            "unevaluatedProperties": false,
+            "description": "[experimental] age-encrypted variable"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "age": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "$ref": "#/$defs/env_age_value"
+                  },
+                  "format": {
+                    "$ref": "#/$defs/env_age_format"
+                  },
+                  "redact": {
+                    "$ref": "#/$defs/env_redact"
+                  }
+                },
+                "required": ["value"],
+                "unevaluatedProperties": false,
+                "description": "[experimental] age-encrypted value (complex format)"
+              }
+            },
+            "required": ["age"],
             "unevaluatedProperties": false
           }
         ]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -60,6 +60,39 @@
         }
       ]
     },
+    "tool_alias_versions": {
+      "description": "tool version aliases",
+      "type": "object",
+      "additionalProperties": {
+        "description": "version alias points to",
+        "type": "string"
+      }
+    },
+    "tool_alias_entry": {
+      "oneOf": [
+        {
+          "description": "where the alias goes",
+          "type": "string"
+        },
+        {
+          "description": "tool to set aliases for",
+          "type": "object",
+          "properties": {
+            "backend": {
+              "description": "where the alias goes",
+              "type": "string"
+            },
+            "versions": {
+              "$ref": "#/$defs/tool_alias_versions"
+            }
+          },
+          "additionalProperties": {
+            "description": "version alias points to",
+            "type": "string"
+          }
+        }
+      ]
+    },
     "env_value": {
       "oneOf": [
         {
@@ -2760,40 +2793,14 @@
       "description": "custom shorthands",
       "type": "object",
       "additionalProperties": {
-        "oneOf": [
-          {
-            "description": "where the alias goes",
-            "type": "string"
-          },
-          {
-            "description": "tool to set aliases for",
-            "type": "object",
-            "additionalProperties": {
-              "description": "version alias points to",
-              "type": "string"
-            }
-          }
-        ]
+        "$ref": "#/$defs/tool_alias_entry"
       }
     },
     "tool_alias": {
       "description": "Tool version aliases",
       "type": "object",
       "additionalProperties": {
-        "oneOf": [
-          {
-            "description": "where the alias goes",
-            "type": "string"
-          },
-          {
-            "description": "tool to set aliases for",
-            "type": "object",
-            "additionalProperties": {
-              "description": "version alias points to",
-              "type": "string"
-            }
-          }
-        ]
+        "$ref": "#/$defs/tool_alias_entry"
       }
     },
     "shell_alias": {


### PR DESCRIPTION
## Summary
- Allow `tool_alias.<tool>.versions` entries in `schema/mise.json`.
- Reuse the same schema shape for deprecated `[alias]` because it uses the same runtime parser.
- Add Tombi schema coverage for a valid version alias table and an invalid non-string version alias value.

## Context
Runtime already accepts `[tool_alias.<tool>.versions]`, but the JSON Schema rejected it. This keeps the schema aligned with the existing parser behavior without changing the config format or runtime parsing.

## Validation
- `mise run render:schema`
- Not run locally: `mise run test:e2e config/test_schema_tombi` did not complete on this Windows machine because the pinned Tombi setup triggered a very long dependency build. Leaving that validation to CI.

*This pull request was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for tool version aliases, including mapping one version label to another.
- **Bug Fixes**
  - Strengthened configuration validation for tool-alias structures and environment/vars entries.
  - Expanded allowed variable value types (including integers/booleans) and improved support for redact-capable object forms.
- **Tests**
  - Added end-to-end fixtures and lint coverage for both valid alias/vars configurations and new invalid scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->