### PR TITLE
fix(lockfile): avoid provenance guesses for opaque tags

### DIFF
--- a/src/backend/version_list.rs
+++ b/src/backend/version_list.rs
@@ -56,11 +56,11 @@ pub fn parse_version_list(
     // If a JSON path is provided (like ".[].version" or ".versions"), try to use it
     // but fall back to text parsing only when the body is not JSON.
     if let Some(json_path) = version_json_path {
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed)
-            && let Ok(extracted) = jq::extract(&json, json_path)
-        {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
             parsed_json_path = true;
-            versions = extracted;
+            if let Ok(extracted) = jq::extract(&json, json_path) {
+                versions = extracted;
+            }
         }
     }
     // If a regex is provided, use it to extract versions

--- a/src/backend/version_list.rs
+++ b/src/backend/version_list.rs
@@ -51,16 +51,17 @@ pub fn parse_version_list(
 ) -> Result<Vec<String>> {
     let mut versions = Vec::new();
     let trimmed = content.trim();
+    let mut parsed_json_path = false;
 
     // If a JSON path is provided (like ".[].version" or ".versions"), try to use it
-    // but fall back to text parsing if JSON parsing fails
+    // but fall back to text parsing only when the body is not JSON.
     if let Some(json_path) = version_json_path {
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed)
             && let Ok(extracted) = jq::extract(&json, json_path)
         {
+            parsed_json_path = true;
             versions = extracted;
         }
-        // If JSON parsing failed or path extraction failed, fall through to text parsing below
     }
     // If a regex is provided, use it to extract versions
     else if let Some(pattern) = version_regex {
@@ -95,7 +96,7 @@ pub fn parse_version_list(
     // When version_regex or version_expr is set, zero matches means the content
     // didn't contain the expected data — don't fall through to line-splitting
     // which would emit garbage (e.g. raw HTML lines as "versions").
-    let explicit_method = version_regex.is_some() || version_expr.is_some();
+    let explicit_method = version_regex.is_some() || version_expr.is_some() || parsed_json_path;
     if versions.is_empty() && !explicit_method {
         for line in trimmed.lines() {
             let line = line.trim();
@@ -329,13 +330,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_json_path_with_wrong_path_falls_back_to_text() {
-        // When version_json_path doesn't match the JSON structure,
-        // it should fall back to text parsing
+    fn test_parse_json_path_with_wrong_path_returns_empty_for_json() {
+        // When version_json_path doesn't match a valid JSON document, it should
+        // return no versions instead of treating the JSON body as a version.
         let content = r#"{"other": "data"}"#;
         let versions = parse_version_list(content, None, Some(".[].version"), None).unwrap();
-        // Falls back to treating JSON as a single line of text
-        assert_eq!(versions, vec![r#"{"other": "data"}"#]);
+        assert!(versions.is_empty());
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1697,8 +1697,10 @@ fn check_single_tool_provenance(
     }
 
     let tools = existing_tools?;
+    let new_version = parse_provenance_version(version)?;
 
-    // Find the highest prior github version with provenance on this platform
+    // Find the highest prior github semver version with provenance on this platform.
+    // Non-semver tags are opaque to mise, so do not guess whether they are upgrades.
     let prior = tools
         .iter()
         .filter(|t| t.version != version)
@@ -1708,12 +1710,12 @@ fn check_single_tool_provenance(
                 .get(platform_key)
                 .is_some_and(|pi| pi.provenance.is_some())
         })
-        .max_by(|a, b| {
-            versions::Versioning::new(&a.version).cmp(&versions::Versioning::new(&b.version))
-        })?;
+        .filter_map(|t| Some((parse_provenance_version(&t.version)?, t)))
+        .max_by(|(a, _), (b, _)| a.cmp(b))
+        .map(|(_, t)| t)?;
 
     // Only flag upgrades — intentional downgrades are allowed
-    if versions::Versioning::new(version) <= versions::Versioning::new(&prior.version) {
+    if new_version <= parse_provenance_version(&prior.version)? {
         return None;
     }
 
@@ -1724,6 +1726,10 @@ fn check_single_tool_provenance(
          attack. Verify the release is authentic before proceeding.",
         prior.version,
     ))
+}
+
+fn parse_provenance_version(version: &str) -> Option<nodejs_semver::Version> {
+    nodejs_semver::Version::parse(version.trim_start_matches(['v', 'V'])).ok()
 }
 
 /// Check if any github backend tool is losing provenance when upgrading versions.
@@ -3918,6 +3924,53 @@ backend = "conda:jq"
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn test_provenance_regression_only_flags_known_semver_upgrades() {
+        let platform = Platform::current().to_key();
+        let mut prior = basic_tool("nightly", "github:owner/repo");
+        prior.platforms.insert(
+            platform.clone(),
+            PlatformInfo {
+                provenance: Some(ProvenanceType::GithubAttestations),
+                ..Default::default()
+            },
+        );
+        let existing = vec![prior];
+
+        assert!(
+            check_single_tool_provenance(
+                Some(&existing),
+                "tool",
+                "release",
+                "github:owner/repo",
+                &platform,
+                None,
+            )
+            .is_none()
+        );
+
+        let mut prior = basic_tool("v1.0.0-rc.1", "github:owner/repo");
+        prior.platforms.insert(
+            platform.clone(),
+            PlatformInfo {
+                provenance: Some(ProvenanceType::GithubAttestations),
+                ..Default::default()
+            },
+        );
+        let existing = vec![prior];
+
+        let err = check_single_tool_provenance(
+            Some(&existing),
+            "tool",
+            "v1.0.0",
+            "github:owner/repo",
+            &platform,
+            None,
+        )
+        .unwrap();
+        assert!(err.contains("has no provenance verification"));
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1711,11 +1711,12 @@ fn check_single_tool_provenance(
                 .is_some_and(|pi| pi.provenance.is_some())
         })
         .filter_map(|t| Some((parse_provenance_version(&t.version)?, t)))
-        .max_by(|(a, _), (b, _)| a.cmp(b))
-        .map(|(_, t)| t)?;
+        .max_by(|(a, _), (b, _)| a.cmp(b))?;
+
+    let (prior_version, prior) = prior;
 
     // Only flag upgrades — intentional downgrades are allowed
-    if new_version <= parse_provenance_version(&prior.version)? {
+    if new_version <= prior_version {
         return None;
     }
 
@@ -1729,7 +1730,7 @@ fn check_single_tool_provenance(
 }
 
 fn parse_provenance_version(version: &str) -> Option<nodejs_semver::Version> {
-    nodejs_semver::Version::parse(version.trim_start_matches(['v', 'V'])).ok()
+    nodejs_semver::Version::parse(strip_leading_v(version)).ok()
 }
 
 /// Check if any github backend tool is losing provenance when upgrading versions.
@@ -2494,8 +2495,8 @@ fn lockfile_version_matches(prefix: &str, version: &str) -> bool {
 
 fn strip_leading_v(version: &str) -> &str {
     version
-        .strip_prefix('v')
-        .or_else(|| version.strip_prefix('V'))
+        .strip_prefix(['v', 'V'])
+        .filter(|stripped| stripped.chars().next().is_some_and(|c| c.is_ascii_digit()))
         .unwrap_or(version)
 }
 
@@ -3069,6 +3070,9 @@ options = { exe = "rg" }
         assert!(lockfile_version_matches("v1.2", "1.2.3"));
         assert!(lockfile_version_matches("V1.2", "v1.2.3"));
         assert!(!lockfile_version_matches("1.3", "v1.2.3"));
+        assert!(!lockfile_version_matches("v", "1.2.3"));
+        assert!(!lockfile_version_matches("v", "v1.2.3"));
+        assert!(lockfile_version_matches("v", "versioned"));
     }
 
     #[test]
@@ -3952,7 +3956,7 @@ backend = "conda:jq"
             check_single_tool_provenance(
                 Some(&existing),
                 "tool",
-                "release",
+                "v1.0.0",
                 "github:owner/repo",
                 &platform,
                 None,
@@ -3980,6 +3984,14 @@ backend = "conda:jq"
         )
         .unwrap();
         assert!(err.contains("has no provenance verification"));
+    }
+
+    #[test]
+    fn test_parse_provenance_version_strips_single_semver_v_prefix() {
+        assert!(parse_provenance_version("v1.2.3").is_some());
+        assert!(parse_provenance_version("V1.2.3").is_some());
+        assert!(parse_provenance_version("vv1.2.3").is_none());
+        assert!(parse_provenance_version("v").is_none());
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -2467,18 +2467,7 @@ pub fn get_locked_version(
         let mut matching: Vec<_> = tools
             .iter()
             .filter(|v| {
-                let norm_prefix = prefix
-                    .strip_prefix('v')
-                    .or(prefix.strip_prefix('V'))
-                    .unwrap_or(prefix);
-                let norm_version = v
-                    .version
-                    .strip_prefix('v')
-                    .or(v.version.strip_prefix('V'))
-                    .unwrap_or(&v.version);
-                let version_matches = prefix == "latest" || norm_version.starts_with(norm_prefix);
-                let options_match = &v.options == request_options;
-                version_matches && options_match
+                lockfile_version_matches(prefix, &v.version) && &v.options == request_options
             })
             .collect();
 
@@ -2497,6 +2486,17 @@ pub fn get_locked_version(
     }
 
     Ok(None)
+}
+
+fn lockfile_version_matches(prefix: &str, version: &str) -> bool {
+    prefix == "latest" || strip_leading_v(version).starts_with(strip_leading_v(prefix))
+}
+
+fn strip_leading_v(version: &str) -> &str {
+    version
+        .strip_prefix('v')
+        .or_else(|| version.strip_prefix('V'))
+        .unwrap_or(version)
 }
 
 /// Get the backend for a tool from the lockfile, ignoring options.
@@ -3060,6 +3060,15 @@ options = { exe = "rg" }
         assert_eq!(lockfile.tools["ripgrep"].len(), 2);
         assert_eq!(lockfile.tools["ripgrep"][0].options.len(), 2);
         assert_eq!(lockfile.tools["ripgrep"][1].options.len(), 1);
+    }
+
+    #[test]
+    fn test_lockfile_version_matches_normalizes_v_prefix() {
+        assert!(lockfile_version_matches("latest", "not-a-semver"));
+        assert!(lockfile_version_matches("1.2", "v1.2.3"));
+        assert!(lockfile_version_matches("v1.2", "1.2.3"));
+        assert!(lockfile_version_matches("V1.2", "v1.2.3"));
+        assert!(!lockfile_version_matches("1.3", "v1.2.3"));
     }
 
     #[test]

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -4,28 +4,17 @@ use versions::{Mess, Versioning};
 
 /// splits a version number into an optional prefix and the remaining version string
 pub fn split_version_prefix(version: &str) -> (String, String) {
-    version
-        .char_indices()
-        .find_map(|(i, c)| {
-            if c.is_ascii_digit() {
-                if i == 0 {
-                    return Some(i);
-                }
-                // If the previous char is a delimiter or 'v', we found a split point.
-                let prev_char = version.chars().nth(i - 1).unwrap();
-                if ['-', '_', '/', '.', 'v', 'V'].contains(&prev_char) {
-                    return Some(i);
-                }
-            }
-            None
-        })
-        .map_or_else(
-            || ("".into(), version.into()),
-            |i| {
-                let (prefix, version) = version.split_at(i);
-                (prefix.into(), version.into())
-            },
-        )
+    let mut prev_char = None;
+    for (i, c) in version.char_indices() {
+        if c.is_ascii_digit()
+            && (i == 0 || prev_char.is_some_and(|c| ['-', '_', '/', '.', 'v', 'V'].contains(&c)))
+        {
+            let (prefix, version) = version.split_at(i);
+            return (prefix.into(), version.into());
+        }
+        prev_char = Some(c);
+    }
+    ("".into(), version.into())
 }
 
 /// split a version number into chunks
@@ -149,6 +138,10 @@ mod tests {
         assert_eq!(
             split_version_prefix("temurin-17.0.7+7"),
             ("temurin-".into(), "17.0.7+7".into())
+        );
+        assert_eq!(
+            split_version_prefix("\u{5de5}\u{5177}-v1.2.3"),
+            ("\u{5de5}\u{5177}-v".into(), "1.2.3".into())
         );
         assert_eq!(split_version_prefix("1.2"), ("".into(), "1.2".into()));
         assert_eq!(


### PR DESCRIPTION
## Summary
- avoid treating opaque GitHub release tags as ordered upgrades when checking provenance regressions
- keep JSON-path version listing from falling back to raw JSON when a valid JSON body has no path matches
- extract locked-version prefix matching into a named helper with focused coverage

## Tests
- `cargo test test_split_version_prefix`
- `cargo test provenance_regression`
- `cargo test test_github_attestations_unavailable_counts_as_missing_for_regression`
- `cargo test version_list`
- `cargo test test_lockfile_version_matches_normalizes_v_prefix`
- `cargo test test_options_matching_in_get_locked_version`
- `mise run test:unit`
- `mise run lint`
- `mise run test:e2e e2e/cli/test_lock_latest`
- `mise run test:e2e e2e/lockfile/test_lockfile_provenance_upgrade`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provenance regression detection and lockfile version matching in supply-chain-sensitive paths; behavior is more conservative (fewer false positives) but could miss edge cases if semver parsing disagrees with tag ordering.
> 
> **Overview**
> Tightens **lockfile** and **version-list** behavior so semver-only logic does not mis-handle opaque GitHub tags or valid JSON bodies, and pins CI nightly to avoid a known rustc ICE.
> 
> **GitHub provenance regression** now compares prior and new releases only when both versions parse as **semver** (`parse_provenance_version` / `strip_leading_v`). Tags like `nightly` no longer count as ordered upgrades against a semver install, so missing provenance on the new release is not flagged as a supply-chain regression in that case; real semver upgrades (e.g. `v1.0.0-rc.1` → `v1.0.0`) still warn when provenance drops.
> 
> **Lockfile version prefix matching** is centralized in `lockfile_version_matches` / `strip_leading_v`: optional `v`/`V` is normalized only when the next character is a digit, so bare `v` does not incorrectly prefix-match numeric versions.
> 
> **JSON `version_json_path` parsing** marks JSON bodies as an explicit extraction method: if JSON parses but the path matches nothing, the result is **empty** instead of falling back to treating the raw JSON (or one line) as a version; non-JSON bodies still fall back to line-based parsing.
> 
> **`split_version_prefix`** is rewritten as a simple scan (same delimiter rules) with coverage for a non-ASCII prefix before `v`.
> 
> **CI** `nightly` job uses `nightly-2026-06-29` instead of rolling nightly due to an upstream ICE before `mise` builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03ce0c7dd73abbd53028e49968e7e61dced73496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version parsing for JSON-path inputs so non-matching JSON extractions now return no versions instead of falling back to the raw JSON text.
  * Made version matching more consistent by handling optional `v`/`V` prefixes and rejecting invalid prefix forms.
  * Tightened provenance checks to avoid false regression warnings for non-semver versions while still detecting real version downgrades/upgrades correctly.
* **Chores**
  * Updated CI to use a fixed nightly Rust toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->