### PR TITLE
fix(brew): support pkg-created cask binaries

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -741,8 +741,12 @@ fn stage_binary(stage: &Path, caskroom: &Path, cask: &Cask, binary: &BinaryArtif
         file::make_symlink(&app_binary, &caskroom_binary)?;
     } else {
         let source = find_binary_source(stage, caskroom, cask, binary)?;
-        file::copy(&source, &caskroom_binary)?;
-        file::make_executable(&caskroom_binary)?;
+        if source.starts_with(stage) || source.starts_with(caskroom) {
+            file::copy(&source, &caskroom_binary)?;
+            file::make_executable(&caskroom_binary)?;
+        } else {
+            file::make_symlink(&source, &caskroom_binary)?;
+        }
     }
     Ok(())
 }
@@ -758,6 +762,11 @@ fn find_binary_source(
     {
         return Ok(source);
     }
+    if let Some(source) = absolute_binary_source(&binary.source)
+        && source.is_file()
+    {
+        return Ok(source);
+    }
     find_artifact(caskroom, &binary.source)
         .or_else(|| find_artifact(stage, &binary.source))
         .filter(|path| path.is_file())
@@ -767,6 +776,13 @@ fn find_binary_source(
                 binary.source
             )
         })
+}
+
+fn absolute_binary_source(source: &str) -> Option<PathBuf> {
+    let prefix = prefix::prefix();
+    let source = source.replace("$HOMEBREW_PREFIX", &prefix.to_string_lossy());
+    let source = PathBuf::from(source);
+    source.is_absolute().then_some(source)
 }
 
 fn generated_caskroom_artifact(caskroom: &Path, cask: &Cask, source: &str) -> Option<PathBuf> {
@@ -2017,6 +2033,40 @@ mod tests {
             crate::file::read_to_string(caskroom.join("bin/op"))?,
             "hook"
         );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stages_absolute_binary_source_from_pkg_install() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        file::create_dir_all(&stage)?;
+        let pkg_binary = tmp
+            .path()
+            .join("Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli");
+        if let Some(parent) = pkg_binary.parent() {
+            file::create_dir_all(parent)?;
+        }
+        crate::file::write(&pkg_binary, "pkg binary")?;
+        let caskroom = caskroom_version_dir("karabiner-elements", "16.1.0");
+        file::create_dir_all(&caskroom)?;
+        let cask = test_cask("karabiner-elements", "16.1.0");
+        let binary = BinaryArtifact {
+            source: pkg_binary.to_string_lossy().to_string(),
+            target: Some("$HOMEBREW_PREFIX/bin/karabiner_cli".to_string()),
+        };
+
+        stage_binary(&stage, &caskroom, &cask, &binary)?;
+        link_binary(&caskroom, &binary)?;
+
+        let staged = caskroom.join("bin/karabiner_cli");
+        assert_eq!(std::fs::read_link(&staged)?, pkg_binary);
+        let target = binary.target_path()?;
+        assert_eq!(std::fs::read_link(&target)?, staged);
+        assert_eq!(crate::file::read_to_string(&target)?, "pkg binary");
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -813,6 +813,17 @@ fn cask_appdir(apps: &[AppArtifact]) -> Result<PathBuf> {
 fn link_binary(caskroom: &Path, binary: &BinaryArtifact) -> Result<()> {
     let caskroom_binary = caskroom_binary_path(caskroom, binary)?;
     if !caskroom_binary.is_file() {
+        if caskroom_binary
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        {
+            let target = std::fs::read_link(&caskroom_binary)?;
+            bail!(
+                "brew-cask: binary artifact '{}' was staged but symlink target '{}' does not exist",
+                binary.source,
+                target.display()
+            );
+        }
         bail!(
             "brew-cask: binary artifact '{}' was not staged",
             binary.source
@@ -2067,6 +2078,38 @@ mod tests {
         let target = binary.target_path()?;
         assert_eq!(std::fs::read_link(&target)?, staged);
         assert_eq!(crate::file::read_to_string(&target)?, "pkg binary");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reports_missing_target_for_dangling_staged_binary_symlink() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        file::create_dir_all(&stage)?;
+        let pkg_binary = tmp
+            .path()
+            .join("Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli");
+        if let Some(parent) = pkg_binary.parent() {
+            file::create_dir_all(parent)?;
+        }
+        crate::file::write(&pkg_binary, "pkg binary")?;
+        let caskroom = caskroom_version_dir("karabiner-elements", "16.1.0");
+        file::create_dir_all(&caskroom)?;
+        let cask = test_cask("karabiner-elements", "16.1.0");
+        let binary = BinaryArtifact {
+            source: pkg_binary.to_string_lossy().to_string(),
+            target: Some("$HOMEBREW_PREFIX/bin/karabiner_cli".to_string()),
+        };
+
+        stage_binary(&stage, &caskroom, &cask, &binary)?;
+        file::remove_file(&pkg_binary)?;
+        let err = link_binary(&caskroom, &binary).unwrap_err().to_string();
+
+        assert!(err.contains("was staged but symlink target"));
+        assert!(err.contains(&pkg_binary.to_string_lossy().to_string()));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- support cask binary artifacts that point at absolute files created by a pkg installer
- stage external pkg-created binaries through the caskroom as symlinks before linking into `$HOMEBREW_PREFIX/bin`
- add a unit test for the Karabiner-style pkg-created `karabiner_cli` path

## Context
This follows up on https://github.com/jdx/mise/discussions/10582 and the partial cask lifecycle support from #10837. GIMP-style hook-generated binaries are handled there, but casks like `karabiner-elements` expose a binary created by the pkg installer at an absolute `/Library/Application Support/...` path.

## Tests
- `cargo fmt --check`
- `cargo test --bin mise system::packages::brew::cask::tests::`
- pre-commit `mise run lint`

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to macOS brew-cask binary staging/linking; symlink-vs-copy behavior is localized and covered by new unit tests.
> 
> **Overview**
> Extends brew-cask binary staging so **binary artifacts can point at absolute files** created by a `.pkg` install (e.g. Karabiner’s `karabiner_cli` under `/Library/Application Support/...`), not only files under the extract stage or caskroom.
> 
> **Resolution:** `find_binary_source` now considers **`absolute_binary_source`** (absolute paths with `$HOMEBREW_PREFIX` expanded) before walking stage/caskroom.
> 
> **Staging:** If the resolved source is **outside** the stage and caskroom trees, the caskroom entry is a **symlink** to that file instead of a copy; in-tree sources still copy and are made executable.
> 
> **Linking:** When the caskroom binary is a symlink whose target is missing, **`link_binary`** fails with an explicit message about the broken symlink target instead of a generic “not staged” error.
> 
> Unix tests cover the Karabiner-style absolute pkg path (stage → prefix `bin` via caskroom symlinks) and the dangling-symlink error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e7d9327cc89c19a5650d3f2d889e6b6c18c3e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for staging binaries sourced from absolute locations.
  * When binaries originate outside the staging area, they are now linked to preserve the source relationship.

* **Bug Fixes**
  * Improved staging/link behavior so staged entries and final installed links correctly reference each other for absolute and staged sources.
  * Added clearer error handling when a staged binary symlink becomes dangling.

* **Tests**
  * Added coverage for absolute-path binary staging and for reporting missing targets for dangling staged symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->