### PR TITLE
chore(herdr): use aqua backend for herdr

### DIFF
--- a/registry/herdr.toml
+++ b/registry/herdr.toml
@@ -1,3 +1,3 @@
-backends = ["github:ogulcancelik/herdr"]
+backends = ["aqua:ogulcancelik/herdr", "github:ogulcancelik/herdr"]
 description = "Agent multiplexer that lives in your terminal"
 test = { cmd = "herdr --version", expected = "herdr {{version}}" }


### PR DESCRIPTION
Aqua Registry [9e4891f1b05eb0429aa36211735958be34015cb4](https://github.com/jdx/mise/blob/d6ccee0b98933300be1ee79cfdf6d1c41f192e35/vendor/aqua-registry/metadata.json#L3C11-L3C51)(v4.531.0) includes herdr (added in [v4.529.0](https://github.com/aquaproj/aqua-registry/releases#release-v4.529.0)) so let's use that registry.

🔗. https://github.com/aquaproj/aqua-registry/pull/55958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded backend support by adding an additional backend option alongside the existing GitHub integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->