### PR TITLE
registry: switch docker-compose from aqua to github backend

### DIFF
--- a/registry/docker-compose.toml
+++ b/registry/docker-compose.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:docker/compose"]
+backends = ["github:docker/compose"]
 description = "Define and run multi-container applications with Docker"
-test = { cmd = "docker-cli-plugin-docker-compose --version", expected = "Docker Compose version" }
+test = { cmd = "docker-compose --version", expected = "Docker Compose version" }


### PR DESCRIPTION
  ## Summary

  The `aqua:docker/compose` backend installs the binary as `docker-cli-plugin-docker-compose` (following Docker's CLI plugin naming convention) instead of the expected `docker-compose` command name. This makes the tool unusable without manual workarounds,
  and also prevents `podman compose` from discovering it as a compose provider.

  Switching to `github:docker/compose` downloads the raw binary (e.g. `docker-compose-darwin-aarch64`) and `clean_binary_name` automatically cleans it to `docker-compose`. No `rename_exe` is needed.

  ## Changes

  - `registry/docker-compose.toml`: `aqua:docker/compose` → `github:docker/compose`
  - Test command: `docker-cli-plugin-docker-compose --version` → `docker-compose --version`

  ## Test plan

  - [x] `mise run lint` passes
  - [x] `mise run test:unit` — all 1582 tests pass
  - [x] `mise run test:e2e e2e/backend/test_github_docker_compose` — e2e test passes
  - [x] Manual: `mise install -f docker-compose` installs binary as `docker-compose`, `docker-compose version` outputs `Docker Compose version v5.3.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker Compose registry source used by the app’s backend setup. This should improve consistency without changing the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->