### PR TITLE
registry: prefer aqua for pi

### DIFF
--- a/registry/pi.toml
+++ b/registry/pi.toml
@@ -1,6 +1,6 @@
 backends = [
-  "github:earendil-works/pi",
   "aqua:earendil-works/pi",
+  "github:earendil-works/pi",
   "npm:@earendil-works/pi-coding-agent",
 ]
 description = "Pi is a minimal terminal coding harness"


### PR DESCRIPTION
## Summary
- move `aqua:earendil-works/pi` ahead of `github:earendil-works/pi` for the `pi` registry shorthand
- align the backend order with #9792, whose body said aqua should be the default after the Earendil Works move

## Context
I searched for related `pi` backend discussions and only found #10439 as relevant. That discussion explains the current GitHub-first behavior, but does not give a reason to prefer GitHub over aqua.

This does not change the Windows workaround from #10439, since aqua uses the same upstream GitHub release assets. It just restores the preferred registry ordering when an aqua entry exists.

## Testing
- `cargo test registry::tests::test_registry_iteration_is_sorted`
- `cargo run --quiet -- registry pi` -> `aqua:earendil-works/pi github:earendil-works/pi npm:@earendil-works/pi-coding-agent`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line registry ordering change with no code or security impact; users can still override with explicit backend syntax.
> 
> **Overview**
> **Reorders the `pi` registry backends** so `aqua:earendil-works/pi` is listed before `github:earendil-works/pi`. For shorthand `mise use pi` (and similar), mise now tries the aqua backend first instead of GitHub releases.
> 
> The npm fallback entry is unchanged. This only affects default backend selection order, not install mechanics or the Windows-related behavior discussed elsewhere for the same upstream assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018835a58758fa0735936cd1ca83a7741c8c73cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the backend listing order in the registry configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->