### PR TITLE
docs(configuration): fix precedence in visual

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ When mise needs configuration, it follows this process:
 
 ```
 /
-├── etc/mise/                         # System-wide config (highest precedence)
+├── etc/mise/                         # System-wide config (lowest precedence)
 │   ├── conf.d/*.toml                 # System fragments, loaded alphabetically
 │   ├── config.toml                   # System defaults
 │   └── config.<env>.toml             # Env-specific system config (MISE_ENV or -E)
@@ -67,7 +67,7 @@ When mise needs configuration, it follows this process:
             ├── mise.<env>.toml       # Env-specific project config
             ├── mise.<env>.local.toml # Env-specific project local overrides
             └── backend/
-                └── mise.toml         # Service-specific config (lowest precedence)
+                └── mise.toml         # Service-specific config (highest precedence)
 ```
 
 ### Merge Behavior by Section


### PR DESCRIPTION
```
docs(configuration): fix precedence in visual

- Fixes the visual aide to show correct configuration precedence. Each
  section of the configuration documentation clarifies that the closer a
  configuration file sits to code the higher its precedence. This fixes
  the visual aide to match the rest of the documentation and examples.

Signed-off-by: Kellin <kellin@retromud.org>
```

I did not open a discussion for this change as I believe it to fall under the "obvious" category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the configuration precedence diagram so it now reflects the proper order between system-wide and service-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->