### PR TITLE
fix(backend): accept arrays for list options

### DIFF
--- a/docs/dev-tools/backends/go.md
+++ b/docs/dev-tools/backends/go.md
@@ -67,4 +67,5 @@ Specify go build tags (passed as `go install -tags`):
 ```toml
 [tools]
 "go:github.com/golang-migrate/migrate/v4/cmd/migrate" = { version = "latest", tags = "postgres" }
+"go:github.com/golang-migrate/migrate/v4/cmd/migrate" = { version = "latest", tags = ["postgres", "mysql"] }
 ```

--- a/docs/dev-tools/backends/go.md
+++ b/docs/dev-tools/backends/go.md
@@ -67,5 +67,6 @@ Specify go build tags (passed as `go install -tags`):
 ```toml
 [tools]
 "go:github.com/golang-migrate/migrate/v4/cmd/migrate" = { version = "latest", tags = "postgres" }
-"go:github.com/golang-migrate/migrate/v4/cmd/migrate" = { version = "latest", tags = ["postgres", "mysql"] }
+# equivalent array form:
+# "go:github.com/golang-migrate/migrate/v4/cmd/migrate" = { version = "latest", tags = ["postgres", "mysql"] }
 ```

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -123,6 +123,7 @@ Install additional components.
 ```toml
 [tools]
 "pipx:harlequin" = { version = "latest", extras = "postgres,s3" }
+"pipx:harlequin" = { version = "latest", extras = ["postgres", "s3"] }
 ```
 
 ### `pipx_args`

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -123,7 +123,8 @@ Install additional components.
 ```toml
 [tools]
 "pipx:harlequin" = { version = "latest", extras = "postgres,s3" }
-"pipx:harlequin" = { version = "latest", extras = ["postgres", "s3"] }
+# equivalent array form:
+# "pipx:harlequin" = { version = "latest", extras = ["postgres", "s3"] }
 ```
 
 ### `pipx_args`

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -43,14 +43,7 @@ impl<'a> GoOptions<'a> {
     }
 
     fn tags(&self) -> Option<String> {
-        match self.values.raw().opts.get("tags") {
-            Some(toml::Value::Array(tags)) => tags
-                .iter()
-                .map(|tag| tag.as_str().map(str::to_string))
-                .collect::<Option<Vec<_>>>()
-                .map(|tags| tags.join(",")),
-            _ => self.values.raw().get_string("tags"),
-        }
+        self.values.comma_joined("tags")
     }
 
     fn lockfile_options(&self) -> BTreeMap<String, String> {
@@ -658,6 +651,7 @@ mod tests {
             "tags".to_string(),
             toml::Value::Array(vec![
                 toml::Value::String("sqlite".to_string()),
+                toml::Value::Integer(1),
                 toml::Value::String("fts5".to_string()),
             ]),
         );

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -42,14 +42,21 @@ impl<'a> GoOptions<'a> {
         }
     }
 
-    fn tags(&self) -> Option<&'a str> {
-        self.values.str("tags")
+    fn tags(&self) -> Option<String> {
+        match self.values.raw().opts.get("tags") {
+            Some(toml::Value::Array(tags)) => tags
+                .iter()
+                .map(|tag| tag.as_str().map(str::to_string))
+                .collect::<Option<Vec<_>>>()
+                .map(|tags| tags.join(",")),
+            _ => self.values.raw().get_string("tags"),
+        }
     }
 
     fn lockfile_options(&self) -> BTreeMap<String, String> {
         let mut result = BTreeMap::new();
         if let Some(value) = self.tags() {
-            result.insert("tags".to_string(), value.to_string());
+            result.insert("tags".to_string(), value);
         }
         result
     }
@@ -637,7 +644,25 @@ mod tests {
             toml::Value::String("sqlite,fts5".to_string()),
         );
 
-        assert_eq!(GoOptions::new(&opts).tags(), Some("sqlite,fts5"));
+        assert_eq!(GoOptions::new(&opts).tags().as_deref(), Some("sqlite,fts5"));
+        assert_eq!(
+            GoOptions::new(&opts).lockfile_options(),
+            BTreeMap::from([("tags".to_string(), "sqlite,fts5".to_string())])
+        );
+    }
+
+    #[test]
+    fn go_options_accepts_array_tags() {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "tags".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("sqlite".to_string()),
+                toml::Value::String("fts5".to_string()),
+            ]),
+        );
+
+        assert_eq!(GoOptions::new(&opts).tags().as_deref(), Some("sqlite,fts5"));
         assert_eq!(
             GoOptions::new(&opts).lockfile_options(),
             BTreeMap::from([("tags".to_string(), "sqlite,fts5".to_string())])

--- a/src/backend/options.rs
+++ b/src/backend/options.rs
@@ -34,6 +34,8 @@ impl<'a> BackendOptions<'a> {
         lookup_platform_value(self.raw, key)
     }
 
+    /// Returns a comma-separated option value from either a string or an array of
+    /// strings, warning about non-string array entries.
     pub(crate) fn comma_joined(&self, key: &str) -> Option<String> {
         match self.raw.opts.get(key) {
             Some(toml::Value::Array(values)) => {

--- a/src/backend/options.rs
+++ b/src/backend/options.rs
@@ -34,6 +34,28 @@ impl<'a> BackendOptions<'a> {
         lookup_platform_value(self.raw, key)
     }
 
+    pub(crate) fn comma_joined(&self, key: &str) -> Option<String> {
+        match self.raw.opts.get(key) {
+            Some(toml::Value::Array(values)) => {
+                let values = values
+                    .iter()
+                    .filter_map(|value| {
+                        value.as_str().map(str::to_string).or_else(|| {
+                            warn!("invalid value in `{key}` array: {value}; expected string");
+                            None
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                if values.is_empty() {
+                    None
+                } else {
+                    Some(values.join(","))
+                }
+            }
+            _ => self.raw.get_string(key),
+        }
+    }
+
     pub(crate) fn platform_string_for_target(
         &self,
         key: &str,
@@ -152,6 +174,32 @@ mod tests {
             Some(&toml::Value::Array(vec![toml::Value::String(
                 "platform".into()
             )]))
+        );
+    }
+
+    #[test]
+    fn test_comma_joined_accepts_string_or_array() {
+        let string_opts = opts_with_value("tags", toml::Value::String("sqlite,fts5".into()));
+        assert_eq!(
+            BackendOptions::new(&string_opts)
+                .comma_joined("tags")
+                .as_deref(),
+            Some("sqlite,fts5")
+        );
+
+        let array_opts = opts_with_value(
+            "tags",
+            toml::Value::Array(vec![
+                toml::Value::String("sqlite".into()),
+                toml::Value::Integer(1),
+                toml::Value::String("fts5".into()),
+            ]),
+        );
+        assert_eq!(
+            BackendOptions::new(&array_opts)
+                .comma_joined("tags")
+                .as_deref(),
+            Some("sqlite,fts5")
         );
     }
 

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -56,14 +56,7 @@ impl<'a> PipxOptions<'a> {
     }
 
     fn extras(&self) -> Option<String> {
-        match self.values.raw().opts.get("extras") {
-            Some(toml::Value::Array(extras)) => extras
-                .iter()
-                .map(|extra| extra.as_str().map(str::to_string))
-                .collect::<Option<Vec<_>>>()
-                .map(|extras| extras.join(",")),
-            _ => self.values.raw().get_string("extras"),
-        }
+        self.values.comma_joined("extras")
     }
 
     fn pipx_args(&self) -> Option<&'a str> {
@@ -858,6 +851,7 @@ mod tests {
             "extras".to_string(),
             toml::Value::Array(vec![
                 toml::Value::String("postgres".to_string()),
+                toml::Value::Integer(1),
                 toml::Value::String("s3".to_string()),
             ]),
         );

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -55,8 +55,15 @@ impl<'a> PipxOptions<'a> {
         }
     }
 
-    fn extras(&self) -> Option<&'a str> {
-        self.values.str("extras")
+    fn extras(&self) -> Option<String> {
+        match self.values.raw().opts.get("extras") {
+            Some(toml::Value::Array(extras)) => extras
+                .iter()
+                .map(|extra| extra.as_str().map(str::to_string))
+                .collect::<Option<Vec<_>>>()
+                .map(|extras| extras.join(",")),
+            _ => self.values.raw().get_string("extras"),
+        }
     }
 
     fn pipx_args(&self) -> Option<&'a str> {
@@ -73,7 +80,13 @@ impl<'a> PipxOptions<'a> {
 
     fn lockfile_options(&self) -> BTreeMap<String, String> {
         let mut result = BTreeMap::new();
+        if let Some(value) = self.extras() {
+            result.insert("extras".to_string(), value);
+        }
         for key in install_time_option_keys() {
+            if key == "extras" {
+                continue;
+            }
             if let Some(value) = self.values.raw().get_string(&key) {
                 result.insert(key, value);
             }
@@ -813,11 +826,57 @@ fn fix_venv_python_symlink(_install_path: &Path, _pkg_name: &str) -> Result<()> 
 
 #[cfg(test)]
 mod tests {
-    use super::{PIPXBackend, PypiPackage, PypiRelease, UV_EXCLUDE_NEWER_VERSION};
+    use super::{
+        PIPXBackend, PipxOptions, PipxRequest, PypiPackage, PypiRelease, UV_EXCLUDE_NEWER_VERSION,
+    };
     use crate::github::GithubRelease;
+    use crate::toolset::ToolVersionOptions;
     use indexmap::IndexMap;
     use pretty_assertions::assert_eq;
     use std::ffi::OsString;
+
+    #[test]
+    fn test_extras_accepts_string_or_array() {
+        let mut string_opts = ToolVersionOptions::default();
+        string_opts.opts.insert(
+            "extras".to_string(),
+            toml::Value::String("postgres,s3".to_string()),
+        );
+        assert_eq!(
+            PipxOptions::new(&string_opts).extras().as_deref(),
+            Some("postgres,s3")
+        );
+        assert_eq!(
+            PipxOptions::new(&string_opts)
+                .lockfile_options()
+                .get("extras"),
+            Some(&"postgres,s3".to_string())
+        );
+
+        let mut array_opts = ToolVersionOptions::default();
+        array_opts.opts.insert(
+            "extras".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("postgres".to_string()),
+                toml::Value::String("s3".to_string()),
+            ]),
+        );
+        assert_eq!(
+            PipxOptions::new(&array_opts).extras().as_deref(),
+            Some("postgres,s3")
+        );
+        assert_eq!(
+            PipxRequest::Pypi("harlequin".to_string())
+                .pipx_request("latest", &PipxOptions::new(&array_opts)),
+            "harlequin[postgres,s3]"
+        );
+        assert_eq!(
+            PipxOptions::new(&array_opts)
+                .lockfile_options()
+                .get("extras"),
+            Some(&"postgres,s3".to_string())
+        );
+    }
 
     #[test]
     fn test_versions_from_pypi_package_skips_yanked_releases() {


### PR DESCRIPTION
## Summary
- Accept TOML arrays for Go backend `tags`, normalized to the existing comma-separated `go install -tags` value.
- Accept TOML arrays for pipx backend `extras`, normalized to the existing comma-separated extras value.
- Update backend docs to show both string and array forms.

## Root cause
These list-like backend options used string-only option readers, so native TOML arrays parsed successfully but were ignored by install and lockfile option logic.

## Validation
- `cargo test -p mise backend::go::tests::go_options_accepts_array_tags`
- `cargo test -p mise backend::pipx::tests::test_extras_accepts_string_or_array`
- `cargo test -p mise backend::go::tests::`
- `cargo test -p mise backend::pipx::tests::`
- pre-commit `mise run lint` hook, including `cargo check --all-features`

Follow-up to #10810 and #10811.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized config parsing change with backward-compatible string form and targeted tests; no auth or install-path behavior changes beyond honoring array config that was previously ignored.
> 
> **Overview**
> Fixes list-like backend tool options that parsed as TOML arrays but were ignored because only string values were read.
> 
> **Shared parsing:** `BackendOptions::comma_joined` normalizes a key from either a comma-separated string or a TOML array of strings (non-string array entries are skipped with a warning).
> 
> **Go** `tags` and **pipx** `extras` now use that helper for `go install -tags`, pipx/uv install spec extras, and lockfile serialization. Pipx lockfile options record normalized `extras` explicitly instead of relying only on the generic install-time key loop.
> 
> Docs for both backends show the equivalent array form. Unit tests cover string and array inputs (including invalid array elements).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3aa9be402d4f9504a5466ceb42ea75d0ecbf44f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added array-style configuration examples for backend tool tags and package extras.

* **Bug Fixes**
  * Improved handling of array-form settings for the Go backend `tags` and the `pipx` backend `extras`.
  * Ensured consistent serialization for generated lockfile and install settings.

* **Tests**
  * Added/updated tests to verify both string and array inputs for these settings and to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->