### PR TITLE
fix(core): clarify python precompiled triple errors

### DIFF
--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -1046,7 +1046,16 @@ fn python_precompiled_url_path(settings: &Settings) -> String {
 
 fn validate_python_precompiled_settings(settings: &Settings) -> Result<()> {
     if let Some(arch) = &settings.python.precompiled_arch
-        && looks_like_python_precompiled_os(arch)
+        && let Some((precompiled_arch, precompiled_os)) = split_python_precompiled_triple(arch)
+    {
+        bail!(
+            "invalid python.precompiled_arch={arch:?}: this looks like a target triple. \
+             Set python.precompiled_arch={precompiled_arch:?} and \
+             python.precompiled_os={precompiled_os:?} instead."
+        );
+    }
+    if let Some(arch) = &settings.python.precompiled_arch
+        && looks_like_python_precompiled_os_value(arch)
     {
         bail!(
             "invalid python.precompiled_arch={arch:?}: this looks like an OS value. \
@@ -1057,7 +1066,16 @@ fn validate_python_precompiled_settings(settings: &Settings) -> Result<()> {
     Ok(())
 }
 
-fn looks_like_python_precompiled_os(value: &str) -> bool {
+fn split_python_precompiled_triple(value: &str) -> Option<(&str, &str)> {
+    ["-unknown-linux", "-apple-darwin", "-pc-windows"]
+        .iter()
+        .find_map(|os_marker| {
+            let index = value.find(os_marker)?;
+            (index > 0).then(|| (&value[..index], &value[index + 1..]))
+        })
+}
+
+fn looks_like_python_precompiled_os_value(value: &str) -> bool {
     value.contains("unknown-linux")
         || value.contains("apple-darwin")
         || value.contains("pc-windows")
@@ -1255,6 +1273,17 @@ plugins/python-build/share/python-build/patches/3.14.5/foo.patch
 
         let err = validate_python_precompiled_settings(&settings).unwrap_err();
         assert!(err.to_string().contains("python.precompiled_os"));
+    }
+
+    #[test]
+    fn test_validate_python_precompiled_settings_rejects_triple_as_arch() {
+        let mut settings = Settings::default();
+        settings.python.precompiled_arch = Some("x86_64-unknown-linux-musl".to_string());
+
+        let err = validate_python_precompiled_settings(&settings).unwrap_err();
+        let err = err.to_string();
+        assert!(err.contains("python.precompiled_arch=\"x86_64\""));
+        assert!(err.contains("python.precompiled_os=\"unknown-linux-musl\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- clarify the Python precompiled settings error when `python.precompiled_arch` is set to a full target triple
- suggest splitting the triple into `python.precompiled_arch` and `python.precompiled_os`
- add a regression test for `x86_64-unknown-linux-musl`

## Context
Follow-up to Cursor Bugbot feedback on #10791: https://github.com/jdx/mise/pull/10791#pullrequestreview-4639251249

## Tests
- `mise run format`
- `cargo test --bin mise test_validate_python_precompiled_settings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation and error-message only at precompiled install time; no change for correctly split arch/os settings.
> 
> **Overview**
> When **`python.precompiled_arch`** is set to a full target triple (e.g. `x86_64-unknown-linux-musl`), validation now fails with a dedicated message that calls out a triple mistake and suggests splitting it into **`python.precompiled_arch`** and **`python.precompiled_os`**, with concrete example values in the error.
> 
> Triple detection is implemented via **`split_python_precompiled_triple`** (markers like `-unknown-linux`, `-apple-darwin`, `-pc-windows`). The existing check for OS-only values in the arch field is unchanged but the helper is renamed to **`looks_like_python_precompiled_os_value`**. A regression test covers the triple case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f631f516f9b67bee41d420883f33a5b4d8130a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Python precompiled settings to catch cases where a full target triple is entered in the architecture field.
  * Error messages now clearly tell you to separate the architecture and operating system values, making misconfiguration easier to correct.
  * Added coverage for this validation so the incorrect input is reliably rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->