### PR TITLE
registry: use vfox for gcc-arm-none-eabi

### DIFF
--- a/registry/gcc-arm-none-eabi.toml
+++ b/registry/gcc-arm-none-eabi.toml
@@ -1,2 +1,5 @@
-backends = ["asdf:mise-plugins/mise-gcc-arm-none-eabi"]
+backends = [
+  "vfox:jdx/vfox-gcc-arm-none-eabi",
+  "asdf:mise-plugins/mise-gcc-arm-none-eabi",
+]
 description = "Arm GNU Toolchain"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,10 +89,6 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
-        assert_str_eq!(
-            shorthands["gcc-arm-none-eabi"][0],
-            "vfox:jdx/vfox-gcc-arm-none-eabi"
-        );
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,6 +89,10 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
+        assert_str_eq!(
+            shorthands["gcc-arm-none-eabi"][0],
+            "vfox:jdx/vfox-gcc-arm-none-eabi"
+        );
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- switch the gcc-arm-none-eabi registry shorthand to prefer `vfox:jdx/vfox-gcc-arm-none-eabi`
- keep `asdf:mise-plugins/mise-gcc-arm-none-eabi` as the fallback backend
- update the shorthand unit test to pin the new default backend

## Plugin
- Forked existing vfox plugin to `jdx/vfox-gcc-arm-none-eabi`: https://github.com/jdx/vfox-gcc-arm-none-eabi
- Fixed mise compatibility in the plugin: lazy-load release metadata during hooks and omit unsupported MD5 checksum metadata.

## Popularity
- Plugin repo: `jdx/vfox-gcc-arm-none-eabi`, 0 GitHub stars, 0 forks, last pushed 2026-07-08
- Source plugin forked from: `ciscoski/vfox-gcc-arm-none-eabi`, 0 GitHub stars, 1 fork, last pushed 2024-09-23
- Tool: Arm GNU Toolchain is already in the registry; this PR only changes the preferred backend for the existing `gcc-arm-none-eabi` shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- `mise run lint` via pre-commit hook
- local linked plugin latest: `./target/debug/mise latest vfox:jdx/vfox-gcc-arm-none-eabi` -> `13.3.Rel1~arm64`
- local linked plugin install: `./target/debug/mise install vfox:jdx/vfox-gcc-arm-none-eabi@13.3.Rel1`
- smoke test: `arm-none-eabi-gcc --version`
- smoke test: `which arm-none-eabi-gcc`

Note: the current asdf plugin fails on this macOS host before listing versions because it requires Bash 4+, while macOS system Bash is 3.2.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only backend ordering change with asdf fallback retained; no core install or auth logic changes in the diff shown.
> 
> **Overview**
> The **`gcc-arm-none-eabi`** registry shorthand now lists **`vfox:jdx/vfox-gcc-arm-none-eabi`** as the **primary** backend, with **`asdf:mise-plugins/mise-gcc-arm-none-eabi`** kept as a **fallback** when vfox is unavailable or unsuitable.
> 
> This is a **backend preference** change only—the tool name and description are unchanged; installs should try vfox first instead of asdf-only resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434629bb75b7542f9915a2e52d380b79199847f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for the `gcc-arm-none-eabi` shorthand to recognize an additional backend option.

* **Bug Fixes**
  * Improved shorthand resolution so `gcc-arm-none-eabi` now maps to the expected backend reference.
  * Kept the prior backend available as a compatibility fallback.

* **Tests**
  * Updated the shorthand resolution unit test to verify the new mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->