### PR TITLE
fix: extend match of Linux musl asset for Android

### DIFF
--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -122,10 +122,6 @@ impl DetectedPlatform {
 static OS_PATTERNS: LazyLock<Vec<(AssetOs, Regex)>> = LazyLock::new(|| {
     vec![
         (
-            AssetOs::Android,
-            Regex::new(r"(?i)(?:\b|_)(?:android)(?:\b|_)").unwrap(),
-        ),
-        (
             AssetOs::Linux,
             Regex::new(r"(?i)(?:\b|_)(?:linux|manylinux(?:[0-9_]+)?|musllinux(?:[0-9_]+)?|ubuntu|debian|fedora|centos|rhel|alpine|arch)(?:\b|_|32|64|-)")
                 .unwrap(),
@@ -137,6 +133,10 @@ static OS_PATTERNS: LazyLock<Vec<(AssetOs, Regex)>> = LazyLock::new(|| {
         (
             AssetOs::Windows,
             Regex::new(r"(?i)(?:\b|_)(?:mingw-w64|win(?:32|64|dows)?)(?:\b|_)").unwrap(),
+        ),
+        (
+            AssetOs::Android,
+            Regex::new(r"(?i)(?:\b|_)(?:android|linux|musllinux(?:[0-9_]+)?)(?:\b|_)").unwrap(),
         ),
     ]
 });
@@ -442,6 +442,9 @@ impl AssetPicker {
         if self.target_os == "linux" || self.target_os == "windows" {
             score += self.score_libc_match(asset);
         }
+        if self.target_os == "linux" || self.target_os == "android" {
+            score += self.score_android_match(asset);
+        }
         score += self.score_format_preferences(asset);
         score += self.score_preferred_name_match(asset);
         score += self.score_build_penalties(asset);
@@ -479,14 +482,18 @@ impl AssetPicker {
 
     fn score_os_match(&self, asset: &str) -> i32 {
         let asset = self.platform_part(asset);
+        let mut asset_with_platform_mismatch = false;
         for (os, pattern) in OS_PATTERNS.iter() {
             if pattern.is_match(asset) {
-                return if os.matches_target(&self.target_os) {
-                    100
+                if os.matches_target(&self.target_os) {
+                    return 100;
                 } else {
-                    -100
+                    asset_with_platform_mismatch = true;
                 };
             }
+        }
+        if asset_with_platform_mismatch {
+            return -100;
         }
         // Check for Windows-specific file extensions (.msi, .exe)
         // These should be penalized on non-Windows platforms
@@ -540,6 +547,30 @@ impl AssetPicker {
             }
         }
         0
+    }
+
+    /// Android binaries tend to work in the following order:
+    /// - android: Pre-compiled targeting Bionic C lib and considering differences from Linux
+    /// - musl: Statically compiled without linking issues, but tend to assume Linux standards
+    /// - gnu: Assumes typical glibc which don't match Bionic C lib
+    ///
+    /// If target OS is not Android scoring is penalized as `linux-android` might tie with other
+    /// scoring if arch segments are present
+    fn score_android_match(&self, asset: &str) -> i32 {
+        let asset = self.platform_part(asset);
+        match (asset.contains("android"), self.target_os.as_str()) {
+            (true, "android") => 20,
+            (false, "android") => {
+                for (libc, pattern) in LIBC_PATTERNS.iter() {
+                    if pattern.is_match(asset) {
+                        return if *libc == AssetLibc::Musl { 10 } else { -10 };
+                    }
+                }
+                0
+            }
+            (true, _) => -200,
+            (false, _) => 0,
+        }
     }
 
     fn score_format_preferences(&self, asset: &str) -> i32 {
@@ -1555,6 +1586,22 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
     }
 
     #[test]
+    fn test_asset_picker_functionality_android_fallback_to_linux_musl() {
+        // rust triplet platforms contain linux as segment in filname for Android binaries
+        let assets = vec![
+            "tool-1.0.0-aarch64-apple-darwin.zip".to_string(),
+            "tool-1.0.0-aarch64-pc-windows-gnu.zip".to_string(),
+            "tool-1.0.0-aarch64-pc-windows-msvc.zip".to_string(),
+            "tool-1.0.0-aarch64-unknown-linux-gnu.zip".to_string(),
+            "tool-1.0.0-aarch64-unknown-linux-musl.zip".to_string(),
+        ];
+        let picked = AssetPicker::with_libc("android".to_string(), "aarch64".to_string(), None)
+            .pick_best_asset(&assets)
+            .unwrap();
+        assert_eq!(picked, "tool-1.0.0-aarch64-unknown-linux-musl.zip");
+    }
+
+    #[test]
     fn test_asset_scoring() {
         let picker = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None);
 
@@ -1571,13 +1618,17 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
             score_linux > score_linux_arm,
             "x86_64 should score higher than arm64"
         );
+        assert!(
+            score_linux > score_android,
+            "Linux should score higher than Android"
+        );
         // Architecture mismatch should result in negative score
         assert!(
             score_linux_arm < 0,
             "Architecture mismatch should be negative, got {}",
             score_linux_arm
         );
-        // Android Linux triplet should have a negative score
+        // Platform mismatch should result in negative score
         assert!(
             score_android < 0,
             "Platform mismatch should be negative, got {}",

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -726,6 +726,9 @@ pub fn detect_platform_from_url(url: &str) -> Option<DetectedPlatform> {
 
     for (os, pattern) in OS_PATTERNS.iter() {
         if pattern.is_match(&filename) {
+            if filename.contains("android") && *os == AssetOs::Linux {
+                continue;
+            }
             detected_os = Some(*os);
             break;
         }
@@ -1672,6 +1675,14 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
         assert_eq!(platform.os, AssetOs::Windows);
         assert_eq!(platform.arch, AssetArch::X64);
         assert_eq!(platform.to_platform_string(), "windows-x64");
+
+        // Test Android URL
+        //
+        let url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.9/zoxide-0.9.9-aarch64-linux-android.tar.gz";
+        let platform = detect_platform_from_url(url).unwrap();
+        assert_eq!(platform.os, AssetOs::Android);
+        assert_eq!(platform.arch, AssetArch::Arm64);
+        assert_eq!(platform.to_platform_string(), "android-arm64");
 
         // Test URL without platform info
         let url = "https://example.com/generic-tool.tar.gz";


### PR DESCRIPTION
Previously we added Android as a valid platform for asset scoring by requiring packages to publish an `*-android-*` artifact. This is expected, as these binaries take in consideration differences between Linux and Android.

Not every package requires Android specific compilation to work on Termux tho. Often, `musl` binaries might work with Android/Termux environment if it's statically linked. Typically tho, they have tend to have network issues specially arround DNS resolution, yet it might work as is if there is no network.

An example, `github:starship/starship`, `github:sharkdp/bat` and `github:jdx/hk` which don't publish Android specific assets, but their `linux-musl` satic binaries can be executed on Termux.

This commit expands the initial Android asset matcher to also consider `linux-musl` as a valid target. For this to work, `OS_PATTERNS` for Android was expanded to allow `linux-musl`, which required some rework on the scoring logic for Linux. Now, the scoring matcher will not stop on the first asset and target_os combination, and fall through to the next matchers.

It will only bail if there was a regex matching the asset file name but no other item matched regex and target_os. This retain effectively the same logic as before, now allowing it the fall-through on similar regex for different OS. To avoid potential performance loss on more common patterns, the Android regex was moved to last of the list to be the last fall-through matcher.

Now that `linux-musl` are a valid target for 2 different platforms, there was an additional boost/demotion logic required, otherwise assets might tie. For Linux target OS, we actually demote any Android marked asset to avoid ties, and for Android targets we boost the score.

Typically, Android/Termux can work with static Linux musl, but will fail with SEGV on GNU glibc binaries due to shared libraries not matching the ABI. The Android boost score take it in consideration and increases the preference in the following order: `*android*`, `*musl*` and `*gnu*`.

Scoring for Linux remains the same, ignoring any Android asset and using the correct `MISE_LIBC` defined.

This will allow Android users to download static musl binaries as a fallback if an Android targeted asset are not published, but there is no guarantee that the upstream package will work as is. If there are issues running Linux musl binaries on Termux, it should be reported upstream. Mise will pickup automatically new releases when they start publishing Android specific assets.

Tested repositories on Termux with this commit:
  - `mise x github:bltavares/opkssh -- opkssh login`
  Downloads Android release from goreleaser and works as expected
  - `mise x github:bltavares/rotz -- rotz install`
  Downloads Android release from cross and works as expected
  - `mise x github:sharkdp/bat -- bat README.md`
  Downloads Linux musl release and works as expected
  - `mise x github:starship/starship -- starship prompt`
  Downloads Linux musl release and works as expected
  - `mise x github:jdx/usage -- usage help`
  Downloads Linux musl release and works as expected
  - `mise x github:jdx/hk -- hk --version`
  Downloads Linux musl release and run, except for network calls (typical Linux on Android issue which requires a targeted Android release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset selection by correctly handling Android artifacts that also include Linux or musl indicators.
  * Refined platform scoring and OS token matching to boost accurate matches and apply stronger mismatch penalties.
  * Improved fallback behavior for Android targets and enhanced platform detection to avoid misclassifying Android artifacts as Linux.
* **Tests**
  * Added and updated test coverage for Android fallback, scoring order/penalties, and platform detection outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->