### PR TITLE
chore(deps): group phf renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,12 @@
       "matchPackageNames": ["/^sigstore-/"],
       "matchManagers": ["cargo"],
       "groupName": "sigstore crates"
+    },
+    {
+      "description": "phf runtime and codegen must stay compatible for generated baked registry maps.",
+      "matchPackageNames": ["phf", "phf_codegen"],
+      "matchManagers": ["cargo"],
+      "groupName": "phf"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- group `phf` and `phf_codegen` Renovate updates together
- keep the rule separate from Renovate's generated dependency PR branch

## Context
PR #10745 showed that updating `phf` without `phf_codegen` breaks generated baked registry maps because runtime and codegen versions diverge.

## Validation
- `jq empty .github/renovate.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate-only configuration with no runtime or application code changes.
> 
> **Overview**
> Adds a Renovate **cargo** `packageRules` entry so **`phf`** and **`phf_codegen`** bump in a single grouped PR (`groupName`: `phf`), matching the existing pattern for rattler and Sigstore crates.
> 
> This prevents Renovate from upgrading only one of the pair, which previously broke **generated baked registry maps** when runtime and codegen versions diverged (see PR #10745).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b82c6deb95418259370c006eec3853cef6a1bbf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped related dependency updates together so future maintenance updates for a pair of Rust libraries are handled in one batch.
  * This should make automated dependency updates easier to review and keep compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->