### PR TITLE
fix(config): restore get_env template helper

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -130,10 +130,20 @@ Tera v2 also adds useful syntax that replaces many old helper filters:
 
 Not every Tera v1 behavior can be made compatible. Undefined variable access is
 stricter in Tera v2, and Tera v1 macros are not supported by mise templates.
-As a temporary escape hatch, set `tera_v1 = true` or `MISE_TERA_V1=1` to render
-templates with Tera v1. This setting is scheduled for removal in mise 2027.4.0.
-Because miserc files are rendered before settings are loaded, this escape hatch
-does not apply while loading miserc itself.
+As a temporary escape hatch, set `MISE_TERA_V1=1` before running mise to render
+templates with Tera v1. In shared `mise.toml` files, prefer the backward-compatible
+env form because older mise releases treat it as a normal environment variable
+instead of failing on an unknown setting:
+
+```toml
+[env]
+MISE_TERA_V1 = true
+```
+
+The newer `[settings] tera_v1 = true` form also works in mise releases that
+support it, but is less compatible with older releases. This escape hatch is
+scheduled for removal in mise 2027.4.0. Because miserc files are rendered before
+settings are loaded, it does not apply while loading miserc itself.
 
 ### Tera Filters
 
@@ -242,11 +252,6 @@ Some functions:
 - `get_random(end, [start])` - Returns a random integer in a range.
   - `end: usize`: upper end of the range
   - `start: usize`: defaults to 0
-- `get_env(name, [default])`: Returns the environment variable value by name.
-  Prefer `env` variable than this function.
-  - `name: String`: the name of the environment variable
-  - `default: String`: a default value in case the environment variable is not found.
-    Throws when can't find the environment variable and `default` is not set.
 
 Tera offers more functions. Read more on [tera documentation](https://keats.github.io/tera/#functions).
 
@@ -261,6 +266,11 @@ of the task definition they are used in. In other words, their return values are
 across task definition(s).
 
 - `exec(command) -> String` – Runs a shell command and returns its output as a string.
+- `get_env(name, [default]) -> String` – Returns the original process environment
+  variable value by name. This helper is provided by mise for compatibility with
+  older Tera templates. Prefer the `env` variable in new templates when possible.
+  The `default` value is used when the environment variable is not present; empty
+  environment variables are returned as-is.
 - `arch() -> String` – Retrieves the system architecture, such as `x64` or `arm64`.
 - `os() -> String` – Returns the name of the operating system,
   e.g. linux, macos, windows.

--- a/settings.toml
+++ b/settings.toml
@@ -2642,6 +2642,10 @@ This is a temporary escape hatch for users whose templates still rely on Tera v1
 cannot be fully emulated by mise's Tera v2 compatibility helpers, such as Tera v1 macros or looser
 undefined variable handling.
 
+For shared `mise.toml` files, prefer setting `MISE_TERA_V1 = true` under `[env]` while migrating.
+Older mise releases treat that as a regular environment variable instead of failing on an unknown
+setting.
+
 New templates should use Tera v2 syntax. This setting is scheduled for removal in mise 2027.4.0.
 """
 env = "MISE_TERA_V1"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -225,6 +225,28 @@ pub struct SettingsFile {
     pub settings: SettingsPartial,
 }
 
+fn parse_boolish_toml_value(value: &toml::Value) -> Option<bool> {
+    match value {
+        toml::Value::Boolean(value) => Some(*value),
+        toml::Value::Integer(0) => Some(false),
+        toml::Value::Integer(1) => Some(true),
+        toml::Value::String(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "y" | "yes" | "true" | "1" | "on" => Some(true),
+            "n" | "no" | "false" | "0" | "off" => Some(false),
+            _ => None,
+        },
+        toml::Value::Table(table) => table.get("value").and_then(parse_boolish_toml_value),
+        _ => None,
+    }
+}
+
+fn tera_v1_from_env_config(raw: &toml::Value) -> Option<bool> {
+    raw.get("env")
+        .and_then(toml::Value::as_table)
+        .and_then(|env| env.get("MISE_TERA_V1"))
+        .and_then(parse_boolish_toml_value)
+}
+
 fn warn_deprecated(key: &str) {
     if let Some(meta) = SETTINGS_META.get(key)
         && let (Some(msg), Some(warn_at), Some(remove_at)) = (
@@ -579,12 +601,16 @@ impl Settings {
     pub fn parse_settings_file(path: &Path) -> Result<SettingsPartial> {
         let raw = file::read_to_string(path)?;
         let mut raw: toml::Value = toml::from_str(&raw)?;
+        let tera_v1_from_env = tera_v1_from_env_config(&raw);
         if let Some(settings) = raw.get_mut("settings").and_then(toml::Value::as_table_mut) {
             strip_local_only_settings(settings, path, crate::config::is_global_config(path));
         }
         let settings_file: SettingsFile = raw.try_into()?;
-
-        Ok(normalize_hidden_config_aliases(settings_file.settings))
+        let mut settings = normalize_hidden_config_aliases(settings_file.settings);
+        if settings.tera_v1.is_none() {
+            settings.tera_v1 = tera_v1_from_env;
+        }
+        Ok(settings)
     }
 
     fn all_settings_files() -> Vec<SettingsPartial> {
@@ -1183,6 +1209,62 @@ mod tests {
         assert_eq!(partial.paranoid, None);
         assert_eq!(partial.trusted_config_paths, None);
         assert_eq!(partial.yes, None);
+    }
+
+    #[test]
+    fn test_parse_settings_file_reads_tera_v1_from_env_directive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".mise.toml");
+        std::fs::write(
+            &path,
+            r#"
+            env.MISE_TERA_V1 = true
+            "#,
+        )
+        .unwrap();
+
+        let partial = Settings::parse_settings_file(&path).unwrap();
+
+        assert_eq!(partial.tera_v1, Some(true));
+    }
+
+    #[test]
+    fn test_parse_settings_file_reads_tera_v1_from_env_value_directive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".mise.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [env]
+            MISE_TERA_V1 = { value = "1" }
+            "#,
+        )
+        .unwrap();
+
+        let partial = Settings::parse_settings_file(&path).unwrap();
+
+        assert_eq!(partial.tera_v1, Some(true));
+    }
+
+    #[test]
+    fn test_parse_settings_file_prefers_explicit_tera_v1_setting() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".mise.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [settings]
+            tera_v1 = false
+
+            [env]
+            MISE_TERA_V1 = true
+            "#,
+        )
+        .unwrap();
+
+        let partial = Settings::parse_settings_file(&path).unwrap();
+
+        assert_eq!(partial.tera_v1, Some(false));
     }
 
     #[test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -366,6 +366,7 @@ pub static BASE_CONTEXT: Lazy<Context> = Lazy::new(|| {
 
 static TERA: Lazy<Tera> = Lazy::new(|| {
     let mut tera = Tera::default();
+    tera.register_function("get_env", tera_get_env(env::PRISTINE_ENV.clone()));
     tera.register_function(
         "arch",
         move |args: Kwargs, _: &State| -> TeraResult<Value> {
@@ -989,6 +990,19 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
 
     tera
 });
+
+fn tera_get_env(env: EnvMap) -> impl Fn(Kwargs, &State) -> TeraResult<Value> {
+    move |args: Kwargs, _: &State| -> TeraResult<Value> {
+        let name = args.must_get::<&str>("name")?;
+        if let Some(value) = env.get(name) {
+            return Ok(Value::from(value.clone()));
+        }
+        if let Some(default) = args.get::<&str>("default")? {
+            return Ok(Value::from(default));
+        }
+        Err(tera_err(format!("Environment variable `{name}` not found")))
+    }
+}
 
 static TERA1: Lazy<tera1::Tera> = Lazy::new(|| {
     let mut tera = tera1::Tera::default();
@@ -1803,6 +1817,45 @@ mod tests {
         let parts: Vec<&str> = result.split('_').collect();
         assert_eq!(parts.len(), 3);
         assert!(parts.iter().all(|p| p.parse::<u32>().is_err())); // no numbers
+    }
+
+    #[test]
+    fn test_get_env_function() {
+        let mut env = EnvMap::new();
+        env.insert("MISE_TEST_GET_ENV".into(), "from-env".into());
+        env.insert("MISE_TEST_EMPTY_ENV".into(), "".into());
+
+        let mut tera = Tera::default();
+        tera.register_function("get_env", tera_get_env(env));
+        let ctx = Context::new();
+
+        assert_eq!(
+            tera.render_str("{{ get_env(name='MISE_TEST_GET_ENV') }}", &ctx, false)
+                .unwrap(),
+            "from-env"
+        );
+        assert_eq!(
+            tera.render_str(
+                "{{ get_env(name='MISE_TEST_MISSING_ENV', default='fallback') }}",
+                &ctx,
+                false
+            )
+            .unwrap(),
+            "fallback"
+        );
+        assert_eq!(
+            tera.render_str(
+                "{{ get_env(name='MISE_TEST_EMPTY_ENV', default='fallback') }}",
+                &ctx,
+                false
+            )
+            .unwrap(),
+            ""
+        );
+        assert!(
+            tera.render_str("{{ get_env(name='MISE_TEST_MISSING_ENV') }}", &ctx, false)
+                .is_err()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Restore `get_env(name=..., default=...)` for Tera v2 templates using mise's original process environment.
- Let `[env] MISE_TERA_V1 = true` opt a shared config into the temporary Tera v1 renderer before templates are rendered.
- Update template docs to describe `get_env` as a mise compatibility helper and recommend the backward-compatible Tera v1 env escape hatch.

Refs discussion #10825.

## Tests
- `cargo fmt`
- `cargo test config::settings::tests::test_parse_settings_file`
- `cargo test tera::tests::test_get_env_function`
- `cargo build`
- `mise run render:schema`
- `git diff --check`
- temp-config repro for `get_env` default/override behavior
- temp-config repro for `[env] MISE_TERA_V1 = true` with a Tera v1 macro

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to template compatibility and early settings parsing; they do not touch auth, installs, or network behavior beyond existing template rendering paths.
> 
> **Overview**
> Restores **`get_env(name, default)`** on the Tera v2 renderer, backed by mise’s **original process environment** (`PRISTINE_ENV`), so older templates keep working; docs move it from “built-in Tera” to a **mise compatibility helper** and still recommend the `env` map for new templates.
> 
> **Settings parsing** now treats **`[env] MISE_TERA_V1`** (including `env.MISE_TERA_V1` and `{ value = "1" }` forms) as **`tera_v1`** when `[settings] tera_v1` is not set; explicit `[settings] tera_v1` wins. Documentation recommends **`MISE_TERA_V1` under `[env]`** in shared configs for older mise versions that ignore unknown settings.
> 
> Unit tests cover env-derived `tera_v1`, precedence, and `get_env` (present, missing+default, empty var).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80f993e753826a02166780c6f2b9ae156aaf32a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enabling Tera v1 template rendering from shared settings files using an environment-based option.
  * Introduced a `get_env` template helper for reading environment values with optional defaults.

* **Documentation**
  * Expanded migration guidance for Tera v2, including a sample configuration and compatibility notes.
  * Updated template function reference to clarify `get_env` behavior and availability for older templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->