### PR TITLE
fix(task): show usage subcommand help

### DIFF
--- a/e2e/tasks/test_task_help
+++ b/e2e/tasks/test_task_help
@@ -31,6 +31,12 @@ assert "mise run greet hello -h 2>&1 || true" "Usage: greet hello [-n --name <na
 
 Flags:
   -n --name <name>  who to greet"
+assert "mise run greet -v hello -h 2>&1 || true" "Usage: greet hello [-n --name <name>]
+
+Flags:
+  -n --name <name>  who to greet"
+assert_contains "mise run greet -h 2>&1 || true" "Usage: greet [-v --verbose…] <SUBCOMMAND>"
+assert_contains "mise run greet -h hello 2>&1 || true" "Usage: greet [-v --verbose…] <SUBCOMMAND>"
 
 cat <<'EOF' >mise.toml
 [tasks.atask]

--- a/e2e/tasks/test_task_help
+++ b/e2e/tasks/test_task_help
@@ -13,6 +13,33 @@ assert "mise run atask --help 2>&1 || true" "Usage: atask <myarg>
 Arguments:
   <myarg>"
 
+cat <<'EOF' >mise.toml
+[tasks.greet]
+usage = '''
+flag "-v --verbose" default=#false var=#true global=#true help="verbose"
+cmd "hello" help="say hello" {
+  flag "-n --name <name>" help="who to greet"
+}
+cmd "bye" help="say goodbye" {
+  flag "-l --loud" default=#false var=#true help="shout it"
+}
+'''
+run = "echo cmd=$usage_cmd name=$usage_name"
+EOF
+
+assert "mise run greet hello -h 2>&1 || true" "Usage: greet hello [-n --name <name>]
+
+Flags:
+  -n --name <name>  who to greet"
+
+cat <<'EOF' >mise.toml
+[tasks.atask]
+usage = 'arg "<myarg>"'
+run = 'echo $usage_myarg'
+[tasks.npm]
+run = 'echo npm'
+EOF
+
 assert_contains "mise --help 2>&1 || true" "Usage: mise [OPTIONS] [TASK] [COMMAND]"
 assert_contains "mise install --help 2>&1 || true" "Usage: mise install [OPTIONS] [TOOL@VERSION]..."
 assert_contains "mise run --help 2>&1 || true" "Usage: run [OPTIONS] [TASK] [ARGS]..."

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -279,7 +279,7 @@ impl Run {
 
                     if has_any_usage_spec(&spec) {
                         // Task has usage spec defined, render help using usage library
-                        println!("{}", usage::docs::cli::render_help(&spec, &spec.cmd, true));
+                        println!("{}", render_usage_help(&spec, &self.args));
                     } else {
                         // Task has no usage defined, show basic task info
                         display_task_help(task)?;
@@ -877,6 +877,66 @@ fn display_task_help(task: &Task) -> Result<()> {
     miseprintln!("{hint}");
     miseprintln!("See https://mise.en.dev/tasks/task-configuration.html for more information.");
     Ok(())
+}
+
+fn render_usage_help(spec: &usage::Spec, args: &[String]) -> String {
+    let cmd = usage_command_for_args(spec, args);
+    usage::docs::cli::render_help(spec, cmd, true)
+}
+
+fn usage_command_for_args<'a>(spec: &'a usage::Spec, args: &[String]) -> &'a usage::SpecCommand {
+    let mut cmd = &spec.cmd;
+    let mut idx = 0;
+    let mut used_default_subcommand = false;
+
+    while idx < args.len() {
+        let arg = &args[idx];
+        if arg == "-h" || arg == "--help" {
+            idx += 1;
+            continue;
+        }
+        if let Some(subcommand) = cmd.find_subcommand(arg) {
+            cmd = subcommand;
+            idx += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            if !arg.contains('=')
+                && (flag_takes_value(&spec.cmd, arg) || flag_takes_value(cmd, arg))
+            {
+                idx += 1;
+            }
+            idx += 1;
+            continue;
+        }
+        if !used_default_subcommand {
+            if let Some(default_name) = &spec.default_subcommand {
+                if let Some(subcommand) = cmd.find_subcommand(default_name) {
+                    cmd = subcommand;
+                    used_default_subcommand = true;
+                    continue;
+                }
+            }
+        }
+        break;
+    }
+
+    cmd
+}
+
+fn flag_takes_value(cmd: &usage::SpecCommand, flag: &str) -> bool {
+    let flag = flag.split_once('=').map(|(flag, _)| flag).unwrap_or(flag);
+    if let Some(long) = flag.strip_prefix("--") {
+        cmd.flags
+            .iter()
+            .any(|f| f.arg.is_some() && f.long.iter().any(|f| f == long))
+    } else if let Some(short) = flag.strip_prefix('-').and_then(|f| f.chars().next()) {
+        cmd.flags
+            .iter()
+            .any(|f| f.arg.is_some() && f.short.contains(&short))
+    } else {
+        false
+    }
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -892,8 +892,7 @@ fn usage_command_for_args<'a>(spec: &'a usage::Spec, args: &[String]) -> &'a usa
     while idx < args.len() {
         let arg = &args[idx];
         if arg == "-h" || arg == "--help" {
-            idx += 1;
-            continue;
+            break;
         }
         if let Some(subcommand) = cmd.find_subcommand(arg) {
             cmd = subcommand;
@@ -909,14 +908,13 @@ fn usage_command_for_args<'a>(spec: &'a usage::Spec, args: &[String]) -> &'a usa
             idx += 1;
             continue;
         }
-        if !used_default_subcommand {
-            if let Some(default_name) = &spec.default_subcommand {
-                if let Some(subcommand) = cmd.find_subcommand(default_name) {
-                    cmd = subcommand;
-                    used_default_subcommand = true;
-                    continue;
-                }
-            }
+        if !used_default_subcommand
+            && let Some(default_name) = &spec.default_subcommand
+            && let Some(subcommand) = cmd.find_subcommand(default_name)
+        {
+            cmd = subcommand;
+            used_default_subcommand = true;
+            continue;
         }
         break;
     }


### PR DESCRIPTION
## Summary
- render usage help for the selected task subcommand instead of always using the root task command
- add an e2e regression for `mise run <task> <subcommand> -h`

## Root Cause
`mise run` handles task-side `-h`/`--help` early so it can avoid unnecessary task setup, but that path always called `usage::docs::cli::render_help(&spec, &spec.cmd, true)`. That rendered the root task help even when the args had already selected a `usage` subcommand.

## Validation
- `cargo check --all-features`
- `mise run build`
- `mise run test:e2e e2e/tasks/test_task_help`
- manual checks for `greet hello -h`, `greet -v hello -h`, and root `greet -h`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to the early help-only code path in `run.rs` with no execution or parsing behavior when tasks actually run; main risk is edge cases in arg walking for unusual flag/subcommand combinations.
> 
> **Overview**
> Fixes **`mise run <task> … -h`** so help reflects the **subcommand and flags implied by the args**, not always the root task usage.
> 
> The early help path now calls **`render_usage_help`**, which walks **`self.args`** (stopping at `-h`/`--help`) to pick the right **`usage::SpecCommand`**: named subcommands, global/value-taking flags (including values after the flag), and optional **default subcommand** handling. Help is rendered with **`usage::docs::cli::render_help`** for that command.
> 
> **E2e** coverage adds a **`greet`** task with global verbose flag and **`hello`/`bye`** subcommands, asserting subcommand-specific help, help with a global flag before the subcommand, and root **`-h`** still listing subcommands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bba6d50b254abb1ce8a18ed5dca7eade72581c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task help output so `-h/--help` shows the correct nested subcommand usage and related flags.
  * Help rendering now better matches the task arguments provided at runtime, including handling verbose/global flags and subcommand-specific options.
* **Tests**
  * Added end-to-end coverage for help/usage output by extending the fixture configuration with a new task containing nested subcommands and assertions for expected help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->