### PR TITLE
schedule releases for Monday morning

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -3,7 +3,7 @@ name: auto-merge-release
 on:
   schedule:
     # 10:00 UTC = 4am CST (winter) / 5am CDT (summer)
-    - cron: "0 10 * * *"
+    - cron: "0 10 * * 1"
   workflow_dispatch:
 
 jobs:
@@ -26,37 +26,10 @@ jobs:
             exit 0
           fi
 
-          # Parse description for section headers (release-plz groups commits by type)
-          # Substantive sections (daily): Features, Bug Fixes, Performance, Security
-          # Non-substantive sections (weekly): Refactor, Revert, Documentation, Chore, Registry, Dependency Updates
-          SUBSTANTIVE=$(echo "$BODY" | grep -E '^[[:space:]]*###.*(Features|Bug Fixes|Performance|Security)' || true)
-
-          if [ -n "$SUBSTANTIVE" ]; then
-            echo "PR #$PR_NUMBER has substantive changes (Features/Bug Fixes/Performance/Security), merging daily"
-          else
-            CREATED=$(gh pr view "$PR_NUMBER" -R jdx/mise --json createdAt --jq '.createdAt')
-            if [ -z "$CREATED" ]; then
-              echo "ERROR: Failed to get PR creation date"
-              exit 1
-            fi
-
-            CREATED_EPOCH=$(date -d "$CREATED" +%s 2>/dev/null)
-            if [ -z "$CREATED_EPOCH" ]; then
-              echo "ERROR: Failed to parse PR creation date: $CREATED"
-              exit 1
-            fi
-
-            NOW_EPOCH=$(date +%s)
-            DAYS_OLD=$(( (NOW_EPOCH - CREATED_EPOCH) / 86400 ))
-            if [ "$DAYS_OLD" -lt 7 ]; then
-              echo "PR #$PR_NUMBER only non-substantive changes (docs/chore/registry/deps), $DAYS_OLD days old; waiting until 7 days"
-              exit 0
-            fi
-            echo "PR #$PR_NUMBER only non-substantive changes, 7+ days old, enabling auto-merge"
-          fi
+          echo "PR #$PR_NUMBER is ready for the Monday morning release window"
 
           gh pr merge "$PR_NUMBER" -R jdx/mise --squash --auto || {
-            echo "Merge failed or PR not ready, will retry tomorrow"
+            echo "Merge failed or PR not ready, will retry on the next run"
             exit 0
           }
         env:


### PR DESCRIPTION
## Summary

- Change the release auto-merge cron from daily to Monday morning only.
- Remove the daily substantive-change shortcut so release PRs are only auto-merged in the Monday release window.

## Validation

- `actionlint .github/workflows/auto-merge-release.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.github/workflows/auto-merge-release.yml` changes; no runtime or application code, with merge behavior simplified to a weekly window.
> 
> **Overview**
> **Release PRs are auto-merged on a fixed weekly schedule** instead of daily with content-based rules.
> 
> The `auto-merge-release` workflow cron changes from **every day at 10:00 UTC** to **Mondays only** (`0 10 * * 1`). `workflow_dispatch` is unchanged for manual runs.
> 
> The merge step **drops** parsing the PR body for substantive sections (Features, Bug Fixes, Performance, Security) and the **7-day wait** for docs/chore-only releases. It still **requires a non-empty PR description**; otherwise it exits without merging. On a scheduled Monday run, an eligible release→main PR is merged with squash auto-merge, with retry messaging updated for the next workflow run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ff9794825f8a40a9c53a38e412c19a216654bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release merge schedule to run weekly on Mondays instead of daily.
  * Adjusted the status message shown when an automatic merge cannot complete, so it now reflects the next scheduled retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->