### PR TITLE
fix(core): improve precompiled setting errors

### DIFF
--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -129,12 +129,21 @@ impl NodePlugin {
             FetchOutcome::Downloaded => Ok(()),
             FetchOutcome::NotFound => {
                 if ctx.locked {
+                    if let Some(message) = node_flavor_not_found_message(opts) {
+                        bail!("{message}\nlocked mode requires the locked precompiled artifact")
+                    }
                     bail!(
                         "precompiled node archive not found and locked mode requires the locked precompiled artifact"
                     )
                 } else if Settings::get().node.compile != Some(false) {
+                    if let Some(message) = node_flavor_not_found_message(opts) {
+                        warn!("{message}");
+                    }
                     self.install_compiling(ctx, tv, opts).await
                 } else {
+                    if let Some(message) = node_flavor_not_found_message(opts) {
+                        bail!("{message}\ncompilation is disabled")
+                    }
                     bail!("precompiled node archive not found and compilation is disabled")
                 }
             }
@@ -1086,6 +1095,19 @@ fn mirror_url_for(node: &crate::config::settings::SettingsNode, filename: &str) 
     mirror
 }
 
+fn node_flavor_not_found_message(opts: &BuildOpts) -> Option<String> {
+    let settings = Settings::get();
+    let flavor = settings.node.flavor.as_deref()?;
+    Some(format!(
+        "precompiled node archive not found for node.flavor={flavor:?}: {}\n\
+         Node flavors are published by the unofficial builds project. Try:\n  \
+         mise settings set node.mirror_url {UNOFFICIAL_NODE_MIRROR_URL}\n  \
+         mise settings set node.flavor {flavor}\n\
+         or unset node.flavor to use official Node binaries.",
+        opts.binary_tarball_url
+    ))
+}
+
 fn os() -> &'static str {
     NodePlugin::map_os(built_info::CFG_OS)
 }
@@ -1292,6 +1314,39 @@ mod tests {
         let musl = mirror_url_for(&node, "node-v24.14.0-linux-x64-musl.tar.gz");
         assert_eq!(glibc.as_str(), "https://corp.example/node/");
         assert_eq!(musl.as_str(), "https://corp.example/node/");
+    }
+
+    #[test]
+    fn test_node_flavor_not_found_message_is_flavor_specific() {
+        let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let _guard = SettingsResetGuard { _lock: lock };
+        let mut settings = SettingsPartial::empty();
+        settings.node.flavor = Some("glibc-217".to_string());
+        Settings::reset(Some(settings));
+
+        let opts = BuildOpts {
+            version: "24.14.0".to_string(),
+            path: vec![],
+            install_path: PathBuf::from("node-v24.14.0"),
+            build_dir: PathBuf::from("node-v24.14.0"),
+            configure_cmd: "./configure".to_string(),
+            make_cmd: "make".to_string(),
+            make_install_cmd: "make install".to_string(),
+            source_tarball_name: "node-v24.14.0.tar.gz".to_string(),
+            source_tarball_path: PathBuf::from("node-v24.14.0.tar.gz"),
+            source_tarball_url: Url::parse("https://nodejs.org/dist/v24.14.0/node-v24.14.0.tar.gz")
+                .unwrap(),
+            binary_tarball_name: "node-v24.14.0-linux-x64-glibc-217.tar.gz".to_string(),
+            binary_tarball_path: PathBuf::from("node-v24.14.0-linux-x64-glibc-217.tar.gz"),
+            binary_tarball_url: Url::parse(
+                "https://nodejs.org/dist/v24.14.0/node-v24.14.0-linux-x64-glibc-217.tar.gz",
+            )
+            .unwrap(),
+        };
+
+        let message = node_flavor_not_found_message(&opts).unwrap();
+        assert!(message.contains("node.flavor=\"glibc-217\""));
+        assert!(message.contains(UNOFFICIAL_NODE_MIRROR_URL));
     }
 
     #[test]

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -856,7 +856,9 @@ impl Backend for PythonPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        if cfg!(windows) || Settings::get().python.compile != Some(true) {
+        let settings = Settings::get();
+        if cfg!(windows) || settings.python.compile != Some(true) {
+            validate_python_precompiled_settings(&settings)?;
             self.install_precompiled(ctx, &mut tv).await?;
         } else {
             self.install_compiled(ctx, &tv).await?;
@@ -1042,6 +1044,25 @@ fn python_precompiled_url_path(settings: &Settings) -> String {
     }
 }
 
+fn validate_python_precompiled_settings(settings: &Settings) -> Result<()> {
+    if let Some(arch) = &settings.python.precompiled_arch
+        && looks_like_python_precompiled_os(arch)
+    {
+        bail!(
+            "invalid python.precompiled_arch={arch:?}: this looks like an OS value. \
+             Use python.precompiled_os={arch:?} instead, and set python.precompiled_arch \
+             to an architecture such as \"x86_64\" or \"aarch64\"."
+        );
+    }
+    Ok(())
+}
+
+fn looks_like_python_precompiled_os(value: &str) -> bool {
+    value.contains("unknown-linux")
+        || value.contains("apple-darwin")
+        || value.contains("pc-windows")
+}
+
 fn python_os(settings: &Settings) -> String {
     if let Some(os) = &settings.python.precompiled_os {
         return os.clone();
@@ -1225,6 +1246,23 @@ plugins/python-build/share/python-build/patches/3.14.5/foo.patch
         );
         assert_eq!(python_precompiled_created_at("2026-06-11"), None);
         assert_eq!(python_precompiled_created_at("notadate"), None);
+    }
+
+    #[test]
+    fn test_validate_python_precompiled_settings_rejects_os_as_arch() {
+        let mut settings = Settings::default();
+        settings.python.precompiled_arch = Some("unknown-linux-musl".to_string());
+
+        let err = validate_python_precompiled_settings(&settings).unwrap_err();
+        assert!(err.to_string().contains("python.precompiled_os"));
+    }
+
+    #[test]
+    fn test_validate_python_precompiled_settings_accepts_arch() {
+        let mut settings = Settings::default();
+        settings.python.precompiled_arch = Some("x86_64".to_string());
+
+        validate_python_precompiled_settings(&settings).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject OS-like values passed to `python.precompiled_arch` before constructing invalid precompiled manifest URLs
- add flavor-specific guidance when a requested precompiled Node artifact is missing
- cover both cases with focused unit tests

## Root cause
`python.precompiled_arch` and `python.precompiled_os` are separate components, but OS/libc triples such as `unknown-linux-musl` were accepted as an arch and then combined with the detected OS. For Node, a missing flavor-specific binary fell through to the generic precompiled archive error or source fallback without explaining the unofficial-builds mirror relationship.

## Tests
- `cargo test -q --bin mise plugins::core::python::tests::test_validate_python_precompiled_settings`
- `cargo test -q --bin mise plugins::core::node::tests::test_node_flavor_not_found_message_is_flavor_specific`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized install-path error messaging and settings validation; no changes to download, checksum, or auth flows.
> 
> **Overview**
> Improves install-time errors when **Node** or **Python** precompiled settings are misconfigured or point at artifacts that are not on the default mirror.
> 
> For **Node**, when a precompiled tarball 404s and `node.flavor` is set, locked installs, compile-disabled failures, and source-compile fallbacks now include flavor-specific text (missing URL, unofficial-builds mirror, suggested `mise settings` commands) instead of only generic messages.
> 
> For **Python**, precompiled installs now run **`validate_python_precompiled_settings`** first and fail fast if `python.precompiled_arch` looks like an OS triple (e.g. `unknown-linux-musl`), directing users to `python.precompiled_os` and a real arch value.
> 
> Unit tests cover the Node flavor message and Python arch/OS validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b20434faedaf9148b884c46d401e4d1712c29cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node precompiled installation messaging to be flavor-aware, including clearer errors for locked mode and guidance when compilation is disabled.
  * Strengthened Python precompiled installation validation by rejecting OS-like entries in the precompiled architecture setting and instructing users to use the precompiled OS field instead.
* **Tests**
  * Added assertions to verify flavor-specific Node not-found messaging and to confirm Python precompiled settings validation accepts architectures while rejecting OS-like values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->