### PR TITLE
fix(install): normalize standalone binary ownership

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -300,6 +300,10 @@ install_mise() {
     tar -xf "$cache_file"
   fi
   mv mise/bin/mise "$install_path"
+  if [ "$(id -u)" = "0" ]; then
+    chown 0:0 "$install_path"
+    chmod 755 "$install_path"
+  fi
 
   # cleanup
   cd / # Move out of $extract_dir before removing it

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -127,8 +127,8 @@ if [[ $os == "windows" ]]; then
 	zip -r "$basename.zip" mise
 	ls -oh "$basename.zip"
 else
-	XZ_OPT=-9 tar -acf "$basename.tar.xz" mise
-	tar -cf - mise | gzip -9 >"$basename.tar.gz"
-	ZSTD_NBTHREADS=0 ZSTD_CLEVEL=19 tar -acf "$basename.tar.zst" mise
+	XZ_OPT=-9 tar --owner=0 --group=0 --numeric-owner -acf "$basename.tar.xz" mise
+	tar --owner=0 --group=0 --numeric-owner -cf - mise | gzip -9 >"$basename.tar.gz"
+	ZSTD_NBTHREADS=0 ZSTD_CLEVEL=19 tar --owner=0 --group=0 --numeric-owner -acf "$basename.tar.zst" mise
 	ls -oh "$basename.tar."*
 fi

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -127,8 +127,8 @@ if [[ $os == "windows" ]]; then
 	zip -r "$basename.zip" mise
 	ls -oh "$basename.zip"
 else
-	XZ_OPT=-9 tar --owner=0 --group=0 --numeric-owner -acf "$basename.tar.xz" mise
-	tar --owner=0 --group=0 --numeric-owner -cf - mise | gzip -9 >"$basename.tar.gz"
-	ZSTD_NBTHREADS=0 ZSTD_CLEVEL=19 tar --owner=0 --group=0 --numeric-owner -acf "$basename.tar.zst" mise
+	XZ_OPT=-9 tar --owner=0 --group=0 -acf "$basename.tar.xz" mise
+	tar --owner=0 --group=0 -cf - mise | gzip -9 >"$basename.tar.gz"
+	ZSTD_NBTHREADS=0 ZSTD_CLEVEL=19 tar --owner=0 --group=0 -acf "$basename.tar.zst" mise
 	ls -oh "$basename.tar."*
 fi


### PR DESCRIPTION
## Summary
- normalize owner/group metadata to 0:0 when building standalone release tarballs
- when the standalone installer runs as root, force the installed binary to root:root with 755 permissions

## Root Cause
Release tarballs preserved the GitHub Actions runner UID/GID, and the installer extracted them with tar before moving the binary into the final install path. When run as root, tar preserves archive ownership by default, so the installed binary could remain owned by UID/GID 1001.

## Impact
Root installs using install.sh, especially with MISE_INSTALL_PATH pointing at a shared location such as /usr/local/bin/mise, could leave the mise binary writable by a local UID 1001 user.

## Validation
- sh -n packaging/standalone/install.envsubst
- bash -n scripts/build-tarball.sh
- mise x shellcheck -- shellcheck packaging/standalone/install.envsubst scripts/build-tarball.sh
- git diff --check
- pre-commit mise run lint hook passed during commit
- local tar smoke test confirmed --owner=0 --group=0 --numeric-owner produces 0:0 archive entries

_This PR was generated by an AI coding assistant._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets install-time file ownership on privileged installs; changes are small and defensive but touch security-sensitive deployment behavior.
> 
> **Overview**
> Fixes a **permission issue** where root installs of the standalone `mise` binary could end up owned by the CI runner UID/GID (e.g. 1001) instead of root, making a system-wide path like `/usr/local/bin/mise` writable by a matching local user.
> 
> **Release builds** (`scripts/build-tarball.sh`) now pass `--owner=0 --group=0` when creating `.tar.xz`, `.tar.gz`, and `.tar.zst` so archive metadata is root:root, not the build host.
> 
> **Standalone installer** (`packaging/standalone/install.envsubst`) adds a root-only step after moving the binary: `chown 0:0` and `chmod 755` on `MISE_INSTALL_PATH`, so even if `tar` preserves bad ownership on extract, the final install is normalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f31313d81e9861c2abaf64206b63958736d7037f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->