### PR TITLE
chore: release 2026.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,128 @@
 # Changelog
 
+## [2026.7.1](https://github.com/jdx/mise/compare/v2026.7.0..v2026.7.1) - 2026-07-07
+
+### 🚀 Features
+
+- **(bootstrap)** add launchd calendar intervals by @jdx in [#10797](https://github.com/jdx/mise/pull/10797)
+- **(cargo)** add native binary install fast path by @jdx in [#10789](https://github.com/jdx/mise/pull/10789)
+- **(config)** add tera v1 escape hatch by @jdx in [#10817](https://github.com/jdx/mise/pull/10817)
+- **(npm)** add aube trust policy excludes by @jdx in [#10783](https://github.com/jdx/mise/pull/10783)
+
+### 🐛 Bug Fixes
+
+- **(backend)** accept native option shapes by @jdx in [#10811](https://github.com/jdx/mise/pull/10811)
+- **(backend)** accept arrays for list options by @jdx in [#10812](https://github.com/jdx/mise/pull/10812)
+- **(brew-cask)** expand font target paths to handle $HOME and return relative paths by @roele in [#10788](https://github.com/jdx/mise/pull/10788)
+- **(cargo)** accept array syntax for features by @jdx in [#10810](https://github.com/jdx/mise/pull/10810)
+- **(cargo)** warn on invalid feature array entries by @jdx in [#10813](https://github.com/jdx/mise/pull/10813)
+- **(cli)** support `--run-windows` for `task add` by @eugencowie in [#10769](https://github.com/jdx/mise/pull/10769)
+- **(config)** restore tera v1 compatibility filters by @jdx in [#10814](https://github.com/jdx/mise/pull/10814)
+- **(config)** delay tera v1 compat warnings by @jdx in [#10815](https://github.com/jdx/mise/pull/10815)
+- **(core)** don't panic when stderr is unwritable by @daandemeyer in [#10773](https://github.com/jdx/mise/pull/10773)
+- **(core)** improve precompiled setting errors by @jdx in [#10791](https://github.com/jdx/mise/pull/10791)
+- **(core)** clarify python precompiled triple errors by @jdx in [#10793](https://github.com/jdx/mise/pull/10793)
+- **(env)** match redaction wildcards as globs by @jdx in [#10729](https://github.com/jdx/mise/pull/10729)
+- **(env)** resolve sops keys from ordered env by @jdx in [#10786](https://github.com/jdx/mise/pull/10786)
+- **(env)** activate sub latest versions offline by @jdx in [#10802](https://github.com/jdx/mise/pull/10802)
+- **(git)** sanitize repository env vars by @risu729 in [#10776](https://github.com/jdx/mise/pull/10776)
+- **(github)** handle raw exe rename by @jdx in [#10798](https://github.com/jdx/mise/pull/10798)
+- **(install)** normalize standalone binary ownership by @jdx in [#10808](https://github.com/jdx/mise/pull/10808)
+- **(install)** avoid preserving archive owner by @jdx in [#10819](https://github.com/jdx/mise/pull/10819)
+- **(lockfile)** preserve header url while restoring asset host by @jdx in [#10728](https://github.com/jdx/mise/pull/10728)
+- **(lockfile)** avoid provenance guesses for opaque tags by @jdx in [#10722](https://github.com/jdx/mise/pull/10722)
+- **(logger)** fix race between log redaction and config reset by @daandemeyer in [#10785](https://github.com/jdx/mise/pull/10785)
+- **(nushell)** resolve str upcase deprecation warning by @martinhiller in [#10778](https://github.com/jdx/mise/pull/10778)
+- **(oci)** normalize apt/dpkg transient state for reproducible package layers by @karteekiitg in [#10731](https://github.com/jdx/mise/pull/10731)
+- **(prune)** don't delete tool versions referenced by tool stubs by @daandemeyer in [#10790](https://github.com/jdx/mise/pull/10790)
+- **(schema)** support vars directives by @risu729 in [#10774](https://github.com/jdx/mise/pull/10774)
+- **(schema)** allow tool alias versions by @JamBalaya56562 in [#10712](https://github.com/jdx/mise/pull/10712)
+- **(search)** include aqua matches when registry misses by @jdx in [#10801](https://github.com/jdx/mise/pull/10801)
+- **(system)** extract suffixless brew cask zip archives by @jdx in [#10800](https://github.com/jdx/mise/pull/10800)
+- **(task)** show usage subcommand help by @jdx in [#10799](https://github.com/jdx/mise/pull/10799)
+- **(vfox/http)** create parent directories in download helpers by @doraemonkeys in [#10767](https://github.com/jdx/mise/pull/10767)
+
+### 📚 Documentation
+
+- **(configuration)** fix precedence in visual by @kellinm in [#10779](https://github.com/jdx/mise/pull/10779)
+- **(env)** clarify env_shell_expand setting by @jdx in [#10787](https://github.com/jdx/mise/pull/10787)
+- **(errors)** replace TODO stub with error message reference by @jdx in [#10724](https://github.com/jdx/mise/pull/10724)
+- **(templates)** update tera documentation links by @risu729 in [#10751](https://github.com/jdx/mise/pull/10751)
+- clarify Go backend version pinning by @zeitlinger in [#10749](https://github.com/jdx/mise/pull/10749)
+
+### 🧪 Testing
+
+- **(oci)** make setuid mode test sandbox-portable by @TyceHerrman in [#10715](https://github.com/jdx/mise/pull/10715)
+- **(oci)** skip metadata dir layer test if special permissions fail by @laozc in [#10816](https://github.com/jdx/mise/pull/10816)
+
+### 📦️ Dependency Updates
+
+- update rust docker digest to 1f0dbad by @renovate[bot] in [#10738](https://github.com/jdx/mise/pull/10738)
+- update zizmorcore/zizmor-action action to v0.5.7 by @renovate[bot] in [#10742](https://github.com/jdx/mise/pull/10742)
+- update docker/build-push-action digest to 53b7df9 by @renovate[bot] in [#10733](https://github.com/jdx/mise/pull/10733)
+- update docker/login-action digest to c99871d by @renovate[bot] in [#10734](https://github.com/jdx/mise/pull/10734)
+- update docker/setup-buildx-action digest to bb05f3f by @renovate[bot] in [#10736](https://github.com/jdx/mise/pull/10736)
+- update docker/metadata-action digest to dc80280 by @renovate[bot] in [#10735](https://github.com/jdx/mise/pull/10735)
+- update rust crate usage-lib to v3.5.3 by @renovate[bot] in [#10741](https://github.com/jdx/mise/pull/10741)
+- update ubuntu:26.04 docker digest to b7f4819 by @renovate[bot] in [#10739](https://github.com/jdx/mise/pull/10739)
+- update rust crate rmcp to v1.8.0 by @renovate[bot] in [#10744](https://github.com/jdx/mise/pull/10744)
+- update rust crate env_logger to v0.11.11 by @renovate[bot] in [#10740](https://github.com/jdx/mise/pull/10740)
+- update rattler by @renovate[bot] in [#10755](https://github.com/jdx/mise/pull/10755)
+- update docker/login-action digest to af1e73f by @renovate[bot] in [#10761](https://github.com/jdx/mise/pull/10761)
+- update namespacelabs/nscloud-cache-action digest to 58bf6e0 by @renovate[bot] in [#10737](https://github.com/jdx/mise/pull/10737)
+- group phf renovate updates by @jdx in [#10784](https://github.com/jdx/mise/pull/10784)
+- update dependency prettier to v3.8.5 by @renovate[bot] in [#10757](https://github.com/jdx/mise/pull/10757)
+- lock file maintenance by @renovate[bot] in [#10781](https://github.com/jdx/mise/pull/10781)
+- update rust crate nodejs-semver to v5 by @renovate[bot] in [#10747](https://github.com/jdx/mise/pull/10747)
+- update actions/cache action to v6 by @renovate[bot] in [#10746](https://github.com/jdx/mise/pull/10746)
+- update rust crate tera to v2 by @renovate[bot] in [#10756](https://github.com/jdx/mise/pull/10756)
+
+### 📦 Registry
+
+- prefer aqua for pi by @jdx in [#10727](https://github.com/jdx/mise/pull/10727)
+- add twg (http:twg) by @ryan-pip in [#10780](https://github.com/jdx/mise/pull/10780)
+- add apm ([github:microsoft/apm](https://github.com/microsoft/apm)) by @toyamarinyon in [#10766](https://github.com/jdx/mise/pull/10766)
+- add nono ([github:nolabs-ai/nono](https://github.com/nolabs-ai/nono)) by @invadersmustdie in [#10675](https://github.com/jdx/mise/pull/10675)
+- add miniserve ([aqua:svenstaro/miniserve](https://github.com/svenstaro/miniserve)) by @joealden in [#10760](https://github.com/jdx/mise/pull/10760)
+
+### Chore
+
+- **(ci)** replace stale PR comment action by @jdx in [#10804](https://github.com/jdx/mise/pull/10804)
+- **(ci)** replace winget releaser action by @jdx in [#10807](https://github.com/jdx/mise/pull/10807)
+- **(ci)** install mold via apt by @jdx in [#10803](https://github.com/jdx/mise/pull/10803)
+- **(ci)** remove fig autocomplete release by @jdx in [#10805](https://github.com/jdx/mise/pull/10805)
+- **(herdr)** use aqua backend for herdr by @himkt in [#10777](https://github.com/jdx/mise/pull/10777)
+- **(release)** improve communique release notes by @jdx in [#10796](https://github.com/jdx/mise/pull/10796)
+
+### New Contributors
+
+- @daandemeyer made their first contribution in [#10790](https://github.com/jdx/mise/pull/10790)
+- @doraemonkeys made their first contribution in [#10767](https://github.com/jdx/mise/pull/10767)
+- @karteekiitg made their first contribution in [#10731](https://github.com/jdx/mise/pull/10731)
+- @joealden made their first contribution in [#10760](https://github.com/jdx/mise/pull/10760)
+- @eugencowie made their first contribution in [#10769](https://github.com/jdx/mise/pull/10769)
+- @invadersmustdie made their first contribution in [#10675](https://github.com/jdx/mise/pull/10675)
+- @toyamarinyon made their first contribution in [#10766](https://github.com/jdx/mise/pull/10766)
+- @kellinm made their first contribution in [#10779](https://github.com/jdx/mise/pull/10779)
+- @martinhiller made their first contribution in [#10778](https://github.com/jdx/mise/pull/10778)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (2)
+
+- [`Mic92/nixfmt-rs`](https://github.com/Mic92/nixfmt-rs)
+- [`russellbanks/Komac`](https://github.com/russellbanks/Komac)
+
+#### Updated Packages (7)
+
+- [`alibaba/open-code-review`](https://github.com/alibaba/open-code-review)
+- [`google/keep-sorted`](https://github.com/google/keep-sorted)
+- [`haskell/ghcup-hs`](https://github.com/haskell/ghcup-hs)
+- [`kubescape/kubescape`](https://github.com/kubescape/kubescape)
+- [`kyverno/kyverno`](https://github.com/kyverno/kyverno)
+- [`nao1215/sqly`](https://github.com/nao1215/sqly)
+- [`openai/codex`](https://github.com/openai/codex)
+
 ## [2026.7.0](https://github.com/jdx/mise/compare/v2026.6.14..v2026.7.0) - 2026-07-02
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.0"
+version = "2026.7.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.0"
+version = "2026.7.1"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.0 macos-arm64 (2026-07-02)
+2026.7.1 macos-arm64 (2026-07-07)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_0.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_1.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_0.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_1.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_0.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_1.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_0.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_1.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.0";
+  version = "2026.7.1";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "30.4k",
+      stars: "30.5k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.0
+Version: 2026.7.1
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.0"
+version: "2026.7.1"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "9e4891f1b05eb0429aa36211735958be34015cb4"
+  "tag": "524929a3a0f5a7cc7cc761f69c8035b9de43ce46"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -5763,6 +5763,34 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: Mic92
+    repo_name: nixfmt-rs
+    description: Rust reimplementation of nixfmt with byte-identical output
+    files:
+      - name: nixfmt
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.1.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: nixfmt-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        github_artifact_attestations:
+          signer_workflow: Mic92/nixfmt-rs/.github/workflows/release-assets.yml
+        supported_envs:
+          - linux
+          - darwin/arm64
+  - type: github_release
     repo_owner: Mikescher
     repo_name: better-docker-ps
     description: Because `docker ps` is annoying and does not fit my monitor/terminal width
@@ -12305,6 +12333,13 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 1.6.4")
+        asset: opencodereview-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: sha256sum.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: opencodereview-{{.OS}}-{{.Arch}}
         format: raw
@@ -12312,6 +12347,8 @@ packages:
           type: github_release
           asset: sha256sum.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: alibaba/open-code-review/.github/workflows/release.yml
   - type: github_release
     repo_owner: allero-io
     repo_name: allero
@@ -44310,13 +44347,17 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.6.0")
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.9.0")
         asset: keep-sorted_{{.OS}}
         format: raw
         supported_envs:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: keep-sorted_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - type: github_release
     repo_owner: google
     repo_name: mtail
@@ -46987,6 +47028,10 @@ packages:
       windows: mingw64
     files:
       - name: ghcup
+    checksum:
+      type: http
+      url: https://downloads.haskell.org/~ghcup/{{trimV .Version}}/SHA256SUMS
+      algorithm: sha256
   - type: github_release
     repo_owner: hasura
     repo_name: graphql-engine
@@ -59020,6 +59065,13 @@ packages:
           - linux/amd64
           - darwin
           - windows
+      - version_constraint: semver("< 4.0.10")
+        asset: kubescape_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.sha256
+          algorithm: sha256
       - version_constraint: "true"
         asset: kubescape_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -59027,6 +59079,8 @@ packages:
           type: github_release
           asset: checksums.sha256
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: kubescape/kubescape/.github/workflows/02-release.yaml
   - type: github_release
     repo_owner: kubeshark
     repo_name: kubeshark
@@ -60012,7 +60066,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.17.2")
         asset: kyverno-cli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -60031,6 +60085,27 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/kyverno/kyverno/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: kyverno-cli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/kyverno/kyverno/.github/workflows/release.yaml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip
@@ -67324,7 +67399,7 @@ packages:
           algorithm: sha256
         supported_envs:
           - linux/amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.24.0")
         asset: sqly_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -67334,6 +67409,27 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: "true"
+        asset: sqly_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/nao1215/sqly/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: nao1215/sqly/.github/workflows/release.yml
   - type: github_release
     repo_owner: natecraddock
     repo_name: zf
@@ -69949,7 +70045,7 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.133.0-alpha.1")
         asset: codex-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zst
         windows_arm_emulation: true
@@ -69965,6 +70061,19 @@ packages:
         overrides:
           - goos: windows
             asset: codex-{{.Arch}}-{{.OS}}.exe.{{.Format}}
+      - version_constraint: "true"
+        asset: codex-package-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: codex
+            src: bin/codex
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
   - type: github_release
     repo_owner: openai
     repo_name: tart
@@ -78511,6 +78620,140 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+  - type: github_release
+    repo_owner: russellbanks
+    repo_name: Komac
+    description: The Community Manifest Creator for WinGet
+    files:
+      - name: komac
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 2.0.0")
+        error_message: The version is too old. Please upgrade to v2.0.0 or later.
+      - version_constraint: Version == "v2.0.0"
+        asset: KomacPortable-{{.OS}}-nightly-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: komac
+            src: KomacPortable-{{.OS}}-nightly-{{.Arch}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: raw
+            asset: KomacPortable-nightly-{{.Arch}}
+      - version_constraint: Version == "v2.0.3"
+        asset: KomacPortable-{{.OS}}-{{trimV .Version}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: komac
+            src: KomacPortable-{{.OS}}-{{trimV .Version}}-{{.Arch}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: raw
+            asset: KomacPortable-{{trimV .Version}}-{{.Arch}}
+      - version_constraint: Version == "v2.2.1"
+        asset: KomacPortable-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: komac
+            src: KomacPortable-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: raw
+            asset: KomacPortable-{{.Arch}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows
+      - version_constraint: Version == "v2.13.0"
+        asset: komac-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: raw
+            asset: komac-{{trimV .Version}}-{{.Arch}}-{{.OS}}
+      - version_constraint: semver("<= 2.0.2")
+        asset: KomacPortable-{{.OS}}-{{.Version}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: komac
+            src: KomacPortable-{{.OS}}-{{.Version}}-{{.Arch}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: raw
+            asset: KomacPortable-{{.Version}}-{{.Arch}}
+      - version_constraint: semver("<= 2.2.0")
+        asset: KomacPortable-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: komac
+            src: KomacPortable-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: raw
+            asset: KomacPortable-{{.Arch}}
+      - version_constraint: semver("<= 2.12.1")
+        asset: komac-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: raw
+            asset: komac-{{trimV .Version}}-{{.Arch}}-{{.OS}}
+      - version_constraint: "true"
+        asset: komac-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: raw
+            asset: komac-{{trimV .Version}}-{{.Arch}}-{{.OS}}
   - type: github_release
     repo_owner: rust-cross
     repo_name: cargo-zigbuild


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** add launchd calendar intervals by @jdx in [#10797](https://github.com/jdx/mise/pull/10797)
- **(cargo)** add native binary install fast path by @jdx in [#10789](https://github.com/jdx/mise/pull/10789)
- **(config)** add tera v1 escape hatch by @jdx in [#10817](https://github.com/jdx/mise/pull/10817)
- **(npm)** add aube trust policy excludes by @jdx in [#10783](https://github.com/jdx/mise/pull/10783)

### 🐛 Bug Fixes

- **(backend)** accept native option shapes by @jdx in [#10811](https://github.com/jdx/mise/pull/10811)
- **(backend)** accept arrays for list options by @jdx in [#10812](https://github.com/jdx/mise/pull/10812)
- **(brew-cask)** expand font target paths to handle $HOME and return relative paths by @roele in [#10788](https://github.com/jdx/mise/pull/10788)
- **(cargo)** accept array syntax for features by @jdx in [#10810](https://github.com/jdx/mise/pull/10810)
- **(cargo)** warn on invalid feature array entries by @jdx in [#10813](https://github.com/jdx/mise/pull/10813)
- **(cli)** support `--run-windows` for `task add` by @eugencowie in [#10769](https://github.com/jdx/mise/pull/10769)
- **(config)** restore tera v1 compatibility filters by @jdx in [#10814](https://github.com/jdx/mise/pull/10814)
- **(config)** delay tera v1 compat warnings by @jdx in [#10815](https://github.com/jdx/mise/pull/10815)
- **(core)** don't panic when stderr is unwritable by @daandemeyer in [#10773](https://github.com/jdx/mise/pull/10773)
- **(core)** improve precompiled setting errors by @jdx in [#10791](https://github.com/jdx/mise/pull/10791)
- **(core)** clarify python precompiled triple errors by @jdx in [#10793](https://github.com/jdx/mise/pull/10793)
- **(env)** match redaction wildcards as globs by @jdx in [#10729](https://github.com/jdx/mise/pull/10729)
- **(env)** resolve sops keys from ordered env by @jdx in [#10786](https://github.com/jdx/mise/pull/10786)
- **(env)** activate sub latest versions offline by @jdx in [#10802](https://github.com/jdx/mise/pull/10802)
- **(git)** sanitize repository env vars by @risu729 in [#10776](https://github.com/jdx/mise/pull/10776)
- **(github)** handle raw exe rename by @jdx in [#10798](https://github.com/jdx/mise/pull/10798)
- **(install)** normalize standalone binary ownership by @jdx in [#10808](https://github.com/jdx/mise/pull/10808)
- **(install)** avoid preserving archive owner by @jdx in [#10819](https://github.com/jdx/mise/pull/10819)
- **(lockfile)** preserve header url while restoring asset host by @jdx in [#10728](https://github.com/jdx/mise/pull/10728)
- **(lockfile)** avoid provenance guesses for opaque tags by @jdx in [#10722](https://github.com/jdx/mise/pull/10722)
- **(logger)** fix race between log redaction and config reset by @daandemeyer in [#10785](https://github.com/jdx/mise/pull/10785)
- **(nushell)** resolve str upcase deprecation warning by @martinhiller in [#10778](https://github.com/jdx/mise/pull/10778)
- **(oci)** normalize apt/dpkg transient state for reproducible package layers by @karteekiitg in [#10731](https://github.com/jdx/mise/pull/10731)
- **(prune)** don't delete tool versions referenced by tool stubs by @daandemeyer in [#10790](https://github.com/jdx/mise/pull/10790)
- **(schema)** support vars directives by @risu729 in [#10774](https://github.com/jdx/mise/pull/10774)
- **(schema)** allow tool alias versions by @JamBalaya56562 in [#10712](https://github.com/jdx/mise/pull/10712)
- **(search)** include aqua matches when registry misses by @jdx in [#10801](https://github.com/jdx/mise/pull/10801)
- **(system)** extract suffixless brew cask zip archives by @jdx in [#10800](https://github.com/jdx/mise/pull/10800)
- **(task)** show usage subcommand help by @jdx in [#10799](https://github.com/jdx/mise/pull/10799)
- **(vfox/http)** create parent directories in download helpers by @doraemonkeys in [#10767](https://github.com/jdx/mise/pull/10767)

### 📚 Documentation

- **(configuration)** fix precedence in visual by @kellinm in [#10779](https://github.com/jdx/mise/pull/10779)
- **(env)** clarify env_shell_expand setting by @jdx in [#10787](https://github.com/jdx/mise/pull/10787)
- **(errors)** replace TODO stub with error message reference by @jdx in [#10724](https://github.com/jdx/mise/pull/10724)
- **(templates)** update tera documentation links by @risu729 in [#10751](https://github.com/jdx/mise/pull/10751)
- clarify Go backend version pinning by @zeitlinger in [#10749](https://github.com/jdx/mise/pull/10749)

### 🧪 Testing

- **(oci)** make setuid mode test sandbox-portable by @TyceHerrman in [#10715](https://github.com/jdx/mise/pull/10715)
- **(oci)** skip metadata dir layer test if special permissions fail by @laozc in [#10816](https://github.com/jdx/mise/pull/10816)

### 📦️ Dependency Updates

- update rust docker digest to 1f0dbad by @renovate[bot] in [#10738](https://github.com/jdx/mise/pull/10738)
- update zizmorcore/zizmor-action action to v0.5.7 by @renovate[bot] in [#10742](https://github.com/jdx/mise/pull/10742)
- update docker/build-push-action digest to 53b7df9 by @renovate[bot] in [#10733](https://github.com/jdx/mise/pull/10733)
- update docker/login-action digest to c99871d by @renovate[bot] in [#10734](https://github.com/jdx/mise/pull/10734)
- update docker/setup-buildx-action digest to bb05f3f by @renovate[bot] in [#10736](https://github.com/jdx/mise/pull/10736)
- update docker/metadata-action digest to dc80280 by @renovate[bot] in [#10735](https://github.com/jdx/mise/pull/10735)
- update rust crate usage-lib to v3.5.3 by @renovate[bot] in [#10741](https://github.com/jdx/mise/pull/10741)
- update ubuntu:26.04 docker digest to b7f4819 by @renovate[bot] in [#10739](https://github.com/jdx/mise/pull/10739)
- update rust crate rmcp to v1.8.0 by @renovate[bot] in [#10744](https://github.com/jdx/mise/pull/10744)
- update rust crate env_logger to v0.11.11 by @renovate[bot] in [#10740](https://github.com/jdx/mise/pull/10740)
- update rattler by @renovate[bot] in [#10755](https://github.com/jdx/mise/pull/10755)
- update docker/login-action digest to af1e73f by @renovate[bot] in [#10761](https://github.com/jdx/mise/pull/10761)
- update namespacelabs/nscloud-cache-action digest to 58bf6e0 by @renovate[bot] in [#10737](https://github.com/jdx/mise/pull/10737)
- group phf renovate updates by @jdx in [#10784](https://github.com/jdx/mise/pull/10784)
- update dependency prettier to v3.8.5 by @renovate[bot] in [#10757](https://github.com/jdx/mise/pull/10757)
- lock file maintenance by @renovate[bot] in [#10781](https://github.com/jdx/mise/pull/10781)
- update rust crate nodejs-semver to v5 by @renovate[bot] in [#10747](https://github.com/jdx/mise/pull/10747)
- update actions/cache action to v6 by @renovate[bot] in [#10746](https://github.com/jdx/mise/pull/10746)
- update rust crate tera to v2 by @renovate[bot] in [#10756](https://github.com/jdx/mise/pull/10756)

### 📦 Registry

- prefer aqua for pi by @jdx in [#10727](https://github.com/jdx/mise/pull/10727)
- add twg (http:twg) by @ryan-pip in [#10780](https://github.com/jdx/mise/pull/10780)
- add apm ([github:microsoft/apm](https://github.com/microsoft/apm)) by @toyamarinyon in [#10766](https://github.com/jdx/mise/pull/10766)
- add nono ([github:nolabs-ai/nono](https://github.com/nolabs-ai/nono)) by @invadersmustdie in [#10675](https://github.com/jdx/mise/pull/10675)
- add miniserve ([aqua:svenstaro/miniserve](https://github.com/svenstaro/miniserve)) by @joealden in [#10760](https://github.com/jdx/mise/pull/10760)

### Chore

- **(ci)** replace stale PR comment action by @jdx in [#10804](https://github.com/jdx/mise/pull/10804)
- **(ci)** replace winget releaser action by @jdx in [#10807](https://github.com/jdx/mise/pull/10807)
- **(ci)** install mold via apt by @jdx in [#10803](https://github.com/jdx/mise/pull/10803)
- **(ci)** remove fig autocomplete release by @jdx in [#10805](https://github.com/jdx/mise/pull/10805)
- **(herdr)** use aqua backend for herdr by @himkt in [#10777](https://github.com/jdx/mise/pull/10777)
- **(release)** improve communique release notes by @jdx in [#10796](https://github.com/jdx/mise/pull/10796)

### New Contributors

- @daandemeyer made their first contribution in [#10790](https://github.com/jdx/mise/pull/10790)
- @doraemonkeys made their first contribution in [#10767](https://github.com/jdx/mise/pull/10767)
- @karteekiitg made their first contribution in [#10731](https://github.com/jdx/mise/pull/10731)
- @joealden made their first contribution in [#10760](https://github.com/jdx/mise/pull/10760)
- @eugencowie made their first contribution in [#10769](https://github.com/jdx/mise/pull/10769)
- @invadersmustdie made their first contribution in [#10675](https://github.com/jdx/mise/pull/10675)
- @toyamarinyon made their first contribution in [#10766](https://github.com/jdx/mise/pull/10766)
- @kellinm made their first contribution in [#10779](https://github.com/jdx/mise/pull/10779)
- @martinhiller made their first contribution in [#10778](https://github.com/jdx/mise/pull/10778)

## 📦 Aqua Registry Updates

### New Packages (2)

- [`Mic92/nixfmt-rs`](https://github.com/Mic92/nixfmt-rs)
- [`russellbanks/Komac`](https://github.com/russellbanks/Komac)

### Updated Packages (7)

- [`alibaba/open-code-review`](https://github.com/alibaba/open-code-review)
- [`google/keep-sorted`](https://github.com/google/keep-sorted)
- [`haskell/ghcup-hs`](https://github.com/haskell/ghcup-hs)
- [`kubescape/kubescape`](https://github.com/kubescape/kubescape)
- [`kyverno/kyverno`](https://github.com/kyverno/kyverno)
- [`nao1215/sqly`](https://github.com/nao1215/sqly)
- [`openai/codex`](https://github.com/openai/codex)