### PR TITLE
fix(vfox): make os.getenv use mise env

### DIFF
--- a/crates/vfox/src/lua_mod/cmd.rs
+++ b/crates/vfox/src/lua_mod/cmd.rs
@@ -10,13 +10,14 @@ pub fn mod_cmd(lua: &Lua) -> LuaResult<()> {
     loaded.set("cmd", cmd.clone())?;
     loaded.set("vfox.cmd", cmd)?;
 
-    // Route Lua's `os.execute` through mise's sanitized env (registry `mise_env`),
-    // matching cmd.exec. Stock `os.execute` inherits mise's raw process env, which
-    // during a combined `mise install` can carry stale `tools = true` values
-    // (e.g. a `CLOUDSDK_PYTHON` rendered before its python dependency was
-    // installed). Plugins that shell out via `os.execute` (e.g. vfox-gcloud's
-    // install.sh) would otherwise use the stale value and fail. When `mise_env`
-    // is unset, `os.execute` behaves exactly as stock. (#10282)
+    // Route Lua's `os.execute` and `os.getenv` through mise's sanitized env
+    // (registry `mise_env`), matching cmd.exec. Stock `os.execute` inherits
+    // mise's raw process env, which during a combined `mise install` can carry
+    // stale `tools = true` values (e.g. a `CLOUDSDK_PYTHON` rendered before its
+    // python dependency was installed). Plugins that shell out via `os.execute`
+    // (e.g. vfox-gcloud's install.sh) would otherwise use the stale value and
+    // fail. When `mise_env` is unset, `os.execute`/`os.getenv` behave like stock.
+    // (#10282, #10711)
     //
     // Reuse the existing `os` table so `os.time`/`os.date`/etc. are preserved; only
     // create one if `os` is absent (`nil`). A non-table `os` propagates the error
@@ -31,6 +32,7 @@ pub fn mod_cmd(lua: &Lua) -> LuaResult<()> {
         }
     };
     os.set("execute", lua.create_function(os_execute)?)?;
+    os.set("getenv", lua.create_function(os_getenv)?)?;
     Ok(())
 }
 
@@ -136,6 +138,31 @@ fn os_execute(lua: &Lua, command: Option<String>) -> LuaResult<i64> {
         .status()
         .map_err(|e| mlua::Error::RuntimeError(format!("Failed to execute command: {e}")))?;
     Ok(status.code().unwrap_or(-1) as i64)
+}
+
+/// Drop-in replacement for Lua's `os.getenv` that reads from the same
+/// mise-constructed environment as `os.execute` when one is available. This
+/// keeps in-process env reads consistent with shell-outs from env module hooks
+/// when the user's shell has not run `mise activate`. (#10711)
+fn os_getenv(lua: &Lua, key: String) -> LuaResult<Option<String>> {
+    if let Ok(mise_env) = lua.named_registry_value::<Table>("mise_env") {
+        return lookup_env_table(&mise_env, &key);
+    }
+    Ok(std::env::var(key).ok())
+}
+
+fn lookup_env_table(env: &Table, key: &str) -> LuaResult<Option<String>> {
+    let exact = env.get::<Option<String>>(key)?;
+    if exact.is_some() || !cfg!(windows) {
+        return Ok(exact);
+    }
+    for pair in env.pairs::<String, String>() {
+        let (env_key, env_value) = pair?;
+        if env_key.eq_ignore_ascii_case(key) {
+            return Ok(Some(env_value));
+        }
+    }
+    Ok(None)
 }
 
 fn cmd_shell(lua: &Lua) -> LuaResult<Vec<String>> {
@@ -256,6 +283,23 @@ mod tests {
             assert(ok == 0, "mise_env not applied to os.execute: " .. tostring(ok))
             local bad = os.execute('[ "$MISE_OS_EXEC_MARKER" = no ]')
             assert(bad ~= 0, "expected non-zero exit on false test")
+        "#,
+        )
+        .exec()
+        .unwrap();
+    }
+
+    #[test]
+    fn test_os_getenv_applies_mise_env() {
+        let lua = Lua::new();
+        mod_cmd(&lua).unwrap();
+        let env = lua.create_table().unwrap();
+        env.set("MISE_OS_GETENV_MARKER", "yes").unwrap();
+        lua.set_named_registry_value("mise_env", env).unwrap();
+        lua.load(
+            r#"
+            assert(os.getenv("MISE_OS_GETENV_MARKER") == "yes")
+            assert(os.getenv("MISE_OS_GETENV_MISSING") == nil)
         "#,
         )
         .exec()

--- a/e2e/env/test_env_module_os_getenv
+++ b/e2e/env/test_env_module_os_getenv
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Test that env module hooks see mise-computed [env] vars through os.getenv
+# even when the current shell has not been activated.
+
+PLUGIN_DIR="$MISE_DATA_DIR/plugins/test-os-getenv"
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'EOFMETA'
+PLUGIN = {}
+PLUGIN.name = "test-os-getenv"
+PLUGIN.version = "1.0.0"
+PLUGIN.homepage = "https://example.com"
+PLUGIN.license = "MIT"
+PLUGIN.description = "Test that os.getenv sees mise env"
+PLUGIN.minRuntimeVersion = "0.3.0"
+EOFMETA
+
+cat >"$PLUGIN_DIR/hooks/mise_env.lua" <<'EOFHOOK'
+function PLUGIN:MiseEnv(ctx)
+    return {
+        env = {
+            {key = "TEST_OS_GETENV_RESULT", value = os.getenv("MISE_TEST_ENV") or "nil"}
+        },
+        cacheable = false,
+        watch_files = {}
+    }
+end
+EOFHOOK
+
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[env]
+MISE_TEST_ENV = "example"
+_.test-os-getenv = {}
+EOF
+
+assert_contains "mise env -s bash" "TEST_OS_GETENV_RESULT=example"


### PR DESCRIPTION
## Summary
- route Lua `os.getenv` through the same `mise_env` table used by `cmd.exec`/`os.execute` when mise provides one
- preserve normal process-env behavior when `mise_env` is absent
- add unit and e2e coverage for env module hooks seeing `[env]` values without `mise activate`

Discussion: #10711

## Tests
- `mise run format`
- `mise --cd crates/vfox run test`
- `mise run test:e2e e2e/env/test_env_module_os_getenv`
- `mise x shfmt -- shfmt -d e2e/env/test_env_module_os_getenv`
- `mise x shellcheck -- shellcheck -x e2e/env/test_env_module_os_getenv`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how env module hooks resolve variables in-process, which affects final `mise env` output, but scope is limited to vfox Lua and falls back to normal process env when `mise_env` is absent.
> 
> **Overview**
> Extends the vfox Lua `os` overrides so **`os.getenv` reads from the same registry `mise_env` table** as `cmd.exec` and `os.execute`, instead of the raw process environment. When `mise_env` is not set, behavior stays the same as stock Lua (`std::env::var`).
> 
> Adds **`lookup_env_table`** for table lookups, with **case-insensitive key matching on Windows** after an exact match fails. Documents the change for **#10711** alongside the existing **#10282** `os.execute` rationale.
> 
> **Tests:** a Rust unit test that `os.getenv` sees values from `mise_env`, and an e2e script where a `MiseEnv` hook reads a `[env]` variable via `os.getenv` and exports it through `mise env` without shell activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3841cd9d380efdb9d68d628c91ece4b505ee6b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lua environment lookups now work through the app’s sanitized environment handling, including `os.getenv` support in shell hooks.
  * Added broader environment key matching behavior on non-Windows systems.

* **Tests**
  * Added end-to-end coverage for reading environment values through Lua hooks in an unactivated shell.
  * Added unit coverage for returning values from the sanitized environment and `nil` for missing keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->