### PR TITLE
feat(bootstrap): add launchd calendar intervals

### DIFF
--- a/docs/bootstrap/launchd.md
+++ b/docs/bootstrap/launchd.md
@@ -10,6 +10,7 @@ program = "~/.local/bin/my-sync"
 args = ["--watch"]
 run_at_load = true
 start_interval = 300
+start_calendar_interval = { hour = 2, minute = 0 }
 environment = { PATH = "/opt/homebrew/bin:/usr/bin:/bin" }
 working_directory = "~"
 stdout_path = "~/Library/Logs/my-sync.log"
@@ -24,22 +25,26 @@ numbers, `.`, `_`, and `-`. mise owns only the plist files it creates with the
 
 ## Supported keys
 
-| TOML key            | launchd key               |
-| ------------------- | ------------------------- |
-| `program`           | `ProgramArguments[0]`     |
-| `args`              | `ProgramArguments[1..]`   |
-| `run_at_load`       | `RunAtLoad`               |
-| `keep_alive`        | `KeepAlive`               |
-| `start_interval`    | `StartInterval`           |
-| `environment`       | `EnvironmentVariables`    |
-| `working_directory` | `WorkingDirectory`        |
-| `stdout_path`       | `StandardOutPath`         |
-| `stderr_path`       | `StandardErrorPath`       |
-| `kickstart`         | run `launchctl kickstart` |
+| TOML key                  | launchd key               |
+| ------------------------- | ------------------------- |
+| `program`                 | `ProgramArguments[0]`     |
+| `args`                    | `ProgramArguments[1..]`   |
+| `run_at_load`             | `RunAtLoad`               |
+| `keep_alive`              | `KeepAlive`               |
+| `start_interval`          | `StartInterval`           |
+| `start_calendar_interval` | `StartCalendarInterval`   |
+| `environment`             | `EnvironmentVariables`    |
+| `working_directory`       | `WorkingDirectory`        |
+| `stdout_path`             | `StandardOutPath`         |
+| `stderr_path`             | `StandardErrorPath`       |
+| `kickstart`               | run `launchctl kickstart` |
 
 `program`, `working_directory`, `stdout_path`, and `stderr_path` expand bare
 `~` and `~/` to the current user's home directory before writing the plist.
 `args` are passed through exactly as written.
+`start_calendar_interval` accepts `minute` (0-59), `hour` (0-23), `day`
+(1-31), `weekday` (0-7), and `month` (1-12), and writes the corresponding
+launchd calendar keys.
 
 ## Semantics
 

--- a/docs/bootstrap/launchd.md
+++ b/docs/bootstrap/launchd.md
@@ -9,7 +9,6 @@ mise can declare macOS user LaunchAgents in
 program = "~/.local/bin/my-sync"
 args = ["--watch"]
 run_at_load = true
-start_interval = 300
 start_calendar_interval = { hour = 2, minute = 0 }
 environment = { PATH = "/opt/homebrew/bin:/usr/bin:/bin" }
 working_directory = "~"
@@ -44,7 +43,15 @@ numbers, `.`, `_`, and `-`. mise owns only the plist files it creates with the
 `args` are passed through exactly as written.
 `start_calendar_interval` accepts `minute` (0-59), `hour` (0-23), `day`
 (1-31), `weekday` (0-7), and `month` (1-12), and writes the corresponding
-launchd calendar keys.
+launchd calendar keys. For multiple independent calendar schedules, use an
+array of inline tables:
+
+```toml
+start_calendar_interval = [{ hour = 3 }, { hour = 12, weekday = 1 }]
+```
+
+`start_interval` and `start_calendar_interval` are independent launchd
+triggers. If both are set, launchd can start the agent from either schedule.
 
 ## Semantics
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2526,6 +2526,7 @@ mod tests {
         args = ["--watch"]
         run_at_load = true
         start_interval = 300
+        start_calendar_interval = { hour = 2, minute = 0 }
         environment = { PATH = "/usr/bin:/bin" }
         working_directory = "~"
         stdout_path = "~/Library/Logs/my-sync.log"
@@ -2540,6 +2541,14 @@ mod tests {
         assert_eq!(agent.args, vec!["--watch"]);
         assert!(agent.run_at_load);
         assert_eq!(agent.start_interval, Some(300));
+        assert_eq!(
+            agent.start_calendar_interval.as_ref().unwrap().hour,
+            Some(2)
+        );
+        assert_eq!(
+            agent.start_calendar_interval.as_ref().unwrap().minute,
+            Some(0)
+        );
         assert_eq!(
             agent.environment.get("PATH").map(String::as_str),
             Some("/usr/bin:/bin")

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2531,6 +2531,10 @@ mod tests {
         working_directory = "~"
         stdout_path = "~/Library/Logs/my-sync.log"
         kickstart = true
+
+        [bootstrap.macos.launchd.agents.my-backup]
+        program = "~/.local/bin/my-backup"
+        start_calendar_interval = [{ hour = 3 }, { hour = 12, weekday = 1 }]
         "#,
         )
         .unwrap();
@@ -2541,14 +2545,13 @@ mod tests {
         assert_eq!(agent.args, vec!["--watch"]);
         assert!(agent.run_at_load);
         assert_eq!(agent.start_interval, Some(300));
-        assert_eq!(
-            agent.start_calendar_interval.as_ref().unwrap().hour,
-            Some(2)
-        );
-        assert_eq!(
-            agent.start_calendar_interval.as_ref().unwrap().minute,
-            Some(0)
-        );
+        let crate::system::launchd::LaunchdCalendarIntervals::Single(interval) =
+            agent.start_calendar_interval.as_ref().unwrap()
+        else {
+            panic!("expected single calendar interval");
+        };
+        assert_eq!(interval.hour, Some(2));
+        assert_eq!(interval.minute, Some(0));
         assert_eq!(
             agent.environment.get("PATH").map(String::as_str),
             Some("/usr/bin:/bin")
@@ -2559,6 +2562,16 @@ mod tests {
             Some("~/Library/Logs/my-sync.log")
         );
         assert!(agent.kickstart);
+        let backup = system.macos.launchd.agents.get("my-backup").unwrap();
+        let crate::system::launchd::LaunchdCalendarIntervals::Multiple(intervals) =
+            backup.start_calendar_interval.as_ref().unwrap()
+        else {
+            panic!("expected multiple calendar intervals");
+        };
+        assert_eq!(intervals.len(), 2);
+        assert_eq!(intervals[0].hour, Some(3));
+        assert_eq!(intervals[1].hour, Some(12));
+        assert_eq!(intervals[1].weekday, Some(1));
         file::remove_file(&p).unwrap();
     }
 

--- a/src/system/launchd.rs
+++ b/src/system/launchd.rs
@@ -25,6 +25,8 @@ pub struct LaunchdTomlConfig {
     #[serde(default)]
     pub start_interval: Option<u64>,
     #[serde(default)]
+    pub start_calendar_interval: Option<LaunchdCalendarInterval>,
+    #[serde(default)]
     pub environment: IndexMap<String, String>,
     #[serde(default)]
     pub working_directory: Option<String>,
@@ -36,6 +38,20 @@ pub struct LaunchdTomlConfig {
     pub kickstart: bool,
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+pub struct LaunchdCalendarInterval {
+    #[serde(default)]
+    pub minute: Option<u8>,
+    #[serde(default)]
+    pub hour: Option<u8>,
+    #[serde(default)]
+    pub day: Option<u8>,
+    #[serde(default)]
+    pub weekday: Option<u8>,
+    #[serde(default)]
+    pub month: Option<u8>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LaunchdRequest {
     pub name: String,
@@ -45,6 +61,7 @@ pub struct LaunchdRequest {
     pub run_at_load: bool,
     pub keep_alive: bool,
     pub start_interval: Option<u64>,
+    pub start_calendar_interval: Option<LaunchdCalendarInterval>,
     pub environment: IndexMap<String, String>,
     pub working_directory: Option<String>,
     pub stdout_path: Option<String>,
@@ -79,6 +96,9 @@ impl LaunchdRequest {
         if program.is_empty() {
             bail!("agent '{name}' must set a non-empty `program`");
         }
+        if let Some(interval) = &config.start_calendar_interval {
+            interval.validate(&name)?;
+        }
         Ok(Self {
             label: format!("dev.mise.{name}"),
             name,
@@ -87,6 +107,7 @@ impl LaunchdRequest {
             run_at_load: config.run_at_load,
             keep_alive: config.keep_alive,
             start_interval: config.start_interval,
+            start_calendar_interval: config.start_calendar_interval,
             environment: config.environment,
             working_directory: config.working_directory,
             stdout_path: config.stdout_path,
@@ -94,6 +115,42 @@ impl LaunchdRequest {
             kickstart: config.kickstart,
         })
     }
+}
+
+impl LaunchdCalendarInterval {
+    fn validate(&self, agent_name: &str) -> Result<()> {
+        if self.minute.is_none()
+            && self.hour.is_none()
+            && self.day.is_none()
+            && self.weekday.is_none()
+            && self.month.is_none()
+        {
+            bail!("agent '{agent_name}' `start_calendar_interval` must set at least one field");
+        }
+        validate_range(agent_name, "minute", self.minute, 0, 59)?;
+        validate_range(agent_name, "hour", self.hour, 0, 23)?;
+        validate_range(agent_name, "day", self.day, 1, 31)?;
+        validate_range(agent_name, "weekday", self.weekday, 0, 7)?;
+        validate_range(agent_name, "month", self.month, 1, 12)?;
+        Ok(())
+    }
+}
+
+fn validate_range(
+    agent_name: &str,
+    field: &str,
+    value: Option<u8>,
+    min: u8,
+    max: u8,
+) -> Result<()> {
+    if let Some(value) = value
+        && !(min..=max).contains(&value)
+    {
+        bail!(
+            "agent '{agent_name}' `start_calendar_interval.{field}` must be between {min} and {max}"
+        );
+    }
+    Ok(())
 }
 
 impl std::fmt::Display for LaunchdRequest {
@@ -234,6 +291,12 @@ fn plist_value(request: &LaunchdRequest) -> Value {
     if let Some(interval) = request.start_interval {
         dict.insert("StartInterval".into(), Value::Integer(interval.into()));
     }
+    if let Some(interval) = &request.start_calendar_interval {
+        dict.insert(
+            "StartCalendarInterval".into(),
+            Value::Dictionary(calendar_interval_value(interval)),
+        );
+    }
     if !request.environment.is_empty() {
         let mut env = Dictionary::new();
         for (key, value) in &request.environment {
@@ -260,6 +323,26 @@ fn plist_value(request: &LaunchdRequest) -> Value {
         );
     }
     Value::Dictionary(dict)
+}
+
+fn calendar_interval_value(interval: &LaunchdCalendarInterval) -> Dictionary {
+    let mut dict = Dictionary::new();
+    if let Some(value) = interval.minute {
+        dict.insert("Minute".into(), Value::Integer(value.into()));
+    }
+    if let Some(value) = interval.hour {
+        dict.insert("Hour".into(), Value::Integer(value.into()));
+    }
+    if let Some(value) = interval.day {
+        dict.insert("Day".into(), Value::Integer(value.into()));
+    }
+    if let Some(value) = interval.weekday {
+        dict.insert("Weekday".into(), Value::Integer(value.into()));
+    }
+    if let Some(value) = interval.month {
+        dict.insert("Month".into(), Value::Integer(value.into()));
+    }
+    dict
 }
 
 fn plist_matches(current: &[u8], request: &LaunchdRequest) -> bool {
@@ -390,6 +473,31 @@ mod tests {
         .unwrap();
         assert_eq!(request.label, "dev.mise.my-agent");
         assert!(LaunchdRequest::from_toml("bad/name".to_string(), Default::default()).is_err());
+        assert!(
+            LaunchdRequest::from_toml(
+                "my-agent".to_string(),
+                LaunchdTomlConfig {
+                    program: Some("/bin/echo".to_string()),
+                    start_calendar_interval: Some(Default::default()),
+                    ..Default::default()
+                },
+            )
+            .is_err()
+        );
+        assert!(
+            LaunchdRequest::from_toml(
+                "my-agent".to_string(),
+                LaunchdTomlConfig {
+                    program: Some("/bin/echo".to_string()),
+                    start_calendar_interval: Some(LaunchdCalendarInterval {
+                        hour: Some(24),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -404,6 +512,11 @@ mod tests {
             run_at_load: true,
             keep_alive: true,
             start_interval: Some(60),
+            start_calendar_interval: Some(LaunchdCalendarInterval {
+                hour: Some(2),
+                minute: Some(0),
+                ..Default::default()
+            }),
             environment,
             working_directory: Some("~".to_string()),
             stdout_path: Some("~/Library/Logs/sync.log".to_string()),
@@ -422,6 +535,13 @@ mod tests {
         assert_eq!(dict.get("RunAtLoad"), Some(&Value::Boolean(true)));
         assert_eq!(dict.get("KeepAlive"), Some(&Value::Boolean(true)));
         assert_eq!(dict.get("StartInterval"), Some(&Value::Integer(60.into())));
+        match dict.get("StartCalendarInterval") {
+            Some(Value::Dictionary(interval)) => {
+                assert_eq!(interval.get("Hour"), Some(&Value::Integer(2.into())));
+                assert_eq!(interval.get("Minute"), Some(&Value::Integer(0.into())));
+            }
+            value => panic!("expected StartCalendarInterval dictionary, got {value:?}"),
+        }
         assert_eq!(
             dict.get("WorkingDirectory"),
             Some(&Value::String(

--- a/src/system/launchd.rs
+++ b/src/system/launchd.rs
@@ -25,7 +25,7 @@ pub struct LaunchdTomlConfig {
     #[serde(default)]
     pub start_interval: Option<u64>,
     #[serde(default)]
-    pub start_calendar_interval: Option<LaunchdCalendarInterval>,
+    pub start_calendar_interval: Option<LaunchdCalendarIntervals>,
     #[serde(default)]
     pub environment: IndexMap<String, String>,
     #[serde(default)]
@@ -52,6 +52,13 @@ pub struct LaunchdCalendarInterval {
     pub month: Option<u8>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum LaunchdCalendarIntervals {
+    Single(LaunchdCalendarInterval),
+    Multiple(Vec<LaunchdCalendarInterval>),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LaunchdRequest {
     pub name: String,
@@ -61,7 +68,7 @@ pub struct LaunchdRequest {
     pub run_at_load: bool,
     pub keep_alive: bool,
     pub start_interval: Option<u64>,
-    pub start_calendar_interval: Option<LaunchdCalendarInterval>,
+    pub start_calendar_interval: Option<LaunchdCalendarIntervals>,
     pub environment: IndexMap<String, String>,
     pub working_directory: Option<String>,
     pub stdout_path: Option<String>,
@@ -133,6 +140,23 @@ impl LaunchdCalendarInterval {
         validate_range(agent_name, "weekday", self.weekday, 0, 7)?;
         validate_range(agent_name, "month", self.month, 1, 12)?;
         Ok(())
+    }
+}
+
+impl LaunchdCalendarIntervals {
+    fn validate(&self, agent_name: &str) -> Result<()> {
+        match self {
+            Self::Single(interval) => interval.validate(agent_name),
+            Self::Multiple(intervals) => {
+                if intervals.is_empty() {
+                    bail!("agent '{agent_name}' `start_calendar_interval` must not be empty");
+                }
+                for interval in intervals {
+                    interval.validate(agent_name)?;
+                }
+                Ok(())
+            }
+        }
     }
 }
 
@@ -294,7 +318,7 @@ fn plist_value(request: &LaunchdRequest) -> Value {
     if let Some(interval) = &request.start_calendar_interval {
         dict.insert(
             "StartCalendarInterval".into(),
-            Value::Dictionary(calendar_interval_value(interval)),
+            calendar_intervals_value(interval),
         );
     }
     if !request.environment.is_empty() {
@@ -323,6 +347,20 @@ fn plist_value(request: &LaunchdRequest) -> Value {
         );
     }
     Value::Dictionary(dict)
+}
+
+fn calendar_intervals_value(intervals: &LaunchdCalendarIntervals) -> Value {
+    match intervals {
+        LaunchdCalendarIntervals::Single(interval) => {
+            Value::Dictionary(calendar_interval_value(interval))
+        }
+        LaunchdCalendarIntervals::Multiple(intervals) => Value::Array(
+            intervals
+                .iter()
+                .map(|interval| Value::Dictionary(calendar_interval_value(interval)))
+                .collect(),
+        ),
+    }
 }
 
 fn calendar_interval_value(interval: &LaunchdCalendarInterval) -> Dictionary {
@@ -478,7 +516,9 @@ mod tests {
                 "my-agent".to_string(),
                 LaunchdTomlConfig {
                     program: Some("/bin/echo".to_string()),
-                    start_calendar_interval: Some(Default::default()),
+                    start_calendar_interval: Some(LaunchdCalendarIntervals::Single(
+                        Default::default(),
+                    )),
                     ..Default::default()
                 },
             )
@@ -489,10 +529,23 @@ mod tests {
                 "my-agent".to_string(),
                 LaunchdTomlConfig {
                     program: Some("/bin/echo".to_string()),
-                    start_calendar_interval: Some(LaunchdCalendarInterval {
-                        hour: Some(24),
-                        ..Default::default()
-                    }),
+                    start_calendar_interval: Some(LaunchdCalendarIntervals::Single(
+                        LaunchdCalendarInterval {
+                            hour: Some(24),
+                            ..Default::default()
+                        }
+                    )),
+                    ..Default::default()
+                },
+            )
+            .is_err()
+        );
+        assert!(
+            LaunchdRequest::from_toml(
+                "my-agent".to_string(),
+                LaunchdTomlConfig {
+                    program: Some("/bin/echo".to_string()),
+                    start_calendar_interval: Some(LaunchdCalendarIntervals::Multiple(vec![])),
                     ..Default::default()
                 },
             )
@@ -512,11 +565,13 @@ mod tests {
             run_at_load: true,
             keep_alive: true,
             start_interval: Some(60),
-            start_calendar_interval: Some(LaunchdCalendarInterval {
-                hour: Some(2),
-                minute: Some(0),
-                ..Default::default()
-            }),
+            start_calendar_interval: Some(LaunchdCalendarIntervals::Single(
+                LaunchdCalendarInterval {
+                    hour: Some(2),
+                    minute: Some(0),
+                    ..Default::default()
+                },
+            )),
             environment,
             working_directory: Some("~".to_string()),
             stdout_path: Some("~/Library/Logs/sync.log".to_string()),
@@ -583,6 +638,61 @@ mod tests {
             value => panic!("expected EnvironmentVariables dictionary, got {value:?}"),
         }
         assert!(plist_matches(&plist, &request));
+    }
+
+    #[test]
+    fn test_render_plist_multiple_calendar_intervals() {
+        let request = LaunchdRequest {
+            name: "sync".to_string(),
+            label: "dev.mise.sync".to_string(),
+            program: "/bin/echo".to_string(),
+            args: vec![],
+            run_at_load: false,
+            keep_alive: false,
+            start_interval: None,
+            start_calendar_interval: Some(LaunchdCalendarIntervals::Multiple(vec![
+                LaunchdCalendarInterval {
+                    hour: Some(3),
+                    minute: Some(0),
+                    ..Default::default()
+                },
+                LaunchdCalendarInterval {
+                    hour: Some(12),
+                    weekday: Some(1),
+                    ..Default::default()
+                },
+            ])),
+            environment: IndexMap::new(),
+            working_directory: None,
+            stdout_path: None,
+            stderr_path: None,
+            kickstart: false,
+        };
+        let plist = render_plist(&request).unwrap();
+        let dict = match Value::from_reader_xml(Cursor::new(plist.as_slice())).unwrap() {
+            Value::Dictionary(dict) => dict,
+            value => panic!("expected dictionary, got {value:?}"),
+        };
+        match dict.get("StartCalendarInterval") {
+            Some(Value::Array(intervals)) => {
+                assert_eq!(intervals.len(), 2);
+                match &intervals[0] {
+                    Value::Dictionary(interval) => {
+                        assert_eq!(interval.get("Hour"), Some(&Value::Integer(3.into())));
+                        assert_eq!(interval.get("Minute"), Some(&Value::Integer(0.into())));
+                    }
+                    value => panic!("expected first calendar interval dictionary, got {value:?}"),
+                }
+                match &intervals[1] {
+                    Value::Dictionary(interval) => {
+                        assert_eq!(interval.get("Hour"), Some(&Value::Integer(12.into())));
+                        assert_eq!(interval.get("Weekday"), Some(&Value::Integer(1.into())));
+                    }
+                    value => panic!("expected second calendar interval dictionary, got {value:?}"),
+                }
+            }
+            value => panic!("expected StartCalendarInterval array, got {value:?}"),
+        }
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- add `start_calendar_interval` support for macOS launchd agents
- render the TOML table to launchd `StartCalendarInterval` plist dictionaries
- validate calendar fields and document the supported ranges

Closes discussion #10770.

## Tests
- `cargo test system::launchd::tests -- --test-threads=1`
- `cargo test config::config_file::mise_toml::tests::test_bootstrap_macos_launchd_agents`
- `mise run lint` (via pre-commit)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, macOS-only experimental bootstrap behavior; misconfigured schedules fail at parse time and only affect user LaunchAgents when explicitly applied.
> 
> **Overview**
> Adds **`start_calendar_interval`** for macOS bootstrap LaunchAgents so jobs can run on calendar schedules, not only **`start_interval`** ticks.
> 
> TOML accepts a single inline table (e.g. `{ hour = 2, minute = 0 }`) or an array of tables for multiple triggers. Config is validated (at least one field per interval, documented ranges for minute/hour/day/weekday/month) and emitted as launchd **`StartCalendarInterval`** in generated plists. **`start_interval`** and calendar schedules can both be set; launchd may fire from either.
> 
> Docs and config/plist tests cover single and multi-interval agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb72add9106d835b2e8fd32d96053c86e76b09f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `start_calendar_interval` scheduling for launch agents.
  * You can now specify hour/minute/day/weekday/month, including multiple schedules.

* **Bug Fixes**
  * Improved validation to reject missing, empty, or out-of-range calendar interval settings.
  * Generated launchd output now reliably includes the correct `StartCalendarInterval` structure.

* **Documentation**
  * Updated the launchd bootstrap guide with the new `start_calendar_interval` TOML examples and supported values, and clarified it is independent of `start_interval`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->