### PR TITLE
fix(registry): add rename_exe for podman to fix installed binary name

### DIFF
--- a/registry/podman.toml
+++ b/registry/podman.toml
@@ -3,5 +3,8 @@ description = "Podman: A tool for managing OCI containers and pods"
 [[backends]]
 full = "github:podman-container-tools/podman"
 
+[backends.options]
+rename_exe = "podman"
+
 [[backends]]
 full = "asdf:tvon/asdf-podman"


### PR DESCRIPTION
  ## Summary

  The podman registry entry installs a binary named `podman-remote-static` instead of the expected `podman`, making the tool unusable without manual symlink workarounds.

  Adding `rename_exe = "podman"` to the github backend options fixes the installed binary name. This follows the same pattern used by helm-diff, tanzu, aws-amplify, yt-dlp, and swiftformat.

  ## Background

  - **#5974**: `matching=podman-remote` was added to the `ubi:` backend to filter out the `.pkg` installer asset (fixing [houseabsolute/ubi#133](https://github.com/houseabsolute/ubi/issues/133))
  - **#6232**: Bulk migration from `ubi:` to `github:` backend carried over the `matching` option, but `matching` is a ubi-only option — silently ignored by the github backend
  - **#8633**: The dead `matching` option was correctly removed, but no `rename_exe` was added to replace the binary naming behavior

  The github backend's asset picker correctly selects the right archive (`podman-remote-static-linux_amd64.tar.gz`) via OS/arch scoring — no `matching` or `asset_pattern` is needed. The problem is purely post-extraction: the binary inside the archive is
  named `podman-remote-static`, not `podman`.

  ## Test plan

  - [x] `mise run lint` passes
  - [x] `mise run test:unit` — all 1582 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option for backend settings to rename the executable to `podman`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->