### PR TITLE
fix(search): include aqua matches when registry misses

### DIFF
--- a/e2e/cli/test_search
+++ b/e2e/cli/test_search
@@ -13,4 +13,5 @@ jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jq
 assert "mise search --match-type equal jq" "jq  Command-line JSON processor. https://github.com/jqlang/jq"
 
 assert_contains "mise search 7zip" "aqua:ip7z/7zip"
+assert_contains "mise search --match-type contains 7zip" "aqua:ip7z/7zip"
 assert_contains "mise search --match-type equal 7zip" "aqua:ip7z/7zip"

--- a/e2e/cli/test_search
+++ b/e2e/cli/test_search
@@ -11,3 +11,6 @@ jq    Command-line JSON processor. https://github.com/jqlang/jq
 jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp"
 
 assert "mise search --match-type equal jq" "jq  Command-line JSON processor. https://github.com/jqlang/jq"
+
+assert_contains "mise search 7zip" "aqua:ip7z/7zip"
+assert_contains "mise search --match-type equal 7zip" "aqua:ip7z/7zip"

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -160,16 +160,9 @@ impl Search {
             return vec![];
         }
 
-        let package_ids = match self.match_type {
-            MatchType::Fuzzy => crate::aqua::aqua_registry_wrapper::aqua_suggest(name),
-            MatchType::Equal | MatchType::Contains => crate::aqua::standard_registry::package_ids()
-                .into_iter()
-                .map(|s| s.to_string())
-                .collect(),
-        };
-
-        package_ids
+        crate::aqua::standard_registry::package_ids()
             .into_iter()
+            .map(|s| s.to_string())
             .filter_map(|id| {
                 let tool_name = id.rsplit_once('/').map_or(id.as_str(), |(_, name)| name);
                 let score = match self.match_type {
@@ -277,17 +270,17 @@ fn get_backends(backends: Vec<&'static str>) -> Vec<String> {
 }
 
 fn get_aqua_description(id: &str) -> String {
-    let fallback = format!("https://github.com/{id}");
+    let fallback = format!("aqua:{id}");
     let Ok(pkg) =
         crate::aqua::standard_registry::package(id).unwrap_or_else(|| Ok(Default::default()))
     else {
         return fallback;
     };
 
-    let backend = if pkg.repo_owner.is_empty() || pkg.repo_name.is_empty() {
-        fallback
-    } else {
+    let backend = if !pkg.repo_owner.is_empty() && !pkg.repo_name.is_empty() {
         format!("https://github.com/{}/{}", pkg.repo_owner, pkg.repo_name)
+    } else {
+        fallback
     };
 
     match pkg.description.as_deref().filter(|d| !d.is_empty()) {

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -108,7 +108,8 @@ impl Search {
         let name = self.name.as_deref().unwrap_or("");
         let mut fuzzy_matcher = FuzzyMatcher::default();
         let fuzzy_pattern = FuzzyPattern::new(&name.to_lowercase());
-        self.get_tools()
+        let mut matches = self
+            .get_tools()
             .iter()
             .filter_map(|(short, rt)| {
                 if name.is_empty() {
@@ -135,8 +136,68 @@ impl Search {
                     }
                 }
             })
-            .sorted_by_key(|(score, _short, _rt)| std::cmp::Reverse(*score))
-            .map(|(_score, short, rt)| (short.to_string(), get_description(rt)))
+            .map(|(score, short, rt)| (score, short.to_string(), get_description(rt)))
+            .collect_vec();
+
+        if matches.is_empty() {
+            matches.extend(self.get_aqua_matches(name, &mut fuzzy_matcher, &fuzzy_pattern));
+        }
+
+        matches
+            .into_iter()
+            .sorted_by_key(|(score, _short, _description)| std::cmp::Reverse(*score))
+            .map(|(_score, short, description)| (short, description))
+            .collect()
+    }
+
+    fn get_aqua_matches(
+        &self,
+        name: &str,
+        fuzzy_matcher: &mut FuzzyMatcher,
+        fuzzy_pattern: &FuzzyPattern,
+    ) -> Vec<(u32, String, String)> {
+        if name.is_empty() {
+            return vec![];
+        }
+
+        let package_ids = match self.match_type {
+            MatchType::Fuzzy => crate::aqua::aqua_registry_wrapper::aqua_suggest(name),
+            MatchType::Equal | MatchType::Contains => crate::aqua::standard_registry::package_ids()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
+        };
+
+        package_ids
+            .into_iter()
+            .filter_map(|id| {
+                let tool_name = id.rsplit_once('/').map_or(id.as_str(), |(_, name)| name);
+                let score = match self.match_type {
+                    MatchType::Equal => {
+                        if tool_name == name || id == name || format!("aqua:{id}") == name {
+                            Some(0)
+                        } else {
+                            None
+                        }
+                    }
+                    MatchType::Contains => {
+                        if tool_name.contains(name) || id.contains(name) {
+                            Some(0)
+                        } else {
+                            None
+                        }
+                    }
+                    MatchType::Fuzzy => {
+                        fuzzy_matcher.score_pattern(&tool_name.to_lowercase(), fuzzy_pattern)
+                    }
+                }?;
+
+                Some((
+                    score,
+                    format!("aqua:{id}"),
+                    get_aqua_description(id.as_str()),
+                ))
+            })
             .collect()
     }
 
@@ -213,4 +274,24 @@ fn get_backends(backends: Vec<&'static str>) -> Vec<String> {
             }
         })
         .collect()
+}
+
+fn get_aqua_description(id: &str) -> String {
+    let fallback = format!("https://github.com/{id}");
+    let Ok(pkg) =
+        crate::aqua::standard_registry::package(id).unwrap_or_else(|| Ok(Default::default()))
+    else {
+        return fallback;
+    };
+
+    let backend = if pkg.repo_owner.is_empty() || pkg.repo_name.is_empty() {
+        fallback
+    } else {
+        format!("https://github.com/{}/{}", pkg.repo_owner, pkg.repo_name)
+    };
+
+    match pkg.description.as_deref().filter(|d| !d.is_empty()) {
+        Some(description) => format!("{description}. {backend}"),
+        None => backend,
+    }
 }


### PR DESCRIPTION
## Summary
- add an aqua fallback to `mise search` when the mise registry has no matches
- format aqua fallback rows with package descriptions and repository URLs
- cover the `7zip` case for fuzzy and exact search

## Root Cause
`mise tool` already uses aqua package suggestions when a shorthand is missing, but `mise search` only queried the mise shorthand registry. That made `mise tool 7zip` suggest `aqua:ip7z/7zip` while `mise search 7zip` failed.

## Validation
- `cargo fmt --check`
- `cargo check -q`
- `mise run test:e2e test_search`
- commit hook: `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only search behavior change with no auth or install-path changes; fallback runs only when registry matches are empty.
> 
> **Overview**
> **`mise search` now falls back to the baked-in Aqua registry** when the mise shorthand registry returns no matches, aligning behavior with tool resolution paths that already suggest `aqua:…` packages.
> 
> When the fallback runs, results use `aqua:{owner/name}` tool names and descriptions built from package metadata (description plus GitHub URL when available). Matching respects the existing `--match-type` modes (fuzzy, contains, equal) against the package name, full id, or `aqua:` prefix.
> 
> E2E tests assert that searching for **`7zip`** surfaces **`aqua:ip7z/7zip`** across fuzzy, contains, and equal match types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5c472ab372aabf07c1e5af4a08bb9102282ecb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise search` now surfaces relevant Aqua package suggestions when no registry matches are found.
  * Aqua results are combined, re-ranked by relevance, and shown with enriched descriptions.

* **Bug Fixes**
  * Improved search matching for `7zip`, including `--match-type contains` and `--match-type equal`.

* **Tests**
  * Added end-to-end coverage to verify `mise search 7zip` includes the expected Aqua entry and that both match-type modes return it as well.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->