### PR TITLE
fix(cli): support `--run-windows` for `task add`

### DIFF
--- a/e2e/tasks/test_task_add
+++ b/e2e/tasks/test_task_add
@@ -5,6 +5,11 @@ assert "cat mise.toml" '[tasks.pre-commit]
 depends = ["test", "render"]
 run = "echo pre-commit"'
 
+mise tasks add os --run-windows "echo windows" -- echo unix
+assert_contains "cat mise.toml" '[tasks.os]
+run = "echo unix"
+run_windows = "echo windows"'
+
 mise tasks add --file pre-commit --depends "test" --depends "render" -- echo pre-commit
 assert "cat mise-tasks/pre-commit" '#!/usr/bin/env bash
 #MISE depends=["test", "render"]

--- a/src/cli/tasks/add.rs
+++ b/src/cli/tasks/add.rs
@@ -213,6 +213,9 @@ impl TasksAdd {
             if !self.run.is_empty() {
                 task.insert("run", shell_words::join(&self.run).into());
             }
+            if let Some(run_windows) = &self.run_windows {
+                task.insert("run_windows", run_windows.clone().into());
+            }
             tasks.insert(&self.task, Item::Table(task));
             file::write(&path, doc.to_string())?;
             config_file::trust(&config_file::config_trust_root(&path))?;


### PR DESCRIPTION
The `--run-windows` flag for `task add` was documented but silently ignored.

This change wires it up so the value is emitted as `run_windows` in the toml output.

e.g. `mise task add os --run-windows "echo windows" -- echo unix` now emits:

```toml
[tasks.os]
run = "echo unix"
run_windows = "echo windows"
```

I left the `--file` path unchanged since file tasks don't seem to have an equivalent of `run_windows`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task creation now preserves a Windows-specific command when provided, so generated task definitions can include both standard and Windows runs.
* **Bug Fixes**
  * Fixed an issue where Windows task commands were not being saved in task configuration files.
* **Tests**
  * Added end-to-end coverage to verify task definitions include both Unix and Windows commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->