### PR TITLE
fix(env): activate sub latest versions offline

### DIFF
--- a/e2e/tools/test_runtime_symlinks
+++ b/e2e/tools/test_runtime_symlinks
@@ -11,3 +11,9 @@ latest ./2.1.0"
 
 assert "mise bin-paths dummy@1.0" "$MISE_DATA_DIR/installs/dummy/1.0/bin"
 assert "mise bin-paths dummy@prefix:1" "$MISE_DATA_DIR/installs/dummy/1/bin"
+
+mise use dummy@sub-1:latest
+mise install
+assert "ls -l $MISE_DATA_DIR/installs/dummy | grep 'sub-1-latest' | awk '{print \$(NF-2),\$(NF)}'" "sub-1-latest ./1.10.0"
+assert_contains "mise hook-env -s bash --force" "$MISE_DATA_DIR/installs/dummy/sub-1-latest/bin"
+assert_not_contains "mise hook-env -s bash --force 2>&1" "missing: dummy@sub-1:latest"

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -6,7 +6,7 @@ use crate::config::{Alias, Config};
 use crate::file::make_symlink_or_file;
 use crate::plugins::VERSION_REGEX;
 use crate::semver::split_version_prefix;
-use crate::toolset::Toolset;
+use crate::toolset::{ToolRequest, Toolset};
 use crate::{backend, env, file};
 use eyre::Result;
 use indexmap::IndexMap;
@@ -16,7 +16,7 @@ use versions::Versioning;
 pub async fn rebuild_for_toolset(config: &Config, ts: &Toolset) -> Result<()> {
     for backend in ts.list_cached_and_current_backends() {
         for installs_dir in install_dirs_for(&backend) {
-            rebuild_symlinks_in_dir(config, &backend, &installs_dir)?;
+            rebuild_symlinks_in_dir(config, ts, &backend, &installs_dir)?;
         }
     }
     Ok(())
@@ -51,6 +51,7 @@ fn install_dirs_for(backend: &Arc<dyn Backend>) -> Vec<PathBuf> {
 
 fn rebuild_symlinks_in_dir(
     config: &Config,
+    ts: &Toolset,
     backend: &Arc<dyn Backend>,
     installs_dir: &Path,
 ) -> Result<()> {
@@ -58,7 +59,7 @@ fn rebuild_symlinks_in_dir(
         .into_iter()
         .filter(|v| is_concrete_install(v))
         .collect::<std::collections::HashSet<_>>();
-    let symlinks = list_symlinks_for_dir(config, backend, installs_dir);
+    let symlinks = list_symlinks_for_dir(config, Some(ts), backend, installs_dir);
     for (from, to) in symlinks {
         let from_name = from.clone();
         let from = installs_dir.join(from);
@@ -99,7 +100,7 @@ fn migrate_real_dirs_in_dir(
         .into_iter()
         .filter(|v| is_concrete_install(v))
         .collect::<std::collections::HashSet<_>>();
-    let symlinks = list_symlinks_for_dir(config, backend, installs_dir);
+    let symlinks = list_symlinks_for_dir(config, None, backend, installs_dir);
     for (from, to) in symlinks {
         let from_name = from.clone();
         let from = installs_dir.join(from);
@@ -116,6 +117,7 @@ fn migrate_real_dirs_in_dir(
 /// Build symlinks for versions found in a specific install directory.
 fn list_symlinks_for_dir(
     config: &Config,
+    ts: Option<&Toolset>,
     backend: &Arc<dyn Backend>,
     installs_dir: &Path,
 ) -> IndexMap<String, PathBuf> {
@@ -150,6 +152,29 @@ fn list_symlinks_for_dir(
                 continue;
             }
             symlinks.insert(format!("{prefix}{from}"), rel_path(&v));
+        }
+    }
+    if let Some(ts) = ts {
+        for (b, tv) in ts.list_current_versions() {
+            if b.ba() != backend.ba() {
+                continue;
+            }
+            if !matches!(tv.request, ToolRequest::Sub { .. }) {
+                continue;
+            }
+            let Some(from) = tv.runtime_pathname() else {
+                continue;
+            };
+            let install_path = tv.install_path();
+            if install_path.parent() != Some(installs_dir) || !install_path.exists() {
+                continue;
+            }
+            if let Some(to) = install_path
+                .file_name()
+                .map(|to| PathBuf::from(".").join(to))
+            {
+                symlinks.insert(from, to);
+            }
         }
     }
     symlinks = symlinks

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -313,10 +313,13 @@ impl ToolVersion {
         }
         .replace([':', '/'], "-")
     }
-    fn runtime_pathname(&self) -> Option<String> {
+    pub(crate) fn runtime_pathname(&self) -> Option<String> {
         let pathname = match &self.request {
-            ToolRequest::Version { version, .. } if version != &self.version => version,
-            ToolRequest::Prefix { prefix, .. } => prefix,
+            ToolRequest::Version { version, .. } if version != &self.version => version.clone(),
+            ToolRequest::Prefix { prefix, .. } => prefix.clone(),
+            ToolRequest::Sub { .. } if self.request.version() != self.version => {
+                self.request.version()
+            }
             _ => return None,
         };
         Some(pathname.replace([':', '/'], "-"))
@@ -588,6 +591,15 @@ impl ToolVersion {
     ) -> Result<Self> {
         let backend = request.backend()?;
         if v == "latest" && opts.offline {
+            let pathname = request.version().replace([':', '/'], "-");
+            let path = backend.ba().installs_path.join(&pathname);
+            let path = env::find_in_shared_installs(path, &backend.ba().tool_dir_name(), &pathname);
+            if let Ok(Some(target)) = crate::file::resolve_symlink(&path)
+                && target.starts_with("./")
+                && let Some(version) = target.file_name().map(|v| v.to_string_lossy().to_string())
+            {
+                return Box::pin(Self::resolve_version(config, request, &version, opts)).await;
+            }
             // Can't resolve sub-N:latest offline (no remote latest, and
             // applying version_sub to latest_installed_version would shift
             // one step too low). Return the raw spec; callers that care


### PR DESCRIPTION
## Summary
- create runtime symlinks for resolved fuzzy tool requests such as `sub-1:latest`
- resolve `sub-*:latest` offline by following that runtime symlink instead of leaving the raw request unresolved
- add e2e coverage for hook-env activating a `sub-*:latest` request without a missing-tool warning

## Root Cause
`hook-env` resolves toolsets with `offline: true` to avoid network work during shell activation. `sub-*:latest` could not resolve offline, so activation kept the raw request (`sub-0.1:latest`) and then treated it as missing even though `mise install` had installed the concrete resolved version.

## Validation
- `cargo fmt --check`
- `cargo check -q`
- `mise run test:e2e e2e/tools/test_runtime_symlinks`
- pre-commit `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core version resolution and install-dir symlink rebuild paths used during activation; behavior change is scoped to sub-version and offline:latest cases with new e2e coverage.
> 
> **Overview**
> Fixes **offline shell activation** for fuzzy **`sub-*:latest`** tool specs when the concrete version is already installed but the raw request would still look “missing” during `hook-env`.
> 
> **Runtime symlinks** now account for resolved **sub-version** requests in the active toolset: rebuild passes the toolset into symlink planning and adds entries that map labels like `sub-1-latest` to the installed concrete directory (not only prefix/`latest` aliases derived from on-disk version folders).
> 
> **Offline resolution** for `sub-N:latest` follows an existing runtime symlink target to the concrete version instead of stopping on the unresolved spec. **`runtime_pathname`** is extended so sub requests with a different request vs resolved version get a stable fuzzy path name.
> 
> E2e coverage asserts **`mise install`** creates the `sub-1-latest` symlink and **`hook-env`** activates without a missing-tool warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 686029f5b9c5269ce13354d5e77918f825904669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of runtime symlinks during installs, including better recognition of existing on-disk symlink targets.
  * Added coverage for sub-version runtime symlink behavior in end-to-end tests.

* **Bug Fixes**
  * Fixed cases where installs could miss or misreport runtime symlinks for selected sub-version toolchains.
  * Offline resolution now better uses existing symlink targets when a concrete version can be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->