### PR TITLE
fix(env): match redaction wildcards as globs

### DIFF
--- a/e2e/tasks/test_task_redactions
+++ b/e2e/tasks/test_task_redactions
@@ -31,6 +31,16 @@ run = 'echo secret: \$SECRET_FOO'
 EOF
 assert "mise run a" "secret: [redacted]"
 
+cat <<'TOML' >mise.toml
+redactions = ["*_KEY"]
+[env]
+DISABLE_FEEDBACK_SURVEY = "1"
+
+[tasks.a]
+run = 'echo "version 1.2.3"'
+TOML
+assert "mise run a" "version 1.2.3"
+
 cat <<EOF >mise.toml
 [env]
 SECRET= {value = "my_secret", redact = true}

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -6,6 +6,7 @@ use crate::config::Config;
 use crate::env_diff::EnvMap;
 use crate::shell::{ShellType, get_shell};
 use crate::toolset::{InstallOptions, Toolset, ToolsetBuilder};
+use crate::wildcard::wildcard_match;
 use indexmap::IndexSet;
 
 /// Exports env vars to activate mise a single time
@@ -231,24 +232,9 @@ impl Env {
     }
 
     fn should_include_key(&self, key: &str, redacted_keys: &IndexSet<String>) -> bool {
-        // Check if key matches any redaction pattern (supporting wildcards)
-        redacted_keys.iter().any(|pattern| {
-            if pattern.contains('*') {
-                // Handle wildcard patterns
-                if pattern == "*" {
-                    true
-                } else if let Some(prefix) = pattern.strip_suffix('*') {
-                    key.starts_with(prefix)
-                } else if let Some(suffix) = pattern.strip_prefix('*') {
-                    key.ends_with(suffix)
-                } else {
-                    // Pattern has * in the middle, not supported yet
-                    false
-                }
-            } else {
-                key == pattern
-            }
-        })
+        redacted_keys
+            .iter()
+            .any(|pattern| wildcard_match(key, pattern))
     }
 }
 

--- a/src/wildcard.rs
+++ b/src/wildcard.rs
@@ -1,5 +1,3 @@
-use std::str::Chars;
-
 pub struct Wildcard {
     patterns: Vec<String>,
 }
@@ -13,7 +11,7 @@ impl Wildcard {
 
     pub fn match_any(&self, input: &str) -> bool {
         for pattern in &self.patterns {
-            if wildcard_match_single(input, pattern) {
+            if wildcard_match(input, pattern) {
                 return true;
             }
         }
@@ -21,47 +19,81 @@ impl Wildcard {
     }
 }
 
-fn wildcard_match_single(input: &str, wildcard: &str) -> bool {
-    let mut input_chars = input.chars();
-    let mut wildcard_chars = wildcard.chars();
+pub(crate) fn wildcard_match(input: &str, wildcard: &str) -> bool {
+    let input_chars: Vec<_> = input.chars().collect();
+    let wildcard_chars: Vec<_> = wildcard.chars().collect();
+    let mut input_idx = 0;
+    let mut wildcard_idx = 0;
+    let mut star_idx = None;
+    let mut star_input_idx = 0;
 
-    loop {
-        match (input_chars.next(), wildcard_chars.next()) {
-            (Some(input_char), Some(wildcard_char)) => {
-                if wildcard_char == '*' {
-                    return wildcard_match_single_star(input_chars, wildcard_chars);
-                } else if wildcard_char == '?' || input_char == wildcard_char {
-                    continue;
-                } else {
-                    return false;
-                }
-            }
-            (None, None) => return true,
-            (None, Some(wildcard_char)) => return wildcard_char == '*',
-            (Some(_), None) => return false,
+    while input_idx < input_chars.len() {
+        if wildcard_idx < wildcard_chars.len()
+            && (wildcard_chars[wildcard_idx] == '?'
+                || wildcard_chars[wildcard_idx] == input_chars[input_idx])
+        {
+            input_idx += 1;
+            wildcard_idx += 1;
+        } else if wildcard_idx < wildcard_chars.len() && wildcard_chars[wildcard_idx] == '*' {
+            star_idx = Some(wildcard_idx);
+            wildcard_idx += 1;
+            star_input_idx = input_idx;
+        } else if let Some(idx) = star_idx {
+            wildcard_idx = idx + 1;
+            star_input_idx += 1;
+            input_idx = star_input_idx;
+        } else {
+            return false;
         }
     }
+
+    while wildcard_idx < wildcard_chars.len() && wildcard_chars[wildcard_idx] == '*' {
+        wildcard_idx += 1;
+    }
+
+    wildcard_idx == wildcard_chars.len()
 }
 
-fn wildcard_match_single_star(mut input_chars: Chars, mut wildcard_chars: Chars) -> bool {
-    loop {
-        match wildcard_chars.next() {
-            Some(wildcard_char) => {
-                if wildcard_char == '*' {
-                    continue;
-                } else {
-                    while let Some(input_char) = input_chars.next() {
-                        if wildcard_match_single(
-                            &input_char.to_string(),
-                            &wildcard_char.to_string(),
-                        ) {
-                            return wildcard_match_single_star(input_chars, wildcard_chars);
-                        }
-                    }
-                    return false;
-                }
-            }
-            None => return true,
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wildcard_match_exact() {
+        assert!(wildcard_match("FOO", "FOO"));
+        assert!(!wildcard_match("FOO", "FOOBAR"));
+        assert!(!wildcard_match("FOO", "BAR"));
+    }
+
+    #[test]
+    fn test_wildcard_match_star() {
+        assert!(wildcard_match("SECRET_FOO", "SECRET*"));
+        assert!(wildcard_match("API_KEY", "*_KEY"));
+        assert!(wildcard_match("AUTH_PROD_KEY", "AUTH_*_KEY"));
+        assert!(wildcard_match("AUTH__KEY", "AUTH_*_KEY"));
+        assert!(wildcard_match("ANYTHING", "*"));
+        assert!(wildcard_match("", "*"));
+        assert!(!wildcard_match("AUTH_KEY", "AUTH_*_KEY"));
+    }
+
+    #[test]
+    fn test_wildcard_match_question() {
+        assert!(wildcard_match("FOO", "F?O"));
+        assert!(!wildcard_match("FO", "F?O"));
+    }
+
+    #[test]
+    fn test_wildcard_match_does_not_treat_suffix_as_subsequence() {
+        assert!(!wildcard_match("DISABLE_FEEDBACK_SURVEY", "*_KEY"));
+        assert!(!wildcard_match("CLOUDSDK_CORE_DISABLE_PROMPTS", "*_CREDS"));
+        assert!(!wildcard_match("NETWORK_CLIENTS_UPDATE", "*_TOKEN"));
+    }
+
+    #[test]
+    fn test_wildcard_match_multiple_stars_backtracks() {
+        assert!(wildcard_match("abcde", "a*d?"));
+        assert!(wildcard_match("abcde", "a*?e"));
+        assert!(wildcard_match("abcde", "*b*d*"));
+        assert!(!wildcard_match("abcde", "a*c?f"));
     }
 }


### PR DESCRIPTION
## Summary
- replace redaction wildcard matching with glob-style backtracking instead of subsequence matching
- reuse the same matcher for `mise env --redacted` filtering
- add a regression for `*_KEY` not matching `DISABLE_FEEDBACK_SURVEY` and redacting `1` from task output

Refs https://github.com/jdx/mise/discussions/10721

## Tests
- `cargo fmt -- --check`
- `cargo test wildcard`
- `mise run test:e2e e2e/tasks/test_task_redactions`
- `mise run test:e2e e2e/cli/test_env_redacted_flags`
- `git diff --check`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core redaction matching used for secrets in task output and `mise env --redacted`; behavior shifts for mid-pattern `*` but is covered by new regression tests.
> 
> **Overview**
> Fixes **over-redaction** where patterns like `*_KEY` were matched like substrings/subsequences, so unrelated env values (e.g. `1` inside `version 1.2.3`) could be scrubbed from task output.
> 
> **`wildcard_match`** is rewritten as **glob-style matching** with `*` backtracking and `?` support; `Wildcard::match_any` and **`mise env --redacted`** key filtering now share this logic instead of prefix/suffix-only rules in `env.rs`.
> 
> Adds unit tests for suffix patterns that must **not** match, multi-star patterns, and an e2e case with `redactions = ["*_KEY"]` asserting task output stays `version 1.2.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996a09c2137b541507934fc35275eb1c546ce082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->