### PR TITLE
restore $LASTEXITCODE after _mise_hook

### DIFF
--- a/e2e-win/mise_hook.Tests.ps1
+++ b/e2e-win/mise_hook.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'mise_hook' {
+    BeforeAll {
+        mise activate pwsh | Out-String | Invoke-Expression
+    }
+
+    AfterAll {
+        mise deactivate
+    }
+
+    It 'doesn''t clobber $LASTEXITCODE' {
+        cmd /C 'exit 12'
+        # simulate interactive command execution
+        prompt
+        $LASTEXITCODE | Should -BeExactly 12
+    }
+}

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -70,13 +70,10 @@ impl Shell for Pwsh {
                     }}
                     default {{
                         & "{exe}" $command @remainingArgs
-                        $status = $LASTEXITCODE
                         if ($(Test-Path -Path Function:\_mise_hook)){{
                             _mise_hook
                         }}
                         _reset_output_encoding
-                        # restore exit code from mise after _mise_hook
-                        $global:LASTEXITCODE = $status
                     }}
                 }}
             }}
@@ -87,10 +84,13 @@ impl Shell for Pwsh {
 
             function Global:_mise_hook {{
                 if ($env:MISE_SHELL -eq "pwsh"){{
+                    $status = $global:LASTEXITCODE
                     $output = & "{exe}" hook-env{flags} $args -s pwsh | Out-String
                     if ($output -and $output.Trim()) {{
                         $output | Invoke-Expression
                     }}
+                    # mise hook-env will have set $LASTEXITCODE, restore previous value
+                    $global:LASTEXITCODE = $status
                 }}
             }}
 

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -47,23 +47,23 @@ function mise {
         }
         default {
             & "/some/dir/mise" $command @remainingArgs
-            $status = $LASTEXITCODE
             if ($(Test-Path -Path Function:\_mise_hook)){
                 _mise_hook
             }
             _reset_output_encoding
-            # restore exit code from mise after _mise_hook
-            $global:LASTEXITCODE = $status
         }
     }
 }
 
 function Global:_mise_hook {
     if ($env:MISE_SHELL -eq "pwsh"){
+        $status = $global:LASTEXITCODE
         $output = & "/some/dir/mise" hook-env --status $args -s pwsh | Out-String
         if ($output -and $output.Trim()) {
             $output | Invoke-Expression
         }
+        # mise hook-env will have set $LASTEXITCODE, restore previous value
+        $global:LASTEXITCODE = $status
     }
 }
 


### PR DESCRIPTION
fixes #9727 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the previous exit code when running PowerShell hooks, so interactive prompts no longer overwrite `$LASTEXITCODE`.
  * Added end-to-end coverage to verify the hook keeps an existing process exit code unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->