### PR TITLE
registry: use vfox for scala

### DIFF
--- a/registry/scala.toml
+++ b/registry/scala.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-scala", "vfox:mise-plugins/vfox-scala"]
+backends = ["vfox:jdx/vfox-scala", "asdf:mise-plugins/mise-scala"]
 description = "Scala language"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -81,6 +81,7 @@ mod tests {
         settings.shorthands_file = Some("../fixtures/shorthands.toml".into());
         let shorthands = get_shorthands(&settings);
         assert_str_eq!(shorthands["aapt2"][0], "vfox:mise-plugins/vfox-aapt2");
+        assert_str_eq!(shorthands["scala"][0], "vfox:jdx/vfox-scala");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- switch the scala registry shorthand to prefer `vfox:jdx/vfox-scala`
- keep `asdf:mise-plugins/mise-scala` as the fallback backend
- update the shorthand unit test to pin the new default backend

## Plugin
- Scala vfox cleanup: https://github.com/jdx/vfox-scala/pull/1

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- `mise run lint` via pre-commit hook
- local linked plugin install: `./target/debug/mise install vfox-scala@3.8.4`
- local linked plugin install: `./target/debug/mise install vfox-scala@2.13.16`
- smoke checked `SCALA_HOME`, `command -v scala`, `command -v scalac`, and executable bin files

Note: `scala -version` and `scalac -version` stop at the missing Java runtime on this machine for both the vfox and asdf plugins, so the install/bin-layout checks are the comparable local verification.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry backend ordering and test-only assertion; no runtime logic or security-sensitive paths change.
> 
> **Overview**
> The **scala** registry entry now lists **`vfox:jdx/vfox-scala`** as the primary backend, with **`asdf:mise-plugins/mise-scala`** kept as the fallback.
> 
> A shorthand unit test asserts that resolving **`scala`** picks the new vfox backend first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a125a6c31e4e46595e56c5641fe1532efeefb8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Scala backend ordering so the Scala shorthand now resolves to the expected provider.
  * Added coverage to confirm the Scala shorthand maps correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->