### PR TITLE
registry: use vfox for groovy

### DIFF
--- a/registry/groovy.toml
+++ b/registry/groovy.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-groovy", "vfox:mise-plugins/vfox-groovy"]
+backends = ["vfox:jdx/vfox-groovy", "asdf:mise-plugins/mise-groovy"]
 description = "A flexible and extensible Java-like language for the JVM"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -82,6 +82,7 @@ mod tests {
         let shorthands = get_shorthands(&settings);
         assert_str_eq!(shorthands["aapt2"][0], "vfox:mise-plugins/vfox-aapt2");
         assert_str_eq!(shorthands["scala"][0], "vfox:jdx/vfox-scala");
+        assert_str_eq!(shorthands["groovy"][0], "vfox:jdx/vfox-groovy");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- switch the groovy registry shorthand to prefer `vfox:jdx/vfox-groovy`
- keep `asdf:mise-plugins/mise-groovy` as the fallback backend
- update the shorthand unit test to pin the new default backend

## Plugin
- Forked existing vfox plugin to `jdx/vfox-groovy`; no plugin code changes were needed.

## Popularity
- Plugin repo: `jdx/vfox-groovy`, 0 GitHub stars, 0 forks
- Source plugin forked from: `mise-plugins/vfox-groovy`
- Tool: Groovy is already in the registry; this PR only changes the preferred backend for the existing `groovy` shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- `mise run lint` via pre-commit hook
- `./target/debug/mise latest asdf:mise-plugins/mise-groovy` and linked `vfox-groovy` both returned `5.0.7`
- local linked plugin install: `./target/debug/mise install vfox-groovy@5.0.7`
- local linked plugin install: `./target/debug/mise install vfox-groovy@4.0.28`
- smoke checked `GROOVY_HOME`, `command -v groovy`, `command -v groovyc`, and executable bin files

Note: `groovy --version` stops at the missing Java runtime on this machine for both the vfox and asdf plugins, so the install/bin-layout checks are the comparable local verification.

*This PR was generated by an AI coding assistant.*