### PR TITLE
fix(vfox): flush downloaded files before returning

### DIFF
--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -213,6 +213,9 @@ async fn download_file(lua: &Lua, input: MultiValue) -> Result<()> {
     tokio::io::AsyncWriteExt::write_all(&mut file, &bytes)
         .await
         .into_lua_err()?;
+    tokio::io::AsyncWriteExt::flush(&mut file)
+        .await
+        .into_lua_err()?;
     Ok(())
 }
 
@@ -345,6 +348,12 @@ async fn try_download_file(lua: &Lua, input: MultiValue) -> Result<MultiValue> {
         }
     };
     if let Err(e) = tokio::io::AsyncWriteExt::write_all(&mut file, &bytes).await {
+        return Ok(MultiValue::from_vec(vec![
+            Value::Nil,
+            Value::String(lua.create_string(e.to_string())?),
+        ]));
+    }
+    if let Err(e) = tokio::io::AsyncWriteExt::flush(&mut file).await {
         return Ok(MultiValue::from_vec(vec![
             Value::Nil,
             Value::String(lua.create_string(e.to_string())?),


### PR DESCRIPTION
## Summary
- flush `tokio::fs::File` after `write_all` in `http.download_file`
- return flush errors from `http.try_download_file` instead of reporting success before bytes are settled
- addresses the `test_try_download_file_success` CI flake from the release PR where the file was read back as empty

## Test
- `mise --cd crates/vfox run test test_try_download_file -- --nocapture`
- `mise --cd crates/vfox run lint`
- `mise --cd crates/vfox run test`

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to plugin download I/O with clearer error handling on flush; no auth or data-model impact.
> 
> **Overview**
> Fixes a race where vfox plugin HTTP downloads could return before bytes were visible on disk, which showed up in CI as **empty files** right after a successful download.
> 
> **`download_file`** and **`try_download_file`** in `crates/vfox/src/lua_mod/http.rs` now call **`flush`** on the output file after **`write_all`**. **`try_download_file`** propagates flush failures as an error instead of reporting success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c11a902bd0f66f49da1eb36858c9f285929c381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file download reliability by ensuring downloaded content is fully written to disk before reporting success.
  * Added proper error handling for write flush failures, so failed downloads now return an error instead of appearing successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->