### PR TITLE
registry: use vfox for mongodb

### DIFF
--- a/registry/mongodb.toml
+++ b/registry/mongodb.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-mongodb", "vfox:echocat/vfox-mongod"]
+backends = ["vfox:jdx/vfox-mongod", "asdf:mise-plugins/mise-mongodb"]
 description = "MongoDB"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -445,8 +445,8 @@ mod tests {
             "https://github.com/mise-plugins/vfox-cmake.git"
         ));
         assert!(is_trusted_plugin(
-            "vfox-echocat-vfox-mongod",
-            "https://github.com/echocat/vfox-mongod.git"
+            "vfox-jdx-vfox-mongod",
+            "https://github.com/jdx/vfox-mongod.git"
         ));
     }
 

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -83,6 +83,7 @@ mod tests {
         assert_str_eq!(shorthands["aapt2"][0], "vfox:mise-plugins/vfox-aapt2");
         assert_str_eq!(shorthands["scala"][0], "vfox:jdx/vfox-scala");
         assert_str_eq!(shorthands["groovy"][0], "vfox:jdx/vfox-groovy");
+        assert_str_eq!(shorthands["mongodb"][0], "vfox:jdx/vfox-mongod");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- switch the mongodb registry shorthand to prefer `vfox:jdx/vfox-mongod`
- keep `asdf:mise-plugins/mise-mongodb` as the fallback backend
- update the shorthand unit test to pin the new default backend

## Plugin
- Forked existing vfox plugin to `jdx/vfox-mongod`; no plugin code changes were needed.

## Popularity
- Plugin repo: `jdx/vfox-mongod`, 0 GitHub stars, 0 forks
- Source plugin forked from: `echocat/vfox-mongod`
- Tool: MongoDB is already in the registry; this PR only changes the preferred backend for the existing `mongodb` shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- `mise run lint` via pre-commit hook
- linked `vfox-mongod` latest returned `8.3.4`
- local linked plugin install: `./target/debug/mise install mongod@8.3.4`
- smoke tests: `mongod --version`, `command -v mongod`, `command -v mongos`
- comparison check: `asdf:mise-plugins/mise-mongodb@8.0.0` installs and runs `mongod --version`; its version listing currently returns no versions locally

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry backend ordering and test expectations only; no changes to install logic, auth, or data handling.
> 
> **Overview**
> MongoDB’s registry entry now **prefers** `vfox:jdx/vfox-mongod` for installs, with `asdf:mise-plugins/mise-mongodb` kept as the **fallback** backend (order swap in `registry/mongodb.toml`).
> 
> Trust and shorthand tests were updated so the official remote is `github.com/jdx/vfox-mongod` and the `mongodb` shorthand’s first backend is pinned to `vfox:jdx/vfox-mongod`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6b7cac3945778c3821c5e3b712924858dcd7e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the MongoDB shorthand to resolve to the current backend source.
  * Adjusted trust handling so the official MongoDB plugin URL is recognized correctly.
  * Reordered the MongoDB backend entries for consistent resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->