### PR TITLE
registry: add twg (http:twg)

### DIFF
--- a/registry/twg.toml
+++ b/registry/twg.toml
@@ -1,0 +1,22 @@
+description = "Command line interface to the Atlassian Teamwork Graph and Cloud services"
+os = ["linux", "macos", "windows"]
+test = { cmd = "twg --version", expected = "{{version}}" }
+
+[[backends]]
+full = "http:twg"
+
+[backends.options]
+bin = "twg"
+checksum_url = "https://teamwork-graph.atlassian.com/cli/SHA256SUMS-v{{ version }}"
+url = 'https://teamwork-graph.atlassian.com/cli/twg-{{ os(macos="darwin") }}-{{ arch() }}-v{{ version }}'
+# Per-version manifest published alongside the binaries; .version tracks the latest stable release
+version_json_path = ".version"
+version_list_url = "https://teamwork-graph.atlassian.com/cli/manifest.json"
+
+[backends.options.platforms.windows-arm64]
+bin = "twg.exe"
+url = "https://teamwork-graph.atlassian.com/cli/twg-windows-arm64-v{{ version }}.exe"
+
+[backends.options.platforms.windows-x64]
+bin = "twg.exe"
+url = "https://teamwork-graph.atlassian.com/cli/twg-windows-x64-v{{ version }}.exe"


### PR DESCRIPTION
Adds [twg](https://developer.atlassian.com/cloud/twg-cli/), the Atlassian Teamwork Graph CLI, to the registry.

- Backend: `http:twg` — twg is not in the aqua registry and its GitHub repo ([atlassian/twg-cli](https://github.com/atlassian/twg-cli)) is docs/issue-tracking only with no releases or tags, so no tier-1 backend is possible. The entry follows the `registry/claude.toml` precedent: binaries come from Atlassian's official CDN, `latest` resolves from the published [release manifest](https://teamwork-graph.atlassian.com/cli/manifest.json) (`.version`), and downloads verify against the published `SHA256SUMS-v{{version}}` files.
- Binary: `twg` (`twg.exe` via platform overrides on Windows)
- Platforms: linux/macos/windows, x64 + arm64 (all six binaries published per version)
- Test: `twg --version` matches `{{version}}`

## Popularity

- Official Atlassian product, generally available: GA at v1.0.0, beta labels removed at v1.0.15, currently v1.0.21 (published 2026-07-03) with an active [changelog](https://developer.atlassian.com/cloud/twg-cli/changelog/)
- The CLI is Atlassian's primary way to give coding agents access to Jira/Confluence/Bitbucket/JSM via the Teamwork Graph, documented at [developer.atlassian.com/cloud/twg-cli](https://developer.atlassian.com/cloud/twg-cli/) with agent-skill integrations for Claude Code, Cursor, and others
- GitHub: [atlassian/twg-cli](https://github.com/atlassian/twg-cli) has 6 stars (created 2026-05-21, pushed 2026-07-06) — note the repo is release-notes/issue-tracking only and distribution is via Atlassian's CDN installer, not GitHub, so stars don't reflect adoption

Verified locally on macos-arm64: version resolution from the manifest, checksum verification against SHA256SUMS, install, and `twg --version` all work through the http backend with these options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new `twg` command-line interface backend.
  * Included download and version-check details so the tool can be installed and verified on supported platforms.
  * Added Windows-specific packages for both ARM64 and x64 systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
