### PR TITLE
fix(install): avoid preserving archive owner

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -295,15 +295,15 @@ install_mise() {
   extract_dir="$(mktemp -d)"
   cd "$extract_dir"
   if [ "$ext" = "tar.zst" ] && ! tar_supports_zstd; then
-    zstd -d -c "$cache_file" | tar -xf -
+    zstd -d -c "$cache_file" | tar --no-same-owner -xf -
   else
-    tar -xf "$cache_file"
+    tar --no-same-owner -xf "$cache_file"
+  fi
+  if [ "$(id -u)" = "0" ]; then
+    chown 0:0 mise/bin/mise
+    chmod 755 mise/bin/mise
   fi
   mv mise/bin/mise "$install_path"
-  if [ "$(id -u)" = "0" ]; then
-    chown 0:0 "$install_path"
-    chmod 755 "$install_path"
-  fi
 
   # cleanup
   cd / # Move out of $extract_dir before removing it


### PR DESCRIPTION
## Summary
- extract standalone installer tarballs with `tar --no-same-owner`
- normalize root ownership and mode while the binary is still inside the private extraction directory, before moving it to `MISE_INSTALL_PATH`

## Rationale
This avoids preserving root-owned archive metadata during extraction and narrows the window where the final installed binary could have unsafe ownership or mode.

## Tests
- `sh -n packaging/standalone/install.envsubst`
- `mise x shellcheck -- shellcheck packaging/standalone/install.envsubst`
- `git diff --check`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer-only hardening around tarball extraction and root-owned binary permissions; no runtime app logic changes.
> 
> **Overview**
> The standalone installer now extracts release tarballs with **`tar --no-same-owner`** (both direct extract and the zstd pipe path), so root-owned metadata from the archive is not applied to files on disk.
> 
> When the script runs as **root**, it **`chown`/`chmod`** the binary at `mise/bin/mise` inside the private temp extract directory **before** moving it to `MISE_INSTALL_PATH`, instead of normalizing ownership only after the move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a1e10e62f643caa08fc391099158ed3cc98b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer behavior when extracting archives so file ownership metadata is no longer applied during install.
  * Fixed root installs to set the correct ownership and permissions before the binary is placed in its final location, helping avoid permission issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->