### PR TITLE
Update sponsor references for jdx.dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,9 +366,9 @@ jobs:
 
           ## 💚 Sponsor mise
 
-          mise is built by [@jdx](https://github.com/jdx) under [**en.dev**](https://en.dev) — an independent studio making developer tooling (mise, [aube](https://aube.en.dev/), and more). Development is funded by sponsors.
+          mise is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools. Development is funded by sponsors.
 
-          If mise saves you or your team time, please consider sponsoring at [en.dev](https://en.dev). Individual and company sponsorships keep mise fast, free, and independent.
+          If mise saves you or your team time, please consider sponsoring at [jdx.dev](https://jdx.dev/sponsors.html). Individual and company sponsorships keep mise fast, free, and independent.
           EOF
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, and <a href="https://coderabbit.link/mise">CodeRabbit</a>.<br>
+  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://37signals.com">37signals</a>.<br>
   <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://37signals.com">37signals</a>.<br>
-  <a href="https://en.dev/sponsors.html">View all sponsors</a>.
+  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, <a href="https://coderabbit.link/mise">CodeRabbit</a>, and <a href="https://supabase.com">Supabase</a>.<br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 
 <hr />
@@ -38,7 +38,7 @@
 </div>
 
 > [!TIP]
-> My latest project, [aube](https://aube.en.dev) just hit stable! It's the fastest Node.js package manager with strong security defaults and is compatible with npm/pnpm/yarn lockfiles!
+> My latest project, [aube](https://aube.jdx.dev) just hit stable! It's the fastest Node.js package manager with strong security defaults and is compatible with npm/pnpm/yarn lockfiles!
 
 ## What is it?
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, <a href="https://coderabbit.link/mise">CodeRabbit</a>, and <a href="https://supabase.com">Supabase</a>.<br>
+  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, and <a href="https://coderabbit.link/mise">CodeRabbit</a>.<br>
   <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 

--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -4,15 +4,15 @@
     <span aria-hidden="true">·</span>
     <span>Copyright © {{ year }}</span>
     <span aria-hidden="true">·</span>
-    <a class="EndevFooterLink" href="https://en.dev">
+    <a class="EndevFooterLink" href="https://jdx.dev">
       <img
         alt=""
         class="EndevFooterLogo"
         height="28"
-        src="https://github.com/endevco.png?size=96"
+        src="https://github.com/jdx.png?size=96"
         width="28"
       />
-      <span>en.dev</span>
+      <span>jdx.dev</span>
     </a>
   </footer>
 </template>

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -36,7 +36,7 @@ import { onMounted, ref } from "vue";
 
 const sponsors = ref([]);
 const error = ref(false);
-const footerTiers = new Set(["anchor", "premier", "partner"]);
+const footerTiers = new Set(["title", "premier", "partner"]);
 const sponsorFeedTimeoutMs = 5000;
 
 const sponsorItems = (items) => (Array.isArray(items) ? items : []);

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -24,7 +24,7 @@
           />
         </a>
       </div>
-      <a class="EndevSponsorsCta" href="https://en.dev/sponsors.html">
+      <a class="EndevSponsorsCta" href="https://jdx.dev/sponsors.html">
         View all sponsors
       </a>
     </div>
@@ -76,7 +76,7 @@ onMounted(async () => {
   );
 
   try {
-    const res = await fetch("https://en.dev/sponsors.json", {
+    const res = await fetch("https://jdx.dev/sponsors.json", {
       headers: { Accept: "application/json" },
       signal: controller.signal,
     });

--- a/docs/cli/patrons.md
+++ b/docs/cli/patrons.md
@@ -6,11 +6,11 @@
 
 Show the individuals supporting mise as Patron-tier members
 
-Lists the individuals on the Patron tier from &lt;<https://en.dev/patrons.json>>.
+Lists the individuals on the Patron tier from &lt;<https://jdx.dev/patrons.json>>.
 The list refreshes daily; supporting terminals will render each patron's
 name as a clickable link via OSC 8 hyperlinks.
 
-To appear here, become a patron at &lt;<https://en.dev>>.
+To appear here, become a patron at &lt;<https://jdx.dev/sponsors.html>>.
 
 ## Flags
 

--- a/docs/cli/sponsors.md
+++ b/docs/cli/sponsors.md
@@ -4,4 +4,4 @@
 - **Usage**: `mise sponsors`
 - **Source code**: [`src/cli/sponsors.rs`](https://github.com/jdx/mise/blob/main/src/cli/sponsors.rs)
 
-Show the companies sponsoring mise and the en.dev project family
+Show the companies sponsoring mise and the jdx.dev open source tools

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -11,7 +11,7 @@ This command uses the `watchexec` tool to watch for changes to files and rerun t
 It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
 
 For more advanced process management (daemon management, auto-restart, readiness checks,
-cron scheduling), see mise's sister project: https://pitchfork.en.dev
+cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 
 ## Arguments
 

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -9,7 +9,7 @@ The code for this is inside of the mise repository at [`./src/backend/npm.rs`](h
 
 This relies on having `npm` installed for resolving package versions.
 With the default `npm.package_manager = "auto"` setting, mise uses
-[`aube`](https://aube.en.dev/) for installing npm packages when it is installed,
+[`aube`](https://aube.jdx.dev/) for installing npm packages when it is installed,
 similar to how the pipx backend uses `uv` when available.
 If you use `aube`, `pnpm`, or `bun` as the package manager, that package manager
 must also be installed.
@@ -88,7 +88,7 @@ npm 11.16.0+.
 
 ### `aube`
 
-[`aube`](https://aube.en.dev/package-manager/lifecycle-scripts) follows the pnpm v11 build approval
+[`aube`](https://aube.jdx.dev/package-manager/lifecycle-scripts) follows the pnpm v11 build approval
 model: dependency lifecycle scripts are denied unless explicitly allowlisted. Use `allow_builds` for
 reviewed dependency builds:
 

--- a/docs/external-resources.md
+++ b/docs/external-resources.md
@@ -4,7 +4,7 @@ Links to articles, videos, and other resources that are relevant to mise.
 
 - 2025-04-09 - Keeping your Swift apps' sensitive data secret - <https://tuist.dev/blog/2025/04/09/secrets>
 - 2025-02-17 - hk: git hook manager that pairs well with mise - <https://hk.jdx.dev>
-- 2025-02-17 - pitchfork: process manager for developers that pairs well with mise - <https://pitchfork.en.dev>
+- 2025-02-17 - pitchfork: process manager for developers that pairs well with mise - <https://pitchfork.jdx.dev>
 - 2025-02-04 - A Mise guide for Swift developers - <https://tuist.dev/blog/2025/02/04/mise>
 - 2025-01-26 - devtools.fm: Jeff Dickey - Mise, Usage, and Pitchfork and the Future of Polyglot Tools - <https://www.devtools.fm/episode/129>
 - 2025-01-12 - [fr] Mise-En-Place: Simplifiez la Gestion de vos Environnements et Tâches – <https://blog.stephane-robert.info/docs/developper/autres-outils/mise-en-place/>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -193,7 +193,7 @@ You can leverage usage in file tasks to get auto-completion working, see [file t
 
 ## What is pitchfork?
 
-pitchfork (<https://pitchfork.en.dev/>) is a process manager for developers.
+pitchfork (<https://pitchfork.jdx.dev/>) is a process manager for developers.
 
 It handles daemon management with features like automatic restarts on failure, smart readiness checks, shell-based auto-start/stop when entering project directories, and cron-style scheduling for periodic tasks.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,12 +68,12 @@ hero:
     </div>
   </div>
 
-  <a class="landing-aube" href="https://aube.en.dev/" aria-label="Try aube">
+  <a class="landing-aube" href="https://aube.jdx.dev/" aria-label="Try aube">
     <div>
       <p class="landing-kicker">Chef's Special</p>
       <h2>Meet <em>aube</em>, a fast Node.js package manager.</h2>
       <p>
-        New from en.dev by @jdx. aube uses your existing lockfile and is ready
+        New from @jdx. aube uses your existing lockfile and is ready
         to try in beta.
       </p>
     </div>

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -575,7 +575,7 @@ Removes a shell alias
 .RE
 .TP
 \fBsponsors\fR
-Show the companies sponsoring mise and the en.dev project family
+Show the companies sponsoring mise and the jdx.dev open source tools
 .TP
 \fBsync\fR
 Synchronize tools from other version managers with mise
@@ -2502,11 +2502,11 @@ If not specified, all tools in global and local configs will be shown
 .SH "MISE PATRONS"
 Show the individuals supporting mise as Patron\-tier members
 
-Lists the individuals on the Patron tier from <https://en.dev/patrons.json>.
+Lists the individuals on the Patron tier from <https://jdx.dev/patrons.json>.
 The list refreshes daily; supporting terminals will render each patron's
 name as a clickable link via OSC 8 hyperlinks.
 
-To appear here, become a patron at <https://en.dev>.
+To appear here, become a patron at <https://jdx.dev/sponsors.html>.
 .PP
 \fBUsage:\fR mise patrons [OPTIONS]
 .PP
@@ -4306,7 +4306,7 @@ This command uses the `watchexec` tool to watch for changes to files and rerun t
 It must be installed for this command to work, but you can install it with `mise use \-g watchexec@latest`.
 
 For more advanced process management (daemon management, auto\-restart, readiness checks,
-cron scheduling), see mise's sister project: https://pitchfork.en.dev
+cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 .PP
 \fBUsage:\fR mise watch [OPTIONS] [<TASK>] [<ARGS>] ...
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2407,11 +2407,11 @@ cmd patrons help="Show the individuals supporting mise as Patron-tier members" {
     long_help #"""
 Show the individuals supporting mise as Patron-tier members
 
-Lists the individuals on the Patron tier from <https://en.dev/patrons.json>.
+Lists the individuals on the Patron tier from <https://jdx.dev/patrons.json>.
 The list refreshes daily; supporting terminals will render each patron's
 name as a clickable link via OSC 8 hyperlinks.
 
-To appear here, become a patron at <https://en.dev>.
+To appear here, become a patron at <https://jdx.dev/sponsors.html>.
 """#
     after_long_help #"""
 Examples:
@@ -3350,7 +3350,7 @@ Examples:
         arg <shell_alias> help="The alias to remove"
     }
 }
-cmd sponsors help="Show the companies sponsoring mise and the en.dev project family"
+cmd sponsors help="Show the companies sponsoring mise and the jdx.dev open source tools"
 cmd sync subcommand_required=#true help="Synchronize tools from other version managers with mise" {
     cmd node help="Symlinks all tool versions from an external tool into mise" {
         long_help #"""
@@ -4342,7 +4342,7 @@ This command uses the `watchexec` tool to watch for changes to files and rerun t
 It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
 
 For more advanced process management (daemon management, auto-restart, readiness checks,
-cron scheduling), see mise's sister project: https://pitchfork.en.dev
+cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 """#
     after_long_help #"""
 Examples:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,7 +28,7 @@ contact:
   - https://github.com/jdx/mise/discussions
   - https://phanective.org
 donation:
-  - https://github.com/sponsors/jdx
+  - https://jdx.dev/sponsors.html
 
 grade: stable
 confinement: classic

--- a/src/cli/patrons.rs
+++ b/src/cli/patrons.rs
@@ -9,11 +9,11 @@ use crate::{dirs, duration, file};
 
 /// Show the individuals supporting mise as Patron-tier members
 ///
-/// Lists the individuals on the Patron tier from <https://en.dev/patrons.json>.
+/// Lists the individuals on the Patron tier from <https://jdx.dev/patrons.json>.
 /// The list refreshes daily; supporting terminals will render each patron's
 /// name as a clickable link via OSC 8 hyperlinks.
 ///
-/// To appear here, become a patron at <https://en.dev>.
+/// To appear here, become a patron at <https://jdx.dev/sponsors.html>.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Patrons {
@@ -43,8 +43,8 @@ struct Patron {
     url: Option<String>,
 }
 
-const PATRONS_URL: &str = "https://en.dev/patrons.json";
-const SPONSOR_URL: &str = "https://en.dev";
+const PATRONS_URL: &str = "https://jdx.dev/patrons.json";
+const SPONSOR_URL: &str = "https://jdx.dev/sponsors.html";
 const CACHE_TTL: Duration = duration::DAILY;
 
 impl Patrons {

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -1,13 +1,13 @@
 use eyre::Result;
 
-/// Show the companies sponsoring mise and the en.dev project family
+/// Show the companies sponsoring mise and the jdx.dev open source tools
 #[derive(Debug, clap::Args)]
 pub struct Sponsors;
 
 impl Sponsors {
     pub fn run(&self) -> Result<()> {
         miseprintln!(
-            "mise and the en.dev project family are sponsored by:\n\n  37signals - https://37signals.com\n\nView all sponsors: https://en.dev/sponsors.html"
+            "mise and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -7,7 +7,7 @@ pub struct Sponsors;
 impl Sponsors {
     pub fn run(&self) -> Result<()> {
         miseprintln!(
-            "mise and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "mise and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -7,7 +7,7 @@ pub struct Sponsors;
 impl Sponsors {
     pub fn run(&self) -> Result<()> {
         miseprintln!(
-            "mise and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "mise and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 /// It must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.
 ///
 /// For more advanced process management (daemon management, auto-restart, readiness checks,
-/// cron scheduling), see mise's sister project: https://pitchfork.en.dev
+/// cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 #[derive(Debug, clap::Args)]
 #[clap(visible_alias = "w", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Watch {

--- a/xtasks/fig/src/mise.ts
+++ b/xtasks/fig/src/mise.ts
@@ -4055,7 +4055,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "sponsors",
       description:
-        "Show the companies sponsoring mise and the en.dev project family",
+        "Show the companies sponsoring mise and the jdx.dev open source tools",
     },
     {
       name: "sync",


### PR DESCRIPTION
## Summary
- list Entire first in the README and sponsors command
- point sponsor and patron links at jdx.dev
- update docs sponsor components, footer copy, release blurb, and generated CLI docs

## Tests
- git diff --check
- npm run docs:build
- cargo run -q -p mise -- sponsors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, URLs, and static sponsor output only; no runtime logic beyond patron fetch URLs and sponsor tier filtering.
> 
> **Overview**
> Repoints **sponsorship and maintainer branding** from **en.dev** to **jdx.dev** across the repo, with **entire.io** called out as title sponsor.
> 
> **README**, docs site footer/sponsors widget, and **release notes** sponsor blurb now link to `jdx.dev` (and `jdx.dev/sponsors.html`). The sponsors UI loads `jdx.dev/sponsors.json` and treats the **`title`** tier (replacing **`anchor`**) for footer logos.
> 
> **CLI behavior and help** change: `mise patrons` fetches `jdx.dev/patrons.json` and points patrons at `jdx.dev/sponsors.html`; `mise sponsors` lists **entire.io** first alongside 37signals and uses jdx.dev wording. Matching updates land in **`mise.usage.kdl`**, generated **`docs/cli/*`**, **`man/man1/mise.1`**, and **`xtasks/fig`**.
> 
> Related product links (**aube**, **pitchfork**) move from `*.en.dev` to **`*.jdx.dev`** in docs and help text. **snapcraft** donation metadata adds `jdx.dev/sponsors.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa23f54c7be6df3c3f1ea67393b2e28052ba168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated sponsored/patron and support references across the website, CLI help, and man/help text to use **jdx.dev**, including refreshed wording/branding.
  * Switched all **Pitchfork** links to **pitchfork.jdx.dev** and updated **aube** links to **aube.jdx.dev**.
  * Updated “View all sponsors” and sponsor/patron JSON links to **jdx.dev** and included **entire.io** in the sponsor credits.
* **Chores**
  * Refreshed release-workflow-generated sponsor credits and snap donation metadata to point to **jdx.dev**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->