### PR TITLE
chore(ci): install mold via apt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,7 +177,8 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - name: Install mold
+        run: sudo apt-get update && sudo apt-get install -y mold
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with:
           tool: cargo-deny,cargo-msrv,cargo-machete

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
       - name: Install mold
-        run: sudo apt-get update && sudo apt-get install -y mold
+        run: sudo apt-get update && sudo apt-get install -y mold=2.30.0+dfsg-1build1
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with:
           tool: cargo-deny,cargo-msrv,cargo-machete

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
       - name: Install mold
-        run: sudo apt-get update && sudo apt-get install -y mold=2.30.0+dfsg-1build1
+        run: sudo apt-get update && sudo apt-get install -y mold
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with:
           tool: cargo-deny,cargo-msrv,cargo-machete


### PR DESCRIPTION
## Summary
- Replace the pinned `rui314/setup-mold` workflow action with an Ubuntu package install step in the lint job.

## Tests
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "ok"'`
- `mise run lint` via pre-commit hook

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency install swap with no application or security logic changes; minor risk if apt mold version or availability differs from the previous action on the runner image.
> 
> **Overview**
> In the **`lint`** job of `.github/workflows/test.yml`, **mold** is no longer installed with the pinned third-party action `rui314/setup-mold`. It is installed with an explicit **`Install mold`** step that runs `sudo apt-get update && sudo apt-get install -y mold`.
> 
> No other jobs or workflow steps change; lint still uses mold the same way for faster linking during `cargo clippy` and related steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43a1ea874326537326d177e501f051b7bfb1b206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and test workflow to install a required tool directly through the system package manager.
  * Improved consistency of the CI setup without changing product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->