### PR TITLE
chore: release 2026.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2026.7.2](https://github.com/jdx/mise/compare/v2026.7.1..v2026.7.2) - 2026-07-07
+
+### 🐛 Bug Fixes
+
+- **(config)** restore get_env template helper by @jdx in [#10830](https://github.com/jdx/mise/pull/10830)
+- **(config)** warn for deprecated settings from sources by @jdx in [#10832](https://github.com/jdx/mise/pull/10832)
+- **(file)** support pax sparse tar extraction by @JamBalaya56562 in [#10821](https://github.com/jdx/mise/pull/10821)
+- **(registry)** add rename_exe for podman to fix installed binary name by @konono in [#10822](https://github.com/jdx/mise/pull/10822)
+- **(vfox)** flush downloaded files before returning by @jdx in [#10833](https://github.com/jdx/mise/pull/10833)
+- accept scoped release tags in cached GitHub asset URLs by @zeitlinger in [#10750](https://github.com/jdx/mise/pull/10750)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (3)
+
+- [`koki-develop/ghasec`](https://github.com/koki-develop/ghasec)
+- [`mpyw/suve`](https://github.com/mpyw/suve)
+- [`sivchari/gopls-lazy`](https://github.com/sivchari/gopls-lazy)
+
 ## [2026.7.1](https://github.com/jdx/mise/compare/v2026.7.0..v2026.7.1) - 2026-07-07
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.1"
+version = "2026.7.2"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.1"
+version = "2026.7.2"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.1 macos-arm64 (2026-07-07)
+2026.7.2 macos-arm64 (2026-07-07)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_1.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_2.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_1.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_2.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_1.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_2.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_1.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_2.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.1";
+  version = "2026.7.2";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.1
+Version: 2026.7.2
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.1"
+version: "2026.7.2"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "524929a3a0f5a7cc7cc761f69c8035b9de43ce46"
+  "tag": "d04ffbfea4b7da88fb9d8fd92f2fa3f2d1efcdfb"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -56303,6 +56303,29 @@ packages:
             format: zip
   - type: github_release
     repo_owner: koki-develop
+    repo_name: ghasec
+    description: Catch security risks in your GitHub Actions workflows
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.3"
+        no_asset: true
+      - version_constraint: "true"
+        asset: ghasec_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: ghasec_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: koki-develop
     repo_name: moview
     description: Play video in terminal
     version_constraint: "false"
@@ -65895,6 +65918,31 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+  - type: github_release
+    repo_owner: mpyw
+    repo_name: suve
+    description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 1.3.0")
+        error_message: |
+          suve versions before v1.3.0 are not supported by the aqua registry.
+          The project changed significantly in earlier releases; please use v1.3.0 or later.
+      - version_constraint: "true"
+        asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          # The Linux GUI build links against webkit2gtk at runtime, so it can't
+          # run on headless machines. Install the dependency-free CLI-only static
+          # build on Linux instead (the archive still exposes a `suve` binary).
+          - goos: linux
+            asset: suve-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: mr-karan
     repo_name: doggo
@@ -82812,6 +82860,22 @@ packages:
             asset: ccowl-{{.OS}}-{{.Arch}}.exe.{{.Format}}
             checksum:
               enabled: false
+  - type: github_release
+    repo_owner: sivchari
+    repo_name: gopls-lazy
+    description: An LSP proxy that lazily scopes gopls to open files, keeping large monorepos fast
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gopls-lazy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: gopls-lazy_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: six-ddc
     repo_name: plow


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(config)** restore get_env template helper by @jdx in [#10830](https://github.com/jdx/mise/pull/10830)
- **(config)** warn for deprecated settings from sources by @jdx in [#10832](https://github.com/jdx/mise/pull/10832)
- **(file)** support pax sparse tar extraction by @JamBalaya56562 in [#10821](https://github.com/jdx/mise/pull/10821)
- **(registry)** add rename_exe for podman to fix installed binary name by @konono in [#10822](https://github.com/jdx/mise/pull/10822)
- **(vfox)** flush downloaded files before returning by @jdx in [#10833](https://github.com/jdx/mise/pull/10833)
- accept scoped release tags in cached GitHub asset URLs by @zeitlinger in [#10750](https://github.com/jdx/mise/pull/10750)

## 📦 Aqua Registry Updates

### New Packages (3)

- [`koki-develop/ghasec`](https://github.com/koki-develop/ghasec)
- [`mpyw/suve`](https://github.com/mpyw/suve)
- [`sivchari/gopls-lazy`](https://github.com/sivchari/gopls-lazy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new packages in the registry.
  * Updated shell completion caches for the latest release.

* **Bug Fixes**
  * Improved handling for several download, extraction, and release-tag edge cases.
  * Restored support for a missing template helper and updated deprecation warnings.

* **Chores**
  * Bumped the release version across packaging files and refreshed the changelog and README examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->