### PR TITLE
security: ignore quick-xml advisories pending upstream fixes

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,8 @@ feature-depth = 1
 ignore = [
   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained - transitive via age/mlua/tabled/rops, no safe upgrade available" },
   { id = "RUSTSEC-2023-0071", reason = "rsa crate Marvin attack vulnerability from sigstore crate - no safe upgrade available" },
+  { id = "RUSTSEC-2026-0194", reason = "quick-xml transitive via plist/self_update/rattler_menuinst; no published upstream release supports quick-xml >=0.41 yet" },
+  { id = "RUSTSEC-2026-0195", reason = "quick-xml transitive via plist/self_update/rattler_menuinst; no published upstream release supports quick-xml >=0.41 yet" },
   #"RUSTSEC-0000-0000",
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
## Summary
- ignore RUSTSEC-2026-0194 and RUSTSEC-2026-0195 while upstream crates still constrain quick-xml below 0.41
- document the current transitive sources: plist, self_update, and rattler_menuinst

## Validation
- mise x cargo:cargo-deny -- cargo deny check advisories
- cargo tree --target all -i quick-xml@0.37.5
- cargo tree --target all -i quick-xml@0.38.4
- cargo tree --target all -i quick-xml@0.39.4

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates advisory ignore entries in deny.toml with documented rationale; no runtime or dependency upgrade behavior changes.
> 
> **Overview**
> Adds **cargo-deny** exceptions for **RUSTSEC-2026-0194** and **RUSTSEC-2026-0195** so `cargo deny check advisories` can pass while transitive **quick-xml** versions stay below **0.41**.
> 
> Each ignore documents that the exposure comes through **plist**, **self_update**, and **rattler_menuinst**, and that no published upstream release yet allows bumping **quick-xml** to a fixed line. This is policy/config only—no application or dependency version changes in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3ef978a50767db1cb845799c0fc2eb72f13e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security exception settings to account for two additional known advisories affecting transitive dependencies.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->