### PR TITLE
fix(config): warn for deprecated settings from sources

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -700,6 +700,10 @@ pub static SETTINGS_META: Lazy<IndexMap<&'static str, SettingsMeta>> = Lazy::new
                     raw_string_literal(&description)
                 ));
             }
+            match props.get("env").and_then(|v| v.as_str()) {
+                Some(env) => lines.push(format!("        env: Some({env:?}),")),
+                None => lines.push("        env: None,".to_string()),
+            }
             push_deprecated_fields(&mut lines, props);
             lines.push("    },".to_string());
         }
@@ -725,6 +729,10 @@ pub static SETTINGS_META: Lazy<IndexMap<&'static str, SettingsMeta>> = Lazy::new
                     "        description: {},",
                     raw_string_literal(&description)
                 ));
+            }
+            match props.get("env").and_then(|v| v.as_str()) {
+                Some(env) => lines.push(format!("        env: Some({env:?}),")),
+                None => lines.push("        env: None,".to_string()),
             }
             push_deprecated_fields(&mut lines, props);
             lines.push("    },".to_string());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -638,6 +638,8 @@ impl Cli {
         // Fast-path for hook-env: exit early if nothing has changed
         // This avoids expensive backend::load_tools() and config loading
         if hook_env_module::should_exit_early_fast() {
+            measure!("logger", { logger::init() });
+            Settings::flush_deprecated_warnings_for_fast_exit();
             return Ok(());
         }
         measure!("logger", { logger::init() });

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 use std::{
     collections::{BTreeSet, HashSet},
-    sync::atomic::Ordering,
+    sync::atomic::{AtomicBool, Ordering},
 };
 use url::Url;
 
@@ -48,6 +48,7 @@ pub struct SettingsMeta {
     // pub key: String,
     pub type_: SettingsType,
     pub description: &'static str,
+    pub env: Option<&'static str>,
     pub deprecated: Option<&'static str>,
     pub deprecated_warn_at: Option<&'static str>,
     pub deprecated_remove_at: Option<&'static str>,
@@ -204,6 +205,9 @@ pub type SettingsPartial = <Settings as Config>::Layer;
 
 static BASE_SETTINGS: RwLock<Option<Arc<Settings>>> = RwLock::new(None);
 static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
+static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
+    Lazy::new(Default::default);
+static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
 static DEFAULT_SETTINGS: Lazy<SettingsPartial> = Lazy::new(|| {
     let mut s = SettingsPartial::empty();
     s.python.default_packages_file = Some(env::HOME.join(".default-python-packages"));
@@ -247,7 +251,93 @@ fn tera_v1_from_env_config(raw: &toml::Value) -> Option<bool> {
         .and_then(parse_boolish_toml_value)
 }
 
-fn warn_deprecated(key: &str) {
+fn deprecated_settings_in_toml_table(settings: &toml::Table) -> Vec<&'static str> {
+    SETTINGS_META
+        .iter()
+        .filter_map(|(key, meta)| {
+            meta.deprecated?;
+            let value = nested_toml_value(settings, key)?;
+            should_warn_deprecated_value(value).then_some(*key)
+        })
+        .collect()
+}
+
+fn deprecated_settings_in_env_directives(raw: &toml::Value) -> Vec<&'static str> {
+    tera_v1_from_env_config(raw)
+        .is_some()
+        .then_some("tera_v1")
+        .into_iter()
+        .collect()
+}
+
+fn deprecated_settings_in_toml_config(raw: &toml::Value) -> Vec<&'static str> {
+    let mut deprecated = Vec::new();
+    if let Some(settings) = raw.get("settings").and_then(toml::Value::as_table) {
+        deprecated.extend(deprecated_settings_in_toml_table(settings));
+    }
+    deprecated.extend(deprecated_settings_in_env_directives(raw));
+    deprecated
+}
+
+fn warn_deprecated_env_settings() {
+    for (key, meta) in SETTINGS_META.iter() {
+        let Some(env_key) = meta.env else {
+            continue;
+        };
+        if meta.deprecated.is_some()
+            && env::var_os(env_key).is_some_and(|value| !value.as_os_str().is_empty())
+        {
+            warn_deprecated(key);
+        }
+    }
+}
+
+fn queue_deprecated(key: &'static str) {
+    PENDING_DEPRECATED_SETTINGS.lock().unwrap().insert(key);
+}
+
+fn queue_deprecated_settings(keys: impl IntoIterator<Item = &'static str>) {
+    for key in keys {
+        warn_deprecated(key);
+    }
+}
+
+fn nested_toml_value<'a>(table: &'a toml::Table, key: &str) -> Option<&'a toml::Value> {
+    let mut parts = key.split('.').collect_vec();
+    let last = parts.pop()?;
+    let mut current = table;
+    for part in parts {
+        current = current.get(part)?.as_table()?;
+    }
+    current.get(last)
+}
+
+fn should_warn_deprecated_value(value: &toml::Value) -> bool {
+    match value {
+        toml::Value::String(value) => !value.is_empty(),
+        toml::Value::Array(value) => !value.is_empty(),
+        toml::Value::Table(value) => {
+            if value.get("unset").and_then(toml::Value::as_bool) == Some(true) {
+                return false;
+            }
+            match value.get("value") {
+                Some(value) => should_warn_deprecated_value(value),
+                None => !value.is_empty(),
+            }
+        }
+        _ => true,
+    }
+}
+
+fn warn_deprecated(key: &'static str) {
+    if !DEPRECATED_WARNINGS_READY.load(Ordering::SeqCst) {
+        queue_deprecated(key);
+        return;
+    }
+    warn_deprecated_now(key);
+}
+
+fn warn_deprecated_now(key: &'static str) {
     if let Some(meta) = SETTINGS_META.get(key)
         && let (Some(msg), Some(warn_at), Some(remove_at)) = (
             meta.deprecated,
@@ -329,6 +419,13 @@ impl Settings {
     }
 
     pub fn warn_default_package_file_deprecated(id: &'static str, package_type: &str) {
+        if SETTINGS_META
+            .get(id)
+            .is_some_and(|m| m.deprecated.is_some())
+        {
+            warn_deprecated(id);
+            return;
+        }
         deprecated_at!(
             "2026.11.0",
             "2027.11.0",
@@ -456,6 +553,29 @@ impl Settings {
         time!("try_get done");
         trace!("Settings: {:#?}", settings);
         Ok(settings)
+    }
+
+    pub fn flush_deprecated_warnings() {
+        if CLI_SETTINGS.lock().unwrap().is_none() {
+            return;
+        }
+        Self::flush_deprecated_warnings_now();
+    }
+
+    pub fn flush_deprecated_warnings_for_fast_exit() {
+        Self::flush_deprecated_warnings_now();
+    }
+
+    fn flush_deprecated_warnings_now() {
+        DEPRECATED_WARNINGS_READY.store(true, Ordering::SeqCst);
+        warn_deprecated_env_settings();
+        let pending = {
+            let mut pending = PENDING_DEPRECATED_SETTINGS.lock().unwrap();
+            std::mem::take(&mut *pending)
+        };
+        for key in pending {
+            warn_deprecated_now(key);
+        }
     }
 
     /// Sets deprecated settings to new names
@@ -605,7 +725,9 @@ impl Settings {
         if let Some(settings) = raw.get_mut("settings").and_then(toml::Value::as_table_mut) {
             strip_local_only_settings(settings, path, crate::config::is_global_config(path));
         }
+        let deprecated = deprecated_settings_in_toml_config(&raw);
         let settings_file: SettingsFile = raw.try_into()?;
+        queue_deprecated_settings(deprecated);
         let mut settings = normalize_hidden_config_aliases(settings_file.settings);
         if settings.tera_v1.is_none() {
             settings.tera_v1 = tera_v1_from_env;
@@ -1265,6 +1387,66 @@ mod tests {
         let partial = Settings::parse_settings_file(&path).unwrap();
 
         assert_eq!(partial.tera_v1, Some(false));
+    }
+
+    #[test]
+    fn test_deprecated_settings_in_toml_table_detects_nested_settings() {
+        let settings = toml::from_str::<toml::Value>(
+            r#"
+            tera_v1 = true
+
+            [aqua]
+            registry_url = "https://example.com/aqua-registry"
+            "#,
+        )
+        .unwrap()
+        .as_table()
+        .unwrap()
+        .clone();
+
+        let deprecated = deprecated_settings_in_toml_table(&settings);
+
+        assert!(deprecated.contains(&"tera_v1"));
+        assert!(deprecated.contains(&"aqua.registry_url"));
+    }
+
+    #[test]
+    fn test_deprecated_settings_in_env_directives_detects_setting_env() {
+        let raw = toml::from_str::<toml::Value>(
+            r#"
+            [env]
+            MISE_TERA_V1 = true
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(deprecated_settings_in_env_directives(&raw), vec!["tera_v1"]);
+    }
+
+    #[test]
+    fn test_deprecated_settings_in_env_directives_ignores_unset_env() {
+        let raw = toml::from_str::<toml::Value>(
+            r#"
+            [env]
+            MISE_TERA_V1 = { unset = true }
+            "#,
+        )
+        .unwrap();
+
+        assert!(deprecated_settings_in_env_directives(&raw).is_empty());
+    }
+
+    #[test]
+    fn test_deprecated_settings_in_env_directives_ignores_child_only_env() {
+        let raw = toml::from_str::<toml::Value>(
+            r#"
+            [env]
+            MISE_SHORTHANDS_FILE = "~/.mise-shorthands"
+            "#,
+        )
+        .unwrap();
+
+        assert!(deprecated_settings_in_env_directives(&raw).is_empty());
     }
 
     #[test]

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -175,6 +175,9 @@ pub fn should_exit_early_fast() -> bool {
     if args.len() < 2 || args[1] != "hook-env" {
         return false;
     }
+    if has_preclap_logging_flag(&args) {
+        return false;
+    }
     // Can't exit early if no previous session
     // Check for dir being set as a proxy for "has valid session"
     // (loaded_configs can be empty if there are no config files)
@@ -401,6 +404,13 @@ fn have_trust_state_dirs_been_modified() -> bool {
         }
     }
     false
+}
+
+fn has_preclap_logging_flag(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        matches!(arg.as_str(), "-q" | "--quiet" | "--silent" | "--log-level")
+            || arg.starts_with("--log-level=")
+    })
 }
 
 fn have_mise_env_vars_been_modified() -> bool {
@@ -743,4 +753,53 @@ pub fn build_alias_commands(
     }
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_preclap_logging_flag;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn detects_logging_flags_that_need_clap_before_fast_exit() {
+        assert!(has_preclap_logging_flag(&args(&[
+            "mise", "hook-env", "-s", "bash", "--quiet"
+        ])));
+        assert!(has_preclap_logging_flag(&args(&["mise", "hook-env", "-q"])));
+        assert!(has_preclap_logging_flag(&args(&[
+            "mise", "hook-env", "--silent"
+        ])));
+        assert!(has_preclap_logging_flag(&args(&[
+            "mise",
+            "hook-env",
+            "--log-level",
+            "error"
+        ])));
+        assert!(has_preclap_logging_flag(&args(&[
+            "mise",
+            "hook-env",
+            "--log-level=error"
+        ])));
+    }
+
+    #[test]
+    fn ignores_logging_flags_that_do_not_suppress_warnings() {
+        assert!(!has_preclap_logging_flag(&args(&[
+            "mise", "hook-env", "-s", "bash"
+        ])));
+        assert!(!has_preclap_logging_flag(&args(&[
+            "mise", "hook-env", "--trace"
+        ])));
+        assert!(!has_preclap_logging_flag(&args(&[
+            "mise", "hook-env", "--debug"
+        ])));
+        assert!(!has_preclap_logging_flag(&args(&[
+            "mise",
+            "hook-env",
+            "--verbose"
+        ])));
+    }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -192,6 +192,7 @@ pub fn init() {
         }
     }
     log::set_max_level(term_level);
+    Settings::flush_deprecated_warnings();
 }
 
 fn init_log_file(log_file: &Path) -> Result<File> {


### PR DESCRIPTION
## Summary
- add setting env var names to SettingsMeta so runtime warnings can use settings.toml metadata
- warn when deprecated settings are explicitly configured via [settings] or process env vars
- warn for the [env] MISE_TERA_V1 compatibility shim without treating every [env] MISE_* value as a current settings source
- avoid consuming deprecation warning IDs before the logger is initialized

Follow-up to #10830.

## Tests
- cargo test config::settings::tests
- cargo build
- git diff --check
- smoke checked deprecated [settings] and process-env warnings with shorthands_file

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches startup ordering for every CLI invocation and hook-env fast exit; incorrect timing could miss warnings or emit them before log-level flags apply, but scope is limited to deprecation messaging rather than config values.
> 
> **Overview**
> Improves **deprecated setting warnings** so they fire when users actually set deprecated options in TOML, process environment, or the `MISE_TERA_V1` `[env]` shim—not only during internal migrations.
> 
> **`SettingsMeta`** now carries each setting’s **`env`** var name (codegen from `settings.toml`). Warnings are **queued** until the logger is ready, then flushed from **`logger::init`** (after CLI flags are applied) or on **`hook-env` fast exit** so dedupe IDs are not consumed too early and messages respect **`-q` / `--silent` / `--log-level`**.
> 
> Config parsing scans **`[settings]`** (including nested keys like `aqua.registry_url`), skips empty/unset values, and treats **`[env] MISE_TERA_V1`** as deprecated without flagging unrelated `MISE_*` entries in `[env]`. Process env checks use metadata **`env`** keys for deprecated settings.
> 
> **`hook-env` fast path** no longer skips when those logging flags are present, so warnings can still run after a minimal logger init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4d31a6006436952e84dea03d3af0e8cc5d00be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deprecated-setting detection in config files, including nested/dotted keys, with warnings suppressed when values are unset/empty.
  * Deprecated warnings now better align with the actual related environment variables (including directive-derived cases), reducing false positives.
  * Deprecated warnings are now emitted even on early exit, and early-exit behavior is adjusted to respect logging-suppression flags.

* **New Features**
  * Settings can now be linked to specific environment-variable keys to provide more accurate deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->