### PR TITLE
fix(prune): don't delete tool versions referenced by tool stubs

### DIFF
--- a/docs/cli/prune.md
+++ b/docs/cli/prune.md
@@ -11,6 +11,9 @@ Versions which are no longer the latest specified in any of those configs are de
 Versions installed only with environment variables `MISE_<TOOL>_VERSION` will be deleted,
 as will versions only referenced on the command line `mise exec <TOOL>@<VERSION>`.
 
+Tool stubs that have been executed are tracked in ~/.local/state/mise/tracked-stubs.
+Versions still referenced by a tracked stub are not deleted.
+
 You can list prunable tools with `mise ls --prunable`
 
 ## Arguments

--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -313,6 +313,17 @@ Tool stubs implement intelligent caching which reduces the overhead mise has whe
 
 Cached stubs have ~4ms of overhead.
 
+## Pruning
+
+Executing a stub tracks it in `~/.local/state/mise/tracked-stubs`, the same way
+config files are tracked when they are used. [`mise prune`](/cli/prune) treats
+tool versions referenced by a tracked stub as needed and will not delete them,
+just like versions required by a tracked config file.
+
+A stub must have been executed at least once on the machine for its tool to be
+protected. If the stub file is later deleted, its tool versions become prunable
+again (unless something else needs them).
+
 ## Alternative: Creating Simple Stubs with `mise x`
 
 For basic use cases, you can quickly create simple tool stubs using the [`mise x`](/cli/exec) command as an alternative to writing TOML configuration manually:

--- a/e2e/cli/test_prune_tool_stub
+++ b/e2e/cli/test_prune_tool_stub
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Tool stubs are tracked when they are executed and `mise prune` must not
+# delete tool versions that are still referenced by a tracked stub.
+
+mkdir -p bin
+
+# stub pinning a concrete version
+cat >bin/dummy <<'EOF'
+#!/usr/bin/env -S mise tool-stub
+tool = "dummy"
+version = "1.0.0"
+EOF
+chmod +x bin/dummy
+
+# executing the stub installs the tool and tracks the stub
+assert_contains "bin/dummy" "This is Dummy 1.0.0!"
+
+# install another version that nothing references
+assert "mise install dummy@2.0.0"
+
+# only the unreferenced version is prunable
+assert_not_contains "mise prune --dry-run 2>&1" "dummy@1.0.0"
+assert_contains "mise prune --dry-run 2>&1" "dummy@2.0.0"
+
+# a tracked stub that fails during backend resolution should not abort prune
+cat >bin/missing-backend <<'EOF'
+#!/usr/bin/env -S mise tool-stub
+tool = "missing-backend"
+version = "1.0.0"
+EOF
+chmod +x bin/missing-backend
+assert_fail "bin/missing-backend"
+assert_contains "mise prune --dry-run 2>&1" "dummy@2.0.0"
+
+MISE_YES=1 assert "mise prune"
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_fail "ls $MISE_DATA_DIR/installs/dummy/2.0.0"
+
+# a fuzzy version protects whichever installed version satisfies it,
+# consistent with config-based retention
+cat >bin/dummy <<'EOF'
+#!/usr/bin/env -S mise tool-stub
+tool = "dummy"
+version = "1"
+EOF
+# the stub bin cache key is based on mtime with second resolution, so make
+# sure the rewritten stub is not mistaken for the old one
+touch -d '2001-01-01' bin/dummy
+assert_contains "bin/dummy" "This is Dummy 1.0.0!"
+assert_not_contains "mise prune --dry-run 2>&1" "dummy@1.0.0"
+
+# http backend stub whose tool name is derived from the stub filename
+cat >bin/hello-world <<'EOF'
+#!/usr/bin/env -S mise tool-stub
+version = "1.0.0"
+url = "https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz"
+bin = "bin/hello-world"
+EOF
+chmod +x bin/hello-world
+assert_succeed "bin/hello-world"
+assert "ls $MISE_DATA_DIR/installs/http-hello-world/1.0.0"
+assert_not_contains "mise prune --dry-run 2>&1" "hello-world@1.0.0"
+
+# deleting the stubs makes their versions prunable again
+rm bin/dummy bin/hello-world
+assert_contains "mise prune --dry-run 2>&1" "dummy@1.0.0"
+assert_contains "mise prune --dry-run 2>&1" "hello-world@1.0.0"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2805,6 +2805,9 @@ Versions which are no longer the latest specified in any of those configs are de
 Versions installed only with environment variables `MISE_<TOOL>_VERSION` will be deleted,
 as will versions only referenced on the command line `mise exec <TOOL>@<VERSION>`.
 
+Tool stubs that have been executed are tracked in ~/.local/state/mise/tracked\-stubs.
+Versions still referenced by a tracked stub are not deleted.
+
 You can list prunable tools with `mise ls \-\-prunable`
 .PP
 \fBUsage:\fR mise prune [OPTIONS] [<INSTALLED_TOOL>] ...

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2721,6 +2721,9 @@ Versions which are no longer the latest specified in any of those configs are de
 Versions installed only with environment variables `MISE_<TOOL>_VERSION` will be deleted,
 as will versions only referenced on the command line `mise exec <TOOL>@<VERSION>`.
 
+Tool stubs that have been executed are tracked in ~/.local/state/mise/tracked-stubs.
+Versions still referenced by a tracked stub are not deleted.
+
 You can list prunable tools with `mise ls --prunable`
 """#
     after_long_help #"""

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -5,7 +5,10 @@ use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::tracking::Tracker;
 use crate::config::{Config, Settings};
 use crate::runtime_symlinks;
-use crate::toolset::{ToolVersion, ToolsetBuilder, get_versions_needed_by_tracked_configs};
+use crate::toolset::{
+    ToolVersion, ToolsetBuilder, get_versions_needed_by_tracked_configs,
+    get_versions_needed_by_tracked_stubs,
+};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::prompt;
 use crate::{backend::Backend, config, exit};
@@ -20,6 +23,9 @@ use super::trust::Trust;
 /// Versions which are no longer the latest specified in any of those configs are deleted.
 /// Versions installed only with environment variables `MISE_<TOOL>_VERSION` will be deleted,
 /// as will versions only referenced on the command line `mise exec <TOOL>@<VERSION>`.
+///
+/// Tool stubs that have been executed are tracked in ~/.local/state/mise/tracked-stubs.
+/// Versions still referenced by a tracked stub are not deleted.
 ///
 /// You can list prunable tools with `mise ls --prunable`
 #[derive(Debug, clap::Args)]
@@ -124,6 +130,12 @@ pub async fn prunable_tools(
     // Remove versions that are still needed by tracked configs
     let needed_versions = get_versions_needed_by_tracked_configs(config, true, true).await?;
     for key in needed_versions {
+        to_delete.remove(&key);
+    }
+
+    // Remove versions that are still needed by tracked tool stubs
+    let needed_by_stubs = get_versions_needed_by_tracked_stubs(config).await?;
+    for key in needed_by_stubs {
         to_delete.remove(&key);
     }
 

--- a/src/cli/tool_stub.rs
+++ b/src/cli/tool_stub.rs
@@ -676,6 +676,16 @@ impl ToolStub {
         }; // Drop the lock before await
 
         let stub = ToolStubFile::from_file(&self.file)?;
+
+        // Track the stub so `mise prune` knows its tool is still needed. Stubs
+        // can live anywhere, so execution time is the only chance to find them.
+        // absolute() rather than canonicalize() so a symlinked stub keeps its
+        // invoked filename, which the tool name can be derived from.
+        let stub_path = std::path::absolute(&self.file).unwrap_or_else(|_| self.file.clone());
+        if let Err(err) = crate::config::tracking::Tracker::track_stub(&stub_path) {
+            crate::warn!("tracking tool stub: {err:#}");
+        }
+
         let mut config = Config::get().await?;
 
         return execute_with_tool_request(&stub, &mut config, args, &self.file).await;

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -15,7 +15,7 @@ use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::outdated_info::prefixed_latest_query;
 use crate::toolset::{
     ConfigScope, InstallOptions, ResolveOptions, ToolSource, ToolVersion, ToolsetBuilder,
-    get_versions_needed_by_tracked_configs_excluding_locks,
+    get_versions_needed_by_tracked_configs_excluding_locks, get_versions_needed_by_tracked_stubs,
 };
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
@@ -403,13 +403,15 @@ impl Upgrade {
                 upgraded_config_paths.insert(path.clone());
             }
         }
-        let versions_needed_by_tracked = get_versions_needed_by_tracked_configs_excluding_locks(
-            config,
-            true,
-            false,
-            &upgraded_config_paths,
-        )
-        .await?;
+        let mut versions_needed_by_tracked =
+            get_versions_needed_by_tracked_configs_excluding_locks(
+                config,
+                true,
+                false,
+                &upgraded_config_paths,
+            )
+            .await?;
+        versions_needed_by_tracked.extend(get_versions_needed_by_tracked_stubs(config).await?);
 
         // Only uninstall old versions of tools that were successfully upgraded
         // and are not needed by any tracked config
@@ -427,7 +429,7 @@ impl Upgrade {
                 let version_key = (old_tv.ba().short.to_string(), old_tv.tv_pathname());
                 if versions_needed_by_tracked.contains(&version_key) {
                     debug!(
-                        "Keeping {}@{} because it's still needed by a tracked config",
+                        "Keeping {}@{} because it's still needed by a tracked config or tool stub",
                         o.name, old_version
                     );
                     continue;

--- a/src/config/tracking.rs
+++ b/src/config/tracking.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use eyre::Result;
 
-use crate::dirs::TRACKED_CONFIGS;
+use crate::dirs::{TRACKED_CONFIGS, TRACKED_STUBS};
 use crate::file::{create_dir_all, make_symlink_or_file};
 use crate::hash::hash_to_str;
 
@@ -12,20 +12,36 @@ pub struct Tracker {}
 
 impl Tracker {
     pub fn track(path: &Path) -> Result<()> {
-        let tracking_path = TRACKED_CONFIGS.join(hash_to_str(&path));
+        Self::track_in(&TRACKED_CONFIGS, path)
+    }
+
+    pub fn track_stub(path: &Path) -> Result<()> {
+        Self::track_in(&TRACKED_STUBS, path)
+    }
+
+    fn track_in(dir: &Path, path: &Path) -> Result<()> {
+        let tracking_path = dir.join(hash_to_str(&path));
         if !tracking_path.exists() {
-            create_dir_all(&*TRACKED_CONFIGS)?;
+            create_dir_all(dir)?;
             make_symlink_or_file(path, &tracking_path)?;
         }
         Ok(())
     }
 
     pub fn list_all() -> Result<Vec<PathBuf>> {
+        Self::list_all_in(&TRACKED_CONFIGS)
+    }
+
+    pub fn list_all_stubs() -> Result<Vec<PathBuf>> {
+        Self::list_all_in(&TRACKED_STUBS)
+    }
+
+    fn list_all_in(dir: &Path) -> Result<Vec<PathBuf>> {
         let mut output = vec![];
-        if !TRACKED_CONFIGS.exists() {
+        if !dir.exists() {
             return Ok(output);
         }
-        for path in read_dir(&*TRACKED_CONFIGS)? {
+        for path in read_dir(dir)? {
             let mut path = path?.path();
             if path.is_symlink() {
                 path = fs::read_link(path)?;
@@ -42,8 +58,13 @@ impl Tracker {
     }
 
     pub fn clean() -> Result<()> {
-        if TRACKED_CONFIGS.is_dir() {
-            for path in read_dir(&*TRACKED_CONFIGS)? {
+        Self::clean_in(&TRACKED_CONFIGS)?;
+        Self::clean_in(&TRACKED_STUBS)
+    }
+
+    fn clean_in(dir: &Path) -> Result<()> {
+        if dir.is_dir() {
+            for path in read_dir(dir)? {
                 let path = path?.path();
                 if !path.exists() {
                     remove_file(&path)?;

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -18,5 +18,6 @@ pub static INSTALLS: Lazy<&Path> = Lazy::new(|| &env::MISE_INSTALLS_DIR);
 pub static SHIMS: Lazy<&Path> = Lazy::new(|| &env::MISE_SHIMS_DIR);
 
 pub static TRACKED_CONFIGS: Lazy<PathBuf> = Lazy::new(|| STATE.join("tracked-configs"));
+pub static TRACKED_STUBS: Lazy<PathBuf> = Lazy::new(|| STATE.join("tracked-stubs"));
 pub static TRUSTED_CONFIGS: Lazy<PathBuf> = Lazy::new(|| STATE.join("trusted-configs"));
 pub static IGNORED_CONFIGS: Lazy<PathBuf> = Lazy::new(|| STATE.join("ignored-configs"));

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -2,7 +2,9 @@ use crate::backend::Backend;
 use crate::cli::args::BackendArg;
 use crate::config::Config;
 use crate::config::settings::{Settings, SettingsStatusMissingTools};
+use crate::config::tracking::Tracker;
 use crate::env::TERM_WIDTH;
+use crate::file::display_path;
 use crate::lockfile::{Lockfile, lockfile_path_for_config};
 use crate::registry::REGISTRY;
 use crate::registry::tool_enabled;
@@ -663,7 +665,7 @@ pub async fn get_versions_needed_by_tracked_configs(
     config: &Arc<Config>,
     use_locked_version: bool,
     offline: bool,
-) -> Result<std::collections::HashSet<(String, String)>> {
+) -> Result<HashSet<(String, String)>> {
     get_versions_needed_by_tracked_configs_excluding_locks(
         config,
         use_locked_version,
@@ -680,8 +682,8 @@ pub async fn get_versions_needed_by_tracked_configs_excluding_locks(
     use_locked_version: bool,
     offline: bool,
     exclude_locked_config_paths: &HashSet<PathBuf>,
-) -> Result<std::collections::HashSet<(String, String)>> {
-    let mut needed = std::collections::HashSet::new();
+) -> Result<HashSet<(String, String)>> {
+    let mut needed = HashSet::new();
     // `mise prune` should keep versions pinned by lockfiles. `mise upgrade`
     // also protects lockfiles for other tracked projects, but excludes configs
     // it just upgraded so stale locks there do not keep the old version alive.
@@ -717,25 +719,82 @@ pub async fn get_versions_needed_by_tracked_configs_excluding_locks(
         }
         let mut ts = Toolset::from(cf.to_tool_request_set()?);
         ts.resolve_with_opts(config, &opts).await?;
-        for (_, tv) in ts.list_current_versions() {
-            needed.insert((tv.ba().short.to_string(), tv.tv_pathname()));
-            // Offline can't resolve `sub-N:latest` to a concrete version
-            // (no remote latest available). Conservatively protect every
-            // installed version of this backend so we don't delete the
-            // active one.
-            if offline
-                && let crate::toolset::ToolRequest::Sub { orig_version, .. } = &tv.request
-                && orig_version == "latest"
-                && let Ok(backend) = tv.backend()
-            {
-                let short = tv.ba().short.to_string();
-                for v in backend.list_installed_versions() {
-                    needed.insert((short.clone(), v));
-                }
+        collect_needed_versions(&ts, offline, &mut needed);
+    }
+    Ok(needed)
+}
+
+/// Get all tool versions that are needed by tracked tool stub files.
+/// Stubs are tracked in ~/.local/state/mise/tracked-stubs when they are
+/// executed. Returns (short_name, tv_pathname) pairs like
+/// [`get_versions_needed_by_tracked_configs`] so `mise prune` and
+/// `mise upgrade` do not delete versions still referenced by a stub.
+pub async fn get_versions_needed_by_tracked_stubs(
+    config: &Arc<Config>,
+) -> Result<HashSet<(String, String)>> {
+    let mut needed = HashSet::new();
+    // Like prune's tracked-config resolution, only installed versions need
+    // protecting, so resolve offline to avoid pointless remote lookups.
+    let opts = ResolveOptions {
+        use_locked_version: true,
+        offline: true,
+        ..Default::default()
+    };
+    for path in Tracker::list_all_stubs()? {
+        // A stub that no longer parses protects nothing, but shouldn't fail
+        // the whole prune either — it may simply have been repurposed.
+        let stub = match crate::cli::tool_stub::ToolStubFile::from_file(&path) {
+            Ok(stub) => stub,
+            Err(err) => {
+                warn!(
+                    "error loading tracked tool stub {}: {err:#}",
+                    display_path(&path)
+                );
+                continue;
+            }
+        };
+        let tr = match stub.to_tool_request(&path) {
+            Ok(tr) => tr,
+            Err(err) => {
+                warn!(
+                    "error resolving tracked tool stub {}: {err:#}",
+                    display_path(&path)
+                );
+                continue;
+            }
+        };
+        let mut ts = Toolset::new(ToolSource::ToolStub(path.clone()));
+        ts.add_version(tr);
+        if let Err(err) = ts.resolve_with_opts(config, &opts).await {
+            warn!(
+                "error resolving tracked tool stub version {}: {err:#}",
+                display_path(&path)
+            );
+            continue;
+        }
+        collect_needed_versions(&ts, true, &mut needed);
+    }
+    Ok(needed)
+}
+
+fn collect_needed_versions(ts: &Toolset, offline: bool, needed: &mut HashSet<(String, String)>) {
+    for (_, tv) in ts.list_current_versions() {
+        needed.insert((tv.ba().short.to_string(), tv.tv_pathname()));
+        // Offline can't resolve `sub-N:latest` to a concrete version
+        // (no remote latest available). Conservatively protect every
+        // installed version of this backend so we don't delete the
+        // active one.
+        if offline
+            && let crate::toolset::ToolRequest::Sub { orig_version, .. } = &tv.request
+            && orig_version == "latest"
+            && let Ok(backend) = tv.backend()
+        {
+            let short = tv.ba().short.to_string();
+            for v in backend.list_installed_versions() {
+                needed.insert((short.clone(), v));
             }
         }
     }
-    Ok(needed)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Tool stubs are now tracked in ~/.local/state/mise/tracked-stubs when they
are executed, mirroring how config files are tracked. mise prune (and the
old-version cleanup in mise upgrade) resolves each tracked stub with the
same parser stub execution uses and treats the resolved versions as
needed, so tools managed exclusively through stubs are no longer pruned.
Deleting a stub file makes its versions prunable again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Executed tool stubs are now tracked locally, so versions they reference are protected from removal.
  * `mise prune` and `mise upgrade` now retain tool versions required by tracked stubs (including pinned, fuzzy, and HTTP-backed stubs).
* **Documentation**
  * Updated `mise prune` help/man pages and developer CLI docs to describe tracked stub behavior and storage location.
* **Tests**
  * Added end-to-end coverage confirming stub-referenced versions remain unprunable during prune and become prunable after stub removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->