### PR TITLE
registry: add miniserve (aqua:svenstaro/miniserve)

### DIFF
--- a/registry/miniserve.toml
+++ b/registry/miniserve.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:svenstaro/miniserve"]
+description = "For when you really just want to serve some files over HTTP right now!"
+test = { cmd = "miniserve --version", expected = "miniserve {{version}}" }


### PR DESCRIPTION
https://github.com/svenstaro/miniserve - 7.7k stars, fast + has a nice directory listing page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new registry entry for Miniserve, making it available as a supported backend.
  * Included a short description and a version check to verify the installation responds correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->