### PR TITLE
fix(env): resolve sops keys from ordered env

### DIFF
--- a/e2e/secrets/test_secrets
+++ b/e2e/secrets/test_secrets
@@ -29,3 +29,14 @@ assert_contains "mise env" "export SECRET=mysecret"
 # sops CLI
 mise settings set sops.rops 0
 assert_contains "mise env" "export SECRET=mysecret"
+
+# ordered env directives can provide the sops key for subsequent _.file directives
+mise settings set sops.rops 1
+mise settings unset sops.age_key_file
+cat >mise.toml <<EOF
+[env]
+MISE_SOPS_AGE_KEY_FILE = "~/age.txt"
+_.file = ".env.yaml"
+EOF
+assert_contains "mise env" "export SECRET=mysecret"
+assert_contains "mise hook-env -s bash --force" "export SECRET=mysecret"

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -217,9 +217,29 @@ mod tests {
     const AGE_PUBLIC_KEY: &str = "age1se5ghfycr4n8kcwc3qwf234ymvmr2lex2a99wh8gpfx97glwt9hqch4569";
     const AGE_PRIVATE_KEY: &str =
         "AGE-SECRET-KEY-1EQUCGFZH8UZKSZ0Z5N5T234YRNDT4U9H7QNYXWRRNJYDDVXE6FWSCPGNJ7";
+    static ENV_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    fn encrypted_toml() -> String {
+        RopsFileBuilder::<TomlFileFormat>::new(r#"SECRET = "mysecret""#)
+            .unwrap()
+            .add_integration_key::<AgeIntegration>(
+                AgeIntegration::parse_key_id(AGE_PUBLIC_KEY).unwrap(),
+            )
+            .encrypt::<AES256GCM, SHA512>()
+            .unwrap()
+            .to_string()
+    }
+
+    fn restore_env_var(key: &str, prev: Option<String>) {
+        match prev {
+            Some(v) => crate::env::set_var(key, v),
+            None => crate::env::remove_var(key),
+        }
+    }
 
     #[tokio::test]
     async fn decrypts_sops_toml_file() {
+        let _lock = ENV_MUTEX.lock().await;
         let prev_age_key = crate::env::var("MISE_SOPS_AGE_KEY").ok();
         let prev_rops = crate::env::var("MISE_SOPS_ROPS").ok();
         crate::env::remove_var("MISE_SOPS_ROPS");
@@ -229,33 +249,82 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let p = tmp.path().join(".env.toml");
 
-        let encrypted = RopsFileBuilder::<TomlFileFormat>::new(r#"SECRET = "mysecret""#)
-            .unwrap()
-            .add_integration_key::<AgeIntegration>(
-                AgeIntegration::parse_key_id(AGE_PUBLIC_KEY).unwrap(),
-            )
-            .encrypt::<AES256GCM, SHA512>()
-            .unwrap()
-            .to_string();
-        file::write(&p, encrypted).unwrap();
+        file::write(&p, encrypted_toml()).unwrap();
 
         let exec_env = TeraEnvMap::new();
         let env = EnvResults::toml(&config, &exec_env, &p, Ok).await.unwrap();
         assert_eq!(env.get("SECRET").unwrap(), "mysecret");
 
-        match prev_age_key {
-            Some(v) => crate::env::set_var("MISE_SOPS_AGE_KEY", v),
-            None => crate::env::remove_var("MISE_SOPS_AGE_KEY"),
-        }
-        match prev_rops {
-            Some(v) => crate::env::set_var("MISE_SOPS_ROPS", v),
-            None => crate::env::remove_var("MISE_SOPS_ROPS"),
-        }
+        restore_env_var("MISE_SOPS_AGE_KEY", prev_age_key);
+        restore_env_var("MISE_SOPS_ROPS", prev_rops);
+        Settings::reset(None);
+    }
+
+    #[tokio::test]
+    async fn decrypts_sops_toml_file_with_exec_env_mise_age_key_file() {
+        let _lock = ENV_MUTEX.lock().await;
+        let prev_age_key = crate::env::var("MISE_SOPS_AGE_KEY").ok();
+        let prev_age_key_file = crate::env::var("MISE_SOPS_AGE_KEY_FILE").ok();
+        let prev_rops = crate::env::var("MISE_SOPS_ROPS").ok();
+        crate::env::remove_var("MISE_SOPS_AGE_KEY");
+        crate::env::remove_var("MISE_SOPS_AGE_KEY_FILE");
+        crate::env::remove_var("MISE_SOPS_ROPS");
+        Settings::reset(None);
+        let config = Config::reset().await.unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join(".env.toml");
+        let key_file = tmp.path().join("age.txt");
+        file::write(&p, encrypted_toml()).unwrap();
+        file::write(&key_file, AGE_PRIVATE_KEY).unwrap();
+
+        let mut exec_env = TeraEnvMap::new();
+        exec_env.insert(
+            "MISE_SOPS_AGE_KEY_FILE".into(),
+            key_file.to_string_lossy().to_string(),
+        );
+        let env = EnvResults::toml(&config, &exec_env, &p, Ok).await.unwrap();
+        assert_eq!(env.get("SECRET").unwrap(), "mysecret");
+
+        restore_env_var("MISE_SOPS_AGE_KEY", prev_age_key);
+        restore_env_var("MISE_SOPS_AGE_KEY_FILE", prev_age_key_file);
+        restore_env_var("MISE_SOPS_ROPS", prev_rops);
+        Settings::reset(None);
+    }
+
+    #[tokio::test]
+    async fn ambient_sops_age_key_file_precedes_exec_env_sops_age_key() {
+        let _lock = ENV_MUTEX.lock().await;
+        let prev_mise_age_key = crate::env::var("MISE_SOPS_AGE_KEY").ok();
+        let prev_sops_age_key = crate::env::var("SOPS_AGE_KEY").ok();
+        let prev_sops_age_key_file = crate::env::var("SOPS_AGE_KEY_FILE").ok();
+        let prev_rops = crate::env::var("MISE_SOPS_ROPS").ok();
+        crate::env::remove_var("MISE_SOPS_AGE_KEY");
+        crate::env::remove_var("SOPS_AGE_KEY");
+        crate::env::remove_var("MISE_SOPS_ROPS");
+        Settings::reset(None);
+        let config = Config::reset().await.unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join(".env.toml");
+        let key_file = tmp.path().join("age.txt");
+        file::write(&p, encrypted_toml()).unwrap();
+        file::write(&key_file, AGE_PRIVATE_KEY).unwrap();
+        crate::env::set_var("SOPS_AGE_KEY_FILE", key_file.to_string_lossy().to_string());
+
+        let mut exec_env = TeraEnvMap::new();
+        exec_env.insert("SOPS_AGE_KEY".into(), "not-an-age-key".into());
+        let env = EnvResults::toml(&config, &exec_env, &p, Ok).await.unwrap();
+        assert_eq!(env.get("SECRET").unwrap(), "mysecret");
+
+        restore_env_var("MISE_SOPS_AGE_KEY", prev_mise_age_key);
+        restore_env_var("SOPS_AGE_KEY", prev_sops_age_key);
+        restore_env_var("SOPS_AGE_KEY_FILE", prev_sops_age_key_file);
+        restore_env_var("MISE_SOPS_ROPS", prev_rops);
         Settings::reset(None);
     }
 
     #[tokio::test]
     async fn errors_when_sops_cli_is_configured_for_toml_file() {
+        let _lock = ENV_MUTEX.lock().await;
         let prev_age_key = crate::env::var("MISE_SOPS_AGE_KEY").ok();
         let prev_rops = crate::env::var("MISE_SOPS_ROPS").ok();
         crate::env::set_var("MISE_SOPS_AGE_KEY", AGE_PRIVATE_KEY);
@@ -265,15 +334,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let p = tmp.path().join(".env.toml");
 
-        let encrypted = RopsFileBuilder::<TomlFileFormat>::new(r#"SECRET = "mysecret""#)
-            .unwrap()
-            .add_integration_key::<AgeIntegration>(
-                AgeIntegration::parse_key_id(AGE_PUBLIC_KEY).unwrap(),
-            )
-            .encrypt::<AES256GCM, SHA512>()
-            .unwrap()
-            .to_string();
-        file::write(&p, encrypted).unwrap();
+        file::write(&p, encrypted_toml()).unwrap();
 
         let exec_env = TeraEnvMap::new();
         let err = EnvResults::toml(&config, &exec_env, &p, Ok)
@@ -285,14 +346,8 @@ mod tests {
             "{err}"
         );
 
-        match prev_age_key {
-            Some(v) => crate::env::set_var("MISE_SOPS_AGE_KEY", v),
-            None => crate::env::remove_var("MISE_SOPS_AGE_KEY"),
-        }
-        match prev_rops {
-            Some(v) => crate::env::set_var("MISE_SOPS_ROPS", v),
-            None => crate::env::remove_var("MISE_SOPS_ROPS"),
-        }
+        restore_env_var("MISE_SOPS_AGE_KEY", prev_age_key);
+        restore_env_var("MISE_SOPS_ROPS", prev_rops);
         Settings::reset(None);
     }
 }

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -44,16 +44,21 @@ impl EnvResults {
                 .map(|e| e.to_string_lossy().to_string())
                 .unwrap_or_default();
             *env = match ext.as_str() {
-                "json" => Self::json(config, &p, parse_template).await?,
-                "yaml" => Self::yaml(config, &p, parse_template).await?,
-                "toml" => Self::toml(config, &p, parse_template).await?,
+                "json" => Self::json(config, exec_env, &p, parse_template).await?,
+                "yaml" => Self::yaml(config, exec_env, &p, parse_template).await?,
+                "toml" => Self::toml(config, exec_env, &p, parse_template).await?,
                 _ => Self::dotenv(&p).await?,
             };
         }
         Ok(out)
     }
 
-    async fn json<PT>(config: &Arc<Config>, p: &Path, parse_template: PT) -> Result<EnvMap>
+    async fn json<PT>(
+        config: &Arc<Config>,
+        exec_env: &TeraEnvMap,
+        p: &Path,
+        parse_template: PT,
+    ) -> Result<EnvMap>
     where
         PT: FnMut(String) -> Result<String>,
     {
@@ -61,9 +66,14 @@ impl EnvResults {
         if let Ok(raw) = file::read_to_string(p) {
             let mut f: Env<serde_json::Value> = serde_json::from_str(&raw).wrap_err_with(errfn)?;
             if !f.sops.is_empty() {
-                let decrypted =
-                    sops::decrypt::<_, JsonFileFormat>(config, &raw, parse_template, "json")
-                        .await?;
+                let decrypted = sops::decrypt::<_, JsonFileFormat>(
+                    config,
+                    exec_env,
+                    &raw,
+                    parse_template,
+                    "json",
+                )
+                .await?;
                 if !decrypted.is_empty() {
                     f = serde_json::from_str(&decrypted).wrap_err_with(errfn)?;
                 } else {
@@ -89,7 +99,12 @@ impl EnvResults {
         }
     }
 
-    async fn yaml<PT>(config: &Arc<Config>, p: &Path, parse_template: PT) -> Result<EnvMap>
+    async fn yaml<PT>(
+        config: &Arc<Config>,
+        exec_env: &TeraEnvMap,
+        p: &Path,
+        parse_template: PT,
+    ) -> Result<EnvMap>
     where
         PT: FnMut(String) -> Result<String>,
     {
@@ -97,9 +112,14 @@ impl EnvResults {
         if let Ok(raw) = file::read_to_string(p) {
             let mut f: Env<serde_yaml::Value> = serde_yaml::from_str(&raw).wrap_err_with(errfn)?;
             if !f.sops.is_empty() {
-                let decrypted =
-                    sops::decrypt::<_, YamlFileFormat>(config, &raw, parse_template, "yaml")
-                        .await?;
+                let decrypted = sops::decrypt::<_, YamlFileFormat>(
+                    config,
+                    exec_env,
+                    &raw,
+                    parse_template,
+                    "yaml",
+                )
+                .await?;
                 if !decrypted.is_empty() {
                     f = serde_yaml::from_str(&decrypted).wrap_err_with(errfn)?;
                 } else {
@@ -125,7 +145,12 @@ impl EnvResults {
         }
     }
 
-    async fn toml<PT>(config: &Arc<Config>, p: &Path, parse_template: PT) -> Result<EnvMap>
+    async fn toml<PT>(
+        config: &Arc<Config>,
+        exec_env: &TeraEnvMap,
+        p: &Path,
+        parse_template: PT,
+    ) -> Result<EnvMap>
     where
         PT: FnMut(String) -> Result<String>,
     {
@@ -133,9 +158,14 @@ impl EnvResults {
         if let Ok(raw) = file::read_to_string(p) {
             let mut f: Env<toml::Value> = toml::from_str(&raw).wrap_err_with(errfn)?;
             if !f.sops.is_empty() {
-                let decrypted =
-                    sops::decrypt::<_, TomlFileFormat>(config, &raw, parse_template, "toml")
-                        .await?;
+                let decrypted = sops::decrypt::<_, TomlFileFormat>(
+                    config,
+                    exec_env,
+                    &raw,
+                    parse_template,
+                    "toml",
+                )
+                .await?;
                 if !decrypted.is_empty() {
                     f = toml::from_str(&decrypted).wrap_err_with(errfn)?;
                 } else {
@@ -209,7 +239,8 @@ mod tests {
             .to_string();
         file::write(&p, encrypted).unwrap();
 
-        let env = EnvResults::toml(&config, &p, Ok).await.unwrap();
+        let exec_env = TeraEnvMap::new();
+        let env = EnvResults::toml(&config, &exec_env, &p, Ok).await.unwrap();
         assert_eq!(env.get("SECRET").unwrap(), "mysecret");
 
         match prev_age_key {
@@ -244,7 +275,10 @@ mod tests {
             .to_string();
         file::write(&p, encrypted).unwrap();
 
-        let err = EnvResults::toml(&config, &p, Ok).await.unwrap_err();
+        let exec_env = TeraEnvMap::new();
+        let err = EnvResults::toml(&config, &exec_env, &p, Ok)
+            .await
+            .unwrap_err();
         assert!(
             err.to_string()
                 .contains("sops.rops=false is not supported for TOML SOPS files"),

--- a/src/sops.rs
+++ b/src/sops.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::backend::configured_toolset_or_path_which;
 use crate::config::{Config, Settings};
 use crate::env;
+use crate::env_diff::EnvMap;
 use crate::file::replace_path;
 use crate::{dirs, file, result};
 use eyre::{WrapErr, eyre};
@@ -10,10 +11,11 @@ use rops::cryptography::cipher::AES256GCM;
 use rops::cryptography::hasher::SHA512;
 use rops::file::RopsFile;
 use rops::file::state::EncryptedFile;
-use tokio::sync::{Mutex, OnceCell};
+use tokio::sync::Mutex;
 
 pub async fn decrypt<PT, F>(
     config: &Arc<Config>,
+    exec_env: &EnvMap,
     input: &str,
     mut parse_template: PT,
     format: &str,
@@ -22,8 +24,6 @@ where
     PT: FnMut(String) -> result::Result<String>,
     F: rops::file::format::FileFormat,
 {
-    static AGE_KEY: OnceCell<Option<String>> = OnceCell::const_new();
-    static AGE_KEY_FILE: OnceCell<Option<std::path::PathBuf>> = OnceCell::const_new();
     static MUTEX: Mutex<()> = Mutex::const_new(());
 
     let use_rops = Settings::get().sops.rops;
@@ -33,100 +33,7 @@ where
         ));
     }
 
-    let age = AGE_KEY
-        .get_or_init(async || {
-            // 1. Check mise-specific MISE_SOPS_AGE_KEY setting first (highest priority)
-            if let Some(age_key) = &Settings::get().sops.age_key
-                && !age_key.is_empty()
-            {
-                return Some(age_key.clone());
-            }
-
-            // 2. Check mise-specific MISE_SOPS_AGE_KEY_FILE setting
-            if let Some(key_file) = &Settings::get().sops.age_key_file {
-                let p = replace_path(
-                    match parse_template(key_file.to_string_lossy().to_string()) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            warn!("failed to parse MISE_SOPS_AGE_KEY_FILE: {}", e);
-                            return None;
-                        }
-                    },
-                );
-                if p.exists()
-                    && let Ok(raw) = file::read_to_string(&p)
-                {
-                    let key = raw
-                        .trim()
-                        .lines()
-                        .filter(|l| !l.starts_with('#'))
-                        .collect::<String>();
-                    if !key.trim().is_empty() {
-                        // Store the path for later use by sops CLI
-                        let _ = AGE_KEY_FILE.get_or_init(|| async { Some(p.clone()) }).await;
-                        return Some(key);
-                    }
-                }
-            }
-
-            // 3. Check standard SOPS_AGE_KEY_FILE environment variable
-            if let Ok(key_file_path) = env::var("SOPS_AGE_KEY_FILE") {
-                let p = replace_path(match parse_template(key_file_path.clone()) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        warn!("failed to parse SOPS_AGE_KEY_FILE: {}", e);
-                        return None;
-                    }
-                });
-                if p.exists()
-                    && let Ok(raw) = file::read_to_string(&p)
-                {
-                    let key = raw
-                        .trim()
-                        .lines()
-                        .filter(|l| !l.starts_with('#'))
-                        .collect::<String>();
-                    if !key.trim().is_empty() {
-                        // Store the path for later use by sops CLI
-                        let _ = AGE_KEY_FILE.get_or_init(|| async { Some(p.clone()) }).await;
-                        return Some(key);
-                    }
-                }
-            }
-
-            // 4. Check standard SOPS_AGE_KEY environment variable (direct key content)
-            if let Ok(key) = env::var("SOPS_AGE_KEY")
-                && !key.trim().is_empty()
-            {
-                return Some(key.trim().to_string());
-            }
-
-            // 5. Fall back to default path ~/.config/mise/age.txt
-            let p = dirs::CONFIG.join("age.txt");
-            let p = replace_path(match parse_template(p.to_string_lossy().to_string()) {
-                Ok(p) => p,
-                Err(e) => {
-                    warn!("failed to parse default sops age key file: {}", e);
-                    return None;
-                }
-            });
-            if p.exists()
-                && let Ok(raw) = file::read_to_string(p.clone())
-            {
-                let key = raw
-                    .trim()
-                    .lines()
-                    .filter(|l| !l.starts_with('#'))
-                    .collect::<String>();
-                if !key.trim().is_empty() {
-                    // Store the path for later use by sops CLI
-                    let _ = AGE_KEY_FILE.get_or_init(|| async { Some(p.clone()) }).await;
-                    return Some(key);
-                }
-            }
-            None
-        })
-        .await;
+    let (age, age_key_file) = resolve_age_key(exec_env, &mut parse_template);
 
     if age.is_none() && !Settings::get().sops.strict {
         debug!("age key not found, skipping decryption in non-strict mode");
@@ -139,7 +46,7 @@ where
     let prev_age_key_file = env::var("SOPS_AGE_KEY_FILE").ok();
 
     // Set SOPS_AGE_KEY_FILE with expanded path if we found one, so sops CLI can use it
-    if let Some(expanded_path) = AGE_KEY_FILE.get().and_then(|f| f.as_ref()) {
+    if let Some(expanded_path) = &age_key_file {
         env::set_var(
             "SOPS_AGE_KEY_FILE",
             expanded_path.to_string_lossy().to_string(),
@@ -254,4 +161,108 @@ where
         env::remove_var("SOPS_AGE_KEY_FILE");
     }
     Ok(output.unwrap_or_default())
+}
+
+fn resolve_age_key<PT>(
+    env: &EnvMap,
+    parse_template: &mut PT,
+) -> (Option<String>, Option<std::path::PathBuf>)
+where
+    PT: FnMut(String) -> result::Result<String>,
+{
+    // 1. Check mise-specific MISE_SOPS_AGE_KEY setting first (highest priority)
+    if let Some(age_key) = &Settings::get().sops.age_key
+        && !age_key.is_empty()
+    {
+        return (Some(age_key.clone()), None);
+    }
+
+    // 2. Check mise-specific MISE_SOPS_AGE_KEY_FILE setting
+    if let Some(key_file) = &Settings::get().sops.age_key_file
+        && let Some((key, path)) = read_age_key_file(
+            key_file.to_string_lossy().to_string(),
+            parse_template,
+            "MISE_SOPS_AGE_KEY_FILE",
+        )
+    {
+        return (Some(key), Some(path));
+    }
+
+    // 3. Check ordered env directives that have already been resolved
+    if let Some(age_key) = env.get("MISE_SOPS_AGE_KEY").filter(|key| !key.is_empty()) {
+        return (Some(age_key.clone()), None);
+    }
+
+    if let Some(key_file) = env.get("MISE_SOPS_AGE_KEY_FILE")
+        && let Some((key, path)) =
+            read_age_key_file(key_file.clone(), parse_template, "MISE_SOPS_AGE_KEY_FILE")
+    {
+        return (Some(key), Some(path));
+    }
+
+    if let Some(key_file) = env.get("SOPS_AGE_KEY_FILE")
+        && let Some((key, path)) =
+            read_age_key_file(key_file.clone(), parse_template, "SOPS_AGE_KEY_FILE")
+    {
+        return (Some(key), Some(path));
+    }
+
+    if let Some(age_key) = env.get("SOPS_AGE_KEY").filter(|key| !key.trim().is_empty()) {
+        return (Some(age_key.trim().to_string()), None);
+    }
+
+    // 4. Check standard SOPS environment variables
+    if let Ok(key_file_path) = env::var("SOPS_AGE_KEY_FILE")
+        && let Some((key, path)) =
+            read_age_key_file(key_file_path, parse_template, "SOPS_AGE_KEY_FILE")
+    {
+        return (Some(key), Some(path));
+    }
+
+    if let Ok(key) = env::var("SOPS_AGE_KEY")
+        && !key.trim().is_empty()
+    {
+        return (Some(key.trim().to_string()), None);
+    }
+
+    // 5. Fall back to default path ~/.config/mise/age.txt
+    if let Some((key, path)) = read_age_key_file(
+        dirs::CONFIG.join("age.txt").to_string_lossy().to_string(),
+        parse_template,
+        "default sops age key file",
+    ) {
+        return (Some(key), Some(path));
+    }
+
+    (None, None)
+}
+
+fn read_age_key_file<PT>(
+    key_file_path: String,
+    parse_template: &mut PT,
+    source: &str,
+) -> Option<(String, std::path::PathBuf)>
+where
+    PT: FnMut(String) -> result::Result<String>,
+{
+    let p = replace_path(match parse_template(key_file_path) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("failed to parse {source}: {e}");
+            return None;
+        }
+    });
+    if p.exists()
+        && let Ok(raw) = file::read_to_string(&p)
+    {
+        let key = raw
+            .trim()
+            .lines()
+            .filter(|l| !l.starts_with('#'))
+            .collect::<String>();
+        if !key.trim().is_empty() {
+            return Some((key, p));
+        }
+    }
+    None
 }

--- a/src/sops.rs
+++ b/src/sops.rs
@@ -207,16 +207,16 @@ where
         return (Some(key), Some(path));
     }
 
-    if let Some(age_key) = env.get("SOPS_AGE_KEY").filter(|key| !key.trim().is_empty()) {
-        return (Some(age_key.trim().to_string()), None);
-    }
-
     // 4. Check standard SOPS environment variables
     if let Ok(key_file_path) = env::var("SOPS_AGE_KEY_FILE")
         && let Some((key, path)) =
             read_age_key_file(key_file_path, parse_template, "SOPS_AGE_KEY_FILE")
     {
         return (Some(key), Some(path));
+    }
+
+    if let Some(age_key) = env.get("SOPS_AGE_KEY").filter(|key| !key.trim().is_empty()) {
+        return (Some(age_key.trim().to_string()), None);
     }
 
     if let Ok(key) = env::var("SOPS_AGE_KEY")


### PR DESCRIPTION
## Summary
- pass the ordered env resolver state into SOPS file decryption
- resolve SOPS age keys from already-resolved `[env]` values before falling back to ambient SOPS env vars
- cover `MISE_SOPS_AGE_KEY_FILE` before `_.file` in both `mise env` and `hook-env`

## Tests
- `mise run format`
- `mise run test:e2e e2e/secrets/test_secrets`
- `cargo test --all-features config::env_directive::file::tests`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret decryption and key-resolution precedence; behavior change is scoped and covered by e2e/unit tests.
> 
> **Overview**
> Fixes SOPS-backed `_.file` env loading when the age key is defined **earlier in the same `[env]` block** (e.g. `MISE_SOPS_AGE_KEY_FILE` before `_.file`), which previously failed in `mise env` and `hook-env` because decryption only looked at settings and the process environment.
> 
> **`sops::decrypt`** now takes the in-progress ordered env map and resolves age keys via **`resolve_age_key`**: mise settings still win, then **already-resolved `[env]` values** (`MISE_SOPS_AGE_KEY`, `MISE_SOPS_AGE_KEY_FILE`, `SOPS_AGE_KEY_FILE`, `SOPS_AGE_KEY`), then ambient `SOPS_*` vars and the default key file. The old **`OnceCell`** cache for keys is removed so each decrypt sees current resolver state.
> 
> JSON/YAML/TOML env file handlers pass **`exec_env`** into decrypt. New e2e and unit tests cover ordered directives and precedence (ambient `SOPS_AGE_KEY_FILE` over a bogus `SOPS_AGE_KEY` in `exec_env`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cde76f415fdf51ee99d4896f8e50d7da1d7a46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret decryption so environment-provided SOPS age key file paths are correctly used when decrypting encrypted files.
  * Fixed cases where ordered environment directives could be skipped, ensuring secrets export properly in shell hooks and environment output.
  * Enhanced reliability so secret handling behaves consistently across TOML/JSON/YAML encrypted configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->