### PR TITLE
feat(npm): add aube trust policy excludes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -79,9 +79,9 @@ installation.
 With the default `npm.package_manager = "auto"` setting, mise installs through `aube` when `aube` is
 installed. If `aube` is not installed, mise installs through `npm`. Setting
 `npm.package_manager = "aube"`, `"pnpm"`, `"bun"`, or `"npm"` chooses that package manager
-explicitly. The `allow_builds`, `aube_args`, `pnpm_args`, `bun_args`, and `npm_args` options only
-affect the package manager that is actually used; an approval option for one package manager does
-not change the behavior of another.
+explicitly. The `allow_builds`, `trust_policy_excludes`, `aube_args`, `pnpm_args`, `bun_args`, and
+`npm_args` options only affect the package manager that is actually used; an approval option for one
+package manager does not change the behavior of another.
 
 For tools that need reviewed dependency build scripts, use `allow_builds` with `aube`, `pnpm`, or
 npm 11.16.0+.
@@ -98,7 +98,8 @@ reviewed dependency builds:
 ```
 
 `allow_builds` is passed to `aube add --global` as one `--allow-build=<pkg>` flag per package.
-Use `aube_args` for other raw aube flags.
+Use `trust_policy_excludes` for reviewed aube trust-policy exceptions, or `aube_args` for other
+raw aube flags.
 Set `allow_builds = true` to pass `--dangerously-allow-all-builds` when you explicitly accept that
 every dependency build script may run.
 
@@ -203,6 +204,29 @@ To allow all dependency build scripts for the install:
 `allow_builds` does not affect `bun` installs because mise's Bun path is a global install and does
 not write a per-transitive `trustedDependencies` allowlist. For npm installs, `allow_builds`
 requires npm 11.16.0+.
+
+### `trust_policy_excludes`
+
+Packages or package version ranges that should be exempt from aube's `trustPolicy=no-downgrade`
+check when `settings.npm.package_manager = "aube"`. Use this for reviewed dependency provenance
+metadata churn without disabling the trust policy for the whole install.
+
+For example, to exempt every version of a dependency:
+
+```toml
+[tools]
+"npm:some-tool" = { version = "latest", trust_policy_excludes = ["undici"] }
+```
+
+To exempt only selected versions, use aube's package-version pattern syntax:
+
+```toml
+[tools]
+"npm:some-tool" = { version = "latest", trust_policy_excludes = ["undici@^5 || >=6 <7"] }
+```
+
+`trust_policy_excludes` is written to the aube install `.npmrc` as `trustPolicyExclude`. It does
+not affect `npm`, `pnpm`, or `bun` installs.
 
 ### `aube_args`
 

--- a/mise.lock
+++ b/mise.lock
@@ -117,61 +117,61 @@ url_api = "https://api.github.com/repos/FiloSottile/age/releases/assets/33375267
 provenance = "github-attestations"
 
 [[tools.aube]]
-version = "1.19.0"
+version = "1.26.0"
 backend = "github:endevco/aube"
 
 [tools.aube."platforms.linux-arm64"]
-checksum = "sha256:9e062f319809013c33d4ccb7eba7a36752e8735d08dabe5c8b227d83ae5de102"
-url = "https://github.com/jdx/aube/releases/download/v1.19.0/aube-v1.19.0-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/445129710"
+checksum = "sha256:e1f730c01b5130835d3b4d6c293821de78ade6f857869963bd2df82cb9ce67e8"
+url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468523290"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-arm64-musl"]
-checksum = "sha256:e4b0ba7a6992c7a4316c4f901cff599ce1f490e6005707254831d10267618017"
-url = "https://github.com/jdx/aube/releases/download/v1.19.0/aube-v1.19.0-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/445109550"
+checksum = "sha256:4611bc48714d03a86523a21575cea7d58a9f43ff44b2b372470bb3d0f13ff9b7"
+url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468497318"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64"]
-checksum = "sha256:2ed5bde0bad38d7b3c34195f7f51e5fd491843e1344f3ad35e386af201561fee"
-url = "https://github.com/jdx/aube/releases/download/v1.19.0/aube-v1.19.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/445116084"
+checksum = "sha256:17ea729b11825366600a2072d81160bd09c027b3a37c13e2e97aa7295625aa07"
+url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468503747"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-baseline"]
-checksum = "sha256:2ed5bde0bad38d7b3c34195f7f51e5fd491843e1344f3ad35e386af201561fee"
-url = "https://github.com/jdx/aube/releases/download/v1.19.0/aube-v1.19.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/445116084"
+checksum = "sha256:17ea729b11825366600a2072d81160bd09c027b3a37c13e2e97aa7295625aa07"
+url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468503747"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl"]
-checksum = "sha256:f0e16a8d4e76feb21010257def908727cbc278d0361e7b3adfeb5d894e11767e"
-url = "https://github.com/jdx/aube/releases/download/v1.19.0/aube-v1.19.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/445114567"
+checksum = "sha256:3a6c90676f0003079eaade3a4027c3349612e7587f7ecf699c864395ff26807c"
+url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468505615"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:f0e16a8d4e76feb21010257def908727cbc278d0361e7b3adfeb5d894e11767e"
-url = "https://github.com/jdx/aube/releases/download/v1.19.0/aube-v1.19.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/445114567"
+checksum = "sha256:3a6c90676f0003079eaade3a4027c3349612e7587f7ecf699c864395ff26807c"
+url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468505615"
 provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
-checksum = "sha256:7652e1a68f0cf14d7228c7e8d6382fe9454d6baf2e0248523006d9fab542e280"
-url = "https://github.com/jdx/aube/releases/download/v1.19.0/aube-v1.19.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/445178323"
+checksum = "sha256:f1e9cca3b4837cb497b0588641781ecd426b5a4c26cd610743a8fad756e02d8f"
+url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468538559"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64"]
-checksum = "sha256:90c471a2c2f7fb101c140ce14da2744d7dbc3dc7badd295079cf5d29b8bd9625"
-url = "https://github.com/jdx/aube/releases/download/v1.19.0/aube-v1.19.0-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/445116933"
+checksum = "sha256:1b594095c26c31e90b5e89ef78cf56ac9b903db83f1ca214db6732d9df09409a"
+url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468508857"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64-baseline"]
-checksum = "sha256:90c471a2c2f7fb101c140ce14da2744d7dbc3dc7badd295079cf5d29b8bd9625"
-url = "https://github.com/jdx/aube/releases/download/v1.19.0/aube-v1.19.0-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/445116933"
+checksum = "sha256:1b594095c26c31e90b5e89ef78cf56ac9b903db83f1ca214db6732d9df09409a"
+url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468508857"
 provenance = "github-attestations"
 
 [[tools.bun]]

--- a/registry/vercel.toml
+++ b/registry/vercel.toml
@@ -1,5 +1,5 @@
 description = "Build and deploy on the Vercel cloud"
-test = { cmd = "vc --version", expected = "{{version}}", tools = ["aube"] }
+test = { cmd = "vc --version", expected = "{{version}}", tools = ["aube@1.26.0"] }
 
 [[backends]]
 full = "npm:vercel"

--- a/registry/vercel.toml
+++ b/registry/vercel.toml
@@ -6,3 +6,4 @@ full = "npm:vercel"
 
 [backends.options]
 allow_builds = ["esbuild"]
+trust_policy_excludes = ["undici"]

--- a/registry/vercel.toml
+++ b/registry/vercel.toml
@@ -1,5 +1,7 @@
 description = "Build and deploy on the Vercel cloud"
-test = { cmd = "vc --version", expected = "{{version}}", tools = ["aube@1.26.0"] }
+test = { cmd = "vc --version", expected = "{{version}}", tools = [
+  "aube@1.26.0",
+] }
 
 [[backends]]
 full = "npm:vercel"

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -65,6 +65,10 @@
     "toolId": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9_.-]+$"
+    },
+    "toolArg": {
+      "type": "string",
+      "pattern": "^\\S+$"
     }
   },
   "properties": {
@@ -175,9 +179,9 @@
         "tools": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/toolId"
+            "$ref": "#/$defs/toolArg"
           },
-          "description": "Additional mise tools to install before running test.cmd. Used only by mise test-tool."
+          "description": "Additional mise tool arguments to install before running test.cmd. Used only by mise test-tool."
         }
       },
       "required": ["cmd", "expected"],

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -80,6 +80,13 @@ impl<'a> NpmOptions<'a> {
         self.values.str("aube_args")
     }
 
+    fn trust_policy_excludes(&self) -> eyre::Result<Vec<String>> {
+        Self::string_list_option(
+            self.values.raw().opts.get("trust_policy_excludes"),
+            "trust_policy_excludes",
+        )
+    }
+
     fn allow_builds(&self) -> eyre::Result<AllowBuilds> {
         let Some(value) = self.values.raw().opts.get("allow_builds") else {
             return Ok(AllowBuilds::None);
@@ -148,13 +155,49 @@ impl<'a> NpmOptions<'a> {
     }
 
     fn canonical_allow_build_packages(mut packages: Vec<String>) -> AllowBuilds {
-        packages.sort();
-        packages.dedup();
+        Self::canonicalize_string_list(&mut packages);
         if packages.is_empty() {
             AllowBuilds::None
         } else {
             AllowBuilds::Packages(packages)
         }
+    }
+
+    fn canonicalize_string_list(values: &mut Vec<String>) {
+        values.retain(|value| !value.is_empty());
+        values.sort();
+        values.dedup();
+    }
+
+    fn string_list_option(value: Option<&toml::Value>, key: &str) -> eyre::Result<Vec<String>> {
+        let Some(value) = value else {
+            return Ok(Vec::new());
+        };
+        let mut values = match value {
+            toml::Value::String(value) => vec![value.clone()],
+            toml::Value::Array(values) => values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map(str::to_string)
+                        .ok_or_else(|| eyre::eyre!("{key} array must contain only strings"))
+                })
+                .collect::<eyre::Result<Vec<_>>>()?,
+            _ => return Err(eyre::eyre!("{key} must be a string or array")),
+        };
+        Self::canonicalize_string_list(&mut values);
+        Ok(values)
+    }
+
+    fn canonical_trust_policy_excludes_lockfile_value(&self) -> eyre::Result<Option<String>> {
+        let excludes = self.trust_policy_excludes()?;
+        Ok((!excludes.is_empty()).then(|| format!("{excludes:?}")))
+    }
+
+    fn aube_trust_policy_excludes_npmrc_value(&self) -> eyre::Result<Option<String>> {
+        let excludes = self.trust_policy_excludes()?;
+        Ok((!excludes.is_empty()).then(|| excludes.join(",")))
     }
 
     fn canonical_allow_builds_lockfile_value(&self) -> eyre::Result<Option<String>> {
@@ -171,6 +214,10 @@ impl<'a> NpmOptions<'a> {
             .filter_map(|key| {
                 let value = if key == "allow_builds" {
                     self.canonical_allow_builds_lockfile_value().ok().flatten()
+                } else if key == "trust_policy_excludes" {
+                    self.canonical_trust_policy_excludes_lockfile_value()
+                        .ok()
+                        .flatten()
                 } else {
                     self.values.raw().opts.get(&key).map(|value| match value {
                         toml::Value::String(value) => value.clone(),
@@ -364,7 +411,7 @@ impl Backend for NPMBackend {
                     .dependency_path_for_install(&ctx.config, Some(&ctx.ts), AUBE_PROGRAM)
                     .await
                     .unwrap_or_else(|| AUBE_PROGRAM.into());
-                self.write_aube_npmrc(&tv.install_path(), ctx.before_date)?;
+                self.write_aube_npmrc(&tv.install_path(), ctx.before_date, &options)?;
                 let mut cmd = CmdLineRunner::new(aube_program)
                     .arg("add")
                     .arg("--global")
@@ -794,7 +841,12 @@ impl NPMBackend {
             .is_some()
     }
 
-    fn write_aube_npmrc(&self, install_path: &Path, before_date: Option<Timestamp>) -> Result<()> {
+    fn write_aube_npmrc(
+        &self,
+        install_path: &Path,
+        before_date: Option<Timestamp>,
+        options: &NpmOptions,
+    ) -> Result<()> {
         let bin_dir = install_path.join("bin");
         crate::file::create_dir_all(install_path)?;
         crate::file::create_dir_all(&bin_dir)?;
@@ -810,6 +862,9 @@ impl NPMBackend {
             ));
             // aube documents minimumReleaseAge in minutes, matching pnpm's setting.
             npmrc.push_str(&format!("minimumReleaseAge={minutes}\n"));
+        }
+        if let Some(excludes) = options.aube_trust_policy_excludes_npmrc_value()? {
+            npmrc.push_str(&format!("trustPolicyExclude={excludes}\n"));
         }
         crate::file::write(install_path.join(".npmrc"), npmrc)?;
         Ok(())
@@ -954,6 +1009,7 @@ pub fn install_time_option_keys() -> Vec<String> {
         "bun_args".into(),
         "aube_args".into(),
         "allow_builds".into(),
+        "trust_policy_excludes".into(),
     ]
 }
 
@@ -1259,6 +1315,14 @@ mod tests {
                 toml::Value::String("sharp".into()),
             ]),
         );
+        options.opts.insert(
+            "trust_policy_excludes".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("undici@^5".into()),
+                toml::Value::String("undici".into()),
+                toml::Value::String("undici".into()),
+            ]),
+        );
         options.install_env.insert(
             "NPM_CONFIG_REGISTRY".to_string(),
             "https://registry.example.com".to_string(),
@@ -1286,7 +1350,65 @@ mod tests {
             resolved.get("allow_builds"),
             Some(&"[\"esbuild\", \"sharp\"]".to_string())
         );
+        assert_eq!(
+            resolved.get("trust_policy_excludes"),
+            Some(&"[\"undici\", \"undici@^5\"]".to_string())
+        );
         assert!(!resolved.contains_key("install_env.NPM_CONFIG_REGISTRY"));
+    }
+
+    #[test]
+    fn test_trust_policy_excludes_accepts_string_or_array() {
+        let mut string_options = ToolVersionOptions::default();
+        string_options.opts.insert(
+            "trust_policy_excludes".to_string(),
+            toml::Value::String("undici".into()),
+        );
+        assert_eq!(
+            NpmOptions::new(&string_options)
+                .trust_policy_excludes()
+                .unwrap(),
+            vec!["undici"]
+        );
+
+        let mut array_options = ToolVersionOptions::default();
+        array_options.opts.insert(
+            "trust_policy_excludes".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("undici@^5".into()),
+                toml::Value::String("undici".into()),
+                toml::Value::String("undici".into()),
+            ]),
+        );
+        assert_eq!(
+            NpmOptions::new(&array_options)
+                .trust_policy_excludes()
+                .unwrap(),
+            vec!["undici", "undici@^5"]
+        );
+    }
+
+    #[test]
+    fn test_write_aube_npmrc_includes_trust_policy_excludes() {
+        let backend = create_npm_backend("vercel");
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("npm-vercel").join("54.20.1");
+        let mut raw_options = ToolVersionOptions::default();
+        raw_options.opts.insert(
+            "trust_policy_excludes".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("undici@^5".into()),
+                toml::Value::String("undici".into()),
+            ]),
+        );
+        let options = NpmOptions::new(&raw_options);
+
+        backend
+            .write_aube_npmrc(&install_path, None, &options)
+            .unwrap();
+
+        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
+        assert!(npmrc.contains("trustPolicyExclude=undici,undici@^5\n"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a structured `trust_policy_excludes` option for npm tools installed through aube
- write the option into aube's install-local `.npmrc` as `trustPolicyExclude`
- add the reviewed `undici` trust-policy exclude to the vercel registry entry

## Notes
- Range support for aube's `trustPolicyExclude` parser is in jdx/aube#989.

## Tests
- cargo test trust_policy_excludes
- cargo test test_resolve_lockfile_options_includes_install_args_only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm install security policy wiring for aube and adds registry-level trust-policy exceptions for Vercel; scope is limited to aube installs and is covered by tests.
> 
> **Overview**
> Adds **`trust_policy_excludes`** as an npm backend install-time option for **aube** installs. Values (string or array, deduped/sorted like `allow_builds`) are written into the install-local `.npmrc` as `trustPolicyExclude` and recorded in lockfile options so reviewed packages can skip aube’s `trustPolicy=no-downgrade` checks without turning the policy off globally.
> 
> **Vercel** registry defaults now set `trust_policy_excludes = ["undici"]`, pin the registry test helper to **`aube@1.26.0`**, and **`mise.lock`** bumps aube to 1.26.0. Registry schema **`test.tools`** entries use a new `toolArg` pattern (e.g. version pins) instead of bare tool IDs. Docs cover the option; tests cover parsing, lockfile canonicalization, and `.npmrc` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d29dd3f740bd42378eed22f13dca68be4971e613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new install-time option, `trust_policy_excludes`, to exempt selected dependency/version ranges from trust-policy downgrade checks.
  * When using Aube-based installs, the exemption is applied via generated npm configuration and propagated into the lockfile options.
  * Vercel configuration now excludes `undici` from these trust-policy checks and pins the Vercel CLI test tool.
* **Documentation**
  * Updated lifecycle-scripts docs to cover `trust_policy_excludes`, including examples and correct scope.
* **Tests**
  * Added/updated coverage for option parsing (string/array), canonicalization, lockfile propagation, and generated npm config output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->