### PR TITLE
fix(cargo): accept array syntax for features

### DIFF
--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -111,6 +111,7 @@ Install additional components (passed as `cargo install --features`):
 ```toml
 [tools]
 "cargo:cargo-edit" = { version = "latest", features = "add" }
+"cargo:sqlx-cli" = { version = "latest", features = ["postgres", "rustls"] }
 ```
 
 This option requires `cargo install`; mise skips `cargo-binstall` when it is set.

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -58,7 +58,14 @@ impl<'a> CargoOptions<'a> {
     }
 
     fn features(&self) -> Option<String> {
-        self.values.raw().get_string("features")
+        match self.values.raw().opts.get("features") {
+            Some(toml::Value::Array(features)) => features
+                .iter()
+                .map(|feature| feature.as_str().map(str::to_string))
+                .collect::<Option<Vec<_>>>()
+                .map(|features| features.join(" ")),
+            _ => self.values.raw().get_string("features"),
+        }
     }
 
     fn default_features_disabled(&self) -> bool {
@@ -74,7 +81,10 @@ impl<'a> CargoOptions<'a> {
 
     fn lockfile_options(&self, target: &PlatformTarget) -> BTreeMap<String, String> {
         let mut result = BTreeMap::new();
-        for key in ["features", "default-features", "crate", "locked"] {
+        if let Some(features) = self.features() {
+            result.insert("features".to_string(), features);
+        }
+        for key in ["default-features", "crate", "locked"] {
             if let Some(value) = self.values.raw().get_string(key) {
                 result.insert(key.to_string(), value.to_string());
             }
@@ -307,8 +317,8 @@ impl CargoBackend {
 
     fn cargo_install_required_options(opts: &ToolVersionOptions) -> Vec<&'static str> {
         let mut options = vec![];
-        if opts
-            .get_string("features")
+        if CargoOptions::new(opts)
+            .features()
             .is_some_and(|features| !features.trim().is_empty())
         {
             options.push("features");
@@ -433,6 +443,30 @@ mod tests {
     }
 
     #[test]
+    fn cargo_options_accepts_array_features() {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "features".into(),
+            toml::Value::Array(vec![
+                toml::Value::String("postgres".into()),
+                toml::Value::String("rustls".into()),
+            ]),
+        );
+
+        let target = PlatformTarget::new(Platform::parse("linux-x64").unwrap());
+        let lock_opts = CargoOptions::new(&opts).lockfile_options(&target);
+
+        assert_eq!(
+            CargoOptions::new(&opts).features().as_deref(),
+            Some("postgres rustls")
+        );
+        assert_eq!(
+            lock_opts.get("features").map(String::as_str),
+            Some("postgres rustls")
+        );
+    }
+
+    #[test]
     fn cargo_options_defaults_to_locked() {
         let opts = ToolVersionOptions::default();
 
@@ -446,6 +480,23 @@ mod tests {
         assert_eq!(
             CargoBackend::cargo_install_required_options(&opts),
             vec!["features", "default-features"]
+        );
+    }
+
+    #[test]
+    fn cargo_install_required_options_detects_array_features() {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "features".into(),
+            toml::Value::Array(vec![
+                toml::Value::String("postgres".into()),
+                toml::Value::String("rustls".into()),
+            ]),
+        );
+
+        assert_eq!(
+            CargoBackend::cargo_install_required_options(&opts),
+            vec!["features"]
         );
     }
 


### PR DESCRIPTION
## Summary
- Accept TOML string-array syntax for cargo `features` and normalize it to the existing space-separated cargo CLI form.
- Persist normalized cargo features into lockfile options.
- Ensure array-style features skip `cargo-binstall`, matching existing string-style feature behavior.

## Root cause
Cargo backend options read `features` through a scalar-only helper, so TOML arrays were valid config values but invisible to install, lockfile, and binstall selection logic.

## Validation
- `cargo test -p mise cargo_options_accepts_array_features`
- `cargo test -p mise cargo_install_required_options_detects_array_features`
- `cargo test -p mise backend::cargo::tests::`
- pre-commit `mise run lint` hook, including `cargo check --all-features`

Discussion: #10809

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to cargo backend option parsing with backward-compatible string handling; no auth, security, or broad architectural changes.
> 
> **Overview**
> Fixes cargo tools where `features` was set as a TOML array (e.g. `["postgres", "rustls"]`) but was ignored because the backend only read scalar strings.
> 
> **`CargoOptions::features()`** now accepts either a string or a string array and normalizes arrays to the space-separated form `cargo install --features` expects. That normalized value is used when building install commands, when writing **lockfile options**, and when deciding whether **`features` forces `cargo install`** (skipping `cargo-binstall`). Existing string `features` values behave as before.
> 
> Docs add an array-syntax example for `cargo:sqlx-cli`. New unit tests cover array normalization and binstall-required-option detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6953df22253d46b5d7ae652b506dcc8fde47f393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cargo now accepts `features` as a TOML array in configuration, making multi-feature setups easier to express.
  - Lockfile-related settings now correctly use the resolved feature list when generating install options.

- **Bug Fixes**
  - Fixed detection of required Cargo install options so array-based feature values are recognized properly.

- **Documentation**
  - Updated the Cargo backend example to show `cargo:sqlx-cli` with PostgreSQL and Rustls features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->