### PR TITLE
chore(ci): replace winget releaser action

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -26,12 +26,13 @@ jobs:
           KOMAC_FORK_OWNER: jdx
           KOMAC_CREATED_WITH: mise release workflow
           KOMAC_CREATED_WITH_URL: https://github.com/jdx/mise
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           $ErrorActionPreference = "Stop"
 
           $Identifier = "jdx.mise"
           $MaxVersionsToKeep = 5
-          $ReleaseTag = "${{ github.event.release.tag_name || inputs.tag }}"
+          $ReleaseTag = $env:RELEASE_TAG
           if ([string]::IsNullOrWhiteSpace($ReleaseTag)) {
             $LatestRelease = Invoke-RestMethod `
               -Uri "https://api.github.com/repos/jdx/mise/releases/latest" `

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -3,22 +3,73 @@ on:
   release:
     types: [released]
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          repository: jdx/winget-pkgs
-          token: ${{ secrets.MISE_GH_TOKEN }}
-          fetch-depth: 0
-      - run: git config user.name mise-en-dev
-      - run: git config user.email release@mise.jdx.dev
-      - run: git remote add microsoft https://github.com/microsoft/winget-pkgs
-      - run: git pull --rebase microsoft master
-      - run: git push -f origin master
-      - uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # main
-        with:
-          identifier: jdx.mise
-          max-versions-to-keep: 5
-          token: ${{ secrets.MISE_GH_TOKEN }}
+      - name: Install komac
+        run: cargo install komac --version 2.16.0 --locked
+
+      - name: Publish to WinGet
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+          KOMAC_FORK_OWNER: jdx
+          KOMAC_CREATED_WITH: mise release workflow
+          KOMAC_CREATED_WITH_URL: https://github.com/jdx/mise
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $Identifier = "jdx.mise"
+          $MaxVersionsToKeep = 5
+          $ReleaseTag = "${{ github.event.release.tag_name || github.ref_name }}"
+
+          $ReleaseInfo = Invoke-RestMethod `
+            -Uri "https://api.github.com/repos/jdx/mise/releases/tags/$ReleaseTag" `
+            -Headers @{ Authorization = "Bearer $env:GITHUB_TOKEN" }
+
+          $Version = $ReleaseInfo.tag_name -replace "^v", ""
+          $Urls = @(
+            $ReleaseInfo.assets |
+              Where-Object { $_.name -match ".(exe|msi|msix|appx)(bundle){0,1}$" } |
+              ForEach-Object { $_.browser_download_url }
+          )
+
+          if (-not $Urls) {
+            throw "No WinGet installer assets found for $ReleaseTag"
+          }
+
+          komac sync-fork
+
+          $UpdateArgs = @(
+            "update",
+            $Identifier,
+            "--version",
+            $Version,
+            "--submit",
+            "--urls"
+          ) + $Urls
+          & komac @UpdateArgs
+
+          komac cleanup --only-merged
+
+          $ToNatural = { [regex]::Replace($_, "\d+", { $args[0].Value.PadLeft(20) }) }
+          $Versions = @(
+            komac list-versions $Identifier --json |
+              ConvertFrom-Json -NoEnumerate |
+              Sort-Object $ToNatural -Descending
+          )
+
+          if ($Versions.Count -gt $MaxVersionsToKeep) {
+            $VersionsToDelete = $Versions[$MaxVersionsToKeep..($Versions.Count - 1)]
+            foreach ($OldVersion in $VersionsToDelete) {
+              komac remove $Identifier `
+                --version $OldVersion `
+                --reason "This version is older than what has been set in max-versions-to-keep by the publisher." `
+                --submit
+            }
+          }

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -3,6 +3,11 @@ on:
   release:
     types: [released]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish. Defaults to the latest release."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -12,7 +17,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Install komac
-        run: cargo install komac --version 2.16.0 --locked
+        run: winget install --id russellbanks.Komac --version 2.16.0 --exact --accept-source-agreements --accept-package-agreements
 
       - name: Publish to WinGet
         shell: pwsh
@@ -26,7 +31,13 @@ jobs:
 
           $Identifier = "jdx.mise"
           $MaxVersionsToKeep = 5
-          $ReleaseTag = "${{ github.event.release.tag_name || github.ref_name }}"
+          $ReleaseTag = "${{ github.event.release.tag_name || inputs.tag }}"
+          if ([string]::IsNullOrWhiteSpace($ReleaseTag)) {
+            $LatestRelease = Invoke-RestMethod `
+              -Uri "https://api.github.com/repos/jdx/mise/releases/latest" `
+              -Headers @{ Authorization = "Bearer $env:GITHUB_TOKEN" }
+            $ReleaseTag = $LatestRelease.tag_name
+          }
 
           $ReleaseInfo = Invoke-RestMethod `
             -Uri "https://api.github.com/repos/jdx/mise/releases/tags/$ReleaseTag" `
@@ -35,7 +46,7 @@ jobs:
           $Version = $ReleaseInfo.tag_name -replace "^v", ""
           $Urls = @(
             $ReleaseInfo.assets |
-              Where-Object { $_.name -match ".(exe|msi|msix|appx)(bundle){0,1}$" } |
+              Where-Object { $_.name -match "\.(exe|msi|msix|appx)(bundle){0,1}$" } |
               ForEach-Object { $_.browser_download_url }
           )
 


### PR DESCRIPTION
## Summary
- Replace `vedantmgoyal9/winget-releaser` with an explicit pinned `komac` workflow.
- Fetch release assets directly from the GitHub release, submit the WinGet manifest with `komac update`, clean merged branches, and prune old versions.
- Drop the extra `jdx/winget-pkgs` checkout and force-push sync step in favor of `komac sync-fork`.

## Tests
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/winget.yml"); puts "ok"'`
- `mise x actionlint -- actionlint .github/workflows/winget.yml`
- `mise run lint` via pre-commit hook

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI release publishing to WinGet but uses `MISE_GH_TOKEN` for API calls and manifest PRs; a misconfigured tag or asset filter could fail or submit wrong installers.
> 
> **Overview**
> The **WinGet publish workflow** no longer uses `vedantmgoyal9/winget-releaser` or manual `jdx/winget-pkgs` checkout, rebase, and force-push sync. It now installs **Komac 2.16.0** on the runner and runs an inline PowerShell job.
> 
> **Manual runs** can pass an optional `tag` input; if unset, the job resolves the tag from the release event or GitHub’s latest release API. It loads release assets, picks installer URLs (`.exe`/`.msi`/etc.), then **`komac sync-fork`**, **`komac update … --submit`**, **`komac cleanup --only-merged`**, and removes excess versions beyond **5** via **`komac remove`**. Workflow **`permissions`** are set to **`contents: read`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cabfe05f372926be18b782627673264f67d256b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->