### PR TITLE
docs: clarify Go backend version pinning

### DIFF
--- a/docs/dev-tools/backends/go.md
+++ b/docs/dev-tools/backends/go.md
@@ -29,6 +29,22 @@ $ hivemind --help
 Hivemind version 1.1.0
 ```
 
+You can also pin a specific Go module version, including an unreleased
+pseudo-version:
+
+```toml
+[tools]
+"go:github.com/grafana/oats" = "v0.7.1-0.20260703092802-96201f1b8136"
+```
+
+If you need to resolve an unreleased revision directly from VCS instead of the
+module proxy, combine the pinned version with [`install_env`](#install_env):
+
+```toml
+[tools]
+"go:github.com/grafana/oats" = { version = "v0.7.1-0.20260703092802-96201f1b8136", install_env = { GOPROXY = "direct", GONOSUMDB = "github.com/grafana/oats" } }
+```
+
 ## Tool Options
 
 The following [tool-options](/dev-tools/#tool-options) are available for the `go` backend—these


### PR DESCRIPTION
## Summary
- add an example showing a Go backend tool pinned to a pseudo-version
- show how to pair that with `install_env` when direct VCS resolution is needed

## Why
This makes it clearer how to target unreleased Go revisions without cloning a repo in consumer CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Go backend guidance with examples for pinning a specific Go module version in `mise.toml`.
  * Added instructions for using unreleased pseudo-versions and resolving unreleased VCS revisions directly without the module proxy.
  * Included environment settings examples for direct module fetching and checksum handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->