### PR TITLE
fix(task): correct env for `task.show_full_cmd` setting

### DIFF
--- a/e2e/tasks/test_task_show_full_cmd
+++ b/e2e/tasks/test_task_show_full_cmd
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# #10469: the `task.show_full_cmd` setting (env MISE_TASK_SHOW_CMD_NO_TRUNC) must
+# #10469: the `task.show_full_cmd` setting (env MISE_TASK_SHOW_FULL_CMD) must
 # echo the FULL multi-line command in the task header, not just the first real
 # command. PR #9844 added display_first_command(), which reduced the echoed header
 # to the first real command (skipping leading shebang/blank/`set ...` lines)
@@ -20,7 +20,7 @@ EOF
 # show_full_cmd ON: the echoed header includes the LATER command line. The literal
 # "echo second-line" only appears in the echoed command (execution prints
 # "second-line", not "echo second-line").
-assert_contains "MISE_TASK_SHOW_CMD_NO_TRUNC=1 mise run multi 2>&1" "echo second-line"
+assert_contains "MISE_TASK_SHOW_FULL_CMD=1 mise run multi 2>&1" "echo second-line"
 
 # show_full_cmd OFF (#9844 behavior preserved): the header shows the first REAL
 # command, skipping the shebang/`set` boilerplate, and later lines are truncated.

--- a/settings.toml
+++ b/settings.toml
@@ -2473,7 +2473,7 @@ type = "Bool"
 
 [task.show_full_cmd]
 description = "Disable truncation of command lines in task execution output. When true, the full command line will be shown."
-env = "MISE_TASK_SHOW_CMD_NO_TRUNC"
+env = "MISE_TASK_SHOW_FULL_CMD"
 type = "Bool"
 
 [task.skip]


### PR DESCRIPTION
Fix a leftover of setting renaming happened during #7344.