### PR TITLE
fix(vfox): clean traditional plugin downloads

### DIFF
--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -244,15 +244,27 @@ impl Vfox {
         version: &str,
         install_dir: ID,
     ) -> Result<InstallResult> {
+        self.install_with_download_dir(sdk, version, install_dir, &self.download_dir)
+            .await
+    }
+
+    pub async fn install_with_download_dir<ID: AsRef<Path>, DD: AsRef<Path>>(
+        &self,
+        sdk: &str,
+        version: &str,
+        install_dir: ID,
+        download_dir: DD,
+    ) -> Result<InstallResult> {
         self.install_plugin(sdk)?;
         let sdk = self.get_sdk_with_env(sdk)?;
         let pre_install = sdk.pre_install(version).await?;
         let install_dir = install_dir.as_ref();
+        let download_dir = download_dir.as_ref();
         trace!("{pre_install:?}");
         let mut verified_attestation = None;
         let mut checksum_verified = false;
         if let Some(url) = pre_install.url.as_ref().map(|s| Url::from_str(s)) {
-            let file = self.download(&url?, &sdk, version).await?;
+            let file = self.download(&url?, &sdk, version, download_dir).await?;
             verified_attestation = self.verify(&pre_install, &file).await?;
             self.extract(&file, install_dir)?;
             // Note: sha1/md5 intentionally excluded — they are unimplemented! and
@@ -490,16 +502,15 @@ impl Vfox {
         sdk.parse_legacy_file(file).await
     }
 
-    async fn download(&self, url: &Url, sdk: &Plugin, version: &str) -> Result<PathBuf> {
+    async fn download(
+        &self,
+        url: &Url,
+        sdk: &Plugin,
+        version: &str,
+        download_dir: &Path,
+    ) -> Result<PathBuf> {
         self.log_emit(format!("Downloading {url}"));
-        let filename = url
-            .path_segments()
-            .and_then(|mut s| s.next_back())
-            .ok_or("No filename in URL")?;
-        let path = self
-            .download_dir
-            .join(format!("{sdk}-{version}"))
-            .join(filename);
+        let path = Self::download_path_for(download_dir, &sdk.name, version, url)?;
         let url_str = url.to_string();
         let bytes = retry_async(&url_str, || async {
             let resp = CLIENT.get(url.clone()).send().await?;
@@ -512,6 +523,19 @@ impl Vfox {
         tokio::io::AsyncWriteExt::write_all(&mut file, &bytes).await?;
         file.sync_all().await?;
         Ok(path)
+    }
+
+    fn download_path_for(
+        download_dir: &Path,
+        sdk: &str,
+        version: &str,
+        url: &Url,
+    ) -> Result<PathBuf> {
+        let filename = url
+            .path_segments()
+            .and_then(|mut s| s.next_back())
+            .ok_or("No filename in URL")?;
+        Ok(download_dir.join(format!("{sdk}-{version}")).join(filename))
     }
 
     async fn verify(
@@ -763,6 +787,17 @@ mod tests {
             install_dir.join("bin")
         };
         assert_eq!(keys[0].value, expected.to_string_lossy().into_owned());
+    }
+
+    #[test]
+    fn test_download_path_for_uses_download_dir() {
+        let url = Url::parse("https://example.com/releases/tool.tar.gz").unwrap();
+        let download_dir = PathBuf::from("custom/downloads/vfox-dummy/1.0.0");
+        let path = Vfox::download_path_for(&download_dir, "dummy", "1.0.0", &url).unwrap();
+        assert_eq!(
+            path,
+            PathBuf::from("custom/downloads/vfox-dummy/1.0.0/dummy-1.0.0/tool.tar.gz")
+        );
     }
 
     #[tokio::test]

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -231,7 +231,12 @@ impl Backend for VfoxBackend {
 
         // Use default vfox behavior for traditional plugins
         let result = vfox
-            .install(&self.pathname, &tv.version, tv.install_path())
+            .install_with_download_dir(
+                &self.pathname,
+                &tv.version,
+                tv.install_path(),
+                tv.download_path(),
+            )
             .await?;
 
         // Record provenance if attestation verification succeeded


### PR DESCRIPTION
## Summary
- route traditional vfox plugin downloads through mise-provided per-tool download directories
- keep standalone vfox install behavior using the vfox default download directory
- add a unit test covering custom download directory path construction

## Root cause
Traditional vfox installs downloaded into `downloads/<sdk>-<version>/...`, while mise cleanup removes `ToolVersion::download_path()` (`downloads/<backend>/<version>`). Passing mise’s per-tool download directory into the vfox installer keeps downloaded artifacts under the tree that mise already removes after install.

## Validation
- `cargo test -p vfox test_download_path_for_uses_download_dir`
- `cargo check -p mise`

Note: `mise --cd crates/vfox run test` was attempted first, but it stalled while bootstrapping `cargo-edit@0.13.10` through `cargo-binstall` before reaching the test phase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing plugins using a user-specified download directory.
  * Downloads now respect the chosen location when building the final file path.

* **Bug Fixes**
  * Improved plugin installation flow so downloaded files are placed in the expected directory during install.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->