### PR TITLE
registry: add apm (github:microsoft/apm)

### DIFF
--- a/registry/apm.toml
+++ b/registry/apm.toml
@@ -1,0 +1,3 @@
+backends = ["github:microsoft/apm"]
+description = "Agent Package Manager"
+test = { cmd = "apm --version", expected = "{{version}}" }


### PR DESCRIPTION
## Summary

Add Microsoft APM to the mise registry via `github:microsoft/apm`.

APM provides prebuilt GitHub release archives for macOS, Linux, and Windows.
The existing GitHub backend installs it correctly with the full backend name.

## Backend choice

- APM is not currently in `aquaproj/aqua-registry`
- `github:microsoft/apm` uses mise's preferred GitHub release backend
- No custom asset matching is needed

## Popularity

- GitHub: `microsoft/apm` has about 3.1k stars
- Latest release: v0.23.1
- Active Microsoft project for managing AI agent packages

## Validation

- `mise use github:microsoft/apm@latest`
- `cargo run -- test-tool apm`

```text
mise apm: OK
Agent Package Manager (APM) CLI version 0.23.1 (d1d926d)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new registry entry for Agent Package Manager, making it available for installation and version checks.
  * Included a built-in version verification command to help confirm correct setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->