### PR TITLE
registry: add ironclaw

### DIFF
--- a/registry/ironclaw.toml
+++ b/registry/ironclaw.toml
@@ -1,0 +1,8 @@
+description = "Secure sandbox runtime that isolates AI coding-agent code with gVisor/runc"
+test = { cmd = "ironctl version", expected = "ironctl v{{version}}" }
+
+[[backends]]
+full = "github:IronSecCo/ironclaw"
+
+[backends.options]
+filter_bins = "ironctl"


### PR DESCRIPTION
## What

Adds an `ironclaw` short-name entry so users can run:

```sh
mise use -g ironclaw@latest
ironctl version
```

instead of the full backend spec.

## Backend choice

Uses the Tier-1 **`github`** backend (`github:IronSecCo/ironclaw`), not
`asdf`/`ubi` (both excluded for new entries per the contributing guide).
Releases follow standard goreleaser conventions
(`ironclaw_<version>_<os>_<arch>.tar.gz` / `.zip`), so platform autodetection
resolves the asset directly from GitHub releases.

The archive ships three binaries (`ironctl`, `ironclaw-controlplane`,
`ironclaw-sandbox`); `filter_bins = "ironctl"` exposes only the user-facing CLI
on PATH. `test` runs `ironctl version`.

## What is IronClaw

Open-source, self-hosted runtime that isolates AI coding-agent code in a real
sandbox (gVisor/runc), so agent-run commands cannot touch the host. MIT
licensed.

## Popularity / maintenance

- Repo: https://github.com/IronSecCo/ironclaw (14 stars, growing)
- Active releases: latest `v0.1.221`, released on a rolling per-commit cadence
- Cross-platform release binaries: linux/macos (amd64+arm64), windows (amd64)
- SBOM + cosign-signed checksums published per release

Happy to adjust the entry (description, test, backend options) if anything
does not fit the registry conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `ironclaw` runtime registry entry, including a secure sandbox configuration and backend sourcing.
  * Added a basic version check to help validate the runtime is available and responding as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->