### PR TITLE
feat(brew): run cask lifecycle hooks

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -74,11 +74,13 @@ and linked into the Homebrew prefix, usually under `<prefix>/bin`. Package
 installers run through mise's normal system-package sudo path, so non-interactive
 runs never hang waiting for a password. Pkg casks must include `pkgutil` receipt
 IDs in their `uninstall` or `zap` metadata so mise can verify installed state
-after the installer writes files outside the Caskroom. Casks that require custom
-installer choices, services, or other cask artifact types fail with a clear
-unsupported artifact error instead of delegating to Homebrew. Lifecycle metadata
-such as `preflight` and `postflight` is not executed, and generated shell
-completions are not installed.
+after the installer writes files outside the Caskroom. For casks with lifecycle
+hooks, mise fetches the sha256-verified cask Ruby source pinned by the API
+metadata and runs supported `preflight`/`postflight` hooks through its own Cask
+DSL shim, without delegating to Homebrew. Casks that require custom installer
+choices, services, unsupported hook DSL, or other cask artifact types fail with
+a clear unsupported artifact error instead of delegating to Homebrew. Generated
+shell completions are not installed.
 
 This exists because shared-library packages — postgres, ffmpeg, imagemagick,
 php — fundamentally can't be served by mise's per-project backends like

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -135,10 +135,10 @@ impl BrewCaskManager {
         let tmp_caskroom = caskroom_tmp_dir(&cask);
         file::remove_all(&tmp_caskroom)?;
         file::create_dir_all(&tmp_caskroom)?;
+        execute_lifecycle_hook(&cask, &tmp_caskroom, "preflight", pr).await?;
         for app in &artifacts.apps {
             install_app(&stage, &tmp_caskroom, app)?;
         }
-        execute_lifecycle_hook(&cask, &tmp_caskroom, "preflight", pr).await?;
         for binary in &artifacts.binaries {
             stage_binary(&stage, &tmp_caskroom, &cask, binary)?;
         }
@@ -148,6 +148,7 @@ impl BrewCaskManager {
         for font in &artifacts.fonts {
             stage_font(&stage, &tmp_caskroom, font)?;
         }
+        execute_lifecycle_hook(&cask, &tmp_caskroom, "postflight", pr).await?;
         write_receipt(&tmp_caskroom, &cask, &artifacts)?;
         file::remove_all(&caskroom)?;
         file::rename(&tmp_caskroom, &caskroom)?;
@@ -159,7 +160,6 @@ impl BrewCaskManager {
             link_font(&caskroom, font)?;
         }
         remove_obsolete_fonts(&cask, &previous_fonts, &font_target_paths(&artifacts)?)?;
-        execute_lifecycle_hook(&cask, &caskroom, "postflight", pr).await?;
         remove_stale_versions(&caskroom_token, &cask.version)?;
         file::remove_all(stage)?;
         Ok(cask.version)
@@ -388,7 +388,7 @@ async fn execute_lifecycle_hook(
         .join("system-brew")
         .join("casks")
         .join("mise-brew-cask-shim.rb");
-    file::write(&shim_path, CASK_SHIM_RB)?;
+    ensure_cask_shim(&shim_path)?;
     if let Some(pr) = pr {
         pr.set_message(format!("run cask {hook}"));
     }
@@ -411,6 +411,13 @@ async fn execute_lifecycle_hook(
         .execute_async()
         .await
         .wrap_err_with(|| format!("brew-cask:{}: failed to run {hook}", cask.token))
+}
+
+fn ensure_cask_shim(path: &Path) -> Result<()> {
+    if file::read_to_string(path).is_ok_and(|contents| contents == CASK_SHIM_RB) {
+        return Ok(());
+    }
+    file::write(path, CASK_SHIM_RB)
 }
 
 async fn fetch_cask_rb(cask: &Cask, pr: Option<&dyn SingleReport>) -> Result<PathBuf> {
@@ -444,7 +451,8 @@ async fn fetch_cask_rb(cask: &Cask, pr: Option<&dyn SingleReport>) -> Result<Pat
     })?;
     let cache_dir = crate::dirs::CACHE.join("system-brew").join("cask-source");
     file::create_dir_all(&cache_dir)?;
-    let dest = cache_dir.join(format!("{}-{}.rb", cask.token, &sha256[..12]));
+    let short_sha = sha256.get(..12).unwrap_or(sha256);
+    let dest = cache_dir.join(format!("{}-{short_sha}.rb", cask.token));
     if dest.exists() && hash::ensure_checksum(&dest, sha256, None, "sha256").is_ok() {
         return Ok(dest);
     }
@@ -760,6 +768,12 @@ fn generated_caskroom_artifact(caskroom: &Path, cask: &Cask, source: &str) -> Op
     let source = PathBuf::from(source);
     let final_caskroom = caskroom_version_dir(&cask.token, &cask.version);
     let relative = source.strip_prefix(final_caskroom).ok()?;
+    if relative
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return None;
+    }
     Some(caskroom.join(relative))
 }
 
@@ -1452,6 +1466,23 @@ mod tests {
         assert_eq!(
             generated_caskroom_artifact(&tmp_caskroom, &cask, source),
             Some(generated)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_generated_caskroom_binary_parent_dirs() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let prefix = tmp.path().join("homebrew");
+        let _guard = BrewPrefixGuard::set(&prefix);
+        let cask = test_cask("gimp", "3.2.4");
+        let tmp_caskroom = tmp.path().join("tmp-caskroom");
+        let source = "$HOMEBREW_PREFIX/Caskroom/gimp/3.2.4/../escape";
+
+        assert_eq!(
+            generated_caskroom_artifact(&tmp_caskroom, &cask, source),
+            None
         );
         Ok(())
     }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -135,7 +135,8 @@ impl BrewCaskManager {
         let tmp_caskroom = caskroom_tmp_dir(&cask);
         file::remove_all(&tmp_caskroom)?;
         file::create_dir_all(&tmp_caskroom)?;
-        execute_lifecycle_hook(&cask, &stage, "preflight", pr).await?;
+        let appdir = cask_appdir(&artifacts.apps)?;
+        execute_lifecycle_hook(&cask, &stage, &appdir, "preflight", pr).await?;
         for app in &artifacts.apps {
             install_app(&stage, &tmp_caskroom, app)?;
         }
@@ -145,7 +146,7 @@ impl BrewCaskManager {
         for font in &artifacts.fonts {
             stage_font(&stage, &tmp_caskroom, font)?;
         }
-        execute_lifecycle_hook(&cask, &tmp_caskroom, "postflight", pr).await?;
+        execute_lifecycle_hook(&cask, &tmp_caskroom, &appdir, "postflight", pr).await?;
         for binary in &artifacts.binaries {
             stage_binary(&stage, &tmp_caskroom, &cask, binary)?;
         }
@@ -376,6 +377,7 @@ fn extract_archive(cask: &Cask, archive: &Path, pr: Option<&dyn SingleReport>) -
 async fn execute_lifecycle_hook(
     cask: &Cask,
     staged_path: &Path,
+    appdir: &Path,
     hook: &str,
     pr: Option<&dyn SingleReport>,
 ) -> Result<()> {
@@ -400,6 +402,7 @@ async fn execute_lifecycle_hook(
             "MISE_BREW_CASK_STAGED_PATH",
             staged_path.display().to_string(),
         ),
+        ("MISE_BREW_CASK_APPDIR", appdir.display().to_string()),
         ("MISE_BREW_PREFIX", prefix::prefix().display().to_string()),
         ("MISE_BREW_CASK_HOOK", hook.to_string()),
     ]);
@@ -755,7 +758,8 @@ fn find_binary_source(
     {
         return Ok(source);
     }
-    find_artifact(stage, &binary.source)
+    find_artifact(caskroom, &binary.source)
+        .or_else(|| find_artifact(stage, &binary.source))
         .filter(|path| path.is_file())
         .ok_or_else(|| {
             eyre!(
@@ -778,6 +782,16 @@ fn generated_caskroom_artifact(caskroom: &Path, cask: &Cask, source: &str) -> Op
         return None;
     }
     Some(caskroom.join(relative))
+}
+
+fn cask_appdir(apps: &[AppArtifact]) -> Result<PathBuf> {
+    let prefix_app_dir = prefix::prefix().join("Applications");
+    for app in apps {
+        if app_target_path(app.target_name())?.starts_with(&prefix_app_dir) {
+            return Ok(prefix_app_dir);
+        }
+    }
+    Ok(PathBuf::from("/Applications"))
 }
 
 fn link_binary(caskroom: &Path, binary: &BinaryArtifact) -> Result<()> {
@@ -1976,6 +1990,47 @@ mod tests {
 
         assert_eq!(crate::file::read_to_string(bin.target_path()?)?, "bin");
         assert_eq!(crate::file::read_to_string(sbin.target_path()?)?, "sbin");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn binary_source_prefers_hook_generated_caskroom_file() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        file::create_dir_all(&stage)?;
+        crate::file::write(stage.join("op"), "stage")?;
+        let caskroom = caskroom_version_dir("binary-only", "1.0.0");
+        file::create_dir_all(&caskroom)?;
+        crate::file::write(caskroom.join("op"), "hook")?;
+        let cask = test_cask("binary-only", "1.0.0");
+        let binary = BinaryArtifact {
+            source: "op".to_string(),
+            target: Some("$HOMEBREW_PREFIX/bin/op".to_string()),
+        };
+
+        stage_binary(&stage, &caskroom, &cask, &binary)?;
+
+        assert_eq!(
+            crate::file::read_to_string(caskroom.join("bin/op"))?,
+            "hook"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cask_appdir_uses_prefix_for_prefix_targeted_apps() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let app = AppArtifact {
+            source: "Example.app".to_string(),
+            target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
+        };
+
+        assert_eq!(cask_appdir(&[app])?, tmp.path().join("Applications"));
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -414,6 +414,9 @@ async fn execute_lifecycle_hook(
 }
 
 fn ensure_cask_shim(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        file::create_dir_all(parent)?;
+    }
     if file::read_to_string(path).is_ok_and(|contents| contents == CASK_SHIM_RB) {
         return Ok(());
     }
@@ -1355,6 +1358,17 @@ mod tests {
             tap_git_head: None,
             raw_base: None,
         }
+    }
+
+    #[test]
+    fn ensure_cask_shim_creates_parent_dir() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let shim_path = tmp.path().join("missing").join("cask_shim.rb");
+
+        ensure_cask_shim(&shim_path)?;
+
+        assert_eq!(file::read_to_string(&shim_path)?, CASK_SHIM_RB);
+        Ok(())
     }
 
     #[test]

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use walkdir::WalkDir;
 
+use super::api::RubySourceChecksum;
 use super::prefix;
+use super::source;
+use crate::cmd::CmdLineRunner;
 use crate::file::{self, ExtractOptions, ExtractionFormat};
 use crate::hash;
 use crate::http::HTTP_FETCH;
@@ -20,6 +23,8 @@ use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::{ProgressIcon, SingleReport};
 
 const API_BASE: &str = "https://formulae.brew.sh/api";
+const HOMEBREW_CASK_RAW: &str = "https://raw.githubusercontent.com/Homebrew/homebrew-cask";
+const CASK_SHIM_RB: &str = include_str!("cask_shim.rb");
 
 pub struct BrewCaskManager {}
 
@@ -32,6 +37,14 @@ struct Cask {
     sha256: Option<String>,
     #[serde(default)]
     artifacts: Vec<Value>,
+    #[serde(default)]
+    ruby_source_path: Option<String>,
+    #[serde(default)]
+    ruby_source_checksum: Option<RubySourceChecksum>,
+    #[serde(default)]
+    tap_git_head: Option<String>,
+    #[serde(skip)]
+    raw_base: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,8 +138,9 @@ impl BrewCaskManager {
         for app in &artifacts.apps {
             install_app(&stage, &tmp_caskroom, app)?;
         }
+        execute_lifecycle_hook(&cask, &tmp_caskroom, "preflight", pr).await?;
         for binary in &artifacts.binaries {
-            stage_binary(&stage, &tmp_caskroom, binary)?;
+            stage_binary(&stage, &tmp_caskroom, &cask, binary)?;
         }
         for pkg in &artifacts.pkgs {
             install_pkg(&stage, pkg)?;
@@ -145,6 +159,7 @@ impl BrewCaskManager {
             link_font(&caskroom, font)?;
         }
         remove_obsolete_fonts(&cask, &previous_fonts, &font_target_paths(&artifacts)?)?;
+        execute_lifecycle_hook(&cask, &caskroom, "postflight", pr).await?;
         remove_stale_versions(&caskroom_token, &cask.version)?;
         file::remove_all(stage)?;
         Ok(cask.version)
@@ -253,19 +268,28 @@ impl SystemPackageManager for BrewCaskManager {
 
 async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
     let name = &req.name;
-    let url = match split_tap_name(name) {
-        Some(("homebrew", "cask", token)) => format!("{API_BASE}/cask/{token}.json"),
+    let (url, raw_base) = match split_tap_name(name) {
+        Some(("homebrew", "cask", token)) => (
+            format!("{API_BASE}/cask/{token}.json"),
+            Some(HOMEBREW_CASK_RAW.to_string()),
+        ),
         Some((owner, tap, token)) => {
             let Some(base) = super::api::tap_raw_base(owner, tap, req.tap_url.as_deref()) else {
                 bail!(
                     "brew-cask: unsupported tap URL for '{name}'; only GitHub tap URLs can be fetched directly"
                 );
             };
-            format!("{base}/api/cask/{token}.json")
+            (
+                format!("{base}/api/cask/{token}.json"),
+                Some(base.trim_end_matches("/HEAD").to_string()),
+            )
         }
-        None => format!("{API_BASE}/cask/{name}.json"),
+        None => (
+            format!("{API_BASE}/cask/{name}.json"),
+            Some(HOMEBREW_CASK_RAW.to_string()),
+        ),
     };
-    HTTP_FETCH
+    let mut cask = HTTP_FETCH
         .json_cached::<Cask, _>(url)
         .await
         .wrap_err_with(|| {
@@ -273,7 +297,9 @@ async fn fetch_cask(req: &PackageRequest) -> Result<Cask> {
                 "failed to fetch Homebrew cask '{name}' directly. \
                  Tapped casks must publish API metadata at api/cask/<token>.json"
             )
-        })
+        })?;
+    cask.raw_base = raw_base;
+    Ok(cask)
 }
 
 async fn fetch_archive(cask: &Cask, pr: Option<&dyn SingleReport>) -> Result<PathBuf> {
@@ -345,6 +371,90 @@ fn extract_archive(cask: &Cask, archive: &Path, pr: Option<&dyn SingleReport>) -
         }
     }
     Ok(extract_dir)
+}
+
+async fn execute_lifecycle_hook(
+    cask: &Cask,
+    staged_path: &Path,
+    hook: &str,
+    pr: Option<&dyn SingleReport>,
+) -> Result<()> {
+    if !has_lifecycle_hook(cask, hook) {
+        return Ok(());
+    }
+    let ruby = source::ruby_bin().await?;
+    let cask_rb = fetch_cask_rb(cask, pr).await?;
+    let shim_path = crate::dirs::CACHE
+        .join("system-brew")
+        .join("casks")
+        .join("mise-brew-cask-shim.rb");
+    file::write(&shim_path, CASK_SHIM_RB)?;
+    if let Some(pr) = pr {
+        pr.set_message(format!("run cask {hook}"));
+    }
+    let runner = CmdLineRunner::new(&ruby).arg(&shim_path).envs([
+        ("MISE_BREW_CASK_FILE", cask_rb.display().to_string()),
+        ("MISE_BREW_CASK_TOKEN", cask.token.clone()),
+        ("MISE_BREW_CASK_VERSION", cask.version.clone()),
+        (
+            "MISE_BREW_CASK_STAGED_PATH",
+            staged_path.display().to_string(),
+        ),
+        ("MISE_BREW_PREFIX", prefix::prefix().display().to_string()),
+        ("MISE_BREW_CASK_HOOK", hook.to_string()),
+    ]);
+    let runner = match pr {
+        Some(pr) => runner.with_pr(pr),
+        None => runner,
+    };
+    runner
+        .execute_async()
+        .await
+        .wrap_err_with(|| format!("brew-cask:{}: failed to run {hook}", cask.token))
+}
+
+async fn fetch_cask_rb(cask: &Cask, pr: Option<&dyn SingleReport>) -> Result<PathBuf> {
+    let rb_path = cask.ruby_source_path.as_ref().ok_or_else(|| {
+        eyre!(
+            "brew-cask:{}: lifecycle hooks require ruby_source_path in API metadata",
+            cask.token
+        )
+    })?;
+    let sha256 = cask
+        .ruby_source_checksum
+        .as_ref()
+        .and_then(|c| c.sha256.as_deref())
+        .ok_or_else(|| {
+            eyre!(
+                "brew-cask:{}: lifecycle hooks require ruby_source_checksum in API metadata",
+                cask.token
+            )
+        })?;
+    let commit = cask.tap_git_head.as_deref().ok_or_else(|| {
+        eyre!(
+            "brew-cask:{}: lifecycle hooks require tap_git_head in API metadata",
+            cask.token
+        )
+    })?;
+    let raw_base = cask.raw_base.as_deref().ok_or_else(|| {
+        eyre!(
+            "brew-cask:{}: lifecycle hooks require a GitHub raw source URL",
+            cask.token
+        )
+    })?;
+    let cache_dir = crate::dirs::CACHE.join("system-brew").join("cask-source");
+    file::create_dir_all(&cache_dir)?;
+    let dest = cache_dir.join(format!("{}-{}.rb", cask.token, &sha256[..12]));
+    if dest.exists() && hash::ensure_checksum(&dest, sha256, None, "sha256").is_ok() {
+        return Ok(dest);
+    }
+    let url = format!("{raw_base}/{commit}/{rb_path}");
+    if let Some(pr) = pr {
+        pr.set_message(format!("download {rb_path}"));
+    }
+    HTTP_FETCH.download_file(&url, &dest, pr).await?;
+    hash::ensure_checksum(&dest, sha256, pr, "sha256")?;
+    Ok(dest)
 }
 
 fn cask_extraction_format(archive: &Path, filename: &str) -> Result<ExtractionFormat> {
@@ -591,7 +701,7 @@ fn font_target_path(font: &FontArtifact) -> Result<PathBuf> {
         .join(name_path))
 }
 
-fn stage_binary(stage: &Path, caskroom: &Path, binary: &BinaryArtifact) -> Result<()> {
+fn stage_binary(stage: &Path, caskroom: &Path, cask: &Cask, binary: &BinaryArtifact) -> Result<()> {
     let caskroom_binary = caskroom_binary_path(caskroom, binary)?;
     file::remove_all(&caskroom_binary)?;
     if let Some(parent) = caskroom_binary.parent() {
@@ -616,18 +726,41 @@ fn stage_binary(stage: &Path, caskroom: &Path, binary: &BinaryArtifact) -> Resul
         })?;
         file::make_symlink(&app_binary, &caskroom_binary)?;
     } else {
-        let source = find_artifact(stage, &binary.source)
-            .filter(|path| path.is_file())
-            .ok_or_else(|| {
-                eyre!(
-                    "brew-cask: binary artifact '{}' was not found",
-                    binary.source
-                )
-            })?;
+        let source = find_binary_source(stage, caskroom, cask, binary)?;
         file::copy(&source, &caskroom_binary)?;
         file::make_executable(&caskroom_binary)?;
     }
     Ok(())
+}
+
+fn find_binary_source(
+    stage: &Path,
+    caskroom: &Path,
+    cask: &Cask,
+    binary: &BinaryArtifact,
+) -> Result<PathBuf> {
+    if let Some(source) = generated_caskroom_artifact(caskroom, cask, &binary.source)
+        && source.is_file()
+    {
+        return Ok(source);
+    }
+    find_artifact(stage, &binary.source)
+        .filter(|path| path.is_file())
+        .ok_or_else(|| {
+            eyre!(
+                "brew-cask: binary artifact '{}' was not found",
+                binary.source
+            )
+        })
+}
+
+fn generated_caskroom_artifact(caskroom: &Path, cask: &Cask, source: &str) -> Option<PathBuf> {
+    let prefix = prefix::prefix();
+    let source = source.replace("$HOMEBREW_PREFIX", &prefix.to_string_lossy());
+    let source = PathBuf::from(source);
+    let final_caskroom = caskroom_version_dir(&cask.token, &cask.version);
+    let relative = source.strip_prefix(final_caskroom).ok()?;
+    Some(caskroom.join(relative))
 }
 
 fn link_binary(caskroom: &Path, binary: &BinaryArtifact) -> Result<()> {
@@ -1162,6 +1295,12 @@ fn is_non_install_artifact(kind: &str) -> bool {
     )
 }
 
+fn has_lifecycle_hook(cask: &Cask, hook: &str) -> bool {
+    cask.artifacts
+        .iter()
+        .any(|artifact| artifact_type(artifact) == hook)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1197,6 +1336,10 @@ mod tests {
             url: "https://example.com/example.zip".to_string(),
             sha256: Some("no_check".to_string()),
             artifacts: Vec::new(),
+            ruby_source_path: None,
+            ruby_source_checksum: None,
+            tap_git_head: None,
+            raw_base: None,
         }
     }
 
@@ -1276,6 +1419,39 @@ mod tests {
                 }],
                 ..Default::default()
             }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn detects_lifecycle_hooks() {
+        let mut cask = test_cask("gimp", "3.2.4");
+        cask.artifacts = vec![
+            serde_json::json!({"preflight": null}),
+            serde_json::json!({"app": ["GIMP.app"]}),
+        ];
+
+        assert!(has_lifecycle_hook(&cask, "preflight"));
+        assert!(!has_lifecycle_hook(&cask, "postflight"));
+    }
+
+    #[test]
+    fn maps_generated_caskroom_binary_to_temp_caskroom() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let prefix = tmp.path().join("homebrew");
+        let _guard = BrewPrefixGuard::set(&prefix);
+        let cask = test_cask("gimp", "3.2.4");
+        let tmp_caskroom = tmp.path().join("tmp-caskroom");
+        let generated = tmp_caskroom.join("gimp.wrapper.sh");
+        file::create_dir_all(&tmp_caskroom)?;
+        std::fs::write(&generated, "#!/bin/sh\n")?;
+
+        let source = "$HOMEBREW_PREFIX/Caskroom/gimp/3.2.4/gimp.wrapper.sh";
+
+        assert_eq!(
+            generated_caskroom_artifact(&tmp_caskroom, &cask, source),
+            Some(generated)
         );
         Ok(())
     }
@@ -1710,12 +1886,13 @@ mod tests {
         crate::file::write(stage.join("op"), "binary")?;
         let caskroom = caskroom_version_dir("binary-only", "1.0.0");
         file::create_dir_all(&caskroom)?;
+        let cask = test_cask("binary-only", "1.0.0");
         let binary = BinaryArtifact {
             source: "op".to_string(),
             target: Some("$HOMEBREW_PREFIX/bin/op".to_string()),
         };
 
-        stage_binary(&stage, &caskroom, &binary)?;
+        stage_binary(&stage, &caskroom, &cask, &binary)?;
         link_binary(&caskroom, &binary)?;
 
         let target = binary.target_path()?;
@@ -1737,6 +1914,7 @@ mod tests {
         crate::file::write(stage.join("sbin/op"), "sbin")?;
         let caskroom = caskroom_version_dir("binary-only", "1.0.0");
         file::create_dir_all(&caskroom)?;
+        let cask = test_cask("binary-only", "1.0.0");
         let bin = BinaryArtifact {
             source: "bin/op".to_string(),
             target: Some("$HOMEBREW_PREFIX/bin/op".to_string()),
@@ -1746,8 +1924,8 @@ mod tests {
             target: Some("$HOMEBREW_PREFIX/sbin/op".to_string()),
         };
 
-        stage_binary(&stage, &caskroom, &bin)?;
-        stage_binary(&stage, &caskroom, &sbin)?;
+        stage_binary(&stage, &caskroom, &cask, &bin)?;
+        stage_binary(&stage, &caskroom, &cask, &sbin)?;
         link_binary(&caskroom, &bin)?;
         link_binary(&caskroom, &sbin)?;
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -135,7 +135,7 @@ impl BrewCaskManager {
         let tmp_caskroom = caskroom_tmp_dir(&cask);
         file::remove_all(&tmp_caskroom)?;
         file::create_dir_all(&tmp_caskroom)?;
-        execute_lifecycle_hook(&cask, &tmp_caskroom, "preflight", pr).await?;
+        execute_lifecycle_hook(&cask, &stage, "preflight", pr).await?;
         for app in &artifacts.apps {
             install_app(&stage, &tmp_caskroom, app)?;
         }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -139,9 +139,6 @@ impl BrewCaskManager {
         for app in &artifacts.apps {
             install_app(&stage, &tmp_caskroom, app)?;
         }
-        for binary in &artifacts.binaries {
-            stage_binary(&stage, &tmp_caskroom, &cask, binary)?;
-        }
         for pkg in &artifacts.pkgs {
             install_pkg(&stage, pkg)?;
         }
@@ -149,6 +146,9 @@ impl BrewCaskManager {
             stage_font(&stage, &tmp_caskroom, font)?;
         }
         execute_lifecycle_hook(&cask, &tmp_caskroom, "postflight", pr).await?;
+        for binary in &artifacts.binaries {
+            stage_binary(&stage, &tmp_caskroom, &cask, binary)?;
+        }
         write_receipt(&tmp_caskroom, &cask, &artifacts)?;
         file::remove_all(&caskroom)?;
         file::rename(&tmp_caskroom, &caskroom)?;

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -71,8 +71,35 @@ class MacOSVersion
     Gem::Version.new(@version) <=> Gem::Version.new(other.to_s)
   end
 
+  def same_release?(other)
+    other = self.class.from_symbol(other) if other.is_a?(Symbol)
+    other = self.class.new(other.to_s) unless other.is_a?(MacOSVersion)
+
+    if major >= 11 || other.major >= 11
+      major == other.major
+    else
+      major == other.major && minor == other.minor
+    end
+  end
+
   def to_s
     @version
+  end
+
+  protected
+
+  def major
+    version_parts[0] || 0
+  end
+
+  def minor
+    version_parts[1] || 0
+  end
+
+  private
+
+  def version_parts
+    @version.split(".").map(&:to_i)
   end
 end
 
@@ -244,7 +271,7 @@ class CaskContext
     matched = case method
     when :or_older then host <= target
     when :or_newer then host >= target
-    when nil then host.to_s == target.to_s
+    when nil then host.same_release?(target)
     else shim_unsupported!("on_#{version} #{method}")
     end
     instance_eval(&block) if matched

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -228,6 +228,14 @@ class CaskContext
     MISE_BREW_PREFIX + "Caskroom"
   end
 
+  def method_missing(name, *args, &block)
+    shim_unsupported!(name)
+  end
+
+  def respond_to_missing?(*args)
+    false
+  end
+
   private
 
   def run_macos_condition(version, method, &block)

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+# mise's Homebrew cask lifecycle shim.
+#
+# This evaluates a sha-verified cask .rb file without requiring Homebrew and
+# executes the lifecycle hook requested by Rust. It intentionally implements a
+# small Cask DSL surface first; unsupported lifecycle code fails loudly instead
+# of falling back to `brew`.
+
+require "etc"
+require "fileutils"
+require "pathname"
+require "rbconfig"
+
+MISE_BREW_CASK_FILE = Pathname.new(ENV.fetch("MISE_BREW_CASK_FILE"))
+MISE_BREW_CASK_TOKEN = ENV.fetch("MISE_BREW_CASK_TOKEN")
+MISE_BREW_CASK_VERSION = ENV.fetch("MISE_BREW_CASK_VERSION")
+MISE_BREW_CASK_STAGED_PATH = Pathname.new(ENV.fetch("MISE_BREW_CASK_STAGED_PATH"))
+MISE_BREW_PREFIX = Pathname.new(ENV.fetch("MISE_BREW_PREFIX"))
+MISE_BREW_CASK_HOOK = ENV.fetch("MISE_BREW_CASK_HOOK")
+
+def odie(message)
+  $stderr.puts "Error: #{message}"
+  exit 1
+end
+
+class ShimUnsupportedError < StandardError; end
+
+def shim_unsupported!(feature)
+  raise ShimUnsupportedError,
+        "cask uses `#{feature}`, which mise's cask shim does not support"
+end
+
+module OS
+  def self.mac?
+    RbConfig::CONFIG["host_os"].include?("darwin")
+  end
+
+  def self.linux?
+    RbConfig::CONFIG["host_os"].include?("linux")
+  end
+end
+
+class MacOSVersion
+  include Comparable
+
+  SYMBOLS = {
+    tahoe: "26", sequoia: "15", sonoma: "14", ventura: "13",
+    monterey: "12", big_sur: "11", catalina: "10.15", mojave: "10.14",
+    high_sierra: "10.13", sierra: "10.12", el_capitan: "10.11",
+  }.freeze
+
+  def self.host
+    @host ||= begin
+      version = OS.mac? ? `sw_vers -productVersion`.strip : "0"
+      new(version.empty? ? "0" : version)
+    end
+  end
+
+  def self.from_symbol(sym)
+    new(SYMBOLS.fetch(sym.to_sym, "0"))
+  end
+
+  def initialize(version)
+    @version = version.to_s
+  end
+
+  def <=>(other)
+    other = self.class.from_symbol(other) if other.is_a?(Symbol)
+    other = self.class.new(other.to_s) unless other.is_a?(MacOSVersion)
+    Gem::Version.new(@version) <=> Gem::Version.new(other.to_s)
+  end
+
+  def to_s
+    @version
+  end
+end
+
+module Hardware
+  module CPU
+    def self.arch
+      RbConfig::CONFIG["host_cpu"] =~ /arm|aarch64/ ? :arm64 : :x86_64
+    end
+
+    def self.arm?
+      arch == :arm64
+    end
+
+    def self.intel?
+      arch == :x86_64
+    end
+
+    def self.cores
+      Etc.respond_to?(:nprocessors) ? Etc.nprocessors : 4
+    end
+  end
+end
+
+class Version
+  include Comparable
+
+  def initialize(version)
+    @version = version.to_s
+  end
+
+  def <=>(other)
+    Gem::Version.new(@version.gsub(/[^0-9.].*\z/, "")) <=> Gem::Version.new(other.to_s.gsub(/[^0-9.].*\z/, ""))
+  end
+
+  def to_s
+    @version
+  end
+
+  def to_str
+    @version
+  end
+
+  def inspect
+    @version.inspect
+  end
+
+  def major
+    token(0)
+  end
+
+  def minor
+    token(1)
+  end
+
+  def patch
+    token(2)
+  end
+
+  def major_minor
+    Version.new(@version.split(".")[0, 2].to_a.join("."))
+  end
+
+  def major_minor_patch
+    Version.new(@version.split(".")[0, 3].to_a.join("."))
+  end
+
+  def csv
+    @version.split(",").map { |part| Version.new(part) }
+  end
+
+  private
+
+  def token(idx)
+    part = @version.split(".")[idx]
+    part.nil? ? nil : Version.new(part)
+  end
+end
+
+class CaskContext
+  attr_reader :token
+
+  def initialize(token)
+    @token = token
+    @version = Version.new(MISE_BREW_CASK_VERSION)
+    @hooks = {}
+    @arch = Hardware::CPU.arch.to_s
+  end
+
+  def run_hook(name)
+    hook = @hooks[name.to_sym]
+    return unless hook
+
+    instance_eval(&hook)
+  end
+
+  def arch(mapping = nil)
+    return @arch if mapping.nil?
+
+    @arch = if Hardware::CPU.arm?
+      mapping.fetch(:arm, mapping.fetch("arm", @arch))
+    else
+      mapping.fetch(:intel, mapping.fetch("intel", @arch))
+    end
+  end
+
+  def version(value = nil)
+    @version = Version.new(value) unless value.nil?
+    @version
+  end
+
+  def sha256(*) nil end
+  def url(*) nil end
+  def name(*) nil end
+  def desc(*) nil end
+  def homepage(*) nil end
+  def livecheck(*) nil end
+  def conflicts_with(*) nil end
+  def depends_on(*) nil end
+  def caveats(*) nil end
+  def app(*) nil end
+  def binary(*) nil end
+  def pkg(*) nil end
+  def font(*) nil end
+  def uninstall(*) nil end
+  def zap(*) nil end
+
+  def preflight(&block) @hooks[:preflight] = block end
+  def postflight(&block) @hooks[:postflight] = block end
+  def uninstall_preflight(&block) @hooks[:uninstall_preflight] = block end
+  def uninstall_postflight(&block) @hooks[:uninstall_postflight] = block end
+
+  def on_catalina(method = nil, &block) run_macos_condition(:catalina, method, &block) end
+  def on_big_sur(method = nil, &block) run_macos_condition(:big_sur, method, &block) end
+  def on_monterey(method = nil, &block) run_macos_condition(:monterey, method, &block) end
+  def on_ventura(method = nil, &block) run_macos_condition(:ventura, method, &block) end
+  def on_sonoma(method = nil, &block) run_macos_condition(:sonoma, method, &block) end
+  def on_sequoia(method = nil, &block) run_macos_condition(:sequoia, method, &block) end
+  def on_tahoe(method = nil, &block) run_macos_condition(:tahoe, method, &block) end
+  def on_intel(&block) instance_eval(&block) if Hardware::CPU.intel? end
+  def on_arm(&block) instance_eval(&block) if Hardware::CPU.arm? end
+  def on_macos(&block) instance_eval(&block) if OS.mac? end
+  def on_linux(&block) instance_eval(&block) if OS.linux? end
+
+  def staged_path
+    MISE_BREW_CASK_STAGED_PATH
+  end
+
+  def appdir
+    Pathname.new("/Applications")
+  end
+
+  def caskroom_path
+    MISE_BREW_PREFIX + "Caskroom"
+  end
+
+  private
+
+  def run_macos_condition(version, method, &block)
+    target = MacOSVersion.from_symbol(version)
+    host = MacOSVersion.host
+    matched = case method
+    when :or_older then host <= target
+    when :or_newer then host >= target
+    when nil then host.to_s == target.to_s
+    else shim_unsupported!("on_#{version} #{method}")
+    end
+    instance_eval(&block) if matched
+  end
+end
+
+def cask(token, &block)
+  $mise_cask_context = CaskContext.new(token)
+  $mise_cask_context.instance_eval(&block)
+end
+
+begin
+  load MISE_BREW_CASK_FILE.to_s
+  ctx = $mise_cask_context
+  odie "no cask block found in #{MISE_BREW_CASK_FILE}" if ctx.nil?
+  odie "expected cask #{MISE_BREW_CASK_TOKEN}, got #{ctx.token}" if ctx.token != MISE_BREW_CASK_TOKEN
+  ctx.run_hook(MISE_BREW_CASK_HOOK)
+rescue ShimUnsupportedError => e
+  odie e.message
+end

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -191,7 +191,7 @@ class CaskContext
 
   def run_hook(name)
     hook = @hooks[name.to_sym]
-    odie "expected cask hook #{name} was not registered" unless hook
+    return unless hook
 
     instance_eval(&hook)
   end

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -16,6 +16,7 @@ MISE_BREW_CASK_FILE = Pathname.new(ENV.fetch("MISE_BREW_CASK_FILE"))
 MISE_BREW_CASK_TOKEN = ENV.fetch("MISE_BREW_CASK_TOKEN")
 MISE_BREW_CASK_VERSION = ENV.fetch("MISE_BREW_CASK_VERSION")
 MISE_BREW_CASK_STAGED_PATH = Pathname.new(ENV.fetch("MISE_BREW_CASK_STAGED_PATH"))
+MISE_BREW_CASK_APPDIR = Pathname.new(ENV.fetch("MISE_BREW_CASK_APPDIR"))
 MISE_BREW_PREFIX = Pathname.new(ENV.fetch("MISE_BREW_PREFIX"))
 MISE_BREW_CASK_HOOK = ENV.fetch("MISE_BREW_CASK_HOOK")
 
@@ -190,7 +191,7 @@ class CaskContext
 
   def run_hook(name)
     hook = @hooks[name.to_sym]
-    return unless hook
+    odie "expected cask hook #{name} was not registered" unless hook
 
     instance_eval(&hook)
   end
@@ -248,7 +249,7 @@ class CaskContext
   end
 
   def appdir
-    Pathname.new("/Applications")
+    MISE_BREW_CASK_APPDIR
   end
 
   def caskroom_path

--- a/src/system/packages/brew/source.rs
+++ b/src/system/packages/brew/source.rs
@@ -179,7 +179,7 @@ pub async fn build(
 
 /// Ensure a mise-managed ruby is installed (precompiled by default) and
 /// return the path to its `ruby` executable.
-async fn ruby_bin() -> Result<PathBuf> {
+pub(crate) async fn ruby_bin() -> Result<PathBuf> {
     let mut config = Config::get().await?;
     let tool: crate::cli::args::ToolArg = "ruby".parse()?;
     let mut ts = ToolsetBuilder::new()


### PR DESCRIPTION
## Summary
- fetch sha256-verified cask Ruby source pinned by Homebrew API metadata when lifecycle hooks are present
- add a mise-owned cask Ruby shim for supported preflight/postflight hooks without delegating to Homebrew
- stage binaries generated under the temporary Caskroom path, covering wrapper-style casks like gimp
- document supported lifecycle behavior and failure mode for unsupported hook DSL

## Tests
- cargo fmt --check
- cargo check
- cargo test --bin mise system::packages::brew::cask::tests::
- ruby -c src/system/packages/brew/cask_shim.rb
- GIMP-style cask shim smoke test

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install paths now execute downloaded Ruby from casks and write into Applications/Caskroom; scope is bounded by a partial DSL shim but hook bugs or unexpected DSL could still affect local installs.
> 
> **Overview**
> **brew-cask** can run supported **`preflight`** and **`postflight`** hooks during install instead of skipping lifecycle metadata entirely.
> 
> When API metadata lists a hook, mise downloads the **pin-commit, sha256-verified** cask `.rb`, evaluates it with a new **`cask_shim.rb`** via mise-managed Ruby, and runs only the requested hook—no `brew` delegation. Unsupported Cask DSL in hook code fails with an explicit error.
> 
> The install pipeline is reordered so **preflight** runs on the extracted stage before apps/pkg/fonts, **postflight** runs on the temp Caskroom before binaries are staged, and binary resolution prefers **hook-generated files under the Caskroom** (with path traversal guards) so wrapper-style casks work. **`ruby_bin()`** is shared from the brew source builder for hook execution.
> 
> Docs describe the new hook behavior and failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2d99f3d82326ff323232dd5940469868945e5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Homebrew cask installs now run supported `preflight` and `postflight` lifecycle hooks during staging.
  * Hook execution is handled via a sha256-verified cached Ruby-based shim (no Homebrew lifecycle delegation).
* **Bug Fixes**
  * Casks that rely on unsupported hook DSL or custom installer choices/services now fail with an `unsupported-artifact` error.
  * Safer resolution of staged generated-wrapper binaries, including parent-directory traversal protection.
* **Documentation**
  * Updated `brew-cask` documentation to clarify hook behavior and that shell completions are not installed.
* **Tests**
  * Expanded tests for hook detection and wrapper-to-stage binary mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->