### PR TITLE
chore(release): improve communique release notes

### DIFF
--- a/communique.toml
+++ b/communique.toml
@@ -1,4 +1,18 @@
-context = "mise prepares project dev environments by managing tools, environment variables, and tasks in one CLI."
+system_extra = """
+Write release notes for mise users, not a commit log.
+
+Start with a short summary only when it adds useful context. For substantial releases, explain the main theme and why it matters before the categorized sections. For very small releases, be direct and modest: one sentence like "This is a small release that fixes ..." is enough, and it is okay to skip a Highlights section entirely.
+
+Calibrate the length and enthusiasm to the actual changes:
+- Major user-facing releases should have a concise narrative summary and a small Highlights section.
+- Medium releases should briefly group the most important additions and fixes.
+- Small releases should not be inflated; prefer a compact Added/Fixed/Changed list.
+- Dependency updates, CI changes, release plumbing, and other internal work should be omitted unless they directly affect users.
+
+When writing bullets, explain the user-visible impact instead of restating the commit subject. For important user-facing features, include a short command or config example when it would help users understand how to try the feature. Keep examples focused and omit them for small fixes or self-explanatory changes. Prefer grouped, readable sections such as Highlights, Added, Fixed, Changed, Documentation, and New Contributors. Include PR links and contributor usernames when available, but do not thank @jdx.
+"""
+
+context = "mise prepares project dev environments by managing tools, environment variables, and tasks in one CLI. It manages dev tools, environment variables, tasks, bootstrap/system setup, lockfiles, and release provenance across platforms."
 
 [defaults]
 emoji = false

--- a/mise.lock
+++ b/mise.lock
@@ -320,61 +320,61 @@ version = "0.2.3"
 backend = "cargo:toml-cli"
 
 [[tools.communique]]
-version = "1.1.3"
+version = "1.2.0"
 backend = "github:jdx/communique"
 
 [tools.communique."platforms.linux-arm64"]
-checksum = "sha256:ed4cfaf449d75f12734be4b5508104fe4bc224e1694052c31dc78b025408a918"
-url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413754362"
+checksum = "sha256:9f5c60c6cb9ada8c8dc491e2c8882770610a6bc9c937939a8998b4fd722ee078"
+url = "https://github.com/jdx/communique/releases/download/v1.2.0/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/457075829"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-arm64-musl"]
-checksum = "sha256:ece7d0bf5946b86bdead1e7fbc6dd40a41585c1c950f3b637489cb783662bf9f"
-url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413753918"
+checksum = "sha256:516e7668f041b32b7d7f9b266135db05fcbdbcf159a77113495383bb9da6d074"
+url = "https://github.com/jdx/communique/releases/download/v1.2.0/communique-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/457075175"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-x64"]
-checksum = "sha256:61b46cf231882e0a10e0489df310ec9b875e83da0f38b60d6ac7bd67e09a15dc"
-url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413753688"
+checksum = "sha256:817f37cc3d243671fb73aaf8bf3fd104a0e2f912c0c51ef02b9afa81de46ffe8"
+url = "https://github.com/jdx/communique/releases/download/v1.2.0/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/457075387"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-x64-baseline"]
-checksum = "sha256:61b46cf231882e0a10e0489df310ec9b875e83da0f38b60d6ac7bd67e09a15dc"
-url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413753688"
+checksum = "sha256:817f37cc3d243671fb73aaf8bf3fd104a0e2f912c0c51ef02b9afa81de46ffe8"
+url = "https://github.com/jdx/communique/releases/download/v1.2.0/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/457075387"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-x64-musl"]
-checksum = "sha256:9c8d784d8bb91e83cd467ed0d26be6ed3290a61a482413d42b12321aee20d5c0"
-url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413753784"
+checksum = "sha256:952544174fa7cb46a578b5adbba5f7f1f3137853cfc46ab5fcd2e102dc398fad"
+url = "https://github.com/jdx/communique/releases/download/v1.2.0/communique-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/457075280"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:9c8d784d8bb91e83cd467ed0d26be6ed3290a61a482413d42b12321aee20d5c0"
-url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413753784"
+checksum = "sha256:952544174fa7cb46a578b5adbba5f7f1f3137853cfc46ab5fcd2e102dc398fad"
+url = "https://github.com/jdx/communique/releases/download/v1.2.0/communique-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/457075280"
 provenance = "github-attestations"
 
 [tools.communique."platforms.macos-arm64"]
-checksum = "sha256:7113bdb84a75ca23cccada1acc348a0770ec16a4b12a128f7b3f6b8c7764d10c"
-url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413753891"
+checksum = "sha256:6f59d1e770f1e9a8104f3f2d3a3f04b83e1d0b9a3c9eed3f1be4203e1d3a0d6a"
+url = "https://github.com/jdx/communique/releases/download/v1.2.0/communique-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/457075119"
 provenance = "github-attestations"
 
 [tools.communique."platforms.windows-x64"]
-checksum = "sha256:887a39f27f86fa785fd3c27e13b4b0360d68827a9bb747cbe1929fd691708456"
-url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413755231"
+checksum = "sha256:9ac291a762e34ec32c2f262f5f47b52760c2605a228c103949caaa0272f920b2"
+url = "https://github.com/jdx/communique/releases/download/v1.2.0/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/457077630"
 provenance = "github-attestations"
 
 [tools.communique."platforms.windows-x64-baseline"]
-checksum = "sha256:887a39f27f86fa785fd3c27e13b4b0360d68827a9bb747cbe1929fd691708456"
-url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413755231"
+checksum = "sha256:9ac291a762e34ec32c2f262f5f47b52760c2605a228c103949caaa0272f920b2"
+url = "https://github.com/jdx/communique/releases/download/v1.2.0/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/457077630"
 provenance = "github-attestations"
 
 [[tools.fd]]


### PR DESCRIPTION
## Summary

- Add mise-specific release-note guidance to `communique.toml`, including proportional handling for major, medium, and very small releases.
- Tell communique to omit internal/dependency/release-plumbing noise unless it affects users, focus bullets on user-visible impact, and include short command/config examples for important user-facing features when useful.
- Bump the locked communique release from 1.1.3 to 1.2.0 across existing lockfile platforms.

## Validation

- `mise x -- taplo fmt --check communique.toml`
- `mise x -- actionlint .github/workflows/release.yml`
- `git diff --check`
- pre-commit `mise run lint`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and dev-tool lockfile only; affects release note text generation, not runtime mise behavior.
> 
> **Overview**
> **Tightens how mise GitHub release notes are generated** by adding a `system_extra` prompt block in `communique.toml` and pairing it with communique **1.2.0** in `mise.lock`.
> 
> The new instructions steer communique away from commit-log style output: notes should target mise users, scale tone and length to release size (major vs small patch), skip internal/dependency noise unless user-visible, and emphasize impact with optional examples for big features. The base `context` string is also expanded so the model has a clearer picture of what mise does.
> 
> Lockfile updates refresh download URLs, checksums, and asset IDs for communique across all pinned platforms so CI/release workflows keep using the pinned binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee22dcc1a413f94f4095494f02861fb70a70d3a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release-note generation guidance so summaries read like user-focused release notes rather than a commit log.
  * Added clearer rules for when to use a “Highlights” section versus a compact bullet list, producing more consistent, release-sized formatting and less extraneous detail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->