### PR TITLE
fix(cargo): warn on invalid feature array entries

### DIFF
--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -59,11 +59,24 @@ impl<'a> CargoOptions<'a> {
 
     fn features(&self) -> Option<String> {
         match self.values.raw().opts.get("features") {
-            Some(toml::Value::Array(features)) => features
-                .iter()
-                .map(|feature| feature.as_str().map(str::to_string))
-                .collect::<Option<Vec<_>>>()
-                .map(|features| features.join(" ")),
+            Some(toml::Value::Array(features)) => {
+                let features = features
+                    .iter()
+                    .filter_map(|feature| {
+                        feature.as_str().map(str::to_string).or_else(|| {
+                            warn!(
+                                "invalid value in cargo features array: {feature}; expected string"
+                            );
+                            None
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                if features.is_empty() {
+                    None
+                } else {
+                    Some(features.join(" "))
+                }
+            }
             _ => self.values.raw().get_string("features"),
         }
     }
@@ -449,6 +462,7 @@ mod tests {
             "features".into(),
             toml::Value::Array(vec![
                 toml::Value::String("postgres".into()),
+                toml::Value::Integer(1),
                 toml::Value::String("rustls".into()),
             ]),
         );


### PR DESCRIPTION
## Summary
- preserve valid cargo feature strings when a TOML array contains a non-string value
- warn about invalid array entries instead of silently dropping the whole features list
- extend the unit test to cover mixed-type feature arrays

## Tests
- cargo test -p mise backend::cargo::tests
- mise run lint

Follow-up to #10810.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing change in cargo install options with clearer warnings and preserved valid features; no auth or security impact.
> 
> **Overview**
> **Cargo `features` TOML arrays** no longer fail entirely when one element is not a string. `CargoOptions::features()` now keeps valid string entries, joins them for `cargo install --features` and lockfile options, and emits a **warning** for each invalid array value.
> 
> If every entry is invalid or the filtered list is empty, behavior matches “no features” (`None`). A unit test now covers mixed string/non-string arrays (e.g. integer `1` between feature names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f64b94d9f79a488af81b98af61ff1fea8e4d10c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of feature lists in configuration files.
  * Non-text entries in feature arrays are now ignored with a warning instead of causing the entire list to be discarded.
  * Valid feature names are still applied as expected, and empty or fully invalid lists are treated as unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->