### PR TITLE
fix(brew-cask): expand font target paths to handle $HOME and return relative paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -678,10 +678,10 @@ impl MiseToml {
                 EnvDirective::Val(key, value, _) => {
                     base_env.insert(key.clone(), value.clone());
                 }
-                EnvDirective::Default(key, value, _) => {
-                    if base_env.get(key).is_none_or(|v| v.is_empty()) {
-                        base_env.insert(key.clone(), value.clone());
-                    }
+                EnvDirective::Default(key, value, _)
+                    if base_env.get(key).is_none_or(|v| v.is_empty()) =>
+                {
+                    base_env.insert(key.clone(), value.clone());
                 }
                 _ => {}
             }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -469,7 +469,28 @@ fn caskroom_font_path(caskroom: &Path, font: &FontArtifact) -> Result<PathBuf> {
 
 fn font_filename(font: &FontArtifact) -> Result<String> {
     match &font.target {
-        Some(target) => Ok(target.clone()),
+        Some(target) => {
+            let home = crate::dirs::HOME.to_string_lossy();
+            let mut expanded = target.replace("$HOME", &home);
+            if let Some(rest) = expanded.strip_prefix("~/") {
+                expanded = home.to_string() + "/" + rest;
+            } else if expanded == "~" {
+                expanded = home.to_string();
+            }
+            let expanded_path = Path::new(&expanded);
+            if expanded_path.is_absolute() {
+                let fonts_dir = crate::dirs::HOME.join("Library").join("Fonts");
+                if let Ok(relative) = expanded_path.strip_prefix(&fonts_dir) {
+                    return Ok(relative.to_string_lossy().to_string());
+                }
+                return expanded_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(str::to_string)
+                    .ok_or_else(|| eyre!("brew-cask: invalid font target '{}'", target));
+            }
+            Ok(expanded)
+        }
         None => Path::new(&font.source)
             .file_name()
             .and_then(|n| n.to_str())
@@ -1361,6 +1382,127 @@ mod tests {
 
         let artifacts = cask_artifacts(&cask)?;
         assert_eq!(artifacts.fonts.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn font_filename_from_source() -> Result<()> {
+        let font = FontArtifact {
+            source: "MyFont-Regular.ttf".to_string(),
+            target: None,
+        };
+        assert_eq!(font_filename(&font)?, "MyFont-Regular.ttf");
+        Ok(())
+    }
+
+    #[test]
+    fn font_filename_simple_target() -> Result<()> {
+        let font = FontArtifact {
+            source: "MyFont.ttf".to_string(),
+            target: Some("RenamedFont.ttf".to_string()),
+        };
+        assert_eq!(font_filename(&font)?, "RenamedFont.ttf");
+        Ok(())
+    }
+
+    #[test]
+    fn font_filename_target_with_home_and_absolute_fonts_path() -> Result<()> {
+        // Simulates the JetBrainsMono pattern:
+        // target: "/$HOME/Library/Fonts/JetBrainsMonoNerdFontPropo-ThinItalic.ttf"
+        let target = "/$HOME/Library/Fonts/JetBrainsMonoNerdFontPropo-ThinItalic.ttf".to_string();
+        let font = FontArtifact {
+            source: "JetBrainsMonoNerdFontPropo-ThinItalic.ttf".to_string(),
+            target: Some(target),
+        };
+        assert_eq!(
+            font_filename(&font)?,
+            "JetBrainsMonoNerdFontPropo-ThinItalic.ttf"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn font_filename_target_with_home_expansion() -> Result<()> {
+        // $HOME without leading slash: "$HOME/Library/Fonts/Font.ttf"
+        let target = "$HOME/Library/Fonts/SomeFont.ttf";
+        let font = FontArtifact {
+            source: "SomeFont.ttf".to_string(),
+            target: Some(target.to_string()),
+        };
+        assert_eq!(font_filename(&font)?, "SomeFont.ttf");
+        Ok(())
+    }
+
+    #[test]
+    fn font_filename_target_with_tilde_expansion() -> Result<()> {
+        // ~/Library/Fonts/Font.ttf should expand to <home>/Library/Fonts/Font.ttf
+        let target = "~/Library/Fonts/TildeFont.ttf";
+        let font = FontArtifact {
+            source: "TildeFont.ttf".to_string(),
+            target: Some(target.to_string()),
+        };
+        assert_eq!(font_filename(&font)?, "TildeFont.ttf");
+        Ok(())
+    }
+
+    #[test]
+    fn font_target_path_from_simple_target() -> Result<()> {
+        let font = FontArtifact {
+            source: "MyFont.ttf".to_string(),
+            target: Some("MyFont.ttf".to_string()),
+        };
+        let expected = crate::dirs::HOME
+            .join("Library")
+            .join("Fonts")
+            .join("MyFont.ttf");
+        assert_eq!(font_target_path(&font)?, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn font_target_path_from_source_only() -> Result<()> {
+        let font = FontArtifact {
+            source: "FontAwesome.otf".to_string(),
+            target: None,
+        };
+        let expected = crate::dirs::HOME
+            .join("Library")
+            .join("Fonts")
+            .join("FontAwesome.otf");
+        assert_eq!(font_target_path(&font)?, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn font_target_path_with_home_absolute_target() -> Result<()> {
+        // Regression: absolute target with $HOME under ~/Library/Fonts
+        // should resolve to the correct path
+        let target = "/$HOME/Library/Fonts/JetBrainsMono.ttf".to_string();
+        let font = FontArtifact {
+            source: "JetBrainsMono.ttf".to_string(),
+            target: Some(target),
+        };
+        let expected = crate::dirs::HOME
+            .join("Library")
+            .join("Fonts")
+            .join("JetBrainsMono.ttf");
+        assert_eq!(font_target_path(&font)?, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn font_target_path_with_tilde_target() -> Result<()> {
+        // ~/Library/Fonts/Font.ttf should resolve to correct path
+        let target = "~/Library/Fonts/TildeFont.ttf".to_string();
+        let font = FontArtifact {
+            source: "TildeFont.ttf".to_string(),
+            target: Some(target),
+        };
+        let expected = crate::dirs::HOME
+            .join("Library")
+            .join("Fonts")
+            .join("TildeFont.ttf");
+        assert_eq!(font_target_path(&font)?, expected);
         Ok(())
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cask font target handling by expanding `$HOME` and `~`/`~/` into the configured home directory.
  * When a target points inside the home Fonts directory, it now returns a cleaned, relative font filename; otherwise it falls back to the base filename.
  * Invalid font targets are now rejected more consistently to prevent unexpected installs.
* **Tests**
  * Added coverage for font filename/target resolution (source-only fonts, simple target renaming, absolute targets under the home Fonts directory, and home-path mapping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->