### PR TITLE
registry: use vfox for emsdk

### DIFF
--- a/registry/emsdk.toml
+++ b/registry/emsdk.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-emsdk"]
+backends = ["vfox:jdx/vfox-emsdk", "asdf:mise-plugins/mise-emsdk"]
 description = "Emscripten is a complete compiler toolchain to WebAssembly, using LLVM, with a special focus on speed, size, and the Web platform"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -84,6 +84,7 @@ mod tests {
         assert_str_eq!(shorthands["scala"][0], "vfox:jdx/vfox-scala");
         assert_str_eq!(shorthands["groovy"][0], "vfox:jdx/vfox-groovy");
         assert_str_eq!(shorthands["mongodb"][0], "vfox:jdx/vfox-mongod");
+        assert_str_eq!(shorthands["emsdk"][0], "vfox:jdx/vfox-emsdk");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- switch the emsdk registry shorthand to prefer `vfox:jdx/vfox-emsdk`
- keep `asdf:mise-plugins/mise-emsdk` as the fallback backend
- update the shorthand unit test to pin the new default backend

## Plugin
- Emsdk vfox parity fixes were merged into `jdx/vfox-emsdk`: https://github.com/jdx/vfox-emsdk/pull/1

## Popularity
- Plugin repo: `jdx/vfox-emsdk`, 0 GitHub stars, 0 forks
- Source plugin forked from: `rektide/vfox-emsdk`
- Tool: emsdk is already in the registry; this PR only changes the preferred backend for the existing `emsdk` shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- `mise run lint` via pre-commit hook
- linked `vfox-emsdk` latest returned `6.0.2`, matching asdf
- local linked plugin install: `./target/debug/mise install emsdk@3.1.74`
- smoke tests: `emcc --version`, `command -v emsdk`, `command -v emcc`, `command -v node`
- env checks: `EMSDK`, `EM_CONFIG`, `EMSCRIPTEN_ROOT`, `LLVM_ROOT`, `BINARYEN_ROOT`, `EMSDK_NODE`, `NODE_JS`
- comparison: `asdf:mise-plugins/mise-emsdk@3.1.74` installs and runs `emcc --version`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only backend ordering change with asdf fallback unchanged; no auth, data, or core install logic modified.
> 
> **Overview**
> **`emsdk`** now resolves through **`vfox:jdx/vfox-emsdk`** first; **`asdf:mise-plugins/mise-emsdk`** remains the fallback in `registry/emsdk.toml`.
> 
> The shorthand unit test asserts that **`emsdk`**’s primary backend string matches the new vfox plugin id, consistent with other **`jdx/vfox-*`** registry entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874e47fd786480a8dc9162ed79c53e42168701b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for the `emsdk` shorthand by adding an additional backend option.
  * Shorthand resolution now recognizes the new backend as the first available match in the configured setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->