### PR TITLE
fix(github): handle raw exe rename

### DIFF
--- a/e2e/backend/test_github
+++ b/e2e/backend/test_github
@@ -37,6 +37,16 @@ mise uninstall github:jdx/mise-test-fixtures
 mise install
 assert_contains "mise x -- hello-world" "hello world"
 
+# Test GitHub backend with a raw file asset and rename_exe
+cat <<EOF >mise.toml
+[tools]
+"github:jdx/mise-test-fixtures" = { version = "1.0.0", asset_pattern = "hello-world", rename_exe = "hello-renamed" }
+EOF
+
+mise uninstall github:jdx/mise-test-fixtures
+mise install
+assert_contains "mise x -- hello-renamed" "hello world"
+
 # Test GitHub backend with mise.lock checksum generation
 export MISE_LOCKFILE=1
 export MISE_EXPERIMENTAL=1

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -6,8 +6,8 @@ use crate::backend::platform_target::PlatformTarget;
 use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
     clean_binary_name, eval_checksum_expr, fetch_checksum_from_file, fetch_checksum_from_shasums,
-    get_filename_from_url, rename_executable_in_dir, shasums_has_entries, template_string,
-    template_string_for_target, verify_artifact,
+    get_filename_from_url, rename_binary_name, rename_executable_in_dir, shasums_has_entries,
+    template_string, template_string_for_target, verify_artifact,
 };
 use crate::backend::version_list;
 use crate::cli::args::BackendArg;
@@ -351,6 +351,12 @@ impl HttpBackend {
         // Check for explicit bin name first
         if let Some(bin_name) = opts.bin() {
             return bin_name;
+        }
+        if let Some(rename_to) = opts.rename_exe() {
+            return rename_binary_name(
+                &file_path.file_name().unwrap().to_string_lossy(),
+                &rename_to,
+            );
         }
 
         // Auto-clean the binary name

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -353,10 +353,12 @@ impl HttpBackend {
             return bin_name;
         }
         if let Some(rename_to) = opts.rename_exe() {
-            return rename_binary_name(
-                &file_path.file_name().unwrap().to_string_lossy(),
-                &rename_to,
-            );
+            let source_name = if file_info.is_compressed_binary {
+                file_info.decompressed_name()
+            } else {
+                file_path.file_name().unwrap().to_string_lossy().to_string()
+            };
+            return rename_binary_name(&source_name, &rename_to);
         }
 
         // Auto-clean the binary name
@@ -1293,5 +1295,28 @@ mod tests {
         let lookup_path = HttpBackend::lookup_install_path(&tv);
 
         assert_eq!(lookup_path, install_path);
+    }
+
+    #[test]
+    fn dest_filename_uses_decompressed_name_for_rename_exe_extension() {
+        let backend = HttpBackend {
+            ba: Arc::new(BackendArg::new_raw(
+                "http-code2prompt".to_string(),
+                Some("http:code2prompt".to_string()),
+                "code2prompt".to_string(),
+                None,
+                BackendResolution::new(true),
+            )),
+        };
+        let raw_opts = crate::toolset::parse_tool_options("rename_exe=code2prompt");
+        let opts = HttpOptions::new(&raw_opts);
+        let file_path = Path::new("code2prompt-x86_64-pc-windows-msvc.exe.gz");
+        let file_info = FileInfo::new(file_path, &opts);
+
+        assert!(file_info.is_compressed_binary);
+        assert_eq!(
+            backend.dest_filename(file_path, &file_info, &opts),
+            "code2prompt.exe"
+        );
     }
 }

--- a/src/backend/platform_tokens.rs
+++ b/src/backend/platform_tokens.rs
@@ -44,14 +44,14 @@ pub fn is_platform_or_version_token(token: &str) -> bool {
     token.chars().next().is_some_and(|c| c.is_ascii_digit())
 }
 
-fn is_os_token(token: &str) -> bool {
+pub(super) fn is_os_token(token: &str) -> bool {
     token.starts_with("manylinux")
         || token.starts_with("musllinux")
         || BINARY_OS_TOKENS.contains(&token)
         || PREFERRED_NAME_OS_TOKENS.contains(&token)
 }
 
-fn is_arch_token(token: &str) -> bool {
+pub(super) fn is_arch_token(token: &str) -> bool {
     BINARY_ARCH_TOKENS.contains(&token) || PREFERRED_NAME_ARCH_TOKENS.contains(&token)
 }
 

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use super::platform_tokens::{BINARY_ARCH_TOKENS, BINARY_OS_TOKENS};
+use super::platform_tokens::{BINARY_ARCH_TOKENS, BINARY_OS_TOKENS, is_platform_or_version_token};
 
 /// Regex pattern for matching version suffixes like -v1.2.3, _1.2.3, etc.
 static VERSION_PATTERN: LazyLock<regex::Regex> =
@@ -552,13 +552,20 @@ pub fn install_artifact(
         let decompressed_name = file_name.trim_end_matches(&format!(".{}", ext));
 
         // Determine the destination path with support for bin_path
+        let rename_exe = lookup_with_fallback(opts, "rename_exe");
         let dest = if let Some(bin_path_template) = lookup_with_fallback(opts, "bin_path") {
             let bin_path = template_string(&bin_path_template, tv);
             let bin_dir = install_path.join(&bin_path);
             file::create_dir_all(&bin_dir)?;
-            bin_dir.join(decompressed_name)
+            if let Some(rename_to) = rename_exe {
+                bin_dir.join(rename_binary_name(decompressed_name, &rename_to))
+            } else {
+                bin_dir.join(decompressed_name)
+            }
         } else if let Some(bin_name) = lookup_with_fallback(opts, "bin") {
             install_path.join(&bin_name)
+        } else if let Some(rename_to) = rename_exe {
+            install_path.join(rename_binary_name(decompressed_name, &rename_to))
         } else {
             // Auto-clean binary names by removing OS/arch suffixes
             let cleaned_name = clean_binary_name(decompressed_name, Some(&tv.ba().tool_name));
@@ -574,12 +581,21 @@ pub fn install_artifact(
             let bin_path = template_string(&bin_path_template, tv);
             let bin_dir = install_path.join(&bin_path);
             file::create_dir_all(&bin_dir)?;
-            let dest = bin_dir.join(file_path.file_name().unwrap());
+            let original_name = file_path.file_name().unwrap().to_string_lossy();
+            let dest_name = lookup_with_fallback(opts, "rename_exe")
+                .map(|rename_to| rename_binary_name(&original_name, &rename_to))
+                .unwrap_or_else(|| original_name.to_string());
+            let dest = bin_dir.join(dest_name);
             file::copy(file_path, &dest)?;
             file::make_executable(&dest)?;
         } else if let Some(bin_name) = lookup_with_fallback(opts, "bin") {
             // If bin is specified, rename the file to this name
             let dest = install_path.join(&bin_name);
+            file::copy(file_path, &dest)?;
+            file::make_executable(&dest)?;
+        } else if let Some(rename_to) = lookup_with_fallback(opts, "rename_exe") {
+            let original_name = file_path.file_name().unwrap().to_string_lossy();
+            let dest = install_path.join(rename_binary_name(&original_name, &rename_to));
             file::copy(file_path, &dest)?;
             file::make_executable(&dest)?;
         } else {
@@ -954,6 +970,17 @@ fn keep_extensions(
     target_path
 }
 
+pub fn rename_binary_name(original_name: &str, new_name: &str) -> String {
+    for ext in [".exe", ".cmd", ".bat", ".sh", ".ps1", ".AppImage"] {
+        if original_name.to_lowercase().ends_with(&ext.to_lowercase())
+            && !new_name.to_lowercase().ends_with(&ext.to_lowercase())
+        {
+            return format!("{new_name}{ext}");
+        }
+    }
+    new_name.to_string()
+}
+
 /// Cleans a binary name by removing OS/arch suffixes and version numbers.
 /// This is useful when downloading single binaries that have platform-specific names.
 /// Executable extensions (.exe, .bat, .sh, etc.) are preserved.
@@ -999,6 +1026,12 @@ pub fn clean_binary_name(name: &str, tool_name: Option<&str>) -> String {
 
     // Try to find and remove platform suffixes
     let mut cleaned = name_without_ext.to_string();
+
+    if let Some(stripped) = strip_platform_token_suffix(&cleaned) {
+        cleaned = stripped;
+        let result = clean_version_suffix(&cleaned, tool_name);
+        return with_ext(result);
+    }
 
     // First try combined OS-arch patterns
     for os in BINARY_OS_TOKENS {
@@ -1077,6 +1110,72 @@ pub fn clean_binary_name(name: &str, tool_name: Option<&str>) -> String {
 
     // Add the extension back if we had one
     with_ext(cleaned)
+}
+
+fn strip_platform_token_suffix(name: &str) -> Option<String> {
+    let mut separators = name
+        .char_indices()
+        .filter_map(|(idx, c)| matches!(c, '-' | '_').then_some(idx))
+        .collect::<Vec<_>>();
+    separators.sort_unstable();
+
+    for idx in separators {
+        let suffix = &name[idx + 1..];
+        let tokens = suffix
+            .split(['-', '_'])
+            .filter(|token| !token.is_empty())
+            .collect::<Vec<_>>();
+        if tokens.len() < 2 {
+            continue;
+        }
+        if !tokens
+            .iter()
+            .all(|token| is_platform_or_version_token(token))
+        {
+            continue;
+        }
+        if !tokens.iter().any(|token| is_os_token(token)) {
+            continue;
+        }
+        if !tokens.iter().any(|token| is_arch_token(token)) {
+            continue;
+        }
+
+        let prefix = &name[..idx];
+        if !prefix.is_empty() {
+            return Some(prefix.to_string());
+        }
+    }
+
+    None
+}
+
+fn is_os_token(token: &str) -> bool {
+    token.starts_with("manylinux")
+        || token.starts_with("musllinux")
+        || BINARY_OS_TOKENS.contains(&token)
+        || matches!(
+            token,
+            "ubuntu"
+                | "debian"
+                | "fedora"
+                | "centos"
+                | "rhel"
+                | "alpine"
+                | "arch"
+                | "mac"
+                | "macosx"
+                | "win32"
+                | "win64"
+                | "mingw"
+                | "mingw32"
+                | "mingw64"
+                | "w64"
+        )
+}
+
+fn is_arch_token(token: &str) -> bool {
+    BINARY_ARCH_TOKENS.contains(&token) || token == "64"
 }
 
 /// Remove version suffixes from binary names.
@@ -1293,6 +1392,13 @@ Path      : C:\\a\\deno\\deno\\target\\release\\deno-x86_64-pc-windows-msvc.zip
         // Test arch before OS
         assert_eq!(clean_binary_name("tool-x86_64-linux", None), "tool");
         assert_eq!(clean_binary_name("tool_amd64_windows", None), "tool");
+        assert_eq!(
+            clean_binary_name(
+                "code2prompt-x86_64-pc-windows-msvc.exe",
+                Some("mufeedvh/code2prompt")
+            ),
+            "code2prompt.exe"
+        );
 
         // Test with tool name hint
         assert_eq!(
@@ -1359,6 +1465,18 @@ Path      : C:\\a\\deno\\deno\\target\\release\\deno-x86_64-pc-windows-msvc.zip
         // Test edge cases
         assert_eq!(clean_binary_name("linux", None), "linux"); // Just OS name
         assert_eq!(clean_binary_name("", None), "");
+    }
+
+    #[test]
+    fn test_rename_binary_name_preserves_executable_extension() {
+        assert_eq!(
+            rename_binary_name("code2prompt-x86_64-pc-windows-msvc.exe", "code2prompt"),
+            "code2prompt.exe"
+        );
+        assert_eq!(
+            rename_binary_name("tool-linux-x64", "tool-renamed"),
+            "tool-renamed"
+        );
     }
 
     #[test]

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -12,7 +12,9 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use super::platform_tokens::{BINARY_ARCH_TOKENS, BINARY_OS_TOKENS, is_platform_or_version_token};
+use super::platform_tokens::{
+    BINARY_ARCH_TOKENS, BINARY_OS_TOKENS, is_arch_token, is_os_token, is_platform_or_version_token,
+};
 
 /// Regex pattern for matching version suffixes like -v1.2.3, _1.2.3, etc.
 static VERSION_PATTERN: LazyLock<regex::Regex> =
@@ -1117,9 +1119,12 @@ fn strip_platform_token_suffix(name: &str) -> Option<String> {
         .char_indices()
         .filter_map(|(idx, c)| matches!(c, '-' | '_').then_some(idx))
         .collect::<Vec<_>>();
-    separators.sort_unstable();
+    separators.sort_unstable_by(|a, b| b.cmp(a));
 
     for idx in separators {
+        if separator_inside_platform_token(name, idx) {
+            continue;
+        }
         let suffix = &name[idx + 1..];
         let tokens = suffix
             .split(['-', '_'])
@@ -1150,32 +1155,22 @@ fn strip_platform_token_suffix(name: &str) -> Option<String> {
     None
 }
 
-fn is_os_token(token: &str) -> bool {
-    token.starts_with("manylinux")
-        || token.starts_with("musllinux")
-        || BINARY_OS_TOKENS.contains(&token)
-        || matches!(
-            token,
-            "ubuntu"
-                | "debian"
-                | "fedora"
-                | "centos"
-                | "rhel"
-                | "alpine"
-                | "arch"
-                | "mac"
-                | "macosx"
-                | "win32"
-                | "win64"
-                | "mingw"
-                | "mingw32"
-                | "mingw64"
-                | "w64"
-        )
-}
+fn separator_inside_platform_token(name: &str, idx: usize) -> bool {
+    if !name[idx..].starts_with('_') {
+        return false;
+    }
 
-fn is_arch_token(token: &str) -> bool {
-    BINARY_ARCH_TOKENS.contains(&token) || token == "64"
+    let token_start = name[..idx]
+        .rfind(['-', '_'])
+        .map(|pos| pos + 1)
+        .unwrap_or(0);
+    let token_end = name[idx + 1..]
+        .find(['-', '_'])
+        .map(|pos| idx + 1 + pos)
+        .unwrap_or(name.len());
+    let token = &name[token_start..token_end];
+
+    is_platform_or_version_token(token)
 }
 
 /// Remove version suffixes from binary names.
@@ -1476,6 +1471,18 @@ Path      : C:\\a\\deno\\deno\\target\\release\\deno-x86_64-pc-windows-msvc.zip
         assert_eq!(
             rename_binary_name("tool-linux-x64", "tool-renamed"),
             "tool-renamed"
+        );
+    }
+
+    #[test]
+    fn test_strip_platform_token_suffix_uses_nearest_valid_suffix() {
+        assert_eq!(
+            strip_platform_token_suffix("code2prompt-x86_64-pc-windows-msvc"),
+            Some("code2prompt".to_string())
+        );
+        assert_eq!(
+            strip_platform_token_suffix("tool-v1.2.3-linux-x86_64"),
+            Some("tool-v1.2.3".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- honor `rename_exe` for raw and compressed single-file installs, including the `github:` backend path
- preserve executable extensions like `.exe` when a raw asset is renamed
- strip full trailing platform token sequences such as `x86_64-pc-windows-msvc` when auto-cleaning raw binary names

## Discussion
Addresses the behavior reported in https://github.com/jdx/mise/discussions/10775.

## Tests
- `cargo test --quiet binary_name`
- `mise run test:e2e e2e/backend/test_github`
- pre-commit `mise run lint` via git hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how installed binary filenames are chosen across GitHub/HTTP install flows; behavior is localized to naming but affects which executables mise exposes.
> 
> **Overview**
> Fixes installs where **`rename_exe`** was ignored for **raw** release assets and **single-file compressed** binaries (the path used by **`github:`** via `install_artifact`), so the configured command name is what lands on disk and on PATH.
> 
> **`rename_binary_name`** keeps executable extensions (e.g. `.exe`) when renaming. **`clean_binary_name`** can strip long trailing platform token runs such as `x86_64-pc-windows-msvc`. The **HTTP** backend’s **`dest_filename`** applies the same rename logic for cached raw/compressed extracts.
> 
> E2E coverage adds a GitHub raw asset install with **`rename_exe`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ab4bd0531f5d6bae4b2a75497a62aa3528118b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `rename_exe` handling for both raw assets and single-binary downloads, ensuring the installed executable name matches the configured rename consistently.
  * Preserved executable extensions when renaming binaries (including compressed `.exe.gz` scenarios).
* **Tests**
  * Added end-to-end and unit test coverage for renamed raw installs and executable naming/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->