### PR TITLE
fix: align self-update TLS backend with feature activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9650,9 +9650,11 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
+ "der 0.8.1",
  "encoding_rs",
  "flate2",
  "log",
+ "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
@@ -9661,6 +9663,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
+ "webpki-root-certs",
  "webpki-roots",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,6 @@ self_update = { version = "0.44", optional = true, default-features = false, fea
   "compression-flate2",
   "signatures",
   "reqwest",
-  "rustls",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -241,7 +240,6 @@ self_update = { version = "0.44", optional = true, default-features = false, fea
   "compression-zip-deflate",
   "signatures",
   "reqwest",
-  "rustls",
 ] }
 zipsign-api = "0.2"
 winapi = { version = "0.3.9", features = ["consoleapi", "minwindef"] }
@@ -277,6 +275,7 @@ native-tls = [
   "ubi/native-tls",
   "vfox/native-tls",
   "xx/native-tls",
+  "self_update?/default-tls",
 ]
 rustls = [
   "gix/blocking-http-transport-reqwest-rust-tls",
@@ -287,6 +286,7 @@ rustls = [
   "ubi/rustls-tls",
   "vfox/rustls",
   "xx/rustls",
+  "self_update?/rustls",
 ]
 rustls-native-roots = [
   "gix/blocking-http-transport-reqwest-rust-tls",
@@ -297,6 +297,7 @@ rustls-native-roots = [
   "ubi/rustls-tls-native-roots",
   "vfox/rustls-native-roots",
   "xx/rustls-native-roots",
+  "self_update?/rustls",
 ]
 
 [package.metadata.binstall]


### PR DESCRIPTION
The `self_update` create gated behind an optional feature alwaus used
`rustls` as it's TLS backend. In comparison, other crates with TLS
features use either `native-tls` or `rustls` configured using build
features.

Building `mise` with `--features native-tls` caused `mise self-update`
command to use a different TLS backend than requested, leading to errors
on platforms which require `native-tls` instead of `rustls`.

This commit aligns the `self_update` feature activation to be inline
with other crates feature activation, so the correct TLS backend is
compiled. It uses the weak feature activation syntax as `self_update` is
an optional feature and optional crate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the updater’s TLS backend selection on both Unix and Windows so it no longer unintentionally enables Rustls when a different TLS option is chosen.

* **Chores**
  * Updated feature/TLS configuration so the selected TLS backend is consistently propagated to the updater across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->