### PR TITLE
fix(core): don't panic when stderr is unwritable

### DIFF
--- a/e2e/cli/test_broken_stderr
+++ b/e2e/cli/test_broken_stderr
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# mise must not crash when stderr is unwritable, e.g. when the process that
+# spawned it (a shim, tool stub, or LSP client) closes its end of the pipe.
+# eprintln!-style macros panic on write errors, and a panic that reaches the
+# panic hook while stderr is broken used to escalate to SIGABRT.
+# /dev/full makes every write fail with ENOSPC, exercising the same code path.
+
+if [[ ! -w /dev/full ]]; then
+  # /dev/full is Linux-only
+  exit 0
+fi
+
+# MISE_DEBUG=1 forces log output to stderr; the subshell keeps stderr pointed
+# at /dev/full since the assert helpers append their own 2>&1
+assert "(MISE_DEBUG=1 mise version >/dev/null 2>/dev/full && echo ok)" "ok"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -93,7 +93,7 @@ impl log::Log for Logger {
             if !out.is_empty() {
                 // Use clx pause/resume for clean logging during progress display
                 progress::pause();
-                eprintln!("{out}");
+                safe_eprintln!("{out}");
                 progress::resume();
             }
         }
@@ -115,7 +115,7 @@ impl Logger {
             if let Ok(log_file) = init_log_file(log_file) {
                 logger.log_file = Some(Mutex::new(log_file));
             } else {
-                eprintln!("mise: could not open log file: {log_file:?}");
+                safe_eprintln!("mise: could not open log file: {log_file:?}");
             }
         }
 
@@ -187,7 +187,7 @@ pub fn init() {
         let file_level = env::MISE_LOG_FILE_LEVEL.unwrap_or(settings.log_level());
         let logger = LOGGER.get_or_init(|| Logger::init(term_level, file_level));
         if let Err(err) = log::set_logger(logger) {
-            eprintln!("mise: could not initialize logger: {err}");
+            safe_eprintln!("mise: could not initialize logger: {err}");
         }
     }
     log::set_max_level(term_level);

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,16 +116,15 @@ fn main() -> eyre::Result<()> {
 
 async fn main_() -> eyre::Result<()> {
     // Configure color-eyre based on color preferences
-    if *env::CLICOLOR == Some(false) {
+    let hook_builder = if *env::CLICOLOR == Some(false) {
         // Use blank theme (no colors) when colors are disabled
-        color_eyre::config::HookBuilder::new()
-            .theme(color_eyre::config::Theme::new())
-            .install()?;
+        color_eyre::config::HookBuilder::new().theme(color_eyre::config::Theme::new())
     } else {
-        // Use default installation with colors
-        color_eyre::install()?;
-    }
-    install_panic_hook();
+        color_eyre::config::HookBuilder::default()
+    };
+    let (panic_hook, eyre_hook) = hook_builder.into_hooks();
+    eyre_hook.install()?;
+    install_panic_hook(panic_hook);
     if std::env::current_dir().is_ok() {
         unsafe {
             path_absolutize::update_cwd();
@@ -161,7 +160,7 @@ fn handle_err(err: Report) -> eyre::Result<()> {
     // Check for miette diagnostic errors and render them specially
     if let Some(diagnostic) = err.downcast_ref::<config::config_file::diagnostic::MiseDiagnostic>()
     {
-        eprintln!("{}", diagnostic.render());
+        safe_eprintln!("{}", diagnostic.render());
         exit(1);
     }
 
@@ -215,8 +214,7 @@ fn stop_multi_progress() {
 
 static ASYNC_PANIC_OCCURRED: AtomicBool = AtomicBool::new(false);
 
-pub fn install_panic_hook() {
-    let default_hook = panic::take_hook();
+pub fn install_panic_hook(panic_hook: color_eyre::config::PanicHook) {
     panic::set_hook(Box::new(move |panic_info| {
         if tokio::runtime::Handle::try_current().is_ok()
             && !ASYNC_PANIC_OCCURRED.swap(true, Ordering::SeqCst)
@@ -232,7 +230,9 @@ pub fn install_panic_hook() {
                 bt_buffer.push_str("[no accessible async backtrace]");
             }
             let all = async_backtrace::taskdump_tree(true);
-            eprintln!(
+            // A panic hook must never panic: a panic while the hook runs
+            // aborts the process with SIGABRT.
+            safe_eprintln!(
                 "=== Async Backtrace (panic occurred in tokio runtime) ===\n\
                 {bt_buffer}\n\
                 ------- TASK DUMP TREE -------\n\
@@ -241,7 +241,10 @@ pub fn install_panic_hook() {
             );
         }
 
-        default_hook(panic_info);
+        // color_eyre's own panic hook prints its report with eprintln!, which
+        // panics when stderr is unwritable — render the report ourselves
+        // instead of chaining to it
+        safe_eprintln!("{}", panic_hook.panic_report(panic_info));
     }));
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,6 +2,16 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 
+/// Like `eprintln!`, but ignores write failures instead of panicking when
+/// stderr is unwritable (e.g. the process that spawned mise closed its end
+/// of the pipe).
+#[macro_export]
+macro_rules! safe_eprintln {
+    ($($arg:tt)*) => {{
+        let _ = calm_io::stderrln!($($arg)*);
+    }};
+}
+
 #[macro_export]
 macro_rules! prefix_println {
     ($prefix:expr, $($arg:tt)*) => {{
@@ -13,7 +23,7 @@ macro_rules! prefix_println {
 macro_rules! prefix_eprintln {
     ($prefix:expr, $($arg:tt)*) => {{
         let msg = format!($($arg)*);
-        let _ = calm_io::stderrln!("{} {}", $prefix, msg);
+        $crate::safe_eprintln!("{} {}", $prefix, msg);
     }};
 }
 

--- a/src/task/task_results_display.rs
+++ b/src/task/task_results_display.rs
@@ -51,7 +51,7 @@ impl TaskResultsDisplay {
     fn display_timing_summary(&self, num_tasks: usize, timer: std::time::Instant) {
         if self.show_timings && num_tasks > 1 {
             let msg = format!("Finished in {}", time::format_duration(timer.elapsed()));
-            let _ = calm_io::stderrln!("{}", style::edim(msg));
+            safe_eprintln!("{}", style::edim(msg));
         }
     }
 
@@ -67,7 +67,7 @@ impl TaskResultsDisplay {
         }
 
         let count = failed.len();
-        let _ = calm_io::stderrln!("{} {} task(s) failed:", style::ered("ERROR"), count);
+        safe_eprintln!("{} {} task(s) failed:", style::ered("ERROR"), count);
         for (task, status) in &failed {
             let prefix = task.estyled_prefix();
             let status_str = status

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -188,7 +188,7 @@ impl VerboseReport {
 
 impl SingleReport for VerboseReport {
     fn println(&self, message: String) {
-        eprintln!("{message}");
+        safe_eprintln!("{message}");
     }
     fn set_message(&self, message: String) {
         let mut prev_message = self.prev_message.lock().unwrap();


### PR DESCRIPTION
When the process that spawned mise (a shim, tool stub, or LSP client)
closes its end of the stderr pipe, every eprintln! panics with
"failed printing to stderr". The panic hook then hit the same panic
in its own eprintln!, and a panic while the hook is running escalates
to a process abort with SIGABRT and a core dump.

Use calm_io::stderrln! (already used by prefix_eprintln!) in the panic
hook, the logger, and VerboseReport so a broken stderr silently drops
log output instead of taking the process down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI stability when standard error is unavailable or unwritable.
  * Error output, panic reporting, and progress/timing messages now safely handle stderr write failures without crashing.
* **Tests**
  * Added an end-to-end test that forces stderr write failures to confirm the CLI still completes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->