### PR TITLE
fix(system): extract suffixless brew cask zip archives

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 
 use async_trait::async_trait;
@@ -317,7 +318,7 @@ fn extract_archive(cask: &Cask, archive: &Path, pr: Option<&dyn SingleReport>) -
     if filename.ends_with(".dmg") {
         file::un_dmg(archive, &extract_dir)?;
     } else {
-        let format = ExtractionFormat::from_file_name(filename);
+        let format = cask_extraction_format(archive, filename)?;
         if format == ExtractionFormat::Raw {
             // Raw executable binary — copy it using the original URL filename so find_artifact
             // can match against the binary stanza source name (e.g. "claude").
@@ -344,6 +345,25 @@ fn extract_archive(cask: &Cask, archive: &Path, pr: Option<&dyn SingleReport>) -
         }
     }
     Ok(extract_dir)
+}
+
+fn cask_extraction_format(archive: &Path, filename: &str) -> Result<ExtractionFormat> {
+    let format = ExtractionFormat::from_file_name(filename);
+    if format != ExtractionFormat::Raw {
+        return Ok(format);
+    }
+    Ok(detect_extraction_format(archive)?.unwrap_or(format))
+}
+
+fn detect_extraction_format(archive: &Path) -> Result<Option<ExtractionFormat>> {
+    let mut file = std::fs::File::open(archive)?;
+    let mut magic = [0; 8];
+    let len = file.read(&mut magic)?;
+    let magic = &magic[..len];
+    if magic.starts_with(b"PK\x03\x04") {
+        return Ok(Some(ExtractionFormat::Zip));
+    }
+    Ok(None)
 }
 
 fn install_app(stage: &Path, caskroom: &Path, app: &AppArtifact) -> Result<()> {
@@ -1157,6 +1177,32 @@ mod tests {
             sha256: Some("no_check".to_string()),
             artifacts: Vec::new(),
         }
+    }
+
+    #[test]
+    fn detects_suffixless_zip_archives() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let archive = tmp.path().join("stable");
+        std::fs::write(&archive, b"PK\x03\x04suffixless zip")?;
+
+        assert_eq!(
+            cask_extraction_format(&archive, "visual-studio-code-1.127.0-stable")?,
+            ExtractionFormat::Zip
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn leaves_suffixless_raw_binaries_raw() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let archive = tmp.path().join("claude");
+        std::fs::write(&archive, b"#!/bin/sh\necho raw\n")?;
+
+        assert_eq!(
+            cask_extraction_format(&archive, "claude-1.0.0-claude")?,
+            ExtractionFormat::Raw
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- detect suffixless zip downloads in brew-cask extraction by sniffing the archive magic bytes
- keep suffixless raw binary casks on the existing raw-file path
- add regression tests for suffixless zip and raw binary cases

## Root Cause
brew-cask chose the extraction format from the cached filename. For Visual Studio Code, Homebrew metadata points at a URL whose final path component is `stable`, so mise cached a suffixless file and treated the downloaded zip as a raw binary instead of extracting `Visual Studio Code.app`.

## Validation
- `cargo fmt --check`
- `cargo test system::packages::brew::cask::tests::`
- pre-commit `mise run lint`

Related to discussion #10764.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is confined to brew-cask archive format detection on macOS; behavior for extension-named archives and confirmed raw binaries is unchanged aside from the new ZIP sniff fallback.
> 
> **Overview**
> Fixes brew-cask installs when the download URL has **no archive extension** (e.g. Visual Studio Code’s `stable` path). Previously `extract_archive` relied only on `ExtractionFormat::from_file_name`, so ZIP payloads were treated as **raw binaries** and never unpacked.
> 
> **`cask_extraction_format`** still uses the filename first; if that yields `Raw`, **`detect_extraction_format`** reads the first bytes and treats **`PK\x03\x04`** as ZIP before choosing copy vs `extract_archive`. Suffixless real binaries (e.g. `claude`) stay on the existing raw path.
> 
> Adds unit tests for suffixless ZIP vs raw detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0c2139bdc46b5a4c484bd00ef378c704b0d102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of cask archive extraction format, including suffixless ZIP-like downloads.
  * Preserved raw binary handling when suffixless content does not match ZIP signatures.
  * Added unit tests to ensure suffixless ZIP magic is classified as ZIP and non-ZIP binary remains raw.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->