### PR TITLE
fix(release): trigger missing release workflow after tag push

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -12,15 +12,46 @@ fi
 git config user.name mise-en-dev
 git config user.email release@mise.jdx.dev
 
+release_workflow_active_for_tag() {
+	local tag="$1"
+	local active
+
+	active="$(
+		gh run list \
+			--workflow release.yml \
+			--branch "$tag" \
+			--limit 10 \
+			--json status,conclusion \
+			--jq 'any(.[]; .status != "completed")' \
+			2>/dev/null || echo false
+	)"
+	[[ $active == "true" ]]
+}
+
+trigger_release_workflow_if_missing() {
+	local tag="$1"
+
+	if [[ -z $tag ]]; then
+		return
+	fi
+
+	if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag" --silent 2>/dev/null; then
+		return
+	fi
+
+	if release_workflow_active_for_tag "$tag"; then
+		echo "Tag $tag has no GitHub Release, but release workflow already exists"
+		return
+	fi
+
+	echo "Tag $tag has no GitHub Release - triggering release workflow"
+	gh workflow run release.yml --ref "$tag"
+}
+
 # Check if the most recent tag has a matching GitHub Release.
 # If not, the previous release workflow likely failed to fire — re-trigger it.
 latest_tag="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)"
-if [[ -n $latest_tag ]]; then
-	if ! gh api "repos/$GITHUB_REPOSITORY/releases/tags/$latest_tag" --silent 2>/dev/null; then
-		echo "Tag $latest_tag has no GitHub Release — triggering release workflow"
-		gh workflow run release.yml --ref "$latest_tag"
-	fi
-fi
+trigger_release_workflow_if_missing "$latest_tag"
 
 exists_on_crates() {
 	crate="$1"
@@ -227,6 +258,10 @@ if [[ $cur_version != "$latest_version" ]]; then
 
 	# Push all tags (mise + any subcrate tags)
 	git push --tags
+	# Give GitHub time to enqueue tag-triggered workflows before falling back
+	# to workflow_dispatch.
+	sleep 15
+	trigger_release_workflow_if_missing "v$cur_version"
 	exit 0
 fi
 


### PR DESCRIPTION
## Summary
- wrap the missing GitHub Release check in a helper that can be reused
- avoid duplicate dispatches when `release.yml` is already active for the tag
- after pushing release tags, wait briefly and dispatch `release.yml` for the new mise tag if GitHub did not enqueue it

## Testing
- `bash -n xtasks/release-plz`
- `git diff --check`
- `gh run list --workflow release.yml --branch v2026.7.0 --limit 10 --json status,conclusion --jq 'any(.[]; .status != "completed")'`\n\n*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release script changes with no runtime product impact; main risk is timing or duplicate/missed dispatches if GitHub API behavior differs from assumptions.
> 
> **Overview**
> Release recovery in `xtasks/release-plz` is refactored so missing GitHub Releases are handled through **`trigger_release_workflow_if_missing`**, which only dispatches **`release.yml`** when there is no release for the tag and no **in-progress** run for that tag branch (via **`release_workflow_active_for_tag`** / `gh run list`).
> 
> The startup check for the latest `v*` tag now calls that helper instead of inline `gh api` + dispatch logic.
> 
> After **`git push --tags`** during a mise release, the script **waits 15 seconds** then runs the same helper for **`v$cur_version`**, so a tag-triggered workflow can enqueue before falling back to **`workflow_dispatch`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f59f5159a8b68b1cdc3fbf333db99d66c40ced7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release handling so new versions are less likely to miss a follow-up release step after tags are published.
  * Added a short delay and smarter retry behavior to better account for timing delays during release processing.
  * Reduced duplicate release-triggering when a release process is already underway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->