### PR TITLE
fix(backend): accept native option shapes

### DIFF
--- a/docs/dev-tools/backends/forgejo.md
+++ b/docs/dev-tools/backends/forgejo.md
@@ -376,7 +376,7 @@ List of binaries to symlink into a filtered `.mise-bins` directory. This is usef
 ```toml
 [tools]
 "forgejo:user/repo" = { version = "latest", filter_bins = "tool" }
-"forgejo:user/repo" = { version = "latest", filter_bins = ["tool", "helper"] }
+"forgejo:user/other-repo" = { version = "latest", filter_bins = ["tool", "helper"] }
 ```
 
 When enabled:

--- a/docs/dev-tools/backends/forgejo.md
+++ b/docs/dev-tools/backends/forgejo.md
@@ -371,11 +371,12 @@ bin_path = "tool-{{ version }}/bin" # expands to tool-1.0.0/bin
 
 ### `filter_bins`
 
-Comma-separated list of binaries to symlink into a filtered `.mise-bins` directory. This is useful when the tool comes with extra binaries that you do not want to expose on PATH.
+List of binaries to symlink into a filtered `.mise-bins` directory. This is useful when the tool comes with extra binaries that you do not want to expose on PATH.
 
 ```toml
 [tools]
 "forgejo:user/repo" = { version = "latest", filter_bins = "tool" }
+"forgejo:user/repo" = { version = "latest", filter_bins = ["tool", "helper"] }
 ```
 
 When enabled:

--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -320,11 +320,12 @@ bin_path = "cli-{{ version }}/bin" # expands to cli-1.0.0/bin
 
 ### `filter_bins`
 
-Comma-separated list of binaries to symlink into a filtered `.mise-bins` directory. This is useful when the tool comes with extra binaries that you do not want to expose on PATH.
+List of binaries to symlink into a filtered `.mise-bins` directory. This is useful when the tool comes with extra binaries that you do not want to expose on PATH.
 
 ```toml
 [tools]
 "github:jgm/pandoc" = { version = "latest", filter_bins = "pandoc" }
+"github:owner/repo" = { version = "latest", filter_bins = ["tool", "helper"] }
 ```
 
 When enabled:

--- a/docs/dev-tools/backends/gitlab.md
+++ b/docs/dev-tools/backends/gitlab.md
@@ -369,7 +369,7 @@ List of binaries to symlink into a filtered `.mise-bins` directory. This is usef
 ```toml
 [tools]
 "gitlab:myorg/mytool" = { version = "1.0.0", filter_bins = "mybin" }
-"gitlab:myorg/mytool" = { version = "1.0.0", filter_bins = ["mybin", "helper"] }
+"gitlab:myorg/other-tool" = { version = "1.0.0", filter_bins = ["mybin", "helper"] }
 ```
 
 When enabled:

--- a/docs/dev-tools/backends/gitlab.md
+++ b/docs/dev-tools/backends/gitlab.md
@@ -364,11 +364,12 @@ bin_path = "gitlab-runner-{{ version }}/bin" # expands to gitlab-runner-1.0.0/bi
 
 ### `filter_bins`
 
-Comma-separated list of binaries to symlink into a filtered `.mise-bins` directory. This is useful when the tool comes with extra binaries that you do not want to expose on PATH.
+List of binaries to symlink into a filtered `.mise-bins` directory. This is useful when the tool comes with extra binaries that you do not want to expose on PATH.
 
 ```toml
 [tools]
 "gitlab:myorg/mytool" = { version = "1.0.0", filter_bins = "mybin" }
+"gitlab:myorg/mytool" = { version = "1.0.0", filter_bins = ["mybin", "helper"] }
 ```
 
 When enabled:

--- a/docs/dev-tools/backends/ubi.md
+++ b/docs/dev-tools/backends/ubi.md
@@ -117,7 +117,7 @@ Set to `true` to extract all files in the tarball instead of just the "bin". Not
 
 ```toml
 [tools]
-"ubi:helix-editor/helix" = { version = "latest", extract_all = "true" }
+"ubi:helix-editor/helix" = { version = "latest", extract_all = true }
 ```
 
 ### `bin_path`
@@ -129,7 +129,7 @@ This only makes sense when `extract_all` is set to `true`.
 [tools]
 "ubi:BurntSushi/ripgrep" = {
   version = "latest",
-  extract_all = "true",
+  extract_all = true,
   bin_path = "target/release",
 }
 ```

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -100,8 +100,12 @@ impl<'a> GitBackendOptions<'a> {
     }
 
     fn filter_bins(&self) -> Option<Vec<String>> {
-        let value = self.values.platform_value("filter_bins")?;
-        let bins: Vec<String> = match value {
+        self.parse_filter_bins(self.values.platform_value_without_base("filter_bins"))
+            .or_else(|| self.parse_filter_bins(self.values.raw().opts.get("filter_bins")))
+    }
+
+    fn parse_filter_bins(&self, value: Option<&toml::Value>) -> Option<Vec<String>> {
+        let bins: Vec<String> = match value? {
             toml::Value::String(filter_bins) => filter_bins
                 .split(',')
                 .map(|s| s.trim().to_string())
@@ -2335,6 +2339,31 @@ mod tests {
         assert_eq!(
             backend.options(&array_opts).filter_bins(),
             Some(vec!["foo".to_string(), "bar".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_filter_bins_falls_back_to_base_when_platform_value_is_empty() {
+        use crate::backend::static_helpers::platform_aliases;
+
+        let backend = create_test_backend();
+        let (os, arch) = platform_aliases().into_iter().next().unwrap();
+        let mut linux = toml::Table::new();
+        linux.insert("filter_bins".into(), toml::Value::Array(vec![]));
+        let mut platforms = toml::Table::new();
+        platforms.insert(format!("{os}-{arch}"), toml::Value::Table(linux));
+
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "filter_bins".to_string(),
+            toml::Value::String("base-bin".to_string()),
+        );
+        opts.opts
+            .insert("platforms".to_string(), toml::Value::Table(platforms));
+
+        assert_eq!(
+            backend.options(&opts).filter_bins(),
+            Some(vec!["base-bin".to_string()])
         );
     }
 

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -100,15 +100,25 @@ impl<'a> GitBackendOptions<'a> {
     }
 
     fn filter_bins(&self) -> Option<Vec<String>> {
-        self.values
-            .platform_string("filter_bins")
-            .map(|filter_bins| {
+        let bins: Vec<String> =
+            if let Some(filter_bins) = self.values.platform_string("filter_bins") {
                 filter_bins
                     .split(',')
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
                     .collect()
-            })
+            } else {
+                let value = self.values.raw().opts.get("filter_bins")?;
+                match value {
+                    toml::Value::Array(values) => values
+                        .iter()
+                        .filter_map(|value| value.as_str().map(|s| s.trim().to_string()))
+                        .filter(|s| !s.is_empty())
+                        .collect(),
+                    _ => return None,
+                }
+            };
+        if bins.is_empty() { None } else { Some(bins) }
     }
 
     /// Substring an asset name must contain to remain a candidate, applied as a
@@ -2301,6 +2311,35 @@ mod tests {
             "forgejo:test/repo".to_string(),
             Some("forgejo:test/repo".to_string()),
         ))
+    }
+
+    #[test]
+    fn test_filter_bins_accepts_string_or_array() {
+        let backend = create_test_backend();
+
+        let mut string_opts = ToolVersionOptions::default();
+        string_opts.opts.insert(
+            "filter_bins".to_string(),
+            toml::Value::String("foo, bar, ".to_string()),
+        );
+        assert_eq!(
+            backend.options(&string_opts).filter_bins(),
+            Some(vec!["foo".to_string(), "bar".to_string()])
+        );
+
+        let mut array_opts = ToolVersionOptions::default();
+        array_opts.opts.insert(
+            "filter_bins".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("foo".to_string()),
+                toml::Value::String(" bar ".to_string()),
+                toml::Value::String("".to_string()),
+            ]),
+        );
+        assert_eq!(
+            backend.options(&array_opts).filter_bins(),
+            Some(vec!["foo".to_string(), "bar".to_string()])
+        );
     }
 
     #[test]

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -100,24 +100,20 @@ impl<'a> GitBackendOptions<'a> {
     }
 
     fn filter_bins(&self) -> Option<Vec<String>> {
-        let bins: Vec<String> =
-            if let Some(filter_bins) = self.values.platform_string("filter_bins") {
-                filter_bins
-                    .split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect()
-            } else {
-                let value = self.values.raw().opts.get("filter_bins")?;
-                match value {
-                    toml::Value::Array(values) => values
-                        .iter()
-                        .filter_map(|value| value.as_str().map(|s| s.trim().to_string()))
-                        .filter(|s| !s.is_empty())
-                        .collect(),
-                    _ => return None,
-                }
-            };
+        let value = self.values.platform_value("filter_bins")?;
+        let bins: Vec<String> = match value {
+            toml::Value::String(filter_bins) => filter_bins
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
+            toml::Value::Array(values) => values
+                .iter()
+                .filter_map(|value| value.as_str().map(|s| s.trim().to_string()))
+                .filter(|s| !s.is_empty())
+                .collect(),
+            _ => return None,
+        };
         if bins.is_empty() { None } else { Some(bins) }
     }
 

--- a/src/backend/options.rs
+++ b/src/backend/options.rs
@@ -1,6 +1,7 @@
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::static_helpers::{
-    list_available_platforms_with_key, lookup_platform_key_for_target, lookup_with_fallback,
+    list_available_platforms_with_key, lookup_platform_key_for_target,
+    lookup_platform_value_with_fallback, lookup_with_fallback,
 };
 use crate::toolset::ToolVersionOptions;
 
@@ -27,6 +28,10 @@ impl<'a> BackendOptions<'a> {
 
     pub(crate) fn platform_string(&self, key: &str) -> Option<String> {
         lookup_with_fallback(self.raw, key)
+    }
+
+    pub(crate) fn platform_value(&self, key: &str) -> Option<&'a toml::Value> {
+        lookup_platform_value_with_fallback(self.raw, key)
     }
 
     pub(crate) fn platform_string_for_target(
@@ -124,6 +129,30 @@ mod tests {
         let mut opts = ToolVersionOptions::default();
         opts.opts.insert(key.to_string(), value);
         opts
+    }
+
+    #[test]
+    fn test_platform_value_prefers_platform_value() {
+        use crate::backend::static_helpers::platform_aliases;
+
+        let mut opts = opts_with_value("filter_bins", toml::Value::String("base".into()));
+        let (os, arch) = platform_aliases().into_iter().next().unwrap();
+        let mut linux = toml::Table::new();
+        linux.insert(
+            "filter_bins".into(),
+            toml::Value::Array(vec![toml::Value::String("platform".into())]),
+        );
+        let mut platforms = toml::Table::new();
+        platforms.insert(format!("{os}-{arch}"), toml::Value::Table(linux));
+        opts.opts
+            .insert("platforms".into(), toml::Value::Table(platforms));
+
+        assert_eq!(
+            BackendOptions::new(&opts).platform_value("filter_bins"),
+            Some(&toml::Value::Array(vec![toml::Value::String(
+                "platform".into()
+            )]))
+        );
     }
 
     #[test]

--- a/src/backend/options.rs
+++ b/src/backend/options.rs
@@ -1,7 +1,7 @@
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::static_helpers::{
-    list_available_platforms_with_key, lookup_platform_key_for_target,
-    lookup_platform_value_with_fallback, lookup_with_fallback,
+    list_available_platforms_with_key, lookup_platform_key_for_target, lookup_platform_value,
+    lookup_with_fallback,
 };
 use crate::toolset::ToolVersionOptions;
 
@@ -30,8 +30,8 @@ impl<'a> BackendOptions<'a> {
         lookup_with_fallback(self.raw, key)
     }
 
-    pub(crate) fn platform_value(&self, key: &str) -> Option<&'a toml::Value> {
-        lookup_platform_value_with_fallback(self.raw, key)
+    pub(crate) fn platform_value_without_base(&self, key: &str) -> Option<&'a toml::Value> {
+        lookup_platform_value(self.raw, key)
     }
 
     pub(crate) fn platform_string_for_target(
@@ -148,7 +148,7 @@ mod tests {
             .insert("platforms".into(), toml::Value::Table(platforms));
 
         assert_eq!(
-            BackendOptions::new(&opts).platform_value("filter_bins"),
+            BackendOptions::new(&opts).platform_value_without_base("filter_bins"),
             Some(&toml::Value::Array(vec![toml::Value::String(
                 "platform".into()
             )]))

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -323,22 +323,12 @@ pub fn platform_aliases() -> Vec<(String, String)> {
 /// Supports nested format (platforms.macos-x64.url) with os-arch dash notation.
 /// Also supports both "platforms" and "platform" prefixes.
 pub fn lookup_platform_key(opts: &ToolVersionOptions, key_type: &str) -> Option<String> {
-    // Try nested platform structure with os-arch format
-    for (os, arch) in platform_aliases() {
-        for prefix in ["platforms", "platform"] {
-            // Try nested format: platforms.macos-x64.url
-            let nested_key = format!("{prefix}.{os}-{arch}.{key_type}");
-            if let Some(val) = opts.get_nested_string(&nested_key) {
-                return Some(val);
-            }
-            // Try flat format: platforms_macos_arm64_url
-            let flat_key = format!("{prefix}_{os}_{arch}_{key_type}");
-            if let Some(val) = opts.get_string(&flat_key) {
-                return Some(val);
-            }
-        }
-    }
-    None
+    lookup_platform_value_for_aliases(
+        platform_aliases(),
+        key_type,
+        |key| opts.get_nested_string(key),
+        |key| opts.get_string(key),
+    )
 }
 
 /// Looks up an option value with platform-specific fallback.
@@ -367,6 +357,28 @@ fn lookup_nested_value<'a>(opts: &'a ToolVersionOptions, key: &str) -> Option<&'
         value = table.get(*part)?;
     }
     Some(value)
+}
+
+fn lookup_platform_value_for_aliases<T>(
+    aliases: Vec<(String, String)>,
+    key_type: &str,
+    mut nested_lookup: impl FnMut(&str) -> Option<T>,
+    mut flat_lookup: impl FnMut(&str) -> Option<T>,
+) -> Option<T> {
+    for (os, arch) in aliases {
+        for prefix in ["platforms", "platform"] {
+            let nested_key = format!("{prefix}.{os}-{arch}.{key_type}");
+            if let Some(val) = nested_lookup(&nested_key) {
+                return Some(val);
+            }
+
+            let flat_key = format!("{prefix}_{os}_{arch}_{key_type}");
+            if let Some(val) = flat_lookup(&flat_key) {
+                return Some(val);
+            }
+        }
+    }
+    None
 }
 
 /// Returns all possible aliases for a given platform target (os, arch).
@@ -405,43 +417,25 @@ pub fn lookup_platform_key_for_target(
     key_type: &str,
     target: &PlatformTarget,
 ) -> Option<String> {
-    // Try nested platform structure with os-arch format
-    for (os, arch) in target_platform_aliases(target) {
-        for prefix in ["platforms", "platform"] {
-            // Try nested format: platforms.macos-x64.url
-            let nested_key = format!("{prefix}.{os}-{arch}.{key_type}");
-            if let Some(val) = opts.get_nested_string(&nested_key) {
-                return Some(val);
-            }
-            // Try flat format: platforms_macos_arm64_url
-            let flat_key = format!("{prefix}_{os}_{arch}_{key_type}");
-            if let Some(val) = opts.get_string(&flat_key) {
-                return Some(val);
-            }
-        }
-    }
-    None
+    lookup_platform_value_for_aliases(
+        target_platform_aliases(target),
+        key_type,
+        |key| opts.get_nested_string(key),
+        |key| opts.get_string(key),
+    )
 }
 
-/// Looks up a raw option value with platform-specific fallback.
-pub fn lookup_platform_value_with_fallback<'a>(
+/// Looks up a raw platform-specific option value.
+pub fn lookup_platform_value<'a>(
     opts: &'a ToolVersionOptions,
     key_type: &str,
 ) -> Option<&'a toml::Value> {
-    for (os, arch) in platform_aliases() {
-        for prefix in ["platforms", "platform"] {
-            let nested_key = format!("{prefix}.{os}-{arch}.{key_type}");
-            if let Some(val) = lookup_nested_value(opts, &nested_key) {
-                return Some(val);
-            }
-
-            let flat_key = format!("{prefix}_{os}_{arch}_{key_type}");
-            if let Some(val) = opts.opts.get(&flat_key) {
-                return Some(val);
-            }
-        }
-    }
-    opts.opts.get(key_type)
+    lookup_platform_value_for_aliases(
+        platform_aliases(),
+        key_type,
+        |key| lookup_nested_value(opts, key),
+        |key| opts.opts.get(key),
+    )
 }
 
 /// Lists platform keys (e.g. "macos-x64") for which a given key_type exists (e.g. "url").

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -355,6 +355,20 @@ pub fn lookup_with_fallback(opts: &ToolVersionOptions, key: &str) -> Option<Stri
     lookup_platform_key(opts, key).or_else(|| opts.get_string(key))
 }
 
+fn lookup_nested_value<'a>(opts: &'a ToolVersionOptions, key: &str) -> Option<&'a toml::Value> {
+    let parts: Vec<&str> = key.split('.').collect();
+    if parts.len() < 2 {
+        return None;
+    }
+
+    let mut value = opts.opts.get(parts[0])?;
+    for part in &parts[1..] {
+        let table = value.as_table()?;
+        value = table.get(*part)?;
+    }
+    Some(value)
+}
+
 /// Returns all possible aliases for a given platform target (os, arch).
 fn target_platform_aliases(target: &PlatformTarget) -> Vec<(String, String)> {
     let os = target.os_name();
@@ -407,6 +421,27 @@ pub fn lookup_platform_key_for_target(
         }
     }
     None
+}
+
+/// Looks up a raw option value with platform-specific fallback.
+pub fn lookup_platform_value_with_fallback<'a>(
+    opts: &'a ToolVersionOptions,
+    key_type: &str,
+) -> Option<&'a toml::Value> {
+    for (os, arch) in platform_aliases() {
+        for prefix in ["platforms", "platform"] {
+            let nested_key = format!("{prefix}.{os}-{arch}.{key_type}");
+            if let Some(val) = lookup_nested_value(opts, &nested_key) {
+                return Some(val);
+            }
+
+            let flat_key = format!("{prefix}_{os}_{arch}_{key_type}");
+            if let Some(val) = opts.opts.get(&flat_key) {
+                return Some(val);
+            }
+        }
+    }
+    opts.opts.get(key_type)
 }
 
 /// Lists platform keys (e.g. "macos-x64") for which a given key_type exists (e.g. "url").

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -474,34 +474,6 @@ impl UbiBackend {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_extract_all_accepts_native_bool_or_string() {
-        let mut bool_opts = ToolVersionOptions::default();
-        bool_opts
-            .opts
-            .insert("extract_all".to_string(), toml::Value::Boolean(true));
-        assert!(UbiOptions::new(&bool_opts).extract_all());
-
-        let mut string_opts = ToolVersionOptions::default();
-        string_opts.opts.insert(
-            "extract_all".to_string(),
-            toml::Value::String("true".to_string()),
-        );
-        assert!(UbiOptions::new(&string_opts).extract_all());
-
-        let mut invalid_opts = ToolVersionOptions::default();
-        invalid_opts.opts.insert(
-            "extract_all".to_string(),
-            toml::Value::String("yes".to_string()),
-        );
-        assert!(!UbiOptions::new(&invalid_opts).extract_all());
-    }
-}
-
 fn name_is_url(n: &str) -> bool {
     n.starts_with("http")
 }
@@ -600,4 +572,32 @@ async fn install(
         RT.block_on(async { ubi.install_binary().await })
             .map_err(|e| eyre::eyre!("{e:#}"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_all_accepts_native_bool_or_string() {
+        let mut bool_opts = ToolVersionOptions::default();
+        bool_opts
+            .opts
+            .insert("extract_all".to_string(), toml::Value::Boolean(true));
+        assert!(UbiOptions::new(&bool_opts).extract_all());
+
+        let mut string_opts = ToolVersionOptions::default();
+        string_opts.opts.insert(
+            "extract_all".to_string(),
+            toml::Value::String("true".to_string()),
+        );
+        assert!(UbiOptions::new(&string_opts).extract_all());
+
+        let mut invalid_opts = ToolVersionOptions::default();
+        invalid_opts.opts.insert(
+            "extract_all".to_string(),
+            toml::Value::String("yes".to_string()),
+        );
+        assert!(!UbiOptions::new(&invalid_opts).extract_all());
+    }
 }

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -1,6 +1,6 @@
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
-use crate::backend::options::{BackendOptions, is_truthy};
+use crate::backend::options::BackendOptions;
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::try_with_v_prefix;
@@ -74,7 +74,7 @@ impl<'a> UbiOptions<'a> {
     }
 
     fn extract_all(&self) -> bool {
-        self.values.str("extract_all").is_some_and(is_truthy)
+        self.values.bool("extract_all")
     }
 
     fn exe(&self) -> Option<&'a str> {
@@ -471,6 +471,34 @@ pub fn install_time_option_keys() -> Vec<String> {
 impl UbiBackend {
     pub fn from_arg(ba: BackendArg) -> Self {
         Self { ba: Arc::new(ba) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_all_accepts_native_bool_or_string() {
+        let mut bool_opts = ToolVersionOptions::default();
+        bool_opts
+            .opts
+            .insert("extract_all".to_string(), toml::Value::Boolean(true));
+        assert!(UbiOptions::new(&bool_opts).extract_all());
+
+        let mut string_opts = ToolVersionOptions::default();
+        string_opts.opts.insert(
+            "extract_all".to_string(),
+            toml::Value::String("true".to_string()),
+        );
+        assert!(UbiOptions::new(&string_opts).extract_all());
+
+        let mut invalid_opts = ToolVersionOptions::default();
+        invalid_opts.opts.insert(
+            "extract_all".to_string(),
+            toml::Value::String("yes".to_string()),
+        );
+        assert!(!UbiOptions::new(&invalid_opts).extract_all());
     }
 }
 


### PR DESCRIPTION
## Summary
- Accept native TOML booleans for `ubi` `extract_all` while preserving existing string values.
- Accept TOML arrays for GitHub/GitLab/Forgejo `filter_bins` while preserving existing comma-separated strings.
- Update backend docs to show the native TOML forms.

## Root cause
Some backend option readers used string-only helpers for options whose natural TOML shape is boolean or list-like. Native TOML values therefore parsed successfully but were ignored by backend option logic.

## Validation
- `cargo test -p mise backend::github::tests::test_filter_bins_accepts_string_or_array`
- `cargo test -p mise backend::ubi::tests::test_extract_all_accepts_native_bool_or_string`
- `cargo test -p mise backend::github::tests::`
- `cargo test -p mise backend::ubi::tests::`
- pre-commit `mise run lint` hook, including `cargo check --all-features`

Follow-up to #10810.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible parsing and documentation changes in install option handling; no auth or security path changes.
> 
> **Overview**
> Fixes backend option parsing so **native TOML values are honored** instead of being dropped when readers only handled strings.
> 
> **`filter_bins`** (GitHub / GitLab / Forgejo via `UnifiedGitBackend`) now accepts a **comma-separated string** or a **TOML array**, with trimming and empty entries ignored. Platform-specific `filter_bins` is resolved through a new **`platform_value_without_base`** / **`lookup_platform_value`** path; if the platform override parses to nothing (e.g. empty array), it **falls back to the base** option.
> 
> **`extract_all`** on the **ubi** backend now uses **`BackendOptions::bool`**, so native `true`/`false` work alongside legacy string forms like `"true"`.
> 
> Backend docs for **`filter_bins`** and **`extract_all`** show array/boolean examples instead of implying strings only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb288c086550f378660ebb6d017721d24e9801e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `filter_bins` now supports both a single value and an array of binaries, with platform-specific overrides applied correctly.
  * `extract_all` configuration examples now use native boolean values.

* **Bug Fixes**
  * Improved `filter_bins` parsing: trims whitespace, ignores empty entries, and treats an empty result as unset (falling back to base settings when needed).

* **Documentation**
  * Updated backend docs/examples for `filter_bins` and `extract_all` across supported backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->