### PR TITLE
fix(vfox/http): create parent directories in download helpers

### DIFF
--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -204,6 +204,11 @@ async fn download_file(lua: &Lua, input: MultiValue) -> Result<()> {
     })
     .await
     .into_lua_err()?;
+    // Create the parent directory so plugins don't have to shell out to `mkdir`
+    // before downloading into a fresh install path.
+    if let Some(parent) = std::path::Path::new(&path).parent() {
+        tokio::fs::create_dir_all(parent).await.into_lua_err()?;
+    }
     let mut file = tokio::fs::File::create(&path).await.into_lua_err()?;
     tokio::io::AsyncWriteExt::write_all(&mut file, &bytes)
         .await
@@ -320,6 +325,16 @@ async fn try_download_file(lua: &Lua, input: MultiValue) -> Result<MultiValue> {
             ]));
         }
     };
+    // Create the parent directory so plugins don't have to shell out to `mkdir`
+    // before downloading into a fresh install path.
+    if let Some(parent) = std::path::Path::new(&path).parent()
+        && let Err(e) = tokio::fs::create_dir_all(parent).await
+    {
+        return Ok(MultiValue::from_vec(vec![
+            Value::Nil,
+            Value::String(lua.create_string(e.to_string())?),
+        ]));
+    }
     let mut file = match tokio::fs::File::create(&path).await {
         Ok(f) => f,
         Err(e) => {
@@ -892,5 +907,71 @@ mod tests {
         .exec_async()
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_try_download_file_creates_parent_dirs() {
+        let server = MockServer::start().await;
+        let test_content = "nested content";
+
+        Mock::given(method("GET"))
+            .and(path("/file.txt"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(test_content))
+            .mount(&server)
+            .await;
+
+        let lua = Lua::new();
+        mod_http(&lua).unwrap();
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // Target a nested directory that does not exist yet.
+        let file_path = temp_dir.path().join("a").join("b").join("downloaded.txt");
+        let path_str = file_path.to_string_lossy().to_string();
+        let url = server.uri() + "/file.txt";
+
+        lua.load(mlua::chunk! {
+            local http = require("http")
+            local ok, err = http.try_download_file({ url = $url, headers = {} }, $path_str)
+            assert(ok == true, "expected true, got: " .. tostring(ok))
+            assert(err == nil, "expected no error, got: " .. tostring(err))
+        })
+        .exec_async()
+        .await
+        .unwrap();
+
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, test_content);
+    }
+
+    #[tokio::test]
+    async fn test_download_file_creates_parent_dirs() {
+        let server = MockServer::start().await;
+        let test_content = "nested content";
+
+        Mock::given(method("GET"))
+            .and(path("/file.txt"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(test_content))
+            .mount(&server)
+            .await;
+
+        let lua = Lua::new();
+        mod_http(&lua).unwrap();
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("x").join("y").join("downloaded.txt");
+        let path_str = file_path.to_string_lossy().to_string();
+        let url = server.uri() + "/file.txt";
+
+        lua.load(mlua::chunk! {
+            local http = require("http")
+            local err = http.download_file({ url = $url, headers = {} }, $path_str)
+            assert(err == nil, "expected no error, got: " .. tostring(err))
+        })
+        .exec_async()
+        .await
+        .unwrap();
+
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, test_content);
     }
 }


### PR DESCRIPTION
Related discussion: https://github.com/jdx/mise/discussions/10561 (Windows Yarn 2+ install failure).

## What

`http.download_file` / `http.try_download_file` wrote to the target path with a bare `File::create`, which fails if the parent directory does not exist. Callers had to `mkdir` the directory themselves before downloading.

This change creates the target's parent directory (`create_dir_all`) before writing, so plugins can download straight into a fresh install path.

## Why

While fixing the Windows Yarn Berry install failure (discussion #10561), the natural cleanup was for the `vfox-yarn` plugin to download `yarn.js` via `http.download_file` instead of shelling out to `curl`/`wget`. That plugin lives in an upstream repo (`mise-plugins/vfox-yarn`) and is vendored here, so the plugin-side fix is submitted separately.

This helper change makes that pattern work without the plugin also having to shell out to `mkdir` first, and benefits any future plugin that downloads into a not-yet-created directory.

## Compatibility

- `create_dir_all` is a no-op when the directory already exists, so every existing caller behaves exactly as before.
- A bare filename (no parent) is handled safely — `Path::parent()` yields `""` and `create_dir_all("")` is a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Downloads now work even when the target folder does not already exist.
  * Errors are handled more gracefully when creating missing parent folders fails.
  * Improved reliability for saving files into nested directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->