### PR TITLE
registry: add age-plugin-se (aqua:remko/age-plugin-se)

### DIFF
--- a/registry/age-plugin-se.toml
+++ b/registry/age-plugin-se.toml
@@ -1,0 +1,4 @@
+backends = ["aqua:remko/age-plugin-se"]
+description = "Age plugin for Apple's Secure Enclave"
+os = ["linux", "macos"]
+test = { cmd = "age-plugin-se --version", expected = "v{{version}}" }


### PR DESCRIPTION
## Summary
- Add `age-plugin-se` registry shorthand backed by `aqua:remko/age-plugin-se`
- Limit shorthand support to Linux and macOS; upstream Windows binary exists, but upstream docs say Windows needs Swift installed separately
- Add registry install test using `age-plugin-se --version`

## Popularity
- GitHub: 230 stars, 8 forks, latest release `v0.2.1` on 2025-12-27, last push 2026-04-12
- Homebrew: formula exists; 273 install-on-request events over 365 days
- aqua: package exists in `aquaproj/aqua-registry`
- Used by: fnox age provider docs list `age-plugin-se` as a supported age plugin integration

## Testing
- `CARGO_TARGET_DIR=/private/tmp/codex-mise-target-age-plugin-se cargo build --bin mise`
- `MISE_NO_CONFIG=1 /private/tmp/codex-mise-target-age-plugin-se/debug/mise test-tool age-plugin-se`
- `git diff --check`
- `python3` TOML parse/assertion for `registry/age-plugin-se.toml`
- `taplo fmt --check registry/age-plugin-se.toml`
- `taplo check registry/age-plugin-se.toml`

Note: `hk check --all --exclude aqua-registry` did not complete in this sandbox because `taplo` panicked in `system-configuration` during the full-repo run before the remaining hooks could complete.

*This pull request was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry support for the `age-plugin-se` plugin, making it available for supported macOS and Linux environments.
  * Included version checking so the plugin can be validated automatically during use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->