### PR TITLE
feat(config): add tera v1 escape hatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5412,6 +5412,7 @@ dependencies = [
  "taplo",
  "tar",
  "tempfile",
+ "tera 1.20.1",
  "tera 2.0.0",
  "terminal_size",
  "test-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ taplo = "0.14"
 tar = "0.4"
 tempfile = "3"
 tera = "2"
+tera1 = { package = "tera", version = "1.20.1" }
 terminal_size = "0.4"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -130,6 +130,8 @@ Tera v2 also adds useful syntax that replaces many old helper filters:
 
 Not every Tera v1 behavior can be made compatible. Undefined variable access is
 stricter in Tera v2, and Tera v1 macros are not supported by mise templates.
+As a temporary escape hatch, set `tera_v1 = true` or `MISE_TERA_V1=1` to render
+templates with Tera v1. This setting is scheduled for removal in mise 2027.4.0.
 
 ### Tera Filters
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -132,6 +132,8 @@ Not every Tera v1 behavior can be made compatible. Undefined variable access is
 stricter in Tera v2, and Tera v1 macros are not supported by mise templates.
 As a temporary escape hatch, set `tera_v1 = true` or `MISE_TERA_V1=1` to render
 templates with Tera v1. This setting is scheduled for removal in mise 2027.4.0.
+Because miserc files are rendered before settings are loaded, this escape hatch
+does not apply while loading miserc itself.
 
 ### Tera Filters
 

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1789,12 +1789,6 @@
             }
           }
         },
-        "tera_v1": {
-          "default": false,
-          "description": "Use Tera v1 instead of Tera v2 for template rendering.",
-          "type": "boolean",
-          "deprecated": true
-        },
         "task_disable_paths": {
           "description": "Paths that mise will not look for tasks in.",
           "type": "array",
@@ -1843,6 +1837,12 @@
         },
         "task_timings": {
           "description": "Show completion message with elapsed time for each task on `mise run`. Default shows when output type is `prefix`.",
+          "type": "boolean",
+          "deprecated": true
+        },
+        "tera_v1": {
+          "default": false,
+          "description": "Use Tera v1 instead of Tera v2 for template rendering.",
           "type": "boolean",
           "deprecated": true
         },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1789,6 +1789,12 @@
             }
           }
         },
+        "tera_v1": {
+          "default": false,
+          "description": "Use Tera v1 instead of Tera v2 for template rendering.",
+          "type": "boolean",
+          "deprecated": true
+        },
         "task_disable_paths": {
           "description": "Paths that mise will not look for tasks in.",
           "type": "array",

--- a/settings.toml
+++ b/settings.toml
@@ -2442,6 +2442,24 @@ export MISE_TASK_MONOREPO_DEPTH=3
 env = "MISE_TASK_MONOREPO_DEPTH"
 type = "Integer"
 
+[tera_v1]
+default = false
+deprecated = "tera_v1 is a temporary compatibility escape hatch for templates that still need Tera v1 behavior. Update templates to Tera v2 syntax instead."
+deprecated_remove_at = "2027.4.0"
+deprecated_warn_at = "2026.10.0"
+description = "Use Tera v1 instead of Tera v2 for template rendering."
+docs = """
+Use Tera v1 instead of Tera v2 for template rendering.
+
+This is a temporary escape hatch for users whose templates still rely on Tera v1 behavior that
+cannot be fully emulated by mise's Tera v2 compatibility helpers, such as Tera v1 macros or looser
+undefined variable handling.
+
+New templates should use Tera v2 syntax. This setting is scheduled for removal in mise 2027.4.0.
+"""
+env = "MISE_TERA_V1"
+type = "Bool"
+
 [task.monorepo_exclude_dirs]
 default = []
 description = "Directory patterns to exclude when discovering monorepo subdirectories."

--- a/settings.toml
+++ b/settings.toml
@@ -2442,24 +2442,6 @@ export MISE_TASK_MONOREPO_DEPTH=3
 env = "MISE_TASK_MONOREPO_DEPTH"
 type = "Integer"
 
-[tera_v1]
-default = false
-deprecated = "tera_v1 is a temporary compatibility escape hatch for templates that still need Tera v1 behavior. Update templates to Tera v2 syntax instead."
-deprecated_remove_at = "2027.4.0"
-deprecated_warn_at = "2026.10.0"
-description = "Use Tera v1 instead of Tera v2 for template rendering."
-docs = """
-Use Tera v1 instead of Tera v2 for template rendering.
-
-This is a temporary escape hatch for users whose templates still rely on Tera v1 behavior that
-cannot be fully emulated by mise's Tera v2 compatibility helpers, such as Tera v1 macros or looser
-undefined variable handling.
-
-New templates should use Tera v2 syntax. This setting is scheduled for removal in mise 2027.4.0.
-"""
-env = "MISE_TERA_V1"
-type = "Bool"
-
 [task.monorepo_exclude_dirs]
 default = []
 description = "Directory patterns to exclude when discovering monorepo subdirectories."
@@ -2645,6 +2627,24 @@ deprecated_warn_at = "2026.8.0"
 description = "Show completion message with elapsed time for each task on `mise run`. Default shows when output type is `prefix`."
 hide = true
 optional = true
+type = "Bool"
+
+[tera_v1]
+default = false
+deprecated = "tera_v1 is a temporary compatibility escape hatch for templates that still need Tera v1 behavior. Update templates to Tera v2 syntax instead."
+deprecated_remove_at = "2027.4.0"
+deprecated_warn_at = "2026.10.0"
+description = "Use Tera v1 instead of Tera v2 for template rendering."
+docs = """
+Use Tera v1 instead of Tera v2 for template rendering.
+
+This is a temporary escape hatch for users whose templates still rely on Tera v1 behavior that
+cannot be fully emulated by mise's Tera v2 compatibility helpers, such as Tera v1 macros or looser
+undefined variable handling.
+
+New templates should use Tera v2 syntax. This setting is scheduled for removal in mise 2027.4.0.
+"""
+env = "MISE_TERA_V1"
 type = "Bool"
 
 [terminal_progress]

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -2263,7 +2263,7 @@ fn template_string_for_target(template: &str, tv: &ToolVersion, target: &Platfor
     ctx.insert("x86_64_arch", x86_64_arch);
     ctx.insert("gnu_arch", gnu_arch);
 
-    let mut tera = crate::tera::get_tera(None);
+    let mut tera = crate::tera::get_tera_v2(None);
     // Register target-aware os() and arch() functions that use the target platform
     // instead of the compile-time platform
     let make_remapping_fn = |value: String| {
@@ -2278,7 +2278,7 @@ fn template_string_for_target(template: &str, tv: &ToolVersion, target: &Platfor
     tera.register_function("os", make_remapping_fn(os.to_string()));
     tera.register_function("arch", make_remapping_fn(arch.to_string()));
 
-    match crate::tera::render_str(&mut tera, template, &ctx) {
+    match crate::tera::render_str_v2(&mut tera, template, &ctx) {
         Ok(rendered) => rendered,
         Err(e) => {
             warn!("Failed to render template '{}': {}", template, e);

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -495,7 +495,7 @@ pub fn template_string_for_target(
     )
 }
 
-fn render_template(template: &str, version: &str, mut tera: tera::Tera) -> String {
+fn render_template(template: &str, version: &str, mut tera: crate::tera::TeraEngine) -> String {
     // Check for legacy {version} syntax and emit deprecation warning
     if template.contains("{version}") && !template.contains("{{version}}") {
         deprecated_at!(

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -26,7 +26,7 @@ impl EnvResults {
     pub async fn file(
         config: &Arc<Config>,
         ctx: &mut tera::Context,
-        tera: &mut Option<tera::Tera>,
+        tera: &mut Option<crate::tera::TeraEngine>,
         r: &mut EnvResults,
         normalize_path: fn(&Path, PathBuf) -> PathBuf,
         source: &Path,

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -4,7 +4,9 @@ use crate::env;
 use crate::env_diff::EnvMap;
 use crate::file::display_path;
 use crate::path_env::PathEnv;
-use crate::tera::{contains_template_syntax, get_tera, render_str, tera_exec};
+use crate::tera::{
+    TeraEngine, contains_template_syntax, get_tera, render_str, tera_exec, tera1_exec,
+};
 use eyre::{Context, eyre};
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -773,7 +775,7 @@ impl EnvResults {
     fn parse_template(
         &self,
         ctx: &tera::Context,
-        tera: &mut Option<tera::Tera>,
+        tera: &mut Option<TeraEngine>,
         path: &Path,
         exec_env: &EnvMap,
         input: &str,
@@ -785,10 +787,17 @@ impl EnvResults {
             trust_check(path)?;
             let tera = tera.get_or_insert_with(|| {
                 let mut tera = get_tera(path.parent());
-                tera.register_function(
-                    "exec",
-                    tera_exec(path.parent().map(|d| d.to_path_buf()), exec_env.clone()),
-                );
+                if let TeraEngine::V2(tera) = &mut tera {
+                    tera.register_function(
+                        "exec",
+                        tera_exec(path.parent().map(|d| d.to_path_buf()), exec_env.clone()),
+                    );
+                } else if let TeraEngine::V1(tera) = &mut tera {
+                    tera.register_function(
+                        "exec",
+                        tera1_exec(path.parent().map(|d| d.to_path_buf()), exec_env.clone()),
+                    );
+                }
                 tera
             });
             output = render_str(tera, input, ctx)

--- a/src/config/env_directive/path.rs
+++ b/src/config/env_directive/path.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 impl EnvResults {
     pub async fn path(
         ctx: &mut tera::Context,
-        tera: &mut Option<tera::Tera>,
+        tera: &mut Option<crate::tera::TeraEngine>,
         r: &mut EnvResults,
         source: &Path,
         exec_env: &EnvMap,

--- a/src/config/env_directive/source.rs
+++ b/src/config/env_directive/source.rs
@@ -9,7 +9,7 @@ impl EnvResults {
     #[allow(clippy::too_many_arguments)]
     pub fn source(
         ctx: &mut tera::Context,
-        tera: &mut Option<tera::Tera>,
+        tera: &mut Option<crate::tera::TeraEngine>,
         paths: &mut Vec<(PathBuf, PathBuf)>,
         r: &mut EnvResults,
         normalize_path: fn(&Path, PathBuf) -> PathBuf,

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -173,7 +173,7 @@ impl EnvResults {
     pub async fn venv(
         config: &Arc<Config>,
         ctx: &mut tera::Context,
-        tera: &mut Option<tera::Tera>,
+        tera: &mut Option<crate::tera::TeraEngine>,
         env: &mut IndexMap<String, (String, Option<PathBuf>)>,
         r: &mut EnvResults,
         normalize_path: fn(&Path, PathBuf) -> PathBuf,

--- a/src/config/miserc.rs
+++ b/src/config/miserc.rs
@@ -18,7 +18,7 @@ use crate::dirs;
 use crate::env;
 use crate::file;
 use crate::tera::{
-    contains_template_syntax, get_miserc_tera, render_str, take_tera_accessed_files,
+    TeraEngine, contains_template_syntax, get_miserc_tera, render_str, take_tera_accessed_files,
 };
 
 static MISERC: OnceLock<MisercSettings> = OnceLock::new();
@@ -88,7 +88,7 @@ pub fn get_override_tool_versions_filenames() -> Option<&'static Vec<String>> {
 /// - `exec()` (depends on Settings, which are not yet loaded)
 /// - `read_file()` (not registered — needs per-file directory context not set up at this stage)
 fn render_miserc_template(
-    tera: &mut Option<tera::Tera>,
+    tera: &mut Option<TeraEngine>,
     content: &str,
     config_root: &Path,
 ) -> String {
@@ -133,7 +133,7 @@ fn load_miserc_settings() -> Result<MisercSettings> {
 
     // Tera is initialized lazily inside render_miserc_template — only paid if a file
     // actually contains template syntax. Shared across all files to avoid redundant clones.
-    let mut tera: Option<tera::Tera> = None;
+    let mut tera: Option<TeraEngine> = None;
 
     for path in files.into_iter().rev() {
         if let Ok(content) = file::read_to_string(&path) {

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -394,15 +394,14 @@ fn desired_content(config: &Config, req: &EditRequest) -> Result<Option<String>>
         BlockSource::File(p) => file::read_to_string(p)?,
     };
     let content = if *template {
-        let tera = crate::tera::get_tera(Some(&req.base));
-        tera.render_str(&raw, &config.tera_ctx, false)
-            .map_err(|err| {
-                eyre::eyre!(
-                    "[dotfiles].\"{}/{}\": failed to render template: {err}",
-                    req.path_raw,
-                    req.id
-                )
-            })?
+        let mut tera = crate::tera::get_tera(Some(&req.base));
+        crate::tera::render_str(&mut tera, &raw, &config.tera_ctx).map_err(|err| {
+            eyre::eyre!(
+                "[dotfiles].\"{}/{}\": failed to render template: {err}",
+                req.path_raw,
+                req.id
+            )
+        })?
     } else {
         raw
     };

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -664,16 +664,14 @@ fn check_content(target: &Path, expected: &[u8]) -> Result<FileState> {
 
 pub fn render_template(config: &Config, req: &FileRequest) -> Result<String> {
     let raw = file::read_to_string(&req.source)?;
-    let tera = crate::tera::get_tera(Some(&req.base));
-    let rendered = tera
-        .render_str(&raw, &config.tera_ctx, false)
-        .map_err(|err| {
-            eyre::eyre!(
-                "[dotfiles].\"{}\": failed to render template {}: {err}",
-                req.target_raw,
-                req.source.display_user()
-            )
-        })?;
+    let mut tera = crate::tera::get_tera(Some(&req.base));
+    let rendered = crate::tera::render_str(&mut tera, &raw, &config.tera_ctx).map_err(|err| {
+        eyre::eyre!(
+            "[dotfiles].\"{}\": failed to render template {}: {err}",
+            req.target_raw,
+            req.source.display_user()
+        )
+    })?;
     Ok(rendered)
 }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -4,7 +4,7 @@ use crate::config::env_directive::{EnvDirective, EnvResolveOptions, EnvResults, 
 use crate::config::{self, Config};
 use crate::path_env::PathEnv;
 use crate::task::task_script_parser::TaskScriptParser;
-use crate::tera::{contains_template_syntax, get_tera, render_str};
+use crate::tera::{TeraEngine, contains_template_syntax, get_tera, render_str};
 use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};
 use console::{measure_text_width, truncate_str};
@@ -156,7 +156,7 @@ impl std::hash::Hash for RunEntry {
 }
 
 impl RunEntry {
-    pub fn render(&self, tera: &mut tera::Tera, tera_ctx: &tera::Context) -> crate::Result<Self> {
+    pub fn render(&self, tera: &mut TeraEngine, tera_ctx: &tera::Context) -> crate::Result<Self> {
         match self {
             RunEntry::Script(s) => Ok(RunEntry::Script(s.clone())),
             RunEntry::SingleTask { task, args, env } => {

--- a/src/task/task_dep.rs
+++ b/src/task/task_dep.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-use crate::tera::{contains_template_syntax, render_str};
+use crate::tera::{TeraEngine, contains_template_syntax, render_str};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TaskDep {
@@ -18,7 +18,7 @@ pub struct TaskDep {
 impl TaskDep {
     pub fn render(
         &mut self,
-        tera: &mut tera::Tera,
+        tera: &mut TeraEngine,
         tera_ctx: &tera::Context,
     ) -> crate::Result<&mut Self> {
         if contains_template_syntax(&self.task) {
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_task_dep_render_shell_style_env() {
         let mut td: TaskDep = "FOO=bar mytask arg1".parse().unwrap();
-        let mut tera = tera::Tera::default();
+        let mut tera = TeraEngine::V2(tera::Tera::default());
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn test_task_dep_render_multiple_env() {
         let mut td: TaskDep = "FOO=bar BAZ=qux mytask".parse().unwrap();
-        let mut tera = tera::Tera::default();
+        let mut tera = TeraEngine::V2(tera::Tera::default());
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn test_task_dep_render_no_env() {
         let mut td: TaskDep = "mytask arg1 arg2".parse().unwrap();
-        let mut tera = tera::Tera::default();
+        let mut tera = TeraEngine::V2(tera::Tera::default());
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -336,7 +336,7 @@ mod tests {
     fn test_task_dep_single_token_with_equals() {
         // Single token like "build=release" should be treated as task name, not env var
         let mut td: TaskDep = "build=release".parse().unwrap();
-        let mut tera = tera::Tera::default();
+        let mut tera = TeraEngine::V2(tera::Tera::default());
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -349,7 +349,7 @@ mod tests {
     fn test_task_dep_only_env_vars_error() {
         // Only env vars without task name should error
         let mut td: TaskDep = "FOO=bar BAZ=qux".parse().unwrap();
-        let mut tera = tera::Tera::default();
+        let mut tera = TeraEngine::V2(tera::Tera::default());
         let ctx = tera::Context::new();
         let result = td.render(&mut tera, &ctx);
 

--- a/src/task/task_dep.rs
+++ b/src/task/task_dep.rs
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_task_dep_render_shell_style_env() {
         let mut td: TaskDep = "FOO=bar mytask arg1".parse().unwrap();
-        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
+        let mut tera = TeraEngine::V2(Box::default());
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn test_task_dep_render_multiple_env() {
         let mut td: TaskDep = "FOO=bar BAZ=qux mytask".parse().unwrap();
-        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
+        let mut tera = TeraEngine::V2(Box::default());
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn test_task_dep_render_no_env() {
         let mut td: TaskDep = "mytask arg1 arg2".parse().unwrap();
-        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
+        let mut tera = TeraEngine::V2(Box::default());
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -336,7 +336,7 @@ mod tests {
     fn test_task_dep_single_token_with_equals() {
         // Single token like "build=release" should be treated as task name, not env var
         let mut td: TaskDep = "build=release".parse().unwrap();
-        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
+        let mut tera = TeraEngine::V2(Box::default());
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -349,7 +349,7 @@ mod tests {
     fn test_task_dep_only_env_vars_error() {
         // Only env vars without task name should error
         let mut td: TaskDep = "FOO=bar BAZ=qux".parse().unwrap();
-        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
+        let mut tera = TeraEngine::V2(Box::default());
         let ctx = tera::Context::new();
         let result = td.render(&mut tera, &ctx);
 

--- a/src/task/task_dep.rs
+++ b/src/task/task_dep.rs
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_task_dep_render_shell_style_env() {
         let mut td: TaskDep = "FOO=bar mytask arg1".parse().unwrap();
-        let mut tera = TeraEngine::V2(tera::Tera::default());
+        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn test_task_dep_render_multiple_env() {
         let mut td: TaskDep = "FOO=bar BAZ=qux mytask".parse().unwrap();
-        let mut tera = TeraEngine::V2(tera::Tera::default());
+        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn test_task_dep_render_no_env() {
         let mut td: TaskDep = "mytask arg1 arg2".parse().unwrap();
-        let mut tera = TeraEngine::V2(tera::Tera::default());
+        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -336,7 +336,7 @@ mod tests {
     fn test_task_dep_single_token_with_equals() {
         // Single token like "build=release" should be treated as task name, not env var
         let mut td: TaskDep = "build=release".parse().unwrap();
-        let mut tera = TeraEngine::V2(tera::Tera::default());
+        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
         let ctx = tera::Context::new();
         td.render(&mut tera, &ctx).unwrap();
 
@@ -349,7 +349,7 @@ mod tests {
     fn test_task_dep_only_env_vars_error() {
         // Only env vars without task name should error
         let mut td: TaskDep = "FOO=bar BAZ=qux".parse().unwrap();
-        let mut tera = TeraEngine::V2(tera::Tera::default());
+        let mut tera = TeraEngine::V2(Box::new(tera::Tera::default()));
         let ctx = tera::Context::new();
         let result = td.render(&mut tera, &ctx);
 

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -3,7 +3,7 @@ use crate::env_diff::EnvMap;
 use crate::exit::exit;
 use crate::shell::ShellType;
 use crate::task::Task;
-use crate::tera::{contains_template_syntax, get_tera, render_str};
+use crate::tera::{contains_template_syntax, get_tera_v2, render_str_v2};
 use eyre::{Context, Result};
 use heck::ToSnakeCase;
 use indexmap::IndexMap;
@@ -40,7 +40,7 @@ impl TaskScriptParser {
     }
 
     fn get_tera(&self) -> tera::Tera {
-        get_tera(self.dir.as_deref())
+        get_tera_v2(self.dir.as_deref())
     }
 
     /// Inject extra vars (from monorepo task config hierarchy) into the tera context
@@ -64,7 +64,7 @@ impl TaskScriptParser {
         script: &str,
         ctx: &tera::Context,
     ) -> Result<String> {
-        render_str(tera, script.trim(), ctx)
+        render_str_v2(tera, script.trim(), ctx)
             .map_err(Self::task_script_tera_error)
             .with_context(|| format!("Failed to render task script: {}", script))
     }
@@ -83,7 +83,7 @@ impl TaskScriptParser {
         usage: &str,
         ctx: &tera::Context,
     ) -> Result<String> {
-        render_str(tera, usage.trim(), ctx)
+        render_str_v2(tera, usage.trim(), ctx)
             .with_context(|| format!("Failed to render task usage: {}", usage))
     }
 

--- a/src/task/task_sources.rs
+++ b/src/task/task_sources.rs
@@ -1,6 +1,6 @@
 use crate::dirs;
 use crate::task::Task;
-use crate::tera::{contains_template_syntax, render_str};
+use crate::tera::{TeraEngine, contains_template_syntax, render_str};
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -80,7 +80,7 @@ impl TaskOutputs {
 
     pub fn render(
         &mut self,
-        tera: &mut tera::Tera,
+        tera: &mut TeraEngine,
         ctx: &tera::Context,
     ) -> eyre::Result<RawOutputTemplates> {
         match self {

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -109,6 +109,23 @@ fn json_path(value: &JsonValue) -> tera1::Result<&str> {
         .ok_or_else(|| tera1_err("filter input must be a string"))
 }
 
+fn insert_tera1_context_value(
+    data: &mut JsonMap<String, JsonValue>,
+    context: &Context,
+    key: &str,
+) -> TeraResult<()> {
+    if data.contains_key(key) {
+        return Ok(());
+    }
+    if let Some(value) = context.get(key) {
+        data.insert(
+            key.to_string(),
+            serde_json::to_value(value).map_err(|e| tera_err(e.to_string()))?,
+        );
+    }
+    Ok(())
+}
+
 fn tera1_context(input: &str, context: &Context) -> TeraResult<tera1::Context> {
     static IDENT_RE: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"[A-Za-z_][A-Za-z0-9_]*").expect("valid ident regex"));
@@ -148,17 +165,15 @@ fn tera1_context(input: &str, context: &Context) -> TeraResult<tera1::Context> {
     });
 
     let mut data = JsonMap::new();
+    for key in ["env", "vars", "tools"] {
+        insert_tera1_context_value(&mut data, context, key)?;
+    }
     for m in IDENT_RE.find_iter(input) {
         let key = m.as_str();
         if RESERVED.contains(key) || data.contains_key(key) {
             continue;
         }
-        if let Some(value) = context.get(key) {
-            data.insert(
-                key.to_string(),
-                serde_json::to_value(value).map_err(|e| tera_err(e.to_string()))?,
-            );
-        }
+        insert_tera1_context_value(&mut data, context, key)?;
     }
     tera1::Context::from_value(JsonValue::Object(data)).map_err(|e| tera_err(e.to_string()))
 }
@@ -2063,6 +2078,24 @@ mod tests {
                 &tera_ctx
             )
             .is_err()
+        );
+    }
+
+    #[test]
+    fn test_tera_v1_context_preserves_common_nested_roots() {
+        let mut tera_ctx = Context::new();
+        tera_ctx.insert("env", &json!({ "FOO": "bar" }));
+        tera_ctx.insert("vars", &json!({ "nested": { "name": "baz" } }));
+        tera_ctx.insert("tools", &json!([{ "name": "node" }]));
+        let mut tera = TeraEngine::V1(Box::new(TERA1.clone()));
+        assert_eq!(
+            render_str(
+                &mut tera,
+                "{% for tool in tools %}{{ env.FOO }} {{ vars.nested.name }} {{ tool.name }}{% endfor %}",
+                &tera_ctx
+            )
+            .unwrap(),
+            "bar baz node"
         );
     }
 

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -55,8 +55,8 @@ pub fn contains_template_syntax(input: &str) -> bool {
 }
 
 pub enum TeraEngine {
-    V2(Tera),
-    V1(tera1::Tera),
+    V2(Box<Tera>),
+    V1(Box<tera1::Tera>),
 }
 
 impl TeraEngine {
@@ -118,12 +118,10 @@ fn tera1_context(input: &str, context: &Context) -> TeraResult<tera1::Context> {
             "as",
             "block",
             "break",
-            "component",
             "continue",
             "elif",
             "else",
             "endblock",
-            "endcomponent",
             "endfilter",
             "endif",
             "endfor",
@@ -395,9 +393,12 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
             let n = args.must_get::<u64>("n")?;
             let alphabet = args.must_get::<&str>("alphabet")?;
             let alphabet = alphabet.chars().collect::<Vec<char>>();
+            if alphabet.is_empty() {
+                return Err(tera_err("choice alphabet must not be empty"));
+            }
             let mut rng = rand::rng();
             let result: String = (0..n)
-                .map(|_| *alphabet.choose(&mut rng).unwrap())
+                .map(|_| *alphabet.choose(&mut rng).expect("alphabet non-empty"))
                 .collect();
             Ok(Value::from(result))
         },
@@ -958,9 +959,15 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
         "semver_matching",
         move |version: &str, args: Kwargs, _: &State| -> TeraResult<bool> {
             let requirement = args.must_get::<&str>("requirement")?;
-            let result = Requirement::new(requirement)
-                .unwrap()
-                .matches(&Versioning::new(version).unwrap());
+            let requirement = Requirement::new(requirement).ok_or_else(|| {
+                tera_err(format!(
+                    "semver_matching requirement is invalid: {requirement}"
+                ))
+            })?;
+            let version = Versioning::new(version).ok_or_else(|| {
+                tera_err(format!("semver_matching version is invalid: {version}"))
+            })?;
+            let result = requirement.matches(&version);
             Ok(result)
         },
     );
@@ -985,9 +992,12 @@ static TERA1: Lazy<tera1::Tera> = Lazy::new(|| {
         let alphabet = json_str_arg(args, "alphabet")?
             .chars()
             .collect::<Vec<char>>();
+        if alphabet.is_empty() {
+            return Err(tera1_err("choice alphabet must not be empty"));
+        }
         let mut rng = rand::rng();
         let result: String = (0..n)
-            .map(|_| *alphabet.choose(&mut rng).unwrap())
+            .map(|_| *alphabet.choose(&mut rng).expect("alphabet non-empty"))
             .collect();
         Ok(json!(result))
     });
@@ -1045,7 +1055,7 @@ static TERA1: Lazy<tera1::Tera> = Lazy::new(|| {
         "absolute",
         tera1_path_filter(|p| Ok(p.absolutize()?.to_path_buf())),
     );
-    tera.register_filter("canonicalize", tera1_path_filter(|p| Ok(p.canonicalize()?)));
+    tera.register_filter("canonicalize", tera1_path_filter(|p| p.canonicalize()));
     tera.register_filter(
         "dirname",
         move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
@@ -1189,9 +1199,15 @@ static TERA1: Lazy<tera1::Tera> = Lazy::new(|| {
                 .first()
                 .and_then(JsonValue::as_str)
                 .ok_or_else(|| tera1_err("semver_matching requirement must be a string"))?;
-            Ok(Requirement::new(requirement)
-                .unwrap()
-                .matches(&Versioning::new(version).unwrap()))
+            let requirement = Requirement::new(requirement).ok_or_else(|| {
+                tera1_err(format!(
+                    "semver_matching requirement is invalid: {requirement}"
+                ))
+            })?;
+            let version = Versioning::new(version).ok_or_else(|| {
+                tera1_err(format!("semver_matching version is invalid: {version}"))
+            })?;
+            Ok(requirement.matches(&version))
         },
     );
 
@@ -1257,17 +1273,17 @@ fn get_tera_v1(dir: Option<&Path>) -> tera1::Tera {
 /// cannot accidentally become available here if `TERA` changes in the future.
 pub fn get_miserc_tera() -> TeraEngine {
     if use_tera_v1() {
-        TeraEngine::V1(TERA1.clone())
+        TeraEngine::V1(Box::new(TERA1.clone()))
     } else {
-        TeraEngine::V2(TERA.clone())
+        TeraEngine::V2(Box::new(TERA.clone()))
     }
 }
 
 pub fn get_tera(dir: Option<&Path>) -> TeraEngine {
     if use_tera_v1() {
-        TeraEngine::V1(get_tera_v1(dir))
+        TeraEngine::V1(Box::new(get_tera_v1(dir)))
     } else {
-        TeraEngine::V2(get_tera_v2(dir))
+        TeraEngine::V2(Box::new(get_tera_v2(dir)))
     }
 }
 
@@ -1301,7 +1317,7 @@ pub fn get_tera_for_target(dir: Option<&Path>, os: &str, arch: &str) -> TeraEngi
         tera.register_function("os_family", move |_: &HashMap<String, JsonValue>| {
             Ok(json!(family))
         });
-        TeraEngine::V1(tera)
+        TeraEngine::V1(Box::new(tera))
     } else {
         let mut tera = get_tera_v2(dir);
         let os = os.to_string();
@@ -1328,7 +1344,7 @@ pub fn get_tera_for_target(dir: Option<&Path>, os: &str, arch: &str) -> TeraEngi
             move |_: Kwargs, _: &State| -> TeraResult<Value> { Ok(Value::from(family)) },
         );
 
-        TeraEngine::V2(tera)
+        TeraEngine::V2(Box::new(tera))
     }
 }
 
@@ -1346,7 +1362,7 @@ pub fn get_tera_preserving_os_arch(dir: Option<&Path>) -> TeraEngine {
         tera.register_function("os", reemit_template_fn_v1("os"));
         tera.register_function("arch", reemit_template_fn_v1("arch"));
         tera.register_function("os_family", reemit_template_fn_v1("os_family"));
-        TeraEngine::V1(tera)
+        TeraEngine::V1(Box::new(tera))
     } else {
         let mut tera = get_tera_v2(dir);
         tera.register_function("os", reemit_template_fn("os"));
@@ -1355,7 +1371,7 @@ pub fn get_tera_preserving_os_arch(dir: Option<&Path>) -> TeraEngine {
         // resolving it against the host here would bake e.g. "unix" into a template
         // that is later rendered for a windows target.
         tera.register_function("os_family", reemit_template_fn("os_family"));
-        TeraEngine::V2(tera)
+        TeraEngine::V2(Box::new(tera))
     }
 }
 
@@ -1377,7 +1393,7 @@ fn reemit_template_fn_v1(
     }
 }
 
-pub fn tera1_exec(
+pub(crate) fn tera1_exec(
     dir: Option<PathBuf>,
     env: EnvMap,
 ) -> impl Fn(&HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
@@ -1407,7 +1423,7 @@ pub fn tera1_exec(
     }
 }
 
-pub fn tera1_read_file(
+pub(crate) fn tera1_read_file(
     dir: Option<PathBuf>,
 ) -> impl Fn(&HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
     move |args: &HashMap<String, JsonValue>| -> tera1::Result<JsonValue> {
@@ -1593,6 +1609,26 @@ mod tests {
 
     use super::*;
     use pretty_assertions::assert_str_eq;
+
+    static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct SettingsGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl SettingsGuard {
+        fn tera_v1() -> Self {
+            let lock = TEST_SETTINGS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            Settings::override_with(|settings| settings.tera_v1 = Some(true));
+            Self { _lock: lock }
+        }
+    }
+
+    impl Drop for SettingsGuard {
+        fn drop(&mut self) {
+            Settings::reset(None);
+        }
+    }
 
     #[tokio::test]
     async fn test_config_root() {
@@ -1971,16 +2007,15 @@ mod tests {
 
     #[test]
     fn test_tera_v1_setting_selects_v1_engine() {
-        Settings::override_with(|settings| settings.tera_v1 = Some(true));
+        let _guard = SettingsGuard::tera_v1();
         assert!(matches!(get_tera(None), TeraEngine::V1(_)));
-        Settings::reset(None);
     }
 
     #[test]
     fn test_tera_v1_engine_renders_v1_macro() {
         let mut tera_ctx = BASE_CONTEXT.clone();
         tera_ctx.insert("name", "mise");
-        let mut tera = TeraEngine::V1(TERA1.clone());
+        let mut tera = TeraEngine::V1(Box::new(TERA1.clone()));
         assert_eq!(
             render_str(
                 &mut tera,
@@ -1991,7 +2026,7 @@ mod tests {
             "hi mise"
         );
 
-        let mut tera = TeraEngine::V2(TERA.clone());
+        let mut tera = TeraEngine::V2(Box::new(TERA.clone()));
         assert!(
             render_str(
                 &mut tera,

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1270,13 +1270,10 @@ fn get_tera_v1(dir: Option<&Path>) -> tera1::Tera {
 /// Returns a Tera instance for use during early initialization (miserc loading).
 /// This is a plain clone of the global `TERA` static. `exec` and `read_file` are absent
 /// because they are only registered in [`get_tera`], not in `TERA` itself — so they
-/// cannot accidentally become available here if `TERA` changes in the future.
+/// cannot accidentally become available here if `TERA` changes in the future. This also
+/// intentionally ignores `tera_v1`, since Settings are not fully loaded at this stage.
 pub fn get_miserc_tera() -> TeraEngine {
-    if use_tera_v1() {
-        TeraEngine::V1(Box::new(TERA1.clone()))
-    } else {
-        TeraEngine::V2(Box::new(TERA.clone()))
-    }
+    TeraEngine::V2(Box::new(TERA.clone()))
 }
 
 pub fn get_tera(dir: Option<&Path>) -> TeraEngine {
@@ -1412,13 +1409,39 @@ pub(crate) fn tera1_exec(
         if let Some(path_val) = env_no_shims.get(&*env::PATH_KEY).cloned() {
             env_no_shims.insert(env::PATH_KEY.to_string(), strip_shims_from_path(&path_val));
         }
-        let mut expr: duct::Expression = cmd(&shell[0], shell_args).full_env(&env_no_shims);
-        if let Some(dir) = &dir {
-            expr = expr.dir(dir);
-        }
+        let run_once = || -> eyre::Result<String> {
+            #[cfg(windows)]
+            {
+                if let Some(mut c) =
+                    crate::path::cmd_verbatim_command(&shell[0], &shell[1..], command)
+                {
+                    c.env_clear();
+                    c.envs(env_no_shims.iter());
+                    if let Some(dir) = &dir {
+                        c.current_dir(dir);
+                    }
+                    let out = c.output()?;
+                    if !out.status.success() {
+                        eyre::bail!(
+                            "exec command failed: {}",
+                            String::from_utf8_lossy(&out.stderr)
+                        );
+                    }
+                    let mut s = String::from_utf8(out.stdout)?;
+                    while s.ends_with('\n') || s.ends_with('\r') {
+                        s.pop();
+                    }
+                    return Ok(s);
+                }
+            }
+            let mut expr: duct::Expression = cmd(&shell[0], &shell_args).full_env(&env_no_shims);
+            if let Some(dir) = &dir {
+                expr = expr.dir(dir);
+            }
+            Ok(expr.read()?)
+        };
         Ok(json!(
-            expr.read()
-                .map_err(|e| tera1_err(format!("exec command: {e}")))?
+            run_once().map_err(|e| tera1_err(format!("exec command: {e}")))?
         ))
     }
 }
@@ -2009,6 +2032,12 @@ mod tests {
     fn test_tera_v1_setting_selects_v1_engine() {
         let _guard = SettingsGuard::tera_v1();
         assert!(matches!(get_tera(None), TeraEngine::V1(_)));
+    }
+
+    #[test]
+    fn test_miserc_tera_ignores_tera_v1_setting() {
+        let _guard = SettingsGuard::tera_v1();
+        assert!(matches!(get_miserc_tera(), TeraEngine::V2(_)));
     }
 
     #[test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::iter::once;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -10,6 +11,7 @@ use heck::{
 use path_absolutize::Absolutize;
 use rand::prelude::*;
 use regex::Regex;
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
 use std::sync::LazyLock as Lazy;
 use tera::{Context, Kwargs, State, Tera, TeraResult, Value};
 use versions::{Requirement, Versioning};
@@ -52,12 +54,115 @@ pub fn contains_template_syntax(input: &str) -> bool {
     input.contains("{{") || input.contains("{%") || input.contains("{#")
 }
 
-pub fn render_str(tera: &mut Tera, input: &str, context: &Context) -> TeraResult<String> {
+pub enum TeraEngine {
+    V2(Tera),
+    V1(tera1::Tera),
+}
+
+impl TeraEngine {
+    fn render_str(&mut self, input: &str, context: &Context) -> TeraResult<String> {
+        match self {
+            Self::V2(tera) => tera.render_str(input, context, false),
+            Self::V1(tera) => {
+                let context = tera1_context(input, context)?;
+                tera.render_str(input, &context)
+                    .map_err(|e| tera_err(e.to_string()))
+            }
+        }
+    }
+}
+
+pub fn render_str(tera: &mut TeraEngine, input: &str, context: &Context) -> TeraResult<String> {
+    tera.render_str(input, context)
+}
+
+pub fn render_str_v2(tera: &mut Tera, input: &str, context: &Context) -> TeraResult<String> {
     tera.render_str(input, context, false)
 }
 
 fn tera_err(message: impl ToString) -> tera::Error {
     tera::Error::message(message)
+}
+
+fn use_tera_v1() -> bool {
+    Settings::try_get().is_ok_and(|settings| settings.tera_v1)
+}
+
+fn tera1_err(message: impl ToString) -> tera1::Error {
+    tera1::Error::msg(message.to_string())
+}
+
+fn json_arg<'a>(args: &'a HashMap<String, JsonValue>, name: &str) -> tera1::Result<&'a JsonValue> {
+    args.get(name)
+        .ok_or_else(|| tera1_err(format!("missing required argument: {name}")))
+}
+
+fn json_str_arg<'a>(args: &'a HashMap<String, JsonValue>, name: &str) -> tera1::Result<&'a str> {
+    json_arg(args, name)?
+        .as_str()
+        .ok_or_else(|| tera1_err(format!("argument `{name}` must be a string")))
+}
+
+fn json_path(value: &JsonValue) -> tera1::Result<&str> {
+    value
+        .as_str()
+        .ok_or_else(|| tera1_err("filter input must be a string"))
+}
+
+fn tera1_context(input: &str, context: &Context) -> TeraResult<tera1::Context> {
+    static IDENT_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"[A-Za-z_][A-Za-z0-9_]*").expect("valid ident regex"));
+    static RESERVED: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+        HashSet::from([
+            "and",
+            "as",
+            "block",
+            "break",
+            "component",
+            "continue",
+            "elif",
+            "else",
+            "endblock",
+            "endcomponent",
+            "endfilter",
+            "endif",
+            "endfor",
+            "endmacro",
+            "endraw",
+            "endset",
+            "extends",
+            "false",
+            "filter",
+            "for",
+            "if",
+            "import",
+            "in",
+            "include",
+            "is",
+            "macro",
+            "not",
+            "or",
+            "raw",
+            "set",
+            "set_global",
+            "true",
+        ])
+    });
+
+    let mut data = JsonMap::new();
+    for m in IDENT_RE.find_iter(input) {
+        let key = m.as_str();
+        if RESERVED.contains(key) || data.contains_key(key) {
+            continue;
+        }
+        if let Some(value) = context.get(key) {
+            data.insert(
+                key.to_string(),
+                serde_json::to_value(value).map_err(|e| tera_err(e.to_string()))?,
+            );
+        }
+    }
+    tera1::Context::from_value(JsonValue::Object(data)).map_err(|e| tera_err(e.to_string()))
 }
 
 fn warn_tera_v1_filter(id: &'static str, name: &str, replacement: &str) {
@@ -863,21 +968,307 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
     tera
 });
 
-/// Returns a Tera instance for use during early initialization (miserc loading).
-/// This is a plain clone of the global `TERA` static. `exec` and `read_file` are absent
-/// because they are only registered in [`get_tera`], not in `TERA` itself — so they
-/// cannot accidentally become available here if `TERA` changes in the future.
-pub fn get_miserc_tera() -> Tera {
-    TERA.clone()
+static TERA1: Lazy<tera1::Tera> = Lazy::new(|| {
+    let mut tera = tera1::Tera::default();
+    tera.register_function("arch", tera1_host_fn(host_arch_name));
+    tera.register_function("os", tera1_host_fn(|| env::consts::OS));
+    tera.register_function("os_family", move |_: &HashMap<String, JsonValue>| {
+        Ok(json!(env::consts::FAMILY))
+    });
+    tera.register_function("num_cpus", move |_: &HashMap<String, JsonValue>| {
+        Ok(json!(num_cpus::get().to_string()))
+    });
+    tera.register_function("choice", move |args: &HashMap<String, JsonValue>| {
+        let n = json_arg(args, "n")?
+            .as_u64()
+            .ok_or_else(|| tera1_err("choice n must be an integer"))?;
+        let alphabet = json_str_arg(args, "alphabet")?
+            .chars()
+            .collect::<Vec<char>>();
+        let mut rng = rand::rng();
+        let result: String = (0..n)
+            .map(|_| *alphabet.choose(&mut rng).unwrap())
+            .collect();
+        Ok(json!(result))
+    });
+    tera.register_function("haiku", move |args: &HashMap<String, JsonValue>| {
+        let words = args
+            .get("words")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(2)
+            .max(1) as usize;
+        let separator = args
+            .get("separator")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("-");
+        let digits = args.get("digits").and_then(JsonValue::as_u64).unwrap_or(2) as usize;
+        Ok(json!(xx::rand::haiku(&xx::rand::HaikuOptions {
+            words,
+            separator,
+            digits,
+        })))
+    });
+
+    tera.register_filter(
+        "hash_file",
+        move |value: &JsonValue, args: &HashMap<String, JsonValue>| {
+            let path = Path::new(json_path(value)?);
+            track_tera_file(path);
+            let mut hash =
+                hash::file_hash_blake3(path, None).map_err(|e| tera1_err(e.to_string()))?;
+            if let Some(len) = args.get("len").and_then(JsonValue::as_u64) {
+                hash = hash.chars().take(len as usize).collect();
+            }
+            Ok(json!(hash))
+        },
+    );
+    tera.register_filter(
+        "hash",
+        move |value: &JsonValue, args: &HashMap<String, JsonValue>| {
+            let s = json_path(value)?;
+            let algorithm = args
+                .get("algorithm")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("sha256");
+            let mut hash = match algorithm {
+                "sha256" => hash::hash_sha256_to_str(s),
+                "blake3" => hash::hash_blake3_to_str(s),
+                _ => return Err(tera1_err(format!("unknown hash algorithm: {algorithm}"))),
+            };
+            if let Some(len) = args.get("len").and_then(JsonValue::as_u64) {
+                hash = hash.chars().take(len as usize).collect();
+            }
+            Ok(json!(hash))
+        },
+    );
+    tera.register_filter(
+        "absolute",
+        tera1_path_filter(|p| Ok(p.absolutize()?.to_path_buf())),
+    );
+    tera.register_filter("canonicalize", tera1_path_filter(|p| Ok(p.canonicalize()?)));
+    tera.register_filter(
+        "dirname",
+        move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
+            let p = Path::new(json_path(value)?);
+            Ok(json!(
+                p.parent()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default()
+            ))
+        },
+    );
+    tera.register_filter(
+        "basename",
+        move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
+            let p = Path::new(json_path(value)?);
+            Ok(json!(
+                p.file_name()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default()
+            ))
+        },
+    );
+    tera.register_filter(
+        "extname",
+        move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
+            let p = Path::new(json_path(value)?);
+            Ok(json!(
+                p.extension()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default()
+            ))
+        },
+    );
+    tera.register_filter(
+        "file_stem",
+        move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
+            let p = Path::new(json_path(value)?);
+            Ok(json!(
+                p.file_stem()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default()
+            ))
+        },
+    );
+    tera.register_filter(
+        "file_size",
+        move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
+            let path = Path::new(json_path(value)?);
+            track_tera_file(path);
+            Ok(json!(
+                path.metadata().map_err(|e| tera1_err(e.to_string()))?.len()
+            ))
+        },
+    );
+    tera.register_filter(
+        "last_modified",
+        move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
+            let path = Path::new(json_path(value)?);
+            track_tera_file(path);
+            Ok(json!(
+                path.metadata()
+                    .map_err(|e| tera1_err(e.to_string()))?
+                    .modified()
+                    .map_err(|e| tera1_err(e.to_string()))?
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map_err(|e| tera1_err(e.to_string()))?
+                    .as_secs()
+            ))
+        },
+    );
+    tera.register_filter(
+        "join_path",
+        move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
+            let arr = value
+                .as_array()
+                .ok_or_else(|| tera1_err("join_path input must be an array of strings"))?;
+            let mut path = PathBuf::new();
+            for value in arr {
+                path.push(
+                    value
+                        .as_str()
+                        .ok_or_else(|| tera1_err("join_path input must be an array of strings"))?,
+                );
+            }
+            Ok(json!(path.to_string_lossy().to_string()))
+        },
+    );
+    tera.register_filter(
+        "quote",
+        move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
+            Ok(json!(format!(
+                "'{}'",
+                json_path(value)?.replace("'", "\\'")
+            )))
+        },
+    );
+    tera.register_filter("kebabcase", tera1_string_filter(|s| s.to_kebab_case()));
+    tera.register_filter(
+        "lowercamelcase",
+        tera1_string_filter(|s| s.to_lower_camel_case()),
+    );
+    tera.register_filter(
+        "shoutykebabcase",
+        tera1_string_filter(|s| s.to_shouty_kebab_case()),
+    );
+    tera.register_filter(
+        "shoutysnakecase",
+        tera1_string_filter(|s| s.to_shouty_snake_case()),
+    );
+    tera.register_filter("snakecase", tera1_string_filter(|s| s.to_snake_case()));
+    tera.register_filter(
+        "uppercamelcase",
+        tera1_string_filter(|s| s.to_upper_camel_case()),
+    );
+
+    tera.register_tester("dir", move |value: Option<&JsonValue>, _: &[JsonValue]| {
+        Ok(value
+            .and_then(JsonValue::as_str)
+            .is_some_and(|s| Path::new(s).is_dir()))
+    });
+    tera.register_tester("file", move |value: Option<&JsonValue>, _: &[JsonValue]| {
+        Ok(value
+            .and_then(JsonValue::as_str)
+            .is_some_and(|s| Path::new(s).is_file()))
+    });
+    tera.register_tester(
+        "exists",
+        move |value: Option<&JsonValue>, _: &[JsonValue]| {
+            Ok(value
+                .and_then(JsonValue::as_str)
+                .is_some_and(|s| Path::new(s).exists()))
+        },
+    );
+    tera.register_tester(
+        "semver_matching",
+        move |value: Option<&JsonValue>, args: &[JsonValue]| {
+            let version = value
+                .and_then(JsonValue::as_str)
+                .ok_or_else(|| tera1_err("semver_matching value must be a string"))?;
+            let requirement = args
+                .first()
+                .and_then(JsonValue::as_str)
+                .ok_or_else(|| tera1_err("semver_matching requirement must be a string"))?;
+            Ok(Requirement::new(requirement)
+                .unwrap()
+                .matches(&Versioning::new(version).unwrap()))
+        },
+    );
+
+    tera
+});
+
+fn host_arch_name() -> &'static str {
+    if cfg!(target_arch = "x86_64") {
+        "x64"
+    } else if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        env::consts::ARCH
+    }
 }
 
-pub fn get_tera(dir: Option<&Path>) -> Tera {
+fn tera1_host_fn(
+    default: fn() -> &'static str,
+) -> impl Fn(&HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
+    move |args| {
+        let value = default();
+        Ok(args
+            .get(value)
+            .and_then(JsonValue::as_str)
+            .map_or_else(|| json!(value), |remapped| json!(remapped)))
+    }
+}
+
+fn tera1_string_filter(
+    f: fn(&str) -> String,
+) -> impl Fn(&JsonValue, &HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
+    move |value, _| Ok(json!(f(json_path(value)?)))
+}
+
+fn tera1_path_filter(
+    f: fn(&Path) -> std::io::Result<PathBuf>,
+) -> impl Fn(&JsonValue, &HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
+    move |value, _| {
+        let p = f(Path::new(json_path(value)?)).map_err(|e| tera1_err(e.to_string()))?;
+        Ok(json!(p.to_string_lossy().to_string()))
+    }
+}
+
+pub(crate) fn get_tera_v2(dir: Option<&Path>) -> Tera {
     let mut tera = TERA.clone();
     let dir = dir.map(PathBuf::from);
     tera.register_function("exec", tera_exec(dir.clone(), env::PRISTINE_ENV.clone()));
     tera.register_function("read_file", tera_read_file(dir));
-
     tera
+}
+
+fn get_tera_v1(dir: Option<&Path>) -> tera1::Tera {
+    let mut tera = TERA1.clone();
+    let dir = dir.map(PathBuf::from);
+    tera.register_function("exec", tera1_exec(dir.clone(), env::PRISTINE_ENV.clone()));
+    tera.register_function("read_file", tera1_read_file(dir));
+    tera
+}
+
+/// Returns a Tera instance for use during early initialization (miserc loading).
+/// This is a plain clone of the global `TERA` static. `exec` and `read_file` are absent
+/// because they are only registered in [`get_tera`], not in `TERA` itself — so they
+/// cannot accidentally become available here if `TERA` changes in the future.
+pub fn get_miserc_tera() -> TeraEngine {
+    if use_tera_v1() {
+        TeraEngine::V1(TERA1.clone())
+    } else {
+        TeraEngine::V2(TERA.clone())
+    }
+}
+
+pub fn get_tera(dir: Option<&Path>) -> TeraEngine {
+    if use_tera_v1() {
+        TeraEngine::V1(get_tera_v1(dir))
+    } else {
+        TeraEngine::V2(get_tera_v2(dir))
+    }
 }
 
 /// Like [`get_tera`] but with `os()` and `arch()` bound to an explicit target
@@ -888,37 +1279,57 @@ pub fn get_tera(dir: Option<&Path>) -> Tera {
 /// `arch` a platform arch name (e.g. "x64", "arm64"), matching the values
 /// returned by the host-bound functions. Remap arguments such as
 /// `os(macos="darwin")` and `arch(x64="amd64")` keep the same semantics.
-pub fn get_tera_for_target(dir: Option<&Path>, os: &str, arch: &str) -> Tera {
-    let mut tera = get_tera(dir);
-
+pub fn get_tera_for_target(dir: Option<&Path>, os: &str, arch: &str) -> TeraEngine {
     // os_family() must follow the target too, not the host.
     let family = if os == "windows" { "windows" } else { "unix" };
-
-    let os = os.to_string();
-    tera.register_function("os", move |args: Kwargs, _: &State| -> TeraResult<Value> {
-        if let Some(remapped) = args.get::<&str>(&os)? {
-            return Ok(Value::from(remapped));
-        }
-        Ok(Value::from(os.clone()))
-    });
-
-    let arch = arch.to_string();
-    tera.register_function(
-        "arch",
-        move |args: Kwargs, _: &State| -> TeraResult<Value> {
-            if let Some(remapped) = args.get::<&str>(&arch)? {
+    if use_tera_v1() {
+        let mut tera = get_tera_v1(dir);
+        let os = os.to_string();
+        tera.register_function("os", move |args: &HashMap<String, JsonValue>| {
+            Ok(args
+                .get(&os)
+                .and_then(JsonValue::as_str)
+                .map_or_else(|| json!(os), |remapped| json!(remapped)))
+        });
+        let arch = arch.to_string();
+        tera.register_function("arch", move |args: &HashMap<String, JsonValue>| {
+            Ok(args
+                .get(&arch)
+                .and_then(JsonValue::as_str)
+                .map_or_else(|| json!(arch), |remapped| json!(remapped)))
+        });
+        tera.register_function("os_family", move |_: &HashMap<String, JsonValue>| {
+            Ok(json!(family))
+        });
+        TeraEngine::V1(tera)
+    } else {
+        let mut tera = get_tera_v2(dir);
+        let os = os.to_string();
+        tera.register_function("os", move |args: Kwargs, _: &State| -> TeraResult<Value> {
+            if let Some(remapped) = args.get::<&str>(&os)? {
                 return Ok(Value::from(remapped));
             }
-            Ok(Value::from(arch.clone()))
-        },
-    );
+            Ok(Value::from(os.clone()))
+        });
 
-    tera.register_function(
-        "os_family",
-        move |_: Kwargs, _: &State| -> TeraResult<Value> { Ok(Value::from(family)) },
-    );
+        let arch = arch.to_string();
+        tera.register_function(
+            "arch",
+            move |args: Kwargs, _: &State| -> TeraResult<Value> {
+                if let Some(remapped) = args.get::<&str>(&arch)? {
+                    return Ok(Value::from(remapped));
+                }
+                Ok(Value::from(arch.clone()))
+            },
+        );
 
-    tera
+        tera.register_function(
+            "os_family",
+            move |_: Kwargs, _: &State| -> TeraResult<Value> { Ok(Value::from(family)) },
+        );
+
+        TeraEngine::V2(tera)
+    }
 }
 
 /// Like [`get_tera`] but with `os()` and `arch()` rewritten to re-emit
@@ -929,15 +1340,88 @@ pub fn get_tera_for_target(dir: Option<&Path>, os: &str, arch: &str) -> Tera {
 /// resolved, but `os()`/`arch()` are deferred so the backend can re-render them
 /// for the host at install time or for an arbitrary target during cross-platform
 /// `mise lock`. Mirrors how `{{ version }}` is preserved via a placeholder.
-pub fn get_tera_preserving_os_arch(dir: Option<&Path>) -> Tera {
-    let mut tera = get_tera(dir);
-    tera.register_function("os", reemit_template_fn("os"));
-    tera.register_function("arch", reemit_template_fn("arch"));
-    // os_family() must be deferred too: it derives from the target OS, so
-    // resolving it against the host here would bake e.g. "unix" into a template
-    // that is later rendered for a windows target.
-    tera.register_function("os_family", reemit_template_fn("os_family"));
-    tera
+pub fn get_tera_preserving_os_arch(dir: Option<&Path>) -> TeraEngine {
+    if use_tera_v1() {
+        let mut tera = get_tera_v1(dir);
+        tera.register_function("os", reemit_template_fn_v1("os"));
+        tera.register_function("arch", reemit_template_fn_v1("arch"));
+        tera.register_function("os_family", reemit_template_fn_v1("os_family"));
+        TeraEngine::V1(tera)
+    } else {
+        let mut tera = get_tera_v2(dir);
+        tera.register_function("os", reemit_template_fn("os"));
+        tera.register_function("arch", reemit_template_fn("arch"));
+        // os_family() must be deferred too: it derives from the target OS, so
+        // resolving it against the host here would bake e.g. "unix" into a template
+        // that is later rendered for a windows target.
+        tera.register_function("os_family", reemit_template_fn("os_family"));
+        TeraEngine::V2(tera)
+    }
+}
+
+fn reemit_template_fn_v1(
+    name: &'static str,
+) -> impl Fn(&HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
+    move |args| {
+        let mut parts: Vec<String> = args
+            .iter()
+            .filter_map(|(k, v)| reemit_arg_literal(v).map(|lit| format!("{k}={lit}")))
+            .collect();
+        let rendered = if parts.is_empty() {
+            format!("{{{{ {name}() }}}}")
+        } else {
+            parts.sort();
+            format!("{{{{ {name}({}) }}}}", parts.join(", "))
+        };
+        Ok(json!(rendered))
+    }
+}
+
+pub fn tera1_exec(
+    dir: Option<PathBuf>,
+    env: EnvMap,
+) -> impl Fn(&HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
+    move |args: &HashMap<String, JsonValue>| -> tera1::Result<JsonValue> {
+        let command = json_str_arg(args, "command")?;
+        let shell = Settings::get()
+            .default_inline_shell()
+            .map_err(|e| tera1_err(e.to_string()))?;
+        let shell_args = shell
+            .iter()
+            .skip(1)
+            .chain(once(&command.to_string()))
+            .cloned()
+            .collect::<Vec<String>>();
+        let mut env_no_shims = env.clone();
+        if let Some(path_val) = env_no_shims.get(&*env::PATH_KEY).cloned() {
+            env_no_shims.insert(env::PATH_KEY.to_string(), strip_shims_from_path(&path_val));
+        }
+        let mut expr: duct::Expression = cmd(&shell[0], shell_args).full_env(&env_no_shims);
+        if let Some(dir) = &dir {
+            expr = expr.dir(dir);
+        }
+        Ok(json!(
+            expr.read()
+                .map_err(|e| tera1_err(format!("exec command: {e}")))?
+        ))
+    }
+}
+
+pub fn tera1_read_file(
+    dir: Option<PathBuf>,
+) -> impl Fn(&HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
+    move |args: &HashMap<String, JsonValue>| -> tera1::Result<JsonValue> {
+        let path_str = json_str_arg(args, "path")?;
+        let path = if let Some(ref base_dir) = dir {
+            base_dir.join(path_str)
+        } else {
+            PathBuf::from(path_str)
+        };
+        track_tera_file(&path);
+        Ok(json!(std::fs::read_to_string(&path).map_err(|e| {
+            tera1_err(format!("read_file({}): {e}", path.display()))
+        })?))
+    }
 }
 
 fn reemit_template_fn(name: &'static str) -> impl Fn(Kwargs, &State) -> TeraResult<Value> {
@@ -1105,7 +1589,7 @@ pub fn tera_read_file(dir: Option<PathBuf>) -> impl Fn(Kwargs, &State) -> TeraRe
 
 #[cfg(test)]
 mod tests {
-    use crate::config::Config;
+    use crate::config::{Config, Settings};
 
     use super::*;
     use pretty_assertions::assert_str_eq;
@@ -1483,6 +1967,39 @@ mod tests {
         tera_ctx.insert("cwd", "/");
         let mut tera = get_tera_for_target(None, os, arch);
         render_str(&mut tera, s, &tera_ctx).unwrap()
+    }
+
+    #[test]
+    fn test_tera_v1_setting_selects_v1_engine() {
+        Settings::override_with(|settings| settings.tera_v1 = Some(true));
+        assert!(matches!(get_tera(None), TeraEngine::V1(_)));
+        Settings::reset(None);
+    }
+
+    #[test]
+    fn test_tera_v1_engine_renders_v1_macro() {
+        let mut tera_ctx = BASE_CONTEXT.clone();
+        tera_ctx.insert("name", "mise");
+        let mut tera = TeraEngine::V1(TERA1.clone());
+        assert_eq!(
+            render_str(
+                &mut tera,
+                "{% macro greet(name) %}hi {{ name }}{% endmacro %}{{ self::greet(name=name) }}",
+                &tera_ctx
+            )
+            .unwrap(),
+            "hi mise"
+        );
+
+        let mut tera = TeraEngine::V2(TERA.clone());
+        assert!(
+            render_str(
+                &mut tera,
+                "{% macro greet(name) %}hi {{ name }}{% endmacro %}{{ self::greet(name=name) }}",
+                &tera_ctx
+            )
+            .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add temporary `tera_v1` / `MISE_TERA_V1` setting to render templates with Tera v1 when users need the old engine.
- Keep Tera v2 as the default and route normal template rendering through a setting-aware `TeraEngine` wrapper.
- Document the escape hatch and schedule it for removal alongside the deprecation cleanup in `2027.4.0`.

## Validation
- `mise run render`
- `cargo test tera::tests::test_tera_v1`
- CLI smoke test rendering a Tera v1 macro with `MISE_TERA_V1=1`
- `cargo check --all-features`
- `git diff --check`
- `mise run lint` via pre-commit hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches template rendering across config, tasks, env, and dotfiles with a dual-engine path; risk is mitigated by defaulting to v2 and scoping the hatch to an explicit deprecated setting.
> 
> **Overview**
> Adds a deprecated **`tera_v1`** / **`MISE_TERA_V1`** setting so users can render templates with Tera v1 (e.g. macros and looser undefined-variable behavior) while Tera v2 remains the default. Template rendering is routed through a new **`TeraEngine`** wrapper that picks v1 or v2 from settings; **`.miserc.toml` loading still always uses v2** because settings are not available yet.
> 
> The change vendors **Tera 1.20.1** alongside v2, registers a parallel v1 helper set (`exec`, `read_file`, path/hash filters, etc.), and updates env/task/dotfiles call sites to use the wrapper. **GitHub URL templates** and **task usage-spec parsing** stay on v2 explicitly. Docs/schema describe the escape hatch and its **2027.4.0** removal timeline.
> 
> Small template hardening is included: **`choice`** errors on an empty alphabet, and **`semver_matching`** validates version/requirement instead of panicking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf298005e7d346c8fe2c3123ff15c9955a0fbe2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a temporary compatibility option to render legacy templates with the older template engine (`tera_v1`, `MISE_TERA_V1`); deprecated with a scheduled removal.
* **Bug Fixes**
  * Improved legacy template compatibility across tasks, task outputs, and miserc templates.
  * Template helpers now fail gracefully: `choice` errors on empty alphabets, and `semver_matching` validates inputs.
  * Template rendering errors are more consistent and keep clearer, target-specific messaging.
* **Documentation**
  * Updated migration guidance, including the limitation that this escape hatch doesn’t apply during `.miserc.toml` loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->