### PR TITLE
docs(env): clarify env_shell_expand setting

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -604,7 +604,7 @@ Supported syntax:
 Expansion runs after Tera template rendering, so both syntaxes can be mixed.
 Undefined variables without a default are left unexpanded and produce a warning.
 
-The setting controls shell expansion:
+The `env_shell_expand` setting controls shell expansion:
 
 - **`true`** or **unset** (default) — enable shell expansion
 - **`false`** — disable shell expansion


### PR DESCRIPTION
## Summary
- name `env_shell_expand` in the shell expansion docs section
- clarify which setting controls shell-style env variable expansion

## Testing
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no code or configuration behavior impact.
> 
> **Overview**
> In the **Shell-style variable expansion** section of the environments docs, the sentence that introduced the on/off behavior now explicitly refers to **`env_shell_expand`** instead of the vague phrase “The setting.”
> 
> No behavior or config semantics change—only clearer linkage between the documented `$VAR` / `${VAR}` syntax and the setting readers should toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e7526cd6bbd84d5786e86b22903c63cfdba77f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the “Shell-style variable expansion” documentation to explicitly name the `env_shell_expand` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->